### PR TITLE
[naga] Check the type of `ImageQuery::Size`'s `level` parameter.

### DIFF
--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -698,8 +698,18 @@ impl super::Validator {
                         let good = match query {
                             crate::ImageQuery::NumLayers => arrayed,
                             crate::ImageQuery::Size { level: None } => true,
-                            crate::ImageQuery::Size { level: Some(_) }
-                            | crate::ImageQuery::NumLevels => class.is_mipmapped(),
+                            crate::ImageQuery::Size { level: Some(level) } => {
+                                match resolver[level] {
+                                    Ti::Scalar(Sc::I32 | Sc::U32) => {}
+                                    _ => {
+                                        return Err(ExpressionError::InvalidImageOtherIndexType(
+                                            level,
+                                        ))
+                                    }
+                                }
+                                class.is_mipmapped()
+                            }
+                            crate::ImageQuery::NumLevels => class.is_mipmapped(),
                             crate::ImageQuery::NumSamples => class.is_multisampled(),
                         };
                         if !good {


### PR DESCRIPTION
Require that the `level` operand of an `ImageQuery::Size` expression is `i32` or `u32`, per spec.

Without this fix, the following WGSL:

    @group(0) @binding(0)
    var t: texture_1d<f32>;
    fn f() -> u32 {
      return textureDimensions(t, false);
    }

produces the following invalid HLSL:

    Texture1D<float4> t : register(t0);

    uint NagaMipDimensions1D(Texture1D<float4> tex, uint mip_level)
    {
        uint4 ret;
        tex.GetDimensions(mip_level, ret.x, ret.y);
        return ret.x;
    }

    uint f()
    {
        return NagaMipDimensions1D(t, false);
    }
