### PR TITLE
Fix `clippy::unneeded_struct_pattern` lints

### DIFF
--- a/naga/src/back/continue_forward.rs
+++ b/naga/src/back/continue_forward.rs
@@ -222,7 +222,7 @@ impl ContinueCtx {
             // forward continue statements within this `Switch`. We can leave
             // the stack empty.
             None => None,
-            Some(&Nesting::Loop { .. }) => {
+            Some(&Nesting::Loop) => {
                 let variable = Rc::new(namer.call("should_continue"));
                 self.stack.push(Nesting::Switch {
                     variable: Rc::clone(&variable),
@@ -253,7 +253,7 @@ impl ContinueCtx {
             // This doesn't indicate a problem: we don't start pushing entries
             // for `Switch` statements unless we have an enclosing `Loop`.
             None => ExitControlFlow::None,
-            Some(Nesting::Loop { .. }) => {
+            Some(Nesting::Loop) => {
                 unreachable!("Unexpected loop state when exiting switch");
             }
             Some(Nesting::Switch {

--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -263,7 +263,7 @@ impl crate::TypeInner {
         match *self {
             crate::TypeInner::Image { .. }
             | crate::TypeInner::Sampler { .. }
-            | crate::TypeInner::AccelerationStructure { .. } => true,
+            | crate::TypeInner::AccelerationStructure => true,
             _ => false,
         }
     }

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -5286,13 +5286,13 @@ template <typename A>
                     LocationMode::VertexOutput,
                     true,
                 ),
-                crate::ShaderStage::Fragment { .. } => (
+                crate::ShaderStage::Fragment => (
                     "fragment",
                     LocationMode::FragmentInput,
                     LocationMode::FragmentOutput,
                     false,
                 ),
-                crate::ShaderStage::Compute { .. } => (
+                crate::ShaderStage::Compute => (
                     "kernel",
                     LocationMode::Uniform,
                     LocationMode::Uniform,

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -957,9 +957,7 @@ impl<'a> ConstantEvaluator<'a> {
             Expression::RayQueryProceedResult | Expression::RayQueryGetIntersection { .. } => {
                 Err(ConstantEvaluatorError::RayQueryExpression)
             }
-            Expression::SubgroupBallotResult { .. } => {
-                Err(ConstantEvaluatorError::SubgroupExpression)
-            }
+            Expression::SubgroupBallotResult => Err(ConstantEvaluatorError::SubgroupExpression),
             Expression::SubgroupOperationResult { .. } => {
                 Err(ConstantEvaluatorError::SubgroupExpression)
             }

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -1107,7 +1107,7 @@ fn invalid_functions() {
         Err(naga::valid::ValidationError::Type {
             source: naga::valid::TypeError::InvalidPointerToUnsized {
                 base: _,
-                space: naga::AddressSpace::WorkGroup { .. },
+                space: naga::AddressSpace::WorkGroup,
             },
             ..
         })

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -35,7 +35,7 @@ impl From<&ResourceType> for BindingTypeName {
             ResourceType::Buffer { .. } => BindingTypeName::Buffer,
             ResourceType::Texture { .. } => BindingTypeName::Texture,
             ResourceType::Sampler { .. } => BindingTypeName::Sampler,
-            ResourceType::AccelerationStructure { .. } => BindingTypeName::AccelerationStructure,
+            ResourceType::AccelerationStructure => BindingTypeName::AccelerationStructure,
         }
     }
 }
@@ -47,7 +47,7 @@ impl From<&BindingType> for BindingTypeName {
             BindingType::Texture { .. } => BindingTypeName::Texture,
             BindingType::StorageTexture { .. } => BindingTypeName::Texture,
             BindingType::Sampler { .. } => BindingTypeName::Sampler,
-            BindingType::AccelerationStructure { .. } => BindingTypeName::AccelerationStructure,
+            BindingType::AccelerationStructure => BindingTypeName::AccelerationStructure,
         }
     }
 }


### PR DESCRIPTION
**Description**
There are many new lints added in the current nighty clippy, and this fixes one class of them.

**Testing**
The warnings no longer appear when using `cargo +nightly clippy`.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
