### PR TITLE
Refactor Wrapped

### DIFF
--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -442,18 +442,23 @@ pub enum Error {
     Override,
 }
 
+#[derive(PartialEq, Eq, Hash)]
+enum WrappedType {
+    ZeroValue(help::WrappedZeroValue),
+    ArrayLength(help::WrappedArrayLength),
+    ImageQuery(help::WrappedImageQuery),
+    ImageLoadScalar(crate::Scalar),
+    Constructor(help::WrappedConstructor),
+    StructMatrixAccess(help::WrappedStructMatrixAccess),
+    MatCx2(help::WrappedMatCx2),
+    Math(help::WrappedMath),
+    UnaryOp(help::WrappedUnaryOp),
+    BinaryOp(help::WrappedBinaryOp),
+}
+
 #[derive(Default)]
 struct Wrapped {
-    zero_values: crate::FastHashSet<help::WrappedZeroValue>,
-    array_lengths: crate::FastHashSet<help::WrappedArrayLength>,
-    image_queries: crate::FastHashSet<help::WrappedImageQuery>,
-    image_load_scalars: crate::FastHashSet<crate::Scalar>,
-    constructors: crate::FastHashSet<help::WrappedConstructor>,
-    struct_matrix_access: crate::FastHashSet<help::WrappedStructMatrixAccess>,
-    mat_cx2s: crate::FastHashSet<help::WrappedMatCx2>,
-    math: crate::FastHashSet<help::WrappedMath>,
-    unary_op: crate::FastHashSet<help::WrappedUnaryOp>,
-    binary_op: crate::FastHashSet<help::WrappedBinaryOp>,
+    types: crate::FastHashSet<WrappedType>,
     /// If true, the sampler heaps have been written out.
     sampler_heaps: bool,
     // Mapping from SamplerIndexBufferKey to the name the namer returned.
@@ -461,15 +466,12 @@ struct Wrapped {
 }
 
 impl Wrapped {
+    fn insert(&mut self, r#type: WrappedType) -> bool {
+        self.types.insert(r#type)
+    }
+
     fn clear(&mut self) {
-        self.array_lengths.clear();
-        self.image_queries.clear();
-        self.constructors.clear();
-        self.struct_matrix_access.clear();
-        self.mat_cx2s.clear();
-        self.math.clear();
-        self.unary_op.clear();
-        self.binary_op.clear();
+        self.types.clear();
     }
 }
 


### PR DESCRIPTION
Filed as a replacement for #7151, which I borked. 😅

---

**Connections**
Resolves #7084 

**Description**
Simplifies the Wrapped struct by extracting variants into an enum and creating a HashSet using that.

**Testing**
Compiled and ran existing tests. Unsure if more testing is needed.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're no bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] Add change to `CHANGELOG.md`. See simple instructions inside file.
