### PR TITLE
build: upgrade `ron` 0.8.1 → 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -1338,7 +1338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2041,7 +2041,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2195,7 +2195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3378,14 +3378,15 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "ron"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+checksum = "63f3aa105dea217ef30d89581b65a4d527a19afc95ef5750be3890e8d3c5b837"
 dependencies = [
  "base64",
  "bitflags 2.9.0",
  "serde",
  "serde_derive",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3434,7 +3435,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4112,7 +4113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4927,7 +4928,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ profiling = { version = "1", default-features = false }
 raw-window-handle = { version = "0.6", default-features = false }
 rayon = "1"
 renderdoc-sys = "1.1.0"
-ron = "0.8"
+ron = "0.9"
 # NOTE: rustc-hash v2 is a completely different hasher with different performance characteristics
 # see discussion here (including with some other alternatives): https://github.com/gfx-rs/wgpu/issues/6999
 # (using default-features = false to support no-std build, avoiding any extra features that may require std::collections)

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -123,7 +123,7 @@ itertools.workspace = true
 # Require at least version 0.7.1 of ron, this version changed how floating points are
 # serialized by forcing them to always have the decimal part, this makes it backwards
 # incompatible with our tests because we do a syntactic diff and not a semantic one.
-ron = "0.8.0"
+ron.workspace = true
 rspirv = { version = "0.11", git = "https://github.com/gfx-rs/rspirv", rev = "b969f175d5663258b4891e44b76c1544da9661ab" }
 serde = { workspace = true, features = ["default", "derive"] }
 spirv = { version = "0.3", features = ["deserialize"] }

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -120,9 +120,6 @@ hashbrown = { workspace = true, features = ["serde"] }
 # are allowed through though.
 hlsl-snapshots = { path = "./hlsl-snapshots" }
 itertools.workspace = true
-# Require at least version 0.7.1 of ron, this version changed how floating points are
-# serialized by forcing them to always have the decimal part, this makes it backwards
-# incompatible with our tests because we do a syntactic diff and not a semantic one.
 ron.workspace = true
 rspirv = { version = "0.11", git = "https://github.com/gfx-rs/rspirv", rev = "b969f175d5663258b4891e44b76c1544da9661ab" }
 serde = { workspace = true, features = ["default", "derive"] }

--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -36,7 +36,7 @@ use std::{
     fs::File,
     panic::Location,
     path::{Path, PathBuf},
-    vec::Vec,
+    string::String,
 };
 
 use super::rank::{LockRank, LockRankSet};
@@ -337,7 +337,7 @@ struct ObservationLog {
     locations_seen: FastHashSet<*const Location<'static>>,
 
     /// Buffer for serializing events, retained for allocation reuse.
-    buffer: Vec<u8>,
+    buffer: String,
 }
 
 #[allow(trivial_casts)]
@@ -354,7 +354,7 @@ impl ObservationLog {
         Ok(ObservationLog {
             log_file,
             locations_seen: FastHashSet::default(),
-            buffer: Vec::new(),
+            buffer: String::new(),
         })
     }
 
@@ -404,9 +404,9 @@ impl ObservationLog {
         self.buffer.clear();
         ron::ser::to_writer(&mut self.buffer, &action)
             .expect("error serializing `lock::observing::Action`");
-        self.buffer.push(b'\n');
+        self.buffer.push('\n');
         self.log_file
-            .write_all(&self.buffer)
+            .write_all(self.buffer.as_bytes())
             .expect("error writing `lock::observing::Action`");
     }
 }


### PR DESCRIPTION
This is a backwards compatible fix necessary to unblock an upgrade to `ron` 0.9.0, like in #7430.

I'm indifferent to squashing vs. rebasing, but the commits are supposed to be helpful. 🙂