### PR TITLE
Fix missing wgt re-export on wgpu for `CopyExternalImageDestInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 - Avoid overflow in query set bounds check validation. By @ErichDonGubler in [#6933](https://github.com/gfx-rs/wgpu/pull/6933).
 - Add Flush to GL Queue::submit. By @cwfitzgerald in [#6941](https://github.com/gfx-rs/wgpu/pull/6941).
 - Fix `wgpu` not building with `--no-default-features` on when targeting `wasm32-unknown-unknown`. By @wumpf in [#6946](https://github.com/gfx-rs/wgpu/pull/6946).
-- Fix `CopyExternalImageDestInfo` not exported on `wgpu`. By @wumpf in [#????](https://github.com/gfx-rs/wgpu/pull/????).
+- Fix `CopyExternalImageDestInfo` not exported on `wgpu`. By @wumpf in [#6962](https://github.com/gfx-rs/wgpu/pull/6962).
 
 #### Vulkan
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 - Avoid overflow in query set bounds check validation. By @ErichDonGubler in [#6933](https://github.com/gfx-rs/wgpu/pull/6933).
 - Add Flush to GL Queue::submit. By @cwfitzgerald in [#6941](https://github.com/gfx-rs/wgpu/pull/6941).
 - Fix `wgpu` not building with `--no-default-features` on when targeting `wasm32-unknown-unknown`. By @wumpf in [#6946](https://github.com/gfx-rs/wgpu/pull/6946).
+- Fix `CopyExternalImageDestInfo` not exported on `wgpu`. By @wumpf in [#????](https://github.com/gfx-rs/wgpu/pull/????).
 
 #### Vulkan
 

--- a/tests/tests/external_texture.rs
+++ b/tests/tests/external_texture.rs
@@ -274,7 +274,7 @@ static IMAGE_BITMAP_IMPORT: GpuTestConfiguration =
                                 origin: src_origin,
                                 flip_y: src_flip_y,
                             },
-                            wgt::CopyExternalImageDestInfo {
+                            wgpu::CopyExternalImageDestInfo {
                                 texture: &texture,
                                 mip_level: 0,
                                 origin: dest_origin,

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -658,7 +658,7 @@ fn map_texture_copy_view(
 }
 
 fn map_tagged_texture_copy_view(
-    view: wgt::CopyExternalImageDestInfo<&crate::api::Texture>,
+    view: crate::CopyExternalImageDestInfo<&crate::api::Texture>,
 ) -> webgpu_sys::GpuCopyExternalImageDestInfo {
     let texture = view.texture.inner.as_webgpu();
     let mapped = webgpu_sys::GpuCopyExternalImageDestInfo::new(&texture.inner);
@@ -2554,8 +2554,8 @@ impl dispatch::QueueInterface for WebQueue {
 
     fn copy_external_image_to_texture(
         &self,
-        source: &wgt::CopyExternalImageSourceInfo,
-        dest: wgt::CopyExternalImageDestInfo<&crate::api::Texture>,
+        source: &crate::CopyExternalImageSourceInfo,
+        dest: crate::CopyExternalImageDestInfo<&crate::api::Texture>,
         size: crate::Extent3d,
     ) {
         self.inner

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -385,7 +385,7 @@ fn map_texture_copy_view(
     expect(unused)
 )]
 fn map_texture_tagged_copy_view(
-    view: wgt::CopyExternalImageDestInfo<&api::Texture>,
+    view: crate::CopyExternalImageDestInfo<&api::Texture>,
 ) -> wgc::command::CopyExternalImageDestInfo {
     wgc::command::CopyExternalImageDestInfo {
         texture: view.texture.inner.as_core().id,
@@ -1771,8 +1771,8 @@ impl dispatch::QueueInterface for CoreQueue {
     #[cfg(any(webgpu, webgl))]
     fn copy_external_image_to_texture(
         &self,
-        source: &wgt::CopyExternalImageSourceInfo,
-        dest: wgt::CopyExternalImageDestInfo<&crate::api::Texture>,
+        source: &crate::CopyExternalImageSourceInfo,
+        dest: crate::CopyExternalImageDestInfo<&crate::api::Texture>,
         size: crate::Extent3d,
     ) {
         match self.context.0.queue_copy_external_image_to_texture(

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -227,8 +227,8 @@ pub trait QueueInterface: CommonTraits {
     #[cfg(any(webgpu, webgl))]
     fn copy_external_image_to_texture(
         &self,
-        source: &wgt::CopyExternalImageSourceInfo,
-        dest: wgt::CopyExternalImageDestInfo<&crate::api::Texture>,
+        source: &crate::CopyExternalImageSourceInfo,
+        dest: crate::CopyExternalImageDestInfo<&crate::api::Texture>,
         size: crate::Extent3d,
     );
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -55,17 +55,18 @@ pub use wgt::{
     AdapterInfo, AddressMode, AstcBlock, AstcChannel, Backend, BackendOptions, Backends,
     BindGroupLayoutEntry, BindingType, BlendComponent, BlendFactor, BlendOperation, BlendState,
     BufferAddress, BufferBindingType, BufferSize, BufferUsages, Color, ColorTargetState,
-    ColorWrites, CommandBufferDescriptor, CompareFunction, CompositeAlphaMode, CoreCounters,
-    DepthBiasState, DepthStencilState, DeviceLostReason, DeviceType, DownlevelCapabilities,
-    DownlevelFlags, Dx12BackendOptions, Dx12Compiler, DynamicOffset, Extent3d, Face, Features,
-    FilterMode, FrontFace, GlBackendOptions, Gles3MinorVersion, HalCounters, ImageSubresourceRange,
-    IndexFormat, InstanceDescriptor, InstanceFlags, InternalCounters, Limits, MaintainResult,
-    MemoryHints, MultisampleState, Origin2d, Origin3d, PipelineStatisticsTypes, PolygonMode,
-    PowerPreference, PredefinedColorSpace, PresentMode, PresentationTimestamp, PrimitiveState,
-    PrimitiveTopology, PushConstantRange, QueryType, RenderBundleDepthStencil, SamplerBindingType,
-    SamplerBorderColor, ShaderLocation, ShaderModel, ShaderRuntimeChecks, ShaderStages,
-    StencilFaceState, StencilOperation, StencilState, StorageTextureAccess, SurfaceCapabilities,
-    SurfaceStatus, TexelCopyBufferLayout, TextureAspect, TextureDimension, TextureFormat,
+    ColorWrites, CommandBufferDescriptor, CompareFunction, CompositeAlphaMode,
+    CopyExternalImageDestInfo, CoreCounters, DepthBiasState, DepthStencilState, DeviceLostReason,
+    DeviceType, DownlevelCapabilities, DownlevelFlags, Dx12BackendOptions, Dx12Compiler,
+    DynamicOffset, Extent3d, Face, Features, FilterMode, FrontFace, GlBackendOptions,
+    Gles3MinorVersion, HalCounters, ImageSubresourceRange, IndexFormat, InstanceDescriptor,
+    InstanceFlags, InternalCounters, Limits, MaintainResult, MemoryHints, MultisampleState,
+    Origin2d, Origin3d, PipelineStatisticsTypes, PolygonMode, PowerPreference,
+    PredefinedColorSpace, PresentMode, PresentationTimestamp, PrimitiveState, PrimitiveTopology,
+    PushConstantRange, QueryType, RenderBundleDepthStencil, SamplerBindingType, SamplerBorderColor,
+    ShaderLocation, ShaderModel, ShaderRuntimeChecks, ShaderStages, StencilFaceState,
+    StencilOperation, StencilState, StorageTextureAccess, SurfaceCapabilities, SurfaceStatus,
+    TexelCopyBufferLayout, TextureAspect, TextureDimension, TextureFormat,
     TextureFormatFeatureFlags, TextureFormatFeatures, TextureSampleType, TextureUsages,
     TextureViewDimension, VertexAttribute, VertexFormat, VertexStepMode, WasmNotSend,
     WasmNotSendSync, WasmNotSync, COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT,
@@ -81,7 +82,6 @@ pub use wgt::{ImageCopyBuffer, ImageCopyTexture, ImageCopyTextureTagged, ImageDa
 pub use wgt::ImageCopyExternalImage;
 #[cfg(any(webgpu, webgl))]
 pub use wgt::{CopyExternalImageSourceInfo, ExternalImageSource};
-
 //
 //
 // Re-exports of dependencies


### PR DESCRIPTION
**Description**
Fixes a missing export from `wgpu`

**Testing**
Use that type through `wgpu`'s re-export (really, everything should imho)

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
