### PR TITLE
Fixed DRM(hopefully)

### DIFF
--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -261,6 +261,7 @@ impl super::Instance {
         extensions.push(khr::display::NAME);
         extensions.push(ext::physical_device_drm::NAME);
         extensions.push(khr::get_display_properties2::NAME);
+        extensions.push(ext::direct_mode_display::NAME);
         extensions.push(ext::acquire_drm_display::NAME);
 
         // Platform-specific WSI extensions


### PR DESCRIPTION
**Connections**
Didn't create an issue

**Description**

According to the docs for [VK_EXT_acquire_drm_display](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_acquire_drm_display.html), it depends on `VK_EXT_direct_mode_display`.

This was not done in the original DRM implementation by https://github.com/gfx-rs/wgpu/commit/7eb69f43b617265d709335d4a7833679fa3fa91c.

This PR is a simple one line fix, adding that extension.

**Testing**
Nothing needed to be tested

**Squash or Rebase?**

Single commit.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
