### PR TITLE
[naga wgsl-in] Implement unary negation during const evaluation for Literal::F64

### DIFF
--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1945,6 +1945,7 @@ impl<'a> ConstantEvaluator<'a> {
                     Literal::I64(v) => Literal::I64(v.wrapping_neg()),
                     Literal::F32(v) => Literal::F32(-v),
                     Literal::F16(v) => Literal::F16(-v),
+                    Literal::F64(v) => Literal::F64(-v),
                     Literal::AbstractInt(v) => Literal::AbstractInt(v.wrapping_neg()),
                     Literal::AbstractFloat(v) => Literal::AbstractFloat(-v),
                     _ => return Err(ConstantEvaluatorError::InvalidUnaryOpArg),

--- a/naga/tests/in/wgsl/f64.wgsl
+++ b/naga/tests/in/wgsl/f64.wgsl
@@ -4,6 +4,7 @@ const k: f64 = 2.0lf;
 fn f(x: f64) -> f64 {
    let y: f64 = 3e1lf + 4.0e2lf;
    var z = y + f64(5);
+   var w = -1.0lf;
    return x + y + k + 5.0lf;
 }
 

--- a/naga/tests/out/glsl/f64.main.Compute.glsl
+++ b/naga/tests/out/glsl/f64.main.Compute.glsl
@@ -7,6 +7,7 @@ const double k = 2.0LF;
 
 double f(double x) {
     double z = 0.0;
+    double w = -1.0LF;
     double y = (30.0LF + 400.0LF);
     z = (y + 5.0LF);
     return (((x + y) + k) + 5.0LF);

--- a/naga/tests/out/hlsl/f64.hlsl
+++ b/naga/tests/out/hlsl/f64.hlsl
@@ -5,6 +5,7 @@ static double v = 1.0L;
 double f(double x)
 {
     double z = (double)0;
+    double w = -1.0L;
 
     double y = (30.0L + 400.0L);
     z = (y + 5.0L);

--- a/naga/tests/out/spv/f64.spvasm
+++ b/naga/tests/out/spv/f64.spvasm
@@ -1,13 +1,13 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 30
+; Bound: 32
 OpCapability Shader
 OpCapability Float64
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %25 "main"
-OpExecutionMode %25 LocalSize 1 1 1
+OpEntryPoint GLCompute %27 "main"
+OpExecutionMode %27 LocalSize 1 1 1
 %2 = OpTypeVoid
 %3 = OpTypeFloat 64
 %4 = OpConstant  %3  1.0
@@ -18,28 +18,30 @@ OpExecutionMode %25 LocalSize 1 1 1
 %12 = OpConstant  %3  30.0
 %13 = OpConstant  %3  400.0
 %14 = OpConstant  %3  5.0
-%16 = OpTypePointer Function %3
-%17 = OpConstantNull  %3
-%26 = OpTypeFunction %2
-%27 = OpConstant  %3  6.0
+%15 = OpConstant  %3  -1.0
+%17 = OpTypePointer Function %3
+%18 = OpConstantNull  %3
+%28 = OpTypeFunction %2
+%29 = OpConstant  %3  6.0
 %10 = OpFunction  %3  None %11
 %9 = OpFunctionParameter  %3
 %8 = OpLabel
-%15 = OpVariable  %16  Function %17
-OpBranch %18
-%18 = OpLabel
-%19 = OpFAdd  %3  %12 %13
-%20 = OpFAdd  %3  %19 %14
-OpStore %15 %20
-%21 = OpFAdd  %3  %9 %19
-%22 = OpFAdd  %3  %21 %5
-%23 = OpFAdd  %3  %22 %14
-OpReturnValue %23
+%16 = OpVariable  %17  Function %18
+%19 = OpVariable  %17  Function %15
+OpBranch %20
+%20 = OpLabel
+%21 = OpFAdd  %3  %12 %13
+%22 = OpFAdd  %3  %21 %14
+OpStore %16 %22
+%23 = OpFAdd  %3  %9 %21
+%24 = OpFAdd  %3  %23 %5
+%25 = OpFAdd  %3  %24 %14
+OpReturnValue %25
 OpFunctionEnd
-%25 = OpFunction  %2  None %26
-%24 = OpLabel
-OpBranch %28
-%28 = OpLabel
-%29 = OpFunctionCall  %3  %10 %27
+%27 = OpFunction  %2  None %28
+%26 = OpLabel
+OpBranch %30
+%30 = OpLabel
+%31 = OpFunctionCall  %3  %10 %29
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/f64.wgsl
+++ b/naga/tests/out/wgsl/f64.wgsl
@@ -4,6 +4,7 @@ var<private> v: f64 = 1.0lf;
 
 fn f(x: f64) -> f64 {
     var z: f64;
+    var w: f64 = -1.0lf;
 
     let y = (30.0lf + 400.0lf);
     z = (y + 5.0lf);


### PR DESCRIPTION
**Description**
This not being implemented made it impossible to express negative f64 literals. This is now fixed, and we've added a test.

**Testing**
Added to snapshot test

**Squash or Rebase?**

Doesn't matter

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.