### PR TITLE
Miscellaneous improvements in the D3D12 backend

### DIFF
--- a/wgpu-hal/src/auxil/dxgi/mod.rs
+++ b/wgpu-hal/src/auxil/dxgi/mod.rs
@@ -3,5 +3,6 @@
 pub mod conv;
 pub mod exception;
 pub mod factory;
+pub mod name;
 pub mod result;
 pub mod time;

--- a/wgpu-hal/src/auxil/dxgi/name.rs
+++ b/wgpu-hal/src/auxil/dxgi/name.rs
@@ -1,0 +1,24 @@
+use windows::Win32::Graphics::Direct3D12::ID3D12Object;
+
+use crate::auxil::dxgi::result::HResult;
+
+/// Helper trait for setting the name of a D3D12 object.
+///
+/// This is implemented on all types that can be converted to an [`ID3D12Object`].
+pub trait ObjectExt {
+    fn set_name(&self, name: &str) -> Result<(), crate::DeviceError>;
+}
+
+impl<T> ObjectExt for T
+where
+    // Windows impls `From` for all parent interfaces, so we can use that to convert to ID3D12Object.
+    //
+    // This includes implementations for references.
+    for<'a> &'a ID3D12Object: From<&'a T>,
+{
+    fn set_name(&self, name: &str) -> Result<(), crate::DeviceError> {
+        let name = windows::core::HSTRING::from(name);
+        let object: &ID3D12Object = self.into();
+        unsafe { object.SetName(&name).into_device_result("SetName") }
+    }
+}

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -8,7 +8,10 @@ use windows_core::Interface;
 
 use super::conv;
 use crate::{
-    auxil::{self, dxgi::result::HResult as _},
+    auxil::{
+        self,
+        dxgi::{name::ObjectExt, result::HResult as _},
+    },
     dx12::borrow_interface_temporarily,
     AccelerationStructureEntries,
 };
@@ -328,8 +331,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         };
 
         if let Some(label) = label {
-            unsafe { list.SetName(&windows::core::HSTRING::from(label)) }
-                .into_device_result("SetName")?;
+            list.set_name(label)?;
         }
 
         self.list = Some(list);

