### PR TITLE
[naga] Fix improper feature gates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ fern = "0.7"
 flume = "0.11"
 futures-lite = "2"
 glam = "0.29"
-half = "2.5" # We require 2.5 to have `Arbitrary` support.
+half = { version = "2.5", default-features = false } # We require 2.5 to have `Arbitrary` support.
 hashbrown = { version = "0.15.2", default-features = false, features = [
     "default-hasher",
     "inline-more",

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -55,6 +55,7 @@ arbitrary = [
     "bitflags/arbitrary",
     "indexmap/arbitrary",
     "half/arbitrary",
+    "half/std",
 ]
 spv-in = ["dep:petgraph", "dep:spirv"]
 spv-out = ["dep:spirv"]

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -50,7 +50,12 @@ deserialize = [
     "hashbrown/serde",
     "indexmap/serde",
 ]
-arbitrary = ["dep:arbitrary", "bitflags/arbitrary", "indexmap/arbitrary"]
+arbitrary = [
+    "dep:arbitrary",
+    "bitflags/arbitrary",
+    "indexmap/arbitrary",
+    "half/arbitrary",
+]
 spv-in = ["dep:petgraph", "dep:spirv"]
 spv-out = ["dep:spirv"]
 wgsl-in = [
@@ -85,12 +90,12 @@ codespan-reporting = { workspace = true, default-features = false, features = [
     "termcolor",
 ] }
 hashbrown.workspace = true
-half = { workspace = true, features = ["arbitrary", "num-traits"] }
+half = { workspace = true, default-features = false, features = ["num-traits"] }
 rustc-hash.workspace = true
 indexmap.workspace = true
 log = "0.4"
 # `half` requires 0.2.16 for `FromBytes` and `ToBytes`.
-num-traits = "0.2.16"
+num-traits = { version = "0.2.16", default-features = false }
 strum = { workspace = true, optional = true }
 spirv = { version = "0.3", optional = true }
 thiserror.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -44,7 +44,7 @@ cfg-if.workspace = true
 ctor.workspace = true
 futures-lite.workspace = true
 glam.workspace = true
-half = { workspace = true, features = ["bytemuck"] }
+half = { workspace = true, features = ["bytemuck", "std"] }
 itertools.workspace = true
 image.workspace = true
 libtest-mimic.workspace = true


### PR DESCRIPTION
**Connections**
- Contributes to #6826

**Description**
The `arbitrary` feature of `half` was always enabled, even when `naga`'s own `arbitrary` feature was not enabled. Likewise, `num-traits` had its default features enabled even though they weren't being used. These issues will add noise to `no_std` efforts in `naga` in the future.

To address this, I have disabled default features in `half` and `num-traits`, and ensured `half/arbitrary` is enabled when `naga/arbitrary` is.

**Testing**

CI

**Squash or Rebase?**

Squash

**Checklist**

- [X] Run `cargo fmt`. (Not Applicable)
- [X] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [X] If this contains user-facing changes, add a `CHANGELOG.md` entry. (Not Applicable)
