### PR TITLE
[naga] Retain unnamed constants' and overrides' types during compaction.

### DIFF
--- a/naga/src/compact/expressions.rs
+++ b/naga/src/compact/expressions.rs
@@ -94,10 +94,11 @@ impl ExpressionTracer<'_> {
             // it.
             Ex::Constant(handle) => {
                 self.constants_used.insert(handle);
-                let init = self.constants[handle].init;
+                let constant = &self.constants[handle];
+                self.types_used.insert(constant.ty);
                 match self.global_expressions_used {
-                    Some(ref mut used) => used.insert(init),
-                    None => self.expressions_used.insert(init),
+                    Some(ref mut used) => used.insert(constant.init),
+                    None => self.expressions_used.insert(constant.init),
                 };
             }
             Ex::Override(handle) => {

--- a/naga/src/compact/expressions.rs
+++ b/naga/src/compact/expressions.rs
@@ -103,7 +103,9 @@ impl ExpressionTracer<'_> {
             }
             Ex::Override(handle) => {
                 self.overrides_used.insert(handle);
-                if let Some(init) = self.overrides[handle].init {
+                let r#override = &self.overrides[handle];
+                self.types_used.insert(r#override.ty);
+                if let Some(init) = r#override.init {
                     match self.global_expressions_used {
                         Some(ref mut used) => used.insert(init),
                         None => self.expressions_used.insert(init),


### PR DESCRIPTION
Ensure that unnamed constants' types are retained, even when the
constants are used only by global expressions. Add a test case.

Similarly for overrides.

The old code marked all named constants as used; then processed
function bodies; and then marked the types of all used constants as
used. This ensured that, as long as a constant was used by a function,
its type would be retained, but didn't address the case where a
constant is used only by a global expression.

Fixes #7072.