### PR TITLE
cleanup: resolve spelling errors in test comments

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -93,7 +93,7 @@ pub fn did_fail<T>(device: &wgpu::Device, callback: impl FnOnce() -> T) -> (bool
     (failed, result)
 }
 
-/// Adds the necissary main function for our gpu test harness.
+/// Adds the necessary main function for our gpu test harness.
 #[macro_export]
 macro_rules! gpu_test_main {
     () => {

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -12,7 +12,7 @@ use crate::{
     GpuTestConfiguration,
 };
 
-/// Parameters and resources hadned to the test function.
+/// Parameters and resources handed to the test function.
 pub struct TestingContext {
     pub instance: Instance,
     pub adapter: Adapter,


### PR DESCRIPTION
**Connections**

**Description**

(see title)

I spotted these while trying out `cargo spellcheck check` in my workarea. Note that I am not pushing `cargo-spellcheck` at this point due to the sheer amount of configuration that would be needed for this.

**Testing**

N/A

**Checklist**

N/A