### PR TITLE
[naga] Error on duplicate fields in structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 
 - Fix some instances of functions which have a return type but don't return a value being incorrectly validated. By @jamienicol in [#7013](https://github.com/gfx-rs/wgpu/pull/7013).
 - Allow abstract expressions to be used in WGSL function return statements. By @jamienicol in [#7035](https://github.com/gfx-rs/wgpu/pull/7035).
+- Error if structs have two fields with the same name. By @SparkyPotato in [#7088](https://github.com/gfx-rs/wgpu/pull/7088).
 
 #### General
 

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -2093,6 +2093,27 @@ fn function_param_redefinition_as_local() {
 }
 
 #[test]
+fn struct_member_redefinition() {
+    check(
+        "
+        struct A {
+            a: f32,
+            a: f32,
+        }
+    ",
+        r###"error: redefinition of `a`
+  ┌─ wgsl:3:13
+  │
+3 │             a: f32,
+  │             ^ previous definition of `a`
+4 │             a: f32,
+  │             ^ redefinition of `a`
+
+"###,
+    )
+}
+
+#[test]
 fn function_must_return_value() {
     check_validation!(
         "fn func() -> i32 {


### PR DESCRIPTION
**Connections**
Fixes #7061 

**Description**
Errors in the WGSL frontend if a struct has two members with the same name. While the linked issue suggests that it would be a verification error, since the IR is arena-based (and names are optional), I thought the fix would be better off in the frontend.

**Testing**
The example code in the issue errors now.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
