### PR TITLE
[metal] Fix handling of stage visibility for binding arrays

### DIFF
--- a/examples/features/src/texture_arrays/mod.rs
+++ b/examples/features/src/texture_arrays/mod.rs
@@ -429,16 +429,6 @@ pub fn main() {
 }
 
 #[cfg(test)]
-fn test_parameters() -> wgpu_test::TestParameters {
-    wgpu_test::TestParameters::default()
-        // https://github.com/gfx-rs/wgpu/issues/7287
-        .expect_fail(wgpu_test::FailureCase::backend_adapter(
-            wgpu::Backends::METAL,
-            "Apple M",
-        ))
-}
-
-#[cfg(test)]
 #[wgpu_test::gpu_test]
 static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "texture-arrays",
@@ -446,7 +436,7 @@ static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTest
     width: 1024,
     height: 768,
     optional_features: wgpu::Features::empty(),
-    base_test_parameters: test_parameters(),
+    base_test_parameters: wgpu_test::TestParameters::default(),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.0)],
     _phantom: std::marker::PhantomData::<Example>,
 };
@@ -459,7 +449,7 @@ static TEST_UNIFORM: crate::framework::ExampleTestParams = crate::framework::Exa
     width: 1024,
     height: 768,
     optional_features: wgpu::Features::empty(),
-    base_test_parameters: test_parameters(),
+    base_test_parameters: wgpu_test::TestParameters::default(),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.0)],
     _phantom: std::marker::PhantomData::<Example>,
 };
@@ -474,7 +464,7 @@ static TEST_NON_UNIFORM: crate::framework::ExampleTestParams =
         height: 768,
         optional_features:
             wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
-        base_test_parameters: test_parameters(),
+        base_test_parameters: wgpu_test::TestParameters::default(),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.0)],
         _phantom: std::marker::PhantomData::<Example>,
     };

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -831,6 +831,10 @@ impl crate::Device for super::Device {
                 for (entry, layout) in layout_and_entry_iter {
                     // Bindless path
                     if layout.count.is_some() {
+                        if !layout.visibility.contains(stage_bit) {
+                            continue;
+                        }
+
                         let count = entry.count;
 
                         let stages = conv::map_render_stages(layout.visibility);


### PR DESCRIPTION
Fixes #7287

**Description**
This fixes the metal implementation of `create_bind_group` when an array binding is not exposed to all shader stages. Previously, the visibility was not considered, so array bindings were passed to all stages. In the texture-arrays tests, the problem manifested as vertex corruption because the texture array was bound to the slot where the shader expected to find the binding sizes.

**Testing**
I have re-enabled the texture-arrays tests, which were previously failing on Mac.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
