### PR TITLE
Fix enumeration of `wgpu` example shaders in `example_wgsl` test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ dependencies = [
  "termcolor",
  "thiserror 2.0.11",
  "unicode-ident",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ strum = { version = "0.26.3", default-features = false, features = ["derive"] }
 trybuild = "1"
 tracy-client = "0.17"
 thiserror = { version = "2", default-features = false }
+walkdir = "2"
 winit = { version = "0.29", features = ["android-native-activity"] }
 
 # Metal dependencies

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -118,3 +118,4 @@ ron = "0.8.0"
 rspirv = { version = "0.11", git = "https://github.com/gfx-rs/rspirv", rev = "b969f175d5663258b4891e44b76c1544da9661ab" }
 serde = { workspace = true, features = ["default", "derive"] }
 spirv = { version = "0.3", features = ["deserialize"] }
+walkdir.workspace = true

--- a/naga/tests/example_wgsl.rs
+++ b/naga/tests/example_wgsl.rs
@@ -1,55 +1,51 @@
 #![cfg(feature = "wgsl-in")]
 
 use naga::{front::wgsl, valid::Validator};
-use std::{fs, path::PathBuf};
+use std::{ffi::OsStr, fs, path::Path};
 
 /// Runs through all example shaders and ensures they are valid wgsl.
 #[test]
 pub fn parse_example_wgsl() {
-    let read_dir = match PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("examples")
-        .read_dir()
-    {
-        Ok(iter) => iter,
-        Err(e) => {
-            log::error!("Unable to open the examples folder: {:?}", e);
-            return;
-        }
-    };
-    for example_entry in read_dir {
-        let read_files = match example_entry {
-            Ok(dir_entry) => match dir_entry.path().read_dir() {
-                Ok(iter) => iter,
-                Err(_) => continue,
-            },
-            Err(e) => {
-                log::warn!("Skipping example: {:?}", e);
-                continue;
-            }
-        };
-        for file_entry in read_files {
-            let shader = match file_entry {
-                Ok(entry) => match entry.path().extension() {
-                    Some(ostr) if ostr == "wgsl" => {
-                        println!("Validating {:?}", entry.path());
-                        fs::read_to_string(entry.path()).unwrap_or_default()
-                    }
-                    _ => continue,
-                },
-                Err(e) => {
-                    log::warn!("Skipping file: {:?}", e);
-                    continue;
-                }
-            };
+    let example_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("examples");
 
-            let module = wgsl::parse_str(&shader).unwrap();
-            //TODO: re-use the validator
-            Validator::new(
-                naga::valid::ValidationFlags::all(),
-                naga::valid::Capabilities::all(),
-            )
-            .validate(&module)
-            .unwrap();
+    println!("Looking for examples in {}", example_path.display());
+
+    let mut example_paths = Vec::new();
+    for example_entry in walkdir::WalkDir::new(example_path) {
+        let Ok(dir_entry) = example_entry else {
+            continue;
+        };
+
+        if !dir_entry.file_type().is_file() {
+            continue;
         }
+
+        let path = dir_entry.path();
+
+        if path.extension().map(OsStr::to_string_lossy).as_deref() == Some("wgsl") {
+            example_paths.push(path.to_path_buf());
+        }
+    }
+
+    assert_ne!(example_paths.len(), 0, "No examples found!");
+
+    println!("Found {} examples", example_paths.len());
+
+    for example_path in example_paths {
+        println!("\tParsing {}", example_path.display());
+
+        let shader = fs::read_to_string(&example_path).unwrap();
+
+        let module = wgsl::parse_str(&shader).unwrap();
+        //TODO: re-use the validator
+        Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        )
+        .validate(&module)
+        .unwrap();
     }
 }

--- a/naga/tests/example_wgsl.rs
+++ b/naga/tests/example_wgsl.rs
@@ -30,7 +30,7 @@ pub fn parse_example_wgsl() {
         }
     }
 
-    assert_ne!(example_paths.len(), 0, "No examples found!");
+    assert!(!example_paths.is_empty(), "No examples found!");
 
     println!("Found {} examples", example_paths.len());
 


### PR DESCRIPTION
A quick rework split out of #5701 

There was no shader files being tested after #6858 merged. This fixes that matching and will make the test fail if it finds zero shaders, also simplifies the code.