### PR TITLE
Fix `clippy::doc_overindented_list_items` lints

### DIFF
--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -3,13 +3,13 @@
 //! Timestamp queries are typically used to profile how long certain operations take on the GPU.
 //! wgpu has several ways of performing gpu timestamp queries:
 //! * passing `wgpu::RenderPassTimestampWrites`/`wgpu::ComputePassTimestampWrites` during render/compute pass creation.
-//!     This writes timestamps for the beginning and end of a given pass.
-//!     (enabled with wgpu::Features::TIMESTAMP_QUERY)
+//!   This writes timestamps for the beginning and end of a given pass.
+//!   (enabled with wgpu::Features::TIMESTAMP_QUERY)
 //! * `wgpu::CommandEncoder::write_timestamp` writes a timestamp between any commands recorded on an encoder.
-//!     (enabled with wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS)
+//!   (enabled with wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS)
 //! * `wgpu::RenderPass/ComputePass::write_timestamp` writes a timestamp within commands of a render pass.
-//!     Note that some GPU architectures do not support this.
-//!     (native only, enabled with wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES)
+//!   Note that some GPU architectures do not support this.
+//!   (native only, enabled with wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES)
 //!
 //! Any timestamp is written to a `wgpu::QuerySet` which needs to be resolved to a buffer with `wgpu::BufferUsages::QUERY_RESOLVE`.
 //! Since this usage is incompatible with `wgpu::BufferUsages::MAP_READ` we need to copy the resolved timestamps to a separate buffer afterwards.

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -291,16 +291,16 @@ impl CommandEncoder {
     /// # Validation
     ///
     /// - blas: Iterator of bottom level acceleration structure entries to build.
-    ///     For each entry, the provided size descriptor must be strictly smaller or equal to the descriptor given at BLAS creation, this means:
-    ///     - Less or equal number of geometries
-    ///     - Same kind of geometry (with index buffer or without) (same vertex/index format)
-    ///     - Same flags
-    ///     - Less or equal number of vertices
-    ///     - Less or equal number of indices (if applicable)
+    ///   For each entry, the provided size descriptor must be strictly smaller or equal to the descriptor given at BLAS creation, this means:
+    ///   - Less or equal number of geometries
+    ///   - Same kind of geometry (with index buffer or without) (same vertex/index format)
+    ///   - Same flags
+    ///   - Less or equal number of vertices
+    ///   - Less or equal number of indices (if applicable)
     /// - tlas: iterator of top level acceleration structure packages to build
-    ///     For each entry:
-    ///     - Each BLAS in each TLAS instance must have been being built in the current call or in a previous call to `build_acceleration_structures` or `build_acceleration_structures_unsafe_tlas`
-    ///     - The number of TLAS instances must be less than or equal to the max number of tlas instances when creating (if creating a package with `TlasPackage::new()` this is already satisfied)
+    ///   For each entry:
+    ///   - Each BLAS in each TLAS instance must have been being built in the current call or in a previous call to `build_acceleration_structures` or `build_acceleration_structures_unsafe_tlas`
+    ///   - The number of TLAS instances must be less than or equal to the max number of tlas instances when creating (if creating a package with `TlasPackage::new()` this is already satisfied)
     ///
     /// If the device the command encoder is created from does not have [Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE] enabled then a validation error is generated
     ///
@@ -331,7 +331,7 @@ impl CommandEncoder {
     ///
     ///    - The contents of the raw instance buffer must be valid for the underling api.
     ///    - All bottom level acceleration structures, referenced in the raw instance buffer must be valid and built,
-    ///       when the corresponding top level acceleration structure is built. (builds may happen in the same invocation of this function).
+    ///      when the corresponding top level acceleration structure is built. (builds may happen in the same invocation of this function).
     ///    - At the time when the top level acceleration structure is used in a bind group, all associated bottom level acceleration structures must be valid,
     ///      and built (no later than the time when the top level acceleration structure was built).
     pub unsafe fn build_acceleration_structures_unsafe_tlas<'a>(

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -272,7 +272,7 @@ pub enum SurfaceTargetUnsafe {
     ///
     /// - `raw_window_handle` & `raw_display_handle` must be valid objects to create a surface upon.
     /// - `raw_window_handle` & `raw_display_handle` must remain valid until after the returned
-    ///    [`Surface`] is  dropped.
+    ///   [`Surface`] is  dropped.
     RawHandle {
         /// Raw display handle, underlying display must outlive the surface created from this.
         raw_display_handle: raw_window_handle::RawDisplayHandle,


### PR DESCRIPTION
**Description**
This fixes a new class of clippy lints for over-indentation of lists in doc comments. This lint is currently in the nightly clippy.

**Testing**
It no longer appears after fixing it.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
