### PR TITLE
Update `REPO_MSRV` to 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ env:
   CI_BINARY_BUILD: "build20"
 
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
-  REPO_MSRV: "1.83"
+  REPO_MSRV: "1.85"
   # This is the MSRV used by the `wgpu-core`, `wgpu-hal`, and `wgpu-types` crates,
   # to ensure that they can be used with firefox.
   CORE_MSRV: "1.76"
@@ -164,20 +164,9 @@ jobs:
             tier: 2
             kind: wgpu-only
 
-          # TODO: Uncomment once web-sys updates past 0.3.76
-          # See https://github.com/rustwasm/wasm-bindgen/pull/4378 for details
-          # - name: WebAssembly Core 1.0
-          #   os: ubuntu-22.04
-          #   target: wasm32v1-none
-          #   tier: 2
-          #   kind: no_std
-
-          # Bare-metal x86-64
-          # TODO: Remove once web-sys updates past 0.3.76
-          # Included while wasm32v1-none is failing to ensure `no_std` does not regress
-          - name: no_std x86_64
+          - name: WebAssembly Core 1.0
             os: ubuntu-22.04
-            target: x86_64-unknown-none
+            target: wasm32v1-none
             tier: 2
             kind: no_std
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,14 +3,14 @@ name: Docs
 on:
   pull_request:
     paths:
-      - '.github/workflows/docs.yml'
+      - ".github/workflows/docs.yml"
   push:
     branches:
       - trunk
 
 env:
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
-  REPO_MSRV: "1.83"
+  REPO_MSRV: "1.85"
 
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,7 +13,7 @@ env:
   #
 
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
-  REPO_MSRV: "1.83"
+  REPO_MSRV: "1.85"
   RUSTFLAGS: -D warnings
 
 jobs:
@@ -36,10 +36,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # We can't rely on an override here, as that would only set
+      # the toolchain for the current directory, not the newly generated project.
       - name: Install repo MSRV toolchain
         run: |
           rustup toolchain install ${{ env.REPO_MSRV }} --no-self-update --profile=minimal
-          rustup override set ${{ env.REPO_MSRV }}
           cargo -V
 
       - name: Disable debug symbols
@@ -74,4 +75,4 @@ jobs:
             [patch.crates-io]
             wgpu = { path = "../wgpu/wgpu" }
           EOF
-          cargo check
+          cargo +${{ env.REPO_MSRV }} check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ ref_as_ptr = "warn"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.85"
 keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 homepage = "https://wgpu.rs/"

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ On Linux, you can point to them using `LD_LIBRARY_PATH` environment.
 
 Due to complex dependants, we have two MSRV policies:
 
-- `naga`, `wgpu-core`, `wgpu-hal`, and `wgpu-types`'s MSRV is **1.76**, but may be lower than the rest of the workspace in the future.
-- The rest of the workspace has an MSRV of **1.83** as well right now, but may be higher than above listed crates.
+- `naga`, `wgpu-core`, `wgpu-hal`, and `wgpu-types`'s MSRV is **1.76**.
+- The rest of the workspace has an MSRV of **1.85**.
 
 It is enforced on CI (in "/.github/workflows/ci.yml") with the `CORE_MSRV` and `REPO_MSRV` variables.
 This version can only be upgraded in breaking releases, though we release a breaking version every three months.

--- a/examples/standalone/01_hello_compute/Cargo.toml
+++ b/examples/standalone/01_hello_compute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wgpu-example-01-hello-compute"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.85"
 publish = false
 
 [dependencies]

--- a/examples/standalone/02_hello_window/Cargo.toml
+++ b/examples/standalone/02_hello_window/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wgpu-example-02-hello-window"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.85"
 publish = false
 
 [dependencies]

--- a/naga/src/back/spv/layout.rs
+++ b/naga/src/back/spv/layout.rs
@@ -108,7 +108,7 @@ impl Instruction {
     }
 
     pub(super) fn to_words(&self, sink: &mut impl Extend<Word>) {
-        sink.extend(Some(self.wc << 16 | self.op as u32));
+        sink.extend(Some((self.wc << 16) | self.op as u32));
         sink.extend(self.type_id);
         sink.extend(self.result_id);
         sink.extend(self.operands.iter().cloned());

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -5572,7 +5572,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                     8 => {
                         inst.expect(5)?;
                         let high = self.next()?;
-                        crate::Literal::U64(u64::from(high) << 32 | u64::from(low))
+                        crate::Literal::U64((u64::from(high) << 32) | u64::from(low))
                     }
                     _ => return Err(Error::InvalidTypeWidth(width as u32)),
                 }
@@ -5587,7 +5587,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                     8 => {
                         inst.expect(5)?;
                         let high = self.next()?;
-                        crate::Literal::I64((u64::from(high) << 32 | u64::from(low)) as i64)
+                        crate::Literal::I64(((u64::from(high) << 32) | u64::from(low)) as i64)
                     }
                     _ => return Err(Error::InvalidTypeWidth(width as u32)),
                 }

--- a/naga/xtask/Cargo.toml
+++ b/naga/xtask/Cargo.toml
@@ -3,7 +3,7 @@ name = "xtask"
 version = "0.1.0"
 edition = "2021"
 publish = false
-rust-version = "1.83"
+rust-version = "1.85"
 
 [dependencies]
 anyhow = "1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83"
