### PR TITLE
[naga spv-out msl-out hlsl-out] Make infinite loop workaround count down instead of up

### DIFF
--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -172,7 +172,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         let loop_bound_name = self.namer.call("loop_bound");
         let max = u32::MAX;
         // Count down from u32::MAX rather than up from 0 to avoid hang on
-        // certain intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
+        // certain Intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
         let decl = format!("{level}uint2 {loop_bound_name} = uint2({max}u, {max}u);");
         let level = level.next();
         let break_and_inc = format!(

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -170,12 +170,14 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         }
 
         let loop_bound_name = self.namer.call("loop_bound");
-        let decl = format!("{level}uint2 {loop_bound_name} = uint2(0u, 0u);");
-        let level = level.next();
         let max = u32::MAX;
+        // Count down from u32::MAX rather than up from 0 to avoid hang on
+        // certain intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
+        let decl = format!("{level}uint2 {loop_bound_name} = uint2({max}u, {max}u);");
+        let level = level.next();
         let break_and_inc = format!(
-            "{level}if (all({loop_bound_name} == uint2({max}u, {max}u))) {{ break; }}
-{level}{loop_bound_name} += uint2({loop_bound_name}.y == {max}u, 1u);"
+            "{level}if (all({loop_bound_name} == uint2(0u, 0u))) {{ break; }}
+{level}{loop_bound_name} -= uint2({loop_bound_name}.y == 0u, 1u);"
         );
 
         Some((decl, break_and_inc))

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -172,7 +172,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         let loop_bound_name = self.namer.call("loop_bound");
         let max = u32::MAX;
         // Count down from u32::MAX rather than up from 0 to avoid hang on
