### PR TITLE
Fix `clippy::manual_repeat_n` lints

### DIFF
--- a/naga/src/arena/mod.rs
+++ b/naga/src/arena/mod.rs
@@ -271,9 +271,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let data = Vec::deserialize(deserializer)?;
-        let span_info = core::iter::repeat(Span::default())
-            .take(data.len())
-            .collect();
+        let span_info = core::iter::repeat_n(Span::default(), data.len()).collect();
 
         Ok(Self { data, span_info })
     }

--- a/naga/src/arena/unique_arena.rs
+++ b/naga/src/arena/unique_arena.rs
@@ -224,9 +224,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let set = FastIndexSet::deserialize(deserializer)?;
-        let span_info = core::iter::repeat(Span::default())
-            .take(set.len())
-            .collect();
+        let span_info = core::iter::repeat_n(Span::default(), set.len()).collect();
 
         Ok(Self { set, span_info })
     }

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -1258,7 +1258,7 @@ impl<'a> Context<'a> {
                         right = self.add_expression(
                             Expression::Compose {
                                 ty,
-                                components: core::iter::repeat(right).take(cols as usize).collect(),
+                                components: core::iter::repeat_n(right, cols as usize).collect(),
                             },
                             meta,
                         )?;

--- a/naga/src/front/glsl/functions.rs
+++ b/naga/src/front/glsl/functions.rs
@@ -348,7 +348,7 @@ impl Frontend {
                 }
             }
             _ => {
-                components = iter::repeat(value).take(columns as usize).collect();
+                components = iter::repeat_n(value, columns as usize).collect();
             }
         }
 

--- a/naga/src/ir/block.rs
+++ b/naga/src/ir/block.rs
@@ -23,9 +23,7 @@ impl Block {
     }
 
     pub fn from_vec(body: Vec<Statement>) -> Self {
-        let span_info = core::iter::repeat(Span::default())
-            .take(body.len())
-            .collect();
+        let span_info = core::iter::repeat_n(Span::default(), body.len()).collect();
         Self { body, span_info }
     }
 

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -590,7 +590,7 @@ pub fn flatten_compose<'arenas>(
                 count = size as usize;
             }
         }
-        core::iter::repeat(expr).take(count)
+        core::iter::repeat_n(expr, count)
     }
 
     // Expressions like `vec4(vec3(vec2(6, 7), 8), 9)` require us to

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -765,7 +765,7 @@ fn set_pipeline(
         {
             // Note that non-0 range start doesn't work anyway https://github.com/gfx-rs/wgpu/issues/4502
             let len = push_constant_range.len() / wgt::PUSH_CONSTANT_ALIGNMENT as usize;
-            state.push_constants.extend(core::iter::repeat(0).take(len));
+            state.push_constants.extend(core::iter::repeat_n(0, len));
         }
 
         // Clear push constant ranges

--- a/wgpu-core/src/init_tracker/texture.rs
+++ b/wgpu-core/src/init_tracker/texture.rs
@@ -53,9 +53,11 @@ pub(crate) struct TextureInitTracker {
 impl TextureInitTracker {
     pub(crate) fn new(mip_level_count: u32, depth_or_array_layers: u32) -> Self {
         TextureInitTracker {
-            mips: core::iter::repeat(TextureLayerInitTracker::new(depth_or_array_layers))
-                .take(mip_level_count as usize)
-                .collect(),
+            mips: core::iter::repeat_n(
+                TextureLayerInitTracker::new(depth_or_array_layers),
+                mip_level_count as usize,
+            )
+            .collect(),
         }
     }
 

--- a/wgpu-core/src/pipeline_cache.rs
+++ b/wgpu-core/src/pipeline_cache.rs
@@ -483,7 +483,7 @@ mod tests {
         let cache = cache
             .into_iter()
             .flatten()
-            .chain(core::iter::repeat(0u8).take(100))
+            .chain(core::iter::repeat_n(0u8, 100))
             .collect::<Vec<u8>>();
         let validation_result = super::validate_pipeline_cache(&cache, &ADAPTER, VALIDATION_KEY);
         let expected: &[u8] = &[0; 100];
@@ -504,7 +504,7 @@ mod tests {
         let cache = cache
             .into_iter()
             .flatten()
-            .chain(core::iter::repeat(0u8).take(200))
+            .chain(core::iter::repeat_n(0u8, 200))
             .collect::<Vec<u8>>();
         let validation_result = super::validate_pipeline_cache(&cache, &ADAPTER, VALIDATION_KEY);
         assert_eq!(validation_result, Err(E::Extended));


### PR DESCRIPTION
**Connections**
None

**Description**
In Rust 1.86, clippy has a lint `manual_repeat_n` where `repeat` / `take` can be `repeat_n` instead.

**Testing**
Code still compiles, passes tests, and doesn't emit this lint any longer from clippy.

**Squash or Rebase?**
Single commit.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
