### PR TITLE
Cleanup CI Jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ env:
 # - web: build for the Web
 # - em: build for the Emscripten
 
-# For build time and size optimization we disable debug
+# For build time and size optimization we disable debug symbols
 # entirely on clippy jobs and reduce it to line-numbers
 # only for ones where we run tests.
 #
@@ -207,13 +207,15 @@ jobs:
           rustup toolchain install ${{ env.REPO_MSRV }} --no-self-update --profile=minimal --component clippy,rust-src
           echo "RUSTC_BOOTSTRAP=1" >> "$GITHUB_ENV"
 
-      - name: disable debug
+      - name: disable debug symbols
         shell: bash
         run: |
           mkdir -p .cargo
-          echo """
-          [profile.dev]
-          debug = false" >> .cargo/config.toml
+
+          cat <<EOF >> .cargo/config.toml
+            [profile.dev]
+            debug = false
+          EOF
 
       - name: caching
         uses: Swatinem/rust-cache@v2
@@ -355,13 +357,15 @@ jobs:
           rustup override set ${{ env.CORE_MSRV }}
           cargo -V
 
-      - name: disable debug
+      - name: disable debug symbols
         shell: bash
         run: |
           mkdir -p .cargo
-          echo """
-          [profile.dev]
-          debug = false" >> .cargo/config.toml
+
+          cat <<EOF >> .cargo/config.toml
+            [profile.dev]
+            debug = false
+          EOF
 
       - name: caching
         uses: Swatinem/rust-cache@v2
@@ -403,7 +407,7 @@ jobs:
         with:
           tool: cargo-hack
 
-      - name: disable debug
+      - name: disable debug symbols
         shell: bash
         run: |
           mkdir -p .cargo
@@ -490,6 +494,16 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest,cargo-llvm-cov
+
+      - name: debug symbols to line-tables-only
+        shell: bash
+        run: |
+          mkdir -p .cargo
+
+          cat <<EOF >> .cargo/config.toml
+            [profile.dev]
+            debug = "line-tables-only"
+          EOF
 
         # Cache step must go before warp and mesa install on windows as they write into the
         # target directory, and rust-cache will overwrite the entirety of the target directory.
@@ -588,14 +602,6 @@ jobs:
           echo "LD_LIBRARY_PATH=$PWD/mesa/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
           echo "LIBGL_DRIVERS_PATH=$PWD/mesa/lib/x86_64-linux-gnu/dri" >> "$GITHUB_ENV"
 
-      - name: disable debug
-        shell: bash
-        run: |
-          mkdir -p .cargo
-          echo """
-          [profile.dev]
-          debug = 1" >> .cargo/config.toml
-
       - name: run wgpu-info
         shell: bash
         run: |
@@ -658,14 +664,6 @@ jobs:
           rustup override set ${{ env.REPO_MSRV }}
           cargo -V
 
-      - name: disable debug
-        shell: bash
-        run: |
-          mkdir -p .cargo
-          echo """
-          [profile.dev]
-          debug = 1" >> .cargo/config.toml
-
       - name: caching
         uses: Swatinem/rust-cache@v2
         with:
@@ -727,13 +725,15 @@ jobs:
           rustup override set ${{ env.REPO_MSRV }}
           cargo -V
 
-      - name: disable debug
+      - name: disable debug symbols
         shell: bash
         run: |
           mkdir -p .cargo
