### PR TITLE
examples: Call pre_present_notify before presenting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 
 - Added a hello window example. By @laycookie in [#6992](https://github.com/gfx-rs/wgpu/pull/6992).
 
+### Examples
+
+- Call `pre_present_notify()` before presenting. By @kjarosh in [#7074](https://github.com/gfx-rs/wgpu/pull/7074).
+
 ## v24.0.0 (2025-01-15)
 
 ### Major changes

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -438,6 +438,7 @@ async fn start<E: Example>(title: &str) {
                             .unwrap()
                             .render(&view, &context.device, &context.queue);
 
+                        window_loop.window.pre_present_notify();
                         frame.present();
 
                         window_loop.window.request_redraw();

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -135,6 +135,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                         }
 
                         queue.submit(Some(encoder.finish()));
+                        window.pre_present_notify();
                         frame.present();
                     }
                     WindowEvent::CloseRequested => target.exit(),

--- a/examples/features/src/hello_windows/mod.rs
+++ b/examples/features/src/hello_windows/mod.rs
@@ -137,6 +137,7 @@ async fn run(event_loop: EventLoop<()>, viewports: Vec<(Arc<Window>, wgpu::Color
                             }
 
                             queue.submit(Some(encoder.finish()));
+                            viewport.desc.window.pre_present_notify();
                             frame.present();
                         }
                     }

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -217,7 +217,7 @@ impl WgpuContext {
 }
 
 async fn run(event_loop: EventLoop<()>, window: Arc<Window>) {
-    let mut wgpu_context = Some(WgpuContext::new(window).await);
+    let mut wgpu_context = Some(WgpuContext::new(window.clone()).await);
     // (6)
     let mut state = Some(AppState::default());
     let main_window_id = wgpu_context.as_ref().unwrap().window.id();
@@ -330,6 +330,7 @@ async fn run(event_loop: EventLoop<()>, window: Arc<Window>) {
                                 render_pass.draw(0..3, 0..1);
                             }
                             wgpu_context_ref.queue.submit(Some(encoder.finish()));
+                            window.pre_present_notify();
                             frame.present();
                         }
                         _ => {}

--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -118,6 +118,7 @@ impl State {
 
         // Submit the command in the queue to execute
         self.queue.submit([encoder.finish()]);
+        self.window.pre_present_notify();
         surface_texture.present();
     }
 }


### PR DESCRIPTION
According to winit docs, `pre_present_notify()` should be called right before calling `present()`.

This actually prevents some issues on Wayland, like freezing the whole application when the window is not visible (ask me how I know).

See https://github.com/ruffle-rs/ruffle/pull/19456

**Testing**

Tested by running examples on Wayland. It's enough to add a `dbg!` in `about_to_wait` to observe the difference. Without this patch nothing's logged when the window is not visible, because the event loop is blocked due to `present()` not returning.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
