### PR TITLE
Allow Short Circuting GL Fences

### DIFF
--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -395,9 +395,7 @@ pub fn op_webgpu_request_adapter(
                     dx12: wgpu_types::Dx12BackendOptions {
                         shader_compiler: wgpu_types::Dx12Compiler::Fxc,
                     },
-                    gl: wgpu_types::GlBackendOptions {
-                        gles_minor_version: wgpu_types::Gles3MinorVersion::default(),
-                    },
+                    gl: wgpu_types::GlBackendOptions::default(),
                 },
             },
         )));

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -36,7 +36,6 @@ pub fn initialize_instance(backends: wgpu::Backends, force_fxc: bool) -> Instanc
     } else {
         wgpu::Dx12Compiler::from_env().unwrap_or(wgpu::Dx12Compiler::StaticDxc)
     };
-    let gles_minor_version = wgpu::Gles3MinorVersion::from_env().unwrap_or_default();
     Instance::new(&wgpu::InstanceDescriptor {
         backends,
         flags: wgpu::InstanceFlags::debugging().with_env(),
@@ -44,7 +43,7 @@ pub fn initialize_instance(backends: wgpu::Backends, force_fxc: bool) -> Instanc
             dx12: wgpu::Dx12BackendOptions {
                 shader_compiler: dx12_shader_compiler,
             },
-            gl: wgpu::GlBackendOptions { gles_minor_version },
+            gl: wgpu::GlBackendOptions::from_env_or_default(),
         },
     })
 }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -75,12 +75,7 @@ impl Instance {
                 let hal_desc = hal::InstanceDescriptor {
                     name: "wgpu",
                     flags: instance_desc.flags,
-                    dx12_shader_compiler: instance_desc
-                        .backend_options
-                        .dx12
-                        .shader_compiler
-                        .clone(),
-                    gles_minor_version: instance_desc.backend_options.gl.gles_minor_version,
+                    backend_options: instance_desc.backend_options.clone(),
                 };
 
                 use hal::Instance as _;

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -97,8 +97,7 @@ impl<A: hal::Api> Example<A> {
             name: "example",
             flags: wgt::InstanceFlags::from_build_config().with_env(),
             // Can't rely on having DXC available, so use FXC instead
-            dx12_shader_compiler: wgt::Dx12Compiler::Fxc,
-            gles_minor_version: wgt::Gles3MinorVersion::default(),
+            backend_options: wgt::BackendOptions::default(),
         };
         let instance = unsafe { A::Instance::init(&instance_desc)? };
         let surface = {

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -138,12 +138,15 @@ fn main() {
                     println!("Hooking up to wgpu-hal");
                     exposed.get_or_insert_with(|| {
                         unsafe {
-                            <hal::api::Gles as hal::Api>::Adapter::new_external(|name| {
-                                // XXX: On WGL this should only be called after the context was made current
-                                gl_config
-                                    .display()
-                                    .get_proc_address(&CString::new(name).expect(name))
-                            })
+                            <hal::api::Gles as hal::Api>::Adapter::new_external(
+                                |name| {
+                                    // XXX: On WGL this should only be called after the context was made current
+                                    gl_config
+                                        .display()
+                                        .get_proc_address(&CString::new(name).expect(name))
+                                },
+                                wgt::GlBackendOptions::default(),
+                            )
                         }
                         .expect("GL adapter can't be initialized")
                     });

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -13,6 +13,7 @@ use std::{
     ptr,
     time::Instant,
 };
+use wgt::Dx12BackendOptions;
 use winit::window::WindowButtons;
 
 const DESIRED_MAX_LATENCY: u32 = 2;
@@ -239,7 +240,12 @@ impl<A: hal::Api> Example<A> {
         let instance_desc = hal::InstanceDescriptor {
             name: "example",
             flags: wgt::InstanceFlags::default(),
-            backend_options: wgt::BackendOptions::default(),
+            backend_options: wgt::BackendOptions {
+                dx12: Dx12BackendOptions {
+                    shader_compiler: wgt::Dx12Compiler::default_dynamic_dxc(),
+                },
+                ..Default::default()
+            },
         };
         let instance = unsafe { A::Instance::init(&instance_desc)? };
         let surface = {

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -239,11 +239,7 @@ impl<A: hal::Api> Example<A> {
         let instance_desc = hal::InstanceDescriptor {
             name: "example",
             flags: wgt::InstanceFlags::default(),
-            dx12_shader_compiler: wgt::Dx12Compiler::DynamicDxc {
-                dxc_path: "dxcompiler.dll".to_string(),
-                dxil_path: "dxil.dll".to_string(),
-            },
-            gles_minor_version: wgt::Gles3MinorVersion::default(),
+            backend_options: wgt::BackendOptions::default(),
         };
         let instance = unsafe { A::Instance::init(&instance_desc)? };
         let surface = {

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -67,7 +67,7 @@ impl crate::Instance for super::Instance {
         }
 
         // Initialize DXC shader compiler
-        let dxc_container = match desc.dx12_shader_compiler.clone() {
+        let dxc_container = match desc.backend_options.dx12.shader_compiler.clone() {
             wgt::Dx12Compiler::DynamicDxc {
                 dxil_path,
                 dxc_path,

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -192,6 +192,7 @@ impl super::Adapter {
 
     pub(super) unsafe fn expose(
         context: super::AdapterContext,
+        backend_options: wgt::GlBackendOptions,
     ) -> Option<crate::ExposedAdapter<super::Api>> {
         let gl = context.lock();
         let extensions = gl.supported_extensions();
@@ -824,6 +825,7 @@ impl super::Adapter {
                     private_caps,
                     workarounds,
                     features,
+                    options: backend_options,
                     shading_language_version,
                     next_shader_id: Default::default(),
                     program_cache: Default::default(),

--- a/wgpu-hal/src/gles/fence.rs
+++ b/wgpu-hal/src/gles/fence.rs
@@ -1,0 +1,167 @@
+use std::sync::atomic::Ordering;
+
+use glow::HasContext;
+
+use crate::AtomicFenceValue;
+
+#[derive(Debug, Copy, Clone)]
+struct GLFence {
+    sync: glow::Fence,
+    value: crate::FenceValue,
+}
+
+#[derive(Debug)]
+pub struct Fence {
+    last_completed: AtomicFenceValue,
+    pending: Vec<GLFence>,
+    fence_mode: wgt::GlFenceBehavior,
+}
+
+impl crate::DynFence for Fence {}
+
+#[cfg(send_sync)]
+unsafe impl Send for Fence {}
+#[cfg(send_sync)]
+unsafe impl Sync for Fence {}
+
+impl Fence {
+    pub fn new(options: &wgt::GlBackendOptions) -> Self {
+        Self {
+            last_completed: AtomicFenceValue::new(0),
+            pending: Vec::new(),
+            fence_mode: options.short_circuit_fences,
+        }
+    }
+
+    pub fn signal(
+        &mut self,
+        gl: &glow::Context,
+        value: crate::FenceValue,
+    ) -> Result<(), crate::DeviceError> {
+        if self.fence_mode.is_auto_finish() {
+            *self.last_completed.get_mut() = value;
+            return Ok(());
+        }
+
+        let sync = unsafe { gl.fence_sync(glow::SYNC_GPU_COMMANDS_COMPLETE, 0) }
+            .map_err(|_| crate::DeviceError::OutOfMemory)?;
+        self.pending.push(GLFence { sync, value });
+
+        Ok(())
+    }
+
+    pub fn satisfied(&self, value: crate::FenceValue) -> bool {
+        self.last_completed.load(Ordering::Relaxed) >= value
+    }
+
+    pub fn get_latest(&self, gl: &glow::Context) -> crate::FenceValue {
+        let mut max_value = self.last_completed.load(Ordering::Relaxed);
+
+        if self.fence_mode.is_auto_finish() {
+            return max_value;
+        }
+
+        for gl_fence in self.pending.iter() {
+            if gl_fence.value <= max_value {
+                // We already know this was good, no need to check again
+                continue;
+            }
+            let status = unsafe { gl.get_sync_status(gl_fence.sync) };
+            if status == glow::SIGNALED {
+                max_value = gl_fence.value;
+            } else {
+                // Anything after the first unsignalled is guaranteed to also be unsignalled
+                break;
+            }
+        }
+
+        // Track the latest value, to save ourselves some querying later
+        self.last_completed.fetch_max(max_value, Ordering::Relaxed);
+
+        max_value
+    }
+
+    pub fn maintain(&mut self, gl: &glow::Context) {
+        if self.fence_mode.is_auto_finish() {
+            return;
+        }
+
+        let latest = self.get_latest(gl);
+        for &gl_fence in self.pending.iter() {
+            if gl_fence.value <= latest {
+                unsafe {
+                    gl.delete_sync(gl_fence.sync);
+                }
+            }
+        }
+        self.pending.retain(|&gl_fence| gl_fence.value > latest);
+    }
+
+    pub fn wait(
+        &self,
+        gl: &glow::Context,
+        wait_value: crate::FenceValue,
+        timeout_ns: u64,
+    ) -> Result<bool, crate::DeviceError> {
+        let last_completed = self.last_completed.load(Ordering::Relaxed);
+
+        if self.fence_mode.is_auto_finish() {
+            return Ok(last_completed >= wait_value);
+        }
+
+        // We already know this fence has been signalled to that value. Return signalled.
+        if last_completed >= wait_value {
+            return Ok(true);
+        }
+
+        // Find a matching fence
+        let gl_fence = self
+            .pending
+            .iter()
+            // Greater or equal as an abundance of caution, but there should be one fence per value
+            .find(|gl_fence| gl_fence.value >= wait_value);
+
+        let Some(gl_fence) = gl_fence else {
+            log::warn!("Tried to wait for {wait_value} but that value has not been signalled yet");
+            return Ok(false);
+        };
+
+        // We should have found a fence with the exact value.
+        debug_assert_eq!(gl_fence.value, wait_value);
+
+        let status = unsafe {
+            gl.client_wait_sync(
+                gl_fence.sync,
+                glow::SYNC_FLUSH_COMMANDS_BIT,
+                timeout_ns as i32,
+            )
+        };
+
+        let signalled = match status {
+            glow::ALREADY_SIGNALED | glow::CONDITION_SATISFIED => true,
+            glow::TIMEOUT_EXPIRED | glow::WAIT_FAILED => false,
+            _ => {
+                log::warn!("Unexpected result from client_wait_sync: {status}");
+                false
+            }
+        };
+
+        if signalled {
+            self.last_completed.fetch_max(wait_value, Ordering::Relaxed);
+        }
+
+        Ok(signalled)
+    }
+
+    pub fn destroy(self, gl: &glow::Context) {
+        if self.fence_mode.is_auto_finish() {
+            return;
+        }
+
+        for gl_fence in self.pending {
+            unsafe {
+                gl.delete_sync(gl_fence.sync);
+            }
+        }
+    }
+}

--- a/wgpu-hal/src/gles/fence.rs
+++ b/wgpu-hal/src/gles/fence.rs
@@ -51,11 +51,11 @@ impl Fence {
     }
 
     pub fn satisfied(&self, value: crate::FenceValue) -> bool {
-        self.last_completed.load(Ordering::Relaxed) >= value
+        self.last_completed.load(Ordering::Acquire) >= value
     }
 
     pub fn get_latest(&self, gl: &glow::Context) -> crate::FenceValue {
-        let mut max_value = self.last_completed.load(Ordering::Relaxed);
+        let mut max_value = self.last_completed.load(Ordering::Acquire);
 
         if self.fence_mode.is_auto_finish() {
             return max_value;
@@ -76,7 +76,7 @@ impl Fence {
         }
 
         // Track the latest value, to save ourselves some querying later
-        self.last_completed.fetch_max(max_value, Ordering::Relaxed);
+        self.last_completed.fetch_max(max_value, Ordering::AcqRel);
 
         max_value
     }
@@ -103,7 +103,7 @@ impl Fence {
         wait_value: crate::FenceValue,
         timeout_ns: u64,
     ) -> Result<bool, crate::DeviceError> {
-        let last_completed = self.last_completed.load(Ordering::Relaxed);
+        let last_completed = self.last_completed.load(Ordering::Acquire);
 
         if self.fence_mode.is_auto_finish() {
             return Ok(last_completed >= wait_value);
@@ -147,7 +147,7 @@ impl Fence {
         };
 
         if signalled {
-            self.last_completed.fetch_max(wait_value, Ordering::Relaxed);
+            self.last_completed.fetch_max(wait_value, Ordering::AcqRel);
         }
 
         Ok(signalled)

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -95,9 +95,12 @@ mod adapter;
 mod command;
 mod conv;
 mod device;
+mod fence;
 mod queue;
 
 use crate::{CopyExtent, TextureDescriptor};
+
+pub use fence::Fence;
 
 #[cfg(not(any(windows, webgl)))]
 pub use self::egl::{AdapterContext, AdapterContextLock};
@@ -120,7 +123,7 @@ use glow::HasContext;
 
 use naga::FastHashMap;
 use parking_lot::Mutex;
-use std::sync::atomic::{AtomicU32, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU8};
 use std::{fmt, ops::Range, sync::Arc};
 
 #[derive(Clone, Debug)]
@@ -226,7 +229,6 @@ bitflags::bitflags! {
         ///
         /// When this is true, instance offset emulation via vertex buffer rebinding and a shader uniform will be disabled.
         const FULLY_FEATURED_INSTANCING = 1 << 16;
-        const USE_REAL_
     }
 }
 
@@ -273,6 +275,7 @@ struct AdapterShared {
     private_caps: PrivateCapabilities,
     features: wgt::Features,
     workarounds: Workarounds,
+    options: wgt::GlBackendOptions,
     shading_language_version: naga::back::glsl::Version,
     next_shader_id: AtomicU32,
     program_cache: Mutex<ProgramCache>,
@@ -732,67 +735,6 @@ pub struct QuerySet {
 }
 
 impl crate::DynQuerySet for QuerySet {}
-
-#[derive(Debug)]
-pub struct Fence {
-    last_completed: crate::AtomicFenceValue,
-    pending: Vec<(crate::FenceValue, glow::Fence)>,
-}
-
-impl crate::DynFence for Fence {}
-
-#[cfg(any(
-    not(target_arch = "wasm32"),
-    all(
-        feature = "fragile-send-sync-non-atomic-wasm",
-        not(target_feature = "atomics")
-    )
-))]
-unsafe impl Send for Fence {}
-#[cfg(any(
-    not(target_arch = "wasm32"),
-    all(
-        feature = "fragile-send-sync-non-atomic-wasm",
-        not(target_feature = "atomics")
-    )
-))]
-unsafe impl Sync for Fence {}
-
-impl Fence {
-    fn get_latest(&self, gl: &glow::Context) -> crate::FenceValue {
-        let mut max_value = self.last_completed.load(Ordering::Relaxed);
-        for &(value, sync) in self.pending.iter() {
-            if value <= max_value {
-                // We already know this was good, no need to check again
-                continue;
-            }
-            let status = unsafe { gl.get_sync_status(sync) };
-            if status == glow::SIGNALED {
-                max_value = value;
-            } else {
-                // Anything after the first unsignalled is guaranteed to also be unsignalled
-                break;
-            }
-        }
-
-        // Track the latest value, to save ourselves some querying later
-        self.last_completed.fetch_max(max_value, Ordering::Relaxed);
-
-        max_value
-    }
-
-    fn maintain(&mut self, gl: &glow::Context) {
-        let latest = self.get_latest(gl);
-        for &(value, sync) in self.pending.iter() {
-            if value <= latest {
-                unsafe {
-                    gl.delete_sync(sync);
-                }
-            }
-        }
-        self.pending.retain(|&(value, _)| value > latest);
-    }
-}
 
 #[derive(Debug)]
 pub struct AccelerationStructure;

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -226,6 +226,7 @@ bitflags::bitflags! {
         ///
         /// When this is true, instance offset emulation via vertex buffer rebinding and a shader uniform will be disabled.
         const FULLY_FEATURED_INSTANCING = 1 << 16;
+        const USE_REAL_
     }
 }
 

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1856,9 +1856,7 @@ impl crate::Queue for super::Queue {
         }
 
         signal_fence.maintain(gl);
-        let sync = unsafe { gl.fence_sync(glow::SYNC_GPU_COMMANDS_COMPLETE, 0) }
-            .map_err(|_| crate::DeviceError::OutOfMemory)?;
-        signal_fence.pending.push((signal_value, sync));
+        signal_fence.signal(gl, signal_value)?;
 
         Ok(())
     }

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -25,7 +25,9 @@ impl AdapterContext {
 }
 
 #[derive(Debug)]
-pub struct Instance;
+pub struct Instance {
+    options: wgt::GlBackendOptions,
+}
 
 impl Instance {
     pub fn create_surface_from_canvas(
@@ -110,9 +112,11 @@ unsafe impl Send for Instance {}
 impl crate::Instance for Instance {
     type A = super::Api;
 
-    unsafe fn init(_desc: &crate::InstanceDescriptor) -> Result<Self, crate::InstanceError> {
+    unsafe fn init(desc: &crate::InstanceDescriptor) -> Result<Self, crate::InstanceError> {
         profiling::scope!("Init OpenGL (WebGL) Backend");
-        Ok(Instance)
+        Ok(Instance {
+            options: desc.backend_options.gl.clone(),
+        })
     }
 
     unsafe fn enumerate_adapters(
@@ -123,10 +127,13 @@ impl crate::Instance for Instance {
             let gl = glow::Context::from_webgl2_context(surface_hint.webgl2_context.clone());
 
             unsafe {
-                super::Adapter::expose(AdapterContext {
-                    glow_context: gl,
-                    webgl2_context: surface_hint.webgl2_context.clone(),
-                })
+                super::Adapter::expose(
+                    AdapterContext {
+                        glow_context: gl,
+                        webgl2_context: surface_hint.webgl2_context.clone(),
+                    },
+                    self.options.clone(),
+                )
             }
             .into_iter()
             .collect()

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1751,8 +1751,7 @@ bitflags::bitflags! {
 pub struct InstanceDescriptor<'a> {
     pub name: &'a str,
     pub flags: wgt::InstanceFlags,
-    pub dx12_shader_compiler: wgt::Dx12Compiler,
-    pub gles_minor_version: wgt::Gles3MinorVersion,
+    pub backend_options: wgt::BackendOptions,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-types/src/instance.rs
+++ b/wgpu-types/src/instance.rs
@@ -216,7 +216,7 @@ impl BackendOptions {
 pub struct GlBackendOptions {
     /// Which OpenGL ES 3 minor version to request, if using OpenGL ES.
     pub gles_minor_version: Gles3MinorVersion,
-    /// TODO DOCS
+    /// Behavior of OpenGL fences. Affects how `on_completed_work_done` and `device.poll` behave.
     pub short_circuit_fences: GlFenceBehavior,
 }
 
@@ -309,6 +309,14 @@ pub enum Dx12Compiler {
 }
 
 impl Dx12Compiler {
+    /// Helper function to construct a `DynamicDxc` variant with default paths.
+    pub fn default_dynamic_dxc() -> Self {
+        Self::DynamicDxc {
+            dxc_path: String::from("dxcompiler.dll"),
+            dxil_path: String::from("dxil.dll"),
+        }
+    }
+
     /// Choose which DX12 shader compiler to use from the environment variable `WGPU_DX12_COMPILER`.
     ///
     /// Valid values, case insensitive:
@@ -321,10 +329,7 @@ impl Dx12Compiler {
             .as_deref()?
             .to_lowercase();
         match value.as_str() {
-            "dxc" | "dynamicdxc" => Some(Self::DynamicDxc {
-                dxc_path: String::from("dxcompiler.dll"),
-                dxil_path: String::from("dxil.dll"),
-            }),
+            "dxc" | "dynamicdxc" => Some(Self::default_dynamic_dxc()),
             "staticdxc" => Some(Self::StaticDxc),
             "fxc" => Some(Self::Fxc),
             _ => None,
@@ -411,6 +416,9 @@ pub enum GlFenceBehavior {
     ///
     /// Previously all `poll(Wait)` acted like the OpenGL fences were signalled even if they weren't.
     /// See <https://github.com/gfx-rs/wgpu/issues/4589> for more information.
+    ///
+    /// When this is set `Queue::on_completed_work_done` will always return the next time the device
+    /// is maintained, not when the work is actually done on the GPU.
     AutoFinish,
 }
 

--- a/wgpu-types/src/instance.rs
+++ b/wgpu-types/src/instance.rs
@@ -216,6 +216,8 @@ impl BackendOptions {
 pub struct GlBackendOptions {
     /// Which OpenGL ES 3 minor version to request, if using OpenGL ES.
     pub gles_minor_version: Gles3MinorVersion,
+    /// TODO DOCS
+    pub short_circuit_fences: GlFenceBehavior,
 }
 
 impl GlBackendOptions {
@@ -225,7 +227,10 @@ impl GlBackendOptions {
     #[must_use]
     pub fn from_env_or_default() -> Self {
         let gles_minor_version = Gles3MinorVersion::from_env().unwrap_or_default();
-        Self { gles_minor_version }
+        Self {
+            gles_minor_version,
+            short_circuit_fences: GlFenceBehavior::Normal,
+        }
     }
 
     /// Takes the given options, modifies them based on the environment variables, and returns the result.
@@ -234,7 +239,11 @@ impl GlBackendOptions {
     #[must_use]
     pub fn with_env(self) -> Self {
         let gles_minor_version = self.gles_minor_version.with_env();
-        Self { gles_minor_version }
+        let short_circuit_fences = self.short_circuit_fences.with_env();
+        Self {
+            gles_minor_version,
+            short_circuit_fences,
+        }
     }
 }
 
@@ -381,6 +390,65 @@ impl Gles3MinorVersion {
     pub fn with_env(self) -> Self {
         if let Some(compiler) = Self::from_env() {
             compiler
+        } else {
+            self
+        }
+    }
+}
+
+/// Dictate the behavior of fences in OpenGL.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum GlFenceBehavior {
+    /// Fences in OpenGL behave normally. If you don't know what to pick, this is what you want.
+    #[default]
+    Normal,
+    /// Fences in OpenGL are short-circuited to always return `true` immediately.
+    ///
+    /// This solves a very specific issue that arose due to a bug in wgpu-core that made
+    /// many WebGL programs work when they "shouldn't" have. If you have code that is trying
+    /// to call `device.poll(wgpu::Maintain::Wait)` on WebGL, you need to enable this option
+    /// for the "Wait" to behave how you would expect.
+    ///
+    /// Previously all `poll(Wait)` acted like the OpenGL fences were signalled even if they weren't.
+    /// See <https://github.com/gfx-rs/wgpu/issues/4589> for more information.
+    AutoFinish,
+}
+
+impl GlFenceBehavior {
+    /// Returns true if the fence behavior is `AutoFinish`.
+    pub fn is_auto_finish(&self) -> bool {
+        matches!(self, Self::AutoFinish)
+    }
+
+    /// Returns true if the fence behavior is `Normal`.
+    pub fn is_normal(&self) -> bool {
+        matches!(self, Self::Normal)
+    }
+
+    /// Choose which minor OpenGL ES version to use from the environment variable `WGPU_GL_FENCE_BEHAVIOR`.
+    ///
+    /// Possible values are `Normal` or `AutoFinish`. Case insensitive.
+    ///
+    /// Use with `unwrap_or_default()` to get the default value if the environment variable is not set.
+    #[must_use]
+    pub fn from_env() -> Option<Self> {
+        let value = crate::env::var("WGPU_GL_FENCE_BEHAVIOR")
+            .as_deref()?
+            .to_lowercase();
+        match value.as_str() {
+            "normal" => Some(Self::Normal),
+            "autofinish" => Some(Self::AutoFinish),
+            _ => None,
+        }
+    }
+
+    /// Takes the given compiler, modifies it based on the `WGPU_GL_FENCE_BEHAVIOR` environment variable, and returns the result.
+    ///
+    /// See `from_env` for more information.
+    #[must_use]
+    pub fn with_env(self) -> Self {
+        if let Some(fence) = Self::from_env() {
+            fence
         } else {
             self
         }


### PR DESCRIPTION
**Connections**

Prerequisite #4589 

**Description**

Allow GL Fences to be put into a "short circuiting" mode where they immediately 

**Testing**
_Explain how this change is tested._

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
