### PR TITLE
[naga] remove unused `CallError::ResultValue`

### DIFF
--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -22,8 +22,6 @@ pub enum CallError {
     ResultAlreadyInScope(Handle<crate::Expression>),
     #[error("Result expression {0:?} is populated by multiple `Call` statements")]
     ResultAlreadyPopulated(Handle<crate::Expression>),
-    #[error("Result value is invalid")]
-    ResultValue(#[source] ExpressionError),
     #[error("Requires {required} arguments, but {seen} are provided")]
     ArgumentCount { required: usize, seen: usize },
     #[error("Argument {index} value {seen_expression:?} doesn't match the type {required:?}")]


### PR DESCRIPTION
**Connections**
fixes https://github.com/gfx-rs/wgpu/issues/6943

**Description**
`CallError::ResultValue` is unused and now removed.

**Testing**
Local tests seem fine.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`.
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
