### PR TITLE
Implement ray query candidate intersection generation and confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Bottom level categories:
 #### Naga
 
 - Support @must_use attribute on function declarations. By @turbocrime in [#6801](https://github.com/gfx-rs/wgpu/pull/6801).
+- Support for generating the candidate intersections from AABB geometry, and confirming the hits. By @kvark in [#7047](https://github.com/gfx-rs/wgpu/pull/7047).
 
 ### Changes
 

--- a/naga/src/back/dot/mod.rs
+++ b/naga/src/back/dot/mod.rs
@@ -293,6 +293,13 @@ impl StatementGraph {
                             self.emits.push((id, result));
                             "RayQueryProceed"
                         }
+                        crate::RayQueryFunction::GenerateIntersection { hit_t } => {
+                            self.dependencies.push((id, hit_t, "hit_t"));
+                            "RayQueryGenerateIntersection"
+                        }
+                        crate::RayQueryFunction::ConfirmIntersection => {
+                            "RayQueryConfirmIntersection"
+                        }
                         crate::RayQueryFunction::Terminate => "RayQueryTerminate",
                     }
                 }

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -2452,7 +2452,20 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                     self.write_expr(module, query, func_ctx)?;
                     writeln!(self.out, ".Proceed();")?;
                 }
+                RayQueryFunction::GenerateIntersection { hit_t } => {
+                    write!(self.out, "{level}")?;
+                    self.write_expr(module, query, func_ctx)?;
+                    write!(self.out, ".CommitProceduralPrimitiveHit(")?;
+                    self.write_expr(module, hit_t, func_ctx)?;
+                    writeln!(self.out, ");")?;
+                }
+                RayQueryFunction::ConfirmIntersection => {
+                    write!(self.out, "{level}")?;
+                    self.write_expr(module, query, func_ctx)?;
+                    writeln!(self.out, ".CommitNonOpaqueTriangleHit();")?;
+                }
                 RayQueryFunction::Terminate => {
+                    write!(self.out, "{level}")?;
                     self.write_expr(module, query, func_ctx)?;
                     writeln!(self.out, ".Abort();")?;
                 }

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -821,6 +821,10 @@ fn adjust_stmt(new_pos: &HandleVec<Expression, Handle<Expression>>, stmt: &mut S
                 crate::RayQueryFunction::Proceed { ref mut result } => {
                     adjust(result);
                 }
+                crate::RayQueryFunction::GenerateIntersection { ref mut hit_t } => {
+                    adjust(hit_t);
+                }
+                crate::RayQueryFunction::ConfirmIntersection => {}
                 crate::RayQueryFunction::Terminate => {}
             }
         }

--- a/naga/src/back/spv/instructions.rs
+++ b/naga/src/back/spv/instructions.rs
@@ -779,6 +779,19 @@ impl super::Instruction {
         instruction
     }
 
+    pub(super) fn ray_query_generate_intersection(query: Word, hit: Word) -> Self {
+        let mut instruction = Self::new(Op::RayQueryGenerateIntersectionKHR);
+        instruction.add_operand(query);
+        instruction.add_operand(hit);
+        instruction
+    }
+
+    pub(super) fn ray_query_confirm_intersection(query: Word) -> Self {
+        let mut instruction = Self::new(Op::RayQueryConfirmIntersectionKHR);
+        instruction.add_operand(query);
+        instruction
+    }
+
     pub(super) fn ray_query_get_intersection(
         op: Op,
         result_type_id: Word,

--- a/naga/src/back/spv/ray.rs
+++ b/naga/src/back/spv/ray.rs
@@ -609,6 +609,19 @@ impl BlockContext<'_> {
                     .body
                     .push(Instruction::ray_query_proceed(result_type_id, id, query_id));
             }
+            crate::RayQueryFunction::GenerateIntersection { hit_t } => {
+                let hit_id = self.cached[hit_t];
+                block
+                    .body
+                    .push(Instruction::ray_query_generate_intersection(
+                        query_id, hit_id,
+                    ));
+            }
+            crate::RayQueryFunction::ConfirmIntersection => {
+                block
+                    .body
+                    .push(Instruction::ray_query_confirm_intersection(query_id));
+            }
             crate::RayQueryFunction::Terminate => {}
         }
     }

