### PR TITLE
Avoid overflows for extreme scissor coordinates

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2408,7 +2408,9 @@ fn set_push_constant(
 fn set_scissor(state: &mut State, rect: Rect<u32>) -> Result<(), RenderPassErrorInner> {
     api_log!("RenderPass::set_scissor_rect {rect:?}");
 
-    if rect.x + rect.w > state.info.extent.width || rect.y + rect.h > state.info.extent.height {
+    if rect.x.saturating_add(rect.w) > state.info.extent.width
+        || rect.y.saturating_add(rect.h) > state.info.extent.height
+    {
         return Err(RenderCommandError::InvalidScissorRect(rect, state.info.extent).into());
     }
     let r = hal::Rect {


### PR DESCRIPTION
**Connections**
None

**Description**
It's possible to cause an overflow during the validation check for extreme scissor coordinates, where x + width or y + height can exceed `u32::MAX`. Instead the coordinates should be caught by the existing validation check.

Currently something like this:

```rust
rpass.set_scissor_rect(1, 1, u32::MAX, u32::MAX);
```

causes a panic:

```
thread 'main' panicked at wgpu-core\src\command\render.rs:2411:8:
attempt to add with overflow
```

**Testing**
Tested `rpass.set_scissor_rect(1, 1, u32::MAX, u32::MAX);` on the cube example

**Squash or Rebase?**

n/a

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
