### PR TITLE
[naga] Remove dead code from `naga::back`.

### DIFF
--- a/naga/src/back/continue_forward.rs
+++ b/naga/src/back/continue_forward.rs
@@ -185,6 +185,7 @@ impl ContinueCtx {
     /// Resets internal state.
     ///
     /// Use this to reuse memory between writing sessions.
+    #[allow(dead_code, reason = "only used by some backends")]
     pub fn clear(&mut self) {
         self.stack.clear();
     }

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -89,6 +89,7 @@ pub(crate) const FREXP_FUNCTION: &str = "naga_frexp";
 // Must match code in glsl_built_in
 pub const FIRST_INSTANCE_BINDING: &str = "naga_vs_first_instance";
 
+#[cfg(any(feature = "serialize", feature = "deserialize"))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 struct BindingMapSerialization {
@@ -130,13 +131,6 @@ impl crate::AtomicFunction {
 }
 
 impl crate::AddressSpace {
-    const fn is_buffer(&self) -> bool {
-        match *self {
-            crate::AddressSpace::Uniform | crate::AddressSpace::Storage { .. } => true,
-            _ => false,
-        }
-    }
-
     /// Whether a variable with this address space can be initialized
     const fn initializable(&self) -> bool {
         match *self {

--- a/naga/src/back/hlsl/help.rs
+++ b/naga/src/back/hlsl/help.rs
@@ -1777,8 +1777,6 @@ impl<W: Write> super::Writer<'_, W> {
     ) -> BackendResult {
         use crate::back::INDENT;
 
-        const RETURN_VARIABLE_NAME: &str = "ret";
-
         // Write function return type and name
         if let crate::TypeInner::Array { base, size, .. } = module.types[zero_value.ty].inner {
             write!(self.out, "typedef ")?;

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -151,6 +151,7 @@ pub struct OffsetsBindTarget {
     pub size: u32,
 }
 
+#[cfg(any(feature = "serialize", feature = "deserialize"))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 struct BindingMapSerialization {
@@ -269,6 +270,7 @@ impl Default for SamplerHeapBindTargets {
     }
 }
 
+#[cfg(any(feature = "serialize", feature = "deserialize"))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 struct SamplerIndexBufferBindingSerialization {
@@ -300,6 +302,7 @@ where
 pub type SamplerIndexBufferBindingMap =
     alloc::collections::BTreeMap<SamplerIndexBufferKey, BindTarget>;
 
+#[cfg(any(feature = "serialize", feature = "deserialize"))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 struct DynamicStorageBufferOffsetTargetSerialization {

--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -1,7 +1,13 @@
 /*!
 Backend functions that export shader [`Module`](super::Module)s into binary and text formats.
 */
-#![allow(dead_code)] // can be dead if none of the enabled backends need it
+#![cfg_attr(
+    not(any(dot_out, glsl_out, hlsl_out, msl_out, spv_out, wgsl_out)),
+    allow(
+        dead_code,
+        reason = "shared helpers can be dead if none of the enabled backends need it"
+    )
+)]
 
 use alloc::string::String;
 

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -68,6 +68,7 @@ pub struct BindTarget {
     pub mutable: bool,
 }
 
+#[cfg(any(feature = "serialize", feature = "deserialize"))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 struct BindingMapSerialization {
@@ -584,13 +585,6 @@ impl ResolvedBinding {
                 sampler: Some(BindSamplerTarget::Inline(index)),
                 ..
             }) => Some(&options.inline_samplers[index as usize]),
-            _ => None,
-        }
-    }
-
-    const fn as_bind_target(&self) -> Option<&BindTarget> {
-        match *self {
-            Self::Resource(ref target) => Some(target),
             _ => None,
         }
     }

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -149,7 +149,6 @@ struct TypeContext<'a> {
     gctx: proc::GlobalCtx<'a>,
     names: &'a FastHashMap<NameKey, String>,
     access: crate::StorageAccess,
-    binding: Option<&'a super::ResolvedBinding>,
     first_time: bool,
 }
 
@@ -323,7 +322,6 @@ struct TypedGlobalVariable<'a> {
     names: &'a FastHashMap<NameKey, String>,
     handle: Handle<crate::GlobalVariable>,
     usage: valid::GlobalUse,
-    binding: Option<&'a super::ResolvedBinding>,
     reference: bool,
 }
 
@@ -356,7 +354,6 @@ impl TypedGlobalVariable<'_> {
             gctx: self.module.to_ctx(),
             names: self.names,
             access: storage_access,
-            binding: self.binding,
             first_time: false,
         };
 
@@ -1513,7 +1510,6 @@ impl<W: Write> Writer<W> {
                     gctx: module.to_ctx(),
                     names: &self.names,
                     access: crate::StorageAccess::empty(),
-                    binding: None,
                     first_time: false,
                 };
                 write!(self.out, "{ty_name} {{}}")?;
@@ -1524,7 +1520,6 @@ impl<W: Write> Writer<W> {
                     gctx: module.to_ctx(),
                     names: &self.names,
                     access: crate::StorageAccess::empty(),
-                    binding: None,
                     first_time: false,
                 };
                 write!(self.out, "{ty_name}")?;
