### PR TITLE
[naga] Let `write_type_inner` match `TypeInner` exhaustively.

### DIFF
--- a/naga/src/common/wgsl/types.rs
+++ b/naga/src/common/wgsl/types.rs
@@ -245,7 +245,13 @@ pub trait TypeContext<W: Write> {
                 let caps = if vertex_return { "<vertex_return>" } else { "" };
                 write!(out, "acceleration_structure{}", caps)?
             }
-            _ => unreachable!("invalid TypeInner"),
+            TypeInner::Struct { .. } => {
+                unreachable!("structs can only be referenced by name in WGSL");
+            }
+            TypeInner::RayQuery { vertex_return } => {
+                let caps = if vertex_return { "<vertex_return>" } else { "" };
+                write!(out, "ray_query{}", caps)?
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Change the match in the `naga::common::wgsl::TypeContext` trait's default implementation of `write_type_inner` to be exhaustive, so that it is more likely to be kept up to date when changes are made to the IR.

Coincidentally, add support for `TypeInner::RayQuery`.
