### PR TITLE
Fix `clippy::manual_contains` lints

### DIFF
--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1191,7 +1191,7 @@ impl Interface {
             ];
             let total_invocations = entry_point.workgroup_size.iter().product::<u32>();
 
-            if entry_point.workgroup_size.iter().any(|&s| s == 0)
+            if entry_point.workgroup_size.contains(&0)
                 || total_invocations > self.limits.max_compute_invocations_per_workgroup
                 || entry_point.workgroup_size[0] > max_workgroup_size_limits[0]
                 || entry_point.workgroup_size[1] > max_workgroup_size_limits[1]

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -1199,7 +1199,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn dispatch(&mut self, count: [u32; 3]) {
         // Empty dispatches are invalid in OpenGL, but valid in WebGPU.
-        if count.iter().any(|&c| c == 0) {
+        if count.contains(&0) {
             return;
         }
         self.cmd_buffer.commands.push(C::Dispatch(count));


### PR DESCRIPTION
**Connections**
None

**Description**
Nightly clippy has a new lint, `manual_contains` and it is triggered in two spots.

**Testing**
The clippy lint no longer triggers and the tests pass.

**Squash or Rebase?**
Single commit, doesn't matter.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
