### PR TITLE
Make `std` usage optional for `wgpu-core`.

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -37,6 +37,11 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wgpu_validate_locks)'] }
 [features]
 #! See docuemntation for the `wgpu` crate for more in-depth information on these features.
 
+# TODO(https://github.com/gfx-rs/wgpu/issues/6826): "std" is a default feature for
+# compatibility with prior behavior only, and should be removed once we know how
+# wgpu-core’s dependents want to handle no_std.
+default = ["std"]
+
 #! ### Logging Configuration
 # --------------------------------------------------------------------
 
@@ -62,7 +67,7 @@ strict_asserts = ["wgpu-types/strict_asserts"]
 # --------------------------------------------------------------------
 
 ## Enable lock order observation.
-observe_locks = ["dep:ron", "serde/serde_derive"]
+observe_locks = ["std", "dep:ron", "serde/serde_derive"]
 
 #! ### Serialization
 # --------------------------------------------------------------------
@@ -71,7 +76,7 @@ observe_locks = ["dep:ron", "serde/serde_derive"]
 serde = ["dep:serde", "wgpu-types/serde", "arrayvec/serde", "hashbrown/serde"]
 
 ## Enable API tracing.
-trace = ["dep:ron", "serde", "naga/serialize"]
+trace = ["serde", "std", "dep:ron", "naga/serialize"]
 
 ## Enable API replaying
 replay = ["serde", "naga/deserialize"]
@@ -106,6 +111,10 @@ counters = ["wgpu-types/counters"]
 fragile-send-sync-non-atomic-wasm = [
     "wgpu-hal/fragile-send-sync-non-atomic-wasm",
 ]
+
+## Enable certain items to be `Send` and `Sync` when they would not otherwise be.
+## Also enables backtraces in some error cases when also under cfg(debug_assertions).
+std = []
 
 #! ### External libraries
 # --------------------------------------------------------------------

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -1,9 +1,12 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
         windows_linux_android: { any(windows, target_os = "linux", target_os = "android") },
-        send_sync: { any(
-            not(target_arch = "wasm32"),
-            all(feature = "fragile-send-sync-non-atomic-wasm", not(target_feature = "atomics"))
+        send_sync: { all(
+            feature = "std",
+            any(
+                not(target_arch = "wasm32"),
+                all(feature = "fragile-send-sync-non-atomic-wasm", not(target_feature = "atomics"))
+            )
         ) },
         dx12: { all(target_os = "windows", feature = "dx12") },
         webgl: { all(target_arch = "wasm32", not(target_os = "emscripten"), feature = "webgl") },

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -6,7 +6,6 @@ use alloc::{
     vec::Vec,
 };
 use core::{fmt, mem::ManuallyDrop, ops::Range};
-use std::sync::OnceLock;
 
 use arrayvec::ArrayVec;
 use thiserror::Error;
@@ -602,7 +601,7 @@ pub struct BindGroupLayout {
     /// We cannot unconditionally remove from the pool, as BGLs that don't come from the pool
     /// (derived BGLs) must not be removed.
     pub(crate) origin: bgl::Origin,
-    pub(crate) exclusive_pipeline: OnceLock<ExclusivePipeline>,
+    pub(crate) exclusive_pipeline: crate::OnceCellOrLock<ExclusivePipeline>,
     #[allow(unused)]
     pub(crate) binding_count_validator: BindingTypeMaxCountValidator,
     /// The `label` from the descriptor used to create the resource.

--- a/wgpu-core/src/lock/mod.rs
+++ b/wgpu-core/src/lock/mod.rs
@@ -33,6 +33,7 @@
 
 pub mod rank;
 
+#[cfg(feature = "std")] // requires thread-locals to work
 #[cfg_attr(not(wgpu_validate_locks), allow(dead_code))]
 mod ranked;
 

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -3,9 +3,9 @@ use core::{cell::UnsafeCell, fmt};
 use crate::lock::{rank, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// A guard that provides read access to snatchable data.
-pub struct SnatchGuard<'a>(#[allow(dead_code)] RwLockReadGuard<'a, ()>);
+pub struct SnatchGuard<'a>(#[expect(dead_code)] RwLockReadGuard<'a, ()>);
 /// A guard that allows snatching the snatchable data.
-pub struct ExclusiveSnatchGuard<'a>(#[allow(dead_code)] RwLockWriteGuard<'a, ()>);
+pub struct ExclusiveSnatchGuard<'a>(#[expect(dead_code)] RwLockWriteGuard<'a, ()>);
 
 /// A value that is mostly immutable but can be "snatched" if we need to destroy
 /// it early.
@@ -61,7 +61,7 @@ impl<T> fmt::Debug for Snatchable<T> {
 unsafe impl<T> Sync for Snatchable<T> {}
 
 use trace::LockTrace;
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, feature = "std"))]
 mod trace {
     use core::{cell::Cell, fmt, panic::Location};
     use std::{backtrace::Backtrace, thread};
@@ -113,7 +113,7 @@ mod trace {
         static SNATCH_LOCK_TRACE: Cell<Option<LockTrace>> = const { Cell::new(None) };
     }
 }
