### PR TITLE
WebGPU spec compliant dual source blending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 #### WebGPU
 
 - Improve efficiency of dropping read-only buffer mappings. By @kpreid in [#7007](https://github.com/gfx-rs/wgpu/pull/7007).
-- `wgpu::Features::DUAL_SOURCE_BLENDING` is now available on WebGPU. By @wumpf in [#????](https://github.com/gfx-rs/wgpu/pull/????).
+- `wgpu::Features::DUAL_SOURCE_BLENDING` is now available on WebGPU. By @wumpf in [#????](https://github.com/gfx-rs/wgpu/pull/????). TODO: not the full story, not a WebGPU thing, it's a Naga/general thing.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 #### WebGPU
 
 - Improve efficiency of dropping read-only buffer mappings. By @kpreid in [#7007](https://github.com/gfx-rs/wgpu/pull/7007).
+- `wgpu::Features::DUAL_SOURCE_BLENDING` is now available on WebGPU. By @wumpf in [#????](https://github.com/gfx-rs/wgpu/pull/????).
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,45 @@ Bottom level categories:
 
 ## Unreleased
 
+### Major changes
+
+#### Split up `Features` internally
+
+Internally split up the `Features` struct and recombine them internally using a macro. There should be no breaking 
+changes from this. This means there are also namespaces (as well as the old `Features::*`) for all wgpu specific
+features and webgpu feature (`FeaturesWGPU` and `FeaturesWebGPU` respectively) and `Features::from_internal_flags` which
+allow you to be explicit about whether features you need are available on the web too.
+
+By @Vecvec in [#6905](https://github.com/gfx-rs/wgpu/pull/6905), [#7086](https://github.com/gfx-rs/wgpu/pull/7086)
+
+#### Refactored internal trace path parameter
+
+Refactored some functions to handle the internal trace path as a string to avoid possible issues with `no_std` support.
+
+By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
+
+#### WebGPU compliant dual source blending feature
+
+Previously, dual source blending was implemented with a `wgpu` native only feature flag and used a custom syntax in wgpu.
+By now, dual source blending was added to the [WebGPU spec as an extension](https://www.w3.org/TR/webgpu/#dom-gpufeaturename-dual-source-blending).
+We're now following suite and implement the official syntax.
+
+Existing shaders using dual source blending need to be updated:
+
+```diff
+struct FragmentOutput{
+-    @location(0) source0: vec4<f32>,
+-    @location(0) @second_blend_source source1: vec4<f32>,
++    @location(0) @blend_src(0) source0: vec4<f32>,
++    @location(0) @blend_src(1) source1: vec4<f32>,
+}
+
+```
+
+With that `wgpu::Features::DUAL_SOURCE_BLENDING` is now available on WebGPU.
+
+By @wumpf in [#????](https://github.com/gfx-rs/wgpu/pull/????)
+
 ### New Features
 
 #### Naga
@@ -56,20 +95,6 @@ Bottom level categories:
 - Rename `instance_id` and `instance_custom_index` to `instance_index` and `instance_custom_data` by @Vecvec in
   [#6780](https://github.com/gfx-rs/wgpu/pull/6780)
 
-##### Split up `Features` internally
-
-Internally split up the `Features` struct and recombine them internally using a macro. There should be no breaking 
-changes from this. This means there are also namespaces (as well as the old `Features::*`) for all wgpu specific
-features and webgpu feature (`FeaturesWGPU` and `FeaturesWebGPU` respectively) and `Features::from_internal_flags` which
-allow you to be explicit about whether features you need are available on the web too.
-
-By @Vecvec in [#6905](https://github.com/gfx-rs/wgpu/pull/6905), [#7086](https://github.com/gfx-rs/wgpu/pull/7086)
-
-##### Refactored internal trace path parameter
-
-Refactored some functions to handle the internal trace path as a string to avoid possible issues with `no_std` support.
-
-By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 
 #### Vulkan
 
@@ -107,7 +132,6 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 #### WebGPU
 
 - Improve efficiency of dropping read-only buffer mappings. By @kpreid in [#7007](https://github.com/gfx-rs/wgpu/pull/7007).
-- `wgpu::Features::DUAL_SOURCE_BLENDING` is now available on WebGPU. By @wumpf in [#????](https://github.com/gfx-rs/wgpu/pull/????). TODO: not the full story, not a WebGPU thing, it's a Naga/general thing.
 
 ### Documentation
 

--- a/naga/src/back/glsl/features.rs
+++ b/naga/src/back/glsl/features.rs
@@ -604,7 +604,7 @@ impl<W> Writer<'_, W> {
                     location: _,
                     interpolation,
                     sampling,
-                    second_blend_source,
+                    blend_src,
                 } => {
                     if interpolation == Some(Interpolation::Linear) {
                         self.features.request(Features::NOPERSPECTIVE_QUALIFIER);
@@ -612,7 +612,7 @@ impl<W> Writer<'_, W> {
                     if sampling == Some(Sampling::Sample) {
                         self.features.request(Features::SAMPLE_QUALIFIER);
                     }
-                    if second_blend_source {
+                    if blend_src.is_some() {
                         self.features.request(Features::DUAL_SOURCE_BLENDING);
                     }
                 }

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -429,8 +429,7 @@ impl fmt::Display for VaryingName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self.binding {
             crate::Binding::Location {
-                second_blend_source: true,
-                ..
+                blend_src: Some(1), ..
             } => {
                 write!(f, "_fs2p_location1",)
             }
@@ -1465,13 +1464,13 @@ impl<'a, W: Write> Writer<'a, W> {
             Some(binding) => binding,
         };
 
-        let (location, interpolation, sampling, second_blend_source) = match *binding {
+        let (location, interpolation, sampling, blend_src) = match *binding {
             crate::Binding::Location {
                 location,
                 interpolation,
                 sampling,
-                second_blend_source,
-            } => (location, interpolation, sampling, second_blend_source),
+                blend_src,
+            } => (location, interpolation, sampling, blend_src),
             crate::Binding::BuiltIn(built_in) => {
                 if let crate::BuiltIn::Position { invariant: true } = built_in {
                     match (self.options.version, self.entry_point.stage) {
@@ -1518,8 +1517,11 @@ impl<'a, W: Write> Writer<'a, W> {
             || !emit_interpolation_and_auxiliary
         {
             if self.options.version.supports_io_locations() {
-                if second_blend_source {
-                    write!(self.out, "layout(location = {location}, index = 1) ")?;
+                if let Some(blend_src) = blend_src {
+                    write!(
+                        self.out,
+                        "layout(location = {location}, index = {blend_src}) "
+                    )?;
                 } else {
                     write!(self.out, "layout(location = {location}) ")?;
                 }
@@ -1527,7 +1529,7 @@ impl<'a, W: Write> Writer<'a, W> {
             } else {
                 Some(VaryingLocation {
                     location,
-                    index: second_blend_source as u32,
+                    index: blend_src.unwrap_or(0),
                 })
             }
         } else {
@@ -1568,7 +1570,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 location,
                 interpolation: None,
                 sampling: None,
-                second_blend_source,
+                blend_src,
             },
             stage: self.entry_point.stage,
             options: VaryingOptions::from_writer_options(self.options, output),

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -523,16 +523,11 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 write!(self.out, " : {builtin_str}")?;
             }
             Some(crate::Binding::Location {
-                second_blend_source: true,
-                ..
+                blend_src: Some(1), ..
             }) => {
                 write!(self.out, " : SV_Target1")?;
             }
-            Some(crate::Binding::Location {
-                location,
-                second_blend_source: false,
-                ..
-            }) => {
+            Some(crate::Binding::Location { location, .. }) => {
                 if stage == Some((ShaderStage::Fragment, Io::Output)) {
                     write!(self.out, " : SV_Target{location}")?;
                 } else {

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -87,7 +87,7 @@ enum ResolvedBinding {
     Attribute(u32),
     Color {
         location: u32,
-        second_blend_source: bool,
+        blend_src: Option<u32>,
     },
     User {
         prefix: &'static str,
@@ -433,18 +433,16 @@ impl Options {
                 location,
                 interpolation,
                 sampling,
-                second_blend_source,
+                blend_src,
             } => match mode {
                 LocationMode::VertexInput => Ok(ResolvedBinding::Attribute(location)),
                 LocationMode::FragmentOutput => {
-                    if second_blend_source && self.lang_version < (1, 2) {
-                        return Err(Error::UnsupportedAttribute(
-                            "second_blend_source".to_string(),
-                        ));
+                    if blend_src.is_some() && self.lang_version < (1, 2) {
+                        return Err(Error::UnsupportedAttribute("blend_src".to_string()));
                     }
                     Ok(ResolvedBinding::Color {
                         location,
-                        second_blend_source,
+                        blend_src,
                     })
                 }
                 LocationMode::VertexOutput | LocationMode::FragmentInput => {
@@ -606,10 +604,10 @@ impl ResolvedBinding {
             Self::Attribute(index) => write!(out, "attribute({index})")?,
             Self::Color {
                 location,
-                second_blend_source,
+                blend_src,
             } => {
-                if second_blend_source {
-                    write!(out, "color({location}) index(1)")?
+                if let Some(blend_src) = blend_src {
+                    write!(out, "color({location}) index({blend_src})")?
                 } else {
                     write!(out, "color({location})")?
                 }

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -1464,7 +1464,7 @@ impl Writer {
                 location,
                 interpolation,
                 sampling,
-                second_blend_source,
+                blend_src,
             } => {
                 self.decorate(id, Decoration::Location, &[location]);
 
@@ -1509,8 +1509,8 @@ impl Writer {
                         }
                     }
                 }
-                if second_blend_source {
-                    self.decorate(id, Decoration::Index, &[1]);
+                if let Some(blend_src) = blend_src {
+                    self.decorate(id, Decoration::Index, &[blend_src]);
                 }
             }
             crate::Binding::BuiltIn(built_in) => {

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -18,7 +18,7 @@ enum Attribute {
     Invariant,
     Interpolate(Option<crate::Interpolation>, Option<crate::Sampling>),
     Location(u32),
-    SecondBlendSource,
+    BlendSrc(u32),
     Stage(ShaderStage),
     WorkGroupSize([u32; 3]),
 }
@@ -340,7 +340,7 @@ impl<W: Write> Writer<W> {
         for attribute in attributes {
             match *attribute {
                 Attribute::Location(id) => write!(self.out, "@location({id}) ")?,
-                Attribute::SecondBlendSource => write!(self.out, "@second_blend_source ")?,
+                Attribute::BlendSrc(blend_src) => write!(self.out, "@blend_src({blend_src}) ")?,
                 Attribute::BuiltIn(builtin_attrib) => {
                     let builtin = builtin_str(builtin_attrib)?;
                     write!(self.out, "@builtin({builtin}) ")?;
@@ -2162,7 +2162,7 @@ fn map_binding_to_attribute(binding: &crate::Binding) -> Vec<Attribute> {
             location,
             interpolation,
             sampling,
-            second_blend_source: false,
+            blend_src: None,
         } => vec![
             Attribute::Location(location),
             Attribute::Interpolate(interpolation, sampling),
@@ -2171,10 +2171,10 @@ fn map_binding_to_attribute(binding: &crate::Binding) -> Vec<Attribute> {
             location,
             interpolation,
             sampling,
-            second_blend_source: true,
+            blend_src: Some(blend_src),
         } => vec![
             Attribute::Location(location),
-            Attribute::SecondBlendSource,
+            Attribute::BlendSrc(blend_src),
             Attribute::Interpolate(interpolation, sampling),
         ],
     }

--- a/naga/src/front/glsl/functions.rs
+++ b/naga/src/front/glsl/functions.rs
@@ -1442,7 +1442,7 @@ impl Context<'_> {
                         location,
                         interpolation,
                         sampling: None,
-                        second_blend_source: false,
+                        blend_src: None,
                     };
                     location += 1;
 
@@ -1478,7 +1478,7 @@ impl Context<'_> {
                                 location,
                                 interpolation,
                                 sampling: None,
-                                second_blend_source: false,
+                                blend_src: None,
                             };
                             location += 1;
                             binding

--- a/naga/src/front/glsl/variables.rs
+++ b/naga/src/front/glsl/variables.rs
@@ -454,7 +454,7 @@ impl Frontend {
                         location,
                         interpolation,
                         sampling,
-                        second_blend_source: false,
+                        blend_src: None,
                     },
                     handle,
                     storage,

--- a/naga/src/front/interpolator.rs
+++ b/naga/src/front/interpolator.rs
@@ -43,7 +43,7 @@ impl crate::Binding {
             location: _,
             interpolation: ref mut interpolation @ None,
             ref mut sampling,
-            second_blend_source: _,
+            blend_src: _,
         } = *self
         {
             match ty.scalar_kind() {

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -250,7 +250,7 @@ impl Decoration {
                 location,
                 interpolation,
                 sampling,
-                second_blend_source: false,
+                blend_src: None,
             }),
             _ => Err(Error::MissingDecoration(spirv::Decoration::Location)),
         }

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -3317,15 +3317,21 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             Some(ast::Binding::BuiltIn(b)) => Some(crate::Binding::BuiltIn(b)),
             Some(ast::Binding::Location {
                 location,
-                second_blend_source,
                 interpolation,
                 sampling,
+                blend_src,
             }) => {
+                let blend_src = if let Some(blend_src) = blend_src {
+                    Some(self.const_u32(blend_src, &mut ctx.as_const())?.0)
+                } else {
+                    None
+                };
+
                 let mut binding = crate::Binding::Location {
                     location: self.const_u32(location, &mut ctx.as_const())?.0,
-                    second_blend_source,
                     interpolation,
                     sampling,
+                    blend_src,
                 };
                 binding.apply_default_interpolation(&ctx.module.types[ty].inner);
                 Some(binding)

--- a/naga/src/front/wgsl/parse/ast.rs
+++ b/naga/src/front/wgsl/parse/ast.rs
@@ -142,9 +142,9 @@ pub enum Binding<'a> {
     BuiltIn(crate::BuiltIn),
     Location {
         location: Handle<Expression<'a>>,
-        second_blend_source: bool,
         interpolation: Option<crate::Interpolation>,
         sampling: Option<crate::Sampling>,
+        blend_src: Option<Handle<Expression<'a>>>,
     },
 }
 

--- a/naga/src/front/wgsl/parse/directive/enable_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/enable_extension.rs
@@ -5,24 +5,32 @@ use crate::{front::wgsl::error::Error, Span};
 
 /// Tracks the status of every enable-extension known to Naga.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EnableExtensions {}
+pub struct EnableExtensions {
+    dual_source_blending: bool,
+}
 
 impl EnableExtensions {
     pub(crate) const fn empty() -> Self {
-        Self {}
+        Self {
+            dual_source_blending: false,
+        }
     }
 
     /// Add an enable-extension to the set requested by a module.
-    #[allow(unreachable_code)]
+    #[expect(unreachable_code)]
     pub(crate) fn add(&mut self, ext: ImplementedEnableExtension) {
-        let _field: &mut bool = match ext {};
-        *_field = true;
+        let field: &mut bool = match ext {
+            ImplementedEnableExtension::DualSourceBlending => &mut self.dual_source_blending,
+        };
+        *field = true;
     }
 
     /// Query whether an enable-extension tracked here has been requested.
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) const fn contains(&self, ext: ImplementedEnableExtension) -> bool {
-        match ext {}
+        match ext {
+            ImplementedEnableExtension::DualSourceBlending => self.dual_source_blending,
+        }
     }
 }
 
@@ -55,7 +63,7 @@ impl EnableExtension {
                 Self::Unimplemented(UnimplementedEnableExtension::ClipDistances)
             }
             Self::DUAL_SOURCE_BLENDING => {
-                Self::Unimplemented(UnimplementedEnableExtension::DualSourceBlending)
+                Self::Implemented(ImplementedEnableExtension::DualSourceBlending)
             }
             _ => return Err(Error::UnknownEnableExtension(span, word)),
         })
@@ -64,11 +72,13 @@ impl EnableExtension {
     /// Maps this [`EnableExtension`] into the sentinel word associated with it in WGSL.
     pub const fn to_ident(self) -> &'static str {
         match self {
-            Self::Implemented(kind) => match kind {},
+            Self::Implemented(kind) => match kind {
+                ImplementedEnableExtension::DualSourceBlending => Self::DUAL_SOURCE_BLENDING,
+            },
+
             Self::Unimplemented(kind) => match kind {
                 UnimplementedEnableExtension::F16 => Self::F16,
                 UnimplementedEnableExtension::ClipDistances => Self::CLIP_DISTANCES,
-                UnimplementedEnableExtension::DualSourceBlending => Self::DUAL_SOURCE_BLENDING,
             },
         }
     }
@@ -76,7 +86,14 @@ impl EnableExtension {
 
 /// A variant of [`EnableExtension::Implemented`].
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
-pub enum ImplementedEnableExtension {}
+pub enum ImplementedEnableExtension {
+    /// Enables the `blend_src` attribute in WGSL.
+    ///
+    /// In the WGSL standard, this corresponds to [`enable dual_source_blending;`].
+    ///
+    /// [`enable dual_source_blending;`]: https://www.w3.org/TR/WGSL/#extension-f16
+    DualSourceBlending,
+}
 
 /// A variant of [`EnableExtension::Unimplemented`].
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
@@ -93,12 +110,6 @@ pub enum UnimplementedEnableExtension {
     ///
     /// [`enable clip_distances;`]: https://www.w3.org/TR/WGSL/#extension-f16
     ClipDistances,
-    /// Enables the `blend_src` attribute in WGSL.
-    ///
-    /// In the WGSL standard, this corresponds to [`enable dual_source_blending;`].
-    ///
-    /// [`enable dual_source_blending;`]: https://www.w3.org/TR/WGSL/#extension-f16
-    DualSourceBlending,
 }
 
 impl UnimplementedEnableExtension {
@@ -106,7 +117,6 @@ impl UnimplementedEnableExtension {
         match self {
             Self::F16 => 4384,
             Self::ClipDistances => 6236,
-            Self::DualSourceBlending => 6402,
         }
     }
 }

--- a/naga/src/front/wgsl/parse/directive/enable_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/enable_extension.rs
@@ -17,7 +17,6 @@ impl EnableExtensions {
     }
 
     /// Add an enable-extension to the set requested by a module.
-    #[expect(unreachable_code)]
     pub(crate) fn add(&mut self, ext: ImplementedEnableExtension) {
         let field: &mut bool = match ext {
             ImplementedEnableExtension::DualSourceBlending => &mut self.dual_source_blending,

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -174,11 +174,11 @@ impl<T> ParsedAttribute<T> {
 #[derive(Default)]
 struct BindingParser<'a> {
     location: ParsedAttribute<Handle<ast::Expression<'a>>>,
-    second_blend_source: ParsedAttribute<bool>,
     built_in: ParsedAttribute<crate::BuiltIn>,
     interpolation: ParsedAttribute<crate::Interpolation>,
     sampling: ParsedAttribute<crate::Sampling>,
     invariant: ParsedAttribute<bool>,
+    blend_src: ParsedAttribute<Handle<ast::Expression<'a>>>,
 }
 
 impl<'a> BindingParser<'a> {
@@ -216,11 +216,15 @@ impl<'a> BindingParser<'a> {
                 }
                 lexer.expect(Token::Paren(')'))?;
             }
-            "second_blend_source" => {
-                self.second_blend_source.set(true, name_span)?;
-            }
+
             "invariant" => {
                 self.invariant.set(true, name_span)?;
+            }
+            "blend_src" => {
+                lexer.expect(Token::Paren('('))?;
+                self.blend_src
+                    .set(parser.general_expression(lexer, ctx)?, name_span)?;
+                lexer.expect(Token::Paren(')'))?;
             }
             _ => return Err(Error::UnknownAttribute(name_span)),
         }
@@ -234,9 +238,10 @@ impl<'a> BindingParser<'a> {
             self.interpolation.value,
             self.sampling.value,
             self.invariant.value.unwrap_or_default(),
+            self.blend_src.value,
         ) {
-            (None, None, None, None, false) => Ok(None),
-            (Some(location), None, interpolation, sampling, false) => {
+            (None, None, None, None, false, None) => Ok(None),
+            (Some(location), None, interpolation, sampling, false, blend_src) => {
                 // Before handing over the completed `Module`, we call
                 // `apply_default_interpolation` to ensure that the interpolation and
                 // sampling have been explicitly specified on all vertex shader output and fragment
@@ -245,16 +250,18 @@ impl<'a> BindingParser<'a> {
                     location,
                     interpolation,
                     sampling,
-                    second_blend_source: self.second_blend_source.value.unwrap_or(false),
+                    blend_src,
                 }))
             }
-            (None, Some(crate::BuiltIn::Position { .. }), None, None, invariant) => {
+            (None, Some(crate::BuiltIn::Position { .. }), None, None, invariant, None) => {
                 Ok(Some(ast::Binding::BuiltIn(crate::BuiltIn::Position {
                     invariant,
                 })))
             }
-            (None, Some(built_in), None, None, false) => Ok(Some(ast::Binding::BuiltIn(built_in))),
-            (_, _, _, _, _) => Err(Error::InconsistentBinding(span)),
+            (None, Some(built_in), None, None, false, None) => {
+                Ok(Some(ast::Binding::BuiltIn(built_in)))
+            }
+            (_, _, _, _, _, _) => Err(Error::InconsistentBinding(span)),
         }
     }
 }

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -965,10 +965,11 @@ pub enum Binding {
     /// [`Fragment`]: crate::ShaderStage::Fragment
     Location {
         location: u32,
-        /// Indicates the 2nd input to the blender when dual-source blending.
-        second_blend_source: bool,
         interpolation: Option<Interpolation>,
         sampling: Option<Sampling>,
+        /// Optional `blend_src` index used for dual source blending.
+        /// See https://www.w3.org/TR/WGSL/#attribute-blend_src
+        blend_src: Option<u32>,
     },
 }
 

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -671,7 +671,7 @@ impl super::Validator {
             return Err(EntryPointError::UnexpectedWorkgroupSize.with_span());
         }
 
-        let info = self
+        let mut info = self
             .validate_function(&ep.function, module, mod_info, true, global_expr_kind)
             .map_err(WithSpan::into_other)?;
 
@@ -728,6 +728,9 @@ impl super::Validator {
                 && !result_built_ins.contains(&crate::BuiltIn::Position { invariant: false })
             {
                 return Err(EntryPointError::MissingVertexOutputPosition.with_span());
+            }
+            if !self.blend_src_mask.is_empty() {
+                info.dual_source_blending = true;
             }
         } else if ep.stage == crate::ShaderStage::Vertex {
             return Err(EntryPointError::MissingVertexOutputPosition.with_span());

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -349,12 +349,10 @@ impl VaryingContext<'_> {
                     if !self.blend_src_mask.insert(blend_src as usize) {
                         return Err(VaryingError::BindingCollisionBlendSrc { blend_src });
                     }
-                } else {
-                    if !self.location_mask.insert(location as usize) {
-                        if self.flags.contains(super::ValidationFlags::BINDINGS) {
-                            return Err(VaryingError::BindingCollision { location });
-                        }
-                    }
+                } else if !self.location_mask.insert(location as usize)
+                    && self.flags.contains(super::ValidationFlags::BINDINGS)
+                {
+                    return Err(VaryingError::BindingCollision { location });
                 }
 
                 if let Some(interpolation) = interpolation {

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -67,6 +67,8 @@ pub enum VaryingError {
     MemberMissingBinding(u32),
     #[error("Multiple bindings at location {location} are present")]
     BindingCollision { location: u32 },
+    #[error("Multiple bindings use the same blend_src {blend_src}")]
+    BindingCollisionBlendSrc { blend_src: u32 },
     #[error("Built-in {0:?} is present more than once")]
     DuplicateBuiltIn(crate::BuiltIn),
     #[error("Capability {0:?} is not supported")]
@@ -75,10 +77,10 @@ pub enum VaryingError {
     InvalidInputAttributeInStage(&'static str, crate::ShaderStage),
     #[error("The attribute {0:?} is not valid for stage {1:?}")]
     InvalidAttributeInStage(&'static str, crate::ShaderStage),
-    #[error(
-        "The location index {location} uses a blend source index of {index} other than 0 or 1."
-    )]
-    InvalidBlendSrcIndex { location: u32, index: u32 },
+    #[error("The blend_src attribute can only be used on location 0, only indices 0 and 1 are valid. Location was {location}, index was {blend_src}.")]
+    InvalidBlendSrcIndex { location: u32, blend_src: u32 },
+    #[error("If blend_src is used, there must be exactly two outputs both with location 0, one with blend_src(0) and the other with blend_src(1).")]
+    IncompleteBlendSrcUsage,
     #[error("Workgroup size is multi dimensional, @builtin(subgroup_id) and @builtin(subgroup_invocation_id) are not supported.")]
     InvalidMultiDimensionalSubgroupBuiltIn,
 }
@@ -112,10 +114,6 @@ pub enum EntryPointError {
     InvalidIntegerInterpolation { location: u32 },
     #[error(transparent)]
     Function(#[from] FunctionError),
-    #[error(
-        "Invalid locations `blend_src` index set {index:?}. Only index 0 and, if dual source blending is enabled, 1 may be set."
-    )]
-    InvalidBlendSrcIndex { index: u32 },
 }
 
 fn storage_usage(access: crate::StorageAccess) -> GlobalUse {
@@ -137,9 +135,8 @@ struct VaryingContext<'a> {
     output: bool,
     types: &'a UniqueArena<crate::Type>,
     type_info: &'a Vec<super::r#type::TypeInfo>,
-    location_mask0: &'a mut BitSet,
-    location_mask1: &'a mut BitSet,
-    blend_src: u32, // 0 if not set.
+    location_mask: &'a mut BitSet,
+    blend_src_mask: &'a mut BitSet,
     built_ins: &'a mut crate::FastHashSet<crate::BuiltIn>,
     capabilities: Capabilities,
     flags: super::ValidationFlags,
@@ -314,13 +311,10 @@ impl VaryingContext<'_> {
                     return Err(VaryingError::NotIOShareableType(ty));
                 }
 
-                // `blend_src` is only valid if dual source blending was explicitly enabled,
-                // see https://www.w3.org/TR/WGSL/#extension-dual_source_blending
-                if let Some(blend_src_index) = blend_src {
+                if let Some(blend_src) = blend_src {
+                    // `blend_src` is only valid if dual source blending was explicitly enabled,
+                    // see https://www.w3.org/TR/WGSL/#extension-dual_source_blending
                     // TODO: check that dual source blending feature was enabled in the shader.
-                    // TODO: If ANY location uses blend_src, all of them have to.
-                    // TODO: all locations must have the same data type
-
                     if !self
                         .capabilities
                         .contains(Capabilities::DUAL_SOURCE_BLENDING)
@@ -341,28 +335,17 @@ impl VaryingContext<'_> {
                             self.stage,
                         ));
                     }
-                    if blend_src_index != 0 && blend_src_index != 1 {
+                    if (blend_src != 0 && blend_src != 1) || location != 0 {
                         return Err(VaryingError::InvalidBlendSrcIndex {
                             location,
-                            index: blend_src_index,
+                            blend_src,
                         });
                     }
-
-                    self.blend_src = blend_src_index;
-
-                    let mask = if blend_src_index == 0 {
-                        &mut self.location_mask0
-                        // TODO: report blend src index
-                    } else {
-                        &mut self.location_mask1
-                    };
-                    if !mask.insert(location as usize) {
-                        if self.flags.contains(super::ValidationFlags::BINDINGS) {
-                            return Err(VaryingError::BindingCollision { location });
-                        }
+                    if !self.blend_src_mask.insert(blend_src as usize) {
+                        return Err(VaryingError::BindingCollisionBlendSrc { blend_src });
                     }
                 } else {
-                    if !self.location_mask0.insert(location as usize) {
+                    if !self.location_mask.insert(location as usize) {
                         if self.flags.contains(super::ValidationFlags::BINDINGS) {
                             return Err(VaryingError::BindingCollision { location });
                         }
@@ -462,6 +445,15 @@ impl VaryingContext<'_> {
                                     .validate_impl(ep, member.ty, binding)
                                     .map_err(|e| e.with_span_context(span_context))?,
                             }
+                        }
+
+                        // If there's any blend_src usage, it must apply to all members of which there must be exactly 2.
+                        if !self.blend_src_mask.is_empty()
+                            && (members.len() != 2 || self.blend_src_mask.len() != 2)
+                        {
+                            let span_context = self.types.get_span_context(ty);
+                            return Err(VaryingError::IncompleteBlendSrcUsage
+                                .with_span_context(span_context));
                         }
                     }
                     _ => {
@@ -665,7 +657,7 @@ impl super::Validator {
             return Err(EntryPointError::UnexpectedWorkgroupSize.with_span());
         }
 
-        let mut info = self
+        let info = self
             .validate_function(&ep.function, module, mod_info, true, global_expr_kind)
             .map_err(WithSpan::into_other)?;
 
@@ -683,8 +675,7 @@ impl super::Validator {
             }
         }
 
-        self.location_mask0.clear();
-        self.location_mask1.clear();
+        self.location_mask.clear();
         let mut argument_built_ins = crate::FastHashSet::default();
         // TODO: add span info to function arguments
         for (index, fa) in ep.function.arguments.iter().enumerate() {
@@ -693,9 +684,8 @@ impl super::Validator {
                 output: false,
                 types: &module.types,
                 type_info: &self.types,
-                location_mask0: &mut self.location_mask0,
-                location_mask1: &mut self.location_mask1,
-                blend_src: self.blend_src_index,
+                location_mask: &mut self.location_mask,
+                blend_src_mask: &mut self.blend_src_mask,
                 built_ins: &mut argument_built_ins,
                 capabilities: self.capabilities,
                 flags: self.flags,
@@ -704,8 +694,7 @@ impl super::Validator {
                 .map_err_inner(|e| EntryPointError::Argument(index as u32, e).with_span())?;
         }
 
-        self.location_mask0.clear();
-        self.location_mask1.clear();
+        self.location_mask.clear();
         if let Some(ref fr) = ep.function.result {
             let mut result_built_ins = crate::FastHashSet::default();
             let mut ctx = VaryingContext {
@@ -713,9 +702,8 @@ impl super::Validator {
                 output: true,
                 types: &module.types,
                 type_info: &self.types,
-                location_mask0: &mut self.location_mask0,
-                location_mask1: &mut self.location_mask1,
-                blend_src: self.blend_src_index,
+                location_mask: &mut self.location_mask,
+                blend_src_mask: &mut self.blend_src_mask,
                 built_ins: &mut result_built_ins,
                 capabilities: self.capabilities,
                 flags: self.flags,

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -81,6 +81,11 @@ pub enum VaryingError {
     InvalidBlendSrcIndex { location: u32, blend_src: u32 },
     #[error("If blend_src is used, there must be exactly two outputs both with location 0, one with blend_src(0) and the other with blend_src(1).")]
     IncompleteBlendSrcUsage,
+    #[error("If blend_src is used, both outputs must have the same type. blend_src(0) has type {blend_src_0_type:?} and blend_src(1) has type {blend_src_1_type:?}.")]
+    BlendSrcOutputTypeMismatch {
+        blend_src_0_type: Handle<crate::Type>,
+        blend_src_1_type: Handle<crate::Type>,
+    },
     #[error("Workgroup size is multi dimensional, @builtin(subgroup_id) and @builtin(subgroup_invocation_id) are not supported.")]
     InvalidMultiDimensionalSubgroupBuiltIn,
 }
@@ -447,13 +452,22 @@ impl VaryingContext<'_> {
                             }
                         }
 
-                        // If there's any blend_src usage, it must apply to all members of which there must be exactly 2.
-                        if !self.blend_src_mask.is_empty()
-                            && (members.len() != 2 || self.blend_src_mask.len() != 2)
-                        {
+                        if !self.blend_src_mask.is_empty() {
                             let span_context = self.types.get_span_context(ty);
-                            return Err(VaryingError::IncompleteBlendSrcUsage
+
+                            // If there's any blend_src usage, it must apply to all members of which there must be exactly 2.
+                            if members.len() != 2 || self.blend_src_mask.len() != 2 {
+                                return Err(VaryingError::IncompleteBlendSrcUsage
+                                    .with_span_context(span_context));
+                            }
+                            // Also, all members must have the same type.
+                            if members[0].ty != members[1].ty {
+                                return Err(VaryingError::BlendSrcOutputTypeMismatch {
+                                    blend_src_0_type: members[0].ty,
+                                    blend_src_1_type: members[1].ty,
+                                }
                                 .with_span_context(span_context));
+                            }
                         }
                     }
                     _ => {

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -76,12 +76,9 @@ pub enum VaryingError {
     #[error("The attribute {0:?} is not valid for stage {1:?}")]
     InvalidAttributeInStage(&'static str, crate::ShaderStage),
     #[error(
-        "The location index {location} cannot be used together with the attribute {attribute:?}"
+        "The location index {location} uses a blend source index of {index} other than 0 or 1."
     )]
-    InvalidLocationAttributeCombination {
-        location: u32,
-        attribute: &'static str,
-    },
+    InvalidBlendSrcIndex { location: u32, index: u32 },
     #[error("Workgroup size is multi dimensional, @builtin(subgroup_id) and @builtin(subgroup_invocation_id) are not supported.")]
     InvalidMultiDimensionalSubgroupBuiltIn,
 }
@@ -116,9 +113,9 @@ pub enum EntryPointError {
     #[error(transparent)]
     Function(#[from] FunctionError),
     #[error(
-        "Invalid locations {location_mask:?} are set while dual source blending. Only location 0 may be set."
+        "Invalid locations `blend_src` index set {index:?}. Only index 0 and, if dual source blending is enabled, 1 may be set."
     )]
-    InvalidLocationsWhileDualSourceBlending { location_mask: BitSet },
+    InvalidBlendSrcIndex { index: u32 },
 }
 
 fn storage_usage(access: crate::StorageAccess) -> GlobalUse {
@@ -138,10 +135,11 @@ fn storage_usage(access: crate::StorageAccess) -> GlobalUse {
 struct VaryingContext<'a> {
     stage: crate::ShaderStage,
     output: bool,
-    second_blend_source: bool,
     types: &'a UniqueArena<crate::Type>,
     type_info: &'a Vec<super::r#type::TypeInfo>,
-    location_mask: &'a mut BitSet,
+    location_mask0: &'a mut BitSet,
+    location_mask1: &'a mut BitSet,
+    blend_src: u32, // 0 if not set.
     built_ins: &'a mut crate::FastHashSet<crate::BuiltIn>,
     capabilities: Capabilities,
     flags: super::ValidationFlags,
@@ -306,7 +304,7 @@ impl VaryingContext<'_> {
                 location,
                 interpolation,
                 sampling,
-                second_blend_source,
+                blend_src,
             } => {
                 // Only IO-shareable types may be stored in locations.
                 if !self.type_info[ty.index()]
@@ -316,7 +314,13 @@ impl VaryingContext<'_> {
                     return Err(VaryingError::NotIOShareableType(ty));
                 }
 
-                if second_blend_source {
+                // `blend_src` is only valid if dual source blending was explicitly enabled,
+                // see https://www.w3.org/TR/WGSL/#extension-dual_source_blending
+                if let Some(blend_src_index) = blend_src {
+                    // TODO: check that dual source blending feature was enabled in the shader.
+                    // TODO: If ANY location uses blend_src, all of them have to.
+                    // TODO: all locations must have the same data type
+
                     if !self
                         .capabilities
                         .contains(Capabilities::DUAL_SOURCE_BLENDING)
@@ -327,27 +331,41 @@ impl VaryingContext<'_> {
                     }
                     if self.stage != crate::ShaderStage::Fragment {
                         return Err(VaryingError::InvalidAttributeInStage(
-                            "second_blend_source",
+                            "blend_src",
                             self.stage,
                         ));
                     }
                     if !self.output {
                         return Err(VaryingError::InvalidInputAttributeInStage(
-                            "second_blend_source",
+                            "blend_src",
                             self.stage,
                         ));
                     }
-                    if location != 0 {
-                        return Err(VaryingError::InvalidLocationAttributeCombination {
+                    if blend_src_index != 0 && blend_src_index != 1 {
+                        return Err(VaryingError::InvalidBlendSrcIndex {
                             location,
-                            attribute: "second_blend_source",
+                            index: blend_src_index,
                         });
                     }
 
-                    self.second_blend_source = true;
-                } else if !self.location_mask.insert(location as usize) {
-                    if self.flags.contains(super::ValidationFlags::BINDINGS) {
-                        return Err(VaryingError::BindingCollision { location });
+                    self.blend_src = blend_src_index;
+
+                    let mask = if blend_src_index == 0 {
+                        &mut self.location_mask0
+                        // TODO: report blend src index
+                    } else {
+                        &mut self.location_mask1
+                    };
+                    if !mask.insert(location as usize) {
+                        if self.flags.contains(super::ValidationFlags::BINDINGS) {
+                            return Err(VaryingError::BindingCollision { location });
+                        }
+                    }
+                } else {
+                    if !self.location_mask0.insert(location as usize) {
+                        if self.flags.contains(super::ValidationFlags::BINDINGS) {
+                            return Err(VaryingError::BindingCollision { location });
+                        }
                     }
                 }
 
@@ -665,17 +683,19 @@ impl super::Validator {
             }
         }
 
-        self.location_mask.clear();
+        self.location_mask0.clear();
+        self.location_mask1.clear();
         let mut argument_built_ins = crate::FastHashSet::default();
         // TODO: add span info to function arguments
         for (index, fa) in ep.function.arguments.iter().enumerate() {
             let mut ctx = VaryingContext {
                 stage: ep.stage,
                 output: false,
-                second_blend_source: false,
                 types: &module.types,
                 type_info: &self.types,
-                location_mask: &mut self.location_mask,
+                location_mask0: &mut self.location_mask0,
+                location_mask1: &mut self.location_mask1,
+                blend_src: self.blend_src_index,
                 built_ins: &mut argument_built_ins,
                 capabilities: self.capabilities,
                 flags: self.flags,
@@ -684,34 +704,24 @@ impl super::Validator {
                 .map_err_inner(|e| EntryPointError::Argument(index as u32, e).with_span())?;
         }
 
-        self.location_mask.clear();
+        self.location_mask0.clear();
+        self.location_mask1.clear();
         if let Some(ref fr) = ep.function.result {
             let mut result_built_ins = crate::FastHashSet::default();
             let mut ctx = VaryingContext {
                 stage: ep.stage,
                 output: true,
-                second_blend_source: false,
                 types: &module.types,
                 type_info: &self.types,
-                location_mask: &mut self.location_mask,
+                location_mask0: &mut self.location_mask0,
+                location_mask1: &mut self.location_mask1,
+                blend_src: self.blend_src_index,
                 built_ins: &mut result_built_ins,
                 capabilities: self.capabilities,
                 flags: self.flags,
             };
             ctx.validate(ep, fr.ty, fr.binding.as_ref())
                 .map_err_inner(|e| EntryPointError::Result(e).with_span())?;
-            if ctx.second_blend_source {
-                // Only the first location may be used when dual source blending
-                if ctx.location_mask.len() == 1 && ctx.location_mask.contains(0) {
-                    info.dual_source_blending = true;
-                } else {
-                    return Err(EntryPointError::InvalidLocationsWhileDualSourceBlending {
-                        location_mask: self.location_mask.clone(),
-                    }
-                    .with_span());
-                }
-            }
-
             if ep.stage == crate::ShaderStage::Vertex
                 && !result_built_ins.contains(&crate::BuiltIn::Position { invariant: false })
             {

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -267,15 +267,8 @@ pub struct Validator {
     subgroup_operations: SubgroupOperationSet,
     types: Vec<r#type::TypeInfo>,
     layouter: Layouter,
-
-    /// Location mask for blend_src 0 or no blend_src specified.
-    location_mask0: BitSet,
-    /// Location mask for blend_src 1.
-    location_mask1: BitSet,
-
-    /// Index of the blend_src attribute, or 0 if no blend_src is specified.
-    blend_src_index: u32,
-
+    location_mask: BitSet,
+    blend_src_mask: BitSet,
     ep_resource_bindings: FastHashSet<crate::ResourceBinding>,
     #[allow(dead_code)]
     switch_values: FastHashSet<crate::SwitchValue>,
@@ -467,9 +460,8 @@ impl Validator {
             subgroup_operations,
             types: Vec::new(),
             layouter: Layouter::default(),
-            location_mask0: BitSet::new(),
-            location_mask1: BitSet::new(),
-            blend_src_index: 0,
+            location_mask: BitSet::new(),
+            blend_src_mask: BitSet::new(),
             ep_resource_bindings: FastHashSet::default(),
             switch_values: FastHashSet::default(),
             valid_expression_list: Vec::new(),
@@ -494,8 +486,8 @@ impl Validator {
     pub fn reset(&mut self) {
         self.types.clear();
         self.layouter.clear();
-        self.location_mask0.clear();
-        self.location_mask1.clear();
+        self.location_mask.clear();
+        self.blend_src_mask.clear();
         self.ep_resource_bindings.clear();
         self.switch_values.clear();
         self.valid_expression_list.clear();

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -267,7 +267,15 @@ pub struct Validator {
     subgroup_operations: SubgroupOperationSet,
     types: Vec<r#type::TypeInfo>,
     layouter: Layouter,
-    location_mask: BitSet,
+
+    /// Location mask for blend_src 0 or no blend_src specified.
+    location_mask0: BitSet,
+    /// Location mask for blend_src 1.
+    location_mask1: BitSet,
+
+    /// Index of the blend_src attribute, or 0 if no blend_src is specified.
+    blend_src_index: u32,
+
     ep_resource_bindings: FastHashSet<crate::ResourceBinding>,
     #[allow(dead_code)]
     switch_values: FastHashSet<crate::SwitchValue>,
@@ -459,7 +467,9 @@ impl Validator {
             subgroup_operations,
             types: Vec::new(),
             layouter: Layouter::default(),
-            location_mask: BitSet::new(),
+            location_mask0: BitSet::new(),
+            location_mask1: BitSet::new(),
+            blend_src_index: 0,
             ep_resource_bindings: FastHashSet::default(),
             switch_values: FastHashSet::default(),
             valid_expression_list: Vec::new(),
@@ -484,7 +494,8 @@ impl Validator {
     pub fn reset(&mut self) {
         self.types.clear();
         self.layouter.clear();
-        self.location_mask.clear();
+        self.location_mask0.clear();
+        self.location_mask1.clear();
         self.ep_resource_bindings.clear();
         self.switch_values.clear();
         self.valid_expression_list.clear();

--- a/naga/tests/in/dualsource.wgsl
+++ b/naga/tests/in/dualsource.wgsl
@@ -1,11 +1,11 @@
-/* Simple test for multiple output sources from fragment shaders */
-struct FragmentOutput{
-    @location(0) color: vec4<f32>,
-    @location(0) @second_blend_source mask: vec4<f32>,
+enable dual_source_blending;
+
+struct FragmentOutput {
+    @location(0) @blend_src(0) output0: vec4<f32>,
+    @location(0) @blend_src(1) output1: vec4<f32>,
 }
+
 @fragment
-fn main(@builtin(position) position: vec4<f32>) -> FragmentOutput {
-    var color = vec4(0.4,0.3,0.2,0.1);
-    var mask = vec4(0.9,0.8,0.7,0.6);
-    return FragmentOutput(color, mask);
+fn main() -> FragmentOutput {
+    return FragmentOutput(vec4(0.4,0.3,0.2,0.1), vec4(0.9,0.8,0.7,0.6));
 }

--- a/naga/tests/out/glsl/dualsource.main.Fragment.glsl
+++ b/naga/tests/out/glsl/dualsource.main.Fragment.glsl
@@ -5,21 +5,16 @@ precision highp float;
 precision highp int;
 
 struct FragmentOutput {
-    vec4 color;
-    vec4 mask;
+    vec4 output0_;
+    vec4 output1_;
 };
-layout(location = 0) out vec4 _fs2p_location0;
+layout(location = 0, index = 0) out vec4 _fs2p_location0;
 layout(location = 0, index = 1) out vec4 _fs2p_location1;
 
 void main() {
-    vec4 position = gl_FragCoord;
-    vec4 color = vec4(0.4, 0.3, 0.2, 0.1);
-    vec4 mask = vec4(0.9, 0.8, 0.7, 0.6);
-    vec4 _e13 = color;
-    vec4 _e14 = mask;
-    FragmentOutput _tmp_return = FragmentOutput(_e13, _e14);
-    _fs2p_location0 = _tmp_return.color;
-    _fs2p_location1 = _tmp_return.mask;
+    FragmentOutput _tmp_return = FragmentOutput(vec4(0.4, 0.3, 0.2, 0.1), vec4(0.9, 0.8, 0.7, 0.6));
+    _fs2p_location0 = _tmp_return.output0_;
+    _fs2p_location1 = _tmp_return.output1_;
     return;
 }
 

--- a/naga/tests/out/hlsl/dualsource.hlsl
+++ b/naga/tests/out/hlsl/dualsource.hlsl
@@ -1,27 +1,17 @@
 struct FragmentOutput {
-    float4 color : SV_Target0;
-    float4 mask : SV_Target1;
-};
-
-struct FragmentInput_main {
-    float4 position_1 : SV_Position;
+    float4 output0_ : SV_Target0;
+    float4 output1_ : SV_Target1;
 };
 
 FragmentOutput ConstructFragmentOutput(float4 arg0, float4 arg1) {
     FragmentOutput ret = (FragmentOutput)0;
-    ret.color = arg0;
-    ret.mask = arg1;
+    ret.output0_ = arg0;
+    ret.output1_ = arg1;
     return ret;
 }
 
-FragmentOutput main(FragmentInput_main fragmentinput_main)
+FragmentOutput main()
 {
-    float4 position = fragmentinput_main.position_1;
-    float4 color = float4(0.4, 0.3, 0.2, 0.1);
-    float4 mask = float4(0.9, 0.8, 0.7, 0.6);
-
-    float4 _e13 = color;
-    float4 _e14 = mask;
-    const FragmentOutput fragmentoutput = ConstructFragmentOutput(_e13, _e14);
+    const FragmentOutput fragmentoutput = ConstructFragmentOutput(float4(0.4, 0.3, 0.2, 0.1), float4(0.9, 0.8, 0.7, 0.6));
     return fragmentoutput;
 }

--- a/naga/tests/out/ir/access.compact.ron
+++ b/naga/tests/out/ir/access.compact.ron
@@ -2523,9 +2523,9 @@
                     ty: 24,
                     binding: Some(Location(
                         location: 0,
-                        second_blend_source: false,
                         interpolation: Some(Perspective),
                         sampling: Some(Center),
+                        blend_src: None,
                     )),
                 )),
                 local_variables: [],

--- a/naga/tests/out/ir/access.ron
+++ b/naga/tests/out/ir/access.ron
@@ -2523,9 +2523,9 @@
                     ty: 24,
                     binding: Some(Location(
                         location: 0,
-                        second_blend_source: false,
                         interpolation: Some(Perspective),
                         sampling: Some(Center),
+                        blend_src: None,
                     )),
                 )),
                 local_variables: [],

--- a/naga/tests/out/ir/shadow.compact.ron
+++ b/naga/tests/out/ir/shadow.compact.ron
@@ -967,9 +967,9 @@
                         ty: 1,
                         binding: Some(Location(
                             location: 0,
-                            second_blend_source: false,
                             interpolation: Some(Perspective),
                             sampling: Some(Center),
+                            blend_src: None,
                         )),
                     ),
                     (
@@ -977,9 +977,9 @@
                         ty: 3,
                         binding: Some(Location(
                             location: 1,
-                            second_blend_source: false,
                             interpolation: Some(Perspective),
                             sampling: Some(Center),
+                            blend_src: None,
                         )),
                     ),
                 ],
@@ -987,9 +987,9 @@
                     ty: 3,
                     binding: Some(Location(
                         location: 0,
-                        second_blend_source: false,
                         interpolation: None,
                         sampling: None,
+                        blend_src: None,
                     )),
                 )),
                 local_variables: [],

--- a/naga/tests/out/ir/shadow.ron
+++ b/naga/tests/out/ir/shadow.ron
@@ -1245,9 +1245,9 @@
                         ty: 1,
                         binding: Some(Location(
                             location: 0,
-                            second_blend_source: false,
                             interpolation: Some(Perspective),
                             sampling: Some(Center),
+                            blend_src: None,
                         )),
                     ),
                     (
@@ -1255,9 +1255,9 @@
                         ty: 3,
                         binding: Some(Location(
                             location: 1,
-                            second_blend_source: false,
                             interpolation: Some(Perspective),
                             sampling: Some(Center),
+                            blend_src: None,
                         )),
                     ),
                 ],
@@ -1265,9 +1265,9 @@
                     ty: 3,
                     binding: Some(Location(
                         location: 0,
-                        second_blend_source: false,
                         interpolation: None,
                         sampling: None,
+                        blend_src: None,
                     )),
                 )),
                 local_variables: [],

--- a/naga/tests/out/ir/spec-constants.compact.ron
+++ b/naga/tests/out/ir/spec-constants.compact.ron
@@ -148,9 +148,9 @@
                         ty: 2,
                         binding: Some(Location(
                             location: 0,
-                            second_blend_source: false,
                             interpolation: Some(Perspective),
                             sampling: Some(Center),
+                            blend_src: None,
                         )),
                         offset: 0,
                     ),
@@ -504,9 +504,9 @@
                         ty: 2,
                         binding: Some(Location(
                             location: 2,
-                            second_blend_source: false,
                             interpolation: None,
                             sampling: None,
+                            blend_src: None,
                         )),
                     ),
                     (
@@ -514,9 +514,9 @@
                         ty: 3,
                         binding: Some(Location(
                             location: 0,
-                            second_blend_source: false,
                             interpolation: None,
                             sampling: None,
+                            blend_src: None,
                         )),
                     ),
                     (
@@ -524,9 +524,9 @@
                         ty: 3,
                         binding: Some(Location(
                             location: 1,
-                            second_blend_source: false,
                             interpolation: None,
                             sampling: None,
+                            blend_src: None,
                         )),
                     ),
                 ],

--- a/naga/tests/out/ir/spec-constants.ron
+++ b/naga/tests/out/ir/spec-constants.ron
@@ -239,9 +239,9 @@
                         ty: 3,
                         binding: Some(Location(
                             location: 0,
-                            second_blend_source: false,
                             interpolation: Some(Perspective),
                             sampling: Some(Center),
+                            blend_src: None,
                         )),
                         offset: 0,
                     ),
@@ -610,9 +610,9 @@
                         ty: 3,
                         binding: Some(Location(
                             location: 2,
-                            second_blend_source: false,
                             interpolation: None,
                             sampling: None,
+                            blend_src: None,
                         )),
                     ),
                     (
@@ -620,9 +620,9 @@
                         ty: 5,
                         binding: Some(Location(
                             location: 0,
-                            second_blend_source: false,
                             interpolation: None,
                             sampling: None,
+                            blend_src: None,
                         )),
                     ),
                     (
@@ -630,9 +630,9 @@
                         ty: 5,
                         binding: Some(Location(
                             location: 1,
-                            second_blend_source: false,
                             interpolation: None,
                             sampling: None,
+                            blend_src: None,
                         )),
                     ),
                 ],

--- a/naga/tests/out/msl/dualsource.msl
+++ b/naga/tests/out/msl/dualsource.msl
@@ -5,23 +5,16 @@
 using metal::uint;
 
 struct FragmentOutput {
-    metal::float4 color;
-    metal::float4 mask;
+    metal::float4 output0_;
+    metal::float4 output1_;
 };
 
-struct main_Input {
-};
 struct main_Output {
-    metal::float4 color [[color(0)]];
-    metal::float4 mask [[color(0) index(1)]];
+    metal::float4 output0_ [[color(0) index(0)]];
+    metal::float4 output1_ [[color(0) index(1)]];
 };
 fragment main_Output main_(
-  metal::float4 position [[position]]
 ) {
-    metal::float4 color = metal::float4(0.4, 0.3, 0.2, 0.1);
-    metal::float4 mask = metal::float4(0.9, 0.8, 0.7, 0.6);
-    metal::float4 _e13 = color;
-    metal::float4 _e14 = mask;
-    const auto _tmp = FragmentOutput {_e13, _e14};
-    return main_Output { _tmp.color, _tmp.mask };
+    const auto _tmp = FragmentOutput {metal::float4(0.4, 0.3, 0.2, 0.1), metal::float4(0.9, 0.8, 0.7, 0.6)};
+    return main_Output { _tmp.output0_, _tmp.output1_ };
 }

--- a/naga/tests/out/spv/dualsource.spvasm
+++ b/naga/tests/out/spv/dualsource.spvasm
@@ -1,52 +1,44 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 34
+; Bound: 26
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %13 "main" %7 %10 %12
-OpExecutionMode %13 OriginUpperLeft
+OpEntryPoint Fragment %10 "main" %7 %9
+OpExecutionMode %10 OriginUpperLeft
 OpMemberDecorate %5 0 Offset 0
 OpMemberDecorate %5 1 Offset 16
-OpDecorate %7 BuiltIn FragCoord
-OpDecorate %10 Location 0
-OpDecorate %12 Location 0
-OpDecorate %12 Index 1
+OpDecorate %7 Location 0
+OpDecorate %7 Index 0
+OpDecorate %9 Location 0
+OpDecorate %9 Index 1
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpTypeVector %4 4
 %5 = OpTypeStruct %3 %3
-%8 = OpTypePointer Input %3
-%7 = OpVariable  %8  Input
-%11 = OpTypePointer Output %3
-%10 = OpVariable  %11  Output
-%12 = OpVariable  %11  Output
-%14 = OpTypeFunction %2
-%15 = OpConstant  %4  0.4
-%16 = OpConstant  %4  0.3
-%17 = OpConstant  %4  0.2
-%18 = OpConstant  %4  0.1
-%19 = OpConstantComposite  %3  %15 %16 %17 %18
-%20 = OpConstant  %4  0.9
-%21 = OpConstant  %4  0.8
-%22 = OpConstant  %4  0.7
-%23 = OpConstant  %4  0.6
-%24 = OpConstantComposite  %3  %20 %21 %22 %23
-%26 = OpTypePointer Function %3
-%13 = OpFunction  %2  None %14
+%8 = OpTypePointer Output %3
+%7 = OpVariable  %8  Output
+%9 = OpVariable  %8  Output
+%11 = OpTypeFunction %2
+%12 = OpConstant  %4  0.4
+%13 = OpConstant  %4  0.3
+%14 = OpConstant  %4  0.2
+%15 = OpConstant  %4  0.1
+%16 = OpConstantComposite  %3  %12 %13 %14 %15
+%17 = OpConstant  %4  0.9
+%18 = OpConstant  %4  0.8
+%19 = OpConstant  %4  0.7
+%20 = OpConstant  %4  0.6
+%21 = OpConstantComposite  %3  %17 %18 %19 %20
+%22 = OpConstantComposite  %5  %16 %21
+%10 = OpFunction  %2  None %11
 %6 = OpLabel
-%25 = OpVariable  %26  Function %19
-%27 = OpVariable  %26  Function %24
-%9 = OpLoad  %3  %7
-OpBranch %28
-%28 = OpLabel
-%29 = OpLoad  %3  %25
-%30 = OpLoad  %3  %27
-%31 = OpCompositeConstruct  %5  %29 %30
-%32 = OpCompositeExtract  %3  %31 0
-OpStore %10 %32
-%33 = OpCompositeExtract  %3  %31 1
-OpStore %12 %33
+OpBranch %23
+%23 = OpLabel
+%24 = OpCompositeExtract  %3  %22 0
+OpStore %7 %24
+%25 = OpCompositeExtract  %3  %22 1
+OpStore %9 %25
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/dualsource.wgsl
+++ b/naga/tests/out/wgsl/dualsource.wgsl
@@ -1,14 +1,9 @@
 struct FragmentOutput {
-    @location(0) color: vec4<f32>,
-    @location(0) @second_blend_source mask: vec4<f32>,
+    @location(0) @blend_src(0) output0_: vec4<f32>,
+    @location(0) @blend_src(1) output1_: vec4<f32>,
 }
 
 @fragment 
-fn main(@builtin(position) position: vec4<f32>) -> FragmentOutput {
-    var color: vec4<f32> = vec4<f32>(0.4f, 0.3f, 0.2f, 0.1f);
-    var mask: vec4<f32> = vec4<f32>(0.9f, 0.8f, 0.7f, 0.6f);
-
-    let _e13 = color;
-    let _e14 = mask;
-    return FragmentOutput(_e13, _e14);
+fn main() -> FragmentOutput {
+    return FragmentOutput(vec4<f32>(0.4f, 0.3f, 0.2f, 0.1f), vec4<f32>(0.9f, 0.8f, 0.7f, 0.6f));
 }

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -3,6 +3,8 @@ Tests for the WGSL front end.
 */
 #![cfg(feature = "wgsl-in")]
 
+use naga::valid::Capabilities;
+
 fn check(input: &str, snapshot: &str) {
     let output = naga::front::wgsl::parse_str(input)
         .expect_err("expected parser error")
@@ -1317,6 +1319,210 @@ fn missing_bindings2() {
             ..
         })
     }
+}
+
+#[test]
+fn invalid_blend_src() {
+    // Missing capability.
+    check_validation! {
+        "
+        enable dual_source_blending;
+        struct FragmentOutput {
+            @location(0) @blend_src(0) output0: vec4<f32>,
+            @location(0) @blend_src(1) output1: vec4<f32>,
+        }
+        @fragment
+        fn main() -> FragmentOutput { return FragmentOutput(vec4(0.0), vec4(1.0)); }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Fragment,
+                source: naga::valid::EntryPointError::Result(
+                    naga::valid::VaryingError::UnsupportedCapability(Capabilities::DUAL_SOURCE_BLENDING),
+                ),
+                ..
+            },
+        )
+    }
+
+    // Using blend_src on an input.
+    check_validation! {
+        "
+        enable dual_source_blending;
+        @fragment
+        fn main(@location(0) @blend_src(0) input: f32) -> vec4f { return vec4f(0.0); }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Fragment,
+                source: naga::valid::EntryPointError::Argument(
+                    0,
+                    naga::valid::VaryingError::InvalidInputAttributeInStage("blend_src", naga::ShaderStage::Fragment),
+                ),
+                ..
+            },
+        ),
+        Capabilities::DUAL_SOURCE_BLENDING
+    }
+
+    // Using blend_src as output on something that isn't a fragment shader.
+    check_validation! {
+        "
+        enable dual_source_blending;
+        struct VertexOutput {
+            @location(0) @blend_src(0) output0: vec4<f32>,
+            @location(0) @blend_src(1) output1: vec4<f32>,
+        }
+        @vertex
+        fn main() -> VertexOutput { return VertexOutput(vec4(0.0), vec4(1.0)); }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Vertex,
+                source: naga::valid::EntryPointError::Result(
+                    naga::valid::VaryingError::InvalidAttributeInStage("blend_src", naga::ShaderStage::Vertex),
+                ),
+                ..
+            },
+        ),
+        Capabilities::DUAL_SOURCE_BLENDING
+    }
+
+    // Invalid blend_src index.
+    check_validation! {
+        "
+        enable dual_source_blending;
+        struct FragmentOutput {
+            @location(0) @blend_src(0) output0: vec4<f32>,
+            @location(0) @blend_src(2) output1: vec4<f32>,
+        }
+        @fragment
+        fn main() -> FragmentOutput { return FragmentOutput(vec4(0.0), vec4(1.0)); }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Fragment,
+                source: naga::valid::EntryPointError::Result(
+                    naga::valid::VaryingError::InvalidBlendSrcIndex { location: 0, blend_src: 2 },
+                ),
+                ..
+            },
+        ),
+        Capabilities::DUAL_SOURCE_BLENDING
+    }
+
+    // Using a location other than 1 on blend_src
+    check_validation! {
+        "
+        enable dual_source_blending;
+        struct FragmentOutput {
+            @location(0) @blend_src(0) output0: vec4<f32>,
+            @location(1) @blend_src(1) output1: vec4<f32>,
+        }
+        @fragment
+        fn main() -> FragmentOutput { return FragmentOutput(vec4(0.0), vec4(1.0)); }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Fragment,
+                source: naga::valid::EntryPointError::Result(
+                    naga::valid::VaryingError::InvalidBlendSrcIndex { location: 1, blend_src: 1 },
+                ),
+                ..
+            },
+        ),
+        Capabilities::DUAL_SOURCE_BLENDING
+    }
+
+    // Using same blend_src several times.
+    check_validation! {
+        "
+        enable dual_source_blending;
+        struct FragmentOutput {
+            @location(0) @blend_src(1) output0: vec4<f32>,
+            @location(0) @blend_src(1) output1: vec4<f32>,
+        }
+        @fragment
+        fn main() -> FragmentOutput { return FragmentOutput(vec4(0.0), vec4(1.0)); }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Fragment,
+                source: naga::valid::EntryPointError::Result(
+                    naga::valid::VaryingError::BindingCollisionBlendSrc { blend_src: 1 },
+                ),
+                ..
+            },
+        ),
+        Capabilities::DUAL_SOURCE_BLENDING
+    }
+
+    // Two attributes, only one has blend_src
+    check_validation! {
+        "
+        enable dual_source_blending;
+        struct FragmentOutput {
+            @location(0) @blend_src(0) output0: vec4<f32>,
+            @location(1) output1: vec4<f32>,
+        }
+        @fragment
+        fn main() -> FragmentOutput { return FragmentOutput(vec4(0.0), vec4(1.0)); }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Fragment,
+                source: naga::valid::EntryPointError::Result(
+                    naga::valid::VaryingError::IncompleteBlendSrcUsage,
+                ),
+                ..
+            },
+        ),
+        Capabilities::DUAL_SOURCE_BLENDING
+    }
+
+    // Single attribute using blend_src.
+    check_validation! {
+        "
+            enable dual_source_blending;
+            struct FragmentOutput {
+                @location(0) @blend_src(0) output0: vec4<f32>,
+            }
+            @fragment
+            fn main() -> FragmentOutput { return FragmentOutput(vec4(0.0)); }
+            ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Fragment,
+                source: naga::valid::EntryPointError::Result(
+                    naga::valid::VaryingError::IncompleteBlendSrcUsage,
+                ),
+                ..
+            },
+        ),
+        Capabilities::DUAL_SOURCE_BLENDING
+    }
+
+    // TODO:
+    // Missing enable directive.
+    // check_validation! {
+    //     "
+    //     struct FragmentOutput {
+    //         @location(0) @blend_src(0) output0: vec4<f32>,
+    //         @location(0) @blend_src(1) output1: vec4<f32>,
+    //     }
+    //     @fragment
+    //     fn main(@builtin(position) position: vec4<f32>) -> FragmentOutput {
+    //         return FragmentOutput(vec4(0.0), vec4(0.0));
+    //     }
+    //     ":
+    //     Err(naga::valid::ValidationError::Function {
+    //         source: naga::valid::FunctionError::Expression {
+    //             source: naga::valid::ExpressionError::IndexOutOfBounds(_, _),
+    //             ..
+    //         },
+    //         ..
+    //     })
+    // }
 }
 
 #[test]

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -1345,6 +1345,21 @@ fn invalid_blend_src() {
         )
     }
 
+    // Missing enable directive.
+    // TODO:
+    // check_validation! {
+    //     "
+    //     struct FragmentOutput {
+    //         @location(0) @blend_src(0) output0: vec4<f32>,
+    //         @location(0) @blend_src(1) output1: vec4<f32>,
+    //     }
+    //     @fragment
+    //     fn main(@builtin(position) position: vec4<f32>) -> FragmentOutput { return FragmentOutput(vec4(0.0), vec4(0.0)); }
+    //     ":
+    //     Err(???),
+    //     Capabilities::DUAL_SOURCE_BLENDING
+    // }
+
     // Using blend_src on an input.
     check_validation! {
         "
@@ -1502,27 +1517,28 @@ fn invalid_blend_src() {
         Capabilities::DUAL_SOURCE_BLENDING
     }
 
-    // TODO:
-    // Missing enable directive.
-    // check_validation! {
-    //     "
-    //     struct FragmentOutput {
-    //         @location(0) @blend_src(0) output0: vec4<f32>,
-    //         @location(0) @blend_src(1) output1: vec4<f32>,
-    //     }
-    //     @fragment
-    //     fn main(@builtin(position) position: vec4<f32>) -> FragmentOutput {
-    //         return FragmentOutput(vec4(0.0), vec4(0.0));
-    //     }
-    //     ":
-    //     Err(naga::valid::ValidationError::Function {
-    //         source: naga::valid::FunctionError::Expression {
-    //             source: naga::valid::ExpressionError::IndexOutOfBounds(_, _),
-    //             ..
-    //         },
-    //         ..
-    //     })
-    // }
+    // Mixed output types.
+    check_validation! {
+        "
+            enable dual_source_blending;
+            struct FragmentOutput {
+                @location(0) @blend_src(0) output0: vec4<f32>,
+                @location(0) @blend_src(1) output1: f32,
+            }
+            @fragment
+            fn main() -> FragmentOutput { return FragmentOutput(vec4(0.0), 1.0); }
+            ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Fragment,
+                source: naga::valid::EntryPointError::Result(
+                    naga::valid::VaryingError::BlendSrcOutputTypeMismatch { blend_src_0_type: _, blend_src_1_type: _ },
+                ),
+                ..
+            },
+        ),
+        Capabilities::DUAL_SOURCE_BLENDING
+    }
 }
 
 #[test]

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3350,17 +3350,16 @@ impl Device {
             None => None,
         };
 
-        // TODO: re-enable
-        // if !pipeline_expects_dual_source_blending && shader_expects_dual_source_blending {
-        //     return Err(
-        //         pipeline::CreateRenderPipelineError::ShaderExpectsPipelineToUseDualSourceBlending,
-        //     );
-        // }
-        // if pipeline_expects_dual_source_blending && !shader_expects_dual_source_blending {
-        //     return Err(
-        //         pipeline::CreateRenderPipelineError::PipelineExpectsShaderToUseDualSourceBlending,
-        //     );
-        // }
+        if !pipeline_expects_dual_source_blending && shader_expects_dual_source_blending {
+            return Err(
+                pipeline::CreateRenderPipelineError::ShaderExpectsPipelineToUseDualSourceBlending,
+            );
+        }
+        if pipeline_expects_dual_source_blending && !shader_expects_dual_source_blending {
+            return Err(
+                pipeline::CreateRenderPipelineError::PipelineExpectsShaderToUseDualSourceBlending,
+            );
+        }
 
         if validated_stages.contains(wgt::ShaderStages::FRAGMENT) {
             for (i, output) in io.iter() {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3350,16 +3350,17 @@ impl Device {
             None => None,
         };
 
-        if !pipeline_expects_dual_source_blending && shader_expects_dual_source_blending {
-            return Err(
-                pipeline::CreateRenderPipelineError::ShaderExpectsPipelineToUseDualSourceBlending,
-            );
-        }
-        if pipeline_expects_dual_source_blending && !shader_expects_dual_source_blending {
-            return Err(
-                pipeline::CreateRenderPipelineError::PipelineExpectsShaderToUseDualSourceBlending,
-            );
-        }
+        // TODO: re-enable
+        // if !pipeline_expects_dual_source_blending && shader_expects_dual_source_blending {
+        //     return Err(
+        //         pipeline::CreateRenderPipelineError::ShaderExpectsPipelineToUseDualSourceBlending,
+        //     );
+        // }
+        // if pipeline_expects_dual_source_blending && !shader_expects_dual_source_blending {
+        //     return Err(
+        //         pipeline::CreateRenderPipelineError::PipelineExpectsShaderToUseDualSourceBlending,
+        //     );
+        // }
 
         if validated_stages.contains(wgt::ShaderStages::FRAGMENT) {
             for (i, output) in io.iter() {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -470,6 +470,10 @@ pub enum CreateRenderPipelineError {
         factor: wgt::BlendFactor,
         target: u32,
     },
+    #[error("Pipeline expects the shader entry point to make use of dual-source blending.")]
+    PipelineExpectsShaderToUseDualSourceBlending,
+    #[error("Shader entry point expects the pipeline to make use of dual-source blending.")]
+    ShaderExpectsPipelineToUseDualSourceBlending,
     #[error("{}", concat!(
         "At least one color attachment or depth-stencil attachment was expected, ",
         "but no render target for the pipeline was specified."

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -470,10 +470,6 @@ pub enum CreateRenderPipelineError {
         factor: wgt::BlendFactor,
         target: u32,
     },
-    #[error("Pipeline expects the shader entry point to make use of dual-source blending.")]
-    PipelineExpectsShaderToUseDualSourceBlending,
-    #[error("Shader entry point expects the pipeline to make use of dual-source blending.")]
-    ShaderExpectsPipelineToUseDualSourceBlending,
     #[error("{}", concat!(
         "At least one color attachment or depth-stencil attachment was expected, ",
         "but no render target for the pipeline was specified."

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -964,17 +964,6 @@ bitflags_array! {
         ///
         /// This is a native only feature.
         const SHADER_EARLY_DEPTH_TEST = 1 << 34;
-        /// Allows two outputs from a shader to be used for blending.
-        /// Note that dual-source blending doesn't support multiple render targets.
-        ///
-        /// For more info see the OpenGL ES extension GL_EXT_blend_func_extended.
-        ///
-        /// Supported platforms:
-        /// - OpenGL ES (with GL_EXT_blend_func_extended)
-        /// - Metal (with MSL 1.2+)
-        /// - Vulkan (with dualSrcBlend)
-        /// - DX12
-        const DUAL_SOURCE_BLENDING = 1 << 35;
         /// Allows shaders to use i64 and u64.
         ///
         /// Supported platforms:
@@ -983,7 +972,7 @@ bitflags_array! {
         /// - Metal (with MSL 2.3+)
         ///
         /// This is a native only feature.
-        const SHADER_INT64 = 1 << 36;
+        const SHADER_INT64 = 1 << 35;
         /// Allows compute and fragment shaders to use the subgroup operation built-ins
         ///
         /// Supported Platforms:
@@ -992,14 +981,14 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const SUBGROUP = 1 << 37;
+        const SUBGROUP = 1 << 36;
         /// Allows vertex shaders to use the subgroup operation built-ins
         ///
         /// Supported Platforms:
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const SUBGROUP_VERTEX = 1 << 38;
+        const SUBGROUP_VERTEX = 1 << 37;
         /// Allows shaders to use the subgroup barrier
         ///
         /// Supported Platforms:
@@ -1007,7 +996,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const SUBGROUP_BARRIER = 1 << 39;
+        const SUBGROUP_BARRIER = 1 << 38;
         /// Allows the use of pipeline cache objects
         ///
         /// Supported platforms:
@@ -1016,7 +1005,7 @@ bitflags_array! {
         /// Unimplemented Platforms:
         /// - DX12
         /// - Metal
-        const PIPELINE_CACHE = 1 << 40;
+        const PIPELINE_CACHE = 1 << 39;
         /// Allows shaders to use i64 and u64 atomic min and max.
         ///
         /// Supported platforms:
@@ -1025,7 +1014,7 @@ bitflags_array! {
         /// - Metal (with MSL 2.4+)
         ///
         /// This is a native only feature.
-        const SHADER_INT64_ATOMIC_MIN_MAX = 1 << 41;
+        const SHADER_INT64_ATOMIC_MIN_MAX = 1 << 40;
         /// Allows shaders to use all i64 and u64 atomic operations.
         ///
         /// Supported platforms:
@@ -1033,7 +1022,7 @@ bitflags_array! {
         /// - DX12 (with SM 6.6+)
         ///
         /// This is a native only feature.
-        const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 42;
+        const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 41;
         /// Allows using the [VK_GOOGLE_display_timing] Vulkan extension.
         ///
         /// This is used for frame pacing to reduce latency, and is generally only available on Android.
@@ -1049,7 +1038,7 @@ bitflags_array! {
         ///
         /// [VK_GOOGLE_display_timing]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html
         /// [`Surface::as_hal()`]: https://docs.rs/wgpu/latest/wgpu/struct.Surface.html#method.as_hal
-        const VULKAN_GOOGLE_DISPLAY_TIMING = 1 << 43;
+        const VULKAN_GOOGLE_DISPLAY_TIMING = 1 << 42;
 
         /// Allows using the [VK_KHR_external_memory_win32] Vulkan extension.
         ///
@@ -1059,7 +1048,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [VK_KHR_external_memory_win32]: https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_external_memory_win32.html
-        const VULKAN_EXTERNAL_MEMORY_WIN32 = 1 << 44;
+        const VULKAN_EXTERNAL_MEMORY_WIN32 = 1 << 43;
 
         /// Enables R64Uint image atomic min and max.
         ///
@@ -1069,7 +1058,7 @@ bitflags_array! {
         /// - Metal (with MSL 3.1+)
         ///
         /// This is a native only feature.
-        const TEXTURE_INT64_ATOMIC = 1 << 45;
+        const TEXTURE_INT64_ATOMIC = 1 << 44;
 
     }
 
@@ -1275,6 +1264,18 @@ bitflags_array! {
         ///
         /// This is a web and native feature.
         const FLOAT32_FILTERABLE = 1 << 11;
+
+        /// Allows two outputs from a shader to be used for blending.
+        /// Note that dual-source blending doesn't support multiple render targets.
+        ///
+        /// For more info see the OpenGL ES extension GL_EXT_blend_func_extended.
+        ///
+        /// Supported platforms:
+        /// - OpenGL ES (with GL_EXT_blend_func_extended)
+        /// - Metal (with MSL 1.2+)
+        /// - Vulkan (with dualSrcBlend)
+        /// - DX12
+        const DUAL_SOURCE_BLENDING = 1 << 12;
     }
 }
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -732,7 +732,6 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
 }
 
 const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 13] = [
-    //TODO: update the name
     (
         wgt::Features::DEPTH_CLIP_CONTROL,
         webgpu_sys::GpuFeatureName::DepthClipControl,

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -490,15 +490,10 @@ fn map_blend_factor(factor: wgt::BlendFactor) -> webgpu_sys::GpuBlendFactor {
         BlendFactor::SrcAlphaSaturated => bf::SrcAlphaSaturated,
         BlendFactor::Constant => bf::Constant,
         BlendFactor::OneMinusConstant => bf::OneMinusConstant,
-        BlendFactor::Src1
-        | BlendFactor::OneMinusSrc1
-        | BlendFactor::Src1Alpha
-        | BlendFactor::OneMinusSrc1Alpha => {
-            panic!(
-                "{:?} is not enabled for this backend",
-                wgt::Features::DUAL_SOURCE_BLENDING
-            )
-        }
+        BlendFactor::Src1 => bf::Src1,
+        BlendFactor::OneMinusSrc1 => bf::OneMinusSrc1,
+        BlendFactor::Src1Alpha => bf::Src1Alpha,
+        BlendFactor::OneMinusSrc1Alpha => bf::OneMinusSrc1Alpha,
     }
 }
 
@@ -782,7 +777,7 @@ const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 13] = [
     ),
     (
         wgt::Features::DUAL_SOURCE_BLENDING,
-        webgpu_sys::GpuFeatureName::Float32Filterable,
+        webgpu_sys::GpuFeatureName::DualSourceBlending,
     ),
 ];
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -731,7 +731,7 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
     }
 }
 
-const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 12] = [
+const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 13] = [
     //TODO: update the name
     (
         wgt::Features::DEPTH_CLIP_CONTROL,
@@ -779,6 +779,10 @@ const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 12] = [
     ),
     (
         wgt::Features::FLOAT32_FILTERABLE,
+        webgpu_sys::GpuFeatureName::Float32Filterable,
+    ),
+    (
+        wgt::Features::DUAL_SOURCE_BLENDING,
         webgpu_sys::GpuFeatureName::Float32Filterable,
     ),
 ];


### PR DESCRIPTION
**Connections**
* Fixes https://github.com/gfx-rs/wgpu/issues/6402

**Description**

Makes the dual source implementation in wgpu WebGPU spec compliant.
This means changing the wgsl syntax & associated validation to match what's described [here](https://www.w3.org/TR/WGSL/#attribute-blend_src) and [here](https://www.w3.org/TR/WGSL/#input-output-locations) and [here](https://www.w3.org/TR/webgpu/#dom-gpufeaturename-dual-source-blending).
Furthermore, makes the dual source blending extension available when targeting WebGPU.

**Testing**
Added a slew of naga tests. Did manual testing in a pet project against native & WebGPU (see also draft todo for ongoing problems)

**Draft TODO**

* [ ] [help wanted:] need to validate the the right enable directive is set but can't quite figure out how to access this in the right places
* [ ] [help wanted] [partially orthogonal]: While trying this out on my pet project I couldn't get it to fly in WebGPU because I was using naga_oil (with a hack, see also https://github.com/bevyengine/naga_oil/issues/113#issuecomment-2660437895) where I have to rely on `Module`->`write_wgsl` which right now ignores all directives 😱 . Fixing that isn't entirely straight forward since `Module` is language agnostic so I have to detect the need for those
* [ ] a more vertical wgpu test checking that happy path works and that shaders needing wgsl require the device to have the correct feature set 
 
**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
