### PR TITLE
Fix new acceleration structure building validation errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,8 @@ By @wumpf in [#7144](https://github.com/gfx-rs/wgpu/pull/7144)
 
 #### General
 
+- Fix some validation errors when building acceleration
+ structures. By @Vecvec in [#7486](https://github.com/gfx-rs/wgpu/pull/7486).
 - Avoid overflow in query set bounds check validation. By @ErichDonGubler in [#6933](https://github.com/gfx-rs/wgpu/pull/6933).
 - Add Flush to GL Queue::submit. By @cwfitzgerald in [#6941](https://github.com/gfx-rs/wgpu/pull/6941).
 - Reduce downlevel `max_color_attachments` limit from 8 to 4 for better GLES compatibility. By @adrian17 in [#6994](https://github.com/gfx-rs/wgpu/pull/6994).

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -699,7 +699,7 @@ impl Global {
                     cmd_buf_raw.transition_buffers(&[hal::BufferBarrier::<dyn hal::DynBuffer> {
                         buffer: tlas.instance_buffer.as_ref(),
                         usage: hal::StateTransition {
-                            from: BufferUses::MAP_READ,
+                            from: BufferUses::TOP_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                             to: BufferUses::COPY_DST,
                         },
                     }]);

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -615,7 +615,8 @@ pub fn map_buffer_usage_to_barrier(
     ) {
         stages |= vk::PipelineStageFlags::ACCELERATION_STRUCTURE_BUILD_KHR;
         access |= vk::AccessFlags::ACCELERATION_STRUCTURE_READ_KHR
-            | vk::AccessFlags::ACCELERATION_STRUCTURE_WRITE_KHR;
+            | vk::AccessFlags::ACCELERATION_STRUCTURE_WRITE_KHR
+            | vk::AccessFlags::SHADER_READ;
     }
     if usage.contains(wgt::BufferUses::ACCELERATION_STRUCTURE_QUERY) {
         stages |= vk::PipelineStageFlags::TRANSFER;


### PR DESCRIPTION
**Connections**
One of the two issues found on matrix by @JMS55, the other one looked very similar but was different.

**Description**
Fixes new validation errors from me updating my vulkan validation layers.

`SHADER_READ` is required by the vulkan specs:
> Accesses to other input buffers as identified by any used values of [VkAccelerationStructureGeometryMotionTrianglesDataNV](https://registry.khronos.org/vulkan/specs/latest/man/html/VkAccelerationStructureGeometryMotionTrianglesDataNV.html)::vertexData, [VkAccelerationStructureGeometryTrianglesDataKHR](https://registry.khronos.org/vulkan/specs/latest/man/html/VkAccelerationStructureGeometryTrianglesDataKHR.html)::vertexData, [VkAccelerationStructureGeometryTrianglesDataKHR](https://registry.khronos.org/vulkan/specs/latest/man/html/VkAccelerationStructureGeometryTrianglesDataKHR.html)::indexData, [VkAccelerationStructureGeometryTrianglesDataKHR](https://registry.khronos.org/vulkan/specs/latest/man/html/VkAccelerationStructureGeometryTrianglesDataKHR.html)::transformData, [VkAccelerationStructureGeometryAabbsDataKHR](https://registry.khronos.org/vulkan/specs/latest/man/html/VkAccelerationStructureGeometryAabbsDataKHR.html)::data, and [VkAccelerationStructureGeometryInstancesDataKHR](https://registry.khronos.org/vulkan/specs/latest/man/html/VkAccelerationStructureGeometryInstancesDataKHR.html)::data must be [synchronized](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#synchronization-dependencies) with the VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR [pipeline stage](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#synchronization-pipeline-stages) and an [access type](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#synchronization-access-types) of VK_ACCESS_SHADER_READ_BIT.

The other one also did not come up until I updated my vulkan validation layer. Not sure why it was map_read, the buffer does not support mapping.

**Testing**
`ray_cube_compute` runs into this already on the latest vulkan validation layer

**Squash or Rebase?**
Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. 
