### PR TITLE
docs: Add links and examples for `VertexAttribute` and friends.

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4725,13 +4725,16 @@ pub enum VertexStepMode {
 
 /// Vertex inputs (attributes) to shaders.
 ///
-/// Arrays of these can be made with the [`vertex_attr_array`]
-/// macro. Vertex attributes are assumed to be tightly packed.
+/// These are used to specify the individual attributes within a [`VertexBufferLayout`].
+/// See its documentation for an example.
+///
+/// The [`vertex_attr_array!`] macro can help create these with appropriate offsets.
 ///
 /// Corresponds to [WebGPU `GPUVertexAttribute`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuvertexattribute).
 ///
-/// [`vertex_attr_array`]: ../wgpu/macro.vertex_attr_array.html
+/// [`vertex_attr_array!`]: ../wgpu/macro.vertex_attr_array.html
+/// [`VertexBufferLayout`]: ../wgpu/struct.VertexBufferLayout.html
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -108,6 +108,8 @@ impl RenderPass<'_> {
     ///
     /// Subsequent calls to [`draw`] and [`draw_indexed`] on this
     /// [`RenderPass`] will use `buffer` as one of the source vertex buffers.
+    /// The format of the data in the buffer is specified by the [`VertexBufferLayout`] in the
+    /// pipeline's [`VertexState`].
     ///
     /// The `slot` refers to the index of the matching descriptor in
     /// [`VertexState::buffers`].

--- a/wgpu/src/api/render_pipeline.rs
+++ b/wgpu/src/api/render_pipeline.rs
@@ -30,12 +30,42 @@ impl RenderPipeline {
     }
 }
 
-/// Describes how the vertex buffer is interpreted.
+/// Specifies an interpretation of the bytes of a vertex buffer as vertex attributes.
 ///
-/// For use in [`VertexState`].
+/// Use this in a [`RenderPipelineDescriptor`] to describe the format of the vertex buffers that
+/// are passed to [`RenderPass::set_vertex_buffer()`].
 ///
 /// Corresponds to [WebGPU `GPUVertexBufferLayout`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuvertexbufferlayout).
+///
+/// # Example
+///
+/// The following example defines a `struct` with three fields,
+/// and a [`VertexBufferLayout`] that contains [`VertexAttribute`]s for each field,
+/// using the [`vertex_attr_array!`] macro to compute attribute offsets:
+///
+/// ```
+/// #[repr(C, packed)]
+/// struct Vertex {
+///     foo: [f32; 2],
+///     bar: f32,
+///     baz: [u16; 4],
+/// }
+///
+/// impl Vertex {
+///     /// Layout to use with a buffer whose contents are a `[Vertex]`.
+///     pub const LAYOUT: wgpu::VertexBufferLayout<'static> = wgpu::VertexBufferLayout {
+///         array_stride: size_of::<Self>() as wgpu::BufferAddress,
+///         step_mode: wgpu::VertexStepMode::Vertex,
+///         attributes: &wgpu::vertex_attr_array![
+///             0 => Float32x2,
+///             1 => Float32,
+///             2 => Uint16x4,
+///         ],
+///     };
+/// }
+///
+/// # assert_eq!(Vertex::LAYOUT.attributes[2].offset, Vertex::LAYOUT.array_stride - 2 * 4);
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct VertexBufferLayout<'a> {
     /// The stride, in bytes, between elements of this buffer (between vertices).
@@ -71,7 +101,11 @@ pub struct VertexState<'a> {
     ///
     /// This implements `Default`, and for most users can be set to `Default::default()`
     pub compilation_options: PipelineCompilationOptions<'a>,
-    /// The format of any vertex buffers used with this pipeline.
+    /// The format of any vertex buffers used with this pipeline via
+    /// [`RenderPass::set_vertex_buffer()`].
+    ///
+    /// The attribute locations and types specified in this layout must match the
+    /// locations and types of the inputs to the `entry_point` function.`
     pub buffers: &'a [VertexBufferLayout<'a>],
 }
 #[cfg(send_sync)]


### PR DESCRIPTION
**Description**
* Added “upward” links from `VertexAttribute` and `VertexBufferLayout` to the places they are used.
* Documented the exact expected inputs of `vertex_attr_array!` and hid the internal implementation.
* Added doc-test examples for:
    * `VertexBufferLayout`, demonstrating how to construct a `VertexBufferLayout` that corresponds to a `struct`.
    * `vertex_attr_array!`, demonstrating exactly what the output of the macro is.

**Testing**
`cargo test --doc` and manual checking for broken links.

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
