### PR TITLE
[vulkan] Automatically add linux buffer sharing extensions if available.

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1056,7 +1056,7 @@ impl PhysicalDeviceProperties {
             extensions.push(khr::external_memory_fd::NAME);
         }
 
-        // Optional `VK_EXT_external_memory_win32`
+        // Optional `VK_EXT_external_memory_dma`
         if self.supports_extension(ext::external_memory_dma_buf::NAME) {
             extensions.push(ext::external_memory_dma_buf::NAME);
         }

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1051,6 +1051,16 @@ impl PhysicalDeviceProperties {
             extensions.push(khr::external_memory_win32::NAME);
         }
 
+        // Optional `VK_KHR_external_memory_fd`
+        if self.supports_extension(khr::external_memory_fd::NAME) {
+            extensions.push(khr::external_memory_fd::NAME);
+        }
+
+        // Optional `VK_EXT_external_memory_win32`
+        if self.supports_extension(ext::external_memory_dma_buf::NAME) {
+            extensions.push(ext::external_memory_dma_buf::NAME);
+        }
+
         // Require `VK_KHR_draw_indirect_count` if the associated feature was requested
         // Even though Vulkan 1.2 has promoted the extension to core, we must require the extension to avoid
         // large amounts of spaghetti involved with using PhysicalDeviceVulkan12Features.


### PR DESCRIPTION
**Connections**

**Description**
Automatically adds the Linux buffer sharing extensions to the enabled extensions list if they are available.

**Testing**
None in wgpu, externally used (though I've tested my use of it and it works).

**Squash or Rebase?**
Squash
<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [n/a] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [n/a] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [n/a] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
