### PR TITLE
Remove `getrandom` from examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,7 +4595,6 @@ dependencies = [
  "env_logger",
  "fern",
  "flume",
- "getrandom 0.2.15",
  "glam",
  "ktx2",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,6 @@ env_logger = "0.11"
 fern = "0.7"
 flume = "0.11"
 futures-lite = "2"
-getrandom = "0.2"
 glam = "0.29"
 hashbrown = { version = "0.14.5", default-features = false, features = [
     "ahash",

--- a/examples/features/Cargo.toml
+++ b/examples/features/Cargo.toml
@@ -35,7 +35,6 @@ bytemuck.workspace = true
 cfg-if.workspace = true
 encase = { workspace = true, features = ["glam"] }
 flume.workspace = true
-getrandom.workspace = true
 glam = { workspace = true, features = ["bytemuck"] }
 ktx2.workspace = true
 log.workspace = true

--- a/examples/features/src/repeated_compute/mod.rs
+++ b/examples/features/src/repeated_compute/mod.rs
@@ -5,6 +5,8 @@
 //! hello-compute example does not such as mapping buffers
 //! and why use the async channels.
 
+use nanorand::Rng;
+
 const OVERFLOW: u32 = 0xffffffff;
 
 async fn run() {
@@ -13,7 +15,7 @@ async fn run() {
 
     for _ in 0..10 {
         for p in numbers.iter_mut() {
-            *p = generate_rand() as u32;
+            *p = nanorand::tls_rng().generate::<u16>() as u32;
         }
 
         compute(&mut numbers, &context).await;
@@ -27,12 +29,6 @@ async fn run() {
             .collect::<Vec<String>>();
         log::info!("Results: {printed_numbers:?}");
     }
-}
-
-fn generate_rand() -> u16 {
-    let mut bytes = [0u8; 2];
-    getrandom::getrandom(&mut bytes[..]).unwrap();
-    u16::from_le_bytes(bytes)
 }
 
 async fn compute(local_buffer: &mut [u32], context: &WgpuContext) {


### PR DESCRIPTION
We didn't need it at all, we have `nanorand` already.

Closes #7171 