### PR TITLE
Add validation tests ensuring destroyed textures and buffers cause submission to fail

### DIFF
--- a/tests/validation_tests/api/buffer.rs
+++ b/tests/validation_tests/api/buffer.rs
@@ -2,6 +2,28 @@
 
 use core::num::NonZero;
 
+/// Ensures that submitting a command buffer referencing an already destroyed buffer
+/// results in an error.
+#[test]
+#[should_panic = "Buffer with '' label has been destroyed"]
+fn destroyed_buffer() {
+    let (device, queue) = crate::request_noop_device();
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 1024,
+        usage: wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder =
+        device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    encoder.clear_buffer(&buffer, 0, None);
+
+    buffer.destroy();
+
+    queue.submit([encoder.finish()]);
+}
+
 mod buffer_slice {
     use super::*;
 

--- a/tests/validation_tests/api/mod.rs
+++ b/tests/validation_tests/api/mod.rs
@@ -1,1 +1,2 @@
 mod buffer;
+mod texture;

--- a/tests/validation_tests/api/texture.rs
+++ b/tests/validation_tests/api/texture.rs
@@ -1,0 +1,56 @@
+//! Tests of [`wgpu::Texture`] and related.
+
+/// Ensures that submitting a command buffer referencing an already destroyed texture
+/// results in an error.
+#[test]
+#[should_panic = "Texture with 'dst' label has been destroyed"]
+fn destroyed_texture() {
+    let (device, queue) = crate::request_noop_device();
+    let size = wgpu::Extent3d {
+        width: 256,
+        height: 256,
+        depth_or_array_layers: 1,
+    };
+    let texture_src = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("src"),
+        size,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let texture_dst = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("dst"),
+        size,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+
+    let mut encoder =
+        device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    encoder.copy_texture_to_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: &texture_src,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyTextureInfo {
+            texture: &texture_dst,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        size,
+    );
+
+    texture_dst.destroy();
+
+    queue.submit([encoder.finish()]);
+}


### PR DESCRIPTION
**Connections**
Closes #6625. The problem described there turned out not to be an issue, but this adds tests to verify that is indeed the case, for peace of mind.

**Description**
Submitting a command buffer which references textures or buffers that have been destroyed should return an error. These tests ensure that is the case. We use the noop backend as this is not GPU-dependent.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
