### PR TITLE
Add `stderr` and `termcolor` features to Naga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,7 @@ By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811), [#6815](h
 - Refactored `use` statements to simplify future `no_std` support. By @bushrat011899 in [#7256](https://github.com/gfx-rs/wgpu/pull/7256)
 - Naga's WGSL frontend no longer allows using the `&` operator to take the address of a component of a vector,
   which is not permitted by the WGSL specification. By @andyleiserson in [#7284](https://github.com/gfx-rs/wgpu/pull/7284)
+- Naga's use of `termcolor` and `stderr` are now optional behind features of the same names. By @bushrat011899 in [#7482](https://github.com/gfx-rs/wgpu/pull/7482)
 
 #### Vulkan
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,6 +2407,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.8.0",
  "bitflags 2.9.0",
+ "cfg-if",
  "cfg_aliases 0.2.1",
  "codespan-reporting",
  "diff",

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -37,6 +37,8 @@ naga = { workspace = true, features = [
     "dot-out",
     "serialize",
     "deserialize",
+    "termcolor",
+    "stderr",
 ] }
 
 bincode.workspace = true

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -80,6 +80,12 @@ hlsl-out-if-target-windows = []
 
 compact = []
 
+## Enables colored output through codespan-reporting and termcolor.
+termcolor = ["codespan-reporting/termcolor"]
+
+## Enables writing output to stderr.
+stderr = []
+
 [dependencies]
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 arrayvec.workspace = true
@@ -87,7 +93,6 @@ bitflags.workspace = true
 bit-set.workspace = true
 codespan-reporting = { workspace = true, default-features = false, features = [
     "std",
-    "termcolor",
 ] }
 hashbrown.workspace = true
 half = { workspace = true, default-features = false, features = ["num-traits"] }

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -91,6 +91,7 @@ arbitrary = { version = "1.4", features = ["derive"], optional = true }
 arrayvec.workspace = true
 bitflags.workspace = true
 bit-set.workspace = true
+cfg-if.workspace = true
 codespan-reporting = { workspace = true, default-features = false }
 hashbrown.workspace = true
 half = { workspace = true, default-features = false, features = ["num-traits"] }
@@ -111,7 +112,6 @@ petgraph = { version = "0.8", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
 unicode-ident = { version = "1.0", optional = true }
-cfg-if.workspace = true
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -84,16 +84,14 @@ compact = []
 termcolor = ["codespan-reporting/termcolor"]
 
 ## Enables writing output to stderr.
-stderr = []
+stderr = ["codespan-reporting/std"]
 
 [dependencies]
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 arrayvec.workspace = true
 bitflags.workspace = true
 bit-set.workspace = true
-codespan-reporting = { workspace = true, default-features = false, features = [
-    "std",
-] }
+codespan-reporting = { workspace = true, default-features = false }
 hashbrown.workspace = true
 half = { workspace = true, default-features = false, features = ["num-traits"] }
 rustc-hash.workspace = true

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -111,6 +111,7 @@ petgraph = { version = "0.8", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
 unicode-ident = { version = "1.0", optional = true }
+cfg-if.workspace = true
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/naga/src/error.rs
+++ b/naga/src/error.rs
@@ -114,15 +114,13 @@ impl DiagnosticBuffer {
 
         cfg_if::cfg_if! {
             if #[cfg(feature = "termcolor")] {
-                let converted = String::from_utf8(inner.into_inner()).unwrap();
+                String::from_utf8(inner.into_inner()).unwrap()
             } else if #[cfg(feature = "stderr")] {
-                let converted = String::from_utf8(inner).unwrap();
+                String::from_utf8(inner).unwrap()
             } else {
-                let converted = inner;
+                inner
             }
-        };
-
-        converted
+        }
     }
 }
 impl<E> Error for ShaderError<E>

--- a/naga/src/error.rs
+++ b/naga/src/error.rs
@@ -64,6 +64,22 @@ type DiagnosticBufferInner = alloc::vec::Vec<u8>;
 #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
 type DiagnosticBufferInner = String;
 
+#[cfg(feature = "termcolor")]
+pub(crate) use codespan_reporting::term::termcolor::WriteColor as _ErrorWrite;
+#[cfg(not(any(feature = "termcolor", feature = "stderr")))]
+pub(crate) use core::fmt::Write as _ErrorWrite;
+#[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
+pub(crate) use std::io::Write as _ErrorWrite;
+
+#[cfg_attr(
+    not(any(feature = "spv-in", feature = "glsl-in")),
+    expect(
+        unused_imports,
+        reason = "only need `ErrorWrite` with an appropriate front-end."
+    )
+)]
+pub(crate) use _ErrorWrite as ErrorWrite;
+
 pub(crate) struct DiagnosticBuffer {
     inner: DiagnosticBufferInner,
 }

--- a/naga/src/error.rs
+++ b/naga/src/error.rs
@@ -40,13 +40,30 @@ impl fmt::Display for ShaderError<crate::WithSpan<crate::valid::ValidationError>
         let label = self.label.as_deref().unwrap_or_default();
         let files = SimpleFile::new(label, &self.source);
         let config = term::Config::default();
