### PR TITLE
override-sized arrays should not have the constructible flag

### DIFF
--- a/naga/src/valid/type.rs
+++ b/naga/src/valid/type.rs
@@ -535,7 +535,6 @@ impl super::Validator {
                             | TypeFlags::COPY
                             | TypeFlags::HOST_SHAREABLE
                             | TypeFlags::ARGUMENT
-                            | TypeFlags::CONSTRUCTIBLE
                     }
                     crate::ArraySize::Dynamic => {
                         // Non-SIZED types may only appear as the last element of a structure.


### PR DESCRIPTION
**Connections**
Resolves #7296

**Description**
Removes the constructible flag from override-sized arrays

**Testing**
N/A

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.

