### PR TITLE
[naga] wgsl automatic conversion for override initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,7 @@ By @wumpf in [#6849](https://github.com/gfx-rs/wgpu/pull/6849).
 - Add a note to help with a common syntax error case for global diagnostic filter directives. By @e-hat in [#6718](https://github.com/gfx-rs/wgpu/pull/6718)
 - Change arithmetic operations between two i32 variables to wrap on overflow to match WGSL spec. By @matthew-wong1 in [#6835](https://github.com/gfx-rs/wgpu/pull/6835).
 - Add directives to suggestions in error message for parsing global items. By @e-hat in [#6723](https://github.com/gfx-rs/wgpu/pull/6723).
+- Automatic conversion for `override` initializers. By @sagudev in [6920](https://github.com/gfx-rs/wgpu/pull/6920)
 
 ##### General
 

--- a/naga/tests/in/overrides.wgsl
+++ b/naga/tests/in/overrides.wgsl
@@ -13,6 +13,8 @@
 
 override inferred_f32 = 2.718;
 
+override auto_conversion: u32 = 0;
+
 var<private> gain_x_10: f32 = gain * 10.;
 var<private> store_override: f32;
 

--- a/naga/tests/out/analysis/overrides.info.ron
+++ b/naga/tests/out/analysis/overrides.info.ron
@@ -2,6 +2,7 @@
     type_flags: [
         ("DATA | SIZED | COPY | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
         ("DATA | SIZED | COPY | IO_SHAREABLE | HOST_SHAREABLE | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
+        ("DATA | SIZED | COPY | IO_SHAREABLE | HOST_SHAREABLE | CREATION_RESOLVED | ARGUMENT | CONSTRUCTIBLE"),
     ],
     functions: [],
     entry_points: [
@@ -187,6 +188,10 @@
         Handle(1),
         Value(Scalar((
             kind: Float,
+            width: 4,
+        ))),
+        Value(Scalar((
+            kind: Uint,
             width: 4,
         ))),
         Handle(1),

--- a/naga/tests/out/glsl/overrides.main.Compute.glsl
+++ b/naga/tests/out/glsl/overrides.main.Compute.glsl
@@ -12,6 +12,7 @@ const float width = 0.0;
 const float depth = 2.3;
 const float height = 4.6;
 const float inferred_f32_ = 2.718;
+const uint auto_conversion = 0u;
 
 float gain_x_10_ = 11.0;
 

--- a/naga/tests/out/hlsl/overrides.hlsl
+++ b/naga/tests/out/hlsl/overrides.hlsl
@@ -5,6 +5,7 @@ static const float width = 0.0;
 static const float depth = 2.3;
 static const float height = 4.6;
 static const float inferred_f32_ = 2.718;
+static const uint auto_conversion = 0u;
 
 static float gain_x_10_ = 11.0;
 static float store_override = (float)0;

--- a/naga/tests/out/ir/overrides.compact.ron
+++ b/naga/tests/out/ir/overrides.compact.ron
@@ -14,6 +14,13 @@
                 width: 4,
             )),
         ),
+        (
+            name: None,
+            inner: Scalar((
+                kind: Uint,
+                width: 4,
+            )),
+        ),
     ],
     special_types: (
         ray_desc: None,
@@ -64,6 +71,12 @@
             ty: 1,
             init: Some(6),
         ),
+        (
+            name: Some("auto_conversion"),
+            id: None,
+            ty: 2,
+            init: Some(7),
+        ),
     ],
     global_variables: [
         (
@@ -71,7 +84,7 @@
             space: Private,
             binding: None,
             ty: 1,
-            init: Some(9),
+            init: Some(10),
         ),
         (
             name: Some("store_override"),
@@ -93,12 +106,13 @@
             right: 3,
         ),
         Literal(F32(2.718)),
+        Literal(U32(0)),
         Override(2),
         Literal(F32(10.0)),
         Binary(
             op: Multiply,
-            left: 7,
-            right: 8,
+            left: 8,
+            right: 9,
         ),
     ],
     functions: [],

--- a/naga/tests/out/ir/overrides.ron
+++ b/naga/tests/out/ir/overrides.ron
@@ -14,6 +14,13 @@
                 width: 4,
             )),
         ),
+        (
+            name: None,
+            inner: Scalar((
+                kind: Uint,
+                width: 4,
+            )),
+        ),
     ],
     special_types: (
         ray_desc: None,
@@ -64,6 +71,12 @@
             ty: 1,
             init: Some(6),
         ),