-        let mut writer = term::termcolor::NoColor::new(Vec::new());
-        term::emit(&mut writer, &config, &files, &self.inner.diagnostic())
-            .expect("cannot write error");
+
+        let emit = |writer| {
+            term::emit(writer, &config, &files, &self.inner.diagnostic())
+                .expect("cannot write error")
+        };
+
+        #[cfg(feature = "termcolor")]
+        let writer = {
+            let mut writer = term::termcolor::NoColor::new(Vec::new());
+            emit(&mut writer);
+            writer.into_inner()
+        };
+
+        #[cfg(not(feature = "termcolor"))]
+        let writer = {
+            let mut writer = Vec::new();
+            emit(&mut writer);
+            writer
+        };
+
         write!(
             f,
             "\nShader validation {}",
-            String::from_utf8_lossy(&writer.into_inner())
+            String::from_utf8_lossy(&writer)
         )
     }
 }

--- a/naga/src/error.rs
+++ b/naga/src/error.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, string::String};
 use core::{error::Error, fmt};
 
 #[derive(Clone, Debug)]
@@ -41,30 +41,66 @@ impl fmt::Display for ShaderError<crate::WithSpan<crate::valid::ValidationError>
         let files = SimpleFile::new(label, &self.source);
         let config = term::Config::default();
 
-        let emit = |writer| {
-            term::emit(writer, &config, &files, &self.inner.diagnostic())
-                .expect("cannot write error")
-        };
-
-        #[cfg(feature = "termcolor")]
         let writer = {
-            let mut writer = term::termcolor::NoColor::new(Vec::new());
-            emit(&mut writer);
-            writer.into_inner()
+            let mut writer = DiagnosticBuffer::new();
+            term::emit(
+                writer.inner_mut(),
+                &config,
+                &files,
+                &self.inner.diagnostic(),
+            )
+            .expect("cannot write error");
+            writer.into_string()
         };
 
-        #[cfg(not(feature = "termcolor"))]
-        let writer = {
-            let mut writer = Vec::new();
-            emit(&mut writer);
-            writer
-        };
+        write!(f, "\nShader validation {}", writer)
+    }
+}
 
-        write!(
-            f,
-            "\nShader validation {}",
-            String::from_utf8_lossy(&writer)
+#[cfg(feature = "termcolor")]
+type DiagnosticBufferInner = codespan_reporting::term::termcolor::NoColor<alloc::vec::Vec<u8>>;
+#[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
+type DiagnosticBufferInner = alloc::vec::Vec<u8>;
+#[cfg(not(any(feature = "termcolor", feature = "stderr")))]
+type DiagnosticBufferInner = String;
+
+pub(crate) struct DiagnosticBuffer {
+    inner: DiagnosticBufferInner,
+}
+
+impl DiagnosticBuffer {
+    #[cfg_attr(
+        not(feature = "termcolor"),
+        expect(
+            clippy::missing_const_for_fn,
+            reason = "`NoColor::new` isn't `const`, but other `inner`s are."
         )
+    )]
+    pub fn new() -> Self {
+        Self {
+            #[cfg(feature = "termcolor")]
+            inner: codespan_reporting::term::termcolor::NoColor::new(alloc::vec::Vec::new()),
+            #[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
+            inner: alloc::vec::Vec::new(),
+            #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
+            inner: String::new(),
+        }
+    }
+
+    pub fn inner_mut(&mut self) -> &mut DiagnosticBufferInner {
+        &mut self.inner
+    }
+
+    pub fn into_string(self) -> String {
+        let Self { inner } = self;
+        #[cfg(feature = "termcolor")]
+        let converted = String::from_utf8(inner.into_inner()).unwrap();
+        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
+        let converted = String::from_utf8(inner).unwrap();
+        #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
+        let converted = inner;
+
+        converted
     }
 }
 impl<E> Error for ShaderError<E>

--- a/naga/src/error.rs
+++ b/naga/src/error.rs
@@ -70,6 +70,7 @@ cfg_if::cfg_if! {
     }
 }
 
+// Using this indirect export to avoid duplicating the expect(...) for all three cases above.
 #[cfg_attr(
     not(any(feature = "spv-in", feature = "glsl-in")),
     expect(

--- a/naga/src/error.rs
+++ b/naga/src/error.rs
@@ -57,19 +57,18 @@ impl fmt::Display for ShaderError<crate::WithSpan<crate::valid::ValidationError>
     }
 }
 
