### PR TITLE
Fix compatibility issues in hello_window example.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,8 @@ be cloned out of the repository to serve as a starting point for your own projec
 
 | Name   | Description | Platforms |
 |--------|-------------|-----------|
-| [hello compute](standalone/1_hello_compute/) | Simplest example and shows how to run a compute shader on a given set of input data and get the results back. | Native-Only |
+| [hello compute](standalone/01_hello_compute/) | Simplest example and shows how to run a compute shader on a given set of input data and get the results back. | Native-Only |
+| [hello window](standalone/02_hello_window/) | Shows how to create a window and render into it. | Native-Only |
 
 You can also use [`cargo-generate`](https://github.com/cargo-generate/cargo-generate) to easily use these as a basis for your own projects.
 


### PR DESCRIPTION
**Connections**
Followup to #6992.

**Description**
* Actually use sRGB surface texture view format.
* Use `PresentMode::AutoVsync`, instead of `Mailbox` which is not supported everywhere.
* Add it to the list in `examples/README.md`.

**Testing**
Ran the example.

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
  - [ ] `--target wasm32-unknown-emscripten`
- [X] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
