### PR TITLE
Fix More Feature Definitions

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -84,7 +84,7 @@ naga-ir = ["dep:naga"]
 strict_asserts = ["wgpu-core?/strict_asserts", "wgpu-types/strict_asserts"]
 
 ## Enables serialization via `serde` on common wgpu types.
-serde = ["dep:serde", "wgpu-core/serde"]
+serde = ["dep:serde", "wgpu-core?/serde"]
 
 # Uncomment once we get to https://github.com/gfx-rs/wgpu/issues/5974
 # ## Allow writing of trace capture files. See [`Adapter::request_device`].
@@ -92,7 +92,7 @@ serde = ["dep:serde", "wgpu-core/serde"]
 
 ## Allow deserializing of trace capture files that were written with the `trace` feature.
 ## To replay a trace file use the [wgpu player](https://github.com/gfx-rs/wgpu/tree/trunk/player).
-replay = ["serde", "wgpu-core/replay"]
+replay = ["serde", "wgpu-core?/replay"]
 
 #! ### Other
 # --------------------------------------------------------------------
@@ -100,7 +100,7 @@ replay = ["serde", "wgpu-core/replay"]
 ## Internally count resources and events for debugging purposes. If the counters
 ## feature is disabled, the counting infrastructure is removed from the build and
 ## the exposed counters always return 0.
-counters = ["wgpu-core/counters"]
+counters = ["wgpu-core?/counters"]
 
 ## Implement `Send` and `Sync` on Wasm, but only if atomics are not enabled.
 ##
@@ -111,8 +111,8 @@ counters = ["wgpu-core/counters"]
 ## but on a wasm binary compiled without atomics we know we are definitely
 ## not in a multithreaded environment.
 fragile-send-sync-non-atomic-wasm = [
-    "wgpu-hal/fragile-send-sync-non-atomic-wasm",
-    "wgpu-core/fragile-send-sync-non-atomic-wasm",
+    "wgpu-hal?/fragile-send-sync-non-atomic-wasm",
+    "wgpu-core?/fragile-send-sync-non-atomic-wasm",
     "wgpu-types/fragile-send-sync-non-atomic-wasm",
 ]
 
@@ -126,7 +126,7 @@ fragile-send-sync-non-atomic-wasm = [
 ## must be shipped alongside `dxcompiler.dll` and `dxil.dll` (which can be downloaded from Microsoft's GitHub).
 ## This feature statically links a version of DXC so that no external binaries are required
 ## to compile DX12 shaders.
-static-dxc = ["wgpu-hal/static-dxc"]
+static-dxc = ["wgpu-hal?/static-dxc"]
 
 #########################
 # Standard Dependencies #


### PR DESCRIPTION
Found a couple more features that if you turn on, wasm will take a wgpu-core dependency when it shoudln't