### PR TITLE
Remove `Arc` from buffer in `util::DownloadBuffer`

### DIFF
--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -9,7 +9,7 @@ mod encoder;
 mod init;
 mod texture_blitter;
 
-use alloc::{borrow::Cow, format, string::String, sync::Arc, vec};
+use alloc::{borrow::Cow, format, string::String, vec};
 use core::ptr::copy_nonoverlapping;
 
 pub use belt::StagingBelt;
@@ -86,7 +86,7 @@ pub fn make_spirv_raw(data: &[u8]) -> Cow<'_, [u32]> {
 
 /// CPU accessible buffer used to download data back from the GPU.
 pub struct DownloadBuffer {
-    _gpu_buffer: Arc<super::Buffer>,
+    _gpu_buffer: super::Buffer,
     mapped_range: dispatch::DispatchBufferMappedRange,
 }
 
@@ -103,12 +103,12 @@ impl DownloadBuffer {
             None => buffer.buffer.map_context.lock().total_size - buffer.offset,
         };
 
-        let download = Arc::new(device.create_buffer(&super::BufferDescriptor {
+        let download = device.create_buffer(&super::BufferDescriptor {
             size,
             usage: super::BufferUsages::COPY_DST | super::BufferUsages::MAP_READ,
             mapped_at_creation: false,
             label: None,
-        }));
+        });
 
         let mut encoder =
             device.create_command_encoder(&super::CommandEncoderDescriptor { label: None });


### PR DESCRIPTION
**Description**
The `wgpu::Buffer` inside of the `wgpu::util::DownloadBuffer` was previously wrapped in an `Arc`, but since wgpu 24 `Buffer` implements clone through an internal `Arc` anyways, so this is redundant.

Since the buffer contained within the `DownloadBuffer` is private, the only way of accessing data in the `DownloadBuffer` seems to be the `Deref` implementation, which does not change in any way, so this should have absolutely no side effects.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests. **I could not get `cargo xtask test` to run on either the original source or my modified code because of #7068**. I don't expect this change to break anything in any way, but I'd be glad if someone could check if everything is OK
