### PR TITLE
minor naga span updates

### DIFF
--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -325,32 +325,6 @@ pub(crate) trait AddSpan: Sized {
     fn with_span_handle<T, A: SpanProvider<T>>(self, handle: Handle<T>, arena: &A) -> Self::Output;
 }
 
-/// Trait abstracting over getting a span from an [`Arena`] or a [`UniqueArena`].
-pub(crate) trait SpanProvider<T> {
-    fn get_span(&self, handle: Handle<T>) -> Span;
-    fn get_span_context(&self, handle: Handle<T>) -> SpanContext {
-        match self.get_span(handle) {
-            x if !x.is_defined() => (Default::default(), "".to_string()),
-            known => (
-                known,
-                format!("{} {:?}", std::any::type_name::<T>(), handle),
-            ),
-        }
-    }
-}
-
-impl<T> SpanProvider<T> for Arena<T> {
-    fn get_span(&self, handle: Handle<T>) -> Span {
-        self.get_span(handle)
-    }
-}
-
-impl<T> SpanProvider<T> for UniqueArena<T> {
-    fn get_span(&self, handle: Handle<T>) -> Span {
-        self.get_span(handle)
-    }
-}
-
 impl<E> AddSpan for E
 where
     E: Error,
@@ -374,6 +348,32 @@ where
         arena: &A,
     ) -> WithSpan<Self> {
         WithSpan::new(self).with_handle(handle, arena)
+    }
+}
+
+/// Trait abstracting over getting a span from an [`Arena`] or a [`UniqueArena`].
+pub(crate) trait SpanProvider<T> {
+    fn get_span(&self, handle: Handle<T>) -> Span;
+    fn get_span_context(&self, handle: Handle<T>) -> SpanContext {
+        match self.get_span(handle) {
+            x if !x.is_defined() => (Default::default(), "".to_string()),
+            known => (
+                known,
+                format!("{} {:?}", std::any::type_name::<T>(), handle),
+            ),
+        }
+    }
+}
+
+impl<T> SpanProvider<T> for Arena<T> {
+    fn get_span(&self, handle: Handle<T>) -> Span {
+        self.get_span(handle)
+    }
+}
+
+impl<T> SpanProvider<T> for UniqueArena<T> {
+    fn get_span(&self, handle: Handle<T>) -> Span {
+        self.get_span(handle)
     }
 }
 

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -383,7 +383,9 @@ impl<T> SpanProvider<T> for UniqueArena<T> {
 /// Convenience trait for [`Result`], adding a [`MapErrWithSpan::map_err_inner`]
 /// mapping to [`WithSpan::and_then`].
 pub trait MapErrWithSpan<E, E2>: Sized {
+    /// The returned output type.
     type Output: Sized;
+
     fn map_err_inner<F, E3>(self, func: F) -> Self::Output
     where
         F: FnOnce(E) -> WithSpan<E3>,
@@ -392,6 +394,7 @@ pub trait MapErrWithSpan<E, E2>: Sized {
 
 impl<T, E, E2> MapErrWithSpan<E, E2> for Result<T, WithSpan<E>> {
     type Output = Result<T, WithSpan<E2>>;
+
     fn map_err_inner<F, E3>(self, func: F) -> Result<T, WithSpan<E2>>
     where
         F: FnOnce(E) -> WithSpan<E3>,

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -327,10 +327,7 @@ pub(crate) trait AddSpan: Sized {
     fn with_span_handle<T, A: SpanProvider<T>>(self, handle: Handle<T>, arena: &A) -> Self::Output;
 }
 
-impl<E> AddSpan for E
-where
-    E: Error,
-{
+impl<E> AddSpan for E {
     type Output = WithSpan<Self>;
 
     fn with_span(self) -> WithSpan<Self> {

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -314,7 +314,9 @@ impl<E> WithSpan<E> {
 
 /// Convenience trait for [`Error`] to be able to apply spans to anything.
 pub(crate) trait AddSpan: Sized {
+    /// The returned output type.
     type Output;
+
     /// See [`WithSpan::new`].
     fn with_span(self) -> Self::Output;
     /// See [`WithSpan::with_span`].
@@ -330,6 +332,7 @@ where
     E: Error,
 {
     type Output = WithSpan<Self>;
+
     fn with_span(self) -> WithSpan<Self> {
         WithSpan::new(self)
     }

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -379,7 +379,7 @@ impl<T> SpanProvider<T> for UniqueArena<T> {
 
 /// Convenience trait for [`Result`], adding a [`MapErrWithSpan::map_err_inner`]
 /// mapping to [`WithSpan::and_then`].
-pub trait MapErrWithSpan<E, E2>: Sized {
+pub(crate) trait MapErrWithSpan<E, E2>: Sized {
     /// The returned output type.
     type Output: Sized;
 


### PR DESCRIPTION
**Connections**

trigger is reducing dependency on `std::error::Error` for other PR: #6938

(help with no-std support as requested in issue: #6826)

**Description**

- move internal naga `span::AddSpan` code to keep internal AddSpan trait & impl together
- remove `where` dependency on `std::error::Error` from AddSpan impl
- add blank lines & returned output type comments to `AddSpan` & `MapErrWithSpan` traits
- update `MapErrWithSpan` to be pub(crate) trait

__NOTE:__ I am submitting this with multiple commits to hopefully keep these proposed updates as clear as possible. I would be happy to squash if needed. I would also be happy to revert the `MapErrWithSpan` trait visibility update if needed.

**Testing**

see checklist below

**Checklist**

- [x] Run `cargo fmt`.
- ~~Run `taplo format`.~~
- [x] Run `cargo clippy`. If applicable, add:
  - ~~`--target wasm32-unknown-unknown`~~
- [x] Run `cargo xtask test` to run tests.
- ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~