### PR TITLE
Fix `clippy::implicit_saturating_sub` lints

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2188,10 +2188,8 @@ impl Global {
 
         let range_size = if let Some(size) = size {
             size
-        } else if offset > buffer.size {
-            0
         } else {
-            buffer.size - offset
+            buffer.size.saturating_sub(offset)
         };
 
         if offset % wgt::MAP_ALIGNMENT != 0 {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -439,10 +439,8 @@ impl Buffer {
     ) -> Result<SubmissionIndex, (BufferMapOperation, BufferAccessError)> {
         let range_size = if let Some(size) = size {
             size
-        } else if offset > self.size {
-            0
         } else {
-            self.size - offset
+            self.size.saturating_sub(offset)
         };
 
         if offset % wgt::MAP_ALIGNMENT != 0 {


### PR DESCRIPTION
**Connections**
None

**Description**
Recent clippy builds have improved detection for implicit saturating subs: https://github.com/rust-lang/rust-clippy/pull/14310

**Testing**
Builds, tests pass, clippy no longer triggers.

**Squash or Rebase?**

Single commit.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
