### PR TITLE
Fix various things so `cbindgen` works for Firefox (again 😩)

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -437,6 +437,7 @@ impl BindingTypeMaxCountValidator {
 }
 
 /// Bindable resource and the slot to bind it to.
+/// cbindgen:ignore
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BindGroupEntry<'a, B = BufferId, S = SamplerId, TV = TextureViewId, TLAS = TlasId>
@@ -459,6 +460,7 @@ where
     pub resource: BindingResource<'a, B, S, TV, TLAS>,
 }
 
+/// cbindgen:ignore
 pub type ResolvedBindGroupEntry<'a> =
     BindGroupEntry<'a, Arc<Buffer>, Arc<Sampler>, Arc<TextureView>, Arc<Tlas>>;
 
@@ -498,6 +500,7 @@ pub struct BindGroupDescriptor<
     pub entries: Cow<'a, [BindGroupEntry<'a, B, S, TV, TLAS>]>,
 }
 
+/// cbindgen:ignore
 pub type ResolvedBindGroupDescriptor<'a> = BindGroupDescriptor<
     'a,
     Arc<BindGroupLayout>,
@@ -691,6 +694,7 @@ where
     pub push_constant_ranges: Cow<'a, [wgt::PushConstantRange]>,
 }
 
+/// cbindgen:ignore
 pub type ResolvedPipelineLayoutDescriptor<'a> = PipelineLayoutDescriptor<'a, Arc<BindGroupLayout>>;
 
 #[derive(Debug)]

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -101,6 +101,7 @@ pub struct ComputePassDescriptor<'a, PTW = PassTimestampWrites> {
     pub timestamp_writes: Option<PTW>,
 }
 
+/// cbindgen:ignore
 type ArcComputePassDescriptor<'a> = ComputePassDescriptor<'a, ArcPassTimestampWrites>;
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/command/timestamp_writes.rs
+++ b/wgpu-core/src/command/timestamp_writes.rs
@@ -14,4 +14,5 @@ pub struct PassTimestampWrites<QS = id::QuerySetId> {
     pub end_of_pass_write_index: Option<u32>,
 }
 
+/// cbindgen:ignore
 pub type ArcPassTimestampWrites = PassTimestampWrites<Arc<crate::resource::QuerySet>>;

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -147,6 +147,7 @@ pub struct ProgrammableStageDescriptor<'a, SM = ShaderModuleId> {
     pub zero_initialize_workgroup_memory: bool,
 }
 
+/// cbindgen:ignore
 pub type ResolvedProgrammableStageDescriptor<'a> =
     ProgrammableStageDescriptor<'a, Arc<ShaderModule>>;
 
@@ -186,6 +187,7 @@ pub struct ComputePipelineDescriptor<
     pub cache: Option<PLC>,
 }
 
+/// cbindgen:ignore
 pub type ResolvedComputePipelineDescriptor<'a> =
     ComputePipelineDescriptor<'a, Arc<PipelineLayout>, Arc<ShaderModule>, Arc<PipelineCache>>;
 
@@ -307,6 +309,7 @@ pub struct VertexState<'a, SM = ShaderModuleId> {
     pub buffers: Cow<'a, [VertexBufferLayout<'a>]>,
 }
 
+/// cbindgen:ignore
 pub type ResolvedVertexState<'a> = VertexState<'a, Arc<ShaderModule>>;
 
 /// Describes fragment processing in a render pipeline.
@@ -319,6 +322,7 @@ pub struct FragmentState<'a, SM = ShaderModuleId> {
     pub targets: Cow<'a, [Option<wgt::ColorTargetState>]>,
 }
 
+/// cbindgen:ignore
 pub type ResolvedFragmentState<'a> = FragmentState<'a, Arc<ShaderModule>>;
 
 /// Describes a render (graphics) pipeline.
@@ -353,6 +357,7 @@ pub struct RenderPipelineDescriptor<
     pub cache: Option<PLC>,
 }
 
