### PR TITLE
[naga] Make two structs with the same members not equivalent

### DIFF
--- a/naga/src/arena/unique_arena.rs
+++ b/naga/src/arena/unique_arena.rs
@@ -16,7 +16,8 @@ use crate::{FastIndexSet, Span};
 /// The element type must implement `Eq` and `Hash`. Insertions of equivalent
 /// elements, according to `Eq`, all return the same `Handle`.
 ///
-/// Once inserted, elements may not be mutated.
+/// Once inserted, elements generally may not be mutated, although a `replace`
+/// method exists to support rare cases.
 ///
 /// `UniqueArena` is similar to [`Arena`]: If `Arena` is vector-like,
 /// `UniqueArena` is `HashSet`-like.

--- a/naga/src/front/wgsl/lower/conversion.rs
+++ b/naga/src/front/wgsl/lower/conversion.rs
@@ -46,7 +46,7 @@ impl<'source> super::ExpressionContext<'source, '_, '_> {
         }
 
         // If `expr` already has the requested type, we're done.
-        if expr_inner.equivalent(goal_inner, types) {
+        if expr_inner.non_struct_equivalent(goal_inner, types) {
             return Ok(expr);
         }
 

--- a/naga/src/front/wgsl/lower/conversion.rs
+++ b/naga/src/front/wgsl/lower/conversion.rs
@@ -46,7 +46,7 @@ impl<'source> super::ExpressionContext<'source, '_, '_> {
         }
 
         // If `expr` already has the requested type, we're done.
-        if expr_inner.non_struct_equivalent(goal_inner, types) {
+        if self.module.compare_types(expr_resolution, goal_ty) {
             return Ok(expr);
         }
 

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1313,7 +1313,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 let init_ty = ectx.register_type(init)?;
                 let explicit_inner = &ectx.module.types[explicit_ty].inner;
                 let init_inner = &ectx.module.types[init_ty].inner;
-                if !explicit_inner.equivalent(init_inner, &ectx.module.types) {
+                if !explicit_inner.non_struct_equivalent(init_inner, &ectx.module.types) {
                     return Err(Box::new(Error::InitializationTypeMismatch {
                         name: name.span,
                         expected: ectx.type_to_string(explicit_ty),

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1311,9 +1311,10 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     })?;
 
                 let init_ty = ectx.register_type(init)?;
-                let explicit_inner = &ectx.module.types[explicit_ty].inner;
-                let init_inner = &ectx.module.types[init_ty].inner;
-                if !explicit_inner.non_struct_equivalent(init_inner, &ectx.module.types) {
+                if !ectx.module.compare_types(
+                    &crate::proc::TypeResolution::Handle(explicit_ty),
+                    &crate::proc::TypeResolution::Handle(init_ty),
+                ) {
                     return Err(Box::new(Error::InitializationTypeMismatch {
                         name: name.span,
                         expected: ectx.type_to_string(explicit_ty),

--- a/naga/src/ir/mod.rs
+++ b/naga/src/ir/mod.rs
@@ -636,6 +636,15 @@ pub struct Type {
 }
 
 /// Enum with additional information, depending on the kind of type.
+///
+/// Comparison using `==` is not reliable in the case of [`Pointer`],
+/// [`ValuePointer`], or [`Struct`] variants. For these variants,
+/// use [`TypeInner::non_struct_equivalent`] or [`compare_types`].
+///
+/// [`compare_types`]: crate::proc::compare_types
+/// [`ValuePointer`]: TypeInner::ValuePointer
+/// [`Pointer`]: TypeInner::Pointer
+/// [`Struct`]: TypeInner::Struct
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
@@ -656,8 +665,9 @@ pub enum TypeInner {
     /// Pointer to another type.
     ///
     /// Pointers to scalars and vectors should be treated as equivalent to
-    /// [`ValuePointer`] types. Use the [`TypeInner::equivalent`] method to
-    /// compare types in a way that treats pointers correctly.
+    /// [`ValuePointer`] types. Use either [`TypeInner::non_struct_equivalent`]
+    /// or [`compare_types`] to compare types in a way that treats pointers
+    /// correctly.
     ///
     /// ## Pointers to non-`SIZED` types
     ///
@@ -679,6 +689,7 @@ pub enum TypeInner {
     /// [`ValuePointer`]: TypeInner::ValuePointer
     /// [`GlobalVariable`]: Expression::GlobalVariable
     /// [`AccessIndex`]: Expression::AccessIndex
+    /// [`compare_types`]: crate::proc::compare_types
     Pointer {
         base: Handle<Type>,
         space: AddressSpace,
@@ -690,12 +701,13 @@ pub enum TypeInner {
     /// `Scalar` or `Vector` type. This is for use in [`TypeResolution::Value`]
     /// variants; see the documentation for [`TypeResolution`] for details.
     ///
-    /// Use the [`TypeInner::equivalent`] method to compare types that could be
-    /// pointers, to ensure that `Pointer` and `ValuePointer` types are
-    /// recognized as equivalent.
+    /// Use [`TypeInner::non_struct_equivalent`] or [`compare_types`] to compare
+    /// types that could be pointers, to ensure that `Pointer` and
+    /// `ValuePointer` types are recognized as equivalent.
     ///
     /// [`TypeResolution`]: crate::proc::TypeResolution
     /// [`TypeResolution::Value`]: crate::proc::TypeResolution::Value
+    /// [`compare_types`]: crate::proc::compare_types
     ValuePointer {
         size: Option<VectorSize>,
         scalar: Scalar,
@@ -744,9 +756,15 @@ pub enum TypeInner {
     /// struct, which may be a dynamically sized [`Array`]. The
     /// `Struct` type itself is `SIZED` when all its members are `SIZED`.
     ///
+    /// Two structure types with different names are not equivalent. Because
+    /// this variant does not contain the name, it is not possible to use it
+    /// to compare struct types. Use [`compare_types`] to compare two types
+    /// that may be structs.
+    ///
     /// [`DATA`]: crate::valid::TypeFlags::DATA
     /// [`SIZED`]: crate::∅TypeFlags::SIZED
     /// [`Array`]: TypeInner::Array
+    /// [`compare_types`]: crate::proc::compare_types
     Struct {
         members: Vec<StructMember>,
         //TODO: should this be unaligned?

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -23,7 +23,7 @@ pub use overloads::{Conclusion, MissingSpecialType, OverloadSet, Rule};
 pub use terminator::ensure_block_returns;
 use thiserror::Error;
 pub use type_methods::min_max_float_representable_by;
-pub use typifier::{ResolveContext, ResolveError, TypeResolution};
+pub use typifier::{compare_types, ResolveContext, ResolveError, TypeResolution};
 
 impl From<super::StorageFormat> for super::Scalar {
     fn from(format: super::StorageFormat) -> Self {
@@ -403,6 +403,10 @@ impl crate::Module {
             global_expressions: &self.global_expressions,
         }
     }
+
+    pub fn compare_types(&self, lhs: &TypeResolution, rhs: &TypeResolution) -> bool {
+        compare_types(lhs, rhs, &self.types)
+    }
 }
 
 #[derive(Debug)]
@@ -490,6 +494,10 @@ impl GlobalCtx<'_> {
             }
             _ => get(*self, handle, arena),
         }
+    }
+
+    pub fn compare_types(&self, lhs: &TypeResolution, rhs: &TypeResolution) -> bool {
+        compare_types(lhs, rhs, self.types)
     }
 }
 

--- a/naga/src/proc/overloads/list.rs
+++ b/naga/src/proc/overloads/list.rs
@@ -100,7 +100,7 @@ impl crate::proc::overloads::OverloadSet for List {
                 match rule.arguments.get(i) {
                     Some(rule_ty) => {
                         let rule_ty = rule_ty.inner_with(types);
-                        if arg_ty.equivalent(rule_ty, types) {
+                        if arg_ty.non_struct_equivalent(rule_ty, types) {
                             log::debug!("    types are equivalent");
                         } else {
                             match arg_ty.automatically_converts_to(rule_ty, types) {
@@ -124,7 +124,7 @@ impl crate::proc::overloads::OverloadSet for List {
             }
             rule.arguments.get(i).is_some_and(|rule_ty| {
                 let rule_ty = rule_ty.inner_with(types);
-                arg_ty.equivalent(rule_ty, types)
+                arg_ty.non_struct_equivalent(rule_ty, types)
                     || arg_ty.automatically_converts_to(rule_ty, types).is_some()
             })
         })

--- a/naga/src/proc/overloads/regular.rs
+++ b/naga/src/proc/overloads/regular.rs
@@ -362,7 +362,7 @@ mod test {
         let inner = resolution.inner_with(arena);
 
         assert!(
-            inner.equivalent(expected, arena),
+            inner.non_struct_equivalent(expected, arena),
             "Expected {:?}, got {:?}",
             expected.for_debug(arena),
             inner.for_debug(arena),

--- a/naga/src/proc/type_methods.rs
+++ b/naga/src/proc/type_methods.rs
@@ -258,12 +258,15 @@ impl crate::TypeInner {
     /// Compare `self` and `rhs` as types.
     ///
     /// This is mostly the same as `<TypeInner as Eq>::eq`, but it treats
-    /// `ValuePointer` and `Pointer` types as equivalent.
+    /// `ValuePointer` and `Pointer` types as equivalent. This method
+    /// cannot be used for structs, because it cannot distinguish two
+    /// structs with different names but the same members. For structs,
+    /// use `Module::compare_types`.
     ///
     /// When you know that one side of the comparison is never a pointer, it's
     /// fine to not bother with canonicalization, and just compare `TypeInner`
     /// values with `==`.
-    pub fn equivalent(
+    pub fn non_struct_equivalent(
         &self,
         rhs: &crate::TypeInner,
         types: &crate::UniqueArena<crate::Type>,

--- a/naga/src/proc/type_methods.rs
+++ b/naga/src/proc/type_methods.rs
@@ -4,6 +4,8 @@
 //! [`Scalar`]: crate::Scalar
 //! [`ScalarKind`]: crate::ScalarKind
 
+use crate::ir;
+
 use super::TypeResolution;
 
 impl crate::ScalarKind {
@@ -255,24 +257,38 @@ impl crate::TypeInner {
         }
     }
 
-    /// Compare `self` and `rhs` as types.
+    /// Compare value type `self` and `rhs` as types.
     ///
     /// This is mostly the same as `<TypeInner as Eq>::eq`, but it treats
-    /// `ValuePointer` and `Pointer` types as equivalent. This method
+    /// [`ValuePointer`] and [`Pointer`] types as equivalent. This method
     /// cannot be used for structs, because it cannot distinguish two
     /// structs with different names but the same members. For structs,
-    /// use `Module::compare_types`.
+    /// use [`compare_types`].
     ///
-    /// When you know that one side of the comparison is never a pointer, it's
-    /// fine to not bother with canonicalization, and just compare `TypeInner`
-    /// values with `==`.
+    /// When you know that one side of the comparison is never a pointer or
+    /// struct, it's fine to not bother with canonicalization, and just
+    /// compare `TypeInner` values with `==`.
+    ///
+    /// # Panics
+    ///
+    /// If both `self` and `rhs` are structs.
+    ///
+    /// [`compare_types`]: crate::proc::compare_types
+    /// [`ValuePointer`]: ir::TypeInner::ValuePointer
+    /// [`Pointer`]: ir::TypeInner::Pointer
     pub fn non_struct_equivalent(
         &self,
-        rhs: &crate::TypeInner,
+        rhs: &ir::TypeInner,
         types: &crate::UniqueArena<crate::Type>,
     ) -> bool {
         let left = self.canonical_form(types);
         let right = rhs.canonical_form(types);
+
+        let left_struct = matches!(*self, ir::TypeInner::Struct { .. });
+        let right_struct = matches!(*rhs, ir::TypeInner::Struct { .. });
+
+        assert!(!left_struct || !right_struct);
+
         left.as_ref().unwrap_or(self) == right.as_ref().unwrap_or(rhs)
     }
 

--- a/naga/src/valid/compose.rs
+++ b/naga/src/valid/compose.rs
@@ -88,7 +88,7 @@ pub fn validate_compose(
                 let comp_res_inner = comp_res.inner_with(gctx.types);
                 // We don't support arrays of pointers, but it seems best not to
                 // embed that assumption here, so use `TypeInner::equivalent`.
-                if !base_inner.equivalent(comp_res_inner, gctx.types) {
+                if !base_inner.non_struct_equivalent(comp_res_inner, gctx.types) {
                     log::error!("Array component[{}] type {:?}", index, comp_res);
                     return Err(ComposeError::ComponentType {
                         index: index as u32,
@@ -109,7 +109,7 @@ pub fn validate_compose(
                 let comp_res_inner = comp_res.inner_with(gctx.types);
                 // We don't support pointers in structs, but it seems best not to embed
                 // that assumption here, so use `TypeInner::equivalent`.
-                if !comp_res_inner.equivalent(member_inner, gctx.types) {
+                if !comp_res_inner.non_struct_equivalent(member_inner, gctx.types) {
                     log::error!("Struct component[{}] type {:?}", index, comp_res);
                     return Err(ComposeError::ComponentType {
                         index: index as u32,

--- a/naga/src/valid/compose.rs
+++ b/naga/src/valid/compose.rs
@@ -84,11 +84,7 @@ pub fn validate_compose(
                 });
             }
             for (index, comp_res) in component_resolutions.enumerate() {
-                let base_inner = &gctx.types[base].inner;
-                let comp_res_inner = comp_res.inner_with(gctx.types);
-                // We don't support arrays of pointers, but it seems best not to
-                // embed that assumption here, so use `TypeInner::equivalent`.
-                if !base_inner.non_struct_equivalent(comp_res_inner, gctx.types) {
+                if !gctx.compare_types(&TypeResolution::Handle(base), &comp_res) {
                     log::error!("Array component[{}] type {:?}", index, comp_res);
                     return Err(ComposeError::ComponentType {
                         index: index as u32,
@@ -105,11 +101,7 @@ pub fn validate_compose(
             }
             for (index, (member, comp_res)) in members.iter().zip(component_resolutions).enumerate()
             {
-                let member_inner = &gctx.types[member.ty].inner;
-                let comp_res_inner = comp_res.inner_with(gctx.types);
-                // We don't support pointers in structs, but it seems best not to embed
-                // that assumption here, so use `TypeInner::equivalent`.
-                if !comp_res_inner.non_struct_equivalent(member_inner, gctx.types) {
+                if !gctx.compare_types(&TypeResolution::Handle(member.ty), &comp_res) {
                     log::error!("Struct component[{}] type {:?}", index, comp_res);
                     return Err(ComposeError::ComponentType {
                         index: index as u32,

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -330,7 +330,7 @@ impl super::Validator {
                         .with_span_handle(expr, context.expressions)
                 })?;
             let arg_inner = &context.types[arg.ty].inner;
-            if !ty.equivalent(arg_inner, context.types) {
+            if !ty.non_struct_equivalent(arg_inner, context.types) {
                 return Err(CallError::ArgumentType {
                     index,
                     required: arg.ty,
@@ -544,7 +544,7 @@ impl super::Validator {
                     // atomic we're operating on.
                     let compare_inner =
                         context.resolve_type(compare, &self.valid_expression_set)?;
-                    if !compare_inner.equivalent(value_inner, context.types) {
+                    if !compare_inner.non_struct_equivalent(value_inner, context.types) {
                         log::error!(
                             "Atomic exchange comparison has a different type from the value"
                         );
@@ -583,7 +583,7 @@ impl super::Validator {
                     // The result expression must be a scalar of the same type as the
                     // atomic we're operating on.
                     let result_inner = &context.types[result_ty].inner;
-                    if !result_inner.equivalent(value_inner, context.types) {
+                    if !result_inner.non_struct_equivalent(value_inner, context.types) {
                         return Err(AtomicError::ResultTypeMismatch(result)
                             .with_span_handle(result, context.expressions)
                             .into_other());
@@ -961,7 +961,7 @@ impl super::Validator {
                     let okay = match (value_ty, expected_ty) {
                         (None, None) => true,
                         (Some(value_inner), Some(expected_inner)) => {
-                            value_inner.equivalent(expected_inner, context.types)
+                            value_inner.non_struct_equivalent(expected_inner, context.types)
                         }
                         (_, _) => false,
                     };
@@ -1441,7 +1441,7 @@ impl super::Validator {
                         base: ty,
                         space: AddressSpace::WorkGroup,
                     };
-                    if !expected_pointer_inner.equivalent(pointer_inner, context.types) {
+                    if !expected_pointer_inner.non_struct_equivalent(pointer_inner, context.types) {
                         return Err(FunctionError::WorkgroupUniformLoadInvalidPointer(pointer)
                             .with_span_static(span, "WorkGroupUniformLoad"));
                     }
@@ -1630,7 +1630,7 @@ impl super::Validator {
         if let Some(init) = var.init {
             let decl_ty = &gctx.types[var.ty].inner;
             let init_ty = fun_info[init].ty.inner_with(gctx.types);
-            if !decl_ty.equivalent(init_ty, gctx.types) {
+            if !decl_ty.non_struct_equivalent(init_ty, gctx.types) {
                 return Err(LocalVariableError::InitializerType);
             }
 

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -638,7 +638,7 @@ impl super::Validator {
 
             let decl_ty = &gctx.types[var.ty].inner;
             let init_ty = mod_info[init].inner_with(gctx.types);
-            if !decl_ty.equivalent(init_ty, gctx.types) {
+            if !decl_ty.non_struct_equivalent(init_ty, gctx.types) {
                 return Err(GlobalVariableError::InitializerType);
             }
         }

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -636,9 +636,10 @@ impl super::Validator {
                 return Err(GlobalVariableError::InitializerExprType);
             }
 
-            let decl_ty = &gctx.types[var.ty].inner;
-            let init_ty = mod_info[init].inner_with(gctx.types);
-            if !decl_ty.non_struct_equivalent(init_ty, gctx.types) {
+            if !gctx.compare_types(
+                &crate::proc::TypeResolution::Handle(var.ty),
+                &mod_info[init],
+            ) {
                 return Err(GlobalVariableError::InitializerType);
             }
         }

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -534,7 +534,7 @@ impl Validator {
 
         let decl_ty = &gctx.types[con.ty].inner;
         let init_ty = mod_info[con.init].inner_with(gctx.types);
-        if !decl_ty.equivalent(init_ty, gctx.types) {
+        if !decl_ty.non_struct_equivalent(init_ty, gctx.types) {
             return Err(ConstantError::InvalidType);
         }
 
@@ -575,7 +575,7 @@ impl Validator {
 
         if let Some(init) = o.init {
             let init_ty = mod_info[init].inner_with(gctx.types);
-            if !decl_ty.equivalent(init_ty, gctx.types) {
+            if !decl_ty.non_struct_equivalent(init_ty, gctx.types) {
                 return Err(OverrideError::InvalidType);
             }
         } else if self.overrides_resolved {

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -532,9 +532,7 @@ impl Validator {
             return Err(ConstantError::InitializerExprType);
         }
 
-        let decl_ty = &gctx.types[con.ty].inner;
-        let init_ty = mod_info[con.init].inner_with(gctx.types);
-        if !decl_ty.non_struct_equivalent(init_ty, gctx.types) {
+        if !gctx.compare_types(&TypeResolution::Handle(con.ty), &mod_info[con.init]) {
             return Err(ConstantError::InvalidType);
         }
 
@@ -560,9 +558,8 @@ impl Validator {
             return Err(OverrideError::NonConstructibleType);
         }
 
-        let decl_ty = &gctx.types[o.ty].inner;
-        match decl_ty {
-            &crate::TypeInner::Scalar(
+        match gctx.types[o.ty].inner {
+            crate::TypeInner::Scalar(
                 crate::Scalar::BOOL
                 | crate::Scalar::I32
                 | crate::Scalar::U32
@@ -574,8 +571,7 @@ impl Validator {
         }
 
         if let Some(init) = o.init {
-            let init_ty = mod_info[init].inner_with(gctx.types);
-            if !decl_ty.non_struct_equivalent(init_ty, gctx.types) {
+            if !gctx.compare_types(&TypeResolution::Handle(o.ty), &mod_info[init]) {
                 return Err(OverrideError::InvalidType);
             }
         } else if self.overrides_resolved {


### PR DESCRIPTION
Fixes #5796

**Description**
Consider two structs with the same members, but different names:
```
struct Foo { a: u32 };
struct Bar { a: u32 };
```
An instance of `Bar` should not be accepted in a context where `Foo` is expected, and vice-versa. We were not previously enforcing this, because we compare `TypeInner`s, and the `TypeInner` for a struct only contains the list of members and the memory stride.

I took the strategy of adding a new mechanism for comparing types using `TypeResolution`s, which additionally have access to the type name (at least in the case of structs, which are always represented as `TypeResolution::Handle` rather than `TypeResolution::Value`). A different strategy would be to add something in the `TypeInner` that makes it possible to distinguish the structs. I briefly went down the path of putting the `Handle<Type>` (or a `usize` intended to come from `Handle<Type>`) in the `TypeInner`, but that seemed like a more involved change because each place that can add a struct to the arena needs to change to understand how to record handle information in the `TypeInner`. We could also put the name itself in the `TypeInner`, but that seemed undesirable.

There is some more work needed before this would be ready, that I deferred until there's agreement on the strategy. One issue is the signature of the `compare_types` method -- taking `TypeResolution`s by value seems not great, but being able to pass either `&TypeResolution` or `Handle` is hard to do generically.

Another issue is making sure that we properly distinguish between the built-in struct types and a user-defined struct type with the same name -- this may be difficult to properly test until we have support for shadowing the built-in types.

**Testing**
Adds several tests in wgsl_errors for various places where our type checking of structs was previously incorrect.

**Squash or Rebase?** Squash, unless there's desire to preserve the refactorings as separate commits.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] Need to add a `CHANGELOG.md` entry.