### PR TITLE
Fix deadlock between snatchable_lock and trackers in Queue::write_texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ By @brodycj in [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 - Fix `wgpu` not building with `--no-default-features` on when targeting `wasm32-unknown-unknown`. By @wumpf in [#6946](https://github.com/gfx-rs/wgpu/pull/6946).
 - Fix `CopyExternalImageDestInfo` not exported on `wgpu`. By @wumpf in [#6962](https://github.com/gfx-rs/wgpu/pull/6962).
 - Fix drop order in `Surface`. By @ed-2100 in [#6997](https://github.com/gfx-rs/wgpu/pull/6997)
+- Fix a possible deadlock within `Queue::write_texture`. By @metamuffin in [#7004](https://github.com/gfx-rs/wgpu/pull/7004)
 
 #### Vulkan
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -697,6 +697,8 @@ impl Queue {
                 .map_err(TransferError::from)?;
         }
 
+        let snatch_guard = self.device.snatchable_lock.read();
+
         let mut pending_writes = self.pending_writes.lock();
         let encoder = pending_writes.activate();
 
@@ -721,7 +723,6 @@ impl Queue {
                     .drain(init_layer_range)
                     .collect::<Vec<std::ops::Range<u32>>>()
                 {
-                    let snatch_guard = self.device.snatchable_lock.read();
                     let mut trackers = self.device.trackers.lock();
                     crate::command::clear_texture(
                         &dst,
@@ -742,8 +743,6 @@ impl Queue {
                     .drain(init_layer_range);
             }
         }
-
-        let snatch_guard = self.device.snatchable_lock.read();
 
         let dst_raw = dst.try_raw(&snatch_guard)?;
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -721,6 +721,7 @@ impl Queue {
                     .drain(init_layer_range)
                     .collect::<Vec<std::ops::Range<u32>>>()
                 {
+                    let snatch_guard = self.device.snatchable_lock.read();
                     let mut trackers = self.device.trackers.lock();
                     crate::command::clear_texture(
                         &dst,
@@ -732,7 +733,7 @@ impl Queue {
                         &mut trackers.textures,
                         &self.device.alignments,
                         self.device.zero_buffer.as_ref(),
-                        &self.device.snatchable_lock.read(),
+                        &snatch_guard,
                     )
                     .map_err(QueueWriteError::from)?;
                 }


### PR DESCRIPTION
**Connections**
Related to #5737

**Description**
The `Device.snatchable_lock` is usually acquired before `Device.trackers` is. Only `Queue.write_texture()` acquired them in reverse order, introducing deadlocks. This PR swaps the order there to align with other usages of those mutexes.

**Testing**
Manually checked all references to trackers mutex for snatchable_lock guards in the same scope.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [x] Run `cargo xtask test` to run tests.  (Some tests failed here, but those fail without my change too)
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
