### PR TITLE
[naga wgsl-in] add fast path of decimal integer parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,8 @@ By @brodycj in [#6924](https://github.com/gfx-rs/wgpu/pull/6924).
 
 - Replace `unicode-xid` with `unicode-ident`. By @CrazyboyQCD in [#7135](https://github.com/gfx-rs/wgpu/pull/7135)
 
+- Add fast path of decimal integer parsing. By @CrazyboyQCD in [#7229](https://github.com/gfx-rs/wgpu/pull/7229)
+
 ### Documentation
 
 - Improved documentation around pipeline caches and `TextureBlitter`. By @DJMcNab in [#6978](https://github.com/gfx-rs/wgpu/pull/6978) and [#7003](https://github.com/gfx-rs/wgpu/pull/7003).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4790f9e8961209112beb783d85449b508673cf4a6a419c8449b210743ac4dbe9"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2337,7 @@ version = "24.0.0"
 dependencies = [
  "arbitrary",
  "arrayvec",
+ "atoi_simd",
  "bit-set 0.8.0",
  "bitflags 2.8.0",
  "cfg_aliases 0.2.1",

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -52,6 +52,7 @@ arbitrary = ["dep:arbitrary", "bitflags/arbitrary", "indexmap/arbitrary"]
 spv-in = ["dep:petgraph", "dep:spirv"]
 spv-out = ["dep:spirv"]
 wgsl-in = [
+    "dep:atoi_simd",
     "dep:hexf-parse",
     "dep:strum",
     "dep:unicode-ident",
@@ -76,6 +77,7 @@ compact = []
 [dependencies]
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 arrayvec.workspace = true
+atoi_simd = { version = "0.16", optional = true, default-features = false }
 bitflags.workspace = true
 bit-set.workspace = true
 termcolor = { version = "1.4.1" }

--- a/naga/src/front/wgsl/parse/number.rs
+++ b/naga/src/front/wgsl/parse/number.rs
@@ -408,6 +408,10 @@ fn parse_dec_float(input: &str, kind: Option<FloatKind>) -> Result<Number, Numbe
 }
 
 fn parse_int(input: &str, kind: Option<IntKind>, radix: u32) -> Result<Number, NumberError> {
+    // fast path for decimal integer parsing.
+    if radix == 10 {
+        return parse_decimal_integer_fast(input, kind);
+    }
     fn map_err(e: core::num::ParseIntError) -> NumberError {
         match *e.kind() {
             core::num::IntErrorKind::PosOverflow | core::num::IntErrorKind::NegOverflow => {
@@ -434,6 +438,41 @@ fn parse_int(input: &str, kind: Option<IntKind>, radix: u32) -> Result<Number, N
             Err(e) => Err(map_err(e)),
         },
         Some(IntKind::U64) => match u64::from_str_radix(input, radix) {
+            Ok(num) => Ok(Number::U64(num)),
+            Err(e) => Err(map_err(e)),
+        },
+    }
+}
+
+fn parse_decimal_integer_fast(input: &str, kind: Option<IntKind>) -> Result<Number, NumberError> {
+    // As leading signs are handled as unary operators, we only need to parse positive number here.
+    use atoi_simd::{parse_pos, AtoiSimdError};
+    fn map_err(e: AtoiSimdError) -> NumberError {
+        if let AtoiSimdError::Overflow(_) = e {
+            NumberError::NotRepresentable
+        } else {
+            unreachable!()
+        }
+    }
+    let input = input.as_bytes();
+    match kind {
+        None => match parse_pos::<i64>(input) {
+            Ok(num) => Ok(Number::AbstractInt(num)),
+            Err(e) => Err(map_err(e)),
+        },
+        Some(IntKind::I32) => match parse_pos::<i32>(input) {
+            Ok(num) => Ok(Number::I32(num)),
+            Err(e) => Err(map_err(e)),
+        },
+        Some(IntKind::U32) => match parse_pos::<u32>(input) {
+            Ok(num) => Ok(Number::U32(num)),
+            Err(e) => Err(map_err(e)),
+        },
+        Some(IntKind::I64) => match parse_pos::<i64>(input) {
+            Ok(num) => Ok(Number::I64(num)),
+            Err(e) => Err(map_err(e)),
+        },
+        Some(IntKind::U64) => match parse_pos::<u64>(input) {
             Ok(num) => Ok(Number::U64(num)),
             Err(e) => Err(map_err(e)),
         },


### PR DESCRIPTION
**Connections**

**Description**
Add fast path of decimal integer parsing for performance.

**Testing**
Run cargo xtask test and passed.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
