### PR TITLE
[naga wgsl] Add `to_wgsl` functions for some Naga IR types.

### DIFF
--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -63,6 +63,7 @@ use thiserror::Error;
 
 use crate::{
     back::{self, Baked},
+    common,
     proc::{self, ExpressionKindTracker, NameKey},
     valid, Handle, ShaderStage, TypeInner,
 };
@@ -3446,7 +3447,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             TypeInner::Vector { size, .. } => write!(
                                 self.out,
                                 ", vec{}(0.0), vec{0}(1.0)",
-                                back::vector_size_str(size)
+                                common::vector_size_str(size)
                             )?,
                             _ => write!(self.out, ", 0.0, 1.0")?,
                         }
@@ -3593,7 +3594,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     Mf::CountTrailingZeros => {
                         match *ctx.resolve_type(arg, &self.module.types) {
                             TypeInner::Vector { size, scalar, .. } => {
-                                let s = back::vector_size_str(size);
+                                let s = common::vector_size_str(size);
                                 if let crate::ScalarKind::Uint = scalar.kind {
                                     write!(self.out, "min(uvec{s}(findLSB(")?;
                                     self.write_expr(arg, ctx)?;
@@ -3623,7 +3624,7 @@ impl<'a, W: Write> Writer<'a, W> {
                         if self.options.version.supports_integer_functions() {
                             match *ctx.resolve_type(arg, &self.module.types) {
                                 TypeInner::Vector { size, scalar } => {
-                                    let s = back::vector_size_str(size);
+                                    let s = common::vector_size_str(size);
 
                                     if let crate::ScalarKind::Uint = scalar.kind {
                                         write!(self.out, "uvec{s}(ivec{s}(31) - findMSB(")?;
@@ -3654,7 +3655,7 @@ impl<'a, W: Write> Writer<'a, W> {
                         } else {
                             match *ctx.resolve_type(arg, &self.module.types) {
                                 TypeInner::Vector { size, scalar } => {
-                                    let s = back::vector_size_str(size);
+                                    let s = common::vector_size_str(size);
 
                                     if let crate::ScalarKind::Uint = scalar.kind {
                                         write!(self.out, "uvec{s}(")?;

--- a/naga/src/back/hlsl/conv.rs
+++ b/naga/src/back/hlsl/conv.rs
@@ -1,3 +1,5 @@
+use crate::common;
+
 use alloc::{borrow::Cow, format, string::String};
 
 use super::Error;
@@ -88,7 +90,7 @@ impl crate::TypeInner {
             crate::TypeInner::Vector { size, scalar } => Cow::Owned(format!(
                 "{}{}",
                 scalar.to_hlsl_str()?,
-                crate::back::vector_size_str(size)
+                common::vector_size_str(size)
             )),
             crate::TypeInner::Matrix {
                 columns,
@@ -97,8 +99,8 @@ impl crate::TypeInner {
             } => Cow::Owned(format!(
                 "{}{}x{}",
                 scalar.to_hlsl_str()?,
-                crate::back::vector_size_str(columns),
-                crate::back::vector_size_str(rows),
+                common::vector_size_str(columns),
+                common::vector_size_str(rows),
             )),
             crate::TypeInner::Array {
                 base,

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -16,6 +16,7 @@ use super::{
 };
 use crate::{
     back::{self, Baked},
+    common,
     proc::{self, index, ExpressionKindTracker, NameKey},
     valid, Handle, Module, RayQueryFunction, Scalar, ScalarKind, ShaderStage, TypeInner,
 };
@@ -1321,7 +1322,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                     self.out,
                     "{}{}",
                     scalar.to_hlsl_str()?,
-                    back::vector_size_str(size)
+                    common::vector_size_str(size)
                 )?;
             }
             TypeInner::Matrix {
@@ -1337,8 +1338,8 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                     self.out,
                     "{}{}x{}",
                     scalar.to_hlsl_str()?,
-                    back::vector_size_str(columns),
-                    back::vector_size_str(rows),
+                    common::vector_size_str(columns),
+                    common::vector_size_str(rows),
                 )?;
             }
             TypeInner::Image {
@@ -3340,7 +3341,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                                     self.out,
                                     "{}{}(",
                                     scalar.to_hlsl_str()?,
-                                    back::vector_size_str(size)
+                                    common::vector_size_str(size)
                                 )?;
                             }
                             TypeInner::Scalar(_) => {
@@ -3351,8 +3352,8 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                                     self.out,
                                     "{}{}x{}(",
                                     scalar.to_hlsl_str()?,
-                                    back::vector_size_str(columns),
-                                    back::vector_size_str(rows)
+                                    common::vector_size_str(columns),
+                                    common::vector_size_str(rows)
                                 )?;
                             }
                             _ => {

--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -250,15 +250,6 @@ pub const fn binary_operation_str(op: crate::BinaryOperator) -> &'static str {
     }
 }
 
-/// Helper function that returns the string corresponding to the [`VectorSize`](crate::VectorSize)
-const fn vector_size_str(size: crate::VectorSize) -> &'static str {
-    match size {
-        crate::VectorSize::Bi => "2",
-        crate::VectorSize::Tri => "3",
-        crate::VectorSize::Quad => "4",
-    }
-}
-
 impl crate::TypeInner {
     /// Returns true if this is a handle to a type rather than the type directly.
     pub const fn is_handle(&self) -> bool {

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -13,6 +13,7 @@ use super::{sampler as sm, Error, LocationMode, Options, PipelineOptions, Transl
 use crate::{
     arena::{Handle, HandleSet},
     back::{self, Baked},
+    common,
     proc::{self, index, ExpressionKindTracker, NameKey, TypeResolution},
     valid, FastHashMap, FastHashSet,
 };
@@ -80,7 +81,7 @@ fn put_numeric_type(
                 "{}::{}{}",
                 NAMESPACE,
                 scalar.to_msl_name(),
-                back::vector_size_str(rows)
+                common::vector_size_str(rows)
             )
         }
         (scalar, &[rows, columns]) => {
@@ -89,8 +90,8 @@ fn put_numeric_type(
                 "{}::{}{}x{}",
                 NAMESPACE,
                 scalar.to_msl_name(),
-                back::vector_size_str(columns),
-                back::vector_size_str(rows)
+                common::vector_size_str(columns),
+                common::vector_size_str(rows)
             )
         }
         (_, _) => Ok(()), // not meaningful
@@ -1408,7 +1409,7 @@ impl<W: Write> Writer<W> {
             .to_msl_name();
         match context.resolve_type(arg) {
             &crate::TypeInner::Vector { size, .. } => {
-                let size = back::vector_size_str(size);
+                let size = common::vector_size_str(size);
                 write!(self.out, "{scalar}{size}(-1), {scalar}{size}(1)")?;
             }
             _ => {
@@ -2133,7 +2134,7 @@ impl<W: Write> Writer<W> {
                         // or metal will complain that select is ambiguous
                         match *inner {
                             crate::TypeInner::Vector { size, scalar } => {
-                                let size = back::vector_size_str(size);
+                                let size = common::vector_size_str(size);
                                 let name = scalar.to_msl_name();
                                 write!(self.out, "{name}{size}")?;
                             }
@@ -2261,7 +2262,7 @@ impl<W: Write> Writer<W> {
                             crate::TypeInner::Vector { size, .. } => write!(
                                 self.out,
                                 "{NAMESPACE}::float{size}({NAMESPACE}::half{size}(",
-                                size = back::vector_size_str(size),
+                                size = common::vector_size_str(size),
                             )?,
                             _ => unreachable!(
                                 "Correct TypeInner for QuantizeToF16 should be already validated"

--- a/naga/src/back/wgsl/mod.rs
+++ b/naga/src/back/wgsl/mod.rs
@@ -14,6 +14,8 @@ use thiserror::Error;
 
 pub use writer::{Writer, WriterFlags};
 
+use crate::common::wgsl;
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
@@ -43,6 +45,20 @@ impl Error {
             kind,
             value: format!("{value:?}"),
         }
+    }
+}
+
+trait ToWgslIfImplemented {
+    fn to_wgsl_if_implemented(self) -> Result<&'static str, Error>;
+}
+
+impl<T> ToWgslIfImplemented for T
+where
+    T: wgsl::TryToWgsl + core::fmt::Debug + Copy,
+{
+    fn to_wgsl_if_implemented(self) -> Result<&'static str, Error> {
+        self.try_to_wgsl()
+            .ok_or_else(|| Error::unsupported(T::DESCRIPTION, self))
     }
 }
 

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -1765,12 +1765,12 @@ impl<W: Write> Writer<W> {
                         let ty = func_ctx.resolve_type(arg, &module.types);
 
                         let Some(overload) = InversePolyfill::find_overload(ty) else {
-                            return Err(Error::UnsupportedMathFunction(fun));
+                            return Err(Error::unsupported("math function", fun));
                         };
 
                         Function::InversePolyfill(overload)
                     }
-                    Mf::Outer => return Err(Error::UnsupportedMathFunction(fun)),
+                    Mf::Outer => return Err(Error::unsupported("math function", fun)),
                 };
 
                 match function {
@@ -1981,7 +1981,7 @@ fn builtin_str(built_in: crate::BuiltIn) -> Result<&'static str, Error> {
         | Bi::PointSize
         | Bi::PointCoord
         | Bi::WorkGroupSize
-        | Bi::DrawID => return Err(Error::Custom(format!("Unsupported builtin {built_in:?}"))),
+        | Bi::DrawID => return Err(Error::unsupported("builtin", built_in)),
     })
 }
 

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -11,7 +11,10 @@ use super::ToWgslIfImplemented as _;
 use crate::back::wgsl::polyfill::InversePolyfill;
 use crate::{
     back::{self, Baked},
-    common::wgsl::{ToWgsl, TryToWgsl},
+    common::{
+        self,
+        wgsl::{ToWgsl, TryToWgsl},
+    },
     proc::{self, ExpressionKindTracker, NameKey},
     valid, Handle, Module, ShaderStage, TypeInner,
 };
@@ -419,7 +422,7 @@ impl<W: Write> Writer<W> {
             TypeInner::Vector { size, scalar } => write!(
                 self.out,
                 "vec{}<{}>",
-                back::vector_size_str(size),
+                common::vector_size_str(size),
                 scalar_kind_str(scalar),
             )?,
             TypeInner::Sampler { comparison: false } => {
@@ -528,8 +531,8 @@ impl<W: Write> Writer<W> {
                 write!(
                     self.out,
                     "mat{}x{}<{}>",
-                    back::vector_size_str(columns),
-                    back::vector_size_str(rows),
+                    common::vector_size_str(columns),
+                    common::vector_size_str(rows),
                     scalar_kind_str(scalar)
                 )?;
             }
@@ -578,7 +581,7 @@ impl<W: Write> Writer<W> {
                         self.out,
                         "ptr<{}, vec{}<{}>",
                         space,
-                        back::vector_size_str(size),
+                        common::vector_size_str(size),
                         scalar_kind_str(scalar)
                     )?;
                     if let Some(access) = maybe_access {
@@ -1295,7 +1298,7 @@ impl<W: Write> Writer<W> {
                 write!(self.out, ")")?
             }
             Expression::Splat { size, value } => {
-                let size = back::vector_size_str(size);
+                let size = common::vector_size_str(size);
                 write!(self.out, "vec{size}(")?;
                 write_expression(self, value)?;
                 write!(self.out, ")")?;
@@ -1591,8 +1594,8 @@ impl<W: Write> Writer<W> {
                         write!(
                             self.out,
                             "mat{}x{}<{}>",
-                            back::vector_size_str(columns),
-                            back::vector_size_str(rows),
+                            common::vector_size_str(columns),
+                            common::vector_size_str(rows),
                             scalar_kind_str
                         )?;
                     }
@@ -1604,7 +1607,7 @@ impl<W: Write> Writer<W> {
                             kind,
                             width: convert.unwrap_or(width),
                         };
-                        let vector_size_str = back::vector_size_str(size);
+                        let vector_size_str = common::vector_size_str(size);
                         let scalar_kind_str = scalar_kind_str(scalar);
                         if convert.is_some() {
                             write!(self.out, "vec{vector_size_str}<{scalar_kind_str}>")?;

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -13,7 +13,7 @@ use crate::{
     back::{self, Baked},
     common::{
         self,
-        wgsl::{ToWgsl, TryToWgsl},
+        wgsl::{address_space_str, ToWgsl, TryToWgsl},
     },
     proc::{self, ExpressionKindTracker, NameKey},
     valid, Handle, Module, ShaderStage, TypeInner,
@@ -1875,33 +1875,6 @@ impl<W: Write> Writer<W> {
     pub fn finish(self) -> W {
         self.out
     }
-}
-
-const fn address_space_str(
-    space: crate::AddressSpace,
-) -> (Option<&'static str>, Option<&'static str>) {
-    use crate::AddressSpace as As;
-
-    (
-        Some(match space {
-            As::Private => "private",
-            As::Uniform => "uniform",
-            As::Storage { access } => {
-                if access.contains(crate::StorageAccess::ATOMIC) {
-                    return (Some("storage"), Some("atomic"));
-                } else if access.contains(crate::StorageAccess::STORE) {
-                    return (Some("storage"), Some("read_write"));
-                } else {
-                    "storage"
-                }
-            }
-            As::PushConstant => "push_constant",
-            As::WorkGroup => "workgroup",
-            As::Handle => return (None, None),
-            As::Function => "function",
-        }),
-        None,
-    )
 }
 
 fn map_binding_to_attribute(binding: &crate::Binding) -> Vec<Attribute> {

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -439,7 +439,7 @@ impl<W: Write> Writer<W> {
                 // More about texture types: https://gpuweb.github.io/gpuweb/wgsl/#sampled-texture-type
                 use crate::ImageClass as Ic;
 
-                let dim_str = image_dimension_str(dim);
+                let dim_str = dim.to_wgsl();
                 let arrayed_str = if arrayed { "_array" } else { "" };
                 let (class_str, multisampled_str, format_str, storage_str) = match class {
                     Ic::Sampled { kind, multi } => (
@@ -1874,17 +1874,6 @@ impl<W: Write> Writer<W> {
     #[allow(clippy::missing_const_for_fn)]
     pub fn finish(self) -> W {
         self.out
-    }
-}
-
-const fn image_dimension_str(dim: crate::ImageDimension) -> &'static str {
-    use crate::ImageDimension as IDim;
-
-    match dim {
-        IDim::D1 => "1d",
-        IDim::D2 => "2d",
-        IDim::D3 => "3d",
-        IDim::Cube => "cube",
     }
 }
 

--- a/naga/src/common/mod.rs
+++ b/naga/src/common/mod.rs
@@ -1,3 +1,12 @@
 //! Code common to the front and backends for specific languages.
 
 pub mod wgsl;
+
+/// Helper function that returns the string corresponding to the [`VectorSize`](crate::VectorSize)
+pub const fn vector_size_str(size: crate::VectorSize) -> &'static str {
+    match size {
+        crate::VectorSize::Bi => "2",
+        crate::VectorSize::Tri => "3",
+        crate::VectorSize::Quad => "4",
+    }
+}

--- a/naga/src/common/wgsl.rs
+++ b/naga/src/common/wgsl.rs
@@ -305,3 +305,22 @@ impl ToWgsl for crate::StorageFormat {
         }
     }
 }
+
+impl TryToWgsl for crate::Scalar {
+    const DESCRIPTION: &'static str = "scalar type";
+
+    fn try_to_wgsl(self) -> Option<&'static str> {
+        use crate::Scalar;
+
+        Some(match self {
+            Scalar::F64 => "f64",
+            Scalar::F32 => "f32",
+            Scalar::I32 => "i32",
+            Scalar::U32 => "u32",
+            Scalar::I64 => "i64",
+            Scalar::U64 => "u64",
+            Scalar::BOOL => "bool",
+            _ => return None,
+        })
+    }
+}

--- a/naga/src/common/wgsl.rs
+++ b/naga/src/common/wgsl.rs
@@ -324,3 +324,16 @@ impl TryToWgsl for crate::Scalar {
         })
     }
 }
+
+impl ToWgsl for crate::ImageDimension {
+    fn to_wgsl(self) -> &'static str {
+        use crate::ImageDimension as IDim;
+
+        match self {
+            IDim::D1 => "1d",
+            IDim::D2 => "2d",
+            IDim::D3 => "3d",
+            IDim::Cube => "cube",
+        }
+    }
+}

--- a/naga/src/common/wgsl.rs
+++ b/naga/src/common/wgsl.rs
@@ -67,3 +67,241 @@ impl StandardFilterableTriggeringRule {
         }
     }
 }
+
+/// Types that can return the WGSL source representation of their
+/// values as a `'static` string.
+///
+/// This trait is specifically for types whose WGSL forms are simple
+/// enough that they can always be returned as a static string.
+///
+/// - If only some values have a WGSL representation, consider
+///   implementing [`TryToWgsl`] instead.
+///
+/// - If a type's WGSL form requires dynamic formatting, so that
+///   returning a `&'static str` isn't feasible, consider implementing
+///   [`std::fmt::Display`] on some wrapper type instead.
+pub trait ToWgsl: Sized {
+    /// Return WGSL source code representation of `self`.
+    fn to_wgsl(self) -> &'static str;
+}
+
+/// Types that may be able to return the WGSL source representation
+/// for their values as a `'static' string.
+///
+/// This trait is specifically for types whose values are either
+/// simple enough that their WGSL form can be represented a static
+/// string, or aren't representable in WGSL at all.
+///
+/// - If all values in the type have `&'static str` representations in
+///   WGSL, consider implementing [`ToWgsl`] instead.
+///
+/// - If a type's WGSL form requires dynamic formatting, so that
+///   returning a `&'static str` isn't feasible, consider implementing
+///   [`std::fmt::Display`] on some wrapper type instead.
+pub trait TryToWgsl: Sized {
+    /// Return the WGSL form of `self` as a `'static` string.
+    ///
+    /// If `self` doesn't have a representation in WGSL (standard or
+    /// as extended by Naga), then return `None`.
+    fn try_to_wgsl(self) -> Option<&'static str>;
+
+    /// What kind of WGSL thing `Self` represents.
+    const DESCRIPTION: &'static str;
+}
+
+impl TryToWgsl for crate::MathFunction {
+    const DESCRIPTION: &'static str = "math function";
+
+    fn try_to_wgsl(self) -> Option<&'static str> {
+        use crate::MathFunction as Mf;
+
+        Some(match self {
+            Mf::Abs => "abs",
+            Mf::Min => "min",
+            Mf::Max => "max",
+            Mf::Clamp => "clamp",
+            Mf::Saturate => "saturate",
+            Mf::Cos => "cos",
+            Mf::Cosh => "cosh",
+            Mf::Sin => "sin",
+            Mf::Sinh => "sinh",
+            Mf::Tan => "tan",
+            Mf::Tanh => "tanh",
+            Mf::Acos => "acos",
+            Mf::Asin => "asin",
+            Mf::Atan => "atan",
+            Mf::Atan2 => "atan2",
+            Mf::Asinh => "asinh",
+            Mf::Acosh => "acosh",
+            Mf::Atanh => "atanh",
+            Mf::Radians => "radians",
+            Mf::Degrees => "degrees",
+            Mf::Ceil => "ceil",
+            Mf::Floor => "floor",
+            Mf::Round => "round",
+            Mf::Fract => "fract",
+            Mf::Trunc => "trunc",
+            Mf::Modf => "modf",
+            Mf::Frexp => "frexp",
+            Mf::Ldexp => "ldexp",
+            Mf::Exp => "exp",
+            Mf::Exp2 => "exp2",
+            Mf::Log => "log",
+            Mf::Log2 => "log2",
+            Mf::Pow => "pow",
+            Mf::Dot => "dot",
+            Mf::Cross => "cross",
+            Mf::Distance => "distance",
+            Mf::Length => "length",
+            Mf::Normalize => "normalize",
+            Mf::FaceForward => "faceForward",
+            Mf::Reflect => "reflect",
+            Mf::Refract => "refract",
+            Mf::Sign => "sign",
+            Mf::Fma => "fma",
+            Mf::Mix => "mix",
+            Mf::Step => "step",
+            Mf::SmoothStep => "smoothstep",
+            Mf::Sqrt => "sqrt",
+            Mf::InverseSqrt => "inverseSqrt",
+            Mf::Transpose => "transpose",
+            Mf::Determinant => "determinant",
+            Mf::QuantizeToF16 => "quantizeToF16",
+            Mf::CountTrailingZeros => "countTrailingZeros",
+            Mf::CountLeadingZeros => "countLeadingZeros",
+            Mf::CountOneBits => "countOneBits",
+            Mf::ReverseBits => "reverseBits",
+            Mf::ExtractBits => "extractBits",
+            Mf::InsertBits => "insertBits",
+            Mf::FirstTrailingBit => "firstTrailingBit",
+            Mf::FirstLeadingBit => "firstLeadingBit",
+            Mf::Pack4x8snorm => "pack4x8snorm",
+            Mf::Pack4x8unorm => "pack4x8unorm",
+            Mf::Pack2x16snorm => "pack2x16snorm",
+            Mf::Pack2x16unorm => "pack2x16unorm",
+            Mf::Pack2x16float => "pack2x16float",
+            Mf::Pack4xI8 => "pack4xI8",
+            Mf::Pack4xU8 => "pack4xU8",
+            Mf::Unpack4x8snorm => "unpack4x8snorm",
+            Mf::Unpack4x8unorm => "unpack4x8unorm",
+            Mf::Unpack2x16snorm => "unpack2x16snorm",
+            Mf::Unpack2x16unorm => "unpack2x16unorm",
+            Mf::Unpack2x16float => "unpack2x16float",
+            Mf::Unpack4xI8 => "unpack4xI8",
+            Mf::Unpack4xU8 => "unpack4xU8",
+
+            // Non-standard math functions.
+            Mf::Inverse | Mf::Outer => return None,
+        })
+    }
+}
+
+impl TryToWgsl for crate::BuiltIn {
+    const DESCRIPTION: &'static str = "builtin value";
+
+    fn try_to_wgsl(self) -> Option<&'static str> {
+        use crate::BuiltIn as Bi;
+        Some(match self {
+            Bi::Position { .. } => "position",
+            Bi::ViewIndex => "view_index",
+            Bi::InstanceIndex => "instance_index",
+            Bi::VertexIndex => "vertex_index",
+            Bi::FragDepth => "frag_depth",
+            Bi::FrontFacing => "front_facing",
+            Bi::PrimitiveIndex => "primitive_index",
+            Bi::SampleIndex => "sample_index",
+            Bi::SampleMask => "sample_mask",
+            Bi::GlobalInvocationId => "global_invocation_id",
+            Bi::LocalInvocationId => "local_invocation_id",
+            Bi::LocalInvocationIndex => "local_invocation_index",
+            Bi::WorkGroupId => "workgroup_id",
+            Bi::NumWorkGroups => "num_workgroups",
+            Bi::NumSubgroups => "num_subgroups",
+            Bi::SubgroupId => "subgroup_id",
+            Bi::SubgroupSize => "subgroup_size",
+            Bi::SubgroupInvocationId => "subgroup_invocation_id",
+
+            // Non-standard built-ins.
+            Bi::BaseInstance
+            | Bi::BaseVertex
+            | Bi::ClipDistance
+            | Bi::CullDistance
+            | Bi::PointSize
+            | Bi::DrawID
+            | Bi::PointCoord
+            | Bi::WorkGroupSize => return None,
+        })
+    }
+}
+
+impl ToWgsl for crate::Interpolation {
+    fn to_wgsl(self) -> &'static str {
+        match self {
+            crate::Interpolation::Perspective => "perspective",
+            crate::Interpolation::Linear => "linear",
+            crate::Interpolation::Flat => "flat",
+        }
+    }
+}
+
+impl ToWgsl for crate::Sampling {
+    fn to_wgsl(self) -> &'static str {
+        match self {
+            crate::Sampling::Center => "center",
+            crate::Sampling::Centroid => "centroid",
+            crate::Sampling::Sample => "sample",
+            crate::Sampling::First => "first",
+            crate::Sampling::Either => "either",
+        }
+    }
+}
+
+impl ToWgsl for crate::StorageFormat {
+    fn to_wgsl(self) -> &'static str {
+        use crate::StorageFormat as Sf;
+
+        match self {
+            Sf::R8Unorm => "r8unorm",
+            Sf::R8Snorm => "r8snorm",
+            Sf::R8Uint => "r8uint",
+            Sf::R8Sint => "r8sint",
+            Sf::R16Uint => "r16uint",
+            Sf::R16Sint => "r16sint",
+            Sf::R16Float => "r16float",
+            Sf::Rg8Unorm => "rg8unorm",
+            Sf::Rg8Snorm => "rg8snorm",
+            Sf::Rg8Uint => "rg8uint",
+            Sf::Rg8Sint => "rg8sint",
+            Sf::R32Uint => "r32uint",
+            Sf::R32Sint => "r32sint",
+            Sf::R32Float => "r32float",
+            Sf::Rg16Uint => "rg16uint",
+            Sf::Rg16Sint => "rg16sint",
+            Sf::Rg16Float => "rg16float",
+            Sf::Rgba8Unorm => "rgba8unorm",
+            Sf::Rgba8Snorm => "rgba8snorm",
+            Sf::Rgba8Uint => "rgba8uint",
+            Sf::Rgba8Sint => "rgba8sint",
+            Sf::Bgra8Unorm => "bgra8unorm",
+            Sf::Rgb10a2Uint => "rgb10a2uint",
+            Sf::Rgb10a2Unorm => "rgb10a2unorm",
+            Sf::Rg11b10Ufloat => "rg11b10float",
+            Sf::R64Uint => "r64uint",
+            Sf::Rg32Uint => "rg32uint",
+            Sf::Rg32Sint => "rg32sint",
+            Sf::Rg32Float => "rg32float",
+            Sf::Rgba16Uint => "rgba16uint",
+            Sf::Rgba16Sint => "rgba16sint",
+            Sf::Rgba16Float => "rgba16float",
+            Sf::Rgba32Uint => "rgba32uint",
+            Sf::Rgba32Sint => "rgba32sint",
+            Sf::Rgba32Float => "rgba32float",
+            Sf::R16Unorm => "r16unorm",
+            Sf::R16Snorm => "r16snorm",
+            Sf::Rg16Unorm => "rg16unorm",
+            Sf::Rg16Snorm => "rg16snorm",
+            Sf::Rgba16Unorm => "rgba16unorm",
+            Sf::Rgba16Snorm => "rgba16snorm",
+        }
+    }
+}


### PR DESCRIPTION
Add `to_wgsl` functions that return the WGSL representations of the following types as `&'static str` values:

- `MathFunction`
- `BuiltIn`
- `Interpolation`
- `Sampling`

Use these functions in the WGSL backend.

Also add `to_wgsl_debug` functions that return some legible string for all possible values, not just those that are defined by the WGSL standard.

There are other types that it would make sense to do this for, like `ImageDimension`, but these are some of the types I ended up needing for diagnostics and logging in #6833, from which I'm trying to spin them out.