### PR TITLE
[naga wgsl-in] Allow explicit cast from AbstractFloat to integer types

### DIFF
--- a/naga/tests/in/wgsl/constructors.wgsl
+++ b/naga/tests/in/wgsl/constructors.wgsl
@@ -64,4 +64,26 @@ fn main() {
     let ic5 = mat2x3<f32>(mat2x3<f32>());
     let ic6 = vec2(vec2<u32>());
     let ic7 = mat2x3(mat2x3<f32>());
+
+    // conversion constructors
+    let cc00 = i32(1u);
+    let cc01 = i32(1f);
+    let cc02 = i32(1);
+    let cc03 = i32(1.0);
+    let cc04 = i32(true);
+    let cc05 = u32(1i);
+    let cc06 = u32(1f);
+    let cc07 = u32(1);
+    let cc08 = u32(1.0);
+    let cc09 = u32(true);
+    let cc10 = f32(1i);
+    let cc11 = f32(1u);
+    let cc12 = f32(1);
+    let cc13 = f32(1.0);
+    let cc14 = f32(true);
+    let cc15 = bool(1i);
+    let cc16 = bool(1u);
+    let cc17 = bool(1f);
+    let cc18 = bool(1);
+    let cc19 = bool(1.0);
 }

--- a/naga/tests/out/spv/constructors.spvasm
+++ b/naga/tests/out/spv/constructors.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 67
+; Bound: 68
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
@@ -71,13 +71,14 @@ OpDecorate %17 ArrayStride 4
 %60 = OpConstantComposite  %20  %21 %21 %21
 %61 = OpConstantComposite  %19  %60 %60
 %62 = OpConstantNull  %19
-%64 = OpTypePointer Function %6
-%65 = OpConstantNull  %6
+%63 = OpConstantTrue  %12
+%65 = OpTypePointer Function %6
+%66 = OpConstantNull  %6
 %38 = OpFunction  %2  None %39
 %37 = OpLabel
-%63 = OpVariable  %64  Function %65
-OpBranch %66
-%66 = OpLabel
-OpStore %63 %42
+%64 = OpVariable  %65  Function %66
+OpBranch %67
+%67 = OpLabel
+OpStore %64 %42
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
And from either AbstractFloat or AbstractInt to bool.

**Connections**
Fixes #7312 

**Description**
AbstractFloat to integer was presumably not implemented as *automatic* conversion between those types is not allowed. However, explicit conversions (for example `i32(1.0)`) are allowed, and are implemented during const evaluation using the same code path in ConstantEvaluator::cast().

The integer conversion constructors treat AbstractFloats as any other floating point type, meaning we must follow the scalar floating point to integral conversion algorithm [1]. This specifies:

    To convert a floating point scalar value X to an integer scalar
    type T:
    * If X is a NaN, the result is an indeterminate value in T.
    * If X is exactly representable in the target type T, then the result is that value.
    * Otherwise, the result is the value in T closest to truncate(X) and also exactly representable in the original floating point type.

Fortunately a rust cast satisfies all these conditions apart from the result being exactly representable in the original floating point type. However, as i32::MIN, i32::MAX, u32::MIN, and u32::MAX are all representable by f64 (the underlying type of AbstractFloat), this is not an issue.

For i64 and u64 using a rust cast will not meet that requirement, but as these types are not present in the WGSL spec we are free to ignore that.

[1] https://www.w3.org/TR/WGSL/#floating-point-conversion

**Testing**
Added snapshot tests

**Squash or Rebase?**

Doesn't matter

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
