### PR TITLE
no-std support in wgpu-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,9 +291,9 @@ jobs:
           # Check wgpu-types with all features except "std".
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features --features strict_asserts,fragile-send-sync-non-atomic-wasm,serde,counters
 
-          # XXX TODO ENABLE
+          # XXX TODO ENABLE:
           # check wgpu-core with all no-std features (all features possible for no-std)
-          # XXX TODO IMPORVE COMMA-SEPARATED no-std feature list here
+          # XXX TODO IMPROVE COMMA-SEPARATED no-std feature list here
           # cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-core --no-default-features --features counters,api_log_info,resource_log_info,renderdoc,strict_asserts,indirect-validation,serde,raw-window-handle,wgsl,glsl,fragile-send-sync-non-atomic-wasm,metal,vulkan,gles,dx12
 
       # Building for native platforms with standard tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,14 +278,23 @@ jobs:
       - name: check no_std
         if: matrix.kind == 'no_std'
         shell: bash
+        # XXX TBD CHECK no-std for wgpu-types & wgpu-core in separate steps - ???
         run: |
           set -e
 
-          # check with no features
+          # check wgpu-types with no features
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features
 
-          # Check with all features except "std".
+          # check wgpu-core with no features
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-core --no-default-features
+
+          # Check wgpu-types with all features except "std".
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features --features strict_asserts,fragile-send-sync-non-atomic-wasm,serde,counters
+
+          # XXX TODO ENABLE
+          # check wgpu-core with all no-std features (all features possible for no-std)
+          # XXX TODO IMPORVE COMMA-SEPARATED no-std feature list here
+          # cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-core --no-default-features --features counters,api_log_info,resource_log_info,renderdoc,strict_asserts,indirect-validation,serde,raw-window-handle,wgsl,glsl,fragile-send-sync-non-atomic-wasm,metal,vulkan,gles,dx12
 
       # Building for native platforms with standard tests.
       - name: check native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,8 +285,9 @@ jobs:
           # check wgpu-types with no features
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features
 
+          # XXX TODO RESOLVE BUILD ISSUE WITH DEPENDENCIES & RE-ENABLE THIS SUB-STEP - XXX TBD MAY NEED TO UPDATE naga for no-std before this will work
           # check wgpu-core with no features
-          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-core --no-default-features
+          # cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-core --no-default-features
 
           # Check wgpu-types with all features except "std".
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features --features strict_asserts,fragile-send-sync-non-atomic-wasm,serde,counters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,10 @@ jobs:
           # build docs
           cargo doc --target ${{ matrix.target }} ${{ matrix.extra-flags }} --all-features --no-deps
 
+          # XXX EXTRA SUB-STEP - (SHOULD) DETECT MISSING IMPORT for no-std
+          # check wgpu-core with no features
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-core --no-default-features
+
       - name: check private item docs
         if: matrix.kind == 'native'
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ Bottom level categories:
 
 ## Unreleased
 
+### Changes
+
+#### Refactored internal trace path parameter
+
+Refactored some functions to handle the internal trace path as a string to avoid possible issues with `no_std` support.
+
+By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
+
 ## v24.0.0 (2025-01-15)
 
 ### Major changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ Bottom level categories:
 
 ## Unreleased
 
+### Major changes
+
+#### no-std support in `wgpu-core`
+
+XXX TODO
+
+By XXX in XXX
+
 ### Changes
 
 #### Use `hashbrown` in `wgpu-core`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Changes
+
+#### Use `hashbrown` in `wgpu-core`
+
+Using in `hashbrown` in `wgpu-core` should improve performance and simplify no-std support.
+
 ## v24.0.0 (2025-01-15)
 
 ### Major changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Bottom level categories:
 
 Using in `hashbrown` in `wgpu-core` should improve performance and simplify no-std support.
 
+By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
+
 ## v24.0.0 (2025-01-15)
 
 ### Major changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4047,6 +4047,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases 0.2.1",
  "document-features",
+ "hashbrown",
  "indexmap",
  "log",
  "naga",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,10 @@ flume = "0.11"
 futures-lite = "2"
 getrandom = "0.2"
 glam = "0.29"
-hashbrown = { version = "0.15.2", default-features = false, features = ["default-hasher", "inline-more"] }
+hashbrown = { version = "0.15.2", default-features = false, features = [
+    "default-hasher",
+    "inline-more",
+] }
 heck = "0.5.0"
 image = { version = "0.24", default-features = false, features = ["png"] }
 indexmap = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ flume = "0.11"
 futures-lite = "2"
 getrandom = "0.2"
 glam = "0.29"
+hashbrown = { version = "0.15.2", default-features = false, features = ["default-hasher", "inline-more"] }
 heck = "0.5.0"
 image = { version = "0.24", default-features = false, features = ["png"] }
 indexmap = "2"

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -662,13 +662,12 @@ pub fn op_webgpu_request_device(
         memory_hints: wgpu_types::MemoryHints::default(),
     };
 
+    let webgpu_trace = std::env::var("DENO_WEBGPU_TRACE").unwrap();
+
     let res = instance.adapter_request_device(
         adapter,
         &descriptor,
-        std::env::var("DENO_WEBGPU_TRACE")
-            .ok()
-            .as_ref()
-            .map(std::path::Path::new),
+        Some(webgpu_trace.as_str()),
         None,
         None,
     );

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -119,6 +119,7 @@ bit-vec.workspace = true
 bitflags.workspace = true
 bytemuck = { workspace = true, optional = true }
 document-features.workspace = true
+hashbrown.workspace = true
 indexmap.workspace = true
 log.workspace = true
 once_cell.workspace = true

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -35,6 +35,13 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wgpu_validate_locks)'] }
 [lib]
 
 [features]
+default = ["std"]
+
+## XXX TODO DOCUMENT THIS
+std = []
+
+# XXX TODO I think I got it right which features actually require std - I think we should find a way to check this in CI
+
 ## Internally count resources and events for debugging purposes. If the counters
 ## feature is disabled, the counting infrastructure is removed from the build and
 ## the exposed counters always return 0.
@@ -63,13 +70,13 @@ indirect-validation = ["naga/wgsl-in"]
 serde = ["dep:serde", "wgt/serde", "arrayvec/serde"]
 
 ## Enable API tracing.
