### PR TITLE
[naga] Require hashbrown's serde feature as a dev-dependency.

### DIFF
--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -105,11 +105,12 @@ cfg_aliases.workspace = true
 [dev-dependencies]
 diff = "0.1"
 env_logger.workspace = true
-itertools.workspace = true
+hashbrown = { workspace = true, features = ["serde"] }
 # This _cannot_ have a version specified. If it does, crates.io will look
 # for a version of the package on crates when we publish naga. Path dependencies
 # are allowed through though.
 hlsl-snapshots = { path = "./hlsl-snapshots" }
+itertools.workspace = true
 # Require at least version 0.7.1 of ron, this version changed how floating points are
 # serialized by forcing them to always have the decimal part, this makes it backwards
 # incompatible with our tests because we do a syntactic diff and not a semantic one.


### PR DESCRIPTION
Add `hashbrown` with the `"serde"` feature as a development dependency for Naga. Regardless of whether Naga's `deserialize` feature is enabled, the snapshot tests need to deserialize parameters saved in files as RON text.

It would also suffice to use `std::collections::HashSet` in the snapshot tests, although we would need to build a `naga::FashHashSet` from the std `HashSet` at one point. Adding the dev-dependency seems slightly simpler.

Fixes #7038.
