### PR TITLE
Fix time for wgpu maintainers meeting.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,10 @@ The WGPU project has multiple official platforms for community engagement:
 - `wgpu` Maintainership Meetings: Every week, the maintainership of the wgpu
   project meets to discuss the project's direction and review ongoing work.
   These meetings are open to the public, and you are welcome to attend. They
-  happen on Google Meet and happen on Wednesday at 16:00 UTC and last approximately
-  an hour. Remember to obey the [`CODE_OF_CONDUCT.md`] in the meeting.
+  happen on Google Meet and happen on Wednesday at 11:00 US Eastern Standard
+  Time and last approximately an hour. Remember to obey the
+  [`CODE_OF_CONDUCT.md`] in the meeting.
+
   - [Meeting Notes]
   - [Meeting Link]
 - [GitHub discussions]: TODO: Experimentally used by some enthusiastic members


### PR DESCRIPTION
Change the time from UTC to US EST. UTC is not affected by US daylight savings time, but the current understanding is that our meeting time is affected.

In the maintainers meeting, we confirmed that this was okay for the European attendees (some have other US DST-affected meetings afterwards) but of course everything can be revisited as needed.
