### PR TITLE
Make lack of spirv-as non-fatal for testing.

### DIFF
--- a/benches/benches/shader.rs
+++ b/benches/benches/shader.rs
@@ -170,16 +170,24 @@ fn frontends(c: &mut Criterion) {
 
     // Assemble all the SPIR-V assembly.
     let mut assembled_spirv = Vec::<Vec<u32>>::new();
-    for input in &inputs_spirv.inner {
-        let output = Command::new("spirv-as")
+    'spirv: for input in &inputs_spirv.inner {
+        let output = match Command::new("spirv-as")
             .arg(&input.filename)
             .arg("-o")
             .arg("-")
             .output()
-            .expect(
-                "Failed to execute spirv-as. It can be installed \
-           q by installing the Vulkan SDK and adding it to your path.",
-            );
+        {
+            Ok(output) => output,
+            Err(e) => {
+                eprintln!(
+                    "Failed to execute spirv-as: {e}\n\
+                    spvasm benchmarks will be skipped.\n\
+                    spirv-as can be installed by installing the Vulkan SDK and adding \
+                        it to your PATH.",
+                );
+                break 'spirv;
+            }
+        };
 
         if !output.status.success() {
             panic!(


### PR DESCRIPTION
**Connections**
~~Workaround (not considered a fix, I guess) for~~ Closes #7233.

**Description**
If executing `spirv-as` fails, skip those benchmarks that depend on it.
This allows `cargo xtask test` to succeed even if `spirv-as` is not present.

**Testing**
`cargo xtask test`

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] Add change to `CHANGELOG.md`. See simple instructions inside file.
