### PR TITLE
Assorted D3D12 suballocation cleanups

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -451,10 +451,9 @@ impl crate::Device for super::Device {
 
     unsafe fn destroy_buffer(&self, buffer: super::Buffer) {
         suballocation::free_resource(
-            self,
+            suballocation::DeviceAllocationContext::from(self),
             buffer.resource,
             buffer.allocation,
-            &self.mem_allocator,
         );
 
         self.counters.buffers.sub(1);
@@ -542,11 +541,9 @@ impl crate::Device for super::Device {
 
     unsafe fn destroy_texture(&self, texture: super::Texture) {
         suballocation::free_resource(
-            self,
+            suballocation::DeviceAllocationContext::from(self),
             texture.resource,
             texture.allocation,
-            // SAFETY: for allocations to exist, the allocator must exist
-            &self.mem_allocator,
         );
 
         self.counters.textures.sub(1);
@@ -1673,10 +1670,9 @@ impl crate::Device for super::Device {
 
         if let Some(sampler_buffer) = group.sampler_index_buffer {
             suballocation::free_resource(
-                self,
+                suballocation::DeviceAllocationContext::from(self),
                 sampler_buffer.buffer,
                 sampler_buffer.allocation,
-                &self.mem_allocator,
             );
         }
 
@@ -2320,10 +2316,9 @@ impl crate::Device for super::Device {
         acceleration_structure: super::AccelerationStructure,
     ) {
         suballocation::free_resource(
-            self,
+            suballocation::DeviceAllocationContext::from(self),
             acceleration_structure.resource,
             acceleration_structure.allocation,
-            &self.mem_allocator,
         );
     }
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -52,10 +52,7 @@ impl super::Device {
             auxil::dxgi::exception::register_exception_handler();
         }
 
-        let mem_allocator = Arc::new(super::suballocation::create_allocator_wrapper(
-            &raw,
-            memory_hints,
-        )?);
+        let mem_allocator = Arc::new(super::suballocation::create_allocator(&raw, memory_hints)?);
 
         let idle_fence: Direct3D12::ID3D12Fence = unsafe {
             profiling::scope!("ID3D12Device::CreateFence");
@@ -2344,7 +2341,7 @@ impl crate::Device for super::Device {
     }
 
     fn generate_allocator_report(&self) -> Option<wgt::AllocatorReport> {
-        let mut upstream = self.mem_allocator.lock().allocator.generate_report();
+        let mut upstream = self.mem_allocator.lock().generate_report();
 
         let allocations = upstream
             .allocations

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -24,8 +24,7 @@ use super::{conv, descriptor, D3D12Lib};
 use crate::{
     auxil::{self, dxgi::result::HResult},
     dx12::{
-        borrow_optional_interface_temporarily, shader_compilation,
-        suballocation::{self, DeviceAllocationContext},
+        borrow_optional_interface_temporarily, shader_compilation, suballocation,
         DynamicStorageBufferOffsets, Event,
     },
     AccelerationStructureEntries, TlasInstance,
@@ -430,8 +429,11 @@ impl crate::Device for super::Device {
             Flags: conv::map_buffer_usage_to_resource_flags(desc.usage),
         };
 
-        let (resource, allocation) =
-            suballocation::create_buffer(DeviceAllocationContext::from(self), desc, raw_desc)?;
+        let (resource, allocation) = suballocation::create_buffer(
+            suballocation::DeviceAllocationContext::from(self),
+            desc,
+            raw_desc,
+        )?;
 
         if let Some(label) = desc.label {
             unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
@@ -514,8 +516,11 @@ impl crate::Device for super::Device {
             Flags: conv::map_texture_usage_to_resource_flags(desc.usage),
         };
 
-        let (resource, allocation) =
-            suballocation::create_texture(DeviceAllocationContext::from(self), desc, raw_desc)?;
+        let (resource, allocation) = suballocation::create_texture(
+            suballocation::DeviceAllocationContext::from(self),
+            desc,
+            raw_desc,
+        )?;
 
         if let Some(label) = desc.label {
             unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
@@ -1582,7 +1587,7 @@ impl crate::Device for super::Device {
             };
 
             let (buffer, allocation) = suballocation::create_buffer(
-                DeviceAllocationContext::from(self),
+                suballocation::DeviceAllocationContext::from(self),
                 &buffer_desc,
                 raw_buffer_desc,
             )?;
@@ -2292,7 +2297,7 @@ impl crate::Device for super::Device {
         };
 
         let (resource, allocation) = suballocation::create_acceleration_structure(
-            DeviceAllocationContext::from(self),
+            suballocation::DeviceAllocationContext::from(self),
             desc,
             raw_desc,
         )?;

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -430,11 +430,8 @@ impl crate::Device for super::Device {
             Flags: conv::map_buffer_usage_to_resource_flags(desc.usage),
         };
 
-        let (resource, allocation) = suballocation::create_buffer_resource(
-            DeviceAllocationContext::from(self),
-            desc,
-            raw_desc,
-        )?;
+        let (resource, allocation) =
+            suballocation::create_buffer(DeviceAllocationContext::from(self), desc, raw_desc)?;
 
         if let Some(label) = desc.label {
             unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
@@ -514,11 +511,8 @@ impl crate::Device for super::Device {
             Flags: conv::map_texture_usage_to_resource_flags(desc.usage),
         };
 
-        let (resource, allocation) = suballocation::create_texture_resource(
-            DeviceAllocationContext::from(self),
-            desc,
-            raw_desc,
-        )?;
+        let (resource, allocation) =
+            suballocation::create_texture(DeviceAllocationContext::from(self), desc, raw_desc)?;
 
         if let Some(label) = desc.label {
             unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
@@ -1586,7 +1580,7 @@ impl crate::Device for super::Device {
                 Flags: Direct3D12::D3D12_RESOURCE_FLAG_NONE,
             };
 
-            let (buffer, allocation) = suballocation::create_buffer_resource(
+            let (buffer, allocation) = suballocation::create_buffer(
                 DeviceAllocationContext::from(self),
                 &buffer_desc,
                 raw_buffer_desc,
@@ -2294,7 +2288,7 @@ impl crate::Device for super::Device {
             Flags: Direct3D12::D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
         };
 
-        let (resource, allocation) = suballocation::create_acceleration_structure_resource(
+        let (resource, allocation) = suballocation::create_acceleration_structure(
             DeviceAllocationContext::from(self),
             desc,
             raw_desc,

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -448,9 +448,12 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn destroy_buffer(&self, buffer: super::Buffer) {
-        // Resource should be dropped before free suballocation
-        drop(buffer.resource);
-        suballocation::free_allocation(self, buffer.allocation, &self.mem_allocator);
+        suballocation::free_resource(
+            self,
+            buffer.resource,
+            buffer.allocation,
+            &self.mem_allocator,
+        );
 
         self.counters.buffers.sub(1);
     }
@@ -533,11 +536,9 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn destroy_texture(&self, texture: super::Texture) {
-        // Resource should be dropped before free suballocation
-        drop(texture.resource);
-
-        suballocation::free_allocation(
+        suballocation::free_resource(
             self,
+            texture.resource,
             texture.allocation,
             // SAFETY: for allocations to exist, the allocator must exist
             &self.mem_allocator,
@@ -1666,10 +1667,12 @@ impl crate::Device for super::Device {
         }
 
         if let Some(sampler_buffer) = group.sampler_index_buffer {
-            // Make sure the buffer is dropped before the allocation
-            drop(sampler_buffer.buffer);
-
-            suballocation::free_allocation(self, sampler_buffer.allocation, &self.mem_allocator);
+            suballocation::free_resource(
+                self,
+                sampler_buffer.buffer,
+                sampler_buffer.allocation,
+                &self.mem_allocator,
+            );
         }
 
         self.counters.bind_groups.sub(1);
@@ -2311,11 +2314,9 @@ impl crate::Device for super::Device {
         &self,
         acceleration_structure: super::AccelerationStructure,
     ) {
-        // Resource should be dropped before suballocation is freed
-        drop(acceleration_structure.resource);
-
-        suballocation::free_allocation(
+        suballocation::free_resource(
             self,
+            acceleration_structure.resource,
             acceleration_structure.allocation,
             &self.mem_allocator,
         );

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -149,6 +149,7 @@ impl super::Device {
                 capacity_views,
             )?,
             sampler_heap: super::sampler::SamplerHeap::new(&raw, &private_caps)?,
+            private_caps,
         };
 
         let mut rtv_pool =
@@ -180,7 +181,6 @@ impl super::Device {
                 fence: idle_fence,
                 event: Event::create(false, false)?,
             },
-            private_caps,
             features,
             shared: Arc::new(shared),
             rtv_pool: Mutex::new(rtv_pool),
@@ -502,7 +502,9 @@ impl crate::Device for super::Device {
                 desc.format,
                 desc.usage,
                 !desc.view_formats.is_empty(),
-                self.private_caps.casting_fully_typed_format_supported,
+                self.shared
+                    .private_caps
+                    .casting_fully_typed_format_supported,
             ),
             SampleDesc: Dxgi::Common::DXGI_SAMPLE_DESC {
                 Count: desc.sample_count,
@@ -1351,7 +1353,7 @@ impl crate::Device for super::Device {
             },
             bind_group_infos,
             naga_options: hlsl::Options {
-                shader_model: self.private_caps.shader_model,
+                shader_model: self.shared.private_caps.shader_model,
                 binding_map,
                 fake_missing_bindings: false,
                 special_constants_binding,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -89,6 +89,7 @@ mod view;
 use std::{borrow::ToOwned as _, ffi, fmt, mem, num::NonZeroU32, ops::Deref, sync::Arc, vec::Vec};
 
 use arrayvec::ArrayVec;
+use gpu_allocator::d3d12::Allocator;
 use parking_lot::{Mutex, RwLock};
 use windows::{
     core::{Free, Interface},
@@ -651,7 +652,7 @@ pub struct Device {
     #[cfg(feature = "renderdoc")]
     render_doc: auxil::renderdoc::RenderDoc,
     null_rtv_handle: descriptor::Handle,
-    mem_allocator: Arc<Mutex<suballocation::GpuAllocatorWrapper>>,
+    mem_allocator: Arc<Mutex<Allocator>>,
     dxc_container: Option<Arc<shader_compilation::DxcContainer>>,
     counters: Arc<wgt::HalCounters>,
 }
@@ -793,7 +794,7 @@ pub struct CommandEncoder {
     allocator: Direct3D12::ID3D12CommandAllocator,
     device: Direct3D12::ID3D12Device,
     shared: Arc<DeviceShared>,
-    mem_allocator: Arc<Mutex<suballocation::GpuAllocatorWrapper>>,
+    mem_allocator: Arc<Mutex<Allocator>>,
 
     null_rtv_handle: descriptor::Handle,
     list: Option<Direct3D12::ID3D12GraphicsCommandList>,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -651,7 +651,7 @@ pub struct Device {
     #[cfg(feature = "renderdoc")]
     render_doc: auxil::renderdoc::RenderDoc,
     null_rtv_handle: descriptor::Handle,
-    mem_allocator: Mutex<suballocation::GpuAllocatorWrapper>,
+    mem_allocator: Arc<Mutex<suballocation::GpuAllocatorWrapper>>,
     dxc_container: Option<Arc<shader_compilation::DxcContainer>>,
     counters: Arc<wgt::HalCounters>,
 }
@@ -793,6 +793,8 @@ pub struct CommandEncoder {
     allocator: Direct3D12::ID3D12CommandAllocator,
     device: Direct3D12::ID3D12Device,
     shared: Arc<DeviceShared>,
+    mem_allocator: Arc<Mutex<suballocation::GpuAllocatorWrapper>>,
+
     null_rtv_handle: descriptor::Handle,
     list: Option<Direct3D12::ID3D12GraphicsCommandList>,
     free_lists: Vec<Direct3D12::ID3D12GraphicsCommandList>,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -835,7 +835,7 @@ unsafe impl Sync for CommandBuffer {}
 pub struct Buffer {
     resource: Direct3D12::ID3D12Resource,
     size: wgt::BufferAddress,
-    allocation: Option<suballocation::Allocation>,
+    allocation: suballocation::Allocation,
 }
 
 unsafe impl Send for Buffer {}
@@ -865,7 +865,7 @@ pub struct Texture {
     size: wgt::Extent3d,
     mip_level_count: u32,
     sample_count: u32,
-    allocation: Option<suballocation::Allocation>,
+    allocation: suballocation::Allocation,
 }
 
 impl Texture {
@@ -984,7 +984,7 @@ enum DynamicBuffer {
 #[derive(Debug)]
 struct SamplerIndexBuffer {
     buffer: Direct3D12::ID3D12Resource,
-    allocation: Option<suballocation::Allocation>,
+    allocation: suballocation::Allocation,
 }
 
 #[derive(Debug)]
@@ -1121,7 +1121,7 @@ impl crate::DynPipelineCache for PipelineCache {}
 #[derive(Debug)]
 pub struct AccelerationStructure {
     resource: Direct3D12::ID3D12Resource,
-    allocation: Option<suballocation::Allocation>,
+    allocation: suballocation::Allocation,
 }
 
 impl crate::DynAccelerationStructure for AccelerationStructure {}
@@ -1375,7 +1375,7 @@ impl crate::Surface for Surface {
             size: sc.size,
             mip_level_count: 1,
             sample_count: 1,
-            allocation: None,
+            allocation: suballocation::Allocation::none(suballocation::AllocationType::Texture),
         };
         Ok(Some(crate::AcquiredSurfaceTexture {
             texture,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -835,7 +835,7 @@ unsafe impl Sync for CommandBuffer {}
 pub struct Buffer {
     resource: Direct3D12::ID3D12Resource,
     size: wgt::BufferAddress,
-    allocation: Option<suballocation::AllocationWrapper>,
+    allocation: Option<suballocation::Allocation>,
 }
 
 unsafe impl Send for Buffer {}
@@ -865,7 +865,7 @@ pub struct Texture {
     size: wgt::Extent3d,
     mip_level_count: u32,
     sample_count: u32,
-    allocation: Option<suballocation::AllocationWrapper>,
+    allocation: Option<suballocation::Allocation>,
 }
 
 impl Texture {
@@ -984,7 +984,7 @@ enum DynamicBuffer {
 #[derive(Debug)]
 struct SamplerIndexBuffer {
     buffer: Direct3D12::ID3D12Resource,
-    allocation: Option<suballocation::AllocationWrapper>,
+    allocation: Option<suballocation::Allocation>,
 }
 
 #[derive(Debug)]
@@ -1121,7 +1121,7 @@ impl crate::DynPipelineCache for PipelineCache {}
 #[derive(Debug)]
 pub struct AccelerationStructure {
     resource: Direct3D12::ID3D12Resource,
-    allocation: Option<suballocation::AllocationWrapper>,
+    allocation: Option<suballocation::Allocation>,
 }
 
 impl crate::DynAccelerationStructure for AccelerationStructure {}

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -630,6 +630,7 @@ struct DeviceShared {
     cmd_signatures: CommandSignatures,
     heap_views: descriptor::GeneralHeap,
     sampler_heap: sampler::SamplerHeap,
+    private_caps: PrivateCapabilities,
 }
 
 unsafe impl Send for DeviceShared {}
@@ -639,7 +640,6 @@ pub struct Device {
     raw: Direct3D12::ID3D12Device,
     present_queue: Direct3D12::ID3D12CommandQueue,
     idler: Idler,
-    private_caps: PrivateCapabilities,
     features: wgt::Features,
     shared: Arc<DeviceShared>,
     // CPU only pools
@@ -660,6 +660,7 @@ impl Drop for Device {
     fn drop(&mut self) {
         self.rtv_pool.lock().free_handle(self.null_rtv_handle);
         if self
+            .shared
             .private_caps
             .instance_flags
             .contains(wgt::InstanceFlags::VALIDATION)

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -23,6 +23,7 @@ pub(super) fn compile_fxc(
     let mut shader_data = None;
     let mut compile_flags = Fxc::D3DCOMPILE_ENABLE_STRICTNESS;
     if device
+        .shared
         .private_caps
         .instance_flags
         .contains(wgt::InstanceFlags::DEBUG)
@@ -290,6 +291,7 @@ pub(super) fn compile_dxc(
     }
 
     if device
+        .shared
         .private_caps
         .instance_flags
         .contains(wgt::InstanceFlags::DEBUG)

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -257,11 +257,15 @@ pub(crate) fn create_acceleration_structure(
     ))
 }
 
-pub(crate) fn free_allocation(
+pub(crate) fn free_resource(
     device: &crate::dx12::Device,
+    resource: Direct3D12::ID3D12Resource,
     allocation: Allocation,
     allocator: &Mutex<Allocator>,
 ) {
+    // Make sure the resource is released before we free the allocation.
+    drop(resource);
+
     let Some(inner) = allocation.inner else {
         return;
     };

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -92,7 +92,7 @@ impl<'a> From<&'a super::CommandEncoder> for DeviceAllocationContext<'a> {
     }
 }
 
-pub(crate) fn create_buffer_resource(
+pub(crate) fn create_buffer(
     ctx: DeviceAllocationContext,
     desc: &crate::BufferDescriptor,
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
@@ -102,7 +102,7 @@ pub(crate) fn create_buffer_resource(
 
     // Workaround for Intel Xe drivers
     if !ctx.shared.private_caps.suballocation_supported {
-        let resource = create_committed_buffer_resource(ctx, desc, raw_desc)?;
+        let resource = create_committed_buffer(ctx, desc, raw_desc)?;
         return Ok((resource, Allocation::none(AllocationType::Buffer)));
     }
 
@@ -151,14 +151,14 @@ pub(crate) fn create_buffer_resource(
     ))
 }
 
-pub(crate) fn create_texture_resource(
+pub(crate) fn create_texture(
     ctx: DeviceAllocationContext,
     desc: &crate::TextureDescriptor,
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
 ) -> Result<(Direct3D12::ID3D12Resource, Allocation), crate::DeviceError> {
     // Workaround for Intel Xe drivers
     if !ctx.shared.private_caps.suballocation_supported {
-        let resource = create_committed_texture_resource(ctx, desc, raw_desc)?;
+        let resource = create_committed_texture(ctx, desc, raw_desc)?;
         return Ok((resource, Allocation::none(AllocationType::Texture)));
     }
 
@@ -201,14 +201,14 @@ pub(crate) fn create_texture_resource(
     ))
 }
 
-pub(crate) fn create_acceleration_structure_resource(
+pub(crate) fn create_acceleration_structure(
     ctx: DeviceAllocationContext,
     desc: &crate::AccelerationStructureDescriptor,
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
 ) -> Result<(Direct3D12::ID3D12Resource, Allocation), crate::DeviceError> {
     // Workaround for Intel Xe drivers
     if !ctx.shared.private_caps.suballocation_supported {
-        let resource = create_committed_acceleration_structure_resource(ctx, desc, raw_desc)?;
+        let resource = create_committed_acceleration_structure(ctx, desc, raw_desc)?;
         return Ok((
             resource,
             Allocation::none(AllocationType::AccelerationStructure),
@@ -317,7 +317,7 @@ impl From<gpu_allocator::AllocationError> for crate::DeviceError {
     }
 }
 
-pub(crate) fn create_committed_buffer_resource(
+pub(crate) fn create_committed_buffer(
     ctx: DeviceAllocationContext,
     desc: &crate::BufferDescriptor,
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
@@ -365,7 +365,7 @@ pub(crate) fn create_committed_buffer_resource(
     resource.ok_or(crate::DeviceError::Unexpected)
 }
 
-pub(crate) fn create_committed_texture_resource(
+pub(crate) fn create_committed_texture(
     ctx: DeviceAllocationContext,
     _desc: &crate::TextureDescriptor,
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
@@ -402,7 +402,7 @@ pub(crate) fn create_committed_texture_resource(
     resource.ok_or(crate::DeviceError::Unexpected)
 }
 
-pub(crate) fn create_committed_acceleration_structure_resource(
+pub(crate) fn create_committed_acceleration_structure(
     ctx: DeviceAllocationContext,
     _desc: &crate::AccelerationStructureDescriptor,
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -57,7 +57,7 @@ pub(crate) fn create_buffer_resource(
     let is_cpu_write = desc.usage.contains(wgt::BufferUses::MAP_WRITE);
 
     // Workaround for Intel Xe drivers
-    if !device.private_caps.suballocation_supported {
+    if !device.shared.private_caps.suballocation_supported {
         return create_committed_buffer_resource(device, desc, raw_desc)
             .map(|resource| (resource, None));
     }
@@ -110,7 +110,7 @@ pub(crate) fn create_texture_resource(
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
 ) -> Result<(Direct3D12::ID3D12Resource, Option<AllocationWrapper>), crate::DeviceError> {
     // Workaround for Intel Xe drivers
-    if !device.private_caps.suballocation_supported {
+    if !device.shared.private_caps.suballocation_supported {
         return create_committed_texture_resource(device, desc, raw_desc)
             .map(|resource| (resource, None));
     }
@@ -157,7 +157,7 @@ pub(crate) fn create_acceleration_structure_resource(
     raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
 ) -> Result<(Direct3D12::ID3D12Resource, Option<AllocationWrapper>), crate::DeviceError> {
     // Workaround for Intel Xe drivers
-    if !device.private_caps.suballocation_supported {
+    if !device.shared.private_caps.suballocation_supported {
         return create_committed_acceleration_structure_resource(device, desc, raw_desc)
             .map(|resource| (resource, None));
     }
@@ -301,7 +301,7 @@ pub(crate) fn create_committed_buffer_resource(
         } else {
             Direct3D12::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE
         },
-        MemoryPoolPreference: match device.private_caps.memory_architecture {
+        MemoryPoolPreference: match device.shared.private_caps.memory_architecture {
             crate::dx12::MemoryArchitecture::NonUnified if !is_cpu_read && !is_cpu_write => {
                 Direct3D12::D3D12_MEMORY_POOL_L1
             }
@@ -316,7 +316,7 @@ pub(crate) fn create_committed_buffer_resource(
     unsafe {
         device.raw.CreateCommittedResource(
             &heap_properties,
-            if device.private_caps.heap_create_not_zeroed {
+            if device.shared.private_caps.heap_create_not_zeroed {
                 Direct3D12::D3D12_HEAP_FLAG_CREATE_NOT_ZEROED
             } else {
                 Direct3D12::D3D12_HEAP_FLAG_NONE
@@ -340,7 +340,7 @@ pub(crate) fn create_committed_texture_resource(
     let heap_properties = Direct3D12::D3D12_HEAP_PROPERTIES {
         Type: Direct3D12::D3D12_HEAP_TYPE_CUSTOM,
         CPUPageProperty: Direct3D12::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE,
-        MemoryPoolPreference: match device.private_caps.memory_architecture {
+        MemoryPoolPreference: match device.shared.private_caps.memory_architecture {
             crate::dx12::MemoryArchitecture::NonUnified => Direct3D12::D3D12_MEMORY_POOL_L1,
             crate::dx12::MemoryArchitecture::Unified { .. } => Direct3D12::D3D12_MEMORY_POOL_L0,
         },
@@ -353,7 +353,7 @@ pub(crate) fn create_committed_texture_resource(
     unsafe {
         device.raw.CreateCommittedResource(
             &heap_properties,
-            if device.private_caps.heap_create_not_zeroed {
+            if device.shared.private_caps.heap_create_not_zeroed {
                 Direct3D12::D3D12_HEAP_FLAG_CREATE_NOT_ZEROED
             } else {
                 Direct3D12::D3D12_HEAP_FLAG_NONE
@@ -377,7 +377,7 @@ pub(crate) fn create_committed_acceleration_structure_resource(
     let heap_properties = Direct3D12::D3D12_HEAP_PROPERTIES {
         Type: Direct3D12::D3D12_HEAP_TYPE_CUSTOM,
         CPUPageProperty: Direct3D12::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE,
-        MemoryPoolPreference: match device.private_caps.memory_architecture {
+        MemoryPoolPreference: match device.shared.private_caps.memory_architecture {
             crate::dx12::MemoryArchitecture::NonUnified => Direct3D12::D3D12_MEMORY_POOL_L1,
             _ => Direct3D12::D3D12_MEMORY_POOL_L0,
         },
@@ -390,7 +390,7 @@ pub(crate) fn create_committed_acceleration_structure_resource(
     unsafe {
         device.raw.CreateCommittedResource(
             &heap_properties,
-            if device.private_caps.heap_create_not_zeroed {
+            if device.shared.private_caps.heap_create_not_zeroed {
                 Direct3D12::D3D12_HEAP_FLAG_CREATE_NOT_ZEROED
             } else {
                 Direct3D12::D3D12_HEAP_FLAG_NONE


### PR DESCRIPTION
**Connections**

Part of my work on #4150.

**Description**

This PR solves two problems:
- After using the suballocation module in anger, I realized there was quite a lot of excess cruft from an older design. This cleans it up and tries to simplify the API.
- This enables me to create buffers from the command encoder, which is something I need for #4150.

Each commit is standalone and the review experience is commit-by-commit.

**Testing**

CI.

**Squash or Rebase?**

Rebase vibes.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
