### PR TITLE
Add exception for `RUSTSEC-2024-0436` (`paste` being unmaintained)

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -26,6 +26,11 @@ skip = [
 wildcards = "deny"
 allow-wildcard-paths = true
 
+[advisories]
+# `paste` crate is no longer maintained https://rustsec.org/advisories/RUSTSEC-2024-0436
+# It's a dependency of `metal` (which is to be replaced with `objc2`) and a transitive dependency of `deno`.
+ignore = ["RUSTSEC-2024-0436"]
+
 [licenses]
 allow = [
     "Apache-2.0",


### PR DESCRIPTION
Fixes this CI failure
https://github.com/gfx-rs/wgpu/actions/runs/13739451273/job/38426968077?pr=7146


`paste` is now unmaintained, `RUSTSEC-2024-0436` is a warning for this.
As of now there's now security issues known and our use of it is fairly limited (see comment)