### PR TITLE
[naga][spv-in] Read ImageSample.offset as expr

### DIFF
--- a/naga/src/front/spv/image.rs
+++ b/naga/src/front/spv/image.rs
@@ -602,16 +602,16 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
                     words_left -= 2;
                 }
                 spirv::ImageOperands::CONST_OFFSET => {
-                    let offset_constant = self.next()?;
-                    let offset_expr = self
-                        .lookup_constant
-                        .lookup(offset_constant)?
-                        .inner
-                        .to_expr();
-                    let offset_handle = ctx
-                        .module
-                        .global_expressions
-                        .append(offset_expr, Default::default());
+                    let offset_expr = self.next()?;
+                    let offset_lexp = self.lookup_expression.lookup(offset_expr)?;
+                    let offset_handle = self.get_expr_handle(
+                        offset_expr,
+                        offset_lexp,
+                        ctx,
+                        emitter,
+                        block,
+                        body_idx,
+                    );
                     offset = Some(offset_handle);
                     words_left -= 1;
                 }


### PR DESCRIPTION
**Connections**
Fixes dota2 shaders test that were failing due to: https://github.com/gfx-rs/wgpu/pull/7213.

**Description**
After https://github.com/gfx-rs/wgpu/pull/7213 offset handle does not refer to global expr arena.

**Testing**
Existing tests.

CI run in my fork: https://github.com/sagudev/wgpu/actions/runs/13737593473/job/38423142607

**Squash or Rebase?** Squash.
<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
