### PR TITLE
[naga wgsl-in] Concretize LHS of bitshift operations if RHS is not a const-expression

### DIFF
--- a/naga/tests/in/wgsl/abstract-types-operators.wgsl
+++ b/naga/tests/in/wgsl/abstract-types-operators.wgsl
@@ -28,11 +28,15 @@ const shl_iaiai: i32 = 1 << 2;
 const shl_iai_u: i32 = 1 << 2u;
 const shl_uaiai: u32 = 1 << 2;
 const shl_uai_u: u32 = 1 << 2u;
+const shlaiaiai = 1 << 2;
+const shlaiai_u = 1 << 2u;
 
 const shr_iaiai: i32 = 1 >> 2;
 const shr_iai_u: i32 = 1 >> 2u;
 const shr_uaiai: u32 = 1 >> 2;
 const shr_uai_u: u32 = 1 >> 2u;
+const shraiaiai = 1 >> 2;
+const shraiai_u = 1 >> 2u;
 
 fn runtime_values() {
   var f: f32 = 42;
@@ -58,6 +62,9 @@ fn runtime_values() {
   var plus_uai_u: u32 = 1 + u;
   var plus_u_uai: u32 = u + 2;
   var plus_u_u_u: u32 = u + u;
+
+  var shl_iai_u: i32 = 1 << u;
+  var shr_iai_u: i32 = 1 << u;
 }
 
 fn wgpu_4445() {

--- a/naga/tests/out/msl/abstract-types-operators.msl
+++ b/naga/tests/out/msl/abstract-types-operators.msl
@@ -29,11 +29,11 @@ constant uint bitflip_uai = 0u;
 constant int least_i32_ = -2147483648;
 constant float least_f32_ = -340282350000000000000000000000000000000.0;
 constant int shl_iaiai = 4;
-constant int shl_iai_u = 4;
+constant int shl_iai_u_1 = 4;
 constant uint shl_uaiai = 4u;
 constant uint shl_uai_u = 4u;
 constant int shr_iaiai = 0;
-constant int shr_iai_u = 0;
+constant int shr_iai_u_1 = 0;
 constant uint shr_uaiai = 0u;
 constant uint shr_uai_u = 0u;
 constant int wgpu_4492_ = -2147483648;
@@ -60,6 +60,8 @@ void runtime_values(
     uint plus_uai_u = {};
     uint plus_u_uai = {};
     uint plus_u_u_u = {};
+    int shl_iai_u = {};
+    int shr_iai_u = {};
     float _e8 = f;
     plus_faf_f = 1.0 + _e8;
     float _e14 = f;
@@ -85,6 +87,10 @@ void runtime_values(
     uint _e52 = u;
     uint _e53 = u;
     plus_u_u_u = _e52 + _e53;
+    uint _e56 = u;
+    shl_iai_u = 1 << _e56;
+    uint _e60 = u;
+    shr_iai_u = 1 << _e60;
     return;
 }
 

--- a/naga/tests/out/spv/abstract-types-operators.spvasm
+++ b/naga/tests/out/spv/abstract-types-operators.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 103
+; Bound: 111
 OpCapability Shader
 OpCapability Linkage
 %1 = OpExtInstImport "GLSL.std.450"
@@ -48,9 +48,11 @@ OpDecorate %6 ArrayStride 4
 %60 = OpConstantNull  %5
 %62 = OpConstantNull  %5
 %64 = OpConstantNull  %5
-%93 = OpConstant  %3  5.0
-%94 = OpConstant  %3  7.0
-%100 = OpTypePointer Workgroup %5
+%66 = OpConstantNull  %4
+%68 = OpConstantNull  %4
+%101 = OpConstant  %3  5.0
+%102 = OpConstant  %3  7.0
+%108 = OpTypePointer Workgroup %5
 %20 = OpFunction  %2  None %21
 %19 = OpLabel
 %63 = OpVariable  %36  Function %64
@@ -60,6 +62,7 @@ OpDecorate %6 ArrayStride 4
 %42 = OpVariable  %32  Function %8
 %38 = OpVariable  %32  Function %8
 %33 = OpVariable  %34  Function %23
+%67 = OpVariable  %34  Function %68
 %61 = OpVariable  %36  Function %62
 %56 = OpVariable  %34  Function %57
 %51 = OpVariable  %34  Function %9
@@ -67,64 +70,71 @@ OpDecorate %6 ArrayStride 4
 %41 = OpVariable  %32  Function %8
 %37 = OpVariable  %32  Function %8
 %31 = OpVariable  %32  Function %22
+%65 = OpVariable  %34  Function %66
 %59 = OpVariable  %36  Function %60
 %54 = OpVariable  %34  Function %55
 %49 = OpVariable  %32  Function %50
 %43 = OpVariable  %32  Function %44
 %39 = OpVariable  %32  Function %40
 %35 = OpVariable  %36  Function %24
-OpBranch %65
-%65 = OpLabel
-%66 = OpLoad  %3  %31
-%67 = OpFAdd  %3  %25 %66
-OpStore %39 %67
-%68 = OpLoad  %3  %31
-%69 = OpFAdd  %3  %25 %68
-OpStore %43 %69
+OpBranch %69
+%69 = OpLabel
 %70 = OpLoad  %3  %31
-%71 = OpFAdd  %3  %70 %26
-OpStore %45 %71
+%71 = OpFAdd  %3  %25 %70
+OpStore %39 %71
 %72 = OpLoad  %3  %31
-%73 = OpFAdd  %3  %72 %26
-OpStore %47 %73
+%73 = OpFAdd  %3  %25 %72
+OpStore %43 %73
 %74 = OpLoad  %3  %31
-%75 = OpLoad  %3  %31
-%76 = OpFAdd  %3  %74 %75
-OpStore %49 %76
-%77 = OpLoad  %4  %33
-%78 = OpIAdd  %4  %27 %77
-OpStore %52 %78
-%79 = OpLoad  %4  %33
-%80 = OpIAdd  %4  %79 %28
-OpStore %54 %80
+%75 = OpFAdd  %3  %74 %26
+OpStore %45 %75
+%76 = OpLoad  %3  %31
+%77 = OpFAdd  %3  %76 %26
+OpStore %47 %77
+%78 = OpLoad  %3  %31
+%79 = OpLoad  %3  %31
+%80 = OpFAdd  %3  %78 %79
+OpStore %49 %80
 %81 = OpLoad  %4  %33
-%82 = OpLoad  %4  %33
-%83 = OpIAdd  %4  %81 %82
-OpStore %56 %83
-%84 = OpLoad  %5  %35
-%85 = OpIAdd  %5  %29 %84
-OpStore %59 %85
-%86 = OpLoad  %5  %35
-%87 = OpIAdd  %5  %86 %30
-OpStore %61 %87
+%82 = OpIAdd  %4  %27 %81
+OpStore %52 %82
+%83 = OpLoad  %4  %33
+%84 = OpIAdd  %4  %83 %28
+OpStore %54 %84
+%85 = OpLoad  %4  %33
+%86 = OpLoad  %4  %33
+%87 = OpIAdd  %4  %85 %86
+OpStore %56 %87
 %88 = OpLoad  %5  %35
-%89 = OpLoad  %5  %35
-%90 = OpIAdd  %5  %88 %89
-OpStore %63 %90
+%89 = OpIAdd  %5  %29 %88
+OpStore %59 %89
+%90 = OpLoad  %5  %35
+%91 = OpIAdd  %5  %90 %30
+OpStore %61 %91
+%92 = OpLoad  %5  %35
+%93 = OpLoad  %5  %35
+%94 = OpIAdd  %5  %92 %93
+OpStore %63 %94
+%95 = OpLoad  %5  %35
+%96 = OpShiftLeftLogical  %4  %27 %95
+OpStore %65 %96
+%97 = OpLoad  %5  %35
+%98 = OpShiftLeftLogical  %4  %27 %97
+OpStore %67 %98
 OpReturn
 OpFunctionEnd
-%92 = OpFunction  %2  None %21
-%91 = OpLabel
-OpBranch %95
-%95 = OpLabel
+%100 = OpFunction  %2  None %21
+%99 = OpLabel
+OpBranch %103
+%103 = OpLabel
 OpReturn
 OpFunctionEnd
-%97 = OpFunction  %2  None %21
-%96 = OpLabel
-OpBranch %98
-%98 = OpLabel
-%99 = OpISub  %4  %27 %27
-%101 = OpAccessChain  %100  %17 %99
-%102 = OpLoad  %5  %101
+%105 = OpFunction  %2  None %21
+%104 = OpLabel
+OpBranch %106
+%106 = OpLabel
+%107 = OpISub  %4  %27 %27
+%109 = OpAccessChain  %108  %17 %107
+%110 = OpLoad  %5  %109
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/abstract-types-operators.wgsl
+++ b/naga/tests/out/wgsl/abstract-types-operators.wgsl
@@ -20,11 +20,11 @@ const bitflip_uai: u32 = 0u;
 const least_i32_: i32 = i32(-2147483648);
 const least_f32_: f32 = -340282350000000000000000000000000000000f;
 const shl_iaiai: i32 = 4i;
-const shl_iai_u: i32 = 4i;
+const shl_iai_u_1: i32 = 4i;
 const shl_uaiai: u32 = 4u;
 const shl_uai_u: u32 = 4u;
 const shr_iaiai: i32 = 0i;
-const shr_iai_u: i32 = 0i;
+const shr_iai_u_1: i32 = 0i;
 const shr_uaiai: u32 = 0u;
 const shr_uai_u: u32 = 0u;
 const wgpu_4492_: i32 = i32(-2147483648);
@@ -52,6 +52,8 @@ fn runtime_values() {
     var plus_uai_u: u32;
     var plus_u_uai: u32;
     var plus_u_u_u: u32;
+    var shl_iai_u: i32;
+    var shr_iai_u: i32;
 
     let _e8 = f;
     plus_faf_f = (1f + _e8);
@@ -78,6 +80,10 @@ fn runtime_values() {
     let _e52 = u;
     let _e53 = u;
     plus_u_u_u = (_e52 + _e53);
+    let _e56 = u;
+    shl_iai_u = (1i << _e56);
+    let _e60 = u;
+    shr_iai_u = (1i << _e60);
     return;
 }
 


### PR DESCRIPTION
**Connections**
Fixes #7243 
Fixes #5085 

**Description**

Naga currently trips up on shaders containing a bitshift where the left operand is an AbstractInt and the right operand is *not* a const expression. This is due to the fact that resulting type of `AbstractInt << u32` is abstract, and we are unable to evaluate it away during const evaluation. This results in abstract-typed expressions in our IR, which causes various issues.

For other binary operations, the type of the left and right operands would be related, therefore the presence of a concrete right operand would tell us which type to convert the left operand to. But for shift operations the right operand's scalar type is always a u32, and does not influence the left operand's type.

Luckily the [WGSL spec](https://www.w3.org/TR/WGSL/#overload-resolution-section) tells us how to avoid this problem:

>   6.1.3. Overload Resolution
> 
>   2. Eliminate any candidate where one of its subexpressions resolves to an abstract type after feasible automatic conversions, but another of the candidate’s subexpressions is not a const-expression.

This, for example, specifies we eliminate the `AbstractInt << u32: AbstractInt` overload candidate, leaving `i32 << u32: i32` as the remaining candidate with the lowest conversion rank. The equivalent also applies for right-bitshifts, and for `vecN<AbstractInt>` operands.

**Testing**
Added to snapshot tests

Dealer's choice

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
