### PR TITLE
Box error values in Results

### DIFF
--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -174,8 +174,8 @@ pub(crate) enum Error<'a> {
     BadTexture(Span),
     BadTypeCast {
         span: Span,
-        from_type: Box<str>,
-        to_type: Box<str>,
+        from_type: String,
+        to_type: String,
     },
     BadTextureSampleType {
         span: Span,
@@ -211,8 +211,8 @@ pub(crate) enum Error<'a> {
     TypeNotInferable(Span),
     InitializationTypeMismatch {
         name: Span,
-        expected: Box<str>,
-        got: Box<str>,
+        expected: String,
+        got: String,
     },
     DeclMissingTypeAndInit(Span),
     MissingAttribute(&'static str, Span),
@@ -342,24 +342,24 @@ impl From<&'static str> for DiagnosticAttributeNotSupportedPosition {
 #[derive(Clone, Debug)]
 pub(crate) struct AutoConversionError {
     pub dest_span: Span,
-    pub dest_type: Box<str>,
+    pub dest_type: String,
     pub source_span: Span,
-    pub source_type: Box<str>,
+    pub source_type: String,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct AutoConversionLeafScalarError {
     pub dest_span: Span,
-    pub dest_scalar: Box<str>,
+    pub dest_scalar: String,
     pub source_span: Span,
-    pub source_type: Box<str>,
+    pub source_type: String,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct ConcretizationFailedError {
     pub expr_span: Span,
-    pub expr_type: Box<str>,
-    pub scalar: Box<str>,
+    pub expr_type: String,
+    pub scalar: String,
     pub inner: ConstantEvaluatorError,
 }
 
@@ -1178,9 +1178,4 @@ impl<'a> Error<'a> {
             }
         }
     }
-}
-
-#[test]
-fn test_error_size() {
-    assert!(size_of::<Error<'_>>() <= 48);
 }

--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -6,7 +6,7 @@ use alloc::{
 };
 use core::num::NonZeroU32;
 
-use crate::front::wgsl::error::Error;
+use crate::front::wgsl::{Error, Result};
 use crate::front::wgsl::lower::{ExpressionContext, Lowerer};
 use crate::front::wgsl::parse::ast;
 use crate::{Handle, Span};
@@ -119,7 +119,7 @@ impl<'source> Lowerer<'source, '_> {
         ty_span: Span,
         components: &[Handle<ast::Expression<'source>>],
         ctx: &mut ExpressionContext<'source, '_, '_>,
-    ) -> Result<Handle<crate::Expression>, Error<'source>> {
+    ) -> Result<'source, Handle<crate::Expression>> {
         use crate::proc::TypeResolution as Tr;
 
         let constructor_h = self.constructor(constructor, ctx)?;
@@ -141,7 +141,7 @@ impl<'source> Lowerer<'source, '_> {
                 let components = ast_components
                     .iter()
                     .map(|&expr| self.expression_for_abstract(expr, ctx))
-                    .collect::<Result<_, _>>()?;
+                    .collect::<Result<_>>()?;
                 let spans = ast_components
                     .iter()
                     .map(|&expr| ctx.ast_expressions.get_span(expr))
@@ -373,7 +373,7 @@ impl<'source> Lowerer<'source, '_> {
                             Default::default(),
                         )
                     })
-                    .collect::<Result<Vec<_>, _>>()?;
+                    .collect::<Result<Vec<_>>>()?;
 
                 let ty = ctx.ensure_type_exists(crate::TypeInner::Matrix {
                     columns,
@@ -410,7 +410,7 @@ impl<'source> Lowerer<'source, '_> {
                             Default::default(),
                         )
                     })
