### PR TITLE
[naga tests] Silence dead code warning.

### DIFF
--- a/naga/tests/validation.rs
+++ b/naga/tests/validation.rs
@@ -472,6 +472,7 @@ mod dummy_interpolation_shader {
         pub source: String,
         pub module: naga::Module,
         pub interpolate_attr: String,
+        #[cfg_attr(not(feature = "glsl-out"), expect(dead_code))]
         pub entry_point: &'static str,
     }
 


### PR DESCRIPTION
Silence warnings about `DummyInterpolationShader::entry_point` being unused in test builds with `wgsl-in` feature but without the `glsl-out` feature.
