### PR TITLE
[naga] Centralize naming of anonymous entry point return types.

### DIFF
--- a/naga/tests/in/glsl/anonymous-entry-point-type.frag
+++ b/naga/tests/in/glsl/anonymous-entry-point-type.frag
@@ -1,0 +1,9 @@
+layout(location = 0) out vec4 o_Target;
+
+struct FragmentOutput {
+  float x;
+};
+
+void main() {
+    o_Target = vec4(0.0);
+}

--- a/naga/tests/out/glsl/quad-vert.main.Vertex.glsl
+++ b/naga/tests/out/glsl/quad-vert.main.Vertex.glsl
@@ -9,7 +9,7 @@ struct gen_gl_PerVertex {
     float gen_gl_ClipDistance[1];
     float gen_gl_CullDistance[1];
 };
-struct type_4 {
+struct VertexOutput {
     vec2 member;
     vec4 gen_gl_Position;
 };
@@ -41,7 +41,7 @@ void main() {
     main_1();
     vec2 _e7 = v_uv;
     vec4 _e8 = unnamed.gen_gl_Position;
-    type_4 _tmp_return = type_4(_e7, _e8);
+    VertexOutput _tmp_return = VertexOutput(_e7, _e8);
     _vs2fs_location0 = _tmp_return.member;
     gl_Position = _tmp_return.gen_gl_Position;
     gl_Position.yz = vec2(-gl_Position.y, gl_Position.z * 2.0 - gl_Position.w);

--- a/naga/tests/out/hlsl/quad-vert.hlsl
+++ b/naga/tests/out/hlsl/quad-vert.hlsl
@@ -6,7 +6,7 @@ struct gl_PerVertex {
     int _end_pad_0;
 };
 
-struct type_4 {
+struct VertexOutput {
     float2 member : LOC0;
     float4 gl_Position : SV_Position;
 };
@@ -44,8 +44,8 @@ void main_1()
     return;
 }
 
-type_4 Constructtype_4(float2 arg0, float4 arg1) {
-    type_4 ret = (type_4)0;
+VertexOutput ConstructVertexOutput(float2 arg0, float4 arg1) {
+    VertexOutput ret = (VertexOutput)0;
     ret.member = arg0;
     ret.gl_Position = arg1;
     return ret;
@@ -58,7 +58,7 @@ VertexOutput_main main(float2 a_uv : LOC1, float2 a_pos : LOC0)
     main_1();
     float2 _e7 = v_uv;
     float4 _e8 = unnamed.gl_Position;
-    const type_4 type_4_ = Constructtype_4(_e7, _e8);
-    const VertexOutput_main type_4_1 = { type_4_.member, type_4_.gl_Position };
-    return type_4_1;
+    const VertexOutput vertexoutput = ConstructVertexOutput(_e7, _e8);
+    const VertexOutput_main vertexoutput_1 = { vertexoutput.member, vertexoutput.gl_Position };
+    return vertexoutput_1;
 }

--- a/naga/tests/out/msl/quad-vert.msl
+++ b/naga/tests/out/msl/quad-vert.msl
@@ -13,7 +13,7 @@ struct gl_PerVertex {
     type_3 gl_ClipDistance;
     type_3 gl_CullDistance;
 };
-struct type_4 {
+struct VertexOutput {
     metal::float2 member;
     metal::float4 gl_Position;
 };
@@ -53,6 +53,6 @@ vertex main_Output main_(
     main_1(v_uv, a_uv_1, unnamed, a_pos_1);
     metal::float2 _e7 = v_uv;
     metal::float4 _e8 = unnamed.gl_Position;
-    const auto _tmp = type_4 {_e7, _e8};
+    const auto _tmp = VertexOutput {_e7, _e8};
     return main_Output { _tmp.member, _tmp.gl_Position };
 }

--- a/naga/tests/out/wgsl/anonymous-entry-point-type.frag.wgsl
+++ b/naga/tests/out/wgsl/anonymous-entry-point-type.frag.wgsl
@@ -1,0 +1,21 @@
+struct FragmentOutput {
+    x: f32,
+}
+
+struct FragmentOutput_1 {
+    @location(0) o_Target: vec4<f32>,
+}
+
+var<private> o_Target: vec4<f32>;
+
+fn main_1() {
+    o_Target = vec4(0f);
+    return;
+}
+
+@fragment 
+fn main() -> FragmentOutput_1 {
+    main_1();
+    let _e1 = o_Target;
+    return FragmentOutput_1(_e1);
+}


### PR DESCRIPTION
When an entry point's return type is anonymous, have `naga::proc::Namer` assign it a name based on its shader stage.

Remove bespoke logic for this from the WGSL backend.

Fixes #7263.
