### PR TITLE
Make `std` usage optional for `wgpu`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ wgpu = { version = "24.0.0", path = "./wgpu", default-features = false, features
     "webgl",
     "noop",       # This should be removed if we ever have non-test crates that depend on wgpu
 ] }
-wgpu-core = { version = "24.0.0", path = "./wgpu-core" }
+wgpu-core = { version = "24.0.0", path = "./wgpu-core", default-features = false }
 wgpu-hal = { version = "24.0.0", path = "./wgpu-hal" }
 wgpu-macros = { version = "24.0.0", path = "./wgpu-macros" }
 wgpu-test = { version = "24.0.0", path = "./tests" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ wgpu-core = { version = "24.0.0", path = "./wgpu-core" }
 wgpu-hal = { version = "24.0.0", path = "./wgpu-hal" }
 wgpu-macros = { version = "24.0.0", path = "./wgpu-macros" }
 wgpu-test = { version = "24.0.0", path = "./tests" }
-wgpu-types = { version = "24.0.0", path = "./wgpu-types" }
+wgpu-types = { version = "24.0.0", path = "./wgpu-types", default-features = false }
 
 wgpu-core-deps-windows-linux-android = { version = "24.0.0", path = "./wgpu-core/platform-deps/windows-linux-android" }
 wgpu-core-deps-apple = { version = "24.0.0", path = "./wgpu-core/platform-deps/apple" }

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -17,6 +17,7 @@ path = "lib.rs"
 # so the whole workspace can built as wasm.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 wgpu-core = { workspace = true, features = [
+    "std",
     "raw-window-handle",
     "trace",
     "replay",

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -29,7 +29,7 @@ ignored = ["cfg_aliases"]
 [lib]
 
 [features]
-default = ["dx12", "metal", "gles", "vulkan", "wgsl", "webgpu"]
+default = ["std", "dx12", "metal", "gles", "vulkan", "wgsl", "webgpu"]
 
 #! ### Backends
 # --------------------------------------------------------------------
@@ -131,6 +131,13 @@ static-dxc = ["wgpu-core?/static-dxc"]
 #! ### Other
 # --------------------------------------------------------------------
 
+## Enables functionality dependent on `std::sync` and `std::thread`:
+## 
+## * `Send + Sync` for wgpu types
+## * `wgpu::util::StagingBelt`
+## * `*_from_env()` functions
+std = ["wgpu-core?/std", "wgpu-types/std"]
+
 ## Internally count resources and events for debugging purposes. If the counters
 ## feature is disabled, the counting infrastructure is removed from the build and
 ## the exposed counters always return 0.
@@ -144,6 +151,7 @@ counters = ["wgpu-core?/counters"]
 ## This is technically *very* unsafe in a multithreaded environment,
 ## but on a wasm binary compiled without atomics is a definitionally single-threaded environment.
 fragile-send-sync-non-atomic-wasm = [
+    "std",
     "wgpu-core?/fragile-send-sync-non-atomic-wasm",
     "wgpu-types/fragile-send-sync-non-atomic-wasm",
 ]

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -3,9 +3,12 @@ fn main() {
         native: { not(target_arch = "wasm32") },
         Emscripten: { all(target_arch = "wasm32", target_os = "emscripten") },
 
-        send_sync: { any(
-            native,
-            all(feature = "fragile-send-sync-non-atomic-wasm", not(target_feature = "atomics"))
+        send_sync: { all(
+            feature = "std",
+            any(
+                native,
+                all(feature = "fragile-send-sync-non-atomic-wasm", not(target_feature = "atomics"))
+            )
         ) },
 
         // Backends - keep this in sync with `wgpu-core/Cargo.toml` & docs in `wgpu/Cargo.toml`

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -111,6 +111,7 @@ pub struct BlasTriangleGeometry<'a> {
     /// Transform buffer offset in bytes (optional, required if transform buffer is present).
     pub transform_buffer_offset: Option<wgt::BufferAddress>,
 }
+#[cfg(send_sync)]
 static_assertions::assert_impl_all!(BlasTriangleGeometry<'_>: WasmNotSendSync);
 
 /// Contains the sets of geometry that go into a [Blas].
@@ -118,6 +119,7 @@ pub enum BlasGeometries<'a> {
     /// Triangle geometry variant.
     TriangleGeometries(Vec<BlasTriangleGeometry<'a>>),
 }
+#[cfg(send_sync)]
 static_assertions::assert_impl_all!(BlasGeometries<'_>: WasmNotSendSync);
 
 /// Builds the given sets of geometry into the given [Blas].
@@ -127,6 +129,7 @@ pub struct BlasBuildEntry<'a> {
     /// Geometries.
     pub geometry: BlasGeometries<'a>,
 }
+#[cfg(send_sync)]
 static_assertions::assert_impl_all!(BlasBuildEntry<'_>: WasmNotSendSync);
 
 #[derive(Debug, Clone)]
@@ -141,6 +144,7 @@ pub struct Blas {
     pub(crate) handle: Option<u64>,
     pub(crate) inner: dispatch::DispatchBlas,
 }
+#[cfg(send_sync)]
 static_assertions::assert_impl_all!(Blas: WasmNotSendSync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(Blas => .inner);

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -1,5 +1,4 @@
 use core::{error, fmt};
-use std::thread;
 
 use crate::*;
 
@@ -42,7 +41,7 @@ impl SurfaceTexture {
 
 impl Drop for SurfaceTexture {
     fn drop(&mut self) {
-        if !self.presented && !thread::panicking() {
+        if !self.presented && !definitely_panicking() {
             self.detail.texture_discard();
         }
     }
@@ -77,3 +76,14 @@ impl fmt::Display for SurfaceError {
 }
 
 impl error::Error for SurfaceError {}
+
+/// Returns `true` if the current thread is unwinding and `false` if it is not or the `std` feature
+/// is disabled.
+fn definitely_panicking() -> bool {
+    #[cfg(feature = "std")]
+    if std::thread::panicking() {
+        return true;
+    }
+
+    false
+}

--- a/wgpu/src/api/tlas.rs
+++ b/wgpu/src/api/tlas.rs
@@ -28,6 +28,7 @@ pub(crate) struct TlasShared {
 pub struct Tlas {
     pub(crate) shared: Arc<TlasShared>,
 }
+#[cfg(send_sync)]
 static_assertions::assert_impl_all!(Tlas: WasmNotSendSync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(Tlas => .shared.inner);
@@ -43,6 +44,7 @@ pub struct TlasBuildEntry<'a> {
     /// Number of instances in the instance buffer.
     pub instance_count: u32,
 }
+#[cfg(send_sync)]
 static_assertions::assert_impl_all!(TlasBuildEntry<'_>: WasmNotSendSync);
 
 /// The safe version of [`TlasBuildEntry`], containing [`TlasInstance`]s instead of a raw buffer.
@@ -51,6 +53,7 @@ pub struct TlasPackage {
     pub(crate) instances: Vec<Option<TlasInstance>>,
     pub(crate) lowest_unmodified: u32,
 }
+#[cfg(send_sync)]
 static_assertions::assert_impl_all!(TlasPackage: WasmNotSendSync);
 
 impl TlasPackage {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -31,6 +31,7 @@
 #![cfg_attr(not(any(wgpu_core, webgpu)), allow(unused))]
 
 extern crate alloc;
+#[cfg(feature = "std")]
 extern crate std;
 #[cfg(wgpu_core)]
 pub extern crate wgpu_core as wgc;

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -1,10 +1,11 @@
+#[cfg(feature = "std")]
 use crate::{Adapter, Instance, RequestAdapterOptions, Surface};
 
 #[cfg(doc)]
 use crate::Backends;
 
 /// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable.
-#[cfg(native)]
+#[cfg(all(feature = "std", native))]
 pub fn initialize_adapter_from_env(
     instance: &Instance,
     compatible_surface: Option<&Surface<'_>>,
@@ -36,7 +37,7 @@ pub fn initialize_adapter_from_env(
 }
 
 /// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable.
-#[cfg(not(native))]
+#[cfg(all(feature = "std", not(native)))]
 pub fn initialize_adapter_from_env(
     _instance: &Instance,
     _compatible_surface: Option<&Surface<'_>>,
@@ -44,6 +45,7 @@ pub fn initialize_adapter_from_env(
     Err(wgt::RequestAdapterError::EnvNotSet)
 }
 
+#[cfg(feature = "std")]
 /// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable and if it doesn't exist fall back on a default adapter.
 pub async fn initialize_adapter_from_env_or_default(
     instance: &Instance,

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -3,6 +3,7 @@
 //! Nothing in this module is a part of the WebGPU API specification;
 //! they are unique to the `wgpu` library.
 
+#[cfg(feature = "std")]
 mod belt;
 mod device;
 mod encoder;
@@ -12,6 +13,7 @@ mod texture_blitter;
 use alloc::{borrow::Cow, format, string::String, sync::Arc, vec};
 use core::ptr::copy_nonoverlapping;
 
+#[cfg(feature = "std")]
 pub use belt::StagingBelt;
 pub use device::{BufferInitDescriptor, DeviceExt};
 pub use encoder::RenderEncoder;


### PR DESCRIPTION
**Connections**
Part of implementing https://github.com/gfx-rs/wgpu/issues/6826. Followup to https://github.com/gfx-rs/wgpu/pull/7279.

**Description**
Adds a `std` feature to `wgpu`, without which it does not depend on `wgpu-core?/std`.

Doesn’t build yet, because the `WasmNotSendSync` trait bound is not met. Further work will be needed, and I’m not sure what yet; I'm publishing this draft PR to help people see what the problem space currently looks like.

**Testing**
TBD

**Squash or Rebase?**
TBD

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
