### PR TITLE
[naga] allow trailing commas in template lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 - Allow abstract expressions to be used in WGSL function return statements. By @jamienicol in [#7035](https://github.com/gfx-rs/wgpu/pull/7035).
 - Error if structs have two fields with the same name. By @SparkyPotato in [#7088](https://github.com/gfx-rs/wgpu/pull/7088).
 - Forward '--keep-coordinate-space' flag to GLSL backend in naga-cli. By @cloone8 in [#7206](https://github.com/gfx-rs/wgpu/pull/7206).
+- Allow template lists to have a trailing comma. By @KentSlaney in [#7142](https://github.com/gfx-rs/wgpu/pull/7142).
 
 #### General
 

--- a/naga/src/front/wgsl/parse/lexer.rs
+++ b/naga/src/front/wgsl/parse/lexer.rs
@@ -352,7 +352,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    pub(in crate::front::wgsl) fn optional_generic_term(&mut self) -> bool {
+    pub(in crate::front::wgsl) fn end_of_generic_arguments(&mut self) -> bool {
         self.skip(Token::Separator(',')) && self.peek().0 != Token::Paren('>')
     }
 

--- a/naga/src/front/wgsl/parse/lexer.rs
+++ b/naga/src/front/wgsl/parse/lexer.rs
@@ -352,6 +352,10 @@ impl<'a> Lexer<'a> {
         }
     }
 
+    pub(in crate::front::wgsl) fn optional_generic_term(&mut self) -> bool {
+        self.skip(Token::Separator(',')) && self.peek().0 != Token::Paren('>')
+    }
+
     /// If the next token matches it is skipped and true is returned
     pub(in crate::front::wgsl) fn skip(&mut self, what: Token<'_>) -> bool {
         let (peeked_token, rest) = self.peek_token_and_rest();

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -576,8 +576,9 @@ impl Parser {
             (Token::Paren('<'), ast::ConstructorType::PartialArray) => {
                 lexer.expect_generic_paren('<')?;
                 let base = self.type_decl(lexer, ctx)?;
-                let size = if lexer.skip(Token::Separator(',')) {
+                let size = if lexer.optional_generic_term() {
                     let expr = self.const_generic_expression(lexer, ctx)?;
+                    lexer.skip(Token::Separator(','));
                     ast::ArraySize::Constant(expr)
                 } else {
                     ast::ArraySize::Dynamic
@@ -1244,6 +1245,7 @@ impl Parser {
         let start = lexer.start_byte_offset();
         let ty = self.type_decl(lexer, ctx)?;
         let span = lexer.span_from(start);
+        lexer.skip(Token::Separator(','));
         lexer.expect_generic_paren('>')?;
         Ok((ty, span))
     }
@@ -1436,8 +1438,10 @@ impl Parser {
                 lexer.expect(Token::Separator(','))?;
                 let base = self.type_decl(lexer, ctx)?;
                 if let crate::AddressSpace::Storage { ref mut access } = space {
-                    *access = if lexer.skip(Token::Separator(',')) {
-                        lexer.next_storage_access()?
+                    *access = if lexer.optional_generic_term() {
+                        let result = lexer.next_storage_access()?;
+                        lexer.skip(Token::Separator(','));
+                        result
                     } else {
                         crate::StorageAccess::LOAD
                     };
@@ -1448,8 +1452,9 @@ impl Parser {
             "array" => {
                 lexer.expect_generic_paren('<')?;
                 let base = self.type_decl(lexer, ctx)?;
-                let size = if lexer.skip(Token::Separator(',')) {
+                let size = if lexer.optional_generic_term() {
                     let size = self.const_generic_expression(lexer, ctx)?;
+                    lexer.skip(Token::Separator(','));
                     ast::ArraySize::Constant(size)
                 } else {
                     ast::ArraySize::Dynamic
@@ -1461,8 +1466,9 @@ impl Parser {
             "binding_array" => {
                 lexer.expect_generic_paren('<')?;
                 let base = self.type_decl(lexer, ctx)?;
-                let size = if lexer.skip(Token::Separator(',')) {
+                let size = if lexer.optional_generic_term() {
                     let size = self.unary_expression(lexer, ctx)?;
+                    lexer.skip(Token::Separator(','));
                     ast::ArraySize::Constant(size)
                 } else {
                     ast::ArraySize::Dynamic

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -576,7 +576,7 @@ impl Parser {
             (Token::Paren('<'), ast::ConstructorType::PartialArray) => {
                 lexer.expect_generic_paren('<')?;
                 let base = self.type_decl(lexer, ctx)?;
-                let size = if lexer.optional_generic_term() {
+                let size = if lexer.end_of_generic_arguments() {
                     let expr = self.const_generic_expression(lexer, ctx)?;
                     lexer.skip(Token::Separator(','));
                     ast::ArraySize::Constant(expr)
@@ -1438,7 +1438,7 @@ impl Parser {
                 lexer.expect(Token::Separator(','))?;
                 let base = self.type_decl(lexer, ctx)?;
                 if let crate::AddressSpace::Storage { ref mut access } = space {
-                    *access = if lexer.optional_generic_term() {
+                    *access = if lexer.end_of_generic_arguments() {
                         let result = lexer.next_storage_access()?;
                         lexer.skip(Token::Separator(','));
                         result
@@ -1452,7 +1452,7 @@ impl Parser {
             "array" => {
                 lexer.expect_generic_paren('<')?;
                 let base = self.type_decl(lexer, ctx)?;
-                let size = if lexer.optional_generic_term() {
+                let size = if lexer.end_of_generic_arguments() {
                     let size = self.const_generic_expression(lexer, ctx)?;
                     lexer.skip(Token::Separator(','));
                     ast::ArraySize::Constant(size)
@@ -1466,7 +1466,7 @@ impl Parser {
             "binding_array" => {
                 lexer.expect_generic_paren('<')?;
                 let base = self.type_decl(lexer, ctx)?;
-                let size = if lexer.optional_generic_term() {
+                let size = if lexer.end_of_generic_arguments() {
                     let size = self.unary_expression(lexer, ctx)?;
                     lexer.skip(Token::Separator(','));
                     ast::ArraySize::Constant(size)

--- a/naga/tests/in/template-list-trailing-comma.toml
+++ b/naga/tests/in/template-list-trailing-comma.toml
@@ -1,0 +1,1 @@
+targets = "IR"

--- a/naga/tests/in/template-list-trailing-comma.wgsl
+++ b/naga/tests/in/template-list-trailing-comma.wgsl
@@ -1,0 +1,15 @@
+var<workgroup> sized_comma: array<u32, 1,>;
+var<workgroup> sized_no_comma: array<u32, 1>;
+
+@group(0) @binding(0)
+var<storage, read_write> unsized_comma: array<u32,>;
+
+@group(0) @binding(1)
+var<storage, read_write> unsized_no_comma: array<u32>;
+
+@compute @workgroup_size(1)
+fn main() {
+    sized_comma[0] = unsized_comma[0];
+    sized_no_comma[0] = unsized_no_comma[0];
+    unsized_no_comma[0] = sized_comma[0] + sized_no_comma[0];
+}

--- a/naga/tests/out/ir/template-list-trailing-comma.compact.ron
+++ b/naga/tests/out/ir/template-list-trailing-comma.compact.ron
@@ -1,0 +1,194 @@
+(
+    types: [
+        (
+            name: None,
+            inner: Scalar((
+                kind: Uint,
+                width: 4,
+            )),
+        ),
+        (
+            name: None,
+            inner: Array(
+                base: 0,
+                size: Constant(1),
+                stride: 4,
+            ),
+        ),
+        (
+            name: None,
+            inner: Array(
+                base: 0,
+                size: Dynamic,
+                stride: 4,
+            ),
+        ),
+    ],
+    special_types: (
+        ray_desc: None,
+        ray_intersection: None,
+        predeclared_types: {},
+    ),
+    constants: [],
+    overrides: [],
+    global_variables: [
+        (
+            name: Some("sized_comma"),
+            space: WorkGroup,
+            binding: None,
+            ty: 1,
+            init: None,
+        ),
+        (
+            name: Some("sized_no_comma"),
+            space: WorkGroup,
+            binding: None,
+            ty: 1,
+            init: None,
+        ),
+        (
+            name: Some("unsized_comma"),
+            space: Storage(
+                access: ("LOAD | STORE"),
+            ),
+            binding: Some((
+                group: 0,
+                binding: 0,
+            )),
+            ty: 2,
+            init: None,
+        ),
+        (
+            name: Some("unsized_no_comma"),
+            space: Storage(
+                access: ("LOAD | STORE"),
+            ),
+            binding: Some((
+                group: 0,
+                binding: 1,
+            )),
+            ty: 2,
+            init: None,
+        ),
+    ],
+    global_expressions: [],
+    functions: [],
+    entry_points: [
+        (
+            name: "main",
+            stage: Compute,
+            early_depth_test: None,
+            workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
+            function: (
+                name: Some("main"),
+                arguments: [],
+                result: None,
+                local_variables: [],
+                expressions: [
+                    GlobalVariable(0),
+                    AccessIndex(
+                        base: 0,
+                        index: 0,
+                    ),
+                    GlobalVariable(2),
+                    AccessIndex(
+                        base: 2,
+                        index: 0,
+                    ),
+                    Load(
+                        pointer: 3,
+                    ),
+                    GlobalVariable(1),
+                    AccessIndex(
+                        base: 5,
+                        index: 0,
+                    ),
+                    GlobalVariable(3),
+                    AccessIndex(
+                        base: 7,
+                        index: 0,
+                    ),
+                    Load(
+                        pointer: 8,
+                    ),
+                    GlobalVariable(3),
+                    AccessIndex(
+                        base: 10,
+                        index: 0,
+                    ),
+                    GlobalVariable(0),
+                    AccessIndex(
+                        base: 12,
+                        index: 0,
+                    ),
+                    Load(
+                        pointer: 13,
+                    ),
+                    GlobalVariable(1),
+                    AccessIndex(
+                        base: 15,
+                        index: 0,
+                    ),
+                    Load(
+                        pointer: 16,
+                    ),
+                    Binary(
+                        op: Add,
+                        left: 14,
+                        right: 17,
+                    ),
+                ],
+                named_expressions: {},
+                body: [
+                    Emit((
+                        start: 1,
+                        end: 2,
+                    )),
+                    Emit((
+                        start: 3,
+                        end: 5,
+                    )),
+                    Store(
+                        pointer: 1,
+                        value: 4,
+                    ),
+                    Emit((
+                        start: 6,
+                        end: 7,
+                    )),
+                    Emit((
+                        start: 8,
+                        end: 10,
+                    )),
+                    Store(
+                        pointer: 6,
+                        value: 9,
+                    ),
+                    Emit((
+                        start: 11,
+                        end: 12,
+                    )),
+                    Emit((
+                        start: 13,
+                        end: 15,
+                    )),
+                    Emit((
+                        start: 16,
+                        end: 19,
+                    )),
+                    Store(
+                        pointer: 11,
+                        value: 18,
+                    ),
+                    Return(
+                        value: None,
+                    ),
+                ],
+                diagnostic_filter_leaf: None,
+            ),
+        ),
+    ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
+)

--- a/naga/tests/out/ir/template-list-trailing-comma.ron
+++ b/naga/tests/out/ir/template-list-trailing-comma.ron
@@ -1,0 +1,194 @@
+(
+    types: [
+        (
+            name: None,
+            inner: Scalar((
+                kind: Uint,
+                width: 4,
+            )),
+        ),
+        (
+            name: None,
+            inner: Array(
+                base: 0,
+                size: Constant(1),
+                stride: 4,
+            ),
+        ),
+        (
+            name: None,
+            inner: Array(
+                base: 0,
+                size: Dynamic,
+                stride: 4,
+            ),
+        ),
+    ],
+    special_types: (
+        ray_desc: None,
+        ray_intersection: None,
+        predeclared_types: {},
+    ),
+    constants: [],
+    overrides: [],
+    global_variables: [
+        (
+            name: Some("sized_comma"),
+            space: WorkGroup,
+            binding: None,
+            ty: 1,
+            init: None,
+        ),
+        (
+            name: Some("sized_no_comma"),
+            space: WorkGroup,
+            binding: None,
+            ty: 1,
+            init: None,
+        ),
+        (
+            name: Some("unsized_comma"),
+            space: Storage(
+                access: ("LOAD | STORE"),
+            ),
+            binding: Some((
+                group: 0,
+                binding: 0,
+            )),
+            ty: 2,
+            init: None,
+        ),
+        (
+            name: Some("unsized_no_comma"),
+            space: Storage(
+                access: ("LOAD | STORE"),
+            ),
+            binding: Some((
+                group: 0,
+                binding: 1,
+            )),
+            ty: 2,
+            init: None,
+        ),
+    ],
+    global_expressions: [],
+    functions: [],
+    entry_points: [
+        (
+            name: "main",
+            stage: Compute,
+            early_depth_test: None,
+            workgroup_size: (1, 1, 1),
+            workgroup_size_overrides: None,
+            function: (
+                name: Some("main"),
+                arguments: [],
+                result: None,
+                local_variables: [],
+                expressions: [
+                    GlobalVariable(0),
+                    AccessIndex(
+                        base: 0,
+                        index: 0,
+                    ),
+                    GlobalVariable(2),
+                    AccessIndex(
+                        base: 2,
+                        index: 0,
+                    ),
+                    Load(
+                        pointer: 3,
+                    ),
+                    GlobalVariable(1),
+                    AccessIndex(
+                        base: 5,
+                        index: 0,
+                    ),
+                    GlobalVariable(3),
+                    AccessIndex(
+                        base: 7,
+                        index: 0,
+                    ),
+                    Load(
+                        pointer: 8,
+                    ),
+                    GlobalVariable(3),
+                    AccessIndex(
+                        base: 10,
+                        index: 0,
+                    ),
+                    GlobalVariable(0),
+                    AccessIndex(
+                        base: 12,
+                        index: 0,
+                    ),
+                    Load(
+                        pointer: 13,
+                    ),
+                    GlobalVariable(1),
+                    AccessIndex(
+                        base: 15,
+                        index: 0,
+                    ),
+                    Load(
+                        pointer: 16,
+                    ),
+                    Binary(
+                        op: Add,
+                        left: 14,
+                        right: 17,
+                    ),
+                ],
+                named_expressions: {},
+                body: [
+                    Emit((
+                        start: 1,
+                        end: 2,
+                    )),
+                    Emit((
+                        start: 3,
+                        end: 5,
+                    )),
+                    Store(
+                        pointer: 1,
+                        value: 4,
+                    ),
+                    Emit((
+                        start: 6,
+                        end: 7,
+                    )),
+                    Emit((
+                        start: 8,
+                        end: 10,
+                    )),
+                    Store(
+                        pointer: 6,
+                        value: 9,
+                    ),
+                    Emit((
+                        start: 11,
+                        end: 12,
+                    )),
+                    Emit((
+                        start: 13,
+                        end: 15,
+                    )),
+                    Emit((
+                        start: 16,
+                        end: 19,
+                    )),
+                    Store(
+                        pointer: 11,
+                        value: 18,
+                    ),
+                    Return(
+                        value: None,
+                    ),
+                ],
+                diagnostic_filter_leaf: None,
+            ),
+        ),
+    ],
+    diagnostic_filters: [],
+    diagnostic_filter_leaf: None,
+)

--- a/tests/gpu-tests/shader/array_size_overrides.rs
+++ b/tests/gpu-tests/shader/array_size_overrides.rs
@@ -6,10 +6,10 @@ use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, TestParameters, Testing
 const SHADER: &str = r#"
     override n = 8;
 
-    var<workgroup> arr: array<u32, n - 2,>;
+    var<workgroup> arr: array<u32, n - 2>;
 
     @group(0) @binding(0)
-    var<storage, read_write> output: array<u32,>;
+    var<storage, read_write> output: array<u32>;
 
     @compute @workgroup_size(1) fn main() {
         // 1d spiral

--- a/tests/gpu-tests/shader/array_size_overrides.rs
+++ b/tests/gpu-tests/shader/array_size_overrides.rs
@@ -6,10 +6,10 @@ use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, TestParameters, Testing
 const SHADER: &str = r#"
     override n = 8;
 
-    var<workgroup> arr: array<u32, n - 2>;
+    var<workgroup> arr: array<u32, n - 2,>;
 
     @group(0) @binding(0)
-    var<storage, read_write> output: array<u32>;
+    var<storage, read_write> output: array<u32,>;
 
     @compute @workgroup_size(1) fn main() {
         // 1d spiral


### PR DESCRIPTION
**Connections**
[template list spec](https://gpuweb.github.io/gpuweb/wgsl/#template-lists-sec)

**Description**
template lists allow for an optional trailing comma, which was not previously accounted for in the lexer

**Testing**
This is tested by adding trailing commas to the `array_size_overrides` test

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