-#[cfg(feature = "termcolor")]
-type DiagnosticBufferInner = codespan_reporting::term::termcolor::NoColor<alloc::vec::Vec<u8>>;
-#[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
-type DiagnosticBufferInner = alloc::vec::Vec<u8>;
-#[cfg(not(any(feature = "termcolor", feature = "stderr")))]
-type DiagnosticBufferInner = String;
-
-#[cfg(feature = "termcolor")]
-pub(crate) use codespan_reporting::term::termcolor::WriteColor as _ErrorWrite;
-#[cfg(not(any(feature = "termcolor", feature = "stderr")))]
-pub(crate) use core::fmt::Write as _ErrorWrite;
-#[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
-pub(crate) use std::io::Write as _ErrorWrite;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "termcolor")] {
+        type DiagnosticBufferInner = codespan_reporting::term::termcolor::NoColor<alloc::vec::Vec<u8>>;
+        pub(crate) use codespan_reporting::term::termcolor::WriteColor as _ErrorWrite;
+    } else if #[cfg(feature = "stderr")] {
+        type DiagnosticBufferInner = alloc::vec::Vec<u8>;
+        pub(crate) use std::io::Write as _ErrorWrite;
+    } else {
+        type DiagnosticBufferInner = String;
+        pub(crate) use core::fmt::Write as _ErrorWrite;
+    }
+}
 
 #[cfg_attr(
     not(any(feature = "spv-in", feature = "glsl-in")),
@@ -93,14 +92,17 @@ impl DiagnosticBuffer {
         )
     )]
     pub fn new() -> Self {
-        Self {
-            #[cfg(feature = "termcolor")]
-            inner: codespan_reporting::term::termcolor::NoColor::new(alloc::vec::Vec::new()),
-            #[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
-            inner: alloc::vec::Vec::new(),
-            #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
-            inner: String::new(),
-        }
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "termcolor")] {
+                let inner = codespan_reporting::term::termcolor::NoColor::new(alloc::vec::Vec::new());
+            } else if #[cfg(feature = "stderr")] {
+                let inner = alloc::vec::Vec::new();
+            } else {
+                let inner = String::new();
+            }
+        };
+
+        Self { inner }
     }
 
     pub fn inner_mut(&mut self) -> &mut DiagnosticBufferInner {
@@ -109,12 +111,16 @@ impl DiagnosticBuffer {
 
     pub fn into_string(self) -> String {
         let Self { inner } = self;
-        #[cfg(feature = "termcolor")]
-        let converted = String::from_utf8(inner.into_inner()).unwrap();
-        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
-        let converted = String::from_utf8(inner).unwrap();
-        #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
-        let converted = inner;
+
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "termcolor")] {
+                let converted = String::from_utf8(inner.into_inner()).unwrap();
+            } else if #[cfg(feature = "stderr")] {
+                let converted = String::from_utf8(inner).unwrap();
+            } else {
+                let converted = inner;
+            }
+        };
 
         converted
     }

--- a/naga/src/front/glsl/error.rs
+++ b/naga/src/front/glsl/error.rs
@@ -16,7 +16,13 @@ use crate::SourceLocation;
 use crate::{proc::ConstantEvaluatorError, Span};
 
 #[cfg(feature = "termcolor")]
