### PR TITLE
[naga] Fix type-checking for `mix` builtin function.

### DIFF
--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -1372,19 +1372,19 @@ impl super::Validator {
                             (Some(ty1), Some(ty2), None) => (ty1, ty2),
                             _ => return Err(ExpressionError::WrongArgumentCount(fun)),
                         };
-                        let arg_width = match *arg_ty {
+                        match *arg_ty {
                             Ti::Scalar(Sc {
                                 kind: Sk::Float,
-                                width,
+                                width: _,
                             })
                             | Ti::Vector {
                                 scalar:
                                     Sc {
                                         kind: Sk::Float,
-                                        width,
+                                        width: _,
                                     },
                                 ..
-                            } => width,
+                            } => {}
                             _ => return Err(ExpressionError::InvalidArgumentType(fun, 0, arg)),
                         };
                         if arg1_ty != arg_ty {
@@ -1394,20 +1394,12 @@ impl super::Validator {
                                 arg1.unwrap(),
                             ));
                         }
-                        // the last argument can always be a scalar
-                        match *arg2_ty {
-                            Ti::Scalar(Sc {
-                                kind: Sk::Float,
-                                width,
-                            }) if width == arg_width => {}
-                            _ if arg2_ty == arg_ty => {}
-                            _ => {
-                                return Err(ExpressionError::InvalidArgumentType(
-                                    fun,
-                                    2,
-                                    arg2.unwrap(),
-                                ));
-                            }
+                        if arg2_ty != arg_ty {
+                            return Err(ExpressionError::InvalidArgumentType(
+                                fun,
+                                2,
+                                arg2.unwrap(),
+                            ));
                         }
                     }
                     Mf::Inverse | Mf::Determinant => {

--- a/naga/tests/in/wgsl/operators.wgsl
+++ b/naga/tests/in/wgsl/operators.wgsl
@@ -11,7 +11,7 @@ fn builtins() -> vec4<f32> {
     let s3 = select(v_f32_one, v_f32_zero, vec4<bool>(false, false, false, false));
     // mix()
     let m1 = mix(v_f32_zero, v_f32_one, v_f32_half);
-    let m2 = mix(v_f32_zero, v_f32_one, 0.1);
+    let m2 = mix(v_f32_zero, v_f32_one, vec4(0.1));
     // bitcast()
     let b1 = bitcast<f32>(v_i32_one.x);
     let b2 = bitcast<vec4<f32>>(v_i32_one);

--- a/naga/tests/out/glsl/operators.main.Compute.glsl
+++ b/naga/tests/out/glsl/operators.main.Compute.glsl
@@ -16,7 +16,7 @@ vec4 builtins() {
     vec4 s2_ = (true ? v_f32_one : v_f32_zero);
     vec4 s3_ = mix(v_f32_one, v_f32_zero, bvec4(false, false, false, false));
     vec4 m1_ = mix(v_f32_zero, v_f32_one, v_f32_half);
-    vec4 m2_ = mix(v_f32_zero, v_f32_one, 0.1);
+    vec4 m2_ = mix(v_f32_zero, v_f32_one, vec4(0.1));
     float b1_ = intBitsToFloat(1);
     vec4 b2_ = intBitsToFloat(v_i32_one);
     ivec4 v_i32_zero = ivec4(0, 0, 0, 0);

--- a/naga/tests/out/hlsl/operators.hlsl
+++ b/naga/tests/out/hlsl/operators.hlsl
@@ -9,7 +9,7 @@ float4 builtins()
     float4 s2_ = (true ? v_f32_one : v_f32_zero);
     float4 s3_ = (bool4(false, false, false, false) ? v_f32_zero : v_f32_one);
     float4 m1_ = lerp(v_f32_zero, v_f32_one, v_f32_half);
-    float4 m2_ = lerp(v_f32_zero, v_f32_one, 0.1);
+    float4 m2_ = lerp(v_f32_zero, v_f32_one, (0.1).xxxx);
     float b1_ = asfloat(int(1));
     float4 b2_ = asfloat(v_i32_one);
     int4 v_i32_zero = int4(int(0), int(0), int(0), int(0));

--- a/naga/tests/out/msl/operators.msl
+++ b/naga/tests/out/msl/operators.msl
@@ -15,7 +15,7 @@ metal::float4 builtins(
     metal::float4 s2_ = true ? v_f32_one : v_f32_zero;
     metal::float4 s3_ = metal::select(v_f32_one, v_f32_zero, metal::bool4(false, false, false, false));
     metal::float4 m1_ = metal::mix(v_f32_zero, v_f32_one, v_f32_half);
-    metal::float4 m2_ = metal::mix(v_f32_zero, v_f32_one, 0.1);
+    metal::float4 m2_ = metal::mix(v_f32_zero, v_f32_one, metal::float4(0.1));
     float b1_ = as_type<float>(1);
     metal::float4 b2_ = as_type<metal::float4>(v_i32_one);
     metal::int4 v_i32_zero = metal::int4(0, 0, 0, 0);

--- a/naga/tests/out/spv/operators.spvasm
+++ b/naga/tests/out/spv/operators.spvasm
@@ -37,7 +37,8 @@ OpDecorate %509 BuiltIn WorkgroupId
 %30 = OpConstantFalse  %8
 %31 = OpConstantComposite  %7  %30 %30 %30 %30
 %32 = OpConstant  %3  0.1
-%33 = OpConstantComposite  %6  %29 %29 %29 %29
+%33 = OpConstantComposite  %4  %32 %32 %32 %32
+%34 = OpConstantComposite  %6  %29 %29 %29 %29
 %54 = OpTypeFunction %6 %6 %6
 %58 = OpConstantComposite  %6  %29 %29 %29 %29
 %60 = OpConstant  %5  -2147483648
@@ -106,23 +107,22 @@ OpDecorate %509 BuiltIn WorkgroupId
 %513 = OpConstantComposite  %10  %17 %17 %17
 %26 = OpFunction  %4  None %27
 %25 = OpLabel
-OpBranch %34
-%34 = OpLabel
-%35 = OpSelect  %5  %28 %23 %29
-%37 = OpCompositeConstruct  %7  %28 %28 %28 %28
-%36 = OpSelect  %4  %37 %18 %20
-%38 = OpSelect  %4  %31 %20 %18
-%39 = OpExtInst  %4  %1 FMix %20 %18 %22
-%41 = OpCompositeConstruct  %4  %32 %32 %32 %32
-%40 = OpExtInst  %4  %1 FMix %20 %18 %41
+OpBranch %35
+%35 = OpLabel
+%36 = OpSelect  %5  %28 %23 %29
+%38 = OpCompositeConstruct  %7  %28 %28 %28 %28
+%37 = OpSelect  %4  %38 %18 %20
+%39 = OpSelect  %4  %31 %20 %18
+%40 = OpExtInst  %4  %1 FMix %20 %18 %22
+%41 = OpExtInst  %4  %1 FMix %20 %18 %33
 %42 = OpBitcast  %3  %23
 %43 = OpBitcast  %4  %24
-%44 = OpCompositeConstruct  %6  %35 %35 %35 %35
-%45 = OpIAdd  %6  %44 %33
+%44 = OpCompositeConstruct  %6  %36 %36 %36 %36
+%45 = OpIAdd  %6  %44 %34
 %46 = OpConvertSToF  %4  %45
-%47 = OpFAdd  %4  %46 %36
-%48 = OpFAdd  %4  %47 %39
-%49 = OpFAdd  %4  %48 %40
+%47 = OpFAdd  %4  %46 %37
+%48 = OpFAdd  %4  %47 %40
+%49 = OpFAdd  %4  %48 %41
 %50 = OpCompositeConstruct  %4  %42 %42 %42 %42
 %51 = OpFAdd  %4  %49 %50
 %52 = OpFAdd  %4  %51 %43

--- a/naga/tests/out/wgsl/operators.wgsl
+++ b/naga/tests/out/wgsl/operators.wgsl
@@ -8,7 +8,7 @@ fn builtins() -> vec4<f32> {
     let s2_ = select(v_f32_zero, v_f32_one, true);
     let s3_ = select(v_f32_one, v_f32_zero, vec4<bool>(false, false, false, false));
     let m1_ = mix(v_f32_zero, v_f32_one, v_f32_half);
-    let m2_ = mix(v_f32_zero, v_f32_one, 0.1f);
+    let m2_ = mix(v_f32_zero, v_f32_one, vec4(0.1f));
     let b1_ = bitcast<f32>(1i);
     let b2_ = bitcast<vec4<f32>>(v_i32_one);
     const v_i32_zero = vec4<i32>(0i, 0i, 0i, 0i);


### PR DESCRIPTION
The third argument of `MathFunction::Mix` must have the same type as the first two; it cannot be a scalar.

GLSL does have an overload with a scalar third argument, but WGSL does not. If we want to support GLSL's overloads, and we don't want to do it by transforming the code in the front end, we should define a new `MathFunction` variant (`GlslMix`), so that Naga's validator can type-check both languages correctly.
