### PR TITLE
[naga] Gracefully handle span lookup with no module source

### DIFF
--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -239,7 +239,7 @@ impl<E> WithSpan<E> {
 
     /// Return a [`SourceLocation`] for our first span, if we have one.
     pub fn location(&self, source: &str) -> Option<SourceLocation> {
-        if self.spans.is_empty() {
+        if self.spans.is_empty() || source.is_empty() {
             return None;
         }
 

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -940,7 +940,7 @@ fn multiple_enables_valid() {
 /// Check the result of validating a WGSL program against a pattern.
 ///
 /// Unless you are generating code programmatically, the
-/// `check_validation_error` macro will probably be more convenient to
+/// `check_validation` macro will probably be more convenient to
 /// use.
 macro_rules! check_one_validation {
     ( $source:expr, $pattern:pat $( if $guard:expr )? ) => {
@@ -1351,6 +1351,17 @@ fn invalid_functions() {
         })
         if function_name == "return_atomic"
     }
+}
+
+#[test]
+fn invalid_return_type() {
+    check_validation! {
+        "fn invalid_return_type() -> i32 { return 0u; }":
+        Err(naga::valid::ValidationError::Function {
+            source: naga::valid::FunctionError::InvalidReturnType(Some(_)),
+            ..
+        })
+    };
 }
 
 #[test]
@@ -2995,4 +3006,36 @@ fn reject_utf8_bom() {
 
 "#,
     );
+}
+
+#[test]
+fn issue7165() {
+    // Regression test for https://github.com/gfx-rs/wgpu/issues/7165
+    let shader = "
+        struct Struct { a: u32 }
+        fn invalid_return_type(a: Struct) -> i32 { return a; }
+    ";
+
+    let module = naga::front::wgsl::parse_str(shader).unwrap();
+    let err = naga::valid::Validator::new(
+        naga::valid::ValidationFlags::all(),
+        naga::valid::Capabilities::default(),
+    )
+    .validate(&module)
+    .unwrap_err();
+
+    // This is a proxy for doing the following (with an error
+    // handler installed so it doesn't immediately panic):
+    //
+    // ```
+    // device.create_shader_module(wgpu::ShaderModuleDescriptor {
+    //     label,
+    //     source: wgpu::ShaderSource::Naga(module),
+    // });
+    // ```
+    //
+    // `ShaderSource::Naga` causes the implementation to proceed with an empty
+    // module source, which (prior to the fix for #7165) could panic when
+    // rendering an error if the module contained spans.
+    let _location = err.location("");
 }


### PR DESCRIPTION
Fixes #7165

**Description**
Gracefully handle looking up the source location for a span when no module source is available. This fixes a possible (although unlikely under normal usage) panic. 

**Testing**
The original repro was via the `wgpu` crate, but rather than add a test at that level, I've added a test in `wgsl_errors` that seems like a reasonable approximation of the original.

I've also added a test for the `InvalidReturnType` error, because I didn't see an existing one, and fixed a stale comment. 

**Squash or Rebase?** Squash, if applicable.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests. _Ran `wgsl_errors` locally, will let CI do the rest._
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. _Technically user-facing, but doesn't seem worth a changelog entry._