-                    .collect::<Result<Vec<_>, _>>()?;
+                    .collect::<Result<Vec<_>>>()?;
 
                 let ty = ctx.ensure_type_exists(crate::TypeInner::Matrix {
                     columns,
@@ -576,7 +576,7 @@ impl<'source> Lowerer<'source, '_> {
         &mut self,
         constructor: &ast::ConstructorType<'source>,
         ctx: &mut ExpressionContext<'source, '_, 'out>,
-    ) -> Result<Constructor<Handle<crate::Type>>, Error<'source>> {
+    ) -> Result<'source, Constructor<Handle<crate::Type>>> {
         let handle = match *constructor {
             ast::ConstructorType::Scalar(scalar) => {
                 let ty = ctx.ensure_type_exists(scalar.to_inner_scalar());

--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -536,11 +536,11 @@ impl<'source> Lowerer<'source, '_> {
 
             // Bad conversion (type cast)
             (Components::One { span, ty_inner, .. }, constructor) => {
-                let from_type = ty_inner.to_wgsl(&ctx.module.to_ctx()).into();
+                let from_type = ty_inner.to_wgsl(&ctx.module.to_ctx());
                 return Err(Box::new(Error::BadTypeCast {
                     span,
                     from_type,
-                    to_type: constructor.to_error_string(ctx).into(),
+                    to_type: constructor.to_error_string(ctx),
                 }));
             }
 

--- a/naga/src/front/wgsl/lower/conversion.rs
+++ b/naga/src/front/wgsl/lower/conversion.rs
@@ -54,8 +54,8 @@ impl<'source> super::ExpressionContext<'source, '_, '_> {
                 Some(scalars) => scalars,
                 None => {
                     let gctx = &self.module.to_ctx();
-                    let source_type = expr_resolution.to_wgsl(gctx).into();
-                    let dest_type = goal_ty.to_wgsl(gctx).into();
+                    let source_type = expr_resolution.to_wgsl(gctx);
+                    let dest_type = goal_ty.to_wgsl(gctx);
 
                     return Err(Box::new(super::Error::AutoConversion(Box::new(
                         AutoConversionError {
@@ -96,10 +96,10 @@ impl<'source> super::ExpressionContext<'source, '_, '_> {
 
         let make_error = || {
             let gctx = &self.module.to_ctx();
-            let source_type = expr_resolution.to_wgsl(gctx).into();
+            let source_type = expr_resolution.to_wgsl(gctx);
             super::Error::AutoConversionLeafScalar(Box::new(AutoConversionLeafScalarError {
                 dest_span: goal_span,
-                dest_scalar: goal_scalar.to_wgsl().into(),
+                dest_scalar: goal_scalar.to_wgsl(),
                 source_span: expr_span,
                 source_type,
             }))
@@ -275,8 +275,8 @@ impl<'source> super::ExpressionContext<'source, '_, '_> {
                         let expr_type = &self.typifier()[expr];
                         super::Error::ConcretizationFailed(Box::new(ConcretizationFailedError {
                             expr_span,
-                            expr_type: expr_type.to_wgsl(&self.module.to_ctx()).into(),
-                            scalar: concretized.to_wgsl().into(),
+                            expr_type: expr_type.to_wgsl(&self.module.to_ctx()),
+                            scalar: concretized.to_wgsl(),
                             inner: err,
                         }))
                     })?;

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1256,8 +1256,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 if !explicit_inner.equivalent(init_inner, &ectx.module.types) {
                     return Err(Box::new(Error::InitializationTypeMismatch {
                         name: name.span,
-                        expected: explicit_inner.to_wgsl(&ectx.module.to_ctx()).into(),
-                        got: init_inner.to_wgsl(&ectx.module.to_ctx()).into(),
+                        expected: explicit_inner.to_wgsl(&ectx.module.to_ctx()),
+                        got: init_inner.to_wgsl(&ectx.module.to_ctx()),
                     }));
                 }
                 ty = explicit_ty;
@@ -1490,8 +1490,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                             let gctx = &ctx.module.to_ctx();
                             return Err(Box::new(Error::InitializationTypeMismatch {
                                 name: l.name.span,
-                                expected: ty.to_wgsl(gctx).into(),
-                                got: init_ty.to_wgsl(gctx).into(),
+                                expected: ty.to_wgsl(gctx),
+                                got: init_ty.to_wgsl(gctx),
                             }));
                         }
                     }
@@ -2194,9 +2194,9 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         let ty = resolve!(ctx, expr);
                         let gctx = &ctx.module.to_ctx();
                         return Err(Box::new(Error::BadTypeCast {
-                            from_type: ty.to_wgsl(gctx).into(),
+                            from_type: ty.to_wgsl(gctx),
                             span: ty_span,
-                            to_type: to_resolved.to_wgsl(gctx).into(),
+                            to_type: to_resolved.to_wgsl(gctx),
                         }));
                     }
                 };

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -27,6 +27,8 @@ use crate::Scalar;
 #[cfg(test)]
 use std::println;
 
+pub(crate) type Result<'a, T> = core::result::Result<T, Error<'a>>;
+
 pub struct Frontend {
     parser: Parser,
 }
@@ -38,11 +40,11 @@ impl Frontend {
         }
     }
 
-    pub fn parse(&mut self, source: &str) -> Result<crate::Module, ParseError> {
+    pub fn parse(&mut self, source: &str) -> core::result::Result<crate::Module, ParseError> {
         self.inner(source).map_err(|x| x.as_parse_error(source))
     }
 
-    fn inner<'a>(&mut self, source: &'a str) -> Result<crate::Module, Error<'a>> {
+    fn inner<'a>(&mut self, source: &'a str) -> Result<'a, crate::Module> {
         let tu = self.parser.parse(source)?;
         let index = index::Index::generate(&tu)?;
         let module = Lowerer::new(&index).lower(tu)?;
@@ -62,7 +64,7 @@ impl Frontend {
 /// for this, particularly if calls to this method are exposed to user input.
 ///
 /// </div>
-pub fn parse_str(source: &str) -> Result<crate::Module, ParseError> {
+pub fn parse_str(source: &str) -> core::result::Result<crate::Module, ParseError> {
     Frontend::new().parse(source)
 }
 

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -17,6 +17,7 @@ pub use crate::front::wgsl::parse::directive::language_extension::{
     ImplementedLanguageExtension, LanguageExtension, UnimplementedLanguageExtension,
 };
 
+use alloc::boxed::Box;
 use thiserror::Error;
 
 use crate::front::wgsl::error::Error;
@@ -27,7 +28,7 @@ use crate::Scalar;
 #[cfg(test)]
 use std::println;
 
-pub(crate) type Result<'a, T> = core::result::Result<T, Error<'a>>;
+pub(crate) type Result<'a, T> = core::result::Result<T, Box<Error<'a>>>;
 
 pub struct Frontend {
     parser: Parser,

--- a/naga/src/front/wgsl/parse/conv.rs
+++ b/naga/src/front/wgsl/parse/conv.rs
@@ -1,8 +1,7 @@
-use super::Error;
-use crate::front::wgsl::Scalar;
+use crate::front::wgsl::{Error, Result, Scalar};
 use crate::Span;
 
-pub fn map_address_space(word: &str, span: Span) -> Result<crate::AddressSpace, Error<'_>> {
+pub fn map_address_space(word: &str, span: Span) -> Result<'_, crate::AddressSpace> {
     match word {
         "private" => Ok(crate::AddressSpace::Private),
         "workgroup" => Ok(crate::AddressSpace::WorkGroup),
@@ -16,7 +15,7 @@ pub fn map_address_space(word: &str, span: Span) -> Result<crate::AddressSpace, 
     }
 }
 
-pub fn map_built_in(word: &str, span: Span) -> Result<crate::BuiltIn, Error<'_>> {
+pub fn map_built_in(word: &str, span: Span) -> Result<'_, crate::BuiltIn> {
     Ok(match word {
         "position" => crate::BuiltIn::Position { invariant: false },
         // vertex
@@ -44,7 +43,7 @@ pub fn map_built_in(word: &str, span: Span) -> Result<crate::BuiltIn, Error<'_>>
     })
 }
 
-pub fn map_interpolation(word: &str, span: Span) -> Result<crate::Interpolation, Error<'_>> {
+pub fn map_interpolation(word: &str, span: Span) -> Result<'_, crate::Interpolation> {
     match word {
         "linear" => Ok(crate::Interpolation::Linear),
         "flat" => Ok(crate::Interpolation::Flat),
@@ -53,7 +52,7 @@ pub fn map_interpolation(word: &str, span: Span) -> Result<crate::Interpolation,
     }
 }
 
-pub fn map_sampling(word: &str, span: Span) -> Result<crate::Sampling, Error<'_>> {
+pub fn map_sampling(word: &str, span: Span) -> Result<'_, crate::Sampling> {
     match word {
         "center" => Ok(crate::Sampling::Center),
         "centroid" => Ok(crate::Sampling::Centroid),
@@ -64,7 +63,7 @@ pub fn map_sampling(word: &str, span: Span) -> Result<crate::Sampling, Error<'_>
     }
 }
 
-pub fn map_storage_format(word: &str, span: Span) -> Result<crate::StorageFormat, Error<'_>> {
+pub fn map_storage_format(word: &str, span: Span) -> Result<'_, crate::StorageFormat> {
     use crate::StorageFormat as Sf;
     Ok(match word {
         "r8unorm" => Sf::R8Unorm,
@@ -264,7 +263,7 @@ pub fn map_standard_fun(word: &str) -> Option<crate::MathFunction> {
 pub fn map_conservative_depth(
     word: &str,
     span: Span,
-) -> Result<crate::ConservativeDepth, Error<'_>> {
+) -> Result<'_, crate::ConservativeDepth> {
     use crate::ConservativeDepth as Cd;
     match word {
         "greater_equal" => Ok(Cd::GreaterEqual),

--- a/naga/src/front/wgsl/parse/conv.rs
+++ b/naga/src/front/wgsl/parse/conv.rs
@@ -1,6 +1,8 @@
 use crate::front::wgsl::{Error, Result, Scalar};
 use crate::Span;
 
+use alloc::boxed::Box;
+
 pub fn map_address_space(word: &str, span: Span) -> Result<'_, crate::AddressSpace> {
     match word {
         "private" => Ok(crate::AddressSpace::Private),
@@ -11,7 +13,7 @@ pub fn map_address_space(word: &str, span: Span) -> Result<'_, crate::AddressSpa
         }),
         "push_constant" => Ok(crate::AddressSpace::PushConstant),
         "function" => Ok(crate::AddressSpace::Function),
-        _ => Err(Error::UnknownAddressSpace(span)),
+        _ => Err(Box::new(Error::UnknownAddressSpace(span))),
     }
 }
 
@@ -39,7 +41,7 @@ pub fn map_built_in(word: &str, span: Span) -> Result<'_, crate::BuiltIn> {
         "subgroup_id" => crate::BuiltIn::SubgroupId,
         "subgroup_size" => crate::BuiltIn::SubgroupSize,
         "subgroup_invocation_id" => crate::BuiltIn::SubgroupInvocationId,
-        _ => return Err(Error::UnknownBuiltin(span)),
+        _ => return Err(Box::new(Error::UnknownBuiltin(span))),
     })
 }
 
