### PR TITLE
Improve the docs of `PipelineCache` and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,10 @@ By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 
 - Stop naga causing undefined behavior when a ray query misses. By @Vecvec in [#6752](https://github.com/gfx-rs/wgpu/pull/6752).
 
+### Documentation
+
+- Improved documentation around pipeline caches. By @DJMcNab in [#6978](https://github.com/gfx-rs/wgpu/pull/6978).
+
 ## v24.0.0 (2025-01-15)
 
 ### Major changes

--- a/wgpu/src/api/common_pipeline.rs
+++ b/wgpu/src/api/common_pipeline.rs
@@ -40,7 +40,7 @@ impl Default for PipelineCompilationOptions<'_> {
 /// Describes a pipeline cache, which allows reusing compilation work
 /// between program runs.
 ///
-/// For use with [`Device::create_pipeline_cache`]
+/// For use with [`Device::create_pipeline_cache`].
 ///
 /// This type is unique to the Rust API of `wgpu`.
 #[derive(Clone, Debug)]

--- a/wgpu/src/api/pipeline_cache.rs
+++ b/wgpu/src/api/pipeline_cache.rs
@@ -5,7 +5,9 @@ use crate::*;
 /// in subsequent executions
 ///
 /// This reuse is only applicable for the same or similar devices.
-/// See [`util::pipeline_cache_key`] for some details.
+/// See [`util::pipeline_cache_key`] for some details and a suggested workflow.
+///
+/// Created using [`Device::create_pipeline_cache`].
 ///
 /// # Background
 ///
@@ -28,6 +30,7 @@ use crate::*;
 ///
 /// # Usage
 ///
+/// This is used as [`RenderPipelineDescriptor::cache`] or [`ComputePipelineDescriptor::cache`].
 /// It is valid to use this resource when creating multiple pipelines, in
 /// which case it will likely cache each of those pipelines.
 /// It is also valid to create a new cache for each pipeline.


### PR DESCRIPTION
**Description**
I was reading through the docs of [`pipeline_cache_key`](https://docs.rs/wgpu/24.0.1/wgpu/util/fn.pipeline_cache_key.html), and found the `todo!`.
I also noticed we were missing some backlinks to `create_pipeline_cache`.

**Testing**
The doctest is compile tested in CI.

**Checklist**

- [X] Run `cargo fmt`. N/A
- [X] Run `taplo format`. N/A
- [X] Run `cargo clippy`. N/A
- [X] Run `cargo xtask test` to run tests. N/A.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
