### PR TITLE
Implement `dot4U8Packed` and `dot4I8Packed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### New Features
+
+#### Naga
+
+- Add polyfills for `dot4U8Packed` and `dot4I8Packed` for all backends. By @robamler in [#7494](https://github.com/gfx-rs/wgpu/pull/7494).
+
 ### Changes
 
 #### General

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -1470,12 +1470,14 @@ impl<W: Write> Writer<W> {
 
     /// Emit code for the arithmetic expression of the dot product.
     ///
+    /// The argument `extractor` is a function that accepts a `Writer`, a handle to a vector,
+    /// and an index. writes out the expression for the component at that index.
     fn put_dot_product(
         &mut self,
         arg: Handle<crate::Expression>,
         arg1: Handle<crate::Expression>,
         size: usize,
-        context: &ExpressionContext,
+        extractor: impl Fn(&mut Self, Handle<crate::Expression>, usize) -> BackendResult,
     ) -> BackendResult {
         // Write parentheses around the dot product expression to prevent operators
         // with different precedences from applying earlier.
@@ -1483,22 +1485,12 @@ impl<W: Write> Writer<W> {
 
         // Cycle through all the components of the vector
         for index in 0..size {
-            let component = back::COMPONENTS[index];
             // Write the addition to the previous product
             // This will print an extra '+' at the beginning but that is fine in msl
             write!(self.out, " + ")?;
-            // Write the first vector expression, this expression is marked to be
-            // cached so unless it can't be cached (for example, it's a Constant)
-            // it shouldn't produce large expressions.
-            self.put_expression(arg, context, true)?;
-            // Access the current component on the first vector
-            write!(self.out, ".{component} * ")?;
-            // Write the second vector expression, this expression is marked to be
-            // cached so unless it can't be cached (for example, it's a Constant)
-            // it shouldn't produce large expressions.
-            self.put_expression(arg1, context, true)?;
-            // Access the current component on the second vector
-            write!(self.out, ".{component}")?;
+            extractor(self, arg, index)?;
+            write!(self.out, " * ")?;
+            extractor(self, arg1, index)?;
         }
 
         write!(self.out, ")")?;
@@ -2194,12 +2186,48 @@ impl<W: Write> Writer<W> {
                             ..
                         } => "dot",
                         crate::TypeInner::Vector { size, .. } => {
-                            return self.put_dot_product(arg, arg1.unwrap(), size as usize, context)
+                            return self.put_dot_product(
+                                arg,
+                                arg1.unwrap(),
+                                size as usize,
+                                |writer, arg, index| {
+                                    // Write the vector expression; this expression is marked to be
+                                    // cached so unless it can't be cached (for example, it's a Constant)
+                                    // it shouldn't produce large expressions.
+                                    writer.put_expression(arg, context, true)?;
+                                    // Access the current component on the vector.
+                                    write!(writer.out, ".{}", back::COMPONENTS[index])?;
+                                    Ok(())
+                                },
+                            );
                         }
                         _ => unreachable!(
                             "Correct TypeInner for dot product should be already validated"
                         ),
                     },
+                    fun @ (Mf::Dot4I8Packed | Mf::Dot4U8Packed) => {
+                        let conversion = match fun {
+                            Mf::Dot4I8Packed => "int",
+                            Mf::Dot4U8Packed => "",
+                            _ => unreachable!(),
+                        };
+
+                        return self.put_dot_product(
+                            arg,
+                            arg1.unwrap(),
+                            4,
+                            |writer, arg, index| {
+                                write!(writer.out, "({}(", conversion)?;
+                                writer.put_expression(arg, context, true)?;
+                                if index == 3 {
+                                    write!(writer.out, ") >> 24)")?;
+                                } else {
+                                    write!(writer.out, ") << {} >> 24)", (3 - index) * 8)?;
+                                }
+                                Ok(())
+                            },
+                        );
+                    }
                     Mf::Outer => return Err(Error::UnsupportedCall(format!("{fun:?}"))),
                     Mf::Cross => "cross",
                     Mf::Distance => "distance",
@@ -3176,6 +3204,10 @@ impl<W: Write> Writer<W> {
                                 _ => {}
                             }
                         }
+                    }
+                    crate::MathFunction::Dot4U8Packed | crate::MathFunction::Dot4I8Packed => {
+                        self.need_bake_expressions.insert(arg);
+                        self.need_bake_expressions.insert(arg1.unwrap());
                     }
                     crate::MathFunction::FirstLeadingBit
                     | crate::MathFunction::Pack4xI8

--- a/naga/src/common/wgsl/to_wgsl.rs
+++ b/naga/src/common/wgsl/to_wgsl.rs
@@ -105,6 +105,8 @@ impl TryToWgsl for crate::MathFunction {
             Mf::Log2 => "log2",
             Mf::Pow => "pow",
             Mf::Dot => "dot",
+            Mf::Dot4I8Packed => "dot4I8Packed",
+            Mf::Dot4U8Packed => "dot4U8Packed",
             Mf::Cross => "cross",
             Mf::Distance => "distance",
             Mf::Length => "length",

--- a/naga/src/front/wgsl/parse/conv.rs
+++ b/naga/src/front/wgsl/parse/conv.rs
@@ -236,6 +236,8 @@ pub fn map_standard_fun(word: &str) -> Option<crate::MathFunction> {
         "pow" => Mf::Pow,
         // geometry
         "dot" => Mf::Dot,
+        "dot4I8Packed" => Mf::Dot4I8Packed,
+        "dot4U8Packed" => Mf::Dot4U8Packed,
         "cross" => Mf::Cross,
         "distance" => Mf::Distance,
         "length" => Mf::Length,

--- a/naga/src/ir/mod.rs
+++ b/naga/src/ir/mod.rs
@@ -1148,6 +1148,8 @@ pub enum MathFunction {
     Pow,
     // geometry
     Dot,
+    Dot4I8Packed,
+    Dot4U8Packed,
     Outer,
     Cross,
     Distance,

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1314,6 +1314,8 @@ impl<'a> ConstantEvaluator<'a> {
             | crate::MathFunction::Frexp
             | crate::MathFunction::Ldexp
             | crate::MathFunction::Dot
+            | crate::MathFunction::Dot4I8Packed
+            | crate::MathFunction::Dot4U8Packed
             | crate::MathFunction::Outer
             | crate::MathFunction::Distance
             | crate::MathFunction::Length

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -223,6 +223,8 @@ impl super::MathFunction {
             Self::Pow => 2,
             // geometry
             Self::Dot => 2,
+            Self::Dot4I8Packed => 2,
+            Self::Dot4U8Packed => 2,
             Self::Outer => 2,
             Self::Cross => 2,
             Self::Distance => 2,

--- a/naga/src/proc/overloads/mathfunction.rs
+++ b/naga/src/proc/overloads/mathfunction.rs
@@ -82,6 +82,8 @@ impl ir::MathFunction {
             }
             Mf::Unpack4xI8 => regular!(1, SCALAR of U32 -> Vec4I).into(),
             Mf::Unpack4xU8 => regular!(1, SCALAR of U32 -> Vec4U).into(),
+            Mf::Dot4I8Packed => regular!(2, SCALAR of U32 -> I32).into(),
+            Mf::Dot4U8Packed => regular!(2, SCALAR of U32 -> U32).into(),
 
             // One-off operations
             Mf::Dot => regular!(2, VECN of NUMERIC -> Scalar).into(),

--- a/naga/src/proc/overloads/regular.rs
+++ b/naga/src/proc/overloads/regular.rs
@@ -209,6 +209,7 @@ pub(in crate::proc::overloads) enum ConclusionRule {
     Frexp,
     Modf,
     U32,
+    I32,
     Vec2F,
     Vec4F,
     Vec4I,
@@ -223,6 +224,7 @@ impl ConclusionRule {
             Self::Frexp => Conclusion::for_frexp_modf(ir::MathFunction::Frexp, size, scalar),
             Self::Modf => Conclusion::for_frexp_modf(ir::MathFunction::Modf, size, scalar),
             Self::U32 => Conclusion::Value(ir::TypeInner::Scalar(ir::Scalar::U32)),
+            Self::I32 => Conclusion::Value(ir::TypeInner::Scalar(ir::Scalar::I32)),
             Self::Vec2F => Conclusion::Value(ir::TypeInner::Vector {
                 size: ir::VectorSize::Bi,
                 scalar: ir::Scalar::F32,

--- a/naga/tests/in/wgsl/const-exprs.wgsl
+++ b/naga/tests/in/wgsl/const-exprs.wgsl
@@ -111,6 +111,20 @@ fn relational() {
     var vec_all_true     = all(vec4(true));
 }
 
+fn packed_dot_product() {
+    // Test dot product of packed vectors on literals, constants, and
+    // combinations thereof.
+    var signed_four = dot4I8Packed(TWO, TWO);
+    var unsigned_four = dot4U8Packed(TWO, TWO);
+    var signed_twelve = dot4I8Packed(TWO + 1u, TWO + 2u);
+    var unsigned_twelve = dot4U8Packed(TWO + 1u, TWO + 2u);
+    var signed_seventy = dot4I8Packed(0x01020304u, 0x05060708u);
+    var unsigned_seventy = dot4U8Packed(0x01020304u, 0x05060708u);
+
+    // This is equivalent to `dot(vec4(-1, 2, -3, 4), vec4(5, 6, -7, -8))`.
+    var minus_four = dot4I8Packed(0xff02fd04u, 0x0506f9f8u);
+}
+
 fn test_local_const() {
     const local_const = 2;
 	var arr: array<f32, local_const>;

--- a/naga/tests/in/wgsl/functions.wgsl
+++ b/naga/tests/in/wgsl/functions.wgsl
@@ -22,8 +22,24 @@ fn test_integer_dot_product() -> i32 {
     return c_4;
 }
 
+fn test_packed_integer_dot_product() -> u32 {
+    let a_5 = 1u;
+    let b_5 = 2u;
+    let c_5: i32 = dot4I8Packed(a_5, b_5);
+
+    let a_6 = 3u;
+    let b_6 = 4u;
+    let c_6: u32 = dot4U8Packed(a_6, b_6);
+
+    // test baking of arguments
+    let c_7: i32 = dot4I8Packed(5u + c_6, 6u + c_6);
+    let c_8: u32 = dot4U8Packed(7u + c_6, 8u + c_6);
+    return c_8;
+}
+
 @compute @workgroup_size(1)
 fn main() {
     let a = test_fma();
     let b = test_integer_dot_product();
+    let c = test_packed_integer_dot_product();
 }

--- a/naga/tests/out/glsl/wgsl-const-exprs.main.Compute.glsl
+++ b/naga/tests/out/glsl/wgsl-const-exprs.main.Compute.glsl
@@ -112,6 +112,17 @@ void relational() {
     return;
 }
 
+void packed_dot_product() {
+    int signed_four = 4;
+    uint unsigned_four = 4u;
+    int signed_twelve = 12;
+    uint unsigned_twelve = 12u;
+    int signed_seventy = 70;
+    uint unsigned_seventy = 70u;
+    int minus_four = -4;
+    return;
+}
+
 void abstract_access(uint i) {
     float a_1 = 1.0;
     uint b_1 = 1u;

--- a/naga/tests/out/glsl/wgsl-functions.main.Compute.glsl
+++ b/naga/tests/out/glsl/wgsl-functions.main.Compute.glsl
@@ -26,9 +26,22 @@ int test_integer_dot_product() {
     return c_4_;
 }
 
+uint test_packed_integer_dot_product() {
+    int c_5_ = (bitfieldExtract(int(1u), 0, 8) * bitfieldExtract(int(2u), 0, 8) + bitfieldExtract(int(1u), 8, 8) * bitfieldExtract(int(2u), 8, 8) + bitfieldExtract(int(1u), 16, 8) * bitfieldExtract(int(2u), 16, 8) + bitfieldExtract(int(1u), 24, 8) * bitfieldExtract(int(2u), 24, 8));
+    uint c_6_ = (bitfieldExtract((3u), 0, 8) * bitfieldExtract((4u), 0, 8) + bitfieldExtract((3u), 8, 8) * bitfieldExtract((4u), 8, 8) + bitfieldExtract((3u), 16, 8) * bitfieldExtract((4u), 16, 8) + bitfieldExtract((3u), 24, 8) * bitfieldExtract((4u), 24, 8));
+    uint _e7 = (5u + c_6_);
+    uint _e9 = (6u + c_6_);
+    int c_7_ = (bitfieldExtract(int(_e7), 0, 8) * bitfieldExtract(int(_e9), 0, 8) + bitfieldExtract(int(_e7), 8, 8) * bitfieldExtract(int(_e9), 8, 8) + bitfieldExtract(int(_e7), 16, 8) * bitfieldExtract(int(_e9), 16, 8) + bitfieldExtract(int(_e7), 24, 8) * bitfieldExtract(int(_e9), 24, 8));
+    uint _e12 = (7u + c_6_);
+    uint _e14 = (8u + c_6_);
+    uint c_8_ = (bitfieldExtract((_e12), 0, 8) * bitfieldExtract((_e14), 0, 8) + bitfieldExtract((_e12), 8, 8) * bitfieldExtract((_e14), 8, 8) + bitfieldExtract((_e12), 16, 8) * bitfieldExtract((_e14), 16, 8) + bitfieldExtract((_e12), 24, 8) * bitfieldExtract((_e14), 24, 8));
+    return c_8_;
+}
+
 void main() {
     vec2 _e0 = test_fma();
     int _e1 = test_integer_dot_product();
+    uint _e2 = test_packed_integer_dot_product();
     return;
 }
 

--- a/naga/tests/out/hlsl/wgsl-const-exprs.hlsl
+++ b/naga/tests/out/hlsl/wgsl-const-exprs.hlsl
@@ -125,6 +125,19 @@ void relational()
     return;
 }
 
+void packed_dot_product()
+{
+    int signed_four = int(4);
+    uint unsigned_four = 4u;
+    int signed_twelve = int(12);
+    uint unsigned_twelve = 12u;
+    int signed_seventy = int(70);
+    uint unsigned_seventy = 70u;
+    int minus_four = int(-4);
+
+    return;
+}
+
 typedef int ret_Constructarray9_int_[9];
 ret_Constructarray9_int_ Constructarray9_int_(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8) {
     int ret[9] = { arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 };

--- a/naga/tests/out/hlsl/wgsl-functions.hlsl
+++ b/naga/tests/out/hlsl/wgsl-functions.hlsl
@@ -18,10 +18,24 @@ int test_integer_dot_product()
     return c_4_;
 }
 
+uint test_packed_integer_dot_product()
+{
+    int c_5_ = dot(int4(1u, 1u >> 8, 1u >> 16, 1u >> 24) << 24 >> 24, int4(2u, 2u >> 8, 2u >> 16, 2u >> 24) << 24 >> 24);
+    uint c_6_ = dot(uint4(3u, 3u >> 8, 3u >> 16, 3u >> 24) << 24 >> 24, uint4(4u, 4u >> 8, 4u >> 16, 4u >> 24) << 24 >> 24);
+    uint _e7 = (5u + c_6_);
+    uint _e9 = (6u + c_6_);
+    int c_7_ = dot(int4(_e7, _e7 >> 8, _e7 >> 16, _e7 >> 24) << 24 >> 24, int4(_e9, _e9 >> 8, _e9 >> 16, _e9 >> 24) << 24 >> 24);
+    uint _e12 = (7u + c_6_);
+    uint _e14 = (8u + c_6_);
+    uint c_8_ = dot(uint4(_e12, _e12 >> 8, _e12 >> 16, _e12 >> 24) << 24 >> 24, uint4(_e14, _e14 >> 8, _e14 >> 16, _e14 >> 24) << 24 >> 24);
+    return c_8_;
+}
+
 [numthreads(1, 1, 1)]
 void main()
 {
     const float2 _e0 = test_fma();
     const int _e1 = test_integer_dot_product();
+    const uint _e2 = test_packed_integer_dot_product();
     return;
 }

--- a/naga/tests/out/msl/wgsl-const-exprs.msl
+++ b/naga/tests/out/msl/wgsl-const-exprs.msl
@@ -128,6 +128,18 @@ void relational(
     return;
 }
 
+void packed_dot_product(
+) {
+    int signed_four = 4;
+    uint unsigned_four = 4u;
+    int signed_twelve = 12;
+    uint unsigned_twelve = 12u;
+    int signed_seventy = 70;
+    uint unsigned_seventy = 70u;
+    int minus_four = -4;
+    return;
+}
+
 void abstract_access(
     uint i
 ) {

--- a/naga/tests/out/msl/wgsl-functions.msl
+++ b/naga/tests/out/msl/wgsl-functions.msl
@@ -27,9 +27,23 @@ int test_integer_dot_product(
     return c_4_;
 }
 
+uint test_packed_integer_dot_product(
+) {
+    int c_5_ = ( + (int(1u) << 24 >> 24) * (int(2u) << 24 >> 24) + (int(1u) << 16 >> 24) * (int(2u) << 16 >> 24) + (int(1u) << 8 >> 24) * (int(2u) << 8 >> 24) + (int(1u) >> 24) * (int(2u) >> 24));
+    uint c_6_ = ( + ((3u) << 24 >> 24) * ((4u) << 24 >> 24) + ((3u) << 16 >> 24) * ((4u) << 16 >> 24) + ((3u) << 8 >> 24) * ((4u) << 8 >> 24) + ((3u) >> 24) * ((4u) >> 24));
+    uint _e7 = 5u + c_6_;
+    uint _e9 = 6u + c_6_;
+    int c_7_ = ( + (int(_e7) << 24 >> 24) * (int(_e9) << 24 >> 24) + (int(_e7) << 16 >> 24) * (int(_e9) << 16 >> 24) + (int(_e7) << 8 >> 24) * (int(_e9) << 8 >> 24) + (int(_e7) >> 24) * (int(_e9) >> 24));
+    uint _e12 = 7u + c_6_;
+    uint _e14 = 8u + c_6_;
+    uint c_8_ = ( + ((_e12) << 24 >> 24) * ((_e14) << 24 >> 24) + ((_e12) << 16 >> 24) * ((_e14) << 16 >> 24) + ((_e12) << 8 >> 24) * ((_e14) << 8 >> 24) + ((_e12) >> 24) * ((_e14) >> 24));
+    return c_8_;
+}
+
 kernel void main_(
 ) {
     metal::float2 _e0 = test_fma();
     int _e1 = test_integer_dot_product();
+    uint _e2 = test_packed_integer_dot_product();
     return;
 }

--- a/naga/tests/out/spv/wgsl-const-exprs.spvasm
+++ b/naga/tests/out/spv/wgsl-const-exprs.spvasm
@@ -1,12 +1,12 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 166
+; Bound: 180
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %156 "main"
-OpExecutionMode %156 LocalSize 2 3 1
+OpEntryPoint GLCompute %170 "main"
+OpExecutionMode %170 LocalSize 2 3 1
 OpDecorate %9 ArrayStride 4
 OpDecorate %14 ArrayStride 4
 %2 = OpTypeVoid
@@ -69,18 +69,22 @@ OpDecorate %14 ArrayStride 4
 %113 = OpConstantComposite  %13  %27 %26 %28
 %115 = OpTypePointer Function %13
 %122 = OpTypePointer Function %5
-%134 = OpTypeFunction %2 %3
-%135 = OpConstant  %3  1
-%136 = OpConstant  %4  5
-%137 = OpConstant  %4  7
-%138 = OpConstant  %4  9
-%139 = OpConstantComposite  %14  %27 %28 %16 %19 %136 %47 %137 %20 %138
-%140 = OpConstantComposite  %6  %27 %28 %16 %19
-%142 = OpTypePointer Function %7
-%144 = OpTypePointer Function %3
-%146 = OpConstantNull  %4
-%148 = OpConstantNull  %4
-%150 = OpTypePointer Function %14
+%133 = OpConstant  %3  4
+%134 = OpConstant  %4  12
+%135 = OpConstant  %3  12
+%136 = OpConstant  %3  70
+%139 = OpTypePointer Function %3
+%149 = OpTypeFunction %2 %3
+%150 = OpConstant  %3  1
+%151 = OpConstant  %4  5
+%152 = OpConstant  %4  7
+%153 = OpConstant  %4  9
+%154 = OpConstantComposite  %14  %27 %28 %16 %19 %151 %47 %152 %20 %153
+%155 = OpConstantComposite  %6  %27 %28 %16 %19
+%157 = OpTypePointer Function %7
+%160 = OpConstantNull  %4
+%162 = OpConstantNull  %4
+%164 = OpTypePointer Function %14
 %34 = OpFunction  %2  None %35
 %33 = OpLabel
 %37 = OpVariable  %38  Function %36
@@ -192,35 +196,48 @@ OpBranch %130
 %130 = OpLabel
 OpReturn
 OpFunctionEnd
-%133 = OpFunction  %2  None %134
-%132 = OpFunctionParameter  %3
+%132 = OpFunction  %2  None %35
 %131 = OpLabel
-%143 = OpVariable  %144  Function %135
-%147 = OpVariable  %43  Function %148
-%141 = OpVariable  %142  Function %82
-%145 = OpVariable  %43  Function %146
-%151 = OpVariable  %150  Function
-OpBranch %149
-%149 = OpLabel
-OpStore %151 %139
-%152 = OpAccessChain  %43  %151 %132
-%153 = OpLoad  %4  %152
-OpStore %145 %153
-%154 = OpVectorExtractDynamic  %4  %140 %132
-OpStore %147 %154
+%142 = OpVariable  %43  Function %53
+%138 = OpVariable  %139  Function %133
+%144 = OpVariable  %43  Function %72
+%141 = OpVariable  %139  Function %135
+%137 = OpVariable  %43  Function %19
+%143 = OpVariable  %139  Function %136
+%140 = OpVariable  %43  Function %134
+OpBranch %145
+%145 = OpLabel
 OpReturn
 OpFunctionEnd
-%156 = OpFunction  %2  None %35
-%155 = OpLabel
-OpBranch %157
-%157 = OpLabel
-%158 = OpFunctionCall  %2  %34
-%159 = OpFunctionCall  %2  %41
-%160 = OpFunctionCall  %2  %46
-%161 = OpFunctionCall  %2  %51
-%162 = OpFunctionCall  %2  %71
-%163 = OpFunctionCall  %2  %77
-%164 = OpFunctionCall  %2  %81
-%165 = OpFunctionCall  %2  %89
+%148 = OpFunction  %2  None %149
+%147 = OpFunctionParameter  %3
+%146 = OpLabel
+%158 = OpVariable  %139  Function %150
+%161 = OpVariable  %43  Function %162
+%156 = OpVariable  %157  Function %82
+%159 = OpVariable  %43  Function %160
+%165 = OpVariable  %164  Function
+OpBranch %163
+%163 = OpLabel
+OpStore %165 %154
+%166 = OpAccessChain  %43  %165 %147
+%167 = OpLoad  %4  %166
+OpStore %159 %167
+%168 = OpVectorExtractDynamic  %4  %155 %147
+OpStore %161 %168
+OpReturn
+OpFunctionEnd
+%170 = OpFunction  %2  None %35
+%169 = OpLabel
+OpBranch %171
+%171 = OpLabel
+%172 = OpFunctionCall  %2  %34
+%173 = OpFunctionCall  %2  %41
+%174 = OpFunctionCall  %2  %46
+%175 = OpFunctionCall  %2  %51
+%176 = OpFunctionCall  %2  %71
+%177 = OpFunctionCall  %2  %77
+%178 = OpFunctionCall  %2  %81
+%179 = OpFunctionCall  %2  %89
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/wgsl-functions.spvasm
+++ b/naga/tests/out/spv/wgsl-functions.spvasm
@@ -1,28 +1,28 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 75
+; Bound: 162
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %70 "main"
-OpExecutionMode %70 LocalSize 1 1 1
+OpEntryPoint GLCompute %156 "main"
+OpExecutionMode %156 LocalSize 1 1 1
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpTypeVector %4 2
 %5 = OpTypeInt 32 1
-%8 = OpTypeFunction %3
-%9 = OpConstant  %4  2.0
-%10 = OpConstantComposite  %3  %9 %9
-%11 = OpConstant  %4  0.5
-%12 = OpConstantComposite  %3  %11 %11
-%17 = OpTypeFunction %5
-%18 = OpConstant  %5  1
-%19 = OpTypeVector %5 2
-%20 = OpConstantComposite  %19  %18 %18
-%21 = OpTypeInt 32 0
-%22 = OpConstant  %21  1
-%23 = OpTypeVector %21 3
+%6 = OpTypeInt 32 0
+%9 = OpTypeFunction %3
+%10 = OpConstant  %4  2.0
+%11 = OpConstantComposite  %3  %10 %10
+%12 = OpConstant  %4  0.5
+%13 = OpConstantComposite  %3  %12 %12
+%18 = OpTypeFunction %5
+%19 = OpConstant  %5  1
+%20 = OpTypeVector %5 2
+%21 = OpConstantComposite  %20  %19 %19
+%22 = OpConstant  %6  1
+%23 = OpTypeVector %6 3
 %24 = OpConstantComposite  %23  %22 %22 %22
 %25 = OpConstant  %5  4
 %26 = OpTypeVector %5 4
@@ -30,39 +30,50 @@ OpExecutionMode %70 LocalSize 1 1 1
 %28 = OpConstant  %5  2
 %29 = OpConstantComposite  %26  %28 %28 %28 %28
 %32 = OpConstantNull  %5
-%41 = OpConstantNull  %21
-%71 = OpTypeFunction %2
-%7 = OpFunction  %3  None %8
-%6 = OpLabel
-OpBranch %13
-%13 = OpLabel
-%14 = OpExtInst  %3  %1 Fma %10 %12 %12
-OpReturnValue %14
+%41 = OpConstantNull  %6
+%71 = OpTypeFunction %6
+%72 = OpConstant  %6  2
+%73 = OpConstant  %6  3
+%74 = OpConstant  %6  4
+%75 = OpConstant  %6  5
+%76 = OpConstant  %6  6
+%77 = OpConstant  %6  7
+%78 = OpConstant  %6  8
+%83 = OpConstant  %6  0
+%84 = OpConstant  %6  16
+%85 = OpConstant  %6  24
+%157 = OpTypeFunction %2
+%8 = OpFunction  %3  None %9
+%7 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%15 = OpExtInst  %3  %1 Fma %11 %13 %13
+OpReturnValue %15
 OpFunctionEnd
-%16 = OpFunction  %5  None %17
-%15 = OpLabel
+%17 = OpFunction  %5  None %18
+%16 = OpLabel
 OpBranch %30
 %30 = OpLabel
-%33 = OpCompositeExtract  %5  %20 0
-%34 = OpCompositeExtract  %5  %20 0
+%33 = OpCompositeExtract  %5  %21 0
+%34 = OpCompositeExtract  %5  %21 0
 %35 = OpIMul  %5  %33 %34
 %36 = OpIAdd  %5  %32 %35
-%37 = OpCompositeExtract  %5  %20 1
-%38 = OpCompositeExtract  %5  %20 1
+%37 = OpCompositeExtract  %5  %21 1
+%38 = OpCompositeExtract  %5  %21 1
 %39 = OpIMul  %5  %37 %38
 %31 = OpIAdd  %5  %36 %39
-%42 = OpCompositeExtract  %21  %24 0
-%43 = OpCompositeExtract  %21  %24 0
-%44 = OpIMul  %21  %42 %43
-%45 = OpIAdd  %21  %41 %44
-%46 = OpCompositeExtract  %21  %24 1
-%47 = OpCompositeExtract  %21  %24 1
-%48 = OpIMul  %21  %46 %47
-%49 = OpIAdd  %21  %45 %48
-%50 = OpCompositeExtract  %21  %24 2
-%51 = OpCompositeExtract  %21  %24 2
-%52 = OpIMul  %21  %50 %51
-%40 = OpIAdd  %21  %49 %52
+%42 = OpCompositeExtract  %6  %24 0
+%43 = OpCompositeExtract  %6  %24 0
+%44 = OpIMul  %6  %42 %43
+%45 = OpIAdd  %6  %41 %44
+%46 = OpCompositeExtract  %6  %24 1
+%47 = OpCompositeExtract  %6  %24 1
+%48 = OpIMul  %6  %46 %47
+%49 = OpIAdd  %6  %45 %48
+%50 = OpCompositeExtract  %6  %24 2
+%51 = OpCompositeExtract  %6  %24 2
+%52 = OpIMul  %6  %50 %51
+%40 = OpIAdd  %6  %49 %52
 %54 = OpCompositeExtract  %5  %27 0
 %55 = OpCompositeExtract  %5  %29 0
 %56 = OpIMul  %5  %54 %55
@@ -81,11 +92,90 @@ OpBranch %30
 %53 = OpIAdd  %5  %65 %68
 OpReturnValue %53
 OpFunctionEnd
-%70 = OpFunction  %2  None %71
+%70 = OpFunction  %6  None %71
 %69 = OpLabel
-OpBranch %72
-%72 = OpLabel
-%73 = OpFunctionCall  %3  %7
-%74 = OpFunctionCall  %5  %16
+OpBranch %79
+%79 = OpLabel
+%81 = OpBitcast  %5  %22
+%82 = OpBitcast  %5  %72
+%86 = OpBitFieldSExtract  %5  %81 %83 %78
+%87 = OpBitFieldSExtract  %5  %82 %83 %78
+%88 = OpIMul  %5  %86 %87
+%89 = OpIAdd  %5  %32 %88
+%90 = OpBitFieldSExtract  %5  %81 %78 %78
+%91 = OpBitFieldSExtract  %5  %82 %78 %78
+%92 = OpIMul  %5  %90 %91
+%93 = OpIAdd  %5  %89 %92
+%94 = OpBitFieldSExtract  %5  %81 %84 %78
+%95 = OpBitFieldSExtract  %5  %82 %84 %78
+%96 = OpIMul  %5  %94 %95
+%97 = OpIAdd  %5  %93 %96
+%98 = OpBitFieldSExtract  %5  %81 %85 %78
+%99 = OpBitFieldSExtract  %5  %82 %85 %78
+%100 = OpIMul  %5  %98 %99
+%80 = OpIAdd  %5  %97 %100
+%102 = OpBitFieldUExtract  %6  %73 %83 %78
+%103 = OpBitFieldUExtract  %6  %74 %83 %78
+%104 = OpIMul  %6  %102 %103
+%105 = OpIAdd  %6  %41 %104
+%106 = OpBitFieldUExtract  %6  %73 %78 %78
+%107 = OpBitFieldUExtract  %6  %74 %78 %78
+%108 = OpIMul  %6  %106 %107
+%109 = OpIAdd  %6  %105 %108
+%110 = OpBitFieldUExtract  %6  %73 %84 %78
+%111 = OpBitFieldUExtract  %6  %74 %84 %78
+%112 = OpIMul  %6  %110 %111
+%113 = OpIAdd  %6  %109 %112
+%114 = OpBitFieldUExtract  %6  %73 %85 %78
+%115 = OpBitFieldUExtract  %6  %74 %85 %78
+%116 = OpIMul  %6  %114 %115
+%101 = OpIAdd  %6  %113 %116
+%117 = OpIAdd  %6  %75 %101
+%118 = OpIAdd  %6  %76 %101
+%120 = OpBitcast  %5  %117
+%121 = OpBitcast  %5  %118
+%122 = OpBitFieldSExtract  %5  %120 %83 %78
+%123 = OpBitFieldSExtract  %5  %121 %83 %78
+%124 = OpIMul  %5  %122 %123
+%125 = OpIAdd  %5  %32 %124
+%126 = OpBitFieldSExtract  %5  %120 %78 %78
+%127 = OpBitFieldSExtract  %5  %121 %78 %78
+%128 = OpIMul  %5  %126 %127
+%129 = OpIAdd  %5  %125 %128
+%130 = OpBitFieldSExtract  %5  %120 %84 %78
+%131 = OpBitFieldSExtract  %5  %121 %84 %78
+%132 = OpIMul  %5  %130 %131
+%133 = OpIAdd  %5  %129 %132
+%134 = OpBitFieldSExtract  %5  %120 %85 %78
+%135 = OpBitFieldSExtract  %5  %121 %85 %78
+%136 = OpIMul  %5  %134 %135
+%119 = OpIAdd  %5  %133 %136
+%137 = OpIAdd  %6  %77 %101
+%138 = OpIAdd  %6  %78 %101
+%140 = OpBitFieldUExtract  %6  %137 %83 %78
+%141 = OpBitFieldUExtract  %6  %138 %83 %78
+%142 = OpIMul  %6  %140 %141
+%143 = OpIAdd  %6  %41 %142
+%144 = OpBitFieldUExtract  %6  %137 %78 %78
+%145 = OpBitFieldUExtract  %6  %138 %78 %78
+%146 = OpIMul  %6  %144 %145
+%147 = OpIAdd  %6  %143 %146
+%148 = OpBitFieldUExtract  %6  %137 %84 %78
+%149 = OpBitFieldUExtract  %6  %138 %84 %78
+%150 = OpIMul  %6  %148 %149
+%151 = OpIAdd  %6  %147 %150
+%152 = OpBitFieldUExtract  %6  %137 %85 %78
+%153 = OpBitFieldUExtract  %6  %138 %85 %78
+%154 = OpIMul  %6  %152 %153
+%139 = OpIAdd  %6  %151 %154
+OpReturnValue %139
+OpFunctionEnd
+%156 = OpFunction  %2  None %157
+%155 = OpLabel
+OpBranch %158
+%158 = OpLabel
+%159 = OpFunctionCall  %3  %8
+%160 = OpFunctionCall  %5  %17
+%161 = OpFunctionCall  %6  %70
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/wgsl-const-exprs.wgsl
+++ b/naga/tests/out/wgsl/wgsl-const-exprs.wgsl
@@ -114,6 +114,18 @@ fn relational() {
     return;
 }
 
+fn packed_dot_product() {
+    var signed_four: i32 = 4i;
+    var unsigned_four: u32 = 4u;
+    var signed_twelve: i32 = 12i;
+    var unsigned_twelve: u32 = 12u;
+    var signed_seventy: i32 = 70i;
+    var unsigned_seventy: u32 = 70u;
+    var minus_four: i32 = -4i;
+
+    return;
+}
+
 fn abstract_access(i: u32) {
     var a_1: f32 = 1f;
     var b_1: u32 = 1u;

--- a/naga/tests/out/wgsl/wgsl-functions.wgsl
+++ b/naga/tests/out/wgsl/wgsl-functions.wgsl
@@ -16,9 +16,18 @@ fn test_integer_dot_product() -> i32 {
     return c_4_;
 }
 
+fn test_packed_integer_dot_product() -> u32 {
+    let c_5_ = dot4I8Packed(1u, 2u);
+    let c_6_ = dot4U8Packed(3u, 4u);
+    let c_7_ = dot4I8Packed((5u + c_6_), (6u + c_6_));
+    let c_8_ = dot4U8Packed((7u + c_6_), (8u + c_6_));
+    return c_8_;
+}
+
 @compute @workgroup_size(1, 1, 1) 
 fn main() {
     let _e0 = test_fma();
     let _e1 = test_integer_dot_product();
+    let _e2 = test_packed_integer_dot_product();
     return;
 }


### PR DESCRIPTION
**Connections**
- Closes #7481
- Closes https://github.com/gfx-rs/wgpu/issues/4544

**Description**
Implements the functions [`dot4U8Packed`](https://www.w3.org/TR/WGSL/#dot4U8Packed-builtin) and [`dot4I8Packed`](https://www.w3.org/TR/WGSL/#dot4I8Packed-builtin) defined in the WGSL spec. These functions perform a dot product between two 4-vectors where each 4-vector is stored in "packed" form (i.e., as a single `u32` with one byte per vector component).

- [x] Polyfills for SPIR-V, HLSL, GLSL, MSL, and WGSL (roughly following approach 2 outlined in #7481)
- [x] const evaluator

**Testing**
I added tests for:
- polyfills in `naga/tests/in/wgsl/functions.wgsl`
- const evaluation in `naga/src/proc/constant_evaluator.rs`

**Squash or Rebase?**
~~Each commit is self-contained and does not introduce any new test failures. However, there are 7 tests that already fail on current trunk on my machine (I'm not sure if that's due to a misconfiguration of my machine or due to a temporarily known bug).~~
  [Update: all tests pass on CI, but needs squashing]

**Open Questions**
- [x] ~~Clippy complains that the method [`spv::BlockContext::write_dot_products`](https://github.com/gfx-rs/wgpu/blob/bc9f93ef29944b1f8e25e0d2a348902ec72d631f/naga/src/back/spv/block.rs#L2613-L2622) has too many arguments because I added an argument `extractor`, which allowed me to reuse the method for packed dot products. Should I revert this and instead have two separate methods (i.e., some code duplication) or would you prefer if I instead annotate the method with `#[allow(clippy::too_many_arguments)]`?~~ 
  [Update: resolved in  23a9418]
- [x] ~~I'm not sure how to verify the test output of SPIR-V for correctness. Do you usually use some tools for this or do you verify `.spvasm`-files manually?~~
[Update: verification with `cargo xtask validate spv` passes]

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
