### PR TITLE
Document `Queue::write_buffer`'s allocation on native APIs

### DIFF
--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -108,7 +108,10 @@ impl Queue {
     ///
     /// If possible, consider using [`Queue::write_buffer_with`] instead. That
     /// method avoids an intermediate copy and is often able to transfer data
-    /// more efficiently than this one.
+    /// more efficiently than this one. Currently on native platforms, for both
+    /// of these methods the staging memory will be a new allocation. This will
+    /// then be released after the next submission. To entirely avoid short-lived
+    /// allocations, you might be able to use [`StagingBelt`](crate::util::StagingBelt).
     pub fn write_buffer(&self, buffer: &Buffer, offset: BufferAddress, data: &[u8]) {
         self.inner.write_buffer(&buffer.inner, offset, data);
     }
@@ -141,6 +144,10 @@ impl Queue {
     /// ```
     ///
     /// This method fails if `size` is greater than the size of `buffer` starting at `offset`.
+    ///
+    /// Currently on native platforms, the staging memory will be a new allocation, which will
+    /// then be released after the next submission. To entirely avoid short-lived
+    /// allocations, you might be able to use [`StagingBelt`](crate::util::StagingBelt).
     #[must_use]
     pub fn write_buffer_with<'a>(
         &'a self,

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -108,10 +108,12 @@ impl Queue {
     ///
     /// If possible, consider using [`Queue::write_buffer_with`] instead. That
     /// method avoids an intermediate copy and is often able to transfer data
-    /// more efficiently than this one. Currently on native platforms, for both
-    /// of these methods the staging memory will be a new allocation. This will
-    /// then be released after the next submission. To entirely avoid short-lived
-    /// allocations, you might be able to use [`StagingBelt`](crate::util::StagingBelt).
+    /// more efficiently than this one. 
+    ///
+    /// Currently on native platforms, for both of these methods the staging 
+    /// memory will be a new allocation. This will then be released after the
+    /// next submission. To entirely avoid short-lived allocations, you might
+    /// be able to use [`StagingBelt`](crate::util::StagingBelt).
     pub fn write_buffer(&self, buffer: &Buffer, offset: BufferAddress, data: &[u8]) {
         self.inner.write_buffer(&buffer.inner, offset, data);
     }

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -108,11 +108,11 @@ impl Queue {
     ///
     /// If possible, consider using [`Queue::write_buffer_with`] instead. That
     /// method avoids an intermediate copy and is often able to transfer data
-    /// more efficiently than this one. 
+    /// more efficiently than this one.
     ///
-    /// Currently on native platforms, for both of these methods the staging 
+    /// Currently on native platforms, for both of these methods the staging
     /// memory will be a new allocation. This will then be released after the
-    /// next submission. To entirely avoid short-lived allocations, you might
+    /// next submission finishes. To entirely avoid short-lived allocations, you might
     /// be able to use [`StagingBelt`](crate::util::StagingBelt).
     pub fn write_buffer(&self, buffer: &Buffer, offset: BufferAddress, data: &[u8]) {
         self.inner.write_buffer(&buffer.inner, offset, data);
@@ -148,7 +148,7 @@ impl Queue {
     /// This method fails if `size` is greater than the size of `buffer` starting at `offset`.
     ///
     /// Currently on native platforms, the staging memory will be a new allocation, which will
-    /// then be released after the next submission. To entirely avoid short-lived
+    /// then be released after the next submission finishes. To entirely avoid short-lived
     /// allocations, you might be able to use [`StagingBelt`](crate::util::StagingBelt).
     #[must_use]
     pub fn write_buffer_with<'a>(


### PR DESCRIPTION
**Description**
The tradeoffs in moving data from the CPU to the GPU are hard to intuit from our current docs.

**Testing**
N/A

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `taplo format`. N/A
- [X] Run `cargo clippy`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown` N/A
- [X] Run `cargo xtask test` to run tests. N/A
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.

Does this need a changelog entry?
