### PR TITLE
Remove additional trait impls from `CommandBuffer`

### DIFF
--- a/wgpu/src/api/command_buffer.rs
+++ b/wgpu/src/api/command_buffer.rs
@@ -1,7 +1,3 @@
-use std::sync::Arc;
-
-use parking_lot::Mutex;
-
 use crate::*;
 
 /// Handle to a command buffer on the GPU.
@@ -11,11 +7,9 @@ use crate::*;
 /// a [`CommandEncoder`] and then calling [`CommandEncoder::finish`].
 ///
 /// Corresponds to [WebGPU `GPUCommandBuffer`](https://gpuweb.github.io/gpuweb/#command-buffer).
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CommandBuffer {
-    pub(crate) inner: Arc<Mutex<Option<dispatch::DispatchCommandBuffer>>>,
+    pub(crate) buffer: dispatch::DispatchCommandBuffer,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(CommandBuffer: Send, Sync);
-
-crate::cmp::impl_eq_ord_hash_arc_address!(CommandBuffer => .inner);

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -1,4 +1,4 @@
-use std::{ops::Range, sync::Arc};
+use std::ops::Range;
 
 use crate::{
     api::{
@@ -35,7 +35,6 @@ crate::cmp::impl_eq_ord_hash_proxy!(CommandEncoder => .inner);
 pub type CommandEncoderDescriptor<'a> = wgt::CommandEncoderDescriptor<Label<'a>>;
 static_assertions::assert_impl_all!(CommandEncoderDescriptor<'_>: Send, Sync);
 
-use parking_lot::Mutex;
 pub use wgt::TexelCopyBufferInfo as TexelCopyBufferInfoBase;
 /// View of a buffer which can be used to copy to/from a texture.
 ///
@@ -59,9 +58,7 @@ impl CommandEncoder {
     pub fn finish(mut self) -> CommandBuffer {
         let buffer = self.inner.finish();
 
-        CommandBuffer {
-            inner: Arc::new(Mutex::new(Some(buffer))),
-        }
+        CommandBuffer { buffer }
     }
 
     /// Begins recording of a render pass.

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -211,12 +211,7 @@ impl Queue {
         &self,
         command_buffers: I,
     ) -> SubmissionIndex {
-        let mut command_buffers = command_buffers.into_iter().map(|comb| {
-            comb.inner
-                .lock()
-                .take()
-                .expect("Command buffer already submitted")
-        });
+        let mut command_buffers = command_buffers.into_iter().map(|comb| comb.buffer);
 
         let index = self.inner.submit(&mut command_buffers);
 

--- a/wgpu/src/cmp.rs
+++ b/wgpu/src/cmp.rs
@@ -65,6 +65,7 @@ macro_rules! impl_eq_ord_hash_proxy {
 /// ```ignore
 /// impl_eq_ord_hash_arc_address!(MyType => .field);
 /// ```
+#[cfg_attr(not(wgpu_core), expect(unused_macros))]
 macro_rules! impl_eq_ord_hash_arc_address {
     ($type:ty => $($access:tt)*) => {
         impl PartialEq for $type {
@@ -102,4 +103,5 @@ macro_rules! impl_eq_ord_hash_arc_address {
     };
 }
 
+#[cfg_attr(not(wgpu_core), expect(unused_imports))]
 pub(crate) use {impl_eq_ord_hash_arc_address, impl_eq_ord_hash_proxy};

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -832,7 +832,7 @@ dispatch_types! {
         {mut type DispatchCommandEncoder = InterfaceTypes::CommandEncoder: CommandEncoderInterface};
         {mut type DispatchComputePass = InterfaceTypes::ComputePass: ComputePassInterface};
         {mut type DispatchRenderPass = InterfaceTypes::RenderPass: RenderPassInterface};
-        {ref type DispatchCommandBuffer = InterfaceTypes::CommandBuffer: CommandBufferInterface};
+        {mut type DispatchCommandBuffer = InterfaceTypes::CommandBuffer: CommandBufferInterface};
         {mut type DispatchRenderBundleEncoder = InterfaceTypes::RenderBundleEncoder: RenderBundleEncoderInterface};
         {ref type DispatchRenderBundle = InterfaceTypes::RenderBundle: RenderBundleInterface};
         {ref type DispatchSurface = InterfaceTypes::Surface: SurfaceInterface};


### PR DESCRIPTION
The only purpose of this type is to be given to `submit`. Being able to clone and share it has no value  .

Remove `Clone` implementation and the inner `Arc<Mutex>`. From there, remove all comparison traits as two `CommandBuffer` are always different.


- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
