### PR TITLE
Improve `cargo-nextext` Configuration

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,6 +2,8 @@
 # terminate them to prevent infinite run-on.
 [profile.default]
 slow-timeout = { period = "45s", terminate-after = 2 }
+fail-fast = false
+retries = 0
 
 # Use two threads for tests with "2 threads" in their name
 [[profile.default.overrides]]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -29,6 +29,8 @@ Commands:
     --list      List all of the tests and their executables without running them
     --retries   Number of times to retry failing tests
 
+    All extra arguments will be forwarded to cargo-nextest (NOT wgpu-info)
+
   vendor-web-sys
     Re-vendor the WebGPU web-sys bindings.
 

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -5,10 +5,7 @@ use xshell::Shell;
 pub fn run_tests(shell: Shell, mut args: Arguments) -> anyhow::Result<()> {
     let llvm_cov = args.contains("--llvm-cov");
     let list = args.contains("--list");
-    let retries = args
-        .opt_value_from_str("--retries")?
-        .unwrap_or(0_u32)
-        .to_string();
+    // Retries handled by cargo nextest natively
 
     // These needs to match the command in "run wgpu-info" in `.github/workflows/ci.yml`
     let llvm_cov_flags: &[_] = if llvm_cov {
@@ -71,14 +68,7 @@ pub fn run_tests(shell: Shell, mut args: Arguments) -> anyhow::Result<()> {
     shell
         .cmd("cargo")
         .args(llvm_cov_nextest_flags)
-        .args([
-            "--benches",
-            "--tests",
-            "--no-fail-fast",
-            "--all-features",
-            "--retries",
-            &retries,
-        ])
+        .args(["--benches", "--tests", "--all-features"])
         .args(args.finish())
         .quiet()
         .run()


### PR DESCRIPTION
Caused me to file https://github.com/nextest-rs/nextest/issues/2147
And fail at using nextest correctly https://github.com/gfx-rs/wgpu/pull/7127

This mainly moves as much configuration into the config file, and importantly does not specify the `--retries` argument unconditionally, so configuration can make certain tests have retries.

