### PR TITLE
Link to `TextureBlitterBuilder` from `TextureBlitter::new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 
 ### Documentation
 
-- Improved documentation around pipeline caches. By @DJMcNab in [#6978](https://github.com/gfx-rs/wgpu/pull/6978).
+- Improved documentation around pipeline caches and `TextureBlitter`. By @DJMcNab in [#6978](https://github.com/gfx-rs/wgpu/pull/6978) and [#7003](https://github.com/gfx-rs/wgpu/pull/7003).
 
 - Added a hello window example. By @laycookie in [#6992](https://github.com/gfx-rs/wgpu/pull/6992).
 

--- a/wgpu/src/util/texture_blitter.rs
+++ b/wgpu/src/util/texture_blitter.rs
@@ -156,6 +156,12 @@ pub struct TextureBlitter {
 
 impl TextureBlitter {
     /// Returns a [`TextureBlitter`] with default settings.
+    ///
+    /// # Arguments
+    /// - `device` - A [`Device`]
+    /// - `format` - The [`TextureFormat`] of the texture that will be copied to. This has to have the `RENDER_TARGET` usage.
+    ///
+    /// Properties of the blitting (such as the [`BlendState`]) can be customised by using [`TextureBlitterBuilder`] instead.
     pub fn new(device: &Device, format: TextureFormat) -> Self {
         TextureBlitterBuilder::new(device, format).build()
     }


### PR DESCRIPTION
**Description**
In Vello, I intend to use the new `TextureBlitter` utility. Because of this, I keep browsing the docs of `TextureBlitter`. However, in most cases I actually want to also review the docs of `TextureBlitterBuilder`, as the customisable settings are useful (see linebender/vello#549, for example). However, there's no easy way to reach that item from [TextureBlitter's docs](https://docs.rs/wgpu/24.0.1/wgpu/util/struct.TextureBlitter.html).

**Checklist**

- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.