@@ -3050,7 +3045,6 @@ impl<W: Write> Writer<W> {
                     gctx: context.module.to_ctx(),
                     names: &self.names,
                     access: crate::StorageAccess::empty(),
-                    binding: None,
                     first_time: false,
                 };
                 write!(self.out, "{ty_name}")?;
@@ -3993,7 +3987,6 @@ impl<W: Write> Writer<W> {
                         gctx: module.to_ctx(),
                         names: &self.names,
                         access: crate::StorageAccess::empty(),
-                        binding: None,
                         first_time: false,
                     };
 
@@ -4049,7 +4042,6 @@ impl<W: Write> Writer<W> {
                                     gctx: module.to_ctx(),
                                     names: &self.names,
                                     access: crate::StorageAccess::empty(),
-                                    binding: None,
                                     first_time: false,
                                 };
                                 writeln!(
@@ -4079,7 +4071,6 @@ impl<W: Write> Writer<W> {
                         gctx: module.to_ctx(),
                         names: &self.names,
                         access: crate::StorageAccess::empty(),
-                        binding: None,
                         first_time: true,
                     };
                     writeln!(self.out, "typedef {ty_name} {name};")?;
@@ -4179,7 +4170,6 @@ template <typename A>
                 gctx: module.to_ctx(),
                 names: &self.names,
                 access: crate::StorageAccess::empty(),
-                binding: None,
                 first_time: false,
             };
             let name = &self.names[&NameKey::Constant(handle)];
@@ -5479,7 +5469,6 @@ template <typename A>
                         gctx: module.to_ctx(),
                         names: &self.names,
                         access: crate::StorageAccess::empty(),
-                        binding: None,
                         first_time: false,
                     };
                     write!(self.out, "{ty_name}")?;
@@ -5497,7 +5486,6 @@ template <typename A>
                     gctx: module.to_ctx(),
                     names: &self.names,
                     access: crate::StorageAccess::empty(),
-                    binding: None,
                     first_time: false,
                 };
                 let separator = separate(
@@ -5520,7 +5508,7 @@ template <typename A>
                     names: &self.names,
                     handle,
                     usage: fun_info[handle],
-                    binding: None,
+
                     reference: true,
                 };
                 let separator =
@@ -5565,7 +5553,6 @@ template <typename A>
                     gctx: module.to_ctx(),
                     names: &self.names,
                     access: crate::StorageAccess::empty(),
-                    binding: None,
                     first_time: false,
                 };
                 let local_name = &self.names[&NameKey::FunctionLocal(fun_handle, local_handle)];
@@ -5793,7 +5780,6 @@ template <typename A>
                         gctx: module.to_ctx(),
                         names: &self.names,
                         access: crate::StorageAccess::empty(),
-                        binding: None,
                         first_time: false,
                     };
                     let resolved = options.resolve_local_binding(binding, in_mode)?;
@@ -5853,7 +5839,6 @@ template <typename A>
                             gctx: module.to_ctx(),
                             names: &self.names,
                             access: crate::StorageAccess::empty(),
-                            binding: None,
                             first_time: true,
                         };
                         let binding = binding.ok_or_else(|| {
@@ -5954,7 +5939,6 @@ template <typename A>
                     gctx: module.to_ctx(),
                     names: &self.names,
                     access: crate::StorageAccess::empty(),
-                    binding: None,
                     first_time: false,
                 };
 
@@ -6139,7 +6123,6 @@ template <typename A>
                     names: &self.names,
                     handle,
                     usage,
-                    binding: resolved.as_ref(),
                     reference: true,
                 };
                 let separator = if is_first_argument {
@@ -6352,7 +6335,7 @@ template <typename A>
                         names: &self.names,
                         handle,
                         usage,
-                        binding: None,
+
                         reference: false,
                     };
                     write!(self.out, "{}", back::INDENT)?;
@@ -6480,7 +6463,6 @@ template <typename A>
                     gctx: module.to_ctx(),
                     names: &self.names,
                     access: crate::StorageAccess::empty(),
-                    binding: None,
                     first_time: false,
                 };
                 write!(self.out, "{}{} {}", back::INDENT, ty_name, name)?;

--- a/naga/src/back/spv/instructions.rs
+++ b/naga/src/back/spv/instructions.rs
@@ -105,10 +105,6 @@ impl super::Instruction {
         instruction
     }
 
-    pub(super) const fn no_line() -> Self {
-        Self::new(Op::NoLine)
-    }
-
     //
     //  Annotation Instructions
     //


### PR DESCRIPTION
**Description**
The `#![allow(dead_code)]` on `naga::back` was hiding dead code in the child modules. In addition to removing the dead code, I changed it to be conditional on actually having no backends enabled. (Note that with #7349, there would actually be no warnings and we could remove the `allow(dead_code)` entirely, but I expect that state of affairs won’t necessarily persist.)

**Testing**
Ran tests, ran lint

**Squash or Rebase?**
Just one commit!

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