--- a/naga/src/compact/statements.rs
+++ b/naga/src/compact/statements.rs
@@ -190,6 +190,10 @@ impl FunctionTracer<'_> {
             Qf::Proceed { result } => {
                 self.expressions_used.insert(result);
             }
+            Qf::GenerateIntersection { hit_t } => {
+                self.expressions_used.insert(hit_t);
+            }
+            Qf::ConfirmIntersection => {}
             Qf::Terminate => {}
         }
     }
@@ -393,6 +397,10 @@ impl FunctionMap {
             Qf::Proceed { ref mut result } => {
                 self.expressions.adjust(result);
             }
+            Qf::GenerateIntersection { ref mut hit_t } => {
+                self.expressions.adjust(hit_t);
+            }
+            Qf::ConfirmIntersection => {}
             Qf::Terminate => {}
         }
     }

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2692,6 +2692,40 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                 .push(crate::Statement::RayQuery { query, fun }, span);
                             return Ok(Some(result));
                         }
+                        "rayQueryGenerateIntersection" => {
+                            let mut args = ctx.prepare_args(arguments, 2, span);
+                            let query = self.ray_query_pointer(args.next()?, ctx)?;
+                            let hit_t = self.expression(args.next()?, ctx)?;
+                            args.finish()?;
+
+                            let fun = crate::RayQueryFunction::GenerateIntersection { hit_t };
+                            let rctx = ctx.runtime_expression_ctx(span)?;
+                            rctx.block
+                                .push(crate::Statement::RayQuery { query, fun }, span);
+                            return Ok(None);
+                        }
+                        "rayQueryConfirmIntersection" => {
+                            let mut args = ctx.prepare_args(arguments, 1, span);
+                            let query = self.ray_query_pointer(args.next()?, ctx)?;
+                            args.finish()?;
+
+                            let fun = crate::RayQueryFunction::ConfirmIntersection;
+                            let rctx = ctx.runtime_expression_ctx(span)?;
+                            rctx.block
+                                .push(crate::Statement::RayQuery { query, fun }, span);
+                            return Ok(None);
+                        }
+                        "rayQueryTerminate" => {
+                            let mut args = ctx.prepare_args(arguments, 1, span);
+                            let query = self.ray_query_pointer(args.next()?, ctx)?;
+                            args.finish()?;
+
+                            let fun = crate::RayQueryFunction::Terminate;
+                            let rctx = ctx.runtime_expression_ctx(span)?;
+                            rctx.block
+                                .push(crate::Statement::RayQuery { query, fun }, span);
+                            return Ok(None);
+                        }
                         "rayQueryGetCommittedIntersection" => {
                             let mut args = ctx.prepare_args(arguments, 1, span);
                             let query = self.ray_query_pointer(args.next()?, ctx)?;

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -1779,6 +1779,16 @@ pub enum RayQueryFunction {
         result: Handle<Expression>,
     },
 
+    /// Add a candidate generated intersection to be included
+    /// in the determination of the closest hit for a ray query.
+    GenerateIntersection {
+        hit_t: Handle<Expression>,
+    },
+
+    /// Confirm a triangle intersection to be included in the determination of
+    /// the closest hit for a ray query.
+    ConfirmIntersection,
+
     Terminate,
 }
 

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -1080,13 +1080,20 @@ impl FunctionInfo {
                 }
                 S::RayQuery { query, ref fun } => {
                     let _ = self.add_ref(query);
-                    if let crate::RayQueryFunction::Initialize {
-                        acceleration_structure,
-                        descriptor,
-                    } = *fun
-                    {
-                        let _ = self.add_ref(acceleration_structure);
-                        let _ = self.add_ref(descriptor);
+                    match *fun {
+                        crate::RayQueryFunction::Initialize {
+                            acceleration_structure,
+                            descriptor,
+                        } => {
+                            let _ = self.add_ref(acceleration_structure);
+                            let _ = self.add_ref(descriptor);
+                        }
+                        crate::RayQueryFunction::Proceed { result: _ } => {}
+                        crate::RayQueryFunction::GenerateIntersection { hit_t } => {
+                            let _ = self.add_ref(hit_t);
+                        }
+                        crate::RayQueryFunction::ConfirmIntersection => {}
+                        crate::RayQueryFunction::Terminate => {}
                     }
                     FunctionUniformity::new()
                 }

--- a/naga/src/valid/handles.rs
+++ b/naga/src/valid/handles.rs
@@ -707,6 +707,10 @@ impl super::Validator {
                     crate::RayQueryFunction::Proceed { result } => {
                         validate_expr(result)?;
                     }
+                    crate::RayQueryFunction::GenerateIntersection { hit_t } => {
+                        validate_expr(hit_t)?;
+                    }
+                    crate::RayQueryFunction::ConfirmIntersection => {}
                     crate::RayQueryFunction::Terminate => {}
                 }
                 Ok(())

--- a/naga/tests/in/ray-query.wgsl
+++ b/naga/tests/in/ray-query.wgsl
@@ -87,5 +87,11 @@ fn main_candidate() {
     var rq: ray_query;
     rayQueryInitialize(&rq, acc_struct, RayDesc(RAY_FLAG_TERMINATE_ON_FIRST_HIT, 0xFFu, 0.1, 100.0, pos, dir));
     let intersection = rayQueryGetCandidateIntersection(&rq);
-    output.visible = u32(intersection.kind == RAY_QUERY_INTERSECTION_AABB);
+    if (intersection.kind == RAY_QUERY_INTERSECTION_AABB) {
+        rayQueryGenerateIntersection(&rq, 10.0);
+    } else if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
+        rayQueryConfirmIntersection(&rq);
+    } else {
+        rayQueryTerminate(&rq);
+    }
 }

