### PR TITLE
[naga wgsl-in] Reject vector constructors with incorrect number of components during const evaluation.

### DIFF
--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -254,6 +254,58 @@ fn constructor_parameter_type_mismatch() {
 }
 
 #[test]
+fn vector_constructor_incorrect_component_count() {
+    // Too few components
+    check(
+        r#"
+            fn x() {
+                _ = vec4(1, 2, 3);
+            }
+        "#,
+        r#"error: Constructor expects 4 components, found 3
+  ┌─ wgsl:3:21
+  │
+3 │                 _ = vec4(1, 2, 3);
+  │                     ^^^^^^^^^^^^^ see msg
+
+"#,
+    );
+
+    // Too many components
+    check(
+        r#"
+            fn x() {
+                _ = vec4(1, 2, 3, 4, 5);
+            }
+        "#,
+        r#"error: Constructor expects 4 components, found 5
+  ┌─ wgsl:3:21
+  │
+3 │                 _ = vec4(1, 2, 3, 4, 5);
+  │                     ^^^^^^^^^^^^^^^^^^^ see msg
+
+"#,
+    );
+
+    // The outer constructor has the correct number of components, but only
+    // because the inner constructor has too many.
+    check(
+        r#"
+            fn x() {
+                _ = vec4(1, vec2(2, 3, 4));
+            }
+        "#,
+        r#"error: Constructor expects 2 components, found 3
+  ┌─ wgsl:3:29
+  │
+3 │                 _ = vec4(1, vec2(2, 3, 4));
+  │                             ^^^^^^^^^^^^^ see msg
+
+"#,
+    );
+}
+
+#[test]
 fn bad_texture_sample_type() {
     check(
         r#"


### PR DESCRIPTION
**Connections**
Fixes #6506 

**Description**
A vector constructor with multiple arguments is represented in IR as a Compose expression. These can be nested, for example due to code such as this: `vec4(1, vec3(2, vec2(3, 4)))`. The total number of components of each argument must match the vector size, meaning `vec4(1, 2, 3, 4, 5)` is invalid. The validation pass already catches such occurences. However, validation runs after constant evaluation, meaning this can cause issues if the expression is evaluated as part of a const expression.

When applying an operation to a vector compose during const evaluation, we typically "flatten" the vector using the function `proc::flatten_compose()`. This silently truncates the list of components to the size implied by the type, meaning invalid code is accepted.

This patch validates that the total number of components in a Compose expression, once flattened, matches the size implied by the type. We do so once as each expression is registered to avoid needing to handle this each time the expression is used in a const expression.

For nested compose expressions, the inner expressions will be registed before the outer ones. This means we can trust that the size implied by the inner expression's type is correct, as it will have already been validated, and can therefore avoid recursing through each nested expression when registering the outer expression.


**Testing**
Added new tests

**Squash or Rebase?**

Either

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
