### PR TITLE
Fix build of `wgpu-hal` on macOS with `features = ["gles"]`.

### DIFF
--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -112,6 +112,7 @@ gles = [
     "dep:libloading",
     "dep:log",
     "dep:ndk-sys",
+    "dep:objc",
     "dep:profiling",
     "dep:wasm-bindgen",
     "dep:web-sys",


### PR DESCRIPTION
**Description**
Without this change, `cargo build -p wgpu-hal --features=gles` will fail if `target_os = "macos"` and the Metal backend is not also enabled.

**Testing**
`cargo build -p wgpu-hal --features=gles`

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
