### PR TITLE
[naga wgsl-in] Parse LHS expressions as such, not as generic expressions

### DIFF
--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -149,6 +149,7 @@ enum Rule {
     Directive,
     GenericExpr,
     EnclosedExpr,
+    LhsExpr,
 }
 
 struct ParsedAttribute<T> {
@@ -926,6 +927,53 @@ impl Parser {
                     let expr = ast::Expression::AddrOf(expr);
                     let span = this.peek_rule_span(lexer);
                     ctx.expressions.append(expr, span)
+                }
+                _ => this.singular_expression(lexer, ctx)?,
+            };
+
+            this.pop_rule_span(lexer);
+            Ok(expr)
+        })
+    }
+
+    /// Parse a `lhs_expression`.
+    ///
+    /// LHS expressions only support the `&` and `*` operators and
+    /// the `[]` and `.` postfix selectors.
+    fn lhs_expression<'a>(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        ctx: &mut ExpressionContext<'a, '_, '_>,
+    ) -> Result<Handle<ast::Expression<'a>>, Error<'a>> {
+        self.track_recursion(|this| {
+            this.push_rule_span(Rule::LhsExpr, lexer);
+            let start = lexer.start_byte_offset();
+            let expr = match lexer.peek() {
+                (Token::Operation('*'), _) => {
+                    let _ = lexer.next();
+                    let expr = this.lhs_expression(lexer, ctx)?;
+                    let expr = ast::Expression::Deref(expr);
+                    let span = this.peek_rule_span(lexer);
+                    ctx.expressions.append(expr, span)
+                }
+                (Token::Operation('&'), _) => {
+                    let _ = lexer.next();
+                    let expr = this.lhs_expression(lexer, ctx)?;
+                    let expr = ast::Expression::AddrOf(expr);
+                    let span = this.peek_rule_span(lexer);
+                    ctx.expressions.append(expr, span)
+                }
+                (Token::Operation('('), _) => {
+                    let _ = lexer.next();
+                    let primary_expr = this.lhs_expression(lexer, ctx)?;
+                    lexer.expect(Token::Paren(')'))?;
+                    this.postfix(start, lexer, ctx, primary_expr)?
+                }
+                (Token::Word(word), span) => {
+                    let _ = lexer.next();
+                    let ident = this.ident_expr(word, span, ctx);
+                    let primary_expr = ctx.expressions.append(ast::Expression::Ident(ident), span);
+                    this.postfix(start, lexer, ctx, primary_expr)?
                 }
                 _ => this.singular_expression(lexer, ctx)?,
             };
@@ -1773,7 +1821,7 @@ impl Parser {
         block: &mut ast::Block<'a>,
     ) -> Result<(), Error<'a>> {
         let span_start = lexer.start_byte_offset();
-        let target = self.general_expression(lexer, ctx)?;
+        let target = self.lhs_expression(lexer, ctx)?;
         self.assignment_op_and_rhs(lexer, ctx, block, target, span_start)
     }
 

--- a/naga/src/front/wgsl/tests.rs
+++ b/naga/src/front/wgsl/tests.rs
@@ -419,6 +419,42 @@ fn parse_expressions() {
 }
 
 #[test]
+fn parse_assignment_statements() {
+    parse_str(
+        "
+        struct Foo { x: i32 };
+
+        fn foo() {
+            var x: u32 = 0u;
+            x++;
+            x--;
+            x = 1u;
+            x += 1u;
+            var v: vec2<f32> = vec2<f32>(1.0, 1.0);
+            v[0] += 1.0;
+            (v)[0] += 1.0;
+            var s: Foo = Foo(0);
+            s.x -= 1;
+            (s.x) -= 1;
+            (s).x -= 1;
+            _ = 5u;
+    }",
+    )
+    .unwrap();
+
+    let error = parse_str(
+        "fn foo() {
+        x|x++;
+    }",
+    )
+    .unwrap_err();
+    assert_eq!(
+        error.message(),
+        "expected assignment or increment/decrement, found \"|\"",
+    );
+}
+
+#[test]
 fn binary_expression_mixed_scalar_and_vector_operands() {
     for (operand, expect_splat) in [
         ('<', false),

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -1759,11 +1759,11 @@ fn binary_statement() {
             3 + 5;
         }
     ",
-        r###"error: expected assignment or increment/decrement, found ";"
-  ┌─ wgsl:3:18
+        r###"error: expected assignment or increment/decrement, found "+"
+  ┌─ wgsl:3:15
   │
 3 │             3 + 5;
-  │                  ^ expected assignment or increment/decrement
+  │               ^ expected assignment or increment/decrement
 
 "###,
     );
@@ -1777,11 +1777,11 @@ fn assign_to_expr() {
             3 + 5 = 10;
         }
         ",
-        r###"error: invalid left-hand side of assignment
-  ┌─ wgsl:3:13
+        r###"error: expected assignment or increment/decrement, found "+"
+  ┌─ wgsl:3:15
   │
 3 │             3 + 5 = 10;
-  │             ^^^^^ cannot assign to this expression
+  │               ^ expected assignment or increment/decrement
 
 "###,
     );


### PR DESCRIPTION
Fixes #4383

**Description**
LHS of assignments was previously parsed as a generic expression. This change applies the correct, more restrictive rules that allow only `&`, `*`, `.`, and `[]`.

**Testing**
Added a test in `front::wgsl::tests`.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
