### PR TITLE
CI: add cargo hack check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,12 @@ jobs:
             tier: 2
             kind: no_std
 
+          - name: hack check - Linux x86_64
+            os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            tier: 1
+            kind: hack
+
     name: Clippy ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
@@ -287,6 +293,15 @@ jobs:
 
           # Check with all features except "std".
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features --features strict_asserts,fragile-send-sync-non-atomic-wasm,serde,counters
+
+      - name: hack check
+        if: matrix.kind == 'hack'
+        shell: bash
+        run: |
+          set -e
+
+          # hack check each feature
+          cargo hack --workspace --feature-powerset --depth 1 clippy
 
       # Building for native platforms with standard tests.
       - name: check native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,9 @@ jobs:
 
           # hack check each feature
           cargo hack --workspace --feature-powerset --depth 1 clippy
+        env:
+          # XXX TBD ???
+          RUSTFLAGS: ""
 
       # Building for native platforms with standard tests.
       - name: check native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,9 @@ jobs:
         run: |
           set -e
 
+          # install cargo-hack
+          cargo install cargo-hack
+
           # hack check each feature
           cargo hack --workspace --feature-powerset --depth 1 clippy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
     #
     # currently high due to documentation time problems on mac.
     # https://github.com/rust-lang/rust/issues/114891
-    timeout-minutes: 30
+    # XXX TBD ??? - increased further to avoid interrupting cargo hack
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use hashbrown::HashMap;
 
 // XXX TODO MORE FOCUSED allow directive
-#[allow(dead_code)]
+#[allow(unused_imports)]
 use crate::{
     api_log, api_log_debug,
     device::{queue::Queue, resource::Device, DeviceDescriptor, DeviceError},

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 
 use hashbrown::HashMap;
 
+// XXX TODO MORE FOCUSED allow directive
+#[allow(dead_code)]
 use crate::{
     api_log, api_log_debug,
     device::{queue::Queue, resource::Device, DeviceDescriptor, DeviceError},

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -141,6 +141,7 @@ define_lock_ranks! {
     rank REGISTRY_STORAGE "Registry::storage" followed by { }
     rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }
     rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }
+    #[allow(dead_code)]
     rank SURFACE_PRESENTATION "Surface::presentation" followed by { }
     rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { }
     rank TEXTURE_INITIALIZATION_STATUS "Texture::initialization_status" followed by { }


### PR DESCRIPTION
**Connections**

Could have helped me avoid a mistake I made in recent PR: #7031

**Description**

Add another task to do cargo hack check with each feature.

I think this can really help check that feature-specific dependencies are done right.

**Testing**

- [ ] __TODO:__ check CI results

**Checklist**

- ~~Run `cargo fmt`.~~
- [x] Run `taplo format`.
- ~~Run `cargo clippy`. If applicable, add:~~
  - ~~`--target wasm32-unknown-unknown`~~
- ~~Run `cargo xtask test` to run tests.~~
- ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~