### PR TITLE
[naga] Implement constant evaluation for the `cross` builtin.

### DIFF
--- a/naga/tests/in/wgsl/cross.wgsl
+++ b/naga/tests/in/wgsl/cross.wgsl
@@ -1,4 +1,4 @@
 // NOTE: invalid combinations are tested in the `validation::bad_cross_builtin_args` test.
 @compute @workgroup_size(1) fn main() {
-    let a = cross(vec3(0., 1., 2.), vec3(0., 1., 2.));
+    let a = cross(vec3(1., 0., 0.), vec3(0., 1., 0.));
 }

--- a/naga/tests/out/glsl/cross.main.Compute.glsl
+++ b/naga/tests/out/glsl/cross.main.Compute.glsl
@@ -7,7 +7,7 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 
 void main() {
-    vec3 a = cross(vec3(0.0, 1.0, 2.0), vec3(0.0, 1.0, 2.0));
+    vec3 a = vec3(0.0, 0.0, 1.0);
     return;
 }
 

--- a/naga/tests/out/hlsl/cross.hlsl
+++ b/naga/tests/out/hlsl/cross.hlsl
@@ -1,6 +1,6 @@
 [numthreads(1, 1, 1)]
 void main()
 {
-    float3 a = cross(float3(0.0, 1.0, 2.0), float3(0.0, 1.0, 2.0));
+    float3 a = float3(0.0, 0.0, 1.0);
     return;
 }

--- a/naga/tests/out/msl/cross.msl
+++ b/naga/tests/out/msl/cross.msl
@@ -7,6 +7,6 @@ using metal::uint;
 
 kernel void main_(
 ) {
-    metal::float3 a = metal::cross(metal::float3(0.0, 1.0, 2.0), metal::float3(0.0, 1.0, 2.0));
+    metal::float3 a = metal::float3(0.0, 0.0, 1.0);
     return;
 }

--- a/naga/tests/out/spv/cross.spvasm
+++ b/naga/tests/out/spv/cross.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 14
+; Bound: 12
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
@@ -13,12 +13,10 @@ OpExecutionMode %6 LocalSize 1 1 1
 %7 = OpTypeFunction %2
 %8 = OpConstant  %4  0.0
 %9 = OpConstant  %4  1.0
-%10 = OpConstant  %4  2.0
-%11 = OpConstantComposite  %3  %8 %9 %10
+%10 = OpConstantComposite  %3  %8 %8 %9
 %6 = OpFunction  %2  None %7
 %5 = OpLabel
-OpBranch %12
-%12 = OpLabel
-%13 = OpExtInst  %3  %1 Cross %11 %11
+OpBranch %11
+%11 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/cross.wgsl
+++ b/naga/tests/out/wgsl/cross.wgsl
@@ -1,5 +1,5 @@
 @compute @workgroup_size(1, 1, 1) 
 fn main() {
-    let a = cross(vec3<f32>(0f, 1f, 2f), vec3<f32>(0f, 1f, 2f));
+    const a = vec3<f32>(0f, 0f, 1f);
     return;
 }

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -7,10 +7,10 @@ use naga::valid::Capabilities;
 
 #[track_caller]
 fn check(input: &str, snapshot: &str) {
-    let output = naga::front::wgsl::parse_str(input)
-        .map(|_| panic!("expected parser error, but parsing succeeded!"))
-        .unwrap_err()
-        .emit_to_string(input);
+    let output = match naga::front::wgsl::parse_str(input) {
+        Ok(_) => panic!("expected parser error, but parsing succeeded!"),
+        Err(err) => err.emit_to_string(input),
+    };
     if output != snapshot {
         for diff in diff::lines(snapshot, &output) {
             match diff {


### PR DESCRIPTION
Add support for `naga::ir::MathFunction::Cross` to `naga::proc::constant_evaluator`.

In the tests:

- Change `naga/tests/in/wgsl/cross.wgsl` to use more interesting argument values. Rather than passing the same vector twice, which yields a cross product of zero, pass in the x and y unit vectors, whose cross product is the z unit vector. Update snapshot output.

- Replace `validation::bad_cross_builtin_args` with a new test, `builtin_cross_product_args`, that is written more in the style of the other tests in this module, and does not depend on the WGSL front end. Because this PR changes the behavior of the constant evaluator, this test stopped behaving as expected.

- In `wgsl_errors::check`, move a `panic!` out of a closure so that the `#[track_caller]` attribute works properly.
