### PR TITLE
Duplicate `BufferSlice` methods onto `Buffer` and vice versa.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Bottom level categories:
 
   By @kpreid in [#7063](https://github.com/gfx-rs/wgpu/pull/7063).
 
+- Added `Buffer` methods corresponding to `BufferSlice` methods, so you can skip creating a `BufferSlice` when it offers no benefit, and `BufferSlice::slice()` for sub-slicing a slice. By @kpreid in [#7123](https://github.com/gfx-rs/wgpu/pull/7123).
+
 #### Naga
 
 - Support @must_use attribute on function declarations. By @turbocrime in [#6801](https://github.com/gfx-rs/wgpu/pull/6801).

--- a/tests/validation_tests/api/buffer.rs
+++ b/tests/validation_tests/api/buffer.rs
@@ -1,0 +1,32 @@
+//! Tests of [`wgpu::Buffer`] and related.
+
+mod buffer_slice {
+    #[test]
+    fn reslice_success() {
+        let (device, _queue) = crate::request_noop_device();
+
+        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 100,
+            usage: wgpu::BufferUsages::VERTEX,
+            mapped_at_creation: false,
+        });
+
+        assert_eq!(buffer.slice(10..90).slice(10..70), buffer.slice(20..80));
+    }
+
+    #[test]
+    #[should_panic = "slice offset 10 size 80 is out of range for buffer of size 80"]
+    fn reslice_out_of_bounds() {
+        let (device, _queue) = crate::request_noop_device();
+
+        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 100,
+            usage: wgpu::BufferUsages::VERTEX,
+            mapped_at_creation: false,
+        });
+
+        buffer.slice(10..90).slice(10..90);
+    }
+}

--- a/tests/validation_tests/api/mod.rs
+++ b/tests/validation_tests/api/mod.rs
@@ -1,0 +1,1 @@
+mod buffer;

--- a/tests/validation_tests/noop.rs
+++ b/tests/validation_tests/noop.rs
@@ -19,22 +19,7 @@ fn device_is_not_available_by_default() {
 
 #[test]
 fn device_and_buffers() {
-    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::NOOP,
-        backend_options: wgpu::BackendOptions {
-            noop: wgpu::NoopBackendOptions { enable: true },
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-    let adapter =
-        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))
-            .expect("adapter");
-    let (device, queue) =
-        pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor::default(), None))
-            .expect("device");
-
-    assert_eq!(adapter.get_info().backend, wgpu::Backend::Noop);
+    let (device, queue) = crate::request_noop_device();
 
     // Demonstrate that creating and *writing* to a buffer succeeds.
     // This also involves creation of a staging buffer.

--- a/tests/validation_tests/root.rs
+++ b/tests/validation_tests/root.rs
@@ -1,3 +1,25 @@
 //! Tests of the [`wgpu`] library API that are not run against a particular GPU.
 
+mod api;
 mod noop;
+
+/// Obtain a device using [`wgpu::Backend::Noop`].
+/// This should never fail.
+fn request_noop_device() -> (wgpu::Device, wgpu::Queue) {
+    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::NOOP,
+        backend_options: wgpu::BackendOptions {
+            noop: wgpu::NoopBackendOptions { enable: true },
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let adapter =
+        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))
+            .expect("adapter");
+    assert_eq!(adapter.get_info().backend, wgpu::Backend::Noop);
+
+    pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor::default(), None))
+        .expect("device")
+}


### PR DESCRIPTION
**Connections**
Part of addressing #6974

**Description**
Duplicates methods of `Buffer` and `BufferSlice` onto each other, so they can be used in more of the same ways:

* `BufferSlice::slice()`
* `Buffer::map_async()`
* `Buffer::get_mapped_range()`
* `Buffer::get_mapped_range_mut()`
* `Buffer::get_mapped_range()`

This allows users to skip creation of `BufferSlice` if they have no use for it, and brings `wgpu` closer to the WebGPU API without removing any Rust convenience.

I also tweaked the "Panics" documentation to be simple and consistent.

**Testing**
Added an API test for the new `slice()` logic. The other methods simply delegate to existing methods.

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
