### PR TITLE
[metal] Metal compute shader passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,7 +203,8 @@ By @wumpf in [#7144](https://github.com/gfx-rs/wgpu/pull/7144)
 
 - Support getting vertices of the hit triangle when raytracing. By @Vecvec in [#7183](https://github.com/gfx-rs/wgpu/pull/7183) .
 
-- Add Metal compute shader passthrough. Use `create_shader_module_msl` on device. By @syl20bnr in [#7326](https://github.com/gfx-rs/wgpu/pull/7326).
+- Replace device `create_shader_module_spirv` with generic `create_shader_module_passthrough` taking a `ShaderModuleDescriptorPassthrough` enum as parameter. By @syl20bnr in [#7326](https://github.com/gfx-rs/wgpu/pull/7326).
+- Add Metal compute shader passthrough. Use `create_shader_module_passthrough` on device. By @syl20bnr in [#7326](https://github.com/gfx-rs/wgpu/pull/7326).
 
 #### Naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@ By @wumpf in [#7144](https://github.com/gfx-rs/wgpu/pull/7144)
 
 - Support getting vertices of the hit triangle when raytracing. By @Vecvec in [#7183](https://github.com/gfx-rs/wgpu/pull/7183) .
 
+- Add Metal compute shader passthrough. Use `create_shader_module_msl` on device. By @syl20bnr in [#7326](https://github.com/gfx-rs/wgpu/pull/7326).
 
 #### Naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,32 @@ layout(location = 0, index = 1) out vec4 output1;
 
 By @wumpf in [#7144](https://github.com/gfx-rs/wgpu/pull/7144)
 
+#### Unify interface for SpirV shader passthrough
+
+Replace device `create_shader_module_spirv` function with a generic `create_shader_module_passthrough` function
+taking a `ShaderModuleDescriptorPassthrough` enum as parameter.
+
+Update your calls to `create_shader_module_spirv` and use `create_shader_module_passthrough` instead:
+
+```diff
+-    device.create_shader_module_spirv(
+-        wgpu::ShaderModuleDescriptorSpirV {
+-            label: Some(&name),
+-            source: Cow::Borrowed(&source),
+-        }
+-    )
++    device.create_shader_module_passthrough(
++        wgpu::ShaderModuleDescriptorPassthrough::SpirV(
++            wgpu::ShaderModuleDescriptorSpirV {
++                label: Some(&name),
++                source: Cow::Borrowed(&source),
++            },
++        ),
++    )
+```
+
+By @syl20bnr in [#7326](https://github.com/gfx-rs/wgpu/pull/7326).
+
 ### New Features
 
 - Added mesh shader support to `wgpu_hal`. By @SupaMaggie70Incorporated in [#7089](https://github.com/gfx-rs/wgpu/pull/7089)
@@ -203,8 +229,9 @@ By @wumpf in [#7144](https://github.com/gfx-rs/wgpu/pull/7144)
 
 - Support getting vertices of the hit triangle when raytracing. By @Vecvec in [#7183](https://github.com/gfx-rs/wgpu/pull/7183) .
 
-- Replace device `create_shader_module_spirv` with generic `create_shader_module_passthrough` taking a `ShaderModuleDescriptorPassthrough` enum as parameter. By @syl20bnr in [#7326](https://github.com/gfx-rs/wgpu/pull/7326).
 - Add Metal compute shader passthrough. Use `create_shader_module_passthrough` on device. By @syl20bnr in [#7326](https://github.com/gfx-rs/wgpu/pull/7326).
+
+- new `Features::MSL_SHADER_PASSTHROUGH` run-time feature allows providing pass-through MSL Metal shaders. By @syl20bnr in [#7326](https://github.com/gfx-rs/wgpu/pull/7326).
 
 #### Naga
 

--- a/deno_webgpu/webidl.rs
+++ b/deno_webgpu/webidl.rs
@@ -417,6 +417,8 @@ pub enum GPUFeatureName {
     VertexWritableStorage,
     #[webidl(rename = "clear-texture")]
     ClearTexture,
+    #[webidl(rename = "msl-shader-passthrough")]
+    MslShaderPassthrough,
     #[webidl(rename = "spirv-shader-passthrough")]
     SpirvShaderPassthrough,
     #[webidl(rename = "multiview")]
@@ -477,6 +479,7 @@ pub fn feature_names_to_features(names: Vec<GPUFeatureName>) -> wgpu_types::Feat
       GPUFeatureName::ConservativeRasterization => Features::CONSERVATIVE_RASTERIZATION,
       GPUFeatureName::VertexWritableStorage => Features::VERTEX_WRITABLE_STORAGE,
       GPUFeatureName::ClearTexture => Features::CLEAR_TEXTURE,
+      GPUFeatureName::MslShaderPassthrough => Features::MSL_SHADER_PASSTHROUGH,
       GPUFeatureName::SpirvShaderPassthrough => Features::SPIRV_SHADER_PASSTHROUGH,
       GPUFeatureName::Multiview => Features::MULTIVIEW,
       GPUFeatureName::VertexAttribute64Bit => Features::VERTEX_ATTRIBUTE_64BIT,

--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -126,16 +126,9 @@ impl DeviceInterface for CustomDevice {
         DispatchShaderModule::custom(CustomShaderModule(self.0.clone()))
     }
 
-    unsafe fn create_shader_module_spirv(
+    unsafe fn create_shader_module_passthrough(
         &self,
-        _desc: &wgpu::ShaderModuleDescriptorSpirV<'_>,
-    ) -> DispatchShaderModule {
-        unimplemented!()
-    }
-
-    unsafe fn create_shader_module_msl(
-        &self,
-        _desc: &wgpu::ShaderModuleDescriptorMsl<'_>,
+        _desc: &wgpu::ShaderModuleDescriptorPassthrough<'_>,
     ) -> DispatchShaderModule {
         unimplemented!()
     }

--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -133,6 +133,13 @@ impl DeviceInterface for CustomDevice {
         unimplemented!()
     }
 
+    unsafe fn create_shader_module_msl(
+        &self,
+        _desc: &wgpu::ShaderModuleDescriptorMsl<'_>,
+    ) -> DispatchShaderModule {
+        unimplemented!()
+    }
+
     fn create_bind_group_layout(
         &self,
         _desc: &wgpu::BindGroupLayoutDescriptor<'_>,

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -237,7 +237,7 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct ModuleInfo {

--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -511,15 +511,14 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
         fail(
             &ctx.device,
             || unsafe {
-                let _ = ctx
-                    .device
-                    .create_shader_module_passthrough(
-                        &wgpu::ShaderModuleDescriptorPassthrough::SpirV(
-                            &wgpu::ShaderModuleDescriptorSpirV {
-                                label: None,
-                                source: std::borrow::Cow::Borrowed(&[]),
-                            })
-                        );
+                let _ = ctx.device.create_shader_module_passthrough(
+                    wgpu::ShaderModuleDescriptorPassthrough::SpirV(
+                        wgpu::ShaderModuleDescriptorSpirV {
+                            label: None,
+                            source: std::borrow::Cow::Borrowed(&[]),
+                        },
+                    ),
+                );
             },
             Some("device with '' label is invalid"),
         );

--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -513,10 +513,13 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
             || unsafe {
                 let _ = ctx
                     .device
-                    .create_shader_module_spirv(&wgpu::ShaderModuleDescriptorSpirV {
-                        label: None,
-                        source: std::borrow::Cow::Borrowed(&[]),
-                    });
+                    .create_shader_module_passthrough(
+                        &wgpu::ShaderModuleDescriptorPassthrough::SpirV(
+                            &wgpu::ShaderModuleDescriptorSpirV {
+                                label: None,
+                                source: std::borrow::Cow::Borrowed(&[]),
+                            })
+                        );
             },
             Some("device with '' label is invalid"),
         );

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -962,7 +962,7 @@ impl Global {
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
-                let data = trace.make_binary(desc.trace_binary_ext(), &desc.trace_data());
+                let data = trace.make_binary(desc.trace_binary_ext(), desc.trace_data());
                 trace.add(trace::Action::CreateShaderModule {
                     id: fid.id(),
                     desc: desc.clone().into(),

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -938,23 +938,21 @@ impl Global {
         (id, Some(error))
     }
 
-    // Unsafe-ness of internal calls has little to do with unsafe-ness of this.
     #[allow(unused_unsafe)]
     /// # Safety
     ///
-    /// This function passes SPIR-V binary to the backend as-is and can potentially result in a
+    /// This function passes source code or binary to the backend as-is and can potentially result in a
     /// driver crash.
-    pub unsafe fn device_create_shader_module_spirv(
+    pub unsafe fn device_create_shader_module_passthrough(
         &self,
         device_id: DeviceId,
-        desc: &pipeline::ShaderModuleDescriptor,
-        source: Cow<[u32]>,
+        desc: &pipeline::ShaderModuleDescriptorPassthrough<'_>,
         id_in: Option<id::ShaderModuleId>,
     ) -> (
         id::ShaderModuleId,
         Option<pipeline::CreateShaderModuleError>,
     ) {
-        profiling::scope!("Device::create_shader_module");
+        profiling::scope!("Device::create_shader_module_passthrough");
 
         let hub = &self.hub;
         let fid = hub.shader_modules.prepare(id_in);
@@ -964,15 +962,17 @@ impl Global {
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
-                let data = trace.make_binary("spv", bytemuck::cast_slice(&source));
+                let data = trace.make_binary(desc.trace_binary_ext(), &desc.trace_data());
                 trace.add(trace::Action::CreateShaderModule {
                     id: fid.id(),
-                    desc: desc.clone(),
+                    desc: desc.clone().into(),
                     data,
                 });
             };
 
-            let shader = match unsafe { device.create_shader_module_spirv(desc, &source) } {
+            let result = unsafe { device.create_shader_module_passthrough(desc) };
+
+            let shader = match result {
                 Ok(shader) => shader,
                 Err(e) => break 'error e,
             };
@@ -981,47 +981,7 @@ impl Global {
             return (id, None);
         };
 
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
-        (id, Some(error))
-    }
-
-    // Unsafe-ness of internal calls has little to do with unsafe-ness of this.
-    #[allow(unused_unsafe)]
-    /// # Safety
-    ///
-    /// This function passes MSL source  code to the backend as-is and can potentially result in a
-    /// driver crash.
-    pub unsafe fn device_create_shader_module_msl(
-        &self,
-        device_id: DeviceId,
-        desc: &pipeline::ShaderModuleDescriptor,
-        source: Cow<str>,
-        entry_point: &str,
-        num_workgroups: (u32, u32, u32),
-        id_in: Option<id::ShaderModuleId>,
-    ) -> (
-        id::ShaderModuleId,
-        Option<pipeline::CreateShaderModuleError>,
-    ) {
-        profiling::scope!("Device::create_shader_module");
-
-        let hub = &self.hub;
-        let fid = hub.shader_modules.prepare(id_in);
-
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
-            let shader = match unsafe {
-                device.create_shader_module_msl(desc, &source, entry_point, num_workgroups)
-            } {
-                Ok(shader) => shader,
-                Err(e) => break 'error e,
-            };
-            let id = fid.assign(Fallible::Valid(shader));
-            api_log!("Device::create_shader_module_spirv -> {id:?}");
-            return (id, None);
-        };
-
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
+        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label().to_string())));
         (id, Some(error))
     }
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -985,6 +985,46 @@ impl Global {
         (id, Some(error))
     }
 
+    // Unsafe-ness of internal calls has little to do with unsafe-ness of this.
+    #[allow(unused_unsafe)]
+    /// # Safety
+    ///
+    /// This function passes MSL source  code to the backend as-is and can potentially result in a
+    /// driver crash.
+    pub unsafe fn device_create_shader_module_msl(
+        &self,
+        device_id: DeviceId,
+        desc: &pipeline::ShaderModuleDescriptor,
+        source: Cow<str>,
+        entry_point: &str,
+        num_workgroups: (u32, u32, u32),
+        id_in: Option<id::ShaderModuleId>,
+    ) -> (
+        id::ShaderModuleId,
+        Option<pipeline::CreateShaderModuleError>,
+    ) {
+        profiling::scope!("Device::create_shader_module");
+
+        let hub = &self.hub;
+        let fid = hub.shader_modules.prepare(id_in);
+
+        let error = 'error: {
+            let device = self.hub.devices.get(device_id);
+            let shader = match unsafe {
+                device.create_shader_module_msl(desc, &source, entry_point, num_workgroups)
+            } {
+                Ok(shader) => shader,
+                Err(e) => break 'error e,
+            };
+            let id = fid.assign(Fallible::Valid(shader));
+            api_log!("Device::create_shader_module_spirv -> {id:?}");
+            return (id, None);
+        };
+
+        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
+        (id, Some(error))
+    }
+
     pub fn shader_module_drop(&self, shader_module_id: id::ShaderModuleId) {
         profiling::scope!("ShaderModule::drop");
         api_log!("ShaderModule::drop {shader_module_id:?}");

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -965,7 +965,20 @@ impl Global {
                 let data = trace.make_binary(desc.trace_binary_ext(), desc.trace_data());
                 trace.add(trace::Action::CreateShaderModule {
                     id: fid.id(),
-                    desc: desc.clone().into(),
+                    desc: match desc {
+                        pipeline::ShaderModuleDescriptorPassthrough::SpirV(inner) => {
+                            pipeline::ShaderModuleDescriptor {
+                                label: inner.label.clone(),
+                                runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
+                            }
+                        }
+                        pipeline::ShaderModuleDescriptorPassthrough::Msl(inner) => {
+                            pipeline::ShaderModuleDescriptor {
+                                label: inner.label.clone(),
+                                runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
+                            }
+                        }
+                    },
                     data,
                 });
             };

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1761,12 +1761,13 @@ impl Device {
                 hal::ShaderInput::SpirV(&inner.source)
             }
             pipeline::ShaderModuleDescriptorPassthrough::Msl(inner) => {
+                self.require_features(wgt::Features::MSL_SHADER_PASSTHROUGH)?;
                 hal::ShaderInput::Msl {
                     shader: inner.source.to_string(),
                     entry_point: inner.entry_point.to_string(),
                     num_workgroups: inner.num_workgroups,
                 }
-            },
+            }
         };
 
         let hal_desc = hal::ShaderModuleDescriptor {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1750,19 +1750,28 @@ impl Device {
     }
 
     #[allow(unused_unsafe)]
-    pub(crate) unsafe fn create_shader_module_spirv<'a>(
+    pub(crate) unsafe fn create_shader_module_passthrough<'a>(
         self: &Arc<Self>,
-        desc: &pipeline::ShaderModuleDescriptor<'a>,
-        source: &'a [u32],
+        descriptor: &pipeline::ShaderModuleDescriptorPassthrough<'a>,
     ) -> Result<Arc<pipeline::ShaderModule>, pipeline::CreateShaderModuleError> {
-        self.check_is_valid()?;
-
-        self.require_features(wgt::Features::SPIRV_SHADER_PASSTHROUGH)?;
-        let hal_desc = hal::ShaderModuleDescriptor {
-            label: desc.label.to_hal(self.instance_flags),
-            runtime_checks: desc.runtime_checks,
+        let hal_shader = match descriptor {
+            pipeline::ShaderModuleDescriptorPassthrough::SpirV(inner) => {
+                self.check_is_valid()?;
+                self.require_features(wgt::Features::SPIRV_SHADER_PASSTHROUGH)?;
+                hal::ShaderInput::SpirV(&inner.source)
+            }
+            pipeline::ShaderModuleDescriptorPassthrough::Msl(inner) => hal::ShaderInput::Msl {
+                shader: inner.source.to_string(),
+                entry_point: inner.entry_point.to_string(),
+                num_workgroups: inner.num_workgroups,
+            },
         };
-        let hal_shader = hal::ShaderInput::SpirV(source);
+
+        let hal_desc = hal::ShaderModuleDescriptor {
+            label: descriptor.label().to_hal(self.instance_flags),
+            runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
+        };
+
         let raw = match unsafe { self.raw().create_shader_module(&hal_desc, hal_shader) } {
             Ok(raw) => raw,
             Err(error) => {
@@ -1782,48 +1791,7 @@ impl Device {
             raw: ManuallyDrop::new(raw),
             device: self.clone(),
             interface: None,
-            label: desc.label.to_string(),
-        };
-
-        let module = Arc::new(module);
-
-        Ok(module)
-    }
-
-    #[allow(unused_unsafe)]
-    pub(crate) unsafe fn create_shader_module_msl<'a>(
-        self: &Arc<Self>,
-        desc: &pipeline::ShaderModuleDescriptor<'a>,
-        source: &'a Cow<str>,
-        entry_point: &str,
-        num_workgroups: (u32, u32, u32),
-    ) -> Result<Arc<pipeline::ShaderModule>, pipeline::CreateShaderModuleError> {
-        let hal_shader = hal::ShaderInput::Msl {
-            shader: source.to_string(),
-            entry_point: entry_point.to_string(),
-            num_workgroups,
-        };
-        let hal_desc = hal::ShaderModuleDescriptor {
-            label: desc.label.to_hal(self.instance_flags),
-            runtime_checks: desc.runtime_checks,
-        };
-        let raw =
-            unsafe { self.raw().create_shader_module(&hal_desc, hal_shader) }.map_err(|error| {
-                match error {
-                    hal::ShaderError::Device(err) => {
-                        pipeline::CreateShaderModuleError::Device(self.handle_hal_error(err))
-                    }
-                    hal::ShaderError::Compilation(msg) => {
-                        log::error!("Shader compilation error: {}", msg);
-                        pipeline::CreateShaderModuleError::Generation
-                    }
-                }
-            })?;
-        let module = pipeline::ShaderModule {
-            raw: ManuallyDrop::new(raw),
-            device: self.clone(),
-            interface: None,
-            label: desc.label.to_string(),
+            label: descriptor.label().to_string(),
         };
 
         Ok(Arc::new(module))

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1790,6 +1790,45 @@ impl Device {
         Ok(module)
     }
 
+    #[allow(unused_unsafe)]
+    pub(crate) unsafe fn create_shader_module_msl<'a>(
+        self: &Arc<Self>,
+        desc: &pipeline::ShaderModuleDescriptor<'a>,
+        source: &'a Cow<str>,
+        entry_point: &str,
+        num_workgroups: (u32, u32, u32),
+    ) -> Result<Arc<pipeline::ShaderModule>, pipeline::CreateShaderModuleError> {
+        let hal_shader = hal::ShaderInput::Msl {
+            shader: source.to_string(),
+            entry_point: entry_point.to_string(),
+            num_workgroups,
+        };
+        let hal_desc = hal::ShaderModuleDescriptor {
+            label: desc.label.to_hal(self.instance_flags),
+            runtime_checks: desc.runtime_checks,
+        };
+        let raw =
+            unsafe { self.raw().create_shader_module(&hal_desc, hal_shader) }.map_err(|error| {
+                match error {
+                    hal::ShaderError::Device(err) => {
+                        pipeline::CreateShaderModuleError::Device(self.handle_hal_error(err))
+                    }
+                    hal::ShaderError::Compilation(msg) => {
+                        log::error!("Shader compilation error: {}", msg);
+                        pipeline::CreateShaderModuleError::Generation
+                    }
+                }
+            })?;
+        let module = pipeline::ShaderModule {
+            raw: ManuallyDrop::new(raw),
+            device: self.clone(),
+            interface: None,
+            label: desc.label.to_string(),
+        };
+
+        Ok(Arc::new(module))
+    }
+
     pub(crate) fn create_command_encoder(
         self: &Arc<Self>,
         label: &crate::Label,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1754,16 +1754,18 @@ impl Device {
         self: &Arc<Self>,
         descriptor: &pipeline::ShaderModuleDescriptorPassthrough<'a>,
     ) -> Result<Arc<pipeline::ShaderModule>, pipeline::CreateShaderModuleError> {
+        self.check_is_valid()?;
         let hal_shader = match descriptor {
             pipeline::ShaderModuleDescriptorPassthrough::SpirV(inner) => {
-                self.check_is_valid()?;
                 self.require_features(wgt::Features::SPIRV_SHADER_PASSTHROUGH)?;
                 hal::ShaderInput::SpirV(&inner.source)
             }
-            pipeline::ShaderModuleDescriptorPassthrough::Msl(inner) => hal::ShaderInput::Msl {
-                shader: inner.source.to_string(),
-                entry_point: inner.entry_point.to_string(),
-                num_workgroups: inner.num_workgroups,
+            pipeline::ShaderModuleDescriptorPassthrough::Msl(inner) => {
+                hal::ShaderInput::Msl {
+                    shader: inner.source.to_string(),
+                    entry_point: inner.entry_point.to_string(),
+                    num_workgroups: inner.num_workgroups,
+                }
             },
         };
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -53,6 +53,24 @@ pub struct ShaderModuleDescriptor<'a> {
     pub runtime_checks: wgt::ShaderRuntimeChecks,
 }
 
+pub type ShaderModuleDescriptorPassthrough<'a> =
+    wgt::CreateShaderModuleDescriptorPassthrough<'a, Label<'a>>;
+
+impl<'a> From<ShaderModuleDescriptorPassthrough<'a>> for ShaderModuleDescriptor<'a> {
+    fn from(val: ShaderModuleDescriptorPassthrough<'a>) -> Self {
+        match val {
+            ShaderModuleDescriptorPassthrough::SpirV(inner) => ShaderModuleDescriptor {
+                label: inner.label.clone(),
+                runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
+            },
+            ShaderModuleDescriptorPassthrough::Msl(inner) => ShaderModuleDescriptor {
+                label: inner.label.clone(),
+                runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
+            },
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ShaderModule {
     pub(crate) raw: ManuallyDrop<Box<dyn hal::DynShaderModule>>,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -56,21 +56,6 @@ pub struct ShaderModuleDescriptor<'a> {
 pub type ShaderModuleDescriptorPassthrough<'a> =
     wgt::CreateShaderModuleDescriptorPassthrough<'a, Label<'a>>;
 
-impl<'a> From<ShaderModuleDescriptorPassthrough<'a>> for ShaderModuleDescriptor<'a> {
-    fn from(val: ShaderModuleDescriptorPassthrough<'a>) -> Self {
-        match val {
-            ShaderModuleDescriptorPassthrough::SpirV(inner) => ShaderModuleDescriptor {
-                label: inner.label.clone(),
-                runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
-            },
-            ShaderModuleDescriptorPassthrough::Msl(inner) => ShaderModuleDescriptor {
-                label: inner.label.clone(),
-                runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
-            },
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct ShaderModule {
     pub(crate) raw: ManuallyDrop<Box<dyn hal::DynShaderModule>>,

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1642,7 +1642,7 @@ impl crate::Device for super::Device {
                 panic!("SPIRV_SHADER_PASSTHROUGH is not enabled for this backend")
             },
             crate::ShaderInput::Msl { .. } => {
-                panic!("MLS_SHADER_PASSTHROUGH is not enabled for this backend")
+                panic!("MSL_SHADER_PASSTHROUGH is not enabled for this backend")
             }
         }
     }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1640,7 +1640,7 @@ impl crate::Device for super::Device {
             }),
             crate::ShaderInput::SpirV(_) => {
                 panic!("SPIRV_SHADER_PASSTHROUGH is not enabled for this backend")
-            },
+            }
             crate::ShaderInput::Msl { .. } => {
                 panic!("MSL_SHADER_PASSTHROUGH is not enabled for this backend")
             }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1640,6 +1640,9 @@ impl crate::Device for super::Device {
             }),
             crate::ShaderInput::SpirV(_) => {
                 panic!("SPIRV_SHADER_PASSTHROUGH is not enabled for this backend")
+            },
+            crate::ShaderInput::Msl { .. } => {
+                panic!("MLS_SHADER_PASSTHROUGH is not enabled for this backend")
             }
         }
     }

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1329,6 +1329,9 @@ impl crate::Device for super::Device {
                 crate::ShaderInput::SpirV(_) => {
                     panic!("`Features::SPIRV_SHADER_PASSTHROUGH` is not enabled")
                 }
+                crate::ShaderInput::Msl { .. } => {
+                    panic!("`Features::MSL_SHADER_PASSTHROUGH` is not enabled")
+                }
                 crate::ShaderInput::Naga(naga) => naga,
             },
             label: desc.label.map(|str| str.to_string()),

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2069,6 +2069,7 @@ pub struct CommandEncoderDescriptor<'a, Q: DynQueue + ?Sized> {
 }
 
 /// Naga shader module.
+#[derive(Default)]
 pub struct NagaShader {
     /// Shader module IR.
     pub module: Cow<'static, naga::Module>,
@@ -2090,6 +2091,11 @@ impl fmt::Debug for NagaShader {
 #[allow(clippy::large_enum_variant)]
 pub enum ShaderInput<'a> {
     Naga(NagaShader),
+    Msl {
+        shader: String,
+        entry_point: String,
+        num_workgroups: (u32, u32, u32),
+    },
     SpirV(&'a [u32]),
 }
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -904,6 +904,7 @@ impl super::PrivateCapabilities {
         use wgt::Features as F;
 
         let mut features = F::empty()
+            | F::MSL_SHADER_PASSTHROUGH
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::VERTEX_WRITABLE_STORAGE
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -4,8 +4,9 @@ use std::{thread, time};
 
 use parking_lot::Mutex;
 
-use super::{conv, ShaderModuleDescriptorPassthrough};
+use super::{conv, PassthroughShader};
 use crate::auxil::map_naga_stage;
+use crate::metal::ShaderModuleSource;
 use crate::TlasInstance;
 
 use metal::foreign_types::ForeignType;
@@ -122,14 +123,15 @@ impl super::Device {
         primitive_class: metal::MTLPrimitiveTopologyClass,
         naga_stage: naga::ShaderStage,
     ) -> Result<CompiledShader, crate::PipelineError> {
-        assert!(stage.module.naga.is_some(), "load_shader required a naga shader");
-
+        let naga_shader = if let ShaderModuleSource::Naga(naga) = &stage.module.source {
+            naga
+        } else {
+            panic!("load_shader required a naga shader");
+        };
         let stage_bit = map_naga_stage(naga_stage);
-        let naga = stage.module.naga.as_ref().unwrap();
-
         let (module, module_info) = naga::back::pipeline_constants::process_overrides(
-            &naga.module,
-            &naga.info,
+            &naga_shader.module,
+            &naga_shader.info,
             stage.constants,
         )
         .map_err(|e| crate::PipelineError::PipelineConstants(stage_bit, format!("MSL: {:?}", e)))?;
@@ -992,9 +994,8 @@ impl crate::Device for super::Device {
 
         match shader {
             crate::ShaderInput::Naga(naga) => Ok(super::ShaderModule {
-                naga: Some(naga),
+                source: ShaderModuleSource::Naga(naga),
                 bounds_checks: desc.runtime_checks,
-                passthrough_desc: None,
             }),
             crate::ShaderInput::Msl {
                 shader: source,
@@ -1015,8 +1016,7 @@ impl crate::Device for super::Device {
                 })?;
 
                 Ok(super::ShaderModule {
-                    naga: None,
-                    passthrough_desc: Some(ShaderModuleDescriptorPassthrough {
+                    source: ShaderModuleSource::Passthrough(PassthroughShader {
                         library,
                         function,
                         entry_point,
@@ -1333,7 +1333,7 @@ impl crate::Device for super::Device {
             let descriptor = metal::ComputePipelineDescriptor::new();
 
             let module = desc.stage.module;
-            let cs = if let Some(ref desc) = module.passthrough_desc {
+            let cs = if let ShaderModuleSource::Passthrough(desc) = &module.source {
                 CompiledShader {
                     library: desc.library.clone(),
                     function: desc.function.clone(),

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -122,11 +122,14 @@ impl super::Device {
         primitive_class: metal::MTLPrimitiveTopologyClass,
         naga_stage: naga::ShaderStage,
     ) -> Result<CompiledShader, crate::PipelineError> {
+        assert!(stage.module.naga.is_some(), "load_shader required a naga shader");
+
         let stage_bit = map_naga_stage(naga_stage);
+        let naga = stage.module.naga.as_ref().unwrap();
 
         let (module, module_info) = naga::back::pipeline_constants::process_overrides(
-            &stage.module.naga.module,
-            &stage.module.naga.info,
+            &naga.module,
+            &naga.info,
             stage.constants,
         )
         .map_err(|e| crate::PipelineError::PipelineConstants(stage_bit, format!("MSL: {:?}", e)))?;
@@ -989,7 +992,7 @@ impl crate::Device for super::Device {
 
         match shader {
             crate::ShaderInput::Naga(naga) => Ok(super::ShaderModule {
-                naga,
+                naga: Some(naga),
                 bounds_checks: desc.runtime_checks,
                 library: None,
                 function: None,
@@ -1015,7 +1018,7 @@ impl crate::Device for super::Device {
                 })?;
 
                 Ok(super::ShaderModule {
-                    naga: crate::NagaShader::default(), // naga modules is not used for passthrough
+                    naga: None, // naga modules is not used for passthrough
                     library: Some(library),
                     function: Some(function),
                     entry_point: Some(entry_point),

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -4,7 +4,7 @@ use std::{thread, time};
 
 use parking_lot::Mutex;
 
-use super::conv;
+use super::{conv, ShaderModuleDescriptorPassthrough};
 use crate::auxil::map_naga_stage;
 use crate::TlasInstance;
 
@@ -994,10 +994,7 @@ impl crate::Device for super::Device {
             crate::ShaderInput::Naga(naga) => Ok(super::ShaderModule {
                 naga: Some(naga),
                 bounds_checks: desc.runtime_checks,
-                library: None,
-                function: None,
-                entry_point: None,
-                num_workgroups: None,
+                passthrough_desc: None,
             }),
             crate::ShaderInput::Msl {
                 shader: source,
@@ -1018,11 +1015,13 @@ impl crate::Device for super::Device {
                 })?;
 
                 Ok(super::ShaderModule {
-                    naga: None, // naga modules is not used for passthrough
-                    library: Some(library),
-                    function: Some(function),
-                    entry_point: Some(entry_point),
-                    num_workgroups: Some(num_workgroups),
+                    naga: None,
+                    passthrough_desc: Some(ShaderModuleDescriptorPassthrough {
+                        library,
+                        function,
+                        entry_point,
+                        num_workgroups,
+                    }),
                     bounds_checks: desc.runtime_checks,
                 })
             }
@@ -1334,18 +1333,14 @@ impl crate::Device for super::Device {
             let descriptor = metal::ComputePipelineDescriptor::new();
 
             let module = desc.stage.module;
-            let cs = if module.function.is_some()
-                && module.library.is_some()
-                && module.num_workgroups.is_some()
-            {
-                let wg_size = module.num_workgroups.unwrap();
+            let cs = if let Some(ref desc) = module.passthrough_desc {
                 CompiledShader {
-                    library: module.library.clone().unwrap(),
-                    function: module.function.clone().unwrap(),
+                    library: desc.library.clone(),
+                    function: desc.function.clone(),
                     wg_size: metal::MTLSize::new(
-                        wg_size.0 as u64,
-                        wg_size.1 as u64,
-                        wg_size.2 as u64,
+                        desc.num_workgroups.0 as u64,
+                        desc.num_workgroups.1 as u64,
+                        desc.num_workgroups.2 as u64,
                     ),
                     wg_memory_sizes: vec![],
                     sized_bindings: vec![],

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -991,7 +991,38 @@ impl crate::Device for super::Device {
             crate::ShaderInput::Naga(naga) => Ok(super::ShaderModule {
                 naga,
                 bounds_checks: desc.runtime_checks,
+                library: None,
+                function: None,
+                entry_point: None,
+                num_workgroups: None,
             }),
+            crate::ShaderInput::Msl {
+                shader: source,
+                entry_point,
+                num_workgroups,
+            } => {
+                let options = metal::CompileOptions::new();
+                // Obtain the locked device from shared
+                let device = self.shared.device.lock();
+                let library = device
+                    .new_library_with_source(&source, &options)
+                    .map_err(|e| crate::ShaderError::Compilation(format!("MSL: {:?}", e)))?;
+                let function = library.get_function(&entry_point, None).map_err(|_| {
+                    crate::ShaderError::Compilation(format!(
+                        "Entry point '{}' not found",
+                        entry_point
+                    ))
+                })?;
+
+                Ok(super::ShaderModule {
+                    naga: crate::NagaShader::default(), // naga modules is not used for passthrough
+                    library: Some(library),
+                    function: Some(function),
+                    entry_point: Some(entry_point),
+                    num_workgroups: Some(num_workgroups),
+                    bounds_checks: desc.runtime_checks,
+                })
+            }
             crate::ShaderInput::SpirV(_) => {
                 panic!("SPIRV_SHADER_PASSTHROUGH is not enabled for this backend")
             }
@@ -1299,13 +1330,34 @@ impl crate::Device for super::Device {
         objc::rc::autoreleasepool(|| {
             let descriptor = metal::ComputePipelineDescriptor::new();
 
-            let cs = self.load_shader(
-                &desc.stage,
-                &[],
-                desc.layout,
-                metal::MTLPrimitiveTopologyClass::Unspecified,
-                naga::ShaderStage::Compute,
-            )?;
+            let module = desc.stage.module;
+            let cs = if module.function.is_some()
+                && module.library.is_some()
+                && module.num_workgroups.is_some()
+            {
+                let wg_size = module.num_workgroups.unwrap();
+                CompiledShader {
+                    library: module.library.clone().unwrap(),
+                    function: module.function.clone().unwrap(),
+                    wg_size: metal::MTLSize::new(
+                        wg_size.0 as u64,
+                        wg_size.1 as u64,
+                        wg_size.2 as u64,
+                    ),
+                    wg_memory_sizes: vec![],
+                    sized_bindings: vec![],
+                    immutable_buffer_mask: 0,
+                }
+            } else {
+                self.load_shader(
+                    &desc.stage,
+                    &[],
+                    desc.layout,
+                    metal::MTLPrimitiveTopologyClass::Unspecified,
+                    naga::ShaderStage::Compute,
+                )?
+            };
+
             descriptor.set_compute_function(Some(&cs.function));
 
             if self.shared.private_caps.supports_mutability {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -782,7 +782,13 @@ unsafe impl Send for BindGroup {}
 unsafe impl Sync for BindGroup {}
 
 #[derive(Debug)]
-pub struct ShaderModuleDescriptorPassthrough {
+pub enum ShaderModuleSource {
+    Naga(crate::NagaShader),
+    Passthrough(PassthroughShader),
+}
+
+#[derive(Debug)]
+pub struct PassthroughShader {
     pub library: metal::Library,
     pub function: metal::Function,
     pub entry_point: String,
@@ -791,9 +797,8 @@ pub struct ShaderModuleDescriptorPassthrough {
 
 #[derive(Debug)]
 pub struct ShaderModule {
-    naga: Option<crate::NagaShader>,
+    source: ShaderModuleSource,
     bounds_checks: wgt::ShaderRuntimeChecks,
-    passthrough_desc: Option<ShaderModuleDescriptorPassthrough>,
 }
 
 impl crate::DynShaderModule for ShaderModule {}

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -785,6 +785,10 @@ unsafe impl Sync for BindGroup {}
 pub struct ShaderModule {
     naga: crate::NagaShader,
     bounds_checks: wgt::ShaderRuntimeChecks,
+    pub library: Option<metal::Library>,
+    pub function: Option<metal::Function>,
+    pub entry_point: Option<String>,
+    pub num_workgroups: Option<(u32, u32, u32)>,
 }
 
 impl crate::DynShaderModule for ShaderModule {}

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -783,7 +783,7 @@ unsafe impl Sync for BindGroup {}
 
 #[derive(Debug)]
 pub struct ShaderModule {
-    naga: crate::NagaShader,
+    naga: Option<crate::NagaShader>,
     bounds_checks: wgt::ShaderRuntimeChecks,
     pub library: Option<metal::Library>,
     pub function: Option<metal::Function>,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -782,13 +782,18 @@ unsafe impl Send for BindGroup {}
 unsafe impl Sync for BindGroup {}
 
 #[derive(Debug)]
+pub struct ShaderModuleDescriptorPassthrough {
+    pub library: metal::Library,
+    pub function: metal::Function,
+    pub entry_point: String,
+    pub num_workgroups: (u32, u32, u32),
+}
+
+#[derive(Debug)]
 pub struct ShaderModule {
     naga: Option<crate::NagaShader>,
     bounds_checks: wgt::ShaderRuntimeChecks,
-    pub library: Option<metal::Library>,
-    pub function: Option<metal::Function>,
-    pub entry_point: Option<String>,
-    pub num_workgroups: Option<(u32, u32, u32)>,
+    passthrough_desc: Option<ShaderModuleDescriptorPassthrough>,
 }
 
 impl crate::DynShaderModule for ShaderModule {}

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1862,6 +1862,9 @@ impl crate::Device for super::Device {
                     .map_err(|e| crate::ShaderError::Compilation(format!("{e}")))?,
                 )
             }
+            crate::ShaderInput::Msl { .. } => {
+                panic!("MSL_SHADER_PASSTHROUGH is not enabled for this backend")
+            }
             crate::ShaderInput::SpirV(spv) => Cow::Borrowed(spv),
         };
 

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -920,6 +920,15 @@ bitflags_array! {
         ///
         /// This is a native only feature.
         const CLEAR_TEXTURE = 1 << 23;
+        /// Enables creating shader modules from Metal MSL computer shaders (unsafe).
+        ///
+        /// Metal data is not parsed or interpreted in any way
+        ///
+        /// Supported platforms:
+        /// - Metal
+        ///
+        /// This is a native only feature.
+        const MSL_SHADER_PASSTHROUGH = 1 << 24;
         /// Enables creating shader modules from SPIR-V binary data (unsafe).
         ///
         /// SPIR-V data is not parsed or interpreted in any way; you can use
@@ -933,7 +942,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [`wgpu::make_spirv_raw!`]: https://docs.rs/wgpu/latest/wgpu/macro.include_spirv_raw.html
-        const SPIRV_SHADER_PASSTHROUGH = 1 << 24;
+        const SPIRV_SHADER_PASSTHROUGH = 1 << 25;
         /// Enables multiview render passes and `builtin(view_index)` in vertex shaders.
         ///
         /// Supported platforms:
@@ -941,7 +950,7 @@ bitflags_array! {
         /// - OpenGL (web only)
         ///
         /// This is a native only feature.
-        const MULTIVIEW = 1 << 25;
+        const MULTIVIEW = 1 << 26;
         /// Enables using 64-bit types for vertex attributes.
         ///
         /// Requires SHADER_FLOAT64.
@@ -949,7 +958,7 @@ bitflags_array! {
         /// Supported Platforms: N/A
         ///
         /// This is a native only feature.
-        const VERTEX_ATTRIBUTE_64BIT = 1 << 26;
+        const VERTEX_ATTRIBUTE_64BIT = 1 << 27;
         /// Enables image atomic fetch add, and, xor, or, min, and max for R32Uint and R32Sint textures.
         ///
         /// Supported platforms:
@@ -958,7 +967,7 @@ bitflags_array! {
         /// - Metal (with MSL 3.1+)
         ///
         /// This is a native only feature.
-        const TEXTURE_ATOMIC = 1 << 27;
+        const TEXTURE_ATOMIC = 1 << 28;
         /// Allows for creation of textures of format [`TextureFormat::NV12`]
         ///
         /// Supported platforms:
@@ -968,7 +977,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [`TextureFormat::NV12`]: super::TextureFormat::NV12
-        const TEXTURE_FORMAT_NV12 = 1 << 28;
+        const TEXTURE_FORMAT_NV12 = 1 << 29;
         /// ***THIS IS EXPERIMENTAL:*** Features enabled by this may have
         /// major bugs in them and are expected to be subject to breaking changes, suggestions
         /// for the API exposed by this should be posted on [the ray-tracing issue](https://github.com/gfx-rs/wgpu/issues/1040)
@@ -980,7 +989,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native-only feature.
-        const EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE = 1 << 29;
+        const EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE = 1 << 30;
 
         // Shader:
 
@@ -994,7 +1003,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native-only feature.
-        const EXPERIMENTAL_RAY_QUERY = 1 << 30;
+        const EXPERIMENTAL_RAY_QUERY = 1 << 31;
         /// Enables 64-bit floating point types in SPIR-V shaders.
         ///
         /// Note: even when supported by GPU hardware, 64-bit floating point operations are
@@ -1004,14 +1013,14 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const SHADER_F64 = 1 << 31;
+        const SHADER_F64 = 1 << 32;
         /// Allows shaders to use i16. Not currently supported in `naga`, only available through `spirv-passthrough`.
         ///
         /// Supported platforms:
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const SHADER_I16 = 1 << 32;
+        const SHADER_I16 = 1 << 33;
         /// Enables `builtin(primitive_index)` in fragment shaders.
         ///
         /// Note: enables geometry processing for pipelines using the builtin.
@@ -1025,14 +1034,14 @@ bitflags_array! {
         /// - OpenGL (some)
         ///
         /// This is a native only feature.
-        const SHADER_PRIMITIVE_INDEX = 1 << 33;
+        const SHADER_PRIMITIVE_INDEX = 1 << 34;
         /// Allows shaders to use the `early_depth_test` attribute.
         ///
         /// Supported platforms:
         /// - GLES 3.1+
         ///
         /// This is a native only feature.
-        const SHADER_EARLY_DEPTH_TEST = 1 << 34;
+        const SHADER_EARLY_DEPTH_TEST = 1 << 35;
         /// Allows shaders to use i64 and u64.
         ///
         /// Supported platforms:
@@ -1041,7 +1050,7 @@ bitflags_array! {
         /// - Metal (with MSL 2.3+)
         ///
         /// This is a native only feature.
-        const SHADER_INT64 = 1 << 35;
+        const SHADER_INT64 = 1 << 36;
         /// Allows compute and fragment shaders to use the subgroup operation built-ins
         ///
         /// Supported Platforms:
@@ -1050,14 +1059,14 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const SUBGROUP = 1 << 36;
+        const SUBGROUP = 1 << 37;
         /// Allows vertex shaders to use the subgroup operation built-ins
         ///
         /// Supported Platforms:
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const SUBGROUP_VERTEX = 1 << 37;
+        const SUBGROUP_VERTEX = 1 << 38;
         /// Allows shaders to use the subgroup barrier
         ///
         /// Supported Platforms:
@@ -1065,7 +1074,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const SUBGROUP_BARRIER = 1 << 38;
+        const SUBGROUP_BARRIER = 1 << 39;
         /// Allows the use of pipeline cache objects
         ///
         /// Supported platforms:
@@ -1074,7 +1083,7 @@ bitflags_array! {
         /// Unimplemented Platforms:
         /// - DX12
         /// - Metal
-        const PIPELINE_CACHE = 1 << 39;
+        const PIPELINE_CACHE = 1 << 40;
         /// Allows shaders to use i64 and u64 atomic min and max.
         ///
         /// Supported platforms:
@@ -1083,7 +1092,7 @@ bitflags_array! {
         /// - Metal (with MSL 2.4+)
         ///
         /// This is a native only feature.
-        const SHADER_INT64_ATOMIC_MIN_MAX = 1 << 40;
+        const SHADER_INT64_ATOMIC_MIN_MAX = 1 << 41;
         /// Allows shaders to use all i64 and u64 atomic operations.
         ///
         /// Supported platforms:
@@ -1091,7 +1100,7 @@ bitflags_array! {
         /// - DX12 (with SM 6.6+)
         ///
         /// This is a native only feature.
-        const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 41;
+        const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 42;
         /// Allows using the [VK_GOOGLE_display_timing] Vulkan extension.
         ///
         /// This is used for frame pacing to reduce latency, and is generally only available on Android.
@@ -1107,7 +1116,7 @@ bitflags_array! {
         ///
         /// [VK_GOOGLE_display_timing]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html
         /// [`Surface::as_hal()`]: https://docs.rs/wgpu/latest/wgpu/struct.Surface.html#method.as_hal
-        const VULKAN_GOOGLE_DISPLAY_TIMING = 1 << 42;
+        const VULKAN_GOOGLE_DISPLAY_TIMING = 1 << 43;
 
         /// Allows using the [VK_KHR_external_memory_win32] Vulkan extension.
         ///
@@ -1117,7 +1126,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [VK_KHR_external_memory_win32]: https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_external_memory_win32.html
-        const VULKAN_EXTERNAL_MEMORY_WIN32 = 1 << 43;
+        const VULKAN_EXTERNAL_MEMORY_WIN32 = 1 << 44;
 
         /// Enables R64Uint image atomic min and max.
         ///
@@ -1127,7 +1136,7 @@ bitflags_array! {
         /// - Metal (with MSL 3.1+)
         ///
         /// This is a native only feature.
-        const TEXTURE_INT64_ATOMIC = 1 << 44;
+        const TEXTURE_INT64_ATOMIC = 1 << 45;
 
         /// Allows uniform buffers to be bound as binding arrays.
         ///
@@ -1144,7 +1153,7 @@ bitflags_array! {
         /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s `shaderUniformBufferArrayNonUniformIndexing` feature)
         ///
         /// This is a native only feature.
-        const UNIFORM_BUFFER_BINDING_ARRAYS = 1 << 45;
+        const UNIFORM_BUFFER_BINDING_ARRAYS = 1 << 46;
 
         /// Enables mesh shaders and task shaders in mesh shader pipelines.
         ///
@@ -1156,7 +1165,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const EXPERIMENTAL_MESH_SHADER = 1 << 46;
+        const EXPERIMENTAL_MESH_SHADER = 1 << 47;
 
         /// ***THIS IS EXPERIMENTAL:*** Features enabled by this may have
         /// major bugs in them and are expected to be subject to breaking changes, suggestions
@@ -1171,7 +1180,7 @@ bitflags_array! {
         /// This is a native only feature
         ///
         /// [`AccelerationStructureFlags::ALLOW_RAY_HIT_VERTEX_RETURN`]: super::AccelerationStructureFlags::ALLOW_RAY_HIT_VERTEX_RETURN
-        const EXPERIMENTAL_RAY_HIT_VERTEX_RETURN = 1 << 47;
+        const EXPERIMENTAL_RAY_HIT_VERTEX_RETURN = 1 << 48;
 
         /// Enables multiview in mesh shader pipelines
         ///
@@ -1183,7 +1192,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const EXPERIMENTAL_MESH_SHADER_MULTIVIEW = 1 << 48;
+        const EXPERIMENTAL_MESH_SHADER_MULTIVIEW = 1 << 49;
     }
 
     /// Features that are not guaranteed to be supported.

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -22,6 +22,7 @@ use core::{
     num::NonZeroU32,
     ops::Range,
 };
+use alloc::borrow::Cow;
 
 use bytemuck::{Pod, Zeroable};
 
@@ -7653,4 +7654,97 @@ pub enum DeviceLostReason {
     Unknown = 0,
     /// After `Device::destroy`
     Destroyed = 1,
+}
+
+/// Descriptor for creating a shader module.
+///
+/// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
+/// only WGSL source code strings are accepted.
+#[derive(Debug, Clone)]
+pub enum CreateShaderModuleDescriptorPassthrough<'a, L> {
+    /// Passthrough for SPIR-V binaries.
+    SpirV(ShaderModuleDescriptorSpirV<'a, L>),
+    /// Passthrough for MSL source code.
+    Msl(ShaderModuleDescriptorMsl<'a, L>),
+}
+
+impl<'a> From<&CreateShaderModuleDescriptorPassthrough<'a, Option<&'a str>>>
+    for CreateShaderModuleDescriptorPassthrough<'a, Option<Cow<'a, str>>>
+{
+    fn from(src: &CreateShaderModuleDescriptorPassthrough<'a, Option<&'a str>>) -> Self {
+        match src {
+            CreateShaderModuleDescriptorPassthrough::SpirV(inner) => {
+                CreateShaderModuleDescriptorPassthrough::SpirV(ShaderModuleDescriptorSpirV {
+                    label: inner.label.map(Cow::from),
+                    source: inner.source.clone(),
+                })
+            }
+            CreateShaderModuleDescriptorPassthrough::Msl(inner) => {
+                CreateShaderModuleDescriptorPassthrough::Msl(ShaderModuleDescriptorMsl {
+                    entry_point: inner.entry_point.clone(),
+                    label: inner.label.map(Cow::from),
+                    num_workgroups: inner.num_workgroups,
+                    source: inner.source.clone(),
+                })
+            }
+        }
+    }
+}
+
+impl<'a, L> CreateShaderModuleDescriptorPassthrough<'a, L> {
+    /// Returns the label of shader module passthrough descriptor.
+    pub fn label(&'a self) -> &'a L {
+        match self {
+            CreateShaderModuleDescriptorPassthrough::SpirV(inner) => &inner.label,
+            CreateShaderModuleDescriptorPassthrough::Msl(inner) => &inner.label,
+        }
+    }
+
+    #[cfg(feature = "trace")]
+    /// Returns the source data for tracing purpose.
+    pub fn trace_data(&self) -> &[u8] {
+        match self {
+            CreateShaderModuleDescriptorPassthrough::SpirV(inner) => {
+                bytemuck::cast_slice(&inner.source)
+            }
+            CreateShaderModuleDescriptorPassthrough::Msl(inner) => inner.source.as_bytes(),
+        }
+    }
+
+    #[cfg(feature = "trace")]
+    /// Returns the binary file extension for tracing purpose.
+    pub fn trace_binary_ext(&self) -> &'static str {
+        match self {
+            CreateShaderModuleDescriptorPassthrough::SpirV(..) => "spv",
+            CreateShaderModuleDescriptorPassthrough::Msl(..) => "msl",
+        }
+    }
+}
+
+/// Descriptor for a shader module given by Metal MSL source.
+///
+/// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
+/// only WGSL source code strings are accepted.
+#[derive(Debug, Clone)]
+pub struct ShaderModuleDescriptorMsl<'a, L> {
+    /// Entrypoint.
+    pub entry_point: String,
+    /// Debug label of the shader module. This will show up in graphics debuggers for easy identification.
+    pub label: L,
+    /// Number of workgroups in each dimension x, y and z.
+    pub num_workgroups: (u32, u32, u32),
+    /// Shader MSL source.
+    pub source: Cow<'a, str>,
+}
+
+/// Descriptor for a shader module given by SPIR-V binary.
+///
+/// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
+/// only WGSL source code strings are accepted.
+#[derive(Debug, Clone)]
+pub struct ShaderModuleDescriptorSpirV<'a, L> {
+    /// Debug label of the shader module. This will show up in graphics debuggers for easy identification.
+    pub label: L,
+    /// Binary SPIR-V data, in 4-byte words.
+    pub source: Cow<'a, [u32]>,
 }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7670,26 +7670,27 @@ pub enum CreateShaderModuleDescriptorPassthrough<'a, L> {
 
 impl<'a, L> CreateShaderModuleDescriptorPassthrough<'a, L> {
     /// Takes a closure and maps the label of the shader module descriptor into another.
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> CreateShaderModuleDescriptorPassthrough<'_, K> {
+    pub fn map_label<K>(
+        &self,
+        fun: impl FnOnce(&L) -> K,
+    ) -> CreateShaderModuleDescriptorPassthrough<'_, K> {
         match self {
             CreateShaderModuleDescriptorPassthrough::SpirV(inner) => {
                 CreateShaderModuleDescriptorPassthrough::<'_, K>::SpirV(
                     ShaderModuleDescriptorSpirV {
                         label: fun(&inner.label),
                         source: inner.source.clone(),
-                    }
+                    },
                 )
-            },
+            }
             CreateShaderModuleDescriptorPassthrough::Msl(inner) => {
-                CreateShaderModuleDescriptorPassthrough::<'_, K>::Msl(
-                    ShaderModuleDescriptorMsl {
-                        entry_point: inner.entry_point.clone(),
-                        label: fun(&inner.label),
-                        num_workgroups: inner.num_workgroups,
-                        source: inner.source.clone(),
-                    }
-                )
-            },
+                CreateShaderModuleDescriptorPassthrough::<'_, K>::Msl(ShaderModuleDescriptorMsl {
+                    entry_point: inner.entry_point.clone(),
+                    label: fun(&inner.label),
+                    num_workgroups: inner.num_workgroups,
+                    source: inner.source.clone(),
+                })
+            }
         }
     }
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -14,6 +14,7 @@ extern crate std;
 
 extern crate alloc;
 
+use alloc::borrow::Cow;
 use alloc::{string::String, vec, vec::Vec};
 use core::{
     fmt,
@@ -22,7 +23,6 @@ use core::{
     num::NonZeroU32,
     ops::Range,
 };
-use alloc::borrow::Cow;
 
 use bytemuck::{Pod, Zeroable};
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -7668,30 +7668,31 @@ pub enum CreateShaderModuleDescriptorPassthrough<'a, L> {
     Msl(ShaderModuleDescriptorMsl<'a, L>),
 }
 
-impl<'a> From<&CreateShaderModuleDescriptorPassthrough<'a, Option<&'a str>>>
-    for CreateShaderModuleDescriptorPassthrough<'a, Option<Cow<'a, str>>>
-{
-    fn from(src: &CreateShaderModuleDescriptorPassthrough<'a, Option<&'a str>>) -> Self {
-        match src {
+impl<'a, L> CreateShaderModuleDescriptorPassthrough<'a, L> {
+    /// Takes a closure and maps the label of the shader module descriptor into another.
+    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> CreateShaderModuleDescriptorPassthrough<'_, K> {
+        match self {
             CreateShaderModuleDescriptorPassthrough::SpirV(inner) => {
-                CreateShaderModuleDescriptorPassthrough::SpirV(ShaderModuleDescriptorSpirV {
-                    label: inner.label.map(Cow::from),
-                    source: inner.source.clone(),
-                })
-            }
+                CreateShaderModuleDescriptorPassthrough::<'_, K>::SpirV(
+                    ShaderModuleDescriptorSpirV {
+                        label: fun(&inner.label),
+                        source: inner.source.clone(),
+                    }
+                )
+            },
             CreateShaderModuleDescriptorPassthrough::Msl(inner) => {
-                CreateShaderModuleDescriptorPassthrough::Msl(ShaderModuleDescriptorMsl {
-                    entry_point: inner.entry_point.clone(),
-                    label: inner.label.map(Cow::from),
-                    num_workgroups: inner.num_workgroups,
-                    source: inner.source.clone(),
-                })
-            }
+                CreateShaderModuleDescriptorPassthrough::<'_, K>::Msl(
+                    ShaderModuleDescriptorMsl {
+                        entry_point: inner.entry_point.clone(),
+                        label: fun(&inner.label),
+                        num_workgroups: inner.num_workgroups,
+                        source: inner.source.clone(),
+                    }
+                )
+            },
         }
     }
-}
 
-impl<'a, L> CreateShaderModuleDescriptorPassthrough<'a, L> {
     /// Returns the label of shader module passthrough descriptor.
     pub fn label(&'a self) -> &'a L {
         match self {

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -172,7 +172,7 @@ impl Device {
         ShaderModule { inner: module }
     }
 
-    /// Creates a shader module for passthrough to bypass naga and validations.
+    /// Creates a shader module which will bypass wgpu's shader tooling and validation and be used directly by the backend.
     ///
     /// # Safety
     ///

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -181,16 +181,9 @@ impl Device {
     #[must_use]
     pub unsafe fn create_shader_module_passthrough(
         &self,
-        desc: &ShaderModuleDescriptorPassthrough<'_>,
+        desc: ShaderModuleDescriptorPassthrough<'_>,
     ) -> ShaderModule {
-        let module = match desc {
-            ShaderModuleDescriptorPassthrough::SpirV(desc) => {
-                unsafe { self.inner.create_shader_module_spirv(desc) }
-            },
-            ShaderModuleDescriptorPassthrough::Msl(desc) => {
-                unsafe { self.inner.create_shader_module_msl(desc) }
-            },
-        };
+        let module = unsafe { self.inner.create_shader_module_passthrough(&desc) };
         ShaderModule { inner: module }
     }
 

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -189,6 +189,21 @@ impl Device {
         ShaderModule { inner: module }
     }
 
+    /// Creates a shader module from Metal MSL shader directly.
+    ///
+    /// # Safety
+    ///
+    /// This function passes the source to the backend as-is and can potentially result in a
+    /// driver crash or bogus behaviour. No attempt is made to ensure that source code is valid.
+    #[must_use]
+    pub unsafe fn create_shader_module_msl(
+        &self,
+        desc: &ShaderModuleDescriptorMsl<'_>,
+    ) -> ShaderModule {
+        let module = unsafe { self.inner.create_shader_module_msl(desc) };
+        ShaderModule { inner: module }
+    }
+
     /// Creates an empty [`CommandEncoder`].
     #[must_use]
     pub fn create_command_encoder(&self, desc: &CommandEncoderDescriptor<'_>) -> CommandEncoder {

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -172,35 +172,25 @@ impl Device {
         ShaderModule { inner: module }
     }
 
-    /// Creates a shader module from SPIR-V binary directly.
+    /// Creates a shader module for passthrough to bypass naga and validations.
     ///
     /// # Safety
     ///
-    /// This function passes binary data to the backend as-is and can potentially result in a
-    /// driver crash or bogus behaviour. No attempt is made to ensure that data is valid SPIR-V.
-    ///
-    /// See also [`include_spirv_raw!`] and [`util::make_spirv_raw`].
+    /// This function passes data to the backend as-is and can potentially result in a
+    /// driver crash or bogus behaviour. No attempt is made to ensure that data is valid.
     #[must_use]
-    pub unsafe fn create_shader_module_spirv(
+    pub unsafe fn create_shader_module_passthrough(
         &self,
-        desc: &ShaderModuleDescriptorSpirV<'_>,
+        desc: &ShaderModuleDescriptorPassthrough<'_>,
     ) -> ShaderModule {
-        let module = unsafe { self.inner.create_shader_module_spirv(desc) };
-        ShaderModule { inner: module }
-    }
-
-    /// Creates a shader module from Metal MSL shader directly.
-    ///
-    /// # Safety
-    ///
-    /// This function passes the source to the backend as-is and can potentially result in a
-    /// driver crash or bogus behaviour. No attempt is made to ensure that source code is valid.
-    #[must_use]
-    pub unsafe fn create_shader_module_msl(
-        &self,
-        desc: &ShaderModuleDescriptorMsl<'_>,
-    ) -> ShaderModule {
-        let module = unsafe { self.inner.create_shader_module_msl(desc) };
+        let module = match desc {
+            ShaderModuleDescriptorPassthrough::SpirV(desc) => {
+                unsafe { self.inner.create_shader_module_spirv(desc) }
+            },
+            ShaderModuleDescriptorPassthrough::Msl(desc) => {
+                unsafe { self.inner.create_shader_module_msl(desc) }
+            },
+        };
         ShaderModule { inner: module }
     }
 

--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -236,3 +236,21 @@ pub struct ShaderModuleDescriptorSpirV<'a> {
     pub source: Cow<'a, [u32]>,
 }
 static_assertions::assert_impl_all!(ShaderModuleDescriptorSpirV<'_>: Send, Sync);
+
+/// Descriptor for a shader module given by Metal MSL source, for use with
+/// [`Device::create_shader_module_msl`].
+///
+/// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
+/// only WGSL source code strings are accepted.
+#[derive(Debug)]
+pub struct ShaderModuleDescriptorMsl<'a> {
+    /// Entrypoint.
+    pub entry_point: String,
+    /// Debug label of the shader module. This will show up in graphics debuggers for easy identification.
+    pub label: Label<'a>,
+    /// Number of workgroups in each dimension x, y and z.
+    pub num_workgroups: (u32, u32, u32),
+    /// Shader MSL source.
+    pub source: Cow<'a, str>,
+}
+static_assertions::assert_impl_all!(ShaderModuleDescriptorMsl<'_>: Send, Sync);

--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -223,8 +223,19 @@ pub struct ShaderModuleDescriptor<'a> {
 }
 static_assertions::assert_impl_all!(ShaderModuleDescriptor<'_>: Send, Sync);
 
-/// Descriptor for a shader module given by SPIR-V binary, for use with
-/// [`Device::create_shader_module_spirv`].
+/// Descriptor for a pre-compiled shader module passthrough, for use with
+/// [`Device::create_shader_module_passthrough`].
+///
+/// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
+/// only WGSL source code strings are accepted.
+pub enum ShaderModuleDescriptorPassthrough<'a> {
+    /// Passthrough for SPIR-V binaries.
+    SpirV(&'a ShaderModuleDescriptorSpirV<'a>),
+    /// Passthrough for MSL source code.
+    Msl(&'a ShaderModuleDescriptorMsl<'a>),
+}
+
+/// Descriptor for a shader module given by SPIR-V binary.
 ///
 /// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
 /// only WGSL source code strings are accepted.
@@ -237,8 +248,7 @@ pub struct ShaderModuleDescriptorSpirV<'a> {
 }
 static_assertions::assert_impl_all!(ShaderModuleDescriptorSpirV<'_>: Send, Sync);
 
-/// Descriptor for a shader module given by Metal MSL source, for use with
-/// [`Device::create_shader_module_msl`].
+/// Descriptor for a shader module given by Metal MSL source.
 ///
 /// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
 /// only WGSL source code strings are accepted.

--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -1,5 +1,4 @@
 use alloc::{
-    borrow::Cow,
     string::{String, ToString as _},
     vec,
     vec::Vec,
@@ -11,9 +10,9 @@ use crate::*;
 /// Handle to a compiled shader module.
 ///
 /// A `ShaderModule` represents a compiled shader module on the GPU. It can be created by passing
-/// source code to [`Device::create_shader_module`] or valid SPIR-V binary to
-/// [`Device::create_shader_module_spirv`]. Shader modules are used to define programmable stages
-/// of a pipeline.
+/// source code to [`Device::create_shader_module`]. MSL shader or SPIR-V binary can also be passed
+/// directly using [`Device::create_shader_module_passthrough`]. Shader modules are used to define
+/// programmable stages of a pipeline.
 ///
 /// Corresponds to [WebGPU `GPUShaderModule`](https://gpuweb.github.io/gpuweb/#shader-module).
 #[derive(Debug, Clone)]
@@ -182,14 +181,14 @@ pub enum ShaderSource<'a> {
     ///
     /// See also: [`util::make_spirv`], [`include_spirv`]
     #[cfg(feature = "spirv")]
-    SpirV(Cow<'a, [u32]>),
+    SpirV(alloc::borrow::Cow<'a, [u32]>),
     /// GLSL module as a string slice.
     ///
     /// Note: GLSL is not yet fully supported and must be a specific ShaderStage.
     #[cfg(feature = "glsl")]
     Glsl {
         /// The source code of the shader.
-        shader: Cow<'a, str>,
+        shader: alloc::borrow::Cow<'a, str>,
         /// The shader stage that the shader targets. For example, `naga::ShaderStage::Vertex`
         stage: naga::ShaderStage,
         /// Key-value pairs to represent defines sent to the glsl preprocessor.
@@ -199,10 +198,10 @@ pub enum ShaderSource<'a> {
     },
     /// WGSL module as a string slice.
     #[cfg(feature = "wgsl")]
-    Wgsl(Cow<'a, str>),
+    Wgsl(alloc::borrow::Cow<'a, str>),
     /// Naga module.
     #[cfg(feature = "naga-ir")]
-    Naga(Cow<'static, naga::Module>),
+    Naga(alloc::borrow::Cow<'static, naga::Module>),
     /// Dummy variant because `Naga` doesn't have a lifetime and without enough active features it
     /// could be the last one active.
     #[doc(hidden)]

--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -223,7 +223,7 @@ pub struct ShaderModuleDescriptor<'a> {
 }
 static_assertions::assert_impl_all!(ShaderModuleDescriptor<'_>: Send, Sync);
 
-/// Descriptor for a pre-compiled shader module passthrough, for use with
+/// Descriptor for a shader module that will bypass wgpu's shader tooling, for use with
 /// [`Device::create_shader_module_passthrough`].
 ///
 /// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,

--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -228,39 +228,17 @@ static_assertions::assert_impl_all!(ShaderModuleDescriptor<'_>: Send, Sync);
 ///
 /// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
 /// only WGSL source code strings are accepted.
-pub enum ShaderModuleDescriptorPassthrough<'a> {
-    /// Passthrough for SPIR-V binaries.
-    SpirV(&'a ShaderModuleDescriptorSpirV<'a>),
-    /// Passthrough for MSL source code.
-    Msl(&'a ShaderModuleDescriptorMsl<'a>),
-}
-
-/// Descriptor for a shader module given by SPIR-V binary.
-///
-/// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
-/// only WGSL source code strings are accepted.
-#[derive(Debug)]
-pub struct ShaderModuleDescriptorSpirV<'a> {
-    /// Debug label of the shader module. This will show up in graphics debuggers for easy identification.
-    pub label: Label<'a>,
-    /// Binary SPIR-V data, in 4-byte words.
-    pub source: Cow<'a, [u32]>,
-}
-static_assertions::assert_impl_all!(ShaderModuleDescriptorSpirV<'_>: Send, Sync);
+pub type ShaderModuleDescriptorPassthrough<'a> =
+    wgt::CreateShaderModuleDescriptorPassthrough<'a, Label<'a>>;
 
 /// Descriptor for a shader module given by Metal MSL source.
 ///
 /// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
 /// only WGSL source code strings are accepted.
-#[derive(Debug)]
-pub struct ShaderModuleDescriptorMsl<'a> {
-    /// Entrypoint.
-    pub entry_point: String,
-    /// Debug label of the shader module. This will show up in graphics debuggers for easy identification.
-    pub label: Label<'a>,
-    /// Number of workgroups in each dimension x, y and z.
-    pub num_workgroups: (u32, u32, u32),
-    /// Shader MSL source.
-    pub source: Cow<'a, str>,
-}
-static_assertions::assert_impl_all!(ShaderModuleDescriptorMsl<'_>: Send, Sync);
+pub type ShaderModuleDescriptorMsl<'a> = wgt::ShaderModuleDescriptorMsl<'a, Label<'a>>;
+
+/// Descriptor for a shader module given by SPIR-V binary.
+///
+/// This type is unique to the Rust API of `wgpu`. In the WebGPU specification,
+/// only WGSL source code strings are accepted.
+pub type ShaderModuleDescriptorSpirV<'a> = wgt::ShaderModuleDescriptorSpirV<'a, Label<'a>>;

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1843,18 +1843,11 @@ impl dispatch::DeviceInterface for WebDevice {
         .into()
     }
 
-    unsafe fn create_shader_module_spirv(
+    unsafe fn create_shader_module_passthrough(
         &self,
-        _desc: &crate::ShaderModuleDescriptorSpirV<'_>,
-    ) -> dispatch::DispatchShaderModule {
-        unreachable!("SPIRV_SHADER_PASSTHROUGH is not enabled for this backend")
-    }
-
-    unsafe fn create_shader_module_msl(
-        &self,
-        _desc: &crate::ShaderModuleDescriptorMsl<'_>,
-    ) -> dispatch::DispatchShaderModule {
-        unreachable!("MSL_SHADER_PASSTHROUGH is not enabled for this backend")
+        desc: &crate::ShaderModuleDescriptorPassthrough<'_>,
+    ) -> DispatchShaderModule {
+        unreachable!("No XXX_SHADER_PASSTHROUGH feature enabled for this backend")
     }
 
     fn create_bind_group_layout(

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1850,6 +1850,13 @@ impl dispatch::DeviceInterface for WebDevice {
         unreachable!("SPIRV_SHADER_PASSTHROUGH is not enabled for this backend")
     }
 
+    unsafe fn create_shader_module_msl(
+        &self,
+        _desc: &crate::ShaderModuleDescriptorMsl<'_>,
+    ) -> dispatch::DispatchShaderModule {
+        unreachable!("MSL_SHADER_PASSTHROUGH is not enabled for this backend")
+    }
+
     fn create_bind_group_layout(
         &self,
         desc: &crate::BindGroupLayoutDescriptor<'_>,

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1845,8 +1845,8 @@ impl dispatch::DeviceInterface for WebDevice {
 
     unsafe fn create_shader_module_passthrough(
         &self,
-        desc: &crate::ShaderModuleDescriptorPassthrough<'_>,
-    ) -> DispatchShaderModule {
+        _desc: &crate::ShaderModuleDescriptorPassthrough<'_>,
+    ) -> dispatch::DispatchShaderModule {
         unreachable!("No XXX_SHADER_PASSTHROUGH feature enabled for this backend")
     }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1047,7 +1047,7 @@ impl dispatch::DeviceInterface for CoreDevice {
         &self,
         desc: &crate::ShaderModuleDescriptorPassthrough<'_>,
     ) -> dispatch::DispatchShaderModule {
-        let desc = desc.into();
+        let desc = desc.map_label(|l| l.map(std::borrow::Cow::from));
         let (id, error) = unsafe {
             self.context
                 .0

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1,5 +1,5 @@
 use alloc::{
-    borrow::Cow::Borrowed,
+    borrow::Cow::{self, Borrowed},
     boxed::Box,
     format,
     string::{String, ToString as _},
@@ -1047,7 +1047,7 @@ impl dispatch::DeviceInterface for CoreDevice {
         &self,
         desc: &crate::ShaderModuleDescriptorPassthrough<'_>,
     ) -> dispatch::DispatchShaderModule {
-        let desc = desc.map_label(|l| l.map(std::borrow::Cow::from));
+        let desc = desc.map_label(|l| l.map(Cow::from));
         let (id, error) = unsafe {
             self.context
                 .0

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1043,76 +1043,30 @@ impl dispatch::DeviceInterface for CoreDevice {
         .into()
     }
 
-    unsafe fn create_shader_module_spirv(
+    unsafe fn create_shader_module_passthrough(
         &self,
-        desc: &crate::ShaderModuleDescriptorSpirV<'_>,
+        desc: &crate::ShaderModuleDescriptorPassthrough<'_>,
     ) -> dispatch::DispatchShaderModule {
-        let descriptor = wgc::pipeline::ShaderModuleDescriptor {
-            label: desc.label.map(Borrowed),
-            // Doesn't matter the value since spirv shaders aren't mutated to include
-            // runtime checks
-            runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
-        };
+        let desc = desc.into();
         let (id, error) = unsafe {
-            self.context.0.device_create_shader_module_spirv(
-                self.id,
-                &descriptor,
-                Borrowed(&desc.source),
-                None,
-            )
+            self.context
+                .0
+                .device_create_shader_module_passthrough(self.id, &desc, None)
         };
-        let compilation_info = match error {
-            Some(cause) => {
-                self.context.handle_error(
-                    &self.error_sink,
-                    cause.clone(),
-                    desc.label,
-                    "Device::create_shader_module_spirv",
-                );
-                CompilationInfo::from(cause)
-            }
-            None => CompilationInfo { messages: vec![] },
-        };
-        CoreShaderModule {
-            context: self.context.clone(),
-            id,
-            compilation_info,
-        }
-        .into()
-    }
 
-    unsafe fn create_shader_module_msl(
-        &self,
-        desc: &crate::ShaderModuleDescriptorMsl<'_>,
-    ) -> dispatch::DispatchShaderModule {
-        let descriptor = wgc::pipeline::ShaderModuleDescriptor {
-            label: desc.label.map(Borrowed),
-            // Doesn't matter the value since msl passthrough shaders aren't mutated to include
-            // runtime checks
-            runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
-        };
-        let (id, error) = unsafe {
-            self.context.0.device_create_shader_module_msl(
-                self.id,
-                &descriptor,
-                Borrowed(&desc.source),
-                &desc.entry_point,
-                desc.num_workgroups,
-                None,
-            )
-        };
         let compilation_info = match error {
             Some(cause) => {
                 self.context.handle_error(
                     &self.error_sink,
                     cause.clone(),
-                    desc.label,
-                    "Device::create_shader_module_msl",
+                    desc.label().as_deref(),
+                    "Device::create_shader_module_passthrough",
                 );
                 CompilationInfo::from(cause)
             }
             None => CompilationInfo { messages: vec![] },
         };
+
         CoreShaderModule {
             context: self.context.clone(),
             id,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1081,6 +1081,46 @@ impl dispatch::DeviceInterface for CoreDevice {
         .into()
     }
 
+    unsafe fn create_shader_module_msl(
+        &self,
+        desc: &crate::ShaderModuleDescriptorMsl<'_>,
+    ) -> dispatch::DispatchShaderModule {
+        let descriptor = wgc::pipeline::ShaderModuleDescriptor {
+            label: desc.label.map(Borrowed),
+            // Doesn't matter the value since msl passthrough shaders aren't mutated to include
+            // runtime checks
+            runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
+        };
+        let (id, error) = unsafe {
+            self.context.0.device_create_shader_module_msl(
+                self.id,
+                &descriptor,
+                Borrowed(&desc.source),
+                &desc.entry_point,
+                desc.num_workgroups,
+                None,
+            )
+        };
+        let compilation_info = match error {
+            Some(cause) => {
+                self.context.handle_error(
+                    &self.error_sink,
+                    cause.clone(),
+                    desc.label,
+                    "Device::create_shader_module_msl",
+                );
+                CompilationInfo::from(cause)
+            }
+            None => CompilationInfo { messages: vec![] },
+        };
+        CoreShaderModule {
+            context: self.context.clone(),
+            id,
+            compilation_info,
+        }
+        .into()
+    }
+
     fn create_bind_group_layout(
         &self,
         desc: &crate::BindGroupLayoutDescriptor<'_>,

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -115,6 +115,10 @@ pub trait DeviceInterface: CommonTraits {
         &self,
         desc: &crate::ShaderModuleDescriptorSpirV<'_>,
     ) -> DispatchShaderModule;
+    unsafe fn create_shader_module_msl(
+        &self,
+        desc: &crate::ShaderModuleDescriptorMsl<'_>,
+    ) -> DispatchShaderModule;
     fn create_bind_group_layout(
         &self,
         desc: &crate::BindGroupLayoutDescriptor<'_>,

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -111,14 +111,12 @@ pub trait DeviceInterface: CommonTraits {
         desc: crate::ShaderModuleDescriptor<'_>,
         shader_bound_checks: crate::ShaderRuntimeChecks,
     ) -> DispatchShaderModule;
-    unsafe fn create_shader_module_spirv(
+
+    unsafe fn create_shader_module_passthrough(
         &self,
-        desc: &crate::ShaderModuleDescriptorSpirV<'_>,
+        desc: &crate::ShaderModuleDescriptorPassthrough<'_>,
     ) -> DispatchShaderModule;
-    unsafe fn create_shader_module_msl(
-        &self,
-        desc: &crate::ShaderModuleDescriptorMsl<'_>,
-    ) -> DispatchShaderModule;
+
     fn create_bind_group_layout(
         &self,
         desc: &crate::BindGroupLayoutDescriptor<'_>,

--- a/wgpu/src/macros.rs
+++ b/wgpu/src/macros.rs
@@ -106,9 +106,11 @@ macro_rules! include_spirv_raw {
     ($($token:tt)*) => {
         {
             //log::info!("including '{}'", $($token)*);
-            $crate::ShaderModuleDescriptorSpirV {
-                label: $crate::__macro_helpers::Some($($token)*),
-                source: $crate::util::make_spirv_raw($crate::__macro_helpers::include_bytes!($($token)*)),
+            $crate::ShaderModuleDescriptorPassthrough::SpirV {
+                $crate::ShaderModuleDescriptorSpirV {
+                    label: $crate::__macro_helpers::Some($($token)*),
+                    source: $crate::util::make_spirv_raw($crate::__macro_helpers::include_bytes!($($token)*)),
+                }
             }
         }
     };

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -39,10 +39,10 @@ pub fn make_spirv(data: &[u8]) -> super::ShaderSource<'_> {
     super::ShaderSource::SpirV(make_spirv_raw(data))
 }
 
-/// Version of `make_spirv` intended for use with [`Device::create_shader_module_spirv`].
+/// Version of `make_spirv` intended for use with [`Device::create_shader_module_passthrough`].
 /// Returns a raw slice instead of [`ShaderSource`](super::ShaderSource).
 ///
-/// [`Device::create_shader_module_spirv`]: crate::Device::create_shader_module_spirv
+/// [`Device::create_shader_module_passthrough`]: crate::Device::create_shader_module_passthrough
 pub fn make_spirv_raw(data: &[u8]) -> Cow<'_, [u32]> {
     const MAGIC_NUMBER: u32 = 0x0723_0203;
     assert_eq!(


### PR DESCRIPTION
**Description**
This PR adds the possibility to directly pass a metal shader and create a compute pipeline to execute the passed shader without any validation. This allows [CubeCL](https://github.com/tracel-ai/cubecl) to use its wgpu runtime to execute metal kernels directly compiled by CubeCL JIT compiler and benefit from support for advanced metal features.

**Testing**
Tested with a WIP metal compiler using the wgpu runtime of CubeCL.
More info about how to test this soon.

**Squash or Rebase?**

Ok to be squashed.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
