### PR TITLE
[naga] Make `Level::next()` public.

### DIFF
--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -70,7 +70,7 @@ pub type PipelineConstants = hashbrown::HashMap<String, f64>;
 pub struct Level(pub usize);
 
 impl Level {
-    const fn next(&self) -> Self {
+    pub const fn next(&self) -> Self {
         Level(self.0 + 1)
     }
 }


### PR DESCRIPTION
**Description**
Makes `naga::back::Level::next()` `pub`. It doesn’t make sense to have `Level` public but not `Level::next()`.

I met this problem while trying to make an out-of-tree backend:

**Testing**
Still builds

**Squash or Rebase?**
Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
