### PR TITLE
[naga] anonymous overrides for array-size expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,7 @@ By @Vecvec in [#6905](https://github.com/gfx-rs/wgpu/pull/6905), [#7086](https:/
 - Forward '--keep-coordinate-space' flag to GLSL backend in naga-cli. By @cloone8 in [#7206](https://github.com/gfx-rs/wgpu/pull/7206).
 - Allow template lists to have a trailing comma. By @KentSlaney in [#7142](https://github.com/gfx-rs/wgpu/pull/7142).
 - Allow WGSL const declarations to have abstract types. By @jamienicol in [#7055](https://github.com/gfx-rs/wgpu/pull/7055) and [#7222](https://github.com/gfx-rs/wgpu/pull/7222).
+- Allows override-sized arrays to resolve to the same size without causing the type arena to panic. By @KentSlaney in [#7082](https://github.com/gfx-rs/wgpu/pull/7082).
 
 #### General
 

--- a/naga/src/arena/mod.rs
+++ b/naga/src/arena/mod.rs
@@ -102,6 +102,18 @@ impl<T> Arena<T> {
             .map(|(i, v)| unsafe { (Handle::from_usize_unchecked(i), v) })
     }
 
+    /// Returns an iterator over the items stored in this arena, returning both
+    /// the item's handle and a reference to it.
+    pub fn iter_mut_span(
+        &mut self,
+    ) -> impl DoubleEndedIterator<Item = (Handle<T>, &mut T, &Span)> + ExactSizeIterator {
+        self.data
+            .iter_mut()
+            .zip(self.span_info.iter())
+            .enumerate()
+            .map(|(i, (v, span))| unsafe { (Handle::from_usize_unchecked(i), v, span) })
+    }
+
     /// Drains the arena, returning an iterator over the items stored.
     pub fn drain(&mut self) -> impl DoubleEndedIterator<Item = (Handle<T>, T, Span)> {
         let arena = core::mem::take(self);

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -442,6 +442,8 @@ pub enum Error {
     Custom(String),
     #[error("overrides should not be present at this stage")]
     Override,
+    #[error(transparent)]
+    ResolveArraySizeError(#[from] proc::ResolveArraySizeError),
 }
 
 #[derive(PartialEq, Eq, Hash)]

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -182,6 +182,8 @@ pub enum Error {
     Override,
     #[error("bitcasting to {0:?} is not supported")]
     UnsupportedBitCast(crate::TypeInner),
+    #[error(transparent)]
+    ResolveArraySizeError(#[from] crate::proc::ResolveArraySizeError),
 }
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]

--- a/naga/src/back/spv/index.rs
+++ b/naga/src/back/spv/index.rs
@@ -268,12 +268,9 @@ impl BlockContext<'_> {
         block: &mut Block,
     ) -> Result<MaybeKnown<u32>, Error> {
         let sequence_ty = self.fun_info[sequence].ty.inner_with(&self.ir_module.types);
-        match sequence_ty.indexable_length(self.ir_module) {
+        match sequence_ty.indexable_length_resolved(self.ir_module) {
             Ok(crate::proc::IndexableLength::Known(known_length)) => {
                 Ok(MaybeKnown::Known(known_length))
-            }
-            Ok(crate::proc::IndexableLength::Pending) => {
-                unreachable!()
             }
             Ok(crate::proc::IndexableLength::Dynamic) => {
                 let length_id = self.write_runtime_array_length(sequence, block)?;

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -75,6 +75,8 @@ pub enum Error {
     Validation(&'static str),
     #[error("overrides should not be present at this stage")]
     Override,
+    #[error(transparent)]
+    ResolveArraySizeError(#[from] crate::proc::ResolveArraySizeError),
 }
 
 #[derive(Default)]

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -502,15 +502,6 @@ pub struct Scalar {
     pub width: Bytes,
 }
 
-#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-pub enum PendingArraySize {
-    Expression(Handle<Expression>),
-    Override(Handle<Override>),
-}
-
 /// Size of an array.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
@@ -521,7 +512,7 @@ pub enum ArraySize {
     /// The array size is constant.
     Constant(core::num::NonZeroU32),
     /// The array size is an override-expression.
-    Pending(PendingArraySize),
+    Pending(Handle<Override>),
     /// The array size can change at runtime.
     Dynamic,
 }

--- a/naga/src/proc/type_methods.rs
+++ b/naga/src/proc/type_methods.rs
@@ -135,7 +135,7 @@ impl crate::TypeInner {
     }
 
     /// Get the size of this type.
-    pub fn size(&self, _gctx: super::GlobalCtx) -> u32 {
+    pub fn size(&self, gctx: super::GlobalCtx) -> u32 {
         match *self {
             Self::Scalar(scalar) | Self::Atomic(scalar) => scalar.width as u32,
             Self::Vector { size, scalar } => size as u32 * scalar.width as u32,
@@ -151,13 +151,13 @@ impl crate::TypeInner {
                 size,
                 stride,
             } => {
-                let count = match size {
-                    crate::ArraySize::Constant(count) => count.get(),
+                let count = match size.resolve(gctx) {
+                    Ok(crate::proc::IndexableLength::Known(count)) => count,
                     // any struct member or array element needing a size at pipeline-creation time
                     // must have a creation-fixed footprint
-                    crate::ArraySize::Pending(_) => 0,
+                    Err(_) => 0,
                     // A dynamically-sized array has to have at least one element
-                    crate::ArraySize::Dynamic => 1,
+                    Ok(crate::proc::IndexableLength::Dynamic) => 1,
                 };
                 count * stride
             }

--- a/naga/src/valid/type.rs
+++ b/naga/src/valid/type.rs
@@ -535,6 +535,7 @@ impl super::Validator {
                             | TypeFlags::COPY
                             | TypeFlags::HOST_SHAREABLE
                             | TypeFlags::ARGUMENT
+                            | TypeFlags::CONSTRUCTIBLE
                     }
                     crate::ArraySize::Dynamic => {
                         // Non-SIZED types may only appear as the last element of a structure.

--- a/naga/tests/validation.rs
+++ b/naga/tests/validation.rs
@@ -307,7 +307,7 @@ fn main() {{
         );
         let module = naga::front::wgsl::parse_str(&source).unwrap();
         let err = valid::Validator::new(Default::default(), valid::Capabilities::all())
-            .validate_no_overrides(&module)
+            .validate(&module)
             .expect_err("module should be invalid");
         assert_eq!(err.emit_to_string(&source), expected_err);
     }
@@ -381,7 +381,7 @@ fn incompatible_interpolation_and_sampling_types() {
     for (invalid_source, invalid_module, interpolation, sampling, interpolate_attr) in invalid_cases
     {
         let err = valid::Validator::new(Default::default(), valid::Capabilities::all())
-            .validate_no_overrides(&invalid_module)
+            .validate(&invalid_module)
             .expect_err(&format!(
                 "module should be invalid for {interpolate_attr:?}"
             ));
@@ -679,7 +679,7 @@ error: Entry point main at Compute is invalid
     for (source, expected_err) in cases {
         let module = naga::front::wgsl::parse_str(source).unwrap();
         let err = valid::Validator::new(Default::default(), valid::Capabilities::all())
-            .validate_no_overrides(&module)
+            .validate(&module)
             .expect_err("module should be invalid");
         println!("{}", err.emit_to_string(source));
         assert_eq!(err.emit_to_string(source), expected_err);


### PR DESCRIPTION
**Connections**
Closes #6722 

**Description**
When 2 arrays are sized with different overrides initialized from the same expression, naga panics because the type arena now contains a duplicate. This resolves the issue by creating an anonymous override for each override-sized array.

**Testing**
This change is tested by adding the [test case that prompted it](https://github.com/gfx-rs/wgpu/pull/6787#pullrequestreview-2576905294)

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
