### PR TITLE
Make buffer mapping example runnable and remove obsolete `Arc`; also add `Device::noop().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,9 +172,9 @@ By @wumpf in [#7144](https://github.com/gfx-rs/wgpu/pull/7144)
 
 - It is now possible to create a dummy `wgpu` device even when no GPU is available. This may be useful for testing of code which manages graphics resources. Currently, it supports reading and writing buffers, and other resource types can be created but do nothing.
 
-  To use it, enable the `noop` feature of `wgpu`, and add `NoopBackendOptions { enable: true }` to the backend options; this is an additional safeguard beyond the `Backends` bits.
+  To use it, enable the `noop` feature of `wgpu`, and either call `Device::noop()`, or add `NoopBackendOptions { enable: true }` to the backend options of your `Instance` (this is an additional safeguard beyond the `Backends` bits).
 
-  By @kpreid in [#7063](https://github.com/gfx-rs/wgpu/pull/7063).
+  By @kpreid in [#7063](https://github.com/gfx-rs/wgpu/pull/7063) and [#7342](https://github.com/gfx-rs/wgpu/pull/7342).
 
 - Add `Buffer` methods corresponding to `BufferSlice` methods, so you can skip creating a `BufferSlice` when it offers no benefit, and `BufferSlice::slice()` for sub-slicing a slice. By @kpreid in [#7123](https://github.com/gfx-rs/wgpu/pull/7123).
 - Add `BufferSlice::buffer()`, `BufferSlice::offset()` and `BufferSlice::size()`. By @kpreid in [#7148](https://github.com/gfx-rs/wgpu/pull/7148).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4602,6 +4602,7 @@ version = "24.0.0"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.0",
+ "bytemuck",
  "cfg_aliases 0.2.1",
  "document-features",
  "hashbrown",

--- a/tests/validation-tests/api/binding_arrays.rs
+++ b/tests/validation-tests/api/binding_arrays.rs
@@ -5,7 +5,7 @@ use wgpu_test::fail;
 
 #[test]
 fn dynamic_offset() {
-    let (device, _queue) = crate::request_noop_device_with_desc(&DeviceDescriptor {
+    let (device, _queue) = wgpu::Device::noop(&DeviceDescriptor {
         required_features: Features::TEXTURE_BINDING_ARRAY,
         required_limits: Limits {
             max_binding_array_elements_per_shader_stage: 4,
@@ -50,7 +50,7 @@ fn dynamic_offset() {
 
 #[test]
 fn uniform_buffer() {
-    let (device, _queue) = crate::request_noop_device_with_desc(&DeviceDescriptor {
+    let (device, _queue) = wgpu::Device::noop(&DeviceDescriptor {
         required_features: Features::TEXTURE_BINDING_ARRAY,
         required_limits: Limits {
             max_binding_array_elements_per_shader_stage: 4,

--- a/tests/validation-tests/api/buffer.rs
+++ b/tests/validation-tests/api/buffer.rs
@@ -5,7 +5,7 @@
 #[test]
 #[should_panic = "Buffer with '' label has been destroyed"]
 fn destroyed_buffer() {
-    let (device, queue) = crate::request_noop_device();
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
     let buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
         size: 1024,

--- a/tests/validation-tests/api/buffer_slice.rs
+++ b/tests/validation-tests/api/buffer_slice.rs
@@ -9,7 +9,7 @@ const ARBITRARY_DESC: &wgpu::BufferDescriptor = &wgpu::BufferDescriptor {
 
 #[test]
 fn reslice_success() {
-    let (device, _queue) = crate::request_noop_device();
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
     let buffer = device.create_buffer(ARBITRARY_DESC);
 
     assert_eq!(buffer.slice(10..90).slice(10..70), buffer.slice(20..80));
@@ -18,7 +18,7 @@ fn reslice_success() {
 #[test]
 #[should_panic = "slice offset 10 size 80 is out of range for buffer of size 80"]
 fn reslice_out_of_bounds() {
-    let (device, _queue) = crate::request_noop_device();
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
     let buffer = device.create_buffer(ARBITRARY_DESC);
 
     buffer.slice(10..90).slice(10..90);
@@ -26,7 +26,7 @@ fn reslice_out_of_bounds() {
 
 #[test]
 fn getters() {
-    let (device, _queue) = crate::request_noop_device();
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
     let buffer = device.create_buffer(ARBITRARY_DESC);
 
     let slice_with_size = buffer.slice(10..90);
@@ -52,7 +52,7 @@ fn getters() {
 
 #[test]
 fn into_buffer_binding() {
-    let (device, _queue) = crate::request_noop_device();
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
     let buffer = device.create_buffer(ARBITRARY_DESC);
 
     // BindingResource doesn’t implement PartialEq, so use matching

--- a/tests/validation-tests/api/texture.rs
+++ b/tests/validation-tests/api/texture.rs
@@ -5,7 +5,7 @@
 #[test]
 #[should_panic = "Texture with 'dst' label has been destroyed"]
 fn destroyed_texture() {
-    let (device, queue) = crate::request_noop_device();
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
     let size = wgpu::Extent3d {
         width: 256,
         height: 256,

--- a/tests/validation-tests/noop.rs
+++ b/tests/validation-tests/noop.rs
@@ -15,8 +15,23 @@ fn device_is_not_available_by_default() {
 }
 
 #[test]
+fn device_is_available_when_requested() {
+    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::NOOP,
+        backend_options: wgpu::BackendOptions {
+            noop: wgpu::NoopBackendOptions { enable: true },
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))
+        .expect("noop backend adapter absent when it should be");
+}
+
+#[test]
 fn device_and_buffers() {
-    let (device, queue) = crate::request_noop_device();
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
 
     // Demonstrate that creating and *writing* to a buffer succeeds.
     // This also involves creation of a staging buffer.

--- a/tests/validation-tests/root.rs
+++ b/tests/validation-tests/root.rs
@@ -2,27 +2,3 @@
 
 mod api;
 mod noop;
-
-/// Obtain a device using [`wgpu::Backend::Noop`].
-/// This should never fail.
-fn request_noop_device() -> (wgpu::Device, wgpu::Queue) {
-    request_noop_device_with_desc(&wgpu::DeviceDescriptor::default())
-}
-
-fn request_noop_device_with_desc(desc: &wgpu::DeviceDescriptor) -> (wgpu::Device, wgpu::Queue) {
-    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::NOOP,
-        backend_options: wgpu::BackendOptions {
-            noop: wgpu::NoopBackendOptions { enable: true },
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-
-    let adapter =
-        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))
-            .expect("adapter");
-    assert_eq!(adapter.get_info().backend, wgpu::Backend::Noop);
-
-    pollster::block_on(adapter.request_device(desc)).expect("device")
-}

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -222,5 +222,9 @@ smallvec.workspace = true
 [target.'cfg(not(target_has_atomic = "64"))'.dependencies]
 portable-atomic.workspace = true
 
+[dev-dependencies]
+# Used in doc-tests
+bytemuck.workspace = true
+
 [build-dependencies]
 cfg_aliases.workspace = true


### PR DESCRIPTION
**Description**
* The buffer mapping example code contains a no-longer-needed `Arc`. Remove it and update the explanation.
* Remove `.slice(..)` too.
* Make the example a fully functional doctest using the noop backend.
* Add `Device::noop()`.
    
  This is a useful shortcut for tests and example code, allowing it to create a noop device concisely without needing to deal with nonexistent fallibility and asynchrony.

**Testing**
Ran tests; read the docs.

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
