### PR TITLE
[d3d12] fix size of buffer

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -402,16 +402,17 @@ impl crate::Device for super::Device {
         &self,
         desc: &crate::BufferDescriptor,
     ) -> Result<super::Buffer, crate::DeviceError> {
-        let mut size = desc.size;
-        if desc.usage.contains(wgt::BufferUses::UNIFORM) {
-            let align_mask = Direct3D12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT as u64 - 1;
-            size = ((size - 1) | align_mask) + 1;
-        }
+        let alloc_size = if desc.usage.contains(wgt::BufferUses::UNIFORM) {
+            desc.size
+                .next_multiple_of(Direct3D12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT as u64)
+        } else {
+            desc.size
+        };
 
         let raw_desc = Direct3D12::D3D12_RESOURCE_DESC {
             Dimension: Direct3D12::D3D12_RESOURCE_DIMENSION_BUFFER,
             Alignment: 0,
-            Width: size,
+            Width: alloc_size,
             Height: 1,
             DepthOrArraySize: 1,
             MipLevels: 1,
@@ -436,7 +437,7 @@ impl crate::Device for super::Device {
 
         Ok(super::Buffer {
             resource,
-            size,
+            size: desc.size,
             allocation,
         })
     }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -404,7 +404,7 @@ impl crate::Device for super::Device {
     ) -> Result<super::Buffer, crate::DeviceError> {
         let alloc_size = if desc.usage.contains(wgt::BufferUses::UNIFORM) {
             desc.size
-                .next_multiple_of(Direct3D12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT as u64)
+                .next_multiple_of(Direct3D12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT.into())
         } else {
             desc.size
         };


### PR DESCRIPTION
**Connections**
https://bugzilla.mozilla.org/show_bug.cgi?id=1869929

**Description**
The buffer size was being aligned to `D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT` (256). The buffer size value is used as the binding size (when none is specified), causing `arrayLength()` to return values larger than what users of the API specified for the buffer size.

**Testing**
Made sure the example is now working properly.
