### PR TITLE
Implement `Clone` for `ShaderModule`

### DIFF
--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -10,7 +10,7 @@ use crate::*;
 /// of a pipeline.
 ///
 /// Corresponds to [WebGPU `GPUShaderModule`](https://gpuweb.github.io/gpuweb/#shader-module).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ShaderModule {
     pub(crate) inner: dispatch::DispatchShaderModule,
 }


### PR DESCRIPTION
**Connections**
I think that it was forgotten by #6665.

It could be useful to backport it to v24 branch?

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