+channel = "1.85"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -250,12 +250,12 @@ impl FailureCase {
     /// Returns true if the given failure "satisfies" this failure case.
     pub(crate) fn matches_failure(&self, failure: &FailureResult) -> bool {
         for reason in self.reasons() {
-            let kind_matched = reason.kind.map_or(true, |kind| kind == failure.kind);
+            let kind_matched = reason.kind.is_none_or(|kind| kind == failure.kind);
 
             let message_matched =
                 reason
                     .message
-                    .map_or(true, |message| matches!(&failure.message, Some(actual) if actual.to_lowercase().contains(&message.to_lowercase())));
+                    .is_none_or(|message| matches!(&failure.message, Some(actual) if actual.to_lowercase().contains(&message.to_lowercase())));
 
             if kind_matched && message_matched {
                 let message = failure.message.as_deref().unwrap_or("*no message*");

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -261,8 +261,7 @@ impl Global {
                 Some(size) => size,
             };
 
-        let scratch_buffer =
-            ScratchBuffer::new(device, scratch_size).map_err(crate::device::DeviceError::from)?;
+        let scratch_buffer = ScratchBuffer::new(device, scratch_size)?;
 
         let scratch_buffer_barrier = hal::BufferBarrier::<dyn hal::DynBuffer> {
             buffer: scratch_buffer.raw(),
@@ -583,8 +582,7 @@ impl Global {
                 Some(size) => size,
             };
 
-        let scratch_buffer =
-            ScratchBuffer::new(device, scratch_size).map_err(crate::device::DeviceError::from)?;
+        let scratch_buffer = ScratchBuffer::new(device, scratch_size)?;
 
         let scratch_buffer_barrier = hal::BufferBarrier::<dyn hal::DynBuffer> {
             buffer: scratch_buffer.raw(),
@@ -645,8 +643,7 @@ impl Global {
                 let mut staging_buffer = StagingBuffer::new(
                     device,
                     wgt::BufferSize::new(instance_buffer_staging_source.len() as u64).unwrap(),
-                )
-                .map_err(crate::device::DeviceError::from)?;
+                )?;
                 staging_buffer.write(&instance_buffer_staging_source);
                 let flushed = staging_buffer.flush();
                 Some(flushed)

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -35,7 +35,9 @@ targets = [
 ignored = ["cfg_aliases"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(web_sys_unstable_apis)', # web-sys uses this
+] }
 
 [lib]
 
@@ -172,6 +174,14 @@ device_lost_panic = []
 #
 # Only affects the d3d12 and vulkan backends.
 internal_error_panic = []
+
+###################
+### Workarounds ###
+###################
+
+# objc's `msg_send` macro injects this in our code https://github.com/SSheldon/rust-objc/issues/125
+# You shouldn't ever enable this feature.
+cargo-clippy = []
 
 [[example]]
 name = "halmark"

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -677,10 +677,11 @@ impl crate::Device for super::Device {
             None => Direct3D12::D3D12_FILTER_REDUCTION_TYPE_STANDARD,
         };
         let mut filter = Direct3D12::D3D12_FILTER(
-            conv::map_filter_mode(desc.min_filter).0 << Direct3D12::D3D12_MIN_FILTER_SHIFT
-                | conv::map_filter_mode(desc.mag_filter).0 << Direct3D12::D3D12_MAG_FILTER_SHIFT
-                | conv::map_filter_mode(desc.mipmap_filter).0 << Direct3D12::D3D12_MIP_FILTER_SHIFT
-                | reduction.0 << Direct3D12::D3D12_FILTER_REDUCTION_TYPE_SHIFT,
+            (conv::map_filter_mode(desc.min_filter).0 << Direct3D12::D3D12_MIN_FILTER_SHIFT)
+                | (conv::map_filter_mode(desc.mag_filter).0 << Direct3D12::D3D12_MAG_FILTER_SHIFT)
+                | (conv::map_filter_mode(desc.mipmap_filter).0
+                    << Direct3D12::D3D12_MIP_FILTER_SHIFT)
+                | (reduction.0 << Direct3D12::D3D12_FILTER_REDUCTION_TYPE_SHIFT),
         );
 
         if desc.anisotropy_clamp != 1 {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -2064,10 +2064,7 @@ impl crate::Device for super::Device {
         let vk_dynamic_state =
             vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
 
-        let raw_pass = self
-            .shared
-            .make_render_pass(compatible_rp_key)
-            .map_err(crate::DeviceError::from)?;
+        let raw_pass = self.shared.make_render_pass(compatible_rp_key)?;
 
         let vk_infos = [{
             vk::GraphicsPipelineCreateInfo::default()

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -803,7 +803,7 @@ fn check_buffer_bounds(
     if let Some(size) = size {
         // Detect integer overflow.
         let end = offset.checked_add(size.get());
-        if end.map_or(true, |end| end > buffer_size) {
+        if end.is_none_or(|end| end > buffer_size) {
             panic!(
                 "slice offset {} size {} is out of range for buffer of size {}",
                 offset, size, buffer_size

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,8 +2,14 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.85"
 publish = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    # Added by xshell
+    'cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)',
+] }
 
 [dependencies]
 # The dependencies in this config have no transitive dependencies.


### PR DESCRIPTION
Motivated by enabling `wasm32v1-none` which requires higher than 1.83, but I realized that updating would be fairly easy.