### PR TITLE
Upgrade `CORE_MSRV` to 1.82 and take advantage of some new features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ env:
   REPO_MSRV: "1.85"
   # This is the MSRV used by the `wgpu-core`, `wgpu-hal`, and `wgpu-types` crates,
   # to ensure that they can be used with firefox.
-  CORE_MSRV: "1.76"
+  CORE_MSRV: "1.80.1"
 
   #
   # Environment variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ env:
   REPO_MSRV: "1.85"
   # This is the MSRV used by the `wgpu-core`, `wgpu-hal`, and `wgpu-types` crates,
   # to ensure that they can be used with firefox.
-  CORE_MSRV: "1.80.1"
+  CORE_MSRV: "1.82.0"
 
   #
   # Environment variables

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ default-members = [
 ]
 
 [workspace.lints.clippy]
-manual_c_str_literals = "allow"
 ref_as_ptr = "warn"
 # NOTE: disallowed-types is configured in other file: clippy.toml
 

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -15,7 +15,7 @@ autotests = false
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.80.0"
+rust-version = "1.82.0"
 
 [[test]]
 name = "naga-test"

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -15,7 +15,7 @@ autotests = false
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.76"
+rust-version = "1.80.0"
 
 [[test]]
 name = "naga-test"

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -2203,8 +2203,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             self.write_stmt(sta, ctx, l2.next())?;
                         }
 
-                        if !case.fall_through
-                            && case.body.last().map_or(true, |s| !s.is_terminator())
+                        if !case.fall_through && case.body.last().is_none_or(|s| !s.is_terminator())
                         {
                             writeln!(self.out, "{}break;", l2.next())?;
                         }

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -1715,14 +1715,14 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                     }
 
                     let last_case = &cases[end_case_idx];
