### PR TITLE
[naga] implement `pointer_composite_access` WGSL language extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Add support for OpAtomicCompareExchange in SPIR-V frontend. By @schell in [#6590](https://github.com/gfx-rs/wgpu/pull/6590).
 - Implement type inference for abstract arguments to user-defined functions. By @jamienicol in [#6577](https://github.com/gfx-rs/wgpu/pull/6577).
 - Allow for override-expressions in array sizes. By @KentSlaney in [#6654](https://github.com/gfx-rs/wgpu/pull/6654).
+- [`pointer_composite_access` WGSL language extension](https://www.w3.org/TR/WGSL/#language_extension-pointer_composite_access) is implemented. By @sagudev in [#6913](https://github.com/gfx-rs/wgpu/pull/6913)
 
 ##### General
 

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -213,7 +213,6 @@ pub(crate) enum Error<'a> {
     InvalidAtomicPointer(Span),
     InvalidAtomicOperandType(Span),
     InvalidRayQueryPointer(Span),
-    Pointer(&'static str, Span),
     NotPointer(Span),
     NotReference(&'static str, Span),
     InvalidAssignment {
@@ -719,11 +718,6 @@ impl<'a> Error<'a> {
                     notes,
                 }
             }
-            Error::Pointer(what, span) => ParseError {
-                message: format!("{what} must not be a pointer"),
-                labels: vec![(span, "expression is a pointer".into())],
-                notes: vec![],
-            },
             Error::ReservedKeyword(name_span) => ParseError {
                 message: format!("name `{}` is a reserved keyword", &source[name_span]),
                 labels: vec![(

--- a/naga/src/front/wgsl/parse/directive/language_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/language_extension.rs
@@ -34,7 +34,7 @@ impl LanguageExtension {
                 Self::Unimplemented(UnimplementedLanguageExtension::UnrestrictedPointerParameters)
             }
             Self::POINTER_COMPOSITE_ACCESS => {
-                Self::Unimplemented(UnimplementedLanguageExtension::PointerCompositeAccess)
+                Self::Implemented(ImplementedLanguageExtension::PointerCompositeAccess)
             }
             _ => return None,
         })
@@ -54,9 +54,6 @@ impl LanguageExtension {
                 UnimplementedLanguageExtension::UnrestrictedPointerParameters => {
                     Self::UNRESTRICTED_POINTER_PARAMETERS
                 }
-                UnimplementedLanguageExtension::PointerCompositeAccess => {
-                    Self::POINTER_COMPOSITE_ACCESS
-                }
             },
         }
     }
@@ -64,7 +61,9 @@ impl LanguageExtension {
 
 /// A variant of [`LanguageExtension::Implemented`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, VariantArray)]
-pub enum ImplementedLanguageExtension {}
+pub enum ImplementedLanguageExtension {
+    PointerCompositeAccess,
+}
 
 impl ImplementedLanguageExtension {
     /// Returns slice of all variants of [`ImplementedLanguageExtension`].
@@ -74,7 +73,11 @@ impl ImplementedLanguageExtension {
 
     /// Maps this [`ImplementedLanguageExtension`] into the sentinel word associated with it in WGSL.
     pub const fn to_ident(self) -> &'static str {
-        match self {}
+        match self {
+            ImplementedLanguageExtension::PointerCompositeAccess => {
+                LanguageExtension::POINTER_COMPOSITE_ACCESS
+            }
+        }
     }
 }
 
@@ -84,7 +87,6 @@ pub enum UnimplementedLanguageExtension {
     ReadOnlyAndReadWriteStorageTextures,
     Packed4x8IntegerDotProduct,
     UnrestrictedPointerParameters,
-    PointerCompositeAccess,
 }
 
 impl UnimplementedLanguageExtension {
@@ -93,7 +95,6 @@ impl UnimplementedLanguageExtension {
             Self::ReadOnlyAndReadWriteStorageTextures => 6204,
             Self::Packed4x8IntegerDotProduct => 6445,
             Self::UnrestrictedPointerParameters => 5158,
-            Self::PointerCompositeAccess => 6192,
         }
     }
 }

--- a/naga/tests/in/access.wgsl
+++ b/naga/tests/in/access.wgsl
@@ -198,3 +198,17 @@ fn assign_to_ptr_components() {
    assign_to_arg_ptr_array_element(&a1);
    fetch_arg_ptr_array_element(&a1);
 }
+
+fn index_ptr(value: bool) -> bool {
+    var a = array<bool, 1>(value);
+    let p = &a;
+    return p[0];
+}
+
+struct S { m: i32 };
+
+fn member_ptr() -> i32 {
+    var s: S = S(42);
+    let p = &s;
+    return p.m;
+}

--- a/naga/tests/in/access.wgsl
+++ b/naga/tests/in/access.wgsl
@@ -212,3 +212,33 @@ fn member_ptr() -> i32 {
     let p = &s;
     return p.m;
 }
+
+struct Inner { delicious: i32 }
+
+struct Outer { om_nom_nom: Inner, thing: u32 }
+
+fn let_members_of_members() -> i32 {
+    let thing = Outer();
+
+    let inner = thing.om_nom_nom;
+    let delishus = inner.delicious;
+
+    if (thing.thing != u32(delishus)) {
+        // LOL
+    }
+
+    return thing.om_nom_nom.delicious;
+}
+
+fn var_members_of_members() -> i32 {
+    var thing = Outer();
+
+    var inner = thing.om_nom_nom;
+    var delishus = inner.delicious;
+
+    if (thing.thing != u32(delishus)) {
+        // LOL
+    }
+
+    return thing.om_nom_nom.delicious;
+}

--- a/naga/tests/out/analysis/access.info.ron
+++ b/naga/tests/out/analysis/access.info.ron
@@ -33,6 +33,9 @@
         ("SIZED | COPY | CREATION_RESOLVED | ARGUMENT"),
         ("DATA | SIZED | COPY | HOST_SHAREABLE | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
         ("SIZED | COPY | CREATION_RESOLVED | ARGUMENT"),
+        ("DATA | SIZED | COPY | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
+        ("DATA | SIZED | COPY | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
+        ("DATA | SIZED | COPY | IO_SHAREABLE | HOST_SHAREABLE | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
     ],
     functions: [
         (
@@ -2953,6 +2956,155 @@
                         kind: Uint,
                         width: 4,
                     ))),
+                ),
+            ],
+            sampling: [],
+            dual_source_blending: false,
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
+            available_stages: ("VERTEX | FRAGMENT | COMPUTE"),
+            uniformity: (
+                non_uniform_result: Some(2),
+                requirements: (""),
+            ),
+            may_kill: false,
+            sampling_set: [],
+            global_uses: [
+                (""),
+                (""),
+                (""),
+                (""),
+                (""),
+            ],
+            expressions: [
+                (
+                    uniformity: (
+                        non_uniform_result: Some(0),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(33),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(0),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(34),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 2,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 34,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 33,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(33),
+                ),
+            ],
+            sampling: [],
+            dual_source_blending: false,
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
+            available_stages: ("VERTEX | FRAGMENT | COMPUTE"),
+            uniformity: (
+                non_uniform_result: Some(2),
+                requirements: (""),
+            ),
+            may_kill: false,
+            sampling_set: [],
+            global_uses: [
+                (""),
+                (""),
+                (""),
+                (""),
+                (""),
+            ],
+            expressions: [
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
+                        kind: Sint,
+                        width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(35),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 35,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 2,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(2),
                 ),
             ],
             sampling: [],

--- a/naga/tests/out/analysis/access.info.ron
+++ b/naga/tests/out/analysis/access.info.ron
@@ -36,6 +36,8 @@
         ("DATA | SIZED | COPY | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
         ("DATA | SIZED | COPY | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
         ("DATA | SIZED | COPY | IO_SHAREABLE | HOST_SHAREABLE | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
+        ("DATA | SIZED | COPY | IO_SHAREABLE | HOST_SHAREABLE | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
+        ("DATA | SIZED | COPY | IO_SHAREABLE | HOST_SHAREABLE | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
     ],
     functions: [
         (
@@ -3100,6 +3102,302 @@
                 (
                     uniformity: (
                         non_uniform_result: Some(2),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(2),
+                ),
+            ],
+            sampling: [],
+            dual_source_blending: false,
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
+            available_stages: ("VERTEX | FRAGMENT | COMPUTE"),
+            uniformity: (
+                non_uniform_result: None,
+                requirements: (""),
+            ),
+            may_kill: false,
+            sampling_set: [],
+            global_uses: [
+                (""),
+                (""),
+                (""),
+                (""),
+                (""),
+            ],
+            expressions: [
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 3,
+                    assignable_global: None,
+                    ty: Handle(37),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(36),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(2),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(0),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
+                        kind: Uint,
+                        width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
+                        kind: Bool,
+                        width: 1,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(36),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(2),
+                ),
+            ],
+            sampling: [],
+            dual_source_blending: false,
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
+            available_stages: ("VERTEX | FRAGMENT | COMPUTE"),
+            uniformity: (
+                non_uniform_result: Some(1),
+                requirements: (""),
+            ),
+            may_kill: false,
+            sampling_set: [],
+            global_uses: [
+                (""),
+                (""),
+                (""),
+                (""),
+                (""),
+            ],
+            expressions: [
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(37),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        requirements: (""),
+                    ),
+                    ref_count: 3,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 37,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 36,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(36),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        requirements: (""),
+                    ),
+                    ref_count: 2,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 36,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 2,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(2),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(7),
+                        requirements: (""),
+                    ),
+                    ref_count: 2,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 2,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 0,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(0),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(7),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Handle(2),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(7),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
+                        kind: Uint,
+                        width: 4,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Scalar((
+                        kind: Bool,
+                        width: 1,
+                    ))),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 36,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        requirements: (""),
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                    ty: Value(Pointer(
+                        base: 2,
+                        space: Function,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(1),
                         requirements: (""),
                     ),
                     ref_count: 1,

--- a/naga/tests/out/glsl/access.assign_through_ptr.Compute.glsl
+++ b/naga/tests/out/glsl/access.assign_through_ptr.Compute.glsl
@@ -22,6 +22,9 @@ struct MatCx2InArray {
 struct AssignToMember {
     uint x;
 };
+struct S {
+    int m;
+};
 
 float read_from_private(inout float foo_1) {
     float _e1 = foo_1;
@@ -60,6 +63,19 @@ uint fetch_arg_ptr_array_element(inout uint p_3[4]) {
 void assign_to_arg_ptr_array_element(inout uint p_4[4]) {
     p_4[1] = 10u;
     return;
+}
+
+bool index_ptr(bool value) {
+    bool a_1[1] = bool[1](false);
+    a_1 = bool[1](value);
+    bool _e4 = a_1[0];
+    return _e4;
+}
+
+int member_ptr() {
+    S s = S(42);
+    int _e4 = s.m;
+    return _e4;
 }
 
 void main() {

--- a/naga/tests/out/glsl/access.assign_through_ptr.Compute.glsl
+++ b/naga/tests/out/glsl/access.assign_through_ptr.Compute.glsl
@@ -25,6 +25,13 @@ struct AssignToMember {
 struct S {
     int m;
 };
+struct Inner {
+    int delicious;
+};
+struct Outer {
+    Inner om_nom_nom;
+    uint thing;
+};
 
 float read_from_private(inout float foo_1) {
     float _e1 = foo_1;
@@ -76,6 +83,30 @@ int member_ptr() {
     S s = S(42);
     int _e4 = s.m;
     return _e4;
+}
+
+int let_members_of_members() {
+    Inner inner_1 = Outer(Inner(0), 0u).om_nom_nom;
+    int delishus_1 = inner_1.delicious;
+    if ((Outer(Inner(0), 0u).thing != uint(delishus_1))) {
+    }
+    return Outer(Inner(0), 0u).om_nom_nom.delicious;
+}
+
+int var_members_of_members() {
+    Outer thing = Outer(Inner(0), 0u);
+    Inner inner = Inner(0);
+    int delishus = 0;
+    Inner _e3 = thing.om_nom_nom;
+    inner = _e3;
+    int _e6 = inner.delicious;
+    delishus = _e6;
+    uint _e9 = thing.thing;
+    int _e10 = delishus;
+    if ((_e9 != uint(_e10))) {
+    }
+    int _e15 = thing.om_nom_nom.delicious;
+    return _e15;
 }
 
 void main() {

--- a/naga/tests/out/glsl/access.assign_to_ptr_components.Compute.glsl
+++ b/naga/tests/out/glsl/access.assign_to_ptr_components.Compute.glsl
@@ -22,6 +22,9 @@ struct MatCx2InArray {
 struct AssignToMember {
     uint x;
 };
+struct S {
+    int m;
+};
 
 float read_from_private(inout float foo_1) {
     float _e1 = foo_1;
@@ -60,6 +63,19 @@ uint fetch_arg_ptr_array_element(inout uint p_3[4]) {
 void assign_to_arg_ptr_array_element(inout uint p_4[4]) {
     p_4[1] = 10u;
     return;
+}
+
+bool index_ptr(bool value) {
+    bool a_1[1] = bool[1](false);
+    a_1 = bool[1](value);
+    bool _e4 = a_1[0];
+    return _e4;
+}
+
+int member_ptr() {
+    S s = S(42);
+    int _e4 = s.m;
+    return _e4;
 }
 
 void main() {

--- a/naga/tests/out/glsl/access.assign_to_ptr_components.Compute.glsl
+++ b/naga/tests/out/glsl/access.assign_to_ptr_components.Compute.glsl
@@ -25,6 +25,13 @@ struct AssignToMember {
 struct S {
     int m;
 };
+struct Inner {
+    int delicious;
+};
+struct Outer {
+    Inner om_nom_nom;
+    uint thing;
+};
 
 float read_from_private(inout float foo_1) {
     float _e1 = foo_1;
@@ -76,6 +83,30 @@ int member_ptr() {
     S s = S(42);
     int _e4 = s.m;
     return _e4;
+}
+
+int let_members_of_members() {
+    Inner inner_1 = Outer(Inner(0), 0u).om_nom_nom;
+    int delishus_1 = inner_1.delicious;
+    if ((Outer(Inner(0), 0u).thing != uint(delishus_1))) {
+    }
+    return Outer(Inner(0), 0u).om_nom_nom.delicious;
+}
+
+int var_members_of_members() {
+    Outer thing = Outer(Inner(0), 0u);
+    Inner inner = Inner(0);
+    int delishus = 0;
+    Inner _e3 = thing.om_nom_nom;
+    inner = _e3;
+    int _e6 = inner.delicious;
+    delishus = _e6;
+    uint _e9 = thing.thing;
+    int _e10 = delishus;
+    if ((_e9 != uint(_e10))) {
+    }
+    int _e15 = thing.om_nom_nom.delicious;
+    return _e15;
 }
 
 void main() {

--- a/naga/tests/out/glsl/access.foo_frag.Fragment.glsl
+++ b/naga/tests/out/glsl/access.foo_frag.Fragment.glsl
@@ -20,6 +20,9 @@ struct MatCx2InArray {
 struct AssignToMember {
     uint x;
 };
+struct S {
+    int m;
+};
 layout(std430) buffer Bar_block_0Fragment {
     mat4x3 _matrix;
     mat2x2 matrix_array[2];
@@ -70,6 +73,19 @@ uint fetch_arg_ptr_array_element(inout uint p_3[4]) {
 void assign_to_arg_ptr_array_element(inout uint p_4[4]) {
     p_4[1] = 10u;
     return;
+}
+
+bool index_ptr(bool value) {
+    bool a_1[1] = bool[1](false);
+    a_1 = bool[1](value);
+    bool _e4 = a_1[0];
+    return _e4;
+}
+
+int member_ptr() {
+    S s = S(42);
+    int _e4 = s.m;
+    return _e4;
 }
 
 void main() {

--- a/naga/tests/out/glsl/access.foo_frag.Fragment.glsl
+++ b/naga/tests/out/glsl/access.foo_frag.Fragment.glsl
@@ -23,6 +23,13 @@ struct AssignToMember {
 struct S {
     int m;
 };
+struct Inner {
+    int delicious;
+};
+struct Outer {
+    Inner om_nom_nom;
+    uint thing;
+};
 layout(std430) buffer Bar_block_0Fragment {
     mat4x3 _matrix;
     mat2x2 matrix_array[2];
@@ -86,6 +93,30 @@ int member_ptr() {
     S s = S(42);
     int _e4 = s.m;
     return _e4;
+}
+
+int let_members_of_members() {
+    Inner inner_1 = Outer(Inner(0), 0u).om_nom_nom;
+    int delishus_1 = inner_1.delicious;
+    if ((Outer(Inner(0), 0u).thing != uint(delishus_1))) {
+    }
+    return Outer(Inner(0), 0u).om_nom_nom.delicious;
+}
+
+int var_members_of_members() {
+    Outer thing = Outer(Inner(0), 0u);
+    Inner inner = Inner(0);
+    int delishus = 0;
+    Inner _e3 = thing.om_nom_nom;
+    inner = _e3;
+    int _e6 = inner.delicious;
+    delishus = _e6;
+    uint _e9 = thing.thing;
+    int _e10 = delishus;
+    if ((_e9 != uint(_e10))) {
+    }
+    int _e15 = thing.om_nom_nom.delicious;
+    return _e15;
 }
 
 void main() {

--- a/naga/tests/out/glsl/access.foo_vert.Vertex.glsl
+++ b/naga/tests/out/glsl/access.foo_vert.Vertex.glsl
@@ -20,6 +20,9 @@ struct MatCx2InArray {
 struct AssignToMember {
     uint x;
 };
+struct S {
+    int m;
+};
 layout(std430) buffer Bar_block_0Vertex {
     mat4x3 _matrix;
     mat2x2 matrix_array[2];
@@ -145,6 +148,19 @@ void assign_to_arg_ptr_array_element(inout uint p_4[4]) {
     return;
 }
 
+bool index_ptr(bool value) {
+    bool a_1[1] = bool[1](false);
+    a_1 = bool[1](value);
+    bool _e4 = a_1[0];
+    return _e4;
+}
+
+int member_ptr() {
+    S s = S(42);
+    int _e4 = s.m;
+    return _e4;
+}
+
 void main() {
     uint vi = uint(gl_VertexID);
     float foo = 0.0;
@@ -156,14 +172,14 @@ void main() {
     mat4x3 _matrix = _group_0_binding_0_vs._matrix;
     uvec2 arr_1[2] = _group_0_binding_0_vs.arr;
     float b = _group_0_binding_0_vs._matrix[3u][0];
-    int a_1 = _group_0_binding_0_vs.data[(uint(_group_0_binding_0_vs.data.length()) - 2u)].value;
+    int a_2 = _group_0_binding_0_vs.data[(uint(_group_0_binding_0_vs.data.length()) - 2u)].value;
     ivec2 c = _group_0_binding_2_vs;
     float _e33 = read_from_private(foo);
-    c2_ = int[5](a_1, int(b), 3, 4, 5);
+    c2_ = int[5](a_2, int(b), 3, 4, 5);
     c2_[(vi + 1u)] = 42;
-    int value = c2_[vi];
+    int value_1 = c2_[vi];
     float _e47 = test_arr_as_arg(float[5][10](float[10](0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), float[10](0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), float[10](0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), float[10](0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), float[10](0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)));
-    gl_Position = vec4((_matrix * vec4(ivec4(value))), 2.0);
+    gl_Position = vec4((_matrix * vec4(ivec4(value_1))), 2.0);
     gl_Position.yz = vec2(-gl_Position.y, gl_Position.z * 2.0 - gl_Position.w);
     return;
 }

--- a/naga/tests/out/glsl/access.foo_vert.Vertex.glsl
+++ b/naga/tests/out/glsl/access.foo_vert.Vertex.glsl
@@ -23,6 +23,13 @@ struct AssignToMember {
 struct S {
     int m;
 };
+struct Inner {
+    int delicious;
+};
+struct Outer {
+    Inner om_nom_nom;
+    uint thing;
+};
 layout(std430) buffer Bar_block_0Vertex {
     mat4x3 _matrix;
     mat2x2 matrix_array[2];
@@ -159,6 +166,30 @@ int member_ptr() {
     S s = S(42);
     int _e4 = s.m;
     return _e4;
+}
+
+int let_members_of_members() {
+    Inner inner_1 = Outer(Inner(0), 0u).om_nom_nom;
+    int delishus_1 = inner_1.delicious;
+    if ((Outer(Inner(0), 0u).thing != uint(delishus_1))) {
+    }
+    return Outer(Inner(0), 0u).om_nom_nom.delicious;
+}
+
+int var_members_of_members() {
+    Outer thing = Outer(Inner(0), 0u);
+    Inner inner = Inner(0);
+    int delishus = 0;
+    Inner _e3 = thing.om_nom_nom;
+    inner = _e3;
+    int _e6 = inner.delicious;
+    delishus = _e6;
+    uint _e9 = thing.thing;
+    int _e10 = delishus;
+    if ((_e9 != uint(_e10))) {
+    }
+    int _e15 = thing.om_nom_nom.delicious;
+    return _e15;
 }
 
 void main() {

--- a/naga/tests/out/hlsl/access.hlsl
+++ b/naga/tests/out/hlsl/access.hlsl
@@ -72,6 +72,10 @@ struct AssignToMember {
     uint x;
 };
 
+struct S {
+    int m;
+};
+
 GlobalConst ConstructGlobalConst(uint arg0, uint3 arg1, int arg2) {
     GlobalConst ret = (GlobalConst)0;
     ret.a = arg0;
@@ -258,6 +262,35 @@ void assign_to_arg_ptr_array_element(inout uint p_4[4])
     return;
 }
 
+typedef bool ret_Constructarray1_bool_[1];
+ret_Constructarray1_bool_ Constructarray1_bool_(bool arg0) {
+    bool ret[1] = { arg0 };
+    return ret;
+}
+
+bool index_ptr(bool value)
+{
+    bool a_1[1] = (bool[1])0;
+
+    a_1 = Constructarray1_bool_(value);
+    bool _e4 = a_1[0];
+    return _e4;
+}
+
+S ConstructS(int arg0) {
+    S ret = (S)0;
+    ret.m = arg0;
+    return ret;
+}
+
+int member_ptr()
+{
+    S s = ConstructS(42);
+
+    int _e4 = s.m;
+    return _e4;
+}
+
 typedef int ret_Constructarray5_int_[5];
 ret_Constructarray5_int_ Constructarray5_int_(int arg0, int arg1, int arg2, int arg3, int arg4) {
     int ret[5] = { arg0, arg1, arg2, arg3, arg4 };
@@ -294,14 +327,14 @@ float4 foo_vert(uint vi : SV_VertexID) : SV_Position
     float4x3 _matrix = float4x3(asfloat(bar.Load3(0+0)), asfloat(bar.Load3(0+16)), asfloat(bar.Load3(0+32)), asfloat(bar.Load3(0+48)));
     uint2 arr_1[2] = Constructarray2_uint2_(asuint(bar.Load2(144+0)), asuint(bar.Load2(144+8)));
     float b = asfloat(bar.Load(0+3u*16+0));
-    int a_1 = asint(bar.Load(0+(((NagaBufferLengthRW(bar) - 160) / 8) - 2u)*8+160));
+    int a_2 = asint(bar.Load(0+(((NagaBufferLengthRW(bar) - 160) / 8) - 2u)*8+160));
     int2 c = asint(qux.Load2(0));
     const float _e33 = read_from_private(foo);
-    c2_ = Constructarray5_int_(a_1, int(b), 3, 4, 5);
+    c2_ = Constructarray5_int_(a_2, int(b), 3, 4, 5);
     c2_[min(uint((vi + 1u)), 4u)] = 42;
-    int value = c2_[min(uint(vi), 4u)];
+    int value_1 = c2_[min(uint(vi), 4u)];
     const float _e47 = test_arr_as_arg(ZeroValuearray5_array10_float__());
-    return float4(mul(float4((value).xxxx), _matrix), 2.0);
+    return float4(mul(float4((value_1).xxxx), _matrix), 2.0);
 }
 
 int2 ZeroValueint2() {

--- a/naga/tests/out/hlsl/access.hlsl
+++ b/naga/tests/out/hlsl/access.hlsl
@@ -76,6 +76,15 @@ struct S {
     int m;
 };
 
+struct Inner {
+    int delicious;
+};
+
+struct Outer {
+    Inner om_nom_nom;
+    uint thing;
+};
+
 GlobalConst ConstructGlobalConst(uint arg0, uint3 arg1, int arg2) {
     GlobalConst ret = (GlobalConst)0;
     ret.a = arg0;
@@ -289,6 +298,37 @@ int member_ptr()
 
     int _e4 = s.m;
     return _e4;
+}
+
+Outer ZeroValueOuter() {
+    return (Outer)0;
+}
+
+int let_members_of_members()
+{
+    Inner inner_1 = ZeroValueOuter().om_nom_nom;
+    int delishus_1 = inner_1.delicious;
+    if ((ZeroValueOuter().thing != uint(delishus_1))) {
+    }
+    return ZeroValueOuter().om_nom_nom.delicious;
+}
+
+int var_members_of_members()
+{
+    Outer thing = ZeroValueOuter();
+    Inner inner = (Inner)0;
+    int delishus = (int)0;
+
+    Inner _e3 = thing.om_nom_nom;
+    inner = _e3;
+    int _e6 = inner.delicious;
+    delishus = _e6;
+    uint _e9 = thing.thing;
+    int _e10 = delishus;
+    if ((_e9 != uint(_e10))) {
+    }
+    int _e15 = thing.om_nom_nom.delicious;
+    return _e15;
 }
 
 typedef int ret_Constructarray5_int_[5];

--- a/naga/tests/out/ir/access.compact.ron
+++ b/naga/tests/out/ir/access.compact.ron
@@ -353,6 +353,35 @@
                 space: Function,
             ),
         ),
+        (
+            name: None,
+            inner: Scalar((
+                kind: Bool,
+                width: 1,
+            )),
+        ),
+        (
+            name: None,
+            inner: Array(
+                base: 33,
+                size: Constant(1),
+                stride: 1,
+            ),
+        ),
+        (
+            name: Some("S"),
+            inner: Struct(
+                members: [
+                    (
+                        name: Some("m"),
+                        ty: 2,
+                        binding: None,
+                        offset: 0,
+                    ),
+                ],
+                span: 4,
+            ),
+        ),
     ],
     special_types: (
         ray_desc: None,
@@ -1843,6 +1872,115 @@
                 ),
                 Return(
                     value: None,
+                ),
+            ],
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            name: Some("index_ptr"),
+            arguments: [
+                (
+                    name: Some("value"),
+                    ty: 33,
+                    binding: None,
+                ),
+            ],
+            result: Some((
+                ty: 33,
+                binding: None,
+            )),
+            local_variables: [
+                (
+                    name: Some("a"),
+                    ty: 34,
+                    init: None,
+                ),
+            ],
+            expressions: [
+                FunctionArgument(0),
+                Compose(
+                    ty: 34,
+                    components: [
+                        0,
+                    ],
+                ),
+                LocalVariable(0),
+                AccessIndex(
+                    base: 2,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 3,
+                ),
+            ],
+            named_expressions: {
+                0: "value",
+                2: "p",
+            },
+            body: [
+                Emit((
+                    start: 1,
+                    end: 2,
+                )),
+                Store(
+                    pointer: 2,
+                    value: 1,
+                ),
+                Emit((
+                    start: 3,
+                    end: 5,
+                )),
+                Return(
+                    value: Some(4),
+                ),
+            ],
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            name: Some("member_ptr"),
+            arguments: [],
+            result: Some((
+                ty: 2,
+                binding: None,
+            )),
+            local_variables: [
+                (
+                    name: Some("s"),
+                    ty: 35,
+                    init: Some(1),
+                ),
+            ],
+            expressions: [
+                Literal(I32(42)),
+                Compose(
+                    ty: 35,
+                    components: [
+                        0,
+                    ],
+                ),
+                LocalVariable(0),
+                AccessIndex(
+                    base: 2,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 3,
+                ),
+            ],
+            named_expressions: {
+                2: "p",
+            },
+            body: [
+                Emit((
+                    start: 1,
+                    end: 2,
+                )),
+                Emit((
+                    start: 3,
+                    end: 5,
+                )),
+                Return(
+                    value: Some(4),
                 ),
             ],
             diagnostic_filter_leaf: None,

--- a/naga/tests/out/ir/access.compact.ron
+++ b/naga/tests/out/ir/access.compact.ron
@@ -382,6 +382,40 @@
                 span: 4,
             ),
         ),
+        (
+            name: Some("Inner"),
+            inner: Struct(
+                members: [
+                    (
+                        name: Some("delicious"),
+                        ty: 2,
+                        binding: None,
+                        offset: 0,
+                    ),
+                ],
+                span: 4,
+            ),
+        ),
+        (
+            name: Some("Outer"),
+            inner: Struct(
+                members: [
+                    (
+                        name: Some("om_nom_nom"),
+                        ty: 36,
+                        binding: None,
+                        offset: 0,
+                    ),
+                    (
+                        name: Some("thing"),
+                        ty: 0,
+                        binding: None,
+                        offset: 4,
+                    ),
+                ],
+                span: 8,
+            ),
+        ),
     ],
     special_types: (
         ray_desc: None,
@@ -1981,6 +2015,192 @@
                 )),
                 Return(
                     value: Some(4),
+                ),
+            ],
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            name: Some("let_members_of_members"),
+            arguments: [],
+            result: Some((
+                ty: 2,
+                binding: None,
+            )),
+            local_variables: [],
+            expressions: [
+                ZeroValue(37),
+                AccessIndex(
+                    base: 0,
+                    index: 0,
+                ),
+                AccessIndex(
+                    base: 1,
+                    index: 0,
+                ),
+                AccessIndex(
+                    base: 0,
+                    index: 1,
+                ),
+                As(
+                    expr: 2,
+                    kind: Uint,
+                    convert: Some(4),
+                ),
+                Binary(
+                    op: NotEqual,
+                    left: 3,
+                    right: 4,
+                ),
+                AccessIndex(
+                    base: 0,
+                    index: 0,
+                ),
+                AccessIndex(
+                    base: 6,
+                    index: 0,
+                ),
+            ],
+            named_expressions: {
+                0: "thing",
+                1: "inner",
+                2: "delishus",
+            },
+            body: [
+                Emit((
+                    start: 1,
+                    end: 2,
+                )),
+                Emit((
+                    start: 2,
+                    end: 3,
+                )),
+                Emit((
+                    start: 3,
+                    end: 6,
+                )),
+                If(
+                    condition: 5,
+                    accept: [],
+                    reject: [],
+                ),
+                Emit((
+                    start: 6,
+                    end: 8,
+                )),
+                Return(
+                    value: Some(7),
+                ),
+            ],
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            name: Some("var_members_of_members"),
+            arguments: [],
+            result: Some((
+                ty: 2,
+                binding: None,
+            )),
+            local_variables: [
+                (
+                    name: Some("thing"),
+                    ty: 37,
+                    init: Some(0),
+                ),
+                (
+                    name: Some("inner"),
+                    ty: 36,
+                    init: None,
+                ),
+                (
+                    name: Some("delishus"),
+                    ty: 2,
+                    init: None,
+                ),
+            ],
+            expressions: [
+                ZeroValue(37),
+                LocalVariable(0),
+                AccessIndex(
+                    base: 1,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 2,
+                ),
+                LocalVariable(1),
+                AccessIndex(
+                    base: 4,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 5,
+                ),
+                LocalVariable(2),
+                AccessIndex(
+                    base: 1,
+                    index: 1,
+                ),
+                Load(
+                    pointer: 8,
+                ),
+                Load(
+                    pointer: 7,
+                ),
+                As(
+                    expr: 10,
+                    kind: Uint,
+                    convert: Some(4),
+                ),
+                Binary(
+                    op: NotEqual,
+                    left: 9,
+                    right: 11,
+                ),
+                AccessIndex(
+                    base: 1,
+                    index: 0,
+                ),
+                AccessIndex(
+                    base: 13,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 14,
+                ),
+            ],
+            named_expressions: {},
+            body: [
+                Emit((
+                    start: 2,
+                    end: 4,
+                )),
+                Store(
+                    pointer: 4,
+                    value: 3,
+                ),
+                Emit((
+                    start: 5,
+                    end: 7,
+                )),
+                Store(
+                    pointer: 7,
+                    value: 6,
+                ),
+                Emit((
+                    start: 8,
+                    end: 13,
+                )),
+                If(
+                    condition: 12,
+                    accept: [],
+                    reject: [],
+                ),
+                Emit((
+                    start: 13,
+                    end: 16,
+                )),
+                Return(
+                    value: Some(15),
                 ),
             ],
             diagnostic_filter_leaf: None,

--- a/naga/tests/out/ir/access.ron
+++ b/naga/tests/out/ir/access.ron
@@ -353,6 +353,35 @@
                 space: Function,
             ),
         ),
+        (
+            name: None,
+            inner: Scalar((
+                kind: Bool,
+                width: 1,
+            )),
+        ),
+        (
+            name: None,
+            inner: Array(
+                base: 33,
+                size: Constant(1),
+                stride: 1,
+            ),
+        ),
+        (
+            name: Some("S"),
+            inner: Struct(
+                members: [
+                    (
+                        name: Some("m"),
+                        ty: 2,
+                        binding: None,
+                        offset: 0,
+                    ),
+                ],
+                span: 4,
+            ),
+        ),
     ],
     special_types: (
         ray_desc: None,
@@ -1843,6 +1872,115 @@
                 ),
                 Return(
                     value: None,
+                ),
+            ],
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            name: Some("index_ptr"),
+            arguments: [
+                (
+                    name: Some("value"),
+                    ty: 33,
+                    binding: None,
+                ),
+            ],
+            result: Some((
+                ty: 33,
+                binding: None,
+            )),
+            local_variables: [
+                (
+                    name: Some("a"),
+                    ty: 34,
+                    init: None,
+                ),
+            ],
+            expressions: [
+                FunctionArgument(0),
+                Compose(
+                    ty: 34,
+                    components: [
+                        0,
+                    ],
+                ),
+                LocalVariable(0),
+                AccessIndex(
+                    base: 2,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 3,
+                ),
+            ],
+            named_expressions: {
+                0: "value",
+                2: "p",
+            },
+            body: [
+                Emit((
+                    start: 1,
+                    end: 2,
+                )),
+                Store(
+                    pointer: 2,
+                    value: 1,
+                ),
+                Emit((
+                    start: 3,
+                    end: 5,
+                )),
+                Return(
+                    value: Some(4),
+                ),
+            ],
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            name: Some("member_ptr"),
+            arguments: [],
+            result: Some((
+                ty: 2,
+                binding: None,
+            )),
+            local_variables: [
+                (
+                    name: Some("s"),
+                    ty: 35,
+                    init: Some(1),
+                ),
+            ],
+            expressions: [
+                Literal(I32(42)),
+                Compose(
+                    ty: 35,
+                    components: [
+                        0,
+                    ],
+                ),
+                LocalVariable(0),
+                AccessIndex(
+                    base: 2,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 3,
+                ),
+            ],
+            named_expressions: {
+                2: "p",
+            },
+            body: [
+                Emit((
+                    start: 1,
+                    end: 2,
+                )),
+                Emit((
+                    start: 3,
+                    end: 5,
+                )),
+                Return(
+                    value: Some(4),
                 ),
             ],
             diagnostic_filter_leaf: None,

--- a/naga/tests/out/ir/access.ron
+++ b/naga/tests/out/ir/access.ron
@@ -382,6 +382,40 @@
                 span: 4,
             ),
         ),
+        (
+            name: Some("Inner"),
+            inner: Struct(
+                members: [
+                    (
+                        name: Some("delicious"),
+                        ty: 2,
+                        binding: None,
+                        offset: 0,
+                    ),
+                ],
+                span: 4,
+            ),
+        ),
+        (
+            name: Some("Outer"),
+            inner: Struct(
+                members: [
+                    (
+                        name: Some("om_nom_nom"),
+                        ty: 36,
+                        binding: None,
+                        offset: 0,
+                    ),
+                    (
+                        name: Some("thing"),
+                        ty: 0,
+                        binding: None,
+                        offset: 4,
+                    ),
+                ],
+                span: 8,
+            ),
+        ),
     ],
     special_types: (
         ray_desc: None,
@@ -1981,6 +2015,192 @@
                 )),
                 Return(
                     value: Some(4),
+                ),
+            ],
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            name: Some("let_members_of_members"),
+            arguments: [],
+            result: Some((
+                ty: 2,
+                binding: None,
+            )),
+            local_variables: [],
+            expressions: [
+                ZeroValue(37),
+                AccessIndex(
+                    base: 0,
+                    index: 0,
+                ),
+                AccessIndex(
+                    base: 1,
+                    index: 0,
+                ),
+                AccessIndex(
+                    base: 0,
+                    index: 1,
+                ),
+                As(
+                    expr: 2,
+                    kind: Uint,
+                    convert: Some(4),
+                ),
+                Binary(
+                    op: NotEqual,
+                    left: 3,
+                    right: 4,
+                ),
+                AccessIndex(
+                    base: 0,
+                    index: 0,
+                ),
+                AccessIndex(
+                    base: 6,
+                    index: 0,
+                ),
+            ],
+            named_expressions: {
+                0: "thing",
+                1: "inner",
+                2: "delishus",
+            },
+            body: [
+                Emit((
+                    start: 1,
+                    end: 2,
+                )),
+                Emit((
+                    start: 2,
+                    end: 3,
+                )),
+                Emit((
+                    start: 3,
+                    end: 6,
+                )),
+                If(
+                    condition: 5,
+                    accept: [],
+                    reject: [],
+                ),
+                Emit((
+                    start: 6,
+                    end: 8,
+                )),
+                Return(
+                    value: Some(7),
+                ),
+            ],
+            diagnostic_filter_leaf: None,
+        ),
+        (
+            name: Some("var_members_of_members"),
+            arguments: [],
+            result: Some((
+                ty: 2,
+                binding: None,
+            )),
+            local_variables: [
+                (
+                    name: Some("thing"),
+                    ty: 37,
+                    init: Some(0),
+                ),
+                (
+                    name: Some("inner"),
+                    ty: 36,
+                    init: None,
+                ),
+                (
+                    name: Some("delishus"),
+                    ty: 2,
+                    init: None,
+                ),
+            ],
+            expressions: [
+                ZeroValue(37),
+                LocalVariable(0),
+                AccessIndex(
+                    base: 1,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 2,
+                ),
+                LocalVariable(1),
+                AccessIndex(
+                    base: 4,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 5,
+                ),
+                LocalVariable(2),
+                AccessIndex(
+                    base: 1,
+                    index: 1,
+                ),
+                Load(
+                    pointer: 8,
+                ),
+                Load(
+                    pointer: 7,
+                ),
+                As(
+                    expr: 10,
+                    kind: Uint,
+                    convert: Some(4),
+                ),
+                Binary(
+                    op: NotEqual,
+                    left: 9,
+                    right: 11,
+                ),
+                AccessIndex(
+                    base: 1,
+                    index: 0,
+                ),
+                AccessIndex(
+                    base: 13,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 14,
+                ),
+            ],
+            named_expressions: {},
+            body: [
+                Emit((
+                    start: 2,
+                    end: 4,
+                )),
+                Store(
+                    pointer: 4,
+                    value: 3,
+                ),
+                Emit((
+                    start: 5,
+                    end: 7,
+                )),
+                Store(
+                    pointer: 7,
+                    value: 6,
+                ),
+                Emit((
+                    start: 8,
+                    end: 13,
+                )),
+                If(
+                    condition: 12,
+                    accept: [],
+                    reject: [],
+                ),
+                Emit((
+                    start: 13,
+                    end: 16,
+                )),
+                Return(
+                    value: Some(15),
                 ),
             ],
             diagnostic_filter_leaf: None,

--- a/naga/tests/out/msl/access.msl
+++ b/naga/tests/out/msl/access.msl
@@ -63,6 +63,12 @@ struct AssignToMember {
 struct type_25 {
     uint inner[4];
 };
+struct type_28 {
+    bool inner[1];
+};
+struct S {
+    int m;
+};
 
 void test_matrix_within_struct_accesses(
     constant Baz& baz
@@ -193,6 +199,22 @@ void assign_to_arg_ptr_array_element(
     return;
 }
 
+bool index_ptr(
+    bool value
+) {
+    type_28 a_1 = {};
+    a_1 = type_28 {value};
+    bool _e4 = a_1.inner[0];
+    return _e4;
+}
+
+int member_ptr(
+) {
+    S s = S {42};
+    int _e4 = s.m;
+    return _e4;
+}
+
 struct foo_vertInput {
 };
 struct foo_vertOutput {
@@ -215,14 +237,14 @@ vertex foo_vertOutput foo_vert(
     metal::float4x3 _matrix = bar._matrix;
     type_10 arr_1 = bar.arr;
     float b = bar._matrix[3u].x;
-    int a_1 = bar.data[(1 + (_buffer_sizes.size1 - 160 - 8) / 8) - 2u].value;
+    int a_2 = bar.data[(1 + (_buffer_sizes.size1 - 160 - 8) / 8) - 2u].value;
     metal::int2 c = qux;
     float _e33 = read_from_private(foo);
-    c2_ = type_20 {a_1, static_cast<int>(b), 3, 4, 5};
+    c2_ = type_20 {a_2, static_cast<int>(b), 3, 4, 5};
     c2_.inner[vi + 1u] = 42;
-    int value = c2_.inner[vi];
+    int value_1 = c2_.inner[vi];
     float _e47 = test_arr_as_arg(type_18 {});
-    return foo_vertOutput { metal::float4(_matrix * static_cast<metal::float4>(metal::int4(value)), 2.0) };
+    return foo_vertOutput { metal::float4(_matrix * static_cast<metal::float4>(metal::int4(value_1)), 2.0) };
 }
 
 

--- a/naga/tests/out/msl/access.msl
+++ b/naga/tests/out/msl/access.msl
@@ -69,6 +69,13 @@ struct type_28 {
 struct S {
     int m;
 };
+struct Inner {
+    int delicious;
+};
+struct Outer {
+    Inner om_nom_nom;
+    uint thing;
+};
 
 void test_matrix_within_struct_accesses(
     constant Baz& baz
@@ -213,6 +220,32 @@ int member_ptr(
     S s = S {42};
     int _e4 = s.m;
     return _e4;
+}
+
+int let_members_of_members(
+) {
+    Inner inner_1 = Outer {}.om_nom_nom;
+    int delishus_1 = Outer {}.om_nom_nom.delicious;
+    if (Outer {}.thing != static_cast<uint>(delishus_1)) {
+    }
+    return Outer {}.om_nom_nom.delicious;
+}
+
+int var_members_of_members(
+) {
+    Outer thing = Outer {};
+    Inner inner = {};
+    int delishus = {};
+    Inner _e3 = thing.om_nom_nom;
+    inner = _e3;
+    int _e6 = inner.delicious;
+    delishus = _e6;
+    uint _e9 = thing.thing;
+    int _e10 = delishus;
+    if (_e9 != static_cast<uint>(_e10)) {
+    }
+    int _e15 = thing.om_nom_nom.delicious;
+    return _e15;
 }
 
 struct foo_vertInput {

--- a/naga/tests/out/spv/access.spvasm
+++ b/naga/tests/out/spv/access.spvasm
@@ -1,18 +1,18 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 342
+; Bound: 366
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %250 "foo_vert" %245 %248
-OpEntryPoint Fragment %303 "foo_frag" %302
-OpEntryPoint GLCompute %321 "assign_through_ptr"
-OpEntryPoint GLCompute %332 "assign_to_ptr_components"
-OpExecutionMode %303 OriginUpperLeft
-OpExecutionMode %321 LocalSize 1 1 1
-OpExecutionMode %332 LocalSize 1 1 1
+OpEntryPoint Vertex %275 "foo_vert" %270 %273
+OpEntryPoint Fragment %327 "foo_frag" %326
+OpEntryPoint GLCompute %345 "assign_through_ptr"
+OpEntryPoint GLCompute %356 "assign_to_ptr_components"
+OpExecutionMode %327 OriginUpperLeft
+OpExecutionMode %345 LocalSize 1 1 1
+OpExecutionMode %356 LocalSize 1 1 1
 OpMemberName %6 0 "a"
 OpMemberName %6 1 "b"
 OpMemberName %6 2 "c"
@@ -32,44 +32,51 @@ OpMemberName %26 0 "am"
 OpName %26 "MatCx2InArray"
 OpMemberName %36 0 "x"
 OpName %36 "AssignToMember"
-OpName %45 "global_const"
-OpName %47 "bar"
-OpName %49 "baz"
-OpName %52 "qux"
-OpName %55 "nested_mat_cx2"
-OpName %59 "test_matrix_within_struct_accesses"
-OpName %87 "idx"
-OpName %89 "t"
-OpName %135 "test_matrix_within_array_within_struct_accesses"
-OpName %145 "idx"
-OpName %146 "t"
-OpName %192 "foo"
-OpName %193 "read_from_private"
-OpName %198 "a"
-OpName %199 "test_arr_as_arg"
-OpName %205 "p"
-OpName %206 "assign_through_ptr_fn"
-OpName %211 "foo"
-OpName %212 "assign_array_through_ptr_fn"
-OpName %219 "p"
-OpName %220 "fetch_arg_ptr_member"
-OpName %226 "p"
-OpName %227 "assign_to_arg_ptr_member"
-OpName %232 "p"
-OpName %233 "fetch_arg_ptr_array_element"
-OpName %239 "p"
-OpName %240 "assign_to_arg_ptr_array_element"
-OpName %245 "vi"
-OpName %250 "foo_vert"
-OpName %262 "foo"
-OpName %263 "c2"
-OpName %303 "foo_frag"
-OpName %321 "assign_through_ptr"
-OpName %326 "val"
-OpName %327 "arr"
-OpName %332 "assign_to_ptr_components"
-OpName %333 "s1"
-OpName %335 "a1"
+OpMemberName %44 0 "m"
+OpName %44 "S"
+OpName %49 "global_const"
+OpName %51 "bar"
+OpName %53 "baz"
+OpName %56 "qux"
+OpName %59 "nested_mat_cx2"
+OpName %63 "test_matrix_within_struct_accesses"
+OpName %91 "idx"
+OpName %93 "t"
+OpName %138 "test_matrix_within_array_within_struct_accesses"
+OpName %148 "idx"
+OpName %149 "t"
+OpName %195 "foo"
+OpName %196 "read_from_private"
+OpName %201 "a"
+OpName %202 "test_arr_as_arg"
+OpName %208 "p"
+OpName %209 "assign_through_ptr_fn"
+OpName %214 "foo"
+OpName %215 "assign_array_through_ptr_fn"
+OpName %222 "p"
+OpName %223 "fetch_arg_ptr_member"
+OpName %229 "p"
+OpName %230 "assign_to_arg_ptr_member"
+OpName %235 "p"
+OpName %236 "fetch_arg_ptr_array_element"
+OpName %242 "p"
+OpName %243 "assign_to_arg_ptr_array_element"
+OpName %248 "value"
+OpName %249 "index_ptr"
+OpName %251 "a"
+OpName %260 "member_ptr"
+OpName %264 "s"
+OpName %270 "vi"
+OpName %275 "foo_vert"
+OpName %286 "foo"
+OpName %287 "c2"
+OpName %327 "foo_frag"
+OpName %345 "assign_through_ptr"
+OpName %350 "val"
+OpName %351 "arr"
+OpName %356 "assign_to_ptr_components"
+OpName %357 "s1"
+OpName %359 "a1"
 OpMemberDecorate %6 0 Offset 0
 OpMemberDecorate %6 1 Offset 16
 OpMemberDecorate %6 2 Offset 28
@@ -102,23 +109,25 @@ OpDecorate %32 ArrayStride 4
 OpDecorate %34 ArrayStride 16
 OpMemberDecorate %36 0 Offset 0
 OpDecorate %38 ArrayStride 4
-OpDecorate %47 DescriptorSet 0
-OpDecorate %47 Binding 0
-OpDecorate %49 DescriptorSet 0
-OpDecorate %49 Binding 1
-OpDecorate %50 Block
-OpMemberDecorate %50 0 Offset 0
-OpDecorate %52 DescriptorSet 0
-OpDecorate %52 Binding 2
-OpDecorate %53 Block
-OpMemberDecorate %53 0 Offset 0
-OpDecorate %55 DescriptorSet 0
-OpDecorate %55 Binding 3
-OpDecorate %56 Block
-OpMemberDecorate %56 0 Offset 0
-OpDecorate %245 BuiltIn VertexIndex
-OpDecorate %248 BuiltIn Position
-OpDecorate %302 Location 0
+OpDecorate %42 ArrayStride 1
+OpMemberDecorate %44 0 Offset 0
+OpDecorate %51 DescriptorSet 0
+OpDecorate %51 Binding 0
+OpDecorate %53 DescriptorSet 0
+OpDecorate %53 Binding 1
+OpDecorate %54 Block
+OpMemberDecorate %54 0 Offset 0
+OpDecorate %56 DescriptorSet 0
+OpDecorate %56 Binding 2
+OpDecorate %57 Block
+OpMemberDecorate %57 0 Offset 0
+OpDecorate %59 DescriptorSet 0
+OpDecorate %59 Binding 3
+OpDecorate %60 Block
+OpMemberDecorate %60 0 Offset 0
+OpDecorate %270 BuiltIn VertexIndex
+OpDecorate %273 BuiltIn Position
+OpDecorate %326 Location 0
 %2 = OpTypeVoid
 %3 = OpTypeInt 32 0
 %4 = OpTypeVector %3 3
@@ -158,379 +167,410 @@ OpDecorate %302 Location 0
 %39 = OpConstant  %3  4
 %38 = OpTypeArray %3 %39
 %40 = OpTypePointer Function %38
-%41 = OpConstant  %3  0
-%42 = OpConstantComposite  %4  %41 %41 %41
-%43 = OpConstant  %5  0
-%44 = OpConstantComposite  %6  %41 %42 %43
-%46 = OpTypePointer Private %6
-%45 = OpVariable  %46  Private %44
-%48 = OpTypePointer StorageBuffer %20
-%47 = OpVariable  %48  StorageBuffer
-%50 = OpTypeStruct %22
-%51 = OpTypePointer Uniform %50
-%49 = OpVariable  %51  Uniform
-%53 = OpTypeStruct %23
-%54 = OpTypePointer StorageBuffer %53
-%52 = OpVariable  %54  StorageBuffer
-%56 = OpTypeStruct %26
-%57 = OpTypePointer Uniform %56
-%55 = OpVariable  %57  Uniform
-%60 = OpTypeFunction %2
-%61 = OpTypePointer Uniform %22
-%63 = OpConstant  %5  1
-%64 = OpConstant  %8  1.0
-%65 = OpConstantComposite  %12  %64 %64
-%66 = OpConstant  %8  2.0
-%67 = OpConstantComposite  %12  %66 %66
-%68 = OpConstant  %8  3.0
+%41 = OpTypeBool
+%43 = OpConstant  %3  1
+%42 = OpTypeArray %41 %43
+%44 = OpTypeStruct %5
+%45 = OpConstant  %3  0
+%46 = OpConstantComposite  %4  %45 %45 %45
+%47 = OpConstant  %5  0
+%48 = OpConstantComposite  %6  %45 %46 %47
+%50 = OpTypePointer Private %6
+%49 = OpVariable  %50  Private %48
+%52 = OpTypePointer StorageBuffer %20
+%51 = OpVariable  %52  StorageBuffer
+%54 = OpTypeStruct %22
+%55 = OpTypePointer Uniform %54
+%53 = OpVariable  %55  Uniform
+%57 = OpTypeStruct %23
+%58 = OpTypePointer StorageBuffer %57
+%56 = OpVariable  %58  StorageBuffer
+%60 = OpTypeStruct %26
+%61 = OpTypePointer Uniform %60
+%59 = OpVariable  %61  Uniform
+%64 = OpTypeFunction %2
+%65 = OpTypePointer Uniform %22
+%67 = OpConstant  %5  1
+%68 = OpConstant  %8  1.0
 %69 = OpConstantComposite  %12  %68 %68
-%70 = OpConstantComposite  %21  %65 %67 %69
-%71 = OpConstantComposite  %22  %70
-%72 = OpConstant  %8  6.0
+%70 = OpConstant  %8  2.0
+%71 = OpConstantComposite  %12  %70 %70
+%72 = OpConstant  %8  3.0
 %73 = OpConstantComposite  %12  %72 %72
-%74 = OpConstant  %8  5.0
-%75 = OpConstantComposite  %12  %74 %74
-%76 = OpConstant  %8  4.0
+%74 = OpConstantComposite  %21  %69 %71 %73
+%75 = OpConstantComposite  %22  %74
+%76 = OpConstant  %8  6.0
 %77 = OpConstantComposite  %12  %76 %76
-%78 = OpConstantComposite  %21  %73 %75 %77
-%79 = OpConstant  %8  9.0
-%80 = OpConstantComposite  %12  %79 %79
-%81 = OpConstant  %8  90.0
-%82 = OpConstantComposite  %12  %81 %81
-%83 = OpConstant  %8  10.0
-%84 = OpConstant  %8  20.0
-%85 = OpConstant  %8  30.0
-%86 = OpConstant  %8  40.0
-%88 = OpTypePointer Function %5
-%90 = OpTypePointer Function %22
-%94 = OpTypePointer Uniform %21
-%97 = OpTypePointer Uniform %12
-%103 = OpTypePointer Uniform %8
-%104 = OpConstant  %3  1
-%119 = OpTypePointer Function %21
-%121 = OpTypePointer Function %12
-%125 = OpTypePointer Function %8
-%136 = OpTypePointer Uniform %26
-%138 = OpConstantNull  %25
-%139 = OpConstantComposite  %26  %138
-%140 = OpConstant  %8  8.0
-%141 = OpConstantComposite  %12  %140 %140
-%142 = OpConstant  %8  7.0
-%143 = OpConstantComposite  %12  %142 %142
-%144 = OpConstantComposite  %24  %141 %143 %73 %75
-%147 = OpTypePointer Function %26
-%151 = OpTypePointer Uniform %25
-%154 = OpTypePointer Uniform %24
-%176 = OpTypePointer Function %25
-%178 = OpTypePointer Function %24
-%194 = OpTypeFunction %8 %27
-%200 = OpTypeFunction %8 %29
-%207 = OpTypeFunction %2 %33
-%208 = OpConstant  %3  42
-%213 = OpTypeFunction %2 %35
-%214 = OpConstantComposite  %31  %64 %64 %64 %64
-%215 = OpConstantComposite  %31  %66 %66 %66 %66
-%216 = OpConstantComposite  %34  %214 %215
-%221 = OpTypeFunction %3 %37
-%228 = OpTypeFunction %2 %37
-%234 = OpTypeFunction %3 %40
-%241 = OpTypeFunction %2 %40
-%246 = OpTypePointer Input %3
-%245 = OpVariable  %246  Input
-%249 = OpTypePointer Output %31
-%248 = OpVariable  %249  Output
-%252 = OpTypePointer StorageBuffer %23
-%255 = OpConstant  %8  0.0
-%256 = OpConstant  %3  3
-%257 = OpConstant  %5  3
-%258 = OpConstant  %5  4
-%259 = OpConstant  %5  5
-%260 = OpConstant  %5  42
-%261 = OpConstantNull  %29
-%264 = OpTypePointer Function %32
-%265 = OpConstantNull  %32
-%270 = OpTypePointer StorageBuffer %9
-%273 = OpTypePointer StorageBuffer %18
-%276 = OpTypePointer StorageBuffer %10
-%277 = OpTypePointer StorageBuffer %8
-%280 = OpTypePointer StorageBuffer %19
-%283 = OpTypePointer StorageBuffer %7
-%284 = OpTypePointer StorageBuffer %5
-%296 = OpTypeVector %5 4
-%302 = OpVariable  %249  Output
-%305 = OpConstantComposite  %10  %255 %255 %255
-%306 = OpConstantComposite  %10  %64 %64 %64
-%307 = OpConstantComposite  %10  %66 %66 %66
-%308 = OpConstantComposite  %10  %68 %68 %68
-%309 = OpConstantComposite  %9  %305 %306 %307 %308
-%310 = OpConstantComposite  %17  %41 %41
-%311 = OpConstantComposite  %17  %104 %104
-%312 = OpConstantComposite  %18  %310 %311
-%313 = OpConstantNull  %23
-%314 = OpConstantComposite  %31  %255 %255 %255 %255
-%322 = OpConstant  %3  33
-%323 = OpConstantComposite  %31  %72 %72 %72 %72
-%324 = OpConstantComposite  %31  %142 %142 %142 %142
-%325 = OpConstantComposite  %34  %323 %324
-%334 = OpConstantNull  %36
-%336 = OpConstantNull  %38
-%59 = OpFunction  %2  None %60
-%58 = OpLabel
-%87 = OpVariable  %88  Function %63
-%89 = OpVariable  %90  Function %71
-%62 = OpAccessChain  %61  %49 %41
-OpBranch %91
-%91 = OpLabel
-%92 = OpLoad  %5  %87
-%93 = OpISub  %5  %92 %63
-OpStore %87 %93
-%95 = OpAccessChain  %94  %62 %41
-%96 = OpLoad  %21  %95
-%98 = OpAccessChain  %97  %62 %41 %41
-%99 = OpLoad  %12  %98
-%100 = OpLoad  %5  %87
-%101 = OpAccessChain  %97  %62 %41 %100
-%102 = OpLoad  %12  %101
-%105 = OpAccessChain  %103  %62 %41 %41 %104
-%106 = OpLoad  %8  %105
-%107 = OpLoad  %5  %87
-%108 = OpAccessChain  %103  %62 %41 %41 %107
+%78 = OpConstant  %8  5.0
+%79 = OpConstantComposite  %12  %78 %78
+%80 = OpConstant  %8  4.0
+%81 = OpConstantComposite  %12  %80 %80
+%82 = OpConstantComposite  %21  %77 %79 %81
+%83 = OpConstant  %8  9.0
+%84 = OpConstantComposite  %12  %83 %83
+%85 = OpConstant  %8  90.0
+%86 = OpConstantComposite  %12  %85 %85
+%87 = OpConstant  %8  10.0
+%88 = OpConstant  %8  20.0
+%89 = OpConstant  %8  30.0
+%90 = OpConstant  %8  40.0
+%92 = OpTypePointer Function %5
+%94 = OpTypePointer Function %22
+%98 = OpTypePointer Uniform %21
+%101 = OpTypePointer Uniform %12
+%107 = OpTypePointer Uniform %8
+%122 = OpTypePointer Function %21
+%124 = OpTypePointer Function %12
+%128 = OpTypePointer Function %8
+%139 = OpTypePointer Uniform %26
+%141 = OpConstantNull  %25
+%142 = OpConstantComposite  %26  %141
+%143 = OpConstant  %8  8.0
+%144 = OpConstantComposite  %12  %143 %143
+%145 = OpConstant  %8  7.0
+%146 = OpConstantComposite  %12  %145 %145
+%147 = OpConstantComposite  %24  %144 %146 %77 %79
+%150 = OpTypePointer Function %26
+%154 = OpTypePointer Uniform %25
+%157 = OpTypePointer Uniform %24
+%179 = OpTypePointer Function %25
+%181 = OpTypePointer Function %24
+%197 = OpTypeFunction %8 %27
+%203 = OpTypeFunction %8 %29
+%210 = OpTypeFunction %2 %33
+%211 = OpConstant  %3  42
+%216 = OpTypeFunction %2 %35
+%217 = OpConstantComposite  %31  %68 %68 %68 %68
+%218 = OpConstantComposite  %31  %70 %70 %70 %70
+%219 = OpConstantComposite  %34  %217 %218
+%224 = OpTypeFunction %3 %37
+%231 = OpTypeFunction %2 %37
+%237 = OpTypeFunction %3 %40
+%244 = OpTypeFunction %2 %40
+%250 = OpTypeFunction %41 %41
+%252 = OpTypePointer Function %42
+%253 = OpConstantNull  %42
+%256 = OpTypePointer Function %41
+%261 = OpTypeFunction %5
+%262 = OpConstant  %5  42
+%263 = OpConstantComposite  %44  %262
+%265 = OpTypePointer Function %44
+%271 = OpTypePointer Input %3
+%270 = OpVariable  %271  Input
+%274 = OpTypePointer Output %31
+%273 = OpVariable  %274  Output
+%277 = OpTypePointer StorageBuffer %23
+%280 = OpConstant  %8  0.0
+%281 = OpConstant  %3  3
+%282 = OpConstant  %5  3
+%283 = OpConstant  %5  4
+%284 = OpConstant  %5  5
+%285 = OpConstantNull  %29
+%288 = OpTypePointer Function %32
+%289 = OpConstantNull  %32
+%294 = OpTypePointer StorageBuffer %9
+%297 = OpTypePointer StorageBuffer %18
+%300 = OpTypePointer StorageBuffer %10
+%301 = OpTypePointer StorageBuffer %8
+%304 = OpTypePointer StorageBuffer %19
+%307 = OpTypePointer StorageBuffer %7
+%308 = OpTypePointer StorageBuffer %5
+%320 = OpTypeVector %5 4
+%326 = OpVariable  %274  Output
+%329 = OpConstantComposite  %10  %280 %280 %280
+%330 = OpConstantComposite  %10  %68 %68 %68
+%331 = OpConstantComposite  %10  %70 %70 %70
+%332 = OpConstantComposite  %10  %72 %72 %72
+%333 = OpConstantComposite  %9  %329 %330 %331 %332
+%334 = OpConstantComposite  %17  %45 %45
+%335 = OpConstantComposite  %17  %43 %43
+%336 = OpConstantComposite  %18  %334 %335
+%337 = OpConstantNull  %23
+%338 = OpConstantComposite  %31  %280 %280 %280 %280
+%346 = OpConstant  %3  33
+%347 = OpConstantComposite  %31  %76 %76 %76 %76
+%348 = OpConstantComposite  %31  %145 %145 %145 %145
+%349 = OpConstantComposite  %34  %347 %348
+%358 = OpConstantNull  %36
+%360 = OpConstantNull  %38
+%63 = OpFunction  %2  None %64
+%62 = OpLabel
+%91 = OpVariable  %92  Function %67
+%93 = OpVariable  %94  Function %75
+%66 = OpAccessChain  %65  %53 %45
+OpBranch %95
+%95 = OpLabel
+%96 = OpLoad  %5  %91
+%97 = OpISub  %5  %96 %67
+OpStore %91 %97
+%99 = OpAccessChain  %98  %66 %45
+%100 = OpLoad  %21  %99
+%102 = OpAccessChain  %101  %66 %45 %45
+%103 = OpLoad  %12  %102
+%104 = OpLoad  %5  %91
+%105 = OpAccessChain  %101  %66 %45 %104
+%106 = OpLoad  %12  %105
+%108 = OpAccessChain  %107  %66 %45 %45 %43
 %109 = OpLoad  %8  %108
-%110 = OpLoad  %5  %87
-%111 = OpAccessChain  %103  %62 %41 %110 %104
+%110 = OpLoad  %5  %91
+%111 = OpAccessChain  %107  %66 %45 %45 %110
 %112 = OpLoad  %8  %111
-%113 = OpLoad  %5  %87
-%114 = OpLoad  %5  %87
-%115 = OpAccessChain  %103  %62 %41 %113 %114
-%116 = OpLoad  %8  %115
-%117 = OpLoad  %5  %87
-%118 = OpIAdd  %5  %117 %63
-OpStore %87 %118
-%120 = OpAccessChain  %119  %89 %41
-OpStore %120 %78
-%122 = OpAccessChain  %121  %89 %41 %41
-OpStore %122 %80
-%123 = OpLoad  %5  %87
-%124 = OpAccessChain  %121  %89 %41 %123
-OpStore %124 %82
-%126 = OpAccessChain  %125  %89 %41 %41 %104
-OpStore %126 %83
-%127 = OpLoad  %5  %87
-%128 = OpAccessChain  %125  %89 %41 %41 %127
-OpStore %128 %84
-%129 = OpLoad  %5  %87
-%130 = OpAccessChain  %125  %89 %41 %129 %104
-OpStore %130 %85
-%131 = OpLoad  %5  %87
-%132 = OpLoad  %5  %87
-%133 = OpAccessChain  %125  %89 %41 %131 %132
-OpStore %133 %86
+%113 = OpLoad  %5  %91
+%114 = OpAccessChain  %107  %66 %45 %113 %43
+%115 = OpLoad  %8  %114
+%116 = OpLoad  %5  %91
+%117 = OpLoad  %5  %91
+%118 = OpAccessChain  %107  %66 %45 %116 %117
+%119 = OpLoad  %8  %118
+%120 = OpLoad  %5  %91
+%121 = OpIAdd  %5  %120 %67
+OpStore %91 %121
+%123 = OpAccessChain  %122  %93 %45
+OpStore %123 %82
+%125 = OpAccessChain  %124  %93 %45 %45
+OpStore %125 %84
+%126 = OpLoad  %5  %91
+%127 = OpAccessChain  %124  %93 %45 %126
+OpStore %127 %86
+%129 = OpAccessChain  %128  %93 %45 %45 %43
+OpStore %129 %87
+%130 = OpLoad  %5  %91
+%131 = OpAccessChain  %128  %93 %45 %45 %130
+OpStore %131 %88
+%132 = OpLoad  %5  %91
+%133 = OpAccessChain  %128  %93 %45 %132 %43
+OpStore %133 %89
+%134 = OpLoad  %5  %91
+%135 = OpLoad  %5  %91
+%136 = OpAccessChain  %128  %93 %45 %134 %135
+OpStore %136 %90
 OpReturn
 OpFunctionEnd
-%135 = OpFunction  %2  None %60
-%134 = OpLabel
-%145 = OpVariable  %88  Function %63
-%146 = OpVariable  %147  Function %139
-%137 = OpAccessChain  %136  %55 %41
-OpBranch %148
-%148 = OpLabel
-%149 = OpLoad  %5  %145
-%150 = OpISub  %5  %149 %63
-OpStore %145 %150
-%152 = OpAccessChain  %151  %137 %41
-%153 = OpLoad  %25  %152
-%155 = OpAccessChain  %154  %137 %41 %41
-%156 = OpLoad  %24  %155
-%157 = OpAccessChain  %97  %137 %41 %41 %41
-%158 = OpLoad  %12  %157
-%159 = OpLoad  %5  %145
-%160 = OpAccessChain  %97  %137 %41 %41 %159
+%138 = OpFunction  %2  None %64
+%137 = OpLabel
+%148 = OpVariable  %92  Function %67
+%149 = OpVariable  %150  Function %142
+%140 = OpAccessChain  %139  %59 %45
+OpBranch %151
+%151 = OpLabel
+%152 = OpLoad  %5  %148
+%153 = OpISub  %5  %152 %67
+OpStore %148 %153
+%155 = OpAccessChain  %154  %140 %45
+%156 = OpLoad  %25  %155
+%158 = OpAccessChain  %157  %140 %45 %45
+%159 = OpLoad  %24  %158
+%160 = OpAccessChain  %101  %140 %45 %45 %45
 %161 = OpLoad  %12  %160
-%162 = OpAccessChain  %103  %137 %41 %41 %41 %104
-%163 = OpLoad  %8  %162
-%164 = OpLoad  %5  %145
-%165 = OpAccessChain  %103  %137 %41 %41 %41 %164
+%162 = OpLoad  %5  %148
+%163 = OpAccessChain  %101  %140 %45 %45 %162
+%164 = OpLoad  %12  %163
+%165 = OpAccessChain  %107  %140 %45 %45 %45 %43
 %166 = OpLoad  %8  %165
-%167 = OpLoad  %5  %145
-%168 = OpAccessChain  %103  %137 %41 %41 %167 %104
+%167 = OpLoad  %5  %148
+%168 = OpAccessChain  %107  %140 %45 %45 %45 %167
 %169 = OpLoad  %8  %168
-%170 = OpLoad  %5  %145
-%171 = OpLoad  %5  %145
-%172 = OpAccessChain  %103  %137 %41 %41 %170 %171
-%173 = OpLoad  %8  %172
-%174 = OpLoad  %5  %145
-%175 = OpIAdd  %5  %174 %63
-OpStore %145 %175
-%177 = OpAccessChain  %176  %146 %41
-OpStore %177 %138
-%179 = OpAccessChain  %178  %146 %41 %41
-OpStore %179 %144
-%180 = OpAccessChain  %121  %146 %41 %41 %41
-OpStore %180 %80
-%181 = OpLoad  %5  %145
-%182 = OpAccessChain  %121  %146 %41 %41 %181
-OpStore %182 %82
-%183 = OpAccessChain  %125  %146 %41 %41 %41 %104
-OpStore %183 %83
-%184 = OpLoad  %5  %145
-%185 = OpAccessChain  %125  %146 %41 %41 %41 %184
-OpStore %185 %84
-%186 = OpLoad  %5  %145
-%187 = OpAccessChain  %125  %146 %41 %41 %186 %104
-OpStore %187 %85
-%188 = OpLoad  %5  %145
-%189 = OpLoad  %5  %145
-%190 = OpAccessChain  %125  %146 %41 %41 %188 %189
-OpStore %190 %86
+%170 = OpLoad  %5  %148
+%171 = OpAccessChain  %107  %140 %45 %45 %170 %43
+%172 = OpLoad  %8  %171
+%173 = OpLoad  %5  %148
+%174 = OpLoad  %5  %148
+%175 = OpAccessChain  %107  %140 %45 %45 %173 %174
+%176 = OpLoad  %8  %175
+%177 = OpLoad  %5  %148
+%178 = OpIAdd  %5  %177 %67
+OpStore %148 %178
+%180 = OpAccessChain  %179  %149 %45
+OpStore %180 %141
+%182 = OpAccessChain  %181  %149 %45 %45
+OpStore %182 %147
+%183 = OpAccessChain  %124  %149 %45 %45 %45
+OpStore %183 %84
+%184 = OpLoad  %5  %148
+%185 = OpAccessChain  %124  %149 %45 %45 %184
+OpStore %185 %86
+%186 = OpAccessChain  %128  %149 %45 %45 %45 %43
+OpStore %186 %87
+%187 = OpLoad  %5  %148
+%188 = OpAccessChain  %128  %149 %45 %45 %45 %187
+OpStore %188 %88
+%189 = OpLoad  %5  %148
+%190 = OpAccessChain  %128  %149 %45 %45 %189 %43
+OpStore %190 %89
+%191 = OpLoad  %5  %148
+%192 = OpLoad  %5  %148
+%193 = OpAccessChain  %128  %149 %45 %45 %191 %192
+OpStore %193 %90
 OpReturn
 OpFunctionEnd
-%193 = OpFunction  %8  None %194
-%192 = OpFunctionParameter  %27
-%191 = OpLabel
-OpBranch %195
-%195 = OpLabel
-%196 = OpLoad  %8  %192
-OpReturnValue %196
+%196 = OpFunction  %8  None %197
+%195 = OpFunctionParameter  %27
+%194 = OpLabel
+OpBranch %198
+%198 = OpLabel
+%199 = OpLoad  %8  %195
+OpReturnValue %199
 OpFunctionEnd
-%199 = OpFunction  %8  None %200
-%198 = OpFunctionParameter  %29
-%197 = OpLabel
-OpBranch %201
-%201 = OpLabel
-%202 = OpCompositeExtract  %28  %198 4
-%203 = OpCompositeExtract  %8  %202 9
-OpReturnValue %203
-OpFunctionEnd
-%206 = OpFunction  %2  None %207
-%205 = OpFunctionParameter  %33
+%202 = OpFunction  %8  None %203
+%201 = OpFunctionParameter  %29
+%200 = OpLabel
+OpBranch %204
 %204 = OpLabel
-OpBranch %209
-%209 = OpLabel
-OpStore %205 %208
+%205 = OpCompositeExtract  %28  %201 4
+%206 = OpCompositeExtract  %8  %205 9
+OpReturnValue %206
+OpFunctionEnd
+%209 = OpFunction  %2  None %210
+%208 = OpFunctionParameter  %33
+%207 = OpLabel
+OpBranch %212
+%212 = OpLabel
+OpStore %208 %211
 OpReturn
 OpFunctionEnd
-%212 = OpFunction  %2  None %213
-%211 = OpFunctionParameter  %35
-%210 = OpLabel
-OpBranch %217
-%217 = OpLabel
-OpStore %211 %216
+%215 = OpFunction  %2  None %216
+%214 = OpFunctionParameter  %35
+%213 = OpLabel
+OpBranch %220
+%220 = OpLabel
+OpStore %214 %219
 OpReturn
 OpFunctionEnd
-%220 = OpFunction  %3  None %221
-%219 = OpFunctionParameter  %37
-%218 = OpLabel
-OpBranch %222
-%222 = OpLabel
-%223 = OpAccessChain  %33  %219 %41
-%224 = OpLoad  %3  %223
-OpReturnValue %224
-OpFunctionEnd
-%227 = OpFunction  %2  None %228
-%226 = OpFunctionParameter  %37
+%223 = OpFunction  %3  None %224
+%222 = OpFunctionParameter  %37
+%221 = OpLabel
+OpBranch %225
 %225 = OpLabel
-OpBranch %229
-%229 = OpLabel
-%230 = OpAccessChain  %33  %226 %41
-OpStore %230 %16
+%226 = OpAccessChain  %33  %222 %45
+%227 = OpLoad  %3  %226
+OpReturnValue %227
+OpFunctionEnd
+%230 = OpFunction  %2  None %231
+%229 = OpFunctionParameter  %37
+%228 = OpLabel
+OpBranch %232
+%232 = OpLabel
+%233 = OpAccessChain  %33  %229 %45
+OpStore %233 %16
 OpReturn
 OpFunctionEnd
-%233 = OpFunction  %3  None %234
-%232 = OpFunctionParameter  %40
-%231 = OpLabel
-OpBranch %235
-%235 = OpLabel
-%236 = OpAccessChain  %33  %232 %104
-%237 = OpLoad  %3  %236
-OpReturnValue %237
-OpFunctionEnd
-%240 = OpFunction  %2  None %241
-%239 = OpFunctionParameter  %40
+%236 = OpFunction  %3  None %237
+%235 = OpFunctionParameter  %40
+%234 = OpLabel
+OpBranch %238
 %238 = OpLabel
-OpBranch %242
-%242 = OpLabel
-%243 = OpAccessChain  %33  %239 %104
-OpStore %243 %16
+%239 = OpAccessChain  %33  %235 %43
+%240 = OpLoad  %3  %239
+OpReturnValue %240
+OpFunctionEnd
+%243 = OpFunction  %2  None %244
+%242 = OpFunctionParameter  %40
+%241 = OpLabel
+OpBranch %245
+%245 = OpLabel
+%246 = OpAccessChain  %33  %242 %43
+OpStore %246 %16
 OpReturn
 OpFunctionEnd
-%250 = OpFunction  %2  None %60
-%244 = OpLabel
-%262 = OpVariable  %27  Function %255
-%263 = OpVariable  %264  Function %265
-%247 = OpLoad  %3  %245
-%251 = OpAccessChain  %61  %49 %41
-%253 = OpAccessChain  %252  %52 %41
-%254 = OpAccessChain  %136  %55 %41
+%249 = OpFunction  %41  None %250
+%248 = OpFunctionParameter  %41
+%247 = OpLabel
+%251 = OpVariable  %252  Function %253
+OpBranch %254
+%254 = OpLabel
+%255 = OpCompositeConstruct  %42  %248
+OpStore %251 %255
+%257 = OpAccessChain  %256  %251 %45
+%258 = OpLoad  %41  %257
+OpReturnValue %258
+OpFunctionEnd
+%260 = OpFunction  %5  None %261
+%259 = OpLabel
+%264 = OpVariable  %265  Function %263
 OpBranch %266
 %266 = OpLabel
-%267 = OpLoad  %8  %262
-OpStore %262 %64
-%268 = OpFunctionCall  %2  %59
-%269 = OpFunctionCall  %2  %135
-%271 = OpAccessChain  %270  %47 %41
-%272 = OpLoad  %9  %271
-%274 = OpAccessChain  %273  %47 %39
-%275 = OpLoad  %18  %274
-%278 = OpAccessChain  %277  %47 %41 %256 %41
-%279 = OpLoad  %8  %278
-%281 = OpArrayLength  %3  %47 5
-%282 = OpISub  %3  %281 %14
-%285 = OpAccessChain  %284  %47 %30 %282 %41
-%286 = OpLoad  %5  %285
-%287 = OpLoad  %23  %253
-%288 = OpFunctionCall  %8  %193 %262
-%289 = OpConvertFToS  %5  %279
-%290 = OpCompositeConstruct  %32  %286 %289 %257 %258 %259
-OpStore %263 %290
-%291 = OpIAdd  %3  %247 %104
-%292 = OpAccessChain  %88  %263 %291
-OpStore %292 %260
-%293 = OpAccessChain  %88  %263 %247
-%294 = OpLoad  %5  %293
-%295 = OpFunctionCall  %8  %199 %261
-%297 = OpCompositeConstruct  %296  %294 %294 %294 %294
-%298 = OpConvertSToF  %31  %297
-%299 = OpMatrixTimesVector  %10  %272 %298
-%300 = OpCompositeConstruct  %31  %299 %66
-OpStore %248 %300
+%267 = OpAccessChain  %92  %264 %45
+%268 = OpLoad  %5  %267
+OpReturnValue %268
+OpFunctionEnd
+%275 = OpFunction  %2  None %64
+%269 = OpLabel
+%286 = OpVariable  %27  Function %280
+%287 = OpVariable  %288  Function %289
+%272 = OpLoad  %3  %270
+%276 = OpAccessChain  %65  %53 %45
+%278 = OpAccessChain  %277  %56 %45
+%279 = OpAccessChain  %139  %59 %45
+OpBranch %290
+%290 = OpLabel
+%291 = OpLoad  %8  %286
+OpStore %286 %68
+%292 = OpFunctionCall  %2  %63
+%293 = OpFunctionCall  %2  %138
+%295 = OpAccessChain  %294  %51 %45
+%296 = OpLoad  %9  %295
+%298 = OpAccessChain  %297  %51 %39
+%299 = OpLoad  %18  %298
+%302 = OpAccessChain  %301  %51 %45 %281 %45
+%303 = OpLoad  %8  %302
+%305 = OpArrayLength  %3  %51 5
+%306 = OpISub  %3  %305 %14
+%309 = OpAccessChain  %308  %51 %30 %306 %45
+%310 = OpLoad  %5  %309
+%311 = OpLoad  %23  %278
+%312 = OpFunctionCall  %8  %196 %286
+%313 = OpConvertFToS  %5  %303
+%314 = OpCompositeConstruct  %32  %310 %313 %282 %283 %284
+OpStore %287 %314
+%315 = OpIAdd  %3  %272 %43
+%316 = OpAccessChain  %92  %287 %315
+OpStore %316 %262
+%317 = OpAccessChain  %92  %287 %272
+%318 = OpLoad  %5  %317
+%319 = OpFunctionCall  %8  %202 %285
+%321 = OpCompositeConstruct  %320  %318 %318 %318 %318
+%322 = OpConvertSToF  %31  %321
+%323 = OpMatrixTimesVector  %10  %296 %322
+%324 = OpCompositeConstruct  %31  %323 %70
+OpStore %273 %324
 OpReturn
 OpFunctionEnd
-%303 = OpFunction  %2  None %60
-%301 = OpLabel
-%304 = OpAccessChain  %252  %52 %41
-OpBranch %315
-%315 = OpLabel
-%316 = OpAccessChain  %277  %47 %41 %104 %14
-OpStore %316 %64
-%317 = OpAccessChain  %270  %47 %41
-OpStore %317 %309
-%318 = OpAccessChain  %273  %47 %39
-OpStore %318 %312
-%319 = OpAccessChain  %284  %47 %30 %104 %41
-OpStore %319 %63
-OpStore %304 %313
-OpStore %302 %314
+%327 = OpFunction  %2  None %64
+%325 = OpLabel
+%328 = OpAccessChain  %277  %56 %45
+OpBranch %339
+%339 = OpLabel
+%340 = OpAccessChain  %301  %51 %45 %43 %14
+OpStore %340 %68
+%341 = OpAccessChain  %294  %51 %45
+OpStore %341 %333
+%342 = OpAccessChain  %297  %51 %39
+OpStore %342 %336
+%343 = OpAccessChain  %308  %51 %30 %43 %45
+OpStore %343 %67
+OpStore %328 %337
+OpStore %326 %338
 OpReturn
 OpFunctionEnd
-%321 = OpFunction  %2  None %60
-%320 = OpLabel
-%326 = OpVariable  %33  Function %322
-%327 = OpVariable  %35  Function %325
-OpBranch %328
-%328 = OpLabel
-%329 = OpFunctionCall  %2  %206 %326
-%330 = OpFunctionCall  %2  %212 %327
+%345 = OpFunction  %2  None %64
+%344 = OpLabel
+%350 = OpVariable  %33  Function %346
+%351 = OpVariable  %35  Function %349
+OpBranch %352
+%352 = OpLabel
+%353 = OpFunctionCall  %2  %209 %350
+%354 = OpFunctionCall  %2  %215 %351
 OpReturn
 OpFunctionEnd
-%332 = OpFunction  %2  None %60
-%331 = OpLabel
-%333 = OpVariable  %37  Function %334
-%335 = OpVariable  %40  Function %336
-OpBranch %337
-%337 = OpLabel
-%338 = OpFunctionCall  %2  %227 %333
-%339 = OpFunctionCall  %3  %220 %333
-%340 = OpFunctionCall  %2  %240 %335
-%341 = OpFunctionCall  %3  %233 %335
+%356 = OpFunction  %2  None %64
+%355 = OpLabel
+%357 = OpVariable  %37  Function %358
+%359 = OpVariable  %40  Function %360
+OpBranch %361
+%361 = OpLabel
+%362 = OpFunctionCall  %2  %230 %357
+%363 = OpFunctionCall  %3  %223 %357
+%364 = OpFunctionCall  %2  %243 %359
+%365 = OpFunctionCall  %3  %236 %359
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/access.spvasm
+++ b/naga/tests/out/spv/access.spvasm
@@ -1,18 +1,18 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 366
+; Bound: 402
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %275 "foo_vert" %270 %273
-OpEntryPoint Fragment %327 "foo_frag" %326
-OpEntryPoint GLCompute %345 "assign_through_ptr"
-OpEntryPoint GLCompute %356 "assign_to_ptr_components"
-OpExecutionMode %327 OriginUpperLeft
-OpExecutionMode %345 LocalSize 1 1 1
-OpExecutionMode %356 LocalSize 1 1 1
+OpEntryPoint Vertex %311 "foo_vert" %306 %309
+OpEntryPoint Fragment %363 "foo_frag" %362
+OpEntryPoint GLCompute %381 "assign_through_ptr"
+OpEntryPoint GLCompute %392 "assign_to_ptr_components"
+OpExecutionMode %363 OriginUpperLeft
+OpExecutionMode %381 LocalSize 1 1 1
+OpExecutionMode %392 LocalSize 1 1 1
 OpMemberName %6 0 "a"
 OpMemberName %6 1 "b"
 OpMemberName %6 2 "c"
@@ -34,49 +34,59 @@ OpMemberName %36 0 "x"
 OpName %36 "AssignToMember"
 OpMemberName %44 0 "m"
 OpName %44 "S"
-OpName %49 "global_const"
-OpName %51 "bar"
-OpName %53 "baz"
-OpName %56 "qux"
-OpName %59 "nested_mat_cx2"
-OpName %63 "test_matrix_within_struct_accesses"
-OpName %91 "idx"
-OpName %93 "t"
-OpName %138 "test_matrix_within_array_within_struct_accesses"
-OpName %148 "idx"
-OpName %149 "t"
-OpName %195 "foo"
-OpName %196 "read_from_private"
-OpName %201 "a"
-OpName %202 "test_arr_as_arg"
-OpName %208 "p"
-OpName %209 "assign_through_ptr_fn"
-OpName %214 "foo"
-OpName %215 "assign_array_through_ptr_fn"
-OpName %222 "p"
-OpName %223 "fetch_arg_ptr_member"
-OpName %229 "p"
-OpName %230 "assign_to_arg_ptr_member"
-OpName %235 "p"
-OpName %236 "fetch_arg_ptr_array_element"
-OpName %242 "p"
-OpName %243 "assign_to_arg_ptr_array_element"
-OpName %248 "value"
-OpName %249 "index_ptr"
-OpName %251 "a"
-OpName %260 "member_ptr"
-OpName %264 "s"
-OpName %270 "vi"
-OpName %275 "foo_vert"
-OpName %286 "foo"
-OpName %287 "c2"
-OpName %327 "foo_frag"
-OpName %345 "assign_through_ptr"
-OpName %350 "val"
-OpName %351 "arr"
-OpName %356 "assign_to_ptr_components"
-OpName %357 "s1"
-OpName %359 "a1"
+OpMemberName %45 0 "delicious"
+OpName %45 "Inner"
+OpMemberName %46 0 "om_nom_nom"
+OpMemberName %46 1 "thing"
+OpName %46 "Outer"
+OpName %51 "global_const"
+OpName %53 "bar"
+OpName %55 "baz"
+OpName %58 "qux"
+OpName %61 "nested_mat_cx2"
+OpName %65 "test_matrix_within_struct_accesses"
+OpName %93 "idx"
+OpName %95 "t"
+OpName %140 "test_matrix_within_array_within_struct_accesses"
+OpName %150 "idx"
+OpName %151 "t"
+OpName %197 "foo"
+OpName %198 "read_from_private"
+OpName %203 "a"
+OpName %204 "test_arr_as_arg"
+OpName %210 "p"
+OpName %211 "assign_through_ptr_fn"
+OpName %216 "foo"
+OpName %217 "assign_array_through_ptr_fn"
+OpName %224 "p"
+OpName %225 "fetch_arg_ptr_member"
+OpName %231 "p"
+OpName %232 "assign_to_arg_ptr_member"
+OpName %237 "p"
+OpName %238 "fetch_arg_ptr_array_element"
+OpName %244 "p"
+OpName %245 "assign_to_arg_ptr_array_element"
+OpName %250 "value"
+OpName %251 "index_ptr"
+OpName %253 "a"
+OpName %262 "member_ptr"
+OpName %266 "s"
+OpName %272 "let_members_of_members"
+OpName %284 "var_members_of_members"
+OpName %285 "thing"
+OpName %287 "inner"
+OpName %290 "delishus"
+OpName %306 "vi"
+OpName %311 "foo_vert"
+OpName %322 "foo"
+OpName %323 "c2"
+OpName %363 "foo_frag"
+OpName %381 "assign_through_ptr"
+OpName %386 "val"
+OpName %387 "arr"
+OpName %392 "assign_to_ptr_components"
+OpName %393 "s1"
+OpName %395 "a1"
 OpMemberDecorate %6 0 Offset 0
 OpMemberDecorate %6 1 Offset 16
 OpMemberDecorate %6 2 Offset 28
@@ -111,23 +121,26 @@ OpMemberDecorate %36 0 Offset 0
 OpDecorate %38 ArrayStride 4
 OpDecorate %42 ArrayStride 1
 OpMemberDecorate %44 0 Offset 0
-OpDecorate %51 DescriptorSet 0
-OpDecorate %51 Binding 0
+OpMemberDecorate %45 0 Offset 0
+OpMemberDecorate %46 0 Offset 0
+OpMemberDecorate %46 1 Offset 4
 OpDecorate %53 DescriptorSet 0
-OpDecorate %53 Binding 1
-OpDecorate %54 Block
-OpMemberDecorate %54 0 Offset 0
-OpDecorate %56 DescriptorSet 0
-OpDecorate %56 Binding 2
-OpDecorate %57 Block
-OpMemberDecorate %57 0 Offset 0
-OpDecorate %59 DescriptorSet 0
-OpDecorate %59 Binding 3
-OpDecorate %60 Block
-OpMemberDecorate %60 0 Offset 0
-OpDecorate %270 BuiltIn VertexIndex
-OpDecorate %273 BuiltIn Position
-OpDecorate %326 Location 0
+OpDecorate %53 Binding 0
+OpDecorate %55 DescriptorSet 0
+OpDecorate %55 Binding 1
+OpDecorate %56 Block
+OpMemberDecorate %56 0 Offset 0
+OpDecorate %58 DescriptorSet 0
+OpDecorate %58 Binding 2
+OpDecorate %59 Block
+OpMemberDecorate %59 0 Offset 0
+OpDecorate %61 DescriptorSet 0
+OpDecorate %61 Binding 3
+OpDecorate %62 Block
+OpMemberDecorate %62 0 Offset 0
+OpDecorate %306 BuiltIn VertexIndex
+OpDecorate %309 BuiltIn Position
+OpDecorate %362 Location 0
 %2 = OpTypeVoid
 %3 = OpTypeInt 32 0
 %4 = OpTypeVector %3 3
@@ -171,406 +184,454 @@ OpDecorate %326 Location 0
 %43 = OpConstant  %3  1
 %42 = OpTypeArray %41 %43
 %44 = OpTypeStruct %5
-%45 = OpConstant  %3  0
-%46 = OpConstantComposite  %4  %45 %45 %45
-%47 = OpConstant  %5  0
-%48 = OpConstantComposite  %6  %45 %46 %47
-%50 = OpTypePointer Private %6
-%49 = OpVariable  %50  Private %48
-%52 = OpTypePointer StorageBuffer %20
-%51 = OpVariable  %52  StorageBuffer
-%54 = OpTypeStruct %22
-%55 = OpTypePointer Uniform %54
-%53 = OpVariable  %55  Uniform
-%57 = OpTypeStruct %23
-%58 = OpTypePointer StorageBuffer %57
-%56 = OpVariable  %58  StorageBuffer
-%60 = OpTypeStruct %26
-%61 = OpTypePointer Uniform %60
-%59 = OpVariable  %61  Uniform
-%64 = OpTypeFunction %2
-%65 = OpTypePointer Uniform %22
-%67 = OpConstant  %5  1
-%68 = OpConstant  %8  1.0
-%69 = OpConstantComposite  %12  %68 %68
-%70 = OpConstant  %8  2.0
+%45 = OpTypeStruct %5
+%46 = OpTypeStruct %45 %3
+%47 = OpConstant  %3  0
+%48 = OpConstantComposite  %4  %47 %47 %47
+%49 = OpConstant  %5  0
+%50 = OpConstantComposite  %6  %47 %48 %49
+%52 = OpTypePointer Private %6
+%51 = OpVariable  %52  Private %50
+%54 = OpTypePointer StorageBuffer %20
+%53 = OpVariable  %54  StorageBuffer
+%56 = OpTypeStruct %22
+%57 = OpTypePointer Uniform %56
+%55 = OpVariable  %57  Uniform
+%59 = OpTypeStruct %23
+%60 = OpTypePointer StorageBuffer %59
+%58 = OpVariable  %60  StorageBuffer
+%62 = OpTypeStruct %26
+%63 = OpTypePointer Uniform %62
+%61 = OpVariable  %63  Uniform
+%66 = OpTypeFunction %2
+%67 = OpTypePointer Uniform %22
+%69 = OpConstant  %5  1
+%70 = OpConstant  %8  1.0
 %71 = OpConstantComposite  %12  %70 %70
-%72 = OpConstant  %8  3.0
+%72 = OpConstant  %8  2.0
 %73 = OpConstantComposite  %12  %72 %72
-%74 = OpConstantComposite  %21  %69 %71 %73
-%75 = OpConstantComposite  %22  %74
-%76 = OpConstant  %8  6.0
-%77 = OpConstantComposite  %12  %76 %76
-%78 = OpConstant  %8  5.0
+%74 = OpConstant  %8  3.0
+%75 = OpConstantComposite  %12  %74 %74
+%76 = OpConstantComposite  %21  %71 %73 %75
+%77 = OpConstantComposite  %22  %76
+%78 = OpConstant  %8  6.0
 %79 = OpConstantComposite  %12  %78 %78
-%80 = OpConstant  %8  4.0
+%80 = OpConstant  %8  5.0
 %81 = OpConstantComposite  %12  %80 %80
-%82 = OpConstantComposite  %21  %77 %79 %81
-%83 = OpConstant  %8  9.0
-%84 = OpConstantComposite  %12  %83 %83
-%85 = OpConstant  %8  90.0
+%82 = OpConstant  %8  4.0
+%83 = OpConstantComposite  %12  %82 %82
+%84 = OpConstantComposite  %21  %79 %81 %83
+%85 = OpConstant  %8  9.0
 %86 = OpConstantComposite  %12  %85 %85
-%87 = OpConstant  %8  10.0
-%88 = OpConstant  %8  20.0
-%89 = OpConstant  %8  30.0
-%90 = OpConstant  %8  40.0
-%92 = OpTypePointer Function %5
-%94 = OpTypePointer Function %22
-%98 = OpTypePointer Uniform %21
-%101 = OpTypePointer Uniform %12
-%107 = OpTypePointer Uniform %8
-%122 = OpTypePointer Function %21
-%124 = OpTypePointer Function %12
-%128 = OpTypePointer Function %8
-%139 = OpTypePointer Uniform %26
-%141 = OpConstantNull  %25
-%142 = OpConstantComposite  %26  %141
-%143 = OpConstant  %8  8.0
-%144 = OpConstantComposite  %12  %143 %143
-%145 = OpConstant  %8  7.0
+%87 = OpConstant  %8  90.0
+%88 = OpConstantComposite  %12  %87 %87
+%89 = OpConstant  %8  10.0
+%90 = OpConstant  %8  20.0
+%91 = OpConstant  %8  30.0
+%92 = OpConstant  %8  40.0
+%94 = OpTypePointer Function %5
+%96 = OpTypePointer Function %22
+%100 = OpTypePointer Uniform %21
+%103 = OpTypePointer Uniform %12
+%109 = OpTypePointer Uniform %8
+%124 = OpTypePointer Function %21
+%126 = OpTypePointer Function %12
+%130 = OpTypePointer Function %8
+%141 = OpTypePointer Uniform %26
+%143 = OpConstantNull  %25
+%144 = OpConstantComposite  %26  %143
+%145 = OpConstant  %8  8.0
 %146 = OpConstantComposite  %12  %145 %145
-%147 = OpConstantComposite  %24  %144 %146 %77 %79
-%150 = OpTypePointer Function %26
-%154 = OpTypePointer Uniform %25
-%157 = OpTypePointer Uniform %24
-%179 = OpTypePointer Function %25
-%181 = OpTypePointer Function %24
-%197 = OpTypeFunction %8 %27
-%203 = OpTypeFunction %8 %29
-%210 = OpTypeFunction %2 %33
-%211 = OpConstant  %3  42
-%216 = OpTypeFunction %2 %35
-%217 = OpConstantComposite  %31  %68 %68 %68 %68
-%218 = OpConstantComposite  %31  %70 %70 %70 %70
-%219 = OpConstantComposite  %34  %217 %218
-%224 = OpTypeFunction %3 %37
-%231 = OpTypeFunction %2 %37
-%237 = OpTypeFunction %3 %40
-%244 = OpTypeFunction %2 %40
-%250 = OpTypeFunction %41 %41
-%252 = OpTypePointer Function %42
-%253 = OpConstantNull  %42
-%256 = OpTypePointer Function %41
-%261 = OpTypeFunction %5
-%262 = OpConstant  %5  42
-%263 = OpConstantComposite  %44  %262
-%265 = OpTypePointer Function %44
-%271 = OpTypePointer Input %3
-%270 = OpVariable  %271  Input
-%274 = OpTypePointer Output %31
-%273 = OpVariable  %274  Output
-%277 = OpTypePointer StorageBuffer %23
-%280 = OpConstant  %8  0.0
-%281 = OpConstant  %3  3
-%282 = OpConstant  %5  3
-%283 = OpConstant  %5  4
-%284 = OpConstant  %5  5
-%285 = OpConstantNull  %29
-%288 = OpTypePointer Function %32
-%289 = OpConstantNull  %32
-%294 = OpTypePointer StorageBuffer %9
-%297 = OpTypePointer StorageBuffer %18
-%300 = OpTypePointer StorageBuffer %10
-%301 = OpTypePointer StorageBuffer %8
-%304 = OpTypePointer StorageBuffer %19
-%307 = OpTypePointer StorageBuffer %7
-%308 = OpTypePointer StorageBuffer %5
-%320 = OpTypeVector %5 4
-%326 = OpVariable  %274  Output
-%329 = OpConstantComposite  %10  %280 %280 %280
-%330 = OpConstantComposite  %10  %68 %68 %68
-%331 = OpConstantComposite  %10  %70 %70 %70
-%332 = OpConstantComposite  %10  %72 %72 %72
-%333 = OpConstantComposite  %9  %329 %330 %331 %332
-%334 = OpConstantComposite  %17  %45 %45
-%335 = OpConstantComposite  %17  %43 %43
-%336 = OpConstantComposite  %18  %334 %335
-%337 = OpConstantNull  %23
-%338 = OpConstantComposite  %31  %280 %280 %280 %280
-%346 = OpConstant  %3  33
-%347 = OpConstantComposite  %31  %76 %76 %76 %76
-%348 = OpConstantComposite  %31  %145 %145 %145 %145
-%349 = OpConstantComposite  %34  %347 %348
-%358 = OpConstantNull  %36
-%360 = OpConstantNull  %38
-%63 = OpFunction  %2  None %64
-%62 = OpLabel
-%91 = OpVariable  %92  Function %67
-%93 = OpVariable  %94  Function %75
-%66 = OpAccessChain  %65  %53 %45
-OpBranch %95
-%95 = OpLabel
-%96 = OpLoad  %5  %91
-%97 = OpISub  %5  %96 %67
-OpStore %91 %97
-%99 = OpAccessChain  %98  %66 %45
-%100 = OpLoad  %21  %99
-%102 = OpAccessChain  %101  %66 %45 %45
-%103 = OpLoad  %12  %102
-%104 = OpLoad  %5  %91
-%105 = OpAccessChain  %101  %66 %45 %104
-%106 = OpLoad  %12  %105
-%108 = OpAccessChain  %107  %66 %45 %45 %43
-%109 = OpLoad  %8  %108
-%110 = OpLoad  %5  %91
-%111 = OpAccessChain  %107  %66 %45 %45 %110
-%112 = OpLoad  %8  %111
-%113 = OpLoad  %5  %91
-%114 = OpAccessChain  %107  %66 %45 %113 %43
-%115 = OpLoad  %8  %114
-%116 = OpLoad  %5  %91
-%117 = OpLoad  %5  %91
-%118 = OpAccessChain  %107  %66 %45 %116 %117
-%119 = OpLoad  %8  %118
-%120 = OpLoad  %5  %91
-%121 = OpIAdd  %5  %120 %67
-OpStore %91 %121
-%123 = OpAccessChain  %122  %93 %45
-OpStore %123 %82
-%125 = OpAccessChain  %124  %93 %45 %45
+%147 = OpConstant  %8  7.0
+%148 = OpConstantComposite  %12  %147 %147
+%149 = OpConstantComposite  %24  %146 %148 %79 %81
+%152 = OpTypePointer Function %26
+%156 = OpTypePointer Uniform %25
+%159 = OpTypePointer Uniform %24
+%181 = OpTypePointer Function %25
+%183 = OpTypePointer Function %24
+%199 = OpTypeFunction %8 %27
+%205 = OpTypeFunction %8 %29
+%212 = OpTypeFunction %2 %33
+%213 = OpConstant  %3  42
+%218 = OpTypeFunction %2 %35
+%219 = OpConstantComposite  %31  %70 %70 %70 %70
+%220 = OpConstantComposite  %31  %72 %72 %72 %72
+%221 = OpConstantComposite  %34  %219 %220
+%226 = OpTypeFunction %3 %37
+%233 = OpTypeFunction %2 %37
+%239 = OpTypeFunction %3 %40
+%246 = OpTypeFunction %2 %40
+%252 = OpTypeFunction %41 %41
+%254 = OpTypePointer Function %42
+%255 = OpConstantNull  %42
+%258 = OpTypePointer Function %41
+%263 = OpTypeFunction %5
+%264 = OpConstant  %5  42
+%265 = OpConstantComposite  %44  %264
+%267 = OpTypePointer Function %44
+%273 = OpConstantNull  %46
+%286 = OpTypePointer Function %46
+%288 = OpTypePointer Function %45
+%289 = OpConstantNull  %45
+%291 = OpConstantNull  %5
+%307 = OpTypePointer Input %3
+%306 = OpVariable  %307  Input
+%310 = OpTypePointer Output %31
+%309 = OpVariable  %310  Output
+%313 = OpTypePointer StorageBuffer %23
+%316 = OpConstant  %8  0.0
+%317 = OpConstant  %3  3
+%318 = OpConstant  %5  3
+%319 = OpConstant  %5  4
+%320 = OpConstant  %5  5
+%321 = OpConstantNull  %29
+%324 = OpTypePointer Function %32
+%325 = OpConstantNull  %32
+%330 = OpTypePointer StorageBuffer %9
+%333 = OpTypePointer StorageBuffer %18
+%336 = OpTypePointer StorageBuffer %10
+%337 = OpTypePointer StorageBuffer %8
+%340 = OpTypePointer StorageBuffer %19
+%343 = OpTypePointer StorageBuffer %7
+%344 = OpTypePointer StorageBuffer %5
+%356 = OpTypeVector %5 4
+%362 = OpVariable  %310  Output
+%365 = OpConstantComposite  %10  %316 %316 %316
+%366 = OpConstantComposite  %10  %70 %70 %70
+%367 = OpConstantComposite  %10  %72 %72 %72
+%368 = OpConstantComposite  %10  %74 %74 %74
+%369 = OpConstantComposite  %9  %365 %366 %367 %368
+%370 = OpConstantComposite  %17  %47 %47
+%371 = OpConstantComposite  %17  %43 %43
+%372 = OpConstantComposite  %18  %370 %371
+%373 = OpConstantNull  %23
+%374 = OpConstantComposite  %31  %316 %316 %316 %316
+%382 = OpConstant  %3  33
+%383 = OpConstantComposite  %31  %78 %78 %78 %78
+%384 = OpConstantComposite  %31  %147 %147 %147 %147
+%385 = OpConstantComposite  %34  %383 %384
+%394 = OpConstantNull  %36
+%396 = OpConstantNull  %38
+%65 = OpFunction  %2  None %66
+%64 = OpLabel
+%93 = OpVariable  %94  Function %69
+%95 = OpVariable  %96  Function %77
+%68 = OpAccessChain  %67  %55 %47
+OpBranch %97
+%97 = OpLabel
+%98 = OpLoad  %5  %93
+%99 = OpISub  %5  %98 %69
+OpStore %93 %99
+%101 = OpAccessChain  %100  %68 %47
+%102 = OpLoad  %21  %101
+%104 = OpAccessChain  %103  %68 %47 %47
+%105 = OpLoad  %12  %104
+%106 = OpLoad  %5  %93
+%107 = OpAccessChain  %103  %68 %47 %106
+%108 = OpLoad  %12  %107
+%110 = OpAccessChain  %109  %68 %47 %47 %43
+%111 = OpLoad  %8  %110
+%112 = OpLoad  %5  %93
+%113 = OpAccessChain  %109  %68 %47 %47 %112
+%114 = OpLoad  %8  %113
+%115 = OpLoad  %5  %93
+%116 = OpAccessChain  %109  %68 %47 %115 %43
+%117 = OpLoad  %8  %116
+%118 = OpLoad  %5  %93
+%119 = OpLoad  %5  %93
+%120 = OpAccessChain  %109  %68 %47 %118 %119
+%121 = OpLoad  %8  %120
+%122 = OpLoad  %5  %93
+%123 = OpIAdd  %5  %122 %69
+OpStore %93 %123
+%125 = OpAccessChain  %124  %95 %47
 OpStore %125 %84
-%126 = OpLoad  %5  %91
-%127 = OpAccessChain  %124  %93 %45 %126
+%127 = OpAccessChain  %126  %95 %47 %47
 OpStore %127 %86
-%129 = OpAccessChain  %128  %93 %45 %45 %43
-OpStore %129 %87
-%130 = OpLoad  %5  %91
-%131 = OpAccessChain  %128  %93 %45 %45 %130
-OpStore %131 %88
-%132 = OpLoad  %5  %91
-%133 = OpAccessChain  %128  %93 %45 %132 %43
-OpStore %133 %89
-%134 = OpLoad  %5  %91
-%135 = OpLoad  %5  %91
-%136 = OpAccessChain  %128  %93 %45 %134 %135
-OpStore %136 %90
+%128 = OpLoad  %5  %93
+%129 = OpAccessChain  %126  %95 %47 %128
+OpStore %129 %88
+%131 = OpAccessChain  %130  %95 %47 %47 %43
+OpStore %131 %89
+%132 = OpLoad  %5  %93
+%133 = OpAccessChain  %130  %95 %47 %47 %132
+OpStore %133 %90
+%134 = OpLoad  %5  %93
+%135 = OpAccessChain  %130  %95 %47 %134 %43
+OpStore %135 %91
+%136 = OpLoad  %5  %93
+%137 = OpLoad  %5  %93
+%138 = OpAccessChain  %130  %95 %47 %136 %137
+OpStore %138 %92
 OpReturn
 OpFunctionEnd
-%138 = OpFunction  %2  None %64
-%137 = OpLabel
-%148 = OpVariable  %92  Function %67
-%149 = OpVariable  %150  Function %142
-%140 = OpAccessChain  %139  %59 %45
-OpBranch %151
-%151 = OpLabel
-%152 = OpLoad  %5  %148
-%153 = OpISub  %5  %152 %67
-OpStore %148 %153
-%155 = OpAccessChain  %154  %140 %45
-%156 = OpLoad  %25  %155
-%158 = OpAccessChain  %157  %140 %45 %45
-%159 = OpLoad  %24  %158
-%160 = OpAccessChain  %101  %140 %45 %45 %45
-%161 = OpLoad  %12  %160
-%162 = OpLoad  %5  %148
-%163 = OpAccessChain  %101  %140 %45 %45 %162
-%164 = OpLoad  %12  %163
-%165 = OpAccessChain  %107  %140 %45 %45 %45 %43
-%166 = OpLoad  %8  %165
-%167 = OpLoad  %5  %148
-%168 = OpAccessChain  %107  %140 %45 %45 %45 %167
-%169 = OpLoad  %8  %168
-%170 = OpLoad  %5  %148
-%171 = OpAccessChain  %107  %140 %45 %45 %170 %43
-%172 = OpLoad  %8  %171
-%173 = OpLoad  %5  %148
-%174 = OpLoad  %5  %148
-%175 = OpAccessChain  %107  %140 %45 %45 %173 %174
-%176 = OpLoad  %8  %175
-%177 = OpLoad  %5  %148
-%178 = OpIAdd  %5  %177 %67
-OpStore %148 %178
-%180 = OpAccessChain  %179  %149 %45
-OpStore %180 %141
-%182 = OpAccessChain  %181  %149 %45 %45
-OpStore %182 %147
-%183 = OpAccessChain  %124  %149 %45 %45 %45
-OpStore %183 %84
-%184 = OpLoad  %5  %148
-%185 = OpAccessChain  %124  %149 %45 %45 %184
+%140 = OpFunction  %2  None %66
+%139 = OpLabel
+%150 = OpVariable  %94  Function %69
+%151 = OpVariable  %152  Function %144
+%142 = OpAccessChain  %141  %61 %47
+OpBranch %153
+%153 = OpLabel
+%154 = OpLoad  %5  %150
+%155 = OpISub  %5  %154 %69
+OpStore %150 %155
+%157 = OpAccessChain  %156  %142 %47
+%158 = OpLoad  %25  %157
+%160 = OpAccessChain  %159  %142 %47 %47
+%161 = OpLoad  %24  %160
+%162 = OpAccessChain  %103  %142 %47 %47 %47
+%163 = OpLoad  %12  %162
+%164 = OpLoad  %5  %150
+%165 = OpAccessChain  %103  %142 %47 %47 %164
+%166 = OpLoad  %12  %165
+%167 = OpAccessChain  %109  %142 %47 %47 %47 %43
+%168 = OpLoad  %8  %167
+%169 = OpLoad  %5  %150
+%170 = OpAccessChain  %109  %142 %47 %47 %47 %169
+%171 = OpLoad  %8  %170
+%172 = OpLoad  %5  %150
+%173 = OpAccessChain  %109  %142 %47 %47 %172 %43
+%174 = OpLoad  %8  %173
+%175 = OpLoad  %5  %150
+%176 = OpLoad  %5  %150
+%177 = OpAccessChain  %109  %142 %47 %47 %175 %176
+%178 = OpLoad  %8  %177
+%179 = OpLoad  %5  %150
+%180 = OpIAdd  %5  %179 %69
+OpStore %150 %180
+%182 = OpAccessChain  %181  %151 %47
+OpStore %182 %143
+%184 = OpAccessChain  %183  %151 %47 %47
+OpStore %184 %149
+%185 = OpAccessChain  %126  %151 %47 %47 %47
 OpStore %185 %86
-%186 = OpAccessChain  %128  %149 %45 %45 %45 %43
-OpStore %186 %87
-%187 = OpLoad  %5  %148
-%188 = OpAccessChain  %128  %149 %45 %45 %45 %187
-OpStore %188 %88
-%189 = OpLoad  %5  %148
-%190 = OpAccessChain  %128  %149 %45 %45 %189 %43
-OpStore %190 %89
-%191 = OpLoad  %5  %148
-%192 = OpLoad  %5  %148
-%193 = OpAccessChain  %128  %149 %45 %45 %191 %192
-OpStore %193 %90
+%186 = OpLoad  %5  %150
+%187 = OpAccessChain  %126  %151 %47 %47 %186
+OpStore %187 %88
+%188 = OpAccessChain  %130  %151 %47 %47 %47 %43
+OpStore %188 %89
+%189 = OpLoad  %5  %150
+%190 = OpAccessChain  %130  %151 %47 %47 %47 %189
+OpStore %190 %90
+%191 = OpLoad  %5  %150
+%192 = OpAccessChain  %130  %151 %47 %47 %191 %43
+OpStore %192 %91
+%193 = OpLoad  %5  %150
+%194 = OpLoad  %5  %150
+%195 = OpAccessChain  %130  %151 %47 %47 %193 %194
+OpStore %195 %92
 OpReturn
 OpFunctionEnd
-%196 = OpFunction  %8  None %197
-%195 = OpFunctionParameter  %27
-%194 = OpLabel
-OpBranch %198
-%198 = OpLabel
-%199 = OpLoad  %8  %195
-OpReturnValue %199
-OpFunctionEnd
-%202 = OpFunction  %8  None %203
-%201 = OpFunctionParameter  %29
+%198 = OpFunction  %8  None %199
+%197 = OpFunctionParameter  %27
+%196 = OpLabel
+OpBranch %200
 %200 = OpLabel
-OpBranch %204
-%204 = OpLabel
-%205 = OpCompositeExtract  %28  %201 4
-%206 = OpCompositeExtract  %8  %205 9
-OpReturnValue %206
+%201 = OpLoad  %8  %197
+OpReturnValue %201
 OpFunctionEnd
-%209 = OpFunction  %2  None %210
-%208 = OpFunctionParameter  %33
-%207 = OpLabel
-OpBranch %212
-%212 = OpLabel
-OpStore %208 %211
+%204 = OpFunction  %8  None %205
+%203 = OpFunctionParameter  %29
+%202 = OpLabel
+OpBranch %206
+%206 = OpLabel
+%207 = OpCompositeExtract  %28  %203 4
+%208 = OpCompositeExtract  %8  %207 9
+OpReturnValue %208
+OpFunctionEnd
+%211 = OpFunction  %2  None %212
+%210 = OpFunctionParameter  %33
+%209 = OpLabel
+OpBranch %214
+%214 = OpLabel
+OpStore %210 %213
 OpReturn
 OpFunctionEnd
-%215 = OpFunction  %2  None %216
-%214 = OpFunctionParameter  %35
-%213 = OpLabel
-OpBranch %220
-%220 = OpLabel
-OpStore %214 %219
+%217 = OpFunction  %2  None %218
+%216 = OpFunctionParameter  %35
+%215 = OpLabel
+OpBranch %222
+%222 = OpLabel
+OpStore %216 %221
 OpReturn
 OpFunctionEnd
-%223 = OpFunction  %3  None %224
-%222 = OpFunctionParameter  %37
-%221 = OpLabel
-OpBranch %225
-%225 = OpLabel
-%226 = OpAccessChain  %33  %222 %45
-%227 = OpLoad  %3  %226
-OpReturnValue %227
+%225 = OpFunction  %3  None %226
+%224 = OpFunctionParameter  %37
+%223 = OpLabel
+OpBranch %227
+%227 = OpLabel
+%228 = OpAccessChain  %33  %224 %47
+%229 = OpLoad  %3  %228
+OpReturnValue %229
 OpFunctionEnd
-%230 = OpFunction  %2  None %231
-%229 = OpFunctionParameter  %37
-%228 = OpLabel
-OpBranch %232
-%232 = OpLabel
-%233 = OpAccessChain  %33  %229 %45
-OpStore %233 %16
-OpReturn
-OpFunctionEnd
-%236 = OpFunction  %3  None %237
-%235 = OpFunctionParameter  %40
+%232 = OpFunction  %2  None %233
+%231 = OpFunctionParameter  %37
+%230 = OpLabel
+OpBranch %234
 %234 = OpLabel
-OpBranch %238
-%238 = OpLabel
-%239 = OpAccessChain  %33  %235 %43
-%240 = OpLoad  %3  %239
-OpReturnValue %240
-OpFunctionEnd
-%243 = OpFunction  %2  None %244
-%242 = OpFunctionParameter  %40
-%241 = OpLabel
-OpBranch %245
-%245 = OpLabel
-%246 = OpAccessChain  %33  %242 %43
-OpStore %246 %16
+%235 = OpAccessChain  %33  %231 %47
+OpStore %235 %16
 OpReturn
 OpFunctionEnd
-%249 = OpFunction  %41  None %250
-%248 = OpFunctionParameter  %41
+%238 = OpFunction  %3  None %239
+%237 = OpFunctionParameter  %40
+%236 = OpLabel
+OpBranch %240
+%240 = OpLabel
+%241 = OpAccessChain  %33  %237 %43
+%242 = OpLoad  %3  %241
+OpReturnValue %242
+OpFunctionEnd
+%245 = OpFunction  %2  None %246
+%244 = OpFunctionParameter  %40
+%243 = OpLabel
+OpBranch %247
 %247 = OpLabel
-%251 = OpVariable  %252  Function %253
-OpBranch %254
-%254 = OpLabel
-%255 = OpCompositeConstruct  %42  %248
-OpStore %251 %255
-%257 = OpAccessChain  %256  %251 %45
-%258 = OpLoad  %41  %257
-OpReturnValue %258
+%248 = OpAccessChain  %33  %244 %43
+OpStore %248 %16
+OpReturn
 OpFunctionEnd
-%260 = OpFunction  %5  None %261
-%259 = OpLabel
-%264 = OpVariable  %265  Function %263
-OpBranch %266
-%266 = OpLabel
-%267 = OpAccessChain  %92  %264 %45
-%268 = OpLoad  %5  %267
-OpReturnValue %268
+%251 = OpFunction  %41  None %252
+%250 = OpFunctionParameter  %41
+%249 = OpLabel
+%253 = OpVariable  %254  Function %255
+OpBranch %256
+%256 = OpLabel
+%257 = OpCompositeConstruct  %42  %250
+OpStore %253 %257
+%259 = OpAccessChain  %258  %253 %47
+%260 = OpLoad  %41  %259
+OpReturnValue %260
 OpFunctionEnd
-%275 = OpFunction  %2  None %64
-%269 = OpLabel
-%286 = OpVariable  %27  Function %280
+%262 = OpFunction  %5  None %263
+%261 = OpLabel
+%266 = OpVariable  %267  Function %265
+OpBranch %268
+%268 = OpLabel
+%269 = OpAccessChain  %94  %266 %47
+%270 = OpLoad  %5  %269
+OpReturnValue %270
+OpFunctionEnd
+%272 = OpFunction  %5  None %263
+%271 = OpLabel
+OpBranch %274
+%274 = OpLabel
+%275 = OpCompositeExtract  %45  %273 0
+%276 = OpCompositeExtract  %5  %275 0
+%277 = OpCompositeExtract  %3  %273 1
+%278 = OpBitcast  %3  %276
+%279 = OpINotEqual  %41  %277 %278
+OpSelectionMerge %280 None
+OpBranchConditional %279 %280 %280
+%280 = OpLabel
+%281 = OpCompositeExtract  %45  %273 0
+%282 = OpCompositeExtract  %5  %281 0
+OpReturnValue %282
+OpFunctionEnd
+%284 = OpFunction  %5  None %263
+%283 = OpLabel
+%285 = OpVariable  %286  Function %273
 %287 = OpVariable  %288  Function %289
-%272 = OpLoad  %3  %270
-%276 = OpAccessChain  %65  %53 %45
-%278 = OpAccessChain  %277  %56 %45
-%279 = OpAccessChain  %139  %59 %45
-OpBranch %290
-%290 = OpLabel
-%291 = OpLoad  %8  %286
-OpStore %286 %68
-%292 = OpFunctionCall  %2  %63
-%293 = OpFunctionCall  %2  %138
-%295 = OpAccessChain  %294  %51 %45
-%296 = OpLoad  %9  %295
-%298 = OpAccessChain  %297  %51 %39
-%299 = OpLoad  %18  %298
-%302 = OpAccessChain  %301  %51 %45 %281 %45
-%303 = OpLoad  %8  %302
-%305 = OpArrayLength  %3  %51 5
-%306 = OpISub  %3  %305 %14
-%309 = OpAccessChain  %308  %51 %30 %306 %45
-%310 = OpLoad  %5  %309
-%311 = OpLoad  %23  %278
-%312 = OpFunctionCall  %8  %196 %286
-%313 = OpConvertFToS  %5  %303
-%314 = OpCompositeConstruct  %32  %310 %313 %282 %283 %284
-OpStore %287 %314
-%315 = OpIAdd  %3  %272 %43
-%316 = OpAccessChain  %92  %287 %315
-OpStore %316 %262
-%317 = OpAccessChain  %92  %287 %272
-%318 = OpLoad  %5  %317
-%319 = OpFunctionCall  %8  %202 %285
-%321 = OpCompositeConstruct  %320  %318 %318 %318 %318
-%322 = OpConvertSToF  %31  %321
-%323 = OpMatrixTimesVector  %10  %296 %322
-%324 = OpCompositeConstruct  %31  %323 %70
-OpStore %273 %324
+%290 = OpVariable  %94  Function %291
+OpBranch %292
+%292 = OpLabel
+%293 = OpAccessChain  %288  %285 %47
+%294 = OpLoad  %45  %293
+OpStore %287 %294
+%295 = OpAccessChain  %94  %287 %47
+%296 = OpLoad  %5  %295
+OpStore %290 %296
+%297 = OpAccessChain  %33  %285 %43
+%298 = OpLoad  %3  %297
+%299 = OpLoad  %5  %290
+%300 = OpBitcast  %3  %299
+%301 = OpINotEqual  %41  %298 %300
+OpSelectionMerge %302 None
+OpBranchConditional %301 %302 %302
+%302 = OpLabel
+%303 = OpAccessChain  %94  %285 %47 %47
+%304 = OpLoad  %5  %303
+OpReturnValue %304
+OpFunctionEnd
+%311 = OpFunction  %2  None %66
+%305 = OpLabel
+%322 = OpVariable  %27  Function %316
+%323 = OpVariable  %324  Function %325
+%308 = OpLoad  %3  %306
+%312 = OpAccessChain  %67  %55 %47
+%314 = OpAccessChain  %313  %58 %47
+%315 = OpAccessChain  %141  %61 %47
+OpBranch %326
+%326 = OpLabel
+%327 = OpLoad  %8  %322
+OpStore %322 %70
+%328 = OpFunctionCall  %2  %65
+%329 = OpFunctionCall  %2  %140
+%331 = OpAccessChain  %330  %53 %47
+%332 = OpLoad  %9  %331
+%334 = OpAccessChain  %333  %53 %39
+%335 = OpLoad  %18  %334
+%338 = OpAccessChain  %337  %53 %47 %317 %47
+%339 = OpLoad  %8  %338
+%341 = OpArrayLength  %3  %53 5
+%342 = OpISub  %3  %341 %14
+%345 = OpAccessChain  %344  %53 %30 %342 %47
+%346 = OpLoad  %5  %345
+%347 = OpLoad  %23  %314
+%348 = OpFunctionCall  %8  %198 %322
+%349 = OpConvertFToS  %5  %339
+%350 = OpCompositeConstruct  %32  %346 %349 %318 %319 %320
+OpStore %323 %350
+%351 = OpIAdd  %3  %308 %43
+%352 = OpAccessChain  %94  %323 %351
+OpStore %352 %264
+%353 = OpAccessChain  %94  %323 %308
+%354 = OpLoad  %5  %353
+%355 = OpFunctionCall  %8  %204 %321
+%357 = OpCompositeConstruct  %356  %354 %354 %354 %354
+%358 = OpConvertSToF  %31  %357
+%359 = OpMatrixTimesVector  %10  %332 %358
+%360 = OpCompositeConstruct  %31  %359 %72
+OpStore %309 %360
 OpReturn
 OpFunctionEnd
-%327 = OpFunction  %2  None %64
-%325 = OpLabel
-%328 = OpAccessChain  %277  %56 %45
-OpBranch %339
-%339 = OpLabel
-%340 = OpAccessChain  %301  %51 %45 %43 %14
-OpStore %340 %68
-%341 = OpAccessChain  %294  %51 %45
-OpStore %341 %333
-%342 = OpAccessChain  %297  %51 %39
-OpStore %342 %336
-%343 = OpAccessChain  %308  %51 %30 %43 %45
-OpStore %343 %67
-OpStore %328 %337
-OpStore %326 %338
-OpReturn
-OpFunctionEnd
-%345 = OpFunction  %2  None %64
-%344 = OpLabel
-%350 = OpVariable  %33  Function %346
-%351 = OpVariable  %35  Function %349
-OpBranch %352
-%352 = OpLabel
-%353 = OpFunctionCall  %2  %209 %350
-%354 = OpFunctionCall  %2  %215 %351
-OpReturn
-OpFunctionEnd
-%356 = OpFunction  %2  None %64
-%355 = OpLabel
-%357 = OpVariable  %37  Function %358
-%359 = OpVariable  %40  Function %360
-OpBranch %361
+%363 = OpFunction  %2  None %66
 %361 = OpLabel
-%362 = OpFunctionCall  %2  %230 %357
-%363 = OpFunctionCall  %3  %223 %357
-%364 = OpFunctionCall  %2  %243 %359
-%365 = OpFunctionCall  %3  %236 %359
+%364 = OpAccessChain  %313  %58 %47
+OpBranch %375
+%375 = OpLabel
+%376 = OpAccessChain  %337  %53 %47 %43 %14
+OpStore %376 %70
+%377 = OpAccessChain  %330  %53 %47
+OpStore %377 %369
+%378 = OpAccessChain  %333  %53 %39
+OpStore %378 %372
+%379 = OpAccessChain  %344  %53 %30 %43 %47
+OpStore %379 %69
+OpStore %364 %373
+OpStore %362 %374
+OpReturn
+OpFunctionEnd
+%381 = OpFunction  %2  None %66
+%380 = OpLabel
+%386 = OpVariable  %33  Function %382
+%387 = OpVariable  %35  Function %385
+OpBranch %388
+%388 = OpLabel
+%389 = OpFunctionCall  %2  %211 %386
+%390 = OpFunctionCall  %2  %217 %387
+OpReturn
+OpFunctionEnd
+%392 = OpFunction  %2  None %66
+%391 = OpLabel
+%393 = OpVariable  %37  Function %394
+%395 = OpVariable  %40  Function %396
+OpBranch %397
+%397 = OpLabel
+%398 = OpFunctionCall  %2  %232 %393
+%399 = OpFunctionCall  %3  %225 %393
+%400 = OpFunctionCall  %2  %245 %395
+%401 = OpFunctionCall  %3  %238 %395
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/access.wgsl
+++ b/naga/tests/out/wgsl/access.wgsl
@@ -29,6 +29,10 @@ struct AssignToMember {
     x: u32,
 }
 
+struct S {
+    m: i32,
+}
+
 var<private> global_const: GlobalConst = GlobalConst(0u, vec3<u32>(0u, 0u, 0u), 0i);
 @group(0) @binding(0) 
 var<storage, read_write> bar: Bar;
@@ -150,6 +154,21 @@ fn assign_to_arg_ptr_array_element(p_4: ptr<function, array<u32, 4>>) {
     return;
 }
 
+fn index_ptr(value: bool) -> bool {
+    var a_1: array<bool, 1>;
+
+    a_1 = array<bool, 1>(value);
+    let _e4 = a_1[0];
+    return _e4;
+}
+
+fn member_ptr() -> i32 {
+    var s: S = S(42i);
+
+    let _e4 = s.m;
+    return _e4;
+}
+
 @vertex 
 fn foo_vert(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4<f32> {
     var foo: f32 = 0f;
@@ -162,15 +181,15 @@ fn foo_vert(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4<f32> {
     let _matrix = bar._matrix;
     let arr_1 = bar.arr;
     let b = bar._matrix[3u][0];
-    let a_1 = bar.data[(arrayLength((&bar.data)) - 2u)].value;
+    let a_2 = bar.data[(arrayLength((&bar.data)) - 2u)].value;
     let c = qux;
     let data_pointer = (&bar.data[0].value);
     let _e33 = read_from_private((&foo));
-    c2_ = array<i32, 5>(a_1, i32(b), 3i, 4i, 5i);
+    c2_ = array<i32, 5>(a_2, i32(b), 3i, 4i, 5i);
     c2_[(vi + 1u)] = 42i;
-    let value = c2_[vi];
+    let value_1 = c2_[vi];
     let _e47 = test_arr_as_arg(array<array<f32, 10>, 5>());
-    return vec4<f32>((_matrix * vec4<f32>(vec4(value))), 2f);
+    return vec4<f32>((_matrix * vec4<f32>(vec4(value_1))), 2f);
 }
 
 @fragment 

--- a/naga/tests/out/wgsl/access.wgsl
+++ b/naga/tests/out/wgsl/access.wgsl
@@ -33,6 +33,15 @@ struct S {
     m: i32,
 }
 
+struct Inner {
+    delicious: i32,
+}
+
+struct Outer {
+    om_nom_nom: Inner,
+    thing: u32,
+}
+
 var<private> global_const: GlobalConst = GlobalConst(0u, vec3<u32>(0u, 0u, 0u), 0i);
 @group(0) @binding(0) 
 var<storage, read_write> bar: Bar;
@@ -167,6 +176,31 @@ fn member_ptr() -> i32 {
 
     let _e4 = s.m;
     return _e4;
+}
+
+fn let_members_of_members() -> i32 {
+    const inner_1 = Outer().om_nom_nom;
+    const delishus_1 = inner_1.delicious;
+    if (Outer().thing != u32(delishus_1)) {
+    }
+    return Outer().om_nom_nom.delicious;
+}
+
+fn var_members_of_members() -> i32 {
+    var thing: Outer = Outer();
+    var inner: Inner;
+    var delishus: i32;
+
+    let _e3 = thing.om_nom_nom;
+    inner = _e3;
+    let _e6 = inner.delicious;
+    delishus = _e6;
+    let _e9 = thing.thing;
+    let _e10 = delishus;
+    if (_e9 != u32(_e10)) {
+    }
+    let _e15 = thing.om_nom_nom.delicious;
+    return _e15;
 }
 
 @vertex 

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -581,44 +581,6 @@ fn local_var_missing_type() {
 }
 
 #[test]
-fn postfix_pointers() {
-    check(
-        r#"
-            fn main() {
-                var v: vec4<f32> = vec4<f32>(1.0, 1.0, 1.0, 1.0);
-                let pv = &v;
-                let a = *pv[3]; // Problematic line
-            }
-        "#,
-        r#"error: the value indexed by a `[]` subscripting expression must not be a pointer
-  ┌─ wgsl:5:26
-  │
-5 │                 let a = *pv[3]; // Problematic line
-  │                          ^^ expression is a pointer
-
-"#,
-    );
-
-    check(
-        r#"
-            struct S { m: i32 };
-            fn main() {
-                var s: S = S(42);
-                let ps = &s;
-                let a = *ps.m; // Problematic line
-            }
-        "#,
-        r#"error: the value accessed by a `.member` expression must not be a pointer
-  ┌─ wgsl:6:26
-  │
-6 │                 let a = *ps.m; // Problematic line
-  │                          ^^ expression is a pointer
-
-"#,
-    );
-}
-
-#[test]
 fn reserved_keyword() {
     // global var
     check(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -854,14 +854,17 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
 
     #[cfg(feature = "wgsl")]
     fn wgsl_language_features(&self) -> crate::WgslLanguageFeatures {
-        wgc::naga::front::wgsl::ImplementedLanguageExtension::all()
-            .iter()
-            .copied()
-            .fold(
-                crate::WgslLanguageFeatures::empty(),
-                #[expect(unreachable_code)]
-                |acc, wle| acc | match wle {},
-            )
+        use wgc::naga::front::wgsl::ImplementedLanguageExtension;
+        ImplementedLanguageExtension::all().iter().copied().fold(
+            crate::WgslLanguageFeatures::empty(),
+            |acc, wle| {
+                acc | match wle {
+                    ImplementedLanguageExtension::PointerCompositeAccess => {
+                        crate::WgslLanguageFeatures::PointerCompositeAccess
+                    }
+                }
+            },
+        )
     }
 }
 


### PR DESCRIPTION
**Connections**
Fix #6192

**Description**
Implementd [`pointer_composite_access` WGSL language extension](https://www.w3.org/TR/WGSL/#language_extension-pointer_composite_access), by removing: https://github.com/gfx-rs/wgpu/blob/30364134f33dd0f9eb4552d75cdf8aa160dfc3f1/naga/src/front/wgsl/error.rs#L216
and replacing it with code that maps declares pointer as references.

https://github.com/gfx-rs/wgpu/pull/6913/commits/fc3503a571382d811a72cf991c079e571d5531fb is not standalone as tests are fixed in next commit, but it's reviewable per commit.

PR in servo: https://github.com/servo/servo/pull/35161

**Testing**
CTS run in servo and added tests. Servo changes (contain expectation changes in two commits, [first](https://github.com/servo/servo/commit/9fa3391e828186a9f45168a6751932ede34c6a8b) on enabled extension [second one](https://github.com/servo/servo/commit/fc66e150e0462ef501a4799546c8107a2b7a5818) on implemented extension): https://github.com/servo/servo/compare/main...sagudev:servo:pointer_composite_access. Related uniformity test are also failing in firefox nightly so this seems to be another naga problem and first expectation is now fixed on trunk by https://github.com/gfx-rs/wgpu/pull/6920

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [x] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