@@ -48,7 +50,7 @@ pub fn map_interpolation(word: &str, span: Span) -> Result<'_, crate::Interpolat
         "linear" => Ok(crate::Interpolation::Linear),
         "flat" => Ok(crate::Interpolation::Flat),
         "perspective" => Ok(crate::Interpolation::Perspective),
-        _ => Err(Error::UnknownAttribute(span)),
+        _ => Err(Box::new(Error::UnknownAttribute(span))),
     }
 }
 
@@ -59,7 +61,7 @@ pub fn map_sampling(word: &str, span: Span) -> Result<'_, crate::Sampling> {
         "sample" => Ok(crate::Sampling::Sample),
         "first" => Ok(crate::Sampling::First),
         "either" => Ok(crate::Sampling::Either),
-        _ => Err(Error::UnknownAttribute(span)),
+        _ => Err(Box::new(Error::UnknownAttribute(span))),
     }
 }
 
@@ -107,7 +109,7 @@ pub fn map_storage_format(word: &str, span: Span) -> Result<'_, crate::StorageFo
         "rgba32sint" => Sf::Rgba32Sint,
         "rgba32float" => Sf::Rgba32Float,
         "bgra8unorm" => Sf::Bgra8Unorm,
-        _ => return Err(Error::UnknownStorageFormat(span)),
+        _ => return Err(Box::new(Error::UnknownStorageFormat(span))),
     })
 }
 
