### PR TITLE
Fix surface drop order.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 - Add Flush to GL Queue::submit. By @cwfitzgerald in [#6941](https://github.com/gfx-rs/wgpu/pull/6941).
 - Fix `wgpu` not building with `--no-default-features` on when targeting `wasm32-unknown-unknown`. By @wumpf in [#6946](https://github.com/gfx-rs/wgpu/pull/6946).
 - Fix `CopyExternalImageDestInfo` not exported on `wgpu`. By @wumpf in [#6962](https://github.com/gfx-rs/wgpu/pull/6962).
+- Fix drop order in `Surface`. By @ed-2100 in [#6997](https://github.com/gfx-rs/wgpu/pull/6997)
 
 #### Vulkan
 

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -23,12 +23,6 @@ static_assertions::assert_impl_all!(SurfaceConfiguration: Send, Sync);
 /// [`GPUCanvasContext`](https://gpuweb.github.io/gpuweb/#canvas-context)
 /// serves a similar role.
 pub struct Surface<'window> {
-    /// Optionally, keep the source of the handle used for the surface alive.
-    ///
-    /// This is useful for platforms where the surface is created from a window and the surface
-    /// would become invalid when the window is dropped.
-    pub(crate) _handle_source: Option<Box<dyn WindowHandle + 'window>>,
-
     /// Additional surface data returned by [`DynContext::instance_create_surface`].
     pub(crate) inner: dispatch::DispatchSurface,
 
@@ -39,6 +33,14 @@ pub struct Surface<'window> {
     // be wrapped in a mutex and since the configuration is only supplied after the surface has
     // been created is is additionally wrapped in an option.
     pub(crate) config: Mutex<Option<SurfaceConfiguration>>,
+
+    /// Optionally, keep the source of the handle used for the surface alive.
+    ///
+    /// This is useful for platforms where the surface is created from a window and the surface
+    /// would become invalid when the window is dropped.
+    ///
+    /// This field must be dropped *after* all other fields to ensure proper cleanup.
+    pub(crate) _handle_source: Option<Box<dyn WindowHandle + 'window>>,
 }
 
 impl Surface<'_> {

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -39,7 +39,7 @@ pub struct Surface<'window> {
     /// This is useful for platforms where the surface is created from a window and the surface
     /// would become invalid when the window is dropped.
     ///
-    /// This field must be dropped *after* all other fields to ensure proper cleanup.
+    /// SAFETY: This field must be dropped *after* all other fields to ensure proper cleanup.
     pub(crate) _handle_source: Option<Box<dyn WindowHandle + 'window>>,
 }
 


### PR DESCRIPTION
**Connections**
Fixes #4650

**Description**
If `Surface` is constructed with an `Arc<Window>` reference and no other strong references are present when the `Surface` is deconstructed, wayland will segfault.
This is because the drop order of `Surface` specifies that `_handle_source` be dropped before `inner`.
This is fixed by reordering the struct such that `_handle_source` is dropped last.

**Testing**
_Explain how this change is tested._

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
