### PR TITLE
use `hashbrown` in more crates (etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,19 +50,15 @@ Bottom level categories:
 
 #### General
 
+- Use `hashbrown` to simplify no-std support. By Brody in [#6938](https://github.com/gfx-rs/wgpu/pull/6938) & [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 - If you use Binding Arrays in a bind group, you may not use Dynamic Offset Buffers or Uniform Buffers in that bind group. By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811)
+
 
 ##### Refactored internal trace path parameter
 
 Refactored some functions to handle the internal trace path as a string to avoid possible issues with `no_std` support.
 
 By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
-
-##### Start using `hashbrown`
-
-Use `hashbrown` in `wgpu-core`, `wgpu-hal` & `wgpu-info` to simplify no-std support. (This may help improve performance as well.)
-
-By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 
 #### Vulkan
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,7 @@ name = "deno_webgpu"
 version = "0.146.0"
 dependencies = [
  "deno_core",
+ "hashbrown",
  "raw-window-handle 0.6.2",
  "serde",
  "thiserror 2.0.11",
@@ -2248,6 +2249,7 @@ dependencies = [
  "codespan-reporting",
  "diff",
  "env_logger",
+ "hashbrown",
  "hexf-parse",
  "hlsl-snapshots",
  "indexmap",
@@ -4392,6 +4394,7 @@ dependencies = [
  "bitflags 2.8.0",
  "cfg_aliases 0.2.1",
  "document-features",
+ "hashbrown",
  "js-sys",
  "log",
  "naga",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ default-members = [
 [workspace.lints.clippy]
 manual_c_str_literals = "allow"
 ref_as_ptr = "warn"
+# NOTE: disallowed-types is configured in other file: clippy.toml
 
 [workspace.package]
 edition = "2021"
@@ -126,9 +127,11 @@ raw-window-handle = "0.6"
 rayon = "1"
 renderdoc-sys = "1.1.0"
 ron = "0.8"
-# rustc-hash 2.0 is a completely different hasher with different performance characteristics
+# NOTE: rustc-hash v2 is a completely different hasher with different performance characteristics
+# see discussion here (including with some other alternatives): https://github.com/gfx-rs/wgpu/issues/6999
+# (using default-features = false to support no-std build, avoiding any extra features that may require std::collections)
+rustc-hash = { version = "1", default-features = false }
 serde_json = "1.0.137"
-rustc-hash = "1"
 serde = { version = "1", default-features = false }
 smallvec = "1"
 static_assertions = "1.1.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,8 @@
+# NOTE: Other global Clippy config is in top-level Cargo.toml.
+
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "use hashbrown::HashMap instead" },
+    { path = "std::collections::HashSet", reason = "use hashbrown::HashSet instead" },
+    { path = "rustc_hash::FxHashMap", reason = "use hashbrown::HashMap instead" },
+    { path = "rustc_hash::FxHashSet", reason = "use hashbrown::HashSet instead" },
+]

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -28,6 +28,7 @@ wgpu-core = { workspace = true, features = [
 wgpu-types = { workspace = true, features = ["serde"] }
 
 deno_core.workspace = true
+hashbrown = { workspace = true, features = ["serde"] }
 raw-window-handle = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -6,11 +6,11 @@ use deno_core::op2;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
+use hashbrown::HashSet;
 use serde::Deserialize;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::collections::HashSet;
 use std::rc::Rc;
 
 use error::WebGpuResult;

--- a/deno_webgpu/pipeline.rs
+++ b/deno_webgpu/pipeline.rs
@@ -5,10 +5,10 @@ use deno_core::op2;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
+use hashbrown::HashMap;
 use serde::Deserialize;
 use serde::Serialize;
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use super::error::WebGpuError;

--- a/examples/features/Cargo.toml
+++ b/examples/features/Cargo.toml
@@ -74,3 +74,6 @@ web-sys = { workspace = true, features = [
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test.workspace = true
+
+[lints.clippy]
+disallowed_types = "allow"

--- a/lock-analyzer/Cargo.toml
+++ b/lock-analyzer/Cargo.toml
@@ -17,3 +17,6 @@ anyhow.workspace = true
 [dependencies.serde]
 workspace = true
 features = ["default", "serde_derive"]
+
+[lints.clippy]
+disallowed_types = "allow"

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -41,8 +41,13 @@ msl-out = []
 ## If you want to enable MSL output it regardless of the target platform, use `naga/msl-out`.
 msl-out-if-target-apple = []
 
-serialize = ["dep:serde", "bitflags/serde", "indexmap/serde"]
-deserialize = ["dep:serde", "bitflags/serde", "indexmap/serde"]
+serialize = ["dep:serde", "bitflags/serde", "hashbrown/serde", "indexmap/serde"]
+deserialize = [
+    "dep:serde",
+    "bitflags/serde",
+    "hashbrown/serde",
+    "indexmap/serde",
+]
 arbitrary = ["dep:arbitrary", "bitflags/arbitrary", "indexmap/arbitrary"]
 spv-in = ["dep:petgraph", "dep:spirv"]
 spv-out = ["dep:spirv"]
@@ -72,6 +77,7 @@ termcolor = { version = "1.4.1" }
 # termcolor minimum version was wrong and was fixed in
 # https://github.com/brendanzab/codespan/commit/e99c867339a877731437e7ee6a903a3d03b5439e
 codespan-reporting = { version = "0.11.0" }
+hashbrown.workspace = true
 rustc-hash.workspace = true
 indexmap.workspace = true
 log = "0.4"

--- a/naga/fuzz/Cargo.toml
+++ b/naga/fuzz/Cargo.toml
@@ -50,3 +50,6 @@ path = "fuzz_targets/ir.rs"
 bench = false
 test = false
 doc = false
+
+[lints.clippy]
+disallowed_types = "allow"

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -51,6 +51,7 @@ use crate::{
     valid, Handle, ShaderStage, TypeInner,
 };
 use features::FeaturesManager;
+use hashbrown::hash_map;
 use std::{
     cmp::Ordering,
     fmt::{self, Error as FmtError, Write},
@@ -4608,7 +4609,6 @@ impl<'a, W: Write> Writer<'a, W> {
 
     /// Helper method used to produce the reflection info that's returned to the user
     fn collect_reflection_info(&mut self) -> Result<ReflectionInfo, Error> {
-        use std::collections::hash_map::Entry;
         let info = self.info.get_entry_point(self.entry_point_idx as usize);
         let mut texture_mapping = crate::FastHashMap::default();
         let mut uniforms = crate::FastHashMap::default();
@@ -4617,13 +4617,13 @@ impl<'a, W: Write> Writer<'a, W> {
             let tex_name = self.reflection_names_globals[&sampling.image].clone();
 
             match texture_mapping.entry(tex_name) {
-                Entry::Vacant(v) => {
+                hash_map::Entry::Vacant(v) => {
                     v.insert(TextureMapping {
                         texture: sampling.image,
                         sampler: Some(sampling.sampler),
                     });
                 }
-                Entry::Occupied(e) => {
+                hash_map::Entry::Occupied(e) => {
                     if e.get().sampler != Some(sampling.sampler) {
                         log::error!("Conflicting samplers for {}", e.key());
                         return Err(Error::ImageMultipleSamplers);
@@ -4641,13 +4641,13 @@ impl<'a, W: Write> Writer<'a, W> {
                 TypeInner::Image { .. } => {
                     let tex_name = self.reflection_names_globals[&handle].clone();
                     match texture_mapping.entry(tex_name) {
-                        Entry::Vacant(v) => {
+                        hash_map::Entry::Vacant(v) => {
                             v.insert(TextureMapping {
                                 texture: handle,
                                 sampler: None,
                             });
                         }
-                        Entry::Occupied(_) => {
+                        hash_map::Entry::Occupied(_) => {
                             // already used with a sampler, do nothing
                         }
                     }

--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -55,7 +55,7 @@ impl std::fmt::Display for Baked {
 /// the key must be the constant's identifier name.
 ///
 /// The value may represent any of WGSL's concrete scalar types.
-pub type PipelineConstants = std::collections::HashMap<String, f64>;
+pub type PipelineConstants = hashbrown::HashMap<String, f64>;
 
 /// Indentation level.
 #[derive(Clone, Copy)]

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -6,7 +6,8 @@ use crate::{
     Arena, Block, Constant, Expression, Function, Handle, Literal, Module, Override, Range, Scalar,
     Span, Statement, TypeInner, WithSpan,
 };
-use std::{borrow::Cow, collections::HashSet, mem};
+use hashbrown::HashSet;
+use std::{borrow::Cow, mem};
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone)]

--- a/naga/src/back/spv/recyclable.rs
+++ b/naga/src/back/spv/recyclable.rs
@@ -38,14 +38,14 @@ impl<T> Recyclable for Vec<T> {
     }
 }
 
-impl<K, V, S: Clone> Recyclable for std::collections::HashMap<K, V, S> {
+impl<K, V, S: Clone> Recyclable for hashbrown::HashMap<K, V, S> {
     fn recycle(mut self) -> Self {
         self.clear();
         self
     }
 }
 
-impl<K, S: Clone> Recyclable for std::collections::HashSet<K, S> {
+impl<K, S: Clone> Recyclable for hashbrown::HashSet<K, S> {
     fn recycle(mut self) -> Self {
         self.clear();
         self

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -12,8 +12,8 @@ use crate::{
     proc::{Alignment, TypeResolution},
     valid::{FunctionInfo, ModuleInfo},
 };
+use hashbrown::hash_map::Entry;
 use spirv::Word;
-use std::collections::hash_map::Entry;
 
 struct FunctionInterface<'a> {
     varying_ids: &'a mut Vec<Word>,
@@ -167,7 +167,11 @@ impl Writer {
                 let selected = match self.capabilities_available {
                     None => first,
                     Some(ref available) => {
-                        match capabilities.iter().find(|cap| available.contains(cap)) {
+                        match capabilities
+                            .iter()
+                            // need explicit type for hashbrown::HashSet::contains fn call to keep rustc happy
+                            .find(|cap| available.contains::<spirv::Capability>(cap))
+                        {
                             Some(&cap) => cap,
                             None => {
                                 return Err(Error::MissingCapabilities(what, capabilities.to_vec()))

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -283,9 +283,15 @@ pub const BOOL_WIDTH: Bytes = 1;
 pub const ABSTRACT_WIDTH: Bytes = 8;
 
 /// Hash map that is faster but not resilient to DoS attacks.
-pub type FastHashMap<K, T> = rustc_hash::FxHashMap<K, T>;
+/// (Similar to rustc_hash::FxHashMap but using hashbrown::HashMap instead of std::collections::HashMap.)
+/// To construct a new instance: `FastHashMap::default()`
+pub type FastHashMap<K, T> =
+    hashbrown::HashMap<K, T, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+
 /// Hash set that is faster but not resilient to DoS attacks.
-pub type FastHashSet<K> = rustc_hash::FxHashSet<K>;
+/// (Similar to rustc_hash::FxHashSet but using hashbrown::HashSet instead of std::collections::HashMap.)
+pub type FastHashSet<K> =
+    hashbrown::HashSet<K, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 /// Insertion-order-preserving hash set (`IndexSet<K>`), but with the same
 /// hasher as `FastHashSet<K>` (faster but not resilient to DoS attacks).
@@ -325,6 +331,7 @@ pub(crate) type NamedExpressions = FastIndexMap<Handle<Expression>, String>;
 pub struct EarlyDepthTest {
     pub conservative: Option<ConservativeDepth>,
 }
+
 /// Enables adjusting depth without disabling early Z.
 ///
 /// To use in a shader:

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -70,3 +70,6 @@ wasm-bindgen-futures.workspace = true
 wasm-bindgen-test.workspace = true
 wasm-bindgen.workspace = true
 web-sys = { workspace = true, features = ["CanvasRenderingContext2d", "Blob"] }
+
+[lints.clippy]
+disallowed_types = "allow"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -60,7 +60,7 @@ strict_asserts = ["wgpu-types/strict_asserts"]
 indirect-validation = ["naga/wgsl-in"]
 
 ## Enables serialization via `serde` on common wgpu types.
-serde = ["dep:serde", "wgpu-types/serde", "arrayvec/serde"]
+serde = ["dep:serde", "wgpu-types/serde", "arrayvec/serde", "hashbrown/serde"]
 
 ## Enable API tracing.
 trace = ["dep:ron", "serde", "naga/serialize"]

--- a/wgpu-hal/src/dx12/sampler.rs
+++ b/wgpu-hal/src/dx12/sampler.rs
@@ -2,7 +2,7 @@
 //!
 //! Nearly identical to the Vulkan sampler cache, with added descriptor heap management.
 
-use std::collections::{hash_map::Entry, HashMap};
+use hashbrown::{hash_map::Entry, HashMap};
 
 use ordered_float::OrderedFloat;
 use parking_lot::Mutex;

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1,6 +1,7 @@
 use super::{conv, PrivateCapabilities};
 use crate::auxil::map_naga_stage;
 use glow::HasContext;
+use naga::FastHashMap;
 use std::{
     cmp::max,
     convert::TryInto,
@@ -16,7 +17,7 @@ type ShaderStage<'a> = (
     naga::ShaderStage,
     &'a crate::ProgrammableStage<'a, super::ShaderModule>,
 );
-type NameBindingMap = rustc_hash::FxHashMap<String, (super::BindingRegister, u8)>;
+type NameBindingMap = FastHashMap<String, (super::BindingRegister, u8)>;
 
 struct CompilationContext<'a> {
     layout: &'a super::PipelineLayout,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -36,6 +36,7 @@ use arrayvec::ArrayVec;
 use bitflags::bitflags;
 use hashbrown::HashMap;
 use metal::foreign_types::ForeignTypeRef as _;
+use naga::FastHashMap;
 use parking_lot::{Mutex, RwLock};
 
 #[derive(Clone, Debug)]
@@ -937,9 +938,9 @@ struct CommandState {
     /// See `device::CompiledShader::sized_bindings` for more details.
     ///
     /// [`ResourceBinding`]: naga::ResourceBinding
-    storage_buffer_length_map: rustc_hash::FxHashMap<naga::ResourceBinding, wgt::BufferSize>,
+    storage_buffer_length_map: FastHashMap<naga::ResourceBinding, wgt::BufferSize>,
 
-    vertex_buffer_size_map: rustc_hash::FxHashMap<u64, wgt::BufferSize>,
+    vertex_buffer_size_map: FastHashMap<u64, wgt::BufferSize>,
 
     work_group_memory_sizes: Vec<u32>,
     push_constants: Vec<u32>,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -42,16 +42,14 @@ use std::{
 
 use arrayvec::ArrayVec;
 use ash::{ext, khr, vk};
-use hashbrown::{HashMap, HashSet};
+use hashbrown::HashSet;
 use parking_lot::{Mutex, RwLock};
-use rustc_hash::FxHasher;
+
+use naga::FastHashMap;
 use wgt::InternalCounter;
 
 const MILLIS_TO_NANOS: u64 = 1_000_000;
 const MAX_TOTAL_ATTACHMENTS: usize = crate::MAX_COLOR_ATTACHMENTS * 2 + 1;
-
-// NOTE: This type alias is similar to rustc_hash::FxHashMap but works with hashbrown.
-type FxHashMap<T, U> = HashMap<T, U, core::hash::BuildHasherDefault<FxHasher>>;
 
 #[derive(Clone, Debug)]
 pub struct Api;
@@ -646,8 +644,8 @@ struct DeviceShared {
     private_caps: PrivateCapabilities,
     workarounds: Workarounds,
     features: wgt::Features,
-    render_passes: Mutex<FxHashMap<RenderPassKey, vk::RenderPass>>,
-    framebuffers: Mutex<FxHashMap<FramebufferKey, vk::Framebuffer>>,
+    render_passes: Mutex<FastHashMap<RenderPassKey, vk::RenderPass>>,
+    framebuffers: Mutex<FastHashMap<FramebufferKey, vk::Framebuffer>>,
     sampler_cache: Mutex<sampler::SamplerCache>,
     memory_allocations_counter: InternalCounter,
 }

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -18,3 +18,6 @@ pico-args.workspace = true
 serde = { workspace = true, features = ["default"] }
 serde_json.workspace = true
 wgpu.workspace = true
+
+[lints.clippy]
+disallowed_types = "allow"

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -140,6 +140,7 @@ wgpu-types = { workspace = true, features = ["serde"] }
 arrayvec.workspace = true
 bitflags.workspace = true
 document-features.workspace = true
+hashbrown.workspace = true
 log.workspace = true
 parking_lot.workspace = true
 profiling.workspace = true

--- a/wgpu/src/api/common_pipeline.rs
+++ b/wgpu/src/api/common_pipeline.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 use crate::*;
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -5,10 +5,10 @@ mod ext_bindings;
 #[allow(clippy::allow_attributes)]
 mod webgpu_sys;
 
+use hashbrown::HashMap;
 use js_sys::Promise;
 use std::{
     cell::RefCell,
-    collections::HashMap,
     fmt,
     future::Future,
     ops::Range,


### PR DESCRIPTION
**Connections**

- helpful for no-std support as requested in issue: #6826
- continuation of `hashbrown` updates introduced in PR: #6925

**Description**

- use `hashbrown` in `naga` & top-level `wgpu` crates
- completely replace indirect usage of `std::collections::HashMap` via `rustc_hash::FxHashMap` in `wgpu-hal`
- use `hashbrown` in main `wgpu` crate
- use `hashbrown` in `deno_webgpu`
- use `hashbrown` with default-features = false, as needed to support no-std build
- other minor updates

**POSSIBLE API IMPACT**

Exported `naga` API with these updates would be exporting types & members using HashMap & HashSet from hashbrown rather than std::collections. I think this is a crucial part of supporting no-std. I don't expect the blast radius to be very high, just wanted to point this out to avoid potential surprises for anyone.

/cc @bushrat011899

**Testing**

- `cargo test --all-features -p naga`
- `cargo test --all-features -p wgpu-core`
- `cargo test --all-features -p wgpu-hal`
- `cargo test --all-features -p wgpu`
- `cargo xtask test`

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - ~~`--target wasm32-unknown-emscripten`~~
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
- [x] Resolve or defer XXX todo items in these updates