### PR TITLE
[examples] Fixes for examples on web

### DIFF
--- a/examples/features/src/boids/mod.rs
+++ b/examples/features/src/boids/mod.rs
@@ -265,9 +265,7 @@ impl crate::framework::Example for Example {
             view,
             resolve_target: None,
             ops: wgpu::Operations {
-                // Not clearing here in order to test wgpu's zero texture initialization on a surface texture.
-                // Users should avoid loading uninitialized memory since this can cause additional overhead.
-                load: wgpu::LoadOp::Load,
+                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
                 store: wgpu::StoreOp::Store,
             },
         })];

--- a/examples/features/src/multiple_render_targets/mod.rs
+++ b/examples/features/src/multiple_render_targets/mod.rs
@@ -454,12 +454,12 @@ impl crate::framework::Example for Example {
             // output textures:
             &[
                 Some(wgpu::ColorTargetState {
-                    format: config.format,
+                    format: config.view_formats[0],
                     blend: None,
                     write_mask: Default::default(),
                 }),
                 Some(wgpu::ColorTargetState {
-                    format: config.format,
+                    format: config.view_formats[0],
                     blend: None,
                     write_mask: Default::default(),
                 }),
@@ -468,10 +468,11 @@ impl crate::framework::Example for Example {
 
         // create our target textures that will receive the simultaneous rendering:
         let texture_targets =
-            TextureTargets::new(device, config.format, config.width, config.height);
+            TextureTargets::new(device, config.view_formats[0], config.width, config.height);
 
         // helper renderer that displays the results in 2 separate viewports:
-        let drawer = TargetRenderer::init(device, &shader, config.format, &texture_targets);
+        let drawer =
+            TargetRenderer::init(device, &shader, config.view_formats[0], &texture_targets);
 
         Self {
             texture_targets,
@@ -491,7 +492,7 @@ impl crate::framework::Example for Example {
         self.screen_width = config.width;
         self.screen_height = config.height;
         self.texture_targets =
-            TextureTargets::new(device, config.format, config.width, config.height);
+            TextureTargets::new(device, config.view_formats[0], config.width, config.height);
         self.drawer.rebuild_resources(device, &self.texture_targets);
     }
 

--- a/examples/features/web-static/index.html
+++ b/examples/features/web-static/index.html
@@ -50,6 +50,11 @@
             margin: 0.5em 0;
         }
 
+        h1 {
+            margin-left: 0.75em;
+            margin-right: 0.75em;
+        }
+
         .backend-list-container {
             display: flex;
             flex-direction: row;
@@ -99,14 +104,18 @@
             text-align: center;
         }
 
-        .main-canvas {
-            margin: 0;
+        #content {
             /* This allows the flexbox to grow to max size, this is needed for WebGPU */
-            flex: 1;
+            flex: 1 1 100%;
             /* This forces CSS to ignore the width/height of the canvas, this is needed for WebGL */
             contain: size;
         }
 
+        .main-canvas {
+            margin: 0;
+            width: 100%;
+            height: 100%;
+        }
 
         #menu-button {
             display: none;
@@ -158,7 +167,9 @@
                 </div>
             </div>
         </div>
-        <canvas class="main-canvas" id="canvas"></canvas>
+        <div id="content">
+            <canvas class="main-canvas" id="canvas"></canvas>
+        </div>
     </div>
     <script type="module">
         const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
Fixes #7364

Assorted fixes for running the examples in a browser.

* `boids` was not rendering anything visible because the boids are white, the initial canvas is white, and the render target was not cleared between frames. It seems like non-web targets clear the canvas automatically, but web does not. However, there could well be a better fix here.
* Change `config.format` to `config.view_formats[0]` for `multiple_render_targets` to resolve `bgra8unorm` vs `bgra8unorm-srgb` format mismatch errors. I believe this makes it consistent with other examples.
* Change the "nothing to see here" message for compute examples to render in the content area rather than replace the whole page (including the navigation). Also reword the message slightly and tweak the styling.
* Change the image output helpers to replace the content canvas (which the relevant tests don't use) with the image element, rather then append the image element to `<body>`. I believe these examples have been broken on web since `<div class="root">` and the top navigation were added to the examples HTML, although I didn't try building old revisions to confirm this. Affects `render_to_texture` and `storage_texture`.

**Testing**
Tested the examples in both Chrome and Firefox, and tested `multiple_render_targets` natively.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
