### PR TITLE
Add getters and `From` implementations to `BufferSlice`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ By @cwfitzgerald in [#7030](https://github.com/gfx-rs/wgpu/pull/7030).
 
 - Add `Buffer` methods corresponding to `BufferSlice` methods, so you can skip creating a `BufferSlice` when it offers no benefit, and `BufferSlice::slice()` for sub-slicing a slice. By @kpreid in [#7123](https://github.com/gfx-rs/wgpu/pull/7123).
 - Add `BufferSlice::buffer()`, `BufferSlice::offset()` and `BufferSlice::size()`. By @kpreid in [#7148](https://github.com/gfx-rs/wgpu/pull/7148).
+- Add `impl From<BufferSlice> for BufferBinding` and `impl From<BufferSlice> for BindingResource`, allowing `BufferSlice`s to be easily used in creating bind groups. By @kpreid in [#7148](https://github.com/gfx-rs/wgpu/pull/7148).
 
 - Add `util::StagingBelt::allocate()` so the staging belt can be used to write textures. By @kpreid in [#6900](https://github.com/gfx-rs/wgpu/pull/6900).
 - Added `CommandEncoder::transition_resources()` for native API interop, and allowing users to slightly optimize barriers. By @JMS55 in [#6678](https://github.com/gfx-rs/wgpu/pull/6678).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,8 @@ By @cwfitzgerald in [#7030](https://github.com/gfx-rs/wgpu/pull/7030).
 
   By @kpreid in [#7063](https://github.com/gfx-rs/wgpu/pull/7063).
 
-- Added `Buffer` methods corresponding to `BufferSlice` methods, so you can skip creating a `BufferSlice` when it offers no benefit, and `BufferSlice::slice()` for sub-slicing a slice. By @kpreid in [#7123](https://github.com/gfx-rs/wgpu/pull/7123).
+- Add `Buffer` methods corresponding to `BufferSlice` methods, so you can skip creating a `BufferSlice` when it offers no benefit, and `BufferSlice::slice()` for sub-slicing a slice. By @kpreid in [#7123](https://github.com/gfx-rs/wgpu/pull/7123).
+- Add `BufferSlice::buffer()`, `BufferSlice::offset()` and `BufferSlice::size()`. By @kpreid in [#7148](https://github.com/gfx-rs/wgpu/pull/7148).
 
 - Add `util::StagingBelt::allocate()` so the staging belt can be used to write textures. By @kpreid in [#6900](https://github.com/gfx-rs/wgpu/pull/6900).
 - Added `CommandEncoder::transition_resources()` for native API interop, and allowing users to slightly optimize barriers. By @JMS55 in [#6678](https://github.com/gfx-rs/wgpu/pull/6678).

--- a/tests/validation_tests/api/buffer.rs
+++ b/tests/validation_tests/api/buffer.rs
@@ -1,16 +1,21 @@
 //! Tests of [`wgpu::Buffer`] and related.
 
+use core::num::NonZero;
+
 mod buffer_slice {
+    use super::*;
+
+    const ARBITRARY_DESC: &wgpu::BufferDescriptor = &wgpu::BufferDescriptor {
+        label: None,
+        size: 100,
+        usage: wgpu::BufferUsages::VERTEX,
+        mapped_at_creation: false,
+    };
+
     #[test]
     fn reslice_success() {
         let (device, _queue) = crate::request_noop_device();
-
-        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: None,
-            size: 100,
-            usage: wgpu::BufferUsages::VERTEX,
-            mapped_at_creation: false,
-        });
+        let buffer = device.create_buffer(ARBITRARY_DESC);
 
         assert_eq!(buffer.slice(10..90).slice(10..70), buffer.slice(20..80));
     }
@@ -19,14 +24,34 @@ mod buffer_slice {
     #[should_panic = "slice offset 10 size 80 is out of range for buffer of size 80"]
     fn reslice_out_of_bounds() {
         let (device, _queue) = crate::request_noop_device();
-
-        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: None,
-            size: 100,
-            usage: wgpu::BufferUsages::VERTEX,
-            mapped_at_creation: false,
-        });
+        let buffer = device.create_buffer(ARBITRARY_DESC);
 
         buffer.slice(10..90).slice(10..90);
+    }
+
+    #[test]
+    fn getters() {
+        let (device, _queue) = crate::request_noop_device();
+        let buffer = device.create_buffer(ARBITRARY_DESC);
+
+        let slice_with_size = buffer.slice(10..90);
+        assert_eq!(
+            (
+                slice_with_size.buffer(),
+                slice_with_size.offset(),
+                slice_with_size.size()
+            ),
+            (&buffer, 10, NonZero::new(80).unwrap())
+        );
+
+        let slice_without_size = buffer.slice(10..);
+        assert_eq!(
+            (
+                slice_without_size.buffer(),
+                slice_without_size.offset(),
+                slice_without_size.size()
+            ),
+            (&buffer, 10, NonZero::new(90).unwrap())
+        );
     }
 }

--- a/tests/validation_tests/api/buffer.rs
+++ b/tests/validation_tests/api/buffer.rs
@@ -54,4 +54,22 @@ mod buffer_slice {
             (&buffer, 10, NonZero::new(90).unwrap())
         );
     }
+
+    #[test]
+    fn into_buffer_binding() {
+        let (device, _queue) = crate::request_noop_device();
+        let buffer = device.create_buffer(ARBITRARY_DESC);
+
+        // BindingResource doesn’t implement PartialEq, so use matching
+        let wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+            buffer: b,
+            offset: 50,
+            size: Some(size),
+        }) = wgpu::BindingResource::from(buffer.slice(50..80))
+        else {
+            panic!("didn't match")
+        };
+        assert_eq!(b, &buffer);
+        assert_eq!(size, NonZero::new(30).unwrap());
+    }
 }

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -360,7 +360,8 @@ impl Buffer {
 ///
 /// You can pass buffer slices to methods like [`RenderPass::set_vertex_buffer`]
 /// and [`RenderPass::set_index_buffer`] to indicate which portion of the buffer
-/// a draw call should consult.
+/// a draw call should consult. You can also convert it to a [`BufferBinding`]
+/// with `.into()`.
 ///
 /// To access the slice's contents on the CPU, you must first [map] the buffer,
 /// and then call [`BufferSlice::get_mapped_range`] or
@@ -527,6 +528,26 @@ impl<'a> BufferSlice<'a> {
             (|| BufferSize::new(self.buffer.size().checked_sub(self.offset)?))()
                 .expect("can't happen: slice has incorrect size for its buffer")
         })
+    }
+}
+
+impl<'a> From<BufferSlice<'a>> for crate::BufferBinding<'a> {
+    /// Convert a [`BufferSlice`] to an equivalent [`BufferBinding`],
+    /// provided that it will be used without a dynamic offset.
+    fn from(value: BufferSlice<'a>) -> Self {
+        BufferBinding {
+            buffer: value.buffer,
+            offset: value.offset,
+            size: value.size,
+        }
+    }
+}
+
+impl<'a> From<BufferSlice<'a>> for crate::BindingResource<'a> {
+    /// Convert a [`BufferSlice`] to an equivalent [`BindingResource::Buffer`],
+    /// provided that it will be used without a dynamic offset.
+    fn from(value: BufferSlice<'a>) -> Self {
+        crate::BindingResource::Buffer(crate::BufferBinding::from(value))
     }
 }
 

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -506,6 +506,28 @@ impl<'a> BufferSlice<'a> {
             readable: self.buffer.usage.contains(BufferUsages::MAP_READ),
         }
     }
