### PR TITLE
Fix 3D Texture Views on Dx12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 #### Dx12
 
 - Fix HLSL storage format generation. By @Vecvec in [#6993](https://github.com/gfx-rs/wgpu/pull/6993)
+- Fix 3D storage texture bindings. By @SparkyPotato in [#7071](https://github.com/gfx-rs/wgpu/pull/7071)
 
 #### WebGPU
 

--- a/wgpu-hal/src/dx12/view.rs
+++ b/wgpu-hal/src/dx12/view.rs
@@ -184,8 +184,8 @@ impl ViewDescriptor {
                 desc.ViewDimension = Direct3D12::D3D12_UAV_DIMENSION_TEXTURE3D;
                 desc.Anonymous.Texture3D = Direct3D12::D3D12_TEX3D_UAV {
                     MipSlice: self.mip_level_base,
-                    FirstWSlice: self.array_layer_base,
-                    WSize: self.array_layer_count,
+                    FirstWSlice: 0,
+                    WSize: u32::MAX,
                 }
             }
             wgt::TextureViewDimension::Cube | wgt::TextureViewDimension::CubeArray => {


### PR DESCRIPTION
**Connections**
Fixes #5157 and by extension https://github.com/bevyengine/bevy/issues/17632

**Description**
Forces all depth slices of 3D textures to be referenced by DX12 texture views, as opposed to only the first slice.

**Testing**
Compiling bevy with the change fixes the above issue.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
