### PR TITLE
Fix request_device call to include missing trace_path argument in 'hello window' example

### DIFF
--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -24,7 +24,7 @@ impl State {
             .await
             .unwrap();
         let (device, queue) = adapter
-            .request_device(&wgpu::DeviceDescriptor::default())
+            .request_device(&wgpu::DeviceDescriptor::default(), None)
             .await
             .unwrap();
 


### PR DESCRIPTION
**Description**
The current implementation of the `request_device` function call is missing the second argument, `trace_path`, which is required by the function signature. This causes the program to fail to compile.

**Solution**
To resolve this issue, I have added `None` as the second argument to the `request_device` call. This is appropriate because the `trace_path` parameter is optional and not required for the current use case.

**Testing**

`cargo run` executes the Program successfully.

**Squash or Rebase?**

rebase

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.