### PR TITLE
Make target defaults align with "butterfly" target set

### DIFF
--- a/naga/tests/in/spv/atomic_compare_exchange.toml
+++ b/naga/tests/in/spv/atomic_compare_exchange.toml
@@ -1,1 +1,0 @@
-targets = "WGSL"

--- a/naga/tests/in/spv/atomic_exchange.toml
+++ b/naga/tests/in/spv/atomic_exchange.toml
@@ -1,1 +1,0 @@
-targets = "WGSL"

--- a/naga/tests/in/spv/atomic_global_struct_field_vertex.toml
+++ b/naga/tests/in/spv/atomic_global_struct_field_vertex.toml
@@ -1,1 +1,0 @@
-targets = "WGSL"

--- a/naga/tests/in/spv/atomic_i_add_sub.toml
+++ b/naga/tests/in/spv/atomic_i_add_sub.toml
@@ -1,1 +1,0 @@
-targets = "WGSL"

--- a/naga/tests/in/spv/atomic_i_decrement.toml
+++ b/naga/tests/in/spv/atomic_i_decrement.toml
@@ -1,1 +1,0 @@
-targets = "WGSL"

--- a/naga/tests/in/spv/atomic_i_increment.toml
+++ b/naga/tests/in/spv/atomic_i_increment.toml
@@ -1,1 +1,0 @@
-targets = "WGSL"

--- a/naga/tests/in/spv/atomic_load_and_store.toml
+++ b/naga/tests/in/spv/atomic_load_and_store.toml
@@ -1,1 +1,0 @@
-targets = "WGSL"

--- a/naga/tests/in/spv/binding-arrays.toml
+++ b/naga/tests/in/spv/binding-arrays.toml
@@ -1,1 +1,0 @@
-targets = "WGSL"

--- a/naga/tests/in/spv/builtin-accessed-outside-entrypoint.toml
+++ b/naga/tests/in/spv/builtin-accessed-outside-entrypoint.toml
@@ -1,4 +1,2 @@
-targets = "WGSL"
-
 [spv-in]
 adjust_coordinate_space = true

--- a/naga/tests/in/wgsl/6438-conflicting-idents.toml
+++ b/naga/tests/in/wgsl/6438-conflicting-idents.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/6772-unpack-expr-accesses.toml
+++ b/naga/tests/in/wgsl/6772-unpack-expr-accesses.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/abstract-types-return.toml
+++ b/naga/tests/in/wgsl/abstract-types-return.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/array-in-ctor.toml
+++ b/naga/tests/in/wgsl/array-in-ctor.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/array-in-function-return-type.toml
+++ b/naga/tests/in/wgsl/array-in-function-return-type.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/atomicOps.toml
+++ b/naga/tests/in/wgsl/atomicOps.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/atomicTexture.toml
+++ b/naga/tests/in/wgsl/atomicTexture.toml
@@ -1,5 +1,4 @@
 god_mode = true
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
 
 [msl]
 fake_missing_bindings = true

--- a/naga/tests/in/wgsl/bitcast.toml
+++ b/naga/tests/in/wgsl/bitcast.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/bits.toml
+++ b/naga/tests/in/wgsl/bits.toml
@@ -1,5 +1,3 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
-
 [msl]
 fake_missing_bindings = false
 lang_version = [1, 2]

--- a/naga/tests/in/wgsl/boids.toml
+++ b/naga/tests/in/wgsl/boids.toml
@@ -1,5 +1,3 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
-
 [msl]
 fake_missing_bindings = false
 lang_version = [1, 0]

--- a/naga/tests/in/wgsl/break-if.toml
+++ b/naga/tests/in/wgsl/break-if.toml
@@ -1,1 +1,0 @@
-targets = "WGSL | GLSL | SPIRV | HLSL | METAL"

--- a/naga/tests/in/wgsl/const-exprs.toml
+++ b/naga/tests/in/wgsl/const-exprs.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/constructors.toml
+++ b/naga/tests/in/wgsl/constructors.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/control-flow.toml
+++ b/naga/tests/in/wgsl/control-flow.toml
@@ -1,4 +1,2 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
-
 [msl]
 lang_version = [1, 2]

--- a/naga/tests/in/wgsl/cross.toml
+++ b/naga/tests/in/wgsl/cross.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/dualsource.toml
+++ b/naga/tests/in/wgsl/dualsource.toml
@@ -1,5 +1,4 @@
 god_mode = true
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
 
 [msl]
 fake_missing_bindings = false

--- a/naga/tests/in/wgsl/empty.toml
+++ b/naga/tests/in/wgsl/empty.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/fragment-output.toml
+++ b/naga/tests/in/wgsl/fragment-output.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/functions.toml
+++ b/naga/tests/in/wgsl/functions.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/globals.toml
+++ b/naga/tests/in/wgsl/globals.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/interpolate_compat.toml
+++ b/naga/tests/in/wgsl/interpolate_compat.toml
@@ -1,5 +1,3 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
-
 [glsl]
 version.Desktop = 400
 writer_flags = ""

--- a/naga/tests/in/wgsl/math-functions.toml
+++ b/naga/tests/in/wgsl/math-functions.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/operators.toml
+++ b/naga/tests/in/wgsl/operators.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/padding.toml
+++ b/naga/tests/in/wgsl/padding.toml
@@ -1,5 +1,3 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
-
 [msl]
 fake_missing_bindings = false
 lang_version = [1, 0]

--- a/naga/tests/in/wgsl/phony_assignment.toml
+++ b/naga/tests/in/wgsl/phony_assignment.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/shadow.toml
+++ b/naga/tests/in/wgsl/shadow.toml
@@ -1,5 +1,3 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
-
 [spv]
 adjust_coordinate_space = true
 debug = true

--- a/naga/tests/in/wgsl/skybox.toml
+++ b/naga/tests/in/wgsl/skybox.toml
@@ -1,5 +1,4 @@
 spv_flow_dump_prefix = ""
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
 
 [msl]
 fake_missing_bindings = false

--- a/naga/tests/in/wgsl/standard.toml
+++ b/naga/tests/in/wgsl/standard.toml
@@ -1,1 +1,0 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"

--- a/naga/tests/in/wgsl/struct-layout.toml
+++ b/naga/tests/in/wgsl/struct-layout.toml
@@ -1,1 +1,0 @@
-targets = "WGSL | GLSL | SPIRV | HLSL | METAL"

--- a/naga/tests/in/wgsl/subgroup-operations.toml
+++ b/naga/tests/in/wgsl/subgroup-operations.toml
@@ -1,5 +1,4 @@
 god_mode = true
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
 
 [msl]
 fake_missing_bindings = false

--- a/naga/tests/in/wgsl/texture-arg.toml
+++ b/naga/tests/in/wgsl/texture-arg.toml
@@ -1,5 +1,3 @@
-targets = "SPIRV | METAL | GLSL | HLSL | WGSL"
-
 [spv]
 adjust_coordinate_space = true
 debug = true

--- a/naga/tests/in/wgsl/workgroup-uniform-load.toml
+++ b/naga/tests/in/wgsl/workgroup-uniform-load.toml
@@ -1,1 +1,0 @@
-targets = "WGSL | GLSL | SPIRV | HLSL | METAL"


### PR DESCRIPTION
**Description**

Small improvement to our snapshot configuration, we now default to the "butterfly" configuration:
- `glsl` and `spirv` will default to `WGSL` only
- `wgsl` will default to all backends.

**Testing**

No changes in snapshot output

**Squash or Rebase?**

Resquash
