### PR TITLE
Adjust imports to allow `no_std`.

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -1,3 +1,21 @@
+use alloc::{
+    borrow::{Cow, ToOwned},
+    boxed::Box,
+    string::String,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+use core::{fmt, mem::ManuallyDrop, ops::Range};
+use std::sync::OnceLock;
+
+use arrayvec::ArrayVec;
+use thiserror::Error;
+
+#[cfg(feature = "serde")]
+use serde::Deserialize;
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
 use crate::{
     device::{
         bgl, Device, DeviceError, MissingDownlevelFlags, MissingFeatures, SHADER_STAGE_COUNT,
@@ -7,30 +25,13 @@ use crate::{
     pipeline::{ComputePipeline, RenderPipeline},
     resource::{
         Buffer, DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
-        MissingTextureUsageError, ResourceErrorIdent, Sampler, TextureView, TrackingData,
+        MissingTextureUsageError, ResourceErrorIdent, Sampler, TextureView, Tlas, TrackingData,
     },
     resource_log,
     snatch::{SnatchGuard, Snatchable},
     track::{BindGroupStates, ResourceUsageCompatibilityError},
     Label,
 };
-
-use arrayvec::ArrayVec;
-
-#[cfg(feature = "serde")]
-use serde::Deserialize;
-#[cfg(feature = "serde")]
-use serde::Serialize;
-
-use std::{
-    borrow::Cow,
-    mem::ManuallyDrop,
-    ops::Range,
-    sync::{Arc, OnceLock, Weak},
-};
-
-use crate::resource::Tlas;
-use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
@@ -477,9 +478,9 @@ where
     [BufferBinding<B>]: ToOwned,
     [S]: ToOwned,
     [TV]: ToOwned,
-    <[BufferBinding<B>] as ToOwned>::Owned: std::fmt::Debug,
-    <[S] as ToOwned>::Owned: std::fmt::Debug,
-    <[TV] as ToOwned>::Owned: std::fmt::Debug,
+    <[BufferBinding<B>] as ToOwned>::Owned: fmt::Debug,
+    <[S] as ToOwned>::Owned: fmt::Debug,
+    <[TV] as ToOwned>::Owned: fmt::Debug,
 {
     /// Slot for which binding provides resource. Corresponds to an entry of the same
     /// binding index in the [`BindGroupLayoutDescriptor`].
@@ -510,11 +511,11 @@ pub struct BindGroupDescriptor<
     [BufferBinding<B>]: ToOwned,
     [S]: ToOwned,
     [TV]: ToOwned,
-    <[BufferBinding<B>] as ToOwned>::Owned: std::fmt::Debug,
-    <[S] as ToOwned>::Owned: std::fmt::Debug,
-    <[TV] as ToOwned>::Owned: std::fmt::Debug,
+    <[BufferBinding<B>] as ToOwned>::Owned: fmt::Debug,
+    <[S] as ToOwned>::Owned: fmt::Debug,
+    <[TV] as ToOwned>::Owned: fmt::Debug,
     [BindGroupEntry<'a, B, S, TV, TLAS>]: ToOwned,
-    <[BindGroupEntry<'a, B, S, TV, TLAS>] as ToOwned>::Owned: std::fmt::Debug,
+    <[BindGroupEntry<'a, B, S, TV, TLAS>] as ToOwned>::Owned: fmt::Debug,
 {
     /// Debug label of the bind group.
     ///
@@ -564,8 +565,8 @@ pub(crate) enum ExclusivePipeline {
     Compute(Weak<ComputePipeline>),
 }
 
-impl std::fmt::Display for ExclusivePipeline {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ExclusivePipeline {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ExclusivePipeline::None => f.write_str("None"),
             ExclusivePipeline::Render(p) => {
@@ -703,7 +704,7 @@ pub enum PushConstantUploadError {
 pub struct PipelineLayoutDescriptor<'a, BGL = BindGroupLayoutId>
 where
     [BGL]: ToOwned,
-    <[BGL] as ToOwned>::Owned: std::fmt::Debug,
+    <[BGL] as ToOwned>::Owned: fmt::Debug,
 {
     /// Debug label of the pipeline layout.
     ///
@@ -866,9 +867,9 @@ where
     [BufferBinding<B>]: ToOwned,
     [S]: ToOwned,
     [TV]: ToOwned,
-    <[BufferBinding<B>] as ToOwned>::Owned: std::fmt::Debug,
-    <[S] as ToOwned>::Owned: std::fmt::Debug,
-    <[TV] as ToOwned>::Owned: std::fmt::Debug,
+    <[BufferBinding<B>] as ToOwned>::Owned: fmt::Debug,
+    <[S] as ToOwned>::Owned: fmt::Debug,
+    <[TV] as ToOwned>::Owned: fmt::Debug,
 {
     Buffer(BufferBinding<B>),
     #[cfg_attr(

--- a/wgpu-core/src/command/allocator.rs
+++ b/wgpu-core/src/command/allocator.rs
@@ -1,3 +1,5 @@
+use alloc::{boxed::Box, vec::Vec};
+
 use crate::lock::{rank, Mutex};
 
 /// A pool of free [`wgpu_hal::CommandEncoder`]s, owned by a `Device`.

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+
+use arrayvec::ArrayVec;
+use thiserror::Error;
 
 use crate::{
     binding_model::{BindGroup, LateMinBufferBindingSizeMismatch, PipelineLayout},
@@ -7,10 +10,14 @@ use crate::{
     resource::{Labeled, ResourceErrorIdent},
 };
 
-use arrayvec::ArrayVec;
-use thiserror::Error;
-
 mod compat {
+    use alloc::{
+        string::{String, ToString as _},
+        sync::{Arc, Weak},
+        vec::Vec,
+    };
+    use core::{num::NonZeroU32, ops::Range};
+
     use arrayvec::ArrayVec;
     use thiserror::Error;
     use wgt::{BindingType, ShaderStages};
@@ -19,11 +26,6 @@ mod compat {
         binding_model::BindGroupLayout,
         error::MultiError,
         resource::{Labeled, ParentDevice, ResourceErrorIdent},
-    };
-    use std::{
-        num::NonZeroU32,
-        ops::Range,
-        sync::{Arc, Weak},
     };
 
     pub(crate) enum Error {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -78,6 +78,21 @@ index format changes.
 
 #![allow(clippy::reversed_empty_ranges)]
 
+use alloc::{
+    borrow::{Cow, ToOwned as _},
+    string::String,
+    sync::Arc,
+    vec::Vec,
+};
+use core::{
+    mem::size_of,
+    num::{NonZeroU32, NonZeroU64},
+    ops::Range,
+};
+
+use arrayvec::ArrayVec;
+use thiserror::Error;
+
 use crate::{
     binding_model::{BindError, BindGroup, PipelineLayout},
     command::{
@@ -101,10 +116,6 @@ use crate::{
     track::RenderBundleScope,
     Label, LabelHelpers,
 };
-use arrayvec::ArrayVec;
-
-use std::{borrow::Cow, mem::size_of, num::NonZeroU32, ops::Range, sync::Arc};
-use thiserror::Error;
 
 use super::{
     render_command::{ArcRenderCommand, RenderCommand},
@@ -455,7 +466,7 @@ impl RenderBundleEncoder {
 
         let render_bundle = RenderBundle {
             base: BasePass {
-                label: desc.label.as_ref().map(|cow| cow.to_string()),
+                label: desc.label.as_deref().map(str::to_owned),
                 commands,
                 dynamic_offsets: flat_dynamic_offsets,
                 string_data: self.base.string_data,
@@ -591,7 +602,7 @@ fn set_index_buffer(
     buffer_id: id::Id<id::markers::Buffer>,
     index_format: wgt::IndexFormat,
     offset: u64,
-    size: Option<std::num::NonZeroU64>,
+    size: Option<NonZeroU64>,
 ) -> Result<(), RenderBundleErrorInner> {
     let buffer = buffer_guard.get(buffer_id).get()?;
 
@@ -624,7 +635,7 @@ fn set_vertex_buffer(
     slot: u32,
     buffer_id: id::Id<id::markers::Buffer>,
     offset: u64,
-    size: Option<std::num::NonZeroU64>,
+    size: Option<NonZeroU64>,
 ) -> Result<(), RenderBundleErrorInner> {
     let max_vertex_buffers = state.device.limits.max_vertex_buffers;
     if slot >= max_vertex_buffers {
@@ -1493,7 +1504,7 @@ where
 pub mod bundle_ffi {
     use super::{RenderBundleEncoder, RenderCommand};
     use crate::{id, RawString};
-    use std::{convert::TryInto, slice};
+    use core::{convert::TryInto, slice};
     use wgt::{BufferAddress, BufferSize, DynamicOffset, IndexFormat};
 
     /// # Safety

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -1,4 +1,5 @@
-use std::{ops::Range, sync::Arc};
+use alloc::{sync::Arc, vec::Vec};
+use core::ops::Range;
 
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1,12 +1,20 @@
+use thiserror::Error;
+use wgt::{BufferAddress, DynamicOffset};
+
+use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
+use core::{fmt, mem::size_of, str};
+
 use crate::{
     binding_model::{
         BindError, BindGroup, LateMinBufferBindingSizeMismatch, PushConstantUploadError,
     },
     command::{
-        bind::Binder,
+        bind::{Binder, BinderError},
         compute_command::ArcComputeCommand,
         end_pipeline_statistics_query,
-        memory_init::{fixup_discarded_surfaces, SurfacesInDiscardState},
+        memory_init::{
+            fixup_discarded_surfaces, CommandBufferTextureMemoryActions, SurfacesInDiscardState,
+        },
         validate_and_begin_pipeline_statistics_query, ArcPassTimestampWrites, BasePass,
         BindGroupStateChange, CommandBuffer, CommandEncoderError, MapPassErr, PassErrorScope,
         PassTimestampWrites, QueryUseError, StateChange,
@@ -16,6 +24,7 @@ use crate::{
     hal_label, id,
     init_tracker::{BufferInitTrackerAction, MemoryInitKind},
     pipeline::ComputePipeline,
+    ray_tracing::TlasAction,
     resource::{
         self, Buffer, DestroyedResourceError, InvalidResourceError, Labeled,
         MissingBufferUsageError, ParentDevice,
@@ -24,13 +33,6 @@ use crate::{
     track::{ResourceUsageCompatibilityError, Tracker, TrackerIndex, UsageScope},
     Label,
 };
-
-use thiserror::Error;
-use wgt::{BufferAddress, DynamicOffset};
-
-use super::{bind::BinderError, memory_init::CommandBufferTextureMemoryActions};
-use crate::ray_tracing::TlasAction;
-use std::{fmt, mem::size_of, str, sync::Arc};
 
 pub struct ComputePass {
     /// All pass data & records is stored here.
@@ -289,7 +291,7 @@ impl Global {
         let hub = &self.hub;
 
         let mut arc_desc = ArcComputePassDescriptor {
-            label: desc.label.as_deref().map(std::borrow::Cow::Borrowed),
+            label: desc.label.as_deref().map(Cow::Borrowed),
             timestamp_writes: None, // Handle only once we resolved the encoder.
         };
 
@@ -363,7 +365,7 @@ impl Global {
         let (mut compute_pass, encoder_error) = self.command_encoder_begin_compute_pass(
             encoder_id,
             &ComputePassDescriptor {
-                label: label.as_deref().map(std::borrow::Cow::Borrowed),
+                label: label.as_deref().map(Cow::Borrowed),
                 timestamp_writes: timestamp_writes.cloned(),
             },
         );

--- a/wgpu-core/src/command/compute_command.rs
+++ b/wgpu-core/src/command/compute_command.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 use crate::{
     binding_model::BindGroup,
@@ -73,8 +73,9 @@ impl ComputeCommand {
     pub fn resolve_compute_command_ids(
         hub: &crate::hub::Hub,
         commands: &[ComputeCommand],
-    ) -> Result<Vec<ArcComputeCommand>, super::ComputePassError> {
+    ) -> Result<alloc::vec::Vec<ArcComputeCommand>, super::ComputePassError> {
         use super::{ComputePassError, PassErrorScope};
+        use alloc::vec::Vec;
 
         let buffers_guard = hub.buffers.read();
         let bind_group_guard = hub.bind_groups.read();

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -1,3 +1,7 @@
+use alloc::boxed::Box;
+
+use thiserror::Error;
+
 use crate::{
     binding_model::{LateMinBufferBindingSizeMismatch, PushConstantUploadError},
     resource::{
@@ -6,8 +10,6 @@ use crate::{
     },
     track::ResourceUsageCompatibilityError,
 };
-
-use thiserror::Error;
 
 use super::bind::BinderError;
 

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -1,4 +1,8 @@
-use std::{ops::Range, sync::Arc, vec::Drain};
+use alloc::{
+    sync::Arc,
+    vec::{Drain, Vec},
+};
+use core::ops::Range;
 
 use hashbrown::hash_map::Entry;
 

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -1,3 +1,6 @@
+use alloc::{sync::Arc, vec, vec::Vec};
+use core::{iter, mem};
+
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;
 use crate::{
@@ -13,7 +16,6 @@ use crate::{
     track::{StatelessTracker, TrackerIndex},
     FastHashMap,
 };
-use std::{iter, sync::Arc};
 use thiserror::Error;
 use wgt::BufferAddress;
 
@@ -39,7 +41,7 @@ impl QueryResetMap {
                 )
             });
 
-        std::mem::replace(&mut vec_pair.0[query as usize], true)
+        mem::replace(&mut vec_pair.0[query as usize], true)
     }
 
     pub fn reset_queries(&mut self, raw_encoder: &mut dyn hal::DynCommandEncoder) {

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -1,4 +1,15 @@
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
+    cmp::max,
+    num::NonZeroU64,
+    ops::{Deref, Range},
+    sync::atomic::Ordering,
+};
+
+use wgt::{math::align_to, BufferUsages, BufferUses, Features};
+
 use crate::{
+    command::CommandBufferMutable,
     device::queue::TempResource,
     global::Global,
     hub::Hub,
@@ -15,16 +26,6 @@ use crate::{
     snatch::SnatchGuard,
     track::PendingTransition,
     FastHashSet,
-};
-
-use wgt::{math::align_to, BufferUsages, BufferUses, Features};
-
-use super::CommandBufferMutable;
-use std::{
-    cmp::max,
-    num::NonZeroU64,
-    ops::{Deref, Range},
-    sync::{atomic::Ordering, Arc},
 };
 
 struct TriangleBufferStore<'a> {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1,3 +1,13 @@
+use alloc::{borrow::Cow, sync::Arc, vec::Vec};
+use core::{fmt, mem::size_of, num::NonZeroU32, ops::Range, str};
+
+use arrayvec::ArrayVec;
+use thiserror::Error;
+use wgt::{
+    BufferAddress, BufferSize, BufferUsages, Color, DynamicOffset, IndexFormat, ShaderStages,
+    TextureSelector, TextureUsages, TextureViewDimension, VertexStepMode,
+};
+
 use crate::binding_model::BindGroup;
 use crate::command::{
     validate_and_begin_occlusion_query, validate_and_begin_pipeline_statistics_query,
@@ -33,19 +43,10 @@ use crate::{
     Label,
 };
 
-use arrayvec::ArrayVec;
-use thiserror::Error;
-use wgt::{
-    BufferAddress, BufferSize, BufferUsages, Color, DynamicOffset, IndexFormat, ShaderStages,
-    TextureSelector, TextureUsages, TextureViewDimension, VertexStepMode,
-};
-
 #[cfg(feature = "serde")]
 use serde::Deserialize;
 #[cfg(feature = "serde")]
 use serde::Serialize;
-
-use std::{borrow::Cow, fmt, mem::size_of, num::NonZeroU32, ops::Range, str, sync::Arc};
 
 use super::render_command::ArcRenderCommand;
 use super::{

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -1,14 +1,14 @@
+use alloc::sync::Arc;
+
+use wgt::{BufferAddress, BufferSize, Color};
+
+use super::{Rect, RenderBundle};
 use crate::{
     binding_model::BindGroup,
     id,
     pipeline::RenderPipeline,
     resource::{Buffer, QuerySet},
 };
-use wgt::{BufferAddress, BufferSize, Color};
-
-use std::sync::Arc;
-
-use super::{Rect, RenderBundle};
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug)]
@@ -127,8 +127,9 @@ impl RenderCommand {
     pub fn resolve_render_command_ids(
         hub: &crate::hub::Hub,
         commands: &[RenderCommand],
-    ) -> Result<Vec<ArcRenderCommand>, super::RenderPassError> {
+    ) -> Result<alloc::vec::Vec<ArcRenderCommand>, super::RenderPassError> {
         use super::{DrawKind, PassErrorScope, RenderPassError};
+        use alloc::vec::Vec;
 
         let buffers_guard = hub.buffers.read();
         let bind_group_guard = hub.bind_groups.read();

--- a/wgpu-core/src/command/timestamp_writes.rs
+++ b/wgpu-core/src/command/timestamp_writes.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 use crate::id;
 

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -1,3 +1,9 @@
+use alloc::{sync::Arc, vec::Vec};
+
+use arrayvec::ArrayVec;
+use thiserror::Error;
+use wgt::{BufferAddress, BufferUsages, Extent3d, TextureSelector, TextureUsages};
+
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;
 use crate::{
@@ -17,12 +23,6 @@ use crate::{
     },
     snatch::SnatchGuard,
 };
-
-use arrayvec::ArrayVec;
-use thiserror::Error;
-use wgt::{BufferAddress, BufferUsages, Extent3d, TextureSelector, TextureUsages};
-
-use std::sync::Arc;
 
 use super::{ClearError, CommandBufferMutable};
 

--- a/wgpu-core/src/device/bgl.rs
+++ b/wgpu-core/src/device/bgl.rs
@@ -1,4 +1,4 @@
-use std::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher};
 
 use crate::{
     binding_model::{self},

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1,3 +1,6 @@
+use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc, vec::Vec};
+use core::{ptr::NonNull, sync::atomic::Ordering};
+
 #[cfg(feature = "trace")]
 use crate::device::trace;
 use crate::{
@@ -27,12 +30,6 @@ use crate::{
 };
 
 use wgt::{BufferAddress, TextureFormat};
-
-use std::{
-    borrow::Cow,
-    ptr::NonNull,
-    sync::{atomic::Ordering, Arc},
-};
 
 use super::{ImplicitPipelineIds, UserClosures};
 
@@ -112,7 +109,7 @@ impl Global {
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
                 let mut desc = desc.clone();
-                let mapped_at_creation = std::mem::replace(&mut desc.mapped_at_creation, false);
+                let mapped_at_creation = core::mem::replace(&mut desc.mapped_at_creation, false);
                 if mapped_at_creation && !desc.usage.contains(wgt::BufferUsages::MAP_WRITE) {
                     desc.usage |= wgt::BufferUsages::COPY_DST;
                 }
@@ -239,7 +236,7 @@ impl Global {
         }
         .map_err(|e| device.handle_hal_error(e))?;
 
-        unsafe { std::ptr::copy_nonoverlapping(data.as_ptr(), mapping.ptr.as_ptr(), data.len()) };
+        unsafe { core::ptr::copy_nonoverlapping(data.as_ptr(), mapping.ptr.as_ptr(), data.len()) };
 
         if !mapping.is_coherent {
             #[allow(clippy::single_range_in_vec_init)]
@@ -968,7 +965,7 @@ impl Global {
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
                 let data = trace.make_binary("spv", unsafe {
-                    std::slice::from_raw_parts(source.as_ptr().cast::<u8>(), source.len() * 4)
+                    core::slice::from_raw_parts(source.as_ptr().cast::<u8>(), source.len() * 4)
                 });
                 trace.add(trace::Action::CreateShaderModule {
                     id: fid.id(),
@@ -1809,7 +1806,7 @@ impl Global {
                     Err(_) => break 'error E::UnsupportedQueueFamily,
                 };
 
-                let mut hal_view_formats = vec![];
+                let mut hal_view_formats = Vec::new();
                 for format in config.view_formats.iter() {
                     if *format == config.format {
                         continue;

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -1,3 +1,8 @@
+use alloc::{sync::Arc, vec::Vec};
+
+use smallvec::SmallVec;
+use thiserror::Error;
+
 use crate::{
     device::{
         queue::{EncoderInFlight, SubmittedWorkDoneClosure, TempResource},
@@ -7,10 +12,6 @@ use crate::{
     snatch::SnatchGuard,
     SubmissionIndex,
 };
-use smallvec::SmallVec;
-
-use std::sync::Arc;
-use thiserror::Error;
 
 /// A command submitted to the GPU for execution.
 ///

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -1,3 +1,6 @@
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::{fmt, num::NonZeroU32};
+
 use crate::{
     binding_model,
     hub::Hub,
@@ -14,8 +17,6 @@ use arrayvec::ArrayVec;
 use smallvec::SmallVec;
 use thiserror::Error;
 use wgt::{BufferAddress, DeviceLostReason, TextureFormat};
-
-use std::num::NonZeroU32;
 
 pub(crate) mod bgl;
 pub mod global;
@@ -236,7 +237,7 @@ pub(crate) fn map_buffer(
     // If this is a write mapping zeroing out the memory here is the only
     // reasonable way as all data is pushed to GPU anyways.
 
-    let mapped = unsafe { std::slice::from_raw_parts_mut(mapping.ptr.as_ptr(), size as usize) };
+    let mapped = unsafe { core::slice::from_raw_parts_mut(mapping.ptr.as_ptr(), size as usize) };
 
     // We can't call flush_mapped_ranges in this case, so we can't drain the uninitialized ranges either
     if !mapping.is_coherent
@@ -288,8 +289,8 @@ pub struct DeviceMismatch {
     pub(super) target_device: ResourceErrorIdent,
 }
 
-impl std::fmt::Display for DeviceMismatch {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl fmt::Display for DeviceMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
             "{} of {} doesn't match {}",

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1,5 +1,18 @@
+use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
+use core::{
+    iter,
+    mem::{self, ManuallyDrop},
+    ptr::NonNull,
+    sync::atomic::Ordering,
+};
+
+use smallvec::SmallVec;
+use thiserror::Error;
+
+use super::{life::LifetimeTracker, Device};
 #[cfg(feature = "trace")]
 use crate::device::trace::Action;
+use crate::scratch::ScratchBuffer;
 use crate::{
     api_log,
     command::{
@@ -24,19 +37,6 @@ use crate::{
     track::{self, Tracker, TrackerIndex},
     FastHashMap, SubmissionIndex,
 };
-
-use smallvec::SmallVec;
-
-use crate::scratch::ScratchBuffer;
-use std::{
-    iter,
-    mem::{self, ManuallyDrop},
-    ptr::NonNull,
-    sync::{atomic::Ordering, Arc},
-};
-use thiserror::Error;
-
-use super::{life::LifetimeTracker, Device};
 
 pub struct Queue {
     raw: Box<dyn hal::DynQueue>,
@@ -721,7 +721,7 @@ impl Queue {
             if has_copy_partial_init_tracker_coverage(size, destination.mip_level, &dst.desc) {
                 for layer_range in dst_initialization_status.mips[destination.mip_level as usize]
                     .drain(init_layer_range)
-                    .collect::<Vec<std::ops::Range<u32>>>()
+                    .collect::<Vec<core::ops::Range<u32>>>()
                 {
                     let mut trackers = self.device.trackers.lock();
                     crate::command::clear_texture(
@@ -974,7 +974,7 @@ impl Queue {
             if has_copy_partial_init_tracker_coverage(&size, destination.mip_level, &dst.desc) {
                 for layer_range in dst_initialization_status.mips[destination.mip_level as usize]
                     .drain(init_layer_range)
-                    .collect::<Vec<std::ops::Range<u32>>>()
+                    .collect::<Vec<core::ops::Range<u32>>>()
                 {
                     let mut trackers = self.device.trackers.lock();
                     crate::command::clear_texture(

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -1,5 +1,5 @@
-use std::mem::ManuallyDrop;
-use std::sync::Arc;
+use alloc::{string::ToString as _, sync::Arc, vec::Vec};
+use core::mem::ManuallyDrop;
 
 use crate::api_log;
 #[cfg(feature = "trace")]

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -1,7 +1,10 @@
-use crate::id;
-use std::ops::Range;
+use alloc::{string::String, vec::Vec};
+use core::ops::Range;
+
 #[cfg(feature = "trace")]
-use std::{borrow::Cow, io::Write as _};
+use {alloc::borrow::Cow, std::io::Write as _};
+
+use crate::id;
 
 //TODO: consider a readable Id that doesn't include the backend
 
@@ -235,7 +238,7 @@ impl Trace {
 
     pub fn make_binary(&mut self, kind: &str, data: &[u8]) -> String {
         self.binary_id += 1;
-        let name = format!("data{}.{}", self.binary_id, kind);
+        let name = std::format!("data{}.{}", self.binary_id, kind);
         let _ = std::fs::write(self.path.join(&name), data);
         name
     }

--- a/wgpu-core/src/error.rs
+++ b/wgpu-core/src/error.rs
@@ -1,5 +1,6 @@
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use core::fmt;
-use std::{error::Error, sync::Arc};
+use std::error::Error; // TODO(https://github.com/gfx-rs/wgpu/issues/6826): use core::error after MSRV bump
 
 use thiserror::Error;
 

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -1,4 +1,5 @@
-use std::{fmt, sync::Arc};
+use alloc::{borrow::ToOwned as _, boxed::Box, sync::Arc};
+use core::{fmt, iter};
 
 use crate::{
     hal_api::HalApi,
@@ -50,7 +51,7 @@ impl Global {
         Self {
             instance: Instance {
                 name: name.to_owned(),
-                instance_per_backend: std::iter::once((A::VARIANT, dyn_instance)).collect(),
+                instance_per_backend: iter::once((A::VARIANT, dyn_instance)).collect(),
                 ..Default::default()
             },
             surfaces: Registry::new(),

--- a/wgpu-core/src/hash_utils.rs
+++ b/wgpu-core/src/hash_utils.rs
@@ -1,14 +1,14 @@
 //! Module for hashing utilities.
 //!
-//! Named hash_utils to prevent clashing with the std::hash module.
+//! Named hash_utils to prevent clashing with the core::hash module.
 
 /// HashMap using a fast, non-cryptographic hash algorithm.
 pub type FastHashMap<K, V> =
-    hashbrown::HashMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+    hashbrown::HashMap<K, V, core::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 /// HashSet using a fast, non-cryptographic hash algorithm.
 pub type FastHashSet<K> =
-    hashbrown::HashSet<K, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+    hashbrown::HashSet<K, core::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 /// IndexMap using a fast, non-cryptographic hash algorithm.
 pub type FastIndexMap<K, V> =
-    indexmap::IndexMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+    indexmap::IndexMap<K, V, core::hash::BuildHasherDefault<rustc_hash::FxHasher>>;

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -100,6 +100,9 @@ flagged as errors as well.
 
 */
 
+use alloc::sync::Arc;
+use core::fmt::Debug;
+
 use crate::{
     binding_model::{BindGroup, BindGroupLayout, PipelineLayout},
     command::{CommandBuffer, RenderBundle},
@@ -111,7 +114,6 @@ use crate::{
         Blas, Buffer, Fallible, QuerySet, Sampler, StagingBuffer, Texture, TextureView, Tlas,
     },
 };
-use std::{fmt::Debug, sync::Arc};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HubReport {

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -1,5 +1,5 @@
 use crate::{Epoch, Index};
-use std::{
+use core::{
     cmp::Ordering,
     fmt::{self, Debug},
     hash::Hash,
@@ -165,7 +165,7 @@ where
     T: Marker,
 {
     #[inline]
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }
 }

--- a/wgpu-core/src/identity.rs
+++ b/wgpu-core/src/identity.rs
@@ -1,9 +1,11 @@
+use alloc::vec::Vec;
+use core::{fmt::Debug, marker::PhantomData};
+
 use crate::{
     id::{Id, Marker},
     lock::{rank, Mutex},
     Epoch, Index,
 };
-use std::{fmt::Debug, marker::PhantomData};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum IdSource {

--- a/wgpu-core/src/indirect_validation.rs
+++ b/wgpu-core/src/indirect_validation.rs
@@ -1,5 +1,6 @@
-use std::mem::size_of;
-use std::num::NonZeroU64;
+use alloc::{boxed::Box, format, string::ToString as _};
+use core::mem::size_of;
+use core::num::NonZeroU64;
 
 use thiserror::Error;
 
@@ -117,7 +118,7 @@ impl IndirectValidation {
             })
         })?;
         let hal_shader = hal::ShaderInput::Naga(hal::NagaShader {
-            module: std::borrow::Cow::Owned(module),
+            module: alloc::borrow::Cow::Owned(module),
             info,
             debug_source: None,
         });

--- a/wgpu-core/src/init_tracker/buffer.rs
+++ b/wgpu-core/src/init_tracker/buffer.rs
@@ -1,6 +1,7 @@
 use super::{InitTracker, MemoryInitKind};
 use crate::resource::Buffer;
-use std::{ops::Range, sync::Arc};
+use alloc::sync::Arc;
+use core::ops::Range;
 
 #[derive(Debug, Clone)]
 pub(crate) struct BufferInitTrackerAction {

--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -31,8 +31,9 @@ system there are two kind of writes:
 
  */
 
+use core::{fmt, iter, ops::Range};
+
 use smallvec::SmallVec;
-use std::{fmt, iter, ops::Range};
 
 mod buffer;
 mod texture;
@@ -280,7 +281,8 @@ impl InitTracker<u32> {
 
 #[cfg(test)]
 mod test {
-    use std::ops::Range;
+    use alloc::{vec, vec::Vec};
+    use core::ops::Range;
 
     type Tracker = super::InitTracker<u32>;
 

--- a/wgpu-core/src/init_tracker/texture.rs
+++ b/wgpu-core/src/init_tracker/texture.rs
@@ -1,7 +1,8 @@
 use super::{InitTracker, MemoryInitKind};
 use crate::resource::Texture;
+use alloc::{sync::Arc, vec::Vec};
 use arrayvec::ArrayVec;
-use std::{ops::Range, sync::Arc};
+use core::ops::Range;
 use wgt::TextureSelector;
 
 #[derive(Debug, Clone)]
@@ -52,7 +53,7 @@ pub(crate) struct TextureInitTracker {
 impl TextureInitTracker {
     pub(crate) fn new(mip_level_count: u32, depth_or_array_layers: u32) -> Self {
         TextureInitTracker {
-            mips: std::iter::repeat(TextureLayerInitTracker::new(depth_or_array_layers))
+            mips: core::iter::repeat(TextureLayerInitTracker::new(depth_or_array_layers))
                 .take(mip_level_count as usize)
                 .collect(),
         }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1,5 +1,10 @@
-use std::borrow::Cow;
-use std::sync::Arc;
+use alloc::{
+    borrow::{Cow, ToOwned as _},
+    boxed::Box,
+    string::String,
+    sync::Arc,
+    vec::Vec,
+};
 
 use hashbrown::HashMap;
 
@@ -111,7 +116,7 @@ impl Instance {
         init(hal::api::Noop, instance_desc, &mut instance_per_backend);
 
         Self {
-            name: name.to_string(),
+            name: name.to_owned(),
             instance_per_backend,
             flags: instance_desc.flags,
         }
@@ -203,7 +208,7 @@ impl Instance {
     #[cfg(metal)]
     pub unsafe fn create_surface_metal(
         &self,
-        layer: *mut std::ffi::c_void,
+        layer: *mut core::ffi::c_void,
     ) -> Result<Surface, CreateSurfaceError> {
         profiling::scope!("Instance::create_surface_metal");
 
@@ -228,7 +233,7 @@ impl Instance {
 
         let surface = Surface {
             presentation: Mutex::new(rank::SURFACE_PRESENTATION, None),
-            surface_per_backend: std::iter::once((Backend::Metal, raw_surface)).collect(),
+            surface_per_backend: core::iter::once((Backend::Metal, raw_surface)).collect(),
         };
 
         Ok(surface)
@@ -245,7 +250,7 @@ impl Instance {
 
         let surface = Surface {
             presentation: Mutex::new(rank::SURFACE_PRESENTATION, None),
-            surface_per_backend: std::iter::once((Backend::Dx12, surface)).collect(),
+            surface_per_backend: core::iter::once((Backend::Dx12, surface)).collect(),
         };
 
         Ok(surface)
@@ -257,7 +262,7 @@ impl Instance {
     /// The visual must be valid and able to be used to make a swapchain with.
     pub unsafe fn create_surface_from_visual(
         &self,
-        visual: *mut std::ffi::c_void,
+        visual: *mut core::ffi::c_void,
     ) -> Result<Surface, CreateSurfaceError> {
         profiling::scope!("Instance::instance_create_surface_from_visual");
         self.create_surface_dx12(|inst| unsafe { inst.create_surface_from_visual(visual) })
@@ -269,7 +274,7 @@ impl Instance {
     /// The surface_handle must be valid and able to be used to make a swapchain with.
     pub unsafe fn create_surface_from_surface_handle(
         &self,
-        surface_handle: *mut std::ffi::c_void,
+        surface_handle: *mut core::ffi::c_void,
     ) -> Result<Surface, CreateSurfaceError> {
         profiling::scope!("Instance::instance_create_surface_from_surface_handle");
         self.create_surface_dx12(|inst| unsafe {
@@ -283,7 +288,7 @@ impl Instance {
     /// The swap_chain_panel must be valid and able to be used to make a swapchain with.
     pub unsafe fn create_surface_from_swap_chain_panel(
         &self,
-        swap_chain_panel: *mut std::ffi::c_void,
+        swap_chain_panel: *mut core::ffi::c_void,
     ) -> Result<Surface, CreateSurfaceError> {
         profiling::scope!("Instance::instance_create_surface_from_swap_chain_panel");
         self.create_surface_dx12(|inst| unsafe {
@@ -773,7 +778,7 @@ impl Global {
     #[cfg(metal)]
     pub unsafe fn instance_create_surface_metal(
         &self,
-        layer: *mut std::ffi::c_void,
+        layer: *mut core::ffi::c_void,
         id_in: Option<SurfaceId>,
     ) -> Result<SurfaceId, CreateSurfaceError> {
         let surface = unsafe { self.instance.create_surface_metal(layer) }?;
@@ -787,7 +792,7 @@ impl Global {
     /// The visual must be valid and able to be used to make a swapchain with.
     pub unsafe fn instance_create_surface_from_visual(
         &self,
-        visual: *mut std::ffi::c_void,
+        visual: *mut core::ffi::c_void,
         id_in: Option<SurfaceId>,
     ) -> Result<SurfaceId, CreateSurfaceError> {
         let surface = unsafe { self.instance.create_surface_from_visual(visual) }?;
@@ -801,7 +806,7 @@ impl Global {
     /// The surface_handle must be valid and able to be used to make a swapchain with.
     pub unsafe fn instance_create_surface_from_surface_handle(
         &self,
-        surface_handle: *mut std::ffi::c_void,
+        surface_handle: *mut core::ffi::c_void,
         id_in: Option<SurfaceId>,
     ) -> Result<SurfaceId, CreateSurfaceError> {
         let surface = unsafe {
@@ -818,7 +823,7 @@ impl Global {
     /// The swap_chain_panel must be valid and able to be used to make a swapchain with.
     pub unsafe fn instance_create_surface_from_swap_chain_panel(
         &self,
-        swap_chain_panel: *mut std::ffi::c_void,
+        swap_chain_panel: *mut core::ffi::c_void,
         id_in: Option<SurfaceId>,
     ) -> Result<SurfaceId, CreateSurfaceError> {
         let surface = unsafe {

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -6,6 +6,7 @@
 #![doc = document_features::document_features!()]
 //!
 
+#![no_std]
 // When we have no backends, we end up with a lot of dead or otherwise unreachable code.
 #![cfg_attr(
     all(
@@ -41,7 +42,10 @@
     rustdoc::private_intra_doc_links
 )]
 #![warn(
+    clippy::alloc_instead_of_core,
     clippy::ptr_as_ptr,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_op_in_unsafe_fn,
@@ -56,6 +60,9 @@
 // (the only reason to use wgpu-core on the web in the first place) that have atomics enabled.
 #![cfg_attr(not(send_sync), allow(clippy::arc_with_non_send_sync))]
 
+extern crate alloc;
+// TODO(https://github.com/gfx-rs/wgpu/issues/6826): this should be optional
+extern crate std;
 extern crate wgpu_hal as hal;
 extern crate wgpu_types as wgt;
 
@@ -98,7 +105,11 @@ pub use validation::{map_storage_format_from_naga, map_storage_format_to_naga};
 pub use hal::{api, MAX_BIND_GROUPS, MAX_COLOR_ATTACHMENTS, MAX_VERTEX_BUFFERS};
 pub use naga;
 
-use std::{borrow::Cow, os::raw::c_char};
+use alloc::{
+    borrow::{Cow, ToOwned as _},
+    string::String,
+};
+use std::os::raw::c_char;
 
 pub(crate) use hash_utils::*;
 
@@ -123,10 +134,10 @@ impl<'a> LabelHelpers<'a> for Label<'a> {
             return None;
         }
 
-        self.as_ref().map(|cow| cow.as_ref())
+        self.as_deref()
     }
     fn to_string(&self) -> String {
-        self.as_ref().map(|cow| cow.to_string()).unwrap_or_default()
+        self.as_deref().map(str::to_owned).unwrap_or_default()
     }
 }
 

--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -28,15 +28,19 @@
 //!
 //! [`lock/rank.rs`]: ../../../src/wgpu_core/lock/rank.rs.html
 
-use crate::FastHashSet;
+#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
 
-use super::rank::{LockRank, LockRankSet};
 use std::{
     cell::RefCell,
+    format,
     fs::File,
     panic::Location,
     path::{Path, PathBuf},
+    vec::Vec,
 };
+
+use super::rank::{LockRank, LockRankSet};
+use crate::FastHashSet;
 
 /// A `Mutex` instrumented for lock acquisition order observation.
 ///
@@ -290,7 +294,7 @@ fn release(saved: Option<HeldLock>) {
     });
 }
 
-thread_local! {
+std::thread_local! {
     static LOCK_STATE: RefCell<ThreadState> = const { RefCell::new(ThreadState::Initial) };
 }
 

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -55,8 +55,9 @@
 //!
 //! [`lock::rank`]: crate::lock::rank
 
+use core::{cell::Cell, fmt, ops, panic::Location};
+
 use super::rank::LockRank;
-use std::{cell::Cell, panic::Location};
 
 /// A `Mutex` instrumented for deadlock prevention.
 ///
@@ -80,7 +81,7 @@ pub struct MutexGuard<'a, T> {
     saved: LockStateGuard,
 }
 
-thread_local! {
+std::thread_local! {
     static LOCK_STATE: Cell<LockState> = const { Cell::new(LockState::INITIAL) };
 }
 
@@ -191,7 +192,7 @@ impl<T> Mutex<T> {
     }
 }
 
-impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
+impl<'a, T> ops::Deref for MutexGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -199,14 +200,14 @@ impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::DerefMut for MutexGuard<'a, T> {
+impl<'a, T> ops::DerefMut for MutexGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.deref_mut()
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for Mutex<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
@@ -280,13 +281,13 @@ impl<'a, T> RwLockWriteGuard<'a, T> {
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for RwLock<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for RwLock<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
 
-impl<'a, T> std::ops::Deref for RwLockReadGuard<'a, T> {
+impl<'a, T> ops::Deref for RwLockReadGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -294,7 +295,7 @@ impl<'a, T> std::ops::Deref for RwLockReadGuard<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::Deref for RwLockWriteGuard<'a, T> {
+impl<'a, T> ops::Deref for RwLockWriteGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -302,7 +303,7 @@ impl<'a, T> std::ops::Deref for RwLockWriteGuard<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::DerefMut for RwLockWriteGuard<'a, T> {
+impl<'a, T> ops::DerefMut for RwLockWriteGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.deref_mut()
     }
@@ -381,7 +382,7 @@ fn non_stack_like() {
 
     // Avoid a double panic from dropping this while unwinding due to the panic
     // we're testing for.
-    std::mem::forget(guard2);
+    core::mem::forget(guard2);
 
     drop(guard1);
 }

--- a/wgpu-core/src/lock/vanilla.rs
+++ b/wgpu-core/src/lock/vanilla.rs
@@ -3,6 +3,8 @@
 //! These definitions are used when no particular lock instrumentation
 //! Cargo feature is selected.
 
+use core::{fmt, ops};
+
 /// A plain wrapper around [`parking_lot::Mutex`].
 ///
 /// This is just like [`parking_lot::Mutex`], except that our [`new`]
@@ -30,7 +32,7 @@ impl<T> Mutex<T> {
     }
 }
 
-impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
+impl<'a, T> ops::Deref for MutexGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -38,14 +40,14 @@ impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::DerefMut for MutexGuard<'a, T> {
+impl<'a, T> ops::DerefMut for MutexGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.deref_mut()
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for Mutex<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
@@ -92,13 +94,13 @@ impl<'a, T> RwLockWriteGuard<'a, T> {
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for RwLock<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for RwLock<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl<'a, T> std::ops::Deref for RwLockReadGuard<'a, T> {
+impl<'a, T> ops::Deref for RwLockReadGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -106,7 +108,7 @@ impl<'a, T> std::ops::Deref for RwLockReadGuard<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::Deref for RwLockWriteGuard<'a, T> {
+impl<'a, T> ops::Deref for RwLockWriteGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -114,7 +116,7 @@ impl<'a, T> std::ops::Deref for RwLockWriteGuard<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::DerefMut for RwLockWriteGuard<'a, T> {
+impl<'a, T> ops::DerefMut for RwLockWriteGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.deref_mut()
     }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -1,3 +1,16 @@
+use alloc::{
+    borrow::Cow,
+    boxed::Box,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec::Vec,
+};
+use core::{marker::PhantomData, mem::ManuallyDrop, num::NonZeroU32};
+
+use arrayvec::ArrayVec;
+use naga::error::ShaderError;
+use thiserror::Error;
+
 pub use crate::pipeline_cache::PipelineCacheValidationError;
 use crate::{
     binding_model::{CreateBindGroupLayoutError, CreatePipelineLayoutError, PipelineLayout},
@@ -7,10 +20,6 @@ use crate::{
     resource::{InvalidResourceError, Labeled, TrackingData},
     resource_log, validation, Label,
 };
-use arrayvec::ArrayVec;
-use naga::error::ShaderError;
-use std::{borrow::Cow, marker::PhantomData, mem::ManuallyDrop, num::NonZeroU32, sync::Arc};
-use thiserror::Error;
 
 /// Information about buffer bindings, which
 /// is validated against the shader (and pipeline)

--- a/wgpu-core/src/pipeline_cache.rs
+++ b/wgpu-core/src/pipeline_cache.rs
@@ -1,4 +1,4 @@
-use std::mem::size_of;
+use core::mem::size_of;
 
 use thiserror::Error;
 use wgt::AdapterInfo;
@@ -277,7 +277,7 @@ impl<'a> Writer<'a> {
         if N > self.data.len() {
             return None;
         }
-        let data = std::mem::take(&mut self.data);
+        let data = core::mem::take(&mut self.data);
         let (start, data) = data.split_at_mut(N);
         self.data = data;
         start.copy_from_slice(array);
@@ -297,6 +297,7 @@ impl<'a> Writer<'a> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{string::String, vec::Vec};
     use wgt::AdapterInfo;
 
     use crate::pipeline_cache::{PipelineCacheValidationError as E, HEADER_LENGTH};
@@ -484,7 +485,7 @@ mod tests {
         let cache = cache
             .into_iter()
             .flatten()
-            .chain(std::iter::repeat(0u8).take(100))
+            .chain(core::iter::repeat(0u8).take(100))
             .collect::<Vec<u8>>();
         let validation_result = super::validate_pipeline_cache(&cache, &ADAPTER, VALIDATION_KEY);
         let expected: &[u8] = &[0; 100];
@@ -505,7 +506,7 @@ mod tests {
         let cache = cache
             .into_iter()
             .flatten()
-            .chain(std::iter::repeat(0u8).take(200))
+            .chain(core::iter::repeat(0u8).take(200))
             .collect::<Vec<u8>>();
         let validation_result = super::validate_pipeline_cache(&cache, &ADAPTER, VALIDATION_KEY);
         assert_eq!(validation_result, Err(E::Extended));

--- a/wgpu-core/src/pool.rs
+++ b/wgpu-core/src/pool.rs
@@ -1,7 +1,5 @@
-use std::{
-    hash::Hash,
-    sync::{Arc, Weak},
-};
+use alloc::sync::{Arc, Weak};
+use core::hash::Hash;
 
 use hashbrown::{hash_map::Entry, HashMap};
 use once_cell::sync::OnceCell;
@@ -107,10 +105,11 @@ impl<K: Clone + Eq + Hash, V> ResourcePool<K, V> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        atomic::{AtomicU32, Ordering},
-        Barrier,
+    use core::{
+        sync::atomic::{AtomicU32, Ordering},
+        time::Duration,
     };
+    use std::{eprintln, sync::Barrier, thread};
 
     use super::*;
 
@@ -202,7 +201,7 @@ mod tests {
                     eprintln!("{idx}: init");
 
                     // Simulate long running constructor, ensuring that both threads will be in get_or_init.
-                    std::thread::sleep(std::time::Duration::from_millis(250));
+                    thread::sleep(Duration::from_millis(250));
 
                     resources.counter.fetch_add(1, Ordering::SeqCst);
 
@@ -215,7 +214,7 @@ mod tests {
             ret
         }
 
-        let thread1 = std::thread::spawn({
+        let thread1 = thread::spawn({
             let resource_clone = Arc::clone(&resources);
             move || thread_inner(1, &resource_clone)
         });
@@ -290,7 +289,7 @@ mod tests {
 
             eprintln!("1: postwait");
             // We wait a little bit, making sure that thread0_inner has started spinning.
-            std::thread::sleep(std::time::Duration::from_millis(250));
+            thread::sleep(Duration::from_millis(250));
             eprintln!("1: postsleep");
 
             // We remove the entry from the pool, allowing thread0_inner to re-create.
@@ -298,7 +297,7 @@ mod tests {
             eprintln!("1: removal");
         }
 
-        let thread1 = std::thread::spawn({
+        let thread1 = thread::spawn({
             let resource_clone = Arc::clone(&resources);
             move || thread1_inner(&resource_clone)
         });

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -9,7 +9,8 @@ When this texture is presented, we remove it from the device tracker as well as
 extract it from the hub.
 !*/
 
-use std::{mem::ManuallyDrop, sync::Arc};
+use alloc::{sync::Arc, vec::Vec};
+use core::mem::ManuallyDrop;
 
 #[cfg(feature = "trace")]
 use crate::device::trace::Action;
@@ -131,7 +132,7 @@ impl Surface {
         let suf = self.raw(device.backend()).unwrap();
         let (texture, status) = match unsafe {
             suf.acquire_texture(
-                Some(std::time::Duration::from_millis(FRAME_TIMEOUT_MS as u64)),
+                Some(core::time::Duration::from_millis(FRAME_TIMEOUT_MS as u64)),
                 fence.as_ref(),
             )
         } {
@@ -139,7 +140,7 @@ impl Surface {
                 drop(fence);
 
                 let texture_desc = wgt::TextureDescriptor {
-                    label: Some(std::borrow::Cow::Borrowed("<Surface Texture>")),
+                    label: Some(alloc::borrow::Cow::Borrowed("<Surface Texture>")),
                     size: wgt::Extent3d {
                         width: config.width,
                         height: config.height,

--- a/wgpu-core/src/ray_tracing.rs
+++ b/wgpu-core/src/ray_tracing.rs
@@ -7,18 +7,21 @@
 // - partial instance buffer uploads (api surface already designed with this in mind)
 // - ([non performance] extract function in build (rust function extraction with guards is a pain))
 
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::num::NonZeroU64;
+
+use thiserror::Error;
+use wgt::{AccelerationStructureGeometryFlags, BufferAddress, IndexFormat, VertexFormat};
+
 use crate::{
     command::CommandEncoderError,
     device::{DeviceError, MissingFeatures},
     id::{BlasId, BufferId, TlasId},
-    resource::{DestroyedResourceError, InvalidResourceError, MissingBufferUsageError},
+    resource::{
+        Blas, DestroyedResourceError, InvalidResourceError, MissingBufferUsageError,
+        ResourceErrorIdent, Tlas,
+    },
 };
-use std::num::NonZeroU64;
-use std::sync::Arc;
-
-use crate::resource::{Blas, ResourceErrorIdent, Tlas};
-use thiserror::Error;
-use wgt::{AccelerationStructureGeometryFlags, BufferAddress, IndexFormat, VertexFormat};
 
 #[derive(Clone, Debug, Error)]
 pub enum CreateBlasError {

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -1,4 +1,5 @@
-use std::{mem::size_of, sync::Arc};
+use alloc::sync::Arc;
+use core::mem::size_of;
 
 use crate::{
     id::Id,
@@ -126,11 +127,10 @@ impl<T: StorageItem + Clone> Registry<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use crate::{id::Marker, resource::ResourceType, storage::StorageItem};
-
     use super::Registry;
+    use crate::{id::Marker, resource::ResourceType, storage::StorageItem};
+    use alloc::sync::Arc;
+
     struct TestData;
     struct TestDataId;
     impl Marker for TestDataId {}

--- a/wgpu-core/src/scratch.rs
+++ b/wgpu-core/src/scratch.rs
@@ -1,8 +1,10 @@
+use alloc::{boxed::Box, sync::Arc};
+use core::mem::ManuallyDrop;
+
+use wgt::BufferUses;
+
 use crate::device::{Device, DeviceError};
 use crate::resource_log;
-use std::mem::ManuallyDrop;
-use std::sync::Arc;
-use wgt::BufferUses;
 
 #[derive(Debug)]
 pub struct ScratchBuffer {

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,14 +1,13 @@
 #![allow(unused)]
 
-use crate::lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::{
-    backtrace::Backtrace,
+use core::{
     cell::{Cell, RefCell, UnsafeCell},
+    fmt,
     panic::{self, Location},
-    thread,
 };
+use std::{backtrace::Backtrace, thread};
 
-use crate::lock::rank;
+use crate::lock::{rank, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// A guard that provides read access to snatchable data.
 pub struct SnatchGuard<'a>(RwLockReadGuard<'a, ()>);
@@ -59,8 +58,8 @@ impl<T> Snatchable<T> {
 
 // Can't safely print the contents of a snatchable object without holding
 // the lock.
-impl<T> std::fmt::Debug for Snatchable<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl<T> fmt::Debug for Snatchable<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<snatchable>")
     }
 }
@@ -73,8 +72,8 @@ struct LockTrace {
     backtrace: Backtrace,
 }
 
-impl std::fmt::Display for LockTrace {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for LockTrace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "a {} lock at {}\n{}",
@@ -117,7 +116,7 @@ impl LockTrace {
     fn exit() {}
 }
 
-thread_local! {
+std::thread_local! {
     static SNATCH_LOCK_TRACE: Cell<Option<LockTrace>> = const { Cell::new(None) };
 }
 

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -1,4 +1,5 @@
-use std::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
+use core::mem;
 
 use crate::id::{Id, Marker};
 use crate::resource::ResourceType;
@@ -41,7 +42,7 @@ macro_rules! impl_storage_item {
 
 /// A table of `T` values indexed by the id type `I`.
 ///
-/// `Storage` implements [`std::ops::Index`], accepting `Id` values as
+/// `Storage` implements [`core::ops::Index`], accepting `Id` values as
 /// indices.
 ///
 /// The table is represented as a vector indexed by the ids' index
@@ -78,7 +79,7 @@ where
         if index >= self.map.len() {
             self.map.resize_with(index + 1, || Element::Vacant);
         }
-        match std::mem::replace(&mut self.map[index], Element::Occupied(value, epoch)) {
+        match mem::replace(&mut self.map[index], Element::Occupied(value, epoch)) {
             Element::Vacant => {}
             Element::Occupied(_, storage_epoch) => {
                 assert_ne!(
@@ -93,7 +94,7 @@ where
 
     pub(crate) fn remove(&mut self, id: Id<T::Marker>) -> T {
         let (index, epoch) = id.unzip();
-        match std::mem::replace(&mut self.map[index as usize], Element::Vacant) {
+        match mem::replace(&mut self.map[index as usize], Element::Vacant) {
             Element::Occupied(value, storage_epoch) => {
                 assert_eq!(epoch, storage_epoch);
                 value

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -4,7 +4,13 @@
 //! a 16 bit bitflag of buffer usages. Because there is only ever
 //! one subresource, they have no selector.
 
-use std::sync::{Arc, Weak};
+use alloc::{
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+
+use hal::BufferBarrier;
+use wgt::{strict_assert, strict_assert_eq, BufferUses};
 
 use super::{PendingTransition, TrackerIndex};
 use crate::{
@@ -15,8 +21,6 @@ use crate::{
         ResourceUsageCompatibilityError, ResourceUses,
     },
 };
-use hal::BufferBarrier;
-use wgt::{strict_assert, strict_assert_eq, BufferUses};
 
 impl ResourceUses for BufferUses {
     const EXCLUSIVE: Self = Self::EXCLUSIVE;

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -1,5 +1,7 @@
 //! The `ResourceMetadata` type.
 
+use alloc::vec::Vec;
+
 use bit_vec::BitVec;
 use wgt::strict_assert;
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -109,7 +109,9 @@ use crate::{
     snatch::SnatchGuard,
 };
 
-use std::{fmt, ops, sync::Arc};
+use alloc::{sync::Arc, vec::Vec};
+use core::{fmt, mem, ops};
+
 use thiserror::Error;
 
 pub(crate) use buffer::{
@@ -513,10 +515,9 @@ impl<'a> Drop for UsageScope<'a> {
         // clear vecs and push into pool
         self.buffers.clear();
         self.textures.clear();
-        self.pool.lock().push((
-            std::mem::take(&mut self.buffers),
-            std::mem::take(&mut self.textures),
-        ));
+        self.pool
+            .lock()
+            .push((mem::take(&mut self.buffers), mem::take(&mut self.textures)));
     }
 }
 

--- a/wgpu-core/src/track/range.rs
+++ b/wgpu-core/src/track/range.rs
@@ -2,7 +2,7 @@
 //TODO: consider getting rid of it.
 use smallvec::SmallVec;
 
-use std::{fmt::Debug, iter, ops::Range};
+use core::{fmt::Debug, iter, ops::Range};
 
 /// Structure that keeps track of a I -> T mapping,
 /// optimized for a case where keys of the same values
@@ -148,7 +148,7 @@ impl<I: Copy + Ord, T: Copy + PartialEq> RangedStates<I, T> {
 
     /// Helper method for isolation that checks the sanity of the results.
     #[cfg(test)]
-    pub fn sanely_isolated(&self, index: Range<I>, default: T) -> Vec<(Range<I>, T)> {
+    pub fn sanely_isolated(&self, index: Range<I>, default: T) -> alloc::vec::Vec<(Range<I>, T)> {
         let mut clone = self.clone();
         let result = clone.isolate(&index, default).to_vec();
         clone.check_sanity();

--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -1,5 +1,5 @@
-use std::slice::Iter;
-use std::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
+use core::slice::Iter;
 
 /// A tracker that holds strong references to resources.
 ///

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -34,11 +34,11 @@ use naga::FastHashMap;
 
 use wgt::{strict_assert, strict_assert_eq, TextureSelector, TextureUses};
 
-use std::{
-    iter,
+use alloc::{
     sync::{Arc, Weak},
-    vec::Drain,
+    vec::{Drain, Vec},
 };
+use core::iter;
 
 impl ResourceUses for TextureUses {
     const EXCLUSIVE: Self = Self::EXCLUSIVE;

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1,9 +1,16 @@
-use crate::{device::bgl, resource::InvalidResourceError, FastHashMap, FastHashSet};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString as _},
+    vec::Vec,
+};
+use core::fmt;
+
 use arrayvec::ArrayVec;
 use hashbrown::hash_map::Entry;
-use std::fmt;
 use thiserror::Error;
 use wgt::{BindGroupLayoutEntry, BindingType};
+
+use crate::{device::bgl, resource::InvalidResourceError, FastHashMap, FastHashSet};
 
 #[derive(Debug)]
 enum ResourceType {

--- a/wgpu-core/src/weak_vec.rs
+++ b/wgpu-core/src/weak_vec.rs
@@ -1,6 +1,6 @@
 //! Module containing the [`WeakVec`] API.
 
-use std::sync::Weak;
+use alloc::{sync::Weak, vec::Vec};
 
 /// An optimized container for `Weak` references of `T` that minimizes reallocations by
 /// dropping older elements that no longer have strong references to them.
@@ -45,7 +45,7 @@ impl<T> WeakVec<T> {
 }
 
 pub(crate) struct WeakVecIter<T> {
-    inner: std::vec::IntoIter<Weak<T>>,
+    inner: alloc::vec::IntoIter<Weak<T>>,
 }
 
 impl<T> Iterator for WeakVecIter<T> {

--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsString, os::windows::ffi::OsStringExt};
+use std::{ffi::OsString, os::windows::ffi::OsStringExt, string::String};
 
 use windows::Win32::Graphics::Dxgi;
 

--- a/wgpu-hal/src/auxil/dxgi/exception.rs
+++ b/wgpu-hal/src/auxil/dxgi/exception.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, slice};
+use std::{
+    borrow::Cow,
+    slice,
+    string::{String, ToString as _},
+};
 
 use parking_lot::Mutex;
 use windows::Win32::{Foundation, System::Diagnostics::Debug};

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{ops::Deref, string::String, vec::Vec};
 
 use windows::{core::Interface as _, Win32::Graphics::Dxgi};
 

--- a/wgpu-hal/src/auxil/dxgi/mod.rs
+++ b/wgpu-hal/src/auxil/dxgi/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
+
 pub mod conv;
 pub mod exception;
 pub mod factory;

--- a/wgpu-hal/src/auxil/renderdoc.rs
+++ b/wgpu-hal/src/auxil/renderdoc.rs
@@ -1,6 +1,6 @@
 //! RenderDoc integration - <https://renderdoc.org/>
 
-use std::{ffi, os, ptr};
+use std::{ffi, os, ptr, string::String};
 
 /// The dynamically loaded RenderDoc API function table
 #[repr(C)]

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -1,8 +1,10 @@
 use std::{
     mem::{size_of, size_of_val},
     ptr,
+    string::String,
     sync::Arc,
     thread,
+    vec::Vec,
 };
 
 use parking_lot::Mutex;

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1,15 +1,17 @@
+use std::{mem, ops::Range, vec::Vec};
+
+use windows::Win32::{
+    Foundation,
+    Graphics::{Direct3D12, Dxgi},
+};
+use windows_core::Interface;
+
 use super::conv;
 use crate::{
     auxil::{self, dxgi::result::HResult as _},
     dx12::borrow_interface_temporarily,
     AccelerationStructureEntries,
 };
-use std::{mem, ops::Range};
-use windows::Win32::{
-    Foundation,
-    Graphics::{Direct3D12, Dxgi},
-};
-use windows_core::Interface;
 
 fn make_box(origin: &wgt::Origin3d, size: &crate::CopyExtent) -> Direct3D12::D3D12_BOX {
     Direct3D12::D3D12_BOX {

--- a/wgpu-hal/src/dx12/descriptor.rs
+++ b/wgpu-hal/src/dx12/descriptor.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, vec::Vec};
 
 use bit_set::BitSet;
 use parking_lot::Mutex;

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -4,8 +4,10 @@ use std::{
     mem::{self, size_of, size_of_val},
     num::NonZeroU32,
     ptr, slice,
+    string::{String, ToString as _},
     sync::Arc,
     time::{Duration, Instant},
+    vec::Vec,
 };
 
 use parking_lot::Mutex;

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -1,4 +1,4 @@
-use std::{mem::size_of_val, sync::Arc};
+use std::{mem::size_of_val, string::String, sync::Arc, vec::Vec};
 
 use parking_lot::RwLock;
 use windows::{

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -72,6 +72,8 @@ Otherwise, we pass a range corresponding only to the current bind group.
 
 !*/
 
+#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
+
 mod adapter;
 mod command;
 mod conv;
@@ -84,7 +86,7 @@ mod suballocation;
 mod types;
 mod view;
 
-use std::{ffi, fmt, mem, num::NonZeroU32, ops::Deref, sync::Arc};
+use std::{borrow::ToOwned as _, ffi, fmt, mem, num::NonZeroU32, ops::Deref, sync::Arc, vec::Vec};
 
 use arrayvec::ArrayVec;
 use parking_lot::{Mutex, RwLock};

--- a/wgpu-hal/src/dx12/sampler.rs
+++ b/wgpu-hal/src/dx12/sampler.rs
@@ -2,6 +2,8 @@
 //!
 //! Nearly identical to the Vulkan sampler cache, with added descriptor heap management.
 
+use std::vec::Vec;
+
 use hashbrown::{hash_map::Entry, HashMap};
 
 use ordered_float::OrderedFloat;

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -1,6 +1,6 @@
+use std::{ffi::CStr, path::PathBuf, string::String, vec::Vec};
+
 use crate::auxil::dxgi::result::HResult;
-use std::ffi::CStr;
-use std::path::PathBuf;
 use thiserror::Error;
 use windows::{
     core::{Interface, PCSTR, PCWSTR},

--- a/wgpu-hal/src/dynamic/adapter.rs
+++ b/wgpu-hal/src/dynamic/adapter.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     Adapter, Api, DeviceError, OpenDevice, SurfaceCapabilities, TextureFormatCapabilities,
 };

--- a/wgpu-hal/src/dynamic/command.rs
+++ b/wgpu-hal/src/dynamic/command.rs
@@ -1,4 +1,5 @@
-use std::ops::Range;
+use alloc::{boxed::Box, vec::Vec};
+use core::ops::Range;
 
 use crate::{
     AccelerationStructureBarrier, Api, Attachment, BufferBarrier, BufferBinding, BufferCopy,
@@ -13,7 +14,7 @@ use super::{
     DynTexture, DynTextureView,
 };
 
-pub trait DynCommandEncoder: DynResource + std::fmt::Debug {
+pub trait DynCommandEncoder: DynResource + core::fmt::Debug {
     unsafe fn begin_encoding(&mut self, label: Label) -> Result<(), DeviceError>;
 
     unsafe fn discard_encoding(&mut self);

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -1,3 +1,5 @@
+use alloc::{borrow::ToOwned as _, boxed::Box, vec::Vec};
+
 use crate::{
     AccelerationStructureBuildSizes, AccelerationStructureDescriptor, Api, BindGroupDescriptor,
     BindGroupLayoutDescriptor, BufferDescriptor, BufferMapping, CommandEncoderDescriptor,

--- a/wgpu-hal/src/dynamic/instance.rs
+++ b/wgpu-hal/src/dynamic/instance.rs
@@ -1,3 +1,5 @@
+use alloc::{boxed::Box, vec::Vec};
+
 use crate::{Api, Capabilities, ExposedAdapter, Instance, InstanceError};
 
 use super::{DynAdapter, DynResource, DynResourceExt as _, DynSurface};

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -12,7 +12,11 @@ pub use instance::{DynExposedAdapter, DynInstance};
 pub use queue::DynQueue;
 pub use surface::{DynAcquiredSurfaceTexture, DynSurface};
 
-use std::any::Any;
+use alloc::boxed::Box;
+use core::{
+    any::{Any, TypeId},
+    fmt,
+};
 
 use wgt::WasmNotSendSync;
 
@@ -33,11 +37,11 @@ macro_rules! impl_dyn_resource {
     ($($type:ty),*) => {
         $(
             impl crate::DynResource for $type {
-                fn as_any(&self) -> &dyn ::std::any::Any {
+                fn as_any(&self) -> &dyn ::core::any::Any {
                     self
                 }
 
-                fn as_any_mut(&mut self) -> &mut dyn ::std::any::Any {
+                fn as_any_mut(&mut self) -> &mut dyn ::core::any::Any {
                     self
                 }
             }
@@ -80,9 +84,9 @@ impl<R: DynResource + ?Sized> DynResourceExt for R {
 
     unsafe fn unbox<T: DynResource + 'static>(self: Box<Self>) -> T {
         debug_assert!(
-            <Self as Any>::type_id(self.as_ref()) == std::any::TypeId::of::<T>(),
+            <Self as Any>::type_id(self.as_ref()) == TypeId::of::<T>(),
             "Resource doesn't have the expected type, expected {:?}, got {:?}",
-            std::any::TypeId::of::<T>(),
+            TypeId::of::<T>(),
             <Self as Any>::type_id(self.as_ref())
         );
 
@@ -100,25 +104,25 @@ impl<R: DynResource + ?Sized> DynResourceExt for R {
     }
 }
 
-pub trait DynAccelerationStructure: DynResource + std::fmt::Debug {}
-pub trait DynBindGroup: DynResource + std::fmt::Debug {}
-pub trait DynBindGroupLayout: DynResource + std::fmt::Debug {}
-pub trait DynBuffer: DynResource + std::fmt::Debug {}
-pub trait DynCommandBuffer: DynResource + std::fmt::Debug {}
-pub trait DynComputePipeline: DynResource + std::fmt::Debug {}
-pub trait DynFence: DynResource + std::fmt::Debug {}
-pub trait DynPipelineCache: DynResource + std::fmt::Debug {}
-pub trait DynPipelineLayout: DynResource + std::fmt::Debug {}
-pub trait DynQuerySet: DynResource + std::fmt::Debug {}
-pub trait DynRenderPipeline: DynResource + std::fmt::Debug {}
-pub trait DynSampler: DynResource + std::fmt::Debug {}
-pub trait DynShaderModule: DynResource + std::fmt::Debug {}
+pub trait DynAccelerationStructure: DynResource + fmt::Debug {}
+pub trait DynBindGroup: DynResource + fmt::Debug {}
+pub trait DynBindGroupLayout: DynResource + fmt::Debug {}
+pub trait DynBuffer: DynResource + fmt::Debug {}
+pub trait DynCommandBuffer: DynResource + fmt::Debug {}
+pub trait DynComputePipeline: DynResource + fmt::Debug {}
+pub trait DynFence: DynResource + fmt::Debug {}
+pub trait DynPipelineCache: DynResource + fmt::Debug {}
+pub trait DynPipelineLayout: DynResource + fmt::Debug {}
+pub trait DynQuerySet: DynResource + fmt::Debug {}
+pub trait DynRenderPipeline: DynResource + fmt::Debug {}
+pub trait DynSampler: DynResource + fmt::Debug {}
+pub trait DynShaderModule: DynResource + fmt::Debug {}
 pub trait DynSurfaceTexture:
-    DynResource + std::borrow::Borrow<dyn DynTexture> + std::fmt::Debug
+    DynResource + core::borrow::Borrow<dyn DynTexture> + fmt::Debug
 {
 }
-pub trait DynTexture: DynResource + std::fmt::Debug {}
-pub trait DynTextureView: DynResource + std::fmt::Debug {}
+pub trait DynTexture: DynResource + fmt::Debug {}
+pub trait DynTextureView: DynResource + fmt::Debug {}
 
 impl<'a> BufferBinding<'a, dyn DynBuffer> {
     pub fn expect_downcast<B: DynBuffer>(self) -> BufferBinding<'a, B> {

--- a/wgpu-hal/src/dynamic/queue.rs
+++ b/wgpu-hal/src/dynamic/queue.rs
@@ -1,3 +1,5 @@
+use alloc::{boxed::Box, vec::Vec};
+
 use crate::{
     DeviceError, DynCommandBuffer, DynFence, DynResource, DynSurface, DynSurfaceTexture,
     FenceValue, Queue, SurfaceError,

--- a/wgpu-hal/src/dynamic/surface.rs
+++ b/wgpu-hal/src/dynamic/surface.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use core::time::Duration;
+
 use crate::{
     DynDevice, DynFence, DynResource, DynSurfaceTexture, Surface, SurfaceConfiguration,
     SurfaceError,
@@ -25,7 +28,7 @@ pub trait DynSurface: DynResource {
 
     unsafe fn acquire_texture(
         &self,
-        timeout: Option<std::time::Duration>,
+        timeout: Option<Duration>,
         fence: &dyn DynFence,
     ) -> Result<Option<DynAcquiredSurfaceTexture>, SurfaceError>;
 
@@ -49,7 +52,7 @@ impl<S: Surface + DynResource> DynSurface for S {
 
     unsafe fn acquire_texture(
         &self,
-        timeout: Option<std::time::Duration>,
+        timeout: Option<Duration>,
         fence: &dyn DynFence,
     ) -> Result<Option<DynAcquiredSurfaceTexture>, SurfaceError> {
         let fence = fence.expect_downcast_ref();

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -1,6 +1,8 @@
+use alloc::{borrow::ToOwned as _, format, string::String, sync::Arc, vec, vec::Vec};
+use core::sync::atomic::AtomicU8;
+
 use glow::HasContext;
 use parking_lot::Mutex;
-use std::sync::{atomic::AtomicU8, Arc};
 use wgt::AstcChannel;
 
 use crate::auxil::db;
@@ -79,7 +81,7 @@ impl super::Adapter {
     /// resulting in an `Err`.
     pub(super) fn parse_full_version(src: &str) -> Result<(u8, u8), crate::InstanceError> {
         let (version, _vendor_info) = match src.find(' ') {
-            Some(i) => (&src[..i], src[i + 1..].to_string()),
+            Some(i) => (&src[..i], src[i + 1..].to_owned()),
             None => (src, String::new()),
         };
 
@@ -1247,7 +1249,9 @@ impl super::AdapterShared {
             let buffer_mapping =
                 unsafe { gl.map_buffer_range(target, offset, length as _, glow::MAP_READ_BIT) };
 
-            unsafe { std::ptr::copy_nonoverlapping(buffer_mapping, dst_data.as_mut_ptr(), length) };
+            unsafe {
+                core::ptr::copy_nonoverlapping(buffer_mapping, dst_data.as_mut_ptr(), length)
+            };
 
             unsafe { gl.unmap_buffer(target) };
         }

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -1,9 +1,13 @@
-use super::{conv, Command as C};
-use arrayvec::ArrayVec;
-use std::{
+use alloc::string::String;
+use core::{
     mem::{self, size_of, size_of_val},
     ops::Range,
+    slice,
 };
+
+use arrayvec::ArrayVec;
+
+use super::{conv, Command as C};
 
 #[derive(Clone, Copy, Debug, Default)]
 struct TextureSlotDesc {
@@ -84,8 +88,7 @@ impl super::CommandBuffer {
     }
 
     fn add_push_constant_data(&mut self, data: &[u32]) -> Range<u32> {
-        let data_raw =
-            unsafe { std::slice::from_raw_parts(data.as_ptr().cast(), size_of_val(data)) };
+        let data_raw = unsafe { slice::from_raw_parts(data.as_ptr().cast(), size_of_val(data)) };
         let start = self.data_bytes.len();
         assert!(start < u32::MAX as usize);
         self.data_bytes.extend_from_slice(data_raw);
@@ -262,7 +265,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn begin_encoding(&mut self, label: crate::Label) -> Result<(), crate::DeviceError> {
         self.state = State::default();
-        self.cmd_buffer.label = label.map(str::to_string);
+        self.cmd_buffer.label = label.map(String::from);
         Ok(())
     }
     unsafe fn discard_encoding(&mut self) {

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1,17 +1,16 @@
-use super::{conv, PrivateCapabilities};
-use crate::auxil::map_naga_stage;
+use alloc::{
+    borrow::ToOwned, format, string::String, string::ToString as _, sync::Arc, vec, vec::Vec,
+};
+use core::{cmp::max, convert::TryInto, num::NonZeroU32, ptr, sync::atomic::Ordering};
+use std::sync::Mutex;
+
+use arrayvec::ArrayVec;
 use glow::HasContext;
 use naga::FastHashMap;
-use std::{
-    cmp::max,
-    convert::TryInto,
-    ptr,
-    sync::{Arc, Mutex},
-};
 
+use super::{conv, PrivateCapabilities};
+use crate::auxil::map_naga_stage;
 use crate::TlasInstance;
-use arrayvec::ArrayVec;
-use std::sync::atomic::Ordering;
 
 type ShaderStage<'a> = (
     naga::ShaderStage,
@@ -24,7 +23,7 @@ struct CompilationContext<'a> {
     sampler_map: &'a mut super::SamplerBindMap,
     name_binding_map: &'a mut NameBindingMap,
     push_constant_items: &'a mut Vec<naga::back::glsl::PushConstantItem>,
-    multiview: Option<std::num::NonZeroU32>,
+    multiview: Option<NonZeroU32>,
 }
 
 impl CompilationContext<'_> {
@@ -117,7 +116,7 @@ impl super::Device {
     #[cfg(any(native, Emscripten))]
     pub unsafe fn texture_from_raw(
         &self,
-        name: std::num::NonZeroU32,
+        name: NonZeroU32,
         desc: &crate::TextureDescriptor,
         drop_callback: Option<crate::DropCallback>,
     ) -> super::Texture {
@@ -144,7 +143,7 @@ impl super::Device {
     #[cfg(any(native, Emscripten))]
     pub unsafe fn texture_from_raw_renderbuffer(
         &self,
-        name: std::num::NonZeroU32,
+        name: NonZeroU32,
         desc: &crate::TextureDescriptor,
         drop_callback: Option<crate::DropCallback>,
     ) -> super::Texture {
@@ -212,7 +211,7 @@ impl super::Device {
         use naga::back::glsl;
         let pipeline_options = glsl::PipelineOptions {
             shader_stage: naga_stage,
-            entry_point: stage.entry_point.to_string(),
+            entry_point: stage.entry_point.to_owned(),
             multiview: context.multiview,
         };
 
@@ -300,7 +299,7 @@ impl super::Device {
         shaders: ArrayVec<ShaderStage<'a>, { crate::MAX_CONCURRENT_SHADER_STAGES }>,
         layout: &super::PipelineLayout,
         #[cfg_attr(target_arch = "wasm32", allow(unused))] label: Option<&str>,
-        multiview: Option<std::num::NonZeroU32>,
+        multiview: Option<NonZeroU32>,
     ) -> Result<Arc<super::PipelineInner>, crate::PipelineError> {
         let mut program_stages = ArrayVec::new();
         let mut group_to_binding_to_slot = Vec::with_capacity(layout.group_infos.len());
@@ -349,7 +348,7 @@ impl super::Device {
         shaders: ArrayVec<ShaderStage<'a>, { crate::MAX_CONCURRENT_SHADER_STAGES }>,
         layout: &super::PipelineLayout,
         #[cfg_attr(target_arch = "wasm32", allow(unused))] label: Option<&str>,
-        multiview: Option<std::num::NonZeroU32>,
+        multiview: Option<NonZeroU32>,
         glsl_version: naga::back::glsl::Version,
         private_caps: PrivateCapabilities,
     ) -> Result<Arc<super::PipelineInner>, crate::PipelineError> {

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1,9 +1,14 @@
+#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
+
+use std::{
+    ffi, mem::ManuallyDrop, os::raw, ptr, rc::Rc, string::String, sync::Arc, time::Duration,
+    vec::Vec,
+};
+
 use glow::HasContext;
 use hashbrown::HashMap;
 use once_cell::sync::Lazy;
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard, RwLock};
-
-use std::{ffi, mem::ManuallyDrop, os::raw, ptr, rc::Rc, sync::Arc, time::Duration};
 
 /// The amount of time to wait while trying to obtain a lock to the adapter context
 const CONTEXT_LOCK_TIMEOUT_SECS: u64 = 1;

--- a/wgpu-hal/src/gles/emscripten.rs
+++ b/wgpu-hal/src/gles/emscripten.rs
@@ -1,10 +1,10 @@
 extern "C" {
     /// returns 1 if success. 0 if failure. extension name must be null terminated
     fn emscripten_webgl_enable_extension(
-        context: std::ffi::c_int,
-        extension: *const std::ffi::c_char,
-    ) -> std::ffi::c_int;
-    fn emscripten_webgl_get_current_context() -> std::ffi::c_int;
+        context: core::ffi::c_int,
+        extension: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
+    fn emscripten_webgl_get_current_context() -> core::ffi::c_int;
 }
 /// Webgl requires extensions to be enabled before using them.
 /// This function can be used to enable webgl extension on emscripten target.

--- a/wgpu-hal/src/gles/fence.rs
+++ b/wgpu-hal/src/gles/fence.rs
@@ -1,4 +1,5 @@
-use std::sync::atomic::Ordering;
+use alloc::vec::Vec;
+use core::sync::atomic::Ordering;
 
 use glow::HasContext;
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -98,8 +98,6 @@ mod device;
 mod fence;
 mod queue;
 
-use crate::{CopyExtent, TextureDescriptor};
-
 pub use fence::Fence;
 
 #[cfg(not(any(windows, webgl)))]
@@ -117,14 +115,19 @@ use self::wgl::AdapterContext;
 #[cfg(windows)]
 use self::wgl::{Instance, Surface};
 
-use arrayvec::ArrayVec;
-
-use glow::HasContext;
-
-use naga::FastHashMap;
+use alloc::{boxed::Box, string::String, string::ToString as _, sync::Arc, vec::Vec};
+use core::{
+    fmt,
+    ops::Range,
+    sync::atomic::{AtomicU32, AtomicU8},
+};
 use parking_lot::Mutex;
-use std::sync::atomic::{AtomicU32, AtomicU8};
-use std::{fmt, ops::Range, sync::Arc};
+
+use arrayvec::ArrayVec;
+use glow::HasContext;
+use naga::FastHashMap;
+
+use crate::{CopyExtent, TextureDescriptor};
 
 #[derive(Clone, Debug)]
 pub struct Api;
@@ -403,7 +406,7 @@ pub struct Texture {
 impl crate::DynTexture for Texture {}
 impl crate::DynSurfaceTexture for Texture {}
 
-impl std::borrow::Borrow<dyn crate::DynTexture> for Texture {
+impl core::borrow::Borrow<dyn crate::DynTexture> for Texture {
     fn borrow(&self) -> &dyn crate::DynTexture {
         self
     }

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -1,16 +1,13 @@
 use super::{conv::is_layered_target, Command as C, PrivateCapabilities};
+use alloc::sync::Arc;
 use arrayvec::ArrayVec;
+use core::{mem::size_of, slice, sync::atomic::Ordering};
 use glow::HasContext;
-use std::{
-    mem::size_of,
-    slice,
-    sync::{atomic::Ordering, Arc},
-};
 
 const DEBUG_ID: u32 = 0;
 
-fn extract_marker<'a>(data: &'a [u8], range: &std::ops::Range<u32>) -> &'a str {
-    std::str::from_utf8(&data[range.start as usize..range.end as usize]).unwrap()
+fn extract_marker<'a>(data: &'a [u8], range: &core::ops::Range<u32>) -> &'a str {
+    core::str::from_utf8(&data[range.start as usize..range.end as usize]).unwrap()
 }
 
 fn get_2d_target(target: u32, array_layer: u32) -> u32 {

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -1,3 +1,5 @@
+use alloc::{format, string::String, vec::Vec};
+
 use glow::HasContext;
 use parking_lot::{Mutex, RwLock};
 use wasm_bindgen::{JsCast, JsValue};
@@ -420,7 +422,7 @@ impl crate::Surface for Surface {
 
     unsafe fn acquire_texture(
         &self,
-        _timeout_ms: Option<std::time::Duration>, //TODO
+        _timeout_ms: Option<core::time::Duration>, //TODO
         _fence: &super::Fence,
     ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
         let swapchain = self.swapchain.read();

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -1,14 +1,19 @@
+#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
+
 use std::{
+    borrow::ToOwned as _,
     ffi::{c_void, CStr, CString},
     mem::{self, size_of, size_of_val, ManuallyDrop},
     os::raw::c_int,
     ptr,
+    string::String,
     sync::{
         mpsc::{sync_channel, SyncSender},
         Arc,
     },
     thread,
     time::Duration,
+    vec::Vec,
 };
 
 use glow::HasContext;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -202,6 +202,7 @@
 //!
 //! [wiki-debug]: https://github.com/gfx-rs/wgpu/wiki/Debugging-wgpu-Applications
 
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![allow(
     // this happens on the GL backend, where it is both thread safe and non-thread safe in the same code.
@@ -226,7 +227,10 @@
     clippy::pattern_type_mismatch,
 )]
 #![warn(
+    clippy::alloc_instead_of_core,
     clippy::ptr_as_ptr,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_op_in_unsafe_fn,
@@ -234,7 +238,12 @@
     unused_qualifications
 )]
 
+extern crate alloc;
 extern crate wgpu_types as wgt;
+// TODO(https://github.com/gfx-rs/wgpu/issues/6826): disable std except on noop and gles-WebGL.
+// Requires Rust 1.81 for core::error::Error.
+#[macro_use]
+extern crate std;
 
 /// DirectX12 API internals.
 #[cfg(dx12)]
@@ -276,14 +285,17 @@ pub use dynamic::{
     DynShaderModule, DynSurface, DynSurfaceTexture, DynTexture, DynTextureView,
 };
 
-use std::{
-    borrow::{Borrow, Cow},
+#[allow(unused)]
+use alloc::boxed::Box;
+use alloc::{borrow::Cow, string::String, sync::Arc, vec::Vec};
+use core::{
+    borrow::Borrow,
     fmt,
     num::NonZeroU32,
     ops::{Range, RangeInclusive},
     ptr::NonNull,
-    sync::Arc,
 };
+use std::error::Error; // TODO(https://github.com/gfx-rs/wgpu/issues/6826): use core::error after MSRV bump
 
 use bitflags::bitflags;
 use parking_lot::Mutex;
@@ -305,7 +317,7 @@ pub const QUERY_SIZE: wgt::BufferAddress = 8;
 pub type Label<'a> = Option<&'a str>;
 pub type MemoryRange = Range<wgt::BufferAddress>;
 pub type FenceValue = u64;
-pub type AtomicFenceValue = std::sync::atomic::AtomicU64;
+pub type AtomicFenceValue = core::sync::atomic::AtomicU64;
 
 /// A callback to signal that wgpu is no longer using a resource.
 #[cfg(any(gles, vulkan))]
@@ -417,7 +429,7 @@ pub struct InstanceError {
 
     /// Underlying error value, if any is available.
     #[source]
-    source: Option<Arc<dyn std::error::Error + Send + Sync + 'static>>,
+    source: Option<Arc<dyn Error + Send + Sync + 'static>>,
 }
 
 impl InstanceError {
@@ -429,10 +441,7 @@ impl InstanceError {
         }
     }
     #[allow(dead_code)] // may be unused on some platforms
-    pub(crate) fn with_source(
-        message: String,
-        source: impl std::error::Error + Send + Sync + 'static,
-    ) -> Self {
+    pub(crate) fn with_source(message: String, source: impl Error + Send + Sync + 'static) -> Self {
         Self {
             message,
             source: Some(Arc::new(source)),
@@ -585,13 +594,13 @@ pub trait Surface: WasmNotSendSync {
     ///
     /// [`texture`]: AcquiredSurfaceTexture::texture
     /// [`SurfaceTexture`]: Api::SurfaceTexture
-    /// [`borrow`]: std::borrow::Borrow::borrow
+    /// [`borrow`]: alloc::borrow::Borrow::borrow
     /// [`Texture`]: Api::Texture
     /// [`Fence`]: Api::Fence
     /// [`self.discard_texture`]: Surface::discard_texture
     unsafe fn acquire_texture(
         &self,
-        timeout: Option<std::time::Duration>,
+        timeout: Option<core::time::Duration>,
         fence: &<Self::A as Api>::Fence,
     ) -> Result<Option<AcquiredSurfaceTexture<Self::A>>, SurfaceError>;
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1,6 +1,11 @@
 use super::{conv, AsNative, TimestampQuerySupport};
 use crate::CommandEncoder as _;
-use std::{borrow::Cow, mem::size_of, ops::Range};
+use std::{
+    borrow::{Cow, ToOwned as _},
+    mem::size_of,
+    ops::Range,
+    vec::Vec,
+};
 
 // has to match `Temp::binding_sizes`
 const WORD_SIZE: usize = 4;

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1,9 +1,8 @@
+use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
+use core::{ptr::NonNull, sync::atomic};
+use std::{thread, time};
+
 use parking_lot::Mutex;
-use std::{
-    ptr::NonNull,
-    sync::{atomic, Arc},
-    thread, time,
-};
 
 use super::conv;
 use crate::auxil::map_naga_stage;
@@ -157,7 +156,7 @@ impl super::Device {
             spirv_cross_compatibility: false,
             fake_missing_bindings: false,
             per_entry_point_map: naga::back::msl::EntryPointResourceMap::from([(
-                stage.entry_point.to_string(),
+                stage.entry_point.to_owned(),
                 ep_resources.clone(),
             )]),
             bounds_check_policies: naga::proc::BoundsCheckPolicies {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -13,6 +13,8 @@ end of the VS buffer table.
 
 !*/
 
+#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
+
 // `MTLFeatureSet` is superseded by `MTLGpuFamily`.
 // However, `MTLGpuFamily` is only supported starting MacOS 10.15, whereas our minimum target is MacOS 10.13,
 // See https://github.com/gpuweb/gpuweb/issues/1069 for minimum spec.
@@ -27,10 +29,13 @@ mod surface;
 mod time;
 
 use std::{
+    borrow::ToOwned as _,
     fmt, iter, ops,
     ptr::NonNull,
+    string::String,
     sync::{atomic, Arc},
     thread,
+    vec::Vec,
 };
 
 use arrayvec::ArrayVec;

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::let_unit_value)] // `let () =` being used to constrain result type
 
+use std::borrow::ToOwned as _;
 use std::mem::ManuallyDrop;
 use std::ptr::NonNull;
 use std::thread;

--- a/wgpu-hal/src/noop/buffer.rs
+++ b/wgpu-hal/src/noop/buffer.rs
@@ -1,7 +1,5 @@
-use core::cell::UnsafeCell;
-use core::ops::Range;
-use core::ptr;
-use std::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
+use core::{cell::UnsafeCell, ops::Range, ptr};
 
 #[derive(Clone, Debug)]
 pub struct Buffer {

--- a/wgpu-hal/src/noop/command.rs
+++ b/wgpu-hal/src/noop/command.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::mem;
 use core::ops::Range;
 

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -1,8 +1,13 @@
 #![allow(unused_variables)]
 
+use alloc::{string::String, vec, vec::Vec};
+use core::{
+    ptr,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
 use crate::TlasInstance;
-use core::ptr;
-use core::sync::atomic::{AtomicU64, Ordering};
 
 mod buffer;
 pub use buffer::Buffer;
@@ -71,7 +76,7 @@ impl crate::DynSurfaceTexture for Resource {}
 impl crate::DynTexture for Resource {}
 impl crate::DynTextureView for Resource {}
 
-impl std::borrow::Borrow<dyn crate::DynTexture> for Resource {
+impl core::borrow::Borrow<dyn crate::DynTexture> for Resource {
     fn borrow(&self) -> &dyn crate::DynTexture {
         self
     }
@@ -202,7 +207,7 @@ impl crate::Surface for Context {
 
     unsafe fn acquire_texture(
         &self,
-        timeout: Option<std::time::Duration>,
+        timeout: Option<Duration>,
         fence: &Fence,
     ) -> Result<Option<crate::AcquiredSurfaceTexture<Api>>, crate::SurfaceError> {
         Ok(None)

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1,9 +1,9 @@
-use super::conv;
+use std::{borrow::ToOwned as _, collections::BTreeMap, ffi::CStr, sync::Arc, vec::Vec};
 
 use ash::{amd, ext, google, khr, vk};
 use parking_lot::Mutex;
 
-use std::{collections::BTreeMap, ffi::CStr, sync::Arc};
+use super::conv;
 
 fn depth_stencil_required_flags() -> vk::FormatFeatureFlags {
     vk::FormatFeatureFlags::SAMPLED_IMAGE | vk::FormatFeatureFlags::DEPTH_STENCIL_ATTACHMENT

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -1,3 +1,5 @@
+use std::vec::Vec;
+
 use ash::vk;
 
 impl super::PrivateCapabilities {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1,20 +1,21 @@
-use super::{conv, RawTlasInstance};
-
-use arrayvec::ArrayVec;
-use ash::{khr, vk};
-use hashbrown::hash_map::Entry;
-use parking_lot::Mutex;
-
-use crate::TlasInstance;
 use std::{
-    borrow::Cow,
+    borrow::{Cow, ToOwned as _},
     collections::BTreeMap,
     ffi::{CStr, CString},
     mem::{self, size_of, MaybeUninit},
     num::NonZeroU32,
     ptr, slice,
     sync::Arc,
+    vec::Vec,
 };
+
+use arrayvec::ArrayVec;
+use ash::{khr, vk};
+use hashbrown::hash_map::Entry;
+use parking_lot::Mutex;
+
+use super::{conv, RawTlasInstance};
+use crate::TlasInstance;
 
 impl super::DeviceShared {
     /// Set the name of `object` to `name`.
@@ -903,7 +904,7 @@ impl super::Device {
                 runtime_checks,
             } => {
                 let pipeline_options = naga::back::spv::PipelineOptions {
-                    entry_point: stage.entry_point.to_string(),
+                    entry_point: stage.entry_point.to_owned(),
                     shader_stage: naga_stage,
                 };
                 let needs_temp_options = !runtime_checks.bounds_checks

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -1,9 +1,13 @@
 use std::{
+    borrow::ToOwned as _,
+    boxed::Box,
     ffi::{c_void, CStr, CString},
     slice,
     str::FromStr,
+    string::{String, ToString as _},
     sync::Arc,
     thread,
+    vec::Vec,
 };
 
 use arrayvec::ArrayVec;

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -24,6 +24,8 @@ Otherwise, we manage a pool of `VkFence` objects behind each `hal::Fence`.
 
 !*/
 
+#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
+
 mod adapter;
 mod command;
 mod conv;
@@ -33,11 +35,13 @@ mod sampler;
 
 use std::{
     borrow::Borrow,
+    boxed::Box,
     ffi::{CStr, CString},
     fmt, mem,
     num::NonZeroU32,
     ops::DerefMut,
     sync::Arc,
+    vec::Vec,
 };
 
 use arrayvec::ArrayVec;

--- a/wgpu/src/api/adapter.rs
+++ b/wgpu/src/api/adapter.rs
@@ -1,4 +1,4 @@
-use std::future::Future;
+use core::future::Future;
 
 use crate::*;
 

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -1,6 +1,9 @@
+use alloc::{boxed::Box, vec::Vec};
+
+use wgt::WasmNotSendSync;
+
 use crate::dispatch;
 use crate::{Buffer, Label};
-use wgt::WasmNotSendSync;
 
 /// Descriptor for the size defining attributes of a triangle geometry, for a bottom level acceleration structure.
 pub type BlasTriangleGeometrySizeDescriptor = wgt::BlasTriangleGeometrySizeDescriptor;

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -1,7 +1,7 @@
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     error, fmt,
     ops::{Bound, Deref, DerefMut, Range, RangeBounds},
-    sync::Arc,
 };
 
 use parking_lot::Mutex;
@@ -701,7 +701,7 @@ pub struct BufferView<'a> {
     inner: dispatch::DispatchBufferMappedRange,
 }
 
-impl std::ops::Deref for BufferView<'_> {
+impl core::ops::Deref for BufferView<'_> {
     type Target = [u8];
 
     #[inline]

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 use crate::{
     api::{

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -1,4 +1,5 @@
-use std::{error, fmt, future::Future, sync::Arc};
+use alloc::{boxed::Box, string::String, sync::Arc};
+use core::{error, fmt, future::Future};
 
 use parking_lot::Mutex;
 
@@ -162,7 +163,7 @@ impl Device {
         let encoder = self.inner.create_render_bundle_encoder(desc);
         RenderBundleEncoder {
             inner: encoder,
-            _p: std::marker::PhantomData,
+            _p: core::marker::PhantomData,
         }
     }
 

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -1,8 +1,10 @@
+#[cfg(native)]
+use alloc::vec::Vec;
+use core::future::Future;
+
 use parking_lot::Mutex;
 
 use crate::{dispatch::InstanceInterface, *};
-
-use std::future::Future;
 
 bitflags::bitflags! {
     /// WGSL language extensions.
@@ -309,7 +311,7 @@ impl Instance {
                 handle_source = None;
 
                 let value: &wasm_bindgen::JsValue = &canvas;
-                let obj = std::ptr::NonNull::from(value).cast();
+                let obj = core::ptr::NonNull::from(value).cast();
                 let raw_window_handle = raw_window_handle::WebCanvasWindowHandle::new(obj).into();
                 let raw_display_handle = raw_window_handle::WebDisplayHandle::new().into();
 
@@ -328,7 +330,7 @@ impl Instance {
                 handle_source = None;
 
                 let value: &wasm_bindgen::JsValue = &canvas;
-                let obj = std::ptr::NonNull::from(value).cast();
+                let obj = core::ptr::NonNull::from(value).cast();
                 let raw_window_handle =
                     raw_window_handle::WebOffscreenCanvasWindowHandle::new(obj).into();
                 let raw_display_handle = raw_window_handle::WebDisplayHandle::new().into();

--- a/wgpu/src/api/mod.rs
+++ b/wgpu/src/api/mod.rs
@@ -85,11 +85,11 @@ pub type Label<'a> = Option<&'a str>;
 /// with the type to be used until the Drop impl is ran. This prevents
 /// lifetimes from being shortened.
 #[derive(Debug)]
-pub(crate) struct PhantomDrop<T>(std::marker::PhantomData<T>);
+pub(crate) struct PhantomDrop<T>(core::marker::PhantomData<T>);
 
 impl<T> Default for PhantomDrop<T> {
     fn default() -> Self {
-        Self(std::marker::PhantomData)
+        Self(core::marker::PhantomData)
     }
 }
 

--- a/wgpu/src/api/pipeline_cache.rs
+++ b/wgpu/src/api/pipeline_cache.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use crate::*;
 
 /// Handle to a pipeline cache, which is used to accelerate
@@ -67,7 +69,7 @@ use crate::*;
 /// [renaming]: std::fs::rename
 #[derive(Debug, Clone)]
 pub struct PipelineCache {
-    pub(crate) inner: dispatch::DispatchPipelineCache,
+    pub(crate) inner: crate::dispatch::DispatchPipelineCache,
 }
 
 #[cfg(send_sync)]

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -1,4 +1,5 @@
-use std::ops::{Deref, DerefMut};
+use alloc::boxed::Box;
+use core::ops::{Deref, DerefMut};
 
 use crate::*;
 

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, num::NonZeroU32, ops::Range};
+use core::{marker::PhantomData, num::NonZeroU32, ops::Range};
 
 use crate::dispatch::RenderBundleEncoderInterface;
 use crate::*;

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 use crate::*;
 pub use wgt::{LoadOp, Operations, StoreOp};

--- a/wgpu/src/api/render_pipeline.rs
+++ b/wgpu/src/api/render_pipeline.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use core::num::NonZeroU32;
 
 use crate::*;
 

--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -1,4 +1,10 @@
-use std::{borrow::Cow, future::Future, marker::PhantomData};
+use alloc::{
+    borrow::Cow,
+    string::{String, ToString as _},
+    vec,
+    vec::Vec,
+};
+use core::{future::Future, marker::PhantomData};
 
 use crate::*;
 

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -1,4 +1,6 @@
-use std::{error, fmt};
+use alloc::{boxed::Box, string::String, vec, vec::Vec};
+use core::fmt;
+use std::error; // TODO(https://github.com/gfx-rs/wgpu/issues/6826): use core::error after MSRV bump
 
 use parking_lot::Mutex;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
@@ -294,7 +296,7 @@ pub enum SurfaceTargetUnsafe {
     ///
     /// - layer must be a valid object to create a surface upon.
     #[cfg(metal)]
-    CoreAnimationLayer(*mut std::ffi::c_void),
+    CoreAnimationLayer(*mut core::ffi::c_void),
 
     /// Surface from `IDCompositionVisual`.
     ///
@@ -302,7 +304,7 @@ pub enum SurfaceTargetUnsafe {
     ///
     /// - visual must be a valid `IDCompositionVisual` to create a surface upon.  Its refcount will be incremented internally and kept live as long as the resulting [`Surface`] is live.
     #[cfg(dx12)]
-    CompositionVisual(*mut std::ffi::c_void),
+    CompositionVisual(*mut core::ffi::c_void),
 
     /// Surface from DX12 `DirectComposition` handle.
     ///
@@ -313,7 +315,7 @@ pub enum SurfaceTargetUnsafe {
     /// - surface_handle must be a valid `DirectComposition` handle to create a surface upon.   Its lifetime **will not** be internally managed: this handle **should not** be freed before
     ///   the resulting [`Surface`] is destroyed.
     #[cfg(dx12)]
-    SurfaceHandle(*mut std::ffi::c_void),
+    SurfaceHandle(*mut core::ffi::c_void),
 
     /// Surface from DX12 `SwapChainPanel`.
     ///
@@ -321,7 +323,7 @@ pub enum SurfaceTargetUnsafe {
     ///
     /// - visual must be a valid SwapChainPanel to create a surface upon.  Its refcount will be incremented internally and kept live as long as the resulting [`Surface`] is live.
     #[cfg(dx12)]
-    SwapChainPanel(*mut std::ffi::c_void),
+    SwapChainPanel(*mut core::ffi::c_void),
 }
 
 impl SurfaceTargetUnsafe {

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -1,4 +1,6 @@
-use std::{error, fmt, thread};
+use core::fmt;
+use std::error; // TODO(https://github.com/gfx-rs/wgpu/issues/6826): use core::error after MSRV bump
+use std::thread;
 
 use crate::*;
 

--- a/wgpu/src/api/tlas.rs
+++ b/wgpu/src/api/tlas.rs
@@ -1,7 +1,8 @@
+use alloc::{sync::Arc, vec, vec::Vec};
+use core::ops::{Index, IndexMut, Range};
+
 use crate::{api::blas::TlasInstance, dispatch};
 use crate::{BindingResource, Buffer, Label};
-use std::ops::{Index, IndexMut, Range};
-use std::sync::Arc;
 use wgt::WasmNotSendSync;
 
 /// Descriptor to create top level acceleration structures.

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -5,16 +5,24 @@ mod ext_bindings;
 #[allow(clippy::allow_attributes)]
 mod webgpu_sys;
 
-use js_sys::Promise;
-use std::{
+use alloc::{
+    boxed::Box,
+    format,
+    rc::Rc,
+    string::{String, ToString as _},
+    vec,
+    vec::Vec,
+};
+use core::{
     cell::RefCell,
     fmt,
     future::Future,
     ops::Range,
     pin::Pin,
-    rc::Rc,
     task::{self, Poll},
 };
+
+use js_sys::Promise;
 use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{dispatch, SurfaceTargetUnsafe};
@@ -54,7 +62,7 @@ impl fmt::Debug for ContextWebGpu {
 
 impl crate::Error {
     fn from_js(js_error: js_sys::Object) -> Self {
-        let source = Box::<dyn std::error::Error + Send + Sync>::from("<WebGPU Error>");
+        let source = Box::<dyn core::error::Error + Send + Sync>::from("<WebGPU Error>");
         if let Some(js_error) = js_error.dyn_ref::<webgpu_sys::GpuValidationError>() {
             crate::Error::Validation {
                 source,
@@ -967,7 +975,7 @@ fn future_compilation_info(
                 .collect()
         }
         Err(_v) => base_messages
-            .chain(std::iter::once(crate::CompilationMessage {
+            .chain(core::iter::once(crate::CompilationMessage {
                 message: "Getting compilation info failed".to_string(),
                 message_type: crate::CompilationMessageType::Error,
                 location: None,

--- a/wgpu/src/backend/webgpu/defined_non_null_js_value.rs
+++ b/wgpu/src/backend/webgpu/defined_non_null_js_value.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use wasm_bindgen::JsValue;
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1,3 +1,20 @@
+use alloc::{
+    borrow::Cow::Borrowed,
+    boxed::Box,
+    format,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+use core::{error::Error, fmt, future::ready, ops::Range, pin::Pin, ptr::NonNull, slice};
+
+use arrayvec::ArrayVec;
+use parking_lot::Mutex;
+use smallvec::SmallVec;
+use wgc::{command::bundle_ffi::*, error::ContextErrorSource, pipeline::CreateShaderModuleError};
+use wgt::WasmNotSendSync;
+
 use crate::{
     api,
     dispatch::{self, BufferMappedRangeInterface, InterfaceTypes},
@@ -5,16 +22,6 @@ use crate::{
     CompilationMessageType, ErrorSource, Features, Label, LoadOp, MapMode, Operations,
     ShaderSource, SurfaceTargetUnsafe, TextureDescriptor,
 };
-
-use arrayvec::ArrayVec;
-use parking_lot::Mutex;
-use smallvec::SmallVec;
-use std::{
-    borrow::Cow::Borrowed, error::Error, fmt, future::ready, ops::Range, pin::Pin, ptr::NonNull,
-    slice, sync::Arc,
-};
-use wgc::{command::bundle_ffi::*, error::ContextErrorSource, pipeline::CreateShaderModuleError};
-use wgt::WasmNotSendSync;
 
 #[derive(Clone)]
 pub struct ContextWgpuCore(Arc<wgc::global::Global>);
@@ -338,7 +345,7 @@ impl ContextWgpuCore {
 
         fn print_tree(output: &mut String, level: &mut usize, e: &(dyn Error + 'static)) {
             let mut print = |e: &(dyn Error + 'static)| {
-                use std::fmt::Write;
+                use core::fmt::Write;
                 writeln!(output, "{}{}", " ".repeat(*level * 2), e).unwrap();
 
                 if let Some(e) = e.source() {
@@ -642,7 +649,7 @@ impl ErrorSinkRaw {
 }
 
 impl fmt::Debug for ErrorSinkRaw {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "ErrorSink")
     }
 }
@@ -2304,7 +2311,7 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
             &wgc::command::RenderPassDescriptor {
                 label: desc.label.map(Borrowed),
                 timestamp_writes: timestamp_writes.as_ref(),
-                color_attachments: std::borrow::Cow::Borrowed(&colors),
+                color_attachments: Borrowed(&colors),
                 depth_stencil_attachment: depth_stencil.as_ref(),
                 occlusion_query_set: desc.occlusion_query_set.map(|qs| qs.inner.as_core().id),
             },

--- a/wgpu/src/cmp.rs
+++ b/wgpu/src/cmp.rs
@@ -4,7 +4,7 @@
 //!
 //! For types (like WebGPU) that don't have such a property, we generate an identifier and use that.
 
-use std::{
+use core::{
     num::NonZeroU64,
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -41,19 +41,19 @@ macro_rules! impl_eq_ord_hash_proxy {
         impl Eq for $type {}
 
         impl PartialOrd for $type {
-            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
                 Some(self.cmp(other))
             }
         }
 
         impl Ord for $type {
-            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            fn cmp(&self, other: &Self) -> core::cmp::Ordering {
                 self $($access)*.cmp(&other $($access)*)
             }
         }
 
-        impl std::hash::Hash for $type {
-            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        impl core::hash::Hash for $type {
+            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
                 self $($access)*.hash(state)
             }
         }
@@ -70,8 +70,8 @@ macro_rules! impl_eq_ord_hash_arc_address {
     ($type:ty => $($access:tt)*) => {
         impl PartialEq for $type {
             fn eq(&self, other: &Self) -> bool {
-                let address_left = std::sync::Arc::as_ptr(&self $($access)*);
-                let address_right = std::sync::Arc::as_ptr(&other $($access)*);
+                let address_left = alloc::sync::Arc::as_ptr(&self $($access)*);
+                let address_right = alloc::sync::Arc::as_ptr(&other $($access)*);
 
                 address_left == address_right
             }
@@ -80,23 +80,23 @@ macro_rules! impl_eq_ord_hash_arc_address {
         impl Eq for $type {}
 
         impl PartialOrd for $type {
-            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
                 Some(self.cmp(other))
             }
         }
 
         impl Ord for $type {
-            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-                let address_left = std::sync::Arc::as_ptr(&self $($access)*);
-                let address_right = std::sync::Arc::as_ptr(&other $($access)*);
+            fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+                let address_left = alloc::sync::Arc::as_ptr(&self $($access)*);
+                let address_right = alloc::sync::Arc::as_ptr(&other $($access)*);
 
                 address_left.cmp(&address_right)
             }
         }
 
-        impl std::hash::Hash for $type {
-            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-                let address = std::sync::Arc::as_ptr(&self $($access)*);
+        impl core::hash::Hash for $type {
+            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+                let address = alloc::sync::Arc::as_ptr(&self $($access)*);
                 address.hash(state)
             }
         }

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -13,7 +13,8 @@
 
 use crate::{WasmNotSend, WasmNotSendSync};
 
-use std::{any::Any, fmt::Debug, future::Future, hash::Hash, ops::Range, pin::Pin, sync::Arc};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
+use core::{any::Any, fmt::Debug, future::Future, hash::Hash, ops::Range, pin::Pin};
 
 use crate::backend;
 
@@ -632,7 +633,7 @@ macro_rules! dispatch_types_inner {
             }
         }
 
-        impl std::ops::Deref for $name {
+        impl core::ops::Deref for $name {
             type Target = dyn $trait;
 
             #[inline]
@@ -763,7 +764,7 @@ macro_rules! dispatch_types_inner {
             }
         }
 
-        impl std::ops::Deref for $name {
+        impl core::ops::Deref for $name {
             type Target = dyn $trait;
 
             #[inline]
@@ -779,7 +780,7 @@ macro_rules! dispatch_types_inner {
             }
         }
 
-        impl std::ops::DerefMut for $name {
+        impl core::ops::DerefMut for $name {
             #[inline]
             fn deref_mut(&mut self) -> &mut Self::Target {
                 match self {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -14,10 +14,14 @@
 //! - **`naga`** ---- Enabled when any non-wgsl shader input is enabled.
 //!
 
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/gfx-rs/wgpu/trunk/logo.png")]
 #![warn(
+    clippy::alloc_instead_of_core,
     clippy::allow_attributes,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
     missing_docs,
     rust_2018_idioms,
     unsafe_op_in_unsafe_fn
@@ -25,6 +29,8 @@
 #![allow(clippy::arc_with_non_send_sync)]
 #![cfg_attr(not(any(wgpu_core, webgpu)), allow(unused))]
 
+extern crate alloc;
+extern crate std;
 #[cfg(wgpu_core)]
 pub extern crate wgpu_core as wgc;
 #[cfg(wgpu_core)]
@@ -111,8 +117,3 @@ pub use raw_window_handle as rwh;
 ///
 #[cfg(any(webgl, webgpu))]
 pub use web_sys;
-
-/// `web-sys` has a `no_std` mode, and instead refers to the `alloc` crate in its generated code.
-/// Since we vendor the WebGPU bindings we need to explicitly add the `alloc` crate ourselves.
-#[cfg(webgpu)]
-extern crate alloc;

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -117,3 +117,6 @@ pub use raw_window_handle as rwh;
 ///
 #[cfg(any(webgl, webgpu))]
 pub use web_sys;
+
+#[doc(hidden)]
+pub use macros::helpers as __macro_helpers;

--- a/wgpu/src/macros.rs
+++ b/wgpu/src/macros.rs
@@ -71,8 +71,8 @@ macro_rules! include_spirv_raw {
         {
             //log::info!("including '{}'", $($token)*);
             $crate::ShaderModuleDescriptorSpirV {
-                label: Some($($token)*),
-                source: $crate::util::make_spirv_raw(include_bytes!($($token)*)),
+                label: $crate::__macro_helpers::Some($($token)*),
+                source: $crate::util::make_spirv_raw($crate::__macro_helpers::include_bytes!($($token)*)),
             }
         }
     };
@@ -94,9 +94,16 @@ macro_rules! include_wgsl {
         {
             //log::info!("including '{}'", $($token)*);
             $crate::ShaderModuleDescriptor {
-                label: Some($($token)*),
-                source: $crate::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!($($token)*))),
+                label: $crate::__macro_helpers::Some($($token)*),
+                source: $crate::ShaderSource::Wgsl($crate::__macro_helpers::Cow::Borrowed($crate::__macro_helpers::include_str!($($token)*))),
             }
         }
     };
+}
+
+#[doc(hidden)]
+pub mod helpers {
+    pub use alloc::borrow::Cow;
+    pub use core::{include_bytes, include_str};
+    pub use Some;
 }

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -2,7 +2,8 @@ use crate::{
     util::align_to, Buffer, BufferAddress, BufferDescriptor, BufferSize, BufferSlice, BufferUsages,
     BufferViewMut, CommandEncoder, Device, MapMode,
 };
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 use std::sync::mpsc;
 
 /// Efficiently performs many buffer writes by sharing and reusing temporary buffers.

--- a/wgpu/src/util/device.rs
+++ b/wgpu/src/util/device.rs
@@ -1,3 +1,5 @@
+use alloc::borrow::ToOwned as _;
+
 use wgt::TextureDataOrder;
 
 /// Describes a [Buffer](crate::Buffer) when allocating.

--- a/wgpu/src/util/encoder.rs
+++ b/wgpu/src/util/encoder.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 use wgt::{BufferAddress, DynamicOffset, IndexFormat};
 

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -9,8 +9,8 @@ mod encoder;
 mod init;
 mod texture_blitter;
 
-use std::sync::Arc;
-use std::{borrow::Cow, ptr::copy_nonoverlapping};
+use alloc::{borrow::Cow, format, string::String, sync::Arc, vec};
+use core::ptr::copy_nonoverlapping;
 
 pub use belt::StagingBelt;
 pub use device::{BufferInitDescriptor, DeviceExt};
@@ -134,7 +134,7 @@ impl DownloadBuffer {
     }
 }
 
-impl std::ops::Deref for DownloadBuffer {
+impl core::ops::Deref for DownloadBuffer {
     type Target = [u8];
     fn deref(&self) -> &[u8] {
         self.mapped_range.slice()


### PR DESCRIPTION
The commits in this PR are individually meaningful and have been tested individually. It might make sense to squash the PR anyway, though.

**Connections**
Part of #6826.

**Description**
Adjust imports in `wgpu`, `wgpu-core`, and `wgpu-hal` so that `std` is not used where not necessary.

I did not add any feature flags to disable `std` usages, so `wgpu` and `wgpu-core` still require `std`, and `wgpu-hal` can only be used without `std` if all platform backends are disabled. Future work after this PR would include making the GLES backend usable with WebGL2 without `std`, and adding feature flags to remove `std`-requiring optional functionality of `wgpu`.

[Update:] There are still uses of `std::error::Error`. These must be changed to `core::error::Error` after the MSRV for these crates is 1.81 or greater.

**Testing**
`xtask test`

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
