### PR TITLE
chore: update noise -> 0.9 & remove from allow-git

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -41,8 +41,6 @@ private = { ignore = true }
 [sources]
 allow-git = [
     # Waiting on releases; used in examples only
-    "https://github.com/Razaekel/noise-rs",
-
     "https://github.com/grovesNL/glow",
     "https://github.com/gfx-rs/metal-rs",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1916,7 +1916,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2046,7 +2046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2372,8 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "noise"
-version = "0.8.2"
-source = "git+https://github.com/Razaekel/noise-rs.git?rev=c6942d4fb70af26db4441edcf41f90fa115333f2#c6942d4fb70af26db4441edcf41f90fa115333f2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6da45c8333f2e152fc665d78a380be060eb84fad8ca4c9f7ac8ca29216cff0cc"
 dependencies = [
  "num-traits",
  "rand",
@@ -3245,7 +3246,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3907,7 +3908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4677,7 +4678,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,7 @@ libloading = "0.8"
 libtest-mimic = "0.8.1"
 log = "0.4"
 nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
-# https://github.com/Razaekel/noise-rs/issues/335 (Updated dependencies)
-noise = { version = "0.8", git = "https://github.com/Razaekel/noise-rs.git", rev = "c6942d4fb70af26db4441edcf41f90fa115333f2" }
+noise = "0.9"
 nv-flip = "0.1"
 obj = "0.10"
 once_cell = "1.20.2"


### PR DESCRIPTION
**Connections**

- Discovered while working on other PR: #7031
- Other, obsolete `allow-git` entries removed in other PR: #7032

**Description**

- update noise -> 0.9
- remove from allow-git, as it looks like the GitHub repository is no longer needed for this

**Testing**

- [x] ~~__TODO:__~~ check CI results ✅

**Checklist**

__N/A__