### PR TITLE
Use TextureViewDescriptor::usage when Creating Texture View

### DIFF
--- a/tests/gpu-tests/texture_view_creation.rs
+++ b/tests/gpu-tests/texture_view_creation.rs
@@ -63,3 +63,40 @@ static DEPTH_ONLY_VIEW_CREATION: GpuTestConfiguration =
             });
         }
     });
+
+#[gpu_test]
+static SHARED_USAGE_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().downlevel_flags(DownlevelFlags::VIEW_FORMATS))
+    .run_async(|ctx| async move {
+        {
+            let (texture_format, view_format) =
+                (TextureFormat::Rgba8Unorm, TextureFormat::Rgba8UnormSrgb);
+            let texture = ctx.device.create_texture(&TextureDescriptor {
+                label: None,
+                size: Extent3d {
+                    width: 256,
+                    height: 256,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: TextureDimension::D2,
+                format: texture_format,
+                usage: TextureUsages::COPY_DST
+                    | TextureUsages::STORAGE_BINDING
+                    | TextureUsages::TEXTURE_BINDING
+                    | TextureUsages::RENDER_ATTACHMENT,
+                view_formats: &[TextureFormat::Rgba8UnormSrgb],
+            });
+            let _view = texture.create_view(&TextureViewDescriptor {
+                aspect: TextureAspect::All,
+                format: Some(view_format),
+                usage: Some(
+                    TextureUsages::COPY_DST
+                        | TextureUsages::TEXTURE_BINDING
+                        | TextureUsages::RENDER_ATTACHMENT,
+                ),
+                ..Default::default()
+            });
+        }
+    });

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1186,9 +1186,8 @@ impl Device {
             }
         };
 
-        let allowed_format_usages = self
-            .describe_format_features(resolved_format)?
-            .allowed_usages;
+        let format_features = self.describe_format_features(resolved_format)?;
+        let allowed_format_usages = format_features.allowed_usages;
         if resolved_usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT)
             && !allowed_format_usages.contains(wgt::TextureUsages::RENDER_ATTACHMENT)
         {
@@ -1364,6 +1363,11 @@ impl Device {
 
         // filter the usages based on the other criteria
         let usage = {
+            let resolved_hal_usage = conv::map_texture_usage(
+                resolved_usage,
+                resolved_format.into(),
+                format_features.flags,
+            );
             let mask_copy = !(wgt::TextureUses::COPY_SRC | wgt::TextureUses::COPY_DST);
             let mask_dimension = match resolved_dimension {
                 TextureViewDimension::Cube | TextureViewDimension::CubeArray => {
@@ -1382,7 +1386,7 @@ impl Device {
             } else {
                 wgt::TextureUses::RESOURCE
             };
-            texture.hal_usage & mask_copy & mask_dimension & mask_mip_level
+            texture.hal_usage & resolved_hal_usage & mask_copy & mask_dimension & mask_mip_level
         };
 
         // use the combined depth-stencil format for the view

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1386,7 +1386,7 @@ impl Device {
             } else {
                 wgt::TextureUses::RESOURCE
             };
-            texture.hal_usage & resolved_hal_usage & mask_copy & mask_dimension & mask_mip_level
+            resolved_hal_usage & mask_copy & mask_dimension & mask_mip_level
         };
 
         // use the combined depth-stencil format for the view

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1014,7 +1014,7 @@ pub struct Texture {
     pub(crate) inner: Snatchable<TextureInner>,
     pub(crate) device: Arc<Device>,
     pub(crate) desc: wgt::TextureDescriptor<(), Vec<wgt::TextureFormat>>,
-    pub(crate) hal_usage: wgt::TextureUses,
+    pub(crate) _hal_usage: wgt::TextureUses,
     pub(crate) format_features: wgt::TextureFormatFeatures,
     pub(crate) initialization_status: RwLock<TextureInitTracker>,
     pub(crate) full_range: TextureSelector,
@@ -1040,7 +1040,7 @@ impl Texture {
             inner: Snatchable::new(inner),
             device: device.clone(),
             desc: desc.map_label(|_| ()),
-            hal_usage,
+            _hal_usage: hal_usage,
             format_features,
             initialization_status: RwLock::new(
                 rank::TEXTURE_INITIALIZATION_STATUS,


### PR DESCRIPTION
**Description**
When certain data formats and texture usages are mixed when creating a texture view, the vulkan backend throws a validation error. However, setting `TextureViewDescriptor::usage` seemingly has no effect. The chosen usage still comes from the parent texture.

I'm not sure if this is intended, but this is the change that solved the issue for me.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
