### PR TITLE
Refactor Cargo.toml Significantly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ env:
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
   WASM_BINDGEN_TEST_TIMEOUT: 300 # 5 minutes
-  CACHE_SUFFIX: c # cache busting
+  CACHE_SUFFIX: d # cache busting
   WGPU_TESTING: true
 
 # We distinguish the following kinds of builds:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,10 +441,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
+name = "byteorder-lite"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -624,12 +624,6 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
-
-[[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -1822,13 +1816,12 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "image"
-version = "0.24.9"
+version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
 dependencies = [
  "bytemuck",
- "byteorder",
- "color_quant",
+ "byteorder-lite",
  "num-traits",
  "png",
 ]
@@ -2284,8 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "noise"
-version = "0.8.2"
-source = "git+https://github.com/Razaekel/noise-rs.git?rev=c6942d4fb70af26db4441edcf41f90fa115333f2#c6942d4fb70af26db4441edcf41f90fa115333f2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6da45c8333f2e152fc665d78a380be060eb84fad8ca4c9f7ac8ca29216cff0cc"
 dependencies = [
  "num-traits",
  "rand",
@@ -3559,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.17.6"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73202d787346a5418f8222eddb5a00f29ea47caf3c7d38a8f2f69f8455fa7c7e"
+checksum = "d90a2c01305b02b76fdd89ac8608bae27e173c829a35f7d76a345ab5d33836db"
 dependencies = [
  "loom",
  "once_cell",
@@ -4007,6 +4001,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wgpu"
 version = "24.0.0"
 dependencies = [
@@ -4109,7 +4113,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
- "web-time",
+ "web-time 1.1.0",
  "wgpu",
  "wgpu-test",
  "winit",
@@ -4226,7 +4230,6 @@ dependencies = [
  "web-sys",
  "wgpu",
  "wgpu-macros",
- "wgpu-types",
 ]
 
 [[package]]
@@ -4616,7 +4619,7 @@ dependencies = [
  "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
- "web-time",
+ "web-time 0.2.4",
  "windows-sys 0.48.0",
  "x11-dl",
  "x11rb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,10 +441,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder-lite"
-version = "0.1.0"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -624,6 +624,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -1816,12 +1822,13 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "image"
-version = "0.25.5"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
 dependencies = [
  "bytemuck",
- "byteorder-lite",
+ "byteorder",
+ "color_quant",
  "num-traits",
  "png",
 ]
@@ -2277,9 +2284,8 @@ dependencies = [
 
 [[package]]
 name = "noise"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da45c8333f2e152fc665d78a380be060eb84fad8ca4c9f7ac8ca29216cff0cc"
+version = "0.8.2"
+source = "git+https://github.com/Razaekel/noise-rs.git?rev=c6942d4fb70af26db4441edcf41f90fa115333f2#c6942d4fb70af26db4441edcf41f90fa115333f2"
 dependencies = [
  "num-traits",
  "rand",
@@ -3553,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.18.0"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90a2c01305b02b76fdd89ac8608bae27e173c829a35f7d76a345ab5d33836db"
+checksum = "73202d787346a5418f8222eddb5a00f29ea47caf3c7d38a8f2f69f8455fa7c7e"
 dependencies = [
  "loom",
  "once_cell",
@@ -4001,16 +4007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wgpu"
 version = "24.0.0"
 dependencies = [
@@ -4113,7 +4109,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
- "web-time 1.1.0",
+ "web-time",
  "wgpu",
  "wgpu-test",
  "winit",
@@ -4619,7 +4615,7 @@ dependencies = [
  "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
- "web-time 0.2.4",
+ "web-time",
  "windows-sys 0.48.0",
  "x11-dl",
  "x11rb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ hashbrown = { version = "0.15.2", default-features = false, features = [
     "inline-more",
 ] }
 heck = "0.5.0"
-image = { version = "0.25", default-features = false, features = ["png"] }
+image = { version = "0.24", default-features = false, features = ["png"] }
 indexmap = "2"
 itertools = { version = "0.13.0" }
 ktx2 = "0.3"
@@ -106,7 +106,8 @@ libloading = "0.8"
 libtest-mimic = "0.8.1"
 log = "0.4"
 nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
-noise = "0.9"
+# https://github.com/Razaekel/noise-rs/issues/335 (Updated dependencies)
+noise = { version = "0.8", git = "https://github.com/Razaekel/noise-rs.git", rev = "c6942d4fb70af26db4441edcf41f90fa115333f2" }
 nv-flip = "0.1"
 obj = "0.10"
 once_cell = "1.20.2"
@@ -133,7 +134,7 @@ smallvec = "1"
 static_assertions = "1.1.0"
 strum = { version = "0.26.0", features = ["derive"] }
 trybuild = "1"
-tracy-client = "0.18"
+tracy-client = "0.17"
 thiserror = "2"
 winit = { version = "0.29", features = ["android-native-activity"] }
 
@@ -174,7 +175,7 @@ wasm-bindgen = "0.2.97"
 wasm-bindgen-futures = "0.4.45"
 wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3.74", default-features = false }
-web-time = "1"
+web-time = "0.2.4"
 
 # deno dependencies
 deno_console = "0.179.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,26 +56,21 @@ repository = "https://github.com/gfx-rs/wgpu"
 version = "24.0.0"
 authors = ["gfx-rs developers"]
 
-[workspace.dependencies.wgc]
-package = "wgpu-core"
-path = "./wgpu-core"
-version = "24.0.0"
-
-[workspace.dependencies.wgt]
-package = "wgpu-types"
-path = "./wgpu-types"
-version = "24.0.0"
-
-[workspace.dependencies.hal]
-package = "wgpu-hal"
-path = "./wgpu-hal"
-version = "24.0.0"
-
-[workspace.dependencies.naga]
-path = "./naga"
-version = "24.0.0"
-
 [workspace.dependencies]
+naga = { version = "24.0.0", path = "./naga" }
+wgpu = { version = "24.0.0", path = "./wgpu", default-features = false, features = [
+    "serde",
+    "wgsl",
+    "dx12",
+    "metal",
+    "static-dxc",
+] }
+wgpu-core = { version = "24.0.0", path = "./wgpu-core" }
+wgpu-hal = { version = "24.0.0", path = "./wgpu-hal" }
+wgpu-macros = { version = "24.0.0", path = "./wgpu-macros" }
+wgpu-test = { version = "24.0.0", path = "./tests" }
+wgpu-types = { version = "24.0.0", path = "./wgpu-types" }
+
 anyhow = "1.0.95"
 argh = "0.1.13"
 arrayvec = "0.7"
@@ -102,7 +97,7 @@ hashbrown = { version = "0.15.2", default-features = false, features = [
     "inline-more",
 ] }
 heck = "0.5.0"
-image = { version = "0.24", default-features = false, features = ["png"] }
+image = { version = "0.25", default-features = false, features = ["png"] }
 indexmap = "2"
 itertools = { version = "0.13.0" }
 ktx2 = "0.3"
@@ -111,8 +106,7 @@ libloading = "0.8"
 libtest-mimic = "0.8.1"
 log = "0.4"
 nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
-# https://github.com/Razaekel/noise-rs/issues/335 (Updated dependencies)
-noise = { version = "0.8", git = "https://github.com/Razaekel/noise-rs.git", rev = "c6942d4fb70af26db4441edcf41f90fa115333f2" }
+noise = "0.9"
 nv-flip = "0.1"
 obj = "0.10"
 once_cell = "1.20.2"
@@ -139,19 +133,8 @@ smallvec = "1"
 static_assertions = "1.1.0"
 strum = { version = "0.26.0", features = ["derive"] }
 trybuild = "1"
-tracy-client = "0.17"
+tracy-client = "0.18"
 thiserror = "2"
-wgpu = { version = "24.0.0", path = "./wgpu", default-features = false, features = [
-    "serde",
-    "wgsl",
-    "dx12",
-    "metal",
-    "static-dxc",
-] }
-wgpu-core = { version = "24.0.0", path = "./wgpu-core" }
-wgpu-macros = { version = "24.0.0", path = "./wgpu-macros" }
-wgpu-test = { version = "24.0.0", path = "./tests" }
-wgpu-types = { version = "24.0.0", path = "./wgpu-types" }
 winit = { version = "0.29", features = ["android-native-activity"] }
 
 # Metal dependencies
@@ -166,7 +149,7 @@ ash = "0.38.0"
 gpu-alloc = "0.6"
 gpu-descriptor = "0.3"
 
-# DX dependencies
+# DX12 dependencies
 bit-set = "0.8"
 gpu-allocator = { version = "0.27", default-features = false }
 range-alloc = "0.1"
@@ -180,7 +163,7 @@ glutin = { version = "0.31", default-features = false }
 glutin-winit = { version = "0.4", default-features = false }
 glutin_wgl_sys = "0.6"
 
-# DX and GLES dependencies
+# DX12 and GLES dependencies
 windows = { version = "0.58", default-features = false }
 
 # wasm32 dependencies
@@ -191,7 +174,7 @@ wasm-bindgen = "0.2.97"
 wasm-bindgen-futures = "0.4.45"
 wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3.74", default-features = false }
-web-time = "0.2.4"
+web-time = "1"
 
 # deno dependencies
 deno_console = "0.179.0"
@@ -206,21 +189,8 @@ termcolor = "1.4.1"
 # android dependencies
 ndk-sys = "0.5.0"
 
-[patch."https://github.com/gfx-rs/naga"]
-
-[patch."https://github.com/zakarumych/gpu-descriptor"]
-#gpu-descriptor = { path = "../gpu-descriptor/gpu-descriptor" }
-
-[patch."https://github.com/zakarumych/gpu-alloc"]
-#gpu-alloc = { path = "../gpu-alloc/gpu-alloc" }
-
-[patch.crates-io]
-#glow = { path = "../glow" }
-#web-sys = { path = "../wasm-bindgen/crates/web-sys" }
-#js-sys = { path = "../wasm-bindgen/crates/js-sys" }
-#wasm-bindgen = { path = "../wasm-bindgen" }
-
 # These overrides allow our examples to explicitly depend on release crates 
+[patch.crates-io]
 wgpu = { path = "./wgpu" }
 
 [profile.release]

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -16,16 +16,7 @@ path = "lib.rs"
 # We make all dependencies conditional on not being wasm,
 # so the whole workspace can built as wasm.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-deno_core.workspace = true
-serde = { workspace = true, features = ["derive"] }
-tokio = { workspace = true, features = ["full"] }
-wgt = { workspace = true, package = "wgpu-types", features = ["serde"] }
-raw-window-handle = { workspace = true }
-thiserror.workspace = true
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgpu-core]
-workspace = true
-features = [
+wgpu-core = { workspace = true, features = [
     "raw-window-handle",
     "trace",
     "replay",
@@ -33,19 +24,29 @@ features = [
     "strict_asserts",
     "wgsl",
     "gles",
-]
+] }
+wgpu-types = { workspace = true, features = ["serde"] }
 
-# We want the wgpu-core Metal backend on macOS and iOS.
-[target.'cfg(target_vendor = "apple")'.dependencies.wgpu-core]
-workspace = true
-features = ["metal"]
+deno_core.workspace = true
+raw-window-handle = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
 
-# We want the wgpu-core Direct3D backend on Windows.
-[target.'cfg(windows)'.dependencies.wgpu-core]
-workspace = true
-features = ["dx12"]
+# Apple Platforms
+#
+# We want the Metal backend.
+[target.'cfg(target_vendor = "apple")'.dependencies]
+wgpu-core = { workspace = true, features = ["metal"] }
 
-# We want the wgpu-core Vulkan backend on Unix (but not Emscripten) and Windows.
-[target.'cfg(any(windows, all(unix, not(target_os = "emscripten"))))'.dependencies.wgpu-core]
-workspace = true
-features = ["vulkan"]
+# Windows
+#
+# We want the DX12 backend.
+[target.'cfg(windows)'.dependencies]
+wgpu-core = { workspace = true, features = ["dx12"] }
+
+# Windows and Unit (not Emscripten)
+#
+# We want the Vulkan backend.
+[target.'cfg(any(windows, all(unix, not(target_os = "emscripten"))))'.dependencies]
+wgpu-core = { workspace = true, features = ["vulkan"] }

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -45,7 +45,7 @@ wgpu-core = { workspace = true, features = ["metal"] }
 [target.'cfg(windows)'.dependencies]
 wgpu-core = { workspace = true, features = ["dx12"] }
 
-# Windows and Unit (not Emscripten)
+# Windows and Unix (not Emscripten)
 #
 # We want the Vulkan backend.
 [target.'cfg(any(windows, all(unix, not(target_os = "emscripten"))))'.dependencies]

--- a/deno_webgpu/binding.rs
+++ b/deno_webgpu/binding.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 use super::error::WebGpuResult;
-use super::wgpu_types;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::OpState;

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 use super::error::WebGpuResult;
-use super::wgpu_types;
 use deno_core::futures::channel::oneshot;
 use deno_core::op2;
 use deno_core::OpState;

--- a/deno_webgpu/bundle.rs
+++ b/deno_webgpu/bundle.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use super::wgpu_types;
 use deno_core::op2;
 use deno_core::OpState;
 use deno_core::Resource;

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use super::wgpu_types;
 use crate::WebGpuQuerySet;
 use deno_core::error::AnyError;
 use deno_core::op2;

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -12,8 +12,6 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
-pub use wgpu_core;
-pub use wgt as wgpu_types;
 
 use error::WebGpuResult;
 

--- a/deno_webgpu/pipeline.rs
+++ b/deno_webgpu/pipeline.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use super::wgpu_types;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::OpState;

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use super::wgpu_types;
 use crate::command_encoder::WebGpuCommandBuffer;
 use crate::Instance;
 use deno_core::error::AnyError;

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use super::wgpu_types;
 use deno_core::op2;
 use deno_core::OpState;
 use deno_core::Resource;

--- a/deno_webgpu/sampler.rs
+++ b/deno_webgpu/sampler.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use super::wgpu_types;
 use deno_core::op2;
 use deno_core::OpState;
 use deno_core::Resource;

--- a/deno_webgpu/shader.rs
+++ b/deno_webgpu/shader.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use super::wgpu_types;
 use deno_core::op2;
 use deno_core::OpState;
 use deno_core::Resource;

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use super::wgpu_types;
 use super::WebGpuResult;
 use deno_core::op2;
 use deno_core::OpState;

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use super::wgpu_types;
 use deno_core::op2;
 use deno_core::OpState;
 use deno_core::Resource;

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -18,17 +18,7 @@ doc = false
 test = false
 
 [dependencies]
-bincode.workspace = true
-codespan-reporting.workspace = true
-env_logger.workspace = true
-argh.workspace = true
-anyhow.workspace = true
-log.workspace = true
-
-[dependencies.naga]
-version = "24.0.0"
-path = "../naga"
-features = [
+naga = { workspace = true, features = [
     "compact",
     "wgsl-in",
     "wgsl-out",
@@ -41,4 +31,11 @@ features = [
     "dot-out",
     "serialize",
     "deserialize",
-]
+] }
+
+bincode.workspace = true
+codespan-reporting.workspace = true
+env_logger.workspace = true
+argh.workspace = true
+anyhow.workspace = true
+log.workspace = true

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -21,17 +21,18 @@ path = "src/bin/play.rs"
 test = false
 
 [dependencies]
+wgpu-types = { workspace = true, features = ["serde"] }
+
 env_logger.workspace = true
 log.workspace = true
 raw-window-handle.workspace = true
 ron.workspace = true
 winit = { workspace = true, optional = true }
 
-[dependencies.wgt]
-workspace = true
-features = ["serde"]
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
+# Non-Webassembly
+#
+# We are a non-wasm only crate, and this allows us to compile.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgpu-core]
 workspace = true
 features = [
     "replay",

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -2,6 +2,9 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
+    extern crate wgpu_core as wgc;
+    extern crate wgpu_types as wgt;
+
     use player::GlobalPlay as _;
     use wgc::device::trace;
 

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -3,6 +3,9 @@
 #![cfg(not(target_arch = "wasm32"))]
 #![warn(clippy::allow_attributes, unsafe_op_in_unsafe_fn)]
 
+extern crate wgpu_core as wgc;
+extern crate wgpu_types as wgt;
+
 use wgc::device::trace;
 
 use std::{borrow::Cow, fs, path::Path};

--- a/player/tests/test.rs
+++ b/player/tests/test.rs
@@ -10,6 +10,9 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
+extern crate wgpu_core as wgc;
+extern crate wgpu_types as wgt;
+
 use player::GlobalPlay;
 use std::{
     fs::{read_to_string, File},

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -25,6 +25,9 @@ harness = true
 webgl = ["wgpu/webgl"]
 
 [dependencies]
+wgpu.workspace = true
+wgpu-macros.workspace = true
+
 anyhow.workspace = true
 arrayvec.workspace = true
 approx.workspace = true
@@ -46,20 +49,20 @@ serde_json.workspace = true
 serde.workspace = true
 strum = { workspace = true, features = ["derive"] }
 trybuild.workspace = true
-wgpu.workspace = true
-wgpu-macros.workspace = true
-wgt = { workspace = true, features = ["serde"] }
 
+# Non-Webassembly
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger.workspace = true
 nv-flip.workspace = true
 parking_lot = { workspace = true, features = ["deadlock_detection"] }
 
+# Webassembly
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log.workspace = true
 wasm-bindgen.workspace = true
 web-sys = { workspace = true }
 
+# Webassembly Dev Dependencies
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 image.workspace = true
 js-sys.workspace = true

--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -35,7 +35,7 @@ use core::fmt;
 ///
 /// [skip]: super::TestParameters::skip
 /// [expect_fail]: super::TestParameters::expect_fail
-/// [`AdapterInfo`]: wgt::AdapterInfo
+/// [`AdapterInfo`]: wgpu::AdapterInfo
 #[derive(Default, Clone)]
 pub struct FailureCase {
     /// Backends expected to fail, or `None` for any backend.
@@ -50,7 +50,7 @@ pub struct FailureCase {
     /// usually the PCI device id. Otherwise, this `FailureCase`
     /// applies regardless of vendor.
     ///
-    /// [`AdapterInfo::device`]: wgt::AdapterInfo::device
+    /// [`AdapterInfo::device`]: wgpu::AdapterInfo::device
     pub vendor: Option<u32>,
 
     /// Name of adapter expected to fail, or `None` for any adapter name.
@@ -59,7 +59,7 @@ pub struct FailureCase {
     /// [`AdapterInfo::name`], then this `FailureCase` applies. If
     /// this is `None`, the adapter name isn't considered.
     ///
-    /// [`AdapterInfo::name`]: wgt::AdapterInfo::name
+    /// [`AdapterInfo::name`]: wgpu::AdapterInfo::name
     pub adapter: Option<&'static str>,
 
     /// Name of driver expected to fail, or `None` for any driver name.
@@ -68,7 +68,7 @@ pub struct FailureCase {
     /// [`AdapterInfo::driver`], then this `FailureCase` applies. If
     /// this is `None`, the driver name isn't considered.
     ///
-    /// [`AdapterInfo::driver`]: wgt::AdapterInfo::driver
+    /// [`AdapterInfo::driver`]: wgpu::AdapterInfo::driver
     pub driver: Option<&'static str>,
 
     /// Reason why the test is expected to fail.
@@ -115,7 +115,7 @@ impl FailureCase {
     /// of the adapter's [`AdapterInfo::name`]. The comparison is
     /// case-insensitive.
     ///
-    /// [`AdapterInfo::name`]: wgt::AdapterInfo::name
+    /// [`AdapterInfo::name`]: wgpu::AdapterInfo::name
     pub fn adapter(adapter: &'static str) -> Self {
         FailureCase {
             adapter: Some(adapter),
@@ -130,7 +130,7 @@ impl FailureCase {
     /// the adapter's [`AdapterInfo::name`]. The string comparison is
     /// case-insensitive.
     ///
-    /// [`AdapterInfo::name`]: wgt::AdapterInfo::name
+    /// [`AdapterInfo::name`]: wgpu::AdapterInfo::name
     pub fn backend_adapter(backends: wgpu::Backends, adapter: &'static str) -> Self {
         FailureCase {
             backends: Some(backends),
@@ -207,7 +207,7 @@ impl FailureCase {
     /// matching.
     pub(crate) fn applies_to_adapter(
         &self,
-        info: &wgt::AdapterInfo,
+        info: &wgpu::AdapterInfo,
     ) -> Option<FailureApplicationReasons> {
         let mut reasons = FailureApplicationReasons::empty();
 

--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -151,7 +151,7 @@ impl ComparisonType {
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn compare_image_output(
     path: impl AsRef<Path> + AsRef<OsStr>,
-    adapter_info: &wgt::AdapterInfo,
+    adapter_info: &wgpu::AdapterInfo,
     width: u32,
     height: u32,
     test_with_alpha: &[u8],
@@ -253,7 +253,7 @@ pub async fn compare_image_output(
 #[cfg(target_arch = "wasm32")]
 pub async fn compare_image_output(
     path: impl AsRef<Path> + AsRef<OsStr>,
-    adapter_info: &wgt::AdapterInfo,
+    adapter_info: &wgpu::AdapterInfo,
     width: u32,
     height: u32,
     test_with_alpha: &[u8],

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -1,5 +1,4 @@
-use wgpu::{Adapter, Device, Instance, Queue};
-use wgt::{Backends, Features, Limits};
+use wgpu::{Adapter, Backends, Device, Features, Instance, Limits, Queue};
 
 use crate::report::AdapterReport;
 

--- a/tests/src/params.rs
+++ b/tests/src/params.rs
@@ -1,5 +1,5 @@
 use arrayvec::ArrayVec;
-use wgt::{DownlevelCapabilities, DownlevelFlags, Features, Limits};
+use wgpu::{DownlevelCapabilities, DownlevelFlags, Features, Limits};
 
 use crate::{
     report::AdapterReport, FailureApplicationReasons, FailureBehavior, FailureCase,
@@ -7,9 +7,9 @@ use crate::{
 };
 
 const LOWEST_DOWNLEVEL_PROPERTIES: wgpu::DownlevelCapabilities = DownlevelCapabilities {
-    flags: wgt::DownlevelFlags::empty(),
-    limits: wgt::DownlevelLimits {},
-    shader_model: wgt::ShaderModel::Sm2,
+    flags: wgpu::DownlevelFlags::empty(),
+    limits: wgpu::DownlevelLimits {},
+    shader_model: wgpu::ShaderModel::Sm2,
 };
 
 /// This information determines if a test should run.
@@ -120,7 +120,7 @@ impl TestInfo {
 
         // Produce a lower-case version of the adapter info, for comparison against
         // `parameters.skips` and `parameters.failures`.
-        let adapter_lowercase_info = wgt::AdapterInfo {
+        let adapter_lowercase_info = wgpu::AdapterInfo {
             name: adapter.info.name.to_lowercase(),
             driver: adapter.info.driver.to_lowercase(),
             ..adapter.info.clone()

--- a/tests/tests/buffer_copy.rs
+++ b/tests/tests/buffer_copy.rs
@@ -1,6 +1,6 @@
 //! Tests for buffer copy validation.
 
-use wgt::BufferAddress;
+use wgpu::BufferAddress;
 
 use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration};
 

--- a/tests/tests/buffer_usages.rs
+++ b/tests/tests/buffer_usages.rs
@@ -1,8 +1,8 @@
 //! Tests for buffer usages validation.
 
+use wgpu::BufferAddress;
 use wgpu::{BufferUsages as Bu, MapMode as Ma};
 use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
-use wgt::BufferAddress;
 
 const BUFFER_SIZE: BufferAddress = 1234;
 

--- a/tests/tests/device.rs
+++ b/tests/tests/device.rs
@@ -603,7 +603,7 @@ static DEVICE_DESTROY_THEN_LOST: GpuTestConfiguration = GpuTestConfiguration::ne
         let callback = Box::new(|reason, _m| {
             WAS_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
             assert!(
-                matches!(reason, wgt::DeviceLostReason::Destroyed),
+                matches!(reason, wgpu::DeviceLostReason::Destroyed),
                 "Device lost info reason should match DeviceLostReason::Destroyed."
             );
         });
@@ -669,18 +669,18 @@ static DIFFERENT_BGL_ORDER_BW_SHADER_AND_API: GpuTestConfiguration = GpuTestConf
                     ),
                 });
 
-        let my_texture = ctx.device.create_texture(&wgt::TextureDescriptor {
+        let my_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
-            size: wgt::Extent3d {
+            size: wgpu::Extent3d {
                 width: 1024,
                 height: 512,
                 depth_or_array_layers: 1,
             },
             mip_level_count: 1,
             sample_count: 1,
-            dimension: wgt::TextureDimension::D2,
-            format: wgt::TextureFormat::Rgba8Unorm,
-            usage: wgt::TextureUsages::RENDER_ATTACHMENT | wgt::TextureUsages::TEXTURE_BINDING,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
         });
 
@@ -689,7 +689,7 @@ static DIFFERENT_BGL_ORDER_BW_SHADER_AND_API: GpuTestConfiguration = GpuTestConf
             format: None,
             dimension: None,
             usage: None,
-            aspect: wgt::TextureAspect::All,
+            aspect: wgpu::TextureAspect::All,
             base_mip_level: 0,
             mip_level_count: None,
             base_array_layer: 0,
@@ -707,10 +707,10 @@ static DIFFERENT_BGL_ORDER_BW_SHADER_AND_API: GpuTestConfiguration = GpuTestConf
                     module: &trivial_shaders_with_some_reversed_bindings,
                     entry_point: Some("fs_main"),
                     compilation_options: Default::default(),
-                    targets: &[Some(wgt::ColorTargetState {
-                        format: wgt::TextureFormat::Bgra8Unorm,
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::Bgra8Unorm,
                         blend: None,
-                        write_mask: wgt::ColorWrites::ALL,
+                        write_mask: wgpu::ColorWrites::ALL,
                     })],
                 }),
                 layout: None,
@@ -723,9 +723,9 @@ static DIFFERENT_BGL_ORDER_BW_SHADER_AND_API: GpuTestConfiguration = GpuTestConf
                     compilation_options: Default::default(),
                     buffers: &[],
                 },
-                primitive: wgt::PrimitiveState::default(),
+                primitive: wgpu::PrimitiveState::default(),
                 depth_stencil: None,
-                multisample: wgt::MultisampleState::default(),
+                multisample: wgpu::MultisampleState::default(),
                 multiview: None,
                 cache: None,
             });

--- a/tests/tests/dispatch_workgroups_indirect.rs
+++ b/tests/tests/dispatch_workgroups_indirect.rs
@@ -180,7 +180,7 @@ impl TestResources {
                 label: None,
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgt::ShaderStages::COMPUTE,
+                    visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Storage { read_only: false },
                         has_dynamic_offset: false,
@@ -195,8 +195,8 @@ impl TestResources {
             .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: None,
                 bind_group_layouts: &[&bgl],
-                push_constant_ranges: &[wgt::PushConstantRange {
-                    stages: wgt::ShaderStages::COMPUTE,
+                push_constant_ranges: &[wgpu::PushConstantRange {
+                    stages: wgpu::ShaderStages::COMPUTE,
                     range: 0..4,
                 }],
             });

--- a/tests/tests/external_texture.rs
+++ b/tests/tests/external_texture.rs
@@ -145,7 +145,7 @@ static IMAGE_BITMAP_IMPORT: GpuTestConfiguration =
                 // The layer the external image's data should end up in.
                 let mut dest_data_layer = 0;
                 // Color space the destination is in.
-                let mut dest_color_space = wgt::PredefinedColorSpace::Srgb;
+                let mut dest_color_space = wgpu::PredefinedColorSpace::Srgb;
                 // If the destination image is premultiplied.
                 let mut dest_premultiplied = false;
                 // Size of the external copy
@@ -164,7 +164,7 @@ static IMAGE_BITMAP_IMPORT: GpuTestConfiguration =
                 match case {
                     TestCase::Normal => {}
                     TestCase::FlipY => {
-                        valid = !matches!(source, wgt::ExternalImageSource::ImageBitmap(_));
+                        valid = !matches!(source, wgpu::ExternalImageSource::ImageBitmap(_));
                         src_flip_y = true;
                         for x in 0..3 {
                             let top = raw_image[(x, 0)];
@@ -174,7 +174,7 @@ static IMAGE_BITMAP_IMPORT: GpuTestConfiguration =
                         }
                     }
                     TestCase::Premultiplied => {
-                        valid = !matches!(source, wgt::ExternalImageSource::ImageBitmap(_));
+                        valid = !matches!(source, wgpu::ExternalImageSource::ImageBitmap(_));
                         dest_premultiplied = true;
                         for pixel in raw_image.pixels_mut() {
                             let mut float_pix = pixel.0.map(|v| v as f32 / 255.0);
@@ -188,8 +188,8 @@ static IMAGE_BITMAP_IMPORT: GpuTestConfiguration =
                         valid = ctx
                             .adapter_downlevel_capabilities
                             .flags
-                            .contains(wgt::DownlevelFlags::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES);
-                        dest_color_space = wgt::PredefinedColorSpace::DisplayP3;
+                            .contains(wgpu::DownlevelFlags::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES);
+                        dest_color_space = wgpu::PredefinedColorSpace::DisplayP3;
 
                         // As we don't test, we don't bother converting the color spaces
                         // in the image as that's relatively annoying.
@@ -198,7 +198,7 @@ static IMAGE_BITMAP_IMPORT: GpuTestConfiguration =
                         valid = ctx
                             .adapter_downlevel_capabilities
                             .flags
-                            .contains(wgt::DownlevelFlags::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES);
+                            .contains(wgpu::DownlevelFlags::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES);
                         src_origin.x = 1;
                         dest_origin.x = 1;
                         copy_size.width = 2;

--- a/tests/tests/oob_indexing.rs
+++ b/tests/tests/oob_indexing.rs
@@ -1,5 +1,5 @@
+use wgpu::{Backend, Backends};
 use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
-use wgt::{Backend, Backends};
 
 /// Tests that writing and reading to the max length of a container (vec, mat, array)
 /// in the workgroup, private and function address spaces + let declarations
@@ -145,7 +145,7 @@ impl TestResources {
                 entries: &[
                     wgpu::BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: wgt::ShaderStages::COMPUTE,
+                        visibility: wgpu::ShaderStages::COMPUTE,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Storage { read_only: false },
                             has_dynamic_offset: false,
@@ -155,7 +155,7 @@ impl TestResources {
                     },
                     wgpu::BindGroupLayoutEntry {
                         binding: 1,
-                        visibility: wgt::ShaderStages::COMPUTE,
+                        visibility: wgpu::ShaderStages::COMPUTE,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Storage { read_only: false },
                             has_dynamic_offset: false,
@@ -289,7 +289,7 @@ async fn d3d12_restrict_dynamic_buffers(ctx: TestingContext) {
             entries: &[
                 wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgt::ShaderStages::COMPUTE,
+                    visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Storage { read_only: false },
                         has_dynamic_offset: false,
@@ -299,7 +299,7 @@ async fn d3d12_restrict_dynamic_buffers(ctx: TestingContext) {
                 },
                 wgpu::BindGroupLayoutEntry {
                     binding: 1,
-                    visibility: wgt::ShaderStages::COMPUTE,
+                    visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Storage { read_only: false },
                         has_dynamic_offset: false,
@@ -309,7 +309,7 @@ async fn d3d12_restrict_dynamic_buffers(ctx: TestingContext) {
                 },
                 wgpu::BindGroupLayoutEntry {
                     binding: 2,
-                    visibility: wgt::ShaderStages::COMPUTE,
+                    visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: true,
@@ -319,7 +319,7 @@ async fn d3d12_restrict_dynamic_buffers(ctx: TestingContext) {
                 },
                 wgpu::BindGroupLayoutEntry {
                     binding: 3,
-                    visibility: wgt::ShaderStages::COMPUTE,
+                    visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Storage { read_only: false },
                         has_dynamic_offset: true,

--- a/tests/tests/ray_tracing/as_create.rs
+++ b/tests/tests/ray_tracing/as_create.rs
@@ -3,9 +3,9 @@ use wgpu::{
     AccelerationStructureUpdateMode, BlasGeometrySizeDescriptors,
     BlasTriangleGeometrySizeDescriptor, CreateBlasDescriptor,
 };
+use wgpu::{IndexFormat, VertexFormat};
 use wgpu_macros::gpu_test;
 use wgpu_test::{fail, GpuTestConfiguration, TestParameters, TestingContext};
-use wgt::{IndexFormat, VertexFormat};
 
 #[gpu_test]
 static BLAS_INVALID_VERTEX_FORMAT: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/ray_tracing/mod.rs
+++ b/tests/tests/ray_tracing/mod.rs
@@ -5,11 +5,11 @@ use wgpu::{
     BlasTriangleGeometry, BlasTriangleGeometrySizeDescriptor, Buffer, CreateBlasDescriptor,
     CreateTlasDescriptor, TlasInstance, TlasPackage,
 };
-use wgpu_test::TestingContext;
-use wgt::{
+use wgpu::{
     AccelerationStructureFlags, AccelerationStructureGeometryFlags,
     AccelerationStructureUpdateMode, BufferAddress, BufferUsages, VertexFormat,
 };
+use wgpu_test::TestingContext;
 
 mod as_build;
 mod as_create;

--- a/tests/tests/ray_tracing/shader.rs
+++ b/tests/tests/ray_tracing/shader.rs
@@ -1,13 +1,13 @@
 use crate::ray_tracing::AsBuildContext;
+use wgpu::BufferUsages;
 use wgpu::{
     include_wgsl, BindGroupDescriptor, BindGroupEntry, BindingResource, BufferDescriptor,
     CommandEncoderDescriptor, ComputePassDescriptor, ComputePipelineDescriptor,
 };
 use wgpu_macros::gpu_test;
 use wgpu_test::{GpuTestConfiguration, TestParameters, TestingContext};
-use wgt::BufferUsages;
 
-const STRUCT_SIZE: wgt::BufferAddress = 176;
+const STRUCT_SIZE: wgpu::BufferAddress = 176;
 
 #[gpu_test]
 static ACCESS_ALL_STRUCT_MEMBERS: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/shader/numeric_builtins.rs
+++ b/tests/tests/shader/numeric_builtins.rs
@@ -84,7 +84,7 @@ fn create_int64_atomic_min_max_test() -> Vec<ShaderTest> {
 static INT64_ATOMIC_MIN_MAX: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(wgt::Features::SHADER_INT64 | wgt::Features::SHADER_INT64_ATOMIC_MIN_MAX)
+            .features(wgpu::Features::SHADER_INT64 | wgpu::Features::SHADER_INT64_ATOMIC_MIN_MAX)
             .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
             .limits(Limits::downlevel_defaults()),
     )
@@ -139,7 +139,7 @@ fn create_int64_atomic_all_ops_test() -> Vec<ShaderTest> {
 static INT64_ATOMIC_ALL_OPS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(wgt::Features::SHADER_INT64 | wgt::Features::SHADER_INT64_ATOMIC_ALL_OPS)
+            .features(wgpu::Features::SHADER_INT64 | wgpu::Features::SHADER_INT64_ATOMIC_ALL_OPS)
             .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
             .limits(Limits::downlevel_defaults()),
     )
@@ -183,7 +183,7 @@ fn create_float32_atomic_test() -> Vec<ShaderTest> {
 static FLOAT32_ATOMIC: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(wgt::Features::SHADER_FLOAT32_ATOMIC)
+            .features(wgpu::Features::SHADER_FLOAT32_ATOMIC)
             .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
             .limits(Limits::downlevel_defaults()),
     )

--- a/tests/tests/vertex_formats/mod.rs
+++ b/tests/tests/vertex_formats/mod.rs
@@ -21,7 +21,7 @@ enum TestCase {
 struct Test<'a> {
     case: TestCase,
     entry_point: &'a str,
-    attributes: &'a [wgt::VertexAttribute],
+    attributes: &'a [wgpu::VertexAttribute],
     input: &'a [u8],
     checksums: &'a [f32],
 }

--- a/tests/tests/vertex_indices/mod.rs
+++ b/tests/tests/vertex_indices/mod.rs
@@ -8,8 +8,8 @@ use std::{num::NonZeroU64, ops::Range};
 use itertools::Itertools;
 use strum::IntoEnumIterator;
 use wgpu::util::{BufferInitDescriptor, DeviceExt, RenderEncoder};
+use wgpu::RenderBundleDescriptor;
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
-use wgt::RenderBundleDescriptor;
 
 /// Generic struct representing a draw call
 struct Draw {

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -38,7 +38,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wgpu_validate_locks)'] }
 ## Internally count resources and events for debugging purposes. If the counters
 ## feature is disabled, the counting infrastructure is removed from the build and
 ## the exposed counters always return 0.
-counters = ["wgt/counters"]
+counters = ["wgpu-types/counters"]
 
 ## Log all API entry points at info instead of trace level.
 ## Also, promotes certain debug log calls to info.
@@ -49,18 +49,18 @@ resource_log_info = []
 
 ## Support the Renderdoc graphics debugger:
 ## <https://renderdoc.org/>
-renderdoc = ["hal/renderdoc"]
+renderdoc = ["wgpu-hal/renderdoc"]
 
 ## Apply run-time checks, even in release builds. These are in addition
 ## to the validation carried out at public APIs in all builds.
-strict_asserts = ["wgt/strict_asserts"]
+strict_asserts = ["wgpu-types/strict_asserts"]
 
 ## Validates indirect draw/dispatch calls. This will also enable naga's
 ## WGSL frontend since we use a WGSL compute shader to do the validation.
 indirect-validation = ["naga/wgsl-in"]
 
 ## Enables serialization via `serde` on common wgpu types.
-serde = ["dep:serde", "wgt/serde", "arrayvec/serde"]
+serde = ["dep:serde", "wgpu-types/serde", "arrayvec/serde"]
 
 ## Enable API tracing.
 trace = ["dep:ron", "serde", "naga/serialize"]
@@ -92,28 +92,32 @@ spirv = ["naga/spv-in", "dep:bytemuck"]
 ## but on a wasm binary compiled without atomics we know we are definitely
 ## not in a multithreaded environment.
 fragile-send-sync-non-atomic-wasm = [
-    "hal/fragile-send-sync-non-atomic-wasm",
-    "wgt/fragile-send-sync-non-atomic-wasm",
+    "wgpu-hal/fragile-send-sync-non-atomic-wasm",
+    "wgpu-types/fragile-send-sync-non-atomic-wasm",
 ]
 
 #! ### Backends, passed through to wgpu-hal
 # --------------------------------------------------------------------
 
 ## Enable the `metal` backend.
-metal = ["hal/metal"]
+metal = ["wgpu-hal/metal"]
 
 ## Enable the `vulkan` backend.
-vulkan = ["hal/vulkan"]
+vulkan = ["wgpu-hal/vulkan"]
 
 ## Enable the `GLES` backend.
 ##
 ## This is used for all of GLES, OpenGL, and WebGL.
-gles = ["hal/gles"]
+gles = ["wgpu-hal/gles"]
 
 ## Enable the `dx12` backend.
-dx12 = ["hal/dx12"]
+dx12 = ["wgpu-hal/dx12"]
 
 [dependencies]
+naga.workspace = true
+wgpu-hal.workspace = true
+wgpu-types.workspace = true
+
 arrayvec.workspace = true
 bit-vec.workspace = true
 bitflags.workspace = true
@@ -131,21 +135,6 @@ rustc-hash.workspace = true
 serde = { workspace = true, features = ["default", "derive"], optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
-
-[dependencies.naga]
-path = "../naga"
-version = "24.0.0"
-
-[dependencies.wgt]
-package = "wgpu-types"
-path = "../wgpu-types"
-version = "24.0.0"
-
-[dependencies.hal]
-package = "wgpu-hal"
-path = "../wgpu-hal"
-version = "24.0.0"
-default-features = false
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -56,6 +56,9 @@
 // (the only reason to use wgpu-core on the web in the first place) that have atomics enabled.
 #![cfg_attr(not(send_sync), allow(clippy::arc_with_non_send_sync))]
 
+extern crate wgpu_hal as hal;
+extern crate wgpu_types as wgt;
+
 pub mod binding_model;
 pub mod command;
 mod conv;

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -34,6 +34,9 @@ targets = [
 # Cargo machete can't check build.rs dependencies. See https://github.com/bnjbvr/cargo-machete/issues/100
 ignored = ["cfg_aliases"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
+
 [lib]
 
 [features]
@@ -96,7 +99,9 @@ dx12 = [
 ## Enables statically linking DXC.
 static-dxc = ["dep:mach-dxcompiler-rs"]
 renderdoc = ["dep:libloading", "dep:renderdoc-sys"]
-fragile-send-sync-non-atomic-wasm = ["wgt/fragile-send-sync-non-atomic-wasm"]
+fragile-send-sync-non-atomic-wasm = [
+    "wgpu-types/fragile-send-sync-non-atomic-wasm",
+]
 # Panic when running into an out-of-memory error (for debugging purposes).
 #
 # Only affects the d3d12 and vulkan backends.
@@ -110,9 +115,6 @@ device_lost_panic = []
 # Only affects the d3d12 and vulkan backends.
 internal_error_panic = []
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
-
 [[example]]
 name = "halmark"
 
@@ -120,74 +122,100 @@ name = "halmark"
 name = "raw-gles"
 required-features = ["gles"]
 
+#####################
+### Platform: All ###
+#####################
+
 [dependencies]
+naga.workspace = true
+wgpu-types.workspace = true
+
+arrayvec.workspace = true
 bitflags.workspace = true
 hashbrown.workspace = true
+log.workspace = true
+once_cell.workspace = true
+ordered-float = { workspace = true, optional = true }
 parking_lot.workspace = true
 profiling = { workspace = true, default-features = false }
 raw-window-handle.workspace = true
-thiserror.workspace = true
-once_cell.workspace = true
-ordered-float = { workspace = true, optional = true }
-
-# backends common
-arrayvec.workspace = true
 rustc-hash.workspace = true
-log.workspace = true
+thiserror.workspace = true
 
-# backend: Gles
+# Backend: GLES
 bytemuck = { workspace = true, optional = true }
 glow = { workspace = true, optional = true }
 
-[dependencies.wgt]
-package = "wgpu-types"
-path = "../wgpu-types"
-version = "24.0.0"
+########################
+### Platform: Native ###
+########################
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-# backend: Vulkan
+# Backend: Vulkan
 ash = { workspace = true, optional = true }
 gpu-alloc = { workspace = true, optional = true }
 gpu-descriptor = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true, features = ["union"] }
-
+# Backend: GLES
 khronos-egl = { workspace = true, features = ["dynamic"], optional = true }
 libloading = { workspace = true, optional = true }
 renderdoc-sys = { workspace = true, optional = true }
 
-[target.'cfg(target_os = "emscripten")'.dependencies]
-khronos-egl = { workspace = true, features = ["static", "no-pkg-config"] }
-#Note: it's unused by emscripten, but we keep it to have single code base in egl.rs
-libloading = { workspace = true, optional = true }
+##########################
+### Platform: All Unix ###
+##########################
+
+[target.'cfg(unix)'.dependencies]
+# Backend: Vulkan
+libc.workspace = true
+
+#########################
+### Platform: Windows ###
+#########################
 
 [target.'cfg(windows)'.dependencies]
-# backend: Dx12 and Gles
+# Backend: Dx12 and GLES
 windows = { workspace = true, optional = true }
-# backend: Dx12
+windows-core = { workspace = true, optional = true }
+# Backend: Dx12
 bit-set = { workspace = true, optional = true }
 range-alloc = { workspace = true, optional = true }
 gpu-allocator = { workspace = true, optional = true }
-# For core macros. This crate is also reexported as windows::core.
-windows-core = { workspace = true, optional = true }
-
-# backend: Gles
+# backend: GLES
 glutin_wgl_sys = { workspace = true, optional = true }
 
+### Platform: x86/x86_64 Windows ###
 # This doesn't support aarch64. See https://github.com/gfx-rs/wgpu/issues/6860.
 #
 # ⚠️ Keep in sync with static_dxc cfg in build.rs and cfg_alias in `wgpu` crate ⚠️
 [target.'cfg(all(windows, not(target_arch = "aarch64")))'.dependencies]
 mach-dxcompiler-rs = { workspace = true, optional = true }
 
-[target.'cfg(target_vendor = "apple")'.dependencies]
-# backend: Metal
-block = { workspace = true, optional = true }
+#######################
+### Platform: Apple ###
+#######################
 
+[target.'cfg(target_vendor = "apple")'.dependencies]
+# Backend: Metal
+block = { workspace = true, optional = true }
+core-graphics-types.workspace = true
 metal.workspace = true
 objc.workspace = true
-core-graphics-types.workspace = true
+
+#########################
+### Platform: Android ###
+#########################
+
+[target.'cfg(target_os = "android")'.dependencies]
+android_system_properties = { workspace = true, optional = true }
+ndk-sys = { workspace = true, optional = true }
+
+#############################
+### Platform: Webassembly ###
+#############################
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+# Backend: GLES
 wasm-bindgen.workspace = true
 web-sys = { workspace = true, features = [
     "default",
@@ -198,44 +226,29 @@ web-sys = { workspace = true, features = [
 ] }
 js-sys = { workspace = true, features = ["default"] }
 
-[target.'cfg(unix)'.dependencies]
-libc.workspace = true
+############################
+### Platform: Emscripten ###
+############################
 
-[target.'cfg(target_os = "android")'.dependencies]
-android_system_properties = { workspace = true, optional = true }
-ndk-sys = { workspace = true, optional = true }
-
-[dependencies.naga]
-path = "../naga"
-version = "24.0.0"
+[target.'cfg(target_os = "emscripten")'.dependencies]
+# Backend: GLES
+khronos-egl = { workspace = true, features = ["static", "no-pkg-config"] }
+# Note: it's unused by emscripten, but we keep it to have single code base in egl.rs
+libloading = { workspace = true, optional = true }
 
 [build-dependencies]
 cfg_aliases.workspace = true
 
-# DEV dependencies
-[dev-dependencies.naga]
-path = "../naga"
-version = "24.0.0"
-features = ["wgsl-in"]
-
 [dev-dependencies]
 cfg-if.workspace = true
 env_logger.workspace = true
-glam.workspace = true       # for ray-traced-triangle example
-winit.workspace = true      # for "halmark" example
+glam.workspace = true                               # for ray-traced-triangle example
+naga = { workspace = true, features = ["wgsl-in"] }
+winit.workspace = true                              # for "halmark" example
 
+### Platform: Windows + MacOS + Linux for "raw-gles" example ###
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))'.dev-dependencies]
-glutin-winit = { workspace = true, features = [
-    "egl",
-    "wgl",
-    "wayland",
-    "x11",
-] } # for "raw-gles" example
-glutin = { workspace = true, features = [
-    "egl",
-    "wgl",
-    "wayland",
-    "x11",
-] } # for "raw-gles" example
-rwh_05 = { version = "0.5", package = "raw-window-handle" } # temporary compatibility for glutin-winit in "raw-gles" example
-winit = { workspace = true, features = ["rwh_05"] } # for "raw-gles" example
+glutin-winit = { workspace = true, features = ["egl", "wgl", "wayland", "x11"] }
+glutin = { workspace = true, features = ["egl", "wgl", "wayland", "x11"] }
+rwh_05 = { version = "0.5", package = "raw-window-handle" }                      # temporary compatibility for glutin-winit
+winit = { workspace = true, features = ["rwh_05"] }

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -68,7 +68,7 @@ struct Example<A: hal::Api> {
     instance: A::Instance,
     adapter: A::Adapter,
     surface: A::Surface,
-    surface_format: wgt::TextureFormat,
+    surface_format: wgpu_types::TextureFormat,
     device: A::Device,
     queue: A::Queue,
     global_group: A::BindGroup,
@@ -95,9 +95,9 @@ impl<A: hal::Api> Example<A> {
     fn init(window: &winit::window::Window) -> Result<Self, Box<dyn std::error::Error>> {
         let instance_desc = hal::InstanceDescriptor {
             name: "example",
-            flags: wgt::InstanceFlags::from_build_config().with_env(),
+            flags: wgpu_types::InstanceFlags::from_build_config().with_env(),
             // Can't rely on having DXC available, so use FXC instead
-            backend_options: wgt::BackendOptions::default(),
+            backend_options: wgpu_types::BackendOptions::default(),
         };
         let instance = unsafe { A::Instance::init(&instance_desc)? };
         let surface = {
@@ -127,9 +127,9 @@ impl<A: hal::Api> Example<A> {
         let hal::OpenDevice { device, queue } = unsafe {
             adapter
                 .open(
-                    wgt::Features::empty(),
-                    &wgt::Limits::default(),
-                    &wgt::MemoryHints::default(),
+                    wgpu_types::Features::empty(),
+                    &wgpu_types::Limits::default(),
+                    &wgpu_types::MemoryHints::default(),
                 )
                 .unwrap()
         };
@@ -140,10 +140,10 @@ impl<A: hal::Api> Example<A> {
                 *surface_caps.maximum_frame_latency.start(),
                 *surface_caps.maximum_frame_latency.end(),
             ),
-            present_mode: wgt::PresentMode::Fifo,
-            composite_alpha_mode: wgt::CompositeAlphaMode::Opaque,
-            format: wgt::TextureFormat::Bgra8UnormSrgb,
-            extent: wgt::Extent3d {
+            present_mode: wgpu_types::PresentMode::Fifo,
+            composite_alpha_mode: wgpu_types::CompositeAlphaMode::Opaque,
+            format: wgpu_types::TextureFormat::Bgra8UnormSrgb,
+            extent: wgpu_types::Extent3d {
                 width: window_size.0,
                 height: window_size.1,
                 depth_or_array_layers: 1,
@@ -176,7 +176,7 @@ impl<A: hal::Api> Example<A> {
         };
         let shader_desc = hal::ShaderModuleDescriptor {
             label: None,
-            runtime_checks: wgt::ShaderRuntimeChecks::checked(),
+            runtime_checks: wgpu_types::ShaderRuntimeChecks::checked(),
         };
         let shader = unsafe {
             device
@@ -188,30 +188,30 @@ impl<A: hal::Api> Example<A> {
             label: None,
             flags: hal::BindGroupLayoutFlags::empty(),
             entries: &[
-                wgt::BindGroupLayoutEntry {
+                wgpu_types::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgt::ShaderStages::VERTEX,
-                    ty: wgt::BindingType::Buffer {
-                        ty: wgt::BufferBindingType::Uniform,
+                    visibility: wgpu_types::ShaderStages::VERTEX,
+                    ty: wgpu_types::BindingType::Buffer {
+                        ty: wgpu_types::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: wgt::BufferSize::new(size_of::<Globals>() as _),
+                        min_binding_size: wgpu_types::BufferSize::new(size_of::<Globals>() as _),
                     },
                     count: None,
                 },
-                wgt::BindGroupLayoutEntry {
+                wgpu_types::BindGroupLayoutEntry {
                     binding: 1,
-                    visibility: wgt::ShaderStages::FRAGMENT,
-                    ty: wgt::BindingType::Texture {
-                        sample_type: wgt::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgt::TextureViewDimension::D2,
+                    visibility: wgpu_types::ShaderStages::FRAGMENT,
+                    ty: wgpu_types::BindingType::Texture {
+                        sample_type: wgpu_types::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu_types::TextureViewDimension::D2,
                         multisampled: false,
                     },
                     count: None,
                 },
-                wgt::BindGroupLayoutEntry {
+                wgpu_types::BindGroupLayoutEntry {
                     binding: 2,
-                    visibility: wgt::ShaderStages::FRAGMENT,
-                    ty: wgt::BindingType::Sampler(wgt::SamplerBindingType::Filtering),
+                    visibility: wgpu_types::ShaderStages::FRAGMENT,
+                    ty: wgpu_types::BindingType::Sampler(wgpu_types::SamplerBindingType::Filtering),
                     count: None,
                 },
             ],
@@ -223,13 +223,13 @@ impl<A: hal::Api> Example<A> {
         let local_bgl_desc = hal::BindGroupLayoutDescriptor {
             label: None,
             flags: hal::BindGroupLayoutFlags::empty(),
-            entries: &[wgt::BindGroupLayoutEntry {
+            entries: &[wgpu_types::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgt::ShaderStages::VERTEX,
-                ty: wgt::BindingType::Buffer {
-                    ty: wgt::BufferBindingType::Uniform,
+                visibility: wgpu_types::ShaderStages::VERTEX,
+                ty: wgpu_types::BindingType::Buffer {
+                    ty: wgpu_types::BufferBindingType::Uniform,
                     has_dynamic_offset: true,
-                    min_binding_size: wgt::BufferSize::new(size_of::<Locals>() as _),
+                    min_binding_size: wgpu_types::BufferSize::new(size_of::<Locals>() as _),
                 },
                 count: None,
             }],
@@ -266,16 +266,16 @@ impl<A: hal::Api> Example<A> {
                 constants: &constants,
                 zero_initialize_workgroup_memory: true,
             }),
-            primitive: wgt::PrimitiveState {
-                topology: wgt::PrimitiveTopology::TriangleStrip,
-                ..wgt::PrimitiveState::default()
+            primitive: wgpu_types::PrimitiveState {
+                topology: wgpu_types::PrimitiveTopology::TriangleStrip,
+                ..wgpu_types::PrimitiveState::default()
             },
             depth_stencil: None,
-            multisample: wgt::MultisampleState::default(),
-            color_targets: &[Some(wgt::ColorTargetState {
+            multisample: wgpu_types::MultisampleState::default(),
+            color_targets: &[Some(wgpu_types::ColorTargetState {
                 format: surface_config.format,
-                blend: Some(wgt::BlendState::ALPHA_BLENDING),
-                write_mask: wgt::ColorWrites::default(),
+                blend: Some(wgpu_types::BlendState::ALPHA_BLENDING),
+                write_mask: wgpu_types::ColorWrites::default(),
             })],
             multiview: None,
             cache: None,
@@ -286,7 +286,7 @@ impl<A: hal::Api> Example<A> {
 
         let staging_buffer_desc = hal::BufferDescriptor {
             label: Some("stage"),
-            size: texture_data.len() as wgt::BufferAddress,
+            size: texture_data.len() as wgpu_types::BufferAddress,
             usage: hal::BufferUses::MAP_WRITE | hal::BufferUses::COPY_SRC,
             memory_flags: hal::MemoryFlags::TRANSIENT | hal::MemoryFlags::PREFER_COHERENT,
         };
@@ -306,15 +306,15 @@ impl<A: hal::Api> Example<A> {
 
         let texture_desc = hal::TextureDescriptor {
             label: None,
-            size: wgt::Extent3d {
+            size: wgpu_types::Extent3d {
                 width: 1,
                 height: 1,
                 depth_or_array_layers: 1,
             },
             mip_level_count: 1,
             sample_count: 1,
-            dimension: wgt::TextureDimension::D2,
-            format: wgt::TextureFormat::Rgba8UnormSrgb,
+            dimension: wgpu_types::TextureDimension::D2,
+            format: wgpu_types::TextureFormat::Rgba8UnormSrgb,
             usage: hal::TextureUses::COPY_DST | hal::TextureUses::RESOURCE,
             memory_flags: hal::MemoryFlags::empty(),
             view_formats: vec![],
@@ -337,7 +337,7 @@ impl<A: hal::Api> Example<A> {
             };
             let texture_barrier1 = hal::TextureBarrier {
                 texture: &texture,
-                range: wgt::ImageSubresourceRange::default(),
+                range: wgpu_types::ImageSubresourceRange::default(),
                 usage: hal::StateTransition {
                     from: hal::TextureUses::UNINITIALIZED,
                     to: hal::TextureUses::COPY_DST,
@@ -345,20 +345,20 @@ impl<A: hal::Api> Example<A> {
             };
             let texture_barrier2 = hal::TextureBarrier {
                 texture: &texture,
-                range: wgt::ImageSubresourceRange::default(),
+                range: wgpu_types::ImageSubresourceRange::default(),
                 usage: hal::StateTransition {
                     from: hal::TextureUses::COPY_DST,
                     to: hal::TextureUses::RESOURCE,
                 },
             };
             let copy = hal::BufferTextureCopy {
-                buffer_layout: wgt::TexelCopyBufferLayout {
+                buffer_layout: wgpu_types::TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(4),
                     rows_per_image: None,
                 },
                 texture_base: hal::TextureCopyBase {
-                    origin: wgt::Origin3d::ZERO,
+                    origin: wgpu_types::Origin3d::ZERO,
                     mip_level: 0,
                     array_layer: 0,
                     aspect: hal::FormatAspects::COLOR,
@@ -379,10 +379,10 @@ impl<A: hal::Api> Example<A> {
 
         let sampler_desc = hal::SamplerDescriptor {
             label: None,
-            address_modes: [wgt::AddressMode::ClampToEdge; 3],
-            mag_filter: wgt::FilterMode::Linear,
-            min_filter: wgt::FilterMode::Nearest,
-            mipmap_filter: wgt::FilterMode::Nearest,
+            address_modes: [wgpu_types::AddressMode::ClampToEdge; 3],
+            mag_filter: wgpu_types::FilterMode::Linear,
+            min_filter: wgpu_types::FilterMode::Nearest,
+            mipmap_filter: wgpu_types::FilterMode::Nearest,
             lod_clamp: 0.0..32.0,
             compare: None,
             anisotropy_clamp: 1,
@@ -404,7 +404,7 @@ impl<A: hal::Api> Example<A> {
 
         let global_buffer_desc = hal::BufferDescriptor {
             label: Some("global"),
-            size: size_of::<Globals>() as wgt::BufferAddress,
+            size: size_of::<Globals>() as wgpu_types::BufferAddress,
             usage: hal::BufferUses::MAP_WRITE | hal::BufferUses::UNIFORM,
             memory_flags: hal::MemoryFlags::PREFER_COHERENT,
         };
@@ -423,13 +423,14 @@ impl<A: hal::Api> Example<A> {
             buffer
         };
 
-        let local_alignment = wgt::math::align_to(
+        let local_alignment = wgpu_types::math::align_to(
             size_of::<Locals>() as u32,
             capabilities.limits.min_uniform_buffer_offset_alignment,
         );
         let local_buffer_desc = hal::BufferDescriptor {
             label: Some("local"),
-            size: (MAX_BUNNIES as wgt::BufferAddress) * (local_alignment as wgt::BufferAddress),
+            size: (MAX_BUNNIES as wgpu_types::BufferAddress)
+                * (local_alignment as wgpu_types::BufferAddress),
             usage: hal::BufferUses::MAP_WRITE | hal::BufferUses::UNIFORM,
             memory_flags: hal::MemoryFlags::PREFER_COHERENT,
         };
@@ -438,9 +439,9 @@ impl<A: hal::Api> Example<A> {
         let view_desc = hal::TextureViewDescriptor {
             label: None,
             format: texture_desc.format,
-            dimension: wgt::TextureViewDimension::D2,
+            dimension: wgpu_types::TextureViewDimension::D2,
             usage: hal::TextureUses::RESOURCE,
-            range: wgt::ImageSubresourceRange::default(),
+            range: wgpu_types::ImageSubresourceRange::default(),
         };
         let texture_view = unsafe { device.create_texture_view(&texture, &view_desc).unwrap() };
 
@@ -486,7 +487,7 @@ impl<A: hal::Api> Example<A> {
             let local_buffer_binding = hal::BufferBinding {
                 buffer: &local_buffer,
                 offset: 0,
-                size: wgt::BufferSize::new(size_of::<Locals>() as _),
+                size: wgpu_types::BufferSize::new(size_of::<Locals>() as _),
             };
             let local_group_desc = hal::BindGroupDescriptor {
                 label: Some("local"),
@@ -648,7 +649,7 @@ impl<A: hal::Api> Example<A> {
             unsafe {
                 let mapping = self
                     .device
-                    .map_buffer(&self.local_buffer, 0..size as wgt::BufferAddress)
+                    .map_buffer(&self.local_buffer, 0..size as wgpu_types::BufferAddress)
                     .unwrap();
                 ptr::copy_nonoverlapping(
                     self.bunnies.as_ptr() as *const u8,
@@ -672,7 +673,7 @@ impl<A: hal::Api> Example<A> {
 
         let target_barrier0 = hal::TextureBarrier {
             texture: surface_tex.borrow(),
-            range: wgt::ImageSubresourceRange::default(),
+            range: wgpu_types::ImageSubresourceRange::default(),
             usage: hal::StateTransition {
                 from: hal::TextureUses::UNINITIALIZED,
                 to: hal::TextureUses::COLOR_TARGET,
@@ -686,9 +687,9 @@ impl<A: hal::Api> Example<A> {
         let surface_view_desc = hal::TextureViewDescriptor {
             label: None,
             format: self.surface_format,
-            dimension: wgt::TextureViewDimension::D2,
+            dimension: wgpu_types::TextureViewDimension::D2,
             usage: hal::TextureUses::COLOR_TARGET,
-            range: wgt::ImageSubresourceRange::default(),
+            range: wgpu_types::ImageSubresourceRange::default(),
         };
         let surface_tex_view = unsafe {
             self.device
@@ -697,7 +698,7 @@ impl<A: hal::Api> Example<A> {
         };
         let pass_desc = hal::RenderPassDescriptor {
             label: None,
-            extent: wgt::Extent3d {
+            extent: wgpu_types::Extent3d {
                 width: self.extent[0],
                 height: self.extent[1],
                 depth_or_array_layers: 1,
@@ -710,7 +711,7 @@ impl<A: hal::Api> Example<A> {
                 },
                 resolve_target: None,
                 ops: hal::AttachmentOps::STORE,
-                clear_value: wgt::Color {
+                clear_value: wgpu_types::Color {
                     r: 0.1,
                     g: 0.2,
                     b: 0.3,
@@ -730,7 +731,8 @@ impl<A: hal::Api> Example<A> {
         }
 
         for i in 0..self.bunnies.len() {
-            let offset = (i as wgt::DynamicOffset) * (self.local_alignment as wgt::DynamicOffset);
+            let offset = (i as wgpu_types::DynamicOffset)
+                * (self.local_alignment as wgpu_types::DynamicOffset);
             unsafe {
                 ctx.encoder
                     .set_bind_group(&self.pipeline_layout, 1, &self.local_group, &[offset]);
@@ -742,7 +744,7 @@ impl<A: hal::Api> Example<A> {
 
         let target_barrier1 = hal::TextureBarrier {
             texture: surface_tex.borrow(),
-            range: wgt::ImageSubresourceRange::default(),
+            range: wgpu_types::ImageSubresourceRange::default(),
             usage: hal::StateTransition {
                 from: hal::TextureUses::COLOR_TARGET,
                 to: hal::TextureUses::PRESENT,

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -145,7 +145,7 @@ fn main() {
                                         .display()
                                         .get_proc_address(&CString::new(name).expect(name))
                                 },
-                                wgt::GlBackendOptions::default(),
+                                wgpu_types::GlBackendOptions::default(),
                             )
                         }
                         .expect("GL adapter can't be initialized")
@@ -276,14 +276,14 @@ fn fill_screen(exposed: &hal::ExposedAdapter<hal::api::Gles>, width: u32, height
 
     let od = unsafe {
         exposed.adapter.open(
-            wgt::Features::empty(),
-            &wgt::Limits::downlevel_defaults(),
-            &wgt::MemoryHints::default(),
+            wgpu_types::Features::empty(),
+            &wgpu_types::Limits::downlevel_defaults(),
+            &wgpu_types::MemoryHints::default(),
         )
     }
     .unwrap();
 
-    let format = wgt::TextureFormat::Rgba8UnormSrgb;
+    let format = wgpu_types::TextureFormat::Rgba8UnormSrgb;
     let texture = <hal::api::Gles as hal::Api>::Texture::default_framebuffer(format);
     let view = unsafe {
         od.device
@@ -292,9 +292,9 @@ fn fill_screen(exposed: &hal::ExposedAdapter<hal::api::Gles>, width: u32, height
                 &hal::TextureViewDescriptor {
                     label: None,
                     format,
-                    dimension: wgt::TextureViewDimension::D2,
+                    dimension: wgpu_types::TextureViewDimension::D2,
                     usage: hal::TextureUses::COLOR_TARGET,
-                    range: wgt::ImageSubresourceRange::default(),
+                    range: wgpu_types::ImageSubresourceRange::default(),
                 },
             )
             .unwrap()
@@ -312,7 +312,7 @@ fn fill_screen(exposed: &hal::ExposedAdapter<hal::api::Gles>, width: u32, height
     let mut fence = unsafe { od.device.create_fence().unwrap() };
     let rp_desc = hal::RenderPassDescriptor {
         label: None,
-        extent: wgt::Extent3d {
+        extent: wgpu_types::Extent3d {
             width,
             height,
             depth_or_array_layers: 1,
@@ -325,7 +325,7 @@ fn fill_screen(exposed: &hal::ExposedAdapter<hal::api::Gles>, width: u32, height
             },
             resolve_target: None,
             ops: hal::AttachmentOps::STORE,
-            clear_value: wgt::Color::BLUE,
+            clear_value: wgpu_types::Color::BLUE,
         })],
         depth_stencil_attachment: None,
         multiview: None,

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -13,7 +13,7 @@ use std::{
     ptr,
     time::Instant,
 };
-use wgt::Dx12BackendOptions;
+use wgpu_types::Dx12BackendOptions;
 use winit::window::WindowButtons;
 
 const DESIRED_MAX_LATENCY: u32 = 2;
@@ -197,7 +197,7 @@ struct Example<A: hal::Api> {
     instance: A::Instance,
     adapter: A::Adapter,
     surface: A::Surface,
-    surface_format: wgt::TextureFormat,
+    surface_format: wgpu_types::TextureFormat,
     device: A::Device,
     queue: A::Queue,
 
@@ -239,10 +239,10 @@ impl<A: hal::Api> Example<A> {
 
         let instance_desc = hal::InstanceDescriptor {
             name: "example",
-            flags: wgt::InstanceFlags::default(),
-            backend_options: wgt::BackendOptions {
+            flags: wgpu_types::InstanceFlags::default(),
+            backend_options: wgpu_types::BackendOptions {
                 dx12: Dx12BackendOptions {
-                    shader_compiler: wgt::Dx12Compiler::default_dynamic_dxc(),
+                    shader_compiler: wgpu_types::Dx12Compiler::default_dynamic_dxc(),
                 },
                 ..Default::default()
             },
@@ -276,8 +276,8 @@ impl<A: hal::Api> Example<A> {
             adapter
                 .open(
                     features,
-                    &wgt::Limits::default(),
-                    &wgt::MemoryHints::Performance,
+                    &wgpu_types::Limits::default(),
+                    &wgpu_types::MemoryHints::Performance,
                 )
                 .unwrap()
         };
@@ -286,9 +286,9 @@ impl<A: hal::Api> Example<A> {
         dbg!(&surface_caps.formats);
         let surface_format = if surface_caps
             .formats
-            .contains(&wgt::TextureFormat::Rgba8Unorm)
+            .contains(&wgpu_types::TextureFormat::Rgba8Unorm)
         {
-            wgt::TextureFormat::Rgba8Unorm
+            wgpu_types::TextureFormat::Rgba8Unorm
         } else {
             *surface_caps.formats.first().unwrap()
         };
@@ -296,10 +296,10 @@ impl<A: hal::Api> Example<A> {
             maximum_frame_latency: DESIRED_MAX_LATENCY
                 .max(*surface_caps.maximum_frame_latency.start())
                 .min(*surface_caps.maximum_frame_latency.end()),
-            present_mode: wgt::PresentMode::Fifo,
-            composite_alpha_mode: wgt::CompositeAlphaMode::Opaque,
+            present_mode: wgpu_types::PresentMode::Fifo,
+            composite_alpha_mode: wgpu_types::CompositeAlphaMode::Opaque,
             format: surface_format,
-            extent: wgt::Extent3d {
+            extent: wgpu_types::Extent3d {
                 width: window_size.0,
                 height: window_size.1,
                 depth_or_array_layers: 1,
@@ -321,30 +321,30 @@ impl<A: hal::Api> Example<A> {
             label: None,
             flags: hal::BindGroupLayoutFlags::empty(),
             entries: &[
-                wgt::BindGroupLayoutEntry {
+                wgpu_types::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgt::ShaderStages::COMPUTE,
-                    ty: wgt::BindingType::Buffer {
-                        ty: wgt::BufferBindingType::Uniform,
+                    visibility: wgpu_types::ShaderStages::COMPUTE,
+                    ty: wgpu_types::BindingType::Buffer {
+                        ty: wgpu_types::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: wgt::BufferSize::new(size_of::<Uniforms>() as _),
+                        min_binding_size: wgpu_types::BufferSize::new(size_of::<Uniforms>() as _),
                     },
                     count: None,
                 },
-                wgt::BindGroupLayoutEntry {
+                wgpu_types::BindGroupLayoutEntry {
                     binding: 1,
-                    visibility: wgt::ShaderStages::COMPUTE,
-                    ty: wgt::BindingType::StorageTexture {
-                        access: wgt::StorageTextureAccess::WriteOnly,
-                        format: wgt::TextureFormat::Rgba8Unorm,
-                        view_dimension: wgt::TextureViewDimension::D2,
+                    visibility: wgpu_types::ShaderStages::COMPUTE,
+                    ty: wgpu_types::BindingType::StorageTexture {
+                        access: wgpu_types::StorageTextureAccess::WriteOnly,
+                        format: wgpu_types::TextureFormat::Rgba8Unorm,
+                        view_dimension: wgpu_types::TextureViewDimension::D2,
                     },
                     count: None,
                 },
-                wgt::BindGroupLayoutEntry {
+                wgpu_types::BindGroupLayoutEntry {
                     binding: 2,
-                    visibility: wgt::ShaderStages::COMPUTE,
-                    ty: wgt::BindingType::AccelerationStructure,
+                    visibility: wgpu_types::ShaderStages::COMPUTE,
+                    ty: wgpu_types::BindingType::AccelerationStructure,
                     count: None,
                 },
             ],
@@ -373,7 +373,7 @@ impl<A: hal::Api> Example<A> {
         };
         let shader_desc = hal::ShaderModuleDescriptor {
             label: None,
-            runtime_checks: wgt::ShaderRuntimeChecks::checked(),
+            runtime_checks: wgpu_types::ShaderRuntimeChecks::checked(),
         };
         let shader_module = unsafe {
             device
@@ -474,14 +474,14 @@ impl<A: hal::Api> Example<A> {
         let blas_triangles = vec![hal::AccelerationStructureTriangles {
             vertex_buffer: Some(&vertices_buffer),
             first_vertex: 0,
-            vertex_format: wgt::VertexFormat::Float32x3,
+            vertex_format: wgpu_types::VertexFormat::Float32x3,
             // each vertex is 3 floats, and floats are stored raw in the array
             vertex_count: vertices.len() as u32 / 3,
             vertex_stride: 3 * 4,
             indices: indices_buffer.as_ref().map(|(buf, len)| {
                 hal::AccelerationStructureTriangleIndices {
                     buffer: Some(buf),
-                    format: wgt::IndexFormat::Uint32,
+                    format: wgpu_types::IndexFormat::Uint32,
                     offset: 0,
                     count: *len as u32,
                 }
@@ -575,27 +575,27 @@ impl<A: hal::Api> Example<A> {
 
         let texture_desc = hal::TextureDescriptor {
             label: None,
-            size: wgt::Extent3d {
+            size: wgpu_types::Extent3d {
                 width: 512,
                 height: 512,
                 depth_or_array_layers: 1,
             },
             mip_level_count: 1,
             sample_count: 1,
-            dimension: wgt::TextureDimension::D2,
-            format: wgt::TextureFormat::Rgba8Unorm,
+            dimension: wgpu_types::TextureDimension::D2,
+            format: wgpu_types::TextureFormat::Rgba8Unorm,
             usage: hal::TextureUses::STORAGE_READ_WRITE | hal::TextureUses::COPY_SRC,
             memory_flags: hal::MemoryFlags::empty(),
-            view_formats: vec![wgt::TextureFormat::Rgba8Unorm],
+            view_formats: vec![wgpu_types::TextureFormat::Rgba8Unorm],
         };
         let texture = unsafe { device.create_texture(&texture_desc).unwrap() };
 
         let view_desc = hal::TextureViewDescriptor {
             label: None,
             format: texture_desc.format,
-            dimension: wgt::TextureViewDimension::D2,
+            dimension: wgpu_types::TextureViewDimension::D2,
             usage: hal::TextureUses::STORAGE_READ_WRITE | hal::TextureUses::COPY_SRC,
-            range: wgt::ImageSubresourceRange::default(),
+            range: wgpu_types::ImageSubresourceRange::default(),
         };
         let texture_view = unsafe { device.create_texture_view(&texture, &view_desc).unwrap() };
 
@@ -791,7 +791,7 @@ impl<A: hal::Api> Example<A> {
 
             let texture_barrier = hal::TextureBarrier {
                 texture: &texture,
-                range: wgt::ImageSubresourceRange::default(),
+                range: wgpu_types::ImageSubresourceRange::default(),
                 usage: hal::StateTransition {
                     from: hal::TextureUses::UNINITIALIZED,
                     to: hal::TextureUses::STORAGE_READ_WRITE,
@@ -865,7 +865,7 @@ impl<A: hal::Api> Example<A> {
 
         let target_barrier0 = hal::TextureBarrier {
             texture: surface_tex.borrow(),
-            range: wgt::ImageSubresourceRange::default(),
+            range: wgpu_types::ImageSubresourceRange::default(),
             usage: hal::StateTransition {
                 from: hal::TextureUses::UNINITIALIZED,
                 to: hal::TextureUses::COPY_DST,
@@ -950,9 +950,9 @@ impl<A: hal::Api> Example<A> {
         let surface_view_desc = hal::TextureViewDescriptor {
             label: None,
             format: self.surface_format,
-            dimension: wgt::TextureViewDimension::D2,
+            dimension: wgpu_types::TextureViewDimension::D2,
             usage: hal::TextureUses::COPY_DST,
-            range: wgt::ImageSubresourceRange::default(),
+            range: wgpu_types::ImageSubresourceRange::default(),
         };
         let surface_tex_view = unsafe {
             self.device
@@ -974,7 +974,7 @@ impl<A: hal::Api> Example<A> {
 
         let target_barrier1 = hal::TextureBarrier {
             texture: surface_tex.borrow(),
-            range: wgt::ImageSubresourceRange::default(),
+            range: wgpu_types::ImageSubresourceRange::default(),
             usage: hal::StateTransition {
                 from: hal::TextureUses::COPY_DST,
                 to: hal::TextureUses::PRESENT,
@@ -982,7 +982,7 @@ impl<A: hal::Api> Example<A> {
         };
         let target_barrier2 = hal::TextureBarrier {
             texture: &self.texture,
-            range: wgt::ImageSubresourceRange::default(),
+            range: wgpu_types::ImageSubresourceRange::default(),
             usage: hal::StateTransition {
                 from: hal::TextureUses::STORAGE_READ_WRITE,
                 to: hal::TextureUses::COPY_SRC,
@@ -990,7 +990,7 @@ impl<A: hal::Api> Example<A> {
         };
         let target_barrier3 = hal::TextureBarrier {
             texture: &self.texture,
-            range: wgt::ImageSubresourceRange::default(),
+            range: wgpu_types::ImageSubresourceRange::default(),
             usage: hal::StateTransition {
                 from: hal::TextureUses::COPY_SRC,
                 to: hal::TextureUses::STORAGE_READ_WRITE,
@@ -1007,13 +1007,13 @@ impl<A: hal::Api> Example<A> {
                     src_base: hal::TextureCopyBase {
                         mip_level: 0,
                         array_layer: 0,
-                        origin: wgt::Origin3d::ZERO,
+                        origin: wgpu_types::Origin3d::ZERO,
                         aspect: hal::FormatAspects::COLOR,
                     },
                     dst_base: hal::TextureCopyBase {
                         mip_level: 0,
                         array_layer: 0,
-                        origin: wgt::Origin3d::ZERO,
+                        origin: wgpu_types::Origin3d::ZERO,
                         aspect: hal::FormatAspects::COLOR,
                     },
                     size: hal::CopyExtent {

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -234,6 +234,8 @@
     unused_qualifications
 )]
 
+extern crate wgpu_types as wgt;
+
 /// DirectX12 API internals.
 #[cfg(dx12)]
 pub mod dx12;

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -25,6 +25,14 @@ targets = [
     "wasm32-unknown-unknown",
 ]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
+
+[lints.clippy]
+std_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+alloc_instead_of_core = "warn"
+
 [lib]
 
 [features]
@@ -35,9 +43,6 @@ fragile-send-sync-non-atomic-wasm = []
 serde = ["dep:serde"]
 # Enables some internal instrumentation for debugging purposes.
 counters = []
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
 
 [dependencies]
 bitflags = { workspace = true, features = ["serde"] }
@@ -62,8 +67,3 @@ web-sys = { workspace = true, default-features = false, features = [
 [dev-dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-
-[lints.clippy]
-std_instead_of_core = "warn"
-std_instead_of_alloc = "warn"
-alloc_instead_of_core = "warn"

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -148,9 +148,6 @@ serde = { workspace = true, features = ["default", "derive"], optional = true }
 smallvec.workspace = true
 static_assertions.workspace = true
 
-[target.'cfg(any(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-js-sys = { workspace = true, features = ["default"] }
-
 ########################################
 # Target Specific Feature Dependencies #
 ########################################

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -25,7 +25,6 @@ targets = [
 # Cargo machete can't check build.rs dependencies. See https://github.com/bnjbvr/cargo-machete/issues/100
 ignored = ["cfg_aliases"]
 
-
 [lib]
 
 [features]
@@ -38,24 +37,24 @@ default = ["wgsl", "dx12", "metal", "webgpu"]
 #! See [#3514](https://github.com/gfx-rs/wgpu/issues/3514) for more details.
 
 ## Enables the DX12 backend on Windows.
-dx12 = ["wgc?/dx12"]
+dx12 = ["wgpu-core?/dx12"]
 
 ## Enables the Metal backend on macOS & iOS.
-metal = ["wgc?/metal"]
+metal = ["wgpu-core?/metal"]
 
 ## Enables the WebGPU backend on Wasm. Disabled when targeting `emscripten`.
 webgpu = ["naga?/wgsl-out"]
 
 ## Enables the GLES backend via [ANGLE](https://github.com/google/angle) on macOS using.
-angle = ["wgc?/gles"]
+angle = ["wgpu-core?/gles"]
 
 ## Enables the Vulkan backend on macOS & iOS.
-vulkan-portability = ["wgc?/vulkan"]
+vulkan-portability = ["wgpu-core?/vulkan"]
 
 ## Enables the GLES backend on Wasm
 ##
 ## * ⚠️ WIP: Currently will also enable GLES dependencies on any other targets.
-webgl = ["dep:hal", "wgc/gles"]
+webgl = ["dep:wgpu-hal", "wgpu-core/gles"]
 
 #! **Note:** In the documentation, if you see that an item depends on a backend,
 #! it means that the item is only available when that backend is enabled _and_ the backend
@@ -65,13 +64,13 @@ webgl = ["dep:hal", "wgc/gles"]
 # --------------------------------------------------------------------
 
 ## Enable accepting SPIR-V shaders as input.
-spirv = ["naga/spv-in", "wgc/spirv"]
+spirv = ["naga/spv-in", "wgpu-core?/spirv"]
 
 ## Enable accepting GLSL shaders as input.
-glsl = ["naga/glsl-in", "wgc/glsl"]
+glsl = ["naga/glsl-in", "wgpu-core?/glsl"]
 
 ## Enable accepting WGSL shaders as input.
-wgsl = ["wgc?/wgsl"]
+wgsl = ["wgpu-core?/wgsl"]
 
 ## Enable accepting naga IR shaders as input.
 naga-ir = ["dep:naga"]
@@ -82,18 +81,18 @@ naga-ir = ["dep:naga"]
 
 ## Apply run-time checks, even in release builds. These are in addition
 ## to the validation carried out at public APIs in all builds.
-strict_asserts = ["wgc?/strict_asserts", "wgt/strict_asserts"]
+strict_asserts = ["wgpu-core?/strict_asserts", "wgpu-types/strict_asserts"]
 
 ## Enables serialization via `serde` on common wgpu types.
-serde = ["dep:serde", "wgc/serde"]
+serde = ["dep:serde", "wgpu-core/serde"]
 
 # Uncomment once we get to https://github.com/gfx-rs/wgpu/issues/5974
 # ## Allow writing of trace capture files. See [`Adapter::request_device`].
-# trace = ["serde", "wgc/trace"]
+# trace = ["serde", "wgpu-core/trace"]
 
 ## Allow deserializing of trace capture files that were written with the `trace` feature.
 ## To replay a trace file use the [wgpu player](https://github.com/gfx-rs/wgpu/tree/trunk/player).
-replay = ["serde", "wgc/replay"]
+replay = ["serde", "wgpu-core/replay"]
 
 #! ### Other
 # --------------------------------------------------------------------
@@ -101,7 +100,7 @@ replay = ["serde", "wgc/replay"]
 ## Internally count resources and events for debugging purposes. If the counters
 ## feature is disabled, the counting infrastructure is removed from the build and
 ## the exposed counters always return 0.
-counters = ["wgc/counters"]
+counters = ["wgpu-core/counters"]
 
 ## Implement `Send` and `Sync` on Wasm, but only if atomics are not enabled.
 ##
@@ -112,9 +111,9 @@ counters = ["wgc/counters"]
 ## but on a wasm binary compiled without atomics we know we are definitely
 ## not in a multithreaded environment.
 fragile-send-sync-non-atomic-wasm = [
-    "hal/fragile-send-sync-non-atomic-wasm",
-    "wgc/fragile-send-sync-non-atomic-wasm",
-    "wgt/fragile-send-sync-non-atomic-wasm",
+    "wgpu-hal/fragile-send-sync-non-atomic-wasm",
+    "wgpu-core/fragile-send-sync-non-atomic-wasm",
+    "wgpu-types/fragile-send-sync-non-atomic-wasm",
 ]
 
 
@@ -127,65 +126,17 @@ fragile-send-sync-non-atomic-wasm = [
 ## must be shipped alongside `dxcompiler.dll` and `dxil.dll` (which can be downloaded from Microsoft's GitHub).
 ## This feature statically links a version of DXC so that no external binaries are required
 ## to compile DX12 shaders.
-static-dxc = ["hal/static-dxc"]
+static-dxc = ["wgpu-hal/static-dxc"]
 
-# wgpu-core is always available as an optional dependency, "wgc".
-# Whenever wgpu-core is selected, we want raw window handle support.
-[dependencies.wgc]
-optional = true
-workspace = true
-features = ["raw-window-handle"]
-
-# wgpu-core is required whenever not targeting web APIs directly.
-# Whenever wgpu-core is selected, we want raw window handle support.
-[target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dependencies.wgc]
-workspace = true
-features = ["raw-window-handle"]
-
-# If we are not targeting WebGL, enable indirect-validation.
-# WebGL doesn't support indirect execution so this is not needed.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
-workspace = true
-features = ["indirect-validation"]
-
-# Enable `wgc` by default on macOS and iOS to allow the `metal` crate feature to
-# enable the Metal backend while being no-op on other targets.
-[target.'cfg(target_vendor = "apple")'.dependencies.wgc]
-workspace = true
-
-# We want the wgpu-core Direct3D backend and OpenGL (via WGL) on Windows.
-[target.'cfg(windows)'.dependencies.wgc]
-workspace = true
-features = ["gles"]
-
-# We want the wgpu-core Vulkan backend on Unix (but not emscripten, macOS, iOS) and Windows.
-[target.'cfg(any(windows, all(unix, not(target_os = "emscripten"), not(target_vendor = "apple"))))'.dependencies.wgc]
-workspace = true
-features = ["vulkan"]
-
-# We want the wgpu-core GLES backend on Unix (but not macOS, iOS).
-[target.'cfg(all(unix, not(target_vendor = "apple")))'.dependencies.wgc]
-workspace = true
-features = ["gles"]
-
-[dependencies.wgt]
-workspace = true
-
-# We need wgpu-hal unless we're targeting the web APIs.
-[target.'cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))'.dependencies]
-hal = { workspace = true }
-
-[target.'cfg(all(not(target_arch = "wasm32"), unix, not(target_vendor = "apple")))'.dependencies]
-hal = { workspace = true, features = ["renderdoc"] }
-
-[target.'cfg(windows)'.dependencies]
-hal = { workspace = true, features = ["renderdoc"] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies.hal]
-workspace = true
-optional = true
+#########################
+# Standard Dependencies #
+#########################
 
 [dependencies]
+naga = { workspace = true, optional = true }
+wgpu-core = { workspace = true, optional = true }
+wgpu-types = { workspace = true, features = ["serde"] }
+
 arrayvec.workspace = true
 bitflags.workspace = true
 document-features.workspace = true
@@ -197,19 +148,47 @@ serde = { workspace = true, features = ["default", "derive"], optional = true }
 smallvec.workspace = true
 static_assertions.workspace = true
 
-[dependencies.naga]
-workspace = true
-optional = true
+[target.'cfg(any(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+js-sys = { workspace = true, features = ["default"] }
 
-[build-dependencies]
-cfg_aliases.workspace = true
+########################################
+# Target Specific Feature Dependencies #
+########################################
 
-# used to test all the example shaders
-[dev-dependencies.naga]
-workspace = true
-features = ["wgsl-in"]
+# Windows
+[target.'cfg(windows)'.dependencies]
+wgpu-core = { workspace = true, features = [
+    "raw-window-handle",
+    "vulkan",
+    "gles",
+] }
+wgpu-hal = { workspace = true, features = ["renderdoc"] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+# Apple Platforms
+[target.'cfg(target_vendor = "apple")'.dependencies]
+wgpu-core = { workspace = true, features = ["raw-window-handle"] }
+wgpu-hal = { workspace = true, features = [] }
+
+# Linux + Android
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+wgpu-core = { workspace = true, features = [
+    "raw-window-handle",
+    "vulkan",
+    "gles",
+] }
+wgpu-hal = { workspace = true, features = ["renderdoc"] }
+
+# Webassembly
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+wgpu-core = { workspace = true, optional = true, features = [
+    "raw-window-handle",
+] }
+wgpu-hal = { workspace = true, optional = true }
+
+js-sys = { workspace = true, features = ["default"] }
+parking_lot.workspace = true
+wasm-bindgen-futures.workspace = true
+wasm-bindgen.workspace = true
 web-sys = { workspace = true, features = [
     "default",
     "Document",
@@ -227,7 +206,11 @@ web-sys = { workspace = true, features = [
     "Event",
     "EventTarget",
 ] }
-wasm-bindgen.workspace = true
-js-sys = { workspace = true, features = ["default"] }
-wasm-bindgen-futures.workspace = true
-parking_lot.workspace = true
+
+# Emscripten
+[target.'cfg(target_os = "emscripten")'.dependencies]
+wgpu-core = { workspace = true, features = ["raw-window-handle", "gles"] }
+wgpu-hal = { workspace = true }
+
+[build-dependencies]
+cfg_aliases.workspace = true

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -25,6 +25,12 @@
 #![allow(clippy::arc_with_non_send_sync)]
 #![cfg_attr(not(any(wgpu_core, webgpu)), allow(unused))]
 
+#[cfg(wgpu_core)]
+pub extern crate wgpu_core as wgc;
+#[cfg(wgpu_core)]
+pub extern crate wgpu_hal as hal;
+pub extern crate wgpu_types as wgt;
+
 //
 //
 // Modules
@@ -57,8 +63,8 @@ pub use wgt::{
     BufferAddress, BufferBindingType, BufferSize, BufferUsages, Color, ColorTargetState,
     ColorWrites, CommandBufferDescriptor, CompareFunction, CompositeAlphaMode,
     CopyExternalImageDestInfo, CoreCounters, DepthBiasState, DepthStencilState, DeviceLostReason,
-    DeviceType, DownlevelCapabilities, DownlevelFlags, Dx12BackendOptions, Dx12Compiler,
-    DynamicOffset, Extent3d, Face, Features, FilterMode, FrontFace, GlBackendOptions,
+    DeviceType, DownlevelCapabilities, DownlevelFlags, DownlevelLimits, Dx12BackendOptions,
+    Dx12Compiler, DynamicOffset, Extent3d, Face, Features, FilterMode, FrontFace, GlBackendOptions,
     Gles3MinorVersion, HalCounters, ImageSubresourceRange, IndexFormat, InstanceDescriptor,
     InstanceFlags, InternalCounters, Limits, MaintainResult, MemoryHints, MultisampleState,
     Origin2d, Origin3d, PipelineStatisticsTypes, PolygonMode, PowerPreference,
@@ -82,22 +88,6 @@ pub use wgt::{ImageCopyBuffer, ImageCopyTexture, ImageCopyTextureTagged, ImageDa
 pub use wgt::ImageCopyExternalImage;
 #[cfg(any(webgpu, webgl))]
 pub use wgt::{CopyExternalImageSourceInfo, ExternalImageSource};
-//
-//
-// Re-exports of dependencies
-//
-//
-
-/// Re-export of our `wgpu-core` dependency.
-///
-#[cfg(wgpu_core)]
-pub use ::wgc as core;
-
-/// Re-export of our `wgpu-hal` dependency.
-///
-///
-#[cfg(wgpu_core)]
-pub use ::hal;
 
 /// Re-export of our `naga` dependency.
 ///

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -219,8 +219,7 @@ pub trait TextureFormatExt {
     /// use wgpu::util::TextureFormatExt;
     /// assert_eq!(wgpu::TextureFormat::from_storage_format(wgpu::naga::StorageFormat::Bgra8Unorm), wgpu::TextureFormat::Bgra8Unorm);
     /// ```
-    #[cfg_attr(docsrs, doc(cfg(any(wgpu_core, naga))))]
-    #[cfg(any(wgpu_core, naga))]
+    #[cfg(wgpu_core)]
     fn from_storage_format(storage_format: crate::naga::StorageFormat) -> Self;
 
     /// Finds the [`StorageFormat`](wgc::naga::StorageFormat) corresponding to the given [`TextureFormat`](wgt::TextureFormat).
@@ -233,20 +232,17 @@ pub trait TextureFormatExt {
     /// use wgpu::util::TextureFormatExt;
     /// assert_eq!(wgpu::TextureFormat::Bgra8Unorm.to_storage_format(), Some(wgpu::naga::StorageFormat::Bgra8Unorm));
     /// ```
-    #[cfg_attr(docsrs, doc(cfg(any(wgpu_core, naga))))]
-    #[cfg(any(wgpu_core, naga))]
+    #[cfg(wgpu_core)]
     fn to_storage_format(&self) -> Option<crate::naga::StorageFormat>;
 }
 
 impl TextureFormatExt for wgt::TextureFormat {
-    #[cfg_attr(docsrs, doc(cfg(any(wgpu_core, naga))))]
-    #[cfg(any(wgpu_core, naga))]
+    #[cfg(wgpu_core)]
     fn from_storage_format(storage_format: crate::naga::StorageFormat) -> Self {
         wgc::map_storage_format_from_naga(storage_format)
     }
 
-    #[cfg_attr(docsrs, doc(cfg(any(wgpu_core, naga))))]
-    #[cfg(any(wgpu_core, naga))]
+    #[cfg(wgpu_core)]
     fn to_storage_format(&self) -> Option<crate::naga::StorageFormat> {
         wgc::map_storage_format_to_naga(*self)
     }


### PR DESCRIPTION
Sorry this bad boy got a bit out of control, but I think puts us in a much better place than we were before.

Step 1 towards #6975 

- Replaces `Cargo.toml` crate renames with `extern crate` renames at the top of the relevant libraries.
- Vastly cleans up the target-soup in `wgpu/Cargo.toml` and `wgpu-hal/Cargo.toml` and adds a variety of comments.
- Stop using separate tables for each dependency.
- Stop using `wgt` in examples and tests.
- Always put local dependencies on top.