### PR TITLE
Remove ci dependency of clippy to tests for faster iteration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,6 @@ jobs:
 
     name: Test WebAssembly
     runs-on: ubuntu-latest
-    needs: [check]
 
     steps:
       - name: checkout repo
@@ -479,7 +478,6 @@ jobs:
 
     name: Test ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    needs: [check]
 
     steps:
       - name: checkout repo


### PR DESCRIPTION
Removes the dependency from clippy to the tests to help reduce latency on waiting on CI. This was made back when we paid for CI.