### PR TITLE
[naga] Simplify iterator construction in `type_expression_tandem`.

### DIFF
--- a/naga/src/arena/mod.rs
+++ b/naga/src/arena/mod.rs
@@ -94,7 +94,7 @@ impl<T> Arena<T> {
 
     /// Returns an iterator over the items stored in this arena, returning both
     /// the item's handle and a reference to it.
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (Handle<T>, &T)> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (Handle<T>, &T)> + ExactSizeIterator {
         self.data
             .iter()
             .enumerate()

--- a/naga/src/arena/unique_arena.rs
+++ b/naga/src/arena/unique_arena.rs
@@ -108,7 +108,7 @@ impl<T> Iterator for UniqueArenaDrain<'_, T> {
 impl<T: Eq + hash::Hash> UniqueArena<T> {
     /// Returns an iterator over the items stored in this arena, returning both
     /// the item's handle and a reference to it.
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (Handle<T>, &T)> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (Handle<T>, &T)> + ExactSizeIterator {
         self.set.iter().enumerate().map(|(i, v)| {
             let index = unsafe { Index::new_unchecked(i as u32) };
             (Handle::new(index), v)

--- a/naga/src/compact/mod.rs
+++ b/naga/src/compact/mod.rs
@@ -303,8 +303,9 @@ impl<'module> ModuleTracer<'module> {
         // as used by the time we visit it is genuinely unused, and can be
         // ignored.
         let mut exprs = self.module.global_expressions.iter().rev().peekable();
-        for ((ty_handle, ty), dep) in self.module.types.iter().rev().zip(max_dep.iter().rev()) {
-            while let Some((expr_handle, expr)) = exprs.next_if(|&(h, _)| Some(h) > *dep) {
+
+        for ((ty_handle, ty), dep) in self.module.types.iter().zip(max_dep).rev() {
+            while let Some((expr_handle, expr)) = exprs.next_if(|&(h, _)| Some(h) > dep) {
                 if self.global_expressions_used.contains(expr_handle) {
                     self.as_const_expression().trace_expression(expr);
                 }


### PR DESCRIPTION
Rather than reversing two iterators and then zipping them, zip them first and then reverse the result.

However, zipped iterators are only reversible if the inputs implement `ExactSizeIterator`, so make `UniqueArena::iter` promise that as well.

For consistency, make `Arena::iter` also promise to return an `ExactSizeIterator`.
