### PR TITLE
docs: Improve linking, backticks

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4085,7 +4085,7 @@ pub enum PollStatus {
 }
 
 impl PollStatus {
-    /// Returns true if the result is [`Self::QueueEmpty`]`.
+    /// Returns true if the result is [`Self::QueueEmpty`].
     #[must_use]
     pub fn is_queue_empty(&self) -> bool {
         matches!(self, Self::QueueEmpty)

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -478,15 +478,15 @@ impl Device {
     /// # Validation
     /// If any of the following is not satisfied a validation error is generated
     ///
-    /// The device ***must*** have [Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE] enabled.
-    /// if `sizes` is [BlasGeometrySizeDescriptors::Triangles] then the following must be satisfied
+    /// The device ***must*** have [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`] enabled.
+    /// if `sizes` is [`BlasGeometrySizeDescriptors::Triangles`] then the following must be satisfied
     /// - For every geometry descriptor (for the purposes this is called `geo_desc`) of `sizes.descriptors` the following must be satisfied:
     ///     - `geo_desc.vertex_format` must be within allowed formats (allowed formats for a given feature set
-    ///       may be queried with [Features::allowed_vertex_formats_for_blas]).
+    ///       may be queried with [`Features::allowed_vertex_formats_for_blas`]).
     ///     - Both or neither of `geo_desc.index_format` and `geo_desc.index_count` must be provided.
     ///
-    /// [Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE]: wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
-    /// [Features::allowed_vertex_formats_for_blas]: wgt::Features::allowed_vertex_formats_for_blas
+    /// [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`]: wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
+    /// [`Features::allowed_vertex_formats_for_blas`]: wgt::Features::allowed_vertex_formats_for_blas
     #[must_use]
     pub fn create_blas(
         &self,
@@ -507,9 +507,9 @@ impl Device {
     /// # Validation
     /// If any of the following is not satisfied a validation error is generated
     ///
-    /// The device ***must*** have [Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE] enabled.
+    /// The device ***must*** have [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`] enabled.
     ///
-    /// [Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE]: wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
+    /// [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`]: wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
     #[must_use]
     pub fn create_tlas(&self, desc: &CreateTlasDescriptor<'_>) -> Tlas {
         let tlas = self.inner.create_tlas(desc);

--- a/wgpu/src/api/mod.rs
+++ b/wgpu/src/api/mod.rs
@@ -80,9 +80,9 @@ pub use tlas::*;
 /// Object debugging label.
 pub type Label<'a> = Option<&'a str>;
 
-/// A cute utility type that works just like PhantomData, but also
-/// implements Drop. This forces any lifetimes that are associated
-/// with the type to be used until the Drop impl is ran. This prevents
+/// A cute utility type that works just like `PhantomData`, but also
+/// implements `Drop`. This forces any lifetimes that are associated
+/// with the type to be used until the `Drop` impl is ran. This prevents
 /// lifetimes from being shortened.
 #[derive(Debug)]
 pub(crate) struct PhantomDrop<T>(core::marker::PhantomData<T>);

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -172,12 +172,13 @@ impl RenderPass<'_> {
     /// Draws primitives from the active vertex buffer(s).
     ///
     /// The active vertex buffer(s) can be set with [`RenderPass::set_vertex_buffer`].
-    /// Does not use an Index Buffer. If you need this see [`RenderPass::draw_indexed`]
+    /// This does not use an index buffer. If you need indexed drawing, see [`RenderPass::draw_indexed`]
     ///
-    /// Panics if vertices Range is outside of the range of the vertices range of any set vertex buffer.
+    /// Panics if `vertices` range is outside of the range of the vertices range of any set vertex buffer.
     ///
-    /// vertices: The range of vertices to draw.
-    /// instances: Range of Instances to draw. Use 0..1 if instance buffers are not used.
+    /// - `vertices`: The range of vertices to draw.
+    /// - `instances`: Range of instances to draw. Use `0..1` if instance buffers are not used.
+    ///
     /// E.g.of how its used internally
     /// ```rust ignore
     /// for instance_id in instance_range {
@@ -199,11 +200,12 @@ impl RenderPass<'_> {
     /// The active index buffer can be set with [`RenderPass::set_index_buffer`]
     /// The active vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
     ///
-    /// Panics if indices Range is outside of the range of the indices range of any set index buffer.
+    /// Panics if `indices` range is outside of the range of the indices range of the set index buffer.
     ///
-    /// indices: The range of indices to draw.
-    /// base_vertex: value added to each index value before indexing into the vertex buffers.
-    /// instances: Range of Instances to draw. Use 0..1 if instance buffers are not used.
+    /// - `indices`: The range of indices to draw.
+    /// - `base_vertex`: value added to each index value before indexing into the vertex buffers.
+    /// - `instances`: Range of instances to draw. Use `0..1` if instance buffers are not used.
+    ///
     /// E.g.of how its used internally
     /// ```rust ignore
     /// for instance_id in instance_range {
@@ -230,7 +232,7 @@ impl RenderPass<'_> {
     /// Indirect drawing has some caveats depending on the features available. We are not currently able to validate
     /// these and issue an error.
     /// - If [`Features::INDIRECT_FIRST_INSTANCE`] is not present on the adapter,
-    ///   [`DrawIndirect::first_instance`](crate::util::DrawIndirectArgs::first_instance) will be ignored.
+    ///   [`DrawIndirectArgs::first_instance`](crate::util::DrawIndirectArgs::first_instance) will be ignored.
     /// - If [`DownlevelFlags::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW`] is not present on the adapter,
     ///   any use of `@builtin(vertex_index)` or `@builtin(instance_index)` in the vertex shader will have different values.
     ///
@@ -249,7 +251,7 @@ impl RenderPass<'_> {
     /// Indirect drawing has some caveats depending on the features available. We are not currently able to validate
     /// these and issue an error.
     /// - If [`Features::INDIRECT_FIRST_INSTANCE`] is not present on the adapter,
-    ///   [`DrawIndexedIndirect::first_instance`](crate::util::DrawIndexedIndirectArgs::first_instance) will be ignored.
+    ///   [`DrawIndexedIndirectArgs::first_instance`](crate::util::DrawIndexedIndirectArgs::first_instance) will be ignored.
     /// - If [`DownlevelFlags::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW`] is not present on the adapter,
     ///   any use of `@builtin(vertex_index)` or `@builtin(instance_index)` in the vertex shader will have different values.
     ///
@@ -372,7 +374,6 @@ impl RenderPass<'_> {
     /// The active index buffer can be set with [`RenderPass::set_index_buffer`], while the active
     /// vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
     ///
-    ///
     /// The structure expected in `indirect_buffer` must conform to [`DrawIndexedIndirectArgs`](crate::util::DrawIndexedIndirectArgs).
     ///
     /// These draw structures are expected to be tightly packed.
@@ -469,13 +470,15 @@ impl RenderPass<'_> {
 
 impl RenderPass<'_> {
     /// Start a occlusion query on this render pass. It can be ended with
-    /// `end_occlusion_query`. Occlusion queries may not be nested.
+    /// [`end_occlusion_query`](Self::end_occlusion_query).
+    /// Occlusion queries may not be nested.
     pub fn begin_occlusion_query(&mut self, query_index: u32) {
         self.inner.begin_occlusion_query(query_index);
     }
 
     /// End the occlusion query on this render pass. It can be started with
-    /// `begin_occlusion_query`. Occlusion queries may not be nested.
+    /// [`begin_occlusion_query`](Self::begin_occlusion_query).
+    /// Occlusion queries may not be nested.
     pub fn end_occlusion_query(&mut self) {
         self.inner.end_occlusion_query();
     }
@@ -484,14 +487,16 @@ impl RenderPass<'_> {
 /// [`Features::PIPELINE_STATISTICS_QUERY`] must be enabled on the device in order to call these functions.
 impl RenderPass<'_> {
     /// Start a pipeline statistics query on this render pass. It can be ended with
-    /// `end_pipeline_statistics_query`. Pipeline statistics queries may not be nested.
+    /// [`end_pipeline_statistics_query`](Self::end_pipeline_statistics_query).
+    /// Pipeline statistics queries may not be nested.
     pub fn begin_pipeline_statistics_query(&mut self, query_set: &QuerySet, query_index: u32) {
         self.inner
             .begin_pipeline_statistics_query(&query_set.inner, query_index);
     }
 
     /// End the pipeline statistics query on this render pass. It can be started with
-    /// `begin_pipeline_statistics_query`. Pipeline statistics queries may not be nested.
+    /// [`begin_pipeline_statistics_query`](Self::begin_pipeline_statistics_query).
+    /// Pipeline statistics queries may not be nested.
     pub fn end_pipeline_statistics_query(&mut self) {
         self.inner.end_pipeline_statistics_query();
     }
@@ -500,7 +505,8 @@ impl RenderPass<'_> {
 /// Describes the timestamp writes of a render pass.
 ///
 /// For use with [`RenderPassDescriptor`].
-/// At least one of `beginning_of_pass_write_index` and `end_of_pass_write_index` must be `Some`.
+/// At least one of [`Self::beginning_of_pass_write_index`] and [`Self::end_of_pass_write_index`]
+/// must be `Some`.
 ///
 /// Corresponds to [WebGPU `GPURenderPassTimestampWrite`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpasstimestampwrites).

--- a/wgpu/src/api/texture_view.rs
+++ b/wgpu/src/api/texture_view.rs
@@ -19,12 +19,12 @@ static_assertions::assert_impl_all!(TextureView: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(TextureView => .inner);
 
 impl TextureView {
-    /// Returns the inner hal TextureView using a callback. The hal texture will be `None` if the
+    /// Returns the inner hal `TextureView` using a callback. The hal texture will be `None` if the
     /// backend type argument does not match with this wgpu Texture
     ///
     /// # Safety
     ///
-    /// - The raw handle obtained from the hal TextureView must not be manually destroyed
+    /// - The raw handle obtained from the hal `TextureView` must not be manually destroyed
     #[cfg(wgpu_core)]
     pub unsafe fn as_hal<A: wgc::hal_api::HalApi, F: FnOnce(Option<&A::TextureView>) -> R, R>(
         &self,

--- a/wgpu/src/api/tlas.rs
+++ b/wgpu/src/api/tlas.rs
@@ -34,18 +34,18 @@ crate::cmp::impl_eq_ord_hash_proxy!(Tlas => .shared.inner);
 
 /// Entry for a top level acceleration structure build.
 /// Used with raw instance buffers for an unvalidated builds.
-/// See [TlasPackage] for the safe version.
+/// See [`TlasPackage`] for the safe version.
 pub struct TlasBuildEntry<'a> {
     /// Reference to the acceleration structure.
     pub tlas: &'a Tlas,
-    /// Reference to the raw instance buffer, each instance is similar to [TlasInstance] but contains a handle to the BLAS.
+    /// Reference to the raw instance buffer, each instance is similar to [`TlasInstance`] but contains a handle to the BLAS.
     pub instance_buffer: &'a Buffer,
     /// Number of instances in the instance buffer.
     pub instance_count: u32,
 }
 static_assertions::assert_impl_all!(TlasBuildEntry<'_>: WasmNotSendSync);
 
-/// The safe version of TlasEntry, containing TlasInstances instead of a raw buffer.
+/// The safe version of [`TlasBuildEntry`], containing [`TlasInstance`]s instead of a raw buffer.
 pub struct TlasPackage {
     pub(crate) tlas: Tlas,
     pub(crate) instances: Vec<Option<TlasInstance>>,
@@ -54,13 +54,13 @@ pub struct TlasPackage {
 static_assertions::assert_impl_all!(TlasPackage: WasmNotSendSync);
 
 impl TlasPackage {
-    /// Construct [TlasPackage] consuming the [Tlas] (prevents modification of the [Tlas] without using this package).
+    /// Construct [`TlasPackage`] consuming the [`Tlas`] (prevents modification of the [`Tlas`] without using this package).
     pub fn new(tlas: Tlas) -> Self {
         let max_instances = tlas.shared.max_instances;
         Self::new_with_instances(tlas, vec![None; max_instances as usize])
     }
 
-    /// Construct [TlasPackage] consuming the [Tlas] (prevents modification of the Tlas without using this package).
+    /// Construct [`TlasPackage`] consuming the [`Tlas`] (prevents modification of the [`Tlas`] without using this package).
     /// This constructor moves the instances into the package (the number of instances needs to fit into tlas,
     /// otherwise when building a validation error will be raised).
     pub fn new_with_instances(tlas: Tlas, instances: Vec<Option<TlasInstance>>) -> Self {
@@ -82,7 +82,7 @@ impl TlasPackage {
     // this recommendation is not useful yet, but is likely to be when ability to update arrives or possible optimisations for building get implemented.
     /// For best performance it is recommended to prefer access to low elements and modify higher elements as little as possible.
     /// This can be done by ordering instances from the most to the least used. It is recommended
-    /// to use [Self::index_mut] unless the option if out of bounds is required
+    /// to use [`Self::index_mut`] unless the option if out of bounds is required
     pub fn get_mut_slice(&mut self, range: Range<usize>) -> Option<&mut [Option<TlasInstance>]> {
         if range.end > self.instances.len() {
             return None;
@@ -99,7 +99,7 @@ impl TlasPackage {
     // this recommendation is not useful yet, but is likely to be when ability to update arrives or possible optimisations for building get implemented.
     /// For best performance it is recommended to prefer access to low elements and modify higher elements as little as possible.
     /// This can be done by ordering instances from the most to the least used. It is recommended
-    /// to use [Self::index_mut] unless the option if out of bounds is required
+    /// to use [`Self::index_mut`] unless the option if out of bounds is required
     pub fn get_mut_single(&mut self, index: usize) -> Option<&mut Option<TlasInstance>> {
         if index >= self.instances.len() {
             return None;
@@ -110,14 +110,14 @@ impl TlasPackage {
         Some(&mut self.instances[index])
     }
 
-    /// Get the binding resource for the underling acceleration structure, to be used when creating a [BindGroup]
+    /// Get the binding resource for the underling acceleration structure, to be used when creating a [`BindGroup`]
     ///
-    /// [BindGroup]: super::BindGroup
+    /// [`BindGroup`]: super::BindGroup
     pub fn as_binding(&self) -> BindingResource<'_> {
         BindingResource::AccelerationStructure(&self.tlas)
     }
 
-    /// Get a reference to the underling [Tlas].
+    /// Get a reference to the underling [`Tlas`].
     pub fn tlas(&self) -> &Tlas {
         &self.tlas
     }

--- a/wgpu/src/cmp.rs
+++ b/wgpu/src/cmp.rs
@@ -1,4 +1,4 @@
-//! We need to impl PartialEq, Eq, PartialOrd, Ord, and Hash for all handle types in wgpu.
+//! We need to impl `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash` for all handle types in wgpu.
 //!
 //! For types that have some already-unique property, we can use that property to implement these traits.
 //!
@@ -27,7 +27,7 @@ impl Identifier {
     }
 }
 
-/// Implements PartialEq, Eq, PartialOrd, Ord, and Hash for a type by proxying the operations to a single field.
+/// Implements `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash` for a type by proxying the operations to a single field.
 ///
 /// ```ignore
 /// impl_eq_ord_hash_proxy!(MyType => .field);
@@ -62,7 +62,7 @@ macro_rules! impl_eq_ord_hash_proxy {
     };
 }
 
-/// Implements PartialEq, Eq, PartialOrd, Ord, and Hash for a type by comparing the addresses of the Arcs.
+/// Implements `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash` for a type by comparing the addresses of the `Arc`s.
 ///
 /// ```ignore
 /// impl_eq_ord_hash_arc_address!(MyType => .field);

--- a/wgpu/src/util/encoder.rs
+++ b/wgpu/src/util/encoder.rs
@@ -34,7 +34,7 @@ pub trait RenderEncoder<'a> {
     /// [`RenderEncoder`] will use `buffer` as one of the source vertex buffers.
     ///
     /// The `slot` refers to the index of the matching descriptor in
-    /// [VertexState::buffers](crate::VertexState::buffers).
+    /// [`VertexState::buffers`](crate::VertexState::buffers).
     ///
     /// [`draw`]: RenderEncoder::draw
     /// [`draw_indexed`]: RenderEncoder::draw_indexed
@@ -91,7 +91,7 @@ pub trait RenderEncoder<'a> {
     /// - 4..8 Fragment
     /// ```
     ///
-    /// You would need to upload this in two set_push_constants calls. First for the `Vertex` range, second for the `Fragment` range.
+    /// You would need to upload this in two `set_push_constants` calls. First for the `Vertex` range, second for the `Fragment` range.
     ///
     /// ```text
     /// For the given ranges:
@@ -99,7 +99,7 @@ pub trait RenderEncoder<'a> {
     /// - 4..12 Fragment
     /// ```
     ///
-    /// You would need to upload this in three set_push_constants calls. First for the `Vertex` only range 0..4, second
+    /// You would need to upload this in three `set_push_constants` calls. First for the `Vertex` only range 0..4, second
     /// for the `Vertex | Fragment` range 4..8, third for the `Fragment` range 8..12.
     fn set_push_constants(&mut self, stages: wgt::ShaderStages, offset: u32, data: &[u8]);
 }

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -3,7 +3,7 @@ use crate::{Adapter, Instance, RequestAdapterOptions, Surface};
 #[cfg(doc)]
 use crate::Backends;
 
-/// Initialize the adapter obeying the WGPU_ADAPTER_NAME environment variable.
+/// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable.
 #[cfg(native)]
 pub fn initialize_adapter_from_env(
     instance: &Instance,
@@ -35,7 +35,7 @@ pub fn initialize_adapter_from_env(
     Some(chosen_adapter.expect("WGPU_ADAPTER_NAME set but no matching adapter found!"))
 }
 
-/// Initialize the adapter obeying the WGPU_ADAPTER_NAME environment variable.
+/// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable.
 #[cfg(not(native))]
 pub fn initialize_adapter_from_env(
     _instance: &Instance,
@@ -44,7 +44,7 @@ pub fn initialize_adapter_from_env(
     None
 }
 
-/// Initialize the adapter obeying the WGPU_ADAPTER_NAME environment variable and if it doesn't exist fall back on a default adapter.
+/// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable and if it doesn't exist fall back on a default adapter.
 pub async fn initialize_adapter_from_env_or_default(
     instance: &Instance,
     compatible_surface: Option<&Surface<'_>>,

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -39,8 +39,8 @@ pub fn make_spirv(data: &[u8]) -> super::ShaderSource<'_> {
     super::ShaderSource::SpirV(make_spirv_raw(data))
 }
 
-/// Version of make_spirv intended for use with [`Device::create_shader_module_spirv`].
-/// Returns raw slice instead of ShaderSource.
+/// Version of `make_spirv` intended for use with [`Device::create_shader_module_spirv`].
+/// Returns a raw slice instead of [`ShaderSource`](super::ShaderSource).
 ///
 /// [`Device::create_shader_module_spirv`]: crate::Device::create_shader_module_spirv
 pub fn make_spirv_raw(data: &[u8]) -> Cow<'_, [u32]> {


### PR DESCRIPTION
**Description**
Improve formatting, linking and backtick usage within docs.

**Testing**
It builds without warnings from these changes.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
