### PR TITLE
Configure `spv-in` settings in toml file

### DIFF
--- a/naga/tests/in/spv/binding-arrays.dynamic.toml
+++ b/naga/tests/in/spv/binding-arrays.dynamic.toml
@@ -1,4 +1,2 @@
-targets = "WGSL"
-
 [spv-in]
 adjust_coordinate_space = true

--- a/naga/tests/in/spv/binding-arrays.static.toml
+++ b/naga/tests/in/spv/binding-arrays.static.toml
@@ -1,4 +1,2 @@
-targets = "WGSL"
-
 [spv-in]
 adjust_coordinate_space = true

--- a/naga/tests/in/spv/do-while.toml
+++ b/naga/tests/in/spv/do-while.toml
@@ -1,1 +1,4 @@
 targets = "METAL | GLSL | HLSL | WGSL"
+
+[spv-in]
+adjust_coordinate_space = true

--- a/naga/tests/in/spv/empty-global-name.toml
+++ b/naga/tests/in/spv/empty-global-name.toml
@@ -1,1 +1,4 @@
 targets = "HLSL | WGSL | METAL"
+
+[spv-in]
+adjust_coordinate_space = true

--- a/naga/tests/in/spv/inv-hyperbolic-trig-functions.toml
+++ b/naga/tests/in/spv/inv-hyperbolic-trig-functions.toml
@@ -1,1 +1,4 @@
 targets = "HLSL | WGSL"
+
+[spv-in]
+adjust_coordinate_space = true

--- a/naga/tests/in/spv/shadow.toml
+++ b/naga/tests/in/spv/shadow.toml
@@ -1,1 +1,4 @@
 targets = "IR | ANALYSIS"
+
+[spv-in]
+adjust_coordinate_space = true

--- a/naga/tests/in/spv/spec-constants-issue-5598.toml
+++ b/naga/tests/in/spv/spec-constants-issue-5598.toml
@@ -1,1 +1,4 @@
 targets = "GLSL"
+
+[spv-in]
+adjust_coordinate_space = true

--- a/naga/tests/in/spv/spec-constants.toml
+++ b/naga/tests/in/spv/spec-constants.toml
@@ -1,1 +1,4 @@
 targets = "IR"
+
+[spv-in]
+adjust_coordinate_space = true

--- a/naga/tests/in/spv/unnamed-gl-per-vertex.toml
+++ b/naga/tests/in/spv/unnamed-gl-per-vertex.toml
@@ -1,1 +1,4 @@
 targets = "METAL | GLSL | HLSL | WGSL"
+
+[spv-in]
+adjust_coordinate_space = true


### PR DESCRIPTION
Missed a step previously, this fully move spv-in settings into the configuration, allowing spirv files to be automatically detected