### PR TITLE
Lower max_color_attachments limit for GL to 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 - Add Flush to GL Queue::submit. By @cwfitzgerald in [#6941](https://github.com/gfx-rs/wgpu/pull/6941).
 - Fix `wgpu` not building with `--no-default-features` on when targeting `wasm32-unknown-unknown`. By @wumpf in [#6946](https://github.com/gfx-rs/wgpu/pull/6946).
 - Fix `CopyExternalImageDestInfo` not exported on `wgpu`. By @wumpf in [#6962](https://github.com/gfx-rs/wgpu/pull/6962).
+- Reduce downlevel `max_color_attachments` limit from 8 to 4 for better OpenGL competibility. By @adrian17 in [#6994](https://github.com/gfx-rs/wgpu/pull/6994).
 
 #### Vulkan
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 - Add Flush to GL Queue::submit. By @cwfitzgerald in [#6941](https://github.com/gfx-rs/wgpu/pull/6941).
 - Fix `wgpu` not building with `--no-default-features` on when targeting `wasm32-unknown-unknown`. By @wumpf in [#6946](https://github.com/gfx-rs/wgpu/pull/6946).
 - Fix `CopyExternalImageDestInfo` not exported on `wgpu`. By @wumpf in [#6962](https://github.com/gfx-rs/wgpu/pull/6962).
-- Reduce downlevel `max_color_attachments` limit from 8 to 4 for better OpenGL competibility. By @adrian17 in [#6994](https://github.com/gfx-rs/wgpu/pull/6994).
+- Reduce downlevel `max_color_attachments` limit from 8 to 4 for better GLES compatibility. By @adrian17 in [#6994](https://github.com/gfx-rs/wgpu/pull/6994).
 
 #### Vulkan
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ wgpu = { version = "24.0.0", path = "./wgpu", default-features = false, features
     "dx12",
     "metal",
     "static-dxc",
+    "webgl",
 ] }
 wgpu-core = { version = "24.0.0", path = "./wgpu-core" }
 wgpu-hal = { version = "24.0.0", path = "./wgpu-hal" }

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -825,6 +825,7 @@ impl super::Adapter {
                     private_caps,
                     workarounds,
                     features,
+                    limits: limits.clone(),
                     options: backend_options,
                     shading_language_version,
                     next_shader_id: Default::default(),

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -274,6 +274,7 @@ struct AdapterShared {
     context: AdapterContext,
     private_caps: PrivateCapabilities,
     features: wgt::Features,
+    limits: wgt::Limits,
     workarounds: Workarounds,
     options: wgt::GlBackendOptions,
     shading_language_version: naga::back::glsl::Version,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1078,8 +1078,8 @@ impl super::Queue {
                             0,
                         )
                     };
-                    for i in 0..crate::MAX_COLOR_ATTACHMENTS {
-                        let target = glow::COLOR_ATTACHMENT0 + i as u32;
+                    for i in 0..self.shared.limits.max_color_attachments {
+                        let target = glow::COLOR_ATTACHMENT0 + i;
                         unsafe {
                             gl.framebuffer_texture_2d(
                                 glow::DRAW_FRAMEBUFFER,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1324,7 +1324,7 @@ impl Limits {
     ///     min_uniform_buffer_offset_alignment: 256,
     ///     min_storage_buffer_offset_alignment: 256,
     ///     max_inter_stage_shader_components: 60,
-    ///     max_color_attachments: 8,
+    ///     max_color_attachments: 4,
     ///     max_color_attachment_bytes_per_sample: 32,
     ///     max_compute_workgroup_storage_size: 16352, // *
     ///     max_compute_invocations_per_workgroup: 256,
@@ -1344,6 +1344,7 @@ impl Limits {
             max_texture_dimension_3d: 256,
             max_storage_buffers_per_shader_stage: 4,
             max_uniform_buffer_binding_size: 16 << 10, // (16 KiB)
+            max_color_attachments: 4,
             // see: https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=7
             max_compute_workgroup_storage_size: 16352,
             ..Self::defaults()
@@ -1381,7 +1382,7 @@ impl Limits {
     ///     min_uniform_buffer_offset_alignment: 256,
     ///     min_storage_buffer_offset_alignment: 256,
     ///     max_inter_stage_shader_components: 31,
-    ///     max_color_attachments: 8,
+    ///     max_color_attachments: 4,
     ///     max_color_attachment_bytes_per_sample: 32,
     ///     max_compute_workgroup_storage_size: 0, // +
     ///     max_compute_invocations_per_workgroup: 0, // +


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/6986

**Description**
Wgpu 23 broke support for older devices that only supported GLES and `max_color_attachments == 4` (which is the minimum mandated by 3.1 spec). The limit technically used to be 8 for much longer, but according to @cwfitzgerald it wasn't enforced before. This change aims to revert this regression.
Only downlevel limits are changed, not default limits.

Note that I can't prove that this is the _only_ thing that needs changing to make wgpu work on such old devices again, because I'm only relying on user reports and can't check it myself.

**Testing**
Ran `cargo test --doc` only.

Only tested manually with a hack, since I don't have access to such a device:
```diff
        let max_color_attachments = unsafe {
            gl.get_parameter_i32(glow::MAX_COLOR_ATTACHMENTS)
                .min(gl.get_parameter_i32(glow::MAX_DRAW_BUFFERS))
                .min(crate::MAX_COLOR_ATTACHMENTS as i32) as u32
        };
+       let max_color_attachments = 4;
```

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