-                    if last_case.body.last().map_or(true, |s| !s.is_terminator()) {
+                    if last_case.body.last().is_none_or(|s| !s.is_terminator()) {
                         writeln!(self.out, "{indent_level_2}break;")?;
                     }
                 } else {
                     for sta in case.body.iter() {
                         self.write_stmt(module, sta, func_ctx, indent_level_2)?;
                     }
-                    if !case.fall_through && case.body.last().map_or(true, |s| !s.is_terminator()) {
+                    if !case.fall_through && case.body.last().is_none_or(|s| !s.is_terminator()) {
                         writeln!(self.out, "{indent_level_2}break;")?;
                     }
                 }

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -723,6 +723,5 @@ pub fn write_string(
 
 #[test]
 fn test_error_size() {
-    use std::mem::size_of;
     assert_eq!(size_of::<Error>(), 32);
 }

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -3223,8 +3223,7 @@ impl<W: Write> Writer<W> {
                         }
 
                         self.put_block(lcase.next(), &case.body, context)?;
-                        if !case.fall_through
-                            && case.body.last().map_or(true, |s| !s.is_terminator())
+                        if !case.fall_through && case.body.last().is_none_or(|s| !s.is_terminator())
                         {
                             writeln!(self.out, "{}break;", lcase.next())?;
                         }

--- a/naga/src/front/spv/function.rs
+++ b/naga/src/front/spv/function.rs
@@ -643,7 +643,7 @@ impl BlockContext<'_> {
                                 let body = lower_impl(blocks, bodies, body_idx);
 
                                 // Handle simple cases that would make a fallthrough statement unreachable code
-                                let fall_through = body.last().map_or(true, |s| !s.is_terminator());
+                                let fall_through = body.last().is_none_or(|s| !s.is_terminator());
 
                                 crate::SwitchCase {
                                     value: crate::SwitchValue::I32(value),

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -17,9 +17,6 @@ use std::ops::Range;
 use termcolor::{ColorChoice, NoColor, StandardStream};
 use thiserror::Error;
 
-#[cfg(test)]
-use std::mem::size_of;
-
 #[derive(Clone, Debug)]
 pub struct ParseError {
     message: String,

--- a/naga/src/non_max_u32.rs
+++ b/naga/src/non_max_u32.rs
@@ -140,6 +140,5 @@ impl<'de> serde::Deserialize<'de> for NonMaxU32 {
 
 #[test]
 fn size() {
-    use core::mem::size_of;
     assert_eq!(size_of::<Option<NonMaxU32>>(), size_of::<u32>());
 }

--- a/naga/src/proc/typifier.rs
+++ b/naga/src/proc/typifier.rs
@@ -908,6 +908,5 @@ impl<'a> ResolveContext<'a> {
 
 #[test]
 fn test_error_size() {
-    use std::mem::size_of;
     assert_eq!(size_of::<ResolveError>(), 32);
 }

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -1140,10 +1140,10 @@ impl super::Validator {
                     };
 
                     // The `coordinate` operand must be a vector of the appropriate size.
-                    if !context
+                    if context
                         .resolve_type(coordinate, &self.valid_expression_set)?
                         .image_storage_coordinates()
-                        .is_some_and(|coord_dim| coord_dim == dim)
+                        .is_none_or(|coord_dim| coord_dim != dim)
                     {
                         return Err(FunctionError::InvalidImageStore(
                             ExpressionError::InvalidImageCoordinateType(dim, coordinate),

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.80.0"
+rust-version = "1.82.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.76"
+rust-version = "1.80.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -85,7 +85,6 @@ use alloc::{
     vec::Vec,
 };
 use core::{
-    mem::size_of,
     num::{NonZeroU32, NonZeroU64},
     ops::Range,
 };

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 use wgt::{BufferAddress, DynamicOffset};
 
 use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
-use core::{fmt, mem::size_of, str};
+use core::{fmt, str};
 
 use crate::{
     binding_model::{

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1,5 +1,5 @@
 use alloc::{borrow::Cow, sync::Arc, vec::Vec};
-use core::{fmt, mem::size_of, num::NonZeroU32, ops::Range, str};
+use core::{fmt, num::NonZeroU32, ops::Range, str};
 
 use arrayvec::ArrayVec;
 use thiserror::Error;

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -303,7 +303,7 @@ impl fmt::Display for DeviceMismatch {
     }
 }
 
-impl std::error::Error for DeviceMismatch {}
+impl core::error::Error for DeviceMismatch {}
 
 #[derive(Clone, Debug, Error)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/wgpu-core/src/error.rs
+++ b/wgpu-core/src/error.rs
@@ -1,6 +1,5 @@
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
-use core::fmt;
-use std::error::Error; // TODO(https://github.com/gfx-rs/wgpu/issues/6826): use core::error after MSRV bump
+use core::{error::Error, fmt};
 
 use thiserror::Error;
 

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -4,7 +4,6 @@ use core::{
     fmt::{self, Debug},
     hash::Hash,
     marker::PhantomData,
-    mem::size_of,
     num::NonZeroU64,
 };
 use wgt::WasmNotSendSync;

--- a/wgpu-core/src/indirect_validation.rs
+++ b/wgpu-core/src/indirect_validation.rs
@@ -1,5 +1,4 @@
 use alloc::{boxed::Box, format, string::ToString as _};
-use core::mem::size_of;
 use core::num::NonZeroU64;
 
 use thiserror::Error;

--- a/wgpu-core/src/pipeline_cache.rs
+++ b/wgpu-core/src/pipeline_cache.rs
@@ -1,5 +1,3 @@
-use core::mem::size_of;
-
 use thiserror::Error;
 use wgt::AdapterInfo;
 

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -1,5 +1,4 @@
 use alloc::sync::Arc;
-use core::mem::size_of;
 
 use crate::{
     id::Id,

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.80.0"
+rust-version = "1.82.0"
 
 [package.metadata.docs.rs]
 # Ideally we would enable all the features.

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.76"
+rust-version = "1.80.0"
 
 [package.metadata.docs.rs]
 # Ideally we would enable all the features.

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -115,7 +115,6 @@ gles = [
     "dep:profiling",
     "dep:wasm-bindgen",
     "dep:web-sys",
-    "once_cell/std",
     "windows/Win32_Graphics_OpenGL",
     "windows/Win32_Graphics_Gdi",
     "windows/Win32_System_LibraryLoader",

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -14,9 +14,7 @@ use winit::{
 
 use std::{
     borrow::{Borrow, Cow},
-    iter,
-    mem::size_of,
-    ptr,
+    iter, ptr,
     time::Instant,
 };
 

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -8,9 +8,7 @@ use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use glam::{Affine3A, Mat4, Vec3};
 use std::{
     borrow::{Borrow, Cow},
-    iter,
-    mem::size_of,
-    ptr,
+    iter, ptr,
     time::Instant,
 };
 use wgpu_types::Dx12BackendOptions;

--- a/wgpu-hal/src/auxil/dxgi/time.rs
+++ b/wgpu-hal/src/auxil/dxgi/time.rs
@@ -62,7 +62,11 @@ impl PresentationTimer {
         let kernelbase =
             libloading::os::windows::Library::open_already_loaded("kernelbase.dll").unwrap();
         // No concerns about lifetimes here as kernelbase is always there.
-        let ptr = unsafe { kernelbase.get(b"QueryInterruptTimePrecise\0").unwrap() };
+        let ptr = unsafe {
+            kernelbase
+                .get(c"QueryInterruptTimePrecise".to_bytes())
+                .unwrap()
+        };
         Self::IPresentationManager {
             fnQueryInterruptTimePrecise: *ptr,
         }

--- a/wgpu-hal/src/auxil/renderdoc.rs
+++ b/wgpu-hal/src/auxil/renderdoc.rs
@@ -71,7 +71,7 @@ impl RenderDoc {
         };
 
         let get_api: libloading::Symbol<GetApiFn> =
-            match unsafe { renderdoc_lib.get(b"RENDERDOC_GetAPI\0") } {
+            match unsafe { renderdoc_lib.get(c"RENDERDOC_GetAPI".to_bytes()) } {
                 Ok(api) => api,
                 Err(e) => {
                     return RenderDoc::NotAvailable {

--- a/wgpu-hal/src/auxil/renderdoc.rs
+++ b/wgpu-hal/src/auxil/renderdoc.rs
@@ -1,6 +1,7 @@
 //! RenderDoc integration - <https://renderdoc.org/>
 #![cfg_attr(not(any(feature = "gles", feature = "vulkan")), allow(dead_code))]
 
+use alloc::format;
 use alloc::string::String;
 use core::{ffi, ptr};
 

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -1,11 +1,4 @@
-use std::{
-    mem::{size_of, size_of_val},
-    ptr,
-    string::String,
-    sync::Arc,
-    thread,
-    vec::Vec,
-};
+use std::{ptr, string::String, sync::Arc, thread, vec::Vec};
 
 use parking_lot::Mutex;
 use windows::{

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 // this has to match Naga's HLSL backend, and also needs to be null-terminated
-const NAGA_LOCATION_SEMANTIC: &[u8] = b"LOC\0";
+const NAGA_LOCATION_SEMANTIC: &[u8] = c"LOC".to_bytes();
 
 impl super::Device {
     pub(super) fn new(

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Cow,
-    ffi,
-    mem::{self, size_of, size_of_val},
+    ffi, mem,
     num::NonZeroU32,
     ptr, slice,
     string::{String, ToString as _},

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -1,4 +1,4 @@
-use std::{mem::size_of_val, string::String, sync::Arc, vec::Vec};
+use std::{string::String, sync::Arc, vec::Vec};
 
 use parking_lot::RwLock;
 use windows::{

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -158,7 +158,8 @@ impl D3D12Lib {
             riid: *const windows_core::GUID,
             ppdevice: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"D3D12CreateDevice\0") }?;
+        let func: libloading::Symbol<Fun> =
+            unsafe { self.lib.get(c"D3D12CreateDevice".to_bytes()) }?;
 
         let mut result__: Option<Direct3D12::ID3D12Device> = None;
 
@@ -199,7 +200,7 @@ impl D3D12Lib {
             pperrorblob: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
         let func: libloading::Symbol<Fun> =
-            unsafe { self.lib.get(b"D3D12SerializeRootSignature\0") }?;
+            unsafe { self.lib.get(c"D3D12SerializeRootSignature".to_bytes()) }?;
 
         let desc = Direct3D12::D3D12_ROOT_SIGNATURE_DESC {
             NumParameters: parameters.len() as _,
@@ -238,7 +239,8 @@ impl D3D12Lib {
             riid: *const windows_core::GUID,
             ppvdebug: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"D3D12GetDebugInterface\0") }?;
+        let func: libloading::Symbol<Fun> =
+            unsafe { self.lib.get(c"D3D12GetDebugInterface".to_bytes()) }?;
 
         let mut result__ = None;
 
@@ -275,7 +277,8 @@ impl DxgiLib {
             riid: *const windows_core::GUID,
             pdebug: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"DXGIGetDebugInterface1\0") }?;
+        let func: libloading::Symbol<Fun> =
+            unsafe { self.lib.get(c"DXGIGetDebugInterface1".to_bytes()) }?;
 
         let mut result__ = None;
 
@@ -304,7 +307,8 @@ impl DxgiLib {
             riid: *const windows_core::GUID,
             ppfactory: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"CreateDXGIFactory2\0") }?;
+        let func: libloading::Symbol<Fun> =
+            unsafe { self.lib.get(c"CreateDXGIFactory2".to_bytes()) }?;
 
         let mut result__ = None;
 
@@ -326,7 +330,8 @@ impl DxgiLib {
             riid: *const windows_core::GUID,
             ppfactory: *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> = unsafe { self.lib.get(b"CreateDXGIFactory1\0") }?;
+        let func: libloading::Symbol<Fun> =
+            unsafe { self.lib.get(c"CreateDXGIFactory1".to_bytes()) }?;
 
         let mut result__ = None;
 

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -112,7 +112,7 @@ impl DxcLib {
                 -> windows_core::HRESULT;
 
             let func: libloading::Symbol<DxcCreateInstanceFn> =
-                self.lib.get(b"DxcCreateInstance\0")?;
+                self.lib.get(c"DxcCreateInstance".to_bytes())?;
             dxc_create_instance::<T>(|clsid, iid, ppv| func(clsid, iid, ppv))
         }
     }

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -203,7 +203,9 @@ impl super::Adapter {
             // emscripten doesn't enable "WEBGL_debug_renderer_info" extension by default. so, we do it manually.
             // See https://github.com/gfx-rs/wgpu/issues/3245 for context
             #[cfg(Emscripten)]
-            if unsafe { super::emscripten::enable_extension("WEBGL_debug_renderer_info\0") } {
+            if unsafe {
+                super::emscripten::enable_extension(c"WEBGL_debug_renderer_info".to_str().unwrap())
+            } {
                 (GL_UNMASKED_VENDOR_WEBGL, GL_UNMASKED_RENDERER_WEBGL)
             } else {
                 (glow::VENDOR, glow::RENDERER)

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -1,9 +1,5 @@
 use alloc::string::String;
-use core::{
-    mem::{self, size_of, size_of_val},
-    ops::Range,
-    slice,
-};
+use core::{mem, ops::Range, slice};
 
 use arrayvec::ArrayVec;
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1,13 +1,19 @@
 #![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
 
 use std::{
-    ffi, mem::ManuallyDrop, os::raw, ptr, rc::Rc, string::String, sync::Arc, time::Duration,
+    ffi,
+    mem::ManuallyDrop,
+    os::raw,
+    ptr,
+    rc::Rc,
+    string::String,
+    sync::{Arc, LazyLock},
+    time::Duration,
     vec::Vec,
 };
 
 use glow::HasContext;
 use hashbrown::HashMap;
-use once_cell::sync::Lazy;
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard, RwLock};
 
 /// The amount of time to wait while trying to obtain a lock to the adapter context
@@ -474,7 +480,8 @@ struct Inner {
 // Different calls to `eglGetPlatformDisplay` may return the same `Display`, making it a global
 // state of all our `EglContext`s. This forces us to track the number of such context to prevent
 // terminating the display if it's currently used by another `EglContext`.
-static DISPLAYS_REFERENCE_COUNT: Lazy<Mutex<HashMap<usize, usize>>> = Lazy::new(Default::default);
+static DISPLAYS_REFERENCE_COUNT: LazyLock<Mutex<HashMap<usize, usize>>> =
+    LazyLock::new(Default::default);
 
 fn initialize_display(
     egl: &EglInstance,

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -147,7 +147,7 @@ impl Drop for DisplayOwner {
         match self.display {
             DisplayRef::X11(ptr) => unsafe {
                 let func: libloading::Symbol<XCloseDisplayFun> =
-                    self.library.get(b"XCloseDisplay\0").unwrap();
+                    self.library.get(c"XCloseDisplay".to_bytes()).unwrap();
                 func(ptr.as_ptr());
             },
             DisplayRef::Wayland => {}
@@ -159,7 +159,8 @@ fn open_x_display() -> Option<DisplayOwner> {
     log::debug!("Loading X11 library to get the current display");
     unsafe {
         let library = find_library(&["libX11.so.6", "libX11.so"])?;
-        let func: libloading::Symbol<XOpenDisplayFun> = library.get(b"XOpenDisplay\0").unwrap();
+        let func: libloading::Symbol<XOpenDisplayFun> =
+            library.get(c"XOpenDisplay".to_bytes()).unwrap();
         let result = func(ptr::null());
         ptr::NonNull::new(result).map(|ptr| DisplayOwner {
             display: DisplayRef::X11(ptr),
@@ -185,10 +186,12 @@ fn test_wayland_display() -> Option<DisplayOwner> {
     log::debug!("Loading Wayland library to get the current display");
     let library = unsafe {
         let client_library = find_library(&["libwayland-client.so.0", "libwayland-client.so"])?;
-        let wl_display_connect: libloading::Symbol<WlDisplayConnectFun> =
-            client_library.get(b"wl_display_connect\0").unwrap();
-        let wl_display_disconnect: libloading::Symbol<WlDisplayDisconnectFun> =
-            client_library.get(b"wl_display_disconnect\0").unwrap();
+        let wl_display_connect: libloading::Symbol<WlDisplayConnectFun> = client_library
+            .get(c"wl_display_connect".to_bytes())
+            .unwrap();
+        let wl_display_disconnect: libloading::Symbol<WlDisplayDisconnectFun> = client_library
+            .get(c"wl_display_disconnect".to_bytes())
+            .unwrap();
         let display = ptr::NonNull::new(wl_display_connect(ptr::null()))?;
         wl_display_disconnect(display.as_ptr());
         find_library(&["libwayland-egl.so.1", "libwayland-egl.so"])?
@@ -1317,7 +1320,7 @@ impl crate::Surface for Surface {
                     (WindowKind::Wayland, Rwh::Wayland(handle)) => {
                         let library = &self.wsi.display_owner.as_ref().unwrap().library;
                         let wl_egl_window_create: libloading::Symbol<WlEglWindowCreateFun> =
-                            unsafe { library.get(b"wl_egl_window_create\0") }.unwrap();
+                            unsafe { library.get(c"wl_egl_window_create".to_bytes()) }.unwrap();
                         let window =
                             unsafe { wl_egl_window_create(handle.surface.as_ptr(), 640, 480) }
                                 .cast();
@@ -1429,7 +1432,7 @@ impl crate::Surface for Surface {
         if let Some(window) = wl_window {
             let library = &self.wsi.display_owner.as_ref().unwrap().library;
             let wl_egl_window_resize: libloading::Symbol<WlEglWindowResizeFun> =
-                unsafe { library.get(b"wl_egl_window_resize\0") }.unwrap();
+                unsafe { library.get(c"wl_egl_window_resize".to_bytes()) }.unwrap();
             unsafe {
                 wl_egl_window_resize(
                     window,
@@ -1501,7 +1504,7 @@ impl crate::Surface for Surface {
                     .expect("unsupported window")
                     .library;
                 let wl_egl_window_destroy: libloading::Symbol<WlEglWindowDestroyFun> =
-                    unsafe { library.get(b"wl_egl_window_destroy\0") }.unwrap();
+                    unsafe { library.get(c"wl_egl_window_destroy".to_bytes()) }.unwrap();
                 unsafe { wl_egl_window_destroy(window) };
             }
         }

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1,7 +1,7 @@
 use super::{conv::is_layered_target, Command as C, PrivateCapabilities};
 use alloc::sync::Arc;
 use arrayvec::ArrayVec;
-use core::{mem::size_of, slice, sync::atomic::Ordering};
+use core::{slice, sync::atomic::Ordering};
 use glow::HasContext;
 
 const DEBUG_ID: u32 = 0;

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -3,7 +3,7 @@
 use std::{
     borrow::ToOwned as _,
     ffi::{c_void, CStr, CString},
-    mem::{self, size_of, size_of_val, ManuallyDrop},
+    mem::{self, ManuallyDrop},
     os::raw::c_int,
     ptr,
     string::String,

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -440,14 +440,13 @@ impl crate::Instance for Instance {
     unsafe fn init(desc: &crate::InstanceDescriptor) -> Result<Self, crate::InstanceError> {
         profiling::scope!("Init OpenGL (WGL) Backend");
         let opengl_module =
-            unsafe { LibraryLoader::LoadLibraryA(PCSTR("opengl32.dll\0".as_ptr())) }.map_err(
-                |e| {
+            unsafe { LibraryLoader::LoadLibraryA(PCSTR(c"opengl32.dll".as_ptr().cast())) }
+                .map_err(|e| {
                     crate::InstanceError::with_source(
                         String::from("unable to load the OpenGL library"),
                         e,
                     )
-                },
-            )?;
+                })?;
 
         let device = create_instance_device()?;
         let dc = device.dc;

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -9,7 +9,7 @@ use std::{
     string::String,
     sync::{
         mpsc::{sync_channel, SyncSender},
-        Arc,
+        Arc, LazyLock,
     },
     thread,
     time::Duration,
@@ -22,7 +22,6 @@ use glutin_wgl_sys::wgl_extra::{
     CONTEXT_PROFILE_MASK_ARB,
 };
 use hashbrown::HashSet;
-use once_cell::sync::Lazy;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use wgt::InstanceFlags;
@@ -325,8 +324,8 @@ fn create_global_window_class() -> Result<CString, crate::InstanceError> {
 }
 
 fn get_global_window_class() -> Result<CString, crate::InstanceError> {
-    static GLOBAL: Lazy<Result<CString, crate::InstanceError>> =
-        Lazy::new(create_global_window_class);
+    static GLOBAL: LazyLock<Result<CString, crate::InstanceError>> =
+        LazyLock::new(create_global_window_class);
     GLOBAL.clone()
 }
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -240,8 +240,9 @@
 
 extern crate alloc;
 extern crate wgpu_types as wgt;
-// TODO(https://github.com/gfx-rs/wgpu/issues/6826): disable std except on noop and gles-WebGL.
-// Requires Rust 1.81 for core::error::Error.
+// Each of these backends needs `std` in some fashion; usually `std::thread` functions.
+// TODO(https://github.com/gfx-rs/wgpu/issues/6826): gles-WebGL backend should be made no-std
+#[cfg(any(dx12, gles, metal, vulkan))]
 #[macro_use]
 extern crate std;
 
@@ -290,12 +291,12 @@ use alloc::boxed::Box;
 use alloc::{borrow::Cow, string::String, sync::Arc, vec::Vec};
 use core::{
     borrow::Borrow,
+    error::Error,
     fmt,
     num::NonZeroU32,
     ops::{Range, RangeInclusive},
     ptr::NonNull,
 };
-use std::error::Error; // TODO(https://github.com/gfx-rs/wgpu/issues/6826): use core::error after MSRV bump
 
 use bitflags::bitflags;
 use parking_lot::Mutex;

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -2,7 +2,6 @@ use super::{conv, AsNative, TimestampQuerySupport};
 use crate::CommandEncoder as _;
 use std::{
     borrow::{Cow, ToOwned as _},
-    mem::size_of,
     ops::Range,
     vec::Vec,
 };

--- a/wgpu-hal/src/metal/layer_observer.rs
+++ b/wgpu-hal/src/metal/layer_observer.rs
@@ -23,8 +23,8 @@ const NSKeyValueObservingOptionNew: usize = 0x01;
 #[allow(non_upper_case_globals)]
 const NSKeyValueObservingOptionInitial: usize = 0x04;
 
-const CONTENTS_SCALE: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"contentsScale\0") };
-const BOUNDS: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"bounds\0") };
+const CONTENTS_SCALE: &CStr = c"contentsScale";
+const BOUNDS: &CStr = c"bounds";
 
 /// Create a new custom layer that tracks parameters from the given super layer.
 ///

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -3,11 +3,7 @@ use super::conv;
 use arrayvec::ArrayVec;
 use ash::vk;
 
-use std::{
-    mem::{self, size_of},
-    ops::Range,
-    slice,
-};
+use std::{mem, ops::Range, slice};
 
 const ALLOCATION_GRANULARITY: u32 = 16;
 const DST_IMAGE_LAYOUT: vk::ImageLayout = vk::ImageLayout::TRANSFER_DST_OPTIMAL;

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::{Cow, ToOwned as _},
     collections::BTreeMap,
     ffi::{CStr, CString},
-    mem::{self, size_of, MaybeUninit},
+    mem::{self, MaybeUninit},
     num::NonZeroU32,
     ptr, slice,
     sync::Arc,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -34,10 +34,8 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5671
         // Versions 1.3.240 through 1.3.250 return a spurious error here if
         // the debug range start and end appear in different command buffers.
-        const KHRONOS_VALIDATION_LAYER: &CStr =
-            unsafe { CStr::from_bytes_with_nul_unchecked(b"Khronos Validation Layer\0") };
         if let Some(layer_properties) = user_data.validation_layer_properties.as_ref() {
-            if layer_properties.layer_description.as_ref() == KHRONOS_VALIDATION_LAYER
+            if layer_properties.layer_description.as_ref() == c"Khronos Validation Layer"
                 && layer_properties.layer_spec_version >= vk::make_api_version(0, 1, 3, 240)
                 && layer_properties.layer_spec_version <= vk::make_api_version(0, 1, 3, 250)
             {
@@ -611,7 +609,7 @@ impl crate::Instance for super::Instance {
         let app_info = vk::ApplicationInfo::default()
             .application_name(app_name.as_c_str())
             .application_version(1)
-            .engine_name(CStr::from_bytes_with_nul(b"wgpu-hal\0").unwrap())
+            .engine_name(c"wgpu-hal")
             .engine_version(2)
             .api_version(
                 // Vulkan 1.0 doesn't like anything but 1.0 passed in here...
@@ -653,8 +651,7 @@ impl crate::Instance for super::Instance {
                 .find(|inst_layer| inst_layer.layer_name_as_c_str() == Ok(name))
         }
 
-        let validation_layer_name =
-            CStr::from_bytes_with_nul(b"VK_LAYER_KHRONOS_validation\0").unwrap();
+        let validation_layer_name = c"VK_LAYER_KHRONOS_validation";
         let validation_layer_properties = find_layer(&instance_layers, validation_layer_name);
 
         // Determine if VK_EXT_validation_features is available, so we can enable
@@ -678,11 +675,9 @@ impl crate::Instance for super::Instance {
             .intersects(wgt::InstanceFlags::GPU_BASED_VALIDATION)
             && validation_features_are_enabled;
 
-        let nv_optimus_layer = CStr::from_bytes_with_nul(b"VK_LAYER_NV_optimus\0").unwrap();
-        let has_nv_optimus = find_layer(&instance_layers, nv_optimus_layer).is_some();
+        let has_nv_optimus = find_layer(&instance_layers, c"VK_LAYER_NV_optimus").is_some();
 
-        let obs_layer = CStr::from_bytes_with_nul(b"VK_LAYER_OBS_HOOK\0").unwrap();
-        let has_obs_layer = find_layer(&instance_layers, obs_layer).is_some();
+        let has_obs_layer = find_layer(&instance_layers, c"VK_LAYER_OBS_HOOK").is_some();
 
         let mut layers: Vec<&'static CStr> = Vec::new();
 

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.80.0"
+rust-version = "1.82.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.76"
+rust-version = "1.80.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -17,7 +17,6 @@ extern crate alloc;
 use alloc::{string::String, vec, vec::Vec};
 use core::{
     hash::{Hash, Hasher},
-    mem::size_of,
     num::NonZeroU32,
     ops::Range,
 };

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -1,6 +1,5 @@
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
-use core::fmt;
-use std::error; // TODO(https://github.com/gfx-rs/wgpu/issues/6826): use core::error after MSRV bump
+use core::{error, fmt};
 
 use parking_lot::Mutex;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-use std::error; // TODO(https://github.com/gfx-rs/wgpu/issues/6826): use core::error after MSRV bump
+use core::{error, fmt};
 use std::thread;
 
 use crate::*;


### PR DESCRIPTION
**Connections**

With patches for [bug 1945020](https://bugzilla.mozilla.org/show_bug.cgi?id=1945020) landing against `mozilla-central`, we should be ready to bump `CORE_MSRV` to Rust 1.82. Woot! 🙌🏻

**Description**

Title says all. 💪

**Testing**

CI and done.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~
