### PR TITLE
[backport] Fix deadlock between snatchable_lock and trackers in Queue::write_texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Bottom level categories:
 
 ## Unreleased
 
+### v24.0.2  (2025-02-??)
+
+#### Bug Fixes
+- Fix a possible deadlock within `Queue::write_texture`. By @metamuffin in [#7004](https://github.com/gfx-rs/wgpu/pull/7004)
+
 ### v24.0.1 (2025-01-22)
 
 #### Bug Fixes

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -697,6 +697,8 @@ impl Queue {
                 .map_err(TransferError::from)?;
         }
 
+        let snatch_guard = self.device.snatchable_lock.read();
+
         let mut pending_writes = self.pending_writes.lock();
         let encoder = pending_writes.activate();
 
@@ -732,7 +734,7 @@ impl Queue {
                         &mut trackers.textures,
                         &self.device.alignments,
                         self.device.zero_buffer.as_ref(),
-                        &self.device.snatchable_lock.read(),
+                        &snatch_guard,
                     )
                     .map_err(QueueWriteError::from)?;
                 }
@@ -741,8 +743,6 @@ impl Queue {
                     .drain(init_layer_range);
             }
         }
-
-        let snatch_guard = self.device.snatchable_lock.read();
 
         let dst_raw = dst.try_raw(&snatch_guard)?;
 


### PR DESCRIPTION
This is a backport of #7004 to v24
