### PR TITLE
Speed Up Benchmarks in Test

### DIFF
--- a/benches/benches/resource_creation.rs
+++ b/benches/benches/resource_creation.rs
@@ -4,7 +4,15 @@ use criterion::{criterion_group, Criterion, Throughput};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::sync::LazyLock;
 
-use crate::DeviceState;
+use crate::{is_test, DeviceState};
+
+fn thread_count_list() -> &'static [usize] {
+    if is_test() {
+        &[2]
+    } else {
+        &[1, 2, 4, 8]
+    }
+}
 
 fn run_bench(ctx: &mut Criterion) {
     let state = LazyLock::new(DeviceState::new);
@@ -14,7 +22,7 @@ fn run_bench(ctx: &mut Criterion) {
     let mut group = ctx.benchmark_group("Resource Creation: Large Buffer");
     group.throughput(Throughput::Elements(RESOURCES_TO_CREATE as _));
 
-    for threads in [1, 2, 4, 8] {
+    for &threads in thread_count_list() {
         let resources_per_thread = RESOURCES_TO_CREATE / threads;
         group.bench_function(
             format!("{threads} threads x {resources_per_thread} resource"),

--- a/benches/benches/root.rs
+++ b/benches/benches/root.rs
@@ -7,6 +7,10 @@ mod renderpass;
 mod resource_creation;
 mod shader;
 
+fn is_test() -> bool {
+    std::env::var("NEXTEST").is_ok()
+}
+
 struct DeviceState {
     adapter_info: wgpu::AdapterInfo,
     device: wgpu::Device,


### PR DESCRIPTION
Our benchmarks had a lot of permutations in our test suite and all calibrated to test with lots of resources.

This is great for a release build in a benchmark, but in a test this takes forever. Some of the larger tests, getting through syncval took 20s per benchmark, causing #7126.

Closes #7126.
Replacing #7127 