-        // certain Intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
+        // certain Intel drivers. See <https://github.com/gfx-rs/wgpu/issues/7319>.
         let decl = format!("{level}uint2 {loop_bound_name} = uint2({max}u, {max}u);");
         let level = level.next();
         let break_and_inc = format!(

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -851,7 +851,7 @@ impl<W: Write> Writer<W> {
 
         let loop_bound_name = self.namer.call("loop_bound");
         // Count down from u32::MAX rather than up from 0 to avoid hang on
-        // certain Intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
+        // certain Intel drivers. See <https://github.com/gfx-rs/wgpu/issues/7319>.
         let decl = format!("{level}uint2 {loop_bound_name} = uint2({}u);", u32::MAX);
         let level = level.next();
         let break_and_inc = format!(

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -850,12 +850,13 @@ impl<W: Write> Writer<W> {
         }
 
         let loop_bound_name = self.namer.call("loop_bound");
-        let decl = format!("{level}uint2 {loop_bound_name} = uint2(0u);");
+        // Count down from u32::MAX rather than up from 0 to avoid hang on
+        // certain intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
+        let decl = format!("{level}uint2 {loop_bound_name} = uint2({}u);", u32::MAX);
         let level = level.next();
-        let max = u32::MAX;
         let break_and_inc = format!(
-            "{level}if ({NAMESPACE}::all({loop_bound_name} == uint2({max}u))) {{ break; }}
-{level}{loop_bound_name} += uint2({loop_bound_name}.y == {max}u, 1u);"
+            "{level}if ({NAMESPACE}::all({loop_bound_name} == uint2(0u))) {{ break; }}
+{level}{loop_bound_name} -= uint2({loop_bound_name}.y == 0u, 1u);"
         );
 
         Some((decl, break_and_inc))

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -851,7 +851,7 @@ impl<W: Write> Writer<W> {
 
         let loop_bound_name = self.namer.call("loop_bound");
         // Count down from u32::MAX rather than up from 0 to avoid hang on
-        // certain intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
+        // certain Intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
         let decl = format!("{level}uint2 {loop_bound_name} = uint2({}u);", u32::MAX);
         let level = level.next();
         let break_and_inc = format!(

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -364,7 +364,7 @@ impl BlockContext<'_> {
         // the high u32 when the low u32 overflows. ie
         // counter -= vec2(select(0u, 1u, counter.y == 0), 1u);
         // Count down from u32::MAX rather than up from 0 to avoid hang on
-        // certain intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
+        // certain Intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
         let low_id = self.gen_id();
         block.body.push(Instruction::composite_extract(
             uint_type_id,

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -310,7 +310,7 @@ impl BlockContext<'_> {
                 uint2_ptr_type_id,
                 loop_counter_var_id,
                 spirv::StorageClass::Function,
-                Some(zero_uint2_const_id),
+                Some(max_uint2_const_id),
             ),
         };
         self.function.force_loop_bounding_vars.push(var);
@@ -331,14 +331,14 @@ impl BlockContext<'_> {
             None,
         ));
 
-        // If both the high and low u32s have reached u32::MAX then break. ie
-        // if (all(eq(loop_counter, vec2(u32::MAX)))) { break; }
+        // If both the high and low u32s have reached 0 then break. ie
+        // if (all(eq(loop_counter, vec2(0)))) { break; }
         let eq_id = self.gen_id();
         block.body.push(Instruction::binary(
             spirv::Op::IEqual,
             bool2_type_id,
             eq_id,
-            max_uint2_const_id,
+            zero_uint2_const_id,
             load_id,
         ));
         let all_eq_id = self.gen_id();
@@ -360,9 +360,11 @@ impl BlockContext<'_> {
         );
         block = Block::new(inc_counter_block_id);
 
-        // To simulate a 64-bit counter we always increment the low u32, and increment
+        // To simulate a 64-bit counter we always decrement the low u32, and decrement
         // the high u32 when the low u32 overflows. ie
-        // counter += vec2(select(0u, 1u, counter.y == u32::MAX), 1u);
+        // counter -= vec2(select(0u, 1u, counter.y == 0), 1u);
+        // Count down from u32::MAX rather than up from 0 to avoid hang on
+        // certain intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
         let low_id = self.gen_id();
         block.body.push(Instruction::composite_extract(
             uint_type_id,
@@ -376,7 +378,7 @@ impl BlockContext<'_> {
             bool_type_id,
             low_overflow_id,
             low_id,
-            max_uint_const_id,
+            zero_uint_const_id,
         ));
         let carry_bit_id = self.gen_id();
         block.body.push(Instruction::select(
@@ -386,19 +388,19 @@ impl BlockContext<'_> {
             one_uint_const_id,
             zero_uint_const_id,
         ));
-        let increment_id = self.gen_id();
+        let decrement_id = self.gen_id();
         block.body.push(Instruction::composite_construct(
             uint2_type_id,
-            increment_id,
+            decrement_id,
             &[carry_bit_id, one_uint_const_id],
         ));
         let result_id = self.gen_id();
         block.body.push(Instruction::binary(
-            spirv::Op::IAdd,
+            spirv::Op::ISub,
             uint2_type_id,
             result_id,
             load_id,
-            increment_id,
+            decrement_id,
         ));
         block
             .body

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -364,7 +364,7 @@ impl BlockContext<'_> {
         // the high u32 when the low u32 overflows. ie
         // counter -= vec2(select(0u, 1u, counter.y == 0), 1u);
         // Count down from u32::MAX rather than up from 0 to avoid hang on
-        // certain Intel drivers. See https://github.com/gfx-rs/wgpu/issues/7319.
+        // certain Intel drivers. See <https://github.com/gfx-rs/wgpu/issues/7319>.
         let low_id = self.gen_id();
         block.body.push(Instruction::composite_extract(
             uint_type_id,

--- a/naga/tests/out/hlsl/boids.hlsl
+++ b/naga/tests/out/hlsl/boids.hlsl
@@ -41,11 +41,11 @@ void main(uint3 global_invocation_id : SV_DispatchThreadID)
     vPos = _e8;
     float2 _e14 = asfloat(particlesSrc.Load2(8+index*16+0));
     vVel = _e14;
-    uint2 loop_bound = uint2(0u, 0u);
+    uint2 loop_bound = uint2(4294967295u, 4294967295u);
     bool loop_init = true;
     while(true) {
-        if (all(loop_bound == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (all(loop_bound == uint2(0u, 0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         if (!loop_init) {
             uint _e91 = i;
             i = (_e91 + 1u);

--- a/naga/tests/out/hlsl/break-if.hlsl
+++ b/naga/tests/out/hlsl/break-if.hlsl
@@ -1,10 +1,10 @@
 void breakIfEmpty()
 {
-    uint2 loop_bound = uint2(0u, 0u);
+    uint2 loop_bound = uint2(4294967295u, 4294967295u);
     bool loop_init = true;
     while(true) {
-        if (all(loop_bound == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (all(loop_bound == uint2(0u, 0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         if (!loop_init) {
             if (true) {
                 break;
@@ -20,11 +20,11 @@ void breakIfEmptyBody(bool a)
     bool b = (bool)0;
     bool c = (bool)0;
 
-    uint2 loop_bound_1 = uint2(0u, 0u);
+    uint2 loop_bound_1 = uint2(4294967295u, 4294967295u);
     bool loop_init_1 = true;
     while(true) {
-        if (all(loop_bound_1 == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound_1 += uint2(loop_bound_1.y == 4294967295u, 1u);
+        if (all(loop_bound_1 == uint2(0u, 0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
         if (!loop_init_1) {
             b = a;
             bool _e2 = b;
@@ -44,11 +44,11 @@ void breakIf(bool a_1)
     bool d = (bool)0;
     bool e = (bool)0;
 
-    uint2 loop_bound_2 = uint2(0u, 0u);
+    uint2 loop_bound_2 = uint2(4294967295u, 4294967295u);
     bool loop_init_2 = true;
     while(true) {
-        if (all(loop_bound_2 == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound_2 += uint2(loop_bound_2.y == 4294967295u, 1u);
+        if (all(loop_bound_2 == uint2(0u, 0u))) { break; }
+        loop_bound_2 -= uint2(loop_bound_2.y == 0u, 1u);
         if (!loop_init_2) {
             bool _e5 = e;
             if ((a_1 == _e5)) {
@@ -67,11 +67,11 @@ void breakIfSeparateVariable()
 {
     uint counter = 0u;
 
-    uint2 loop_bound_3 = uint2(0u, 0u);
+    uint2 loop_bound_3 = uint2(4294967295u, 4294967295u);
     bool loop_init_3 = true;
     while(true) {
-        if (all(loop_bound_3 == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound_3 += uint2(loop_bound_3.y == 4294967295u, 1u);
+        if (all(loop_bound_3 == uint2(0u, 0u))) { break; }
+        loop_bound_3 -= uint2(loop_bound_3.y == 0u, 1u);
         if (!loop_init_3) {
             uint _e5 = counter;
             if ((_e5 == 5u)) {

--- a/naga/tests/out/hlsl/collatz.hlsl
+++ b/naga/tests/out/hlsl/collatz.hlsl
@@ -14,10 +14,10 @@ uint collatz_iterations(uint n_base)
     uint i = 0u;
 
     n = n_base;
-    uint2 loop_bound = uint2(0u, 0u);
+    uint2 loop_bound = uint2(4294967295u, 4294967295u);
     while(true) {
-        if (all(loop_bound == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (all(loop_bound == uint2(0u, 0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         uint _e4 = n;
         if ((_e4 > 1u)) {
         } else {

--- a/naga/tests/out/hlsl/control-flow.hlsl
+++ b/naga/tests/out/hlsl/control-flow.hlsl
@@ -64,10 +64,10 @@ void switch_const_expr_case_selectors()
 
 void loop_switch_continue(int x)
 {
-    uint2 loop_bound = uint2(0u, 0u);
+    uint2 loop_bound = uint2(4294967295u, 4294967295u);
     while(true) {
-        if (all(loop_bound == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (all(loop_bound == uint2(0u, 0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         bool should_continue = false;
         switch(x) {
             case 1: {
@@ -87,10 +87,10 @@ void loop_switch_continue(int x)
 
 void loop_switch_continue_nesting(int x_1, int y, int z)
 {
-    uint2 loop_bound_1 = uint2(0u, 0u);
+    uint2 loop_bound_1 = uint2(4294967295u, 4294967295u);
     while(true) {
-        if (all(loop_bound_1 == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound_1 += uint2(loop_bound_1.y == 4294967295u, 1u);
+        if (all(loop_bound_1 == uint2(0u, 0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
         bool should_continue_1 = false;
         switch(x_1) {
             case 1: {
@@ -104,10 +104,10 @@ void loop_switch_continue_nesting(int x_1, int y, int z)
                         break;
                     }
                     default: {
-                        uint2 loop_bound_2 = uint2(0u, 0u);
+                        uint2 loop_bound_2 = uint2(4294967295u, 4294967295u);
                         while(true) {
-                            if (all(loop_bound_2 == uint2(4294967295u, 4294967295u))) { break; }
-                            loop_bound_2 += uint2(loop_bound_2.y == 4294967295u, 1u);
+                            if (all(loop_bound_2 == uint2(0u, 0u))) { break; }
+                            loop_bound_2 -= uint2(loop_bound_2.y == 0u, 1u);
                             bool should_continue_2 = false;
                             switch(z) {
                                 case 1: {
@@ -146,10 +146,10 @@ void loop_switch_continue_nesting(int x_1, int y, int z)
             continue;
         }
     }
-    uint2 loop_bound_3 = uint2(0u, 0u);
+    uint2 loop_bound_3 = uint2(4294967295u, 4294967295u);
     while(true) {
-        if (all(loop_bound_3 == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound_3 += uint2(loop_bound_3.y == 4294967295u, 1u);
+        if (all(loop_bound_3 == uint2(0u, 0u))) { break; }
+        loop_bound_3 -= uint2(loop_bound_3.y == 0u, 1u);
         bool should_continue_4 = false;
         do {
             do {
@@ -171,10 +171,10 @@ void loop_switch_omit_continue_variable_checks(int x_2, int y_1, int z_1, int w)
 {
     int pos_1 = int(0);
 
-    uint2 loop_bound_4 = uint2(0u, 0u);
+    uint2 loop_bound_4 = uint2(4294967295u, 4294967295u);
     while(true) {
-        if (all(loop_bound_4 == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound_4 += uint2(loop_bound_4.y == 4294967295u, 1u);
+        if (all(loop_bound_4 == uint2(0u, 0u))) { break; }
+        loop_bound_4 -= uint2(loop_bound_4.y == 0u, 1u);
         bool should_continue_5 = false;
         switch(x_2) {
             case 1: {
@@ -186,10 +186,10 @@ void loop_switch_omit_continue_variable_checks(int x_2, int y_1, int z_1, int w)
             }
         }
     }
-    uint2 loop_bound_5 = uint2(0u, 0u);
+    uint2 loop_bound_5 = uint2(4294967295u, 4294967295u);
     while(true) {
-        if (all(loop_bound_5 == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound_5 += uint2(loop_bound_5.y == 4294967295u, 1u);
+        if (all(loop_bound_5 == uint2(0u, 0u))) { break; }
+        loop_bound_5 -= uint2(loop_bound_5.y == 0u, 1u);
         bool should_continue_6 = false;
         switch(x_2) {
             case 1: {

--- a/naga/tests/out/hlsl/do-while.hlsl
+++ b/naga/tests/out/hlsl/do-while.hlsl
@@ -1,10 +1,10 @@
 void fb1_(inout bool cond)
 {
-    uint2 loop_bound = uint2(0u, 0u);
+    uint2 loop_bound = uint2(4294967295u, 4294967295u);
     bool loop_init = true;
     while(true) {
-        if (all(loop_bound == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (all(loop_bound == uint2(0u, 0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         if (!loop_init) {
             bool _e1 = cond;
             if (!(_e1)) {

--- a/naga/tests/out/hlsl/ray-query.hlsl
+++ b/naga/tests/out/hlsl/ray-query.hlsl
@@ -84,10 +84,10 @@ RayIntersection query_loop(float3 pos, float3 dir, RaytracingAccelerationStructu
     RayQuery<RAY_FLAG_NONE> rq_1;
 
     rq_1.TraceRayInline(acs, ConstructRayDesc_(4u, 255u, 0.1, 100.0, pos, dir).flags, ConstructRayDesc_(4u, 255u, 0.1, 100.0, pos, dir).cull_mask, RayDescFromRayDesc_(ConstructRayDesc_(4u, 255u, 0.1, 100.0, pos, dir)));
-    uint2 loop_bound = uint2(0u, 0u);
+    uint2 loop_bound = uint2(4294967295u, 4294967295u);
     while(true) {
-        if (all(loop_bound == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (all(loop_bound == uint2(0u, 0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         const bool _e9 = rq_1.Proceed();
         if (_e9) {
         } else {

--- a/naga/tests/out/hlsl/shadow.hlsl
+++ b/naga/tests/out/hlsl/shadow.hlsl
@@ -95,11 +95,11 @@ float4 fs_main(FragmentInput_fs_main fragmentinput_fs_main) : SV_Target0
     uint i = 0u;
 
     float3 normal_1 = normalize(in_.world_normal);
-    uint2 loop_bound = uint2(0u, 0u);
+    uint2 loop_bound = uint2(4294967295u, 4294967295u);
     bool loop_init = true;
     while(true) {
-        if (all(loop_bound == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (all(loop_bound == uint2(0u, 0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         if (!loop_init) {
             uint _e40 = i;
             i = (_e40 + 1u);
@@ -134,11 +134,11 @@ float4 fs_main_without_storage(FragmentInput_fs_main_without_storage fragmentinp
     uint i_1 = 0u;
 
     float3 normal_2 = normalize(in_1.world_normal);
-    uint2 loop_bound_1 = uint2(0u, 0u);
+    uint2 loop_bound_1 = uint2(4294967295u, 4294967295u);
     bool loop_init_1 = true;
     while(true) {
-        if (all(loop_bound_1 == uint2(4294967295u, 4294967295u))) { break; }
-        loop_bound_1 += uint2(loop_bound_1.y == 4294967295u, 1u);
+        if (all(loop_bound_1 == uint2(0u, 0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
         if (!loop_init_1) {
             uint _e40 = i_1;
             i_1 = (_e40 + 1u);

--- a/naga/tests/out/msl/atomicCompareExchange.msl
+++ b/naga/tests/out/msl/atomicCompareExchange.msl
@@ -76,11 +76,11 @@ kernel void test_atomic_compare_exchange_i32_(
     uint i = 0u;
     int old = {};
     bool exchanged = {};
-    uint2 loop_bound = uint2(0u);
+    uint2 loop_bound = uint2(4294967295u);
     bool loop_init = true;
     while(true) {
-        if (metal::all(loop_bound == uint2(4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         if (!loop_init) {
             uint _e27 = i;
             i = _e27 + 1u;
@@ -96,10 +96,10 @@ kernel void test_atomic_compare_exchange_i32_(
             int _e8 = metal::atomic_load_explicit(&arr_i32_.inner[_e6], metal::memory_order_relaxed);
             old = _e8;
             exchanged = false;
-            uint2 loop_bound_1 = uint2(0u);
+            uint2 loop_bound_1 = uint2(4294967295u);
             while(true) {
-                if (metal::all(loop_bound_1 == uint2(4294967295u))) { break; }
-                loop_bound_1 += uint2(loop_bound_1.y == 4294967295u, 1u);
+                if (metal::all(loop_bound_1 == uint2(0u))) { break; }
+                loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
                 bool _e12 = exchanged;
                 if (!(_e12)) {
                 } else {
@@ -127,11 +127,11 @@ kernel void test_atomic_compare_exchange_u32_(
     uint i_1 = 0u;
     uint old_1 = {};
     bool exchanged_1 = {};
-    uint2 loop_bound_2 = uint2(0u);
+    uint2 loop_bound_2 = uint2(4294967295u);
     bool loop_init_1 = true;
     while(true) {
-        if (metal::all(loop_bound_2 == uint2(4294967295u))) { break; }
-        loop_bound_2 += uint2(loop_bound_2.y == 4294967295u, 1u);
+        if (metal::all(loop_bound_2 == uint2(0u))) { break; }
+        loop_bound_2 -= uint2(loop_bound_2.y == 0u, 1u);
         if (!loop_init_1) {
             uint _e27 = i_1;
             i_1 = _e27 + 1u;
@@ -147,10 +147,10 @@ kernel void test_atomic_compare_exchange_u32_(
             uint _e8 = metal::atomic_load_explicit(&arr_u32_.inner[_e6], metal::memory_order_relaxed);
             old_1 = _e8;
             exchanged_1 = false;
-            uint2 loop_bound_3 = uint2(0u);
+            uint2 loop_bound_3 = uint2(4294967295u);
             while(true) {
-                if (metal::all(loop_bound_3 == uint2(4294967295u))) { break; }
-                loop_bound_3 += uint2(loop_bound_3.y == 4294967295u, 1u);
+                if (metal::all(loop_bound_3 == uint2(0u))) { break; }
+                loop_bound_3 -= uint2(loop_bound_3.y == 0u, 1u);
                 bool _e12 = exchanged_1;
                 if (!(_e12)) {
                 } else {

--- a/naga/tests/out/msl/boids.msl
+++ b/naga/tests/out/msl/boids.msl
@@ -55,11 +55,11 @@ kernel void main_(
     vPos = _e8;
     metal::float2 _e14 = particlesSrc.particles[index].vel;
     vVel = _e14;
-    uint2 loop_bound = uint2(0u);
+    uint2 loop_bound = uint2(4294967295u);
     bool loop_init = true;
     while(true) {
-        if (metal::all(loop_bound == uint2(4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         if (!loop_init) {
             uint _e91 = i;
             i = _e91 + 1u;

--- a/naga/tests/out/msl/break-if.msl
+++ b/naga/tests/out/msl/break-if.msl
@@ -7,11 +7,11 @@ using metal::uint;
 
 void breakIfEmpty(
 ) {
-    uint2 loop_bound = uint2(0u);
+    uint2 loop_bound = uint2(4294967295u);
     bool loop_init = true;
     while(true) {
-        if (metal::all(loop_bound == uint2(4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         if (!loop_init) {
             if (true) {
                 break;
@@ -27,11 +27,11 @@ void breakIfEmptyBody(
 ) {
     bool b = {};
     bool c = {};
-    uint2 loop_bound_1 = uint2(0u);
+    uint2 loop_bound_1 = uint2(4294967295u);
     bool loop_init_1 = true;
     while(true) {
-        if (metal::all(loop_bound_1 == uint2(4294967295u))) { break; }
-        loop_bound_1 += uint2(loop_bound_1.y == 4294967295u, 1u);
+        if (metal::all(loop_bound_1 == uint2(0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
         if (!loop_init_1) {
             b = a;
             bool _e2 = b;
@@ -51,11 +51,11 @@ void breakIf(
 ) {
     bool d = {};
     bool e = {};
-    uint2 loop_bound_2 = uint2(0u);
+    uint2 loop_bound_2 = uint2(4294967295u);
     bool loop_init_2 = true;
     while(true) {
-        if (metal::all(loop_bound_2 == uint2(4294967295u))) { break; }
-        loop_bound_2 += uint2(loop_bound_2.y == 4294967295u, 1u);
+        if (metal::all(loop_bound_2 == uint2(0u))) { break; }
+        loop_bound_2 -= uint2(loop_bound_2.y == 0u, 1u);
         if (!loop_init_2) {
             bool _e5 = e;
             if (a_1 == e) {
@@ -73,11 +73,11 @@ void breakIf(
 void breakIfSeparateVariable(
 ) {
     uint counter = 0u;
-    uint2 loop_bound_3 = uint2(0u);
+    uint2 loop_bound_3 = uint2(4294967295u);
     bool loop_init_3 = true;
     while(true) {
-        if (metal::all(loop_bound_3 == uint2(4294967295u))) { break; }
-        loop_bound_3 += uint2(loop_bound_3.y == 4294967295u, 1u);
+        if (metal::all(loop_bound_3 == uint2(0u))) { break; }
+        loop_bound_3 -= uint2(loop_bound_3.y == 0u, 1u);
         if (!loop_init_3) {
             uint _e5 = counter;
             if (counter == 5u) {

--- a/naga/tests/out/msl/collatz.msl
+++ b/naga/tests/out/msl/collatz.msl
@@ -27,10 +27,10 @@ uint collatz_iterations(
     uint n = {};
     uint i = 0u;
     n = n_base;
-    uint2 loop_bound = uint2(0u);
+    uint2 loop_bound = uint2(4294967295u);
     while(true) {
-        if (metal::all(loop_bound == uint2(4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         uint _e4 = n;
         if (_e4 > 1u) {
         } else {

--- a/naga/tests/out/msl/control-flow.msl
+++ b/naga/tests/out/msl/control-flow.msl
@@ -75,10 +75,10 @@ void switch_const_expr_case_selectors(
 void loop_switch_continue(
     int x
 ) {
-    uint2 loop_bound = uint2(0u);
+    uint2 loop_bound = uint2(4294967295u);
     while(true) {
-        if (metal::all(loop_bound == uint2(4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         switch(x) {
             case 1: {
                 continue;
@@ -96,10 +96,10 @@ void loop_switch_continue_nesting(
     int y,
     int z
 ) {
-    uint2 loop_bound_1 = uint2(0u);
+    uint2 loop_bound_1 = uint2(4294967295u);
     while(true) {
-        if (metal::all(loop_bound_1 == uint2(4294967295u))) { break; }
-        loop_bound_1 += uint2(loop_bound_1.y == 4294967295u, 1u);
+        if (metal::all(loop_bound_1 == uint2(0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
         switch(x_1) {
             case 1: {
                 continue;
@@ -110,10 +110,10 @@ void loop_switch_continue_nesting(
                         continue;
                     }
                     default: {
-                        uint2 loop_bound_2 = uint2(0u);
+                        uint2 loop_bound_2 = uint2(4294967295u);
                         while(true) {
-                            if (metal::all(loop_bound_2 == uint2(4294967295u))) { break; }
-                            loop_bound_2 += uint2(loop_bound_2.y == 4294967295u, 1u);
+                            if (metal::all(loop_bound_2 == uint2(0u))) { break; }
+                            loop_bound_2 -= uint2(loop_bound_2.y == 0u, 1u);
                             switch(z) {
                                 case 1: {
                                     continue;
@@ -138,10 +138,10 @@ void loop_switch_continue_nesting(
             }
         }
     }
-    uint2 loop_bound_3 = uint2(0u);
+    uint2 loop_bound_3 = uint2(4294967295u);
     while(true) {
-        if (metal::all(loop_bound_3 == uint2(4294967295u))) { break; }
-        loop_bound_3 += uint2(loop_bound_3.y == 4294967295u, 1u);
+        if (metal::all(loop_bound_3 == uint2(0u))) { break; }
+        loop_bound_3 -= uint2(loop_bound_3.y == 0u, 1u);
         switch(y) {
             case 1:
             default: {
@@ -164,10 +164,10 @@ void loop_switch_omit_continue_variable_checks(
     int w
 ) {
     int pos_1 = 0;
-    uint2 loop_bound_4 = uint2(0u);
+    uint2 loop_bound_4 = uint2(4294967295u);
     while(true) {
-        if (metal::all(loop_bound_4 == uint2(4294967295u))) { break; }
-        loop_bound_4 += uint2(loop_bound_4.y == 4294967295u, 1u);
+        if (metal::all(loop_bound_4 == uint2(0u))) { break; }
+        loop_bound_4 -= uint2(loop_bound_4.y == 0u, 1u);
         switch(x_2) {
             case 1: {
                 pos_1 = 1;
@@ -178,10 +178,10 @@ void loop_switch_omit_continue_variable_checks(
             }
         }
     }
-    uint2 loop_bound_5 = uint2(0u);
+    uint2 loop_bound_5 = uint2(4294967295u);
     while(true) {
-        if (metal::all(loop_bound_5 == uint2(4294967295u))) { break; }
-        loop_bound_5 += uint2(loop_bound_5.y == 4294967295u, 1u);
+        if (metal::all(loop_bound_5 == uint2(0u))) { break; }
+        loop_bound_5 -= uint2(loop_bound_5.y == 0u, 1u);
         switch(x_2) {
             case 1: {
                 break;

--- a/naga/tests/out/msl/do-while.msl
+++ b/naga/tests/out/msl/do-while.msl
@@ -8,11 +8,11 @@ using metal::uint;
 void fb1_(
     thread bool& cond
 ) {
-    uint2 loop_bound = uint2(0u);
+    uint2 loop_bound = uint2(4294967295u);
     bool loop_init = true;
     while(true) {
-        if (metal::all(loop_bound == uint2(4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         if (!loop_init) {
             bool _e1 = cond;
             if (!(cond)) {

--- a/naga/tests/out/msl/overrides-ray-query.msl
+++ b/naga/tests/out/msl/overrides-ray-query.msl
@@ -33,10 +33,10 @@ kernel void main_(
     rq.intersector.force_opacity((desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
     rq.intersector.accept_any_intersection((desc.flags & 4) != 0);
     rq.intersection = rq.intersector.intersect(metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax), acc_struct, desc.cull_mask);    rq.ready = true;
-    uint2 loop_bound = uint2(0u);
+    uint2 loop_bound = uint2(4294967295u);
     while(true) {
-        if (metal::all(loop_bound == uint2(4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         bool _e31 = rq.ready;
         if (_e31) {
         } else {

--- a/naga/tests/out/msl/ray-query.msl
+++ b/naga/tests/out/msl/ray-query.msl
@@ -53,10 +53,10 @@ RayIntersection query_loop(
     rq_1.intersector.force_opacity((_e8.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (_e8.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
     rq_1.intersector.accept_any_intersection((_e8.flags & 4) != 0);
     rq_1.intersection = rq_1.intersector.intersect(metal::raytracing::ray(_e8.origin, _e8.dir, _e8.tmin, _e8.tmax), acs, _e8.cull_mask);    rq_1.ready = true;
-    uint2 loop_bound = uint2(0u);
+    uint2 loop_bound = uint2(4294967295u);
     while(true) {
-        if (metal::all(loop_bound == uint2(4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         bool _e9 = rq_1.ready;
         if (_e9) {
         } else {

--- a/naga/tests/out/msl/shadow.msl
+++ b/naga/tests/out/msl/shadow.msl
@@ -100,11 +100,11 @@ fragment fs_mainOutput fs_main(
     metal::float3 color = c_ambient;
     uint i = 0u;
     metal::float3 normal_1 = metal::normalize(in.world_normal);
-    uint2 loop_bound = uint2(0u);
+    uint2 loop_bound = uint2(4294967295u);
     bool loop_init = true;
     while(true) {
-        if (metal::all(loop_bound == uint2(4294967295u))) { break; }
-        loop_bound += uint2(loop_bound.y == 4294967295u, 1u);
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
         if (!loop_init) {
             uint _e40 = i;
             i = _e40 + 1u;
@@ -153,11 +153,11 @@ fragment fs_main_without_storageOutput fs_main_without_storage(
     metal::float3 color_1 = c_ambient;
     uint i_1 = 0u;
     metal::float3 normal_2 = metal::normalize(in_1.world_normal);
-    uint2 loop_bound_1 = uint2(0u);
+    uint2 loop_bound_1 = uint2(4294967295u);
     bool loop_init_1 = true;
     while(true) {
-        if (metal::all(loop_bound_1 == uint2(4294967295u))) { break; }
-        loop_bound_1 += uint2(loop_bound_1.y == 4294967295u, 1u);
+        if (metal::all(loop_bound_1 == uint2(0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
         if (!loop_init_1) {
             uint _e40 = i_1;
             i_1 = _e40 + 1u;

--- a/naga/tests/out/spv/6220-break-from-loop.spvasm
+++ b/naga/tests/out/spv/6220-break-from-loop.spvasm
@@ -26,7 +26,7 @@ OpMemoryModel Logical GLSL450
 %5 = OpFunction  %2  None %6
 %4 = OpLabel
 %10 = OpVariable  %11  Function %7
-%27 = OpVariable  %19  Function %23
+%27 = OpVariable  %19  Function %26
 OpBranch %12
 %12 = OpLabel
 OpBranch %13
@@ -35,16 +35,16 @@ OpLoopMerge %14 %16 None
 OpBranch %28
 %28 = OpLabel
 %29 = OpLoad  %18  %27
-%30 = OpIEqual  %21  %26 %29
+%30 = OpIEqual  %21  %23 %29
 %31 = OpAll  %20  %30
 OpSelectionMerge %32 None
 OpBranchConditional %31 %14 %32
 %32 = OpLabel
 %33 = OpCompositeExtract  %17  %29 1
-%34 = OpIEqual  %20  %33 %25
+%34 = OpIEqual  %20  %33 %22
 %35 = OpSelect  %17  %34 %24 %22
 %36 = OpCompositeConstruct  %18  %35 %24
-%37 = OpIAdd  %18  %29 %36
+%37 = OpISub  %18  %29 %36
 OpStore %27 %37
 OpBranch %15
 %15 = OpLabel

--- a/naga/tests/out/spv/7048-multiple-dynamic-3.spvasm
+++ b/naga/tests/out/spv/7048-multiple-dynamic-3.spvasm
@@ -42,8 +42,8 @@ OpDecorate %6 ArrayStride 16
 %25 = OpVariable  %22  Function %26
 %19 = OpVariable  %20  Function %14
 %24 = OpVariable  %20  Function %14
-%39 = OpVariable  %33  Function %36
-%67 = OpVariable  %33  Function %36
+%39 = OpVariable  %33  Function %38
+%67 = OpVariable  %33  Function %38
 %58 = OpVariable  %57  Function
 OpBranch %27
 %27 = OpLabel
@@ -53,16 +53,16 @@ OpLoopMerge %29 %31 None
 OpBranch %40
 %40 = OpLabel
 %41 = OpLoad  %32  %39
-%42 = OpIEqual  %35  %38 %41
+%42 = OpIEqual  %35  %36 %41
 %43 = OpAll  %34  %42
 OpSelectionMerge %44 None
 OpBranchConditional %43 %29 %44
 %44 = OpLabel
 %45 = OpCompositeExtract  %8  %41 1
-%46 = OpIEqual  %34  %45 %37
+%46 = OpIEqual  %34  %45 %14
 %47 = OpSelect  %8  %46 %15 %14
 %48 = OpCompositeConstruct  %32  %47 %15
-%49 = OpIAdd  %32  %41 %48
+%49 = OpISub  %32  %41 %48
 OpStore %39 %49
 OpBranch %30
 %30 = OpLabel
@@ -95,16 +95,16 @@ OpLoopMerge %64 %66 None
 OpBranch %68
 %68 = OpLabel
 %69 = OpLoad  %32  %67
-%70 = OpIEqual  %35  %38 %69
+%70 = OpIEqual  %35  %36 %69
 %71 = OpAll  %34  %70
 OpSelectionMerge %72 None
 OpBranchConditional %71 %64 %72
 %72 = OpLabel
 %73 = OpCompositeExtract  %8  %69 1
-%74 = OpIEqual  %34  %73 %37
+%74 = OpIEqual  %34  %73 %14
 %75 = OpSelect  %8  %74 %15 %14
 %76 = OpCompositeConstruct  %32  %75 %15
-%77 = OpIAdd  %32  %69 %76
+%77 = OpISub  %32  %69 %76
 OpStore %67 %77
 OpBranch %65
 %65 = OpLabel

--- a/naga/tests/out/spv/atomicCompareExchange-int64.spvasm
+++ b/naga/tests/out/spv/atomicCompareExchange-int64.spvasm
@@ -74,8 +74,8 @@ OpMemberDecorate %16 0 Offset 0
 %27 = OpVariable  %28  Function %22
 %29 = OpVariable  %30  Function %31
 %32 = OpVariable  %33  Function %34
-%46 = OpVariable  %41  Function %43
-%74 = OpVariable  %41  Function %43
+%46 = OpVariable  %41  Function %45
+%74 = OpVariable  %41  Function %45
 %23 = OpAccessChain  %21  %12 %22
 OpBranch %35
 %35 = OpLabel
@@ -85,16 +85,16 @@ OpLoopMerge %37 %39 None
 OpBranch %47
 %47 = OpLabel
 %48 = OpLoad  %40  %46
-%49 = OpIEqual  %42  %45 %48
+%49 = OpIEqual  %42  %43 %48
 %50 = OpAll  %9  %49
 OpSelectionMerge %51 None
 OpBranchConditional %50 %37 %51
 %51 = OpLabel
 %52 = OpCompositeExtract  %3  %48 1
-%53 = OpIEqual  %9  %52 %44
+%53 = OpIEqual  %9  %52 %22
 %54 = OpSelect  %3  %53 %26 %22
 %55 = OpCompositeConstruct  %40  %54 %26
-%56 = OpIAdd  %40  %48 %55
+%56 = OpISub  %40  %48 %55
 OpStore %46 %56
 OpBranch %38
 %38 = OpLabel
@@ -118,16 +118,16 @@ OpLoopMerge %71 %73 None
 OpBranch %75
 %75 = OpLabel
 %76 = OpLoad  %40  %74
-%77 = OpIEqual  %42  %45 %76
+%77 = OpIEqual  %42  %43 %76
 %78 = OpAll  %9  %77
 OpSelectionMerge %79 None
 OpBranchConditional %78 %71 %79
 %79 = OpLabel
 %80 = OpCompositeExtract  %3  %76 1
-%81 = OpIEqual  %9  %80 %44
+%81 = OpIEqual  %9  %80 %22
 %82 = OpSelect  %3  %81 %26 %22
 %83 = OpCompositeConstruct  %40  %82 %26
-%84 = OpIAdd  %40  %76 %83
+%84 = OpISub  %40  %76 %83
 OpStore %74 %84
 OpBranch %72
 %72 = OpLabel
@@ -174,8 +174,8 @@ OpFunctionEnd
 %108 = OpVariable  %28  Function %22
 %109 = OpVariable  %110  Function %111
 %112 = OpVariable  %33  Function %113
-%119 = OpVariable  %41  Function %43
-%144 = OpVariable  %41  Function %43
+%119 = OpVariable  %41  Function %45
+%144 = OpVariable  %41  Function %45
 %106 = OpAccessChain  %105  %15 %22
 OpBranch %114
 %114 = OpLabel
@@ -185,16 +185,16 @@ OpLoopMerge %116 %118 None
 OpBranch %120
 %120 = OpLabel
 %121 = OpLoad  %40  %119
-%122 = OpIEqual  %42  %45 %121
+%122 = OpIEqual  %42  %43 %121
 %123 = OpAll  %9  %122
 OpSelectionMerge %124 None
 OpBranchConditional %123 %116 %124
 %124 = OpLabel
 %125 = OpCompositeExtract  %3  %121 1
-%126 = OpIEqual  %9  %125 %44
+%126 = OpIEqual  %9  %125 %22
 %127 = OpSelect  %3  %126 %26 %22
 %128 = OpCompositeConstruct  %40  %127 %26
-%129 = OpIAdd  %40  %121 %128
+%129 = OpISub  %40  %121 %128
 OpStore %119 %129
 OpBranch %117
 %117 = OpLabel
@@ -218,16 +218,16 @@ OpLoopMerge %141 %143 None
 OpBranch %145
 %145 = OpLabel
 %146 = OpLoad  %40  %144
-%147 = OpIEqual  %42  %45 %146
+%147 = OpIEqual  %42  %43 %146
 %148 = OpAll  %9  %147
 OpSelectionMerge %149 None
 OpBranchConditional %148 %141 %149
 %149 = OpLabel
 %150 = OpCompositeExtract  %3  %146 1
-%151 = OpIEqual  %9  %150 %44
+%151 = OpIEqual  %9  %150 %22
 %152 = OpSelect  %3  %151 %26 %22
 %153 = OpCompositeConstruct  %40  %152 %26
-%154 = OpIAdd  %40  %146 %153
+%154 = OpISub  %40  %146 %153
 OpStore %144 %154
 OpBranch %142
 %142 = OpLabel

--- a/naga/tests/out/spv/atomicCompareExchange.spvasm
+++ b/naga/tests/out/spv/atomicCompareExchange.spvasm
@@ -69,8 +69,8 @@ OpMemberDecorate %15 0 Offset 0
 %27 = OpVariable  %28  Function %21
 %29 = OpVariable  %30  Function %31
 %32 = OpVariable  %33  Function %34
-%46 = OpVariable  %41  Function %43
-%73 = OpVariable  %41  Function %43
+%46 = OpVariable  %41  Function %45
+%73 = OpVariable  %41  Function %45
 %22 = OpAccessChain  %20  %11 %21
 OpBranch %35
 %35 = OpLabel
@@ -80,16 +80,16 @@ OpLoopMerge %37 %39 None
 OpBranch %47
 %47 = OpLabel
 %48 = OpLoad  %40  %46
-%49 = OpIEqual  %42  %45 %48
+%49 = OpIEqual  %42  %43 %48
 %50 = OpAll  %8  %49
 OpSelectionMerge %51 None
 OpBranchConditional %50 %37 %51
 %51 = OpLabel
 %52 = OpCompositeExtract  %3  %48 1
-%53 = OpIEqual  %8  %52 %44
+%53 = OpIEqual  %8  %52 %21
 %54 = OpSelect  %3  %53 %26 %21
 %55 = OpCompositeConstruct  %40  %54 %26
-%56 = OpIAdd  %40  %48 %55
+%56 = OpISub  %40  %48 %55
 OpStore %46 %56
 OpBranch %38
 %38 = OpLabel
@@ -113,16 +113,16 @@ OpLoopMerge %70 %72 None
 OpBranch %74
 %74 = OpLabel
 %75 = OpLoad  %40  %73
-%76 = OpIEqual  %42  %45 %75
+%76 = OpIEqual  %42  %43 %75
 %77 = OpAll  %8  %76
 OpSelectionMerge %78 None
 OpBranchConditional %77 %70 %78
 %78 = OpLabel
 %79 = OpCompositeExtract  %3  %75 1
-%80 = OpIEqual  %8  %79 %44
+%80 = OpIEqual  %8  %79 %21
 %81 = OpSelect  %3  %80 %26 %21
 %82 = OpCompositeConstruct  %40  %81 %26
-%83 = OpIAdd  %40  %75 %82
+%83 = OpISub  %40  %75 %82
 OpStore %73 %83
 OpBranch %71
 %71 = OpLabel
@@ -171,8 +171,8 @@ OpFunctionEnd
 %108 = OpVariable  %28  Function %21
 %109 = OpVariable  %28  Function %110
 %111 = OpVariable  %33  Function %112
-%118 = OpVariable  %41  Function %43
-%143 = OpVariable  %41  Function %43
+%118 = OpVariable  %41  Function %45
+%143 = OpVariable  %41  Function %45
 %107 = OpAccessChain  %106  %14 %21
 OpBranch %113
 %113 = OpLabel
@@ -182,16 +182,16 @@ OpLoopMerge %115 %117 None
 OpBranch %119
 %119 = OpLabel
 %120 = OpLoad  %40  %118
-%121 = OpIEqual  %42  %45 %120
+%121 = OpIEqual  %42  %43 %120
 %122 = OpAll  %8  %121
 OpSelectionMerge %123 None
 OpBranchConditional %122 %115 %123
 %123 = OpLabel
 %124 = OpCompositeExtract  %3  %120 1
-%125 = OpIEqual  %8  %124 %44
+%125 = OpIEqual  %8  %124 %21
 %126 = OpSelect  %3  %125 %26 %21
 %127 = OpCompositeConstruct  %40  %126 %26
-%128 = OpIAdd  %40  %120 %127
+%128 = OpISub  %40  %120 %127
 OpStore %118 %128
 OpBranch %116
 %116 = OpLabel
@@ -215,16 +215,16 @@ OpLoopMerge %140 %142 None
 OpBranch %144
 %144 = OpLabel
 %145 = OpLoad  %40  %143
-%146 = OpIEqual  %42  %45 %145
+%146 = OpIEqual  %42  %43 %145
 %147 = OpAll  %8  %146
 OpSelectionMerge %148 None
 OpBranchConditional %147 %140 %148
 %148 = OpLabel
 %149 = OpCompositeExtract  %3  %145 1
-%150 = OpIEqual  %8  %149 %44
+%150 = OpIEqual  %8  %149 %21
 %151 = OpSelect  %3  %150 %26 %21
 %152 = OpCompositeConstruct  %40  %151 %26
-%153 = OpIAdd  %40  %145 %152
+%153 = OpISub  %40  %145 %152
 OpStore %143 %153
 OpBranch %141
 %141 = OpLabel

--- a/naga/tests/out/spv/boids.spvasm
+++ b/naga/tests/out/spv/boids.spvasm
@@ -235,7 +235,7 @@ OpDecorate %21 BuiltIn GlobalInvocationId
 %50 = OpVariable  %38  Function %51
 %45 = OpVariable  %46  Function %31
 %42 = OpVariable  %38  Function %30
-%77 = OpVariable  %72  Function %74
+%77 = OpVariable  %72  Function %76
 %23 = OpLoad  %11  %21
 %28 = OpAccessChain  %26  %14 %27
 OpBranch %54
@@ -270,16 +270,16 @@ OpLoopMerge %68 %70 None
 OpBranch %78
 %78 = OpLabel
 %79 = OpLoad  %71  %77
-%80 = OpIEqual  %73  %76 %79
+%80 = OpIEqual  %73  %74 %79
 %81 = OpAll  %56  %80
 OpSelectionMerge %82 None
 OpBranchConditional %81 %68 %82
 %82 = OpLabel
 %83 = OpCompositeExtract  %4  %79 1
-%84 = OpIEqual  %56  %83 %75
+%84 = OpIEqual  %56  %83 %27
 %85 = OpSelect  %4  %84 %33 %27
 %86 = OpCompositeConstruct  %71  %85 %33
-%87 = OpIAdd  %71  %79 %86
+%87 = OpISub  %71  %79 %86
 OpStore %77 %87
 OpBranch %69
 %69 = OpLabel

--- a/naga/tests/out/spv/break-if.spvasm
+++ b/naga/tests/out/spv/break-if.spvasm
@@ -30,7 +30,7 @@ OpExecutionMode %115 LocalSize 1 1 1
 %93 = OpTypePointer Function %4
 %6 = OpFunction  %2  None %7
 %5 = OpLabel
-%22 = OpVariable  %15  Function %18
+%22 = OpVariable  %15  Function %21
 OpBranch %9
 %9 = OpLabel
 OpBranch %10
@@ -39,16 +39,16 @@ OpLoopMerge %11 %13 None
 OpBranch %23
 %23 = OpLabel
 %24 = OpLoad  %14  %22
-%25 = OpIEqual  %16  %21 %24
+%25 = OpIEqual  %16  %18 %24
 %26 = OpAll  %3  %25
 OpSelectionMerge %27 None
 OpBranchConditional %26 %11 %27
 %27 = OpLabel
 %28 = OpCompositeExtract  %4  %24 1
-%29 = OpIEqual  %3  %28 %20
+%29 = OpIEqual  %3  %28 %17
 %30 = OpSelect  %4  %29 %19 %17
 %31 = OpCompositeConstruct  %14  %30 %19
-%32 = OpIAdd  %14  %24 %31
+%32 = OpISub  %14  %24 %31
 OpStore %22 %32
 OpBranch %12
 %12 = OpLabel
@@ -63,7 +63,7 @@ OpFunctionEnd
 %33 = OpLabel
 %37 = OpVariable  %38  Function %39
 %40 = OpVariable  %38  Function %41
-%47 = OpVariable  %15  Function %18
+%47 = OpVariable  %15  Function %21
 OpBranch %42
 %42 = OpLabel
 OpBranch %43
@@ -72,16 +72,16 @@ OpLoopMerge %44 %46 None
 OpBranch %48
 %48 = OpLabel
 %49 = OpLoad  %14  %47
-%50 = OpIEqual  %16  %21 %49
+%50 = OpIEqual  %16  %18 %49
 %51 = OpAll  %3  %50
 OpSelectionMerge %52 None
 OpBranchConditional %51 %44 %52
 %52 = OpLabel
 %53 = OpCompositeExtract  %4  %49 1
-%54 = OpIEqual  %3  %53 %20
+%54 = OpIEqual  %3  %53 %17
 %55 = OpSelect  %4  %54 %19 %17
 %56 = OpCompositeConstruct  %14  %55 %19
-%57 = OpIAdd  %14  %49 %56
+%57 = OpISub  %14  %49 %56
 OpStore %47 %57
 OpBranch %45
 %45 = OpLabel
@@ -102,7 +102,7 @@ OpFunctionEnd
 %62 = OpLabel
 %65 = OpVariable  %38  Function %66
 %67 = OpVariable  %38  Function %68
-%74 = OpVariable  %15  Function %18
+%74 = OpVariable  %15  Function %21
 OpBranch %69
 %69 = OpLabel
 OpBranch %70
@@ -111,16 +111,16 @@ OpLoopMerge %71 %73 None
 OpBranch %75
 %75 = OpLabel
 %76 = OpLoad  %14  %74
-%77 = OpIEqual  %16  %21 %76
+%77 = OpIEqual  %16  %18 %76
 %78 = OpAll  %3  %77
 OpSelectionMerge %79 None
 OpBranchConditional %78 %71 %79
 %79 = OpLabel
 %80 = OpCompositeExtract  %4  %76 1
-%81 = OpIEqual  %3  %80 %20
+%81 = OpIEqual  %3  %80 %17
 %82 = OpSelect  %4  %81 %19 %17
 %83 = OpCompositeConstruct  %14  %82 %19
-%84 = OpIAdd  %14  %76 %83
+%84 = OpISub  %14  %76 %83
 OpStore %74 %84
 OpBranch %72
 %72 = OpLabel
@@ -139,7 +139,7 @@ OpFunctionEnd
 %90 = OpFunction  %2  None %7
 %89 = OpLabel
 %92 = OpVariable  %93  Function %17
-%99 = OpVariable  %15  Function %18
+%99 = OpVariable  %15  Function %21
 OpBranch %94
 %94 = OpLabel
 OpBranch %95
@@ -148,16 +148,16 @@ OpLoopMerge %96 %98 None
 OpBranch %100
 %100 = OpLabel
 %101 = OpLoad  %14  %99
-%102 = OpIEqual  %16  %21 %101
+%102 = OpIEqual  %16  %18 %101
 %103 = OpAll  %3  %102
 OpSelectionMerge %104 None
 OpBranchConditional %103 %96 %104
 %104 = OpLabel
 %105 = OpCompositeExtract  %4  %101 1
-%106 = OpIEqual  %3  %105 %20
+%106 = OpIEqual  %3  %105 %17
 %107 = OpSelect  %4  %106 %19 %17
 %108 = OpCompositeConstruct  %14  %107 %19
-%109 = OpIAdd  %14  %101 %108
+%109 = OpISub  %14  %101 %108
 OpStore %99 %109
 OpBranch %97
 %97 = OpLabel

--- a/naga/tests/out/spv/collatz.spvasm
+++ b/naga/tests/out/spv/collatz.spvasm
@@ -114,7 +114,7 @@ OpFunctionEnd
 %28 = OpLabel
 %34 = OpVariable  %35  Function %36
 %37 = OpVariable  %35  Function %16
-%49 = OpVariable  %44  Function %46
+%49 = OpVariable  %44  Function %48
 OpBranch %38
 %38 = OpLabel
 OpLine %3 15 5
@@ -126,16 +126,16 @@ OpLoopMerge %40 %42 None
 OpBranch %50
 %50 = OpLabel
 %51 = OpLoad  %43  %49
-%52 = OpIEqual  %45  %48 %51
+%52 = OpIEqual  %45  %46 %51
 %53 = OpAll  %15  %52
 OpSelectionMerge %54 None
 OpBranchConditional %53 %40 %54
 %54 = OpLabel
 %55 = OpCompositeExtract  %4  %51 1
-%56 = OpIEqual  %15  %55 %47
+%56 = OpIEqual  %15  %55 %16
 %57 = OpSelect  %4  %56 %18 %16
 %58 = OpCompositeConstruct  %43  %57 %18
-%59 = OpIAdd  %43  %51 %58
+%59 = OpISub  %43  %51 %58
 OpStore %49 %59
 OpBranch %41
 %41 = OpLabel

--- a/naga/tests/out/spv/control-flow.spvasm
+++ b/naga/tests/out/spv/control-flow.spvasm
@@ -107,7 +107,7 @@ OpFunctionEnd
 %43 = OpFunction  %2  None %9
 %42 = OpFunctionParameter  %5
 %41 = OpLabel
-%57 = OpVariable  %50  Function %53
+%57 = OpVariable  %50  Function %56
 OpBranch %44
 %44 = OpLabel
 OpBranch %45
@@ -116,16 +116,16 @@ OpLoopMerge %46 %48 None
 OpBranch %58
 %58 = OpLabel
 %59 = OpLoad  %49  %57
-%60 = OpIEqual  %52  %56 %59
+%60 = OpIEqual  %52  %53 %59
 %61 = OpAll  %51  %60
 OpSelectionMerge %62 None
 OpBranchConditional %61 %46 %62
 %62 = OpLabel
 %63 = OpCompositeExtract  %4  %59 1
-%64 = OpIEqual  %51  %63 %55
+%64 = OpIEqual  %51  %63 %23
 %65 = OpSelect  %4  %64 %54 %23
 %66 = OpCompositeConstruct  %49  %65 %54
-%67 = OpIAdd  %49  %59 %66
+%67 = OpISub  %49  %59 %66
 OpStore %57 %67
 OpBranch %47
 %47 = OpLabel
@@ -147,9 +147,9 @@ OpFunctionEnd
 %73 = OpFunctionParameter  %5
 %74 = OpFunctionParameter  %5
 %71 = OpLabel
-%82 = OpVariable  %50  Function %53
-%104 = OpVariable  %50  Function %53
-%124 = OpVariable  %50  Function %53
+%82 = OpVariable  %50  Function %56
+%104 = OpVariable  %50  Function %56
+%124 = OpVariable  %50  Function %56
 OpBranch %77
 %77 = OpLabel
 OpBranch %78
@@ -158,16 +158,16 @@ OpLoopMerge %79 %81 None
 OpBranch %83
 %83 = OpLabel
 %84 = OpLoad  %49  %82
-%85 = OpIEqual  %52  %56 %84
+%85 = OpIEqual  %52  %53 %84
 %86 = OpAll  %51  %85
 OpSelectionMerge %87 None
 OpBranchConditional %86 %79 %87
 %87 = OpLabel
 %88 = OpCompositeExtract  %4  %84 1
-%89 = OpIEqual  %51  %88 %55
+%89 = OpIEqual  %51  %88 %23
 %90 = OpSelect  %4  %89 %54 %23
 %91 = OpCompositeConstruct  %49  %90 %54
-%92 = OpIAdd  %49  %84 %91
+%92 = OpISub  %49  %84 %91
 OpStore %82 %92
 OpBranch %80
 %80 = OpLabel
@@ -187,16 +187,16 @@ OpLoopMerge %101 %103 None
 OpBranch %105
 %105 = OpLabel
 %106 = OpLoad  %49  %104
-%107 = OpIEqual  %52  %56 %106
+%107 = OpIEqual  %52  %53 %106
 %108 = OpAll  %51  %107
 OpSelectionMerge %109 None
 OpBranchConditional %108 %101 %109
 %109 = OpLabel
 %110 = OpCompositeExtract  %4  %106 1
-%111 = OpIEqual  %51  %110 %55
+%111 = OpIEqual  %51  %110 %23
 %112 = OpSelect  %4  %111 %54 %23
 %113 = OpCompositeConstruct  %49  %112 %54
-%114 = OpIAdd  %49  %106 %113
+%114 = OpISub  %49  %106 %113
 OpStore %104 %114
 OpBranch %102
 %102 = OpLabel
@@ -232,16 +232,16 @@ OpLoopMerge %121 %123 None
 OpBranch %125
 %125 = OpLabel
 %126 = OpLoad  %49  %124
-%127 = OpIEqual  %52  %56 %126
+%127 = OpIEqual  %52  %53 %126
 %128 = OpAll  %51  %127
 OpSelectionMerge %129 None
 OpBranchConditional %128 %121 %129
 %129 = OpLabel
 %130 = OpCompositeExtract  %4  %126 1
-%131 = OpIEqual  %51  %130 %55
+%131 = OpIEqual  %51  %130 %23
 %132 = OpSelect  %4  %131 %54 %23
 %133 = OpCompositeConstruct  %49  %132 %54
-%134 = OpIAdd  %49  %126 %133
+%134 = OpISub  %49  %126 %133
 OpStore %124 %134
 OpBranch %122
 %122 = OpLabel
@@ -268,8 +268,8 @@ OpFunctionEnd
 %143 = OpFunctionParameter  %5
 %139 = OpLabel
 %148 = OpVariable  %149  Function %16
-%155 = OpVariable  %50  Function %53
-%173 = OpVariable  %50  Function %53
+%155 = OpVariable  %50  Function %56
+%173 = OpVariable  %50  Function %56
 OpBranch %150
 %150 = OpLabel
 OpBranch %151
@@ -278,16 +278,16 @@ OpLoopMerge %152 %154 None
 OpBranch %156
 %156 = OpLabel
 %157 = OpLoad  %49  %155
-%158 = OpIEqual  %52  %56 %157
+%158 = OpIEqual  %52  %53 %157
 %159 = OpAll  %51  %158
 OpSelectionMerge %160 None
 OpBranchConditional %159 %152 %160
 %160 = OpLabel
 %161 = OpCompositeExtract  %4  %157 1
-%162 = OpIEqual  %51  %161 %55
+%162 = OpIEqual  %51  %161 %23
 %163 = OpSelect  %4  %162 %54 %23
 %164 = OpCompositeConstruct  %49  %163 %54
-%165 = OpIAdd  %49  %157 %164
+%165 = OpISub  %49  %157 %164
 OpStore %155 %165
 OpBranch %153
 %153 = OpLabel
@@ -309,16 +309,16 @@ OpLoopMerge %170 %172 None
 OpBranch %174
 %174 = OpLabel
 %175 = OpLoad  %49  %173
-%176 = OpIEqual  %52  %56 %175
+%176 = OpIEqual  %52  %53 %175
 %177 = OpAll  %51  %176
 OpSelectionMerge %178 None
 OpBranchConditional %177 %170 %178
 %178 = OpLabel
 %179 = OpCompositeExtract  %4  %175 1
-%180 = OpIEqual  %51  %179 %55
+%180 = OpIEqual  %51  %179 %23
 %181 = OpSelect  %4  %180 %54 %23
 %182 = OpCompositeConstruct  %49  %181 %54
-%183 = OpIAdd  %49  %175 %182
+%183 = OpISub  %49  %175 %182
 OpStore %173 %183
 OpBranch %171
 %171 = OpLabel

--- a/naga/tests/out/spv/debug-symbol-large-source.spvasm
+++ b/naga/tests/out/spv/debug-symbol-large-source.spvasm
@@ -8017,7 +8017,7 @@ OpFunctionEnd
 %216 = OpVariable  %217  Function %135
 %212 = OpVariable  %87  Function %213
 %215 = OpVariable  %125  Function %78
-%236 = OpVariable  %232  Function %233
+%236 = OpVariable  %232  Function %235
 OpBranch %218
 %218 = OpLabel
 OpLine %3 7179 13
@@ -8042,16 +8042,16 @@ OpLoopMerge %229 %231 None
 OpBranch %237
 %237 = OpLabel
 %238 = OpLoad  %10  %236
-%239 = OpIEqual  %115  %235 %238
+%239 = OpIEqual  %115  %233 %238
 %240 = OpAll  %112  %239
 OpSelectionMerge %241 None
 OpBranchConditional %240 %229 %241
 %241 = OpLabel
 %242 = OpCompositeExtract  %8  %238 1
-%243 = OpIEqual  %112  %242 %234
+%243 = OpIEqual  %112  %242 %135
 %244 = OpSelect  %8  %243 %126 %135
 %245 = OpCompositeConstruct  %10  %244 %126
-%246 = OpIAdd  %10  %238 %245
+%246 = OpISub  %10  %238 %245
 OpStore %236 %246
 OpBranch %230
 %230 = OpLabel

--- a/naga/tests/out/spv/debug-symbol-simple.spvasm
+++ b/naga/tests/out/spv/debug-symbol-simple.spvasm
@@ -148,7 +148,7 @@ OpFunctionEnd
 %55 = OpVariable  %28  Function %56
 %57 = OpVariable  %58  Function %50
 %59 = OpVariable  %60  Function %61
-%75 = OpVariable  %69  Function %72
+%75 = OpVariable  %69  Function %74
 %45 = OpLoad  %7  %43
 %47 = OpLoad  %5  %46
 %42 = OpCompositeConstruct  %8  %45 %47
@@ -165,16 +165,16 @@ OpLoopMerge %65 %67 None
 OpBranch %76
 %76 = OpLabel
 %77 = OpLoad  %68  %75
-%78 = OpIEqual  %71  %74 %77
+%78 = OpIEqual  %71  %72 %77
 %79 = OpAll  %70  %78
 OpSelectionMerge %80 None
 OpBranchConditional %79 %65 %80
 %80 = OpLabel
 %81 = OpCompositeExtract  %31  %77 1
-%82 = OpIEqual  %70  %81 %73
+%82 = OpIEqual  %70  %81 %36
 %83 = OpSelect  %31  %82 %30 %36
 %84 = OpCompositeConstruct  %68  %83 %30
-%85 = OpIAdd  %68  %77 %84
+%85 = OpISub  %68  %77 %84
 OpStore %75 %85
 OpBranch %66
 %66 = OpLabel

--- a/naga/tests/out/spv/debug-symbol-terrain.spvasm
+++ b/naga/tests/out/spv/debug-symbol-terrain.spvasm
@@ -852,7 +852,7 @@ OpFunctionEnd
 %216 = OpVariable  %217  Function %135
 %212 = OpVariable  %87  Function %213
 %215 = OpVariable  %125  Function %78
-%236 = OpVariable  %232  Function %233
+%236 = OpVariable  %232  Function %235
 OpBranch %218
 %218 = OpLabel
 OpLine %3 36 13
@@ -877,16 +877,16 @@ OpLoopMerge %229 %231 None
 OpBranch %237
 %237 = OpLabel
 %238 = OpLoad  %10  %236
-%239 = OpIEqual  %115  %235 %238
+%239 = OpIEqual  %115  %233 %238
 %240 = OpAll  %112  %239
 OpSelectionMerge %241 None
 OpBranchConditional %240 %229 %241
 %241 = OpLabel
 %242 = OpCompositeExtract  %8  %238 1
-%243 = OpIEqual  %112  %242 %234
+%243 = OpIEqual  %112  %242 %135
 %244 = OpSelect  %8  %243 %126 %135
 %245 = OpCompositeConstruct  %10  %244 %126
-%246 = OpIAdd  %10  %238 %245
+%246 = OpISub  %10  %238 %245
 OpStore %236 %246
 OpBranch %230
 %230 = OpLabel

--- a/naga/tests/out/spv/overrides-ray-query.main.spvasm
+++ b/naga/tests/out/spv/overrides-ray-query.main.spvasm
@@ -52,7 +52,7 @@ OpDecorate %10 Binding 0
 %13 = OpFunction  %2  None %14
 %12 = OpLabel
 %27 = OpVariable  %28  Function
-%49 = OpVariable  %41  Function %45
+%49 = OpVariable  %41  Function %48
 %15 = OpLoad  %4  %10
 OpBranch %29
 %29 = OpLabel
@@ -69,16 +69,16 @@ OpLoopMerge %37 %39 None
 OpBranch %50
 %50 = OpLabel
 %51 = OpLoad  %40  %49
-%52 = OpIEqual  %43  %48 %51
+%52 = OpIEqual  %43  %45 %51
 %53 = OpAll  %42  %52
 OpSelectionMerge %54 None
 OpBranchConditional %53 %37 %54
 %54 = OpLabel
 %55 = OpCompositeExtract  %6  %51 1
-%56 = OpIEqual  %42  %55 %47
+%56 = OpIEqual  %42  %55 %44
 %57 = OpSelect  %6  %56 %46 %44
 %58 = OpCompositeConstruct  %40  %57 %46
-%59 = OpIAdd  %40  %51 %58
+%59 = OpISub  %40  %51 %58
 OpStore %49 %59
 OpBranch %38
 %38 = OpLabel

--- a/naga/tests/out/spv/ray-query.spvasm
+++ b/naga/tests/out/spv/ray-query.spvasm
@@ -158,7 +158,7 @@ OpFunctionEnd
 %23 = OpFunctionParameter  %16
 %20 = OpLabel
 %31 = OpVariable  %32  Function
-%53 = OpVariable  %46  Function %49
+%53 = OpVariable  %46  Function %52
 %24 = OpLoad  %5  %23
 OpBranch %33
 %33 = OpLabel
@@ -176,16 +176,16 @@ OpLoopMerge %42 %44 None
 OpBranch %54
 %54 = OpLabel
 %55 = OpLoad  %45  %53
-%56 = OpIEqual  %47  %52 %55
+%56 = OpIEqual  %47  %49 %55
 %57 = OpAll  %8  %56
 OpSelectionMerge %58 None
 OpBranchConditional %57 %42 %58
 %58 = OpLabel
 %59 = OpCompositeExtract  %6  %55 1
-%60 = OpIEqual  %8  %59 %51
+%60 = OpIEqual  %8  %59 %48
 %61 = OpSelect  %6  %60 %50 %48
 %62 = OpCompositeConstruct  %45  %61 %50
-%63 = OpIAdd  %45  %55 %62
+%63 = OpISub  %45  %55 %62
 OpStore %53 %63
 OpBranch %43
 %43 = OpLabel

--- a/naga/tests/out/spv/shadow.spvasm
+++ b/naga/tests/out/spv/shadow.spvasm
@@ -423,7 +423,7 @@ OpFunctionEnd
 %132 = OpLabel
 %150 = OpVariable  %103  Function %24
 %151 = OpVariable  %152  Function %88
-%166 = OpVariable  %161  Function %163
+%166 = OpVariable  %161  Function %165
 %136 = OpLoad  %6  %134
 %139 = OpLoad  %11  %137
 %141 = OpLoad  %6  %140
@@ -445,16 +445,16 @@ OpLoopMerge %157 %159 None
 OpBranch %167
 %167 = OpLabel
 %168 = OpLoad  %160  %166
-%169 = OpIEqual  %162  %165 %168
+%169 = OpIEqual  %162  %163 %168
 %170 = OpAll  %56  %169
 OpSelectionMerge %171 None
 OpBranchConditional %170 %157 %171
 %171 = OpLabel
 %172 = OpCompositeExtract  %7  %168 1
-%173 = OpIEqual  %56  %172 %164
+%173 = OpIEqual  %56  %172 %88
 %174 = OpSelect  %7  %173 %115 %88
 %175 = OpCompositeConstruct  %160  %174 %115
-%176 = OpIAdd  %160  %168 %175
+%176 = OpISub  %160  %168 %175
 OpStore %166 %176
 OpBranch %158
 %158 = OpLabel
@@ -530,7 +530,7 @@ OpFunctionEnd
 %219 = OpLabel
 %235 = OpVariable  %103  Function %24
 %236 = OpVariable  %152  Function %88
-%244 = OpVariable  %161  Function %163
+%244 = OpVariable  %161  Function %165
 %222 = OpLoad  %6  %221
 %224 = OpLoad  %11  %223
 %226 = OpLoad  %6  %225
@@ -552,16 +552,16 @@ OpLoopMerge %241 %243 None
 OpBranch %245
 %245 = OpLabel
 %246 = OpLoad  %160  %244
-%247 = OpIEqual  %162  %165 %246
+%247 = OpIEqual  %162  %163 %246
 %248 = OpAll  %56  %247
 OpSelectionMerge %249 None
 OpBranchConditional %248 %241 %249
 %249 = OpLabel
 %250 = OpCompositeExtract  %7  %246 1
-%251 = OpIEqual  %56  %250 %164
+%251 = OpIEqual  %56  %250 %88
 %252 = OpSelect  %7  %251 %115 %88
 %253 = OpCompositeConstruct  %160  %252 %115
-%254 = OpIAdd  %160  %246 %253
+%254 = OpISub  %160  %246 %253
 OpStore %244 %254
 OpBranch %242
 %242 = OpLabel


### PR DESCRIPTION
**Connections**
Fixes #7319 

**Description**
To avoid generating code containing infinite loops, and therefore incurring the wrath of undefined behaviour, we insert a counter into each loop that will break after 2^64 iterations. This was previously implemented as two u32 variables counting up from zero.

We have been informed that this construct can cause certain Intel drivers to hang. Instead, we must count down from u32::MAX. Counting down is more fun, anyway.

**Testing**
Inspected snapshot changes

**Squash or Rebase?**

Either

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