+
+    /// Returns the buffer this is a slice of.
+    ///
+    /// You should usually not need to call this, and if you received the buffer from code you
+    /// do not control, you should refrain from accessing the buffer outside the bounds of the
+    /// slice. Nevertheless, it’s possible to get this access, so this method makes it simple.
+    pub fn buffer(&self) -> &'a Buffer {
+        self.buffer
+    }
+
+    /// Returns the offset in [`Self::buffer()`] this slice starts at.
+    pub fn offset(&self) -> BufferAddress {
+        self.offset
+    }
+
+    /// Returns the size of this slice.
+    pub fn size(&self) -> BufferSize {
+        self.size.unwrap_or_else(|| {
+            (|| BufferSize::new(self.buffer.size().checked_sub(self.offset)?))()
+                .expect("can't happen: slice has incorrect size for its buffer")
+        })
+    }
 }
 
 /// The mapped portion of a buffer, if any, and its outstanding views.


### PR DESCRIPTION
**Connections**
Part of addressing https://github.com/gfx-rs/wgpu/issues/6974

**Description**
This PR adds functions to make `BufferSlice` usable in more situations.

* `BufferSlice::buffer()`, `BufferSlice::offset()` and `BufferSlice::size()` allow decomposing a `BufferSlice`. This allows a function which receives a `BufferSlice` to use it, for example, in texture copy operations. I'd like to have a more ergonomic interface to that, but I haven’t thought of one; adding these getters ensures that there is never any unavoidable inexpressiveness. However,
    * It is arguably undesirable to allow going from a `BufferSlice` to its `Buffer` and accessing data outside the slice. I think that this is worth considering, but that on net it is more important to be flexible than to be strict, here, particularly as buffers are interior mutable and clonable so there is no fundamental mutability-xor-sharing like `&mut [u8]` would have.
    * `BufferSlice::size()` returns a `BufferSize` rather than an `Option<BufferSize>`. See #7147 for context on why I think this is the right choice — the `Option` should, I think, be considered an obsolete implementation detail.
* `impl From<BufferSlice> for BufferBinding`
* `impl From<BufferSlice> for BindingResource`

Please merge this PR without squashing; the commits are self-contained.

**Testing**
Added and ran API tests.

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