+        (
+            name: Some("auto_conversion"),
+            id: None,
+            ty: 2,
+            init: Some(7),
+        ),
     ],
     global_variables: [
         (
@@ -71,7 +84,7 @@
             space: Private,
             binding: None,
             ty: 1,
-            init: Some(9),
+            init: Some(10),
         ),
         (
             name: Some("store_override"),
@@ -93,12 +106,13 @@
             right: 3,
         ),
         Literal(F32(2.718)),
+        Literal(U32(0)),
         Override(2),
         Literal(F32(10.0)),
         Binary(
             op: Multiply,
-            left: 7,
-            right: 8,
+            left: 8,
+            right: 9,
         ),
     ],
     functions: [],

--- a/naga/tests/out/msl/overrides.msl
+++ b/naga/tests/out/msl/overrides.msl
@@ -11,6 +11,7 @@ constant float width = 0.0;
 constant float depth = 2.3;
 constant float height = 4.6;
 constant float inferred_f32_ = 2.718;
+constant uint auto_conversion = 0u;
 
 kernel void main_(
 ) {

--- a/naga/tests/out/spv/overrides.main.spvasm
+++ b/naga/tests/out/spv/overrides.main.spvasm
@@ -1,46 +1,48 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 33
+; Bound: 35
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %20 "main"
-OpExecutionMode %20 LocalSize 1 1 1
+OpEntryPoint GLCompute %22 "main"
+OpExecutionMode %22 LocalSize 1 1 1
 %2 = OpTypeVoid
 %3 = OpTypeBool
 %4 = OpTypeFloat 32
-%5 = OpConstantTrue  %3
-%6 = OpConstant  %4  2.3
-%7 = OpConstant  %4  0.0
-%8 = OpConstantFalse  %3
-%9 = OpConstant  %4  1.1
-%10 = OpConstant  %4  2.0
-%11 = OpConstant  %4  4.6
-%12 = OpConstant  %4  2.718
-%13 = OpConstant  %4  10.0
-%14 = OpConstant  %4  11.0
-%16 = OpTypePointer Private %4
-%15 = OpVariable  %16  Private %14
-%18 = OpConstantNull  %4
-%17 = OpVariable  %16  Private %18
-%21 = OpTypeFunction %2
-%22 = OpConstant  %4  23.0
-%24 = OpTypePointer Function %4
-%26 = OpTypePointer Function %3
-%27 = OpConstantNull  %3
-%29 = OpConstantNull  %4
-%20 = OpFunction  %2  None %21
-%19 = OpLabel
-%23 = OpVariable  %24  Function %22
-%25 = OpVariable  %26  Function %27
-%28 = OpVariable  %24  Function %29
-OpBranch %30
-%30 = OpLabel
-OpStore %25 %5
-%31 = OpLoad  %4  %15
-%32 = OpFMul  %4  %31 %13
-OpStore %28 %32
-OpStore %17 %9
+%5 = OpTypeInt 32 0
+%6 = OpConstantTrue  %3
+%7 = OpConstant  %4  2.3
+%8 = OpConstant  %4  0.0
+%9 = OpConstantFalse  %3
+%10 = OpConstant  %4  1.1
+%11 = OpConstant  %4  2.0
+%12 = OpConstant  %4  4.6
+%13 = OpConstant  %4  2.718
+%14 = OpConstant  %5  0
+%15 = OpConstant  %4  10.0
+%16 = OpConstant  %4  11.0
+%18 = OpTypePointer Private %4
+%17 = OpVariable  %18  Private %16
+%20 = OpConstantNull  %4
+%19 = OpVariable  %18  Private %20
+%23 = OpTypeFunction %2
+%24 = OpConstant  %4  23.0
+%26 = OpTypePointer Function %4
+%28 = OpTypePointer Function %3
+%29 = OpConstantNull  %3
+%31 = OpConstantNull  %4
+%22 = OpFunction  %2  None %23
+%21 = OpLabel
+%25 = OpVariable  %26  Function %24
+%27 = OpVariable  %28  Function %29
+%30 = OpVariable  %26  Function %31
+OpBranch %32
+%32 = OpLabel
+OpStore %27 %6
+%33 = OpLoad  %4  %17
+%34 = OpFMul  %4  %33 %15
+OpStore %30 %34
+OpStore %19 %10
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
**Connections**
Fix #6919.

**Description**
Refactor init and type into separate function from var, then use this new function for overrides.

**Testing**
There is new case in overrides.wgsl test.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