-trace = ["dep:ron", "serde", "naga/serialize"]
+trace = ["std", "dep:ron", "serde", "naga/serialize"]
 
 ## Enable lock order observation.
-observe_locks = ["dep:ron", "serde/serde_derive"]
+observe_locks = ["std", "dep:ron", "serde/serde_derive"]
 
 ## Enable API replaying
-replay = ["serde", "naga/deserialize"]
+replay = ["std", "serde", "naga/deserialize"]
 
 ## Enable creating instances using raw-window-handle
 raw-window-handle = ["dep:raw-window-handle"]

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alias::*,
     device::{
         bgl, Device, DeviceError, MissingDownlevelFlags, MissingFeatures, SHADER_STAGE_COUNT,
     },

--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -1,3 +1,4 @@
+use crate::alias::*;
 use crate::lock::{rank, Mutex};
 
 /// A pool of free [`wgpu_hal::CommandEncoder`]s, owned by a `Device`.

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
+    alias::*,
     binding_model::{BindGroup, LateMinBufferBindingSizeMismatch, PipelineLayout},
     device::SHADER_STAGE_COUNT,
     pipeline::LateSizedBufferGroup,
@@ -16,6 +17,7 @@ mod compat {
     use wgt::{BindingType, ShaderStages};
 
     use crate::{
+        alias::*,
         binding_model::BindGroupLayout,
         error::MultiError,
         resource::{Labeled, ParentDevice, ResourceErrorIdent},

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -79,6 +79,7 @@ index format changes.
 #![allow(clippy::reversed_empty_ranges)]
 
 use crate::{
+    alias::*,
     binding_model::{BindError, BindGroup, PipelineLayout},
     command::{
         BasePass, BindGroupStateChange, ColorAttachmentError, DrawError, MapPassErr,
@@ -1573,7 +1574,7 @@ where
 
 pub mod bundle_ffi {
     use super::{RenderBundleEncoder, RenderCommand};
-    use crate::{id, RawString};
+    use crate::{alias::*, id, RawString};
     use std::{convert::TryInto, slice};
     use wgt::{BufferAddress, BufferSize, DynamicOffset, IndexFormat};
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -1,3 +1,5 @@
+use crate::alias::*;
+
 use std::{ops::Range, sync::Arc};
 
 #[cfg(feature = "trace")]

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alias::*,
     binding_model::{
         BindError, BindGroup, LateMinBufferBindingSizeMismatch, PushConstantUploadError,
     },

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
+    alias::*,
     binding_model::BindGroup,
     id,
     pipeline::ComputePipeline,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alias::*,
     binding_model::{LateMinBufferBindingSizeMismatch, PushConstantUploadError},
     resource::{
         DestroyedResourceError, MissingBufferUsageError, MissingTextureUsageError,

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -1,4 +1,6 @@
-use std::{collections::hash_map::Entry, ops::Range, sync::Arc, vec::Drain};
+use std::{ops::Range, sync::Arc, vec::Drain};
+
+use hashbrown::hash_map::Entry;
 
 use crate::{
     device::Device,

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -3,6 +3,7 @@ use std::{ops::Range, sync::Arc, vec::Drain};
 use hashbrown::hash_map::Entry;
 
 use crate::{
+    alias::*,
     device::Device,
     init_tracker::*,
     resource::{DestroyedResourceError, ParentDevice, Texture, Trackable},

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -13,6 +13,8 @@ mod render_command;
 mod timestamp_writes;
 mod transfer;
 
+use crate::alias::*;
+
 use std::mem::{self, ManuallyDrop};
 use std::sync::Arc;
 

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;
 use crate::{
+    alias::*,
     command::{CommandBuffer, CommandEncoderError},
     device::{DeviceError, MissingFeatures},
     global::Global,

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alias::*,
     device::queue::TempResource,
     global::Global,
     hub::Hub,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1,3 +1,4 @@
+use crate::alias::*;
 use crate::binding_model::BindGroup;
 use crate::command::{
     validate_and_begin_occlusion_query, validate_and_begin_pipeline_statistics_query,

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alias::*,
     binding_model::BindGroup,
     id,
     pipeline::RenderPipeline,

--- a/wgpu-core/src/command/timestamp_writes.rs
+++ b/wgpu-core/src/command/timestamp_writes.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::alias::*;
 use crate::id;
 
 /// Describes the writing of timestamp values in a render or compute pass.

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;
 use crate::{
+    alias::*,
     api_log,
     command::{clear_texture, CommandEncoderError},
     conv,

--- a/wgpu-core/src/device/bgl.rs
+++ b/wgpu-core/src/device/bgl.rs
@@ -1,6 +1,7 @@
 use std::hash::{Hash, Hasher};
 
 use crate::{
+    alias::*,
     binding_model::{self},
     FastIndexMap,
 };

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "trace")]
 use crate::device::trace;
 use crate::{
+    alias::*,
     api_log,
     binding_model::{
         self, BindGroupEntry, BindingResource, BufferBinding, ResolvedBindGroupDescriptor,

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alias::*,
     device::{
         queue::{EncoderInFlight, SubmittedWorkDoneClosure, TempResource},
         DeviceError,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alias::*,
     binding_model,
     hub::Hub,
     id::{BindGroupLayoutId, PipelineLayoutId},

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "trace")]
 use crate::device::trace::Action;
 use crate::{
+    alias::*,
     api_log,
     command::{
         extract_texture_selector, validate_linear_texture_data, validate_texture_copy_range,

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -1,3 +1,5 @@
+use crate::alias::*;
+
 use std::mem::ManuallyDrop;
 use std::sync::Arc;
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2712,8 +2712,8 @@ impl Device {
             .map(|mut bgl_entry_map| {
                 bgl_entry_map.sort();
                 match unique_bind_group_layouts.entry(bgl_entry_map) {
-                    std::collections::hash_map::Entry::Occupied(v) => Ok(Arc::clone(v.get())),
-                    std::collections::hash_map::Entry::Vacant(e) => {
+                    hashbrown::hash_map::Entry::Occupied(v) => Ok(Arc::clone(v.get())),
+                    hashbrown::hash_map::Entry::Vacant(e) => {
                         match self.create_bind_group_layout(
                             &None,
                             e.key().clone(),

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -193,11 +193,11 @@ impl Device {
         raw_device: Box<dyn hal::DynDevice>,
         adapter: &Arc<Adapter>,
         desc: &DeviceDescriptor,
-        trace_path: Option<&std::path::Path>,
+        trace_dir_name: Option<&str>,
         instance_flags: wgt::InstanceFlags,
     ) -> Result<Self, DeviceError> {
         #[cfg(not(feature = "trace"))]
-        if let Some(_) = trace_path {
+        if let Some(_) = trace_dir_name {
             log::error!("Feature 'trace' is not enabled");
         }
         let fence = unsafe { raw_device.create_fence() }.map_err(DeviceError::from_hal)?;
@@ -256,7 +256,7 @@ impl Device {
             #[cfg(feature = "trace")]
             trace: Mutex::new(
                 rank::DEVICE_TRACE,
-                trace_path.and_then(|path| match trace::Trace::new(path) {
+                trace_dir_name.and_then(|dir_path_name| match trace::Trace::new(dir_path_name) {
                     Ok(mut trace) => {
                         trace.add(trace::Action::Init {
                             desc: desc.clone(),
@@ -265,7 +265,7 @@ impl Device {
                         Some(trace)
                     }
                     Err(e) => {
-                        log::error!("Unable to start a trace in '{path:?}': {e}");
+                        log::error!("Unable to start a trace in '{dir_path_name:?}': {e}");
                         None
                     }
                 }),

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "trace")]
 use crate::device::trace;
 use crate::{
+    alias::*,
     binding_model::{self, BindGroup, BindGroupLayout, BindGroupLayoutEntryError},
     command, conv,
     device::{

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -220,7 +220,8 @@ pub struct Trace {
 
 #[cfg(feature = "trace")]
 impl Trace {
-    pub fn new(path: &std::path::Path) -> Result<Self, std::io::Error> {
+    pub fn new(dir_path_name: &str) -> Result<Self, std::io::Error> {
+        let path = std::path::Path::new(dir_path_name);
         log::info!("Tracing into '{:?}'", path);
         let mut file = std::fs::File::create(path.join(FILE_NAME))?;
         file.write_all(b"[\n")?;

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -1,3 +1,4 @@
+use crate::alias::*;
 use crate::id;
 use std::ops::Range;
 #[cfg(feature = "trace")]

--- a/wgpu-core/src/error.rs
+++ b/wgpu-core/src/error.rs
@@ -1,3 +1,5 @@
+use crate::alias::*;
+
 use core::fmt;
 use std::{error::Error, sync::Arc};
 

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -1,3 +1,5 @@
+use crate::alias::*;
+
 use std::{fmt, sync::Arc};
 
 use crate::{

--- a/wgpu-core/src/hash_utils.rs
+++ b/wgpu-core/src/hash_utils.rs
@@ -4,10 +4,10 @@
 
 /// HashMap using a fast, non-cryptographic hash algorithm.
 pub type FastHashMap<K, V> =
-    std::collections::HashMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+    hashbrown::HashMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 /// HashSet using a fast, non-cryptographic hash algorithm.
 pub type FastHashSet<K> =
-    std::collections::HashSet<K, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+    hashbrown::HashSet<K, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 /// IndexMap using a fast, non-cryptographic hash algorithm.
 pub type FastIndexMap<K, V> =

--- a/wgpu-core/src/hash_utils.rs
+++ b/wgpu-core/src/hash_utils.rs
@@ -2,6 +2,8 @@
 //!
 //! Named hash_utils to prevent clashing with the std::hash module.
 
+use crate::alias::*;
+
 /// HashMap using a fast, non-cryptographic hash algorithm.
 pub type FastHashMap<K, V> =
     hashbrown::HashMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -101,6 +101,7 @@ flagged as errors as well.
 */
 
 use crate::{
+    alias::*,
     binding_model::{BindGroup, BindGroupLayout, PipelineLayout},
     command::{CommandBuffer, RenderBundle},
     device::{queue::Queue, Device},

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -1,3 +1,5 @@
+// XXX TBD FMT ???
+use crate::alias::*;
 use crate::{Epoch, Index};
 use std::{
     cmp::Ordering,

--- a/wgpu-core/src/identity.rs
+++ b/wgpu-core/src/identity.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alias::*,
     id::{Id, Marker},
     lock::{rank, Mutex},
     Epoch, Index,

--- a/wgpu-core/src/indirect_validation.rs
+++ b/wgpu-core/src/indirect_validation.rs
@@ -1,3 +1,5 @@
+use crate::alias::*;
+
 use std::mem::size_of;
 use std::num::NonZeroU64;
 

--- a/wgpu-core/src/init_tracker/buffer.rs
+++ b/wgpu-core/src/init_tracker/buffer.rs
@@ -1,4 +1,5 @@
 use super::{InitTracker, MemoryInitKind};
+use crate::alias::*;
 use crate::resource::Buffer;
 use std::{ops::Range, sync::Arc};
 

--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -31,6 +31,8 @@ system there are two kind of writes:
 
  */
 
+use crate::alias::*;
+
 use smallvec::SmallVec;
 use std::{fmt, iter, ops::Range};
 

--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -282,6 +282,7 @@ impl InitTracker<u32> {
 
 #[cfg(test)]
 mod test {
+    use crate::alias::*;
     use std::ops::Range;
 
     type Tracker = super::InitTracker<u32>;

--- a/wgpu-core/src/init_tracker/texture.rs
+++ b/wgpu-core/src/init_tracker/texture.rs
@@ -1,4 +1,6 @@
 use super::{InitTracker, MemoryInitKind};
+// XXX TBD FMT ???
+use crate::alias::*;
 use crate::{resource::Texture, track::TextureSelector};
 use arrayvec::ArrayVec;
 use std::{ops::Range, sync::Arc};

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1,5 +1,7 @@
+use std::borrow::Cow;
 use std::sync::Arc;
-use std::{borrow::Cow, collections::HashMap};
+
+use hashbrown::HashMap;
 
 use crate::{
     api_log, api_log_debug,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1,3 +1,5 @@
+use crate::alias::*;
+
 use std::borrow::Cow;
 use std::sync::Arc;
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -620,11 +620,17 @@ impl Adapter {
         hal_device: hal::DynOpenDevice,
         desc: &DeviceDescriptor,
         instance_flags: wgt::InstanceFlags,
-        trace_path: Option<&std::path::Path>,
+        trace_dir_name: Option<&str>,
     ) -> Result<(Arc<Device>, Arc<Queue>), RequestDeviceError> {
         api_log!("Adapter::create_device");
 
-        let device = Device::new(hal_device.device, self, desc, trace_path, instance_flags)?;
+        let device = Device::new(
+            hal_device.device,
+            self,
+            desc,
+            trace_dir_name,
+            instance_flags,
+        )?;
         let device = Arc::new(device);
 
         let queue = Queue::new(device.clone(), hal_device.queue)?;
@@ -639,7 +645,7 @@ impl Adapter {
         self: &Arc<Self>,
         desc: &DeviceDescriptor,
         instance_flags: wgt::InstanceFlags,
-        trace_path: Option<&std::path::Path>,
+        trace_dir_name: Option<&str>,
     ) -> Result<(Arc<Device>, Arc<Queue>), RequestDeviceError> {
         // Verify all features were exposed by the adapter
         if !self.raw.features.contains(desc.required_features) {
@@ -686,7 +692,7 @@ impl Adapter {
         }
         .map_err(DeviceError::from_hal)?;
 
-        self.create_device_and_queue_from_hal(open, desc, instance_flags, trace_path)
+        self.create_device_and_queue_from_hal(open, desc, instance_flags, trace_dir_name)
     }
 }
 
@@ -927,7 +933,7 @@ impl Global {
         &self,
         adapter_id: AdapterId,
         desc: &DeviceDescriptor,
-        trace_path: Option<&std::path::Path>,
+        trace_dir_name: Option<&str>,
         device_id_in: Option<DeviceId>,
         queue_id_in: Option<QueueId>,
     ) -> Result<(DeviceId, QueueId), RequestDeviceError> {
@@ -939,7 +945,7 @@ impl Global {
 
         let adapter = self.hub.adapters.get(adapter_id);
         let (device, queue) =
-            adapter.create_device_and_queue(desc, self.instance.flags, trace_path)?;
+            adapter.create_device_and_queue(desc, self.instance.flags, trace_dir_name)?;
 
         let device_id = device_fid.assign(device);
         resource_log!("Created Device {:?}", device_id);
@@ -959,7 +965,7 @@ impl Global {
         adapter_id: AdapterId,
         hal_device: hal::DynOpenDevice,
         desc: &DeviceDescriptor,
-        trace_path: Option<&std::path::Path>,
+        trace_dir_name: Option<&str>,
         device_id_in: Option<DeviceId>,
         queue_id_in: Option<QueueId>,
     ) -> Result<(DeviceId, QueueId), RequestDeviceError> {
@@ -973,7 +979,7 @@ impl Global {
             hal_device,
             desc,
             self.instance.flags,
-            trace_path,
+            trace_dir_name,
         )?;
 
         let device_id = devices_fid.assign(device);

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -251,10 +251,10 @@ pub(crate) mod alias {
             pub(crate) use super::std::sync::*;
             pub(crate) use core::sync::*;
             // XXX TBD ??? - UPDATE FOR std vs test ???
-            // XXX TODO ENSURE BUILD WITH THE FOLLOWING ALIAS IS TESTED IN CI:
             // XXX TBD NAMING - ???
-            #[cfg(not(any(feature = "std", test)))]
-            pub(crate) use crate::OnceCell as OnceLock;
+            // XXX TODO UNCOMMENT - XXX TBD THIS SHOULD TRIGGER CI BUILD FAILURE
+            // #[cfg(not(any(feature = "std", test)))]
+            // pub(crate) use crate::OnceCell as OnceLock;
         }
         // XXX TBD ??? - UPDATE FOR std vs test ???
         // #[cfg(feature = "std")]

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -221,6 +221,8 @@ pub(crate) fn get_greatest_common_divisor(mut a: u32, mut b: u32) -> u32 {
 
 // XXX TBD CLEANUP NEEDED BELOW - ???
 // XXX TBD SHOULD THIS BE A SEPARATE MODULE - ???
+// XXX TODO CLEANUP WARNING(S) & REMOVE ALLOW(S)
+#[allow(unused_imports)]
 pub(crate) mod alias {
     pub(crate) use std::prelude::v1::*;
     pub(crate) mod std {

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -230,8 +230,10 @@ pub(crate) mod alias {
                     alloc::format, borrow::ToOwned, boxed::Box, string::String, string::ToString,
                     vec, vec::Vec,
                 };
-                #[cfg(feature = "std")]
-                pub(crate) use super::super::thread_local;
+                // XXX TBD ??? - UPDATE FOR std vs test ???
+                // #[cfg(feature = "std")]
+                #[cfg(any(feature = "std", test))]
+                pub(crate) use super::super::{eprintln, thread_local};
             }
         }
         pub(crate) use core::{
@@ -242,23 +244,26 @@ pub(crate) mod alias {
         pub(crate) use alloc::{boxed, string, vec};
         pub(crate) mod borrow {
             pub(crate) use super::alloc::borrow::*;
-            // XXX
-            // pub(crate) use core::borrow::*;
         }
         pub(crate) mod sync {
             pub(crate) use super::alloc::sync::*;
             pub(crate) use core::sync::*;
+            #[cfg(any(feature = "std", test))]
+            pub(crate) use super::std::sync::*;
+            // XXX TBD ??? - UPDATE FOR std vs test ???
+            // XXX TODO ENSURE BUILD WITH THE FOLLOWING ALIAS IS TESTED IN CI:
             // XXX TBD NAMING - ???
-            #[cfg(feature = "std")]
-            pub(crate) use super::std::sync::OnceLock;
-            // XXX TBD NAMING - ???
-            #[cfg(not(feature = "std"))]
+            #[cfg(not(any(feature = "std", test)))]
             pub(crate) use crate::OnceCell as OnceLock;
         }
-        #[cfg(feature = "std")]
+        // XXX TBD ??? - UPDATE FOR std vs test ???
+        // #[cfg(feature = "std")]
+        #[cfg(any(feature = "std", test))]
         extern crate std;
-        #[cfg(feature = "std")]
-        pub(crate) use std::{backtrace, env, fs, io, path, process, thread, thread_local};
+        // XXX TBD ??? - UPDATE FOR std vs test ???
+        // #[cfg(feature = "std")]
+        #[cfg(any(feature = "std", test))]
+        pub(crate) use std::{backtrace, env, eprintln, fs, io, path, process, thread, thread_local};
     }
 }
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -254,9 +254,8 @@ pub(crate) mod alias {
             pub(crate) use core::sync::*;
             // XXX TBD ??? - UPDATE FOR std vs test ???
             // XXX TBD NAMING - ???
-            // XXX TODO UNCOMMENT - XXX XXX THIS COMMENTED-OUT IMPORT SHOULD TRIGGER CI BUILD FAILURE
-            // #[cfg(not(any(feature = "std", test)))]
-            // pub(crate) use crate::OnceCell as OnceLock;
+            #[cfg(not(any(feature = "std", test)))]
+            pub(crate) use crate::OnceCell as OnceLock;
         }
         // XXX TBD ??? - UPDATE FOR std vs test ???
         // #[cfg(feature = "std")]
@@ -269,15 +268,18 @@ pub(crate) mod alias {
             backtrace, env, eprintln, fs, io, path, process, thread, thread_local,
         };
         // XXX TBD MOVE THIS - ???
-        // XXX TODO ADD NOTE - IMPORTING error from std, if possible, to avoid MSRV issue
+        // XXX TODO ADD NOTE - IMPORTING error from std, if possible, to AVOID IMPACT on CORE MSRV
+        // XXX TBD CONSIDER UPDATING CORE MSRV - expected to impact Firefox - found these references:
+        // - https://github.com/gfx-rs/wgpu/pull/6003
+        // - https://searchfox.org/mozilla-central/source/python/mozboot/mozboot/util.py
+        // - https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html
         // XXX TBD ??? - UPDATE FOR std vs test ???
         // #[cfg(feature = "std")]
         #[cfg(any(feature = "std", test))]
         pub(crate) use std::error;
-        // XXX TODO UNCOMMENT - XXX XXX THIS COMMENTED-OUT IMPORT SHOULD TRIGGER CI BUILD FAILURE
-        // XXX TBD THIS IMPORT (IF UNCOMMENTED) IS EXPECTED TO BREAK MSRV - XXX TODO CI SHOULD DETECT THIS
-        // #[cfg(not(any(feature = "std", test)))]
-        // pub(crate) use core::error;
+        // XXX TODO ADD NOTE - EXPECTED TO IMPACT CORE MSRV for no-std
+        #[cfg(not(any(feature = "std", test)))]
+        pub(crate) use core::error;
     }
 }
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -55,6 +55,8 @@
 // Therefore, this is only really a concern for users targeting WebGL
 // (the only reason to use wgpu-core on the web in the first place) that have atomics enabled.
 #![cfg_attr(not(send_sync), allow(clippy::arc_with_non_send_sync))]
+// XXX TODO ADD NICE SEPARATING COMMENT HERE
+#![no_std]
 
 pub mod binding_model;
 pub mod command;
@@ -95,7 +97,13 @@ pub use validation::{map_storage_format_from_naga, map_storage_format_to_naga};
 pub use hal::{api, MAX_BIND_GROUPS, MAX_COLOR_ATTACHMENTS, MAX_VERTEX_BUFFERS};
 pub use naga;
 
-use std::{borrow::Cow, os::raw::c_char};
+// XXX TBD PLACEMENT - ???
+use core::ffi::c_char;
+use std::borrow::Cow;
+
+// XXX TBD PLACEMENT - ???
+#[cfg(not(feature = "std"))]
+use once_cell::sync::OnceCell;
 
 pub(crate) use hash_utils::*;
 
@@ -210,6 +218,51 @@ pub(crate) fn get_greatest_common_divisor(mut a: u32, mut b: u32) -> u32 {
         }
     }
 }
+
+// XXX TBD CLEANUP NEEDED BELOW - ???
+// XXX TBD SHOULD THIS BE A SEPARATE MODULE - ???
+pub(crate) mod alias {
+    pub(crate) use std::prelude::v1::*;
+    pub(crate) mod std {
+        pub(crate) mod prelude {
+            pub(crate) mod v1 {
+                pub(crate) use super::super::{
+                    alloc::format, borrow::ToOwned, boxed::Box, string::String, string::ToString,
+                    vec, vec::Vec,
+                };
+                #[cfg(feature = "std")]
+                pub(crate) use super::super::thread_local;
+            }
+        }
+        pub(crate) use core::{
+            cell, cmp, convert, error, ffi, fmt, hash, iter, marker, mem, num, ops, panic, ptr,
+            slice, str, time,
+        };
+        extern crate alloc;
+        pub(crate) use alloc::{boxed, string, vec};
+        pub(crate) mod borrow {
+            pub(crate) use super::alloc::borrow::*;
+            // XXX
+            // pub(crate) use core::borrow::*;
+        }
+        pub(crate) mod sync {
+            pub(crate) use super::alloc::sync::*;
+            pub(crate) use core::sync::*;
+            // XXX TBD NAMING - ???
+            #[cfg(feature = "std")]
+            pub(crate) use super::std::sync::OnceLock;
+            // XXX TBD NAMING - ???
+            #[cfg(not(feature = "std"))]
+            pub(crate) use crate::OnceCell as OnceLock;
+        }
+        #[cfg(feature = "std")]
+        extern crate std;
+        #[cfg(feature = "std")]
+        pub(crate) use std::{backtrace, env, fs, io, path, process, thread, thread_local};
+    }
+}
+
+use alias::*;
 
 #[test]
 fn test_lcd() {

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -247,9 +247,9 @@ pub(crate) mod alias {
         }
         pub(crate) mod sync {
             pub(crate) use super::alloc::sync::*;
-            pub(crate) use core::sync::*;
             #[cfg(any(feature = "std", test))]
             pub(crate) use super::std::sync::*;
+            pub(crate) use core::sync::*;
             // XXX TBD ??? - UPDATE FOR std vs test ???
             // XXX TODO ENSURE BUILD WITH THE FOLLOWING ALIAS IS TESTED IN CI:
             // XXX TBD NAMING - ???
@@ -263,7 +263,9 @@ pub(crate) mod alias {
         // XXX TBD ??? - UPDATE FOR std vs test ???
         // #[cfg(feature = "std")]
         #[cfg(any(feature = "std", test))]
-        pub(crate) use std::{backtrace, env, eprintln, fs, io, path, process, thread, thread_local};
+        pub(crate) use std::{
+            backtrace, env, eprintln, fs, io, path, process, thread, thread_local,
+        };
     }
 }
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -239,8 +239,8 @@ pub(crate) mod alias {
             }
         }
         pub(crate) use core::{
-            cell, cmp, convert, error, ffi, fmt, hash, iter, marker, mem, num, ops, panic, ptr,
-            slice, str, time,
+            cell, cmp, convert, ffi, fmt, hash, iter, marker, mem, num, ops, panic, ptr, slice,
+            str, time,
         };
         extern crate alloc;
         pub(crate) use alloc::{boxed, string, vec};
@@ -254,7 +254,7 @@ pub(crate) mod alias {
             pub(crate) use core::sync::*;
             // XXX TBD ??? - UPDATE FOR std vs test ???
             // XXX TBD NAMING - ???
-            // XXX TODO UNCOMMENT - XXX TBD THIS SHOULD TRIGGER CI BUILD FAILURE
+            // XXX TODO UNCOMMENT - XXX XXX THIS COMMENTED-OUT IMPORT SHOULD TRIGGER CI BUILD FAILURE
             // #[cfg(not(any(feature = "std", test)))]
             // pub(crate) use crate::OnceCell as OnceLock;
         }
@@ -268,6 +268,16 @@ pub(crate) mod alias {
         pub(crate) use std::{
             backtrace, env, eprintln, fs, io, path, process, thread, thread_local,
         };
+        // XXX TBD MOVE THIS - ???
+        // XXX TODO ADD NOTE - IMPORTING error from std, if possible, to avoid MSRV issue
+        // XXX TBD ??? - UPDATE FOR std vs test ???
+        // #[cfg(feature = "std")]
+        #[cfg(any(feature = "std", test))]
+        pub(crate) use std::error;
+        // XXX TODO UNCOMMENT - XXX XXX THIS COMMENTED-OUT IMPORT SHOULD TRIGGER CI BUILD FAILURE
+        // XXX TBD THIS IMPORT (IF UNCOMMENTED) IS EXPECTED TO BREAK MSRV - XXX TODO CI SHOULD DETECT THIS
+        // #[cfg(not(any(feature = "std", test)))]
+        // pub(crate) use core::error;
     }
 }
 

--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -28,6 +28,7 @@
 //!
 //! [`lock/rank.rs`]: ../../../src/wgpu_core/lock/rank.rs.html
 
+use crate::alias::*;
 use crate::FastHashSet;
 
 use super::rank::{LockRank, LockRankSet};

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -60,9 +60,6 @@ use crate::alias::*;
 use super::rank::LockRank;
 use std::{cell::Cell, panic::Location};
 
-#[cfg(not(feature = "std"))]
-use parking_lot;
-
 /// A `Mutex` instrumented for deadlock prevention.
 ///
 /// This is just a wrapper around a [`parking_lot::Mutex`], along with

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -55,8 +55,13 @@
 //!
 //! [`lock::rank`]: crate::lock::rank
 
+use crate::alias::*;
+
 use super::rank::LockRank;
 use std::{cell::Cell, panic::Location};
+
+#[cfg(not(feature = "std"))]
+use parking_lot;
 
 /// A `Mutex` instrumented for deadlock prevention.
 ///
@@ -80,9 +85,13 @@ pub struct MutexGuard<'a, T> {
     saved: LockStateGuard,
 }
 
+#[cfg(feature = "std")]
 thread_local! {
     static LOCK_STATE: Cell<LockState> = const { Cell::new(LockState::INITIAL) };
 }
+
+#[cfg(not(feature = "std"))]
+static LOCK_STATE: parking_lot::Mutex<LockState> = parking_lot::Mutex::new(LockState::INITIAL);
 
 /// Per-thread state for the deadlock checker.
 #[derive(Debug, Copy, Clone)]
@@ -123,6 +132,9 @@ impl Drop for LockStateGuard {
     }
 }
 
+// XXX TBD I wonder if we should refactor the functions below to improve separation of std vs no-std code ???
+
+// XXX TODO UPDATE COMMENTS FOR std vs no-std
 /// Check and record the acquisition of a lock with `new_rank`.
 ///
 /// Check that acquiring a lock with `new_rank` is permitted at this point, and
@@ -130,7 +142,11 @@ impl Drop for LockStateGuard {
 ///
 /// Return the `LockState` that must be restored when this thread is released.
 fn acquire(new_rank: LockRank, location: &'static Location<'static>) -> LockState {
+    #[cfg(feature = "std")]
     let state = LOCK_STATE.get();
+    #[cfg(not(feature = "std"))]
+    let mut state = LOCK_STATE.lock();
+
     // Initially, it's fine to acquire any lock. So we only
     // need to check when `last_acquired` is `Some`.
     if let Some((ref last_rank, ref last_location)) = state.last_acquired {
@@ -148,20 +164,40 @@ fn acquire(new_rank: LockRank, location: &'static Location<'static>) -> LockStat
             last_rank.bit.member_name(),
         );
     }
-    LOCK_STATE.set(LockState {
+
+    let new_state = LockState {
         last_acquired: Some((new_rank, location)),
         depth: state.depth + 1,
-    });
-    state
+    };
+
+    #[cfg(feature = "std")]
+    LOCK_STATE.set(new_state);
+    #[cfg(not(feature = "std"))]
+    {
+        *state = new_state
+    }
+
+    #[cfg(feature = "std")]
+    return state;
+    #[cfg(not(feature = "std"))]
+    *state
 }
 
+// XXX TBD UPDATE COMMENTS FOR std vs no-std - ???
 /// Record the release of a lock whose saved state was `saved`.
 ///
 /// Check that locks are being acquired in stacking order, and update the
 /// per-thread state accordingly.
 fn release(saved: LockState) {
+    #[cfg(feature = "std")]
     let prior = LOCK_STATE.replace(saved);
 
+    #[cfg(not(feature = "std"))]
+    {
+        *(LOCK_STATE.lock()) = saved
+    }
+
+    #[cfg(feature = "std")]
     // Although Rust allows mutex guards to be dropped in any
     // order, this analysis requires that locks be acquired and
     // released in stack order: the next lock to be released must be

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -346,6 +346,7 @@ impl<'a, T> std::ops::DerefMut for RwLockWriteGuard<'a, T> {
 
 /// Locks can be acquired in the order indicated by their ranks.
 #[test]
+#[cfg(feature = "std")] // XXX TBD ??? / XXX TODO XXX
 fn permitted() {
     use super::rank;
 
@@ -357,6 +358,7 @@ fn permitted() {
 }
 
 /// Locks can only be acquired in the order indicated by their ranks.
+#[cfg(feature = "std")] // XXX TBD ??? / XXX TODO FIX BEHAVIOR OR FIX TEST for no-std
 #[test]
 #[should_panic(expected = "Locking pawn after locking rook")]
 fn forbidden_unrelated() {
@@ -374,6 +376,7 @@ fn forbidden_unrelated() {
 /// These two locks *could* be acquired in this order, but only if other locks
 /// are acquired in between them. Skipping ranks isn't allowed.
 #[test]
+#[cfg(feature = "std")] // XXX TBD ??? / XXX TODO FIX BEHAVIOR OR FIX TEST for no-std
 #[should_panic(expected = "Locking knight after locking pawn")]
 fn forbidden_skip() {
     use super::rank;
@@ -387,6 +390,7 @@ fn forbidden_skip() {
 
 /// Locks can be acquired and released in a stack-like order.
 #[test]
+#[cfg(feature = "std")] // XXX TBD ??? / XXX TODO FIX BEHAVIOR OR FIX TEST for no-std
 fn stack_like() {
     use super::rank;
 
@@ -405,6 +409,7 @@ fn stack_like() {
 
 /// Locks can only be acquired and released in a stack-like order.
 #[test]
+#[cfg(feature = "std")] // XXX TBD ??? / XXX TODO FIX BEHAVIOR OR FIX TEST for no-std
 #[should_panic(expected = "Lock not released in stacking order")]
 fn non_stack_like() {
     use super::rank;

--- a/wgpu-core/src/lock/vanilla.rs
+++ b/wgpu-core/src/lock/vanilla.rs
@@ -3,6 +3,8 @@
 //! These definitions are used when no particular lock instrumentation
 //! Cargo feature is selected.
 
+use crate::alias::*;
+
 /// A plain wrapper around [`parking_lot::Mutex`].
 ///
 /// This is just like [`parking_lot::Mutex`], except that our [`new`]

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -1,5 +1,6 @@
 pub use crate::pipeline_cache::PipelineCacheValidationError;
 use crate::{
+    alias::*,
     binding_model::{CreateBindGroupLayoutError, CreatePipelineLayoutError, PipelineLayout},
     command::ColorAttachmentError,
     device::{Device, DeviceError, MissingDownlevelFlags, MissingFeatures, RenderPassContext},

--- a/wgpu-core/src/pipeline_cache.rs
+++ b/wgpu-core/src/pipeline_cache.rs
@@ -1,3 +1,5 @@
+use crate::alias::*;
+
 use std::mem::size_of;
 
 use thiserror::Error;
@@ -297,6 +299,8 @@ impl<'a> Writer<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::alias::*;
+
     use wgt::AdapterInfo;
 
     use crate::pipeline_cache::{PipelineCacheValidationError as E, HEADER_LENGTH};

--- a/wgpu-core/src/pool.rs
+++ b/wgpu-core/src/pool.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::{hash_map::Entry, HashMap},
     hash::Hash,
     sync::{Arc, Weak},
 };
 
+use hashbrown::{hash_map::Entry, HashMap};
 use once_cell::sync::OnceCell;
 
 use crate::lock::{rank, Mutex};

--- a/wgpu-core/src/pool.rs
+++ b/wgpu-core/src/pool.rs
@@ -108,6 +108,7 @@ impl<K: Clone + Eq + Hash, V> ResourcePool<K, V> {
 
 #[cfg(test)]
 mod tests {
+    use crate::alias::*;
     use std::sync::{
         atomic::{AtomicU32, Ordering},
         Barrier,

--- a/wgpu-core/src/pool.rs
+++ b/wgpu-core/src/pool.rs
@@ -6,6 +6,7 @@ use std::{
 use hashbrown::{hash_map::Entry, HashMap};
 use once_cell::sync::OnceCell;
 
+use crate::alias::*;
 use crate::lock::{rank, Mutex};
 use crate::FastHashMap;
 

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -9,6 +9,8 @@ When this texture is presented, we remove it from the device tracker as well as
 extract it from the hub.
 !*/
 
+use crate::alias::*;
+
 use std::{mem::ManuallyDrop, sync::Arc};
 
 #[cfg(feature = "trace")]

--- a/wgpu-core/src/ray_tracing.rs
+++ b/wgpu-core/src/ray_tracing.rs
@@ -8,6 +8,7 @@
 // - ([non performance] extract function in build (rust function extraction with guards is a pain))
 
 use crate::{
+    alias::*,
     command::CommandEncoderError,
     device::{DeviceError, MissingFeatures},
     id::{BlasId, BufferId, TlasId},

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -1,6 +1,7 @@
 use std::{mem::size_of, sync::Arc};
 
 use crate::{
+    alias::*,
     id::Id,
     identity::IdentityManager,
     lock::{rank, RwLock, RwLockReadGuard, RwLockWriteGuard},
@@ -128,7 +129,7 @@ impl<T: StorageItem + Clone> Registry<T> {
 mod tests {
     use std::sync::Arc;
 
-    use crate::{id::Marker, resource::ResourceType, storage::StorageItem};
+    use crate::{alias::*, id::Marker, resource::ResourceType, storage::StorageItem};
 
     use super::Registry;
     struct TestData;

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "trace")]
 use crate::device::trace;
 use crate::{
+    alias::*,
     binding_model::BindGroup,
     device::{
         queue, resource::DeferredDestroy, BufferMapPendingClosure, Device, DeviceError,

--- a/wgpu-core/src/scratch.rs
+++ b/wgpu-core/src/scratch.rs
@@ -1,3 +1,4 @@
+use crate::alias::*;
 use crate::device::{Device, DeviceError};
 use crate::resource_log;
 use hal::BufferUses;

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,11 +1,14 @@
 #![allow(unused)]
 
+use crate::alias::*;
 use crate::lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+#[cfg(feature = "std")]
+use std::backtrace::Backtrace;
+#[cfg(all(feature = "std", debug_assertions))]
+use std::thread;
 use std::{
-    backtrace::Backtrace,
     cell::{Cell, RefCell, UnsafeCell},
     panic::{self, Location},
-    thread,
 };
 
 use crate::lock::rank;
@@ -70,20 +73,25 @@ unsafe impl<T> Sync for Snatchable<T> {}
 struct LockTrace {
     purpose: &'static str,
     caller: &'static Location<'static>,
+    #[cfg(feature = "std")]
     backtrace: Backtrace,
 }
 
 impl std::fmt::Display for LockTrace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[cfg(feature = "std")]
+        let backtrace_info = &self.backtrace;
+        #[cfg(not(feature = "std"))]
+        let backtrace_info = "";
         write!(
             f,
             "a {} lock at {}\n{}",
-            self.purpose, self.caller, self.backtrace
+            self.purpose, self.caller, backtrace_info
         )
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(all(feature = "std", debug_assertions))]
 impl LockTrace {
     #[track_caller]
     fn enter(purpose: &'static str) {
@@ -111,12 +119,13 @@ impl LockTrace {
     }
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(all(feature = "std", debug_assertions)))]
 impl LockTrace {
     fn enter(purpose: &'static str) {}
     fn exit() {}
 }
 
+#[cfg(feature = "std")]
 thread_local! {
     static SNATCH_LOCK_TRACE: Cell<Option<LockTrace>> = const { Cell::new(None) };
 }

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -1,3 +1,5 @@
+use crate::alias::*;
+
 use std::sync::Arc;
 
 use crate::id::{Id, Marker};

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -4,6 +4,8 @@
 //! a 16 bit bitflag of buffer usages. Because there is only ever
 //! one subresource, they have no selector.
 
+use crate::alias::*;
+
 use std::sync::{Arc, Weak};
 
 use super::{PendingTransition, TrackerIndex};

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -1,5 +1,7 @@
 //! The `ResourceMetadata` type.
 
+use crate::alias::*;
+
 use bit_vec::BitVec;
 use wgt::strict_assert;
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -102,6 +102,7 @@ mod stateless;
 mod texture;
 
 use crate::{
+    alias::*,
     binding_model, command,
     lock::{rank, Mutex},
     pipeline,

--- a/wgpu-core/src/track/range.rs
+++ b/wgpu-core/src/track/range.rs
@@ -2,6 +2,8 @@
 //TODO: consider getting rid of it.
 use smallvec::SmallVec;
 
+use crate::alias::*;
+
 use std::{fmt::Debug, iter, ops::Range};
 
 /// Structure that keeps track of a I -> T mapping,

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -1,3 +1,5 @@
+use crate::alias::*;
+
 use std::slice::Iter;
 use std::sync::Arc;
 

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -20,6 +20,7 @@
 
 use super::{range::RangedStates, PendingTransition, PendingTransitionList};
 use crate::{
+    alias::*,
     resource::{Texture, TextureInner, TextureView, Trackable},
     snatch::SnatchGuard,
     track::{

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1,6 +1,7 @@
 use crate::{device::bgl, resource::InvalidResourceError, FastHashMap, FastHashSet};
 use arrayvec::ArrayVec;
-use std::{collections::hash_map::Entry, fmt};
+use hashbrown::hash_map::Entry;
+use std::fmt;
 use thiserror::Error;
 use wgt::{BindGroupLayoutEntry, BindingType};
 

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1,4 +1,4 @@
-use crate::{device::bgl, resource::InvalidResourceError, FastHashMap, FastHashSet};
+use crate::{alias::*, device::bgl, resource::InvalidResourceError, FastHashMap, FastHashSet};
 use arrayvec::ArrayVec;
 use hashbrown::hash_map::Entry;
 use std::fmt;

--- a/wgpu-core/src/weak_vec.rs
+++ b/wgpu-core/src/weak_vec.rs
@@ -47,6 +47,8 @@ impl<T> WeakVec<T> {
 }
 
 pub(crate) struct WeakVecIter<T> {
+    // XXX TODO CLEANUP WARNING(S) & REMOVE ALLOW(S)
+    #[allow(unused_qualifications)]
     inner: std::vec::IntoIter<Weak<T>>,
 }
 

--- a/wgpu-core/src/weak_vec.rs
+++ b/wgpu-core/src/weak_vec.rs
@@ -1,5 +1,7 @@
 //! Module containing the [`WeakVec`] API.
 
+use crate::alias::*;
+
 use std::sync::Weak;
 
 /// An optimized container for `Weak` references of `T` that minimizes reallocations by


### PR DESCRIPTION
__STATUS:__ INITIAL DRAFT with blocking TODO items multiple XXX todo items; documentation TODO; ~~CI failures are expected at this point~~

__MAJOR BLOCKING ITEMS:__

- [ ] I would highly recommend resolving no-std support in dependencies first: `naga`, `wgpu-hal`
- [x] ~~review & hopefully merge preparation PRs listed below~~

---

**Connections**

- main issue: #6826
- recently merged PR for `wgpu-types`: #6892
- based on multiple preparation PRs:
  - #6924
  - #6925 (partial) - only includes updates proposed for `wgpu-core` at this point

---

**Description**

no-std support in `wgpu-core` (per title), with help from new "std" feature

NOTE that this is based on recent preparation PRs listed above, hopefully they will be reviewed & merged soon. I would like to rebase this once the preparation PRs are hopefully approved & merged.

/cc @bushrat011899 - many thanks for your recent contributions

---

**Testing**

- ~~`cargo build --no-default-features -p wgpu-core`~~ - XXX TODO KNOWN BUILD FAILURE NOT DETECTED BY CI TESTING (NEED TO FIX THIS)
- `cargo build --all-features -p wgpu-core`
- `cargo build --all-features -p wgpu`
- ~~`cargo test --no-default-features -p wgpu-core`~~ - XXX TODO KNOWN FAILURE NOT DETECTED BY CI TESTING (NEED TO FIX THIS) 
- `cargo test --all-features -p wgpu-core`
- `cargo test --all-features -p wgpu`
- `cargo xtask test` (I had to set CXXFLAGS in my environment on macOS, looks like a known issue with bindgen - XXX I would like to investigate & resolve this)

---

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
- [x] ~~check for & resolve any CI failures (if possible)~~
- [ ] update any other documentation (feature documentation from Cargo.toml, for example)
- [ ] Resolve or defer all XXX todo items in these changes