-          echo """
-          [profile.dev]
-          debug = 1" >> .cargo/config.toml
+
+          cat <<EOF >> .cargo/config.toml
+            [profile.dev]
+            debug = false
+          EOF
 
       - name: caching
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,6 @@ env:
   # Corresponds to https://github.com/gfx-rs/ci-build/releases
   CI_BINARY_BUILD: "build19"
 
-  # We sometimes need nightly to use special things in CI.
-  #
-  # In order to prevent CI regressions, we pin the nightly version.
-  NIGHTLY_VERSION: "nightly-2024-10-17"
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
   REPO_MSRV: "1.83"
   # This is the MSRV used by the `wgpu-core`, `wgpu-hal`, and `wgpu-types` crates,
@@ -399,8 +395,8 @@ jobs:
 
       - name: Install Nightly Toolchain
         run: |
-          rustup toolchain install ${{ env.NIGHTLY_VERSION }} --no-self-update --profile=minimal --component clippy
-          cargo +${{ env.NIGHTLY_VERSION }} -V
+          rustup toolchain install ${{ env.REPO_MSRV }} --no-self-update --profile=minimal
+          cargo +${{ env.REPO_MSRV }} -V
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2
@@ -420,7 +416,9 @@ jobs:
         run: |
           set -e
 
-          cargo +${{ env.NIGHTLY_VERSION }} hack generate-lockfile --remove-dev-deps -Z minimal-versions -p naga -p naga-cli
+          cargo +${{ env.REPO_MSRV }} hack generate-lockfile --remove-dev-deps -Z minimal-versions -p naga -p naga-cli
+        env:
+          RUSTC_BOOTSTRAP: 1
 
       - name: Clippy
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,9 +9,8 @@ on:
       - trunk
 
 env:
-  # We need to use nightly for various features
-  # when building docs.rs style docs.
-  NIGHTLY_VERSION: nightly-2025-01-09
+  # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
+  REPO_MSRV: "1.83"
 
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
@@ -28,17 +27,21 @@ jobs:
           persist-credentials: false
 
       - name: Install documentation toolchain
-        run: rustup toolchain install ${{ env.NIGHTLY_VERSION }} --no-self-update --profile=minimal
-
-      - name: Build the docs (nightly)
         run: |
-          cargo +${{ env.NIGHTLY_VERSION }} doc --no-deps --lib
+          rustup toolchain install ${{ env.REPO_MSRV }} --no-self-update --profile=minimal
+          rustup override set ${{ env.REPO_MSRV }}
+
+      - name: caching
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: doc-build
+
+      - name: Build the docs
+        run: |
+          cargo doc --no-deps --lib --document-private-items
         env:
           RUSTDOCFLAGS: --cfg docsrs
-
-      - name: Build the docs (stable)
-        run: cargo +stable doc --no-deps --lib
-        if: ${{ failure() }}
+          RUSTC_BOOTSTRAP: 1
 
       - name: Deploy the docs
         uses: JamesIves/github-pages-deploy-action@v4.7.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,16 @@ jobs:
           rustup toolchain install ${{ env.REPO_MSRV }} --no-self-update --profile=minimal
           rustup override set ${{ env.REPO_MSRV }}
 
+      - name: disable debug symbols
+        shell: bash
+        run: |
+          mkdir -p .cargo
+
+          cat <<EOF >> .cargo/config.toml
+            [profile.dev]
+            debug = false
+          EOF
+
       - name: caching
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -40,6 +40,16 @@ jobs:
           rustup override set ${{ env.REPO_MSRV }}
           cargo -V
 
+      - name: disable debug symbols
+        shell: bash
+        run: |
+          mkdir -p .cargo
+
+          cat <<EOF >> .cargo/config.toml
+            [profile.dev]
+            debug = false
+          EOF
+
       - name: caching
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -40,6 +40,11 @@ jobs:
           rustup override set ${{ env.REPO_MSRV }}
           cargo -V
 
+      - name: caching
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: cargo-generate-${{ matrix.name }}
+
       - name: "Install cargo-generate"
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,16 @@ jobs:
       - name: Install wasm-bindgen
         run: cargo +stable install wasm-bindgen-cli --version=$WASM_BINDGEN_VERSION
 
+      - name: debug symbols to line-tables-only
+        shell: bash
+        run: |
+          mkdir -p .cargo
+
+          cat <<EOF >> .cargo/config.toml
+            [profile.dev]
+            debug = "line-tables-only"
+          EOF
+
       - name: caching
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,6 @@ env:
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
-  RUSTFLAGS:
 
 jobs:
   publish:
@@ -36,6 +35,11 @@ jobs:
 
       - name: Install wasm-bindgen
         run: cargo +stable install wasm-bindgen-cli --version=$WASM_BINDGEN_VERSION
+
+      - name: caching
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: publish-build
 
       - name: Build examples
         run: cargo xtask run-wasm --no-serve

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -31,6 +31,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: debug symbols to line-tables-only
+        shell: bash
+        run: |
+          mkdir -p .cargo
+
+          cat <<EOF >> .cargo/config.toml
+            [profile.dev]
+            debug = "line-tables-only"
+          EOF
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
@@ -76,6 +86,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: debug symbols to line-tables-only
+        shell: bash
+        run: |
+          mkdir -p .cargo
+
+          cat <<EOF >> .cargo/config.toml
+            [profile.dev]
+            debug = "line-tables-only"
+          EOF
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
@@ -107,6 +127,16 @@ jobs:
 
       - name: Install graphviz
         run: sudo apt-get install graphviz
+
+      - name: debug symbols to line-tables-only
+        shell: bash
+        run: |
+          mkdir -p .cargo
+
+          cat <<EOF >> .cargo/config.toml
+            [profile.dev]
+            debug = "line-tables-only"
+          EOF
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
- Closes #5444
- Stop using nightly versions for various things, instead use `RUSTC_BOOTSTRAP` so we can use the same stable version for everything.
- Add caches to a few jobs