--- a/naga/tests/out/hlsl/ray-query.hlsl
+++ b/naga/tests/out/hlsl/ray-query.hlsl
@@ -150,6 +150,16 @@ void main_candidate()
     float3 dir_2 = float3(0.0, 1.0, 0.0);
     rq.TraceRayInline(acc_struct, ConstructRayDesc_(4u, 255u, 0.1, 100.0, pos_2, dir_2).flags, ConstructRayDesc_(4u, 255u, 0.1, 100.0, pos_2, dir_2).cull_mask, RayDescFromRayDesc_(ConstructRayDesc_(4u, 255u, 0.1, 100.0, pos_2, dir_2)));
     RayIntersection intersection_1 = GetCandidateIntersection(rq);
-    output.Store(0, asuint(uint((intersection_1.kind == 3u))));
-    return;
+    if ((intersection_1.kind == 3u)) {
+        rq.CommitProceduralPrimitiveHit(10.0);
+        return;
+    } else {
+        if ((intersection_1.kind == 1u)) {
+            rq.CommitNonOpaqueTriangleHit();
+            return;
+        } else {
+            rq.Abort();
+            return;
+        }
+    }
 }

--- a/naga/tests/out/msl/overrides-ray-query.msl
+++ b/naga/tests/out/msl/overrides-ray-query.msl
@@ -38,7 +38,6 @@ kernel void main_(
         if (metal::all(loop_bound == uint2(4294967295u))) { break; }
         loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
         bool _e31 = rq.ready;
-        rq.ready = false;
         if (_e31) {
         } else {
             break;

--- a/naga/tests/out/msl/ray-query.msl
+++ b/naga/tests/out/msl/ray-query.msl
@@ -58,7 +58,6 @@ RayIntersection query_loop(
         if (metal::all(loop_bound == uint2(4294967295u))) { break; }
         loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
         bool _e9 = rq_1.ready;
-        rq_1.ready = false;
         if (_e9) {
         } else {
             break;
@@ -93,7 +92,6 @@ kernel void main_(
 
 kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
-, device Output& output [[user(fake0)]]
 ) {
     _RayQuery rq = {};
     metal::float3 pos_2 = metal::float3(0.0);
@@ -105,6 +103,14 @@ kernel void main_candidate(
     rq.intersector.accept_any_intersection((_e12.flags & 4) != 0);
     rq.intersection = rq.intersector.intersect(metal::raytracing::ray(_e12.origin, _e12.dir, _e12.tmin, _e12.tmax), acc_struct, _e12.cull_mask);    rq.ready = true;
     RayIntersection intersection_1 = RayIntersection {_map_intersection_type(rq.intersection.type), rq.intersection.distance, rq.intersection.user_instance_id, rq.intersection.instance_id, {}, rq.intersection.geometry_id, rq.intersection.primitive_id, rq.intersection.triangle_barycentric_coord, rq.intersection.triangle_front_facing, {}, rq.intersection.object_to_world_transform, rq.intersection.world_to_object_transform};
-    output.visible = static_cast<uint>(intersection_1.kind == 3u);
-    return;
+    if (intersection_1.kind == 3u) {
+        return;
+    } else {
+        if (intersection_1.kind == 1u) {
+            return;
+        } else {
+            rq.ready = false;
+            return;
+        }
+    }
 }

--- a/naga/tests/out/spv/ray-query.spvasm
+++ b/naga/tests/out/spv/ray-query.spvasm
@@ -1,14 +1,14 @@
 ; SPIR-V
 ; Version: 1.4
 ; Generator: rspirv
-; Bound: 160
+; Bound: 166
 OpCapability Shader
 OpCapability RayQueryKHR
 OpExtension "SPV_KHR_ray_query"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %123 "main" %15 %17
-OpEntryPoint GLCompute %143 "main_candidate" %15 %17
+OpEntryPoint GLCompute %143 "main_candidate" %15
 OpExecutionMode %123 LocalSize 1 1 1
 OpExecutionMode %143 LocalSize 1 1 1
 OpMemberDecorate %10 0 Offset 0
@@ -92,7 +92,8 @@ OpMemberDecorate %18 0 Offset 0
 %129 = OpConstantComposite  %4  %109 %107 %109
 %132 = OpTypePointer StorageBuffer %6
 %137 = OpTypePointer StorageBuffer %4
-%146 = OpConstantComposite  %12  %27 %28 %29 %30 %128 %129
+%145 = OpConstantComposite  %12  %27 %28 %29 %30 %128 %129
+%146 = OpConstant  %3  10.0
 %57 = OpFunction  %10  None %56
 %59 = OpFunctionParameter  %32
 %60 = OpLabel
@@ -226,21 +227,35 @@ OpFunctionEnd
 %142 = OpLabel
 %147 = OpVariable  %32  Function
 %144 = OpLoad  %5  %15
-%145 = OpAccessChain  %126  %17 %64
 OpBranch %148
 %148 = OpLabel
-%149 = OpCompositeExtract  %6  %146 0
-%150 = OpCompositeExtract  %6  %146 1
-%151 = OpCompositeExtract  %3  %146 2
-%152 = OpCompositeExtract  %3  %146 3
-%153 = OpCompositeExtract  %4  %146 4
-%154 = OpCompositeExtract  %4  %146 5
+%149 = OpCompositeExtract  %6  %145 0
+%150 = OpCompositeExtract  %6  %145 1
+%151 = OpCompositeExtract  %3  %145 2
+%152 = OpCompositeExtract  %3  %145 3
+%153 = OpCompositeExtract  %4  %145 4
+%154 = OpCompositeExtract  %4  %145 5
 OpRayQueryInitializeKHR %147 %144 %149 %150 %153 %151 %154 %152
 %155 = OpFunctionCall  %10  %57 %147
 %156 = OpCompositeExtract  %6  %155 0
 %157 = OpIEqual  %8  %156 %78
-%158 = OpSelect  %6  %157 %62 %64
-%159 = OpAccessChain  %132  %145 %64
-OpStore %159 %158
+OpSelectionMerge %158 None
+OpBranchConditional %157 %159 %160
+%159 = OpLabel
+OpRayQueryGenerateIntersectionKHR %147 %146
+OpReturn
+%160 = OpLabel
+%161 = OpCompositeExtract  %6  %155 0
+%162 = OpIEqual  %8  %161 %62
+OpSelectionMerge %163 None
+OpBranchConditional %162 %164 %165
+%164 = OpLabel
+OpRayQueryConfirmIntersectionKHR %147
+OpReturn
+%165 = OpLabel
+OpReturn
+%163 = OpLabel
+OpBranch %158
+%158 = OpLabel
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
**Connections**
Fixes #6759

**Description**
Implements missing functionality for working with candidate intersections.

These functions are only functional in SPIR-V and HLSL.
Metal doesn't appear to expose this in the "old" API - we need to hook up their newer ray query objects.

**Testing**
Just shader validation. The function signatures are fairly straightforward.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
