### PR TITLE
chore: workspace lint improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ default-members = [
     "wgpu",
 ]
 
-[workspace.lints.clippy]
-manual_c_str_literals = "allow"
-ref_as_ptr = "warn"
+[workspace.lints.rust]
+manual_c_str_literals = "forbid"
+ref_as_ptr = "forbid"
 
 [workspace.package]
 edition = "2021"


### PR DESCRIPTION
**Connections**

May help unblock other PR: #6938

**Description**

Proposed updates:

- Existing lints that are in `[lints.clippy]` section of top-level `Cargo.toml` should be in `[lints.rustc]` section instead.
- Setting these lints to `"forbid"` can help enforce the existing code quality without triggering any new CI errors at this point.

In other PR #6938 I need to configure new Clippy linting in separate `clippy.toml` file. I could easily rename the existing lint section in PR #6938 as well but I would rather not do this.

**Testing**

- `cargo clippy --all-features`

**Checklist**

- ~~Run `cargo fmt`.~~
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
  - ~~`--target wasm32-unknown-emscripten`~~
- ~~Run `cargo xtask test` to run tests.~~
- ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~