### PR TITLE
fix(wgsl-in): increase brace limit to 127

### DIFF
--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -3120,12 +3120,7 @@ impl Parser {
         // > …
         // >
         // > Maximum nesting depth of brace-enclosed statements in a function[:] 127
-        //
-        // _However_, we choose 64 instead because (a) it avoids stack overflows in CI and
-        // (b) we expect the limit to be decreased to 63 based on this conversation in
-        // WebGPU CTS upstream:
-        // <https://github.com/gpuweb/cts/pull/3389#discussion_r1543742701>
-        const BRACE_NESTING_MAXIMUM: u8 = 64;
+        const BRACE_NESTING_MAXIMUM: u8 = 127;
         if brace_nesting_level + 1 > BRACE_NESTING_MAXIMUM {
             return Err(Box::new(Error::ExceededLimitForNestedBraces {
                 span: brace_span,

--- a/naga/tests/wgsl_errors.rs
+++ b/naga/tests/wgsl_errors.rs
@@ -2699,12 +2699,12 @@ fn limit_braced_statement_nesting() {
     let too_many_braces = "fn f() {{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{";
 
     let expected_diagnostic = r###"error: brace nesting limit reached
-  ┌─ wgsl:1:72
+  ┌─ wgsl:1:135
   │
 1 │ fn f() {{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{
-  │                                                                        ^ limit reached at this brace
+  │                                                                                                                                       ^ limit reached at this brace
   │
-  = note: nesting limit is currently set to 64
+  = note: nesting limit is currently set to 127
 
 "###;
 
@@ -2797,15 +2797,68 @@ fn too_many_unclosed_loops() {
        loop {
        loop {
        loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
+       loop {
            ";
 
     let expected_diagnostic = r###"error: brace nesting limit reached
-   ┌─ wgsl:65:13
-   │
-65 │        loop {
-   │             ^ limit reached at this brace
-   │
-   = note: nesting limit is currently set to 64
+    ┌─ wgsl:128:13
+    │
+128 │        loop {
+    │             ^ limit reached at this brace
+    │
+    = note: nesting limit is currently set to 127
 
 "###;
 


### PR DESCRIPTION
Follow-up to #5447 and <https://github.com/gfx-rs/wgpu/issues/4352> that should work now that <https://github.com/gfx-rs/wgpu/pull/7346> has merged. 