### PR TITLE
wgpu: Fix some cfg guards

### DIFF
--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -1,4 +1,4 @@
-#[cfg(native)]
+#[cfg(wgpu_core)]
 use alloc::vec::Vec;
 use core::future::Future;
 
@@ -213,7 +213,7 @@ impl Instance {
     /// # Arguments
     ///
     /// - `backends` - Backends from which to enumerate adapters.
-    #[cfg(native)]
+    #[cfg(wgpu_core)]
     pub fn enumerate_adapters(&self, backends: Backends) -> Vec<Adapter> {
         let Some(core_instance) = self.inner.as_core_opt() else {
             return Vec::new();

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -61,7 +61,7 @@ impl ContextWgpuCore {
         Self(unsafe { Arc::new(wgc::global::Global::from_instance(core_instance)) })
     }
 
-    #[cfg(native)]
+    #[cfg(wgpu_core)]
     pub fn enumerate_adapters(&self, backends: wgt::Backends) -> Vec<wgc::id::AdapterId> {
         self.0.enumerate_adapters(backends)
     }

--- a/wgpu/src/cmp.rs
+++ b/wgpu/src/cmp.rs
@@ -67,7 +67,7 @@ macro_rules! impl_eq_ord_hash_proxy {
 /// ```ignore
 /// impl_eq_ord_hash_arc_address!(MyType => .field);
 /// ```
-#[cfg_attr(not(wgpu_core), expect(unused_macros))]
+#[cfg_attr(not(any(wgpu_core, custom)), expect(unused_macros))]
 macro_rules! impl_eq_ord_hash_arc_address {
     ($type:ty => $($access:tt)*) => {
         impl PartialEq for $type {
@@ -105,5 +105,5 @@ macro_rules! impl_eq_ord_hash_arc_address {
     };
 }
 
-#[cfg_attr(not(wgpu_core), expect(unused_imports))]
+#[cfg_attr(not(any(wgpu_core, custom)), expect(unused_imports))]
 pub(crate) use {impl_eq_ord_hash_arc_address, impl_eq_ord_hash_proxy};

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -4,7 +4,7 @@ use crate::{Adapter, Instance, RequestAdapterOptions, Surface};
 use crate::Backends;
 
 /// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable.
-#[cfg(native)]
+#[cfg(wgpu_core)]
 pub fn initialize_adapter_from_env(
     instance: &Instance,
     compatible_surface: Option<&Surface<'_>>,
@@ -36,7 +36,7 @@ pub fn initialize_adapter_from_env(
 }
 
 /// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable.
-#[cfg(not(native))]
+#[cfg(not(wgpu_core))]
 pub fn initialize_adapter_from_env(
     _instance: &Instance,
     _compatible_surface: Option<&Surface<'_>>,


### PR DESCRIPTION
**Connections**
Extracted from #7407.

**Description**
All guards should actually refer to `wgpu_core` instead of `native`

**Testing**
It compiles.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
