### PR TITLE
[naga spv-out] Clean up type lookup utilities

### DIFF
--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -157,10 +157,7 @@ impl Writer {
         position_id: Word,
         body: &mut Vec<Instruction>,
     ) -> Result<(), Error> {
-        let float_ptr_type_id = self.get_type_id(LookupType::Local(LocalType::LocalPointer {
-            base: NumericType::Scalar(crate::Scalar::F32),
-            class: spirv::StorageClass::Output,
-        }));
+        let float_ptr_type_id = self.get_f32_pointer_type_id(spirv::StorageClass::Output);
         let index_y_id = self.get_index_constant(1);
         let access_id = self.id_gen.next();
         body.push(Instruction::access_chain(
@@ -170,9 +167,7 @@ impl Writer {
             &[index_y_id],
         ));
 
-        let float_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-            NumericType::Scalar(crate::Scalar::F32),
-        )));
+        let float_type_id = self.get_f32_type_id();
         let load_id = self.id_gen.next();
         body.push(Instruction::load(float_type_id, load_id, access_id, None));
 
@@ -194,9 +189,7 @@ impl Writer {
         frag_depth_id: Word,
         body: &mut Vec<Instruction>,
     ) -> Result<(), Error> {
-        let float_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-            NumericType::Scalar(crate::Scalar::F32),
-        )));
+        let float_type_id = self.get_f32_type_id();
         let zero_scalar_id = self.get_constant_scalar(crate::Literal::F32(0.0));
         let one_scalar_id = self.get_constant_scalar(crate::Literal::F32(1.0));
 

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -1168,9 +1168,8 @@ impl BlockContext<'_> {
                                 &crate::TypeInner::Vector { size, .. },
                                 &crate::TypeInner::Scalar(scalar),
                             ) => {
-                                let selector_type_id = self.get_type_id(LookupType::Local(
-                                    LocalType::Numeric(NumericType::Vector { size, scalar }),
-                                ));
+                                let selector_type_id =
+                                    self.get_numeric_type_id(NumericType::Vector { size, scalar });
                                 self.temp_list.clear();
                                 self.temp_list.resize(size as usize, arg2_id);
 
@@ -1274,9 +1273,7 @@ impl BlockContext<'_> {
                                 )
                             }
                             crate::TypeInner::Scalar(scalar) => (
-                                self.get_type_id(LookupType::Local(LocalType::Numeric(
-                                    NumericType::Scalar(scalar),
-                                ))),
+                                self.get_numeric_type_id(NumericType::Scalar(scalar)),
                                 self.writer
                                     .get_constant_scalar_with(scalar.width * 8 - 1, scalar)?,
                                 scalar.width,
@@ -1341,9 +1338,8 @@ impl BlockContext<'_> {
                             .writer
                             .get_constant_scalar(crate::Literal::U32(bit_width as u32));
 
-                        let u32_type = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                            NumericType::Scalar(crate::Scalar::U32),
-                        )));
+                        let u32_type =
+                            self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::U32));
 
                         // o = min(offset, w)
                         let offset_id = self.gen_id();
@@ -1392,9 +1388,8 @@ impl BlockContext<'_> {
                             .writer
                             .get_constant_scalar(crate::Literal::U32(bit_width as u32));
 
-                        let u32_type = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                            NumericType::Scalar(crate::Scalar::U32),
-                        )));
+                        let u32_type =
+                            self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::U32));
 
                         // o = min(offset, w)
                         let offset_id = self.gen_id();
@@ -1460,16 +1455,14 @@ impl BlockContext<'_> {
                             Mf::Pack4xU8 => (crate::ScalarKind::Uint, false),
                             _ => unreachable!(),
                         };
-                        let uint_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                            NumericType::Scalar(crate::Scalar::U32),
-                        )));
+                        let uint_type_id =
+                            self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::U32));
 
-                        let int_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                            NumericType::Scalar(crate::Scalar {
+                        let int_type_id =
+                            self.get_numeric_type_id(NumericType::Scalar(crate::Scalar {
                                 kind: int_type,
                                 width: 4,
-                            }),
-                        )));
+                            }));
 
                         let mut last_instruction = Instruction::new(spirv::Op::Nop);
 
@@ -1546,17 +1539,15 @@ impl BlockContext<'_> {
                             _ => unreachable!(),
                         };
 
-                        let sint_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                            NumericType::Scalar(crate::Scalar::I32),
-                        )));
+                        let sint_type_id =
+                            self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::I32));
 
                         let eight = self.writer.get_constant_scalar(crate::Literal::U32(8));
-                        let int_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                            NumericType::Scalar(crate::Scalar {
+                        let int_type_id =
+                            self.get_numeric_type_id(NumericType::Scalar(crate::Scalar {
                                 kind: int_type,
                                 width: 4,
-                            }),
-                        )));
+                            }));
                         block
                             .body
                             .reserve(usize::from(VEC_LENGTH) * 2 + usize::from(is_signed));
@@ -1838,12 +1829,10 @@ impl BlockContext<'_> {
                     self.temp_list.clear();
                     self.temp_list.resize(size as usize, condition_id);
 
-                    let bool_vector_type_id = self.get_type_id(LookupType::Local(
-                        LocalType::Numeric(NumericType::Vector {
-                            size,
-                            scalar: condition_scalar,
-                        }),
-                    ));
+                    let bool_vector_type_id = self.get_numeric_type_id(NumericType::Vector {
+                        size,
+                        scalar: condition_scalar,
+                    });
 
                     let id = self.gen_id();
                     block.body.push(Instruction::composite_construct(
@@ -2347,11 +2336,10 @@ impl BlockContext<'_> {
     ) {
         self.temp_list.clear();
 
-        let vector_type_id =
-            self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
-                size: rows,
-                scalar: crate::Scalar::float(width),
-            })));
+        let vector_type_id = self.get_numeric_type_id(NumericType::Vector {
+            size: rows,
+            scalar: crate::Scalar::float(width),
+        });
 
         for index in 0..columns as u32 {
             let column_id_left = self.gen_id();
@@ -3109,12 +3097,10 @@ impl BlockContext<'_> {
                             )
                         }
                         crate::AtomicFunction::Exchange { compare: Some(cmp) } => {
-                            let scalar_type_id = self.get_type_id(LookupType::Local(
-                                LocalType::Numeric(NumericType::Scalar(scalar)),
-                            ));
-                            let bool_type_id = self.get_type_id(LookupType::Local(
-                                LocalType::Numeric(NumericType::Scalar(crate::Scalar::BOOL)),
-                            ));
+                            let scalar_type_id =
+                                self.get_numeric_type_id(NumericType::Scalar(scalar));
+                            let bool_type_id =
+                                self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::BOOL));
 
                             let cas_result_id = self.gen_id();
                             let equality_result_id = self.gen_id();

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -277,13 +277,13 @@ impl BlockContext<'_> {
     /// See [`crate::back::msl::Writer::gen_force_bounded_loop_statements`] for details
     /// of why this is required.
     fn write_force_bounded_loop_instructions(&mut self, mut block: Block, merge_id: Word) -> Block {
-        let uint_type_id = self.writer.get_uint_type_id();
-        let uint2_type_id = self.writer.get_uint2_type_id();
+        let uint_type_id = self.writer.get_u32_type_id();
+        let uint2_type_id = self.writer.get_vec2u_type_id();
         let uint2_ptr_type_id = self
             .writer
-            .get_uint2_pointer_type_id(spirv::StorageClass::Function);
+            .get_vec2u_pointer_type_id(spirv::StorageClass::Function);
         let bool_type_id = self.writer.get_bool_type_id();
-        let bool2_type_id = self.writer.get_bool2_type_id();
+        let bool2_type_id = self.writer.get_vec2_bool_type_id();
         let zero_uint_const_id = self.writer.get_constant_scalar(crate::Literal::U32(0));
         let zero_uint2_const_id = self.writer.get_constant_composite(
             LookupType::Local(LocalType::Numeric(NumericType::Vector {

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -575,7 +575,7 @@ impl BlockContext<'_> {
                             }
                         };
 
-                        let binding_type_id = self.get_type_id(LookupType::Handle(binding_type));
+                        let binding_type_id = self.get_handle_type_id(binding_type);
 
                         let load_id = self.gen_id();
                         block.body.push(Instruction::load(
@@ -666,7 +666,7 @@ impl BlockContext<'_> {
                             }
                         };
 
-                        let binding_type_id = self.get_type_id(LookupType::Handle(binding_type));
+                        let binding_type_id = self.get_handle_type_id(binding_type);
 
                         let load_id = self.gen_id();
                         block.body.push(Instruction::load(
@@ -1920,7 +1920,7 @@ impl BlockContext<'_> {
                     .writer
                     .write_ray_query_get_intersection_function(committed, self.ir_module);
                 let ray_intersection = self.ir_module.special_types.ray_intersection.unwrap();
-                let intersection_type_id = self.get_type_id(LookupType::Handle(ray_intersection));
+                let intersection_type_id = self.get_handle_type_id(ray_intersection);
                 let id = self.gen_id();
                 block.body.push(Instruction::function_call(
                     intersection_type_id,
@@ -3250,7 +3250,7 @@ impl BlockContext<'_> {
             // need to end it with some kind of return instruction.
             BlockExit::Return => match self.ir_function.result {
                 Some(ref result) if self.function.entry_point_context.is_none() => {
-                    let type_id = self.get_type_id(LookupType::Handle(result.ty));
+                    let type_id = self.get_handle_type_id(result.ty);
                     let null_id = self.writer.get_constant_null(type_id);
                     Instruction::return_value(null_id)
                 }

--- a/naga/src/back/spv/image.rs
+++ b/naga/src/back/spv/image.rs
@@ -126,12 +126,10 @@ impl Load {
         // image produces a scalar `f32`, so in that case we need to find
         // the right SPIR-V type for the access instruction here.
         let type_id = match image_class {
-            crate::ImageClass::Depth { .. } => {
-                ctx.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
-                    size: crate::VectorSize::Quad,
-                    scalar: crate::Scalar::F32,
-                })))
-            }
+            crate::ImageClass::Depth { .. } => ctx.get_numeric_type_id(NumericType::Vector {
+                size: crate::VectorSize::Quad,
+                scalar: crate::Scalar::F32,
+            }),
             _ => result_type_id,
         };
 
@@ -340,9 +338,7 @@ impl BlockContext<'_> {
             }
         };
         let reconciled_array_index_id = if let Some(cast) = cast {
-            let component_ty_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                NumericType::Scalar(component_scalar),
-            )));
+            let component_ty_id = self.get_numeric_type_id(NumericType::Scalar(component_scalar));
             let reconciled_id = self.gen_id();
             block.body.push(Instruction::unary(
                 cast,
@@ -356,11 +352,10 @@ impl BlockContext<'_> {
         };
 
         // Find the SPIR-V type for the combined coordinates/index vector.
-        let type_id =
-            self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
-                size,
-                scalar: component_scalar,
-            })));
+        let type_id = self.get_numeric_type_id(NumericType::Vector {
+            size,
+            scalar: component_scalar,
+        });
 
         // Schmear the coordinates and index together.
         let value_id = self.gen_id();
@@ -527,9 +522,7 @@ impl BlockContext<'_> {
             &[spirv::Capability::ImageQuery],
         )?;
 
-        let i32_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-            NumericType::Scalar(crate::Scalar::I32),
-        )));
+        let i32_type_id = self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::I32));
 
         // If `level` is `Some`, clamp it to fall within bounds. This must
         // happen first, because we'll use it to query the image size for
@@ -612,9 +605,7 @@ impl BlockContext<'_> {
         )?;
 
         let bool_type_id = self.writer.get_bool_type_id();
-        let i32_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-            NumericType::Scalar(crate::Scalar::I32),
-        )));
+        let i32_type_id = self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::I32));
 
         let null_id = access.out_of_bounds_value(self);
 
@@ -684,8 +675,7 @@ impl BlockContext<'_> {
             },
             None => NumericType::Scalar(crate::Scalar::BOOL),
         };
-        let coords_bool_type_id =
-            self.get_type_id(LookupType::Local(LocalType::Numeric(coords_numeric_type)));
+        let coords_bool_type_id = self.get_numeric_type_id(coords_numeric_type);
         let coords_conds_id = self.gen_id();
         selection.block().body.push(Instruction::binary(
             spirv::Op::ULessThan,
@@ -836,10 +826,10 @@ impl BlockContext<'_> {
             _ => false,
         };
         let sample_result_type_id = if needs_sub_access {
-            self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
+            self.get_numeric_type_id(NumericType::Vector {
                 size: crate::VectorSize::Quad,
                 scalar: crate::Scalar::F32,
-            })))
+            })
         } else {
             result_type_id
         };
@@ -937,9 +927,8 @@ impl BlockContext<'_> {
                     }
                 ) {
                     let lod_f32_id = self.gen_id();
-                    let f32_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                        NumericType::Scalar(crate::Scalar::F32),
-                    )));
+                    let f32_type_id =
+                        self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::F32));
                     let convert_op = match *self.fun_info[lod_handle]
                         .ty
                         .inner_with(&self.ir_module.types)
@@ -1079,8 +1068,7 @@ impl BlockContext<'_> {
                     None => NumericType::Scalar(crate::Scalar::U32),
                 };
 
-                let extended_size_type_id =
-                    self.get_type_id(LookupType::Local(LocalType::Numeric(vector_numeric_type)));
+                let extended_size_type_id = self.get_numeric_type_id(vector_numeric_type);
 
                 let (query_op, level_id) = match class {
                     Ic::Sampled { multi: true, .. }
@@ -1146,11 +1134,10 @@ impl BlockContext<'_> {
                     Id::D2 | Id::Cube => crate::VectorSize::Tri,
                     Id::D3 => crate::VectorSize::Quad,
                 };
-                let extended_size_type_id =
-                    self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
-                        size: vec_size,
-                        scalar: crate::Scalar::U32,
-                    })));
+                let extended_size_type_id = self.get_numeric_type_id(NumericType::Vector {
+                    size: vec_size,
+                    scalar: crate::Scalar::U32,
+                });
                 let id_extended = self.gen_id();
                 let mut inst = Instruction::image_query(
                     spirv::Op::ImageQuerySizeLod,

--- a/naga/src/back/spv/image.rs
+++ b/naga/src/back/spv/image.rs
@@ -845,7 +845,7 @@ impl BlockContext<'_> {
         };
 
         // OpTypeSampledImage
-        let image_type_id = self.get_type_id(LookupType::Handle(image_type));
+        let image_type_id = self.get_handle_type_id(image_type);
         let sampled_image_type_id =
             self.get_type_id(LookupType::Local(LocalType::SampledImage { image_type_id }));
 

--- a/naga/src/back/spv/index.rs
+++ b/naga/src/back/spv/index.rs
@@ -243,7 +243,7 @@ impl BlockContext<'_> {
         };
         let length_id = self.gen_id();
         block.body.push(Instruction::array_length(
-            self.writer.get_uint_type_id(),
+            self.writer.get_u32_type_id(),
             length_id,
             structure_id,
             last_member_index,
@@ -314,7 +314,7 @@ impl BlockContext<'_> {
                 let max_index_id = self.gen_id();
                 block.body.push(Instruction::binary(
                     spirv::Op::ISub,
-                    self.writer.get_uint_type_id(),
+                    self.writer.get_u32_type_id(),
                     max_index_id,
                     length_id,
                     const_one_id,
@@ -371,7 +371,7 @@ impl BlockContext<'_> {
         block.body.push(Instruction::ext_inst(
             self.writer.gl450_ext_inst_id,
             spirv::GLOp::UMin,
-            self.writer.get_uint_type_id(),
+            self.writer.get_u32_type_id(),
             restricted_index_id,
             &[index_id, max_index_id],
         ));

--- a/naga/src/back/spv/index.rs
+++ b/naga/src/back/spv/index.rs
@@ -226,7 +226,7 @@ impl BlockContext<'_> {
                 let element_type_id = match self.ir_module.types[global.ty].inner {
                     crate::TypeInner::BindingArray { base, size: _ } => {
                         let class = map_storage_class(global.space);
-                        self.get_pointer_id(base, class)
+                        self.get_pointer_type_id(base, class)
                     }
                     _ => return Err(Error::Validation("array length expression case-5")),
                 };

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -748,6 +748,10 @@ impl BlockContext<'_> {
         self.writer.get_type_id(lookup_type)
     }
 
+    fn get_handle_type_id(&mut self, handle: Handle<crate::Type>) -> Word {
+        self.writer.get_handle_type_id(handle)
+    }
+
     fn get_expression_type_id(&mut self, tr: &TypeResolution) -> Word {
         self.writer.get_expression_type_id(tr)
     }

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -772,6 +772,10 @@ impl BlockContext<'_> {
     ) -> Word {
         self.writer.get_pointer_type_id(handle, class)
     }
+
+    fn get_numeric_type_id(&mut self, numeric: NumericType) -> Word {
+        self.writer.get_numeric_type_id(numeric)
+    }
 }
 
 pub struct Writer {

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -761,8 +761,8 @@ impl BlockContext<'_> {
             .get_constant_scalar(crate::Literal::I32(scope as _))
     }
 
-    fn get_pointer_id(&mut self, handle: Handle<crate::Type>, class: spirv::StorageClass) -> Word {
-        self.writer.get_pointer_id(handle, class)
+    fn get_pointer_type_id(&mut self, handle: Handle<crate::Type>, class: spirv::StorageClass) -> Word {
+        self.writer.get_pointer_type_id(handle, class)
     }
 }
 

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -765,7 +765,11 @@ impl BlockContext<'_> {
             .get_constant_scalar(crate::Literal::I32(scope as _))
     }
 
-    fn get_pointer_type_id(&mut self, handle: Handle<crate::Type>, class: spirv::StorageClass) -> Word {
+    fn get_pointer_type_id(
+        &mut self,
+        handle: Handle<crate::Type>,
+        class: spirv::StorageClass,
+    ) -> Word {
         self.writer.get_pointer_type_id(handle, class)
     }
 }

--- a/naga/src/back/spv/ray.rs
+++ b/naga/src/back/spv/ray.rs
@@ -21,7 +21,7 @@ impl Writer {
             return func_id;
         }
         let ray_intersection = ir_module.special_types.ray_intersection.unwrap();
-        let intersection_type_id = self.get_type_id(LookupType::Handle(ray_intersection));
+        let intersection_type_id = self.get_handle_type_id(ray_intersection);
         let intersection_pointer_type_id =
             self.get_type_id(LookupType::Local(LocalType::Pointer {
                 base: ray_intersection,

--- a/naga/src/back/spv/ray.rs
+++ b/naga/src/back/spv/ray.rs
@@ -5,8 +5,8 @@ Generating SPIR-V for ray query operations.
 use alloc::vec;
 
 use super::{
-    Block, BlockContext, Function, FunctionArgument, Instruction, LocalType, LookupFunctionType,
-    LookupType, NumericType, Writer,
+    Block, BlockContext, Function, FunctionArgument, Instruction, LookupFunctionType, NumericType,
+    Writer,
 };
 use crate::arena::Handle;
 use crate::{Type, TypeInner};
@@ -36,12 +36,11 @@ impl Writer {
         let flag_pointer_type_id =
             self.get_pointer_type_id(flag_type, spirv::StorageClass::Function);
 
-        let transform_type_id =
-            self.get_numeric_type_id(NumericType::Matrix {
-                columns: crate::VectorSize::Quad,
-                rows: crate::VectorSize::Tri,
-                scalar: crate::Scalar::F32,
-            });
+        let transform_type_id = self.get_numeric_type_id(NumericType::Matrix {
+            columns: crate::VectorSize::Quad,
+            rows: crate::VectorSize::Tri,
+            scalar: crate::Scalar::F32,
+        });
         let transform_type = ir_module
             .types
             .get(&Type {
@@ -56,11 +55,10 @@ impl Writer {
         let transform_pointer_type_id =
             self.get_pointer_type_id(transform_type, spirv::StorageClass::Function);
 
-        let barycentrics_type_id =
-            self.get_numeric_type_id(NumericType::Vector {
-                size: crate::VectorSize::Bi,
-                scalar: crate::Scalar::F32,
-            });
+        let barycentrics_type_id = self.get_numeric_type_id(NumericType::Vector {
+            size: crate::VectorSize::Bi,
+            scalar: crate::Scalar::F32,
+        });
         let barycentrics_type = ir_module
             .types
             .get(&Type {
@@ -497,9 +495,8 @@ impl BlockContext<'_> {
                 let desc_id = self.cached[descriptor];
                 let acc_struct_id = self.get_handle_id(acceleration_structure);
 
-                let flag_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                    NumericType::Scalar(crate::Scalar::U32),
-                )));
+                let flag_type_id =
+                    self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::U32));
                 let ray_flags_id = self.gen_id();
                 block.body.push(Instruction::composite_extract(
                     flag_type_id,
@@ -515,9 +512,8 @@ impl BlockContext<'_> {
                     &[1],
                 ));
 
-                let scalar_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                    NumericType::Scalar(crate::Scalar::F32),
-                )));
+                let scalar_type_id =
+                    self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::F32));
                 let tmin_id = self.gen_id();
                 block.body.push(Instruction::composite_extract(
                     scalar_type_id,
@@ -533,11 +529,10 @@ impl BlockContext<'_> {
                     &[3],
                 ));
 
-                let vector_type_id =
-                    self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
-                        size: crate::VectorSize::Tri,
-                        scalar: crate::Scalar::F32,
-                    })));
+                let vector_type_id = self.get_numeric_type_id(NumericType::Vector {
+                    size: crate::VectorSize::Tri,
+                    scalar: crate::Scalar::F32,
+                });
                 let ray_origin_id = self.gen_id();
                 block.body.push(Instruction::composite_extract(
                     vector_type_id,

--- a/naga/src/back/spv/ray.rs
+++ b/naga/src/back/spv/ray.rs
@@ -37,11 +37,11 @@ impl Writer {
             self.get_pointer_type_id(flag_type, spirv::StorageClass::Function);
 
         let transform_type_id =
-            self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Matrix {
+            self.get_numeric_type_id(NumericType::Matrix {
                 columns: crate::VectorSize::Quad,
                 rows: crate::VectorSize::Tri,
                 scalar: crate::Scalar::F32,
-            })));
+            });
         let transform_type = ir_module
             .types
             .get(&Type {
@@ -57,10 +57,10 @@ impl Writer {
             self.get_pointer_type_id(transform_type, spirv::StorageClass::Function);
 
         let barycentrics_type_id =
-            self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
+            self.get_numeric_type_id(NumericType::Vector {
                 size: crate::VectorSize::Bi,
                 scalar: crate::Scalar::F32,
-            })));
+            });
         let barycentrics_type = ir_module
             .types
             .get(&Type {

--- a/naga/src/back/spv/subgroup.rs
+++ b/naga/src/back/spv/subgroup.rs
@@ -1,9 +1,5 @@
 use super::{Block, BlockContext, Error, Instruction, NumericType};
-use crate::{
-    arena::Handle,
-    back::spv::{LocalType, LookupType},
-    TypeInner,
-};
+use crate::{arena::Handle, TypeInner};
 
 impl BlockContext<'_> {
     pub(super) fn write_subgroup_ballot(
@@ -16,11 +12,10 @@ impl BlockContext<'_> {
             "GroupNonUniformBallot",
             &[spirv::Capability::GroupNonUniformBallot],
         )?;
-        let vec4_u32_type_id =
-            self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Vector {
-                size: crate::VectorSize::Quad,
-                scalar: crate::Scalar::U32,
-            })));
+        let vec4_u32_type_id = self.get_numeric_type_id(NumericType::Vector {
+            size: crate::VectorSize::Quad,
+            scalar: crate::Scalar::U32,
+        });
         let exec_scope_id = self.get_index_constant(spirv::Scope::Subgroup as u32);
         let predicate = if let Some(predicate) = *predicate {
             self.cached[predicate]

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -240,7 +240,7 @@ impl Writer {
         self.get_type_id(LookupType::Local(local))
     }
 
-    pub(super) fn get_pointer_id(
+    pub(super) fn get_pointer_type_id(
         &mut self,
         handle: Handle<crate::Type>,
         class: spirv::StorageClass,
@@ -285,7 +285,7 @@ impl Writer {
         class: spirv::StorageClass,
     ) -> Word {
         match *resolution {
-            TypeResolution::Handle(handle) => self.get_pointer_id(handle, class),
+            TypeResolution::Handle(handle) => self.get_pointer_type_id(handle, class),
             TypeResolution::Value(ref inner) => {
                 let base = NumericType::from_inner(inner).unwrap();
                 self.get_type_id(LookupType::Local(LocalType::LocalPointer { base, class }))
@@ -638,7 +638,7 @@ impl Writer {
             let class = spirv::StorageClass::Input;
             let handle_ty = ir_module.types[argument.ty].inner.is_handle();
             let argument_type_id = match handle_ty {
-                true => self.get_pointer_id(argument.ty, spirv::StorageClass::UniformConstant),
+                true => self.get_pointer_type_id(argument.ty, spirv::StorageClass::UniformConstant),
                 false => self.get_type_id(LookupType::Handle(argument.ty)),
             };
 
@@ -869,7 +869,7 @@ impl Writer {
                         gv.handle_id = id;
                     } else if global_needs_wrapper(ir_module, var) {
                         let class = map_storage_class(var.space);
-                        let pointer_type_id = self.get_pointer_id(var.ty, class);
+                        let pointer_type_id = self.get_pointer_type_id(var.ty, class);
                         let index_id = self.get_index_constant(0);
                         let id = self.id_gen.next();
                         prelude.body.push(Instruction::access_chain(
@@ -931,7 +931,7 @@ impl Writer {
             let init_word = variable.init.map(|constant| context.cached[constant]);
             let pointer_type_id = context
                 .writer
-                .get_pointer_id(variable.ty, spirv::StorageClass::Function);
+                .get_pointer_type_id(variable.ty, spirv::StorageClass::Function);
             let instruction = Instruction::variable(
                 pointer_type_id,
                 id,
@@ -1756,7 +1756,7 @@ impl Writer {
         binding: &crate::Binding,
     ) -> Result<Word, Error> {
         let id = self.id_gen.next();
-        let pointer_type_id = self.get_pointer_id(ty, class);
+        let pointer_type_id = self.get_pointer_type_id(ty, class);
         Instruction::variable(pointer_type_id, id, class, None)
             .to_words(&mut self.logical_layout.declarations);
 
@@ -2089,7 +2089,7 @@ impl Writer {
             if substitute_inner_type_lookup.is_some() {
                 inner_type_id
             } else {
-                self.get_pointer_id(global_variable.ty, class)
+                self.get_pointer_type_id(global_variable.ty, class)
             }
         };
 

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -297,30 +297,30 @@ impl Writer {
         }
     }
 
+    pub(super) fn get_numeric_type_id(&mut self, numeric: NumericType) -> Word {
+        self.get_type_id(LocalType::Numeric(numeric).into())
+    }
+
     pub(super) fn get_u32_type_id(&mut self) -> Word {
-        let local_type = LocalType::Numeric(NumericType::Scalar(crate::Scalar::U32));
-        self.get_type_id(local_type.into())
+        self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::U32))
     }
 
     pub(super) fn get_f32_type_id(&mut self) -> Word {
-        let local_type = LocalType::Numeric(NumericType::Scalar(crate::Scalar::F32));
-        self.get_type_id(local_type.into())
+        self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::F32))
     }
 
     pub(super) fn get_vec2u_type_id(&mut self) -> Word {
-        let local_type = LocalType::Numeric(NumericType::Vector {
+        self.get_numeric_type_id(NumericType::Vector {
             size: crate::VectorSize::Bi,
             scalar: crate::Scalar::U32,
-        });
-        self.get_type_id(local_type.into())
+        })
     }
 
     pub(super) fn get_vec3u_type_id(&mut self) -> Word {
-        let local_type = LocalType::Numeric(NumericType::Vector {
+        self.get_numeric_type_id(NumericType::Vector {
             size: crate::VectorSize::Tri,
             scalar: crate::Scalar::U32,
-        });
-        self.get_type_id(local_type.into())
+        })
     }
 
     pub(super) fn get_f32_pointer_type_id(&mut self, class: spirv::StorageClass) -> Word {
@@ -354,24 +354,21 @@ impl Writer {
     }
 
     pub(super) fn get_bool_type_id(&mut self) -> Word {
-        let local_type = LocalType::Numeric(NumericType::Scalar(crate::Scalar::BOOL));
-        self.get_type_id(local_type.into())
+        self.get_numeric_type_id(NumericType::Scalar(crate::Scalar::BOOL))
     }
 
     pub(super) fn get_vec2_bool_type_id(&mut self) -> Word {
-        let local_type = LocalType::Numeric(NumericType::Vector {
+        self.get_numeric_type_id(NumericType::Vector {
             size: crate::VectorSize::Bi,
             scalar: crate::Scalar::BOOL,
-        });
-        self.get_type_id(local_type.into())
+        })
     }
 
     pub(super) fn get_vec3_bool_type_id(&mut self) -> Word {
-        let local_type = LocalType::Numeric(NumericType::Vector {
+        self.get_numeric_type_id(NumericType::Vector {
             size: crate::VectorSize::Tri,
             scalar: crate::Scalar::BOOL,
-        });
-        self.get_type_id(local_type.into())
+        })
     }
 
     pub(super) fn decorate(&mut self, id: Word, decoration: spirv::Decoration, operands: &[Word]) {
@@ -506,7 +503,7 @@ impl Writer {
         let mut block = Block::new(label_id);
 
         let bool_type = return_type.with_scalar(crate::Scalar::BOOL);
-        let bool_type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(bool_type)));
+        let bool_type_id = self.get_numeric_type_id(bool_type);
 
         let maybe_splat_const = |writer: &mut Self, const_id| match return_type {
             NumericType::Scalar(_) => const_id,
@@ -1195,9 +1192,7 @@ impl Writer {
             match numeric {
                 NumericType::Scalar(scalar) => self.make_scalar(id, scalar),
                 NumericType::Vector { size, scalar } => {
-                    let scalar_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                        NumericType::Scalar(scalar),
-                    )));
+                    let scalar_id = self.get_numeric_type_id(NumericType::Scalar(scalar));
                     Instruction::type_vector(id, scalar_id, size)
                 }
                 NumericType::Matrix {
@@ -1205,9 +1200,7 @@ impl Writer {
                     rows,
                     scalar,
                 } => {
-                    let column_id = self.get_type_id(LookupType::Local(LocalType::Numeric(
-                        NumericType::Vector { size: rows, scalar },
-                    )));
+                    let column_id = self.get_numeric_type_id(NumericType::Vector { size: rows, scalar });
                     Instruction::type_matrix(id, column_id, columns)
                 }
             };
@@ -1469,9 +1462,7 @@ impl Writer {
                 self.debugs.push(Instruction::name(id, name));
             }
         }
-        let type_id = self.get_type_id(LookupType::Local(LocalType::Numeric(NumericType::Scalar(
-            value.scalar(),
-        ))));
+        let type_id = self.get_numeric_type_id(NumericType::Scalar(value.scalar()));
         let instruction = match *value {
             crate::Literal::F64(value) => {
                 let bits = value.to_bits();

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -1188,22 +1188,22 @@ impl Writer {
     }
 
     fn write_numeric_type_declaration_local(&mut self, id: Word, numeric: NumericType) {
-        let instruction =
-            match numeric {
-                NumericType::Scalar(scalar) => self.make_scalar(id, scalar),
-                NumericType::Vector { size, scalar } => {
-                    let scalar_id = self.get_numeric_type_id(NumericType::Scalar(scalar));
-                    Instruction::type_vector(id, scalar_id, size)
-                }
-                NumericType::Matrix {
-                    columns,
-                    rows,
-                    scalar,
-                } => {
-                    let column_id = self.get_numeric_type_id(NumericType::Vector { size: rows, scalar });
-                    Instruction::type_matrix(id, column_id, columns)
-                }
-            };
+        let instruction = match numeric {
+            NumericType::Scalar(scalar) => self.make_scalar(id, scalar),
+            NumericType::Vector { size, scalar } => {
+                let scalar_id = self.get_numeric_type_id(NumericType::Scalar(scalar));
+                Instruction::type_vector(id, scalar_id, size)
+            }
+            NumericType::Matrix {
+                columns,
+                rows,
+                scalar,
+            } => {
+                let column_id =
+                    self.get_numeric_type_id(NumericType::Vector { size: rows, scalar });
+                Instruction::type_matrix(id, column_id, columns)
+            }
+        };
 
         instruction.to_words(&mut self.logical_layout.declarations);
     }

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -293,17 +293,17 @@ impl Writer {
         }
     }
 
-    pub(super) fn get_uint_type_id(&mut self) -> Word {
+    pub(super) fn get_u32_type_id(&mut self) -> Word {
         let local_type = LocalType::Numeric(NumericType::Scalar(crate::Scalar::U32));
         self.get_type_id(local_type.into())
     }
 
-    pub(super) fn get_float_type_id(&mut self) -> Word {
+    pub(super) fn get_f32_type_id(&mut self) -> Word {
         let local_type = LocalType::Numeric(NumericType::Scalar(crate::Scalar::F32));
         self.get_type_id(local_type.into())
     }
 
-    pub(super) fn get_uint2_type_id(&mut self) -> Word {
+    pub(super) fn get_vec2u_type_id(&mut self) -> Word {
         let local_type = LocalType::Numeric(NumericType::Vector {
             size: crate::VectorSize::Bi,
             scalar: crate::Scalar::U32,
@@ -311,7 +311,7 @@ impl Writer {
         self.get_type_id(local_type.into())
     }
 
-    pub(super) fn get_uint3_type_id(&mut self) -> Word {
+    pub(super) fn get_vec3u_type_id(&mut self) -> Word {
         let local_type = LocalType::Numeric(NumericType::Vector {
             size: crate::VectorSize::Tri,
             scalar: crate::Scalar::U32,
@@ -319,7 +319,7 @@ impl Writer {
         self.get_type_id(local_type.into())
     }
 
-    pub(super) fn get_float_pointer_type_id(&mut self, class: spirv::StorageClass) -> Word {
+    pub(super) fn get_f32_pointer_type_id(&mut self, class: spirv::StorageClass) -> Word {
         let local_type = LocalType::LocalPointer {
             base: NumericType::Scalar(crate::Scalar::F32),
             class,
@@ -327,7 +327,7 @@ impl Writer {
         self.get_type_id(local_type.into())
     }
 
-    pub(super) fn get_uint2_pointer_type_id(&mut self, class: spirv::StorageClass) -> Word {
+    pub(super) fn get_vec2u_pointer_type_id(&mut self, class: spirv::StorageClass) -> Word {
         let local_type = LocalType::LocalPointer {
             base: NumericType::Vector {
                 size: crate::VectorSize::Bi,
@@ -338,7 +338,7 @@ impl Writer {
         self.get_type_id(local_type.into())
     }
 
-    pub(super) fn get_uint3_pointer_type_id(&mut self, class: spirv::StorageClass) -> Word {
+    pub(super) fn get_vec3u_pointer_type_id(&mut self, class: spirv::StorageClass) -> Word {
         let local_type = LocalType::LocalPointer {
             base: NumericType::Vector {
                 size: crate::VectorSize::Tri,
@@ -354,7 +354,7 @@ impl Writer {
         self.get_type_id(local_type.into())
     }
 
-    pub(super) fn get_bool2_type_id(&mut self) -> Word {
+    pub(super) fn get_vec2_bool_type_id(&mut self) -> Word {
         let local_type = LocalType::Numeric(NumericType::Vector {
             size: crate::VectorSize::Bi,
             scalar: crate::Scalar::BOOL,
@@ -362,7 +362,7 @@ impl Writer {
         self.get_type_id(local_type.into())
     }
 
-    pub(super) fn get_bool3_type_id(&mut self) -> Word {
+    pub(super) fn get_vec3_bool_type_id(&mut self) -> Word {
         let local_type = LocalType::Numeric(NumericType::Vector {
             size: crate::VectorSize::Tri,
             scalar: crate::Scalar::BOOL,
@@ -787,7 +787,7 @@ impl Writer {
                     {
                         // add point size artificially
                         let varying_id = self.id_gen.next();
-                        let pointer_type_id = self.get_float_pointer_type_id(class);
+                        let pointer_type_id = self.get_f32_pointer_type_id(class);
                         Instruction::variable(pointer_type_id, varying_id, class, None)
                             .to_words(&mut self.logical_layout.declarations);
                         self.decorate(
@@ -1650,7 +1650,7 @@ impl Writer {
             return None;
         }
 
-        let uint3_type_id = self.get_uint3_type_id();
+        let uint3_type_id = self.get_vec3u_type_id();
 
         let mut pre_if_block = Block::new(entry_id);
 
@@ -1659,7 +1659,7 @@ impl Writer {
         } else {
             let varying_id = self.id_gen.next();
             let class = spirv::StorageClass::Input;
-            let pointer_type_id = self.get_uint3_pointer_type_id(class);
+            let pointer_type_id = self.get_vec3u_pointer_type_id(class);
 
             Instruction::variable(pointer_type_id, varying_id, class, None)
                 .to_words(&mut self.logical_layout.declarations);
@@ -1680,7 +1680,7 @@ impl Writer {
         };
 
         let zero_id = self.get_constant_null(uint3_type_id);
-        let bool3_type_id = self.get_bool3_type_id();
+        let bool3_type_id = self.get_vec3_bool_type_id();
 
         let eq_id = self.id_gen.next();
         pre_if_block.body.push(Instruction::binary(


### PR DESCRIPTION
Fixing #7240 gets easier if everyone would just use utility functions to look up types instead of calling `get_type_id` themselves. This PR gives the existing SPIR-V type lookup utilities names more consistent with modern WGSL, introduces a few new utilities, and then makes all the sites I could find actually use them.

There should be no change in behavior.