### PR TITLE
Refactor WGSL front end's `MathFunction` handling

### DIFF
--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2582,7 +2582,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                 {
                                     // This is the argument that killed our dreams.
                                     let inconsistent_span =
-                                        ctx.ast_expressions.get_span(arguments[prior_index]);
+                                        ctx.get_expression_span(unconverted_arguments[prior_index]);
                                     let inconsistent_ty =
                                         ctx.as_diagnostic_display(prior_ty).to_string();
 
@@ -2621,7 +2621,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     // given the argument types supplied above.
                     let rule = remaining_overloads.most_preferred();
 
-                    let mut converted_arguments = Vec::with_capacity(arguments.len());
+                    let mut converted_arguments = Vec::with_capacity(unconverted_arguments.len());
                     for (i, &unconverted) in unconverted_arguments.iter().enumerate() {
                         let goal_inner = rule.arguments[i].inner_with(&ctx.module.types);
                         let converted = match goal_inner.scalar_for_conversions(&ctx.module.types) {

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2617,13 +2617,11 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     let rule = remaining_overloads.most_preferred();
 
                     let mut converted_arguments = Vec::with_capacity(arguments.len());
-                    for (i, (&ast, unconverted)) in
-                        arguments.iter().zip(unconverted_arguments).enumerate()
-                    {
+                    for (i, &unconverted) in unconverted_arguments.iter().enumerate() {
                         let goal_inner = rule.arguments[i].inner_with(&ctx.module.types);
                         let converted = match goal_inner.scalar_for_conversions(&ctx.module.types) {
                             Some(goal_scalar) => {
-                                let arg_span = ctx.ast_expressions.get_span(ast);
+                                let arg_span = ctx.get_expression_span(unconverted);
                                 ctx.try_automatic_conversion_for_leaf_scalar(
                                     unconverted,
                                     goal_scalar,


### PR DESCRIPTION
This depends on #6833. Rebase (but squash is fine too).

This PR is a nothingburger: just code motion, renames, and minor refactorings. Commits are split for easy review.

To prepare for further use of the `OverloadSet` trait, refactor the code in `naga::front::wgsl::lower::Lowerer::call` that handles calls to builtin functions in the `MathFunctions` enum. This results in three new methods on `Lowerer`:

- `resolve_overloads`, which does the interesting work of selecting an overload based on the argument types at the call, generating diagnostics if something goes wrong, or returning a specific overload if all goes well;
- `apply_automatic_conversions_for_call`, which takes care of actually applying whatever automatic conversions are needed to apply those arguments to that overload;
- and `math_function_helper`, which uses the above two to build an `Expression::Math` expression.