+/// cbindgen:ignore
 pub type ResolvedRenderPipelineDescriptor<'a> =
     RenderPipelineDescriptor<'a, Arc<PipelineLayout>, Arc<ShaderModule>, Arc<PipelineCache>>;
 

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -6,21 +6,27 @@ pub(super) mod renderdoc;
 
 pub mod db {
     pub mod amd {
+        /// cbindgen:ignore
         pub const VENDOR: u32 = 0x1002;
     }
     pub mod apple {
+        /// cbindgen:ignore
         pub const VENDOR: u32 = 0x106B;
     }
     pub mod arm {
+        /// cbindgen:ignore
         pub const VENDOR: u32 = 0x13B5;
     }
     pub mod broadcom {
+        /// cbindgen:ignore
         pub const VENDOR: u32 = 0x14E4;
     }
     pub mod imgtec {
+        /// cbindgen:ignore
         pub const VENDOR: u32 = 0x1010;
     }
     pub mod intel {
+        /// cbindgen:ignore
         pub const VENDOR: u32 = 0x8086;
         pub const DEVICE_KABY_LAKE_MASK: u32 = 0x5900;
         pub const DEVICE_SKY_LAKE_MASK: u32 = 0x1900;
@@ -30,12 +36,15 @@ pub mod db {
         //
         // To match Vulkan, we use the VkVendorId for Mesa in the gles backend so that lavapipe (Vulkan) and
         // llvmpipe (OpenGL) have the same vendor id.
+        /// cbindgen:ignore
         pub const VENDOR: u32 = 0x10005;
     }
     pub mod nvidia {
+        /// cbindgen:ignore
         pub const VENDOR: u32 = 0x10DE;
     }
     pub mod qualcomm {
+        /// cbindgen:ignore
         pub const VENDOR: u32 = 0x5143;
     }
 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -299,6 +299,7 @@ pub const MAX_VERTEX_BUFFERS: usize = 16;
 pub const MAX_COLOR_ATTACHMENTS: usize = 8;
 pub const MAX_MIP_LEVELS: u32 = 16;
 /// Size of a single occlusion/timestamp query, when copied into a buffer, in bytes.
+/// cbindgen:ignore
 pub const QUERY_SIZE: wgt::BufferAddress = 8;
 
 pub type Label<'a> = Option<&'a str>;
@@ -1969,6 +1970,7 @@ impl<'a, T: DynTextureView + ?Sized> Clone for TextureBinding<'a, T> {
     }
 }
 
+/// cbindgen:ignore
 #[derive(Clone, Debug)]
 pub struct BindGroupEntry {
     pub binding: u32,

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -98,7 +98,7 @@ macro_rules! bitflags_array {
         pub struct $name {
             $(
                 #[allow(missing_docs)]
-                $lower_inner_name: $inner_name,
+                $vis $lower_inner_name: $inner_name,
             )*
         }
 

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -399,16 +399,14 @@ macro_rules! bitflags_array {
             /// Takes in a name and returns Self if it matches or none if the name does not match
             /// the name of any of the flags. Name is capitalisation dependent.
             pub fn from_name(name: &str) -> Option<Self> {
-                $(
+                match name {
                     $(
-                        {
-                            if name == stringify!($Flag) {
-                                return Some(Self::$Flag);
-                            }
-                        }
+                        $(
+                            stringify!($Flag) => Some(Self::$Flag),
+                        )*
                     )*
-                )*
-                None
+                    _ => None,
+                }
             }
 
             /// Combines the features from the internal flags into the entire features struct

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -12,6 +12,49 @@ use core::mem::size_of;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+pub use webgpu_impl::*;
+mod webgpu_impl {
+    //! Constant values for [`super::FeaturesWebGPU`], separated so they can be picked up by
+    //! `cbindgen` in `mozilla-central` (where Firefox is developed).
+    #![allow(missing_docs)]
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_DEPTH_CLIP_CONTROL: u64 = 1 << 0;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_DEPTH32FLOAT_STENCIL8: u64 = 1 << 1;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_TEXTURE_COMPRESSION_BC: u64 = 1 << 2;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_TEXTURE_COMPRESSION_BC_SLICED_3D: u64 = 1 << 3;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_TEXTURE_COMPRESSION_ETC2: u64 = 1 << 4;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_TEXTURE_COMPRESSION_ASTC: u64 = 1 << 5;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_TIMESTAMP_QUERY: u64 = 1 << 6;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_INDIRECT_FIRST_INSTANCE: u64 = 1 << 7;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_SHADER_F16: u64 = 1 << 8;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_RG11B10UFLOAT_RENDERABLE: u64 = 1 << 9;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_BGRA8UNORM_STORAGE: u64 = 1 << 10;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_FLOAT32_FILTERABLE: u64 = 1 << 11;
+}
+
 macro_rules! bitflags_array_impl {
     ($impl_name:ident $inner_name:ident $name:ident $op:tt $($struct_names:ident)*) => (
         impl core::ops::$impl_name for $name {
@@ -1138,7 +1181,7 @@ bitflags_array! {
         /// - some mobile chips
         ///
         /// This is a web and native feature.
-        const DEPTH_CLIP_CONTROL = 1 << 0;
+        const DEPTH_CLIP_CONTROL = WEBGPU_FEATURE_DEPTH_CLIP_CONTROL;
 
         /// Allows for explicit creation of textures of format [`TextureFormat::Depth32FloatStencil8`]
         ///
@@ -1151,7 +1194,7 @@ bitflags_array! {
         /// This is a web and native feature.
         ///
         /// [`TextureFormat::Depth32FloatStencil8`]: super::TextureFormat::Depth32FloatStencil8
-        const DEPTH32FLOAT_STENCIL8 = 1 << 1;
+        const DEPTH32FLOAT_STENCIL8 = WEBGPU_FEATURE_DEPTH32FLOAT_STENCIL8;
 
         /// Enables BCn family of compressed textures. All BCn textures use 4x4 pixel blocks
         /// with 8 or 16 bytes per block.
@@ -1169,7 +1212,7 @@ bitflags_array! {
         /// - Mobile (All Apple9 and some Apple7 and Apple8 devices)
         ///
         /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_BC = 1 << 2;
+        const TEXTURE_COMPRESSION_BC = WEBGPU_FEATURE_TEXTURE_COMPRESSION_BC;
 
 
         /// Allows the 3d dimension for textures with BC compressed formats.
@@ -1182,7 +1225,7 @@ bitflags_array! {
         /// - Mobile (All Apple9 and some Apple7 and Apple8 devices)
         ///
         /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_BC_SLICED_3D = 1 << 3;
+        const TEXTURE_COMPRESSION_BC_SLICED_3D = WEBGPU_FEATURE_TEXTURE_COMPRESSION_BC_SLICED_3D;
 
         /// Enables ETC family of compressed textures. All ETC textures use 4x4 pixel blocks.
         /// ETC2 RGB and RGBA1 are 8 bytes per block. RTC2 RGBA8 and EAC are 16 bytes per block.
@@ -1198,7 +1241,7 @@ bitflags_array! {
         /// - Mobile (some)
         ///
         /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_ETC2 = 1 << 4;
+        const TEXTURE_COMPRESSION_ETC2 = WEBGPU_FEATURE_TEXTURE_COMPRESSION_ETC2;
 
         /// Enables ASTC family of compressed textures. ASTC textures use pixel blocks varying from 4x4 to 12x12.
         /// Blocks are always 16 bytes.
@@ -1214,7 +1257,7 @@ bitflags_array! {
         /// - Mobile (some)
         ///
         /// This is a web and native feature.
-        const TEXTURE_COMPRESSION_ASTC = 1 << 5;
+        const TEXTURE_COMPRESSION_ASTC = WEBGPU_FEATURE_TEXTURE_COMPRESSION_ASTC;
 
         /// Enables use of Timestamp Queries. These queries tell the current gpu timestamp when
         /// all work before the query is finished.
@@ -1243,7 +1286,7 @@ bitflags_array! {
         /// [`ComputePassDescriptor::timestamp_writes`]: https://docs.rs/wgpu/latest/wgpu/struct.ComputePassDescriptor.html#structfield.timestamp_writes
         /// [`CommandEncoder::resolve_query_set`]: https://docs.rs/wgpu/latest/wgpu/struct.CommandEncoder.html#method.resolve_query_set
         /// [`Queue::get_timestamp_period`]: https://docs.rs/wgpu/latest/wgpu/struct.Queue.html#method.get_timestamp_period
-        const TIMESTAMP_QUERY = 1 << 6;
+        const TIMESTAMP_QUERY = WEBGPU_FEATURE_TIMESTAMP_QUERY;
 
         /// Allows non-zero value for the `first_instance` member in indirect draw calls.
         ///
@@ -1262,7 +1305,7 @@ bitflags_array! {
         /// - OpenGL ES / WebGL
         ///
         /// This is a web and native feature.
-        const INDIRECT_FIRST_INSTANCE = 1 << 7;
+        const INDIRECT_FIRST_INSTANCE = WEBGPU_FEATURE_INDIRECT_FIRST_INSTANCE;
 
         /// Allows shaders to acquire the FP16 ability
         ///
@@ -1273,7 +1316,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a web and native feature.
-        const SHADER_F16 = 1 << 8;
+        const SHADER_F16 = WEBGPU_FEATURE_SHADER_F16;
 
 
         /// Allows for usage of textures of format [`TextureFormat::Rg11b10Ufloat`] as a render target
@@ -1286,7 +1329,7 @@ bitflags_array! {
         /// This is a web and native feature.
         ///
         /// [`TextureFormat::Rg11b10Ufloat`]: super::TextureFormat::Rg11b10Ufloat
-        const RG11B10UFLOAT_RENDERABLE = 1 << 9;
+        const RG11B10UFLOAT_RENDERABLE = WEBGPU_FEATURE_RG11B10UFLOAT_RENDERABLE;
 
         /// Allows the [`TextureUsages::STORAGE_BINDING`] usage on textures with format [`TextureFormat::Bgra8Unorm`]
         ///
@@ -1299,7 +1342,7 @@ bitflags_array! {
         ///
         /// [`TextureFormat::Bgra8Unorm`]: super::TextureFormat::Bgra8Unorm
         /// [`TextureUsages::STORAGE_BINDING`]: super::TextureUsages::STORAGE_BINDING
-        const BGRA8UNORM_STORAGE = 1 << 10;
+        const BGRA8UNORM_STORAGE = WEBGPU_FEATURE_BGRA8UNORM_STORAGE;
 
 
         /// Allows textures with formats "r32float", "rg32float", and "rgba32float" to be filterable.
@@ -1311,7 +1354,7 @@ bitflags_array! {
         /// - GL with one of `GL_ARB_color_buffer_float`/`GL_EXT_color_buffer_float`/`OES_texture_float_linear`
         ///
         /// This is a web and native feature.
-        const FLOAT32_FILTERABLE = 1 << 11;
+        const FLOAT32_FILTERABLE = WEBGPU_FEATURE_FLOAT32_FILTERABLE;
     }
 }
 

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -374,10 +374,9 @@ macro_rules! bitflags_array {
                 // The ? operator does not work in a const context.
                 Some(Self {
                     $(
-                        $lower_inner_name: if let Some($lower_inner_name) = $inner_name::from_bits($lower_inner_name) {
-                            $lower_inner_name
-                        } else {
-                            return None
+                        $lower_inner_name: match $inner_name::from_bits($lower_inner_name) {
+                            Some(some) => some,
+                            None => return None,
                         },
                     )*
                 })

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -97,6 +97,7 @@ macro_rules! bitflags_array {
         $(#[$outer])*
         pub struct $name {
             $(
+                #[allow(missing_docs)]
                 $lower_inner_name: $inner_name,
             )*
         }

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -69,29 +69,37 @@ macro_rules! bitflags_independent_two_arg {
 /// in a u64, we can't use a u128 because of FFI, and the number of flags is increasing.
 macro_rules! bitflags_array {
     (
-    $(#[$outer:meta])* pub struct $name:ident: [$T:ty; $Len:expr];
-    $($(#[$bit_outer:meta])*
-    $vis:vis struct $inner_name:ident $lower_inner_name:ident {
+        $(#[$outer:meta])*
+        pub struct $name:ident: [$T:ty; $Len:expr];
+
         $(
-            $(#[$inner:ident $($args:tt)*])*
-            const $Flag:tt = $value:expr;
-        )*
-    })*
-    ) => {
-        $(
-        bitflags::bitflags! {
-            $(#[$bit_outer])*
-            $vis struct $inner_name: $T {
+            $(#[$bit_outer:meta])*
+            $vis:vis struct $inner_name:ident $lower_inner_name:ident {
                 $(
-                    $(#[$inner $($args)*])*
-                    const $Flag = $value;
+                    $(#[$inner:ident $($args:tt)*])*
+                    const $Flag:tt = $value:expr;
                 )*
             }
-        }
+        )*
+    ) => {
+        $(
+            bitflags::bitflags! {
+                $(#[$bit_outer])*
+                $vis struct $inner_name: $T {
+                    $(
+                        $(#[$inner $($args)*])*
+                        const $Flag = $value;
+                    )*
+                }
+            }
         )*
 
         $(#[$outer])*
-        pub struct $name{ $($lower_inner_name: $inner_name,)* }
+        pub struct $name {
+            $(
+                $lower_inner_name: $inner_name,
+            )*
+        }
 
         /// Bits from `Features` in array form
         #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
@@ -116,7 +124,9 @@ macro_rules! bitflags_array {
         #[cfg(feature = "serde")]
         impl Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where S: serde::Serializer {
+            where
+                S: serde::Serializer,
+            {
                 bitflags::serde::serialize(self, serializer)
             }
         }
@@ -124,7 +134,9 @@ macro_rules! bitflags_array {
         #[cfg(feature = "serde")]
         impl<'de> Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where D: serde::Deserializer<'de> {
+            where
+                D: serde::Deserializer<'de>,
+            {
                 bitflags::serde::deserialize(deserializer)
             }
         }
@@ -165,61 +177,62 @@ macro_rules! bitflags_array {
 
         #[cfg(feature = "serde")]
         impl WriteHex for FeatureBits {
-             fn write_hex<W: fmt::Write>(&self, mut writer: W) -> fmt::Result {
-                 let [$($lower_inner_name,)*] = self.0;
-                 let mut wrote = false;
-                 let mut stager = alloc::string::String::with_capacity(size_of::<$T>() * 2);
-                 // we don't want to write it if it's just zero as there may be multiple zeros
-                 // resulting in something like "00" being written out. We do want to write it if
-                 // there has already been something written though.
-                 $(if ($lower_inner_name != 0) || wrote {
-                     // First we write to a staging string, then we add any zeros (e.g if #1
-                     // is f and a u8 and #2 is a then the two combined would be f0a which requires
-                     // a 0 inserted)
-                     $lower_inner_name.write_hex(&mut stager)?;
-                     if (stager.len() != size_of::<$T>() * 2) && wrote {
-                         let zeros_to_write = (size_of::<$T>() * 2) - stager.len();
-                         for _ in 0..zeros_to_write {
-                             writer.write_char('0')?
-                         }
-                     }
-                     writer.write_str(&stager)?;
-                     stager.clear();
-                     wrote = true;
-                 })*
-                 if !wrote {
-                     writer.write_str("0")?;
-                 }
-                 Ok(())
-             }
+            fn write_hex<W: fmt::Write>(&self, mut writer: W) -> fmt::Result {
+                let [$($lower_inner_name,)*] = self.0;
+                let mut wrote = false;
+                let mut stager = alloc::string::String::with_capacity(size_of::<$T>() * 2);
+                // we don't want to write it if it's just zero as there may be multiple zeros
+                // resulting in something like "00" being written out. We do want to write it if
+                // there has already been something written though.
+                $(if ($lower_inner_name != 0) || wrote {
+                    // First we write to a staging string, then we add any zeros (e.g if #1
+                    // is f and a u8 and #2 is a then the two combined would be f0a which requires
+                    // a 0 inserted)
+                    $lower_inner_name.write_hex(&mut stager)?;
+                    if (stager.len() != size_of::<$T>() * 2) && wrote {
+                        let zeros_to_write = (size_of::<$T>() * 2) - stager.len();
+                        for _ in 0..zeros_to_write {
+                            writer.write_char('0')?
+                        }
+                    }
+                    writer.write_str(&stager)?;
+                    stager.clear();
+                    wrote = true;
+                })*
+                if !wrote {
+                    writer.write_str("0")?;
+                }
+                Ok(())
+            }
         }
 
         #[cfg(feature = "serde")]
         impl ParseHex for FeatureBits {
-             fn parse_hex(input: &str) -> Result<Self, ParseError> {
+            fn parse_hex(input: &str) -> Result<Self, ParseError> {
 
-                 let mut unset = Self::EMPTY;
-                 let mut end = input.len();
-                 if end == 0 {
-                     return Err(ParseError::empty_flag())
-                 }
-                 // we iterate starting at the least significant places and going up
-                 for (idx, _) in [$(stringify!($lower_inner_name),)*].iter().enumerate().rev() {
-                     // A byte is two hex places - u8 (1 byte) = 0x00 (2 hex places).
-                     let checked_start = end.checked_sub(size_of::<$T>() * 2);
-                     let start = checked_start.unwrap_or(0);
+                let mut unset = Self::EMPTY;
+                let mut end = input.len();
+                if end == 0 {
+                    return Err(ParseError::empty_flag())
+                }
+                // we iterate starting at the least significant places and going up
+                for (idx, _) in [$(stringify!($lower_inner_name),)*].iter().enumerate().rev() {
+                    // A byte is two hex places - u8 (1 byte) = 0x00 (2 hex places).
+                    let checked_start = end.checked_sub(size_of::<$T>() * 2);
+                    let start = checked_start.unwrap_or(0);
 
-                     let cur_input = &input[start..end];
-                     unset.0[idx] = <$T>::from_str_radix(cur_input, 16).map_err(|_|ParseError::invalid_hex_flag(cur_input))?;
+                    let cur_input = &input[start..end];
+                    unset.0[idx] = <$T>::from_str_radix(cur_input, 16)
+                        .map_err(|_|ParseError::invalid_hex_flag(cur_input))?;
 
-                     end = start;
+                    end = start;
 
-                     if let None = checked_start {
-                         break;
-                     }
-                 }
-                 Ok(unset)
-             }
+                    if let None = checked_start {
+                        break;
+                    }
+                }
+                Ok(unset)
+            }
         }
 
         impl bitflags::Bits for FeatureBits {
@@ -234,12 +247,16 @@ macro_rules! bitflags_array {
             type Bits = FeatureBits;
 
             fn bits(&self) -> FeatureBits {
-                FeatureBits([$(self.$lower_inner_name.bits(),)*])
+                FeatureBits([
+                    $(self.$lower_inner_name.bits(),)*
+                ])
             }
 
-            fn from_bits_retain(bits:FeatureBits) -> Self {
+            fn from_bits_retain(bits: FeatureBits) -> Self {
                 let [$($lower_inner_name,)*] = bits.0;
-                Self { $($lower_inner_name: $inner_name::from_bits_retain($lower_inner_name),)* }
+                Self {
+                    $($lower_inner_name: $inner_name::from_bits_retain($lower_inner_name),)*
+                }
             }
 
             fn empty() -> Self {
@@ -252,21 +269,33 @@ macro_rules! bitflags_array {
         }
 
         impl $name {
-            pub(crate) const FLAGS: &'static [bitflags::Flag<Self>] = &[$($(bitflags::Flag::new(stringify!($Flag), $name::$Flag),)*)*];
+            pub(crate) const FLAGS: &'static [bitflags::Flag<Self>] = &[
+                $(
+                    $(
+                        bitflags::Flag::new(stringify!($Flag), $name::$Flag),
+                    )*
+                )*
+            ];
 
             /// Gets the set flags as a container holding an array of bits.
             pub const fn bits(&self) -> FeatureBits {
-                FeatureBits([$(self.$lower_inner_name.bits(),)*])
+                FeatureBits([
+                    $(self.$lower_inner_name.bits(),)*
+                ])
             }
 
             /// Returns self with no flags set.
             pub const fn empty() -> Self {
-                Self { $($lower_inner_name: $inner_name::empty(),)* }
+                Self {
+                    $($lower_inner_name: $inner_name::empty(),)*
+                }
             }
 
             /// Returns self with all flags set.
             pub const fn all() -> Self {
-                Self { $($lower_inner_name: $inner_name::all(),)* }
+                Self {
+                    $($lower_inner_name: $inner_name::all(),)*
+                }
             }
 
             /// Whether all the bits set in `other` are all set in `self`
@@ -312,7 +341,9 @@ macro_rules! bitflags_array {
 
             /// Bitwise not - `!self`
             pub const fn complement(self) -> Self {
-                Self { $($lower_inner_name: self.$lower_inner_name.complement(),)* }
+                Self {
+                    $($lower_inner_name: self.$lower_inner_name.complement(),)*
+                }
             }
 
             /// Calls [Self::insert] if `set` is true and otherwise calls [Self::remove].
@@ -340,11 +371,15 @@ macro_rules! bitflags_array {
             pub const fn from_bits(bits:FeatureBits) -> Option<Self> {
                 let [$($lower_inner_name,)*] = bits.0;
                 // The ? operator does not work in a const context.
-                Some(Self { $($lower_inner_name: if let Some($lower_inner_name) = $inner_name::from_bits($lower_inner_name) {
-                    $lower_inner_name
-                } else {
-                    return None
-                },)* })
+                Some(Self {
+                    $(
+                        $lower_inner_name: if let Some($lower_inner_name) = $inner_name::from_bits($lower_inner_name) {
+                            $lower_inner_name
+                        } else {
+                            return None
+                        },
+                    )*
+                })
             }
 
             /// Takes in [`FeatureBits`] and returns Self with only valid bits (all other bits removed)
@@ -363,11 +398,15 @@ macro_rules! bitflags_array {
             /// Takes in a name and returns Self if it matches or none if the name does not match
             /// the name of any of the flags. Name is capitalisation dependent.
             pub fn from_name(name: &str) -> Option<Self> {
-                $($({
-                    if name == stringify!($Flag) {
-                        return Some(Self::$Flag);
-                    }
-                })*)*
+                $(
+                    $(
+                        {
+                            if name == stringify!($Flag) {
+                                return Some(Self::$Flag);
+                            }
+                        }
+                    )*
+                )*
                 None
             }
 
@@ -389,29 +428,29 @@ macro_rules! bitflags_array {
             }
 
             $(
-            $(
-            $(#[$inner $($args)*])*
-            // We need this for structs with only a member.
-            #[allow(clippy::needless_update)]
-            pub const $Flag: Self = Self {
-                $lower_inner_name: $inner_name::from_bits_truncate($value),
-                ..Self::empty()
-            };
-            )*
+                $(
+                    $(#[$inner $($args)*])*
+                    // We need this for structs with only a member.
+                    #[allow(clippy::needless_update)]
+                    pub const $Flag: Self = Self {
+                        $lower_inner_name: $inner_name::from_bits_truncate($value),
+                        ..Self::empty()
+                    };
+                )*
             )*
         }
 
         $(
-        impl From<$inner_name> for Features {
-            // We need this for structs with only a member.
-            #[allow(clippy::needless_update)]
-            fn from($lower_inner_name: $inner_name) -> Self {
-                Self {
-                    $lower_inner_name,
-                    ..Self::empty()
+            impl From<$inner_name> for Features {
+                // We need this for structs with only a member.
+                #[allow(clippy::needless_update)]
+                fn from($lower_inner_name: $inner_name) -> Self {
+                    Self {
+                        $lower_inner_name,
+                        ..Self::empty()
+                    }
                 }
             }
-        }
         )*
     };
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4750,8 +4750,10 @@ bitflags::bitflags! {
         /// The argument to a write-only mapping.
         const MAP_WRITE = 1 << 1;
         /// The source of a hardware copy.
+        /// cbindgen:ignore
         const COPY_SRC = 1 << 2;
         /// The destination of a hardware copy.
+        /// cbindgen:ignore
         const COPY_DST = 1 << 3;
         /// The index buffer used for drawing.
         const INDEX = 1 << 4;
@@ -4760,8 +4762,10 @@ bitflags::bitflags! {
         /// A uniform buffer bound in a bind group.
         const UNIFORM = 1 << 6;
         /// A read-only storage buffer used in a bind group.
+        /// cbindgen:ignore
         const STORAGE_READ_ONLY = 1 << 7;
         /// A read-write buffer used in a bind group.
+        /// cbindgen:ignore
         const STORAGE_READ_WRITE = 1 << 8;
         /// The indirect or count buffer in a indirect draw or dispatch.
         const INDIRECT = 1 << 9;
@@ -5020,8 +5024,10 @@ bitflags::bitflags! {
         /// Ready to present image to the surface.
         const PRESENT = 1 << 1;
         /// The source of a hardware copy.
+        /// cbindgen:ignore
         const COPY_SRC = 1 << 2;
         /// The destination of a hardware copy.
+        /// cbindgen:ignore
         const COPY_DST = 1 << 3;
         /// Read-only sampled or fetched resource.
         const RESOURCE = 1 << 4;
@@ -5032,20 +5038,27 @@ bitflags::bitflags! {
         /// Read-write depth stencil usage
         const DEPTH_STENCIL_WRITE = 1 << 7;
         /// Read-only storage texture usage. Corresponds to a UAV in d3d, so is exclusive, despite being read only.
+        /// cbindgen:ignore
         const STORAGE_READ_ONLY = 1 << 8;
         /// Write-only storage texture usage.
+        /// cbindgen:ignore
         const STORAGE_WRITE_ONLY = 1 << 9;
         /// Read-write storage texture usage.
+        /// cbindgen:ignore
         const STORAGE_READ_WRITE = 1 << 10;
         /// Image atomic enabled storage.
+        /// cbindgen:ignore
         const STORAGE_ATOMIC = 1 << 11;
         /// The combination of states that a texture may be in _at the same time_.
+        /// cbindgen:ignore
         const INCLUSIVE = Self::COPY_SRC.bits() | Self::RESOURCE.bits() | Self::DEPTH_STENCIL_READ.bits();
         /// The combination of states that a texture must exclusively be in.
+        /// cbindgen:ignore
         const EXCLUSIVE = Self::COPY_DST.bits() | Self::COLOR_TARGET.bits() | Self::DEPTH_STENCIL_WRITE.bits() | Self::STORAGE_READ_ONLY.bits() | Self::STORAGE_WRITE_ONLY.bits() | Self::STORAGE_READ_WRITE.bits() | Self::STORAGE_ATOMIC.bits() | Self::PRESENT.bits();
         /// The combination of all usages that the are guaranteed to be be ordered by the hardware.
         /// If a usage is ordered, then if the texture state doesn't change between draw calls, there
         /// are no barriers needed for synchronization.
+        /// cbindgen:ignore
         const ORDERED = Self::INCLUSIVE.bits() | Self::COLOR_TARGET.bits() | Self::DEPTH_STENCIL_WRITE.bits() | Self::STORAGE_READ_ONLY.bits();
 
         /// Flag used by the wgpu-core texture tracker to say a texture is in different states for every sub-resource


### PR DESCRIPTION
PRs in the last few weeks have regressed Firefox's usage of `cbindgen`, and I'm here to undo the damage without actually reverting them. To wit, I'm aware of these being regressed by:

* #7079
* #7056
* #6905

Things still compile and run, so I'm confident things should still work.

_**Recommended review experience is commit-by-commit. Each individual commit should pass CI! Please merge this with `Rebase and merge`.**_ 
