### PR TITLE
Additional documentation for buffer mapping, types, and constants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,7 +243,7 @@ By @Vecvec in [#6905](https://github.com/gfx-rs/wgpu/pull/6905), [#7086](https:/
 ### Documentation
 
 - Improved documentation around pipeline caches and `TextureBlitter`. By @DJMcNab in [#6978](https://github.com/gfx-rs/wgpu/pull/6978) and [#7003](https://github.com/gfx-rs/wgpu/pull/7003).
-- Improved documentation of `PresentMode`. By @kpreid in [#7211](https://github.com/gfx-rs/wgpu/pull/7211).
+- Improved documentation of `PresentMode`, buffer mapping functions, memory alignment requirements, texture formats’ automatic conversions, and various types and constants. By @kpreid in [#7211](https://github.com/gfx-rs/wgpu/pull/7211) and [#7283](https://github.com/gfx-rs/wgpu/pull/7283).
 
 - Added a hello window example. By @laycookie in [#6992](https://github.com/gfx-rs/wgpu/pull/6992).
 

--- a/wgpu-types/src/counters.rs
+++ b/wgpu-types/src/counters.rs
@@ -102,7 +102,7 @@ impl core::fmt::Debug for InternalCounter {
     }
 }
 
-/// `wgpu-hal`'s internal counters.
+/// `wgpu-hal`'s part of [`InternalCounters`].
 #[allow(missing_docs)]
 #[derive(Clone, Default)]
 pub struct HalCounters {
@@ -132,13 +132,16 @@ pub struct HalCounters {
     pub memory_allocations: InternalCounter,
 }
 
-/// `wgpu-core`'s internal counters.
+/// `wgpu-core`'s part of [`InternalCounters`].
 #[derive(Clone, Default)]
 pub struct CoreCounters {
     // TODO    #[cfg(features=)]
 }
 
 /// All internal counters, exposed for debugging purposes.
+///
+/// Obtain this from
+/// [`Device::get_internal_counters()`](../wgpu/struct.Device.html#method.get_internal_counters).
 #[derive(Clone, Default)]
 pub struct InternalCounters {
     /// `wgpu-core` counters.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1784,7 +1784,11 @@ pub enum AstcChannel {
 /// * `Unorm` formats linearly scale the integer range of the storage format to a floating-point
 ///   range of 0 to 1, inclusive.
 /// * `Snorm` formats linearly scale the integer range of the storage format to a floating-point
-///   range of &minus;1 to 1, inclusive.
+///   range of &minus;1 to 1, inclusive, except that the most negative value
+///   (&minus;128 for 8-bit, &minus;32768 for 16-bit) is excluded; on conversion,
+///   it is treated as identical to the second most negative
+///   (&minus;127 for 8-bit, &minus;32767 for 16-bit),
+///   so that the positive and negative ranges are symmetric.
 /// * `UnormSrgb` formats apply the [sRGB transfer function] so that the storage is sRGB encoded
 ///   while the shader works with linear intensity values.
 /// * `Uint`, `Sint`, and `Float` formats perform no conversion.
@@ -1799,7 +1803,7 @@ pub enum TextureFormat {
     // Normal 8 bit formats
     /// Red channel only. 8 bit integer per channel. [0, 255] converted to/from float [0, 1] in shader.
     R8Unorm,
-    /// Red channel only. 8 bit integer per channel. [-127, 127] converted to/from float [-1, 1] in shader.
+    /// Red channel only. 8 bit integer per channel. [&minus;127, 127] converted to/from float [&minus;1, 1] in shader.
     R8Snorm,
     /// Red channel only. 8 bit integer per channel. Unsigned in shader.
     R8Uint,
@@ -1815,7 +1819,7 @@ pub enum TextureFormat {
     ///
     /// [`Features::TEXTURE_FORMAT_16BIT_NORM`] must be enabled to use this texture format.
     R16Unorm,
-    /// Red channel only. 16 bit integer per channel. [0, 65535] converted to/from float [-1, 1] in shader.
+    /// Red channel only. 16 bit integer per channel. [&minus;32767, 32767] converted to/from float [&minus;1, 1] in shader.
     ///
     /// [`Features::TEXTURE_FORMAT_16BIT_NORM`] must be enabled to use this texture format.
     R16Snorm,
@@ -1823,7 +1827,7 @@ pub enum TextureFormat {
     R16Float,
     /// Red and green channels. 8 bit integer per channel. [0, 255] converted to/from float [0, 1] in shader.
     Rg8Unorm,
-    /// Red and green channels. 8 bit integer per channel. [-127, 127] converted to/from float [-1, 1] in shader.
+    /// Red and green channels. 8 bit integer per channel. [&minus;127, 127] converted to/from float [&minus;1, 1] in shader.
     Rg8Snorm,
     /// Red and green channels. 8 bit integer per channel. Unsigned in shader.
     Rg8Uint,
@@ -1845,7 +1849,7 @@ pub enum TextureFormat {
     ///
     /// [`Features::TEXTURE_FORMAT_16BIT_NORM`] must be enabled to use this texture format.
     Rg16Unorm,
-    /// Red and green channels. 16 bit integer per channel. [0, 65535] converted to/from float [-1, 1] in shader.
+    /// Red and green channels. 16 bit integer per channel. [&minus;32767, 32767] converted to/from float [&minus;1, 1] in shader.
     ///
     /// [`Features::TEXTURE_FORMAT_16BIT_NORM`] must be enabled to use this texture format.
     Rg16Snorm,
@@ -1855,7 +1859,7 @@ pub enum TextureFormat {
     Rgba8Unorm,
     /// Red, green, blue, and alpha channels. 8 bit integer per channel. Srgb-color [0, 255] converted to/from linear-color float [0, 1] in shader.
     Rgba8UnormSrgb,
-    /// Red, green, blue, and alpha channels. 8 bit integer per channel. [-127, 127] converted to/from float [-1, 1] in shader.
+    /// Red, green, blue, and alpha channels. 8 bit integer per channel. [&minus;127, 127] converted to/from float [&minus;1, 1] in shader.
     Rgba8Snorm,
     /// Red, green, blue, and alpha channels. 8 bit integer per channel. Unsigned in shader.
     Rgba8Uint,
@@ -1895,7 +1899,7 @@ pub enum TextureFormat {
     ///
     /// [`Features::TEXTURE_FORMAT_16BIT_NORM`] must be enabled to use this texture format.
     Rgba16Unorm,
-    /// Red, green, blue, and alpha. 16 bit integer per channel. [0, 65535] converted to/from float [-1, 1] in shader.
+    /// Red, green, blue, and alpha. 16 bit integer per channel. [&minus;32767, 32767] converted to/from float [&minus;1, 1] in shader.
     ///
     /// [`Features::TEXTURE_FORMAT_16BIT_NORM`] must be enabled to use this texture format.
     Rgba16Snorm,
@@ -1999,7 +2003,7 @@ pub enum TextureFormat {
     /// [`Features::TEXTURE_COMPRESSION_BC_SLICED_3D`] must be enabled to use this texture format with 3D dimension.
     Bc4RUnorm,
     /// 4x4 block compressed texture. 8 bytes per block (4 bit/px). 8 color pallet. 8 bit R.
-    /// [-127, 127] converted to/from float [-1, 1] in shader.
+    /// [&minus;127, 127] converted to/from float [&minus;1, 1] in shader.
     ///
     /// Also known as RGTC1.
     ///
@@ -2015,7 +2019,7 @@ pub enum TextureFormat {
     /// [`Features::TEXTURE_COMPRESSION_BC_SLICED_3D`] must be enabled to use this texture format with 3D dimension.
     Bc5RgUnorm,
     /// 4x4 block compressed texture. 16 bytes per block (8 bit/px). 8 color red pallet + 8 color green pallet. 8 bit RG.
-    /// [-127, 127] converted to/from float [-1, 1] in shader.
+    /// [&minus;127, 127] converted to/from float [&minus;1, 1] in shader.
     ///
     /// Also known as RGTC2.
     ///
@@ -2088,7 +2092,7 @@ pub enum TextureFormat {
     /// [`Features::TEXTURE_COMPRESSION_ETC2`] must be enabled to use this texture format.
     EacR11Unorm,
     /// 4x4 block compressed texture. 8 bytes per block (4 bit/px). Complex pallet. 11 bit integer R.
-    /// [-127, 127] converted to/from float [-1, 1] in shader.
+    /// [&minus;127, 127] converted to/from float [&minus;1, 1] in shader.
     ///
     /// [`Features::TEXTURE_COMPRESSION_ETC2`] must be enabled to use this texture format.
     EacR11Snorm,
@@ -2098,7 +2102,7 @@ pub enum TextureFormat {
     /// [`Features::TEXTURE_COMPRESSION_ETC2`] must be enabled to use this texture format.
     EacRg11Unorm,
     /// 4x4 block compressed texture. 16 bytes per block (8 bit/px). Complex pallet. 11 bit integer R + 11 bit integer G.
-    /// [-127, 127] converted to/from float [-1, 1] in shader.
+    /// [&minus;127, 127] converted to/from float [&minus;1, 1] in shader.
     ///
     /// [`Features::TEXTURE_COMPRESSION_ETC2`] must be enabled to use this texture format.
     EacRg11Snorm,
@@ -4650,11 +4654,11 @@ pub enum VertexFormat {
     Unorm8x2 = 7,
     /// Four unsigned bytes (u8). [0, 255] converted to float [0, 1] `vec4<f32>` in shaders.
     Unorm8x4 = 8,
-    /// One signed byte (i8). [-127, 127] converted to float [-1, 1] `f32` in shaders.
+    /// One signed byte (i8). [&minus;127, 127] converted to float [&minus;1, 1] `f32` in shaders.
     Snorm8 = 9,
-    /// Two signed bytes (i8). [-127, 127] converted to float [-1, 1] `vec2<f32>` in shaders.
+    /// Two signed bytes (i8). [&minus;127, 127] converted to float [&minus;1, 1] `vec2<f32>` in shaders.
     Snorm8x2 = 10,
-    /// Four signed bytes (i8). [-127, 127] converted to float [-1, 1] `vec4<f32>` in shaders.
+    /// Four signed bytes (i8). [&minus;127, 127] converted to float [&minus;1, 1] `vec4<f32>` in shaders.
     Snorm8x4 = 11,
     /// One unsigned short (u16). `u32` in shaders.
     Uint16 = 12,
@@ -4674,11 +4678,11 @@ pub enum VertexFormat {
     Unorm16x2 = 19,
     /// Four unsigned shorts (u16). [0, 65535] converted to float [0, 1] `vec4<f32>` in shaders.
     Unorm16x4 = 20,
-    /// One signed short (i16). [-32767, 32767] converted to float [-1, 1] `f32` in shaders.
+    /// One signed short (i16). [&minus;32767, 32767] converted to float [&minus;1, 1] `f32` in shaders.
     Snorm16 = 21,
-    /// Two signed shorts (i16). [-32767, 32767] converted to float [-1, 1] `vec2<f32>` in shaders.
+    /// Two signed shorts (i16). [&minus;32767, 32767] converted to float [&minus;1, 1] `vec2<f32>` in shaders.
     Snorm16x2 = 22,
-    /// Four signed shorts (i16). [-32767, 32767] converted to float [-1, 1] `vec4<f32>` in shaders.
+    /// Four signed shorts (i16). [&minus;32767, 32767] converted to float [&minus;1, 1] `vec4<f32>` in shaders.
     Snorm16x4 = 23,
     /// One half-precision float (no Rust equiv). `f32` in shaders.
     Float16 = 24,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -38,35 +38,71 @@ pub use counters::*;
 pub use features::*;
 pub use instance::*;
 
-/// Integral type used for buffer offsets.
+/// Integral type used for [`Buffer`] offsets and sizes.
+///
+/// [`Buffer`]: ../wgpu/struct.Buffer.html
 pub type BufferAddress = u64;
-/// Integral type used for buffer slice sizes.
+
+/// Integral type used for [`BufferSlice`] sizes.
+///
+/// Note that while this type is non-zero, a [`Buffer`] *per se* can have a size of zero,
+/// but no slice or mapping can be created from it.
+///
+/// [`Buffer`]: ../wgpu/struct.Buffer.html
+/// [`BufferSlice`]: ../wgpu/struct.BufferSlice.html
 pub type BufferSize = core::num::NonZeroU64;
+
 /// Integral type used for binding locations in shaders.
+///
+/// Used in [`VertexAttribute`]s and errors.
+///
+/// [`VertexAttribute`]: ../wgpu/struct.VertexAttribute.html
 pub type ShaderLocation = u32;
-/// Integral type used for dynamic bind group offsets.
+
+/// Integral type used for
+/// [dynamic bind group offsets](../wgpu/struct.RenderPass.html#method.set_bind_group).
 pub type DynamicOffset = u32;
 
-/// Buffer-Texture copies must have [`bytes_per_row`] aligned to this number.
+/// Buffer-to-texture copies must have [`bytes_per_row`] aligned to this number.
 ///
-/// This doesn't apply to [`Queue::write_texture`][Qwt].
+/// This doesn't apply to [`Queue::write_texture`][Qwt], only to [`copy_buffer_to_texture()`].
 ///
 /// [`bytes_per_row`]: TexelCopyBufferLayout::bytes_per_row
+/// [`copy_buffer_to_texture()`]: ../wgpu/struct.Queue.html#method.copy_buffer_to_texture
 /// [Qwt]: ../wgpu/struct.Queue.html#method.write_texture
 pub const COPY_BYTES_PER_ROW_ALIGNMENT: u32 = 256;
-/// An offset into the query resolve buffer has to be aligned to this.
+
+/// An [offset into the query resolve buffer] has to be aligned to this.
+///
+/// [offset into the query resolve buffer]: ../wgpu/struct.CommandEncoder.html#method.resolve_query_set
 pub const QUERY_RESOLVE_BUFFER_ALIGNMENT: BufferAddress = 256;
+
 /// Buffer to buffer copy as well as buffer clear offsets and sizes must be aligned to this number.
 pub const COPY_BUFFER_ALIGNMENT: BufferAddress = 4;
-/// Size to align mappings.
+
+/// Minimum alignment of buffer mappings.
+///
+/// The range passed to [`map_async()`] or [`get_mapped_range()`] must be at least this aligned.
+///
+/// [`map_async()`]: ../wgpu/struct.Buffer.html#method.map_async
+/// [`get_mapped_range()`]: ../wgpu/struct.Buffer.html#method.get_mapped_range
 pub const MAP_ALIGNMENT: BufferAddress = 8;
-/// Vertex buffer strides have to be aligned to this number.
+
+/// [Vertex buffer strides] have to be a multiple of this number.
+///
+/// [Vertex buffer strides]: ../wgpu/struct.VertexBufferLayout.html#structfield.array_stride
 pub const VERTEX_STRIDE_ALIGNMENT: BufferAddress = 4;
-/// Alignment all push constants need
+/// Ranges of [writes to push constant storage] must be at least this aligned.
+///
+/// [writes to push constant storage]: ../wgpu/struct.RenderPass.html#method.set_push_constants
 pub const PUSH_CONSTANT_ALIGNMENT: u32 = 4;
-/// Maximum queries in a query set
+
+/// Maximum queries in a [`QuerySetDescriptor`].
 pub const QUERY_SET_MAX_QUERIES: u32 = 4096;
-/// Size of a single piece of query data.
+
+/// Size in bytes of a single piece of [query] data.
+///
+/// [query]: ../wgpu/struct.QuerySet.html
 pub const QUERY_SIZE: u32 = 8;
 
 /// Backends supported by wgpu.
@@ -1739,13 +1775,24 @@ pub enum AstcChannel {
     Hdr,
 }
 
-/// Underlying texture data format.
+/// Format in which a texture’s texels are stored in GPU memory.
 ///
-/// If there is a conversion in the format (such as srgb -> linear), the conversion listed here is for
-/// loading from texture in a shader. When writing to the texture, the opposite conversion takes place.
+/// Certain formats additionally specify a conversion.
+/// When these formats are used in a shader, the conversion automatically takes place when loading
+/// from or storing to the texture.
+///
+/// * `Unorm` formats linearly scale the integer range of the storage format to a floating-point
+///   range of 0 to 1, inclusive.
+/// * `Snorm` formats linearly scale the integer range of the storage format to a floating-point
+///   range of &minus;1 to 1, inclusive.
+/// * `UnormSrgb` formats apply the [sRGB transfer function] so that the storage is sRGB encoded
+///   while the shader works with linear intensity values.
+/// * `Uint`, `Sint`, and `Float` formats perform no conversion.
 ///
 /// Corresponds to [WebGPU `GPUTextureFormat`](
 /// https://gpuweb.github.io/gpuweb/#enumdef-gputextureformat).
+///
+/// [sRGB transfer function]: https://en.wikipedia.org/wiki/SRGB#Transfer_function_(%22gamma%22)
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum TextureFormat {
@@ -5676,12 +5723,15 @@ fn test_max_mips() {
     );
 }
 
-/// Describes a `TextureView`.
+/// Describes a [`TextureView`].
 ///
-/// For use with `Texture::create_view`.
+/// For use with [`Texture::create_view()`].
 ///
 /// Corresponds to [WebGPU `GPUTextureViewDescriptor`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gputextureviewdescriptor).
+///
+/// [`TextureView`]: ../wgpu/struct.TextureView.html
+/// [`Texture::create_view()`]: ../wgpu/struct.Texture.html#method.create_view
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct TextureViewDescriptor<L> {
     /// Debug label of the texture view. This will show up in graphics debuggers for easy identification.
@@ -5901,10 +5951,15 @@ impl<L: Default> Default for SamplerDescriptor<L> {
     }
 }
 
-/// Kind of data the texture holds.
+/// Selects a subset of the data a [`Texture`] holds.
+///
+/// Used in [texture views](TextureViewDescriptor) and
+/// [texture copy operations](TexelCopyTextureInfo).
 ///
 /// Corresponds to [WebGPU `GPUTextureAspect`](
 /// https://gpuweb.github.io/gpuweb/#enumdef-gputextureaspect).
+///
+/// [`Texture`]: ../wgpu/struct.Texture.html
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -6363,12 +6418,16 @@ pub enum SamplerBindingType {
     Comparison,
 }
 
-/// Specific type of a binding.
+/// Type of a binding in a [bind group layout][`BindGroupLayoutEntry`].
 ///
-/// For use in [`BindGroupLayoutEntry`].
+/// For each binding in a layout, a [`BindGroup`] must provide a [`BindingResource`] of the
+/// corresponding type.
 ///
 /// Corresponds to WebGPU's mutually exclusive fields within [`GPUBindGroupLayoutEntry`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpubindgrouplayoutentry).
+///
+/// [`BindingResource`]: ../wgpu/enum.BindingResource.html
+/// [`BindGroup`]: ../wgpu/struct.BindGroup.html
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum BindingType {
@@ -6953,10 +7012,12 @@ impl<L> QuerySetDescriptor<L> {
     }
 }
 
-/// Type of query contained in a `QuerySet`.
+/// Type of query contained in a [`QuerySet`].
 ///
 /// Corresponds to [WebGPU `GPUQueryType`](
 /// https://gpuweb.github.io/gpuweb/#enumdef-gpuquerytype).
+///
+/// [`QuerySet`]: ../wgpu/struct.QuerySet.html
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum QueryType {
@@ -6984,14 +7045,16 @@ pub enum QueryType {
 }
 
 bitflags::bitflags! {
-    /// Flags for which pipeline data should be recorded.
+    /// Flags for which pipeline data should be recorded in a query.
+    ///
+    /// Used in [`QueryType`].
     ///
     /// The amount of values written when resolved depends
-    /// on the amount of flags. If 3 flags are enabled, 3
-    /// 64-bit values will be written per-query.
+    /// on the amount of flags set. For example, if 3 flags are set, 3
+    /// 64-bit values will be written per query.
     ///
     /// The order they are written is the order they are declared
-    /// in this bitflags. If you enabled `CLIPPER_PRIMITIVES_OUT`
+    /// in these bitflags. For example, if you enabled `CLIPPER_PRIMITIVES_OUT`
     /// and `COMPUTE_SHADER_INVOCATIONS`, it would write 16 bytes,
     /// the first 8 bytes being the primitive out value, the last 8
     /// bytes being the compute shader invocation count.

--- a/wgpu/src/api/bind_group.rs
+++ b/wgpu/src/api/bind_group.rs
@@ -17,7 +17,9 @@ static_assertions::assert_impl_all!(BindGroup: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(BindGroup => .inner);
 
-/// Resource that can be bound to a pipeline.
+/// Resource to be bound by a [`BindGroup`] for use with a pipeline.
+///
+/// The pipeline’s [`BindGroupLayout`] must contain a matching [`BindingType`].
 ///
 /// Corresponds to [WebGPU `GPUBindingResource`](
 /// https://gpuweb.github.io/gpuweb/#typedefdef-gpubindingresource).

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -312,7 +312,7 @@ impl Buffer {
     /// `self`. See the documentation for [`BufferView`] for details.
     ///
     /// `bounds` may be less than the bounds passed to [`Self::map_async()`],
-    /// and multiple views may be obtained and used simultanously as long as they do not overlap.
+    /// and multiple views may be obtained and used simultaneously as long as they do not overlap.
     ///
     /// This can also be performed using [`BufferSlice::get_mapped_range()`].
     ///
@@ -339,7 +339,7 @@ impl Buffer {
     /// This is only available on WebGPU, on any other backends this will return `None`.
     ///
     /// `bounds` may be less than the bounds passed to [`Self::map_async()`],
-    /// and multiple views may be obtained and used simultanously as long as they do not overlap.
+    /// and multiple views may be obtained and used simultaneously as long as they do not overlap.
     ///
     /// This can also be performed using [`BufferSlice::get_mapped_range_as_array_buffer()`].
     ///
@@ -362,7 +362,7 @@ impl Buffer {
     /// `self`. See the documentation for [`BufferViewMut`] for more details.
     ///
     /// `bounds` may be less than the bounds passed to [`Self::map_async()`],
-    /// and multiple views may be obtained and used simultanously as long as they do not overlap.
+    /// and multiple views may be obtained and used simultaneously as long as they do not overlap.
     ///
     /// This can also be performed using [`BufferSlice::get_mapped_range_mut()`].
     ///
@@ -507,7 +507,7 @@ impl<'a> BufferSlice<'a> {
     /// Returns a [`BufferView`] referring to the buffer range represented by
     /// `self`. See the documentation for [`BufferView`] for details.
     ///
-    /// Multiple views may be obtained and used simultanously as long as they are from
+    /// Multiple views may be obtained and used simultaneously as long as they are from
     /// non-overlapping slices.
     ///
     /// This can also be performed using [`Buffer::get_mapped_range()`].
@@ -537,7 +537,7 @@ impl<'a> BufferSlice<'a> {
     ///
     /// This is only available on WebGPU, on any other backends this will return `None`.
     ///
-    /// Multiple views may be obtained and used simultanously as long as they are from
+    /// Multiple views may be obtained and used simultaneously as long as they are from
     /// non-overlapping slices.
     ///
     /// This can also be performed using [`Buffer::get_mapped_range_as_array_buffer()`].
@@ -559,7 +559,7 @@ impl<'a> BufferSlice<'a> {
     /// Returns a [`BufferViewMut`] referring to the buffer range represented by
     /// `self`. See the documentation for [`BufferViewMut`] for more details.
     ///
-    /// Multiple views may be obtained and used simultanously as long as they are from
+    /// Multiple views may be obtained and used simultaneously as long as they are from
     /// non-overlapping slices.
     ///
     /// This can also be performed using [`Buffer::get_mapped_range_mut()`].

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -218,7 +218,7 @@ impl Buffer {
         }
     }
 
-    /// Return a [`BufferSlice`] referring to the portion of `self`'s contents
+    /// Returns a [`BufferSlice`] referring to the portion of `self`'s contents
     /// indicated by `bounds`. Regardless of what sort of data `self` stores,
     /// `bounds` start and end are given in bytes.
     ///
@@ -230,6 +230,11 @@ impl Buffer {
     /// `buffer.slice(..)` refers to the entire buffer, and `buffer.slice(n..)`
     /// refers to the portion starting at the `n`th byte and extending to the
     /// end of the buffer.
+    ///
+    /// # Panics
+    ///
+    /// - If `bounds` is outside of the bounds of `self`.
+    /// - If `bounds` has a length less than 1.
     pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice<'_> {
         let (offset, size) = range_to_offset_size(bounds);
         check_buffer_bounds(self.size, offset, size);
@@ -240,7 +245,10 @@ impl Buffer {
         }
     }
 
-    /// Flushes any pending write operations and unmaps the buffer from host memory.
+    /// Unmaps the buffer from host memory.
+    ///
+    /// This terminates the effect of all previous [`map_async()`](Self::map_async) operations and
+    /// makes the buffer available for use by the GPU again.
     pub fn unmap(&self) {
         self.map_context.lock().reset();
         self.inner.unmap();
@@ -265,17 +273,30 @@ impl Buffer {
         self.usage
     }
 
-    /// Map the buffer. Buffer is ready to map once the callback is called.
+    /// Map the buffer to host (CPU) memory, making it available for reading or writing
+    /// via [`get_mapped_range()`](Self::get_mapped_range).
+    /// It is available once the `callback` is called with an [`Ok`] response.
     ///
     /// For the callback to complete, either `queue.submit(..)`, `instance.poll_all(..)`, or `device.poll(..)`
     /// must be called elsewhere in the runtime, possibly integrated into an event loop or run on a separate thread.
     ///
-    /// The callback will be called on the thread that first calls the above functions after the gpu work
+    /// The callback will be called on the thread that first calls the above functions after the GPU work
     /// has completed. There are no restrictions on the code you can run in the callback, however on native the
     /// call to the function will not complete until the callback returns, so prefer keeping callbacks short
     /// and used to set flags, send messages, etc.
     ///
+    /// As long as a buffer is mapped, it is not available for use by any other commands;
+    /// at all times, either the GPU or the CPU has exclusive access to the contents of the buffer.
+    ///
     /// This can also be performed using [`BufferSlice::map_async()`].
+    ///
+    /// # Panics
+    ///
+    /// - If the buffer is already mapped.
+    /// - If the buffer’s [`BufferUsages`] do not allow the requested [`MapMode`].
+    /// - If `bounds` is outside of the bounds of `self`.
+    /// - If `bounds` has a length less than 1.
+    /// - If the start and end of `bounds` are not be aligned to [`MAP_ALIGNMENT`].
     pub fn map_async<S: RangeBounds<BufferAddress>>(
         &self,
         mode: MapMode,
@@ -287,13 +308,19 @@ impl Buffer {
 
     /// Gain read-only access to the bytes of a [mapped] [`Buffer`].
     ///
-    /// Return a [`BufferView`] referring to the buffer range represented by
+    /// Returns a [`BufferView`] referring to the buffer range represented by
     /// `self`. See the documentation for [`BufferView`] for details.
+    ///
+    /// `bounds` may be less than the bounds passed to [`Self::map_async()`],
+    /// and multiple views may be obtained and used simultanously as long as they do not overlap.
     ///
     /// This can also be performed using [`BufferSlice::get_mapped_range()`].
     ///
     /// # Panics
     ///
+    /// - If `bounds` is outside of the bounds of `self`.
+    /// - If `bounds` has a length less than 1.
+    /// - If the start and end of `bounds` are not aligned to [`MAP_ALIGNMENT`].
     /// - If the buffer to which `self` refers is not currently [mapped].
     /// - If you try to create overlapping views of a buffer, mutable or otherwise.
     ///
@@ -311,7 +338,16 @@ impl Buffer {
     ///
     /// This is only available on WebGPU, on any other backends this will return `None`.
     ///
+    /// `bounds` may be less than the bounds passed to [`Self::map_async()`],
+    /// and multiple views may be obtained and used simultanously as long as they do not overlap.
+    ///
     /// This can also be performed using [`BufferSlice::get_mapped_range_as_array_buffer()`].
+    ///
+    /// # Panics
+    ///
+    /// - If `bounds` is outside of the bounds of `self`.
+    /// - If `bounds` has a length less than 1.
+    /// - If the start and end of `bounds` are not aligned to [`MAP_ALIGNMENT`].
     #[cfg(webgpu)]
     pub fn get_mapped_range_as_array_buffer<S: RangeBounds<BufferAddress>>(
         &self,
@@ -322,13 +358,19 @@ impl Buffer {
 
     /// Gain write access to the bytes of a [mapped] [`Buffer`].
     ///
-    /// Return a [`BufferViewMut`] referring to the buffer range represented by
+    /// Returns a [`BufferViewMut`] referring to the buffer range represented by
     /// `self`. See the documentation for [`BufferViewMut`] for more details.
+    ///
+    /// `bounds` may be less than the bounds passed to [`Self::map_async()`],
+    /// and multiple views may be obtained and used simultanously as long as they do not overlap.
     ///
     /// This can also be performed using [`BufferSlice::get_mapped_range_mut()`].
     ///
     /// # Panics
     ///
+    /// - If `bounds` is outside of the bounds of `self`.
+    /// - If `bounds` has a length less than 1.
+    /// - If the start and end of `bounds` are not aligned to [`MAP_ALIGNMENT`].
     /// - If the buffer to which `self` refers is not currently [mapped].
     /// - If you try to create overlapping views of a buffer, mutable or otherwise.
     ///
@@ -398,6 +440,11 @@ impl<'a> BufferSlice<'a> {
     /// `buffer.slice(..)` refers to the entire buffer, and `buffer.slice(n..)`
     /// refers to the portion starting at the `n`th byte and extending to the
     /// end of the buffer.
+    ///
+    /// # Panics
+    ///
+    /// - If `bounds` is outside of the bounds of `self`.
+    /// - If `bounds` has a length less than 1.
     pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice<'a> {
         let (offset, size) = range_to_offset_size(bounds);
         check_buffer_bounds(
@@ -415,17 +462,28 @@ impl<'a> BufferSlice<'a> {
         }
     }
 
-    /// Map the buffer. Buffer is ready to map once the callback is called.
+    /// Map the buffer to host (CPU) memory, making it available for reading or writing
+    /// via [`get_mapped_range()`](Self::get_mapped_range).
+    /// It is available once the `callback` is called with an [`Ok`] response.
     ///
     /// For the callback to complete, either `queue.submit(..)`, `instance.poll_all(..)`, or `device.poll(..)`
     /// must be called elsewhere in the runtime, possibly integrated into an event loop or run on a separate thread.
     ///
-    /// The callback will be called on the thread that first calls the above functions after the gpu work
+    /// The callback will be called on the thread that first calls the above functions after the GPU work
     /// has completed. There are no restrictions on the code you can run in the callback, however on native the
     /// call to the function will not complete until the callback returns, so prefer keeping callbacks short
     /// and used to set flags, send messages, etc.
     ///
+    /// As long as a buffer is mapped, it is not available for use by any other commands;
+    /// at all times, either the GPU or the CPU has exclusive access to the contents of the buffer.
+    ///
     /// This can also be performed using [`Buffer::map_async()`].
+    ///
+    /// # Panics
+    ///
+    /// - If the buffer is already mapped.
+    /// - If the buffer’s [`BufferUsages`] do not allow the requested [`MapMode`].
+    /// - If the endpoints of this slice are not aligned to [`MAP_ALIGNMENT`] within the buffer.
     pub fn map_async(
         &self,
         mode: MapMode,
@@ -446,13 +504,17 @@ impl<'a> BufferSlice<'a> {
 
     /// Gain read-only access to the bytes of a [mapped] [`Buffer`].
     ///
-    /// Return a [`BufferView`] referring to the buffer range represented by
+    /// Returns a [`BufferView`] referring to the buffer range represented by
     /// `self`. See the documentation for [`BufferView`] for details.
+    ///
+    /// Multiple views may be obtained and used simultanously as long as they are from
+    /// non-overlapping slices.
     ///
     /// This can also be performed using [`Buffer::get_mapped_range()`].
     ///
     /// # Panics
     ///
+    /// - If the endpoints of this slice are not aligned to [`MAP_ALIGNMENT`] within the buffer.
     /// - If the buffer to which `self` refers is not currently [mapped].
     /// - If you try to create overlapping views of a buffer, mutable or otherwise.
     ///
@@ -475,7 +537,14 @@ impl<'a> BufferSlice<'a> {
     ///
     /// This is only available on WebGPU, on any other backends this will return `None`.
     ///
+    /// Multiple views may be obtained and used simultanously as long as they are from
+    /// non-overlapping slices.
+    ///
     /// This can also be performed using [`Buffer::get_mapped_range_as_array_buffer()`].
+    ///
+    /// # Panics
+    ///
+    /// - If the endpoints of this slice are not aligned to [`MAP_ALIGNMENT`] within the buffer.
     #[cfg(webgpu)]
     pub fn get_mapped_range_as_array_buffer(&self) -> Option<js_sys::ArrayBuffer> {
         let end = self.buffer.map_context.lock().add(self.offset, self.size);
@@ -487,13 +556,17 @@ impl<'a> BufferSlice<'a> {
 
     /// Gain write access to the bytes of a [mapped] [`Buffer`].
     ///
-    /// Return a [`BufferViewMut`] referring to the buffer range represented by
+    /// Returns a [`BufferViewMut`] referring to the buffer range represented by
     /// `self`. See the documentation for [`BufferViewMut`] for more details.
+    ///
+    /// Multiple views may be obtained and used simultanously as long as they are from
+    /// non-overlapping slices.
     ///
     /// This can also be performed using [`Buffer::get_mapped_range_mut()`].
     ///
     /// # Panics
     ///
+    /// - If the endpoints of this slice are not aligned to [`MAP_ALIGNMENT`].
     /// - If the buffer to which `self` refers is not currently [mapped].
     /// - If you try to create overlapping views of a buffer, mutable or otherwise.
     ///

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -217,6 +217,8 @@ impl CommandEncoder {
     ///
     /// Occlusion and timestamp queries are 8 bytes each (see [`crate::QUERY_SIZE`]). For pipeline statistics queries,
     /// see [`PipelineStatisticsTypes`] for more information.
+    ///
+    /// `destination_offset` must be aligned to [`QUERY_RESOLVE_BUFFER_ALIGNMENT`].
     pub fn resolve_query_set(
         &mut self,
         query_set: &QuerySet,

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -585,7 +585,7 @@ impl From<wgc::instance::RequestDeviceError> for RequestDeviceError {
 pub trait UncapturedErrorHandler: Fn(Error) + Send + 'static {}
 impl<T> UncapturedErrorHandler for T where T: Fn(Error) + Send + 'static {}
 
-/// Filter for error scopes.
+/// Kinds of [`Error`]s a [`Device::push_error_scope()`] may be configured to catch.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub enum ErrorFilter {
     /// Catch only out-of-memory errors.
@@ -610,15 +610,19 @@ pub type ErrorSource = Box<dyn error::Error + Send + Sync + 'static>;
 #[cfg_attr(docsrs, doc(cfg(all())))]
 pub type ErrorSource = Box<dyn error::Error + 'static>;
 
-/// Error type
+/// Errors resulting from usage of GPU APIs.
+///
+/// By default, errors translate into panics. Depending on the backend and circumstances,
+/// errors may occur synchronously or asynchronously. When errors need to be handled, use
+/// [`Device::push_error_scope()`] or [`Device::on_uncaptured_error()`].
 #[derive(Debug)]
 pub enum Error {
-    /// Out of memory error
+    /// Out of memory.
     OutOfMemory {
         /// Lower level source of the error.
         source: ErrorSource,
     },
-    /// Validation error, signifying a bug in code or data
+    /// Validation error, signifying a bug in code or data provided to `wgpu`.
     Validation {
         /// Lower level source of the error.
         source: ErrorSource,

--- a/wgpu/src/api/render_pipeline.rs
+++ b/wgpu/src/api/render_pipeline.rs
@@ -38,7 +38,9 @@ impl RenderPipeline {
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuvertexbufferlayout).
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct VertexBufferLayout<'a> {
-    /// The stride, in bytes, between elements of this buffer.
+    /// The stride, in bytes, between elements of this buffer (between vertices).
+    ///
+    /// This must be a multiple of [`VERTEX_STRIDE_ALIGNMENT`].
     pub array_stride: BufferAddress,
     /// How often this vertex buffer is "stepped" forward.
     pub step_mode: VertexStepMode,


### PR DESCRIPTION
**Description**
Additional documentation, especially for:
* items defined in `wgpu-types`
* alignment requirements
* buffer mapping functions
* texture formats’ automatic conversions

**Testing**
Manually tested that all the links work.

**Squash or Rebase?**
Squash

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
