### PR TITLE
Workaround #7200

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,3 +19,13 @@ threads-required = 4
 [[profile.default.overrides]]
 filter = 'test(~8_threads) | test(~8 threads)'
 threads-required = 8
+
+#
+# Workarounds for flaky tests
+#
+
+# https://github.com/gfx-rs/wgpu/issues/7200
+[[profile.default.overrides]]
+filter = 'test(wgpu_test::image_atomics::image_32_atomics)'
+# platform = 'cfg(target_vendor = "apple")'
+retries = 1


### PR DESCRIPTION
Adds a platform dependent retry on that test, as there's some racy something going on somewhere causing it to fail occasionally.