-use codespan_reporting::term::termcolor::WriteColor;
+use codespan_reporting::term::termcolor::WriteColor as ErrorWrite;
+
+#[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
+use std::io::Write as ErrorWrite;
+
+#[cfg(not(any(feature = "termcolor", feature = "stderr")))]
+use core::fmt::Write as ErrorWrite;
 
 fn join_with_comma(list: &[ExpectedToken]) -> String {
     let mut string = "".to_string();
@@ -168,25 +174,11 @@ pub struct ParseErrors {
 }
 
 impl ParseErrors {
-    pub fn emit_to_writer(
-        &self,
-        #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
-        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut impl std::io::Write,
-        #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
-        writer: &mut dyn core::fmt::Write,
-        source: &str,
-    ) {
+    pub fn emit_to_writer(&self, writer: &mut impl ErrorWrite, source: &str) {
         self.emit_to_writer_with_path(writer, source, "glsl");
     }
 
-    pub fn emit_to_writer_with_path(
-        &self,
-        #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
-        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut impl std::io::Write,
-        #[cfg(not(any(feature = "termcolor", feature = "stderr")))] writer: &mut impl core::fmt::Write,
-        source: &str,
-        path: &str,
-    ) {
+    pub fn emit_to_writer_with_path(&self, writer: &mut impl ErrorWrite, source: &str, path: &str) {
         let path = path.to_string();
         let files = SimpleFile::new(path, source);
         let config = term::Config::default();

--- a/naga/src/front/glsl/error.rs
+++ b/naga/src/front/glsl/error.rs
@@ -171,7 +171,7 @@ impl ParseErrors {
     pub fn emit_to_writer(
         &self,
         #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
-        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut dyn std::io::Write,
+        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut impl std::io::Write,
         #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
         writer: &mut dyn core::fmt::Write,
         source: &str,
@@ -182,9 +182,8 @@ impl ParseErrors {
     pub fn emit_to_writer_with_path(
         &self,
         #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
-        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut dyn std::io::Write,
-        #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
-        writer: &mut dyn core::fmt::Write,
+        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut impl std::io::Write,
+        #[cfg(not(any(feature = "termcolor", feature = "stderr")))] writer: &mut impl core::fmt::Write,
         source: &str,
         path: &str,
     ) {

--- a/naga/src/front/glsl/error.rs
+++ b/naga/src/front/glsl/error.rs
@@ -13,16 +13,7 @@ use thiserror::Error;
 
 use super::token::TokenValue;
 use crate::SourceLocation;
-use crate::{proc::ConstantEvaluatorError, Span};
-
-#[cfg(feature = "termcolor")]
-use codespan_reporting::term::termcolor::WriteColor as ErrorWrite;
-
-#[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
-use std::io::Write as ErrorWrite;
-
-#[cfg(not(any(feature = "termcolor", feature = "stderr")))]
-use core::fmt::Write as ErrorWrite;
+use crate::{error::ErrorWrite, proc::ConstantEvaluatorError, Span};
 
 fn join_with_comma(list: &[ExpectedToken]) -> String {
     let mut string = "".to_string();

--- a/naga/src/front/glsl/error.rs
+++ b/naga/src/front/glsl/error.rs
@@ -8,13 +8,15 @@ use alloc::{
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term;
-use codespan_reporting::term::termcolor::{NoColor, WriteColor};
 use pp_rs::token::PreprocessorError;
 use thiserror::Error;
 
 use super::token::TokenValue;
 use crate::SourceLocation;
 use crate::{proc::ConstantEvaluatorError, Span};
+
+#[cfg(feature = "termcolor")]
+use codespan_reporting::term::termcolor::{NoColor, WriteColor};
 
 fn join_with_comma(list: &[ExpectedToken]) -> String {
     let mut string = "".to_string();
@@ -166,10 +168,12 @@ pub struct ParseErrors {
 }
 
 impl ParseErrors {
+    #[cfg(feature = "termcolor")]
     pub fn emit_to_writer(&self, writer: &mut impl WriteColor, source: &str) {
         self.emit_to_writer_with_path(writer, source, "glsl");
     }
 
+    #[cfg(feature = "termcolor")]
     pub fn emit_to_writer_with_path(&self, writer: &mut impl WriteColor, source: &str, path: &str) {
         let path = path.to_string();
         let files = SimpleFile::new(path, source);
@@ -187,9 +191,33 @@ impl ParseErrors {
     }
 
     pub fn emit_to_string(&self, source: &str) -> String {
-        let mut writer = NoColor::new(Vec::new());
-        self.emit_to_writer(&mut writer, source);
-        String::from_utf8(writer.into_inner()).unwrap()
+        #[cfg(feature = "termcolor")]
+        {
+            let mut writer = NoColor::new(Vec::new());
+            self.emit_to_writer(&mut writer, source);
+            String::from_utf8(writer.into_inner()).unwrap()
+        }
+
+        #[cfg(not(feature = "termcolor"))]
+        {
+            let mut writer = Vec::new();
+
+            let path = "glsl".to_string();
+            let files = SimpleFile::new(path, source);
+            let config = term::Config::default();
+
+            for err in &self.errors {
+                let mut diagnostic = Diagnostic::error().with_message(err.kind.to_string());
+
+                if let Some(range) = err.meta.to_range() {
+                    diagnostic = diagnostic.with_labels(vec![Label::primary((), range)]);
+                }
+
+                term::emit(&mut writer, &config, &files, &diagnostic).expect("cannot write error");
+            }
+
+            String::from_utf8(writer).unwrap()
+        }
     }
 }
 

--- a/naga/src/front/glsl/error.rs
+++ b/naga/src/front/glsl/error.rs
@@ -16,7 +16,7 @@ use crate::SourceLocation;
 use crate::{proc::ConstantEvaluatorError, Span};
 
 #[cfg(feature = "termcolor")]
-use codespan_reporting::term::termcolor::{NoColor, WriteColor};
+use codespan_reporting::term::termcolor::WriteColor;
 
 fn join_with_comma(list: &[ExpectedToken]) -> String {
     let mut string = "".to_string();
@@ -168,13 +168,26 @@ pub struct ParseErrors {
 }
 
 impl ParseErrors {
-    #[cfg(feature = "termcolor")]
-    pub fn emit_to_writer(&self, writer: &mut impl WriteColor, source: &str) {
+    pub fn emit_to_writer(
+        &self,
+        #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
+        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut dyn std::io::Write,
+        #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
+        writer: &mut dyn core::fmt::Write,
+        source: &str,
+    ) {
         self.emit_to_writer_with_path(writer, source, "glsl");
     }
 
-    #[cfg(feature = "termcolor")]
-    pub fn emit_to_writer_with_path(&self, writer: &mut impl WriteColor, source: &str, path: &str) {
+    pub fn emit_to_writer_with_path(
+        &self,
+        #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
+        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut dyn std::io::Write,
+        #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
+        writer: &mut dyn core::fmt::Write,
+        source: &str,
+        path: &str,
+    ) {
         let path = path.to_string();
         let files = SimpleFile::new(path, source);
         let config = term::Config::default();
@@ -191,33 +204,9 @@ impl ParseErrors {
     }
 
     pub fn emit_to_string(&self, source: &str) -> String {
-        #[cfg(feature = "termcolor")]
-        {
-            let mut writer = NoColor::new(Vec::new());
-            self.emit_to_writer(&mut writer, source);
-            String::from_utf8(writer.into_inner()).unwrap()
-        }
-
-        #[cfg(not(feature = "termcolor"))]
-        {
-            let mut writer = Vec::new();
-
-            let path = "glsl".to_string();
-            let files = SimpleFile::new(path, source);
-            let config = term::Config::default();
-
-            for err in &self.errors {
-                let mut diagnostic = Diagnostic::error().with_message(err.kind.to_string());
-
-                if let Some(range) = err.meta.to_range() {
-                    diagnostic = diagnostic.with_labels(vec![Label::primary((), range)]);
-                }
-
-                term::emit(&mut writer, &config, &files, &diagnostic).expect("cannot write error");
-            }
-
-            String::from_utf8(writer).unwrap()
-        }
+        let mut writer = crate::error::DiagnosticBuffer::new();
+        self.emit_to_writer(writer.inner_mut(), source);
+        writer.into_string()
     }
 }
 

--- a/naga/src/front/spv/error.rs
+++ b/naga/src/front/spv/error.rs
@@ -11,7 +11,13 @@ use super::ModuleState;
 use crate::{arena::Handle, front::atomic_upgrade};
 
 #[cfg(feature = "termcolor")]
-use codespan_reporting::term::termcolor::WriteColor;
+use codespan_reporting::term::termcolor::WriteColor as ErrorWrite;
+
+#[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
+use std::io::Write as ErrorWrite;
+
+#[cfg(not(any(feature = "termcolor", feature = "stderr")))]
+use core::fmt::Write as ErrorWrite;
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
@@ -154,25 +160,11 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn emit_to_writer(
-        &self,
-        #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
-        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut impl std::io::Write,
-        #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
-        writer: &mut dyn core::fmt::Write,
-        source: &str,
-    ) {
+    pub fn emit_to_writer(&self, writer: &mut impl ErrorWrite, source: &str) {
         self.emit_to_writer_with_path(writer, source, "glsl");
     }
 
-    pub fn emit_to_writer_with_path(
-        &self,
-        #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
-        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut impl std::io::Write,
-        #[cfg(not(any(feature = "termcolor", feature = "stderr")))] writer: &mut impl core::fmt::Write,
-        source: &str,
-        path: &str,
-    ) {
+    pub fn emit_to_writer_with_path(&self, writer: &mut impl ErrorWrite, source: &str, path: &str) {
         let path = path.to_string();
         let files = SimpleFile::new(path, source);
         let config = term::Config::default();

--- a/naga/src/front/spv/error.rs
+++ b/naga/src/front/spv/error.rs
@@ -157,7 +157,7 @@ impl Error {
     pub fn emit_to_writer(
         &self,
         #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
-        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut dyn std::io::Write,
+        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut impl std::io::Write,
         #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
         writer: &mut dyn core::fmt::Write,
         source: &str,
@@ -168,9 +168,8 @@ impl Error {
     pub fn emit_to_writer_with_path(
         &self,
         #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
-        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut dyn std::io::Write,
-        #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
-        writer: &mut dyn core::fmt::Write,
+        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut impl std::io::Write,
+        #[cfg(not(any(feature = "termcolor", feature = "stderr")))] writer: &mut impl core::fmt::Write,
         source: &str,
         path: &str,
     ) {

--- a/naga/src/front/spv/error.rs
+++ b/naga/src/front/spv/error.rs
@@ -7,10 +7,12 @@ use alloc::{
 use codespan_reporting::diagnostic::Diagnostic;
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term;
-use codespan_reporting::term::termcolor::{NoColor, WriteColor};
 
 use super::ModuleState;
 use crate::{arena::Handle, front::atomic_upgrade};
+
+#[cfg(feature = "termcolor")]
+use codespan_reporting::term::termcolor::{NoColor, WriteColor};
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
@@ -153,10 +155,12 @@ pub enum Error {
 }
 
 impl Error {
+    #[cfg(feature = "termcolor")]
     pub fn emit_to_writer(&self, writer: &mut impl WriteColor, source: &str) {
         self.emit_to_writer_with_path(writer, source, "glsl");
     }
 
+    #[cfg(feature = "termcolor")]
     pub fn emit_to_writer_with_path(&self, writer: &mut impl WriteColor, source: &str, path: &str) {
         let path = path.to_string();
         let files = SimpleFile::new(path, source);
@@ -167,9 +171,26 @@ impl Error {
     }
 
     pub fn emit_to_string(&self, source: &str) -> String {
-        let mut writer = NoColor::new(Vec::new());
-        self.emit_to_writer(&mut writer, source);
-        String::from_utf8(writer.into_inner()).unwrap()
+        #[cfg(feature = "termcolor")]
+        {
+            let mut writer = NoColor::new(Vec::new());
+            self.emit_to_writer(&mut writer, source);
+            String::from_utf8(writer.into_inner()).unwrap()
+        }
+
+        #[cfg(not(feature = "termcolor"))]
+        {
+            let mut writer = Vec::new();
+
+            let path = "glsl".to_string();
+            let files = SimpleFile::new(path, source);
+            let config = term::Config::default();
+            let diagnostic = Diagnostic::error().with_message(format!("{self:?}"));
+
+            term::emit(&mut writer, &config, &files, &diagnostic).expect("cannot write error");
+
+            String::from_utf8(writer).unwrap()
+        }
     }
 }
 

--- a/naga/src/front/spv/error.rs
+++ b/naga/src/front/spv/error.rs
@@ -1,7 +1,6 @@
 use alloc::{
     format,
     string::{String, ToString},
-    vec::Vec,
 };
 
 use codespan_reporting::diagnostic::Diagnostic;
@@ -12,7 +11,7 @@ use super::ModuleState;
 use crate::{arena::Handle, front::atomic_upgrade};
 
 #[cfg(feature = "termcolor")]
-use codespan_reporting::term::termcolor::{NoColor, WriteColor};
+use codespan_reporting::term::termcolor::WriteColor;
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
@@ -155,13 +154,26 @@ pub enum Error {
 }
 
 impl Error {
-    #[cfg(feature = "termcolor")]
-    pub fn emit_to_writer(&self, writer: &mut impl WriteColor, source: &str) {
+    pub fn emit_to_writer(
+        &self,
+        #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
+        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut dyn std::io::Write,
+        #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
+        writer: &mut dyn core::fmt::Write,
+        source: &str,
+    ) {
         self.emit_to_writer_with_path(writer, source, "glsl");
     }
 
-    #[cfg(feature = "termcolor")]
-    pub fn emit_to_writer_with_path(&self, writer: &mut impl WriteColor, source: &str, path: &str) {
+    pub fn emit_to_writer_with_path(
+        &self,
+        #[cfg(feature = "termcolor")] writer: &mut impl WriteColor,
+        #[cfg(all(not(feature = "termcolor"), feature = "stderr"))] writer: &mut dyn std::io::Write,
+        #[cfg(not(any(feature = "termcolor", feature = "stderr")))]
+        writer: &mut dyn core::fmt::Write,
+        source: &str,
+        path: &str,
+    ) {
         let path = path.to_string();
         let files = SimpleFile::new(path, source);
         let config = term::Config::default();
@@ -171,26 +183,9 @@ impl Error {
     }
 
     pub fn emit_to_string(&self, source: &str) -> String {
-        #[cfg(feature = "termcolor")]
-        {
-            let mut writer = NoColor::new(Vec::new());
-            self.emit_to_writer(&mut writer, source);
-            String::from_utf8(writer.into_inner()).unwrap()
-        }
-
-        #[cfg(not(feature = "termcolor"))]
-        {
-            let mut writer = Vec::new();
-
-            let path = "glsl".to_string();
-            let files = SimpleFile::new(path, source);
-            let config = term::Config::default();
-            let diagnostic = Diagnostic::error().with_message(format!("{self:?}"));
-
-            term::emit(&mut writer, &config, &files, &diagnostic).expect("cannot write error");
-
-            String::from_utf8(writer).unwrap()
-        }
+        let mut writer = crate::error::DiagnosticBuffer::new();
+        self.emit_to_writer(writer.inner_mut(), source);
+        writer.into_string()
     }
 }
 

--- a/naga/src/front/spv/error.rs
+++ b/naga/src/front/spv/error.rs
@@ -8,16 +8,7 @@ use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term;
 
 use super::ModuleState;
-use crate::{arena::Handle, front::atomic_upgrade};
-
-#[cfg(feature = "termcolor")]
-use codespan_reporting::term::termcolor::WriteColor as ErrorWrite;
-
-#[cfg(all(not(feature = "termcolor"), feature = "stderr"))]
-use std::io::Write as ErrorWrite;
-
-#[cfg(not(any(feature = "termcolor", feature = "stderr")))]
-use core::fmt::Write as ErrorWrite;
+use crate::{arena::Handle, error::ErrorWrite, front::atomic_upgrade};
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -106,25 +106,10 @@ impl ParseError {
         let files = SimpleFile::new(path, source);
         let config = term::Config::default();
 
-        let emit = |writer| {
-            term::emit(writer, &config, &files, &self.diagnostic()).expect("cannot write error")
-        };
-
-        #[cfg(feature = "termcolor")]
-        let writer = {
-            let mut writer = term::termcolor::NoColor::new(Vec::new());
-            emit(&mut writer);
-            writer.into_inner()
-        };
-
-        #[cfg(not(feature = "termcolor"))]
-        let writer = {
-            let mut writer = Vec::new();
-            emit(&mut writer);
-            writer
-        };
-
-        String::from_utf8(writer).unwrap()
+        let mut writer = crate::error::DiagnosticBuffer::new();
+        term::emit(writer.inner_mut(), &config, &files, &self.diagnostic())
+            .expect("cannot write error");
+        writer.into_string()
     }
 
     /// Returns a [`SourceLocation`] for the first label in the error message.

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -14,7 +14,6 @@ use super::parse::lexer::Token;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term;
-use codespan_reporting::term::termcolor::{ColorChoice, NoColor, StandardStream};
 use thiserror::Error;
 
 use alloc::{
@@ -26,6 +25,9 @@ use alloc::{
     vec::Vec,
 };
 use core::ops::Range;
+
+#[cfg(feature = "termcolor")]
+use codespan_reporting::term::termcolor::{ColorChoice, NoColor, StandardStream};
 
 #[derive(Clone, Debug)]
 pub struct ParseError {
@@ -68,11 +70,13 @@ impl ParseError {
     }
 
     /// Emits a summary of the error to standard error stream.
+    #[cfg(feature = "stderr")]
     pub fn emit_to_stderr(&self, source: &str) {
         self.emit_to_stderr_with_path(source, "wgsl")
     }
 
     /// Emits a summary of the error to standard error stream.
+    #[cfg(feature = "stderr")]
     pub fn emit_to_stderr_with_path<P>(&self, source: &str, path: P)
     where
         P: AsRef<std::path::Path>,
@@ -80,7 +84,13 @@ impl ParseError {
         let path = path.as_ref().display().to_string();
         let files = SimpleFile::new(path, source);
         let config = term::Config::default();
+
+        #[cfg(feature = "termcolor")]
         let writer = StandardStream::stderr(ColorChoice::Auto);
+
+        #[cfg(not(feature = "termcolor"))]
+        let writer = std::io::stderr();
+
         term::emit(&mut writer.lock(), &config, &files, &self.diagnostic())
             .expect("cannot write error");
     }
@@ -98,9 +108,26 @@ impl ParseError {
         let path = path.as_ref().display().to_string();
         let files = SimpleFile::new(path, source);
         let config = term::Config::default();
-        let mut writer = NoColor::new(Vec::new());
-        term::emit(&mut writer, &config, &files, &self.diagnostic()).expect("cannot write error");
-        String::from_utf8(writer.into_inner()).unwrap()
+
+        let emit = |writer| {
+            term::emit(writer, &config, &files, &self.diagnostic()).expect("cannot write error")
+        };
+
+        #[cfg(feature = "termcolor")]
+        let writer = {
+            let mut writer = NoColor::new(Vec::new());
+            emit(&mut writer);
+            writer.into_inner()
+        };
+
+        #[cfg(not(feature = "termcolor"))]
+        let writer = {
+            let mut writer = Vec::new();
+            emit(&mut writer);
+            writer
+        };
+
+        String::from_utf8(writer).unwrap()
     }
 
     /// Returns a [`SourceLocation`] for the first label in the error message.

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -82,11 +82,13 @@ impl ParseError {
         let files = SimpleFile::new(path, source);
         let config = term::Config::default();
 
-        #[cfg(feature = "termcolor")]
-        let writer = term::termcolor::StandardStream::stderr(term::termcolor::ColorChoice::Auto);
-
-        #[cfg(not(feature = "termcolor"))]
-        let writer = std::io::stderr();
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "termcolor")] {
+                let writer = term::termcolor::StandardStream::stderr(term::termcolor::ColorChoice::Auto);
+            } else {
+                let writer = std::io::stderr();
+            }
+        }
 
         term::emit(&mut writer.lock(), &config, &files, &self.diagnostic())
             .expect("cannot write error");

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -26,9 +26,6 @@ use alloc::{
 };
 use core::ops::Range;
 
-#[cfg(feature = "termcolor")]
-use codespan_reporting::term::termcolor::{ColorChoice, NoColor, StandardStream};
-
 #[derive(Clone, Debug)]
 pub struct ParseError {
     message: String,
@@ -86,7 +83,7 @@ impl ParseError {
         let config = term::Config::default();
 
         #[cfg(feature = "termcolor")]
-        let writer = StandardStream::stderr(ColorChoice::Auto);
+        let writer = term::termcolor::StandardStream::stderr(term::termcolor::ColorChoice::Auto);
 
         #[cfg(not(feature = "termcolor"))]
         let writer = std::io::stderr();
@@ -115,7 +112,7 @@ impl ParseError {
 
         #[cfg(feature = "termcolor")]
         let writer = {
-            let mut writer = NoColor::new(Vec::new());
+            let mut writer = term::termcolor::NoColor::new(Vec::new());
             emit(&mut writer);
             writer.into_inner()
         };

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -110,7 +110,9 @@ void main() {
     wgsl_out,
 
     feature = "spv-in",
-    feature = "wgsl-in"
+    feature = "wgsl-in",
+
+    feature = "stderr",
 ))]
 extern crate std;
 

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -292,11 +292,13 @@ impl<E> WithSpan<E> {
         let files = files::SimpleFile::new(path, source);
         let config = term::Config::default();
 
-        #[cfg(feature = "termcolor")]
-        let writer = term::termcolor::StandardStream::stderr(term::termcolor::ColorChoice::Auto);
-
-        #[cfg(not(feature = "termcolor"))]
-        let writer = std::io::stderr();
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "termcolor")] {
+                let writer = term::termcolor::StandardStream::stderr(term::termcolor::ColorChoice::Auto);
+            } else {
+                let writer = std::io::stderr();
+            }
+        }
 
         term::emit(&mut writer.lock(), &config, &files, &self.diagnostic())
             .expect("cannot write error");

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -320,25 +320,10 @@ impl<E> WithSpan<E> {
         let files = files::SimpleFile::new(path, source);
         let config = term::Config::default();
 
-        let emit = |writer| {
-            term::emit(writer, &config, &files, &self.diagnostic()).expect("cannot write error")
-        };
-
-        #[cfg(feature = "termcolor")]
-        let writer = {
-            let mut writer = term::termcolor::NoColor::new(Vec::new());
-            emit(&mut writer);
-            writer.into_inner()
-        };
-
-        #[cfg(not(feature = "termcolor"))]
-        let writer = {
-            let mut writer = Vec::new();
-            emit(&mut writer);
-            writer
-        };
-
-        String::from_utf8(writer).unwrap()
+        let mut writer = crate::error::DiagnosticBuffer::new();
+        term::emit(writer.inner_mut(), &config, &files, &self.diagnostic())
+            .expect("cannot write error");
+        writer.into_string()
     }
 }
 

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -273,6 +273,7 @@ impl<E> WithSpan<E> {
     }
 
     /// Emits a summary of the error to standard error stream.
+    #[cfg(feature = "stderr")]
     pub fn emit_to_stderr(&self, source: &str)
     where
         E: Error,
@@ -281,16 +282,22 @@ impl<E> WithSpan<E> {
     }
 
     /// Emits a summary of the error to standard error stream.
+    #[cfg(feature = "stderr")]
     pub fn emit_to_stderr_with_path(&self, source: &str, path: &str)
     where
         E: Error,
     {
-        use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
         use codespan_reporting::{files, term};
 
         let files = files::SimpleFile::new(path, source);
         let config = term::Config::default();
-        let writer = StandardStream::stderr(ColorChoice::Auto);
+
+        #[cfg(feature = "termcolor")]
+        let writer = term::termcolor::StandardStream::stderr(term::termcolor::ColorChoice::Auto);
+
+        #[cfg(not(feature = "termcolor"))]
+        let writer = std::io::stderr();
+
         term::emit(&mut writer.lock(), &config, &files, &self.diagnostic())
             .expect("cannot write error");
     }
@@ -308,14 +315,30 @@ impl<E> WithSpan<E> {
     where
         E: Error,
     {
-        use codespan_reporting::term::termcolor::NoColor;
         use codespan_reporting::{files, term};
 
         let files = files::SimpleFile::new(path, source);
         let config = term::Config::default();
-        let mut writer = NoColor::new(Vec::new());
-        term::emit(&mut writer, &config, &files, &self.diagnostic()).expect("cannot write error");
-        String::from_utf8(writer.into_inner()).unwrap()
+
+        let emit = |writer| {
+            term::emit(writer, &config, &files, &self.diagnostic()).expect("cannot write error")
+        };
+
+        #[cfg(feature = "termcolor")]
+        let writer = {
+            let mut writer = term::termcolor::NoColor::new(Vec::new());
+            emit(&mut writer);
+            writer.into_inner()
+        };
+
+        #[cfg(not(feature = "termcolor"))]
+        let writer = {
+            let mut writer = Vec::new();
+            emit(&mut writer);
+            writer
+        };
+
+        String::from_utf8(writer).unwrap()
     }
 }
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -324,9 +324,9 @@ cfg_aliases.workspace = true
 [dev-dependencies]
 cfg-if.workspace = true
 env_logger.workspace = true
-glam.workspace = true                               # for ray-traced-triangle example
-naga = { workspace = true, features = ["wgsl-in"] }
-winit.workspace = true                              # for "halmark" example
+glam.workspace = true                                            # for ray-traced-triangle example
+naga = { workspace = true, features = ["wgsl-in", "termcolor"] }
+winit.workspace = true                                           # for "halmark" example
 
 ### Platform: Windows + MacOS + Linux for "raw-gles" example ###
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))'.dev-dependencies]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -153,7 +153,7 @@ fragile-send-sync-non-atomic-wasm = [
 #########################
 
 [dependencies]
-naga = { workspace = true, optional = true }
+naga = { workspace = true, optional = true, features = ["termcolor"] }
 wgpu-core = { workspace = true, optional = true }
 wgpu-types.workspace = true
 


### PR DESCRIPTION
**Connections**
- Contributes to #6826

**Description**
To add eventual `no_std` support, `termcolor` must be an optional dependency. It is currently only required by `codespan-reporting` when its `termcolor` feature is enabled. This PR adds a similar `termcolor` feature to `naga`, which is enabled in `naga-cli`, `wgpu`, and `wgpu-hal`. Additionally, a `stderr` feature was added to allow enabling the `std` crate within `naga` for the purposes of using `std::io::stderr` directly when `termcolor` cannot be used. This is currently only enabled in `naga-cli` since the public API gated by this feature is unused in the rest of WGPU.

**Testing**

Compiled with and without `termcolor` feature enabled.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
