### PR TITLE
fix(wgsl-in): allow `f16`s in `override`s

### DIFF
--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -566,6 +566,7 @@ impl Validator {
                 crate::Scalar::BOOL
                 | crate::Scalar::I32
                 | crate::Scalar::U32
+                | crate::Scalar::F16
                 | crate::Scalar::F32
                 | crate::Scalar::F64,
             ) => {}


### PR DESCRIPTION
- Part of #5701 that we missed.