### PR TITLE
[d3d12] bound check dynamic buffers

### DIFF
--- a/naga/src/back/hlsl/help.rs
+++ b/naga/src/back/hlsl/help.rs
@@ -1248,6 +1248,8 @@ impl<W: Write> super::Writer<'_, W> {
                 space: u8::MAX,
                 register: key.group,
                 binding_array_size: None,
+                dynamic_storage_buffer_offsets_index: None,
+                restrict_indexing: false,
             },
             None => {
                 unreachable!("Sampler buffer of group {key:?} not bound to a register");

--- a/naga/src/back/hlsl/keywords.rs
+++ b/naga/src/back/hlsl/keywords.rs
@@ -907,3 +907,5 @@ pub const TYPES: &[&str] = &{
 
     res
 };
+
+pub const RESERVED_PREFIXES: &[&str] = &["__dynamic_buffer_offsets"];

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -131,7 +131,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
             super::keywords::RESERVED,
             super::keywords::TYPES,
             super::keywords::RESERVED_CASE_INSENSITIVE,
-            &[],
+            super::keywords::RESERVED_PREFIXES,
             &mut self.names,
         );
         self.entry_point_io.clear();
@@ -251,6 +251,22 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 write!(self.out, ", space{}", bt.space)?;
             }
             writeln!(self.out, ");")?;
+
+            // Extra newline for readability
+            writeln!(self.out)?;
+        }
+
+        for (group, bt) in self.options.dynamic_storage_buffer_offsets_targets.iter() {
+            writeln!(self.out, "struct __dynamic_buffer_offsetsTy{} {{", group)?;
+            for i in 0..bt.size {
+                writeln!(self.out, "{}uint _{};", back::INDENT, i)?;
+            }
+            writeln!(self.out, "}};")?;
+            writeln!(
+                self.out,
+                "ConstantBuffer<__dynamic_buffer_offsetsTy{}> __dynamic_buffer_offsets{}: register(b{}, space{});",
+                group, group, bt.register, bt.space
+            )?;
 
             // Extra newline for readability
             writeln!(self.out)?;
@@ -2777,7 +2793,20 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                                 | crate::AddressSpace::PushConstant,
                             )
                             | None => true,
-                            Some(crate::AddressSpace::Uniform) => false, // TODO: needs checks for dynamic uniform buffers, see https://github.com/gfx-rs/wgpu/issues/4483
+                            Some(crate::AddressSpace::Uniform) => {
+                                // check if BindTarget.restrict_indexing is set, this is used for dynamic buffers
+                                let var_handle = self.fill_access_chain(module, base, func_ctx)?;
+                                let bind_target = self
+                                    .options
+                                    .resolve_resource_binding(
+                                        module.global_variables[var_handle]
+                                            .binding
+                                            .as_ref()
+                                            .unwrap(),
+                                    )
+                                    .unwrap();
+                                bind_target.restrict_indexing
+                            }
                             Some(
                                 crate::AddressSpace::Handle | crate::AddressSpace::Storage { .. },
                             ) => unreachable!(),

--- a/naga/tests/in/bounds-check-dynamic-buffer.param.ron
+++ b/naga/tests/in/bounds-check-dynamic-buffer.param.ron
@@ -1,0 +1,17 @@
+(
+    hlsl: (
+        binding_map: {
+            (group: 0, binding: 0): (space: 0, register: 0),
+            (group: 0, binding: 1): (space: 0, register: 1),
+            (group: 0, binding: 2): (space: 0, register: 0, restrict_indexing: true),
+            (group: 0, binding: 3): (space: 0, register: 2, dynamic_storage_buffer_offsets_index: Some(0)),
+            (group: 0, binding: 4): (space: 0, register: 3, dynamic_storage_buffer_offsets_index: Some(1)),
+            (group: 1, binding: 0): (space: 0, register: 4, dynamic_storage_buffer_offsets_index: Some(0)),
+        },
+        dynamic_storage_buffer_offsets_targets: {
+            0: (space: 0, register: 1, size: 2),
+            1: (space: 0, register: 2, size: 1),
+        },
+        restrict_indexing: true
+    ),
+)

