### PR TITLE
[v24] decrement binding size to match with max buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Bottom level categories:
 * Implement `Clone` on `ShaderModule`. By @a1phyr in [#6937](https://github.com/gfx-rs/wgpu/pull/6937).
 - Fix `CopyExternalImageDestInfo` not exported on `wgpu`. By @wumpf in [#6962](https://github.com/gfx-rs/wgpu/pull/6962).
 - Reduce downlevel `max_color_attachments` limit from 8 to 4 for better GLES compatibility. By @adrian17 in [#6994](https://github.com/gfx-rs/wgpu/pull/6994).
+- Decrement max_storage_buffer_binding_size by 1 to match max_buffer_size. By @minus1ms in [#7217](https://github.com/gfx-rs/wgpu/pull/7217)
 
 ## v24.0.0 (2025-01-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Bottom level categories:
 
 #### Bug Fixes
 - Fix a possible deadlock within `Queue::write_texture`. By @metamuffin in [#7004](https://github.com/gfx-rs/wgpu/pull/7004)
+- Decrement `max_storage_buffer_binding_size` by 1 to match `max_buffer_size`. By @minus1ms in [#7217](https://github.com/gfx-rs/wgpu/pull/7217)
 
 ### v24.0.1 (2025-01-22)
 
@@ -53,7 +54,6 @@ Bottom level categories:
 * Implement `Clone` on `ShaderModule`. By @a1phyr in [#6937](https://github.com/gfx-rs/wgpu/pull/6937).
 - Fix `CopyExternalImageDestInfo` not exported on `wgpu`. By @wumpf in [#6962](https://github.com/gfx-rs/wgpu/pull/6962).
 - Reduce downlevel `max_color_attachments` limit from 8 to 4 for better GLES compatibility. By @adrian17 in [#6994](https://github.com/gfx-rs/wgpu/pull/6994).
-- Decrement `max_storage_buffer_binding_size` by 1 to match `max_buffer_size`. By @minus1ms in [#7217](https://github.com/gfx-rs/wgpu/pull/7217)
 
 ## v24.0.0 (2025-01-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Bottom level categories:
 * Implement `Clone` on `ShaderModule`. By @a1phyr in [#6937](https://github.com/gfx-rs/wgpu/pull/6937).
 - Fix `CopyExternalImageDestInfo` not exported on `wgpu`. By @wumpf in [#6962](https://github.com/gfx-rs/wgpu/pull/6962).
 - Reduce downlevel `max_color_attachments` limit from 8 to 4 for better GLES compatibility. By @adrian17 in [#6994](https://github.com/gfx-rs/wgpu/pull/6994).
-- Decrement max_storage_buffer_binding_size by 1 to match max_buffer_size. By @minus1ms in [#7217](https://github.com/gfx-rs/wgpu/pull/7217)
+- Decrement `max_storage_buffer_binding_size` by 1 to match `max_buffer_size`. By @minus1ms in [#7217](https://github.com/gfx-rs/wgpu/pull/7217)
 
 ## v24.0.0 (2025-01-15)
 

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -44,7 +44,7 @@ pub mod db {
 /// Interestingly, the index itself can't reach that high, because the minimum
 /// element size is 4 bytes, but the compiler toolchain still computes the
 /// offset at some intermediate point, internally, as i32.
-pub const MAX_I32_BINDING_SIZE: u32 = 1 << 31;
+pub const MAX_I32_BINDING_SIZE: u32 = (1 << 31) - 1;
 
 pub fn map_naga_stage(stage: naga::ShaderStage) -> wgt::ShaderStages {
     match stage {


### PR DESCRIPTION
same as:

https://github.com/gfx-rs/wgpu/pull/7177

i just need that in the patch