### PR TITLE
Improved DRM Extensions Handling

### DIFF
--- a/wgpu-hal/src/vulkan/drm.rs
+++ b/wgpu-hal/src/vulkan/drm.rs
@@ -20,9 +20,13 @@ impl super::Instance {
         height: u32,
         refresh_rate: u32,
     ) -> Result<super::Surface, crate::InstanceError> {
-        if !self.shared.extensions.contains(&khr::display::NAME) {
+        if !self
+            .shared
+            .extensions
+            .contains(&ext::acquire_drm_display::NAME)
+        {
             return Err(crate::InstanceError::new(
-                "Vulkan driver does not support VK_KHR_display".to_string(),
+                "Vulkan driver does not support VK_EXT_acquire_drm_display".to_string(),
             ));
         }
 

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -257,13 +257,6 @@ impl super::Instance {
         // VK_KHR_surface
         extensions.push(khr::surface::NAME);
 
-        // Extensions needed for drm support
-        extensions.push(khr::display::NAME);
-        extensions.push(ext::physical_device_drm::NAME);
-        extensions.push(khr::get_display_properties2::NAME);
-        extensions.push(ext::direct_mode_display::NAME);
-        extensions.push(ext::acquire_drm_display::NAME);
-
         // Platform-specific WSI extensions
         if cfg!(all(
             unix,
@@ -289,6 +282,19 @@ impl super::Instance {
             // VK_EXT_metal_surface
             extensions.push(ext::metal_surface::NAME);
             extensions.push(khr::portability_enumeration::NAME);
+        }
+        if cfg!(all(
+            unix,
+            not(target_vendor = "apple"),
+            not(target_family = "wasm")
+        )) {
+            // VK_EXT_acquire_drm_display -> VK_EXT_direct_mode_display -> VK_KHR_display
+            extensions.push(ext::acquire_drm_display::NAME);
+            extensions.push(ext::direct_mode_display::NAME);
+            extensions.push(khr::display::NAME);
+            //  VK_EXT_physical_device_drm -> VK_KHR_get_physical_device_properties2
+            extensions.push(ext::physical_device_drm::NAME);
+            extensions.push(khr::get_display_properties2::NAME);
         }
 
         if flags.contains(wgt::InstanceFlags::DEBUG) {


### PR DESCRIPTION
This PR brings improved handling of DRM extensions. The extensions are now properly feature-gated like other WSI-specific ones so they are only requested if necessary. Error handling is improved since we check for the actual VK_EXT_acquire_drm_display extension which the other ones depend on. I did consider adding a check for VK_EXT_physical_device_drm but either my understanding of how Vulkan extensions work is wrong or RADV is lying since it doesn't report the extension as present despite being clearly used via VkPhysicalDeviceDrmPropertiesEXT. Functionality-wise this doesn't change anything, just makes the handling of extensions and errors more robust and in line with the rest of WGPU.