--- a/naga/tests/in/bounds-check-dynamic-buffer.wgsl
+++ b/naga/tests/in/bounds-check-dynamic-buffer.wgsl
@@ -1,0 +1,30 @@
+@group(0) @binding(0)
+var<storage, read_write> in: u32;
+@group(0) @binding(1)
+var<storage, read_write> out: array<u32>;
+
+struct T {
+    @size(16)
+    t: u32
+}
+
+@group(0) @binding(2)
+var<uniform> in_data_uniform: array<T, 1>;
+
+@group(0) @binding(3)
+var<storage, read_write> in_data_storage_g0_b3: array<T, 1>;
+
+@group(0) @binding(4)
+var<storage, read_write> in_data_storage_g0_b4: array<T, 1>;
+
+@group(1) @binding(0)
+var<storage, read_write> in_data_storage_g1_b0: array<T, 1>;
+
+@compute @workgroup_size(1)
+fn main() {
+    let i = in;
+    out[0] = in_data_uniform[i].t;
+    out[1] = in_data_storage_g0_b3[i].t;
+    out[2] = in_data_storage_g0_b4[i].t;
+    out[3] = in_data_storage_g1_b0[i].t;
+}

--- a/naga/tests/out/hlsl/bounds-check-dynamic-buffer.hlsl
+++ b/naga/tests/out/hlsl/bounds-check-dynamic-buffer.hlsl
@@ -1,0 +1,39 @@
+struct __dynamic_buffer_offsetsTy0 {
+    uint _0;
+    uint _1;
+};
+ConstantBuffer<__dynamic_buffer_offsetsTy0> __dynamic_buffer_offsets0: register(b1, space0);
+
+struct __dynamic_buffer_offsetsTy1 {
+    uint _0;
+};
+ConstantBuffer<__dynamic_buffer_offsetsTy1> __dynamic_buffer_offsets1: register(b2, space0);
+
+struct T {
+    uint t;
+    int _end_pad_0;
+    int _end_pad_1;
+    int _end_pad_2;
+};
+
+RWByteAddressBuffer in_ : register(u0);
+RWByteAddressBuffer out_ : register(u1);
+cbuffer in_data_uniform : register(b0) { T in_data_uniform[1]; }
+RWByteAddressBuffer in_data_storage_g0_b3_ : register(u2);
+RWByteAddressBuffer in_data_storage_g0_b4_ : register(u3);
+RWByteAddressBuffer in_data_storage_g1_b0_ : register(u4);
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    uint i = asuint(in_.Load(0));
+    uint _e7 = in_data_uniform[min(uint(i), 0u)].t;
+    out_.Store(0, asuint(_e7));
+    uint _e13 = asuint(in_data_storage_g0_b3_.Load(0+i*16+__dynamic_buffer_offsets0._0));
+    out_.Store(4, asuint(_e13));
+    uint _e19 = asuint(in_data_storage_g0_b4_.Load(0+i*16+__dynamic_buffer_offsets0._1));
+    out_.Store(8, asuint(_e19));
+    uint _e25 = asuint(in_data_storage_g1_b0_.Load(0+i*16+__dynamic_buffer_offsets1._0));
+    out_.Store(12, asuint(_e25));
+    return;
+}

--- a/naga/tests/out/hlsl/bounds-check-dynamic-buffer.ron
+++ b/naga/tests/out/hlsl/bounds-check-dynamic-buffer.ron
@@ -1,0 +1,12 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"main",
+            target_profile:"cs_5_1",
+        ),
+    ],
+)

--- a/naga/tests/snapshots.rs
+++ b/naga/tests/snapshots.rs
@@ -239,8 +239,13 @@ impl Input {
         let mut param_path = self.input_path();
         param_path.set_extension("param.ron");
         match fs::read_to_string(&param_path) {
-            Ok(string) => ron::de::from_str(&string)
-                .unwrap_or_else(|_| panic!("Couldn't parse param file: {}", param_path.display())),
+            Ok(string) => match ron::de::from_str(&string) {
+                Ok(params) => params,
+                Err(e) => panic!(
+                    "Couldn't parse param file: {} due to: {e}",
+                    param_path.display()
+                ),
+            },
             Err(_) => Parameters::default(),
         }
     }
@@ -834,6 +839,7 @@ fn convert_wgsl() {
             Targets::SPIRV | Targets::METAL | Targets::GLSL,
         ),
         ("policy-mix", Targets::SPIRV | Targets::METAL),
+        ("bounds-check-dynamic-buffer", Targets::HLSL),
         (
             "texture-arg",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,

--- a/tests/tests/oob_indexing.rs
+++ b/tests/tests/oob_indexing.rs
@@ -230,3 +230,229 @@ impl TestResources {
         }
     }
 }
