### PR TITLE
Enable Storage Texture Binding Arrays on DX12

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -339,6 +339,7 @@ impl super::Adapter {
 
         features.set(
             wgt::Features::TEXTURE_BINDING_ARRAY
+                | wgt::Features::STORAGE_RESOURCE_BINDING_ARRAY
                 | wgt::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING
                 | wgt::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
             shader_model >= naga::back::hlsl::ShaderModel::V5_1,


### PR DESCRIPTION
Closes #6743 

Turns out naga already supported this.