### PR TITLE
trace directory path updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ Bottom level categories:
 
 ## Unreleased
 
+### Changes
+
+#### Refactored internal trace path parameter
+
+Refactored some functions to handle the internal trace path as a string to avoid possible issues with `no_std` support.
+
+By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
+
 ## v24.0.0 (2025-01-15)
 
 ### Major changes

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -662,13 +662,12 @@ pub fn op_webgpu_request_device(
         memory_hints: wgpu_types::MemoryHints::default(),
     };
 
+    let webgpu_trace = std::env::var("DENO_WEBGPU_TRACE").unwrap();
+
     let res = instance.adapter_request_device(
         adapter,
         &descriptor,
-        std::env::var("DENO_WEBGPU_TRACE")
-            .ok()
-            .as_ref()
-            .map(std::path::Path::new),
+        Some(webgpu_trace.as_str()),
         None,
         None,
     );

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -193,11 +193,11 @@ impl Device {
         raw_device: Box<dyn hal::DynDevice>,
         adapter: &Arc<Adapter>,
         desc: &DeviceDescriptor,
-        trace_path: Option<&std::path::Path>,
+        trace_dir_name: Option<&str>,
         instance_flags: wgt::InstanceFlags,
     ) -> Result<Self, DeviceError> {
         #[cfg(not(feature = "trace"))]
-        if let Some(_) = trace_path {
+        if let Some(_) = trace_dir_name {
             log::error!("Feature 'trace' is not enabled");
         }
         let fence = unsafe { raw_device.create_fence() }.map_err(DeviceError::from_hal)?;
@@ -256,7 +256,7 @@ impl Device {
             #[cfg(feature = "trace")]
             trace: Mutex::new(
                 rank::DEVICE_TRACE,
-                trace_path.and_then(|path| match trace::Trace::new(path) {
+                trace_dir_name.and_then(|dir_path_name| match trace::Trace::new(dir_path_name) {
                     Ok(mut trace) => {
                         trace.add(trace::Action::Init {
                             desc: desc.clone(),
@@ -265,7 +265,7 @@ impl Device {
                         Some(trace)
                     }
                     Err(e) => {
-                        log::error!("Unable to start a trace in '{path:?}': {e}");
+                        log::error!("Unable to start a trace in '{dir_path_name:?}': {e}");
                         None
                     }
                 }),

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -220,7 +220,8 @@ pub struct Trace {
 
 #[cfg(feature = "trace")]
 impl Trace {
-    pub fn new(path: &std::path::Path) -> Result<Self, std::io::Error> {
+    pub fn new(dir_path_name: &str) -> Result<Self, std::io::Error> {
+        let path = std::path::Path::new(dir_path_name);
         log::info!("Tracing into '{:?}'", path);
         let mut file = std::fs::File::create(path.join(FILE_NAME))?;
         file.write_all(b"[\n")?;

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -620,11 +620,17 @@ impl Adapter {
         hal_device: hal::DynOpenDevice,
         desc: &DeviceDescriptor,
         instance_flags: wgt::InstanceFlags,
-        trace_path: Option<&std::path::Path>,
+        trace_dir_name: Option<&str>,
     ) -> Result<(Arc<Device>, Arc<Queue>), RequestDeviceError> {
         api_log!("Adapter::create_device");
 
-        let device = Device::new(hal_device.device, self, desc, trace_path, instance_flags)?;
+        let device = Device::new(
+            hal_device.device,
+            self,
+            desc,
+            trace_dir_name,
+            instance_flags,
+        )?;
         let device = Arc::new(device);
 
         let queue = Queue::new(device.clone(), hal_device.queue)?;
@@ -639,7 +645,7 @@ impl Adapter {
         self: &Arc<Self>,
         desc: &DeviceDescriptor,
         instance_flags: wgt::InstanceFlags,
-        trace_path: Option<&std::path::Path>,
+        trace_dir_name: Option<&str>,
     ) -> Result<(Arc<Device>, Arc<Queue>), RequestDeviceError> {
         // Verify all features were exposed by the adapter
         if !self.raw.features.contains(desc.required_features) {
@@ -686,7 +692,7 @@ impl Adapter {
         }
         .map_err(DeviceError::from_hal)?;
 
-        self.create_device_and_queue_from_hal(open, desc, instance_flags, trace_path)
+        self.create_device_and_queue_from_hal(open, desc, instance_flags, trace_dir_name)
     }
 }
 
@@ -927,7 +933,7 @@ impl Global {
         &self,
         adapter_id: AdapterId,
         desc: &DeviceDescriptor,
-        trace_path: Option<&std::path::Path>,
+        trace_dir_name: Option<&str>,
         device_id_in: Option<DeviceId>,
         queue_id_in: Option<QueueId>,
     ) -> Result<(DeviceId, QueueId), RequestDeviceError> {
@@ -939,7 +945,7 @@ impl Global {
 
         let adapter = self.hub.adapters.get(adapter_id);
         let (device, queue) =
-            adapter.create_device_and_queue(desc, self.instance.flags, trace_path)?;
+            adapter.create_device_and_queue(desc, self.instance.flags, trace_dir_name)?;
 
         let device_id = device_fid.assign(device);
         resource_log!("Created Device {:?}", device_id);
@@ -959,7 +965,7 @@ impl Global {
         adapter_id: AdapterId,
         hal_device: hal::DynOpenDevice,
         desc: &DeviceDescriptor,
-        trace_path: Option<&std::path::Path>,
+        trace_dir_name: Option<&str>,
         device_id_in: Option<DeviceId>,
         queue_id_in: Option<QueueId>,
     ) -> Result<(DeviceId, QueueId), RequestDeviceError> {
@@ -973,7 +979,7 @@ impl Global {
             hal_device,
             desc,
             self.instance.flags,
-            trace_path,
+            trace_dir_name,
         )?;
 
         let device_id = devices_fid.assign(device);


### PR DESCRIPTION
**Connections**

- Help me work on some updates to support `wgpu-core` with no-std ref: #6826
- Note that tracing is temporarily removed, with plans to add back ref: #5974

**Description**

I am working on some updates to support `wgpu-core` with no-std ref: #6826

The various `trace_path: Option<&std::path::Path>` arguments sprinkled throughout multiple modules get in my way, I just hacked these to unblock my progress for now.

Considering that `std::path::Path` amounts to a fancy string container anyways, my idea is to update these arguments to accept optional string for now.

I think this shouldn't break anything since `wgpu` is calling `Global::adapter_request_device` with `trace_path: None` at this point.

**Testing**

- `cargo build --all-features -p wgpu-core`
- `cargo build --all-features -p wgpu`

**Checklist**

- [x] Run `cargo fmt`. ✅
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add: ✅
  - [x] `--target wasm32-unknown-unknown` ✅
  - ~~`--target wasm32-unknown-emscripten`~~ ❌
- [x] Run `cargo xtask test` to run tests. ✅
- ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ :x: