### PR TITLE
[naga spv-out] Avoid duplicating SPIR-V OpTypePointer instructions

### DIFF
--- a/naga/src/back/spv/image.rs
+++ b/naga/src/back/spv/image.rs
@@ -1236,10 +1236,8 @@ impl BlockContext<'_> {
             return Err(Error::Validation("Invalid image class"));
         };
         let scalar = format.into();
-        let pointer_type_id = self.get_type_id(LookupType::Local(LocalType::LocalPointer {
-            base: NumericType::Scalar(scalar),
-            class: spirv::StorageClass::Image,
-        }));
+        let scalar_type_id = self.get_numeric_type_id(NumericType::Scalar(scalar));
+        let pointer_type_id = self.get_pointer_type_id(scalar_type_id, spirv::StorageClass::Image);
         let signed = scalar.kind == crate::ScalarKind::Sint;
         if scalar.width == 8 {
             self.writer

--- a/naga/src/back/spv/index.rs
+++ b/naga/src/back/spv/index.rs
@@ -225,8 +225,9 @@ impl BlockContext<'_> {
             Some(index_id) => {
                 let element_type_id = match self.ir_module.types[global.ty].inner {
                     crate::TypeInner::BindingArray { base, size: _ } => {
+                        let base_id = self.get_handle_type_id(base);
                         let class = map_storage_class(global.space);
-                        self.get_pointer_type_id(base, class)
+                        self.get_pointer_type_id(base_id, class)
                     }
                     _ => return Err(Error::Validation("array length expression case-5")),
                 };

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -348,9 +348,9 @@ impl NumericType {
 /// never synthesizes new struct types, so `LocalType` has nothing for that.
 ///
 /// Each `LocalType` variant should be handled identically to its analogous
-/// `TypeInner` variant. You can use the [`LocalType::from_inner`] function to
-/// help with this, by converting everything possible to a `LocalType` before
-/// inspecting it.
+/// `TypeInner` variant. You can use the [`Writer::localtype_from_inner`]
+/// function to help with this, by converting everything possible to a
+/// `LocalType` before inspecting it.
 ///
 /// ## `LocalType` equality and SPIR-V `OpType` uniqueness
 ///
@@ -370,8 +370,10 @@ impl NumericType {
 /// variant, is designed to help us deduplicate `OpTypeImage` instructions. See
 /// its documentation for details.
 ///
-/// `LocalType` also includes variants like `Pointer` that do not need to be
-/// unique - but it is harmless to avoid the duplication.
+/// SPIR-V does not require pointer types to be unique - but different
+/// SPIR-V ids are considered to be distinct pointer types. Since Naga
+/// uses structural type equality, we need to represent each Naga
+/// equivalence class with a single SPIR-V `OpTypePointer`.
 ///
 /// As it always must, the `Hash` implementation respects the `Eq` relation.
 ///
@@ -380,12 +382,8 @@ impl NumericType {
 enum LocalType {
     /// A numeric type.
     Numeric(NumericType),
-    LocalPointer {
-        base: NumericType,
-        class: spirv::StorageClass,
-    },
     Pointer {
-        base: Handle<crate::Type>,
+        base: Word,
         class: spirv::StorageClass,
     },
     Image(LocalImageType),
@@ -393,16 +391,6 @@ enum LocalType {
         image_type_id: Word,
     },
     Sampler,
-    /// Equivalent to a [`LocalType::Pointer`] whose `base` is a Naga IR [`BindingArray`]. SPIR-V
-    /// permits duplicated `OpTypePointer` ids, so it's fine to have two different [`LocalType`]
-    /// representations for pointer types.
-    ///
-    /// [`BindingArray`]: crate::TypeInner::BindingArray
-    PointerToBindingArray {
-        base: Handle<crate::Type>,
-        size: u32,
-        space: crate::AddressSpace,
-    },
     BindingArray {
         base: Handle<crate::Type>,
         size: u32,
@@ -449,52 +437,6 @@ impl From<LocalType> for LookupType {
 struct LookupFunctionType {
     parameter_type_ids: Vec<Word>,
     return_type_id: Word,
-}
-
-impl LocalType {
-    fn from_inner(inner: &crate::TypeInner) -> Option<Self> {
-        Some(match *inner {
-            crate::TypeInner::Scalar(_)
-            | crate::TypeInner::Atomic(_)
-            | crate::TypeInner::Vector { .. }
-            | crate::TypeInner::Matrix { .. } => {
-                // We expect `NumericType::from_inner` to handle all
-                // these cases, so unwrap.
-                LocalType::Numeric(NumericType::from_inner(inner).unwrap())
-            }
-            crate::TypeInner::Pointer { base, space } => LocalType::Pointer {
-                base,
-                class: helpers::map_storage_class(space),
-            },
-            crate::TypeInner::ValuePointer {
-                size: Some(size),
-                scalar,
-                space,
-            } => LocalType::LocalPointer {
-                base: NumericType::Vector { size, scalar },
-                class: helpers::map_storage_class(space),
-            },
-            crate::TypeInner::ValuePointer {
-                size: None,
-                scalar,
-                space,
-            } => LocalType::LocalPointer {
-                base: NumericType::Scalar(scalar),
-                class: helpers::map_storage_class(space),
-            },
-            crate::TypeInner::Image {
-                dim,
-                arrayed,
-                class,
-            } => LocalType::Image(LocalImageType::from_inner(dim, arrayed, class)),
-            crate::TypeInner::Sampler { comparison: _ } => LocalType::Sampler,
-            crate::TypeInner::AccelerationStructure { .. } => LocalType::AccelerationStructure,
-            crate::TypeInner::RayQuery { .. } => LocalType::RayQuery,
-            crate::TypeInner::Array { .. }
-            | crate::TypeInner::Struct { .. }
-            | crate::TypeInner::BindingArray { .. } => return None,
-        })
-    }
 }
 
 #[derive(Debug)]
@@ -765,12 +707,8 @@ impl BlockContext<'_> {
             .get_constant_scalar(crate::Literal::I32(scope as _))
     }
 
-    fn get_pointer_type_id(
-        &mut self,
-        handle: Handle<crate::Type>,
-        class: spirv::StorageClass,
-    ) -> Word {
-        self.writer.get_pointer_type_id(handle, class)
+    fn get_pointer_type_id(&mut self, base: Word, class: spirv::StorageClass) -> Word {
+        self.writer.get_pointer_type_id(base, class)
     }
 
     fn get_numeric_type_id(&mut self, numeric: NumericType) -> Word {

--- a/naga/src/back/spv/ray.rs
+++ b/naga/src/back/spv/ray.rs
@@ -9,7 +9,6 @@ use super::{
     Writer,
 };
 use crate::arena::Handle;
-use crate::{Type, TypeInner};
 
 impl Writer {
     pub(super) fn write_ray_query_get_intersection_function(
@@ -23,65 +22,30 @@ impl Writer {
         let ray_intersection = ir_module.special_types.ray_intersection.unwrap();
         let intersection_type_id = self.get_handle_type_id(ray_intersection);
         let intersection_pointer_type_id =
-            self.get_pointer_type_id(ray_intersection, spirv::StorageClass::Function);
+            self.get_pointer_type_id(intersection_type_id, spirv::StorageClass::Function);
 
         let flag_type_id = self.get_u32_type_id();
-        let flag_type = ir_module
-            .types
-            .get(&Type {
-                name: None,
-                inner: TypeInner::Scalar(crate::Scalar::U32),
-            })
-            .unwrap();
         let flag_pointer_type_id =
-            self.get_pointer_type_id(flag_type, spirv::StorageClass::Function);
+            self.get_pointer_type_id(flag_type_id, spirv::StorageClass::Function);
 
         let transform_type_id = self.get_numeric_type_id(NumericType::Matrix {
             columns: crate::VectorSize::Quad,
             rows: crate::VectorSize::Tri,
             scalar: crate::Scalar::F32,
         });
-        let transform_type = ir_module
-            .types
-            .get(&Type {
-                name: None,
-                inner: TypeInner::Matrix {
-                    columns: crate::VectorSize::Quad,
-                    rows: crate::VectorSize::Tri,
-                    scalar: crate::Scalar::F32,
-                },
-            })
-            .unwrap();
         let transform_pointer_type_id =
-            self.get_pointer_type_id(transform_type, spirv::StorageClass::Function);
+            self.get_pointer_type_id(transform_type_id, spirv::StorageClass::Function);
 
         let barycentrics_type_id = self.get_numeric_type_id(NumericType::Vector {
             size: crate::VectorSize::Bi,
             scalar: crate::Scalar::F32,
         });
-        let barycentrics_type = ir_module
-            .types
-            .get(&Type {
-                name: None,
-                inner: TypeInner::Vector {
-                    size: crate::VectorSize::Bi,
-                    scalar: crate::Scalar::F32,
-                },
-            })
-            .unwrap();
         let barycentrics_pointer_type_id =
-            self.get_pointer_type_id(barycentrics_type, spirv::StorageClass::Function);
+            self.get_pointer_type_id(barycentrics_type_id, spirv::StorageClass::Function);
 
         let bool_type_id = self.get_bool_type_id();
-        let bool_type = ir_module
-            .types
-            .get(&Type {
-                name: None,
-                inner: TypeInner::Scalar(crate::Scalar::BOOL),
-            })
-            .unwrap();
         let bool_pointer_type_id =
-            self.get_pointer_type_id(bool_type, spirv::StorageClass::Function);
+            self.get_pointer_type_id(bool_type_id, spirv::StorageClass::Function);
 
         let scalar_type_id = self.get_f32_type_id();
         let float_pointer_type_id = self.get_f32_pointer_type_id(spirv::StorageClass::Function);

--- a/naga/tests/out/spv/access.spvasm
+++ b/naga/tests/out/spv/access.spvasm
@@ -1,18 +1,18 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 403
+; Bound: 402
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %312 "foo_vert" %307 %310
-OpEntryPoint Fragment %364 "foo_frag" %363
-OpEntryPoint GLCompute %382 "assign_through_ptr"
-OpEntryPoint GLCompute %393 "assign_to_ptr_components"
-OpExecutionMode %364 OriginUpperLeft
-OpExecutionMode %382 LocalSize 1 1 1
-OpExecutionMode %393 LocalSize 1 1 1
+OpEntryPoint Vertex %311 "foo_vert" %306 %309
+OpEntryPoint Fragment %363 "foo_frag" %362
+OpEntryPoint GLCompute %381 "assign_through_ptr"
+OpEntryPoint GLCompute %392 "assign_to_ptr_components"
+OpExecutionMode %363 OriginUpperLeft
+OpExecutionMode %381 LocalSize 1 1 1
+OpExecutionMode %392 LocalSize 1 1 1
 %3 = OpString "access.wgsl"
 OpSource Unknown 0 %3 "// This snapshot tests accessing various containers, dereferencing pointers.
 
@@ -293,46 +293,46 @@ OpName %62 "nested_mat_cx2"
 OpName %66 "test_matrix_within_struct_accesses"
 OpName %94 "idx"
 OpName %96 "t"
-OpName %141 "test_matrix_within_array_within_struct_accesses"
-OpName %151 "idx"
-OpName %152 "t"
-OpName %198 "foo"
-OpName %199 "read_from_private"
-OpName %204 "a"
-OpName %205 "test_arr_as_arg"
-OpName %211 "p"
-OpName %212 "assign_through_ptr_fn"
-OpName %217 "foo"
-OpName %218 "assign_array_through_ptr_fn"
-OpName %225 "p"
-OpName %226 "fetch_arg_ptr_member"
-OpName %232 "p"
-OpName %233 "assign_to_arg_ptr_member"
-OpName %238 "p"
-OpName %239 "fetch_arg_ptr_array_element"
-OpName %245 "p"
-OpName %246 "assign_to_arg_ptr_array_element"
-OpName %251 "value"
-OpName %252 "index_ptr"
-OpName %254 "a"
-OpName %263 "member_ptr"
-OpName %267 "s"
-OpName %273 "let_members_of_members"
-OpName %285 "var_members_of_members"
-OpName %286 "thing"
-OpName %288 "inner"
-OpName %291 "delishus"
-OpName %307 "vi"
-OpName %312 "foo_vert"
-OpName %323 "foo"
-OpName %324 "c2"
-OpName %364 "foo_frag"
-OpName %382 "assign_through_ptr"
-OpName %387 "val"
-OpName %388 "arr"
-OpName %393 "assign_to_ptr_components"
-OpName %394 "s1"
-OpName %396 "a1"
+OpName %140 "test_matrix_within_array_within_struct_accesses"
+OpName %150 "idx"
+OpName %151 "t"
+OpName %197 "foo"
+OpName %198 "read_from_private"
+OpName %203 "a"
+OpName %204 "test_arr_as_arg"
+OpName %210 "p"
+OpName %211 "assign_through_ptr_fn"
+OpName %216 "foo"
+OpName %217 "assign_array_through_ptr_fn"
+OpName %224 "p"
+OpName %225 "fetch_arg_ptr_member"
+OpName %231 "p"
+OpName %232 "assign_to_arg_ptr_member"
+OpName %237 "p"
+OpName %238 "fetch_arg_ptr_array_element"
+OpName %244 "p"
+OpName %245 "assign_to_arg_ptr_array_element"
+OpName %250 "value"
+OpName %251 "index_ptr"
+OpName %253 "a"
+OpName %262 "member_ptr"
+OpName %266 "s"
+OpName %272 "let_members_of_members"
+OpName %284 "var_members_of_members"
+OpName %285 "thing"
+OpName %287 "inner"
+OpName %290 "delishus"
+OpName %306 "vi"
+OpName %311 "foo_vert"
+OpName %322 "foo"
+OpName %323 "c2"
+OpName %363 "foo_frag"
+OpName %381 "assign_through_ptr"
+OpName %386 "val"
+OpName %387 "arr"
+OpName %392 "assign_to_ptr_components"
+OpName %393 "s1"
+OpName %395 "a1"
 OpMemberDecorate %7 0 Offset 0
 OpMemberDecorate %7 1 Offset 16
 OpMemberDecorate %7 2 Offset 28
@@ -384,9 +384,9 @@ OpDecorate %62 DescriptorSet 0
 OpDecorate %62 Binding 3
 OpDecorate %63 Block
 OpMemberDecorate %63 0 Offset 0
-OpDecorate %307 BuiltIn VertexIndex
-OpDecorate %310 BuiltIn Position
-OpDecorate %363 Location 0
+OpDecorate %306 BuiltIn VertexIndex
+OpDecorate %309 BuiltIn Position
+OpDecorate %362 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 0
 %5 = OpTypeVector %4 3
@@ -482,83 +482,82 @@ OpDecorate %363 Location 0
 %110 = OpTypePointer Uniform %9
 %125 = OpTypePointer Function %22
 %127 = OpTypePointer Function %13
-%131 = OpTypePointer Function %9
-%142 = OpTypePointer Uniform %27
-%144 = OpConstantNull  %26
-%145 = OpConstantComposite  %27  %144
-%146 = OpConstant  %9  8.0
-%147 = OpConstantComposite  %13  %146 %146
-%148 = OpConstant  %9  7.0
-%149 = OpConstantComposite  %13  %148 %148
-%150 = OpConstantComposite  %25  %147 %149 %80 %82
-%153 = OpTypePointer Function %27
-%157 = OpTypePointer Uniform %26
-%160 = OpTypePointer Uniform %25
-%182 = OpTypePointer Function %26
-%184 = OpTypePointer Function %25
-%200 = OpTypeFunction %9 %28
-%206 = OpTypeFunction %9 %30
-%213 = OpTypeFunction %2 %34
-%214 = OpConstant  %4  42
-%219 = OpTypeFunction %2 %36
-%220 = OpConstantComposite  %32  %71 %71 %71 %71
-%221 = OpConstantComposite  %32  %73 %73 %73 %73
-%222 = OpConstantComposite  %35  %220 %221
-%227 = OpTypeFunction %4 %38
-%234 = OpTypeFunction %2 %38
-%240 = OpTypeFunction %4 %41
-%247 = OpTypeFunction %2 %41
-%253 = OpTypeFunction %42 %42
-%255 = OpTypePointer Function %43
-%256 = OpConstantNull  %43
-%259 = OpTypePointer Function %42
-%264 = OpTypeFunction %6
-%265 = OpConstant  %6  42
-%266 = OpConstantComposite  %45  %265
-%268 = OpTypePointer Function %45
-%274 = OpConstantNull  %47
-%287 = OpTypePointer Function %47
-%289 = OpTypePointer Function %46
-%290 = OpConstantNull  %46
-%292 = OpConstantNull  %6
-%308 = OpTypePointer Input %4
-%307 = OpVariable  %308  Input
-%311 = OpTypePointer Output %32
-%310 = OpVariable  %311  Output
-%314 = OpTypePointer StorageBuffer %24
-%317 = OpConstant  %9  0.0
-%318 = OpConstant  %4  3
-%319 = OpConstant  %6  3
-%320 = OpConstant  %6  4
-%321 = OpConstant  %6  5
-%322 = OpConstantNull  %30
-%325 = OpTypePointer Function %33
-%326 = OpConstantNull  %33
-%331 = OpTypePointer StorageBuffer %10
-%334 = OpTypePointer StorageBuffer %19
-%337 = OpTypePointer StorageBuffer %11
-%338 = OpTypePointer StorageBuffer %9
-%341 = OpTypePointer StorageBuffer %20
-%344 = OpTypePointer StorageBuffer %8
-%345 = OpTypePointer StorageBuffer %6
-%357 = OpTypeVector %6 4
-%363 = OpVariable  %311  Output
-%366 = OpConstantComposite  %11  %317 %317 %317
-%367 = OpConstantComposite  %11  %71 %71 %71
-%368 = OpConstantComposite  %11  %73 %73 %73
-%369 = OpConstantComposite  %11  %75 %75 %75
-%370 = OpConstantComposite  %10  %366 %367 %368 %369
-%371 = OpConstantComposite  %18  %48 %48
-%372 = OpConstantComposite  %18  %44 %44
-%373 = OpConstantComposite  %19  %371 %372
-%374 = OpConstantNull  %24
-%375 = OpConstantComposite  %32  %317 %317 %317 %317
-%383 = OpConstant  %4  33
-%384 = OpConstantComposite  %32  %79 %79 %79 %79
-%385 = OpConstantComposite  %32  %148 %148 %148 %148
-%386 = OpConstantComposite  %35  %384 %385
-%395 = OpConstantNull  %37
-%397 = OpConstantNull  %39
+%141 = OpTypePointer Uniform %27
+%143 = OpConstantNull  %26
+%144 = OpConstantComposite  %27  %143
+%145 = OpConstant  %9  8.0
+%146 = OpConstantComposite  %13  %145 %145
+%147 = OpConstant  %9  7.0
+%148 = OpConstantComposite  %13  %147 %147
+%149 = OpConstantComposite  %25  %146 %148 %80 %82
+%152 = OpTypePointer Function %27
+%156 = OpTypePointer Uniform %26
+%159 = OpTypePointer Uniform %25
+%181 = OpTypePointer Function %26
+%183 = OpTypePointer Function %25
+%199 = OpTypeFunction %9 %28
+%205 = OpTypeFunction %9 %30
+%212 = OpTypeFunction %2 %34
+%213 = OpConstant  %4  42
+%218 = OpTypeFunction %2 %36
+%219 = OpConstantComposite  %32  %71 %71 %71 %71
+%220 = OpConstantComposite  %32  %73 %73 %73 %73
+%221 = OpConstantComposite  %35  %219 %220
+%226 = OpTypeFunction %4 %38
+%233 = OpTypeFunction %2 %38
+%239 = OpTypeFunction %4 %41
+%246 = OpTypeFunction %2 %41
+%252 = OpTypeFunction %42 %42
+%254 = OpTypePointer Function %43
+%255 = OpConstantNull  %43
+%258 = OpTypePointer Function %42
+%263 = OpTypeFunction %6
+%264 = OpConstant  %6  42
+%265 = OpConstantComposite  %45  %264
+%267 = OpTypePointer Function %45
+%273 = OpConstantNull  %47
+%286 = OpTypePointer Function %47
+%288 = OpTypePointer Function %46
+%289 = OpConstantNull  %46
+%291 = OpConstantNull  %6
+%307 = OpTypePointer Input %4
+%306 = OpVariable  %307  Input
+%310 = OpTypePointer Output %32
+%309 = OpVariable  %310  Output
+%313 = OpTypePointer StorageBuffer %24
+%316 = OpConstant  %9  0.0
+%317 = OpConstant  %4  3
+%318 = OpConstant  %6  3
+%319 = OpConstant  %6  4
+%320 = OpConstant  %6  5
+%321 = OpConstantNull  %30
+%324 = OpTypePointer Function %33
+%325 = OpConstantNull  %33
+%330 = OpTypePointer StorageBuffer %10
+%333 = OpTypePointer StorageBuffer %19
+%336 = OpTypePointer StorageBuffer %11
+%337 = OpTypePointer StorageBuffer %9
+%340 = OpTypePointer StorageBuffer %20
+%343 = OpTypePointer StorageBuffer %8
+%344 = OpTypePointer StorageBuffer %6
+%356 = OpTypeVector %6 4
+%362 = OpVariable  %310  Output
+%365 = OpConstantComposite  %11  %316 %316 %316
+%366 = OpConstantComposite  %11  %71 %71 %71
+%367 = OpConstantComposite  %11  %73 %73 %73
+%368 = OpConstantComposite  %11  %75 %75 %75
+%369 = OpConstantComposite  %10  %365 %366 %367 %368
+%370 = OpConstantComposite  %18  %48 %48
+%371 = OpConstantComposite  %18  %44 %44
+%372 = OpConstantComposite  %19  %370 %371
+%373 = OpConstantNull  %24
+%374 = OpConstantComposite  %32  %316 %316 %316 %316
+%382 = OpConstant  %4  33
+%383 = OpConstantComposite  %32  %79 %79 %79 %79
+%384 = OpConstantComposite  %32  %147 %147 %147 %147
+%385 = OpConstantComposite  %35  %383 %384
+%394 = OpConstantNull  %37
+%396 = OpConstantNull  %39
 %66 = OpFunction  %2  None %67
 %65 = OpLabel
 %94 = OpVariable  %95  Function %70
@@ -633,91 +632,91 @@ OpLine %3 59 5
 OpLine %3 59 5
 OpLine %3 59 5
 OpLine %3 59 5
-%132 = OpAccessChain  %131  %96 %48 %48 %44
-OpStore %132 %90
+%131 = OpAccessChain  %28  %96 %48 %48 %44
+OpStore %131 %90
 OpLine %3 60 5
 OpLine %3 60 5
-%133 = OpLoad  %6  %94
+%132 = OpLoad  %6  %94
 OpLine %3 60 5
-%134 = OpAccessChain  %131  %96 %48 %48 %133
-OpStore %134 %91
+%133 = OpAccessChain  %28  %96 %48 %48 %132
+OpStore %133 %91
 OpLine %3 61 5
-%135 = OpLoad  %6  %94
+%134 = OpLoad  %6  %94
 OpLine %3 61 5
 OpLine %3 61 5
-%136 = OpAccessChain  %131  %96 %48 %135 %44
-OpStore %136 %92
+%135 = OpAccessChain  %28  %96 %48 %134 %44
+OpStore %135 %92
 OpLine %3 62 5
+%136 = OpLoad  %6  %94
 %137 = OpLoad  %6  %94
-%138 = OpLoad  %6  %94
 OpLine %3 62 5
-%139 = OpAccessChain  %131  %96 %48 %137 %138
-OpStore %139 %93
+%138 = OpAccessChain  %28  %96 %48 %136 %137
+OpStore %138 %93
 OpReturn
 OpFunctionEnd
-%141 = OpFunction  %2  None %67
-%140 = OpLabel
-%151 = OpVariable  %95  Function %70
-%152 = OpVariable  %153  Function %145
-%143 = OpAccessChain  %142  %62 %48
-OpBranch %154
-%154 = OpLabel
+%140 = OpFunction  %2  None %67
+%139 = OpLabel
+%150 = OpVariable  %95  Function %70
+%151 = OpVariable  %152  Function %144
+%142 = OpAccessChain  %141  %62 %48
+OpBranch %153
+%153 = OpLabel
 OpLine %3 75 5
-%155 = OpLoad  %6  %151
-%156 = OpISub  %6  %155 %70
+%154 = OpLoad  %6  %150
+%155 = OpISub  %6  %154 %70
 OpLine %3 75 5
-OpStore %151 %156
+OpStore %150 %155
 OpLine %3 78 14
-%158 = OpAccessChain  %157  %143 %48
-%159 = OpLoad  %26  %158
+%157 = OpAccessChain  %156  %142 %48
+%158 = OpLoad  %26  %157
 OpLine %3 79 14
 OpLine %3 79 14
-%161 = OpAccessChain  %160  %143 %48 %48
-%162 = OpLoad  %25  %161
+%160 = OpAccessChain  %159  %142 %48 %48
+%161 = OpLoad  %25  %160
 OpLine %3 80 14
 OpLine %3 80 14
 OpLine %3 80 14
-%163 = OpAccessChain  %104  %143 %48 %48 %48
-%164 = OpLoad  %13  %163
+%162 = OpAccessChain  %104  %142 %48 %48 %48
+%163 = OpLoad  %13  %162
 OpLine %3 81 14
 OpLine %3 81 14
-%165 = OpLoad  %6  %151
-%166 = OpAccessChain  %104  %143 %48 %48 %165
-%167 = OpLoad  %13  %166
+%164 = OpLoad  %6  %150
+%165 = OpAccessChain  %104  %142 %48 %48 %164
+%166 = OpLoad  %13  %165
 OpLine %3 82 14
 OpLine %3 82 14
 OpLine %3 82 14
 OpLine %3 82 14
-%168 = OpAccessChain  %110  %143 %48 %48 %48 %44
-%169 = OpLoad  %9  %168
+%167 = OpAccessChain  %110  %142 %48 %48 %48 %44
+%168 = OpLoad  %9  %167
 OpLine %3 83 14
 OpLine %3 83 14
 OpLine %3 83 14
-%170 = OpLoad  %6  %151
-%171 = OpAccessChain  %110  %143 %48 %48 %48 %170
-%172 = OpLoad  %9  %171
+%169 = OpLoad  %6  %150
+%170 = OpAccessChain  %110  %142 %48 %48 %48 %169
+%171 = OpLoad  %9  %170
 OpLine %3 84 14
 OpLine %3 84 14
-%173 = OpLoad  %6  %151
+%172 = OpLoad  %6  %150
 OpLine %3 84 14
-%174 = OpAccessChain  %110  %143 %48 %48 %173 %44
-%175 = OpLoad  %9  %174
+%173 = OpAccessChain  %110  %142 %48 %48 %172 %44
+%174 = OpLoad  %9  %173
 OpLine %3 85 14
 OpLine %3 85 14
-%176 = OpLoad  %6  %151
-%177 = OpLoad  %6  %151
-%178 = OpAccessChain  %110  %143 %48 %48 %176 %177
-%179 = OpLoad  %9  %178
+%175 = OpLoad  %6  %150
+%176 = OpLoad  %6  %150
+%177 = OpAccessChain  %110  %142 %48 %48 %175 %176
+%178 = OpLoad  %9  %177
 OpLine %3 87 13
 OpLine %3 89 5
-%180 = OpLoad  %6  %151
-%181 = OpIAdd  %6  %180 %70
+%179 = OpLoad  %6  %150
+%180 = OpIAdd  %6  %179 %70
 OpLine %3 89 5
-OpStore %151 %181
+OpStore %150 %180
 OpLine %3 92 5
 OpLine %3 92 5
-%183 = OpAccessChain  %182  %152 %48
-OpStore %183 %144
+%182 = OpAccessChain  %181  %151 %48
+OpStore %182 %143
 OpLine %3 93 5
 OpLine %3 93 5
 OpLine %3 93 27
@@ -725,344 +724,344 @@ OpLine %3 93 43
 OpLine %3 93 59
 OpLine %3 93 15
 OpLine %3 93 5
-%185 = OpAccessChain  %184  %152 %48 %48
-OpStore %185 %150
+%184 = OpAccessChain  %183  %151 %48 %48
+OpStore %184 %149
 OpLine %3 94 5
 OpLine %3 94 5
 OpLine %3 94 5
 OpLine %3 94 18
 OpLine %3 94 5
-%186 = OpAccessChain  %127  %152 %48 %48 %48
-OpStore %186 %87
+%185 = OpAccessChain  %127  %151 %48 %48 %48
+OpStore %185 %87
 OpLine %3 95 5
 OpLine %3 95 5
-%187 = OpLoad  %6  %151
+%186 = OpLoad  %6  %150
 OpLine %3 95 20
 OpLine %3 95 5
-%188 = OpAccessChain  %127  %152 %48 %48 %187
-OpStore %188 %89
+%187 = OpAccessChain  %127  %151 %48 %48 %186
+OpStore %187 %89
 OpLine %3 96 5
 OpLine %3 96 5
 OpLine %3 96 5
 OpLine %3 96 5
 OpLine %3 96 5
-%189 = OpAccessChain  %131  %152 %48 %48 %48 %44
-OpStore %189 %90
+%188 = OpAccessChain  %28  %151 %48 %48 %48 %44
+OpStore %188 %90
 OpLine %3 97 5
 OpLine %3 97 5
 OpLine %3 97 5
-%190 = OpLoad  %6  %151
+%189 = OpLoad  %6  %150
 OpLine %3 97 5
-%191 = OpAccessChain  %131  %152 %48 %48 %48 %190
-OpStore %191 %91
+%190 = OpAccessChain  %28  %151 %48 %48 %48 %189
+OpStore %190 %91
 OpLine %3 98 5
 OpLine %3 98 5
-%192 = OpLoad  %6  %151
+%191 = OpLoad  %6  %150
 OpLine %3 98 5
 OpLine %3 98 5
-%193 = OpAccessChain  %131  %152 %48 %48 %192 %44
-OpStore %193 %92
+%192 = OpAccessChain  %28  %151 %48 %48 %191 %44
+OpStore %192 %92
 OpLine %3 99 5
 OpLine %3 99 5
-%194 = OpLoad  %6  %151
-%195 = OpLoad  %6  %151
+%193 = OpLoad  %6  %150
+%194 = OpLoad  %6  %150
 OpLine %3 99 5
-%196 = OpAccessChain  %131  %152 %48 %48 %194 %195
-OpStore %196 %93
+%195 = OpAccessChain  %28  %151 %48 %48 %193 %194
+OpStore %195 %93
 OpReturn
 OpFunctionEnd
-%199 = OpFunction  %9  None %200
-%198 = OpFunctionParameter  %28
-%197 = OpLabel
-OpBranch %201
-%201 = OpLabel
+%198 = OpFunction  %9  None %199
+%197 = OpFunctionParameter  %28
+%196 = OpLabel
+OpBranch %200
+%200 = OpLabel
 OpLine %3 102 22
-%202 = OpLoad  %9  %198
-OpReturnValue %202
+%201 = OpLoad  %9  %197
+OpReturnValue %201
 OpFunctionEnd
-%205 = OpFunction  %9  None %206
-%204 = OpFunctionParameter  %30
-%203 = OpLabel
-OpBranch %207
-%207 = OpLabel
+%204 = OpFunction  %9  None %205
+%203 = OpFunctionParameter  %30
+%202 = OpLabel
+OpBranch %206
+%206 = OpLabel
 OpLine %3 107 12
-%208 = OpCompositeExtract  %29  %204 4
+%207 = OpCompositeExtract  %29  %203 4
 OpLine %3 107 12
-%209 = OpCompositeExtract  %9  %208 9
-OpReturnValue %209
+%208 = OpCompositeExtract  %9  %207 9
+OpReturnValue %208
 OpFunctionEnd
-%212 = OpFunction  %2  None %213
-%211 = OpFunctionParameter  %34
-%210 = OpLabel
-OpBranch %215
-%215 = OpLabel
+%211 = OpFunction  %2  None %212
+%210 = OpFunctionParameter  %34
+%209 = OpLabel
+OpBranch %214
+%214 = OpLabel
 OpLine %3 155 5
-OpStore %211 %214
+OpStore %210 %213
 OpReturn
 OpFunctionEnd
-%218 = OpFunction  %2  None %219
-%217 = OpFunctionParameter  %36
-%216 = OpLabel
-OpBranch %223
-%223 = OpLabel
+%217 = OpFunction  %2  None %218
+%216 = OpFunctionParameter  %36
+%215 = OpLabel
+OpBranch %222
+%222 = OpLabel
 OpLine %3 159 32
 OpLine %3 159 43
 OpLine %3 159 32
 OpLine %3 159 12
 OpLine %3 159 5
-OpStore %217 %222
+OpStore %216 %221
 OpReturn
 OpFunctionEnd
-%226 = OpFunction  %4  None %227
-%225 = OpFunctionParameter  %38
-%224 = OpLabel
-OpBranch %228
-%228 = OpLabel
+%225 = OpFunction  %4  None %226
+%224 = OpFunctionParameter  %38
+%223 = OpLabel
+OpBranch %227
+%227 = OpLabel
 OpLine %3 176 10
-%229 = OpAccessChain  %34  %225 %48
-%230 = OpLoad  %4  %229
-OpReturnValue %230
+%228 = OpAccessChain  %34  %224 %48
+%229 = OpLoad  %4  %228
+OpReturnValue %229
 OpFunctionEnd
-%233 = OpFunction  %2  None %234
-%232 = OpFunctionParameter  %38
-%231 = OpLabel
-OpBranch %235
-%235 = OpLabel
+%232 = OpFunction  %2  None %233
+%231 = OpFunctionParameter  %38
+%230 = OpLabel
+OpBranch %234
+%234 = OpLabel
 OpLine %3 180 3
 OpLine %3 180 3
-%236 = OpAccessChain  %34  %232 %48
-OpStore %236 %17
+%235 = OpAccessChain  %34  %231 %48
+OpStore %235 %17
 OpReturn
 OpFunctionEnd
-%239 = OpFunction  %4  None %240
-%238 = OpFunctionParameter  %41
-%237 = OpLabel
-OpBranch %241
-%241 = OpLabel
+%238 = OpFunction  %4  None %239
+%237 = OpFunctionParameter  %41
+%236 = OpLabel
+OpBranch %240
+%240 = OpLabel
 OpLine %3 184 10
-%242 = OpAccessChain  %34  %238 %44
-%243 = OpLoad  %4  %242
-OpReturnValue %243
+%241 = OpAccessChain  %34  %237 %44
+%242 = OpLoad  %4  %241
+OpReturnValue %242
 OpFunctionEnd
-%246 = OpFunction  %2  None %247
-%245 = OpFunctionParameter  %41
-%244 = OpLabel
-OpBranch %248
-%248 = OpLabel
+%245 = OpFunction  %2  None %246
+%244 = OpFunctionParameter  %41
+%243 = OpLabel
+OpBranch %247
+%247 = OpLabel
 OpLine %3 188 3
 OpLine %3 188 3
-%249 = OpAccessChain  %34  %245 %44
-OpStore %249 %17
+%248 = OpAccessChain  %34  %244 %44
+OpStore %248 %17
 OpReturn
 OpFunctionEnd
-%252 = OpFunction  %42  None %253
-%251 = OpFunctionParameter  %42
-%250 = OpLabel
-%254 = OpVariable  %255  Function %256
-OpBranch %257
-%257 = OpLabel
+%251 = OpFunction  %42  None %252
+%250 = OpFunctionParameter  %42
+%249 = OpLabel
+%253 = OpVariable  %254  Function %255
+OpBranch %256
+%256 = OpLabel
 OpLine %3 203 13
-%258 = OpCompositeConstruct  %43  %251
+%257 = OpCompositeConstruct  %43  %250
 OpLine %3 203 5
-OpStore %254 %258
+OpStore %253 %257
 OpLine %3 205 12
-%260 = OpAccessChain  %259  %254 %48
-%261 = OpLoad  %42  %260
-OpReturnValue %261
+%259 = OpAccessChain  %258  %253 %48
+%260 = OpLoad  %42  %259
+OpReturnValue %260
 OpFunctionEnd
-%263 = OpFunction  %6  None %264
-%262 = OpLabel
-%267 = OpVariable  %268  Function %266
-OpBranch %269
-%269 = OpLabel
+%262 = OpFunction  %6  None %263
+%261 = OpLabel
+%266 = OpVariable  %267  Function %265
+OpBranch %268
+%268 = OpLabel
 OpLine %3 211 16
 OpLine %3 213 12
-%270 = OpAccessChain  %95  %267 %48
-%271 = OpLoad  %6  %270
-OpReturnValue %271
+%269 = OpAccessChain  %95  %266 %48
+%270 = OpLoad  %6  %269
+OpReturnValue %270
 OpFunctionEnd
-%273 = OpFunction  %6  None %264
-%272 = OpLabel
-OpBranch %275
-%275 = OpLabel
+%272 = OpFunction  %6  None %263
+%271 = OpLabel
+OpBranch %274
+%274 = OpLabel
 OpLine %3 223 17
-%276 = OpCompositeExtract  %46  %274 0
+%275 = OpCompositeExtract  %46  %273 0
 OpLine %3 224 20
-%277 = OpCompositeExtract  %6  %276 0
+%276 = OpCompositeExtract  %6  %275 0
 OpLine %3 226 9
-%278 = OpCompositeExtract  %4  %274 1
-%279 = OpBitcast  %4  %277
-%280 = OpINotEqual  %42  %278 %279
+%277 = OpCompositeExtract  %4  %273 1
+%278 = OpBitcast  %4  %276
+%279 = OpINotEqual  %42  %277 %278
 OpLine %3 226 5
-OpSelectionMerge %281 None
-OpBranchConditional %280 %281 %281
-%281 = OpLabel
+OpSelectionMerge %280 None
+OpBranchConditional %279 %280 %280
+%280 = OpLabel
 OpLine %3 230 12
-%282 = OpCompositeExtract  %46  %274 0
-%283 = OpCompositeExtract  %6  %282 0
-OpReturnValue %283
+%281 = OpCompositeExtract  %46  %273 0
+%282 = OpCompositeExtract  %6  %281 0
+OpReturnValue %282
 OpFunctionEnd
-%285 = OpFunction  %6  None %264
-%284 = OpLabel
-%286 = OpVariable  %287  Function %274
-%288 = OpVariable  %289  Function %290
-%291 = OpVariable  %95  Function %292
-OpBranch %293
-%293 = OpLabel
+%284 = OpFunction  %6  None %263
+%283 = OpLabel
+%285 = OpVariable  %286  Function %273
+%287 = OpVariable  %288  Function %289
+%290 = OpVariable  %95  Function %291
+OpBranch %292
+%292 = OpLabel
 OpLine %3 236 17
-%294 = OpAccessChain  %289  %286 %48
-%295 = OpLoad  %46  %294
+%293 = OpAccessChain  %288  %285 %48
+%294 = OpLoad  %46  %293
 OpLine %3 236 5
-OpStore %288 %295
+OpStore %287 %294
 OpLine %3 237 20
-%296 = OpAccessChain  %95  %288 %48
-%297 = OpLoad  %6  %296
+%295 = OpAccessChain  %95  %287 %48
+%296 = OpLoad  %6  %295
 OpLine %3 237 5
-OpStore %291 %297
+OpStore %290 %296
 OpLine %3 239 9
-%298 = OpAccessChain  %34  %286 %44
-%299 = OpLoad  %4  %298
-%300 = OpLoad  %6  %291
-%301 = OpBitcast  %4  %300
-%302 = OpINotEqual  %42  %299 %301
+%297 = OpAccessChain  %34  %285 %44
+%298 = OpLoad  %4  %297
+%299 = OpLoad  %6  %290
+%300 = OpBitcast  %4  %299
+%301 = OpINotEqual  %42  %298 %300
 OpLine %3 239 5
-OpSelectionMerge %303 None
-OpBranchConditional %302 %303 %303
-%303 = OpLabel
+OpSelectionMerge %302 None
+OpBranchConditional %301 %302 %302
+%302 = OpLabel
 OpLine %3 243 12
-%304 = OpAccessChain  %95  %286 %48 %48
-%305 = OpLoad  %6  %304
-OpReturnValue %305
+%303 = OpAccessChain  %95  %285 %48 %48
+%304 = OpLoad  %6  %303
+OpReturnValue %304
 OpFunctionEnd
-%312 = OpFunction  %2  None %67
-%306 = OpLabel
-%323 = OpVariable  %28  Function %317
-%324 = OpVariable  %325  Function %326
-%309 = OpLoad  %4  %307
-%313 = OpAccessChain  %68  %56 %48
-%315 = OpAccessChain  %314  %59 %48
-%316 = OpAccessChain  %142  %62 %48
-OpBranch %327
-%327 = OpLabel
+%311 = OpFunction  %2  None %67
+%305 = OpLabel
+%322 = OpVariable  %28  Function %316
+%323 = OpVariable  %324  Function %325
+%308 = OpLoad  %4  %306
+%312 = OpAccessChain  %68  %56 %48
+%314 = OpAccessChain  %313  %59 %48
+%315 = OpAccessChain  %141  %62 %48
+OpBranch %326
+%326 = OpLabel
 OpLine %3 1 1
-%328 = OpLoad  %9  %323
+%327 = OpLoad  %9  %322
 OpLine %3 115 5
-OpStore %323 %71
+OpStore %322 %71
 OpLine %3 117 2
-%329 = OpFunctionCall  %2  %66
+%328 = OpFunctionCall  %2  %66
 OpLine %3 118 2
-%330 = OpFunctionCall  %2  %141
+%329 = OpFunctionCall  %2  %140
 OpLine %3 121 16
-%332 = OpAccessChain  %331  %54 %48
-%333 = OpLoad  %10  %332
+%331 = OpAccessChain  %330  %54 %48
+%332 = OpLoad  %10  %331
 OpLine %3 122 12
-%335 = OpAccessChain  %334  %54 %40
-%336 = OpLoad  %19  %335
+%334 = OpAccessChain  %333  %54 %40
+%335 = OpLoad  %19  %334
 OpLine %3 124 10
-%339 = OpAccessChain  %338  %54 %48 %318 %48
-%340 = OpLoad  %9  %339
+%338 = OpAccessChain  %337  %54 %48 %317 %48
+%339 = OpLoad  %9  %338
 OpLine %3 125 10
 OpLine %3 125 19
-%342 = OpArrayLength  %4  %54 5
+%341 = OpArrayLength  %4  %54 5
 OpLine %3 125 10
-%343 = OpISub  %4  %342 %15
-%346 = OpAccessChain  %345  %54 %31 %343 %48
-%347 = OpLoad  %6  %346
+%342 = OpISub  %4  %341 %15
+%345 = OpAccessChain  %344  %54 %31 %342 %48
+%346 = OpLoad  %6  %345
 OpLine %3 126 10
-%348 = OpLoad  %24  %315
+%347 = OpLoad  %24  %314
 OpLine %3 129 53
 OpLine %3 129 53
 OpLine %3 130 18
-%349 = OpFunctionCall  %9  %199 %323
+%348 = OpFunctionCall  %9  %198 %322
 OpLine %3 133 28
-%350 = OpConvertFToS  %6  %340
+%349 = OpConvertFToS  %6  %339
 OpLine %3 133 11
-%351 = OpCompositeConstruct  %33  %347 %350 %319 %320 %321
+%350 = OpCompositeConstruct  %33  %346 %349 %318 %319 %320
 OpLine %3 133 2
-OpStore %324 %351
+OpStore %323 %350
 OpLine %3 134 2
-%352 = OpIAdd  %4  %309 %44
+%351 = OpIAdd  %4  %308 %44
 OpLine %3 134 2
-%353 = OpAccessChain  %95  %324 %352
-OpStore %353 %265
+%352 = OpAccessChain  %95  %323 %351
+OpStore %352 %264
 OpLine %3 135 14
-%354 = OpAccessChain  %95  %324 %309
-%355 = OpLoad  %6  %354
+%353 = OpAccessChain  %95  %323 %308
+%354 = OpLoad  %6  %353
 OpLine %3 137 2
-%356 = OpFunctionCall  %9  %205 %322
+%355 = OpFunctionCall  %9  %204 %321
 OpLine %3 139 19
-%358 = OpCompositeConstruct  %357  %355 %355 %355 %355
-%359 = OpConvertSToF  %32  %358
-%360 = OpMatrixTimesVector  %11  %333 %359
+%357 = OpCompositeConstruct  %356  %354 %354 %354 %354
+%358 = OpConvertSToF  %32  %357
+%359 = OpMatrixTimesVector  %11  %332 %358
 OpLine %3 139 9
-%361 = OpCompositeConstruct  %32  %360 %73
-OpStore %310 %361
+%360 = OpCompositeConstruct  %32  %359 %73
+OpStore %309 %360
 OpReturn
 OpFunctionEnd
-%364 = OpFunction  %2  None %67
-%362 = OpLabel
-%365 = OpAccessChain  %314  %59 %48
-OpBranch %376
-%376 = OpLabel
+%363 = OpFunction  %2  None %67
+%361 = OpLabel
+%364 = OpAccessChain  %313  %59 %48
+OpBranch %375
+%375 = OpLabel
 OpLine %3 145 2
 OpLine %3 145 2
 OpLine %3 145 2
-%377 = OpAccessChain  %338  %54 %48 %44 %15
-OpStore %377 %71
+%376 = OpAccessChain  %337  %54 %48 %44 %15
+OpStore %376 %71
 OpLine %3 146 2
 OpLine %3 146 28
 OpLine %3 146 44
 OpLine %3 146 60
 OpLine %3 146 16
 OpLine %3 146 2
-%378 = OpAccessChain  %331  %54 %48
-OpStore %378 %370
+%377 = OpAccessChain  %330  %54 %48
+OpStore %377 %369
 OpLine %3 147 2
 OpLine %3 147 32
 OpLine %3 147 12
 OpLine %3 147 2
-%379 = OpAccessChain  %334  %54 %40
-OpStore %379 %373
+%378 = OpAccessChain  %333  %54 %40
+OpStore %378 %372
 OpLine %3 148 2
 OpLine %3 148 2
 OpLine %3 148 2
-%380 = OpAccessChain  %345  %54 %31 %44 %48
-OpStore %380 %70
+%379 = OpAccessChain  %344  %54 %31 %44 %48
+OpStore %379 %70
 OpLine %3 149 2
-OpStore %365 %374
+OpStore %364 %373
 OpLine %3 151 9
-OpStore %363 %375
+OpStore %362 %374
 OpReturn
 OpFunctionEnd
-%382 = OpFunction  %2  None %67
-%381 = OpLabel
-%387 = OpVariable  %34  Function %383
-%388 = OpVariable  %36  Function %386
-OpBranch %389
-%389 = OpLabel
+%381 = OpFunction  %2  None %67
+%380 = OpLabel
+%386 = OpVariable  %34  Function %382
+%387 = OpVariable  %36  Function %385
+OpBranch %388
+%388 = OpLabel
 OpLine %3 165 5
-%390 = OpFunctionCall  %2  %212 %387
+%389 = OpFunctionCall  %2  %211 %386
 OpLine %3 167 32
 OpLine %3 167 43
 OpLine %3 167 32
 OpLine %3 167 12
 OpLine %3 168 5
-%391 = OpFunctionCall  %2  %218 %388
+%390 = OpFunctionCall  %2  %217 %387
 OpReturn
 OpFunctionEnd
-%393 = OpFunction  %2  None %67
-%392 = OpLabel
-%394 = OpVariable  %38  Function %395
-%396 = OpVariable  %41  Function %397
-OpBranch %398
-%398 = OpLabel
+%392 = OpFunction  %2  None %67
+%391 = OpLabel
+%393 = OpVariable  %38  Function %394
+%395 = OpVariable  %41  Function %396
+OpBranch %397
+%397 = OpLabel
 OpLine %3 194 4
-%399 = OpFunctionCall  %2  %233 %394
+%398 = OpFunctionCall  %2  %232 %393
 OpLine %3 195 4
-%400 = OpFunctionCall  %4  %226 %394
+%399 = OpFunctionCall  %4  %225 %393
 OpLine %3 198 4
-%401 = OpFunctionCall  %2  %246 %396
+%400 = OpFunctionCall  %2  %245 %395
 OpLine %3 199 4
-%402 = OpFunctionCall  %4  %239 %396
+%401 = OpFunctionCall  %4  %238 %395
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/binding-arrays.spvasm
+++ b/naga/tests/out/spv/binding-arrays.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 413
+; Bound: 412
 OpCapability Shader
 OpCapability ImageQuery
 OpCapability ShaderNonUniform
@@ -41,44 +41,44 @@ OpDecorate %113 NonUniform
 OpDecorate %114 NonUniform
 OpDecorate %115 NonUniform
 OpDecorate %116 NonUniform
+OpDecorate %139 NonUniform
 OpDecorate %140 NonUniform
 OpDecorate %141 NonUniform
 OpDecorate %142 NonUniform
-OpDecorate %143 NonUniform
+OpDecorate %178 NonUniform
 OpDecorate %179 NonUniform
-OpDecorate %180 NonUniform
+OpDecorate %206 NonUniform
 OpDecorate %207 NonUniform
-OpDecorate %208 NonUniform
+OpDecorate %222 NonUniform
 OpDecorate %223 NonUniform
-OpDecorate %224 NonUniform
+OpDecorate %238 NonUniform
 OpDecorate %239 NonUniform
-OpDecorate %240 NonUniform
+OpDecorate %259 NonUniform
 OpDecorate %260 NonUniform
 OpDecorate %261 NonUniform
 OpDecorate %262 NonUniform
-OpDecorate %263 NonUniform
+OpDecorate %283 NonUniform
 OpDecorate %284 NonUniform
 OpDecorate %285 NonUniform
 OpDecorate %286 NonUniform
-OpDecorate %287 NonUniform
+OpDecorate %307 NonUniform
 OpDecorate %308 NonUniform
 OpDecorate %309 NonUniform
 OpDecorate %310 NonUniform
-OpDecorate %311 NonUniform
+OpDecorate %331 NonUniform
 OpDecorate %332 NonUniform
 OpDecorate %333 NonUniform
 OpDecorate %334 NonUniform
-OpDecorate %335 NonUniform
+OpDecorate %355 NonUniform
 OpDecorate %356 NonUniform
 OpDecorate %357 NonUniform
 OpDecorate %358 NonUniform
-OpDecorate %359 NonUniform
+OpDecorate %379 NonUniform
 OpDecorate %380 NonUniform
 OpDecorate %381 NonUniform
 OpDecorate %382 NonUniform
-OpDecorate %383 NonUniform
+OpDecorate %394 NonUniform
 OpDecorate %395 NonUniform
-OpDecorate %396 NonUniform
 %2 = OpTypeVoid
 %3 = OpTypeInt 32 0
 %4 = OpTypeStruct %3
@@ -101,10 +101,10 @@ OpDecorate %396 NonUniform
 %21 = OpTypeStruct %3
 %22 = OpTypeVector %6 4
 %23 = OpTypeVector %3 2
-%27 = OpConstant  %3  10
-%26 = OpTypeArray %5 %27
-%25 = OpTypePointer UniformConstant %26
-%24 = OpVariable  %25  UniformConstant
+%26 = OpConstant  %3  10
+%25 = OpTypeArray %5 %26
+%27 = OpTypePointer UniformConstant %25
+%24 = OpVariable  %27  UniformConstant
 %29 = OpTypePointer UniformConstant %8
 %28 = OpVariable  %29  UniformConstant
 %31 = OpTypePointer UniformConstant %11
@@ -147,15 +147,14 @@ OpDecorate %396 NonUniform
 %97 = OpTypePointer UniformConstant %18
 %100 = OpTypeSampledImage %5
 %121 = OpTypePointer UniformConstant %14
-%124 = OpTypePointer UniformConstant %18
-%127 = OpTypeSampledImage %14
-%150 = OpTypeBool
-%151 = OpConstantNull  %22
-%157 = OpTypeVector %150 2
-%193 = OpTypePointer UniformConstant %10
-%196 = OpTypeVector %3 3
-%228 = OpTypePointer UniformConstant %12
-%388 = OpTypePointer UniformConstant %16
+%126 = OpTypeSampledImage %14
+%149 = OpTypeBool
+%150 = OpConstantNull  %22
+%156 = OpTypeVector %149 2
+%192 = OpTypePointer UniformConstant %10
+%195 = OpTypeVector %3 3
+%227 = OpTypePointer UniformConstant %12
+%387 = OpTypePointer UniformConstant %16
 %52 = OpFunction  %2  None %53
 %45 = OpLabel
 %68 = OpVariable  %69  Function %57
@@ -217,334 +216,334 @@ OpStore %72 %112
 OpStore %72 %120
 %122 = OpAccessChain  %121  %34 %55
 %123 = OpLoad  %14  %122
-%125 = OpAccessChain  %124  %40 %55
-%126 = OpLoad  %18  %125
-%128 = OpSampledImage  %127  %123 %126
-%129 = OpImageDrefGather  %22  %128 %61 %58
-%130 = OpLoad  %22  %72
-%131 = OpFAdd  %22  %130 %129
-OpStore %72 %131
-%132 = OpAccessChain  %121  %34 %77
-%133 = OpLoad  %14  %132
-%134 = OpAccessChain  %124  %40 %77
-%135 = OpLoad  %18  %134
-%136 = OpSampledImage  %127  %133 %135
-%137 = OpImageDrefGather  %22  %136 %61 %58
-%138 = OpLoad  %22  %72
-%139 = OpFAdd  %22  %138 %137
-OpStore %72 %139
-%140 = OpAccessChain  %121  %34 %78
-%141 = OpLoad  %14  %140
-%142 = OpAccessChain  %124  %40 %78
-%143 = OpLoad  %18  %142
-%144 = OpSampledImage  %127  %141 %143
-%145 = OpImageDrefGather  %22  %144 %61 %58
-%146 = OpLoad  %22  %72
-%147 = OpFAdd  %22  %146 %145
-OpStore %72 %147
-%148 = OpAccessChain  %79  %24 %55
-%149 = OpLoad  %5  %148
-%152 = OpImageQueryLevels  %62  %149
-%153 = OpULessThan  %150  %63 %152
-OpSelectionMerge %154 None
-OpBranchConditional %153 %155 %154
-%155 = OpLabel
-%156 = OpImageQuerySizeLod  %64  %149 %63
-%158 = OpULessThan  %157  %65 %156
-%159 = OpAll  %150  %158
-OpBranchConditional %159 %160 %154
-%160 = OpLabel
-%161 = OpImageFetch  %22  %149 %65 Lod %63
-OpBranch %154
+%124 = OpAccessChain  %97  %40 %55
+%125 = OpLoad  %18  %124
+%127 = OpSampledImage  %126  %123 %125
+%128 = OpImageDrefGather  %22  %127 %61 %58
+%129 = OpLoad  %22  %72
+%130 = OpFAdd  %22  %129 %128
+OpStore %72 %130
+%131 = OpAccessChain  %121  %34 %77
+%132 = OpLoad  %14  %131
+%133 = OpAccessChain  %97  %40 %77
+%134 = OpLoad  %18  %133
+%135 = OpSampledImage  %126  %132 %134
+%136 = OpImageDrefGather  %22  %135 %61 %58
+%137 = OpLoad  %22  %72
+%138 = OpFAdd  %22  %137 %136
+OpStore %72 %138
+%139 = OpAccessChain  %121  %34 %78
+%140 = OpLoad  %14  %139
+%141 = OpAccessChain  %97  %40 %78
+%142 = OpLoad  %18  %141
+%143 = OpSampledImage  %126  %140 %142
+%144 = OpImageDrefGather  %22  %143 %61 %58
+%145 = OpLoad  %22  %72
+%146 = OpFAdd  %22  %145 %144
+OpStore %72 %146
+%147 = OpAccessChain  %79  %24 %55
+%148 = OpLoad  %5  %147
+%151 = OpImageQueryLevels  %62  %148
+%152 = OpULessThan  %149  %63 %151
+OpSelectionMerge %153 None
+OpBranchConditional %152 %154 %153
 %154 = OpLabel
-%162 = OpPhi  %22  %151 %74 %151 %155 %161 %160
-%163 = OpLoad  %22  %72
-%164 = OpFAdd  %22  %163 %162
-OpStore %72 %164
-%165 = OpAccessChain  %79  %24 %77
-%166 = OpLoad  %5  %165
-%167 = OpImageQueryLevels  %62  %166
-%168 = OpULessThan  %150  %63 %167
-OpSelectionMerge %169 None
-OpBranchConditional %168 %170 %169
-%170 = OpLabel
-%171 = OpImageQuerySizeLod  %64  %166 %63
-%172 = OpULessThan  %157  %65 %171
-%173 = OpAll  %150  %172
-OpBranchConditional %173 %174 %169
-%174 = OpLabel
-%175 = OpImageFetch  %22  %166 %65 Lod %63
-OpBranch %169
+%155 = OpImageQuerySizeLod  %64  %148 %63
+%157 = OpULessThan  %156  %65 %155
+%158 = OpAll  %149  %157
+OpBranchConditional %158 %159 %153
+%159 = OpLabel
+%160 = OpImageFetch  %22  %148 %65 Lod %63
+OpBranch %153
+%153 = OpLabel
+%161 = OpPhi  %22  %150 %74 %150 %154 %160 %159
+%162 = OpLoad  %22  %72
+%163 = OpFAdd  %22  %162 %161
+OpStore %72 %163
+%164 = OpAccessChain  %79  %24 %77
+%165 = OpLoad  %5  %164
+%166 = OpImageQueryLevels  %62  %165
+%167 = OpULessThan  %149  %63 %166
+OpSelectionMerge %168 None
+OpBranchConditional %167 %169 %168
 %169 = OpLabel
-%176 = OpPhi  %22  %151 %154 %151 %170 %175 %174
-%177 = OpLoad  %22  %72
-%178 = OpFAdd  %22  %177 %176
-OpStore %72 %178
-%179 = OpAccessChain  %79  %24 %78
-%180 = OpLoad  %5  %179
-%181 = OpImageQueryLevels  %62  %180
-%182 = OpULessThan  %150  %63 %181
-OpSelectionMerge %183 None
-OpBranchConditional %182 %184 %183
-%184 = OpLabel
-%185 = OpImageQuerySizeLod  %64  %180 %63
-%186 = OpULessThan  %157  %65 %185
-%187 = OpAll  %150  %186
-OpBranchConditional %187 %188 %183
-%188 = OpLabel
-%189 = OpImageFetch  %22  %180 %65 Lod %63
-OpBranch %183
+%170 = OpImageQuerySizeLod  %64  %165 %63
+%171 = OpULessThan  %156  %65 %170
+%172 = OpAll  %149  %171
+OpBranchConditional %172 %173 %168
+%173 = OpLabel
+%174 = OpImageFetch  %22  %165 %65 Lod %63
+OpBranch %168
+%168 = OpLabel
+%175 = OpPhi  %22  %150 %153 %150 %169 %174 %173
+%176 = OpLoad  %22  %72
+%177 = OpFAdd  %22  %176 %175
+OpStore %72 %177
+%178 = OpAccessChain  %79  %24 %78
+%179 = OpLoad  %5  %178
+%180 = OpImageQueryLevels  %62  %179
+%181 = OpULessThan  %149  %63 %180
+OpSelectionMerge %182 None
+OpBranchConditional %181 %183 %182
 %183 = OpLabel
-%190 = OpPhi  %22  %151 %169 %151 %184 %189 %188
-%191 = OpLoad  %22  %72
-%192 = OpFAdd  %22  %191 %190
-OpStore %72 %192
-%194 = OpAccessChain  %193  %30 %55
-%195 = OpLoad  %10  %194
-%197 = OpImageQuerySizeLod  %196  %195 %55
-%198 = OpCompositeExtract  %3  %197 2
-%199 = OpLoad  %3  %66
-%200 = OpIAdd  %3  %199 %198
-OpStore %66 %200
-%201 = OpAccessChain  %193  %30 %77
-%202 = OpLoad  %10  %201
-%203 = OpImageQuerySizeLod  %196  %202 %55
-%204 = OpCompositeExtract  %3  %203 2
-%205 = OpLoad  %3  %66
-%206 = OpIAdd  %3  %205 %204
-OpStore %66 %206
-%207 = OpAccessChain  %193  %30 %78
-%208 = OpLoad  %10  %207
-%209 = OpImageQuerySizeLod  %196  %208 %55
-%210 = OpCompositeExtract  %3  %209 2
-%211 = OpLoad  %3  %66
-%212 = OpIAdd  %3  %211 %210
-OpStore %66 %212
-%213 = OpAccessChain  %79  %28 %55
-%214 = OpLoad  %5  %213
-%215 = OpImageQueryLevels  %3  %214
-%216 = OpLoad  %3  %66
-%217 = OpIAdd  %3  %216 %215
-OpStore %66 %217
-%218 = OpAccessChain  %79  %28 %77
-%219 = OpLoad  %5  %218
-%220 = OpImageQueryLevels  %3  %219
-%221 = OpLoad  %3  %66
-%222 = OpIAdd  %3  %221 %220
-OpStore %66 %222
-%223 = OpAccessChain  %79  %28 %78
-%224 = OpLoad  %5  %223
-%225 = OpImageQueryLevels  %3  %224
-%226 = OpLoad  %3  %66
-%227 = OpIAdd  %3  %226 %225
-OpStore %66 %227
-%229 = OpAccessChain  %228  %32 %55
-%230 = OpLoad  %12  %229
-%231 = OpImageQuerySamples  %3  %230
-%232 = OpLoad  %3  %66
-%233 = OpIAdd  %3  %232 %231
-OpStore %66 %233
-%234 = OpAccessChain  %228  %32 %77
-%235 = OpLoad  %12  %234
-%236 = OpImageQuerySamples  %3  %235
-%237 = OpLoad  %3  %66
-%238 = OpIAdd  %3  %237 %236
-OpStore %66 %238
-%239 = OpAccessChain  %228  %32 %78
-%240 = OpLoad  %12  %239
-%241 = OpImageQuerySamples  %3  %240
-%242 = OpLoad  %3  %66
-%243 = OpIAdd  %3  %242 %241
-OpStore %66 %243
-%244 = OpAccessChain  %79  %28 %55
-%245 = OpLoad  %5  %244
-%246 = OpAccessChain  %97  %38 %55
-%247 = OpLoad  %18  %246
-%248 = OpSampledImage  %100  %245 %247
-%249 = OpImageSampleImplicitLod  %22  %248 %61
-%250 = OpLoad  %22  %72
-%251 = OpFAdd  %22  %250 %249
-OpStore %72 %251
-%252 = OpAccessChain  %79  %28 %77
-%253 = OpLoad  %5  %252
-%254 = OpAccessChain  %97  %38 %77
-%255 = OpLoad  %18  %254
-%256 = OpSampledImage  %100  %253 %255
-%257 = OpImageSampleImplicitLod  %22  %256 %61
-%258 = OpLoad  %22  %72
-%259 = OpFAdd  %22  %258 %257
-OpStore %72 %259
-%260 = OpAccessChain  %79  %28 %78
-%261 = OpLoad  %5  %260
-%262 = OpAccessChain  %97  %38 %78
-%263 = OpLoad  %18  %262
-%264 = OpSampledImage  %100  %261 %263
-%265 = OpImageSampleImplicitLod  %22  %264 %61
-%266 = OpLoad  %22  %72
-%267 = OpFAdd  %22  %266 %265
-OpStore %72 %267
-%268 = OpAccessChain  %79  %28 %55
-%269 = OpLoad  %5  %268
-%270 = OpAccessChain  %97  %38 %55
-%271 = OpLoad  %18  %270
-%272 = OpSampledImage  %100  %269 %271
-%273 = OpImageSampleImplicitLod  %22  %272 %61 Bias %58
-%274 = OpLoad  %22  %72
-%275 = OpFAdd  %22  %274 %273
-OpStore %72 %275
-%276 = OpAccessChain  %79  %28 %77
-%277 = OpLoad  %5  %276
-%278 = OpAccessChain  %97  %38 %77
-%279 = OpLoad  %18  %278
-%280 = OpSampledImage  %100  %277 %279
-%281 = OpImageSampleImplicitLod  %22  %280 %61 Bias %58
-%282 = OpLoad  %22  %72
-%283 = OpFAdd  %22  %282 %281
-OpStore %72 %283
-%284 = OpAccessChain  %79  %28 %78
-%285 = OpLoad  %5  %284
-%286 = OpAccessChain  %97  %38 %78
-%287 = OpLoad  %18  %286
-%288 = OpSampledImage  %100  %285 %287
-%289 = OpImageSampleImplicitLod  %22  %288 %61 Bias %58
-%290 = OpLoad  %22  %72
-%291 = OpFAdd  %22  %290 %289
-OpStore %72 %291
-%292 = OpAccessChain  %121  %34 %55
-%293 = OpLoad  %14  %292
-%294 = OpAccessChain  %124  %40 %55
-%295 = OpLoad  %18  %294
-%296 = OpSampledImage  %127  %293 %295
-%297 = OpImageSampleDrefImplicitLod  %6  %296 %61 %58
-%298 = OpLoad  %6  %70
-%299 = OpFAdd  %6  %298 %297
-OpStore %70 %299
-%300 = OpAccessChain  %121  %34 %77
-%301 = OpLoad  %14  %300
-%302 = OpAccessChain  %124  %40 %77
-%303 = OpLoad  %18  %302
-%304 = OpSampledImage  %127  %301 %303
-%305 = OpImageSampleDrefImplicitLod  %6  %304 %61 %58
-%306 = OpLoad  %6  %70
-%307 = OpFAdd  %6  %306 %305
-OpStore %70 %307
-%308 = OpAccessChain  %121  %34 %78
-%309 = OpLoad  %14  %308
-%310 = OpAccessChain  %124  %40 %78
-%311 = OpLoad  %18  %310
-%312 = OpSampledImage  %127  %309 %311
-%313 = OpImageSampleDrefImplicitLod  %6  %312 %61 %58
-%314 = OpLoad  %6  %70
-%315 = OpFAdd  %6  %314 %313
-OpStore %70 %315
-%316 = OpAccessChain  %121  %34 %55
-%317 = OpLoad  %14  %316
-%318 = OpAccessChain  %124  %40 %55
-%319 = OpLoad  %18  %318
-%320 = OpSampledImage  %127  %317 %319
-%321 = OpImageSampleDrefExplicitLod  %6  %320 %61 %58 Lod %58
-%322 = OpLoad  %6  %70
-%323 = OpFAdd  %6  %322 %321
-OpStore %70 %323
-%324 = OpAccessChain  %121  %34 %77
-%325 = OpLoad  %14  %324
-%326 = OpAccessChain  %124  %40 %77
-%327 = OpLoad  %18  %326
-%328 = OpSampledImage  %127  %325 %327
-%329 = OpImageSampleDrefExplicitLod  %6  %328 %61 %58 Lod %58
-%330 = OpLoad  %6  %70
-%331 = OpFAdd  %6  %330 %329
-OpStore %70 %331
-%332 = OpAccessChain  %121  %34 %78
-%333 = OpLoad  %14  %332
-%334 = OpAccessChain  %124  %40 %78
-%335 = OpLoad  %18  %334
-%336 = OpSampledImage  %127  %333 %335
-%337 = OpImageSampleDrefExplicitLod  %6  %336 %61 %58 Lod %58
-%338 = OpLoad  %6  %70
-%339 = OpFAdd  %6  %338 %337
-OpStore %70 %339
-%340 = OpAccessChain  %79  %28 %55
-%341 = OpLoad  %5  %340
-%342 = OpAccessChain  %97  %38 %55
-%343 = OpLoad  %18  %342
-%344 = OpSampledImage  %100  %341 %343
-%345 = OpImageSampleExplicitLod  %22  %344 %61 Grad %61 %61
-%346 = OpLoad  %22  %72
-%347 = OpFAdd  %22  %346 %345
-OpStore %72 %347
-%348 = OpAccessChain  %79  %28 %77
-%349 = OpLoad  %5  %348
-%350 = OpAccessChain  %97  %38 %77
-%351 = OpLoad  %18  %350
-%352 = OpSampledImage  %100  %349 %351
-%353 = OpImageSampleExplicitLod  %22  %352 %61 Grad %61 %61
-%354 = OpLoad  %22  %72
-%355 = OpFAdd  %22  %354 %353
-OpStore %72 %355
-%356 = OpAccessChain  %79  %28 %78
-%357 = OpLoad  %5  %356
-%358 = OpAccessChain  %97  %38 %78
-%359 = OpLoad  %18  %358
-%360 = OpSampledImage  %100  %357 %359
-%361 = OpImageSampleExplicitLod  %22  %360 %61 Grad %61 %61
-%362 = OpLoad  %22  %72
-%363 = OpFAdd  %22  %362 %361
-OpStore %72 %363
-%364 = OpAccessChain  %79  %28 %55
-%365 = OpLoad  %5  %364
-%366 = OpAccessChain  %97  %38 %55
-%367 = OpLoad  %18  %366
-%368 = OpSampledImage  %100  %365 %367
-%369 = OpImageSampleExplicitLod  %22  %368 %61 Lod %58
-%370 = OpLoad  %22  %72
-%371 = OpFAdd  %22  %370 %369
-OpStore %72 %371
-%372 = OpAccessChain  %79  %28 %77
-%373 = OpLoad  %5  %372
-%374 = OpAccessChain  %97  %38 %77
-%375 = OpLoad  %18  %374
-%376 = OpSampledImage  %100  %373 %375
-%377 = OpImageSampleExplicitLod  %22  %376 %61 Lod %58
-%378 = OpLoad  %22  %72
-%379 = OpFAdd  %22  %378 %377
-OpStore %72 %379
-%380 = OpAccessChain  %79  %28 %78
-%381 = OpLoad  %5  %380
-%382 = OpAccessChain  %97  %38 %78
-%383 = OpLoad  %18  %382
-%384 = OpSampledImage  %100  %381 %383
-%385 = OpImageSampleExplicitLod  %22  %384 %61 Lod %58
-%386 = OpLoad  %22  %72
-%387 = OpFAdd  %22  %386 %385
-OpStore %72 %387
-%389 = OpAccessChain  %388  %36 %55
-%390 = OpLoad  %16  %389
-%391 = OpLoad  %22  %72
-OpImageWrite %390 %65 %391
-%392 = OpAccessChain  %388  %36 %77
-%393 = OpLoad  %16  %392
-%394 = OpLoad  %22  %72
-OpImageWrite %393 %65 %394
-%395 = OpAccessChain  %388  %36 %78
-%396 = OpLoad  %16  %395
-%397 = OpLoad  %22  %72
-OpImageWrite %396 %65 %397
-%398 = OpLoad  %23  %68
-%399 = OpLoad  %3  %66
-%400 = OpCompositeConstruct  %23  %399 %399
-%401 = OpIAdd  %23  %398 %400
-%402 = OpConvertUToF  %60  %401
-%403 = OpLoad  %22  %72
-%404 = OpCompositeExtract  %6  %402 0
-%405 = OpCompositeExtract  %6  %402 1
-%406 = OpCompositeExtract  %6  %402 0
-%407 = OpCompositeExtract  %6  %402 1
-%408 = OpCompositeConstruct  %22  %404 %405 %406 %407
-%409 = OpFAdd  %22  %403 %408
-%410 = OpLoad  %6  %70
-%411 = OpCompositeConstruct  %22  %410 %410 %410 %410
-%412 = OpFAdd  %22  %409 %411
-OpStore %50 %412
+%184 = OpImageQuerySizeLod  %64  %179 %63
+%185 = OpULessThan  %156  %65 %184
+%186 = OpAll  %149  %185
+OpBranchConditional %186 %187 %182
+%187 = OpLabel
+%188 = OpImageFetch  %22  %179 %65 Lod %63
+OpBranch %182
+%182 = OpLabel
+%189 = OpPhi  %22  %150 %168 %150 %183 %188 %187
+%190 = OpLoad  %22  %72
+%191 = OpFAdd  %22  %190 %189
+OpStore %72 %191
+%193 = OpAccessChain  %192  %30 %55
+%194 = OpLoad  %10  %193
+%196 = OpImageQuerySizeLod  %195  %194 %55
+%197 = OpCompositeExtract  %3  %196 2
+%198 = OpLoad  %3  %66
+%199 = OpIAdd  %3  %198 %197
+OpStore %66 %199
+%200 = OpAccessChain  %192  %30 %77
+%201 = OpLoad  %10  %200
+%202 = OpImageQuerySizeLod  %195  %201 %55
+%203 = OpCompositeExtract  %3  %202 2
+%204 = OpLoad  %3  %66
+%205 = OpIAdd  %3  %204 %203
+OpStore %66 %205
+%206 = OpAccessChain  %192  %30 %78
+%207 = OpLoad  %10  %206
+%208 = OpImageQuerySizeLod  %195  %207 %55
+%209 = OpCompositeExtract  %3  %208 2
+%210 = OpLoad  %3  %66
+%211 = OpIAdd  %3  %210 %209
+OpStore %66 %211
+%212 = OpAccessChain  %79  %28 %55
+%213 = OpLoad  %5  %212
+%214 = OpImageQueryLevels  %3  %213
+%215 = OpLoad  %3  %66
+%216 = OpIAdd  %3  %215 %214
+OpStore %66 %216
+%217 = OpAccessChain  %79  %28 %77
+%218 = OpLoad  %5  %217
+%219 = OpImageQueryLevels  %3  %218
+%220 = OpLoad  %3  %66
+%221 = OpIAdd  %3  %220 %219
+OpStore %66 %221
+%222 = OpAccessChain  %79  %28 %78
+%223 = OpLoad  %5  %222
+%224 = OpImageQueryLevels  %3  %223
+%225 = OpLoad  %3  %66
+%226 = OpIAdd  %3  %225 %224
+OpStore %66 %226
+%228 = OpAccessChain  %227  %32 %55
+%229 = OpLoad  %12  %228
+%230 = OpImageQuerySamples  %3  %229
+%231 = OpLoad  %3  %66
+%232 = OpIAdd  %3  %231 %230
+OpStore %66 %232
+%233 = OpAccessChain  %227  %32 %77
+%234 = OpLoad  %12  %233
+%235 = OpImageQuerySamples  %3  %234
+%236 = OpLoad  %3  %66
+%237 = OpIAdd  %3  %236 %235
+OpStore %66 %237
+%238 = OpAccessChain  %227  %32 %78
+%239 = OpLoad  %12  %238
+%240 = OpImageQuerySamples  %3  %239
+%241 = OpLoad  %3  %66
+%242 = OpIAdd  %3  %241 %240
+OpStore %66 %242
+%243 = OpAccessChain  %79  %28 %55
+%244 = OpLoad  %5  %243
+%245 = OpAccessChain  %97  %38 %55
+%246 = OpLoad  %18  %245
+%247 = OpSampledImage  %100  %244 %246
+%248 = OpImageSampleImplicitLod  %22  %247 %61
+%249 = OpLoad  %22  %72
+%250 = OpFAdd  %22  %249 %248
+OpStore %72 %250
+%251 = OpAccessChain  %79  %28 %77
+%252 = OpLoad  %5  %251
+%253 = OpAccessChain  %97  %38 %77
+%254 = OpLoad  %18  %253
+%255 = OpSampledImage  %100  %252 %254
+%256 = OpImageSampleImplicitLod  %22  %255 %61
+%257 = OpLoad  %22  %72
+%258 = OpFAdd  %22  %257 %256
+OpStore %72 %258
+%259 = OpAccessChain  %79  %28 %78
+%260 = OpLoad  %5  %259
+%261 = OpAccessChain  %97  %38 %78
+%262 = OpLoad  %18  %261
+%263 = OpSampledImage  %100  %260 %262
+%264 = OpImageSampleImplicitLod  %22  %263 %61
+%265 = OpLoad  %22  %72
+%266 = OpFAdd  %22  %265 %264
+OpStore %72 %266
+%267 = OpAccessChain  %79  %28 %55
+%268 = OpLoad  %5  %267
+%269 = OpAccessChain  %97  %38 %55
+%270 = OpLoad  %18  %269
+%271 = OpSampledImage  %100  %268 %270
+%272 = OpImageSampleImplicitLod  %22  %271 %61 Bias %58
+%273 = OpLoad  %22  %72
+%274 = OpFAdd  %22  %273 %272
+OpStore %72 %274
+%275 = OpAccessChain  %79  %28 %77
+%276 = OpLoad  %5  %275
+%277 = OpAccessChain  %97  %38 %77
+%278 = OpLoad  %18  %277
+%279 = OpSampledImage  %100  %276 %278
+%280 = OpImageSampleImplicitLod  %22  %279 %61 Bias %58
+%281 = OpLoad  %22  %72
+%282 = OpFAdd  %22  %281 %280
+OpStore %72 %282
+%283 = OpAccessChain  %79  %28 %78
+%284 = OpLoad  %5  %283
+%285 = OpAccessChain  %97  %38 %78
+%286 = OpLoad  %18  %285
+%287 = OpSampledImage  %100  %284 %286
+%288 = OpImageSampleImplicitLod  %22  %287 %61 Bias %58
+%289 = OpLoad  %22  %72
+%290 = OpFAdd  %22  %289 %288
+OpStore %72 %290
+%291 = OpAccessChain  %121  %34 %55
+%292 = OpLoad  %14  %291
+%293 = OpAccessChain  %97  %40 %55
+%294 = OpLoad  %18  %293
+%295 = OpSampledImage  %126  %292 %294
+%296 = OpImageSampleDrefImplicitLod  %6  %295 %61 %58
+%297 = OpLoad  %6  %70
+%298 = OpFAdd  %6  %297 %296
+OpStore %70 %298
+%299 = OpAccessChain  %121  %34 %77
+%300 = OpLoad  %14  %299
+%301 = OpAccessChain  %97  %40 %77
+%302 = OpLoad  %18  %301
+%303 = OpSampledImage  %126  %300 %302
+%304 = OpImageSampleDrefImplicitLod  %6  %303 %61 %58
+%305 = OpLoad  %6  %70
+%306 = OpFAdd  %6  %305 %304
+OpStore %70 %306
+%307 = OpAccessChain  %121  %34 %78
+%308 = OpLoad  %14  %307
+%309 = OpAccessChain  %97  %40 %78
+%310 = OpLoad  %18  %309
+%311 = OpSampledImage  %126  %308 %310
+%312 = OpImageSampleDrefImplicitLod  %6  %311 %61 %58
+%313 = OpLoad  %6  %70
+%314 = OpFAdd  %6  %313 %312
+OpStore %70 %314
+%315 = OpAccessChain  %121  %34 %55
+%316 = OpLoad  %14  %315
+%317 = OpAccessChain  %97  %40 %55
+%318 = OpLoad  %18  %317
+%319 = OpSampledImage  %126  %316 %318
+%320 = OpImageSampleDrefExplicitLod  %6  %319 %61 %58 Lod %58
+%321 = OpLoad  %6  %70
+%322 = OpFAdd  %6  %321 %320
+OpStore %70 %322
+%323 = OpAccessChain  %121  %34 %77
+%324 = OpLoad  %14  %323
+%325 = OpAccessChain  %97  %40 %77
+%326 = OpLoad  %18  %325
+%327 = OpSampledImage  %126  %324 %326
+%328 = OpImageSampleDrefExplicitLod  %6  %327 %61 %58 Lod %58
+%329 = OpLoad  %6  %70
+%330 = OpFAdd  %6  %329 %328
+OpStore %70 %330
+%331 = OpAccessChain  %121  %34 %78
+%332 = OpLoad  %14  %331
+%333 = OpAccessChain  %97  %40 %78
+%334 = OpLoad  %18  %333
+%335 = OpSampledImage  %126  %332 %334
+%336 = OpImageSampleDrefExplicitLod  %6  %335 %61 %58 Lod %58
+%337 = OpLoad  %6  %70
+%338 = OpFAdd  %6  %337 %336
+OpStore %70 %338
+%339 = OpAccessChain  %79  %28 %55
+%340 = OpLoad  %5  %339
+%341 = OpAccessChain  %97  %38 %55
+%342 = OpLoad  %18  %341
+%343 = OpSampledImage  %100  %340 %342
+%344 = OpImageSampleExplicitLod  %22  %343 %61 Grad %61 %61
+%345 = OpLoad  %22  %72
+%346 = OpFAdd  %22  %345 %344
+OpStore %72 %346
+%347 = OpAccessChain  %79  %28 %77
+%348 = OpLoad  %5  %347
+%349 = OpAccessChain  %97  %38 %77
+%350 = OpLoad  %18  %349
+%351 = OpSampledImage  %100  %348 %350
+%352 = OpImageSampleExplicitLod  %22  %351 %61 Grad %61 %61
+%353 = OpLoad  %22  %72
+%354 = OpFAdd  %22  %353 %352
+OpStore %72 %354
+%355 = OpAccessChain  %79  %28 %78
+%356 = OpLoad  %5  %355
+%357 = OpAccessChain  %97  %38 %78
+%358 = OpLoad  %18  %357
+%359 = OpSampledImage  %100  %356 %358
+%360 = OpImageSampleExplicitLod  %22  %359 %61 Grad %61 %61
+%361 = OpLoad  %22  %72
+%362 = OpFAdd  %22  %361 %360
+OpStore %72 %362
+%363 = OpAccessChain  %79  %28 %55
+%364 = OpLoad  %5  %363
+%365 = OpAccessChain  %97  %38 %55
+%366 = OpLoad  %18  %365
+%367 = OpSampledImage  %100  %364 %366
+%368 = OpImageSampleExplicitLod  %22  %367 %61 Lod %58
+%369 = OpLoad  %22  %72
+%370 = OpFAdd  %22  %369 %368
+OpStore %72 %370
+%371 = OpAccessChain  %79  %28 %77
+%372 = OpLoad  %5  %371
+%373 = OpAccessChain  %97  %38 %77
+%374 = OpLoad  %18  %373
+%375 = OpSampledImage  %100  %372 %374
+%376 = OpImageSampleExplicitLod  %22  %375 %61 Lod %58
+%377 = OpLoad  %22  %72
+%378 = OpFAdd  %22  %377 %376
+OpStore %72 %378
+%379 = OpAccessChain  %79  %28 %78
+%380 = OpLoad  %5  %379
+%381 = OpAccessChain  %97  %38 %78
+%382 = OpLoad  %18  %381
+%383 = OpSampledImage  %100  %380 %382
+%384 = OpImageSampleExplicitLod  %22  %383 %61 Lod %58
+%385 = OpLoad  %22  %72
+%386 = OpFAdd  %22  %385 %384
+OpStore %72 %386
+%388 = OpAccessChain  %387  %36 %55
+%389 = OpLoad  %16  %388
+%390 = OpLoad  %22  %72
+OpImageWrite %389 %65 %390
+%391 = OpAccessChain  %387  %36 %77
+%392 = OpLoad  %16  %391
+%393 = OpLoad  %22  %72
+OpImageWrite %392 %65 %393
+%394 = OpAccessChain  %387  %36 %78
+%395 = OpLoad  %16  %394
+%396 = OpLoad  %22  %72
+OpImageWrite %395 %65 %396
+%397 = OpLoad  %23  %68
+%398 = OpLoad  %3  %66
+%399 = OpCompositeConstruct  %23  %398 %398
+%400 = OpIAdd  %23  %397 %399
+%401 = OpConvertUToF  %60  %400
+%402 = OpLoad  %22  %72
+%403 = OpCompositeExtract  %6  %401 0
+%404 = OpCompositeExtract  %6  %401 1
+%405 = OpCompositeExtract  %6  %401 0
+%406 = OpCompositeExtract  %6  %401 1
+%407 = OpCompositeConstruct  %22  %403 %404 %405 %406
+%408 = OpFAdd  %22  %402 %407
+%409 = OpLoad  %6  %70
+%410 = OpCompositeConstruct  %22  %409 %409 %409 %409
+%411 = OpFAdd  %22  %408 %410
+OpStore %50 %411
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/binding-buffer-arrays.spvasm
+++ b/naga/tests/out/spv/binding-buffer-arrays.spvasm
@@ -36,10 +36,10 @@ OpDecorate %55 NonUniform
 %9 = OpConstant  %3  1
 %8 = OpTypeArray %7 %9
 %10 = OpTypeStruct %3
-%14 = OpConstant  %3  10
-%13 = OpTypeArray %7 %14
-%12 = OpTypePointer StorageBuffer %13
-%11 = OpVariable  %12  StorageBuffer
+%13 = OpConstant  %3  10
+%12 = OpTypeArray %7 %13
+%14 = OpTypePointer StorageBuffer %12
+%11 = OpVariable  %14  StorageBuffer
 %16 = OpTypeStruct %4
 %17 = OpTypePointer Uniform %16
 %15 = OpVariable  %17  Uniform

--- a/naga/tests/out/spv/bounds-check-restrict.spvasm
+++ b/naga/tests/out/spv/bounds-check-restrict.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 180
+; Bound: 178
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -39,20 +39,18 @@ OpDecorate %12 Binding 0
 %32 = OpConstant  %6  1
 %35 = OpConstant  %6  3
 %42 = OpTypePointer StorageBuffer %7
-%43 = OpTypePointer StorageBuffer %3
-%51 = OpTypeFunction %3 %7 %11
-%58 = OpTypeFunction %7 %11
-%60 = OpTypePointer StorageBuffer %8
-%61 = OpTypePointer StorageBuffer %7
-%62 = OpConstant  %6  2
-%70 = OpTypeFunction %3 %11 %11
-%79 = OpConstant  %3  100.0
-%91 = OpTypeFunction %3
-%105 = OpTypeFunction %2 %11 %3
-%129 = OpTypeFunction %2 %11 %7
-%138 = OpTypeFunction %2 %11 %11 %3
-%158 = OpTypeFunction %2 %3
-%168 = OpConstant  %6  1000
+%50 = OpTypeFunction %3 %7 %11
+%57 = OpTypeFunction %7 %11
+%59 = OpTypePointer StorageBuffer %8
+%60 = OpConstant  %6  2
+%68 = OpTypeFunction %3 %11 %11
+%77 = OpConstant  %3  100.0
+%89 = OpTypeFunction %3
+%103 = OpTypeFunction %2 %11 %3
+%127 = OpTypeFunction %2 %11 %7
+%136 = OpTypeFunction %2 %11 %11 %3
+%156 = OpTypeFunction %2 %3
+%166 = OpConstant  %6  1000
 %16 = OpFunction  %3  None %17
 %15 = OpFunctionParameter  %11
 %14 = OpLabel
@@ -80,180 +78,180 @@ OpFunctionEnd
 %38 = OpLabel
 OpBranch %41
 %41 = OpLabel
-%44 = OpExtInst  %6  %1 UMin %39 %35
-%45 = OpAccessChain  %43  %12 %32 %44
-%46 = OpLoad  %3  %45
-OpReturnValue %46
+%43 = OpExtInst  %6  %1 UMin %39 %35
+%44 = OpAccessChain  %20  %12 %32 %43
+%45 = OpLoad  %3  %44
+OpReturnValue %45
 OpFunctionEnd
-%50 = OpFunction  %3  None %51
-%48 = OpFunctionParameter  %7
-%49 = OpFunctionParameter  %11
-%47 = OpLabel
-OpBranch %52
-%52 = OpLabel
-%53 = OpExtInst  %6  %1 UMin %49 %35
-%54 = OpVectorExtractDynamic  %3  %48 %53
-OpReturnValue %54
+%49 = OpFunction  %3  None %50
+%47 = OpFunctionParameter  %7
+%48 = OpFunctionParameter  %11
+%46 = OpLabel
+OpBranch %51
+%51 = OpLabel
+%52 = OpExtInst  %6  %1 UMin %48 %35
+%53 = OpVectorExtractDynamic  %3  %47 %52
+OpReturnValue %53
 OpFunctionEnd
-%57 = OpFunction  %7  None %58
-%56 = OpFunctionParameter  %11
-%55 = OpLabel
-OpBranch %59
-%59 = OpLabel
-%63 = OpExtInst  %6  %1 UMin %56 %62
-%64 = OpAccessChain  %61  %12 %62 %63
-%65 = OpLoad  %7  %64
-OpReturnValue %65
+%56 = OpFunction  %7  None %57
+%55 = OpFunctionParameter  %11
+%54 = OpLabel
+OpBranch %58
+%58 = OpLabel
+%61 = OpExtInst  %6  %1 UMin %55 %60
+%62 = OpAccessChain  %42  %12 %60 %61
+%63 = OpLoad  %7  %62
+OpReturnValue %63
 OpFunctionEnd
-%69 = OpFunction  %3  None %70
-%67 = OpFunctionParameter  %11
-%68 = OpFunctionParameter  %11
-%66 = OpLabel
-OpBranch %71
-%71 = OpLabel
-%72 = OpExtInst  %6  %1 UMin %68 %35
-%73 = OpExtInst  %6  %1 UMin %67 %62
-%74 = OpAccessChain  %43  %12 %62 %73 %72
-%75 = OpLoad  %3  %74
-OpReturnValue %75
+%67 = OpFunction  %3  None %68
+%65 = OpFunctionParameter  %11
+%66 = OpFunctionParameter  %11
+%64 = OpLabel
+OpBranch %69
+%69 = OpLabel
+%70 = OpExtInst  %6  %1 UMin %66 %35
+%71 = OpExtInst  %6  %1 UMin %65 %60
+%72 = OpAccessChain  %20  %12 %60 %71 %70
+%73 = OpLoad  %3  %72
+OpReturnValue %73
 OpFunctionEnd
-%78 = OpFunction  %3  None %17
-%77 = OpFunctionParameter  %11
-%76 = OpLabel
-OpBranch %80
-%80 = OpLabel
-%81 = OpConvertSToF  %3  %77
-%82 = OpFDiv  %3  %81 %79
-%83 = OpExtInst  %3  %1 Sin %82
-%84 = OpFMul  %3  %83 %79
-%85 = OpConvertFToS  %11  %84
-%86 = OpExtInst  %6  %1 UMin %85 %21
-%87 = OpAccessChain  %20  %12 %23 %86
-%88 = OpLoad  %3  %87
-OpReturnValue %88
+%76 = OpFunction  %3  None %17
+%75 = OpFunctionParameter  %11
+%74 = OpLabel
+OpBranch %78
+%78 = OpLabel
+%79 = OpConvertSToF  %3  %75
+%80 = OpFDiv  %3  %79 %77
+%81 = OpExtInst  %3  %1 Sin %80
+%82 = OpFMul  %3  %81 %77
+%83 = OpConvertFToS  %11  %82
+%84 = OpExtInst  %6  %1 UMin %83 %21
+%85 = OpAccessChain  %20  %12 %23 %84
+%86 = OpLoad  %3  %85
+OpReturnValue %86
 OpFunctionEnd
-%90 = OpFunction  %3  None %91
-%89 = OpLabel
-OpBranch %92
-%92 = OpLabel
-%93 = OpAccessChain  %20  %12 %23 %21
+%88 = OpFunction  %3  None %89
+%87 = OpLabel
+OpBranch %90
+%90 = OpLabel
+%91 = OpAccessChain  %20  %12 %23 %21
+%92 = OpLoad  %3  %91
+%93 = OpAccessChain  %20  %12 %32 %35
 %94 = OpLoad  %3  %93
-%95 = OpAccessChain  %43  %12 %32 %35
-%96 = OpLoad  %3  %95
-%97 = OpFAdd  %3  %94 %96
-%98 = OpAccessChain  %43  %12 %62 %62 %35
-%99 = OpLoad  %3  %98
-%100 = OpFAdd  %3  %97 %99
-OpReturnValue %100
+%95 = OpFAdd  %3  %92 %94
+%96 = OpAccessChain  %20  %12 %60 %60 %35
+%97 = OpLoad  %3  %96
+%98 = OpFAdd  %3  %95 %97
+OpReturnValue %98
 OpFunctionEnd
-%104 = OpFunction  %2  None %105
-%102 = OpFunctionParameter  %11
-%103 = OpFunctionParameter  %3
-%101 = OpLabel
-OpBranch %106
-%106 = OpLabel
-%107 = OpExtInst  %6  %1 UMin %102 %21
-%108 = OpAccessChain  %20  %12 %23 %107
-OpStore %108 %103
+%102 = OpFunction  %2  None %103
+%100 = OpFunctionParameter  %11
+%101 = OpFunctionParameter  %3
+%99 = OpLabel
+OpBranch %104
+%104 = OpLabel
+%105 = OpExtInst  %6  %1 UMin %100 %21
+%106 = OpAccessChain  %20  %12 %23 %105
+OpStore %106 %101
 OpReturn
 OpFunctionEnd
-%112 = OpFunction  %2  None %105
-%110 = OpFunctionParameter  %11
-%111 = OpFunctionParameter  %3
-%109 = OpLabel
-OpBranch %113
-%113 = OpLabel
-%114 = OpArrayLength  %6  %12 3
-%115 = OpISub  %6  %114 %32
-%116 = OpExtInst  %6  %1 UMin %110 %115
-%117 = OpAccessChain  %20  %12 %35 %116
-OpStore %117 %111
+%110 = OpFunction  %2  None %103
+%108 = OpFunctionParameter  %11
+%109 = OpFunctionParameter  %3
+%107 = OpLabel
+OpBranch %111
+%111 = OpLabel
+%112 = OpArrayLength  %6  %12 3
+%113 = OpISub  %6  %112 %32
+%114 = OpExtInst  %6  %1 UMin %108 %113
+%115 = OpAccessChain  %20  %12 %35 %114
+OpStore %115 %109
 OpReturn
 OpFunctionEnd
-%121 = OpFunction  %2  None %105
-%119 = OpFunctionParameter  %11
-%120 = OpFunctionParameter  %3
-%118 = OpLabel
-OpBranch %122
-%122 = OpLabel
-%123 = OpExtInst  %6  %1 UMin %119 %35
-%124 = OpAccessChain  %43  %12 %32 %123
-OpStore %124 %120
+%119 = OpFunction  %2  None %103
+%117 = OpFunctionParameter  %11
+%118 = OpFunctionParameter  %3
+%116 = OpLabel
+OpBranch %120
+%120 = OpLabel
+%121 = OpExtInst  %6  %1 UMin %117 %35
+%122 = OpAccessChain  %20  %12 %32 %121
+OpStore %122 %118
 OpReturn
 OpFunctionEnd
-%128 = OpFunction  %2  None %129
-%126 = OpFunctionParameter  %11
-%127 = OpFunctionParameter  %7
-%125 = OpLabel
-OpBranch %130
-%130 = OpLabel
-%131 = OpExtInst  %6  %1 UMin %126 %62
-%132 = OpAccessChain  %61  %12 %62 %131
-OpStore %132 %127
+%126 = OpFunction  %2  None %127
+%124 = OpFunctionParameter  %11
+%125 = OpFunctionParameter  %7
+%123 = OpLabel
+OpBranch %128
+%128 = OpLabel
+%129 = OpExtInst  %6  %1 UMin %124 %60
+%130 = OpAccessChain  %42  %12 %60 %129
+OpStore %130 %125
 OpReturn
 OpFunctionEnd
-%137 = OpFunction  %2  None %138
-%134 = OpFunctionParameter  %11
-%135 = OpFunctionParameter  %11
-%136 = OpFunctionParameter  %3
-%133 = OpLabel
-OpBranch %139
-%139 = OpLabel
-%140 = OpExtInst  %6  %1 UMin %135 %35
-%141 = OpExtInst  %6  %1 UMin %134 %62
-%142 = OpAccessChain  %43  %12 %62 %141 %140
-OpStore %142 %136
+%135 = OpFunction  %2  None %136
+%132 = OpFunctionParameter  %11
+%133 = OpFunctionParameter  %11
+%134 = OpFunctionParameter  %3
+%131 = OpLabel
+OpBranch %137
+%137 = OpLabel
+%138 = OpExtInst  %6  %1 UMin %133 %35
+%139 = OpExtInst  %6  %1 UMin %132 %60
+%140 = OpAccessChain  %20  %12 %60 %139 %138
+OpStore %140 %134
 OpReturn
 OpFunctionEnd
-%146 = OpFunction  %2  None %105
-%144 = OpFunctionParameter  %11
-%145 = OpFunctionParameter  %3
-%143 = OpLabel
-OpBranch %147
-%147 = OpLabel
-%148 = OpConvertSToF  %3  %144
-%149 = OpFDiv  %3  %148 %79
-%150 = OpExtInst  %3  %1 Sin %149
-%151 = OpFMul  %3  %150 %79
-%152 = OpConvertFToS  %11  %151
-%153 = OpExtInst  %6  %1 UMin %152 %21
-%154 = OpAccessChain  %20  %12 %23 %153
-OpStore %154 %145
+%144 = OpFunction  %2  None %103
+%142 = OpFunctionParameter  %11
+%143 = OpFunctionParameter  %3
+%141 = OpLabel
+OpBranch %145
+%145 = OpLabel
+%146 = OpConvertSToF  %3  %142
+%147 = OpFDiv  %3  %146 %77
+%148 = OpExtInst  %3  %1 Sin %147
+%149 = OpFMul  %3  %148 %77
+%150 = OpConvertFToS  %11  %149
+%151 = OpExtInst  %6  %1 UMin %150 %21
+%152 = OpAccessChain  %20  %12 %23 %151
+OpStore %152 %143
 OpReturn
 OpFunctionEnd
-%157 = OpFunction  %2  None %158
-%156 = OpFunctionParameter  %3
-%155 = OpLabel
-OpBranch %159
-%159 = OpLabel
-%160 = OpAccessChain  %20  %12 %23 %21
-OpStore %160 %156
-%161 = OpAccessChain  %43  %12 %32 %35
-OpStore %161 %156
-%162 = OpAccessChain  %43  %12 %62 %62 %35
-OpStore %162 %156
+%155 = OpFunction  %2  None %156
+%154 = OpFunctionParameter  %3
+%153 = OpLabel
+OpBranch %157
+%157 = OpLabel
+%158 = OpAccessChain  %20  %12 %23 %21
+OpStore %158 %154
+%159 = OpAccessChain  %20  %12 %32 %35
+OpStore %159 %154
+%160 = OpAccessChain  %20  %12 %60 %60 %35
+OpStore %160 %154
 OpReturn
 OpFunctionEnd
-%164 = OpFunction  %3  None %91
+%162 = OpFunction  %3  None %89
+%161 = OpLabel
+OpBranch %163
 %163 = OpLabel
-OpBranch %165
-%165 = OpLabel
-%166 = OpArrayLength  %6  %12 3
-%167 = OpISub  %6  %166 %32
-%169 = OpExtInst  %6  %1 UMin %168 %167
-%170 = OpAccessChain  %20  %12 %35 %169
-%171 = OpLoad  %3  %170
-OpReturnValue %171
+%164 = OpArrayLength  %6  %12 3
+%165 = OpISub  %6  %164 %32
+%167 = OpExtInst  %6  %1 UMin %166 %165
+%168 = OpAccessChain  %20  %12 %35 %167
+%169 = OpLoad  %3  %168
+OpReturnValue %169
 OpFunctionEnd
-%174 = OpFunction  %2  None %158
-%173 = OpFunctionParameter  %3
-%172 = OpLabel
-OpBranch %175
-%175 = OpLabel
-%176 = OpArrayLength  %6  %12 3
-%177 = OpISub  %6  %176 %32
-%178 = OpExtInst  %6  %1 UMin %168 %177
-%179 = OpAccessChain  %20  %12 %35 %178
-OpStore %179 %173
+%172 = OpFunction  %2  None %156
+%171 = OpFunctionParameter  %3
+%170 = OpLabel
+OpBranch %173
+%173 = OpLabel
+%174 = OpArrayLength  %6  %12 3
+%175 = OpISub  %6  %174 %32
+%176 = OpExtInst  %6  %1 UMin %166 %175
+%177 = OpAccessChain  %20  %12 %35 %176
+OpStore %177 %171
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/bounds-check-zero.spvasm
+++ b/naga/tests/out/spv/bounds-check-zero.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 220
+; Bound: 218
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -39,24 +39,22 @@ OpDecorate %12 Binding 0
 %34 = OpTypePointer StorageBuffer %9
 %37 = OpConstant  %6  3
 %47 = OpTypePointer StorageBuffer %7
-%48 = OpTypePointer StorageBuffer %3
-%49 = OpConstant  %6  4
-%51 = OpConstant  %6  1
-%61 = OpTypeFunction %3 %7 %11
-%71 = OpTypeFunction %7 %11
-%73 = OpTypePointer StorageBuffer %8
-%74 = OpTypePointer StorageBuffer %7
-%76 = OpConstant  %6  2
-%78 = OpConstantNull  %7
-%87 = OpTypeFunction %3 %11 %11
-%100 = OpConstant  %3  100.0
-%115 = OpTypeFunction %3
-%117 = OpConstant  %6  9
-%130 = OpTypeFunction %2 %11 %3
-%159 = OpTypeFunction %2 %11 %7
-%170 = OpTypeFunction %2 %11 %11 %3
-%195 = OpTypeFunction %2 %3
-%204 = OpConstant  %6  1000
+%48 = OpConstant  %6  4
+%50 = OpConstant  %6  1
+%60 = OpTypeFunction %3 %7 %11
+%70 = OpTypeFunction %7 %11
+%72 = OpTypePointer StorageBuffer %8
+%74 = OpConstant  %6  2
+%76 = OpConstantNull  %7
+%85 = OpTypeFunction %3 %11 %11
+%98 = OpConstant  %3  100.0
+%113 = OpTypeFunction %3
+%115 = OpConstant  %6  9
+%128 = OpTypeFunction %2 %11 %3
+%157 = OpTypeFunction %2 %11 %7
+%168 = OpTypeFunction %2 %11 %11 %3
+%193 = OpTypeFunction %2 %3
+%202 = OpConstant  %6  1000
 %16 = OpFunction  %3  None %17
 %15 = OpFunctionParameter  %11
 %14 = OpLabel
@@ -95,250 +93,250 @@ OpFunctionEnd
 %43 = OpLabel
 OpBranch %46
 %46 = OpLabel
-%50 = OpULessThan  %22  %44 %49
-OpSelectionMerge %53 None
-OpBranchConditional %50 %54 %53
-%54 = OpLabel
-%52 = OpAccessChain  %48  %12 %51 %44
-%55 = OpLoad  %3  %52
-OpBranch %53
+%49 = OpULessThan  %22  %44 %48
+OpSelectionMerge %52 None
+OpBranchConditional %49 %53 %52
 %53 = OpLabel
-%56 = OpPhi  %3  %25 %46 %55 %54
-OpReturnValue %56
+%51 = OpAccessChain  %20  %12 %50 %44
+%54 = OpLoad  %3  %51
+OpBranch %52
+%52 = OpLabel
+%55 = OpPhi  %3  %25 %46 %54 %53
+OpReturnValue %55
 OpFunctionEnd
-%60 = OpFunction  %3  None %61
-%58 = OpFunctionParameter  %7
-%59 = OpFunctionParameter  %11
-%57 = OpLabel
-OpBranch %62
-%62 = OpLabel
-%63 = OpULessThan  %22  %59 %49
-OpSelectionMerge %64 None
-OpBranchConditional %63 %65 %64
-%65 = OpLabel
-%66 = OpVectorExtractDynamic  %3  %58 %59
-OpBranch %64
+%59 = OpFunction  %3  None %60
+%57 = OpFunctionParameter  %7
+%58 = OpFunctionParameter  %11
+%56 = OpLabel
+OpBranch %61
+%61 = OpLabel
+%62 = OpULessThan  %22  %58 %48
+OpSelectionMerge %63 None
+OpBranchConditional %62 %64 %63
 %64 = OpLabel
-%67 = OpPhi  %3  %25 %62 %66 %65
-OpReturnValue %67
+%65 = OpVectorExtractDynamic  %3  %57 %58
+OpBranch %63
+%63 = OpLabel
+%66 = OpPhi  %3  %25 %61 %65 %64
+OpReturnValue %66
 OpFunctionEnd
-%70 = OpFunction  %7  None %71
-%69 = OpFunctionParameter  %11
-%68 = OpLabel
-OpBranch %72
-%72 = OpLabel
-%75 = OpULessThan  %22  %69 %37
-OpSelectionMerge %79 None
-OpBranchConditional %75 %80 %79
-%80 = OpLabel
-%77 = OpAccessChain  %74  %12 %76 %69
-%81 = OpLoad  %7  %77
-OpBranch %79
-%79 = OpLabel
-%82 = OpPhi  %7  %78 %72 %81 %80
-OpReturnValue %82
+%69 = OpFunction  %7  None %70
+%68 = OpFunctionParameter  %11
+%67 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%73 = OpULessThan  %22  %68 %37
+OpSelectionMerge %77 None
+OpBranchConditional %73 %78 %77
+%78 = OpLabel
+%75 = OpAccessChain  %47  %12 %74 %68
+%79 = OpLoad  %7  %75
+OpBranch %77
+%77 = OpLabel
+%80 = OpPhi  %7  %76 %71 %79 %78
+OpReturnValue %80
 OpFunctionEnd
-%86 = OpFunction  %3  None %87
-%84 = OpFunctionParameter  %11
-%85 = OpFunctionParameter  %11
-%83 = OpLabel
-OpBranch %88
-%88 = OpLabel
-%89 = OpULessThan  %22  %85 %49
-%90 = OpULessThan  %22  %84 %37
-%91 = OpLogicalAnd  %22  %89 %90
-OpSelectionMerge %93 None
-OpBranchConditional %91 %94 %93
-%94 = OpLabel
-%92 = OpAccessChain  %48  %12 %76 %84 %85
-%95 = OpLoad  %3  %92
-OpBranch %93
-%93 = OpLabel
-%96 = OpPhi  %3  %25 %88 %95 %94
-OpReturnValue %96
+%84 = OpFunction  %3  None %85
+%82 = OpFunctionParameter  %11
+%83 = OpFunctionParameter  %11
+%81 = OpLabel
+OpBranch %86
+%86 = OpLabel
+%87 = OpULessThan  %22  %83 %48
+%88 = OpULessThan  %22  %82 %37
+%89 = OpLogicalAnd  %22  %87 %88
+OpSelectionMerge %91 None
+OpBranchConditional %89 %92 %91
+%92 = OpLabel
+%90 = OpAccessChain  %20  %12 %74 %82 %83
+%93 = OpLoad  %3  %90
+OpBranch %91
+%91 = OpLabel
+%94 = OpPhi  %3  %25 %86 %93 %92
+OpReturnValue %94
 OpFunctionEnd
-%99 = OpFunction  %3  None %17
-%98 = OpFunctionParameter  %11
-%97 = OpLabel
-OpBranch %101
-%101 = OpLabel
-%102 = OpConvertSToF  %3  %98
-%103 = OpFDiv  %3  %102 %100
-%104 = OpExtInst  %3  %1 Sin %103
-%105 = OpFMul  %3  %104 %100
-%106 = OpConvertFToS  %11  %105
-%107 = OpULessThan  %22  %106 %5
-OpSelectionMerge %109 None
-OpBranchConditional %107 %110 %109
-%110 = OpLabel
-%108 = OpAccessChain  %20  %12 %23 %106
-%111 = OpLoad  %3  %108
-OpBranch %109
-%109 = OpLabel
-%112 = OpPhi  %3  %25 %101 %111 %110
-OpReturnValue %112
+%97 = OpFunction  %3  None %17
+%96 = OpFunctionParameter  %11
+%95 = OpLabel
+OpBranch %99
+%99 = OpLabel
+%100 = OpConvertSToF  %3  %96
+%101 = OpFDiv  %3  %100 %98
+%102 = OpExtInst  %3  %1 Sin %101
+%103 = OpFMul  %3  %102 %98
+%104 = OpConvertFToS  %11  %103
+%105 = OpULessThan  %22  %104 %5
+OpSelectionMerge %107 None
+OpBranchConditional %105 %108 %107
+%108 = OpLabel
+%106 = OpAccessChain  %20  %12 %23 %104
+%109 = OpLoad  %3  %106
+OpBranch %107
+%107 = OpLabel
+%110 = OpPhi  %3  %25 %99 %109 %108
+OpReturnValue %110
 OpFunctionEnd
-%114 = OpFunction  %3  None %115
-%113 = OpLabel
-OpBranch %116
-%116 = OpLabel
-%118 = OpAccessChain  %20  %12 %23 %117
+%112 = OpFunction  %3  None %113
+%111 = OpLabel
+OpBranch %114
+%114 = OpLabel
+%116 = OpAccessChain  %20  %12 %23 %115
+%117 = OpLoad  %3  %116
+%118 = OpAccessChain  %20  %12 %50 %37
 %119 = OpLoad  %3  %118
-%120 = OpAccessChain  %48  %12 %51 %37
-%121 = OpLoad  %3  %120
-%122 = OpFAdd  %3  %119 %121
-%123 = OpAccessChain  %48  %12 %76 %76 %37
-%124 = OpLoad  %3  %123
-%125 = OpFAdd  %3  %122 %124
-OpReturnValue %125
+%120 = OpFAdd  %3  %117 %119
+%121 = OpAccessChain  %20  %12 %74 %74 %37
+%122 = OpLoad  %3  %121
+%123 = OpFAdd  %3  %120 %122
+OpReturnValue %123
 OpFunctionEnd
-%129 = OpFunction  %2  None %130
-%127 = OpFunctionParameter  %11
-%128 = OpFunctionParameter  %3
-%126 = OpLabel
-OpBranch %131
-%131 = OpLabel
-%132 = OpULessThan  %22  %127 %5
-OpSelectionMerge %134 None
-OpBranchConditional %132 %135 %134
-%135 = OpLabel
-%133 = OpAccessChain  %20  %12 %23 %127
-OpStore %133 %128
-OpBranch %134
+%127 = OpFunction  %2  None %128
+%125 = OpFunctionParameter  %11
+%126 = OpFunctionParameter  %3
+%124 = OpLabel
+OpBranch %129
+%129 = OpLabel
+%130 = OpULessThan  %22  %125 %5
+OpSelectionMerge %132 None
+OpBranchConditional %130 %133 %132
+%133 = OpLabel
+%131 = OpAccessChain  %20  %12 %23 %125
+OpStore %131 %126
+OpBranch %132
+%132 = OpLabel
+OpReturn
+OpFunctionEnd
+%137 = OpFunction  %2  None %128
+%135 = OpFunctionParameter  %11
+%136 = OpFunctionParameter  %3
 %134 = OpLabel
+OpBranch %138
+%138 = OpLabel
+%139 = OpArrayLength  %6  %12 3
+%140 = OpULessThan  %22  %135 %139
+OpSelectionMerge %142 None
+OpBranchConditional %140 %143 %142
+%143 = OpLabel
+%141 = OpAccessChain  %20  %12 %37 %135
+OpStore %141 %136
+OpBranch %142
+%142 = OpLabel
 OpReturn
 OpFunctionEnd
-%139 = OpFunction  %2  None %130
-%137 = OpFunctionParameter  %11
-%138 = OpFunctionParameter  %3
-%136 = OpLabel
-OpBranch %140
-%140 = OpLabel
-%141 = OpArrayLength  %6  %12 3
-%142 = OpULessThan  %22  %137 %141
-OpSelectionMerge %144 None
-OpBranchConditional %142 %145 %144
-%145 = OpLabel
-%143 = OpAccessChain  %20  %12 %37 %137
-OpStore %143 %138
-OpBranch %144
+%147 = OpFunction  %2  None %128
+%145 = OpFunctionParameter  %11
+%146 = OpFunctionParameter  %3
 %144 = OpLabel
+OpBranch %148
+%148 = OpLabel
+%149 = OpULessThan  %22  %145 %48
+OpSelectionMerge %151 None
+OpBranchConditional %149 %152 %151
+%152 = OpLabel
+%150 = OpAccessChain  %20  %12 %50 %145
+OpStore %150 %146
+OpBranch %151
+%151 = OpLabel
 OpReturn
 OpFunctionEnd
-%149 = OpFunction  %2  None %130
-%147 = OpFunctionParameter  %11
-%148 = OpFunctionParameter  %3
-%146 = OpLabel
-OpBranch %150
-%150 = OpLabel
-%151 = OpULessThan  %22  %147 %49
-OpSelectionMerge %153 None
-OpBranchConditional %151 %154 %153
-%154 = OpLabel
-%152 = OpAccessChain  %48  %12 %51 %147
-OpStore %152 %148
-OpBranch %153
+%156 = OpFunction  %2  None %157
+%154 = OpFunctionParameter  %11
+%155 = OpFunctionParameter  %7
 %153 = OpLabel
+OpBranch %158
+%158 = OpLabel
+%159 = OpULessThan  %22  %154 %37
+OpSelectionMerge %161 None
+OpBranchConditional %159 %162 %161
+%162 = OpLabel
+%160 = OpAccessChain  %47  %12 %74 %154
+OpStore %160 %155
+OpBranch %161
+%161 = OpLabel
 OpReturn
 OpFunctionEnd
-%158 = OpFunction  %2  None %159
-%156 = OpFunctionParameter  %11
-%157 = OpFunctionParameter  %7
-%155 = OpLabel
-OpBranch %160
-%160 = OpLabel
-%161 = OpULessThan  %22  %156 %37
-OpSelectionMerge %163 None
-OpBranchConditional %161 %164 %163
-%164 = OpLabel
-%162 = OpAccessChain  %74  %12 %76 %156
-OpStore %162 %157
-OpBranch %163
+%167 = OpFunction  %2  None %168
+%164 = OpFunctionParameter  %11
+%165 = OpFunctionParameter  %11
+%166 = OpFunctionParameter  %3
 %163 = OpLabel
+OpBranch %169
+%169 = OpLabel
+%170 = OpULessThan  %22  %165 %48
+%171 = OpULessThan  %22  %164 %37
+%172 = OpLogicalAnd  %22  %170 %171
+OpSelectionMerge %174 None
+OpBranchConditional %172 %175 %174
+%175 = OpLabel
+%173 = OpAccessChain  %20  %12 %74 %164 %165
+OpStore %173 %166
+OpBranch %174
+%174 = OpLabel
 OpReturn
 OpFunctionEnd
-%169 = OpFunction  %2  None %170
-%166 = OpFunctionParameter  %11
-%167 = OpFunctionParameter  %11
-%168 = OpFunctionParameter  %3
-%165 = OpLabel
-OpBranch %171
-%171 = OpLabel
-%172 = OpULessThan  %22  %167 %49
-%173 = OpULessThan  %22  %166 %37
-%174 = OpLogicalAnd  %22  %172 %173
-OpSelectionMerge %176 None
-OpBranchConditional %174 %177 %176
-%177 = OpLabel
-%175 = OpAccessChain  %48  %12 %76 %166 %167
-OpStore %175 %168
-OpBranch %176
+%179 = OpFunction  %2  None %128
+%177 = OpFunctionParameter  %11
+%178 = OpFunctionParameter  %3
 %176 = OpLabel
+OpBranch %180
+%180 = OpLabel
+%181 = OpConvertSToF  %3  %177
+%182 = OpFDiv  %3  %181 %98
+%183 = OpExtInst  %3  %1 Sin %182
+%184 = OpFMul  %3  %183 %98
+%185 = OpConvertFToS  %11  %184
+%186 = OpULessThan  %22  %185 %5
+OpSelectionMerge %188 None
+OpBranchConditional %186 %189 %188
+%189 = OpLabel
+%187 = OpAccessChain  %20  %12 %23 %185
+OpStore %187 %178
+OpBranch %188
+%188 = OpLabel
 OpReturn
 OpFunctionEnd
-%181 = OpFunction  %2  None %130
-%179 = OpFunctionParameter  %11
-%180 = OpFunctionParameter  %3
-%178 = OpLabel
-OpBranch %182
-%182 = OpLabel
-%183 = OpConvertSToF  %3  %179
-%184 = OpFDiv  %3  %183 %100
-%185 = OpExtInst  %3  %1 Sin %184
-%186 = OpFMul  %3  %185 %100
-%187 = OpConvertFToS  %11  %186
-%188 = OpULessThan  %22  %187 %5
-OpSelectionMerge %190 None
-OpBranchConditional %188 %191 %190
-%191 = OpLabel
-%189 = OpAccessChain  %20  %12 %23 %187
-OpStore %189 %180
-OpBranch %190
+%192 = OpFunction  %2  None %193
+%191 = OpFunctionParameter  %3
 %190 = OpLabel
+OpBranch %194
+%194 = OpLabel
+%195 = OpAccessChain  %20  %12 %23 %115
+OpStore %195 %191
+%196 = OpAccessChain  %20  %12 %50 %37
+OpStore %196 %191
+%197 = OpAccessChain  %20  %12 %74 %74 %37
+OpStore %197 %191
 OpReturn
 OpFunctionEnd
-%194 = OpFunction  %2  None %195
-%193 = OpFunctionParameter  %3
-%192 = OpLabel
-OpBranch %196
-%196 = OpLabel
-%197 = OpAccessChain  %20  %12 %23 %117
-OpStore %197 %193
-%198 = OpAccessChain  %48  %12 %51 %37
-OpStore %198 %193
-%199 = OpAccessChain  %48  %12 %76 %76 %37
-OpStore %199 %193
-OpReturn
-OpFunctionEnd
-%201 = OpFunction  %3  None %115
+%199 = OpFunction  %3  None %113
+%198 = OpLabel
+OpBranch %200
 %200 = OpLabel
-OpBranch %202
-%202 = OpLabel
-%203 = OpArrayLength  %6  %12 3
-%205 = OpULessThan  %22  %204 %203
-OpSelectionMerge %207 None
-OpBranchConditional %205 %208 %207
-%208 = OpLabel
-%206 = OpAccessChain  %20  %12 %37 %204
-%209 = OpLoad  %3  %206
-OpBranch %207
-%207 = OpLabel
-%210 = OpPhi  %3  %25 %202 %209 %208
-OpReturnValue %210
+%201 = OpArrayLength  %6  %12 3
+%203 = OpULessThan  %22  %202 %201
+OpSelectionMerge %205 None
+OpBranchConditional %203 %206 %205
+%206 = OpLabel
+%204 = OpAccessChain  %20  %12 %37 %202
+%207 = OpLoad  %3  %204
+OpBranch %205
+%205 = OpLabel
+%208 = OpPhi  %3  %25 %200 %207 %206
+OpReturnValue %208
 OpFunctionEnd
-%213 = OpFunction  %2  None %195
-%212 = OpFunctionParameter  %3
-%211 = OpLabel
-OpBranch %214
-%214 = OpLabel
-%215 = OpArrayLength  %6  %12 3
-%216 = OpULessThan  %22  %204 %215
-OpSelectionMerge %218 None
-OpBranchConditional %216 %219 %218
-%219 = OpLabel
-%217 = OpAccessChain  %20  %12 %37 %204
-OpStore %217 %212
-OpBranch %218
-%218 = OpLabel
+%211 = OpFunction  %2  None %193
+%210 = OpFunctionParameter  %3
+%209 = OpLabel
+OpBranch %212
+%212 = OpLabel
+%213 = OpArrayLength  %6  %12 3
+%214 = OpULessThan  %22  %202 %213
+OpSelectionMerge %216 None
+OpBranchConditional %214 %217 %216
+%217 = OpLabel
+%215 = OpAccessChain  %20  %12 %37 %202
+OpStore %215 %210
+OpBranch %216
+%216 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/debug-symbol-large-source.spvasm
+++ b/naga/tests/out/spv/debug-symbol-large-source.spvasm
@@ -1,19 +1,19 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 674
+; Bound: 672
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %368 "gen_terrain_compute" %365
-OpEntryPoint Vertex %445 "gen_terrain_vertex" %436 %439 %441 %443
-OpEntryPoint Fragment %495 "gen_terrain_fragment" %485 %487 %490 %493 %494
-OpEntryPoint Vertex %588 "vs_main" %579 %582 %584 %585 %587
-OpEntryPoint Fragment %613 "fs_main" %606 %608 %610 %612
-OpExecutionMode %368 LocalSize 64 1 1
-OpExecutionMode %495 OriginUpperLeft
-OpExecutionMode %613 OriginUpperLeft
+OpEntryPoint GLCompute %367 "gen_terrain_compute" %364
+OpEntryPoint Vertex %444 "gen_terrain_vertex" %435 %438 %440 %442
+OpEntryPoint Fragment %493 "gen_terrain_fragment" %483 %485 %488 %491 %492
+OpEntryPoint Vertex %586 "vs_main" %577 %580 %582 %583 %585
+OpEntryPoint Fragment %611 "fs_main" %604 %606 %608 %610
+OpExecutionMode %367 LocalSize 64 1 1
+OpExecutionMode %493 OriginUpperLeft
+OpExecutionMode %611 OriginUpperLeft
 %3 = OpString "debug-symbol-large-source.wgsl"
 OpSource Unknown 0 %3 "//This is a test 这是测试 これはテストだ 테스트입니다 This is a test 这是测试 これはテストだ 테스트입니다 This is a test 这是测试 これはテストだ 테스트입니다
 //This is a test 这是测试 これはテストだ 테스트입니다 This is a test 这是测试 これはテストだ 테스트입니다 This is a test 这是测试 これはテストだ 테스트입니다
@@ -7533,53 +7533,53 @@ OpName %203 "p"
 OpName %204 "fbm"
 OpName %212 "x"
 OpName %214 "v"
-OpName %216 "a"
-OpName %217 "i"
-OpName %237 "loop_bound"
-OpName %270 "p"
-OpName %271 "min_max_height"
-OpName %272 "terrain_point"
-OpName %283 "p"
-OpName %284 "min_max_height"
-OpName %285 "terrain_vertex"
-OpName %314 "naga_div"
-OpName %316 "lhs"
-OpName %317 "rhs"
-OpName %323 "vert_index"
-OpName %324 "chunk_size"
-OpName %325 "chunk_corner"
-OpName %326 "index_to_p"
-OpName %342 "p"
-OpName %343 "color23"
-OpName %365 "gid"
-OpName %368 "gen_terrain_compute"
-OpName %428 "naga_mod"
-OpName %429 "lhs"
-OpName %430 "rhs"
-OpName %436 "vindex"
-OpName %439 "index"
-OpName %441 "position"
-OpName %443 "uv"
-OpName %445 "gen_terrain_vertex"
-OpName %485 "index"
-OpName %487 "position"
-OpName %490 "uv"
-OpName %493 "vert_component"
-OpName %494 "index"
-OpName %495 "gen_terrain_fragment"
-OpName %498 "vert_component"
-OpName %499 "index"
-OpName %579 "position"
-OpName %582 "normal"
-OpName %584 "clip_position"
-OpName %585 "normal"
-OpName %587 "world_pos"
-OpName %588 "vs_main"
-OpName %606 "clip_position"
-OpName %608 "normal"
-OpName %610 "world_pos"
-OpName %613 "fs_main"
-OpName %622 "color"
+OpName %215 "a"
+OpName %216 "i"
+OpName %236 "loop_bound"
+OpName %269 "p"
+OpName %270 "min_max_height"
+OpName %271 "terrain_point"
+OpName %282 "p"
+OpName %283 "min_max_height"
+OpName %284 "terrain_vertex"
+OpName %313 "naga_div"
+OpName %315 "lhs"
+OpName %316 "rhs"
+OpName %322 "vert_index"
+OpName %323 "chunk_size"
+OpName %324 "chunk_corner"
+OpName %325 "index_to_p"
+OpName %341 "p"
+OpName %342 "color23"
+OpName %364 "gid"
+OpName %367 "gen_terrain_compute"
+OpName %427 "naga_mod"
+OpName %428 "lhs"
+OpName %429 "rhs"
+OpName %435 "vindex"
+OpName %438 "index"
+OpName %440 "position"
+OpName %442 "uv"
+OpName %444 "gen_terrain_vertex"
+OpName %483 "index"
+OpName %485 "position"
+OpName %488 "uv"
+OpName %491 "vert_component"
+OpName %492 "index"
+OpName %493 "gen_terrain_fragment"
+OpName %496 "vert_component"
+OpName %497 "index"
+OpName %577 "position"
+OpName %580 "normal"
+OpName %582 "clip_position"
+OpName %583 "normal"
+OpName %585 "world_pos"
+OpName %586 "vs_main"
+OpName %604 "clip_position"
+OpName %606 "normal"
+OpName %608 "world_pos"
+OpName %611 "fs_main"
+OpName %620 "color"
 OpMemberDecorate %13 0 Offset 0
 OpMemberDecorate %13 1 Offset 8
 OpMemberDecorate %13 2 Offset 16
@@ -7638,27 +7638,27 @@ OpDecorate %49 DescriptorSet 2
 OpDecorate %49 Binding 2
 OpDecorate %50 DescriptorSet 2
 OpDecorate %50 Binding 3
-OpDecorate %365 BuiltIn GlobalInvocationId
-OpDecorate %436 BuiltIn VertexIndex
-OpDecorate %439 Location 0
-OpDecorate %439 Flat
-OpDecorate %441 BuiltIn Position
-OpDecorate %443 Location 1
-OpDecorate %485 Location 0
-OpDecorate %485 Flat
-OpDecorate %487 BuiltIn FragCoord
-OpDecorate %490 Location 1
-OpDecorate %493 Location 0
-OpDecorate %494 Location 1
-OpDecorate %579 Location 0
-OpDecorate %582 Location 1
-OpDecorate %584 BuiltIn Position
-OpDecorate %585 Location 0
-OpDecorate %587 Location 1
-OpDecorate %606 BuiltIn FragCoord
-OpDecorate %608 Location 0
-OpDecorate %610 Location 1
-OpDecorate %612 Location 0
+OpDecorate %364 BuiltIn GlobalInvocationId
+OpDecorate %435 BuiltIn VertexIndex
+OpDecorate %438 Location 0
+OpDecorate %438 Flat
+OpDecorate %440 BuiltIn Position
+OpDecorate %442 Location 1
+OpDecorate %483 Location 0
+OpDecorate %483 Flat
+OpDecorate %485 BuiltIn FragCoord
+OpDecorate %488 Location 1
+OpDecorate %491 Location 0
+OpDecorate %492 Location 1
+OpDecorate %577 Location 0
+OpDecorate %580 Location 1
+OpDecorate %582 BuiltIn Position
+OpDecorate %583 Location 0
+OpDecorate %585 Location 1
+OpDecorate %604 BuiltIn FragCoord
+OpDecorate %606 Location 0
+OpDecorate %608 Location 1
+OpDecorate %610 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %5 = OpTypeVector %4 3
@@ -7751,87 +7751,85 @@ OpDecorate %612 Location 0
 %210 = OpConstant  %4  0.47942555
 %211 = OpConstantComposite  %6  %209 %210
 %213 = OpConstantNull  %6
-%215 = OpTypePointer Function %4
-%218 = OpTypePointer Function %8
-%233 = OpTypePointer Function %10
-%234 = OpConstantComposite  %10  %135 %135
-%235 = OpConstant  %8  4294967295
-%236 = OpConstantComposite  %10  %235 %235
-%273 = OpTypeFunction %5 %6 %6
-%286 = OpTypeFunction %14 %6 %6
-%287 = OpConstant  %4  0.1
-%288 = OpConstantComposite  %6  %287 %74
-%289 = OpConstantComposite  %6  %74 %287
-%290 = OpConstant  %4  -0.1
-%291 = OpConstantComposite  %6  %290 %74
-%292 = OpConstantComposite  %6  %74 %290
-%315 = OpTypeFunction %8 %8 %8
-%327 = OpTypeFunction %6 %8 %10 %11
-%344 = OpTypeFunction %5 %6
-%345 = OpConstant  %4  23.0
-%346 = OpConstant  %4  32.0
-%347 = OpConstantComposite  %6  %345 %346
-%348 = OpConstant  %4  -43.0
-%349 = OpConstant  %4  3.0
-%350 = OpConstantComposite  %6  %348 %349
-%366 = OpTypePointer Input %19
-%365 = OpVariable  %366  Input
-%369 = OpTypeFunction %2
-%370 = OpTypePointer Uniform %13
-%372 = OpConstant  %8  6
-%373 = OpConstant  %8  2
-%374 = OpConstant  %8  3
-%375 = OpConstant  %8  4
-%378 = OpTypePointer Uniform %10
-%381 = OpTypePointer Uniform %11
-%385 = OpTypePointer StorageBuffer %15
-%386 = OpTypePointer StorageBuffer %14
-%387 = OpTypePointer Uniform %6
-%394 = OpTypePointer Uniform %8
-%415 = OpTypePointer StorageBuffer %17
-%416 = OpTypePointer StorageBuffer %8
-%437 = OpTypePointer Input %8
-%436 = OpVariable  %437  Input
-%440 = OpTypePointer Output %8
-%439 = OpVariable  %440  Output
-%442 = OpTypePointer Output %7
-%441 = OpVariable  %442  Output
-%444 = OpTypePointer Output %6
-%443 = OpVariable  %444  Output
-%446 = OpTypePointer Uniform %20
-%448 = OpConstant  %4  -1.0
-%449 = OpConstantComposite  %6  %448 %448
-%464 = OpTypePointer Uniform %8
-%485 = OpVariable  %437  Input
-%488 = OpTypePointer Input %7
-%487 = OpVariable  %488  Input
-%491 = OpTypePointer Input %6
-%490 = OpVariable  %491  Input
-%493 = OpVariable  %440  Output
-%494 = OpVariable  %440  Output
-%497 = OpConstant  %4  6.0
-%580 = OpTypePointer Input %5
-%579 = OpVariable  %580  Input
-%582 = OpVariable  %580  Input
-%584 = OpVariable  %442  Output
-%586 = OpTypePointer Output %5
-%585 = OpVariable  %586  Output
-%587 = OpVariable  %586  Output
-%589 = OpTypePointer Uniform %24
-%592 = OpTypePointer Uniform %23
-%606 = OpVariable  %488  Input
-%608 = OpVariable  %580  Input
-%610 = OpVariable  %580  Input
-%612 = OpVariable  %442  Output
-%615 = OpTypePointer Uniform %25
-%617 = OpConstantComposite  %5  %287 %287 %287
-%618 = OpConstant  %4  0.7
-%619 = OpConstantComposite  %5  %78 %287 %618
-%620 = OpConstant  %4  0.2
-%621 = OpConstantComposite  %5  %620 %620 %620
-%623 = OpConstantNull  %5
-%638 = OpTypePointer Uniform %5
-%647 = OpTypePointer Uniform %7
+%217 = OpTypePointer Function %8
+%232 = OpTypePointer Function %10
+%233 = OpConstantComposite  %10  %135 %135
+%234 = OpConstant  %8  4294967295
+%235 = OpConstantComposite  %10  %234 %234
+%272 = OpTypeFunction %5 %6 %6
+%285 = OpTypeFunction %14 %6 %6
+%286 = OpConstant  %4  0.1
+%287 = OpConstantComposite  %6  %286 %74
+%288 = OpConstantComposite  %6  %74 %286
+%289 = OpConstant  %4  -0.1
+%290 = OpConstantComposite  %6  %289 %74
+%291 = OpConstantComposite  %6  %74 %289
+%314 = OpTypeFunction %8 %8 %8
+%326 = OpTypeFunction %6 %8 %10 %11
+%343 = OpTypeFunction %5 %6
+%344 = OpConstant  %4  23.0
+%345 = OpConstant  %4  32.0
+%346 = OpConstantComposite  %6  %344 %345
+%347 = OpConstant  %4  -43.0
+%348 = OpConstant  %4  3.0
+%349 = OpConstantComposite  %6  %347 %348
+%365 = OpTypePointer Input %19
+%364 = OpVariable  %365  Input
+%368 = OpTypeFunction %2
+%369 = OpTypePointer Uniform %13
+%371 = OpConstant  %8  6
+%372 = OpConstant  %8  2
+%373 = OpConstant  %8  3
+%374 = OpConstant  %8  4
+%377 = OpTypePointer Uniform %10
+%380 = OpTypePointer Uniform %11
+%384 = OpTypePointer StorageBuffer %15
+%385 = OpTypePointer StorageBuffer %14
+%386 = OpTypePointer Uniform %6
+%393 = OpTypePointer Uniform %8
+%414 = OpTypePointer StorageBuffer %17
+%415 = OpTypePointer StorageBuffer %8
+%436 = OpTypePointer Input %8
+%435 = OpVariable  %436  Input
+%439 = OpTypePointer Output %8
+%438 = OpVariable  %439  Output
+%441 = OpTypePointer Output %7
+%440 = OpVariable  %441  Output
+%443 = OpTypePointer Output %6
+%442 = OpVariable  %443  Output
+%445 = OpTypePointer Uniform %20
+%447 = OpConstant  %4  -1.0
+%448 = OpConstantComposite  %6  %447 %447
+%483 = OpVariable  %436  Input
+%486 = OpTypePointer Input %7
+%485 = OpVariable  %486  Input
+%489 = OpTypePointer Input %6
+%488 = OpVariable  %489  Input
+%491 = OpVariable  %439  Output
+%492 = OpVariable  %439  Output
+%495 = OpConstant  %4  6.0
+%578 = OpTypePointer Input %5
+%577 = OpVariable  %578  Input
+%580 = OpVariable  %578  Input
+%582 = OpVariable  %441  Output
+%584 = OpTypePointer Output %5
+%583 = OpVariable  %584  Output
+%585 = OpVariable  %584  Output
+%587 = OpTypePointer Uniform %24
+%590 = OpTypePointer Uniform %23
+%604 = OpVariable  %486  Input
+%606 = OpVariable  %578  Input
+%608 = OpVariable  %578  Input
+%610 = OpVariable  %441  Output
+%613 = OpTypePointer Uniform %25
+%615 = OpConstantComposite  %5  %286 %286 %286
+%616 = OpConstant  %4  0.7
+%617 = OpConstantComposite  %5  %78 %286 %616
+%618 = OpConstant  %4  0.2
+%619 = OpConstantComposite  %5  %618 %618 %618
+%621 = OpConstantNull  %5
+%636 = OpTypePointer Uniform %5
+%645 = OpTypePointer Uniform %7
 %53 = OpFunction  %5  None %54
 %52 = OpFunctionParameter  %5
 %51 = OpLabel
@@ -8015,656 +8013,656 @@ OpFunctionEnd
 %204 = OpFunction  %4  None %68
 %203 = OpFunctionParameter  %6
 %202 = OpLabel
-%214 = OpVariable  %215  Function %74
-%217 = OpVariable  %218  Function %135
+%214 = OpVariable  %125  Function %74
+%216 = OpVariable  %217  Function %135
 %212 = OpVariable  %87  Function %213
-%216 = OpVariable  %215  Function %78
-%237 = OpVariable  %233  Function %234
-OpBranch %219
-%219 = OpLabel
+%215 = OpVariable  %125  Function %78
+%236 = OpVariable  %232  Function %233
+OpBranch %218
+%218 = OpLabel
 OpLine %3 7179 13
-%220 = OpVectorTimesScalar  %6  %203 %206
+%219 = OpVectorTimesScalar  %6  %203 %206
 OpLine %3 7179 5
-OpStore %212 %220
+OpStore %212 %219
 OpLine %3 7182 17
 OpLine %3 7183 14
 OpLine %3 7184 15
-%221 = OpCompositeExtract  %4  %211 0
+%220 = OpCompositeExtract  %4  %211 0
+%221 = OpCompositeExtract  %4  %211 1
 %222 = OpCompositeExtract  %4  %211 1
-%223 = OpCompositeExtract  %4  %211 1
-%224 = OpFNegate  %4  %223
-%225 = OpCompositeExtract  %4  %211 0
-%226 = OpCompositeConstruct  %6  %221 %222
-%227 = OpCompositeConstruct  %6  %224 %225
-%228 = OpCompositeConstruct  %9  %226 %227
-OpBranch %229
-%229 = OpLabel
+%223 = OpFNegate  %4  %222
+%224 = OpCompositeExtract  %4  %211 0
+%225 = OpCompositeConstruct  %6  %220 %221
+%226 = OpCompositeConstruct  %6  %223 %224
+%227 = OpCompositeConstruct  %9  %225 %226
+OpBranch %228
+%228 = OpLabel
 OpLine %3 7186 5
-OpLoopMerge %230 %232 None
-OpBranch %238
-%238 = OpLabel
-%239 = OpLoad  %10  %237
-%240 = OpIEqual  %115  %236 %239
-%241 = OpAll  %112  %240
-OpSelectionMerge %242 None
-OpBranchConditional %241 %230 %242
-%242 = OpLabel
-%243 = OpCompositeExtract  %8  %239 1
-%244 = OpIEqual  %112  %243 %235
-%245 = OpSelect  %8  %244 %126 %135
-%246 = OpCompositeConstruct  %10  %245 %126
-%247 = OpIAdd  %10  %239 %246
-OpStore %237 %247
-OpBranch %231
-%231 = OpLabel
-OpLine %3 7186 22
-%248 = OpLoad  %8  %217
-%249 = OpULessThan  %112  %248 %205
-OpLine %3 7186 21
-OpSelectionMerge %250 None
-OpBranchConditional %249 %250 %251
-%251 = OpLabel
+OpLoopMerge %229 %231 None
+OpBranch %237
+%237 = OpLabel
+%238 = OpLoad  %10  %236
+%239 = OpIEqual  %115  %235 %238
+%240 = OpAll  %112  %239
+OpSelectionMerge %241 None
+OpBranchConditional %240 %229 %241
+%241 = OpLabel
+%242 = OpCompositeExtract  %8  %238 1
+%243 = OpIEqual  %112  %242 %234
+%244 = OpSelect  %8  %243 %126 %135
+%245 = OpCompositeConstruct  %10  %244 %126
+%246 = OpIAdd  %10  %238 %245
+OpStore %236 %246
 OpBranch %230
+%230 = OpLabel
+OpLine %3 7186 22
+%247 = OpLoad  %8  %216
+%248 = OpULessThan  %112  %247 %205
+OpLine %3 7186 21
+OpSelectionMerge %249 None
+OpBranchConditional %248 %249 %250
 %250 = OpLabel
+OpBranch %229
+%249 = OpLabel
+OpBranch %251
+%251 = OpLabel
+OpLine %3 1 1
+%253 = OpLoad  %4  %214
+%254 = OpLoad  %4  %215
+%255 = OpLoad  %6  %212
+OpLine %3 7187 21
+%256 = OpFunctionCall  %4  %67 %255
+OpLine %3 7187 13
+%257 = OpFMul  %4  %254 %256
+%258 = OpFAdd  %4  %253 %257
+OpLine %3 7187 9
+OpStore %214 %258
+OpLine %3 7188 13
+%259 = OpLoad  %6  %212
+%260 = OpMatrixTimesVector  %6  %227 %259
+OpLine %3 7188 13
+%261 = OpVectorTimesScalar  %6  %260 %81
+%262 = OpFAdd  %6  %261 %208
+OpLine %3 7188 9
+OpStore %212 %262
+OpLine %3 1 1
+%263 = OpLoad  %4  %215
+OpLine %3 7189 13
+%264 = OpFMul  %4  %263 %78
+OpLine %3 7189 9
+OpStore %215 %264
 OpBranch %252
 %252 = OpLabel
+OpBranch %231
+%231 = OpLabel
 OpLine %3 1 1
-%254 = OpLoad  %4  %214
-%255 = OpLoad  %4  %216
-%256 = OpLoad  %6  %212
-OpLine %3 7187 21
-%257 = OpFunctionCall  %4  %67 %256
-OpLine %3 7187 13
-%258 = OpFMul  %4  %255 %257
-%259 = OpFAdd  %4  %254 %258
-OpLine %3 7187 9
-OpStore %214 %259
-OpLine %3 7188 13
-%260 = OpLoad  %6  %212
-%261 = OpMatrixTimesVector  %6  %228 %260
-OpLine %3 7188 13
-%262 = OpVectorTimesScalar  %6  %261 %81
-%263 = OpFAdd  %6  %262 %208
-OpLine %3 7188 9
-OpStore %212 %263
-OpLine %3 1 1
-%264 = OpLoad  %4  %216
-OpLine %3 7189 13
-%265 = OpFMul  %4  %264 %78
-OpLine %3 7189 9
-OpStore %216 %265
-OpBranch %253
-%253 = OpLabel
-OpBranch %232
-%232 = OpLabel
-OpLine %3 1 1
-%266 = OpLoad  %8  %217
+%265 = OpLoad  %8  %216
 OpLine %3 7186 43
-%267 = OpIAdd  %8  %266 %126
+%266 = OpIAdd  %8  %265 %126
 OpLine %3 7186 39
-OpStore %217 %267
-OpBranch %229
-%230 = OpLabel
+OpStore %216 %266
+OpBranch %228
+%229 = OpLabel
 OpLine %3 1 1
-%268 = OpLoad  %4  %214
-OpReturnValue %268
+%267 = OpLoad  %4  %214
+OpReturnValue %267
 OpFunctionEnd
-%272 = OpFunction  %5  None %273
+%271 = OpFunction  %5  None %272
+%269 = OpFunctionParameter  %6
 %270 = OpFunctionParameter  %6
-%271 = OpFunctionParameter  %6
-%269 = OpLabel
-OpBranch %274
-%274 = OpLabel
+%268 = OpLabel
+OpBranch %273
+%273 = OpLabel
 OpLine %3 7220 9
+%274 = OpCompositeExtract  %4  %269 0
 %275 = OpCompositeExtract  %4  %270 0
-%276 = OpCompositeExtract  %4  %271 0
-%277 = OpCompositeExtract  %4  %271 1
+%276 = OpCompositeExtract  %4  %270 1
 OpLine %3 7221 49
-%278 = OpFunctionCall  %4  %204 %270
+%277 = OpFunctionCall  %4  %204 %269
 OpLine %3 7219 12
-%279 = OpExtInst  %4  %1 FMix %276 %277 %278
-%280 = OpCompositeExtract  %4  %270 1
-%281 = OpCompositeConstruct  %5  %275 %279 %280
-OpReturnValue %281
+%278 = OpExtInst  %4  %1 FMix %275 %276 %277
+%279 = OpCompositeExtract  %4  %269 1
+%280 = OpCompositeConstruct  %5  %274 %278 %279
+OpReturnValue %280
 OpFunctionEnd
-%285 = OpFunction  %14  None %286
+%284 = OpFunction  %14  None %285
+%282 = OpFunctionParameter  %6
 %283 = OpFunctionParameter  %6
-%284 = OpFunctionParameter  %6
-%282 = OpLabel
-OpBranch %293
-%293 = OpLabel
+%281 = OpLabel
+OpBranch %292
+%292 = OpLabel
 OpLine %3 7227 13
-%294 = OpFunctionCall  %5  %272 %283 %284
+%293 = OpFunctionCall  %5  %271 %282 %283
 OpLine %3 7229 29
-%295 = OpFAdd  %6  %283 %288
+%294 = OpFAdd  %6  %282 %287
 OpLine %3 7229 15
-%296 = OpFunctionCall  %5  %272 %295 %284
+%295 = OpFunctionCall  %5  %271 %294 %283
 OpLine %3 7229 15
-%297 = OpFSub  %5  %296 %294
+%296 = OpFSub  %5  %295 %293
 OpLine %3 7230 29
-%298 = OpFAdd  %6  %283 %289
+%297 = OpFAdd  %6  %282 %288
 OpLine %3 7230 15
-%299 = OpFunctionCall  %5  %272 %298 %284
+%298 = OpFunctionCall  %5  %271 %297 %283
 OpLine %3 7230 15
-%300 = OpFSub  %5  %299 %294
+%299 = OpFSub  %5  %298 %293
 OpLine %3 7231 29
-%301 = OpFAdd  %6  %283 %291
+%300 = OpFAdd  %6  %282 %290
 OpLine %3 7231 15
-%302 = OpFunctionCall  %5  %272 %301 %284
+%301 = OpFunctionCall  %5  %271 %300 %283
 OpLine %3 7231 15
-%303 = OpFSub  %5  %302 %294
+%302 = OpFSub  %5  %301 %293
 OpLine %3 7232 29
-%304 = OpFAdd  %6  %283 %292
+%303 = OpFAdd  %6  %282 %291
 OpLine %3 7232 15
-%305 = OpFunctionCall  %5  %272 %304 %284
+%304 = OpFunctionCall  %5  %271 %303 %283
 OpLine %3 7232 15
-%306 = OpFSub  %5  %305 %294
+%305 = OpFSub  %5  %304 %293
 OpLine %3 7234 14
-%307 = OpExtInst  %5  %1 Cross %300 %297
-%308 = OpExtInst  %5  %1 Normalize %307
+%306 = OpExtInst  %5  %1 Cross %299 %296
+%307 = OpExtInst  %5  %1 Normalize %306
 OpLine %3 7235 14
-%309 = OpExtInst  %5  %1 Cross %306 %303
-%310 = OpExtInst  %5  %1 Normalize %309
+%308 = OpExtInst  %5  %1 Cross %305 %302
+%309 = OpExtInst  %5  %1 Normalize %308
 OpLine %3 7237 14
-%311 = OpFAdd  %5  %308 %310
+%310 = OpFAdd  %5  %307 %309
 OpLine %3 7237 13
-%312 = OpVectorTimesScalar  %5  %311 %78
+%311 = OpVectorTimesScalar  %5  %310 %78
 OpLine %3 7239 12
-%313 = OpCompositeConstruct  %14  %294 %312
-OpReturnValue %313
+%312 = OpCompositeConstruct  %14  %293 %311
+OpReturnValue %312
 OpFunctionEnd
-%314 = OpFunction  %8  None %315
+%313 = OpFunction  %8  None %314
+%315 = OpFunctionParameter  %8
 %316 = OpFunctionParameter  %8
-%317 = OpFunctionParameter  %8
-%318 = OpLabel
-%319 = OpIEqual  %112  %317 %135
-%320 = OpSelect  %8  %319 %126 %317
-%321 = OpUDiv  %8  %316 %320
-OpReturnValue %321
+%317 = OpLabel
+%318 = OpIEqual  %112  %316 %135
+%319 = OpSelect  %8  %318 %126 %316
+%320 = OpUDiv  %8  %315 %319
+OpReturnValue %320
 OpFunctionEnd
-%326 = OpFunction  %6  None %327
-%323 = OpFunctionParameter  %8
-%324 = OpFunctionParameter  %10
-%325 = OpFunctionParameter  %11
-%322 = OpLabel
-OpBranch %328
-%328 = OpLabel
+%325 = OpFunction  %6  None %326
+%322 = OpFunctionParameter  %8
+%323 = OpFunctionParameter  %10
+%324 = OpFunctionParameter  %11
+%321 = OpLabel
+OpBranch %327
+%327 = OpLabel
 OpLine %3 7244 9
-%329 = OpConvertUToF  %4  %323
-%330 = OpCompositeExtract  %8  %324 0
+%328 = OpConvertUToF  %4  %322
+%329 = OpCompositeExtract  %8  %323 0
 OpLine %3 7244 9
-%331 = OpIAdd  %8  %330 %126
-%332 = OpConvertUToF  %4  %331
-%333 = OpFRem  %4  %329 %332
-%334 = OpCompositeExtract  %8  %324 0
+%330 = OpIAdd  %8  %329 %126
+%331 = OpConvertUToF  %4  %330
+%332 = OpFRem  %4  %328 %331
+%333 = OpCompositeExtract  %8  %323 0
 OpLine %3 7243 12
-%335 = OpIAdd  %8  %334 %126
-%336 = OpFunctionCall  %8  %314 %323 %335
-%337 = OpConvertUToF  %4  %336
-%338 = OpCompositeConstruct  %6  %333 %337
-%339 = OpConvertSToF  %6  %325
-%340 = OpFAdd  %6  %338 %339
-OpReturnValue %340
+%334 = OpIAdd  %8  %333 %126
+%335 = OpFunctionCall  %8  %313 %322 %334
+%336 = OpConvertUToF  %4  %335
+%337 = OpCompositeConstruct  %6  %332 %336
+%338 = OpConvertSToF  %6  %324
+%339 = OpFAdd  %6  %337 %338
+OpReturnValue %339
 OpFunctionEnd
-%343 = OpFunction  %5  None %344
-%342 = OpFunctionParameter  %6
-%341 = OpLabel
-OpBranch %351
-%351 = OpLabel
+%342 = OpFunction  %5  None %343
+%341 = OpFunctionParameter  %6
+%340 = OpLabel
+OpBranch %350
+%350 = OpLabel
 OpLine %3 7413 9
-%352 = OpFunctionCall  %4  %67 %342
+%351 = OpFunctionCall  %4  %67 %341
 OpLine %3 7413 9
-%353 = OpFMul  %4  %352 %78
+%352 = OpFMul  %4  %351 %78
 OpLine %3 7413 9
-%354 = OpFAdd  %4  %353 %78
+%353 = OpFAdd  %4  %352 %78
 OpLine %3 7414 17
-%355 = OpFAdd  %6  %342 %347
+%354 = OpFAdd  %6  %341 %346
 OpLine %3 7414 9
-%356 = OpFunctionCall  %4  %67 %355
+%355 = OpFunctionCall  %4  %67 %354
 OpLine %3 7414 9
-%357 = OpFMul  %4  %356 %78
+%356 = OpFMul  %4  %355 %78
 OpLine %3 7414 9
-%358 = OpFAdd  %4  %357 %78
+%357 = OpFAdd  %4  %356 %78
 OpLine %3 7415 17
-%359 = OpFAdd  %6  %342 %350
+%358 = OpFAdd  %6  %341 %349
 OpLine %3 7415 9
-%360 = OpFunctionCall  %4  %67 %359
+%359 = OpFunctionCall  %4  %67 %358
 OpLine %3 7415 9
-%361 = OpFMul  %4  %360 %78
+%360 = OpFMul  %4  %359 %78
 OpLine %3 7412 12
-%362 = OpFAdd  %4  %361 %78
-%363 = OpCompositeConstruct  %5  %354 %358 %362
-OpReturnValue %363
+%361 = OpFAdd  %4  %360 %78
+%362 = OpCompositeConstruct  %5  %353 %357 %361
+OpReturnValue %362
 OpFunctionEnd
-%368 = OpFunction  %2  None %369
-%364 = OpLabel
-%367 = OpLoad  %19  %365
-%371 = OpAccessChain  %370  %29 %135
-OpBranch %376
-%376 = OpLabel
+%367 = OpFunction  %2  None %368
+%363 = OpLabel
+%366 = OpLoad  %19  %364
+%370 = OpAccessChain  %369  %29 %135
+OpBranch %375
+%375 = OpLabel
 OpLine %3 7254 22
-%377 = OpCompositeExtract  %8  %367 0
+%376 = OpCompositeExtract  %8  %366 0
 OpLine %3 7256 36
-%379 = OpAccessChain  %378  %371 %135
-%380 = OpLoad  %10  %379
+%378 = OpAccessChain  %377  %370 %135
+%379 = OpLoad  %10  %378
 OpLine %3 7256 59
-%382 = OpAccessChain  %381  %371 %126
-%383 = OpLoad  %11  %382
+%381 = OpAccessChain  %380  %370 %126
+%382 = OpLoad  %11  %381
 OpLine %3 7256 13
-%384 = OpFunctionCall  %6  %326 %377 %380 %383
+%383 = OpFunctionCall  %6  %325 %376 %379 %382
 OpLine %3 7258 5
 OpLine %3 7258 51
-%388 = OpAccessChain  %387  %371 %373
-%389 = OpLoad  %6  %388
+%387 = OpAccessChain  %386  %370 %372
+%388 = OpLoad  %6  %387
 OpLine %3 7258 33
-%390 = OpFunctionCall  %14  %285 %384 %389
+%389 = OpFunctionCall  %14  %284 %383 %388
 OpLine %3 7258 5
-%391 = OpAccessChain  %386  %32 %135 %377
-OpStore %391 %390
+%390 = OpAccessChain  %385  %32 %135 %376
+OpStore %390 %389
 OpLine %3 7261 23
-%392 = OpCompositeExtract  %8  %367 0
+%391 = OpCompositeExtract  %8  %366 0
 OpLine %3 7261 23
-%393 = OpIMul  %8  %392 %372
+%392 = OpIMul  %8  %391 %371
 OpLine %3 7263 24
-%395 = OpAccessChain  %394  %371 %135 %135
-%396 = OpLoad  %8  %395
+%394 = OpAccessChain  %393  %370 %135 %135
+%395 = OpLoad  %8  %394
 OpLine %3 7263 24
-%397 = OpAccessChain  %394  %371 %135 %126
-%398 = OpLoad  %8  %397
-%399 = OpIMul  %8  %396 %398
+%396 = OpAccessChain  %393  %370 %135 %126
+%397 = OpLoad  %8  %396
+%398 = OpIMul  %8  %395 %397
 OpLine %3 7263 8
-%400 = OpIMul  %8  %399 %372
-%401 = OpUGreaterThanEqual  %112  %393 %400
+%399 = OpIMul  %8  %398 %371
+%400 = OpUGreaterThanEqual  %112  %392 %399
 OpLine %3 7263 5
-OpSelectionMerge %402 None
-OpBranchConditional %401 %403 %402
-%403 = OpLabel
-OpReturn
+OpSelectionMerge %401 None
+OpBranchConditional %400 %402 %401
 %402 = OpLabel
+OpReturn
+%401 = OpLabel
 OpLine %3 7265 28
-%404 = OpCompositeExtract  %8  %367 0
+%403 = OpCompositeExtract  %8  %366 0
 OpLine %3 7265 15
-%405 = OpAccessChain  %394  %371 %135 %135
-%406 = OpLoad  %8  %405
-%407 = OpFunctionCall  %8  %314 %404 %406
-%408 = OpIAdd  %8  %377 %407
+%404 = OpAccessChain  %393  %370 %135 %135
+%405 = OpLoad  %8  %404
+%406 = OpFunctionCall  %8  %313 %403 %405
+%407 = OpIAdd  %8  %376 %406
 OpLine %3 7266 15
-%409 = OpIAdd  %8  %408 %126
+%408 = OpIAdd  %8  %407 %126
 OpLine %3 7267 15
-%410 = OpAccessChain  %394  %371 %135 %135
-%411 = OpLoad  %8  %410
-%412 = OpIAdd  %8  %408 %411
+%409 = OpAccessChain  %393  %370 %135 %135
+%410 = OpLoad  %8  %409
+%411 = OpIAdd  %8  %407 %410
 OpLine %3 7267 15
-%413 = OpIAdd  %8  %412 %126
+%412 = OpIAdd  %8  %411 %126
 OpLine %3 7268 15
-%414 = OpIAdd  %8  %413 %126
+%413 = OpIAdd  %8  %412 %126
 OpLine %3 7270 5
 OpLine %3 7270 5
-%417 = OpAccessChain  %416  %34 %135 %393
-OpStore %417 %408
+%416 = OpAccessChain  %415  %34 %135 %392
+OpStore %416 %407
 OpLine %3 7271 5
 OpLine %3 7271 5
-%418 = OpIAdd  %8  %393 %126
+%417 = OpIAdd  %8  %392 %126
 OpLine %3 7271 5
-%419 = OpAccessChain  %416  %34 %135 %418
-OpStore %419 %413
+%418 = OpAccessChain  %415  %34 %135 %417
+OpStore %418 %412
 OpLine %3 7272 5
 OpLine %3 7272 5
-%420 = OpIAdd  %8  %393 %373
+%419 = OpIAdd  %8  %392 %372
 OpLine %3 7272 5
-%421 = OpAccessChain  %416  %34 %135 %420
-OpStore %421 %414
+%420 = OpAccessChain  %415  %34 %135 %419
+OpStore %420 %413
 OpLine %3 7273 5
 OpLine %3 7273 5
-%422 = OpIAdd  %8  %393 %374
+%421 = OpIAdd  %8  %392 %373
 OpLine %3 7273 5
-%423 = OpAccessChain  %416  %34 %135 %422
-OpStore %423 %408
+%422 = OpAccessChain  %415  %34 %135 %421
+OpStore %422 %407
 OpLine %3 7274 5
 OpLine %3 7274 5
-%424 = OpIAdd  %8  %393 %375
+%423 = OpIAdd  %8  %392 %374
 OpLine %3 7274 5
-%425 = OpAccessChain  %416  %34 %135 %424
-OpStore %425 %414
+%424 = OpAccessChain  %415  %34 %135 %423
+OpStore %424 %413
 OpLine %3 7275 5
 OpLine %3 7275 5
-%426 = OpIAdd  %8  %393 %205
+%425 = OpIAdd  %8  %392 %205
 OpLine %3 7275 5
-%427 = OpAccessChain  %416  %34 %135 %426
-OpStore %427 %409
+%426 = OpAccessChain  %415  %34 %135 %425
+OpStore %426 %408
 OpReturn
 OpFunctionEnd
-%428 = OpFunction  %8  None %315
+%427 = OpFunction  %8  None %314
+%428 = OpFunctionParameter  %8
 %429 = OpFunctionParameter  %8
-%430 = OpFunctionParameter  %8
-%431 = OpLabel
-%432 = OpIEqual  %112  %430 %135
-%433 = OpSelect  %8  %432 %126 %430
-%434 = OpUMod  %8  %429 %433
-OpReturnValue %434
+%430 = OpLabel
+%431 = OpIEqual  %112  %429 %135
+%432 = OpSelect  %8  %431 %126 %429
+%433 = OpUMod  %8  %428 %432
+OpReturnValue %433
 OpFunctionEnd
-%445 = OpFunction  %2  None %369
-%435 = OpLabel
-%438 = OpLoad  %8  %436
-%447 = OpAccessChain  %446  %36 %135
-OpBranch %450
-%450 = OpLabel
+%444 = OpFunction  %2  None %368
+%434 = OpLabel
+%437 = OpLoad  %8  %435
+%446 = OpAccessChain  %445  %36 %135
+OpBranch %449
+%449 = OpLabel
 OpLine %3 7304 19
-%451 = OpIAdd  %8  %438 %373
+%450 = OpIAdd  %8  %437 %372
 OpLine %3 7304 18
-%452 = OpFunctionCall  %8  %314 %451 %374
+%451 = OpFunctionCall  %8  %313 %450 %373
 OpLine %3 7304 13
-%453 = OpFunctionCall  %8  %428 %452 %373
-%454 = OpConvertUToF  %4  %453
+%452 = OpFunctionCall  %8  %427 %451 %372
+%453 = OpConvertUToF  %4  %452
 OpLine %3 7305 19
-%455 = OpIAdd  %8  %438 %126
+%454 = OpIAdd  %8  %437 %126
 OpLine %3 7305 18
-%456 = OpFunctionCall  %8  %314 %455 %374
+%455 = OpFunctionCall  %8  %313 %454 %373
 OpLine %3 7305 13
-%457 = OpFunctionCall  %8  %428 %456 %373
-%458 = OpConvertUToF  %4  %457
+%456 = OpFunctionCall  %8  %427 %455 %372
+%457 = OpConvertUToF  %4  %456
 OpLine %3 7306 14
-%459 = OpCompositeConstruct  %6  %454 %458
+%458 = OpCompositeConstruct  %6  %453 %457
 OpLine %3 7308 30
-%460 = OpVectorTimesScalar  %6  %459 %81
+%459 = OpVectorTimesScalar  %6  %458 %81
 OpLine %3 7308 30
-%461 = OpFAdd  %6  %449 %460
+%460 = OpFAdd  %6  %448 %459
 OpLine %3 7308 20
-%462 = OpCompositeConstruct  %7  %461 %74 %56
+%461 = OpCompositeConstruct  %7  %460 %74 %56
 OpLine %3 7311 21
-%463 = OpCompositeExtract  %4  %459 0
+%462 = OpCompositeExtract  %4  %458 0
 OpLine %3 7311 21
-%465 = OpAccessChain  %464  %447 %374
-%466 = OpLoad  %8  %465
-%467 = OpConvertUToF  %4  %466
-%468 = OpFMul  %4  %463 %467
-%469 = OpCompositeExtract  %4  %459 1
+%463 = OpAccessChain  %393  %446 %373
+%464 = OpLoad  %8  %463
+%465 = OpConvertUToF  %4  %464
+%466 = OpFMul  %4  %462 %465
+%467 = OpCompositeExtract  %4  %458 1
 OpLine %3 7311 17
-%470 = OpAccessChain  %464  %447 %374
-%471 = OpLoad  %8  %470
-%472 = OpConvertUToF  %4  %471
-%473 = OpFMul  %4  %469 %472
-%474 = OpFAdd  %4  %468 %473
-%475 = OpConvertFToU  %8  %474
+%468 = OpAccessChain  %393  %446 %373
+%469 = OpLoad  %8  %468
+%470 = OpConvertUToF  %4  %469
+%471 = OpFMul  %4  %467 %470
+%472 = OpFAdd  %4  %466 %471
+%473 = OpConvertFToU  %8  %472
 OpLine %3 7311 17
-%476 = OpAccessChain  %464  %447 %375
-%477 = OpLoad  %8  %476
-%478 = OpIAdd  %8  %475 %477
+%474 = OpAccessChain  %393  %446 %374
+%475 = OpLoad  %8  %474
+%476 = OpIAdd  %8  %473 %475
 OpLine %3 7313 12
-%479 = OpCompositeConstruct  %21  %478 %462 %459
-%480 = OpCompositeExtract  %8  %479 0
-OpStore %439 %480
-%481 = OpCompositeExtract  %7  %479 1
-OpStore %441 %481
-%482 = OpCompositeExtract  %6  %479 2
-OpStore %443 %482
+%477 = OpCompositeConstruct  %21  %476 %461 %458
+%478 = OpCompositeExtract  %8  %477 0
+OpStore %438 %478
+%479 = OpCompositeExtract  %7  %477 1
+OpStore %440 %479
+%480 = OpCompositeExtract  %6  %477 2
+OpStore %442 %480
 OpReturn
 OpFunctionEnd
-%495 = OpFunction  %2  None %369
-%483 = OpLabel
-%498 = OpVariable  %215  Function %74
-%499 = OpVariable  %218  Function %135
-%486 = OpLoad  %8  %485
-%489 = OpLoad  %7  %487
-%492 = OpLoad  %6  %490
-%484 = OpCompositeConstruct  %21  %486 %489 %492
-%496 = OpAccessChain  %446  %36 %135
-OpBranch %500
-%500 = OpLabel
+%493 = OpFunction  %2  None %368
+%481 = OpLabel
+%496 = OpVariable  %125  Function %74
+%497 = OpVariable  %217  Function %135
+%484 = OpLoad  %8  %483
+%487 = OpLoad  %7  %485
+%490 = OpLoad  %6  %488
+%482 = OpCompositeConstruct  %21  %484 %487 %490
+%494 = OpAccessChain  %445  %36 %135
+OpBranch %498
+%498 = OpLabel
 OpLine %3 7324 17
-%501 = OpCompositeExtract  %6  %484 2
-%502 = OpCompositeExtract  %4  %501 0
+%499 = OpCompositeExtract  %6  %482 2
+%500 = OpCompositeExtract  %4  %499 0
 OpLine %3 7324 17
-%503 = OpAccessChain  %464  %496 %374
-%504 = OpLoad  %8  %503
-%505 = OpConvertUToF  %4  %504
-%506 = OpFMul  %4  %502 %505
-%507 = OpCompositeExtract  %6  %484 2
-%508 = OpCompositeExtract  %4  %507 1
+%501 = OpAccessChain  %393  %494 %373
+%502 = OpLoad  %8  %501
+%503 = OpConvertUToF  %4  %502
+%504 = OpFMul  %4  %500 %503
+%505 = OpCompositeExtract  %6  %482 2
+%506 = OpCompositeExtract  %4  %505 1
 OpLine %3 7324 70
-%509 = OpAccessChain  %464  %496 %374
+%507 = OpAccessChain  %393  %494 %373
+%508 = OpLoad  %8  %507
+OpLine %3 7324 13
+%509 = OpAccessChain  %393  %494 %373
 %510 = OpLoad  %8  %509
+%511 = OpIMul  %8  %508 %510
+%512 = OpConvertUToF  %4  %511
+%513 = OpFMul  %4  %506 %512
+%514 = OpFAdd  %4  %504 %513
+%515 = OpConvertFToU  %8  %514
 OpLine %3 7324 13
-%511 = OpAccessChain  %464  %496 %374
-%512 = OpLoad  %8  %511
-%513 = OpIMul  %8  %510 %512
-%514 = OpConvertUToF  %4  %513
-%515 = OpFMul  %4  %508 %514
-%516 = OpFAdd  %4  %506 %515
-%517 = OpConvertFToU  %8  %516
-OpLine %3 7324 13
-%518 = OpAccessChain  %464  %496 %375
-%519 = OpLoad  %8  %518
-%520 = OpIAdd  %8  %517 %519
+%516 = OpAccessChain  %393  %494 %374
+%517 = OpLoad  %8  %516
+%518 = OpIAdd  %8  %515 %517
 OpLine %3 7325 32
-%521 = OpConvertUToF  %4  %520
+%519 = OpConvertUToF  %4  %518
 OpLine %3 7325 22
-%522 = OpFDiv  %4  %521 %497
-%523 = OpExtInst  %4  %1 Floor %522
-%524 = OpConvertFToU  %8  %523
+%520 = OpFDiv  %4  %519 %495
+%521 = OpExtInst  %4  %1 Floor %520
+%522 = OpConvertFToU  %8  %521
 OpLine %3 7326 22
-%525 = OpFunctionCall  %8  %428 %520 %372
+%523 = OpFunctionCall  %8  %427 %518 %371
 OpLine %3 7328 36
-%526 = OpAccessChain  %378  %496 %135
-%527 = OpLoad  %10  %526
+%524 = OpAccessChain  %377  %494 %135
+%525 = OpLoad  %10  %524
 OpLine %3 7328 57
-%528 = OpAccessChain  %381  %496 %126
-%529 = OpLoad  %11  %528
+%526 = OpAccessChain  %380  %494 %126
+%527 = OpLoad  %11  %526
 OpLine %3 7328 13
-%530 = OpFunctionCall  %6  %326 %524 %527 %529
+%528 = OpFunctionCall  %6  %325 %522 %525 %527
 OpLine %3 7329 31
-%531 = OpAccessChain  %387  %496 %373
-%532 = OpLoad  %6  %531
+%529 = OpAccessChain  %386  %494 %372
+%530 = OpLoad  %6  %529
 OpLine %3 7329 13
-%533 = OpFunctionCall  %14  %285 %530 %532
+%531 = OpFunctionCall  %14  %284 %528 %530
 OpLine %3 7333 5
-OpSelectionMerge %534 None
-OpSwitch %525 %541 0 %535 1 %536 2 %537 3 %538 4 %539 5 %540
-%535 = OpLabel
+OpSelectionMerge %532 None
+OpSwitch %523 %539 0 %533 1 %534 2 %535 3 %536 4 %537 5 %538
+%533 = OpLabel
 OpLine %3 7334 37
-%542 = OpCompositeExtract  %5  %533 0
-%543 = OpCompositeExtract  %4  %542 0
+%540 = OpCompositeExtract  %5  %531 0
+%541 = OpCompositeExtract  %4  %540 0
 OpLine %3 7334 20
-OpStore %498 %543
-OpBranch %534
-%536 = OpLabel
-OpLine %3 7335 37
-%544 = OpCompositeExtract  %5  %533 0
-%545 = OpCompositeExtract  %4  %544 1
-OpLine %3 7335 20
-OpStore %498 %545
-OpBranch %534
-%537 = OpLabel
-OpLine %3 7336 37
-%546 = OpCompositeExtract  %5  %533 0
-%547 = OpCompositeExtract  %4  %546 2
-OpLine %3 7336 20
-OpStore %498 %547
-OpBranch %534
-%538 = OpLabel
-OpLine %3 7337 37
-%548 = OpCompositeExtract  %5  %533 1
-%549 = OpCompositeExtract  %4  %548 0
-OpLine %3 7337 20
-OpStore %498 %549
-OpBranch %534
-%539 = OpLabel
-OpLine %3 7338 37
-%550 = OpCompositeExtract  %5  %533 1
-%551 = OpCompositeExtract  %4  %550 1
-OpLine %3 7338 20
-OpStore %498 %551
-OpBranch %534
-%540 = OpLabel
-OpLine %3 7339 37
-%552 = OpCompositeExtract  %5  %533 1
-%553 = OpCompositeExtract  %4  %552 2
-OpLine %3 7339 20
-OpStore %498 %553
-OpBranch %534
-%541 = OpLabel
-OpBranch %534
+OpStore %496 %541
+OpBranch %532
 %534 = OpLabel
+OpLine %3 7335 37
+%542 = OpCompositeExtract  %5  %531 0
+%543 = OpCompositeExtract  %4  %542 1
+OpLine %3 7335 20
+OpStore %496 %543
+OpBranch %532
+%535 = OpLabel
+OpLine %3 7336 37
+%544 = OpCompositeExtract  %5  %531 0
+%545 = OpCompositeExtract  %4  %544 2
+OpLine %3 7336 20
+OpStore %496 %545
+OpBranch %532
+%536 = OpLabel
+OpLine %3 7337 37
+%546 = OpCompositeExtract  %5  %531 1
+%547 = OpCompositeExtract  %4  %546 0
+OpLine %3 7337 20
+OpStore %496 %547
+OpBranch %532
+%537 = OpLabel
+OpLine %3 7338 37
+%548 = OpCompositeExtract  %5  %531 1
+%549 = OpCompositeExtract  %4  %548 1
+OpLine %3 7338 20
+OpStore %496 %549
+OpBranch %532
+%538 = OpLabel
+OpLine %3 7339 37
+%550 = OpCompositeExtract  %5  %531 1
+%551 = OpCompositeExtract  %4  %550 2
+OpLine %3 7339 20
+OpStore %496 %551
+OpBranch %532
+%539 = OpLabel
+OpBranch %532
+%532 = OpLabel
 OpLine %3 7343 15
-%554 = OpAccessChain  %394  %496 %135 %135
-%555 = OpLoad  %8  %554
-%556 = OpFunctionCall  %8  %314 %524 %555
-%557 = OpIAdd  %8  %524 %556
+%552 = OpAccessChain  %393  %494 %135 %135
+%553 = OpLoad  %8  %552
+%554 = OpFunctionCall  %8  %313 %522 %553
+%555 = OpIAdd  %8  %522 %554
 OpLine %3 7344 15
-%558 = OpIAdd  %8  %557 %126
+%556 = OpIAdd  %8  %555 %126
 OpLine %3 7345 15
-%559 = OpAccessChain  %394  %496 %135 %135
-%560 = OpLoad  %8  %559
-%561 = OpIAdd  %8  %557 %560
+%557 = OpAccessChain  %393  %494 %135 %135
+%558 = OpLoad  %8  %557
+%559 = OpIAdd  %8  %555 %558
 OpLine %3 7345 15
-%562 = OpIAdd  %8  %561 %126
+%560 = OpIAdd  %8  %559 %126
 OpLine %3 7346 15
-%563 = OpIAdd  %8  %562 %126
+%561 = OpIAdd  %8  %560 %126
 OpLine %3 7349 5
-OpSelectionMerge %564 None
-OpSwitch %525 %569 0 %565 3 %565 2 %566 4 %566 1 %567 5 %568
-%565 = OpLabel
+OpSelectionMerge %562 None
+OpSwitch %523 %567 0 %563 3 %563 2 %564 4 %564 1 %565 5 %566
+%563 = OpLabel
 OpLine %3 7350 24
-OpStore %499 %557
-OpBranch %564
-%566 = OpLabel
-OpLine %3 7351 24
-OpStore %499 %563
-OpBranch %564
-%567 = OpLabel
-OpLine %3 7352 20
-OpStore %499 %562
-OpBranch %564
-%568 = OpLabel
-OpLine %3 7353 20
-OpStore %499 %558
-OpBranch %564
-%569 = OpLabel
-OpBranch %564
+OpStore %497 %555
+OpBranch %562
 %564 = OpLabel
+OpLine %3 7351 24
+OpStore %497 %561
+OpBranch %562
+%565 = OpLabel
+OpLine %3 7352 20
+OpStore %497 %560
+OpBranch %562
+%566 = OpLabel
+OpLine %3 7353 20
+OpStore %497 %556
+OpBranch %562
+%567 = OpLabel
+OpBranch %562
+%562 = OpLabel
 OpLine %3 7356 13
-%570 = OpCompositeExtract  %8  %484 0
+%568 = OpCompositeExtract  %8  %482 0
 OpLine %3 7356 5
-OpStore %499 %570
+OpStore %497 %568
 OpLine %3 7365 27
-%571 = OpLoad  %4  %498
-%572 = OpBitcast  %8  %571
+%569 = OpLoad  %4  %496
+%570 = OpBitcast  %8  %569
 OpLine %3 7366 12
-%573 = OpLoad  %8  %499
-%574 = OpCompositeConstruct  %22  %572 %573
-%575 = OpCompositeExtract  %8  %574 0
-OpStore %493 %575
-%576 = OpCompositeExtract  %8  %574 1
-OpStore %494 %576
+%571 = OpLoad  %8  %497
+%572 = OpCompositeConstruct  %22  %570 %571
+%573 = OpCompositeExtract  %8  %572 0
+OpStore %491 %573
+%574 = OpCompositeExtract  %8  %572 1
+OpStore %492 %574
 OpReturn
 OpFunctionEnd
-%588 = OpFunction  %2  None %369
-%577 = OpLabel
-%581 = OpLoad  %5  %579
-%583 = OpLoad  %5  %582
-%578 = OpCompositeConstruct  %14  %581 %583
-%590 = OpAccessChain  %589  %39 %135
-OpBranch %591
-%591 = OpLabel
+%586 = OpFunction  %2  None %368
+%575 = OpLabel
+%579 = OpLoad  %5  %577
+%581 = OpLoad  %5  %580
+%576 = OpCompositeConstruct  %14  %579 %581
+%588 = OpAccessChain  %587  %39 %135
+OpBranch %589
+%589 = OpLabel
 OpLine %3 7397 25
-%593 = OpAccessChain  %592  %590 %126
-%594 = OpLoad  %23  %593
-%595 = OpCompositeExtract  %5  %578 0
+%591 = OpAccessChain  %590  %588 %126
+%592 = OpLoad  %23  %591
+%593 = OpCompositeExtract  %5  %576 0
 OpLine %3 7397 25
-%596 = OpCompositeConstruct  %7  %595 %56
-%597 = OpMatrixTimesVector  %7  %594 %596
+%594 = OpCompositeConstruct  %7  %593 %56
+%595 = OpMatrixTimesVector  %7  %592 %594
 OpLine %3 7398 18
-%598 = OpCompositeExtract  %5  %578 1
+%596 = OpCompositeExtract  %5  %576 1
 OpLine %3 7399 12
-%599 = OpCompositeExtract  %5  %578 0
-%600 = OpCompositeConstruct  %26  %597 %598 %599
-%601 = OpCompositeExtract  %7  %600 0
-OpStore %584 %601
-%602 = OpCompositeExtract  %5  %600 1
-OpStore %585 %602
-%603 = OpCompositeExtract  %5  %600 2
-OpStore %587 %603
+%597 = OpCompositeExtract  %5  %576 0
+%598 = OpCompositeConstruct  %26  %595 %596 %597
+%599 = OpCompositeExtract  %7  %598 0
+OpStore %582 %599
+%600 = OpCompositeExtract  %5  %598 1
+OpStore %583 %600
+%601 = OpCompositeExtract  %5  %598 2
+OpStore %585 %601
 OpReturn
 OpFunctionEnd
-%613 = OpFunction  %2  None %369
-%604 = OpLabel
-%622 = OpVariable  %95  Function %623
-%607 = OpLoad  %7  %606
+%611 = OpFunction  %2  None %368
+%602 = OpLabel
+%620 = OpVariable  %95  Function %621
+%605 = OpLoad  %7  %604
+%607 = OpLoad  %5  %606
 %609 = OpLoad  %5  %608
-%611 = OpLoad  %5  %610
-%605 = OpCompositeConstruct  %26  %607 %609 %611
-%614 = OpAccessChain  %589  %39 %135
-%616 = OpAccessChain  %615  %42 %135
-OpBranch %624
-%624 = OpLabel
+%603 = OpCompositeConstruct  %26  %605 %607 %609
+%612 = OpAccessChain  %587  %39 %135
+%614 = OpAccessChain  %613  %42 %135
+OpBranch %622
+%622 = OpLabel
 OpLine %3 7421 28
 OpLine %3 7421 17
-%625 = OpCompositeExtract  %5  %605 2
-%626 = OpExtInst  %5  %1 Fract %625
-%627 = OpExtInst  %5  %1 SmoothStep %80 %617 %626
+%623 = OpCompositeExtract  %5  %603 2
+%624 = OpExtInst  %5  %1 Fract %623
+%625 = OpExtInst  %5  %1 SmoothStep %80 %615 %624
 OpLine %3 7421 5
-OpStore %622 %627
+OpStore %620 %625
 OpLine %3 7422 17
 OpLine %3 7422 13
-%628 = OpAccessChain  %125  %622 %135
+%626 = OpAccessChain  %125  %620 %135
+%627 = OpLoad  %4  %626
+%628 = OpAccessChain  %125  %620 %126
 %629 = OpLoad  %4  %628
-%630 = OpAccessChain  %125  %622 %126
-%631 = OpLoad  %4  %630
-%632 = OpFMul  %4  %629 %631
-%633 = OpAccessChain  %125  %622 %373
-%634 = OpLoad  %4  %633
-%635 = OpFMul  %4  %632 %634
-%636 = OpCompositeConstruct  %5  %635 %635 %635
-%637 = OpExtInst  %5  %1 FMix %619 %621 %636
+%630 = OpFMul  %4  %627 %629
+%631 = OpAccessChain  %125  %620 %372
+%632 = OpLoad  %4  %631
+%633 = OpFMul  %4  %630 %632
+%634 = OpCompositeConstruct  %5  %633 %633 %633
+%635 = OpExtInst  %5  %1 FMix %617 %619 %634
 OpLine %3 7422 5
-OpStore %622 %637
+OpStore %620 %635
 OpLine %3 7425 25
-%639 = OpAccessChain  %638  %616 %126
-%640 = OpLoad  %5  %639
-%641 = OpVectorTimesScalar  %5  %640 %287
+%637 = OpAccessChain  %636  %614 %126
+%638 = OpLoad  %5  %637
+%639 = OpVectorTimesScalar  %5  %638 %286
 OpLine %3 7427 21
-%642 = OpAccessChain  %638  %616 %135
-%643 = OpLoad  %5  %642
-%644 = OpCompositeExtract  %5  %605 2
-%645 = OpFSub  %5  %643 %644
-%646 = OpExtInst  %5  %1 Normalize %645
+%640 = OpAccessChain  %636  %614 %135
+%641 = OpLoad  %5  %640
+%642 = OpCompositeExtract  %5  %603 2
+%643 = OpFSub  %5  %641 %642
+%644 = OpExtInst  %5  %1 Normalize %643
 OpLine %3 7428 20
-%648 = OpAccessChain  %647  %614 %135
-%649 = OpLoad  %7  %648
-%650 = OpVectorShuffle  %5  %649 %649 0 1 2
-%651 = OpCompositeExtract  %5  %605 2
-%652 = OpFSub  %5  %650 %651
-%653 = OpExtInst  %5  %1 Normalize %652
+%646 = OpAccessChain  %645  %612 %135
+%647 = OpLoad  %7  %646
+%648 = OpVectorShuffle  %5  %647 %647 0 1 2
+%649 = OpCompositeExtract  %5  %603 2
+%650 = OpFSub  %5  %648 %649
+%651 = OpExtInst  %5  %1 Normalize %650
 OpLine %3 7429 20
-%654 = OpFAdd  %5  %653 %646
-%655 = OpExtInst  %5  %1 Normalize %654
+%652 = OpFAdd  %5  %651 %644
+%653 = OpExtInst  %5  %1 Normalize %652
 OpLine %3 7431 32
-%656 = OpCompositeExtract  %5  %605 1
-%657 = OpDot  %4  %656 %646
+%654 = OpCompositeExtract  %5  %603 1
+%655 = OpDot  %4  %654 %644
 OpLine %3 7431 28
-%658 = OpExtInst  %4  %1 FMax %657 %74
+%656 = OpExtInst  %4  %1 FMax %655 %74
 OpLine %3 7432 25
-%659 = OpAccessChain  %638  %616 %126
-%660 = OpLoad  %5  %659
-%661 = OpVectorTimesScalar  %5  %660 %658
+%657 = OpAccessChain  %636  %614 %126
+%658 = OpLoad  %5  %657
+%659 = OpVectorTimesScalar  %5  %658 %656
 OpLine %3 7434 37
-%662 = OpCompositeExtract  %5  %605 1
-%663 = OpDot  %4  %662 %655
+%660 = OpCompositeExtract  %5  %603 1
+%661 = OpDot  %4  %660 %653
 OpLine %3 7434 33
-%664 = OpExtInst  %4  %1 FMax %663 %74
+%662 = OpExtInst  %4  %1 FMax %661 %74
 OpLine %3 7434 29
-%665 = OpExtInst  %4  %1 Pow %664 %346
+%663 = OpExtInst  %4  %1 Pow %662 %345
 OpLine %3 7435 26
-%666 = OpAccessChain  %638  %616 %126
-%667 = OpLoad  %5  %666
-%668 = OpVectorTimesScalar  %5  %667 %665
+%664 = OpAccessChain  %636  %614 %126
+%665 = OpLoad  %5  %664
+%666 = OpVectorTimesScalar  %5  %665 %663
 OpLine %3 7437 18
-%669 = OpFAdd  %5  %641 %661
-%670 = OpFAdd  %5  %669 %668
-%671 = OpLoad  %5  %622
-%672 = OpFMul  %5  %670 %671
+%667 = OpFAdd  %5  %639 %659
+%668 = OpFAdd  %5  %667 %666
+%669 = OpLoad  %5  %620
+%670 = OpFMul  %5  %668 %669
 OpLine %3 7439 12
-%673 = OpCompositeConstruct  %7  %672 %56
-OpStore %612 %673
+%671 = OpCompositeConstruct  %7  %670 %56
+OpStore %610 %671
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/debug-symbol-simple.spvasm
+++ b/naga/tests/out/spv/debug-symbol-simple.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 111
+; Bound: 110
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
@@ -115,7 +115,6 @@ OpDecorate %48 Location 0
 %72 = OpConstantComposite  %68  %36 %36
 %73 = OpConstant  %31  4294967295
 %74 = OpConstantComposite  %68  %73 %73
-%94 = OpTypePointer Function %4
 %21 = OpFunction  %2  None %22
 %10 = OpLabel
 %24 = OpVariable  %25  Function %26
@@ -197,40 +196,40 @@ OpLine %3 27 18
 OpLine %3 27 9
 OpStore %59 %93
 OpLine %3 28 9
-%95 = OpLoad  %4  %59
+%94 = OpLoad  %4  %59
 OpLine %3 28 9
-%96 = OpFMul  %4  %95 %52
-%97 = OpAccessChain  %94  %55 %36
-%98 = OpLoad  %4  %97
-%99 = OpFAdd  %4  %98 %96
+%95 = OpFMul  %4  %94 %52
+%96 = OpAccessChain  %60  %55 %36
+%97 = OpLoad  %4  %96
+%98 = OpFAdd  %4  %97 %95
 OpLine %3 28 9
-%100 = OpAccessChain  %94  %55 %36
-OpStore %100 %99
+%99 = OpAccessChain  %60  %55 %36
+OpStore %99 %98
 OpLine %3 29 9
-%101 = OpLoad  %4  %59
+%100 = OpLoad  %4  %59
 OpLine %3 29 9
-%102 = OpFMul  %4  %101 %53
-%103 = OpAccessChain  %94  %55 %30
-%104 = OpLoad  %4  %103
-%105 = OpFAdd  %4  %104 %102
+%101 = OpFMul  %4  %100 %53
+%102 = OpAccessChain  %60  %55 %30
+%103 = OpLoad  %4  %102
+%104 = OpFAdd  %4  %103 %101
 OpLine %3 29 9
-%106 = OpAccessChain  %94  %55 %30
-OpStore %106 %105
+%105 = OpAccessChain  %60  %55 %30
+OpStore %105 %104
 OpBranch %91
 %91 = OpLabel
 OpBranch %67
 %67 = OpLabel
 OpLine %3 26 29
-%107 = OpLoad  %9  %57
-%108 = OpIAdd  %9  %107 %54
+%106 = OpLoad  %9  %57
+%107 = OpIAdd  %9  %106 %54
 OpLine %3 26 29
-OpStore %57 %108
+OpStore %57 %107
 OpBranch %64
 %65 = OpLabel
 OpLine %3 1 1
-%109 = OpLoad  %5  %55
+%108 = OpLoad  %5  %55
 OpLine %3 32 12
-%110 = OpCompositeConstruct  %7  %109 %23
-OpStore %48 %110
+%109 = OpCompositeConstruct  %7  %108 %23
+OpStore %48 %109
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/debug-symbol-terrain.spvasm
+++ b/naga/tests/out/spv/debug-symbol-terrain.spvasm
@@ -1,19 +1,19 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 674
+; Bound: 672
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %368 "gen_terrain_compute" %365
-OpEntryPoint Vertex %445 "gen_terrain_vertex" %436 %439 %441 %443
-OpEntryPoint Fragment %495 "gen_terrain_fragment" %485 %487 %490 %493 %494
-OpEntryPoint Vertex %588 "vs_main" %579 %582 %584 %585 %587
-OpEntryPoint Fragment %613 "fs_main" %606 %608 %610 %612
-OpExecutionMode %368 LocalSize 64 1 1
-OpExecutionMode %495 OriginUpperLeft
-OpExecutionMode %613 OriginUpperLeft
+OpEntryPoint GLCompute %367 "gen_terrain_compute" %364
+OpEntryPoint Vertex %444 "gen_terrain_vertex" %435 %438 %440 %442
+OpEntryPoint Fragment %493 "gen_terrain_fragment" %483 %485 %488 %491 %492
+OpEntryPoint Vertex %586 "vs_main" %577 %580 %582 %583 %585
+OpEntryPoint Fragment %611 "fs_main" %604 %606 %608 %610
+OpExecutionMode %367 LocalSize 64 1 1
+OpExecutionMode %493 OriginUpperLeft
+OpExecutionMode %611 OriginUpperLeft
 %3 = OpString "debug-symbol-terrain.wgsl"
 OpSource Unknown 0 %3 "// Taken from https://github.com/sotrh/learn-wgpu/blob/11820796f5e1dbce42fb1119f04ddeb4b167d2a0/code/intermediate/tutorial13-terrain/src/terrain.wgsl
 // ============================
@@ -368,53 +368,53 @@ OpName %203 "p"
 OpName %204 "fbm"
 OpName %212 "x"
 OpName %214 "v"
-OpName %216 "a"
-OpName %217 "i"
-OpName %237 "loop_bound"
-OpName %270 "p"
-OpName %271 "min_max_height"
-OpName %272 "terrain_point"
-OpName %283 "p"
-OpName %284 "min_max_height"
-OpName %285 "terrain_vertex"
-OpName %314 "naga_div"
-OpName %316 "lhs"
-OpName %317 "rhs"
-OpName %323 "vert_index"
-OpName %324 "chunk_size"
-OpName %325 "chunk_corner"
-OpName %326 "index_to_p"
-OpName %342 "p"
-OpName %343 "color23"
-OpName %365 "gid"
-OpName %368 "gen_terrain_compute"
-OpName %428 "naga_mod"
-OpName %429 "lhs"
-OpName %430 "rhs"
-OpName %436 "vindex"
-OpName %439 "index"
-OpName %441 "position"
-OpName %443 "uv"
-OpName %445 "gen_terrain_vertex"
-OpName %485 "index"
-OpName %487 "position"
-OpName %490 "uv"
-OpName %493 "vert_component"
-OpName %494 "index"
-OpName %495 "gen_terrain_fragment"
-OpName %498 "vert_component"
-OpName %499 "index"
-OpName %579 "position"
-OpName %582 "normal"
-OpName %584 "clip_position"
-OpName %585 "normal"
-OpName %587 "world_pos"
-OpName %588 "vs_main"
-OpName %606 "clip_position"
-OpName %608 "normal"
-OpName %610 "world_pos"
-OpName %613 "fs_main"
-OpName %622 "color"
+OpName %215 "a"
+OpName %216 "i"
+OpName %236 "loop_bound"
+OpName %269 "p"
+OpName %270 "min_max_height"
+OpName %271 "terrain_point"
+OpName %282 "p"
+OpName %283 "min_max_height"
+OpName %284 "terrain_vertex"
+OpName %313 "naga_div"
+OpName %315 "lhs"
+OpName %316 "rhs"
+OpName %322 "vert_index"
+OpName %323 "chunk_size"
+OpName %324 "chunk_corner"
+OpName %325 "index_to_p"
+OpName %341 "p"
+OpName %342 "color23"
+OpName %364 "gid"
+OpName %367 "gen_terrain_compute"
+OpName %427 "naga_mod"
+OpName %428 "lhs"
+OpName %429 "rhs"
+OpName %435 "vindex"
+OpName %438 "index"
+OpName %440 "position"
+OpName %442 "uv"
+OpName %444 "gen_terrain_vertex"
+OpName %483 "index"
+OpName %485 "position"
+OpName %488 "uv"
+OpName %491 "vert_component"
+OpName %492 "index"
+OpName %493 "gen_terrain_fragment"
+OpName %496 "vert_component"
+OpName %497 "index"
+OpName %577 "position"
+OpName %580 "normal"
+OpName %582 "clip_position"
+OpName %583 "normal"
+OpName %585 "world_pos"
+OpName %586 "vs_main"
+OpName %604 "clip_position"
+OpName %606 "normal"
+OpName %608 "world_pos"
+OpName %611 "fs_main"
+OpName %620 "color"
 OpMemberDecorate %13 0 Offset 0
 OpMemberDecorate %13 1 Offset 8
 OpMemberDecorate %13 2 Offset 16
@@ -473,27 +473,27 @@ OpDecorate %49 DescriptorSet 2
 OpDecorate %49 Binding 2
 OpDecorate %50 DescriptorSet 2
 OpDecorate %50 Binding 3
-OpDecorate %365 BuiltIn GlobalInvocationId
-OpDecorate %436 BuiltIn VertexIndex
-OpDecorate %439 Location 0
-OpDecorate %439 Flat
-OpDecorate %441 BuiltIn Position
-OpDecorate %443 Location 1
-OpDecorate %485 Location 0
-OpDecorate %485 Flat
-OpDecorate %487 BuiltIn FragCoord
-OpDecorate %490 Location 1
-OpDecorate %493 Location 0
-OpDecorate %494 Location 1
-OpDecorate %579 Location 0
-OpDecorate %582 Location 1
-OpDecorate %584 BuiltIn Position
-OpDecorate %585 Location 0
-OpDecorate %587 Location 1
-OpDecorate %606 BuiltIn FragCoord
-OpDecorate %608 Location 0
-OpDecorate %610 Location 1
-OpDecorate %612 Location 0
+OpDecorate %364 BuiltIn GlobalInvocationId
+OpDecorate %435 BuiltIn VertexIndex
+OpDecorate %438 Location 0
+OpDecorate %438 Flat
+OpDecorate %440 BuiltIn Position
+OpDecorate %442 Location 1
+OpDecorate %483 Location 0
+OpDecorate %483 Flat
+OpDecorate %485 BuiltIn FragCoord
+OpDecorate %488 Location 1
+OpDecorate %491 Location 0
+OpDecorate %492 Location 1
+OpDecorate %577 Location 0
+OpDecorate %580 Location 1
+OpDecorate %582 BuiltIn Position
+OpDecorate %583 Location 0
+OpDecorate %585 Location 1
+OpDecorate %604 BuiltIn FragCoord
+OpDecorate %606 Location 0
+OpDecorate %608 Location 1
+OpDecorate %610 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %5 = OpTypeVector %4 3
@@ -586,87 +586,85 @@ OpDecorate %612 Location 0
 %210 = OpConstant  %4  0.47942555
 %211 = OpConstantComposite  %6  %209 %210
 %213 = OpConstantNull  %6
-%215 = OpTypePointer Function %4
-%218 = OpTypePointer Function %8
-%233 = OpTypePointer Function %10
-%234 = OpConstantComposite  %10  %135 %135
-%235 = OpConstant  %8  4294967295
-%236 = OpConstantComposite  %10  %235 %235
-%273 = OpTypeFunction %5 %6 %6
-%286 = OpTypeFunction %14 %6 %6
-%287 = OpConstant  %4  0.1
-%288 = OpConstantComposite  %6  %287 %74
-%289 = OpConstantComposite  %6  %74 %287
-%290 = OpConstant  %4  -0.1
-%291 = OpConstantComposite  %6  %290 %74
-%292 = OpConstantComposite  %6  %74 %290
-%315 = OpTypeFunction %8 %8 %8
-%327 = OpTypeFunction %6 %8 %10 %11
-%344 = OpTypeFunction %5 %6
-%345 = OpConstant  %4  23.0
-%346 = OpConstant  %4  32.0
-%347 = OpConstantComposite  %6  %345 %346
-%348 = OpConstant  %4  -43.0
-%349 = OpConstant  %4  3.0
-%350 = OpConstantComposite  %6  %348 %349
-%366 = OpTypePointer Input %19
-%365 = OpVariable  %366  Input
-%369 = OpTypeFunction %2
-%370 = OpTypePointer Uniform %13
-%372 = OpConstant  %8  6
-%373 = OpConstant  %8  2
-%374 = OpConstant  %8  3
-%375 = OpConstant  %8  4
-%378 = OpTypePointer Uniform %10
-%381 = OpTypePointer Uniform %11
-%385 = OpTypePointer StorageBuffer %15
-%386 = OpTypePointer StorageBuffer %14
-%387 = OpTypePointer Uniform %6
-%394 = OpTypePointer Uniform %8
-%415 = OpTypePointer StorageBuffer %17
-%416 = OpTypePointer StorageBuffer %8
-%437 = OpTypePointer Input %8
-%436 = OpVariable  %437  Input
-%440 = OpTypePointer Output %8
-%439 = OpVariable  %440  Output
-%442 = OpTypePointer Output %7
-%441 = OpVariable  %442  Output
-%444 = OpTypePointer Output %6
-%443 = OpVariable  %444  Output
-%446 = OpTypePointer Uniform %20
-%448 = OpConstant  %4  -1.0
-%449 = OpConstantComposite  %6  %448 %448
-%464 = OpTypePointer Uniform %8
-%485 = OpVariable  %437  Input
-%488 = OpTypePointer Input %7
-%487 = OpVariable  %488  Input
-%491 = OpTypePointer Input %6
-%490 = OpVariable  %491  Input
-%493 = OpVariable  %440  Output
-%494 = OpVariable  %440  Output
-%497 = OpConstant  %4  6.0
-%580 = OpTypePointer Input %5
-%579 = OpVariable  %580  Input
-%582 = OpVariable  %580  Input
-%584 = OpVariable  %442  Output
-%586 = OpTypePointer Output %5
-%585 = OpVariable  %586  Output
-%587 = OpVariable  %586  Output
-%589 = OpTypePointer Uniform %24
-%592 = OpTypePointer Uniform %23
-%606 = OpVariable  %488  Input
-%608 = OpVariable  %580  Input
-%610 = OpVariable  %580  Input
-%612 = OpVariable  %442  Output
-%615 = OpTypePointer Uniform %25
-%617 = OpConstantComposite  %5  %287 %287 %287
-%618 = OpConstant  %4  0.7
-%619 = OpConstantComposite  %5  %78 %287 %618
-%620 = OpConstant  %4  0.2
-%621 = OpConstantComposite  %5  %620 %620 %620
-%623 = OpConstantNull  %5
-%638 = OpTypePointer Uniform %5
-%647 = OpTypePointer Uniform %7
+%217 = OpTypePointer Function %8
+%232 = OpTypePointer Function %10
+%233 = OpConstantComposite  %10  %135 %135
+%234 = OpConstant  %8  4294967295
+%235 = OpConstantComposite  %10  %234 %234
+%272 = OpTypeFunction %5 %6 %6
+%285 = OpTypeFunction %14 %6 %6
+%286 = OpConstant  %4  0.1
+%287 = OpConstantComposite  %6  %286 %74
+%288 = OpConstantComposite  %6  %74 %286
+%289 = OpConstant  %4  -0.1
+%290 = OpConstantComposite  %6  %289 %74
+%291 = OpConstantComposite  %6  %74 %289
+%314 = OpTypeFunction %8 %8 %8
+%326 = OpTypeFunction %6 %8 %10 %11
+%343 = OpTypeFunction %5 %6
+%344 = OpConstant  %4  23.0
+%345 = OpConstant  %4  32.0
+%346 = OpConstantComposite  %6  %344 %345
+%347 = OpConstant  %4  -43.0
+%348 = OpConstant  %4  3.0
+%349 = OpConstantComposite  %6  %347 %348
+%365 = OpTypePointer Input %19
+%364 = OpVariable  %365  Input
+%368 = OpTypeFunction %2
+%369 = OpTypePointer Uniform %13
+%371 = OpConstant  %8  6
+%372 = OpConstant  %8  2
+%373 = OpConstant  %8  3
+%374 = OpConstant  %8  4
+%377 = OpTypePointer Uniform %10
+%380 = OpTypePointer Uniform %11
+%384 = OpTypePointer StorageBuffer %15
+%385 = OpTypePointer StorageBuffer %14
+%386 = OpTypePointer Uniform %6
+%393 = OpTypePointer Uniform %8
+%414 = OpTypePointer StorageBuffer %17
+%415 = OpTypePointer StorageBuffer %8
+%436 = OpTypePointer Input %8
+%435 = OpVariable  %436  Input
+%439 = OpTypePointer Output %8
+%438 = OpVariable  %439  Output
+%441 = OpTypePointer Output %7
+%440 = OpVariable  %441  Output
+%443 = OpTypePointer Output %6
+%442 = OpVariable  %443  Output
+%445 = OpTypePointer Uniform %20
+%447 = OpConstant  %4  -1.0
+%448 = OpConstantComposite  %6  %447 %447
+%483 = OpVariable  %436  Input
+%486 = OpTypePointer Input %7
+%485 = OpVariable  %486  Input
+%489 = OpTypePointer Input %6
+%488 = OpVariable  %489  Input
+%491 = OpVariable  %439  Output
+%492 = OpVariable  %439  Output
+%495 = OpConstant  %4  6.0
+%578 = OpTypePointer Input %5
+%577 = OpVariable  %578  Input
+%580 = OpVariable  %578  Input
+%582 = OpVariable  %441  Output
+%584 = OpTypePointer Output %5
+%583 = OpVariable  %584  Output
+%585 = OpVariable  %584  Output
+%587 = OpTypePointer Uniform %24
+%590 = OpTypePointer Uniform %23
+%604 = OpVariable  %486  Input
+%606 = OpVariable  %578  Input
+%608 = OpVariable  %578  Input
+%610 = OpVariable  %441  Output
+%613 = OpTypePointer Uniform %25
+%615 = OpConstantComposite  %5  %286 %286 %286
+%616 = OpConstant  %4  0.7
+%617 = OpConstantComposite  %5  %78 %286 %616
+%618 = OpConstant  %4  0.2
+%619 = OpConstantComposite  %5  %618 %618 %618
+%621 = OpConstantNull  %5
+%636 = OpTypePointer Uniform %5
+%645 = OpTypePointer Uniform %7
 %53 = OpFunction  %5  None %54
 %52 = OpFunctionParameter  %5
 %51 = OpLabel
@@ -850,656 +848,656 @@ OpFunctionEnd
 %204 = OpFunction  %4  None %68
 %203 = OpFunctionParameter  %6
 %202 = OpLabel
-%214 = OpVariable  %215  Function %74
-%217 = OpVariable  %218  Function %135
+%214 = OpVariable  %125  Function %74
+%216 = OpVariable  %217  Function %135
 %212 = OpVariable  %87  Function %213
-%216 = OpVariable  %215  Function %78
-%237 = OpVariable  %233  Function %234
-OpBranch %219
-%219 = OpLabel
+%215 = OpVariable  %125  Function %78
+%236 = OpVariable  %232  Function %233
+OpBranch %218
+%218 = OpLabel
 OpLine %3 36 13
-%220 = OpVectorTimesScalar  %6  %203 %206
+%219 = OpVectorTimesScalar  %6  %203 %206
 OpLine %3 36 5
-OpStore %212 %220
+OpStore %212 %219
 OpLine %3 39 17
 OpLine %3 40 14
 OpLine %3 41 15
-%221 = OpCompositeExtract  %4  %211 0
+%220 = OpCompositeExtract  %4  %211 0
+%221 = OpCompositeExtract  %4  %211 1
 %222 = OpCompositeExtract  %4  %211 1
-%223 = OpCompositeExtract  %4  %211 1
-%224 = OpFNegate  %4  %223
-%225 = OpCompositeExtract  %4  %211 0
-%226 = OpCompositeConstruct  %6  %221 %222
-%227 = OpCompositeConstruct  %6  %224 %225
-%228 = OpCompositeConstruct  %9  %226 %227
-OpBranch %229
-%229 = OpLabel
+%223 = OpFNegate  %4  %222
+%224 = OpCompositeExtract  %4  %211 0
+%225 = OpCompositeConstruct  %6  %220 %221
+%226 = OpCompositeConstruct  %6  %223 %224
+%227 = OpCompositeConstruct  %9  %225 %226
+OpBranch %228
+%228 = OpLabel
 OpLine %3 43 5
-OpLoopMerge %230 %232 None
-OpBranch %238
-%238 = OpLabel
-%239 = OpLoad  %10  %237
-%240 = OpIEqual  %115  %236 %239
-%241 = OpAll  %112  %240
-OpSelectionMerge %242 None
-OpBranchConditional %241 %230 %242
-%242 = OpLabel
-%243 = OpCompositeExtract  %8  %239 1
-%244 = OpIEqual  %112  %243 %235
-%245 = OpSelect  %8  %244 %126 %135
-%246 = OpCompositeConstruct  %10  %245 %126
-%247 = OpIAdd  %10  %239 %246
-OpStore %237 %247
-OpBranch %231
-%231 = OpLabel
-OpLine %3 43 22
-%248 = OpLoad  %8  %217
-%249 = OpULessThan  %112  %248 %205
-OpLine %3 43 21
-OpSelectionMerge %250 None
-OpBranchConditional %249 %250 %251
-%251 = OpLabel
+OpLoopMerge %229 %231 None
+OpBranch %237
+%237 = OpLabel
+%238 = OpLoad  %10  %236
+%239 = OpIEqual  %115  %235 %238
+%240 = OpAll  %112  %239
+OpSelectionMerge %241 None
+OpBranchConditional %240 %229 %241
+%241 = OpLabel
+%242 = OpCompositeExtract  %8  %238 1
+%243 = OpIEqual  %112  %242 %234
+%244 = OpSelect  %8  %243 %126 %135
+%245 = OpCompositeConstruct  %10  %244 %126
+%246 = OpIAdd  %10  %238 %245
+OpStore %236 %246
 OpBranch %230
+%230 = OpLabel
+OpLine %3 43 22
+%247 = OpLoad  %8  %216
+%248 = OpULessThan  %112  %247 %205
+OpLine %3 43 21
+OpSelectionMerge %249 None
+OpBranchConditional %248 %249 %250
 %250 = OpLabel
+OpBranch %229
+%249 = OpLabel
+OpBranch %251
+%251 = OpLabel
+OpLine %3 1 1
+%253 = OpLoad  %4  %214
+%254 = OpLoad  %4  %215
+%255 = OpLoad  %6  %212
+OpLine %3 44 21
+%256 = OpFunctionCall  %4  %67 %255
+OpLine %3 44 13
+%257 = OpFMul  %4  %254 %256
+%258 = OpFAdd  %4  %253 %257
+OpLine %3 44 9
+OpStore %214 %258
+OpLine %3 45 13
+%259 = OpLoad  %6  %212
+%260 = OpMatrixTimesVector  %6  %227 %259
+OpLine %3 45 13
+%261 = OpVectorTimesScalar  %6  %260 %81
+%262 = OpFAdd  %6  %261 %208
+OpLine %3 45 9
+OpStore %212 %262
+OpLine %3 1 1
+%263 = OpLoad  %4  %215
+OpLine %3 46 13
+%264 = OpFMul  %4  %263 %78
+OpLine %3 46 9
+OpStore %215 %264
 OpBranch %252
 %252 = OpLabel
+OpBranch %231
+%231 = OpLabel
 OpLine %3 1 1
-%254 = OpLoad  %4  %214
-%255 = OpLoad  %4  %216
-%256 = OpLoad  %6  %212
-OpLine %3 44 21
-%257 = OpFunctionCall  %4  %67 %256
-OpLine %3 44 13
-%258 = OpFMul  %4  %255 %257
-%259 = OpFAdd  %4  %254 %258
-OpLine %3 44 9
-OpStore %214 %259
-OpLine %3 45 13
-%260 = OpLoad  %6  %212
-%261 = OpMatrixTimesVector  %6  %228 %260
-OpLine %3 45 13
-%262 = OpVectorTimesScalar  %6  %261 %81
-%263 = OpFAdd  %6  %262 %208
-OpLine %3 45 9
-OpStore %212 %263
-OpLine %3 1 1
-%264 = OpLoad  %4  %216
-OpLine %3 46 13
-%265 = OpFMul  %4  %264 %78
-OpLine %3 46 9
-OpStore %216 %265
-OpBranch %253
-%253 = OpLabel
-OpBranch %232
-%232 = OpLabel
-OpLine %3 1 1
-%266 = OpLoad  %8  %217
+%265 = OpLoad  %8  %216
 OpLine %3 43 43
-%267 = OpIAdd  %8  %266 %126
+%266 = OpIAdd  %8  %265 %126
 OpLine %3 43 39
-OpStore %217 %267
-OpBranch %229
-%230 = OpLabel
+OpStore %216 %266
+OpBranch %228
+%229 = OpLabel
 OpLine %3 1 1
-%268 = OpLoad  %4  %214
-OpReturnValue %268
+%267 = OpLoad  %4  %214
+OpReturnValue %267
 OpFunctionEnd
-%272 = OpFunction  %5  None %273
+%271 = OpFunction  %5  None %272
+%269 = OpFunctionParameter  %6
 %270 = OpFunctionParameter  %6
-%271 = OpFunctionParameter  %6
-%269 = OpLabel
-OpBranch %274
-%274 = OpLabel
+%268 = OpLabel
+OpBranch %273
+%273 = OpLabel
 OpLine %3 77 9
+%274 = OpCompositeExtract  %4  %269 0
 %275 = OpCompositeExtract  %4  %270 0
-%276 = OpCompositeExtract  %4  %271 0
-%277 = OpCompositeExtract  %4  %271 1
+%276 = OpCompositeExtract  %4  %270 1
 OpLine %3 78 49
-%278 = OpFunctionCall  %4  %204 %270
+%277 = OpFunctionCall  %4  %204 %269
 OpLine %3 76 12
-%279 = OpExtInst  %4  %1 FMix %276 %277 %278
-%280 = OpCompositeExtract  %4  %270 1
-%281 = OpCompositeConstruct  %5  %275 %279 %280
-OpReturnValue %281
+%278 = OpExtInst  %4  %1 FMix %275 %276 %277
+%279 = OpCompositeExtract  %4  %269 1
+%280 = OpCompositeConstruct  %5  %274 %278 %279
+OpReturnValue %280
 OpFunctionEnd
-%285 = OpFunction  %14  None %286
+%284 = OpFunction  %14  None %285
+%282 = OpFunctionParameter  %6
 %283 = OpFunctionParameter  %6
-%284 = OpFunctionParameter  %6
-%282 = OpLabel
-OpBranch %293
-%293 = OpLabel
+%281 = OpLabel
+OpBranch %292
+%292 = OpLabel
 OpLine %3 84 13
-%294 = OpFunctionCall  %5  %272 %283 %284
+%293 = OpFunctionCall  %5  %271 %282 %283
 OpLine %3 86 29
-%295 = OpFAdd  %6  %283 %288
+%294 = OpFAdd  %6  %282 %287
 OpLine %3 86 15
-%296 = OpFunctionCall  %5  %272 %295 %284
+%295 = OpFunctionCall  %5  %271 %294 %283
 OpLine %3 86 15
-%297 = OpFSub  %5  %296 %294
+%296 = OpFSub  %5  %295 %293
 OpLine %3 87 29
-%298 = OpFAdd  %6  %283 %289
+%297 = OpFAdd  %6  %282 %288
 OpLine %3 87 15
-%299 = OpFunctionCall  %5  %272 %298 %284
+%298 = OpFunctionCall  %5  %271 %297 %283
 OpLine %3 87 15
-%300 = OpFSub  %5  %299 %294
+%299 = OpFSub  %5  %298 %293
 OpLine %3 88 29
-%301 = OpFAdd  %6  %283 %291
+%300 = OpFAdd  %6  %282 %290
 OpLine %3 88 15
-%302 = OpFunctionCall  %5  %272 %301 %284
+%301 = OpFunctionCall  %5  %271 %300 %283
 OpLine %3 88 15
-%303 = OpFSub  %5  %302 %294
+%302 = OpFSub  %5  %301 %293
 OpLine %3 89 29
-%304 = OpFAdd  %6  %283 %292
+%303 = OpFAdd  %6  %282 %291
 OpLine %3 89 15
-%305 = OpFunctionCall  %5  %272 %304 %284
+%304 = OpFunctionCall  %5  %271 %303 %283
 OpLine %3 89 15
-%306 = OpFSub  %5  %305 %294
+%305 = OpFSub  %5  %304 %293
 OpLine %3 91 14
-%307 = OpExtInst  %5  %1 Cross %300 %297
-%308 = OpExtInst  %5  %1 Normalize %307
+%306 = OpExtInst  %5  %1 Cross %299 %296
+%307 = OpExtInst  %5  %1 Normalize %306
 OpLine %3 92 14
-%309 = OpExtInst  %5  %1 Cross %306 %303
-%310 = OpExtInst  %5  %1 Normalize %309
+%308 = OpExtInst  %5  %1 Cross %305 %302
+%309 = OpExtInst  %5  %1 Normalize %308
 OpLine %3 94 14
-%311 = OpFAdd  %5  %308 %310
+%310 = OpFAdd  %5  %307 %309
 OpLine %3 94 13
-%312 = OpVectorTimesScalar  %5  %311 %78
+%311 = OpVectorTimesScalar  %5  %310 %78
 OpLine %3 96 12
-%313 = OpCompositeConstruct  %14  %294 %312
-OpReturnValue %313
+%312 = OpCompositeConstruct  %14  %293 %311
+OpReturnValue %312
 OpFunctionEnd
-%314 = OpFunction  %8  None %315
+%313 = OpFunction  %8  None %314
+%315 = OpFunctionParameter  %8
 %316 = OpFunctionParameter  %8
-%317 = OpFunctionParameter  %8
-%318 = OpLabel
-%319 = OpIEqual  %112  %317 %135
-%320 = OpSelect  %8  %319 %126 %317
-%321 = OpUDiv  %8  %316 %320
-OpReturnValue %321
+%317 = OpLabel
+%318 = OpIEqual  %112  %316 %135
+%319 = OpSelect  %8  %318 %126 %316
+%320 = OpUDiv  %8  %315 %319
+OpReturnValue %320
 OpFunctionEnd
-%326 = OpFunction  %6  None %327
-%323 = OpFunctionParameter  %8
-%324 = OpFunctionParameter  %10
-%325 = OpFunctionParameter  %11
-%322 = OpLabel
-OpBranch %328
-%328 = OpLabel
+%325 = OpFunction  %6  None %326
+%322 = OpFunctionParameter  %8
+%323 = OpFunctionParameter  %10
+%324 = OpFunctionParameter  %11
+%321 = OpLabel
+OpBranch %327
+%327 = OpLabel
 OpLine %3 101 9
-%329 = OpConvertUToF  %4  %323
-%330 = OpCompositeExtract  %8  %324 0
+%328 = OpConvertUToF  %4  %322
+%329 = OpCompositeExtract  %8  %323 0
 OpLine %3 101 9
-%331 = OpIAdd  %8  %330 %126
-%332 = OpConvertUToF  %4  %331
-%333 = OpFRem  %4  %329 %332
-%334 = OpCompositeExtract  %8  %324 0
+%330 = OpIAdd  %8  %329 %126
+%331 = OpConvertUToF  %4  %330
+%332 = OpFRem  %4  %328 %331
+%333 = OpCompositeExtract  %8  %323 0
 OpLine %3 100 12
-%335 = OpIAdd  %8  %334 %126
-%336 = OpFunctionCall  %8  %314 %323 %335
-%337 = OpConvertUToF  %4  %336
-%338 = OpCompositeConstruct  %6  %333 %337
-%339 = OpConvertSToF  %6  %325
-%340 = OpFAdd  %6  %338 %339
-OpReturnValue %340
+%334 = OpIAdd  %8  %333 %126
+%335 = OpFunctionCall  %8  %313 %322 %334
+%336 = OpConvertUToF  %4  %335
+%337 = OpCompositeConstruct  %6  %332 %336
+%338 = OpConvertSToF  %6  %324
+%339 = OpFAdd  %6  %337 %338
+OpReturnValue %339
 OpFunctionEnd
-%343 = OpFunction  %5  None %344
-%342 = OpFunctionParameter  %6
-%341 = OpLabel
-OpBranch %351
-%351 = OpLabel
+%342 = OpFunction  %5  None %343
+%341 = OpFunctionParameter  %6
+%340 = OpLabel
+OpBranch %350
+%350 = OpLabel
 OpLine %3 270 9
-%352 = OpFunctionCall  %4  %67 %342
+%351 = OpFunctionCall  %4  %67 %341
 OpLine %3 270 9
-%353 = OpFMul  %4  %352 %78
+%352 = OpFMul  %4  %351 %78
 OpLine %3 270 9
-%354 = OpFAdd  %4  %353 %78
+%353 = OpFAdd  %4  %352 %78
 OpLine %3 271 17
-%355 = OpFAdd  %6  %342 %347
+%354 = OpFAdd  %6  %341 %346
 OpLine %3 271 9
-%356 = OpFunctionCall  %4  %67 %355
+%355 = OpFunctionCall  %4  %67 %354
 OpLine %3 271 9
-%357 = OpFMul  %4  %356 %78
+%356 = OpFMul  %4  %355 %78
 OpLine %3 271 9
-%358 = OpFAdd  %4  %357 %78
+%357 = OpFAdd  %4  %356 %78
 OpLine %3 272 17
-%359 = OpFAdd  %6  %342 %350
+%358 = OpFAdd  %6  %341 %349
 OpLine %3 272 9
-%360 = OpFunctionCall  %4  %67 %359
+%359 = OpFunctionCall  %4  %67 %358
 OpLine %3 272 9
-%361 = OpFMul  %4  %360 %78
+%360 = OpFMul  %4  %359 %78
 OpLine %3 269 12
-%362 = OpFAdd  %4  %361 %78
-%363 = OpCompositeConstruct  %5  %354 %358 %362
-OpReturnValue %363
+%361 = OpFAdd  %4  %360 %78
+%362 = OpCompositeConstruct  %5  %353 %357 %361
+OpReturnValue %362
 OpFunctionEnd
-%368 = OpFunction  %2  None %369
-%364 = OpLabel
-%367 = OpLoad  %19  %365
-%371 = OpAccessChain  %370  %29 %135
-OpBranch %376
-%376 = OpLabel
+%367 = OpFunction  %2  None %368
+%363 = OpLabel
+%366 = OpLoad  %19  %364
+%370 = OpAccessChain  %369  %29 %135
+OpBranch %375
+%375 = OpLabel
 OpLine %3 111 22
-%377 = OpCompositeExtract  %8  %367 0
+%376 = OpCompositeExtract  %8  %366 0
 OpLine %3 113 36
-%379 = OpAccessChain  %378  %371 %135
-%380 = OpLoad  %10  %379
+%378 = OpAccessChain  %377  %370 %135
+%379 = OpLoad  %10  %378
 OpLine %3 113 59
-%382 = OpAccessChain  %381  %371 %126
-%383 = OpLoad  %11  %382
+%381 = OpAccessChain  %380  %370 %126
+%382 = OpLoad  %11  %381
 OpLine %3 113 13
-%384 = OpFunctionCall  %6  %326 %377 %380 %383
+%383 = OpFunctionCall  %6  %325 %376 %379 %382
 OpLine %3 115 5
 OpLine %3 115 51
-%388 = OpAccessChain  %387  %371 %373
-%389 = OpLoad  %6  %388
+%387 = OpAccessChain  %386  %370 %372
+%388 = OpLoad  %6  %387
 OpLine %3 115 33
-%390 = OpFunctionCall  %14  %285 %384 %389
+%389 = OpFunctionCall  %14  %284 %383 %388
 OpLine %3 115 5
-%391 = OpAccessChain  %386  %32 %135 %377
-OpStore %391 %390
+%390 = OpAccessChain  %385  %32 %135 %376
+OpStore %390 %389
 OpLine %3 118 23
-%392 = OpCompositeExtract  %8  %367 0
+%391 = OpCompositeExtract  %8  %366 0
 OpLine %3 118 23
-%393 = OpIMul  %8  %392 %372
+%392 = OpIMul  %8  %391 %371
 OpLine %3 120 25
-%395 = OpAccessChain  %394  %371 %135 %135
-%396 = OpLoad  %8  %395
+%394 = OpAccessChain  %393  %370 %135 %135
+%395 = OpLoad  %8  %394
 OpLine %3 120 25
-%397 = OpAccessChain  %394  %371 %135 %126
-%398 = OpLoad  %8  %397
-%399 = OpIMul  %8  %396 %398
+%396 = OpAccessChain  %393  %370 %135 %126
+%397 = OpLoad  %8  %396
+%398 = OpIMul  %8  %395 %397
 OpLine %3 120 9
-%400 = OpIMul  %8  %399 %372
-%401 = OpUGreaterThanEqual  %112  %393 %400
+%399 = OpIMul  %8  %398 %371
+%400 = OpUGreaterThanEqual  %112  %392 %399
 OpLine %3 120 5
-OpSelectionMerge %402 None
-OpBranchConditional %401 %403 %402
-%403 = OpLabel
-OpReturn
+OpSelectionMerge %401 None
+OpBranchConditional %400 %402 %401
 %402 = OpLabel
+OpReturn
+%401 = OpLabel
 OpLine %3 122 28
-%404 = OpCompositeExtract  %8  %367 0
+%403 = OpCompositeExtract  %8  %366 0
 OpLine %3 122 15
-%405 = OpAccessChain  %394  %371 %135 %135
-%406 = OpLoad  %8  %405
-%407 = OpFunctionCall  %8  %314 %404 %406
-%408 = OpIAdd  %8  %377 %407
+%404 = OpAccessChain  %393  %370 %135 %135
+%405 = OpLoad  %8  %404
+%406 = OpFunctionCall  %8  %313 %403 %405
+%407 = OpIAdd  %8  %376 %406
 OpLine %3 123 15
-%409 = OpIAdd  %8  %408 %126
+%408 = OpIAdd  %8  %407 %126
 OpLine %3 124 15
-%410 = OpAccessChain  %394  %371 %135 %135
-%411 = OpLoad  %8  %410
-%412 = OpIAdd  %8  %408 %411
+%409 = OpAccessChain  %393  %370 %135 %135
+%410 = OpLoad  %8  %409
+%411 = OpIAdd  %8  %407 %410
 OpLine %3 124 15
-%413 = OpIAdd  %8  %412 %126
+%412 = OpIAdd  %8  %411 %126
 OpLine %3 125 15
-%414 = OpIAdd  %8  %413 %126
+%413 = OpIAdd  %8  %412 %126
 OpLine %3 127 5
 OpLine %3 127 5
-%417 = OpAccessChain  %416  %34 %135 %393
-OpStore %417 %408
+%416 = OpAccessChain  %415  %34 %135 %392
+OpStore %416 %407
 OpLine %3 128 5
 OpLine %3 128 5
-%418 = OpIAdd  %8  %393 %126
+%417 = OpIAdd  %8  %392 %126
 OpLine %3 128 5
-%419 = OpAccessChain  %416  %34 %135 %418
-OpStore %419 %413
+%418 = OpAccessChain  %415  %34 %135 %417
+OpStore %418 %412
 OpLine %3 129 5
 OpLine %3 129 5
-%420 = OpIAdd  %8  %393 %373
+%419 = OpIAdd  %8  %392 %372
 OpLine %3 129 5
-%421 = OpAccessChain  %416  %34 %135 %420
-OpStore %421 %414
+%420 = OpAccessChain  %415  %34 %135 %419
+OpStore %420 %413
 OpLine %3 130 5
 OpLine %3 130 5
-%422 = OpIAdd  %8  %393 %374
+%421 = OpIAdd  %8  %392 %373
 OpLine %3 130 5
-%423 = OpAccessChain  %416  %34 %135 %422
-OpStore %423 %408
+%422 = OpAccessChain  %415  %34 %135 %421
+OpStore %422 %407
 OpLine %3 131 5
 OpLine %3 131 5
-%424 = OpIAdd  %8  %393 %375
+%423 = OpIAdd  %8  %392 %374
 OpLine %3 131 5
-%425 = OpAccessChain  %416  %34 %135 %424
-OpStore %425 %414
+%424 = OpAccessChain  %415  %34 %135 %423
+OpStore %424 %413
 OpLine %3 132 5
 OpLine %3 132 5
-%426 = OpIAdd  %8  %393 %205
+%425 = OpIAdd  %8  %392 %205
 OpLine %3 132 5
-%427 = OpAccessChain  %416  %34 %135 %426
-OpStore %427 %409
+%426 = OpAccessChain  %415  %34 %135 %425
+OpStore %426 %408
 OpReturn
 OpFunctionEnd
-%428 = OpFunction  %8  None %315
+%427 = OpFunction  %8  None %314
+%428 = OpFunctionParameter  %8
 %429 = OpFunctionParameter  %8
-%430 = OpFunctionParameter  %8
-%431 = OpLabel
-%432 = OpIEqual  %112  %430 %135
-%433 = OpSelect  %8  %432 %126 %430
-%434 = OpUMod  %8  %429 %433
-OpReturnValue %434
+%430 = OpLabel
+%431 = OpIEqual  %112  %429 %135
+%432 = OpSelect  %8  %431 %126 %429
+%433 = OpUMod  %8  %428 %432
+OpReturnValue %433
 OpFunctionEnd
-%445 = OpFunction  %2  None %369
-%435 = OpLabel
-%438 = OpLoad  %8  %436
-%447 = OpAccessChain  %446  %36 %135
-OpBranch %450
-%450 = OpLabel
+%444 = OpFunction  %2  None %368
+%434 = OpLabel
+%437 = OpLoad  %8  %435
+%446 = OpAccessChain  %445  %36 %135
+OpBranch %449
+%449 = OpLabel
 OpLine %3 161 19
-%451 = OpIAdd  %8  %438 %373
+%450 = OpIAdd  %8  %437 %372
 OpLine %3 161 18
-%452 = OpFunctionCall  %8  %314 %451 %374
+%451 = OpFunctionCall  %8  %313 %450 %373
 OpLine %3 161 13
-%453 = OpFunctionCall  %8  %428 %452 %373
-%454 = OpConvertUToF  %4  %453
+%452 = OpFunctionCall  %8  %427 %451 %372
+%453 = OpConvertUToF  %4  %452
 OpLine %3 162 19
-%455 = OpIAdd  %8  %438 %126
+%454 = OpIAdd  %8  %437 %126
 OpLine %3 162 18
-%456 = OpFunctionCall  %8  %314 %455 %374
+%455 = OpFunctionCall  %8  %313 %454 %373
 OpLine %3 162 13
-%457 = OpFunctionCall  %8  %428 %456 %373
-%458 = OpConvertUToF  %4  %457
+%456 = OpFunctionCall  %8  %427 %455 %372
+%457 = OpConvertUToF  %4  %456
 OpLine %3 163 14
-%459 = OpCompositeConstruct  %6  %454 %458
+%458 = OpCompositeConstruct  %6  %453 %457
 OpLine %3 165 30
-%460 = OpVectorTimesScalar  %6  %459 %81
+%459 = OpVectorTimesScalar  %6  %458 %81
 OpLine %3 165 30
-%461 = OpFAdd  %6  %449 %460
+%460 = OpFAdd  %6  %448 %459
 OpLine %3 165 20
-%462 = OpCompositeConstruct  %7  %461 %74 %56
+%461 = OpCompositeConstruct  %7  %460 %74 %56
 OpLine %3 168 21
-%463 = OpCompositeExtract  %4  %459 0
+%462 = OpCompositeExtract  %4  %458 0
 OpLine %3 168 21
-%465 = OpAccessChain  %464  %447 %374
-%466 = OpLoad  %8  %465
-%467 = OpConvertUToF  %4  %466
-%468 = OpFMul  %4  %463 %467
-%469 = OpCompositeExtract  %4  %459 1
+%463 = OpAccessChain  %393  %446 %373
+%464 = OpLoad  %8  %463
+%465 = OpConvertUToF  %4  %464
+%466 = OpFMul  %4  %462 %465
+%467 = OpCompositeExtract  %4  %458 1
 OpLine %3 168 17
-%470 = OpAccessChain  %464  %447 %374
-%471 = OpLoad  %8  %470
-%472 = OpConvertUToF  %4  %471
-%473 = OpFMul  %4  %469 %472
-%474 = OpFAdd  %4  %468 %473
-%475 = OpConvertFToU  %8  %474
+%468 = OpAccessChain  %393  %446 %373
+%469 = OpLoad  %8  %468
+%470 = OpConvertUToF  %4  %469
+%471 = OpFMul  %4  %467 %470
+%472 = OpFAdd  %4  %466 %471
+%473 = OpConvertFToU  %8  %472
 OpLine %3 168 17
-%476 = OpAccessChain  %464  %447 %375
-%477 = OpLoad  %8  %476
-%478 = OpIAdd  %8  %475 %477
+%474 = OpAccessChain  %393  %446 %374
+%475 = OpLoad  %8  %474
+%476 = OpIAdd  %8  %473 %475
 OpLine %3 170 12
-%479 = OpCompositeConstruct  %21  %478 %462 %459
-%480 = OpCompositeExtract  %8  %479 0
-OpStore %439 %480
-%481 = OpCompositeExtract  %7  %479 1
-OpStore %441 %481
-%482 = OpCompositeExtract  %6  %479 2
-OpStore %443 %482
+%477 = OpCompositeConstruct  %21  %476 %461 %458
+%478 = OpCompositeExtract  %8  %477 0
+OpStore %438 %478
+%479 = OpCompositeExtract  %7  %477 1
+OpStore %440 %479
+%480 = OpCompositeExtract  %6  %477 2
+OpStore %442 %480
 OpReturn
 OpFunctionEnd
-%495 = OpFunction  %2  None %369
-%483 = OpLabel
-%498 = OpVariable  %215  Function %74
-%499 = OpVariable  %218  Function %135
-%486 = OpLoad  %8  %485
-%489 = OpLoad  %7  %487
-%492 = OpLoad  %6  %490
-%484 = OpCompositeConstruct  %21  %486 %489 %492
-%496 = OpAccessChain  %446  %36 %135
-OpBranch %500
-%500 = OpLabel
+%493 = OpFunction  %2  None %368
+%481 = OpLabel
+%496 = OpVariable  %125  Function %74
+%497 = OpVariable  %217  Function %135
+%484 = OpLoad  %8  %483
+%487 = OpLoad  %7  %485
+%490 = OpLoad  %6  %488
+%482 = OpCompositeConstruct  %21  %484 %487 %490
+%494 = OpAccessChain  %445  %36 %135
+OpBranch %498
+%498 = OpLabel
 OpLine %3 181 17
-%501 = OpCompositeExtract  %6  %484 2
-%502 = OpCompositeExtract  %4  %501 0
+%499 = OpCompositeExtract  %6  %482 2
+%500 = OpCompositeExtract  %4  %499 0
 OpLine %3 181 17
-%503 = OpAccessChain  %464  %496 %374
-%504 = OpLoad  %8  %503
-%505 = OpConvertUToF  %4  %504
-%506 = OpFMul  %4  %502 %505
-%507 = OpCompositeExtract  %6  %484 2
-%508 = OpCompositeExtract  %4  %507 1
+%501 = OpAccessChain  %393  %494 %373
+%502 = OpLoad  %8  %501
+%503 = OpConvertUToF  %4  %502
+%504 = OpFMul  %4  %500 %503
+%505 = OpCompositeExtract  %6  %482 2
+%506 = OpCompositeExtract  %4  %505 1
 OpLine %3 181 70
-%509 = OpAccessChain  %464  %496 %374
+%507 = OpAccessChain  %393  %494 %373
+%508 = OpLoad  %8  %507
+OpLine %3 181 13
+%509 = OpAccessChain  %393  %494 %373
 %510 = OpLoad  %8  %509
+%511 = OpIMul  %8  %508 %510
+%512 = OpConvertUToF  %4  %511
+%513 = OpFMul  %4  %506 %512
+%514 = OpFAdd  %4  %504 %513
+%515 = OpConvertFToU  %8  %514
 OpLine %3 181 13
-%511 = OpAccessChain  %464  %496 %374
-%512 = OpLoad  %8  %511
-%513 = OpIMul  %8  %510 %512
-%514 = OpConvertUToF  %4  %513
-%515 = OpFMul  %4  %508 %514
-%516 = OpFAdd  %4  %506 %515
-%517 = OpConvertFToU  %8  %516
-OpLine %3 181 13
-%518 = OpAccessChain  %464  %496 %375
-%519 = OpLoad  %8  %518
-%520 = OpIAdd  %8  %517 %519
+%516 = OpAccessChain  %393  %494 %374
+%517 = OpLoad  %8  %516
+%518 = OpIAdd  %8  %515 %517
 OpLine %3 182 32
-%521 = OpConvertUToF  %4  %520
+%519 = OpConvertUToF  %4  %518
 OpLine %3 182 22
-%522 = OpFDiv  %4  %521 %497
-%523 = OpExtInst  %4  %1 Floor %522
-%524 = OpConvertFToU  %8  %523
+%520 = OpFDiv  %4  %519 %495
+%521 = OpExtInst  %4  %1 Floor %520
+%522 = OpConvertFToU  %8  %521
 OpLine %3 183 22
-%525 = OpFunctionCall  %8  %428 %520 %372
+%523 = OpFunctionCall  %8  %427 %518 %371
 OpLine %3 185 36
-%526 = OpAccessChain  %378  %496 %135
-%527 = OpLoad  %10  %526
+%524 = OpAccessChain  %377  %494 %135
+%525 = OpLoad  %10  %524
 OpLine %3 185 57
-%528 = OpAccessChain  %381  %496 %126
-%529 = OpLoad  %11  %528
+%526 = OpAccessChain  %380  %494 %126
+%527 = OpLoad  %11  %526
 OpLine %3 185 13
-%530 = OpFunctionCall  %6  %326 %524 %527 %529
+%528 = OpFunctionCall  %6  %325 %522 %525 %527
 OpLine %3 186 31
-%531 = OpAccessChain  %387  %496 %373
-%532 = OpLoad  %6  %531
+%529 = OpAccessChain  %386  %494 %372
+%530 = OpLoad  %6  %529
 OpLine %3 186 13
-%533 = OpFunctionCall  %14  %285 %530 %532
+%531 = OpFunctionCall  %14  %284 %528 %530
 OpLine %3 190 5
-OpSelectionMerge %534 None
-OpSwitch %525 %541 0 %535 1 %536 2 %537 3 %538 4 %539 5 %540
-%535 = OpLabel
+OpSelectionMerge %532 None
+OpSwitch %523 %539 0 %533 1 %534 2 %535 3 %536 4 %537 5 %538
+%533 = OpLabel
 OpLine %3 191 37
-%542 = OpCompositeExtract  %5  %533 0
-%543 = OpCompositeExtract  %4  %542 0
+%540 = OpCompositeExtract  %5  %531 0
+%541 = OpCompositeExtract  %4  %540 0
 OpLine %3 191 20
-OpStore %498 %543
-OpBranch %534
-%536 = OpLabel
-OpLine %3 192 37
-%544 = OpCompositeExtract  %5  %533 0
-%545 = OpCompositeExtract  %4  %544 1
-OpLine %3 192 20
-OpStore %498 %545
-OpBranch %534
-%537 = OpLabel
-OpLine %3 193 37
-%546 = OpCompositeExtract  %5  %533 0
-%547 = OpCompositeExtract  %4  %546 2
-OpLine %3 193 20
-OpStore %498 %547
-OpBranch %534
-%538 = OpLabel
-OpLine %3 194 37
-%548 = OpCompositeExtract  %5  %533 1
-%549 = OpCompositeExtract  %4  %548 0
-OpLine %3 194 20
-OpStore %498 %549
-OpBranch %534
-%539 = OpLabel
-OpLine %3 195 37
-%550 = OpCompositeExtract  %5  %533 1
-%551 = OpCompositeExtract  %4  %550 1
-OpLine %3 195 20
-OpStore %498 %551
-OpBranch %534
-%540 = OpLabel
-OpLine %3 196 37
-%552 = OpCompositeExtract  %5  %533 1
-%553 = OpCompositeExtract  %4  %552 2
-OpLine %3 196 20
-OpStore %498 %553
-OpBranch %534
-%541 = OpLabel
-OpBranch %534
+OpStore %496 %541
+OpBranch %532
 %534 = OpLabel
+OpLine %3 192 37
+%542 = OpCompositeExtract  %5  %531 0
+%543 = OpCompositeExtract  %4  %542 1
+OpLine %3 192 20
+OpStore %496 %543
+OpBranch %532
+%535 = OpLabel
+OpLine %3 193 37
+%544 = OpCompositeExtract  %5  %531 0
+%545 = OpCompositeExtract  %4  %544 2
+OpLine %3 193 20
+OpStore %496 %545
+OpBranch %532
+%536 = OpLabel
+OpLine %3 194 37
+%546 = OpCompositeExtract  %5  %531 1
+%547 = OpCompositeExtract  %4  %546 0
+OpLine %3 194 20
+OpStore %496 %547
+OpBranch %532
+%537 = OpLabel
+OpLine %3 195 37
+%548 = OpCompositeExtract  %5  %531 1
+%549 = OpCompositeExtract  %4  %548 1
+OpLine %3 195 20
+OpStore %496 %549
+OpBranch %532
+%538 = OpLabel
+OpLine %3 196 37
+%550 = OpCompositeExtract  %5  %531 1
+%551 = OpCompositeExtract  %4  %550 2
+OpLine %3 196 20
+OpStore %496 %551
+OpBranch %532
+%539 = OpLabel
+OpBranch %532
+%532 = OpLabel
 OpLine %3 200 15
-%554 = OpAccessChain  %394  %496 %135 %135
-%555 = OpLoad  %8  %554
-%556 = OpFunctionCall  %8  %314 %524 %555
-%557 = OpIAdd  %8  %524 %556
+%552 = OpAccessChain  %393  %494 %135 %135
+%553 = OpLoad  %8  %552
+%554 = OpFunctionCall  %8  %313 %522 %553
+%555 = OpIAdd  %8  %522 %554
 OpLine %3 201 15
-%558 = OpIAdd  %8  %557 %126
+%556 = OpIAdd  %8  %555 %126
 OpLine %3 202 15
-%559 = OpAccessChain  %394  %496 %135 %135
-%560 = OpLoad  %8  %559
-%561 = OpIAdd  %8  %557 %560
+%557 = OpAccessChain  %393  %494 %135 %135
+%558 = OpLoad  %8  %557
+%559 = OpIAdd  %8  %555 %558
 OpLine %3 202 15
-%562 = OpIAdd  %8  %561 %126
+%560 = OpIAdd  %8  %559 %126
 OpLine %3 203 15
-%563 = OpIAdd  %8  %562 %126
+%561 = OpIAdd  %8  %560 %126
 OpLine %3 206 5
-OpSelectionMerge %564 None
-OpSwitch %525 %569 0 %565 3 %565 2 %566 4 %566 1 %567 5 %568
-%565 = OpLabel
+OpSelectionMerge %562 None
+OpSwitch %523 %567 0 %563 3 %563 2 %564 4 %564 1 %565 5 %566
+%563 = OpLabel
 OpLine %3 207 24
-OpStore %499 %557
-OpBranch %564
-%566 = OpLabel
-OpLine %3 208 24
-OpStore %499 %563
-OpBranch %564
-%567 = OpLabel
-OpLine %3 209 20
-OpStore %499 %562
-OpBranch %564
-%568 = OpLabel
-OpLine %3 210 20
-OpStore %499 %558
-OpBranch %564
-%569 = OpLabel
-OpBranch %564
+OpStore %497 %555
+OpBranch %562
 %564 = OpLabel
+OpLine %3 208 24
+OpStore %497 %561
+OpBranch %562
+%565 = OpLabel
+OpLine %3 209 20
+OpStore %497 %560
+OpBranch %562
+%566 = OpLabel
+OpLine %3 210 20
+OpStore %497 %556
+OpBranch %562
+%567 = OpLabel
+OpBranch %562
+%562 = OpLabel
 OpLine %3 213 13
-%570 = OpCompositeExtract  %8  %484 0
+%568 = OpCompositeExtract  %8  %482 0
 OpLine %3 213 5
-OpStore %499 %570
+OpStore %497 %568
 OpLine %3 222 27
-%571 = OpLoad  %4  %498
-%572 = OpBitcast  %8  %571
+%569 = OpLoad  %4  %496
+%570 = OpBitcast  %8  %569
 OpLine %3 223 12
-%573 = OpLoad  %8  %499
-%574 = OpCompositeConstruct  %22  %572 %573
-%575 = OpCompositeExtract  %8  %574 0
-OpStore %493 %575
-%576 = OpCompositeExtract  %8  %574 1
-OpStore %494 %576
+%571 = OpLoad  %8  %497
+%572 = OpCompositeConstruct  %22  %570 %571
+%573 = OpCompositeExtract  %8  %572 0
+OpStore %491 %573
+%574 = OpCompositeExtract  %8  %572 1
+OpStore %492 %574
 OpReturn
 OpFunctionEnd
-%588 = OpFunction  %2  None %369
-%577 = OpLabel
-%581 = OpLoad  %5  %579
-%583 = OpLoad  %5  %582
-%578 = OpCompositeConstruct  %14  %581 %583
-%590 = OpAccessChain  %589  %39 %135
-OpBranch %591
-%591 = OpLabel
+%586 = OpFunction  %2  None %368
+%575 = OpLabel
+%579 = OpLoad  %5  %577
+%581 = OpLoad  %5  %580
+%576 = OpCompositeConstruct  %14  %579 %581
+%588 = OpAccessChain  %587  %39 %135
+OpBranch %589
+%589 = OpLabel
 OpLine %3 254 25
-%593 = OpAccessChain  %592  %590 %126
-%594 = OpLoad  %23  %593
-%595 = OpCompositeExtract  %5  %578 0
+%591 = OpAccessChain  %590  %588 %126
+%592 = OpLoad  %23  %591
+%593 = OpCompositeExtract  %5  %576 0
 OpLine %3 254 25
-%596 = OpCompositeConstruct  %7  %595 %56
-%597 = OpMatrixTimesVector  %7  %594 %596
+%594 = OpCompositeConstruct  %7  %593 %56
+%595 = OpMatrixTimesVector  %7  %592 %594
 OpLine %3 255 18
-%598 = OpCompositeExtract  %5  %578 1
+%596 = OpCompositeExtract  %5  %576 1
 OpLine %3 256 12
-%599 = OpCompositeExtract  %5  %578 0
-%600 = OpCompositeConstruct  %26  %597 %598 %599
-%601 = OpCompositeExtract  %7  %600 0
-OpStore %584 %601
-%602 = OpCompositeExtract  %5  %600 1
-OpStore %585 %602
-%603 = OpCompositeExtract  %5  %600 2
-OpStore %587 %603
+%597 = OpCompositeExtract  %5  %576 0
+%598 = OpCompositeConstruct  %26  %595 %596 %597
+%599 = OpCompositeExtract  %7  %598 0
+OpStore %582 %599
+%600 = OpCompositeExtract  %5  %598 1
+OpStore %583 %600
+%601 = OpCompositeExtract  %5  %598 2
+OpStore %585 %601
 OpReturn
 OpFunctionEnd
-%613 = OpFunction  %2  None %369
-%604 = OpLabel
-%622 = OpVariable  %95  Function %623
-%607 = OpLoad  %7  %606
+%611 = OpFunction  %2  None %368
+%602 = OpLabel
+%620 = OpVariable  %95  Function %621
+%605 = OpLoad  %7  %604
+%607 = OpLoad  %5  %606
 %609 = OpLoad  %5  %608
-%611 = OpLoad  %5  %610
-%605 = OpCompositeConstruct  %26  %607 %609 %611
-%614 = OpAccessChain  %589  %39 %135
-%616 = OpAccessChain  %615  %42 %135
-OpBranch %624
-%624 = OpLabel
+%603 = OpCompositeConstruct  %26  %605 %607 %609
+%612 = OpAccessChain  %587  %39 %135
+%614 = OpAccessChain  %613  %42 %135
+OpBranch %622
+%622 = OpLabel
 OpLine %3 278 28
 OpLine %3 278 17
-%625 = OpCompositeExtract  %5  %605 2
-%626 = OpExtInst  %5  %1 Fract %625
-%627 = OpExtInst  %5  %1 SmoothStep %80 %617 %626
+%623 = OpCompositeExtract  %5  %603 2
+%624 = OpExtInst  %5  %1 Fract %623
+%625 = OpExtInst  %5  %1 SmoothStep %80 %615 %624
 OpLine %3 278 5
-OpStore %622 %627
+OpStore %620 %625
 OpLine %3 279 17
 OpLine %3 279 13
-%628 = OpAccessChain  %125  %622 %135
+%626 = OpAccessChain  %125  %620 %135
+%627 = OpLoad  %4  %626
+%628 = OpAccessChain  %125  %620 %126
 %629 = OpLoad  %4  %628
-%630 = OpAccessChain  %125  %622 %126
-%631 = OpLoad  %4  %630
-%632 = OpFMul  %4  %629 %631
-%633 = OpAccessChain  %125  %622 %373
-%634 = OpLoad  %4  %633
-%635 = OpFMul  %4  %632 %634
-%636 = OpCompositeConstruct  %5  %635 %635 %635
-%637 = OpExtInst  %5  %1 FMix %619 %621 %636
+%630 = OpFMul  %4  %627 %629
+%631 = OpAccessChain  %125  %620 %372
+%632 = OpLoad  %4  %631
+%633 = OpFMul  %4  %630 %632
+%634 = OpCompositeConstruct  %5  %633 %633 %633
+%635 = OpExtInst  %5  %1 FMix %617 %619 %634
 OpLine %3 279 5
-OpStore %622 %637
+OpStore %620 %635
 OpLine %3 282 25
-%639 = OpAccessChain  %638  %616 %126
-%640 = OpLoad  %5  %639
-%641 = OpVectorTimesScalar  %5  %640 %287
+%637 = OpAccessChain  %636  %614 %126
+%638 = OpLoad  %5  %637
+%639 = OpVectorTimesScalar  %5  %638 %286
 OpLine %3 284 21
-%642 = OpAccessChain  %638  %616 %135
-%643 = OpLoad  %5  %642
-%644 = OpCompositeExtract  %5  %605 2
-%645 = OpFSub  %5  %643 %644
-%646 = OpExtInst  %5  %1 Normalize %645
+%640 = OpAccessChain  %636  %614 %135
+%641 = OpLoad  %5  %640
+%642 = OpCompositeExtract  %5  %603 2
+%643 = OpFSub  %5  %641 %642
+%644 = OpExtInst  %5  %1 Normalize %643
 OpLine %3 285 20
-%648 = OpAccessChain  %647  %614 %135
-%649 = OpLoad  %7  %648
-%650 = OpVectorShuffle  %5  %649 %649 0 1 2
-%651 = OpCompositeExtract  %5  %605 2
-%652 = OpFSub  %5  %650 %651
-%653 = OpExtInst  %5  %1 Normalize %652
+%646 = OpAccessChain  %645  %612 %135
+%647 = OpLoad  %7  %646
+%648 = OpVectorShuffle  %5  %647 %647 0 1 2
+%649 = OpCompositeExtract  %5  %603 2
+%650 = OpFSub  %5  %648 %649
+%651 = OpExtInst  %5  %1 Normalize %650
 OpLine %3 286 20
-%654 = OpFAdd  %5  %653 %646
-%655 = OpExtInst  %5  %1 Normalize %654
+%652 = OpFAdd  %5  %651 %644
+%653 = OpExtInst  %5  %1 Normalize %652
 OpLine %3 288 32
-%656 = OpCompositeExtract  %5  %605 1
-%657 = OpDot  %4  %656 %646
+%654 = OpCompositeExtract  %5  %603 1
+%655 = OpDot  %4  %654 %644
 OpLine %3 288 28
-%658 = OpExtInst  %4  %1 FMax %657 %74
+%656 = OpExtInst  %4  %1 FMax %655 %74
 OpLine %3 289 25
-%659 = OpAccessChain  %638  %616 %126
-%660 = OpLoad  %5  %659
-%661 = OpVectorTimesScalar  %5  %660 %658
+%657 = OpAccessChain  %636  %614 %126
+%658 = OpLoad  %5  %657
+%659 = OpVectorTimesScalar  %5  %658 %656
 OpLine %3 291 37
-%662 = OpCompositeExtract  %5  %605 1
-%663 = OpDot  %4  %662 %655
+%660 = OpCompositeExtract  %5  %603 1
+%661 = OpDot  %4  %660 %653
 OpLine %3 291 33
-%664 = OpExtInst  %4  %1 FMax %663 %74
+%662 = OpExtInst  %4  %1 FMax %661 %74
 OpLine %3 291 29
-%665 = OpExtInst  %4  %1 Pow %664 %346
+%663 = OpExtInst  %4  %1 Pow %662 %345
 OpLine %3 292 26
-%666 = OpAccessChain  %638  %616 %126
-%667 = OpLoad  %5  %666
-%668 = OpVectorTimesScalar  %5  %667 %665
+%664 = OpAccessChain  %636  %614 %126
+%665 = OpLoad  %5  %664
+%666 = OpVectorTimesScalar  %5  %665 %663
 OpLine %3 294 18
-%669 = OpFAdd  %5  %641 %661
-%670 = OpFAdd  %5  %669 %668
-%671 = OpLoad  %5  %622
-%672 = OpFMul  %5  %670 %671
+%667 = OpFAdd  %5  %639 %659
+%668 = OpFAdd  %5  %667 %666
+%669 = OpLoad  %5  %620
+%670 = OpFMul  %5  %668 %669
 OpLine %3 296 12
-%673 = OpCompositeConstruct  %7  %672 %56
-OpStore %612 %673
+%671 = OpCompositeConstruct  %7  %670 %56
+OpStore %610 %671
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/globals.spvasm
+++ b/naga/tests/out/spv/globals.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 174
+; Bound: 172
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
@@ -143,13 +143,11 @@ OpDecorate %116 BuiltIn LocalInvocationId
 %148 = OpTypePointer StorageBuffer %10
 %149 = OpConstant  %7  1
 %152 = OpConstant  %7  5
-%154 = OpTypePointer Uniform %12
-%155 = OpTypePointer Uniform %4
-%156 = OpConstant  %7  3
-%159 = OpConstant  %7  4
-%161 = OpTypePointer StorageBuffer %4
-%172 = OpConstant  %23  2
-%173 = OpConstant  %7  256
+%154 = OpTypePointer Uniform %4
+%155 = OpConstant  %7  3
+%158 = OpConstant  %7  4
+%170 = OpConstant  %23  2
+%171 = OpConstant  %7  256
 %53 = OpFunction  %2  None %54
 %52 = OpFunctionParameter  %8
 %51 = OpLabel
@@ -233,24 +231,24 @@ OpStore %147 %145
 %151 = OpLoad  %4  %150
 %153 = OpAccessChain  %128  %26 %152
 OpStore %153 %151
-%157 = OpAccessChain  %155  %98 %60 %156
-%158 = OpLoad  %4  %157
-%160 = OpAccessChain  %128  %26 %159
-OpStore %160 %158
-%162 = OpAccessChain  %161  %94 %149
-%163 = OpLoad  %4  %162
-%164 = OpAccessChain  %128  %26 %156
-OpStore %164 %163
-%165 = OpAccessChain  %73  %94 %60 %60
-%166 = OpLoad  %4  %165
-%167 = OpAccessChain  %128  %26 %18
-OpStore %167 %166
-%168 = OpAccessChain  %161  %94 %149
-OpStore %168 %107
-%169 = OpArrayLength  %7  %33 0
-%170 = OpConvertUToF  %4  %169
-%171 = OpAccessChain  %128  %26 %149
-OpStore %171 %170
-OpAtomicStore %28 %172 %173 %18
+%156 = OpAccessChain  %154  %98 %60 %155
+%157 = OpLoad  %4  %156
+%159 = OpAccessChain  %128  %26 %158
+OpStore %159 %157
+%160 = OpAccessChain  %73  %94 %149
+%161 = OpLoad  %4  %160
+%162 = OpAccessChain  %128  %26 %155
+OpStore %162 %161
+%163 = OpAccessChain  %73  %94 %60 %60
+%164 = OpLoad  %4  %163
+%165 = OpAccessChain  %128  %26 %18
+OpStore %165 %164
+%166 = OpAccessChain  %73  %94 %149
+OpStore %166 %107
+%167 = OpArrayLength  %7  %33 0
+%168 = OpConvertUToF  %4  %167
+%169 = OpAccessChain  %128  %26 %149
+OpStore %169 %168
+OpAtomicStore %28 %170 %171 %18
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/image.spvasm
+++ b/naga/tests/out/spv/image.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 550
+; Bound: 548
 OpCapability Shader
 OpCapability Image1D
 OpCapability Sampled1D
@@ -9,20 +9,20 @@ OpCapability SampledCubeArray
 OpCapability ImageQuery
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %100 "main" %97
-OpEntryPoint GLCompute %194 "depth_load" %192
-OpEntryPoint Vertex %214 "queries" %212
-OpEntryPoint Vertex %266 "levels_queries" %265
-OpEntryPoint Fragment %297 "texture_sample" %296
-OpEntryPoint Fragment %443 "texture_sample_comparison" %441
-OpEntryPoint Fragment %499 "gather" %498
-OpEntryPoint Fragment %533 "depth_no_comparison" %532
-OpExecutionMode %100 LocalSize 16 1 1
-OpExecutionMode %194 LocalSize 16 1 1
-OpExecutionMode %297 OriginUpperLeft
-OpExecutionMode %443 OriginUpperLeft
-OpExecutionMode %499 OriginUpperLeft
-OpExecutionMode %533 OriginUpperLeft
+OpEntryPoint GLCompute %98 "main" %95
+OpEntryPoint GLCompute %192 "depth_load" %190
+OpEntryPoint Vertex %212 "queries" %210
+OpEntryPoint Vertex %264 "levels_queries" %263
+OpEntryPoint Fragment %295 "texture_sample" %294
+OpEntryPoint Fragment %441 "texture_sample_comparison" %439
+OpEntryPoint Fragment %497 "gather" %496
+OpEntryPoint Fragment %531 "depth_no_comparison" %530
+OpExecutionMode %98 LocalSize 16 1 1
+OpExecutionMode %192 LocalSize 16 1 1
+OpExecutionMode %295 OriginUpperLeft
+OpExecutionMode %441 OriginUpperLeft
+OpExecutionMode %497 OriginUpperLeft
+OpExecutionMode %531 OriginUpperLeft
 %3 = OpString "image.wgsl"
 OpSource Unknown 0 %3 "@group(0) @binding(0)
 var image_mipmapped_src: texture_2d<u32>;
@@ -228,35 +228,35 @@ OpName %40 "image_array_src"
 OpName %42 "image_dup_src"
 OpName %44 "image_1d_src"
 OpName %46 "image_dst"
-OpName %48 "image_1d"
-OpName %50 "image_2d"
-OpName %52 "image_2d_u32"
-OpName %53 "image_2d_i32"
-OpName %55 "image_2d_array"
-OpName %57 "image_cube"
-OpName %59 "image_cube_array"
-OpName %61 "image_3d"
-OpName %63 "image_aa"
-OpName %65 "sampler_reg"
-OpName %67 "sampler_cmp"
-OpName %69 "image_2d_depth"
-OpName %71 "image_2d_array_depth"
-OpName %73 "image_cube_depth"
-OpName %75 "naga_mod"
-OpName %77 "lhs"
-OpName %78 "rhs"
-OpName %97 "local_id"
-OpName %100 "main"
-OpName %192 "local_id"
-OpName %194 "depth_load"
-OpName %214 "queries"
-OpName %266 "levels_queries"
-OpName %297 "texture_sample"
-OpName %310 "a"
-OpName %443 "texture_sample_comparison"
-OpName %448 "a"
-OpName %499 "gather"
-OpName %533 "depth_no_comparison"
+OpName %47 "image_1d"
+OpName %49 "image_2d"
+OpName %51 "image_2d_u32"
+OpName %52 "image_2d_i32"
+OpName %54 "image_2d_array"
+OpName %56 "image_cube"
+OpName %58 "image_cube_array"
+OpName %60 "image_3d"
+OpName %62 "image_aa"
+OpName %64 "sampler_reg"
+OpName %66 "sampler_cmp"
+OpName %67 "image_2d_depth"
+OpName %69 "image_2d_array_depth"
+OpName %71 "image_cube_depth"
+OpName %73 "naga_mod"
+OpName %75 "lhs"
+OpName %76 "rhs"
+OpName %95 "local_id"
+OpName %98 "main"
+OpName %190 "local_id"
+OpName %192 "depth_load"
+OpName %212 "queries"
+OpName %264 "levels_queries"
+OpName %295 "texture_sample"
+OpName %308 "a"
+OpName %441 "texture_sample_comparison"
+OpName %446 "a"
+OpName %497 "gather"
+OpName %531 "depth_no_comparison"
 OpDecorate %32 DescriptorSet 0
 OpDecorate %32 Binding 0
 OpDecorate %34 DescriptorSet 0
@@ -276,42 +276,42 @@ OpDecorate %44 Binding 7
 OpDecorate %46 NonReadable
 OpDecorate %46 DescriptorSet 0
 OpDecorate %46 Binding 2
-OpDecorate %48 DescriptorSet 0
-OpDecorate %48 Binding 0
-OpDecorate %50 DescriptorSet 0
-OpDecorate %50 Binding 1
+OpDecorate %47 DescriptorSet 0
+OpDecorate %47 Binding 0
+OpDecorate %49 DescriptorSet 0
+OpDecorate %49 Binding 1
+OpDecorate %51 DescriptorSet 0
+OpDecorate %51 Binding 2
 OpDecorate %52 DescriptorSet 0
-OpDecorate %52 Binding 2
-OpDecorate %53 DescriptorSet 0
-OpDecorate %53 Binding 3
-OpDecorate %55 DescriptorSet 0
-OpDecorate %55 Binding 4
-OpDecorate %57 DescriptorSet 0
-OpDecorate %57 Binding 5
-OpDecorate %59 DescriptorSet 0
-OpDecorate %59 Binding 6
-OpDecorate %61 DescriptorSet 0
-OpDecorate %61 Binding 7
-OpDecorate %63 DescriptorSet 0
-OpDecorate %63 Binding 8
-OpDecorate %65 DescriptorSet 1
-OpDecorate %65 Binding 0
+OpDecorate %52 Binding 3
+OpDecorate %54 DescriptorSet 0
+OpDecorate %54 Binding 4
+OpDecorate %56 DescriptorSet 0
+OpDecorate %56 Binding 5
+OpDecorate %58 DescriptorSet 0
+OpDecorate %58 Binding 6
+OpDecorate %60 DescriptorSet 0
+OpDecorate %60 Binding 7
+OpDecorate %62 DescriptorSet 0
+OpDecorate %62 Binding 8
+OpDecorate %64 DescriptorSet 1
+OpDecorate %64 Binding 0
+OpDecorate %66 DescriptorSet 1
+OpDecorate %66 Binding 1
 OpDecorate %67 DescriptorSet 1
-OpDecorate %67 Binding 1
+OpDecorate %67 Binding 2
 OpDecorate %69 DescriptorSet 1
-OpDecorate %69 Binding 2
+OpDecorate %69 Binding 3
 OpDecorate %71 DescriptorSet 1
-OpDecorate %71 Binding 3
-OpDecorate %73 DescriptorSet 1
-OpDecorate %73 Binding 4
-OpDecorate %97 BuiltIn LocalInvocationId
-OpDecorate %192 BuiltIn LocalInvocationId
-OpDecorate %212 BuiltIn Position
-OpDecorate %265 BuiltIn Position
-OpDecorate %296 Location 0
-OpDecorate %441 Location 0
-OpDecorate %498 Location 0
-OpDecorate %532 Location 0
+OpDecorate %71 Binding 4
+OpDecorate %95 BuiltIn LocalInvocationId
+OpDecorate %190 BuiltIn LocalInvocationId
+OpDecorate %210 BuiltIn Position
+OpDecorate %263 BuiltIn Position
+OpDecorate %294 Location 0
+OpDecorate %439 Location 0
+OpDecorate %496 Location 0
+OpDecorate %530 Location 0
 %2 = OpTypeVoid
 %5 = OpTypeInt 32 0
 %4 = OpTypeImage %5 2D 0 0 0 1 Unknown
@@ -355,706 +355,704 @@ OpDecorate %532 Location 0
 %42 = OpVariable  %43  UniformConstant
 %45 = OpTypePointer UniformConstant %12
 %44 = OpVariable  %45  UniformConstant
-%47 = OpTypePointer UniformConstant %11
-%46 = OpVariable  %47  UniformConstant
-%49 = OpTypePointer UniformConstant %16
-%48 = OpVariable  %49  UniformConstant
-%51 = OpTypePointer UniformConstant %17
-%50 = OpVariable  %51  UniformConstant
-%52 = OpVariable  %33  UniformConstant
-%54 = OpTypePointer UniformConstant %18
-%53 = OpVariable  %54  UniformConstant
-%56 = OpTypePointer UniformConstant %19
-%55 = OpVariable  %56  UniformConstant
-%58 = OpTypePointer UniformConstant %20
-%57 = OpVariable  %58  UniformConstant
-%60 = OpTypePointer UniformConstant %21
-%59 = OpVariable  %60  UniformConstant
-%62 = OpTypePointer UniformConstant %22
-%61 = OpVariable  %62  UniformConstant
-%64 = OpTypePointer UniformConstant %23
-%63 = OpVariable  %64  UniformConstant
-%66 = OpTypePointer UniformConstant %25
-%65 = OpVariable  %66  UniformConstant
-%68 = OpTypePointer UniformConstant %25
+%46 = OpVariable  %43  UniformConstant
+%48 = OpTypePointer UniformConstant %16
+%47 = OpVariable  %48  UniformConstant
+%50 = OpTypePointer UniformConstant %17
+%49 = OpVariable  %50  UniformConstant
+%51 = OpVariable  %33  UniformConstant
+%53 = OpTypePointer UniformConstant %18
+%52 = OpVariable  %53  UniformConstant
+%55 = OpTypePointer UniformConstant %19
+%54 = OpVariable  %55  UniformConstant
+%57 = OpTypePointer UniformConstant %20
+%56 = OpVariable  %57  UniformConstant
+%59 = OpTypePointer UniformConstant %21
+%58 = OpVariable  %59  UniformConstant
+%61 = OpTypePointer UniformConstant %22
+%60 = OpVariable  %61  UniformConstant
+%63 = OpTypePointer UniformConstant %23
+%62 = OpVariable  %63  UniformConstant
+%65 = OpTypePointer UniformConstant %25
+%64 = OpVariable  %65  UniformConstant
+%66 = OpVariable  %65  UniformConstant
+%68 = OpTypePointer UniformConstant %26
 %67 = OpVariable  %68  UniformConstant
-%70 = OpTypePointer UniformConstant %26
+%70 = OpTypePointer UniformConstant %27
 %69 = OpVariable  %70  UniformConstant
-%72 = OpTypePointer UniformConstant %27
+%72 = OpTypePointer UniformConstant %28
 %71 = OpVariable  %72  UniformConstant
-%74 = OpTypePointer UniformConstant %28
-%73 = OpVariable  %74  UniformConstant
-%76 = OpTypeFunction %14 %14 %14
-%81 = OpTypeBool
-%80 = OpTypeVector %81 2
-%82 = OpConstant  %15  0
-%83 = OpConstantComposite  %14  %82 %82
-%85 = OpConstant  %15  -2147483648
-%86 = OpConstant  %15  -1
-%87 = OpConstantComposite  %14  %85 %85
-%88 = OpConstantComposite  %14  %86 %86
-%93 = OpConstantComposite  %14  %30 %30
-%98 = OpTypePointer Input %13
-%97 = OpVariable  %98  Input
-%101 = OpTypeFunction %2
-%108 = OpConstant  %15  10
-%109 = OpConstant  %15  20
-%110 = OpConstantComposite  %14  %108 %109
-%112 = OpTypeVector %5 2
-%120 = OpTypeVector %5 4
-%134 = OpTypeVector %15 3
-%192 = OpVariable  %98  Input
-%213 = OpTypePointer Output %24
-%212 = OpVariable  %213  Output
-%223 = OpConstant  %5  0
-%265 = OpVariable  %213  Output
-%296 = OpVariable  %213  Output
-%303 = OpConstant  %8  0.5
-%304 = OpTypeVector %8 2
-%305 = OpConstantComposite  %304  %303 %303
-%306 = OpTypeVector %8 3
-%307 = OpConstantComposite  %306  %303 %303 %303
-%308 = OpConstant  %8  2.3
-%309 = OpConstant  %8  2.0
-%311 = OpTypePointer Function %24
-%312 = OpConstantNull  %24
-%315 = OpTypeSampledImage %16
-%320 = OpTypeSampledImage %17
-%341 = OpTypeSampledImage %19
-%402 = OpTypeSampledImage %21
-%442 = OpTypePointer Output %8
-%441 = OpVariable  %442  Output
-%449 = OpTypePointer Function %8
-%450 = OpConstantNull  %8
-%452 = OpTypeSampledImage %26
-%457 = OpTypeSampledImage %27
-%470 = OpTypeSampledImage %28
-%477 = OpConstant  %8  0.0
-%498 = OpVariable  %213  Output
-%509 = OpConstant  %5  1
-%512 = OpConstant  %5  3
-%517 = OpTypeSampledImage %4
-%520 = OpTypeVector %15 4
-%521 = OpTypeSampledImage %18
-%532 = OpVariable  %213  Output
-%75 = OpFunction  %14  None %76
-%77 = OpFunctionParameter  %14
-%78 = OpFunctionParameter  %14
-%79 = OpLabel
-%84 = OpIEqual  %80  %78 %83
-%89 = OpIEqual  %80  %77 %87
-%90 = OpIEqual  %80  %78 %88
-%91 = OpLogicalAnd  %80  %89 %90
-%92 = OpLogicalOr  %80  %84 %91
-%94 = OpSelect  %14  %92 %93 %78
-%95 = OpSRem  %14  %77 %94
-OpReturnValue %95
+%74 = OpTypeFunction %14 %14 %14
+%79 = OpTypeBool
+%78 = OpTypeVector %79 2
+%80 = OpConstant  %15  0
+%81 = OpConstantComposite  %14  %80 %80
+%83 = OpConstant  %15  -2147483648
+%84 = OpConstant  %15  -1
+%85 = OpConstantComposite  %14  %83 %83
+%86 = OpConstantComposite  %14  %84 %84
+%91 = OpConstantComposite  %14  %30 %30
+%96 = OpTypePointer Input %13
+%95 = OpVariable  %96  Input
+%99 = OpTypeFunction %2
+%106 = OpConstant  %15  10
+%107 = OpConstant  %15  20
+%108 = OpConstantComposite  %14  %106 %107
+%110 = OpTypeVector %5 2
+%118 = OpTypeVector %5 4
+%132 = OpTypeVector %15 3
+%190 = OpVariable  %96  Input
+%211 = OpTypePointer Output %24
+%210 = OpVariable  %211  Output
+%221 = OpConstant  %5  0
+%263 = OpVariable  %211  Output
+%294 = OpVariable  %211  Output
+%301 = OpConstant  %8  0.5
+%302 = OpTypeVector %8 2
+%303 = OpConstantComposite  %302  %301 %301
+%304 = OpTypeVector %8 3
+%305 = OpConstantComposite  %304  %301 %301 %301
+%306 = OpConstant  %8  2.3
+%307 = OpConstant  %8  2.0
+%309 = OpTypePointer Function %24
+%310 = OpConstantNull  %24
+%313 = OpTypeSampledImage %16
+%318 = OpTypeSampledImage %17
+%339 = OpTypeSampledImage %19
+%400 = OpTypeSampledImage %21
+%440 = OpTypePointer Output %8
+%439 = OpVariable  %440  Output
+%447 = OpTypePointer Function %8
+%448 = OpConstantNull  %8
+%450 = OpTypeSampledImage %26
+%455 = OpTypeSampledImage %27
+%468 = OpTypeSampledImage %28
+%475 = OpConstant  %8  0.0
+%496 = OpVariable  %211  Output
+%507 = OpConstant  %5  1
+%510 = OpConstant  %5  3
+%515 = OpTypeSampledImage %4
+%518 = OpTypeVector %15 4
+%519 = OpTypeSampledImage %18
+%530 = OpVariable  %211  Output
+%73 = OpFunction  %14  None %74
+%75 = OpFunctionParameter  %14
+%76 = OpFunctionParameter  %14
+%77 = OpLabel
+%82 = OpIEqual  %78  %76 %81
+%87 = OpIEqual  %78  %75 %85
+%88 = OpIEqual  %78  %76 %86
+%89 = OpLogicalAnd  %78  %87 %88
+%90 = OpLogicalOr  %78  %82 %89
+%92 = OpSelect  %14  %90 %91 %76
+%93 = OpSRem  %14  %75 %92
+OpReturnValue %93
 OpFunctionEnd
-%100 = OpFunction  %2  None %101
-%96 = OpLabel
-%99 = OpLoad  %13  %97
-%102 = OpLoad  %4  %32
-%103 = OpLoad  %6  %34
-%104 = OpLoad  %9  %38
-%105 = OpLoad  %10  %40
-%106 = OpLoad  %12  %44
-%107 = OpLoad  %11  %46
-OpBranch %111
-%111 = OpLabel
+%98 = OpFunction  %2  None %99
+%94 = OpLabel
+%97 = OpLoad  %13  %95
+%100 = OpLoad  %4  %32
+%101 = OpLoad  %6  %34
+%102 = OpLoad  %9  %38
+%103 = OpLoad  %10  %40
+%104 = OpLoad  %12  %44
+%105 = OpLoad  %11  %46
+OpBranch %109
+%109 = OpLabel
 OpLine %3 20 15
-%113 = OpImageQuerySize  %112  %104
+%111 = OpImageQuerySize  %110  %102
 OpLine %3 21 15
-%114 = OpVectorShuffle  %112  %99 %99 0 1
-%115 = OpIMul  %112  %113 %114
-%116 = OpBitcast  %14  %115
+%112 = OpVectorShuffle  %110  %97 %97 0 1
+%113 = OpIMul  %110  %111 %112
+%114 = OpBitcast  %14  %113
 OpLine %3 21 15
-%117 = OpFunctionCall  %14  %75 %116 %110
+%115 = OpFunctionCall  %14  %73 %114 %108
 OpLine %3 23 18
-%118 = OpCompositeExtract  %5  %99 2
-%119 = OpBitcast  %15  %118
-%121 = OpImageFetch  %120  %102 %117 Lod %119
+%116 = OpCompositeExtract  %5  %97 2
+%117 = OpBitcast  %15  %116
+%119 = OpImageFetch  %118  %100 %115 Lod %117
 OpLine %3 25 20
-%122 = OpCompositeExtract  %5  %99 2
-%124 = OpImageFetch  %120  %102 %117 Lod %122
+%120 = OpCompositeExtract  %5  %97 2
+%122 = OpImageFetch  %118  %100 %115 Lod %120
 OpLine %3 26 18
-%125 = OpCompositeExtract  %5  %99 2
-%126 = OpBitcast  %15  %125
-%127 = OpImageFetch  %120  %103 %117 Sample %126
+%123 = OpCompositeExtract  %5  %97 2
+%124 = OpBitcast  %15  %123
+%125 = OpImageFetch  %118  %101 %115 Sample %124
 OpLine %3 27 18
-%128 = OpImageRead  %120  %104 %117
+%126 = OpImageRead  %118  %102 %115
 OpLine %3 28 52
-%129 = OpCompositeExtract  %5  %99 2
-%130 = OpCompositeExtract  %5  %99 2
-%131 = OpBitcast  %15  %130
+%127 = OpCompositeExtract  %5  %97 2
+%128 = OpCompositeExtract  %5  %97 2
+%129 = OpBitcast  %15  %128
 OpLine %3 28 18
-%132 = OpIAdd  %15  %131 %30
-%133 = OpBitcast  %15  %129
-%135 = OpCompositeConstruct  %134  %117 %133
-%136 = OpImageFetch  %120  %105 %135 Lod %132
+%130 = OpIAdd  %15  %129 %30
+%131 = OpBitcast  %15  %127
+%133 = OpCompositeConstruct  %132  %115 %131
+%134 = OpImageFetch  %118  %103 %133 Lod %130
 OpLine %3 29 52
-%137 = OpCompositeExtract  %5  %99 2
+%135 = OpCompositeExtract  %5  %97 2
+%136 = OpBitcast  %15  %135
+%137 = OpCompositeExtract  %5  %97 2
 %138 = OpBitcast  %15  %137
-%139 = OpCompositeExtract  %5  %99 2
-%140 = OpBitcast  %15  %139
 OpLine %3 29 18
-%141 = OpIAdd  %15  %140 %30
-%142 = OpCompositeConstruct  %134  %117 %138
-%143 = OpImageFetch  %120  %105 %142 Lod %141
+%139 = OpIAdd  %15  %138 %30
+%140 = OpCompositeConstruct  %132  %115 %136
+%141 = OpImageFetch  %118  %103 %140 Lod %139
 OpLine %3 30 18
-%144 = OpCompositeExtract  %5  %99 0
+%142 = OpCompositeExtract  %5  %97 0
+%143 = OpBitcast  %15  %142
+%144 = OpCompositeExtract  %5  %97 2
 %145 = OpBitcast  %15  %144
-%146 = OpCompositeExtract  %5  %99 2
-%147 = OpBitcast  %15  %146
-%148 = OpImageFetch  %120  %106 %145 Lod %147
+%146 = OpImageFetch  %118  %104 %143 Lod %145
 OpLine %3 32 19
-%149 = OpBitcast  %112  %117
-%150 = OpCompositeExtract  %5  %99 2
-%151 = OpBitcast  %15  %150
-%152 = OpImageFetch  %120  %102 %149 Lod %151
+%147 = OpBitcast  %110  %115
+%148 = OpCompositeExtract  %5  %97 2
+%149 = OpBitcast  %15  %148
+%150 = OpImageFetch  %118  %100 %147 Lod %149
 OpLine %3 33 19
-%153 = OpBitcast  %112  %117
-%154 = OpCompositeExtract  %5  %99 2
-%155 = OpBitcast  %15  %154
-%156 = OpImageFetch  %120  %103 %153 Sample %155
+%151 = OpBitcast  %110  %115
+%152 = OpCompositeExtract  %5  %97 2
+%153 = OpBitcast  %15  %152
+%154 = OpImageFetch  %118  %101 %151 Sample %153
 OpLine %3 34 19
-%157 = OpBitcast  %112  %117
-%158 = OpImageRead  %120  %104 %157
+%155 = OpBitcast  %110  %115
+%156 = OpImageRead  %118  %102 %155
 OpLine %3 35 48
-%159 = OpBitcast  %112  %117
-%160 = OpCompositeExtract  %5  %99 2
-%161 = OpCompositeExtract  %5  %99 2
-%162 = OpBitcast  %15  %161
+%157 = OpBitcast  %110  %115
+%158 = OpCompositeExtract  %5  %97 2
+%159 = OpCompositeExtract  %5  %97 2
+%160 = OpBitcast  %15  %159
 OpLine %3 35 19
-%163 = OpIAdd  %15  %162 %30
-%164 = OpCompositeConstruct  %13  %159 %160
-%165 = OpImageFetch  %120  %105 %164 Lod %163
+%161 = OpIAdd  %15  %160 %30
+%162 = OpCompositeConstruct  %13  %157 %158
+%163 = OpImageFetch  %118  %103 %162 Lod %161
 OpLine %3 36 48
-%166 = OpBitcast  %112  %117
-%167 = OpCompositeExtract  %5  %99 2
+%164 = OpBitcast  %110  %115
+%165 = OpCompositeExtract  %5  %97 2
+%166 = OpBitcast  %15  %165
+%167 = OpCompositeExtract  %5  %97 2
 %168 = OpBitcast  %15  %167
-%169 = OpCompositeExtract  %5  %99 2
-%170 = OpBitcast  %15  %169
 OpLine %3 36 19
-%171 = OpIAdd  %15  %170 %30
-%172 = OpBitcast  %5  %168
-%173 = OpCompositeConstruct  %13  %166 %172
-%174 = OpImageFetch  %120  %105 %173 Lod %171
+%169 = OpIAdd  %15  %168 %30
+%170 = OpBitcast  %5  %166
+%171 = OpCompositeConstruct  %13  %164 %170
+%172 = OpImageFetch  %118  %103 %171 Lod %169
 OpLine %3 37 19
-%175 = OpCompositeExtract  %5  %99 0
-%177 = OpCompositeExtract  %5  %99 2
-%178 = OpBitcast  %15  %177
-%179 = OpImageFetch  %120  %106 %175 Lod %178
+%173 = OpCompositeExtract  %5  %97 0
+%175 = OpCompositeExtract  %5  %97 2
+%176 = OpBitcast  %15  %175
+%177 = OpImageFetch  %118  %104 %173 Lod %176
 OpLine %3 39 29
-%180 = OpCompositeExtract  %15  %117 0
-%181 = OpIAdd  %120  %121 %127
-%182 = OpIAdd  %120  %181 %128
-%183 = OpIAdd  %120  %182 %136
-%184 = OpIAdd  %120  %183 %143
+%178 = OpCompositeExtract  %15  %115 0
+%179 = OpIAdd  %118  %119 %125
+%180 = OpIAdd  %118  %179 %126
+%181 = OpIAdd  %118  %180 %134
+%182 = OpIAdd  %118  %181 %141
 OpLine %3 39 5
-OpImageWrite %107 %180 %184
+OpImageWrite %105 %178 %182
 OpLine %3 41 29
-%185 = OpCompositeExtract  %15  %117 0
-%186 = OpBitcast  %5  %185
-%187 = OpIAdd  %120  %152 %156
-%188 = OpIAdd  %120  %187 %158
-%189 = OpIAdd  %120  %188 %165
-%190 = OpIAdd  %120  %189 %174
+%183 = OpCompositeExtract  %15  %115 0
+%184 = OpBitcast  %5  %183
+%185 = OpIAdd  %118  %150 %154
+%186 = OpIAdd  %118  %185 %156
+%187 = OpIAdd  %118  %186 %163
+%188 = OpIAdd  %118  %187 %172
 OpLine %3 41 5
-OpImageWrite %107 %186 %190
+OpImageWrite %105 %184 %188
 OpReturn
 OpFunctionEnd
-%194 = OpFunction  %2  None %101
-%191 = OpLabel
-%193 = OpLoad  %13  %192
-%195 = OpLoad  %7  %36
-%196 = OpLoad  %9  %38
-%197 = OpLoad  %11  %46
-OpBranch %198
-%198 = OpLabel
+%192 = OpFunction  %2  None %99
+%189 = OpLabel
+%191 = OpLoad  %13  %190
+%193 = OpLoad  %7  %36
+%194 = OpLoad  %9  %38
+%195 = OpLoad  %11  %46
+OpBranch %196
+%196 = OpLabel
 OpLine %3 46 26
-%199 = OpImageQuerySize  %112  %196
+%197 = OpImageQuerySize  %110  %194
 OpLine %3 47 27
-%200 = OpVectorShuffle  %112  %193 %193 0 1
-%201 = OpIMul  %112  %199 %200
-%202 = OpBitcast  %14  %201
+%198 = OpVectorShuffle  %110  %191 %191 0 1
+%199 = OpIMul  %110  %197 %198
+%200 = OpBitcast  %14  %199
 OpLine %3 47 27
-%203 = OpFunctionCall  %14  %75 %202 %110
+%201 = OpFunctionCall  %14  %73 %200 %108
 OpLine %3 48 20
-%204 = OpCompositeExtract  %5  %193 2
-%205 = OpBitcast  %15  %204
-%206 = OpImageFetch  %24  %195 %203 Sample %205
-%207 = OpCompositeExtract  %8  %206 0
+%202 = OpCompositeExtract  %5  %191 2
+%203 = OpBitcast  %15  %202
+%204 = OpImageFetch  %24  %193 %201 Sample %203
+%205 = OpCompositeExtract  %8  %204 0
 OpLine %3 49 29
-%208 = OpCompositeExtract  %15  %203 0
-%209 = OpConvertFToU  %5  %207
-%210 = OpCompositeConstruct  %120  %209 %209 %209 %209
+%206 = OpCompositeExtract  %15  %201 0
+%207 = OpConvertFToU  %5  %205
+%208 = OpCompositeConstruct  %118  %207 %207 %207 %207
 OpLine %3 49 5
-OpImageWrite %197 %208 %210
+OpImageWrite %195 %206 %208
 OpReturn
 OpFunctionEnd
-%214 = OpFunction  %2  None %101
-%211 = OpLabel
-%215 = OpLoad  %16  %48
-%216 = OpLoad  %17  %50
-%217 = OpLoad  %19  %55
-%218 = OpLoad  %20  %57
-%219 = OpLoad  %21  %59
-%220 = OpLoad  %22  %61
-%221 = OpLoad  %23  %63
-OpBranch %222
-%222 = OpLabel
+%212 = OpFunction  %2  None %99
+%209 = OpLabel
+%213 = OpLoad  %16  %47
+%214 = OpLoad  %17  %49
+%215 = OpLoad  %19  %54
+%216 = OpLoad  %20  %56
+%217 = OpLoad  %21  %58
+%218 = OpLoad  %22  %60
+%219 = OpLoad  %23  %62
+OpBranch %220
+%220 = OpLabel
 OpLine %3 74 18
-%224 = OpImageQuerySizeLod  %5  %215 %223
+%222 = OpImageQuerySizeLod  %5  %213 %221
 OpLine %3 75 22
-%225 = OpBitcast  %15  %224
-%226 = OpImageQuerySizeLod  %5  %215 %225
+%223 = OpBitcast  %15  %222
+%224 = OpImageQuerySizeLod  %5  %213 %223
 OpLine %3 76 18
-%227 = OpImageQuerySizeLod  %112  %216 %223
+%225 = OpImageQuerySizeLod  %110  %214 %221
 OpLine %3 77 22
-%228 = OpImageQuerySizeLod  %112  %216 %30
+%226 = OpImageQuerySizeLod  %110  %214 %30
 OpLine %3 78 24
-%229 = OpImageQuerySizeLod  %13  %217 %223
-%230 = OpVectorShuffle  %112  %229 %229 0 1
+%227 = OpImageQuerySizeLod  %13  %215 %221
+%228 = OpVectorShuffle  %110  %227 %227 0 1
 OpLine %3 79 28
-%231 = OpImageQuerySizeLod  %13  %217 %30
-%232 = OpVectorShuffle  %112  %231 %231 0 1
+%229 = OpImageQuerySizeLod  %13  %215 %30
+%230 = OpVectorShuffle  %110  %229 %229 0 1
 OpLine %3 80 20
-%233 = OpImageQuerySizeLod  %112  %218 %223
+%231 = OpImageQuerySizeLod  %110  %216 %221
 OpLine %3 81 24
-%234 = OpImageQuerySizeLod  %112  %218 %30
+%232 = OpImageQuerySizeLod  %110  %216 %30
 OpLine %3 82 26
-%235 = OpImageQuerySizeLod  %13  %219 %223
-%236 = OpVectorShuffle  %112  %235 %235 0 0
+%233 = OpImageQuerySizeLod  %13  %217 %221
+%234 = OpVectorShuffle  %110  %233 %233 0 0
 OpLine %3 83 30
-%237 = OpImageQuerySizeLod  %13  %219 %30
-%238 = OpVectorShuffle  %112  %237 %237 0 0
+%235 = OpImageQuerySizeLod  %13  %217 %30
+%236 = OpVectorShuffle  %110  %235 %235 0 0
 OpLine %3 84 18
-%239 = OpImageQuerySizeLod  %13  %220 %223
+%237 = OpImageQuerySizeLod  %13  %218 %221
 OpLine %3 85 22
-%240 = OpImageQuerySizeLod  %13  %220 %30
+%238 = OpImageQuerySizeLod  %13  %218 %30
 OpLine %3 86 21
-%241 = OpImageQuerySize  %112  %221
+%239 = OpImageQuerySize  %110  %219
 OpLine %3 88 15
-%242 = OpCompositeExtract  %5  %227 1
-%243 = OpIAdd  %5  %224 %242
+%240 = OpCompositeExtract  %5  %225 1
+%241 = OpIAdd  %5  %222 %240
+%242 = OpCompositeExtract  %5  %226 1
+%243 = OpIAdd  %5  %241 %242
 %244 = OpCompositeExtract  %5  %228 1
 %245 = OpIAdd  %5  %243 %244
 %246 = OpCompositeExtract  %5  %230 1
 %247 = OpIAdd  %5  %245 %246
-%248 = OpCompositeExtract  %5  %232 1
+%248 = OpCompositeExtract  %5  %231 1
 %249 = OpIAdd  %5  %247 %248
-%250 = OpCompositeExtract  %5  %233 1
+%250 = OpCompositeExtract  %5  %232 1
 %251 = OpIAdd  %5  %249 %250
 %252 = OpCompositeExtract  %5  %234 1
 %253 = OpIAdd  %5  %251 %252
 %254 = OpCompositeExtract  %5  %236 1
 %255 = OpIAdd  %5  %253 %254
-%256 = OpCompositeExtract  %5  %238 1
+%256 = OpCompositeExtract  %5  %237 2
 %257 = OpIAdd  %5  %255 %256
-%258 = OpCompositeExtract  %5  %239 2
+%258 = OpCompositeExtract  %5  %238 2
 %259 = OpIAdd  %5  %257 %258
-%260 = OpCompositeExtract  %5  %240 2
-%261 = OpIAdd  %5  %259 %260
 OpLine %3 91 12
-%262 = OpConvertUToF  %8  %261
-%263 = OpCompositeConstruct  %24  %262 %262 %262 %262
-OpStore %212 %263
+%260 = OpConvertUToF  %8  %259
+%261 = OpCompositeConstruct  %24  %260 %260 %260 %260
+OpStore %210 %261
 OpReturn
 OpFunctionEnd
-%266 = OpFunction  %2  None %101
-%264 = OpLabel
-%267 = OpLoad  %17  %50
-%268 = OpLoad  %19  %55
-%269 = OpLoad  %20  %57
-%270 = OpLoad  %21  %59
-%271 = OpLoad  %22  %61
-%272 = OpLoad  %23  %63
-OpBranch %273
-%273 = OpLabel
+%264 = OpFunction  %2  None %99
+%262 = OpLabel
+%265 = OpLoad  %17  %49
+%266 = OpLoad  %19  %54
+%267 = OpLoad  %20  %56
+%268 = OpLoad  %21  %58
+%269 = OpLoad  %22  %60
+%270 = OpLoad  %23  %62
+OpBranch %271
+%271 = OpLabel
 OpLine %3 96 25
-%274 = OpImageQueryLevels  %5  %267
+%272 = OpImageQueryLevels  %5  %265
 OpLine %3 97 25
-%275 = OpImageQuerySizeLod  %13  %268 %223
-%276 = OpCompositeExtract  %5  %275 2
+%273 = OpImageQuerySizeLod  %13  %266 %221
+%274 = OpCompositeExtract  %5  %273 2
 OpLine %3 98 31
-%277 = OpImageQueryLevels  %5  %268
+%275 = OpImageQueryLevels  %5  %266
 OpLine %3 99 31
-%278 = OpImageQuerySizeLod  %13  %268 %223
-%279 = OpCompositeExtract  %5  %278 2
+%276 = OpImageQuerySizeLod  %13  %266 %221
+%277 = OpCompositeExtract  %5  %276 2
 OpLine %3 100 27
-%280 = OpImageQueryLevels  %5  %269
+%278 = OpImageQueryLevels  %5  %267
 OpLine %3 101 33
-%281 = OpImageQueryLevels  %5  %270
+%279 = OpImageQueryLevels  %5  %268
 OpLine %3 102 27
-%282 = OpImageQuerySizeLod  %13  %270 %223
-%283 = OpCompositeExtract  %5  %282 2
+%280 = OpImageQuerySizeLod  %13  %268 %221
+%281 = OpCompositeExtract  %5  %280 2
 OpLine %3 103 25
-%284 = OpImageQueryLevels  %5  %271
+%282 = OpImageQueryLevels  %5  %269
 OpLine %3 104 26
-%285 = OpImageQuerySamples  %5  %272
+%283 = OpImageQuerySamples  %5  %270
 OpLine %3 106 15
-%286 = OpIAdd  %5  %276 %283
-%287 = OpIAdd  %5  %286 %285
-%288 = OpIAdd  %5  %287 %274
-%289 = OpIAdd  %5  %288 %277
-%290 = OpIAdd  %5  %289 %284
-%291 = OpIAdd  %5  %290 %280
-%292 = OpIAdd  %5  %291 %281
+%284 = OpIAdd  %5  %274 %281
+%285 = OpIAdd  %5  %284 %283
+%286 = OpIAdd  %5  %285 %272
+%287 = OpIAdd  %5  %286 %275
+%288 = OpIAdd  %5  %287 %282
+%289 = OpIAdd  %5  %288 %278
+%290 = OpIAdd  %5  %289 %279
 OpLine %3 108 12
-%293 = OpConvertUToF  %8  %292
-%294 = OpCompositeConstruct  %24  %293 %293 %293 %293
-OpStore %265 %294
+%291 = OpConvertUToF  %8  %290
+%292 = OpCompositeConstruct  %24  %291 %291 %291 %291
+OpStore %263 %292
 OpReturn
 OpFunctionEnd
-%297 = OpFunction  %2  None %101
-%295 = OpLabel
-%310 = OpVariable  %311  Function %312
-%298 = OpLoad  %16  %48
-%299 = OpLoad  %17  %50
-%300 = OpLoad  %19  %55
-%301 = OpLoad  %21  %59
-%302 = OpLoad  %25  %65
-OpBranch %313
-%313 = OpLabel
+%295 = OpFunction  %2  None %99
+%293 = OpLabel
+%308 = OpVariable  %309  Function %310
+%296 = OpLoad  %16  %47
+%297 = OpLoad  %17  %49
+%298 = OpLoad  %19  %54
+%299 = OpLoad  %21  %58
+%300 = OpLoad  %25  %64
+OpBranch %311
+%311 = OpLabel
 OpLine %3 116 14
 OpLine %3 117 15
 OpLine %3 120 5
-%314 = OpCompositeExtract  %8  %305 0
-%316 = OpSampledImage  %315  %298 %302
-%317 = OpImageSampleImplicitLod  %24  %316 %314
-%318 = OpLoad  %24  %310
-%319 = OpFAdd  %24  %318 %317
+%312 = OpCompositeExtract  %8  %303 0
+%314 = OpSampledImage  %313  %296 %300
+%315 = OpImageSampleImplicitLod  %24  %314 %312
+%316 = OpLoad  %24  %308
+%317 = OpFAdd  %24  %316 %315
 OpLine %3 120 5
-OpStore %310 %319
+OpStore %308 %317
 OpLine %3 121 5
-%321 = OpSampledImage  %320  %299 %302
-%322 = OpImageSampleImplicitLod  %24  %321 %305
-%323 = OpLoad  %24  %310
-%324 = OpFAdd  %24  %323 %322
+%319 = OpSampledImage  %318  %297 %300
+%320 = OpImageSampleImplicitLod  %24  %319 %303
+%321 = OpLoad  %24  %308
+%322 = OpFAdd  %24  %321 %320
 OpLine %3 121 5
-OpStore %310 %324
+OpStore %308 %322
 OpLine %3 122 5
-%325 = OpSampledImage  %320  %299 %302
-%326 = OpImageSampleImplicitLod  %24  %325 %305 ConstOffset %31
-%327 = OpLoad  %24  %310
-%328 = OpFAdd  %24  %327 %326
+%323 = OpSampledImage  %318  %297 %300
+%324 = OpImageSampleImplicitLod  %24  %323 %303 ConstOffset %31
+%325 = OpLoad  %24  %308
+%326 = OpFAdd  %24  %325 %324
 OpLine %3 122 5
-OpStore %310 %328
+OpStore %308 %326
 OpLine %3 123 5
-%329 = OpSampledImage  %320  %299 %302
-%330 = OpImageSampleExplicitLod  %24  %329 %305 Lod %308
-%331 = OpLoad  %24  %310
-%332 = OpFAdd  %24  %331 %330
+%327 = OpSampledImage  %318  %297 %300
+%328 = OpImageSampleExplicitLod  %24  %327 %303 Lod %306
+%329 = OpLoad  %24  %308
+%330 = OpFAdd  %24  %329 %328
 OpLine %3 123 5
-OpStore %310 %332
+OpStore %308 %330
 OpLine %3 124 5
-%333 = OpSampledImage  %320  %299 %302
-%334 = OpImageSampleExplicitLod  %24  %333 %305 Lod|ConstOffset %308 %31
-%335 = OpLoad  %24  %310
-%336 = OpFAdd  %24  %335 %334
+%331 = OpSampledImage  %318  %297 %300
+%332 = OpImageSampleExplicitLod  %24  %331 %303 Lod|ConstOffset %306 %31
+%333 = OpLoad  %24  %308
+%334 = OpFAdd  %24  %333 %332
 OpLine %3 124 5
-OpStore %310 %336
+OpStore %308 %334
 OpLine %3 125 5
-%337 = OpSampledImage  %320  %299 %302
-%338 = OpImageSampleImplicitLod  %24  %337 %305 Bias|ConstOffset %309 %31
-%339 = OpLoad  %24  %310
-%340 = OpFAdd  %24  %339 %338
+%335 = OpSampledImage  %318  %297 %300
+%336 = OpImageSampleImplicitLod  %24  %335 %303 Bias|ConstOffset %307 %31
+%337 = OpLoad  %24  %308
+%338 = OpFAdd  %24  %337 %336
 OpLine %3 125 5
-OpStore %310 %340
+OpStore %308 %338
 OpLine %3 126 5
-%342 = OpConvertUToF  %8  %223
-%343 = OpCompositeConstruct  %306  %305 %342
-%344 = OpSampledImage  %341  %300 %302
-%345 = OpImageSampleImplicitLod  %24  %344 %343
-%346 = OpLoad  %24  %310
-%347 = OpFAdd  %24  %346 %345
+%340 = OpConvertUToF  %8  %221
+%341 = OpCompositeConstruct  %304  %303 %340
+%342 = OpSampledImage  %339  %298 %300
+%343 = OpImageSampleImplicitLod  %24  %342 %341
+%344 = OpLoad  %24  %308
+%345 = OpFAdd  %24  %344 %343
 OpLine %3 126 5
-OpStore %310 %347
+OpStore %308 %345
 OpLine %3 127 5
-%348 = OpConvertUToF  %8  %223
-%349 = OpCompositeConstruct  %306  %305 %348
-%350 = OpSampledImage  %341  %300 %302
-%351 = OpImageSampleImplicitLod  %24  %350 %349 ConstOffset %31
-%352 = OpLoad  %24  %310
-%353 = OpFAdd  %24  %352 %351
+%346 = OpConvertUToF  %8  %221
+%347 = OpCompositeConstruct  %304  %303 %346
+%348 = OpSampledImage  %339  %298 %300
+%349 = OpImageSampleImplicitLod  %24  %348 %347 ConstOffset %31
+%350 = OpLoad  %24  %308
+%351 = OpFAdd  %24  %350 %349
 OpLine %3 127 5
-OpStore %310 %353
+OpStore %308 %351
 OpLine %3 128 5
-%354 = OpConvertUToF  %8  %223
-%355 = OpCompositeConstruct  %306  %305 %354
-%356 = OpSampledImage  %341  %300 %302
-%357 = OpImageSampleExplicitLod  %24  %356 %355 Lod %308
-%358 = OpLoad  %24  %310
-%359 = OpFAdd  %24  %358 %357
+%352 = OpConvertUToF  %8  %221
+%353 = OpCompositeConstruct  %304  %303 %352
+%354 = OpSampledImage  %339  %298 %300
+%355 = OpImageSampleExplicitLod  %24  %354 %353 Lod %306
+%356 = OpLoad  %24  %308
+%357 = OpFAdd  %24  %356 %355
 OpLine %3 128 5
-OpStore %310 %359
+OpStore %308 %357
 OpLine %3 129 5
-%360 = OpConvertUToF  %8  %223
-%361 = OpCompositeConstruct  %306  %305 %360
-%362 = OpSampledImage  %341  %300 %302
-%363 = OpImageSampleExplicitLod  %24  %362 %361 Lod|ConstOffset %308 %31
-%364 = OpLoad  %24  %310
-%365 = OpFAdd  %24  %364 %363
+%358 = OpConvertUToF  %8  %221
+%359 = OpCompositeConstruct  %304  %303 %358
+%360 = OpSampledImage  %339  %298 %300
+%361 = OpImageSampleExplicitLod  %24  %360 %359 Lod|ConstOffset %306 %31
+%362 = OpLoad  %24  %308
+%363 = OpFAdd  %24  %362 %361
 OpLine %3 129 5
-OpStore %310 %365
+OpStore %308 %363
 OpLine %3 130 5
-%366 = OpConvertUToF  %8  %223
-%367 = OpCompositeConstruct  %306  %305 %366
-%368 = OpSampledImage  %341  %300 %302
-%369 = OpImageSampleImplicitLod  %24  %368 %367 Bias|ConstOffset %309 %31
-%370 = OpLoad  %24  %310
-%371 = OpFAdd  %24  %370 %369
+%364 = OpConvertUToF  %8  %221
+%365 = OpCompositeConstruct  %304  %303 %364
+%366 = OpSampledImage  %339  %298 %300
+%367 = OpImageSampleImplicitLod  %24  %366 %365 Bias|ConstOffset %307 %31
+%368 = OpLoad  %24  %308
+%369 = OpFAdd  %24  %368 %367
 OpLine %3 130 5
-OpStore %310 %371
+OpStore %308 %369
 OpLine %3 131 5
-%372 = OpConvertSToF  %8  %82
-%373 = OpCompositeConstruct  %306  %305 %372
-%374 = OpSampledImage  %341  %300 %302
-%375 = OpImageSampleImplicitLod  %24  %374 %373
-%376 = OpLoad  %24  %310
-%377 = OpFAdd  %24  %376 %375
+%370 = OpConvertSToF  %8  %80
+%371 = OpCompositeConstruct  %304  %303 %370
+%372 = OpSampledImage  %339  %298 %300
+%373 = OpImageSampleImplicitLod  %24  %372 %371
+%374 = OpLoad  %24  %308
+%375 = OpFAdd  %24  %374 %373
 OpLine %3 131 5
-OpStore %310 %377
+OpStore %308 %375
 OpLine %3 132 5
-%378 = OpConvertSToF  %8  %82
-%379 = OpCompositeConstruct  %306  %305 %378
-%380 = OpSampledImage  %341  %300 %302
-%381 = OpImageSampleImplicitLod  %24  %380 %379 ConstOffset %31
-%382 = OpLoad  %24  %310
-%383 = OpFAdd  %24  %382 %381
+%376 = OpConvertSToF  %8  %80
+%377 = OpCompositeConstruct  %304  %303 %376
+%378 = OpSampledImage  %339  %298 %300
+%379 = OpImageSampleImplicitLod  %24  %378 %377 ConstOffset %31
+%380 = OpLoad  %24  %308
+%381 = OpFAdd  %24  %380 %379
 OpLine %3 132 5
-OpStore %310 %383
+OpStore %308 %381
 OpLine %3 133 5
-%384 = OpConvertSToF  %8  %82
-%385 = OpCompositeConstruct  %306  %305 %384
-%386 = OpSampledImage  %341  %300 %302
-%387 = OpImageSampleExplicitLod  %24  %386 %385 Lod %308
-%388 = OpLoad  %24  %310
-%389 = OpFAdd  %24  %388 %387
+%382 = OpConvertSToF  %8  %80
+%383 = OpCompositeConstruct  %304  %303 %382
+%384 = OpSampledImage  %339  %298 %300
+%385 = OpImageSampleExplicitLod  %24  %384 %383 Lod %306
+%386 = OpLoad  %24  %308
+%387 = OpFAdd  %24  %386 %385
 OpLine %3 133 5
-OpStore %310 %389
+OpStore %308 %387
 OpLine %3 134 5
-%390 = OpConvertSToF  %8  %82
-%391 = OpCompositeConstruct  %306  %305 %390
-%392 = OpSampledImage  %341  %300 %302
-%393 = OpImageSampleExplicitLod  %24  %392 %391 Lod|ConstOffset %308 %31
-%394 = OpLoad  %24  %310
-%395 = OpFAdd  %24  %394 %393
+%388 = OpConvertSToF  %8  %80
+%389 = OpCompositeConstruct  %304  %303 %388
+%390 = OpSampledImage  %339  %298 %300
+%391 = OpImageSampleExplicitLod  %24  %390 %389 Lod|ConstOffset %306 %31
+%392 = OpLoad  %24  %308
+%393 = OpFAdd  %24  %392 %391
 OpLine %3 134 5
-OpStore %310 %395
+OpStore %308 %393
 OpLine %3 135 5
-%396 = OpConvertSToF  %8  %82
-%397 = OpCompositeConstruct  %306  %305 %396
-%398 = OpSampledImage  %341  %300 %302
-%399 = OpImageSampleImplicitLod  %24  %398 %397 Bias|ConstOffset %309 %31
-%400 = OpLoad  %24  %310
-%401 = OpFAdd  %24  %400 %399
+%394 = OpConvertSToF  %8  %80
+%395 = OpCompositeConstruct  %304  %303 %394
+%396 = OpSampledImage  %339  %298 %300
+%397 = OpImageSampleImplicitLod  %24  %396 %395 Bias|ConstOffset %307 %31
+%398 = OpLoad  %24  %308
+%399 = OpFAdd  %24  %398 %397
 OpLine %3 135 5
-OpStore %310 %401
+OpStore %308 %399
 OpLine %3 136 5
-%403 = OpConvertUToF  %8  %223
-%404 = OpCompositeConstruct  %24  %307 %403
-%405 = OpSampledImage  %402  %301 %302
-%406 = OpImageSampleImplicitLod  %24  %405 %404
-%407 = OpLoad  %24  %310
-%408 = OpFAdd  %24  %407 %406
+%401 = OpConvertUToF  %8  %221
+%402 = OpCompositeConstruct  %24  %305 %401
+%403 = OpSampledImage  %400  %299 %300
+%404 = OpImageSampleImplicitLod  %24  %403 %402
+%405 = OpLoad  %24  %308
+%406 = OpFAdd  %24  %405 %404
 OpLine %3 136 5
-OpStore %310 %408
+OpStore %308 %406
 OpLine %3 137 5
-%409 = OpConvertUToF  %8  %223
-%410 = OpCompositeConstruct  %24  %307 %409
-%411 = OpSampledImage  %402  %301 %302
-%412 = OpImageSampleExplicitLod  %24  %411 %410 Lod %308
-%413 = OpLoad  %24  %310
-%414 = OpFAdd  %24  %413 %412
+%407 = OpConvertUToF  %8  %221
+%408 = OpCompositeConstruct  %24  %305 %407
+%409 = OpSampledImage  %400  %299 %300
+%410 = OpImageSampleExplicitLod  %24  %409 %408 Lod %306
+%411 = OpLoad  %24  %308
+%412 = OpFAdd  %24  %411 %410
 OpLine %3 137 5
-OpStore %310 %414
+OpStore %308 %412
 OpLine %3 138 5
-%415 = OpConvertUToF  %8  %223
-%416 = OpCompositeConstruct  %24  %307 %415
-%417 = OpSampledImage  %402  %301 %302
-%418 = OpImageSampleImplicitLod  %24  %417 %416 Bias %309
-%419 = OpLoad  %24  %310
-%420 = OpFAdd  %24  %419 %418
+%413 = OpConvertUToF  %8  %221
+%414 = OpCompositeConstruct  %24  %305 %413
+%415 = OpSampledImage  %400  %299 %300
+%416 = OpImageSampleImplicitLod  %24  %415 %414 Bias %307
+%417 = OpLoad  %24  %308
+%418 = OpFAdd  %24  %417 %416
 OpLine %3 138 5
-OpStore %310 %420
+OpStore %308 %418
 OpLine %3 139 5
-%421 = OpConvertSToF  %8  %82
-%422 = OpCompositeConstruct  %24  %307 %421
-%423 = OpSampledImage  %402  %301 %302
-%424 = OpImageSampleImplicitLod  %24  %423 %422
-%425 = OpLoad  %24  %310
-%426 = OpFAdd  %24  %425 %424
+%419 = OpConvertSToF  %8  %80
+%420 = OpCompositeConstruct  %24  %305 %419
+%421 = OpSampledImage  %400  %299 %300
+%422 = OpImageSampleImplicitLod  %24  %421 %420
+%423 = OpLoad  %24  %308
+%424 = OpFAdd  %24  %423 %422
 OpLine %3 139 5
-OpStore %310 %426
+OpStore %308 %424
 OpLine %3 140 5
-%427 = OpConvertSToF  %8  %82
-%428 = OpCompositeConstruct  %24  %307 %427
-%429 = OpSampledImage  %402  %301 %302
-%430 = OpImageSampleExplicitLod  %24  %429 %428 Lod %308
-%431 = OpLoad  %24  %310
-%432 = OpFAdd  %24  %431 %430
+%425 = OpConvertSToF  %8  %80
+%426 = OpCompositeConstruct  %24  %305 %425
+%427 = OpSampledImage  %400  %299 %300
+%428 = OpImageSampleExplicitLod  %24  %427 %426 Lod %306
+%429 = OpLoad  %24  %308
+%430 = OpFAdd  %24  %429 %428
 OpLine %3 140 5
-OpStore %310 %432
+OpStore %308 %430
 OpLine %3 141 5
-%433 = OpConvertSToF  %8  %82
-%434 = OpCompositeConstruct  %24  %307 %433
-%435 = OpSampledImage  %402  %301 %302
-%436 = OpImageSampleImplicitLod  %24  %435 %434 Bias %309
-%437 = OpLoad  %24  %310
-%438 = OpFAdd  %24  %437 %436
+%431 = OpConvertSToF  %8  %80
+%432 = OpCompositeConstruct  %24  %305 %431
+%433 = OpSampledImage  %400  %299 %300
+%434 = OpImageSampleImplicitLod  %24  %433 %432 Bias %307
+%435 = OpLoad  %24  %308
+%436 = OpFAdd  %24  %435 %434
 OpLine %3 141 5
-OpStore %310 %438
+OpStore %308 %436
 OpLine %3 1 1
-%439 = OpLoad  %24  %310
-OpStore %296 %439
+%437 = OpLoad  %24  %308
+OpStore %294 %437
 OpReturn
 OpFunctionEnd
-%443 = OpFunction  %2  None %101
-%440 = OpLabel
-%448 = OpVariable  %449  Function %450
-%444 = OpLoad  %25  %67
-%445 = OpLoad  %26  %69
-%446 = OpLoad  %27  %71
-%447 = OpLoad  %28  %73
-OpBranch %451
-%451 = OpLabel
+%441 = OpFunction  %2  None %99
+%438 = OpLabel
+%446 = OpVariable  %447  Function %448
+%442 = OpLoad  %25  %66
+%443 = OpLoad  %26  %67
+%444 = OpLoad  %27  %69
+%445 = OpLoad  %28  %71
+OpBranch %449
+%449 = OpLabel
 OpLine %3 156 14
 OpLine %3 157 15
 OpLine %3 160 5
-%453 = OpSampledImage  %452  %445 %444
-%454 = OpImageSampleDrefImplicitLod  %8  %453 %305 %303
-%455 = OpLoad  %8  %448
-%456 = OpFAdd  %8  %455 %454
+%451 = OpSampledImage  %450  %443 %442
+%452 = OpImageSampleDrefImplicitLod  %8  %451 %303 %301
+%453 = OpLoad  %8  %446
+%454 = OpFAdd  %8  %453 %452
 OpLine %3 160 5
-OpStore %448 %456
+OpStore %446 %454
 OpLine %3 161 5
-%458 = OpConvertUToF  %8  %223
-%459 = OpCompositeConstruct  %306  %305 %458
-%460 = OpSampledImage  %457  %446 %444
-%461 = OpImageSampleDrefImplicitLod  %8  %460 %459 %303
-%462 = OpLoad  %8  %448
-%463 = OpFAdd  %8  %462 %461
+%456 = OpConvertUToF  %8  %221
+%457 = OpCompositeConstruct  %304  %303 %456
+%458 = OpSampledImage  %455  %444 %442
+%459 = OpImageSampleDrefImplicitLod  %8  %458 %457 %301
+%460 = OpLoad  %8  %446
+%461 = OpFAdd  %8  %460 %459
 OpLine %3 161 5
-OpStore %448 %463
+OpStore %446 %461
 OpLine %3 162 5
-%464 = OpConvertSToF  %8  %82
-%465 = OpCompositeConstruct  %306  %305 %464
-%466 = OpSampledImage  %457  %446 %444
-%467 = OpImageSampleDrefImplicitLod  %8  %466 %465 %303
-%468 = OpLoad  %8  %448
-%469 = OpFAdd  %8  %468 %467
+%462 = OpConvertSToF  %8  %80
+%463 = OpCompositeConstruct  %304  %303 %462
+%464 = OpSampledImage  %455  %444 %442
+%465 = OpImageSampleDrefImplicitLod  %8  %464 %463 %301
+%466 = OpLoad  %8  %446
+%467 = OpFAdd  %8  %466 %465
 OpLine %3 162 5
-OpStore %448 %469
+OpStore %446 %467
 OpLine %3 163 5
-%471 = OpSampledImage  %470  %447 %444
-%472 = OpImageSampleDrefImplicitLod  %8  %471 %307 %303
-%473 = OpLoad  %8  %448
-%474 = OpFAdd  %8  %473 %472
+%469 = OpSampledImage  %468  %445 %442
+%470 = OpImageSampleDrefImplicitLod  %8  %469 %305 %301
+%471 = OpLoad  %8  %446
+%472 = OpFAdd  %8  %471 %470
 OpLine %3 163 5
-OpStore %448 %474
+OpStore %446 %472
 OpLine %3 164 5
-%475 = OpSampledImage  %452  %445 %444
-%476 = OpImageSampleDrefExplicitLod  %8  %475 %305 %303 Lod %477
-%478 = OpLoad  %8  %448
-%479 = OpFAdd  %8  %478 %476
+%473 = OpSampledImage  %450  %443 %442
+%474 = OpImageSampleDrefExplicitLod  %8  %473 %303 %301 Lod %475
+%476 = OpLoad  %8  %446
+%477 = OpFAdd  %8  %476 %474
 OpLine %3 164 5
-OpStore %448 %479
+OpStore %446 %477
 OpLine %3 165 5
-%480 = OpConvertUToF  %8  %223
-%481 = OpCompositeConstruct  %306  %305 %480
-%482 = OpSampledImage  %457  %446 %444
-%483 = OpImageSampleDrefExplicitLod  %8  %482 %481 %303 Lod %477
-%484 = OpLoad  %8  %448
-%485 = OpFAdd  %8  %484 %483
+%478 = OpConvertUToF  %8  %221
+%479 = OpCompositeConstruct  %304  %303 %478
+%480 = OpSampledImage  %455  %444 %442
+%481 = OpImageSampleDrefExplicitLod  %8  %480 %479 %301 Lod %475
+%482 = OpLoad  %8  %446
+%483 = OpFAdd  %8  %482 %481
 OpLine %3 165 5
-OpStore %448 %485
+OpStore %446 %483
 OpLine %3 166 5
-%486 = OpConvertSToF  %8  %82
-%487 = OpCompositeConstruct  %306  %305 %486
-%488 = OpSampledImage  %457  %446 %444
-%489 = OpImageSampleDrefExplicitLod  %8  %488 %487 %303 Lod %477
-%490 = OpLoad  %8  %448
-%491 = OpFAdd  %8  %490 %489
+%484 = OpConvertSToF  %8  %80
+%485 = OpCompositeConstruct  %304  %303 %484
+%486 = OpSampledImage  %455  %444 %442
+%487 = OpImageSampleDrefExplicitLod  %8  %486 %485 %301 Lod %475
+%488 = OpLoad  %8  %446
+%489 = OpFAdd  %8  %488 %487
 OpLine %3 166 5
-OpStore %448 %491
+OpStore %446 %489
 OpLine %3 167 5
-%492 = OpSampledImage  %470  %447 %444
-%493 = OpImageSampleDrefExplicitLod  %8  %492 %307 %303 Lod %477
-%494 = OpLoad  %8  %448
-%495 = OpFAdd  %8  %494 %493
+%490 = OpSampledImage  %468  %445 %442
+%491 = OpImageSampleDrefExplicitLod  %8  %490 %305 %301 Lod %475
+%492 = OpLoad  %8  %446
+%493 = OpFAdd  %8  %492 %491
 OpLine %3 167 5
-OpStore %448 %495
+OpStore %446 %493
 OpLine %3 1 1
-%496 = OpLoad  %8  %448
-OpStore %441 %496
+%494 = OpLoad  %8  %446
+OpStore %439 %494
 OpReturn
 OpFunctionEnd
-%499 = OpFunction  %2  None %101
-%497 = OpLabel
-%500 = OpLoad  %17  %50
-%501 = OpLoad  %4  %52
-%502 = OpLoad  %18  %53
-%503 = OpLoad  %25  %65
-%504 = OpLoad  %25  %67
-%505 = OpLoad  %26  %69
-OpBranch %506
-%506 = OpLabel
+%497 = OpFunction  %2  None %99
+%495 = OpLabel
+%498 = OpLoad  %17  %49
+%499 = OpLoad  %4  %51
+%500 = OpLoad  %18  %52
+%501 = OpLoad  %25  %64
+%502 = OpLoad  %25  %66
+%503 = OpLoad  %26  %67
+OpBranch %504
+%504 = OpLabel
 OpLine %3 173 14
 OpLine %3 175 15
-%507 = OpSampledImage  %320  %500 %503
-%508 = OpImageGather  %24  %507 %305 %509
+%505 = OpSampledImage  %318  %498 %501
+%506 = OpImageGather  %24  %505 %303 %507
 OpLine %3 176 22
-%510 = OpSampledImage  %320  %500 %503
-%511 = OpImageGather  %24  %510 %305 %512 ConstOffset %31
+%508 = OpSampledImage  %318  %498 %501
+%509 = OpImageGather  %24  %508 %303 %510 ConstOffset %31
 OpLine %3 177 21
-%513 = OpSampledImage  %452  %505 %504
-%514 = OpImageDrefGather  %24  %513 %305 %303
+%511 = OpSampledImage  %450  %503 %502
+%512 = OpImageDrefGather  %24  %511 %303 %301
 OpLine %3 178 28
-%515 = OpSampledImage  %452  %505 %504
-%516 = OpImageDrefGather  %24  %515 %305 %303 ConstOffset %31
+%513 = OpSampledImage  %450  %503 %502
+%514 = OpImageDrefGather  %24  %513 %303 %301 ConstOffset %31
 OpLine %3 180 13
-%518 = OpSampledImage  %517  %501 %503
-%519 = OpImageGather  %120  %518 %305 %223
+%516 = OpSampledImage  %515  %499 %501
+%517 = OpImageGather  %118  %516 %303 %221
 OpLine %3 181 13
-%522 = OpSampledImage  %521  %502 %503
-%523 = OpImageGather  %520  %522 %305 %223
+%520 = OpSampledImage  %519  %500 %501
+%521 = OpImageGather  %518  %520 %303 %221
 OpLine %3 182 13
-%524 = OpConvertUToF  %24  %519
-%525 = OpConvertSToF  %24  %523
-%526 = OpFAdd  %24  %524 %525
+%522 = OpConvertUToF  %24  %517
+%523 = OpConvertSToF  %24  %521
+%524 = OpFAdd  %24  %522 %523
 OpLine %3 184 12
-%527 = OpFAdd  %24  %508 %511
-%528 = OpFAdd  %24  %527 %514
-%529 = OpFAdd  %24  %528 %516
-%530 = OpFAdd  %24  %529 %526
-OpStore %498 %530
+%525 = OpFAdd  %24  %506 %509
+%526 = OpFAdd  %24  %525 %512
+%527 = OpFAdd  %24  %526 %514
+%528 = OpFAdd  %24  %527 %524
+OpStore %496 %528
 OpReturn
 OpFunctionEnd
-%533 = OpFunction  %2  None %101
-%531 = OpLabel
-%534 = OpLoad  %25  %65
-%535 = OpLoad  %26  %69
-OpBranch %536
-%536 = OpLabel
+%531 = OpFunction  %2  None %99
+%529 = OpLabel
+%532 = OpLoad  %25  %64
+%533 = OpLoad  %26  %67
+OpBranch %534
+%534 = OpLabel
 OpLine %3 189 14
 OpLine %3 191 15
-%537 = OpSampledImage  %452  %535 %534
-%538 = OpImageSampleImplicitLod  %24  %537 %305
-%539 = OpCompositeExtract  %8  %538 0
+%535 = OpSampledImage  %450  %533 %532
+%536 = OpImageSampleImplicitLod  %24  %535 %303
+%537 = OpCompositeExtract  %8  %536 0
 OpLine %3 192 22
-%540 = OpSampledImage  %452  %535 %534
-%541 = OpImageGather  %24  %540 %305 %223
+%538 = OpSampledImage  %450  %533 %532
+%539 = OpImageGather  %24  %538 %303 %221
 OpLine %3 193 21
-%542 = OpSampledImage  %452  %535 %534
-%544 = OpConvertSToF  %8  %30
-%543 = OpImageSampleExplicitLod  %24  %542 %305 Lod %544
-%545 = OpCompositeExtract  %8  %543 0
+%540 = OpSampledImage  %450  %533 %532
+%542 = OpConvertSToF  %8  %30
+%541 = OpImageSampleExplicitLod  %24  %540 %303 Lod %542
+%543 = OpCompositeExtract  %8  %541 0
 OpLine %3 191 15
-%546 = OpCompositeConstruct  %24  %539 %539 %539 %539
-%547 = OpFAdd  %24  %546 %541
-%548 = OpCompositeConstruct  %24  %545 %545 %545 %545
-%549 = OpFAdd  %24  %547 %548
-OpStore %532 %549
+%544 = OpCompositeConstruct  %24  %537 %537 %537 %537
+%545 = OpFAdd  %24  %544 %539
+%546 = OpCompositeConstruct  %24  %543 %543 %543 %543
+%547 = OpFAdd  %24  %545 %546
+OpStore %530 %547
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/interface.vertex.spvasm
+++ b/naga/tests/out/spv/interface.vertex.spvasm
@@ -1,11 +1,11 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 39
+; Bound: 38
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %29 "vertex" %15 %18 %20 %22 %24 %26
+OpEntryPoint Vertex %28 "vertex" %15 %18 %20 %22 %24 %26
 OpMemberDecorate %5 0 Offset 0
 OpMemberDecorate %5 1 Offset 16
 OpMemberDecorate %7 0 Offset 0
@@ -41,26 +41,25 @@ OpDecorate %26 BuiltIn PointSize
 %22 = OpVariable  %23  Output
 %25 = OpTypePointer Output %3
 %24 = OpVariable  %25  Output
-%27 = OpTypePointer Output %3
-%26 = OpVariable  %27  Output
-%28 = OpConstant  %3  1.0
-%30 = OpTypeFunction %2
-%31 = OpConstantComposite  %4  %28 %28 %28 %28
-%29 = OpFunction  %2  None %30
+%26 = OpVariable  %25  Output
+%27 = OpConstant  %3  1.0
+%29 = OpTypeFunction %2
+%30 = OpConstantComposite  %4  %27 %27 %27 %27
+%28 = OpFunction  %2  None %29
 %14 = OpLabel
 %17 = OpLoad  %6  %15
 %19 = OpLoad  %6  %18
 %21 = OpLoad  %6  %20
-OpStore %26 %28
-OpBranch %32
-%32 = OpLabel
-%33 = OpIAdd  %6  %17 %19
-%34 = OpIAdd  %6  %33 %21
-%35 = OpConvertUToF  %3  %34
-%36 = OpCompositeConstruct  %5  %31 %35
-%37 = OpCompositeExtract  %4  %36 0
-OpStore %22 %37
-%38 = OpCompositeExtract  %3  %36 1
-OpStore %24 %38
+OpStore %26 %27
+OpBranch %31
+%31 = OpLabel
+%32 = OpIAdd  %6  %17 %19
+%33 = OpIAdd  %6  %32 %21
+%34 = OpConvertUToF  %3  %33
+%35 = OpCompositeConstruct  %5  %30 %34
+%36 = OpCompositeExtract  %4  %35 0
+OpStore %22 %36
+%37 = OpCompositeExtract  %3  %35 1
+OpStore %24 %37
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/interpolate.spvasm
+++ b/naga/tests/out/spv/interpolate.spvasm
@@ -1,14 +1,14 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 140
+; Bound: 139
 OpCapability Shader
 OpCapability SampleRateShading
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %31 "vert_main" %11 %13 %15 %16 %17 %19 %21 %23 %24 %25 %26 %27 %28
-OpEntryPoint Fragment %138 "frag_main" %109 %112 %115 %117 %119 %122 %125 %128 %130 %132 %134 %136
-OpExecutionMode %138 OriginUpperLeft
+OpEntryPoint Vertex %30 "vert_main" %11 %13 %15 %16 %17 %19 %21 %23 %24 %25 %26 %27 %28
+OpEntryPoint Fragment %137 "frag_main" %108 %111 %114 %116 %118 %121 %124 %127 %129 %131 %133 %135
+OpExecutionMode %137 OriginUpperLeft
 %3 = OpString "interpolate.wgsl"
 OpSource Unknown 0 %3 "//TODO: merge with \"interface\"?
 
@@ -77,21 +77,21 @@ OpName %24 "perspective"
 OpName %25 "perspective_centroid"
 OpName %26 "perspective_sample"
 OpName %27 "perspective_center"
-OpName %31 "vert_main"
-OpName %61 "out"
-OpName %109 "position"
-OpName %112 "_flat"
-OpName %115 "flat_first"
-OpName %117 "flat_either"
-OpName %119 "_linear"
-OpName %122 "linear_centroid"
-OpName %125 "linear_sample"
-OpName %128 "linear_center"
-OpName %130 "perspective"
-OpName %132 "perspective_centroid"
-OpName %134 "perspective_sample"
-OpName %136 "perspective_center"
-OpName %138 "frag_main"
+OpName %30 "vert_main"
+OpName %60 "out"
+OpName %108 "position"
+OpName %111 "_flat"
+OpName %114 "flat_first"
+OpName %116 "flat_either"
+OpName %118 "_linear"
+OpName %121 "linear_centroid"
+OpName %124 "linear_sample"
+OpName %127 "linear_center"
+OpName %129 "perspective"
+OpName %131 "perspective_centroid"
+OpName %133 "perspective_sample"
+OpName %135 "perspective_center"
+OpName %137 "frag_main"
 OpMemberDecorate %9 0 Offset 0
 OpMemberDecorate %9 1 Offset 16
 OpMemberDecorate %9 2 Offset 20
@@ -128,29 +128,29 @@ OpDecorate %26 Location 10
 OpDecorate %26 Sample
 OpDecorate %27 Location 11
 OpDecorate %28 BuiltIn PointSize
-OpDecorate %109 BuiltIn FragCoord
-OpDecorate %112 Location 0
-OpDecorate %112 Flat
-OpDecorate %115 Location 1
-OpDecorate %115 Flat
-OpDecorate %117 Location 2
-OpDecorate %117 Flat
-OpDecorate %119 Location 3
-OpDecorate %119 NoPerspective
-OpDecorate %122 Location 4
-OpDecorate %122 NoPerspective
-OpDecorate %122 Centroid
-OpDecorate %125 Location 6
-OpDecorate %125 NoPerspective
-OpDecorate %125 Sample
-OpDecorate %128 Location 7
-OpDecorate %128 NoPerspective
-OpDecorate %130 Location 8
-OpDecorate %132 Location 9
-OpDecorate %132 Centroid
-OpDecorate %134 Location 10
-OpDecorate %134 Sample
-OpDecorate %136 Location 11
+OpDecorate %108 BuiltIn FragCoord
+OpDecorate %111 Location 0
+OpDecorate %111 Flat
+OpDecorate %114 Location 1
+OpDecorate %114 Flat
+OpDecorate %116 Location 2
+OpDecorate %116 Flat
+OpDecorate %118 Location 3
+OpDecorate %118 NoPerspective
+OpDecorate %121 Location 4
+OpDecorate %121 NoPerspective
+OpDecorate %121 Centroid
+OpDecorate %124 Location 6
+OpDecorate %124 NoPerspective
+OpDecorate %124 Sample
+OpDecorate %127 Location 7
+OpDecorate %127 NoPerspective
+OpDecorate %129 Location 8
+OpDecorate %131 Location 9
+OpDecorate %131 Centroid
+OpDecorate %133 Location 10
+OpDecorate %133 Sample
+OpDecorate %135 Location 11
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %5 = OpTypeVector %4 4
@@ -175,178 +175,177 @@ OpDecorate %136 Location 11
 %25 = OpVariable  %18  Output
 %26 = OpVariable  %18  Output
 %27 = OpVariable  %18  Output
-%29 = OpTypePointer Output %4
-%28 = OpVariable  %29  Output
-%30 = OpConstant  %4  1.0
-%32 = OpTypeFunction %2
-%33 = OpConstant  %4  2.0
-%34 = OpConstant  %4  4.0
-%35 = OpConstant  %4  5.0
-%36 = OpConstant  %4  6.0
-%37 = OpConstantComposite  %5  %33 %34 %35 %36
-%38 = OpConstant  %6  8
-%39 = OpConstant  %6  9
-%40 = OpConstant  %6  10
-%41 = OpConstant  %4  27.0
-%42 = OpConstant  %4  64.0
-%43 = OpConstant  %4  125.0
-%44 = OpConstantComposite  %7  %42 %43
-%45 = OpConstant  %4  216.0
-%46 = OpConstant  %4  343.0
-%47 = OpConstant  %4  512.0
-%48 = OpConstantComposite  %8  %45 %46 %47
-%49 = OpConstant  %4  255.0
-%50 = OpConstant  %4  511.0
-%51 = OpConstant  %4  1024.0
-%52 = OpConstantComposite  %8  %49 %50 %51
-%53 = OpConstant  %4  729.0
-%54 = OpConstant  %4  1000.0
-%55 = OpConstant  %4  1331.0
-%56 = OpConstant  %4  1728.0
-%57 = OpConstantComposite  %5  %53 %54 %55 %56
-%58 = OpConstant  %4  2197.0
-%59 = OpConstant  %4  2744.0
-%60 = OpConstant  %4  2812.0
-%62 = OpTypePointer Function %9
-%63 = OpConstantNull  %9
-%65 = OpTypePointer Function %5
-%66 = OpConstant  %6  0
-%68 = OpTypePointer Function %6
-%69 = OpConstant  %6  1
-%71 = OpConstant  %6  2
-%73 = OpConstant  %6  3
-%75 = OpTypePointer Function %4
-%76 = OpConstant  %6  4
-%78 = OpTypePointer Function %7
-%79 = OpConstant  %6  5
-%81 = OpTypePointer Function %8
-%82 = OpConstant  %6  6
-%84 = OpConstant  %6  7
-%89 = OpConstant  %6  11
-%110 = OpTypePointer Input %5
-%109 = OpVariable  %110  Input
-%113 = OpTypePointer Input %6
-%112 = OpVariable  %113  Input
-%115 = OpVariable  %113  Input
-%117 = OpVariable  %113  Input
-%120 = OpTypePointer Input %4
-%119 = OpVariable  %120  Input
-%123 = OpTypePointer Input %7
-%122 = OpVariable  %123  Input
-%126 = OpTypePointer Input %8
-%125 = OpVariable  %126  Input
-%128 = OpVariable  %126  Input
-%130 = OpVariable  %110  Input
-%132 = OpVariable  %120  Input
-%134 = OpVariable  %120  Input
-%136 = OpVariable  %120  Input
-%31 = OpFunction  %2  None %32
+%28 = OpVariable  %18  Output
+%29 = OpConstant  %4  1.0
+%31 = OpTypeFunction %2
+%32 = OpConstant  %4  2.0
+%33 = OpConstant  %4  4.0
+%34 = OpConstant  %4  5.0
+%35 = OpConstant  %4  6.0
+%36 = OpConstantComposite  %5  %32 %33 %34 %35
+%37 = OpConstant  %6  8
+%38 = OpConstant  %6  9
+%39 = OpConstant  %6  10
+%40 = OpConstant  %4  27.0
+%41 = OpConstant  %4  64.0
+%42 = OpConstant  %4  125.0
+%43 = OpConstantComposite  %7  %41 %42
+%44 = OpConstant  %4  216.0
+%45 = OpConstant  %4  343.0
+%46 = OpConstant  %4  512.0
+%47 = OpConstantComposite  %8  %44 %45 %46
+%48 = OpConstant  %4  255.0
+%49 = OpConstant  %4  511.0
+%50 = OpConstant  %4  1024.0
+%51 = OpConstantComposite  %8  %48 %49 %50
+%52 = OpConstant  %4  729.0
+%53 = OpConstant  %4  1000.0
+%54 = OpConstant  %4  1331.0
+%55 = OpConstant  %4  1728.0
+%56 = OpConstantComposite  %5  %52 %53 %54 %55
+%57 = OpConstant  %4  2197.0
+%58 = OpConstant  %4  2744.0
+%59 = OpConstant  %4  2812.0
+%61 = OpTypePointer Function %9
+%62 = OpConstantNull  %9
+%64 = OpTypePointer Function %5
+%65 = OpConstant  %6  0
+%67 = OpTypePointer Function %6
+%68 = OpConstant  %6  1
+%70 = OpConstant  %6  2
+%72 = OpConstant  %6  3
+%74 = OpTypePointer Function %4
+%75 = OpConstant  %6  4
+%77 = OpTypePointer Function %7
+%78 = OpConstant  %6  5
+%80 = OpTypePointer Function %8
+%81 = OpConstant  %6  6
+%83 = OpConstant  %6  7
+%88 = OpConstant  %6  11
+%109 = OpTypePointer Input %5
+%108 = OpVariable  %109  Input
+%112 = OpTypePointer Input %6
+%111 = OpVariable  %112  Input
+%114 = OpVariable  %112  Input
+%116 = OpVariable  %112  Input
+%119 = OpTypePointer Input %4
+%118 = OpVariable  %119  Input
+%122 = OpTypePointer Input %7
+%121 = OpVariable  %122  Input
+%125 = OpTypePointer Input %8
+%124 = OpVariable  %125  Input
+%127 = OpVariable  %125  Input
+%129 = OpVariable  %109  Input
+%131 = OpVariable  %119  Input
+%133 = OpVariable  %119  Input
+%135 = OpVariable  %119  Input
+%30 = OpFunction  %2  None %31
 %10 = OpLabel
-%61 = OpVariable  %62  Function %63
-OpStore %28 %30
-OpBranch %64
-%64 = OpLabel
+%60 = OpVariable  %61  Function %62
+OpStore %28 %29
+OpBranch %63
+%63 = OpLabel
 OpLine %3 24 4
 OpLine %3 24 19
 OpLine %3 24 4
-%67 = OpAccessChain  %65  %61 %66
-OpStore %67 %37
+%66 = OpAccessChain  %64  %60 %65
+OpStore %66 %36
 OpLine %3 25 4
 OpLine %3 25 4
-%70 = OpAccessChain  %68  %61 %69
-OpStore %70 %38
+%69 = OpAccessChain  %67  %60 %68
+OpStore %69 %37
 OpLine %3 26 4
 OpLine %3 26 4
-%72 = OpAccessChain  %68  %61 %71
-OpStore %72 %39
+%71 = OpAccessChain  %67  %60 %70
+OpStore %71 %38
 OpLine %3 27 4
 OpLine %3 27 4
-%74 = OpAccessChain  %68  %61 %73
-OpStore %74 %40
+%73 = OpAccessChain  %67  %60 %72
+OpStore %73 %39
 OpLine %3 28 4
 OpLine %3 28 4
-%77 = OpAccessChain  %75  %61 %76
-OpStore %77 %41
+%76 = OpAccessChain  %74  %60 %75
+OpStore %76 %40
 OpLine %3 29 4
 OpLine %3 29 26
 OpLine %3 29 4
-%80 = OpAccessChain  %78  %61 %79
-OpStore %80 %44
+%79 = OpAccessChain  %77  %60 %78
+OpStore %79 %43
 OpLine %3 30 4
 OpLine %3 30 24
 OpLine %3 30 4
-%83 = OpAccessChain  %81  %61 %82
-OpStore %83 %48
+%82 = OpAccessChain  %80  %60 %81
+OpStore %82 %47
 OpLine %3 31 4
 OpLine %3 31 24
 OpLine %3 31 4
-%85 = OpAccessChain  %81  %61 %84
-OpStore %85 %52
+%84 = OpAccessChain  %80  %60 %83
+OpStore %84 %51
 OpLine %3 32 4
 OpLine %3 32 22
 OpLine %3 32 4
-%86 = OpAccessChain  %65  %61 %38
+%85 = OpAccessChain  %64  %60 %37
+OpStore %85 %56
+OpLine %3 33 4
+OpLine %3 33 4
+%86 = OpAccessChain  %74  %60 %38
 OpStore %86 %57
-OpLine %3 33 4
-OpLine %3 33 4
-%87 = OpAccessChain  %75  %61 %39
+OpLine %3 34 4
+OpLine %3 34 4
+%87 = OpAccessChain  %74  %60 %39
 OpStore %87 %58
-OpLine %3 34 4
-OpLine %3 34 4
-%88 = OpAccessChain  %75  %61 %40
-OpStore %88 %59
 OpLine %3 35 4
 OpLine %3 35 4
-%90 = OpAccessChain  %75  %61 %89
-OpStore %90 %60
+%89 = OpAccessChain  %74  %60 %88
+OpStore %89 %59
 OpLine %3 1 1
-%91 = OpLoad  %9  %61
-%92 = OpCompositeExtract  %5  %91 0
-OpStore %11 %92
-%93 = OpAccessChain  %29  %11 %69
-%94 = OpLoad  %4  %93
-%95 = OpFNegate  %4  %94
-OpStore %93 %95
-%96 = OpCompositeExtract  %6  %91 1
-OpStore %13 %96
-%97 = OpCompositeExtract  %6  %91 2
-OpStore %15 %97
-%98 = OpCompositeExtract  %6  %91 3
-OpStore %16 %98
-%99 = OpCompositeExtract  %4  %91 4
-OpStore %17 %99
-%100 = OpCompositeExtract  %7  %91 5
-OpStore %19 %100
-%101 = OpCompositeExtract  %8  %91 6
-OpStore %21 %101
-%102 = OpCompositeExtract  %8  %91 7
-OpStore %23 %102
-%103 = OpCompositeExtract  %5  %91 8
-OpStore %24 %103
-%104 = OpCompositeExtract  %4  %91 9
-OpStore %25 %104
-%105 = OpCompositeExtract  %4  %91 10
-OpStore %26 %105
-%106 = OpCompositeExtract  %4  %91 11
-OpStore %27 %106
+%90 = OpLoad  %9  %60
+%91 = OpCompositeExtract  %5  %90 0
+OpStore %11 %91
+%92 = OpAccessChain  %18  %11 %68
+%93 = OpLoad  %4  %92
+%94 = OpFNegate  %4  %93
+OpStore %92 %94
+%95 = OpCompositeExtract  %6  %90 1
+OpStore %13 %95
+%96 = OpCompositeExtract  %6  %90 2
+OpStore %15 %96
+%97 = OpCompositeExtract  %6  %90 3
+OpStore %16 %97
+%98 = OpCompositeExtract  %4  %90 4
+OpStore %17 %98
+%99 = OpCompositeExtract  %7  %90 5
+OpStore %19 %99
+%100 = OpCompositeExtract  %8  %90 6
+OpStore %21 %100
+%101 = OpCompositeExtract  %8  %90 7
+OpStore %23 %101
+%102 = OpCompositeExtract  %5  %90 8
+OpStore %24 %102
+%103 = OpCompositeExtract  %4  %90 9
+OpStore %25 %103
+%104 = OpCompositeExtract  %4  %90 10
+OpStore %26 %104
+%105 = OpCompositeExtract  %4  %90 11
+OpStore %27 %105
 OpReturn
 OpFunctionEnd
-%138 = OpFunction  %2  None %32
-%107 = OpLabel
-%111 = OpLoad  %5  %109
-%114 = OpLoad  %6  %112
-%116 = OpLoad  %6  %115
-%118 = OpLoad  %6  %117
-%121 = OpLoad  %4  %119
-%124 = OpLoad  %7  %122
-%127 = OpLoad  %8  %125
-%129 = OpLoad  %8  %128
-%131 = OpLoad  %5  %130
-%133 = OpLoad  %4  %132
-%135 = OpLoad  %4  %134
-%137 = OpLoad  %4  %136
-%108 = OpCompositeConstruct  %9  %111 %114 %116 %118 %121 %124 %127 %129 %131 %133 %135 %137
-OpBranch %139
-%139 = OpLabel
+%137 = OpFunction  %2  None %31
+%106 = OpLabel
+%110 = OpLoad  %5  %108
+%113 = OpLoad  %6  %111
+%115 = OpLoad  %6  %114
+%117 = OpLoad  %6  %116
+%120 = OpLoad  %4  %118
+%123 = OpLoad  %7  %121
+%126 = OpLoad  %8  %124
+%128 = OpLoad  %8  %127
+%130 = OpLoad  %5  %129
+%132 = OpLoad  %4  %131
+%134 = OpLoad  %4  %133
+%136 = OpLoad  %4  %135
+%107 = OpCompositeConstruct  %9  %110 %113 %115 %117 %120 %123 %126 %128 %130 %132 %134 %136
+OpBranch %138
+%138 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/interpolate_compat.spvasm
+++ b/naga/tests/out/spv/interpolate_compat.spvasm
@@ -1,14 +1,14 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 134
+; Bound: 133
 OpCapability Shader
 OpCapability SampleRateShading
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %30 "vert_main" %11 %13 %15 %16 %18 %20 %22 %23 %24 %25 %26 %27
-OpEntryPoint Fragment %132 "frag_main" %105 %108 %111 %113 %116 %119 %122 %124 %126 %128 %130
-OpExecutionMode %132 OriginUpperLeft
+OpEntryPoint Vertex %29 "vert_main" %11 %13 %15 %16 %18 %20 %22 %23 %24 %25 %26 %27
+OpEntryPoint Fragment %131 "frag_main" %104 %107 %110 %112 %115 %118 %121 %123 %125 %127 %129
+OpExecutionMode %131 OriginUpperLeft
 %3 = OpString "interpolate_compat.wgsl"
 OpSource Unknown 0 %3 "// NOTE: This is basically the same as `interpolate.wgsl`, except for the removal of
 // `@interpolate(flat, first)`, which is unsupported in GLSL and `compat`.
@@ -77,20 +77,20 @@ OpName %23 "perspective"
 OpName %24 "perspective_centroid"
 OpName %25 "perspective_sample"
 OpName %26 "perspective_center"
-OpName %30 "vert_main"
-OpName %59 "out"
-OpName %105 "position"
-OpName %108 "_flat"
-OpName %111 "flat_either"
-OpName %113 "_linear"
-OpName %116 "linear_centroid"
-OpName %119 "linear_sample"
-OpName %122 "linear_center"
-OpName %124 "perspective"
-OpName %126 "perspective_centroid"
-OpName %128 "perspective_sample"
-OpName %130 "perspective_center"
-OpName %132 "frag_main"
+OpName %29 "vert_main"
+OpName %58 "out"
+OpName %104 "position"
+OpName %107 "_flat"
+OpName %110 "flat_either"
+OpName %112 "_linear"
+OpName %115 "linear_centroid"
+OpName %118 "linear_sample"
+OpName %121 "linear_center"
+OpName %123 "perspective"
+OpName %125 "perspective_centroid"
+OpName %127 "perspective_sample"
+OpName %129 "perspective_center"
+OpName %131 "frag_main"
 OpMemberDecorate %9 0 Offset 0
 OpMemberDecorate %9 1 Offset 16
 OpMemberDecorate %9 2 Offset 20
@@ -124,27 +124,27 @@ OpDecorate %25 Location 10
 OpDecorate %25 Sample
 OpDecorate %26 Location 11
 OpDecorate %27 BuiltIn PointSize
-OpDecorate %105 BuiltIn FragCoord
-OpDecorate %108 Location 0
-OpDecorate %108 Flat
-OpDecorate %111 Location 2
-OpDecorate %111 Flat
-OpDecorate %113 Location 3
-OpDecorate %113 NoPerspective
-OpDecorate %116 Location 4
-OpDecorate %116 NoPerspective
-OpDecorate %116 Centroid
-OpDecorate %119 Location 6
-OpDecorate %119 NoPerspective
-OpDecorate %119 Sample
-OpDecorate %122 Location 7
-OpDecorate %122 NoPerspective
-OpDecorate %124 Location 8
-OpDecorate %126 Location 9
-OpDecorate %126 Centroid
-OpDecorate %128 Location 10
-OpDecorate %128 Sample
-OpDecorate %130 Location 11
+OpDecorate %104 BuiltIn FragCoord
+OpDecorate %107 Location 0
+OpDecorate %107 Flat
+OpDecorate %110 Location 2
+OpDecorate %110 Flat
+OpDecorate %112 Location 3
+OpDecorate %112 NoPerspective
+OpDecorate %115 Location 4
+OpDecorate %115 NoPerspective
+OpDecorate %115 Centroid
+OpDecorate %118 Location 6
+OpDecorate %118 NoPerspective
+OpDecorate %118 Sample
+OpDecorate %121 Location 7
+OpDecorate %121 NoPerspective
+OpDecorate %123 Location 8
+OpDecorate %125 Location 9
+OpDecorate %125 Centroid
+OpDecorate %127 Location 10
+OpDecorate %127 Sample
+OpDecorate %129 Location 11
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %5 = OpTypeVector %4 4
@@ -168,169 +168,168 @@ OpDecorate %130 Location 11
 %24 = OpVariable  %17  Output
 %25 = OpVariable  %17  Output
 %26 = OpVariable  %17  Output
-%28 = OpTypePointer Output %4
-%27 = OpVariable  %28  Output
-%29 = OpConstant  %4  1.0
-%31 = OpTypeFunction %2
-%32 = OpConstant  %4  2.0
-%33 = OpConstant  %4  4.0
-%34 = OpConstant  %4  5.0
-%35 = OpConstant  %4  6.0
-%36 = OpConstantComposite  %5  %32 %33 %34 %35
-%37 = OpConstant  %6  8
-%38 = OpConstant  %6  10
-%39 = OpConstant  %4  27.0
-%40 = OpConstant  %4  64.0
-%41 = OpConstant  %4  125.0
-%42 = OpConstantComposite  %7  %40 %41
-%43 = OpConstant  %4  216.0
-%44 = OpConstant  %4  343.0
-%45 = OpConstant  %4  512.0
-%46 = OpConstantComposite  %8  %43 %44 %45
-%47 = OpConstant  %4  255.0
-%48 = OpConstant  %4  511.0
-%49 = OpConstant  %4  1024.0
-%50 = OpConstantComposite  %8  %47 %48 %49
-%51 = OpConstant  %4  729.0
-%52 = OpConstant  %4  1000.0
-%53 = OpConstant  %4  1331.0
-%54 = OpConstant  %4  1728.0
-%55 = OpConstantComposite  %5  %51 %52 %53 %54
-%56 = OpConstant  %4  2197.0
-%57 = OpConstant  %4  2744.0
-%58 = OpConstant  %4  2812.0
-%60 = OpTypePointer Function %9
-%61 = OpConstantNull  %9
-%63 = OpTypePointer Function %5
-%64 = OpConstant  %6  0
-%66 = OpTypePointer Function %6
-%67 = OpConstant  %6  1
-%69 = OpConstant  %6  2
-%71 = OpTypePointer Function %4
-%72 = OpConstant  %6  3
-%74 = OpTypePointer Function %7
-%75 = OpConstant  %6  4
-%77 = OpTypePointer Function %8
-%78 = OpConstant  %6  5
-%80 = OpConstant  %6  6
-%82 = OpConstant  %6  7
-%85 = OpConstant  %6  9
-%106 = OpTypePointer Input %5
-%105 = OpVariable  %106  Input
-%109 = OpTypePointer Input %6
-%108 = OpVariable  %109  Input
-%111 = OpVariable  %109  Input
-%114 = OpTypePointer Input %4
-%113 = OpVariable  %114  Input
-%117 = OpTypePointer Input %7
-%116 = OpVariable  %117  Input
-%120 = OpTypePointer Input %8
-%119 = OpVariable  %120  Input
-%122 = OpVariable  %120  Input
-%124 = OpVariable  %106  Input
-%126 = OpVariable  %114  Input
-%128 = OpVariable  %114  Input
-%130 = OpVariable  %114  Input
-%30 = OpFunction  %2  None %31
+%27 = OpVariable  %17  Output
+%28 = OpConstant  %4  1.0
+%30 = OpTypeFunction %2
+%31 = OpConstant  %4  2.0
+%32 = OpConstant  %4  4.0
+%33 = OpConstant  %4  5.0
+%34 = OpConstant  %4  6.0
+%35 = OpConstantComposite  %5  %31 %32 %33 %34
+%36 = OpConstant  %6  8
+%37 = OpConstant  %6  10
+%38 = OpConstant  %4  27.0
+%39 = OpConstant  %4  64.0
+%40 = OpConstant  %4  125.0
+%41 = OpConstantComposite  %7  %39 %40
+%42 = OpConstant  %4  216.0
+%43 = OpConstant  %4  343.0
+%44 = OpConstant  %4  512.0
+%45 = OpConstantComposite  %8  %42 %43 %44
+%46 = OpConstant  %4  255.0
+%47 = OpConstant  %4  511.0
+%48 = OpConstant  %4  1024.0
+%49 = OpConstantComposite  %8  %46 %47 %48
+%50 = OpConstant  %4  729.0
+%51 = OpConstant  %4  1000.0
+%52 = OpConstant  %4  1331.0
+%53 = OpConstant  %4  1728.0
+%54 = OpConstantComposite  %5  %50 %51 %52 %53
+%55 = OpConstant  %4  2197.0
+%56 = OpConstant  %4  2744.0
+%57 = OpConstant  %4  2812.0
+%59 = OpTypePointer Function %9
+%60 = OpConstantNull  %9
+%62 = OpTypePointer Function %5
+%63 = OpConstant  %6  0
+%65 = OpTypePointer Function %6
+%66 = OpConstant  %6  1
+%68 = OpConstant  %6  2
+%70 = OpTypePointer Function %4
+%71 = OpConstant  %6  3
+%73 = OpTypePointer Function %7
+%74 = OpConstant  %6  4
+%76 = OpTypePointer Function %8
+%77 = OpConstant  %6  5
+%79 = OpConstant  %6  6
+%81 = OpConstant  %6  7
+%84 = OpConstant  %6  9
+%105 = OpTypePointer Input %5
+%104 = OpVariable  %105  Input
+%108 = OpTypePointer Input %6
+%107 = OpVariable  %108  Input
+%110 = OpVariable  %108  Input
+%113 = OpTypePointer Input %4
+%112 = OpVariable  %113  Input
+%116 = OpTypePointer Input %7
+%115 = OpVariable  %116  Input
+%119 = OpTypePointer Input %8
+%118 = OpVariable  %119  Input
+%121 = OpVariable  %119  Input
+%123 = OpVariable  %105  Input
+%125 = OpVariable  %113  Input
+%127 = OpVariable  %113  Input
+%129 = OpVariable  %113  Input
+%29 = OpFunction  %2  None %30
 %10 = OpLabel
-%59 = OpVariable  %60  Function %61
-OpStore %27 %29
-OpBranch %62
-%62 = OpLabel
+%58 = OpVariable  %59  Function %60
+OpStore %27 %28
+OpBranch %61
+%61 = OpLabel
 OpLine %3 26 4
 OpLine %3 26 19
 OpLine %3 26 4
-%65 = OpAccessChain  %63  %59 %64
-OpStore %65 %36
+%64 = OpAccessChain  %62  %58 %63
+OpStore %64 %35
 OpLine %3 27 4
 OpLine %3 27 4
-%68 = OpAccessChain  %66  %59 %67
-OpStore %68 %37
+%67 = OpAccessChain  %65  %58 %66
+OpStore %67 %36
 OpLine %3 29 4
 OpLine %3 29 4
-%70 = OpAccessChain  %66  %59 %69
-OpStore %70 %38
+%69 = OpAccessChain  %65  %58 %68
+OpStore %69 %37
 OpLine %3 30 4
 OpLine %3 30 4
-%73 = OpAccessChain  %71  %59 %72
-OpStore %73 %39
+%72 = OpAccessChain  %70  %58 %71
+OpStore %72 %38
 OpLine %3 31 4
 OpLine %3 31 26
 OpLine %3 31 4
-%76 = OpAccessChain  %74  %59 %75
-OpStore %76 %42
+%75 = OpAccessChain  %73  %58 %74
+OpStore %75 %41
 OpLine %3 32 4
 OpLine %3 32 24
 OpLine %3 32 4
-%79 = OpAccessChain  %77  %59 %78
-OpStore %79 %46
+%78 = OpAccessChain  %76  %58 %77
+OpStore %78 %45
 OpLine %3 33 4
 OpLine %3 33 24
 OpLine %3 33 4
-%81 = OpAccessChain  %77  %59 %80
-OpStore %81 %50
+%80 = OpAccessChain  %76  %58 %79
+OpStore %80 %49
 OpLine %3 34 4
 OpLine %3 34 22
 OpLine %3 34 4
-%83 = OpAccessChain  %63  %59 %82
+%82 = OpAccessChain  %62  %58 %81
+OpStore %82 %54
+OpLine %3 35 4
+OpLine %3 35 4
+%83 = OpAccessChain  %70  %58 %36
 OpStore %83 %55
-OpLine %3 35 4
-OpLine %3 35 4
-%84 = OpAccessChain  %71  %59 %37
-OpStore %84 %56
 OpLine %3 36 4
 OpLine %3 36 4
-%86 = OpAccessChain  %71  %59 %85
+%85 = OpAccessChain  %70  %58 %84
+OpStore %85 %56
+OpLine %3 37 4
+OpLine %3 37 4
+%86 = OpAccessChain  %70  %58 %37
 OpStore %86 %57
-OpLine %3 37 4
-OpLine %3 37 4
-%87 = OpAccessChain  %71  %59 %38
-OpStore %87 %58
 OpLine %3 1 1
-%88 = OpLoad  %9  %59
-%89 = OpCompositeExtract  %5  %88 0
-OpStore %11 %89
-%90 = OpAccessChain  %28  %11 %67
-%91 = OpLoad  %4  %90
-%92 = OpFNegate  %4  %91
-OpStore %90 %92
-%93 = OpCompositeExtract  %6  %88 1
-OpStore %13 %93
-%94 = OpCompositeExtract  %6  %88 2
-OpStore %15 %94
-%95 = OpCompositeExtract  %4  %88 3
-OpStore %16 %95
-%96 = OpCompositeExtract  %7  %88 4
-OpStore %18 %96
-%97 = OpCompositeExtract  %8  %88 5
-OpStore %20 %97
-%98 = OpCompositeExtract  %8  %88 6
-OpStore %22 %98
-%99 = OpCompositeExtract  %5  %88 7
-OpStore %23 %99
-%100 = OpCompositeExtract  %4  %88 8
-OpStore %24 %100
-%101 = OpCompositeExtract  %4  %88 9
-OpStore %25 %101
-%102 = OpCompositeExtract  %4  %88 10
-OpStore %26 %102
+%87 = OpLoad  %9  %58
+%88 = OpCompositeExtract  %5  %87 0
+OpStore %11 %88
+%89 = OpAccessChain  %17  %11 %66
+%90 = OpLoad  %4  %89
+%91 = OpFNegate  %4  %90
+OpStore %89 %91
+%92 = OpCompositeExtract  %6  %87 1
+OpStore %13 %92
+%93 = OpCompositeExtract  %6  %87 2
+OpStore %15 %93
+%94 = OpCompositeExtract  %4  %87 3
+OpStore %16 %94
+%95 = OpCompositeExtract  %7  %87 4
+OpStore %18 %95
+%96 = OpCompositeExtract  %8  %87 5
+OpStore %20 %96
+%97 = OpCompositeExtract  %8  %87 6
+OpStore %22 %97
+%98 = OpCompositeExtract  %5  %87 7
+OpStore %23 %98
+%99 = OpCompositeExtract  %4  %87 8
+OpStore %24 %99
+%100 = OpCompositeExtract  %4  %87 9
+OpStore %25 %100
+%101 = OpCompositeExtract  %4  %87 10
+OpStore %26 %101
 OpReturn
 OpFunctionEnd
-%132 = OpFunction  %2  None %31
-%103 = OpLabel
-%107 = OpLoad  %5  %105
-%110 = OpLoad  %6  %108
-%112 = OpLoad  %6  %111
-%115 = OpLoad  %4  %113
-%118 = OpLoad  %7  %116
-%121 = OpLoad  %8  %119
-%123 = OpLoad  %8  %122
-%125 = OpLoad  %5  %124
-%127 = OpLoad  %4  %126
-%129 = OpLoad  %4  %128
-%131 = OpLoad  %4  %130
-%104 = OpCompositeConstruct  %9  %107 %110 %112 %115 %118 %121 %123 %125 %127 %129 %131
-OpBranch %133
-%133 = OpLabel
+%131 = OpFunction  %2  None %30
+%102 = OpLabel
+%106 = OpLoad  %5  %104
+%109 = OpLoad  %6  %107
+%111 = OpLoad  %6  %110
+%114 = OpLoad  %4  %112
+%117 = OpLoad  %7  %115
+%120 = OpLoad  %8  %118
+%122 = OpLoad  %8  %121
+%124 = OpLoad  %5  %123
+%126 = OpLoad  %4  %125
+%128 = OpLoad  %4  %127
+%130 = OpLoad  %4  %129
+%103 = OpCompositeConstruct  %9  %106 %109 %111 %114 %117 %120 %122 %124 %126 %128 %130
+OpBranch %132
+%132 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/operators.spvasm
+++ b/naga/tests/out/spv/operators.spvasm
@@ -1,13 +1,13 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 528
+; Bound: 527
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %513 "main" %510
-OpExecutionMode %513 LocalSize 1 1 1
-OpDecorate %510 BuiltIn WorkgroupId
+OpEntryPoint GLCompute %512 "main" %509
+OpExecutionMode %512 LocalSize 1 1 1
+OpDecorate %509 BuiltIn WorkgroupId
 %2 = OpTypeVoid
 %3 = OpTypeFloat 32
 %4 = OpTypeVector %3 4
@@ -101,10 +101,9 @@ OpDecorate %510 BuiltIn WorkgroupId
 %418 = OpTypePointer Function %5
 %419 = OpConstantNull  %5
 %421 = OpTypePointer Function %14
-%449 = OpTypePointer Function %5
-%511 = OpTypePointer Input %15
-%510 = OpVariable  %511  Input
-%514 = OpConstantComposite  %10  %17 %17 %17
+%510 = OpTypePointer Input %15
+%509 = OpVariable  %510  Input
+%513 = OpConstantComposite  %10  %17 %17 %17
 %26 = OpFunction  %4  None %27
 %25 = OpLabel
 OpBranch %34
@@ -524,88 +523,88 @@ OpStore %417 %446
 %447 = OpLoad  %5  %417
 %448 = OpISub  %5  %447 %23
 OpStore %417 %448
-%450 = OpAccessChain  %449  %420 %157
-%451 = OpLoad  %5  %450
-%452 = OpIAdd  %5  %451 %23
-%453 = OpAccessChain  %449  %420 %157
-OpStore %453 %452
-%454 = OpAccessChain  %449  %420 %157
-%455 = OpLoad  %5  %454
-%456 = OpISub  %5  %455 %23
-%457 = OpAccessChain  %449  %420 %157
-OpStore %457 %456
+%449 = OpAccessChain  %418  %420 %157
+%450 = OpLoad  %5  %449
+%451 = OpIAdd  %5  %450 %23
+%452 = OpAccessChain  %418  %420 %157
+OpStore %452 %451
+%453 = OpAccessChain  %418  %420 %157
+%454 = OpLoad  %5  %453
+%455 = OpISub  %5  %454 %23
+%456 = OpAccessChain  %418  %420 %157
+OpStore %456 %455
 OpReturn
 OpFunctionEnd
-%459 = OpFunction  %2  None %122
-%458 = OpLabel
-OpBranch %460
-%460 = OpLabel
+%458 = OpFunction  %2  None %122
+%457 = OpLabel
+OpBranch %459
+%459 = OpLabel
+%460 = OpSNegate  %5  %23
 %461 = OpSNegate  %5  %23
-%462 = OpSNegate  %5  %23
-%463 = OpSNegate  %5  %462
-%464 = OpSNegate  %5  %23
-%465 = OpSNegate  %5  %464
-%466 = OpSNegate  %5  %23
-%467 = OpSNegate  %5  %466
-%468 = OpSNegate  %5  %23
+%462 = OpSNegate  %5  %461
+%463 = OpSNegate  %5  %23
+%464 = OpSNegate  %5  %463
+%465 = OpSNegate  %5  %23
+%466 = OpSNegate  %5  %465
+%467 = OpSNegate  %5  %23
+%468 = OpSNegate  %5  %467
 %469 = OpSNegate  %5  %468
-%470 = OpSNegate  %5  %469
-%471 = OpSNegate  %5  %23
+%470 = OpSNegate  %5  %23
+%471 = OpSNegate  %5  %470
 %472 = OpSNegate  %5  %471
 %473 = OpSNegate  %5  %472
-%474 = OpSNegate  %5  %473
-%475 = OpSNegate  %5  %23
+%474 = OpSNegate  %5  %23
+%475 = OpSNegate  %5  %474
 %476 = OpSNegate  %5  %475
 %477 = OpSNegate  %5  %476
 %478 = OpSNegate  %5  %477
-%479 = OpSNegate  %5  %478
-%480 = OpSNegate  %5  %23
+%479 = OpSNegate  %5  %23
+%480 = OpSNegate  %5  %479
 %481 = OpSNegate  %5  %480
 %482 = OpSNegate  %5  %481
 %483 = OpSNegate  %5  %482
-%484 = OpSNegate  %5  %483
+%484 = OpFNegate  %3  %17
 %485 = OpFNegate  %3  %17
-%486 = OpFNegate  %3  %17
-%487 = OpFNegate  %3  %486
-%488 = OpFNegate  %3  %17
-%489 = OpFNegate  %3  %488
-%490 = OpFNegate  %3  %17
-%491 = OpFNegate  %3  %490
-%492 = OpFNegate  %3  %17
+%486 = OpFNegate  %3  %485
+%487 = OpFNegate  %3  %17
+%488 = OpFNegate  %3  %487
+%489 = OpFNegate  %3  %17
+%490 = OpFNegate  %3  %489
+%491 = OpFNegate  %3  %17
+%492 = OpFNegate  %3  %491
 %493 = OpFNegate  %3  %492
-%494 = OpFNegate  %3  %493
-%495 = OpFNegate  %3  %17
+%494 = OpFNegate  %3  %17
+%495 = OpFNegate  %3  %494
 %496 = OpFNegate  %3  %495
 %497 = OpFNegate  %3  %496
-%498 = OpFNegate  %3  %497
-%499 = OpFNegate  %3  %17
+%498 = OpFNegate  %3  %17
+%499 = OpFNegate  %3  %498
 %500 = OpFNegate  %3  %499
 %501 = OpFNegate  %3  %500
 %502 = OpFNegate  %3  %501
-%503 = OpFNegate  %3  %502
-%504 = OpFNegate  %3  %17
+%503 = OpFNegate  %3  %17
+%504 = OpFNegate  %3  %503
 %505 = OpFNegate  %3  %504
 %506 = OpFNegate  %3  %505
 %507 = OpFNegate  %3  %506
-%508 = OpFNegate  %3  %507
 OpReturn
 OpFunctionEnd
-%513 = OpFunction  %2  None %122
-%509 = OpLabel
-%512 = OpLoad  %15  %510
-OpBranch %515
-%515 = OpLabel
-%516 = OpFunctionCall  %4  %26
-%517 = OpCompositeExtract  %16  %512 0
-%518 = OpConvertUToF  %3  %517
-%519 = OpCompositeExtract  %16  %512 1
-%520 = OpBitcast  %5  %519
-%521 = OpFunctionCall  %4  %74 %518 %520
-%522 = OpFunctionCall  %10  %112 %514
-%523 = OpFunctionCall  %2  %121
-%524 = OpFunctionCall  %2  %242
-%525 = OpFunctionCall  %2  %349
-%526 = OpFunctionCall  %2  %376
-%527 = OpFunctionCall  %2  %415
+%512 = OpFunction  %2  None %122
+%508 = OpLabel
+%511 = OpLoad  %15  %509
+OpBranch %514
+%514 = OpLabel
+%515 = OpFunctionCall  %4  %26
+%516 = OpCompositeExtract  %16  %511 0
+%517 = OpConvertUToF  %3  %516
+%518 = OpCompositeExtract  %16  %511 1
+%519 = OpBitcast  %5  %518
+%520 = OpFunctionCall  %4  %74 %517 %519
+%521 = OpFunctionCall  %10  %112 %513
+%522 = OpFunctionCall  %2  %121
+%523 = OpFunctionCall  %2  %242
+%524 = OpFunctionCall  %2  %349
+%525 = OpFunctionCall  %2  %376
+%526 = OpFunctionCall  %2  %415
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/storage-textures.spvasm
+++ b/naga/tests/out/spv/storage-textures.spvasm
@@ -1,15 +1,15 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 42
+; Bound: 39
 OpCapability Shader
 OpCapability StorageImageExtendedFormats
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %20 "csLoad"
-OpEntryPoint GLCompute %35 "csStore"
-OpExecutionMode %20 LocalSize 1 1 1
-OpExecutionMode %35 LocalSize 1 1 1
+OpEntryPoint GLCompute %17 "csLoad"
+OpEntryPoint GLCompute %32 "csStore"
+OpExecutionMode %17 LocalSize 1 1 1
+OpExecutionMode %32 LocalSize 1 1 1
 OpDecorate %7 NonWritable
 OpDecorate %7 DescriptorSet 0
 OpDecorate %7 Binding 0
@@ -22,12 +22,12 @@ OpDecorate %11 Binding 2
 OpDecorate %13 NonReadable
 OpDecorate %13 DescriptorSet 1
 OpDecorate %13 Binding 0
+OpDecorate %14 NonReadable
+OpDecorate %14 DescriptorSet 1
+OpDecorate %14 Binding 1
 OpDecorate %15 NonReadable
 OpDecorate %15 DescriptorSet 1
-OpDecorate %15 Binding 1
-OpDecorate %17 NonReadable
-OpDecorate %17 DescriptorSet 1
-OpDecorate %17 Binding 2
+OpDecorate %15 Binding 2
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpTypeImage %4 2D 0 0 0 2 R32f
@@ -39,41 +39,38 @@ OpDecorate %17 Binding 2
 %9 = OpVariable  %10  UniformConstant
 %12 = OpTypePointer UniformConstant %6
 %11 = OpVariable  %12  UniformConstant
-%14 = OpTypePointer UniformConstant %3
-%13 = OpVariable  %14  UniformConstant
-%16 = OpTypePointer UniformConstant %5
-%15 = OpVariable  %16  UniformConstant
-%18 = OpTypePointer UniformConstant %6
-%17 = OpVariable  %18  UniformConstant
-%21 = OpTypeFunction %2
-%25 = OpTypeInt 32 0
-%26 = OpConstant  %25  0
-%27 = OpTypeVector %25 2
-%28 = OpConstantComposite  %27  %26 %26
-%30 = OpTypeVector %4 4
-%39 = OpConstant  %4  0.0
-%40 = OpConstantComposite  %30  %39 %39 %39 %39
-%20 = OpFunction  %2  None %21
-%19 = OpLabel
-%22 = OpLoad  %3  %7
-%23 = OpLoad  %5  %9
-%24 = OpLoad  %6  %11
-OpBranch %29
-%29 = OpLabel
-%31 = OpImageRead  %30  %22 %28
-%32 = OpImageRead  %30  %23 %28
-%33 = OpImageRead  %30  %24 %28
+%13 = OpVariable  %8  UniformConstant
+%14 = OpVariable  %10  UniformConstant
+%15 = OpVariable  %12  UniformConstant
+%18 = OpTypeFunction %2
+%22 = OpTypeInt 32 0
+%23 = OpConstant  %22  0
+%24 = OpTypeVector %22 2
+%25 = OpConstantComposite  %24  %23 %23
+%27 = OpTypeVector %4 4
+%36 = OpConstant  %4  0.0
+%37 = OpConstantComposite  %27  %36 %36 %36 %36
+%17 = OpFunction  %2  None %18
+%16 = OpLabel
+%19 = OpLoad  %3  %7
+%20 = OpLoad  %5  %9
+%21 = OpLoad  %6  %11
+OpBranch %26
+%26 = OpLabel
+%28 = OpImageRead  %27  %19 %25
+%29 = OpImageRead  %27  %20 %25
+%30 = OpImageRead  %27  %21 %25
 OpReturn
 OpFunctionEnd
-%35 = OpFunction  %2  None %21
-%34 = OpLabel
-%36 = OpLoad  %3  %13
-%37 = OpLoad  %5  %15
-%38 = OpLoad  %6  %17
-OpBranch %41
-%41 = OpLabel
-OpImageWrite %36 %28 %40
-OpImageWrite %37 %28 %40
-OpImageWrite %38 %28 %40
+%32 = OpFunction  %2  None %18
+%31 = OpLabel
+%33 = OpLoad  %3  %13
+%34 = OpLoad  %5  %14
+%35 = OpLoad  %6  %15
+OpBranch %38
+%38 = OpLabel
+OpImageWrite %33 %25 %37
+OpImageWrite %34 %25 %37
+OpImageWrite %35 %25 %37
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/workgroup-uniform-load.spvasm
+++ b/naga/tests/out/spv/workgroup-uniform-load.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 40
+; Bound: 39
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
@@ -23,44 +23,43 @@ OpDecorate %19 BuiltIn LocalInvocationId
 %15 = OpTypeFunction %2
 %16 = OpConstant  %4  10
 %18 = OpConstantNull  %5
-%20 = OpTypePointer Input %7
-%19 = OpVariable  %20  Input
-%22 = OpConstantNull  %7
-%24 = OpTypeBool
-%23 = OpTypeVector %24 3
-%29 = OpConstant  %3  2
-%30 = OpConstant  %3  264
-%33 = OpTypePointer Workgroup %4
+%19 = OpVariable  %12  Input
+%21 = OpConstantNull  %7
+%23 = OpTypeBool
+%22 = OpTypeVector %23 3
+%28 = OpConstant  %3  2
+%29 = OpConstant  %3  264
+%32 = OpTypePointer Workgroup %4
 %14 = OpFunction  %2  None %15
 %10 = OpLabel
 %13 = OpLoad  %7  %11
 OpBranch %17
 %17 = OpLabel
-%21 = OpLoad  %7  %19
-%25 = OpIEqual  %23  %21 %22
-%26 = OpAll  %24  %25
-OpSelectionMerge %27 None
-OpBranchConditional %26 %28 %27
-%28 = OpLabel
-OpStore %8 %18
-OpBranch %27
+%20 = OpLoad  %7  %19
+%24 = OpIEqual  %22  %20 %21
+%25 = OpAll  %23  %24
+OpSelectionMerge %26 None
+OpBranchConditional %25 %27 %26
 %27 = OpLabel
-OpControlBarrier %29 %29 %30
-OpBranch %31
-%31 = OpLabel
-%32 = OpCompositeExtract  %3  %13 0
-OpControlBarrier %29 %29 %30
-%34 = OpAccessChain  %33  %8 %32
-%35 = OpLoad  %4  %34
-OpControlBarrier %29 %29 %30
-%36 = OpSGreaterThan  %24  %35 %16
-OpSelectionMerge %37 None
-OpBranchConditional %36 %38 %39
-%38 = OpLabel
-OpControlBarrier %29 %29 %30
-OpReturn
-%39 = OpLabel
-OpReturn
+OpStore %8 %18
+OpBranch %26
+%26 = OpLabel
+OpControlBarrier %28 %28 %29
+OpBranch %30
+%30 = OpLabel
+%31 = OpCompositeExtract  %3  %13 0
+OpControlBarrier %28 %28 %29
+%33 = OpAccessChain  %32  %8 %31
+%34 = OpLoad  %4  %33
+OpControlBarrier %28 %28 %29
+%35 = OpSGreaterThan  %23  %34 %16
+OpSelectionMerge %36 None
+OpBranchConditional %35 %37 %38
 %37 = OpLabel
+OpControlBarrier %28 %28 %29
+OpReturn
+%38 = OpLabel
+OpReturn
+%36 = OpLabel
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
Fixes #7240.
Depends on #7244.

Simplify `naga::back::spv::LocalType` to have only one variant for
representing pointers, and use the SPIR-V type as the base type, so
that `LocalType` values are equal when the SPIR-V pointer types they
map to would be equal as well.

This avoids emitting multiple `OpTypePointer` instructions, which
SPIR-V would interpret as distinct types, for equivalent Naga IR
pointer types.

Change the `get_pointer_type_id` utility function accordingly, and
adjust its callers.

Change `LocalType::from_inner` into `Writer::localtype_from_inner`, so
that it can call `Writer` methods to build base types. Adjust users.
