### PR TITLE
Allow no core when custom backend enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,8 +283,8 @@ jobs:
         run: |
           set -e
 
-          # check with no features
-          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu -p wgpu-hal --no-default-features
+          # check with core feature
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu -p wgpu-hal --no-default-features --features "core"
 
           # Don't check samples since we use winit in our samples which has dropped support for Emscripten.
 

--- a/tests/dependency-tests/root.rs
+++ b/tests/dependency-tests/root.rs
@@ -96,7 +96,7 @@ fn get_all_wgpu_features() -> Vec<String> {
 fn wasm32_without_webgl_or_noop_does_not_depend_on_wgpu_core() {
     let all_features = get_all_wgpu_features();
 
-    let removed_features = ["webgl", "noop", "wgpu-core"];
+    let removed_features = ["webgl", "noop", "wgpu-core", "core"];
 
     let features_no_webgl: Vec<&str> = all_features
         .iter()
@@ -110,6 +110,18 @@ fn wasm32_without_webgl_or_noop_does_not_depend_on_wgpu_core() {
         target: "wasm32-unknown-unknown",
         packages: &["wgpu"],
         features: &features_no_webgl,
+        default_features: false,
+        search_terms: &[Search::Negative("wgpu-core")],
+    });
+}
+
+#[test]
+fn wgpu_example_custom_backend_does_not_depend_on_wgpu_core() {
+    check_feature_dependency(Requirement {
+        human_readable_name: "wgpu-example-custom-backend does not depend on `wgpu-core`",
+        target: "x86_64-unknown-linux-gnu",
+        packages: &["wgpu-example-custom-backend"],
+        features: &[],
         default_features: false,
         search_terms: &[Search::Negative("wgpu-core")],
     });
@@ -232,10 +244,10 @@ fn windows_with_no_features_does_not_depend_on_glow_windows_or_ash() {
 #[test]
 fn windows_with_no_features_depends_on_renderdoc_sys() {
     check_feature_dependency(Requirement {
-        human_readable_name: "windows with no features depends on renderdoc-sys",
+        human_readable_name: "windows with only core should depends on renderdoc-sys",
         target: "x86_64-pc-windows-msvc",
         packages: &["wgpu"],
-        features: &[],
+        features: &["core"],
         default_features: false,
         search_terms: &[Search::Positive("renderdoc-sys")],
     });

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -29,22 +29,22 @@ ignored = ["cfg_aliases"]
 [lib]
 
 [features]
-default = ["dx12", "metal", "gles", "vulkan", "wgsl", "webgpu"]
+default = ["dx12", "metal", "gles", "vulkan", "wgsl", "webgpu", "core"]
 
 #! ### Backends
 # --------------------------------------------------------------------
 
 ## Enables the DX12 backend on Windows.
-dx12 = ["wgpu-core?/dx12"]
+dx12 = ["wgpu-core/dx12"]
 
 ## Enables the Metal backend on macOS & iOS.
-metal = ["wgpu-core?/metal"]
+metal = ["wgpu-core/metal"]
 
 ## Enables the Vulkan backend on Windows, Linux, and Android.
-vulkan = ["wgpu-core?/vulkan"]
+vulkan = ["wgpu-core/vulkan"]
 
 ## Enables the OpenGL/GLES backend on Windows, Linux, Android, and Emscripten.
-gles = ["wgpu-core?/gles"]
+gles = ["wgpu-core/gles"]
 
 ## Enables the WebGPU backend on WebAssembly.
 webgpu = [
@@ -62,10 +62,10 @@ webgpu = [
 #! ### Conditional Backends
 
 ## Enables the GLES backend on macOS only for use with [ANGLE](https://github.com/google/angle).
-angle = ["wgpu-core?/angle"]
+angle = ["wgpu-core/angle"]
 
 ## Enables the Vulkan backend on macOS & iOS only for use with [MoltenVK](https://github.com/KhronosGroup/MoltenVK).
-vulkan-portability = ["wgpu-core?/vulkan-portability"]
+vulkan-portability = ["wgpu-core/vulkan-portability"]
 
 ## Enables the GLES backend on WebAssembly only.
 webgl = ["wgpu-core/webgl", "dep:wgpu-hal", "dep:smallvec"]
@@ -82,7 +82,14 @@ noop = ["wgpu-core/noop"]
 #! it means that the item is only available when that backend is enabled _and_ the backend
 #! is supported on the current platform.
 
+## Enable support for creating and loading custom wgpu backends
 custom = []
+
+## Enables wgpu-core if platform supports it
+##
+## This exist so we can allow users to bring their own contexts
+## and not need to get wgpu-core
+core = ["dep:wgpu-core"]
 
 #! ### Shading language support
 # --------------------------------------------------------------------
@@ -176,13 +183,13 @@ static_assertions.workspace = true
 # Not Webassembly #
 ###################
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-# Needed for only wgpu-core backend. Not optional as only wgpu-core backend exists on native platforms.
+# Needed for only wgpu-core backend
 wgpu-core = { workspace = true, features = [
     "raw-window-handle",
     "renderdoc",
     "indirect-validation",
     "portable-atomic",
-] }
+], optional = true }
 wgpu-hal.workspace = true
 
 smallvec.workspace = true

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -32,10 +32,8 @@ fn main() {
 
         wgpu_core: {
             any(
-                // On native, wgpu_core is currently always enabled, even if there's no backend enabled at all.
-                native,
+                feature = "core",
                 // `wgpu_core` is implied if any backend other than WebGPU is enabled.
-                // (this is redundant except for `gles` and `noop`)
                 webgl, dx12, metal, vulkan, gles, noop
             )
         },

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -1,4 +1,4 @@
-#[cfg(native)]
+#[cfg(wgpu_core)]
 use alloc::vec::Vec;
 use core::future::Future;
 
@@ -213,7 +213,7 @@ impl Instance {
     /// # Arguments
     ///
     /// - `backends` - Backends from which to enumerate adapters.
-    #[cfg(native)]
+    #[cfg(wgpu_core)]
     pub fn enumerate_adapters(&self, backends: Backends) -> Vec<Adapter> {
         let Some(core_instance) = self.inner.as_core_opt() else {
             return Vec::new();

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -61,7 +61,7 @@ impl ContextWgpuCore {
         Self(unsafe { Arc::new(wgc::global::Global::from_instance(core_instance)) })
     }
 
-    #[cfg(native)]
+    #[cfg(wgpu_core)]
     pub fn enumerate_adapters(&self, backends: wgt::Backends) -> Vec<wgc::id::AdapterId> {
         self.0.enumerate_adapters(backends)
     }

--- a/wgpu/src/cmp.rs
+++ b/wgpu/src/cmp.rs
@@ -67,7 +67,7 @@ macro_rules! impl_eq_ord_hash_proxy {
 /// ```ignore
 /// impl_eq_ord_hash_arc_address!(MyType => .field);
 /// ```
-#[cfg_attr(not(wgpu_core), expect(unused_macros))]
+#[cfg_attr(not(any(wgpu_core, custom)), expect(unused_macros))]
 macro_rules! impl_eq_ord_hash_arc_address {
     ($type:ty => $($access:tt)*) => {
         impl PartialEq for $type {
@@ -105,5 +105,5 @@ macro_rules! impl_eq_ord_hash_arc_address {
     };
 }
 
-#[cfg_attr(not(wgpu_core), expect(unused_imports))]
+#[cfg_attr(not(any(wgpu_core, custom)), expect(unused_imports))]
 pub(crate) use {impl_eq_ord_hash_arc_address, impl_eq_ord_hash_proxy};

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -4,7 +4,7 @@ use crate::{Adapter, Instance, RequestAdapterOptions, Surface};
 use crate::Backends;
 
 /// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable.
-#[cfg(native)]
+#[cfg(wgpu_core)]
 pub fn initialize_adapter_from_env(
     instance: &Instance,
     compatible_surface: Option<&Surface<'_>>,
@@ -36,7 +36,7 @@ pub fn initialize_adapter_from_env(
 }
 
 /// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable.
-#[cfg(not(native))]
+#[cfg(not(wgpu_core))]
 pub fn initialize_adapter_from_env(
     _instance: &Instance,
     _compatible_surface: Option<&Surface<'_>>,


### PR DESCRIPTION
**Connections**
Fixes #7329

**Description**
Currently wgpu assumes on native only we always need core, but that's not the case now that we have custom backend. Users of custom backend might not want to bring core into deps tree.

**Testing**
There is a new test and there are also existing tests.

**Squash or Rebase?** Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
