### PR TITLE
[naga] Disallow logical operators `&&` and `||` on vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,7 @@ By @wumpf in [#7144](https://github.com/gfx-rs/wgpu/pull/7144)
 - Allows override-sized arrays to resolve to the same size without causing the type arena to panic. By @KentSlaney in [#7082](https://github.com/gfx-rs/wgpu/pull/7082).
 - Allow abstract types to be used for WGSL switch statement selector and case selector expressions. By @jamienicol in [#7250](https://github.com/gfx-rs/wgpu/pull/7250).
 - Apply automatic conversions to `let` declarations, and accept `vecN()` as a constructor for vectors (in any context). By @andyleiserson in [#7367](https://github.com/gfx-rs/wgpu/pull/7367).
+- The `&&` and `||` operators are no longer allowed on vectors. By @andyleiserson in [#7368](https://github.com/gfx-rs/wgpu/pull/7368).
 
 #### General
 

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -2227,10 +2227,13 @@ impl<'a> ConstantEvaluator<'a> {
             | BinaryOperator::And
             | BinaryOperator::ExclusiveOr
             | BinaryOperator::InclusiveOr
-            | BinaryOperator::LogicalAnd
-            | BinaryOperator::LogicalOr
             | BinaryOperator::ShiftLeft
             | BinaryOperator::ShiftRight => left_ty,
+
+            BinaryOperator::LogicalAnd | BinaryOperator::LogicalOr => {
+                // Not supported on vectors
+                return Err(ConstantEvaluatorError::InvalidBinaryOpArgs);
+            }
         };
 
         let components = components

--- a/naga/src/proc/typifier.rs
+++ b/naga/src/proc/typifier.rs
@@ -614,7 +614,8 @@ impl<'a> ResolveContext<'a> {
                         TypeResolution::Value(bool)
                     } else {
                         return Err(ResolveError::IncompatibleOperands(format!(
-                            "{op:?}({ty:?}, _)"
+                            "{op:?}({:?}, _)",
+                            ty.for_debug(types),
                         )));
                     }
                 }

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -3185,7 +3185,7 @@ fn vector_logical_ops() {
         "fn foo(a: vec2<bool>, b: vec2<bool>) {
             let y = a && b;
         }",
-        r#"error: Incompatible operands: LogicalAnd(Vector { size: Bi, scalar: Scalar { kind: Bool, width: 1 } }, _)
+        r#"error: Incompatible operands: LogicalAnd(vec2<bool>, _)
 
 "#,
     );
@@ -3194,7 +3194,7 @@ fn vector_logical_ops() {
         "fn foo(a: vec2<bool>, b: vec2<bool>) {
             let y = a || b;
         }",
-        r#"error: Incompatible operands: LogicalOr(Vector { size: Bi, scalar: Scalar { kind: Bool, width: 1 } }, _)
+        r#"error: Incompatible operands: LogicalOr(vec2<bool>, _)
 
 "#,
     );

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -3156,6 +3156,51 @@ fn matrix_vector_pointers() {
 }
 
 #[test]
+fn vector_logical_ops() {
+    // Const context
+    check(
+        "const and = vec2(true, false) && vec2(false, false);",
+        r###"error: Cannot apply the binary op to the arguments
+  ┌─ wgsl:1:13
+  │
+1 │ const and = vec2(true, false) && vec2(false, false);
+  │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ see msg
+
+"###,
+    );
+
+    check(
+        "const or = vec2(true, false) || vec2(false, false);",
+        r###"error: Cannot apply the binary op to the arguments
+  ┌─ wgsl:1:12
+  │
+1 │ const or = vec2(true, false) || vec2(false, false);
+  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ see msg
+
+"###,
+    );
+
+    // Runtime context
+    check(
+        "fn foo(a: vec2<bool>, b: vec2<bool>) {
+            let y = a && b;
+        }",
+        r#"error: Incompatible operands: LogicalAnd(Vector { size: Bi, scalar: Scalar { kind: Bool, width: 1 } }, _)
+
+"#,
+    );
+
+    check(
+        "fn foo(a: vec2<bool>, b: vec2<bool>) {
+            let y = a || b;
+        }",
+        r#"error: Incompatible operands: LogicalOr(Vector { size: Bi, scalar: Scalar { kind: Bool, width: 1 } }, _)
+
+"#,
+    );
+}
+
+#[test]
 fn issue7165() {
     // Regression test for https://github.com/gfx-rs/wgpu/issues/7165
     let shader = "


### PR DESCRIPTION
**Connections**
Fixes #6856

**Description**
This change disallows the logical operators `&&` and `||` on vectors, which WGSL does not allow. There are two relevant codepaths, one for constant evaluation and one for type checking of expressions to be evaluated at runtime.

I tested this change locally in combination with #7339. The two changes actually do not conflict and interact minimally. In #7339, I implemented a transformation while lowering to IR that gets applied only if the operands have a correct (scalar) type. If the operands are not scalars, the expression is passed through with the expectation that validation rejects it. This change affects what will ultimately pass validation.

Arguably, these operators should be removed from the Naga IR entirely. I have not done that, because the `BinaryOperator` enum is shared by the AST and IR representations.

**Testing**
Added tests in wgsl_errors to verify both operators are rejected in both const and runtime contexts.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] Add a `CHANGELOG.md` entry.
