### PR TITLE
Fix building `wgpu` with `--no-default-feautures` on web (`wasm32-unknown-unknown`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,9 @@ jobs:
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} --tests --features glsl,spirv
           cargo doc --target ${{ matrix.target }} ${{ matrix.extra-flags }} --no-deps --features glsl,spirv
 
+          # check with no features
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} --no-default-features
+
           # all features
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} --tests --all-features
           cargo doc --target ${{ matrix.target }} ${{ matrix.extra-flags }} --no-deps --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 ### Bug Fixes
 
 * Avoid overflow in query set bounds check validation. By @ErichDonGubler in [#????].
+* Fix `wgpu` not building with `--no-default-features` on when targeting `wasm32-unknown-unknown`. By @wumpf in [#6946](https://github.com/gfx-rs/wgpu/pull/6946).
 
 ## v24.0.0 (2025-01-15)
 

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -636,6 +636,8 @@ macro_rules! dispatch_types_inner {
                     Self::Core(value) => value.as_ref(),
                     #[cfg(webgpu)]
                     Self::WebGPU(value) => value.as_ref(),
+                    #[cfg(not(any(wgpu_core, webgpu)))]
+                    _ => panic!("No context available. You need to enable one of wgpu's backend feature build flags."),
                 }
             }
         }
@@ -765,6 +767,8 @@ macro_rules! dispatch_types_inner {
                     Self::Core(value) => value,
                     #[cfg(webgpu)]
                     Self::WebGPU(value) => value,
+                    #[cfg(not(any(wgpu_core, webgpu)))]
+                    _ => panic!("No context available. You need to enable one of wgpu's backend feature build flags."),
                 }
             }
         }
@@ -777,6 +781,8 @@ macro_rules! dispatch_types_inner {
                     Self::Core(value) => value,
                     #[cfg(webgpu)]
                     Self::WebGPU(value) => value,
+                    #[cfg(not(any(wgpu_core, webgpu)))]
+                    _ => panic!("No context available. You need to enable one of wgpu's backend feature build flags."),
                 }
             }
         }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -23,6 +23,7 @@
     unsafe_op_in_unsafe_fn
 )]
 #![allow(clippy::arc_with_non_send_sync)]
+#![cfg_attr(not(any(wgpu_core, webgpu)), allow(unused))]
 
 //
 //


### PR DESCRIPTION
**Connections**

* A bit related to https://github.com/gfx-rs/wgpu/issues/3514
    * if we proper feature gated all backend, this would also happen on native!

**Description**
When building with `--no-default-features` on web, we have neither `wgpu_core` nor `webgpu` meta features enabled. This causes the match expressions not to compile.

A nicer way to solve this would be an `empty` backend as previously proposed [here](https://github.com/gfx-rs/wgpu/pull/4815#discussion_r1412774160) where @daxpedda made a good case for it.
I was pushing against it back then because of yet-another-place-naming-all-interfaces, but I think I changed my mind on this and this would actually be really useful to have - we could automatically enable the empty-backend when neither webgpu or wgc are enabled _and_ allow it to be added via feature & created explicitly etc.
.... but more on that in another PR. For now I wanted this one to be usable in a patch release!


**Testing**
Added previously failing check to ci

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