+
+/// Tests behavior of OOB accesses for dynamic buffers.
+///
+/// This test is specific to D3D12 since Vulkan and Metal behave differently and
+/// the WGSL spec allows for multiple behaviors when it comes to OOB accesses.
+#[gpu_test]
+static D3D12_RESTRICT_DYNAMIC_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
+            .limits(wgpu::Limits::downlevel_defaults())
+            .skip(FailureCase::backend(Backends::all() - Backends::DX12)),
+    )
+    .run_async(d3d12_restrict_dynamic_buffers);
+
+async fn d3d12_restrict_dynamic_buffers(ctx: TestingContext) {
+    let shader_src = "
+        @group(0) @binding(0)
+        var<storage, read_write> in: u32;
+        @group(0) @binding(1)
+        var<storage, read_write> out: array<u32>;
+
+        struct T {
+            @size(16)
+            t: u32
+        }
+
+        @group(0) @binding(2)
+        var<uniform> in_data_uniform: array<T, 1>;
+
+        @group(0) @binding(3)
+        var<storage, read_write> in_data_storage: array<T, 1>;
+
+        @compute @workgroup_size(1)
+        fn main() {
+            let i = in;
+            out[0] = in_data_uniform[i].t;   // should be 1 since we clamp the index
+
+            out[1] = in_data_storage[i].t;   // should be 3 since we rely on the D3D12 runtime to bound check and
+                                                // the index is still in the bounds of the buffer
+
+            out[2] = in_data_storage[i+1].t; // should be 0 since we rely on the D3D12 runtime to bound check
+        }
+    ";
+
+    let module = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(shader_src.into()),
+        });
+
+    let bgl = ctx
+        .device
+        .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: None,
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgt::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgt::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgt::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgt::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: true,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+    let layout = ctx
+        .device
+        .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[&bgl],
+            push_constant_ranges: &[],
+        });
+
+    let pipeline = ctx
+        .device
+        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: Some(&layout),
+            module: &module,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+    let in_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 4,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let out_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 3 * 4,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let in_data_uniform_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 256 + 8 * 4,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let in_data_storage_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 256 + 8 * 4,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let readback_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 3 * 4,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: None,
+        layout: &bgl,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: in_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: out_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &in_data_uniform_buffer,
+                    offset: 0,
+                    size: Some(std::num::NonZeroU64::new(4 * 4).unwrap()),
+                }),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &in_data_storage_buffer,
+                    offset: 0,
+                    size: Some(std::num::NonZeroU64::new(4 * 4).unwrap()),
+                }),
+            },
+        ],
+    });
+
+    ctx.queue
+        .write_buffer(&in_buffer, 0, bytemuck::bytes_of(&1_u32));
+
+    #[rustfmt::skip]
+        let in_data = [
+            1_u32, 2_u32, 2_u32, 2_u32,
+            3_u32, 4_u32, 4_u32, 4_u32,
+        ];
+
+    ctx.queue
+        .write_buffer(&in_data_uniform_buffer, 256, bytemuck::bytes_of(&in_data));
+    ctx.queue
+        .write_buffer(&in_data_storage_buffer, 256, bytemuck::bytes_of(&in_data));
+
+    let mut encoder = ctx.device.create_command_encoder(&Default::default());
+    {
+        let mut compute_pass = encoder.begin_compute_pass(&Default::default());
+        compute_pass.set_pipeline(&pipeline);
+        compute_pass.set_bind_group(0, &bind_group, &[256, 256]);
+        compute_pass.dispatch_workgroups(1, 1, 1);
+    }
+
+    encoder.copy_buffer_to_buffer(&out_buffer, 0, &readback_buffer, 0, 3 * 4);
+
+    ctx.queue.submit(Some(encoder.finish()));
+
+    readback_buffer
+        .slice(..)
+        .map_async(wgpu::MapMode::Read, |_| {});
+
+    ctx.async_poll(wgpu::Maintain::wait())
+        .await
+        .panic_on_timeout();
+
+    let view = readback_buffer.slice(..).get_mapped_range();
+
+    let current_res: [u32; 3] = *bytemuck::from_bytes(&view);
+    drop(view);
+    readback_buffer.unmap();
+
+    assert_eq!([1, 3, 0], current_res);
+}

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -538,8 +538,10 @@ impl super::Adapter {
                     //   for the descriptor table
                     // - If a bind group has samplers it will consume a `DWORD`
                     //   for the descriptor table
-                    // - Each dynamic buffer will consume `2 DWORDs` for the
+                    // - Each dynamic uniform buffer will consume `2 DWORDs` for the
                     //   root descriptor
+                    // - Each dynamic storage buffer will consume `1 DWORD` for a
+                    //   root constant representing the dynamic offset
                     // - The special constants buffer count as constants
                     //
                     // Since we can't know beforehand all root signatures that


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/4483.

**Description**
To achieve this for dynamic storage buffers we changed the way we bind them. They now go in root tables and we pass the offset via a root constant.

**Testing**
Existing tests pass and I added a new test.
