### PR TITLE
fix(dx12): map composite alpha mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 
 - Fix HLSL storage format generation. By @Vecvec in [#6993](https://github.com/gfx-rs/wgpu/pull/6993) and [#7104](https://github.com/gfx-rs/wgpu/pull/7104)
 - Fix 3D storage texture bindings. By @SparkyPotato in [#7071](https://github.com/gfx-rs/wgpu/pull/7071)
-- Fix DX12 composite alpha modes. By @amrbashir [#7117](https://github.com/gfx-rs/wgpu/pull/7117)
+- Fix DX12 composite alpha modes. By @amrbashir in [#7117](https://github.com/gfx-rs/wgpu/pull/7117)
 
 #### WebGPU
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 
 - Fix HLSL storage format generation. By @Vecvec in [#6993](https://github.com/gfx-rs/wgpu/pull/6993) and [#7104](https://github.com/gfx-rs/wgpu/pull/7104)
 - Fix 3D storage texture bindings. By @SparkyPotato in [#7071](https://github.com/gfx-rs/wgpu/pull/7071)
+- Fix DX12 composite alpha modes. By @amrbashir [#7117](https://github.com/gfx-rs/wgpu/pull/7117)
 
 #### WebGPU
 

--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -281,6 +281,13 @@ pub fn map_vertex_format(format: wgt::VertexFormat) -> Dxgi::Common::DXGI_FORMAT
     }
 }
 
-pub fn map_acomposite_alpha_mode(_mode: wgt::CompositeAlphaMode) -> Dxgi::Common::DXGI_ALPHA_MODE {
-    Dxgi::Common::DXGI_ALPHA_MODE_IGNORE
+pub fn map_acomposite_alpha_mode(mode: wgt::CompositeAlphaMode) -> Dxgi::Common::DXGI_ALPHA_MODE {
+    match mode {
+        wgt::CompositeAlphaMode::PreMultiplied => Dxgi::Common::DXGI_ALPHA_MODE_PREMULTIPLIED,
+        wgt::CompositeAlphaMode::PostMultiplied => Dxgi::Common::DXGI_ALPHA_MODE_STRAIGHT,
+        wgt::CompositeAlphaMode::Opaque => Dxgi::Common::DXGI_ALPHA_MODE_IGNORE,
+        wgt::CompositeAlphaMode::Auto | wgt::CompositeAlphaMode::Inherit => {
+            Dxgi::Common::DXGI_ALPHA_MODE_UNSPECIFIED
+        }
+    }
 }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -863,13 +863,18 @@ impl crate::Adapter for super::Adapter {
                 | wgt::TextureUses::COPY_SRC
                 | wgt::TextureUses::COPY_DST,
             present_modes,
-            composite_alpha_modes: vec![
-                wgt::CompositeAlphaMode::Auto,
-                wgt::CompositeAlphaMode::Inherit,
-                wgt::CompositeAlphaMode::Opaque,
-                wgt::CompositeAlphaMode::PostMultiplied,
-                wgt::CompositeAlphaMode::PreMultiplied,
-            ],
+            composite_alpha_modes: match surface.target {
+                SurfaceTarget::WndHandle(_) => vec![wgt::CompositeAlphaMode::Opaque],
+                SurfaceTarget::Visual(_)
+                | SurfaceTarget::SurfaceHandle(_)
+                | SurfaceTarget::SwapChainPanel(_) => vec![
+                    wgt::CompositeAlphaMode::Auto,
+                    wgt::CompositeAlphaMode::Inherit,
+                    wgt::CompositeAlphaMode::Opaque,
+                    wgt::CompositeAlphaMode::PostMultiplied,
+                    wgt::CompositeAlphaMode::PreMultiplied,
+                ],
+            },
         })
     }
 

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -863,7 +863,13 @@ impl crate::Adapter for super::Adapter {
                 | wgt::TextureUses::COPY_SRC
                 | wgt::TextureUses::COPY_DST,
             present_modes,
-            composite_alpha_modes: vec![wgt::CompositeAlphaMode::Opaque],
+            composite_alpha_modes: vec![
+                wgt::CompositeAlphaMode::Auto,
+                wgt::CompositeAlphaMode::Inherit,
+                wgt::CompositeAlphaMode::Opaque,
+                wgt::CompositeAlphaMode::PostMultiplied,
+                wgt::CompositeAlphaMode::PreMultiplied,
+            ],
         })
     }
 


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

closes #7108

**Description**
_Describe what problem this is solving, and how it's solved._

Fix wgpu alpha modes when using it with windows DirectComposition.

**Testing**
_Explain how this change is tested._

This PR was tested using the repro at https://github.com/microsoft/windows-rs/blob/91cfd289eeae05fa0bb6bdbe37a8426061f77c6e/crates/samples/windows/dcomp/src/main.rs

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [X] Add change to `CHANGELOG.md`. See simple instructions inside file.
