### PR TITLE
Validate sample count in `copy_texture_to_texture`

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -145,6 +145,13 @@ pub enum TransferError {
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),
     #[error("Source texture sample count must be 1, got {sample_count}")]
     InvalidSampleCount { sample_count: u32 },
+    #[error(
+        "Source sample count ({src_sample_count:?}) and destination sample count ({dst_sample_count:?}) are not equal"
+    )]
+    SampleCountNotEqual {
+        src_sample_count: u32,
+        dst_sample_count: u32,
+    },
     #[error("Requested mip level {requested} does no exist (count: {count})")]
     InvalidMipLevel { requested: u32, count: u32 },
 }
@@ -1099,6 +1106,14 @@ impl Global {
         }
         if dst_tex_base.aspect != dst_texture_aspects {
             return Err(TransferError::CopyDstMissingAspects.into());
+        }
+
+        if src_texture.desc.sample_count != dst_texture.desc.sample_count {
+            return Err(TransferError::SampleCountNotEqual {
+                src_sample_count: src_texture.desc.sample_count,
+                dst_sample_count: dst_texture.desc.sample_count,
+            }
+            .into());
         }
 
         // Handle texture init *before* dealing with barrier transitions so we


### PR DESCRIPTION
**Connections**
Fix #6286

**Description**
Return error if sample count of src and dest are not equal per spec: https://www.w3.org/TR/webgpu/#ref-for-dom-gputexture-samplecount%E2%91%A4.

**Testing**
It isn't but I believe there should be tests in CTS. 

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
