### PR TITLE
avoid default features in many dependencies (etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Bottom level categories:
 
 #### General
 
+- Avoid using default features in many dependencies, etc. By Brody in [#7031](https://github.com/gfx-rs/wgpu/pull/7031)
 - Use `hashbrown` to simplify no-std support. By Brody in [#6938](https://github.com/gfx-rs/wgpu/pull/6938) & [#6925](https://github.com/gfx-rs/wgpu/pull/6925).
 - If you use Binding Arrays in a bind group, you may not use Dynamic Offset Buffers or Uniform Buffers in that bind group. By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,12 +72,13 @@ wgpu-macros = { version = "24.0.0", path = "./wgpu-macros" }
 wgpu-test = { version = "24.0.0", path = "./tests" }
 wgpu-types = { version = "24.0.0", path = "./wgpu-types" }
 
-anyhow = "1.0.95"
-argh = "0.1.13"
-arrayvec = "0.7"
+anyhow = { version = "1.0.95", default-features = false }
 approx = "0.5"
+argh = "0.1.13"
+arrayvec = { version = "0.7.6", default-features = false }
 bincode = "1"
-bit-vec = "0.8"
+bit-set = { version = "0.8", default-features = false }
+bit-vec = { version = "0.8", default-features = false }
 bitflags = "2.7"
 bytemuck = { version = "1.21", features = ["derive", "min_const_generics"] }
 cfg_aliases = "0.2.1"
@@ -99,10 +100,10 @@ hashbrown = { version = "0.15.2", default-features = false, features = [
 ] }
 heck = "0.5.0"
 image = { version = "0.24", default-features = false, features = ["png"] }
-indexmap = "2"
+indexmap = { version = "2.7.1", default-features = false }
 itertools = { version = "0.13.0" }
 ktx2 = "0.3"
-libc = "0.2"
+libc = { version = "0.2", default-features = false }
 libloading = "0.8"
 libtest-mimic = "0.8.1"
 log = "0.4"
@@ -110,9 +111,10 @@ nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
 noise = "0.9"
 nv-flip = "0.1"
 obj = "0.10"
-once_cell = "1.20.2"
+# NOTE: once_cell/std is *required* for some commonly-used features, selecting this per crate
+once_cell = { version = "1.20.2", default-features = false }
 # Firefox has 3.4.0 vendored, so we allow that version in our dependencies
-ordered-float = ">=3,<=4.6"
+ordered-float = { version = ">=3,<=4.6", default-features = false }
 parking_lot = "0.12.1"
 pico-args = { version = "0.5.0", features = [
     "eq-separator",
@@ -122,7 +124,7 @@ pico-args = { version = "0.5.0", features = [
 png = "0.17.16"
 pollster = "0.4"
 profiling = { version = "1", default-features = false }
-raw-window-handle = "0.6"
+raw-window-handle = { version = "0.6", default-features = false }
 rayon = "1"
 renderdoc-sys = "1.1.0"
 ron = "0.8"
@@ -134,10 +136,10 @@ serde_json = "1.0.137"
 serde = { version = "1", default-features = false }
 smallvec = "1"
 static_assertions = "1.1.0"
-strum = { version = "0.26.0", features = ["derive"] }
+strum = { version = "0.26.3", default-features = false, features = ["derive"] }
 trybuild = "1"
 tracy-client = "0.17"
-thiserror = "2"
+thiserror = { version = "2", default-features = false }
 winit = { version = "0.29", features = ["android-native-activity"] }
 
 # Metal dependencies
@@ -153,7 +155,6 @@ gpu-alloc = "0.6"
 gpu-descriptor = "0.3"
 
 # DX12 dependencies
-bit-set = "0.8"
 gpu-allocator = { version = "0.27", default-features = false }
 range-alloc = "0.1"
 mach-dxcompiler-rs = { version = "0.1.4", default-features = false }

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -37,5 +37,5 @@ bincode.workspace = true
 codespan-reporting.workspace = true
 env_logger.workspace = true
 argh.workspace = true
-anyhow.workspace = true
+anyhow = { workspace = true, features = ["std"] }
 log.workspace = true

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -51,7 +51,13 @@ deserialize = [
 arbitrary = ["dep:arbitrary", "bitflags/arbitrary", "indexmap/arbitrary"]
 spv-in = ["dep:petgraph", "dep:spirv"]
 spv-out = ["dep:spirv"]
-wgsl-in = ["dep:hexf-parse", "dep:unicode-xid", "compact"]
+wgsl-in = [
+    "dep:hexf-parse",
+    "dep:strum",
+    "dep:unicode-xid",
+    "indexmap/std",
+    "compact",
+]
 wgsl-out = []
 
 ## Enables outputting to HLSL (Microsoft's High-Level Shader Language).
@@ -81,7 +87,7 @@ hashbrown.workspace = true
 rustc-hash.workspace = true
 indexmap.workspace = true
 log = "0.4"
-strum.workspace = true
+strum = { workspace = true, optional = true }
 spirv = { version = "0.3", optional = true }
 thiserror.workspace = true
 serde = { version = "1.0.217", features = [

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -126,7 +126,7 @@ document-features.workspace = true
 hashbrown.workspace = true
 indexmap.workspace = true
 log.workspace = true
-once_cell.workspace = true
+once_cell = { workspace = true, features = ["std"] }
 parking_lot.workspace = true
 profiling = { workspace = true, default-features = false }
 raw-window-handle = { workspace = true, optional = true }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -60,12 +60,14 @@ vulkan = [
 ]
 gles = [
     "naga/glsl-out",
+    "once_cell/std",
     "dep:bytemuck",
     "dep:glow",
     "dep:glutin_wgl_sys",
     "dep:khronos-egl",
     "dep:libloading",
     "dep:ndk-sys",
+    "dep:once_cell",
     "windows/Win32_Graphics_OpenGL",
     "windows/Win32_Graphics_Gdi",
     "windows/Win32_System_LibraryLoader",
@@ -134,7 +136,7 @@ arrayvec.workspace = true
 bitflags.workspace = true
 hashbrown.workspace = true
 log.workspace = true
-once_cell.workspace = true
+once_cell = { workspace = true, optional = true }
 ordered-float = { workspace = true, optional = true }
 parking_lot.workspace = true
 profiling = { workspace = true, default-features = false }


### PR DESCRIPTION
**Connections**

Some of these dependency updates are needed for no-std support:

- as requested in issue: #6826
- especially needed for naga - PR in progress: #6940

I think making the dependency updates in this isolated PR can help keep the no-std updates cleaner & more focused.

**Description**

- use `default-features = false` for more dependencies in top-level `Cargo.toml`
- only use `strum` for `wgsl-in` in `naga` crate
- move some dependencies in top-level `Cargo.toml`

__Testing__

- checked CI testing results in personal branches:
  - https://github.com/brody4hire/wgpu/commits/brody-cargo-dep-cleanup-ci-testing
  - https://github.com/brody4hire/wgpu/commits/brody-pr-7031-ci-testing
- `cargo hack --workspace --feature-powerset --depth 1 check` (equivalent to using `cargo hack --workspace --each-feature check`) is now OK ✅

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - ~~`--target wasm32-unknown-unknown`~~
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.