### PR TITLE
chore: remove obsolete entries from allow-git in .deny.toml

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -41,8 +41,6 @@ private = { ignore = true }
 [sources]
 allow-git = [
     # Waiting on releases; used in examples only
-    "https://github.com/grovesNL/glow",
-    "https://github.com/gfx-rs/metal-rs",
 ]
 unknown-registry = "deny"
 unknown-git = "deny"


### PR DESCRIPTION
**Connections**

Discovered while working on other PR: #7031

_The remaining entry is removed by other recent PR: #7033_

__NOTE:__ After this PR together with #7033 we _could_ completely remove `allow-git` from `. deny.toml`, but I think we should leave it in case it is possibly needed someday (again) in the future.

**Description**

Remove items no longer needed from `allow-git`:

- https://github.com/grovesNL/glow - removed from Cargo.lock in commit: 484457d95993b00b91905fae0e539a093423cc28 (update for release `0.19.0`)
- https://github.com/gfx-rs/metal-rs - removed from Cargo.lock in commit: 779261e64daa6cf76c826532b7a1561d8ec203fd (update with release `24.0.0`)

From `git log -p` it looks to me like references to these repositories have been 

**Testing**

- [x] ~~__TODO:__~~ check CI results ✅

**Checklist**

__N/A__