-#[cfg(not(debug_assertions))]
+#[cfg(not(all(debug_assertions, feature = "std")))]
 mod trace {
     pub(super) struct LockTrace {
         _private: (),

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,18 +1,11 @@
-#![allow(unused)]
-
-use core::{
-    cell::{Cell, RefCell, UnsafeCell},
-    fmt,
-    panic::{self, Location},
-};
-use std::{backtrace::Backtrace, thread};
+use core::{cell::UnsafeCell, fmt};
 
 use crate::lock::{rank, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// A guard that provides read access to snatchable data.
-pub struct SnatchGuard<'a>(RwLockReadGuard<'a, ()>);
+pub struct SnatchGuard<'a>(#[allow(dead_code)] RwLockReadGuard<'a, ()>);
 /// A guard that allows snatching the snatchable data.
-pub struct ExclusiveSnatchGuard<'a>(RwLockWriteGuard<'a, ()>);
+pub struct ExclusiveSnatchGuard<'a>(#[allow(dead_code)] RwLockWriteGuard<'a, ()>);
 
 /// A value that is mostly immutable but can be "snatched" if we need to destroy
 /// it early.
@@ -31,6 +24,7 @@ impl<T> Snatchable<T> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn empty() -> Self {
         Snatchable {
             value: UnsafeCell::new(None),
@@ -66,58 +60,69 @@ impl<T> fmt::Debug for Snatchable<T> {
 
 unsafe impl<T> Sync for Snatchable<T> {}
 
-struct LockTrace {
-    purpose: &'static str,
-    caller: &'static Location<'static>,
-    backtrace: Backtrace,
-}
-
-impl fmt::Display for LockTrace {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "a {} lock at {}\n{}",
-            self.purpose, self.caller, self.backtrace
-        )
-    }
-}
-
+use trace::LockTrace;
 #[cfg(debug_assertions)]
-impl LockTrace {
-    #[track_caller]
-    fn enter(purpose: &'static str) {
-        let new = LockTrace {
-            purpose,
-            caller: Location::caller(),
-            backtrace: Backtrace::capture(),
-        };
+mod trace {
+    use core::{cell::Cell, fmt, panic::Location};
+    use std::{backtrace::Backtrace, thread};
 
-        if let Some(prev) = SNATCH_LOCK_TRACE.take() {
-            let current = thread::current();
-            let name = current.name().unwrap_or("<unnamed>");
-            panic!(
-                "thread '{name}' attempted to acquire a snatch lock recursively.\n\
-                 - Currently trying to acquire {new}\n\
-                 - Previously acquired {prev}",
-            );
-        } else {
-            SNATCH_LOCK_TRACE.set(Some(new));
+    pub(super) struct LockTrace {
+        purpose: &'static str,
+        caller: &'static Location<'static>,
+        backtrace: Backtrace,
+    }
+
+    impl fmt::Display for LockTrace {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "a {} lock at {}\n{}",
+                self.purpose, self.caller, self.backtrace
+            )
         }
     }
 
-    fn exit() {
-        SNATCH_LOCK_TRACE.take();
+    impl LockTrace {
+        #[track_caller]
+        pub(super) fn enter(purpose: &'static str) {
+            let new = LockTrace {
+                purpose,
+                caller: Location::caller(),
+                backtrace: Backtrace::capture(),
+            };
+
+            if let Some(prev) = SNATCH_LOCK_TRACE.take() {
+                let current = thread::current();
+                let name = current.name().unwrap_or("<unnamed>");
+                panic!(
+                    "thread '{name}' attempted to acquire a snatch lock recursively.\n\
+                 - Currently trying to acquire {new}\n\
+                 - Previously acquired {prev}",
+                );
+            } else {
+                SNATCH_LOCK_TRACE.set(Some(new));
+            }
+        }
+
+        pub(super) fn exit() {
+            SNATCH_LOCK_TRACE.take();
+        }
+    }
+
+    std::thread_local! {
+        static SNATCH_LOCK_TRACE: Cell<Option<LockTrace>> = const { Cell::new(None) };
     }
 }
-
 #[cfg(not(debug_assertions))]
-impl LockTrace {
-    fn enter(purpose: &'static str) {}
-    fn exit() {}
-}
+mod trace {
+    pub(super) struct LockTrace {
+        _private: (),
+    }
 
-std::thread_local! {
-    static SNATCH_LOCK_TRACE: Cell<Option<LockTrace>> = const { Cell::new(None) };
+    impl LockTrace {
+        pub(super) fn enter(_purpose: &'static str) {}
+        pub(super) fn exit() {}
+    }
 }
 
 /// A Device-global lock for all snatchable data.


### PR DESCRIPTION
**Connections**
Part of implementing #6826. Followup to #7189.

**Description**
Adds a `std` feature, enabled by default, to `wgpu-core`. When that feature is disabled, the following functionality is not available:

* `Send + Sync` for resources.
* `trace` feature.
* `observe_locks` feature.
* Snatch lock recursive locking assertion.

~~Also, `RawString` stops tracking the OS definition and is always `*const u8`. This is a bad idea and will break `wgpu`’s code on platforms where `c_char = i8`, but I don’t know what should be done instead; I’m not familiar with the reasons for `bundle_ffi`’s design. Please advise.~~

**Testing**
`wgpu-core`’s dependencies (notably `naga`) still require `std`, so this can’t be fully tested yet, but the test suite still passes, and building `wgpu-core` with the feature disabled succeeds.

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
