### PR TITLE
Use `BufferSlice` in `StagingBelt::allocate()`.

### DIFF
--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -1,5 +1,5 @@
 use crate::{
-    util::align_to, Buffer, BufferAddress, BufferDescriptor, BufferSize, BufferUsages,
+    util::align_to, Buffer, BufferAddress, BufferDescriptor, BufferSize, BufferSlice, BufferUsages,
     BufferViewMut, CommandEncoder, Device, MapMode,
 };
 use std::fmt;
@@ -77,14 +77,14 @@ impl StagingBelt {
         size: BufferSize,
         device: &Device,
     ) -> BufferViewMut<'_> {
-        let (mapped, belt_buffer, offset_in_belt_buffer) = self.allocate(
+        let (mapped, slice_of_belt) = self.allocate(
             size,
             const { BufferSize::new(crate::COPY_BUFFER_ALIGNMENT).unwrap() },
             device,
         );
         encoder.copy_buffer_to_buffer(
-            belt_buffer,
-            offset_in_belt_buffer,
+            slice_of_belt.buffer(),
+            slice_of_belt.offset(),
             target,
             offset,
             size.get(),
@@ -120,7 +120,7 @@ impl StagingBelt {
         size: BufferSize,
         alignment: BufferSize,
         device: &Device,
-    ) -> (BufferViewMut<'_>, &Buffer, BufferAddress) {
+    ) -> (BufferViewMut<'_>, BufferSlice<'_>) {
         assert!(
             alignment.get().is_power_of_two(),
             "alignment must be a power of two, not {alignment}"
@@ -161,14 +161,10 @@ impl StagingBelt {
         self.active_chunks.push(chunk);
         let chunk = self.active_chunks.last().unwrap();
 
-        (
-            chunk
-                .buffer
-                .slice(allocation_offset..allocation_offset + size.get())
-                .get_mapped_range_mut(),
-            &chunk.buffer,
-            allocation_offset,
-        )
+        let slice = chunk
+            .buffer
+            .slice(allocation_offset..allocation_offset + size.get());
+        (slice.get_mapped_range_mut(), slice)
     }
 
     /// Prepare currently mapped buffers for use in a submission.

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -77,7 +77,7 @@ impl StagingBelt {
         size: BufferSize,
         device: &Device,
     ) -> BufferViewMut<'_> {
-        let (mapped, slice_of_belt) = self.allocate(
+        let slice_of_belt = self.allocate(
             size,
             const { BufferSize::new(crate::COPY_BUFFER_ALIGNMENT).unwrap() },
             device,
@@ -89,14 +89,20 @@ impl StagingBelt {
             offset,
             size.get(),
         );
-        mapped
+        slice_of_belt.get_mapped_range_mut()
     }
 
     /// Allocate a staging belt slice with the given `size` and `alignment` and return it.
     ///
-    /// This allows you to do whatever you want with the slice after, such as
-    /// copying it to a texture or executing a compute shader that reads it, whereas
-    /// [`StagingBelt::write_buffer()`] can only write to other buffers.
+    /// To use this slice, call [`BufferSlice::get_mapped_range_mut()`] and write your data into
+    /// that [`BufferViewMut`].
+    /// (The view must be dropped before [`StagingBelt::finish()`] is called.)
+    ///
+    /// You can then record your own GPU commands to perform with the slice,
+    /// such as copying it to a texture or executing a compute shader that reads it (whereas
+    /// [`StagingBelt::write_buffer()`] can only write to other buffers).
+    /// All commands involving this slice must be submitted after
+    /// [`StagingBelt::finish()`] is called and before [`StagingBelt::recall()`] is called.
     ///
     /// If the `size` is greater than the space available in any free internal buffer, a new buffer
     /// will be allocated for it. Therefore, the `chunk_size` passed to [`StagingBelt::new()`]
@@ -104,23 +110,13 @@ impl StagingBelt {
     ///
     /// The chosen slice will be positioned within the buffer at a multiple of `alignment`,
     /// which may be used to meet alignment requirements for the operation you wish to perform
-    /// with the slice. This does not necessarily affect the alignment of the mapping.
-    ///
-    /// Three values are returned:
-    ///
-    /// * The mapped buffer view which you should write into from the CPU side (Rust code).
-    /// * The buffer containing the slice, for you to use in GPU commands.
-    ///   All commands involving this slice must be submitted after
-    ///   [`StagingBelt::finish()`] is called and before [`StagingBelt::recall()`] is called.
-    /// * The offset within the buffer at which the slice starts.
-    ///   This offset should be used for all GPU commands, and should not be used with
-    ///   the mapped buffer view.
+    /// with the slice. This does not necessarily affect the alignment of the [`BufferViewMut`].
     pub fn allocate(
         &mut self,
         size: BufferSize,
         alignment: BufferSize,
         device: &Device,
-    ) -> (BufferViewMut<'_>, BufferSlice<'_>) {
+    ) -> BufferSlice<'_> {
         assert!(
             alignment.get().is_power_of_two(),
             "alignment must be a power of two, not {alignment}"
@@ -161,10 +157,9 @@ impl StagingBelt {
         self.active_chunks.push(chunk);
         let chunk = self.active_chunks.last().unwrap();
 
-        let slice = chunk
+        chunk
             .buffer
-            .slice(allocation_offset..allocation_offset + size.get());
-        (slice.get_mapped_range_mut(), slice)
+            .slice(allocation_offset..allocation_offset + size.get())
     }
 
     /// Prepare currently mapped buffers for use in a submission.


### PR DESCRIPTION
**Connections**
Implements the plan described in review comment https://github.com/gfx-rs/wgpu/pull/6900#discussion_r1953669787 and was made possible by #7148.

**Description**
Simplifies the tuple returned by `StagingBelt::allocate()` by returning a `BufferSlice` instead of a `Buffer` and offset.

**Testing**
`allocate()` has no tests, but I tested that this API still works with my application.

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] ~~Add change to `CHANGELOG.md`. See simple instructions inside file.~~ `StagingBelt` is new this release cycle and already in the changelog.