--- a/wgpu-hal/src/dx12/conv.rs
+++ b/wgpu-hal/src/dx12/conv.rs
@@ -1,4 +1,4 @@
-use windows::Win32::Graphics::{Direct3D, Direct3D12};
+use windows::Win32::Graphics::{Direct3D, Direct3D12, Dxgi};
 
 pub fn map_buffer_usage_to_resource_flags(
     usage: wgt::BufferUses,
@@ -10,6 +10,26 @@ pub fn map_buffer_usage_to_resource_flags(
         flags |= Direct3D12::D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     }
     flags
+}
+
+pub fn map_buffer_descriptor(
+    desc: &crate::BufferDescriptor<'_>,
+) -> Direct3D12::D3D12_RESOURCE_DESC {
+    Direct3D12::D3D12_RESOURCE_DESC {
+        Dimension: Direct3D12::D3D12_RESOURCE_DIMENSION_BUFFER,
+        Alignment: 0,
+        Width: desc.size,
+        Height: 1,
+        DepthOrArraySize: 1,
+        MipLevels: 1,
+        Format: Dxgi::Common::DXGI_FORMAT_UNKNOWN,
+        SampleDesc: Dxgi::Common::DXGI_SAMPLE_DESC {
+            Count: 1,
+            Quality: 0,
+        },
+        Layout: Direct3D12::D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+        Flags: map_buffer_usage_to_resource_flags(desc.usage),
+    }
 }
 
 pub fn map_texture_dimension(dim: wgt::TextureDimension) -> Direct3D12::D3D12_RESOURCE_DIMENSION {

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -429,11 +429,8 @@ impl crate::Device for super::Device {
             Flags: conv::map_buffer_usage_to_resource_flags(desc.usage),
         };
 
-        let (resource, allocation) = suballocation::create_buffer(
-            suballocation::DeviceAllocationContext::from(self),
-            desc,
-            raw_desc,
-        )?;
+        let (resource, allocation) =
+            suballocation::DeviceAllocationContext::from(self).create_buffer(desc, raw_desc)?;
 
         if let Some(label) = desc.label {
             unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
@@ -450,11 +447,8 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn destroy_buffer(&self, buffer: super::Buffer) {
-        suballocation::free_resource(
-            suballocation::DeviceAllocationContext::from(self),
-            buffer.resource,
-            buffer.allocation,
-        );
+        suballocation::DeviceAllocationContext::from(self)
+            .free_resource(buffer.resource, buffer.allocation);
 
         self.counters.buffers.sub(1);
     }
@@ -515,11 +509,8 @@ impl crate::Device for super::Device {
             Flags: conv::map_texture_usage_to_resource_flags(desc.usage),
         };
 
-        let (resource, allocation) = suballocation::create_texture(
-            suballocation::DeviceAllocationContext::from(self),
-            desc,
-            raw_desc,
-        )?;
+        let (resource, allocation) =
+            suballocation::DeviceAllocationContext::from(self).create_texture(desc, raw_desc)?;
 
         if let Some(label) = desc.label {
             unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
@@ -540,11 +531,8 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn destroy_texture(&self, texture: super::Texture) {
-        suballocation::free_resource(
-            suballocation::DeviceAllocationContext::from(self),
-            texture.resource,
-            texture.allocation,
-        );
+        suballocation::DeviceAllocationContext::from(self)
+            .free_resource(texture.resource, texture.allocation);
 
         self.counters.textures.sub(1);
     }
@@ -1583,11 +1571,8 @@ impl crate::Device for super::Device {
                 Flags: Direct3D12::D3D12_RESOURCE_FLAG_NONE,
             };
 
-            let (buffer, allocation) = suballocation::create_buffer(
-                suballocation::DeviceAllocationContext::from(self),
-                &buffer_desc,
-                raw_buffer_desc,
-            )?;
+            let (buffer, allocation) = suballocation::DeviceAllocationContext::from(self)
+                .create_buffer(&buffer_desc, raw_buffer_desc)?;
 
             unsafe { buffer.SetName(&windows::core::HSTRING::from(&*label)) }
                 .into_device_result("SetName")?;
@@ -1669,11 +1654,8 @@ impl crate::Device for super::Device {
         }
 
         if let Some(sampler_buffer) = group.sampler_index_buffer {
-            suballocation::free_resource(
-                suballocation::DeviceAllocationContext::from(self),
-                sampler_buffer.buffer,
-                sampler_buffer.allocation,
-            );
+            suballocation::DeviceAllocationContext::from(self)
+                .free_resource(sampler_buffer.buffer, sampler_buffer.allocation);
         }
 
         self.counters.bind_groups.sub(1);
@@ -2292,11 +2274,8 @@ impl crate::Device for super::Device {
             Flags: Direct3D12::D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
         };
 
-        let (resource, allocation) = suballocation::create_acceleration_structure(
-            suballocation::DeviceAllocationContext::from(self),
-            desc,
-            raw_desc,
-        )?;
+        let (resource, allocation) = suballocation::DeviceAllocationContext::from(self)
+            .create_acceleration_structure(desc, raw_desc)?;
 
         if let Some(label) = desc.label {
             unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
@@ -2315,8 +2294,7 @@ impl crate::Device for super::Device {
         &self,
         acceleration_structure: super::AccelerationStructure,
     ) {
-        suballocation::free_resource(
-            suballocation::DeviceAllocationContext::from(self),
+        suballocation::DeviceAllocationContext::from(self).free_resource(
             acceleration_structure.resource,
             acceleration_structure.allocation,
         );

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -22,7 +22,10 @@ use windows::{
 
 use super::{conv, descriptor, D3D12Lib};
 use crate::{
-    auxil::{self, dxgi::result::HResult},
+    auxil::{
+        self,
+        dxgi::{name::ObjectExt, result::HResult},
+    },
     dx12::{
         borrow_optional_interface_temporarily, shader_compilation, suballocation,
         DynamicStorageBufferOffsets, Event,
@@ -424,8 +427,7 @@ impl crate::Device for super::Device {
             suballocation::DeviceAllocationContext::from(self).create_buffer(&desc)?;
 
         if let Some(label) = desc.label {
-            unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
-                .into_device_result("SetName")?;
+            resource.set_name(label)?;
         }
 
         self.counters.buffers.add(1);
@@ -504,8 +506,7 @@ impl crate::Device for super::Device {
             suballocation::DeviceAllocationContext::from(self).create_texture(desc, raw_desc)?;
 
         if let Some(label) = desc.label {
-            unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
-                .into_device_result("SetName")?;
+            resource.set_name(label)?;
         }
 
         self.counters.textures.add(1);
@@ -720,8 +721,7 @@ impl crate::Device for super::Device {
         .into_device_result("Command allocator creation")?;
 
         if let Some(label) = desc.label {
-            unsafe { allocator.SetName(&windows::core::HSTRING::from(label)) }
-                .into_device_result("SetName")?;
+            allocator.set_name(label)?;
         }
 
         self.counters.command_encoders.add(1);
@@ -1315,8 +1315,7 @@ impl crate::Device for super::Device {
         };
 
         if let Some(label) = desc.label {
-            unsafe { raw.SetName(&windows::core::HSTRING::from(label)) }
-                .into_device_result("SetName")?;
+            raw.set_name(label)?;
         }
 
         self.counters.pipeline_layouts.add(1);
@@ -1549,8 +1548,7 @@ impl crate::Device for super::Device {
             let (buffer, allocation) =
                 suballocation::DeviceAllocationContext::from(self).create_buffer(&buffer_desc)?;
 
-            unsafe { buffer.SetName(&windows::core::HSTRING::from(&*label)) }
-                .into_device_result("SetName")?;
+            buffer.set_name(&*label)?;
 
             let mut mapping = ptr::null_mut::<ffi::c_void>();
             unsafe { buffer.Map(0, None, Some(&mut mapping)) }.into_device_result("Map")?;
@@ -1835,8 +1833,7 @@ impl crate::Device for super::Device {
         };
 
         if let Some(label) = desc.label {
-            unsafe { raw.SetName(&windows::core::HSTRING::from(label)) }
-                .into_device_result("SetName")?;
+            raw.set_name(label)?;
         }
 
         self.counters.render_pipelines.add(1);
@@ -1899,8 +1896,7 @@ impl crate::Device for super::Device {
         })?;
 
         if let Some(label) = desc.label {
-            unsafe { raw.SetName(&windows::core::HSTRING::from(label)) }
-                .into_device_result("SetName")?;
+            raw.set_name(label)?;
         }
 
         self.counters.compute_pipelines.add(1);
@@ -1958,8 +1954,7 @@ impl crate::Device for super::Device {
         let raw = raw.ok_or(crate::DeviceError::Unexpected)?;
 
         if let Some(label) = desc.label {
-            unsafe { raw.SetName(&windows::core::HSTRING::from(label)) }
-                .into_device_result("SetName")?;
+            raw.set_name(label)?;
         }
 
         self.counters.query_sets.add(1);
@@ -2253,8 +2248,7 @@ impl crate::Device for super::Device {
             .create_acceleration_structure(desc, raw_desc)?;
 
         if let Some(label) = desc.label {
-            unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
-                .into_device_result("SetName")?;
+            resource.set_name(label)?;
         }
 
         // for some reason there is no counter for acceleration structures

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -414,10 +414,8 @@ impl crate::Device for super::Device {
                 .next_multiple_of(Direct3D12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT.into())
         }
 
-        let raw_desc = conv::map_buffer_descriptor(&desc);
-
         let (resource, allocation) =
-            suballocation::DeviceAllocationContext::from(self).create_buffer(&desc, raw_desc)?;
+            suballocation::DeviceAllocationContext::from(self).create_buffer(&desc)?;
 
         if let Some(label) = desc.label {
             unsafe { resource.SetName(&windows::core::HSTRING::from(label)) }
@@ -1542,10 +1540,8 @@ impl crate::Device for super::Device {
                 memory_flags: crate::MemoryFlags::empty(),
             };
 
-            let raw_buffer_desc = conv::map_buffer_descriptor(&buffer_desc);
-
-            let (buffer, allocation) = suballocation::DeviceAllocationContext::from(self)
-                .create_buffer(&buffer_desc, raw_buffer_desc)?;
+            let (buffer, allocation) =
+                suballocation::DeviceAllocationContext::from(self).create_buffer(&buffer_desc)?;
 
             unsafe { buffer.SetName(&windows::core::HSTRING::from(&*label)) }
                 .into_device_result("SetName")?;

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -426,10 +426,6 @@ impl crate::Device for super::Device {
         let (resource, allocation) =
             suballocation::DeviceAllocationContext::from(self).create_buffer(&desc)?;
 
-        if let Some(label) = desc.label {
-            resource.set_name(label)?;
-        }
-
         self.counters.buffers.add(1);
 
         Ok(super::Buffer {
@@ -504,10 +500,6 @@ impl crate::Device for super::Device {
 
         let (resource, allocation) =
             suballocation::DeviceAllocationContext::from(self).create_texture(desc, raw_desc)?;
-
-        if let Some(label) = desc.label {
-            resource.set_name(label)?;
-        }
 
         self.counters.textures.add(1);
 
@@ -1538,7 +1530,7 @@ impl crate::Device for super::Device {
             };
 
             let buffer_desc = crate::BufferDescriptor {
-                label: None,
+                label: Some(&label),
                 size: buffer_size,
                 usage: wgt::BufferUses::STORAGE_READ_ONLY | wgt::BufferUses::MAP_WRITE,
                 // D3D12 backend doesn't care about the memory flags
@@ -1547,8 +1539,6 @@ impl crate::Device for super::Device {
 
             let (buffer, allocation) =
                 suballocation::DeviceAllocationContext::from(self).create_buffer(&buffer_desc)?;
-
-            buffer.set_name(&*label)?;
 
             let mut mapping = ptr::null_mut::<ffi::c_void>();
             unsafe { buffer.Map(0, None, Some(&mut mapping)) }.into_device_result("Map")?;
@@ -2246,10 +2236,6 @@ impl crate::Device for super::Device {
 
         let (resource, allocation) = suballocation::DeviceAllocationContext::from(self)
             .create_acceleration_structure(desc, raw_desc)?;
-
-        if let Some(label) = desc.label {
-            resource.set_name(label)?;
-        }
 
         // for some reason there is no counter for acceleration structures
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -383,7 +383,10 @@ impl super::Device {
             size,
             mip_level_count,
             sample_count,
-            allocation: suballocation::Allocation::none(suballocation::AllocationType::Texture),
+            allocation: suballocation::Allocation::none(
+                suballocation::AllocationType::Texture,
+                format.theoretical_memory_footprint(size),
+            ),
         }
     }
 
@@ -394,7 +397,10 @@ impl super::Device {
         super::Buffer {
             resource,
             size,
-            allocation: suballocation::Allocation::none(suballocation::AllocationType::Buffer),
+            allocation: suballocation::Allocation::none(
+                suballocation::AllocationType::Buffer,
+                size,
+            ),
         }
     }
 }

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -834,6 +834,9 @@ unsafe impl Sync for CommandBuffer {}
 #[derive(Debug)]
 pub struct Buffer {
     resource: Direct3D12::ID3D12Resource,
+    // While the allocation also has _a_ size, it may not
+    // be the same as the original size of the buffer,
+    // as the allocation size varies for assorted reasons.
     size: wgt::BufferAddress,
     allocation: suballocation::Allocation,
 }

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -1375,7 +1375,10 @@ impl crate::Surface for Surface {
             size: sc.size,
             mip_level_count: 1,
             sample_count: 1,
-            allocation: suballocation::Allocation::none(suballocation::AllocationType::Texture),
+            allocation: suballocation::Allocation::none(
+                suballocation::AllocationType::Texture,
+                sc.format.theoretical_memory_footprint(sc.size),
+            ),
         };
         Ok(Some(crate::AcquiredSurfaceTexture {
             texture,

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -5,7 +5,7 @@ use gpu_allocator::{
 use parking_lot::Mutex;
 use windows::Win32::Graphics::Direct3D12;
 
-use crate::auxil::dxgi::result::HResult as _;
+use crate::{auxil::dxgi::result::HResult as _, dx12::conv};
 
 #[derive(Debug)]
 pub(crate) enum AllocationType {
@@ -96,10 +96,11 @@ impl<'a> DeviceAllocationContext<'a> {
     pub(crate) fn create_buffer(
         &self,
         desc: &crate::BufferDescriptor,
-        raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
     ) -> Result<(Direct3D12::ID3D12Resource, Allocation), crate::DeviceError> {
         let is_cpu_read = desc.usage.contains(wgt::BufferUses::MAP_READ);
         let is_cpu_write = desc.usage.contains(wgt::BufferUses::MAP_WRITE);
+
+        let raw_desc = conv::map_buffer_descriptor(desc);
 
         // Workaround for Intel Xe drivers
         if !self.shared.private_caps.suballocation_supported {

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -159,7 +159,7 @@ impl<'a> DeviceAllocationContext<'a> {
     ) -> Result<(Direct3D12::ID3D12Resource, Allocation), crate::DeviceError> {
         // Workaround for Intel Xe drivers
         if !self.shared.private_caps.suballocation_supported {
-            let resource = self.create_committed_texture(desc, raw_desc)?;
+            let resource = self.create_committed_texture(raw_desc)?;
             return Ok((resource, Allocation::none(AllocationType::Texture)));
         }
 
@@ -209,7 +209,7 @@ impl<'a> DeviceAllocationContext<'a> {
     ) -> Result<(Direct3D12::ID3D12Resource, Allocation), crate::DeviceError> {
         // Workaround for Intel Xe drivers
         if !self.shared.private_caps.suballocation_supported {
-            let resource = self.create_committed_acceleration_structure(desc, raw_desc)?;
+            let resource = self.create_committed_acceleration_structure(raw_desc)?;
             return Ok((
                 resource,
                 Allocation::none(AllocationType::AccelerationStructure),
@@ -284,7 +284,7 @@ impl<'a> DeviceAllocationContext<'a> {
         };
     }
 
-    pub(crate) fn create_committed_buffer(
+    fn create_committed_buffer(
         &self,
         desc: &crate::BufferDescriptor,
         raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
@@ -332,9 +332,8 @@ impl<'a> DeviceAllocationContext<'a> {
         resource.ok_or(crate::DeviceError::Unexpected)
     }
 
-    pub(crate) fn create_committed_texture(
+    fn create_committed_texture(
         &self,
-        _desc: &crate::TextureDescriptor,
         raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
     ) -> Result<Direct3D12::ID3D12Resource, crate::DeviceError> {
         let heap_properties = Direct3D12::D3D12_HEAP_PROPERTIES {
@@ -369,9 +368,8 @@ impl<'a> DeviceAllocationContext<'a> {
         resource.ok_or(crate::DeviceError::Unexpected)
     }
 
-    pub(crate) fn create_committed_acceleration_structure(
+    fn create_committed_acceleration_structure(
         &self,
-        _desc: &crate::AccelerationStructureDescriptor,
         raw_desc: Direct3D12::D3D12_RESOURCE_DESC,
     ) -> Result<Direct3D12::ID3D12Resource, crate::DeviceError> {
         let heap_properties = Direct3D12::D3D12_HEAP_PROPERTIES {

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -5,7 +5,10 @@ use gpu_allocator::{
 use parking_lot::Mutex;
 use windows::Win32::Graphics::Direct3D12;
 
-use crate::{auxil::dxgi::result::HResult as _, dx12::conv};
+use crate::{
+    auxil::dxgi::{name::ObjectExt, result::HResult as _},
+    dx12::conv,
+};
 
 #[derive(Debug)]
 pub(crate) enum AllocationType {
@@ -149,6 +152,10 @@ impl<'a> DeviceAllocationContext<'a> {
             self.create_committed_buffer(desc, location)?
         };
 
+        if let Some(label) = desc.label {
+            resource.set_name(label)?;
+        }
+
         self.counters.buffer_memory.add(allocation.size() as isize);
 
         Ok((resource, allocation))
@@ -165,6 +172,10 @@ impl<'a> DeviceAllocationContext<'a> {
             self.create_committed_texture(desc, raw_desc)?
         };
 
+        if let Some(label) = desc.label {
+            resource.set_name(label)?;
+        }
+
         self.counters.texture_memory.add(allocation.size() as isize);
 
         Ok((resource, allocation))
@@ -180,6 +191,10 @@ impl<'a> DeviceAllocationContext<'a> {
         } else {
             self.create_committed_acceleration_structure(desc, raw_desc)?
         };
+
+        if let Some(label) = desc.label {
+            resource.set_name(label)?;
+        }
 
         self.counters
             .acceleration_structure_memory


### PR DESCRIPTION
**Connections**

Enables work on #4150 

**Description**

This continues the refactoring of D3D12 suballocation internals started #7476. Importantly it now draws the abstraction lines in very easy to understand ways, and allows internal backend code to easily make and destroy buffers without needing to duplicate significant code.

Additionally, there are some smaller changes in here which make life in the D3D12 backend easier.

Previously when the suballocation support was false, the memory counters did nothing. Now with unified code paths, these counters are always as close as possible to accurate.

**Testing**

CI

**Squash or Rebase?**

Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
