### PR TITLE
Fix `wgpu-info`'s use of DXC

### DIFF
--- a/wgpu-info/src/report.rs
+++ b/wgpu-info/src/report.rs
@@ -3,7 +3,8 @@ use std::io;
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 use wgpu::{
-    AdapterInfo, DownlevelCapabilities, Features, Limits, TextureFormat, TextureFormatFeatures,
+    AdapterInfo, DownlevelCapabilities, Dx12Compiler, Features, Limits, TextureFormat,
+    TextureFormatFeatures,
 };
 
 use crate::texture;
@@ -19,9 +20,10 @@ pub struct GpuReport {
 impl GpuReport {
     pub fn generate() -> Self {
         let instance = wgpu::Instance::new(&{
-            let mut desc = wgpu::InstanceDescriptor::from_env_or_default();
-            desc.flags = wgpu::InstanceFlags::debugging().with_env();
-            desc
+            let mut desc = wgpu::InstanceDescriptor::default();
+            desc.backend_options.dx12.shader_compiler = Dx12Compiler::StaticDxc;
+            desc.flags = wgpu::InstanceFlags::debugging();
+            desc.with_env()
         });
         let adapters = instance.enumerate_adapters(wgpu::Backends::all());
 


### PR DESCRIPTION
Found in #5701 

Broken by #6895 