### PR TITLE
naga-cli: forward '--keep-coordinate-space' flag to GLSL backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 - Fix some instances of functions which have a return type but don't return a value being incorrectly validated. By @jamienicol in [#7013](https://github.com/gfx-rs/wgpu/pull/7013).
 - Allow abstract expressions to be used in WGSL function return statements. By @jamienicol in [#7035](https://github.com/gfx-rs/wgpu/pull/7035).
 - Error if structs have two fields with the same name. By @SparkyPotato in [#7088](https://github.com/gfx-rs/wgpu/pull/7088).
+- Forward '--keep-coordinate-space' flag to GLSL backend in naga-cli. By @cloone8 in [#7206](https://github.com/gfx-rs/wgpu/pull/7206).
 
 #### General
 

--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -446,6 +446,10 @@ fn run() -> anyhow::Result<()> {
         naga::back::spv::WriterFlags::ADJUST_COORDINATE_SPACE,
         !params.keep_coordinate_space,
     );
+    params.glsl.writer_flags.set(
+        naga::back::glsl::WriterFlags::ADJUST_COORDINATE_SPACE,
+        !params.keep_coordinate_space,
+    );
 
     if args.bulk_validate {
         return bulk_validate(args, &params);


### PR DESCRIPTION
**Description**

Although `naga-cli` exposes a `--keep-coordinate-space` flag, it currently (seems to) have no effect in the GLSL backend. This PR forwards the flag to the `glsl::Options::writer_flags` bitflags, fixing that.

**Testing**

Tested the output of a simple vertex shader with the flag both set and unset. If the flag is set, the final coordinate conversion is not done. As the conversion was already part of the codebase, I haven't worked out the math or anything (I'll readily admit I'm not an OpenGL nor WebGPU expert).

I also ran `cargo xtask test` and it seemed to give 5 failures, but since I haven't changed anything "functional" I presume it's just a setup related thing.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

(Also, I tried to find the instructions in `CHANGELOG.md` on how to add this change, but I couldn't find any. If you want me to add a changelog note, let me know :) )

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file. 
