### PR TITLE
Update `codespan-reporting` to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,10 +746,11 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
  "unicode-width",
 ]
@@ -1337,7 +1338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2040,7 +2041,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2194,7 +2195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2419,7 +2420,6 @@ dependencies = [
  "serde",
  "spirv 0.3.0+sdk-1.3.268.0",
  "strum 0.26.3",
- "termcolor",
  "thiserror 2.0.12",
  "toml",
  "unicode-ident",
@@ -3434,7 +3434,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4112,7 +4112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4927,7 +4927,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,7 +1338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2041,7 +2041,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2195,7 +2195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3434,7 +3434,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4112,7 +4112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4927,7 +4927,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ cargo_metadata = "0.19"
 cfg_aliases = "0.2.1"
 cfg-if = "1"
 criterion = "0.5"
-codespan-reporting = "0.11"
+codespan-reporting = { version = "0.12", default-features = false }
 ctor = "0.2"
 document-features = "0.2.11"
 encase = "0.10.0"

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -40,7 +40,7 @@ naga = { workspace = true, features = [
 ] }
 
 bincode.workspace = true
-codespan-reporting.workspace = true
+codespan-reporting = { workspace = true, features = ["std", "termcolor"] }
 env_logger.workspace = true
 argh.workspace = true
 anyhow = { workspace = true, features = ["std"] }

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -40,7 +40,10 @@ naga = { workspace = true, features = [
 ] }
 
 bincode.workspace = true
-codespan-reporting = { workspace = true, features = ["std", "termcolor"] }
+codespan-reporting = { workspace = true, default-features = false, features = [
+    "std",
+    "termcolor",
+] }
 env_logger.workspace = true
 argh.workspace = true
 anyhow = { workspace = true, features = ["std"] }

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -85,11 +85,10 @@ arbitrary = { version = "1.4", features = ["derive"], optional = true }
 arrayvec.workspace = true
 bitflags.workspace = true
 bit-set.workspace = true
-termcolor = { version = "1.4.1" }
-# remove termcolor dep when updating to the next version of codespan-reporting
-# termcolor minimum version was wrong and was fixed in
-# https://github.com/brendanzab/codespan/commit/e99c867339a877731437e7ee6a903a3d03b5439e
-codespan-reporting = { version = "0.11.0" }
+codespan-reporting = { workspace = true, default-features = false, features = [
+    "std",
+    "termcolor",
+] }
 hashbrown.workspace = true
 half = { workspace = true, features = ["arbitrary", "num-traits"] }
 rustc-hash.workspace = true

--- a/naga/src/error.rs
+++ b/naga/src/error.rs
@@ -40,7 +40,7 @@ impl fmt::Display for ShaderError<crate::WithSpan<crate::valid::ValidationError>
         let label = self.label.as_deref().unwrap_or_default();
         let files = SimpleFile::new(label, &self.source);
         let config = term::Config::default();
-        let mut writer = termcolor::NoColor::new(Vec::new());
+        let mut writer = term::termcolor::NoColor::new(Vec::new());
         term::emit(&mut writer, &config, &files, &self.inner.diagnostic())
             .expect("cannot write error");
         write!(

--- a/naga/src/front/glsl/error.rs
+++ b/naga/src/front/glsl/error.rs
@@ -9,7 +9,7 @@ use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term;
 use pp_rs::token::PreprocessorError;
-use termcolor::{NoColor, WriteColor};
+use term::termcolor::{NoColor, WriteColor};
 use thiserror::Error;
 
 use super::token::TokenValue;

--- a/naga/src/front/glsl/error.rs
+++ b/naga/src/front/glsl/error.rs
@@ -8,8 +8,8 @@ use alloc::{
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term;
+use codespan_reporting::term::termcolor::{NoColor, WriteColor};
 use pp_rs::token::PreprocessorError;
-use term::termcolor::{NoColor, WriteColor};
 use thiserror::Error;
 
 use super::token::TokenValue;

--- a/naga/src/front/spv/error.rs
+++ b/naga/src/front/spv/error.rs
@@ -7,7 +7,7 @@ use alloc::{
 use codespan_reporting::diagnostic::Diagnostic;
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term;
-use term::termcolor::{NoColor, WriteColor};
+use codespan_reporting::term::termcolor::{NoColor, WriteColor};
 
 use super::ModuleState;
 use crate::{arena::Handle, front::atomic_upgrade};

--- a/naga/src/front/spv/error.rs
+++ b/naga/src/front/spv/error.rs
@@ -7,7 +7,7 @@ use alloc::{
 use codespan_reporting::diagnostic::Diagnostic;
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term;
-use termcolor::{NoColor, WriteColor};
+use term::termcolor::{NoColor, WriteColor};
 
 use super::ModuleState;
 use crate::{arena::Handle, front::atomic_upgrade};

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -14,7 +14,7 @@ use super::parse::lexer::Token;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term;
-use term::termcolor::{ColorChoice, NoColor, StandardStream};
+use codespan_reporting::term::termcolor::{ColorChoice, NoColor, StandardStream};
 use thiserror::Error;
 
 use alloc::{

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -14,7 +14,7 @@ use super::parse::lexer::Token;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term;
-use termcolor::{ColorChoice, NoColor, StandardStream};
+use term::termcolor::{ColorChoice, NoColor, StandardStream};
 use thiserror::Error;
 
 use alloc::{

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -285,8 +285,8 @@ impl<E> WithSpan<E> {
     where
         E: Error,
     {
+        use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
         use codespan_reporting::{files, term};
-        use term::termcolor::{ColorChoice, StandardStream};
 
         let files = files::SimpleFile::new(path, source);
         let config = term::Config::default();
@@ -308,8 +308,8 @@ impl<E> WithSpan<E> {
     where
         E: Error,
     {
+        use codespan_reporting::term::termcolor::NoColor;
         use codespan_reporting::{files, term};
-        use term::termcolor::NoColor;
 
         let files = files::SimpleFile::new(path, source);
         let config = term::Config::default();


### PR DESCRIPTION
**Connections**

- Contributes to #6826

**Description**

- Bumped `codespan-reporting` to 0.12, which adds `no_std` support

**Testing**

- CI

**Squash or Rebase?**

Squash (assuming I may need to submit follow-up commits)

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry.