@@ -260,16 +262,13 @@ pub fn map_standard_fun(word: &str) -> Option<crate::MathFunction> {
     })
 }
 
-pub fn map_conservative_depth(
-    word: &str,
-    span: Span,
-) -> Result<'_, crate::ConservativeDepth> {
+pub fn map_conservative_depth(word: &str, span: Span) -> Result<'_, crate::ConservativeDepth> {
     use crate::ConservativeDepth as Cd;
     match word {
         "greater_equal" => Ok(Cd::GreaterEqual),
         "less_equal" => Ok(Cd::LessEqual),
         "unchanged" => Ok(Cd::Unchanged),
-        _ => Err(Error::UnknownConservativeDepth(span)),
+        _ => Err(Box::new(Error::UnknownConservativeDepth(span))),
     }
 }
 

--- a/naga/src/front/wgsl/parse/directive.rs
+++ b/naga/src/front/wgsl/parse/directive.rs
@@ -5,6 +5,8 @@
 pub mod enable_extension;
 pub(crate) mod language_extension;
 
+use alloc::boxed::Box;
+
 /// A parsed sentinel word indicating the type of directive to be parsed next.
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(test, derive(strum::EnumIter))]
@@ -37,7 +39,7 @@ impl crate::diagnostic_filter::Severity {
     #[cfg(feature = "wgsl-in")]
     pub(crate) fn report_wgsl_parse_diag<'a>(
         self,
-        err: crate::front::wgsl::error::Error<'a>,
+        err: Box<crate::front::wgsl::error::Error<'a>>,
         source: &str,
     ) -> crate::front::wgsl::Result<'a, ()> {
         self.report_diag(err, |e, level| {

--- a/naga/src/front/wgsl/parse/directive.rs
+++ b/naga/src/front/wgsl/parse/directive.rs
@@ -39,7 +39,7 @@ impl crate::diagnostic_filter::Severity {
         self,
         err: crate::front::wgsl::error::Error<'a>,
         source: &str,
-    ) -> Result<(), crate::front::wgsl::error::Error<'a>> {
+    ) -> crate::front::wgsl::Result<'a, ()> {
         self.report_diag(err, |e, level| {
             let e = e.as_parse_error(source);
             log::log!(level, "{}", e.emit_to_string(source));

--- a/naga/src/front/wgsl/parse/directive/enable_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/enable_extension.rs
@@ -2,7 +2,8 @@
 //!
 //! The focal point of this module is the [`EnableExtension`] API.
 
-use crate::{front::wgsl::error::Error, Span};
+use crate::Span;
+use crate::front::wgsl::{Error, Result};
 
 /// Tracks the status of every enable-extension known to Naga.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -61,7 +62,7 @@ impl EnableExtension {
     const DUAL_SOURCE_BLENDING: &'static str = "dual_source_blending";
 
     /// Convert from a sentinel word in WGSL into its associated [`EnableExtension`], if possible.
-    pub(crate) fn from_ident(word: &str, span: Span) -> Result<Self, Error<'_>> {
+    pub(crate) fn from_ident(word: &str, span: Span) -> Result<Self> {
         Ok(match word {
             Self::F16 => Self::Unimplemented(UnimplementedEnableExtension::F16),
             Self::CLIP_DISTANCES => {

--- a/naga/src/front/wgsl/parse/directive/enable_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/enable_extension.rs
@@ -2,8 +2,10 @@
 //!
 //! The focal point of this module is the [`EnableExtension`] API.
 
-use crate::Span;
 use crate::front::wgsl::{Error, Result};
+use crate::Span;
+
+use alloc::boxed::Box;
 
 /// Tracks the status of every enable-extension known to Naga.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -71,7 +73,7 @@ impl EnableExtension {
             Self::DUAL_SOURCE_BLENDING => {
                 Self::Implemented(ImplementedEnableExtension::DualSourceBlending)
             }
-            _ => return Err(Error::UnknownEnableExtension(span, word)),
+            _ => return Err(Box::new(Error::UnknownEnableExtension(span, word))),
         })
     }
 

--- a/naga/src/front/wgsl/tests.rs
+++ b/naga/src/front/wgsl/tests.rs
@@ -684,7 +684,7 @@ fn parse_repeated_attributes() {
 
         let result = Frontend::new().inner(&shader);
         assert!(matches!(
-            result.unwrap_err(),
+            *result.unwrap_err(),
             Error::RepeatedAttribute(span) if span == expected_span
         ));
     }
@@ -700,7 +700,7 @@ fn parse_missing_workgroup_size() {
     let shader = "@compute fn vs() -> vec4<f32> { return vec4<f32>(0.0); }";
     let result = Frontend::new().inner(shader);
     assert!(matches!(
-        result.unwrap_err(),
+        *result.unwrap_err(),
         Error::MissingWorkgroupSize(span) if span == Span::new(1, 8)
     ));
 }


### PR DESCRIPTION
Use `String` in variants of `naga::front::wgsl::Error`, not `Box<str>`.

Change the WGSL front end to always return `Error` values boxed, so that the size of `Error` does not affect the performance of success paths. This reduces the minimum size of `Result`s in the WGSL front end from 48 bytes to 8.

Delete test `naga::front::wgsl::error::test_error_size`. Since `Error` is always returned boxed, its size should have no effect on `Result` size.
