### PR TITLE
Allow to get raw swap chain from DX12 surface

### DIFF
--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -547,8 +547,8 @@ unsafe impl Send for Surface {}
 unsafe impl Sync for Surface {}
 
 impl Surface {
-    pub fn swap_chain(&self) -> &RwLock<Option<SwapChain>> {
-        &self.swap_chain
+    pub fn swap_chain(&self) -> Option<Dxgi::IDXGISwapChain3> {
+        Some(self.swap_chain.lock().as_ref()?.raw.clone())
     }
 }
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -512,7 +512,7 @@ impl Instance {
 unsafe impl Send for Instance {}
 unsafe impl Sync for Instance {}
 
-struct SwapChain {
+pub struct SwapChain {
     // TODO: Drop order frees the SWC before the raw image pointers...?
     raw: Dxgi::IDXGISwapChain3,
     // need to associate raw image pointers with the swapchain so they can be properly released
@@ -545,6 +545,12 @@ pub struct Surface {
 
 unsafe impl Send for Surface {}
 unsafe impl Sync for Surface {}
+
+impl Surface {
+    pub fn swap_chain(&self) -> &RwLock<Option<SwapChain>> {
+        &self.swap_chain
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 enum MemoryArchitecture {
@@ -1139,6 +1145,10 @@ impl SwapChain {
                 Err(crate::SurfaceError::Lost)
             }
         }
+    }
+
+    pub fn as_raw(&self) -> &Dxgi::IDXGISwapChain3 {
+        &self.raw
     }
 }
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -512,7 +512,7 @@ impl Instance {
 unsafe impl Send for Instance {}
 unsafe impl Sync for Instance {}
 
-pub struct SwapChain {
+struct SwapChain {
     // TODO: Drop order frees the SWC before the raw image pointers...?
     raw: Dxgi::IDXGISwapChain3,
     // need to associate raw image pointers with the swapchain so they can be properly released
@@ -548,7 +548,7 @@ unsafe impl Sync for Surface {}
 
 impl Surface {
     pub fn swap_chain(&self) -> Option<Dxgi::IDXGISwapChain3> {
-        Some(self.swap_chain.lock().as_ref()?.raw.clone())
+        Some(self.swap_chain.read().as_ref()?.raw.clone())
     }
 }
 
@@ -1145,10 +1145,6 @@ impl SwapChain {
                 Err(crate::SurfaceError::Lost)
             }
         }
-    }
-
-    pub fn as_raw(&self) -> &Dxgi::IDXGISwapChain3 {
-        &self.raw
     }
 }
 


### PR DESCRIPTION
Very small change to allow getting a raw swap chain from a DX12 `Surface`.