### PR TITLE
Fix Android compilation of Vulkan DRM support 

### DIFF
--- a/wgpu-hal/src/vulkan/drm.rs
+++ b/wgpu-hal/src/vulkan/drm.rs
@@ -73,7 +73,7 @@ impl super::Instance {
             let render_devid =
                 libc::makedev(drm_props.render_major as _, drm_props.render_minor as _);
 
-            if primary_devid == drm_stat.st_rdev || render_devid == drm_stat.st_rdev {
+            if [primary_devid, render_devid].contains(&drm_stat.st_rdev) {
                 physical_device = Some(device)
             }
         }

--- a/wgpu-hal/src/vulkan/drm.rs
+++ b/wgpu-hal/src/vulkan/drm.rs
@@ -73,7 +73,13 @@ impl super::Instance {
             let render_devid =
                 libc::makedev(drm_props.render_major as _, drm_props.render_minor as _);
 
-            if [primary_devid, render_devid].contains(&drm_stat.st_rdev) {
+            // Various platforms use different widths between `dev_t` and `c_int`, so just
+            // force-convert to `u64` to keep things portable.
+            #[allow(clippy::useless_conversion)]
+            if [primary_devid, render_devid]
+                .map(u64::from)
+                .contains(&drm_stat.st_rdev)
+            {
                 physical_device = Some(device)
             }
         }


### PR DESCRIPTION
**Connections**

CC @morr0ne, @SupaMaggie70Incorporated, @cwfitzgerald.

**Description**

A few Android builds in Firefox are broken when attempting to consume latest WGPU mainline history. The cause is that `dev_t` is not necessarily the same width as the `*devid`s we check against, notably on some common architectures for Android. Because they/Android hate you. Sigh.

Just make DRM `*devid`s compare as `u64`s.

**Testing**

it compile again yay plz no more 😭

**Squash or Rebase?**

Rebase plz.
