### PR TITLE
[doc] Fix unbalanced backticks

### DIFF
--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -52,7 +52,7 @@ struct Args {
 
     /// the shader model to use if targeting HLSL
     ///
-    /// May be `50`, 51`, or `60`
+    /// May be `50`, `51`, or `60`
     #[argh(option)]
     shader_model: Option<ShaderModelArg>,
 

--- a/naga/src/common/wgsl/to_wgsl.rs
+++ b/naga/src/common/wgsl/to_wgsl.rs
@@ -21,7 +21,7 @@ pub trait ToWgsl: Sized {
 }
 
 /// Types that may be able to return the WGSL source representation
-/// for their values as a `'static' string.
+/// for their values as a `'static` string.
 ///
 /// This trait is specifically for types whose values are either
 /// simple enough that their WGSL form can be represented a static

--- a/naga/src/ir/mod.rs
+++ b/naga/src/ir/mod.rs
@@ -979,12 +979,12 @@ pub enum UnaryOperator {
 ///     either on the left or the right.
 ///
 /// -   A [`Matrix`] on the left can be multiplied by a [`Vector`] on the right
-///     if the matrix has as many columns as the vector has components (`matCxR
-///     * VecC`).
+///     if the matrix has as many columns as the vector has components
+///     (`matCxR * VecC`).
 ///
 /// -   A [`Vector`] on the left can be multiplied by a [`Matrix`] on the right
-///     if the matrix has as many rows as the vector has components (`VecR *
-///     matCxR`).
+///     if the matrix has as many rows as the vector has components
+///     (`VecR * matCxR`).
 ///
 /// -   Two matrices can be multiplied if the left operand has as many columns
 ///     as the right operand has rows (`matNxR * matCxN`).
@@ -2258,7 +2258,7 @@ pub struct SpecialTypes {
     /// this if needed and return the handle.
     pub ray_intersection: Option<Handle<Type>>,
 
-    /// Type for `RayVertexReturn
+    /// Type for `RayVertexReturn`.
     ///
     /// Call [`Module::generate_vertex_return_type`]
     pub ray_vertex_return: Option<Handle<Type>>,

--- a/naga/src/non_max_u32.rs
+++ b/naga/src/non_max_u32.rs
@@ -42,11 +42,11 @@ use core::num::NonZeroU32;
 ///
 /// Although this should not be observable to its users, a `NonMaxU32` whose
 /// value is `n` is a newtype around a [`NonZeroU32`] whose value is `n + 1`.
-/// This way, the range of values that `NonMaxU32` can represent, `0..=u32::MAX
-/// - 1`, is mapped to the range `1..=u32::MAX`, which is the range that
-/// [`NonZeroU32`] can represent. (And conversely, since [`u32`] addition wraps
-/// around, the value unrepresentable in `NonMaxU32`, [`u32::MAX`], becomes the
-/// value unrepresentable in [`NonZeroU32`], `0`.)
+/// This way, the range of values that `NonMaxU32` can represent,
+/// `0..=u32::MAX - 1`, is mapped to the range `1..=u32::MAX`, which is the
+/// range that /// [`NonZeroU32`] can represent. (And conversely, since
+/// [`u32`] addition wraps around, the value unrepresentable in `NonMaxU32`,
+/// [`u32::MAX`], becomes the value unrepresentable in [`NonZeroU32`], `0`.)
 ///
 /// [`NonZeroU32`]: core::num::NonZeroU32
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/wgpu/src/api/render_pipeline.rs
+++ b/wgpu/src/api/render_pipeline.rs
@@ -105,7 +105,7 @@ pub struct VertexState<'a> {
     /// [`RenderPass::set_vertex_buffer()`].
     ///
     /// The attribute locations and types specified in this layout must match the
-    /// locations and types of the inputs to the `entry_point` function.`
+    /// locations and types of the inputs to the `entry_point` function.
     pub buffers: &'a [VertexBufferLayout<'a>],
 }
 #[cfg(send_sync)]


### PR DESCRIPTION
**Connections**
None

**Description**
There are unbalanced backticks within the doc comments as indicated by `cargo clippy -- -W clippy::doc_markdown`.

**Testing**
The lints related to unbalanced backticks no longer trigger.

**Squash or Rebase?**
This is a single commit.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
