### PR TITLE
Start using `hashbrown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,9 @@ Bottom level categories:
 
 ### Changes
 
-#### Use `hashbrown` in `wgpu-core` & `wgpu-hal`
+#### Start using `hashbrown`
 
-Using in `hashbrown` should improve performance and simplify no-std support.
+Using `hashbrown` in `wgpu-core`, `wgpu-hal` & `wgpu-info` should help improve performance and simplify no-std support.
 
 By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Changes
+
+#### Use `hashbrown` in `wgpu-core`
+
+Using in `hashbrown` in `wgpu-core` should improve performance and simplify no-std support.
+
 ## v24.0.0 (2025-01-15)
 
 ### Major changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Bottom level categories:
 
 #### Start using `hashbrown`
 
-Using `hashbrown` in `wgpu-core`, `wgpu-hal` & `wgpu-info` should help improve performance and simplify no-std support.
+Use `hashbrown` in `wgpu-core`, `wgpu-hal` & `wgpu-info` to simplify no-std support. (This may help improve performance as well.)
 
 By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Bottom level categories:
 
 Using in `hashbrown` in `wgpu-core` should improve performance and simplify no-std support.
 
+By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
+
 ## v24.0.0 (2025-01-15)
 
 ### Major changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,9 @@ Bottom level categories:
 
 ### Changes
 
-#### Use `hashbrown` in `wgpu-core`
+#### Use `hashbrown` in `wgpu-core` & `wgpu-hal`
 
-Using in `hashbrown` in `wgpu-core` should improve performance and simplify no-std support.
+Using in `hashbrown` should improve performance and simplify no-std support.
 
 By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,6 +1605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -4155,6 +4156,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.8.0",
  "env_logger",
+ "hashbrown",
  "pico-args",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4047,6 +4047,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases 0.2.1",
  "document-features",
+ "hashbrown",
  "indexmap",
  "log",
  "naga",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4118,6 +4118,7 @@ dependencies = [
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
+ "hashbrown",
  "js-sys",
  "khronos-egl",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,10 @@ flume = "0.11"
 futures-lite = "2"
 getrandom = "0.2"
 glam = "0.29"
-hashbrown = { version = "0.15.2", default-features = false, features = ["default-hasher", "inline-more"] }
+hashbrown = { version = "0.15.2", default-features = false, features = [
+    "default-hasher",
+    "inline-more",
+] }
 heck = "0.5.0"
 image = { version = "0.24", default-features = false, features = ["png"] }
 indexmap = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ flume = "0.11"
 futures-lite = "2"
 getrandom = "0.2"
 glam = "0.29"
+hashbrown = { version = "0.15.2", default-features = false, features = ["default-hasher", "inline-more"] }
 heck = "0.5.0"
 image = { version = "0.24", default-features = false, features = ["png"] }
 indexmap = "2"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -119,6 +119,7 @@ bit-vec.workspace = true
 bitflags.workspace = true
 bytemuck = { workspace = true, optional = true }
 document-features.workspace = true
+hashbrown.workspace = true
 indexmap.workspace = true
 log.workspace = true
 once_cell.workspace = true

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -1,4 +1,6 @@
-use std::{collections::hash_map::Entry, ops::Range, sync::Arc, vec::Drain};
+use std::{ops::Range, sync::Arc, vec::Drain};
+
+use hashbrown::hash_map::Entry;
 
 use crate::{
     device::Device,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2712,8 +2712,8 @@ impl Device {
             .map(|mut bgl_entry_map| {
                 bgl_entry_map.sort();
                 match unique_bind_group_layouts.entry(bgl_entry_map) {
-                    std::collections::hash_map::Entry::Occupied(v) => Ok(Arc::clone(v.get())),
-                    std::collections::hash_map::Entry::Vacant(e) => {
+                    hashbrown::hash_map::Entry::Occupied(v) => Ok(Arc::clone(v.get())),
+                    hashbrown::hash_map::Entry::Vacant(e) => {
                         match self.create_bind_group_layout(
                             &None,
                             e.key().clone(),

--- a/wgpu-core/src/hash_utils.rs
+++ b/wgpu-core/src/hash_utils.rs
@@ -4,10 +4,10 @@
 
 /// HashMap using a fast, non-cryptographic hash algorithm.
 pub type FastHashMap<K, V> =
-    std::collections::HashMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+    hashbrown::HashMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 /// HashSet using a fast, non-cryptographic hash algorithm.
 pub type FastHashSet<K> =
-    std::collections::HashSet<K, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+    hashbrown::HashSet<K, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 /// IndexMap using a fast, non-cryptographic hash algorithm.
 pub type FastIndexMap<K, V> =

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1,5 +1,7 @@
+use std::borrow::Cow;
 use std::sync::Arc;
-use std::{borrow::Cow, collections::HashMap};
+
+use hashbrown::HashMap;
 
 use crate::{
     api_log, api_log_debug,

--- a/wgpu-core/src/pool.rs
+++ b/wgpu-core/src/pool.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::{hash_map::Entry, HashMap},
     hash::Hash,
     sync::{Arc, Weak},
 };
 
+use hashbrown::{hash_map::Entry, HashMap};
 use once_cell::sync::OnceCell;
 
 use crate::lock::{rank, Mutex};

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1,6 +1,7 @@
 use crate::{device::bgl, resource::InvalidResourceError, FastHashMap, FastHashSet};
 use arrayvec::ArrayVec;
-use std::{collections::hash_map::Entry, fmt};
+use hashbrown::hash_map::Entry;
+use std::fmt;
 use thiserror::Error;
 use wgt::{BindGroupLayoutEntry, BindingType};
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -121,6 +121,7 @@ required-features = ["gles"]
 
 [dependencies]
 bitflags.workspace = true
+hashbrown.workspace = true
 parking_lot.workspace = true
 profiling = { workspace = true, default-features = false }
 raw-window-handle.workspace = true

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1,10 +1,9 @@
 use glow::HasContext;
+use hashbrown::HashMap;
 use once_cell::sync::Lazy;
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard, RwLock};
 
-use std::{
-    collections::HashMap, ffi, mem::ManuallyDrop, os::raw, ptr, rc::Rc, sync::Arc, time::Duration,
-};
+use std::{ffi, mem::ManuallyDrop, os::raw, ptr, rc::Rc, sync::Arc, time::Duration};
 
 /// The amount of time to wait while trying to obtain a lock to the adapter context
 const CONTEXT_LOCK_TIMEOUT_SECS: u64 = 1;

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     ffi::{c_void, CStr, CString},
     mem::{self, size_of, size_of_val, ManuallyDrop},
     os::raw::c_int,
@@ -17,6 +16,7 @@ use glutin_wgl_sys::wgl_extra::{
     Wgl, CONTEXT_CORE_PROFILE_BIT_ARB, CONTEXT_DEBUG_BIT_ARB, CONTEXT_FLAGS_ARB,
     CONTEXT_PROFILE_MASK_ARB,
 };
+use hashbrown::HashSet;
 use once_cell::sync::Lazy;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -26,7 +26,6 @@ mod surface;
 mod time;
 
 use std::{
-    collections::HashMap,
     fmt, iter, ops,
     ptr::NonNull,
     sync::{atomic, Arc},
@@ -35,6 +34,7 @@ use std::{
 
 use arrayvec::ArrayVec;
 use bitflags::bitflags;
+use hashbrown::HashMap;
 use metal::foreign_types::ForeignTypeRef as _;
 use parking_lot::{Mutex, RwLock};
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -2,12 +2,13 @@ use super::{conv, RawTlasInstance};
 
 use arrayvec::ArrayVec;
 use ash::{khr, vk};
+use hashbrown::hash_map::Entry;
 use parking_lot::Mutex;
 
 use crate::TlasInstance;
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry, BTreeMap},
+    collections::BTreeMap,
     ffi::{CStr, CString},
     mem::{self, size_of, MaybeUninit},
     num::NonZeroU32,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -33,7 +33,6 @@ mod sampler;
 
 use std::{
     borrow::Borrow,
-    collections::HashSet,
     ffi::{CStr, CString},
     fmt, mem,
     num::NonZeroU32,
@@ -42,11 +41,16 @@ use std::{
 
 use arrayvec::ArrayVec;
 use ash::{ext, khr, vk};
+use hashbrown::{HashMap, HashSet};
 use parking_lot::{Mutex, RwLock};
+use rustc_hash::FxHasher;
 use wgt::InternalCounter;
 
 const MILLIS_TO_NANOS: u64 = 1_000_000;
 const MAX_TOTAL_ATTACHMENTS: usize = crate::MAX_COLOR_ATTACHMENTS * 2 + 1;
+
+// NOTE: This type alias is similar to rustc_hash::FxHashMap but works with hashbrown.
+type FxHashMap<T, U> = HashMap<T, U, core::hash::BuildHasherDefault<FxHasher>>;
 
 #[derive(Clone, Debug)]
 pub struct Api;
@@ -641,8 +645,8 @@ struct DeviceShared {
     private_caps: PrivateCapabilities,
     workarounds: Workarounds,
     features: wgt::Features,
-    render_passes: Mutex<rustc_hash::FxHashMap<RenderPassKey, vk::RenderPass>>,
-    framebuffers: Mutex<rustc_hash::FxHashMap<FramebufferKey, vk::Framebuffer>>,
+    render_passes: Mutex<FxHashMap<RenderPassKey, vk::RenderPass>>,
+    framebuffers: Mutex<FxHashMap<FramebufferKey, vk::Framebuffer>>,
     sampler_cache: Mutex<sampler::SamplerCache>,
     memory_allocations_counter: InternalCounter,
 }

--- a/wgpu-hal/src/vulkan/sampler.rs
+++ b/wgpu-hal/src/vulkan/sampler.rs
@@ -2,9 +2,8 @@
 //!
 //! Nearly identical to the DX12 sampler cache, without descriptor heap management.
 
-use std::collections::{hash_map::Entry, HashMap};
-
 use ash::vk;
+use hashbrown::{hash_map::Entry, HashMap};
 use ordered_float::OrderedFloat;
 
 /// If the allowed sampler count is above this value, the sampler cache is disabled.

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 anyhow.workspace = true
 bitflags.workspace = true
 env_logger.workspace = true
+hashbrown = { workspace = true, features = ["serde"] }
 pico-args.workspace = true
 serde = { workspace = true, features = ["default"] }
 serde_json.workspace = true

--- a/wgpu-info/src/report.rs
+++ b/wgpu-info/src/report.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, io};
+use std::io;
 
+use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 use wgpu::{
     AdapterInfo, DownlevelCapabilities, Features, Limits, TextureFormat, TextureFormatFeatures,


### PR DESCRIPTION
**Connections**

- help prepare for no-std support in wgpu-core ref: #6826

**Description**

see title

Use `hashbrown` in `wgpu-core`, `wgpu-hal` & `wgpu-info` to simplify no-std support. (This may help improve performance as well.)

Holding off on updating the following crates to use hashbrown:

- `naga` - I encountered some build issues with `spirv::Capability`. I think using hashbrown in `naga` would be good for no-std build, without the spirv-related feature.
- main `wgpu` crate - I encountered some issues testing with webgpu backend & did not feel like introducing a possibly breaking change to the public API. I may revisit this (someday).

**Testing**

- `cargo build --all-features -p wgpu-core`

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - ~~`--target wasm32-unknown-emscripten`~~
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
