### PR TITLE
[naga] Place the `#[track_caller]` attribute on some test utilities.

### DIFF
--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -5,6 +5,7 @@ Tests for the WGSL front end.
 
 use naga::valid::Capabilities;
 
+#[track_caller]
 fn check(input: &str, snapshot: &str) {
     let output = naga::front::wgsl::parse_str(input)
         .expect_err("expected parser error")
@@ -902,6 +903,7 @@ macro_rules! check_validation {
     }
 }
 
+#[track_caller]
 fn validation_error(
     source: &str,
     caps: naga::valid::Capabilities,


### PR DESCRIPTION
Place the `#[track_caller]` attribute on the `check` and `validation_error` functions in the Naga `wgsl_errors` test module, so that panics or assertion failures will point to the actual test, not to the code in the utility function.
