### PR TITLE
feat: add nix `flake.nix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,121 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1738477724,
+        "narHash": "sha256-S1x0F7q9cJ6EEmZsakse2Ps6Adi7NadxRtGiuWUlwT0=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "1936bb37b1d8597273e3611873dc09dd61b09818",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738435198,
+        "narHash": "sha256-5+Hmo4nbqw8FrW85FlNm4IIrRnZ7bn0cmXlScNsNRLo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f6687779bf4c396250831aa5a32cbfeb85bb07a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1738433753,
+        "narHash": "sha256-lyhEsEf5FQzV+KHVkfxIApMOFWHqyls5+llcQ/uhV6Y=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "88b901878e684e4f68f104fdbc48749f41bcccd3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = inputs.flake-utils.lib.defaultSystems;
+      imports = [ ./nix ];
+    };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,10 @@
+{
+  imports = [ ./rust.nix ];
+
+  perSystem =
+    { self', ... }:
+    {
+      # rust + minimal wgpu deps for standard dev shell
+      devShells.default = self'.devShells.rust;
+    };
+}

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -1,0 +1,65 @@
+{ inputs, ... }:
+{
+  perSystem =
+    {
+      self',
+      pkgs,
+      system,
+      ...
+    }:
+    let
+      fnx = inputs.fenix.packages.${system};
+    in
+    {
+      # rust toolchain
+      packages.rust = fnx.combine [
+        fnx.stable.cargo
+        fnx.stable.rust-src
+        fnx.stable.rustc
+
+        # it's generally recommended to use nightly rustfmt
+        fnx.complete.rustfmt
+
+        # utils
+        fnx.stable.clippy
+        fnx.stable.rust-analyzer
+      ];
+
+      devShells.rust =
+        let
+          # window manager deps, could probably split this based on system but
+          # this is simpler and doesn't hurt that much
+          wmDeps = [
+            # wayland
+            pkgs.wayland
+            pkgs.libxkbcommon
+
+            # x
+            pkgs.xorg.libX11
+            pkgs.xorg.libXcursor
+            pkgs.xorg.libXrandr
+            pkgs.xorg.libXi
+          ];
+          vulkanDeps = [
+            # this is the main one to get it running
+            pkgs.vulkan-loader
+            # this is just for extra features
+            pkgs.vulkan-headers
+            pkgs.vulkan-tools
+            pkgs.vulkan-tools-lunarg
+            pkgs.vulkan-extension-layer
+            pkgs.vulkan-validation-layers # don't need them *strictly* but immensely helpful
+          ];
+          nixRustDeps = [
+            pkgs.pkg-config
+            pkgs.udev
+          ];
+          allDeps = wmDeps ++ vulkanDeps ++ nixRustDeps;
+        in
+        pkgs.mkShell {
+          name = "Development shell for working on wgpu";
+          packages = [ self'.packages.rust ];
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath allDeps;
+        };
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -20,30 +20,42 @@
 # use `direnv allow` to automatically always use this file
 # if you're navigating into this or a subfolder.
 
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 pkgs.mkShell rec {
   buildInputs = with pkgs; [
     # necessary for building wgpu in 3rd party packages (in most cases)
     libxkbcommon
-    wayland xorg.libX11 xorg.libXcursor xorg.libXrandr xorg.libXi
+    wayland
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXrandr
+    xorg.libXi
     alsa-lib
-    fontconfig freetype
-    shaderc directx-shader-compiler
-    pkg-config cmake
+    fontconfig
+    freetype
+    shaderc
+    directx-shader-compiler
+    pkg-config
+    cmake
     mold # could use any linker, needed for rustix (but mold is fast)
 
     libGL
-    vulkan-headers vulkan-loader
-    vulkan-tools vulkan-tools-lunarg
+    vulkan-headers
+    vulkan-loader
+    vulkan-tools
+    vulkan-tools-lunarg
     vulkan-extension-layer
     vulkan-validation-layers # don't need them *strictly* but immensely helpful
 
     # necessary for developing (all of) wgpu itself
-    cargo-nextest cargo-fuzz
+    cargo-nextest
+    cargo-fuzz
 
     # nice for developing wgpu itself
-    typos 
+    typos
 
     # if you don't already have rust installed through other means,
     # this shell.nix can do that for you with this below
@@ -51,7 +63,8 @@ pkgs.mkShell rec {
     rustup
 
     # nice tools
-    gdb rr
+    gdb
+    rr
     evcxr
     valgrind
     renderdoc


### PR DESCRIPTION
**Connections**

- the existing `shell.nix` file

**Description**

There are currently two major ways of using nix: With and without flakes. Currently the repo only hosts a `shell.nix` file which supports the non-flake way of running nix stuff like development shells. This PR adds a `flake.nix` and a modularized directory `nix` where people can find the implementation of the flake-devshell. 

- Compared to the `shell.nix` file, this development shell only includes the necessary dependency to get the wgpu examples running. People are free to extend this minimal devshell and tailor it to their own needs. 
- The flake approach also supports locking dependencies which helps with the reproducibility of everything.

**Testing**

- I entered the devShell on my machine and ran the hallmark example successfully. ✅ 