### PR TITLE
[naga wgsl-in] Handle struct types in error messages properly.

### DIFF
--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -1764,6 +1764,10 @@ impl TypeContext for WriterTypeContext<'_> {
         self.names[&NameKey::Type(handle)].as_str()
     }
 
+    fn write_unnamed_struct<W: Write>(&self, _: &TypeInner, _: &mut W) -> core::fmt::Result {
+        unreachable!("the WGSL back end should always provide type handles");
+    }
+
     fn write_override<W: Write>(&self, _: Handle<crate::Override>, _: &mut W) -> core::fmt::Result {
         unreachable!("overrides should be validated out");
     }

--- a/naga/src/common/diagnostic_display.rs
+++ b/naga/src/common/diagnostic_display.rs
@@ -1,6 +1,6 @@
 //! Displaying Naga IR terms in diagnostic output.
 
-use crate::proc::{GlobalCtx, Rule};
+use crate::proc::{GlobalCtx, Rule, TypeResolution};
 use crate::{Handle, Scalar, Type, TypeInner};
 
 #[cfg(any(feature = "wgsl-in", feature = "wgsl-out"))]
@@ -48,6 +48,17 @@ use core::fmt;
 /// source language to use, any use site that does not supply this
 /// indication will provoke a compile-time error.
 pub struct DiagnosticDisplay<T>(pub T);
+
+impl fmt::Display for DiagnosticDisplay<(&TypeResolution, GlobalCtx<'_>)> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (resolution, ctx) = self.0;
+
+        match *resolution {
+            TypeResolution::Handle(handle) => DiagnosticDisplay((handle, ctx)).fmt(f),
+            TypeResolution::Value(ref inner) => DiagnosticDisplay((inner, ctx)).fmt(f),
+        }
+    }
+}
 
 impl fmt::Display for DiagnosticDisplay<(Handle<Type>, GlobalCtx<'_>)> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/naga/src/common/diagnostic_display.rs
+++ b/naga/src/common/diagnostic_display.rs
@@ -53,10 +53,16 @@ impl fmt::Display for DiagnosticDisplay<(&TypeResolution, GlobalCtx<'_>)> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (resolution, ctx) = self.0;
 
-        match *resolution {
-            TypeResolution::Handle(handle) => DiagnosticDisplay((handle, ctx)).fmt(f),
-            TypeResolution::Value(ref inner) => DiagnosticDisplay((inner, ctx)).fmt(f),
+        #[cfg(any(feature = "wgsl-in", feature = "wgsl-out"))]
+        ctx.write_type_resolution(resolution, f)?;
+
+        #[cfg(not(any(feature = "wgsl-in", feature = "wgsl-out")))]
+        {
+            let _ = ctx;
+            write!(f, "{resolution:?}")?;
         }
+
+        Ok(())
     }
 }
 

--- a/naga/src/common/diagnostic_display.rs
+++ b/naga/src/common/diagnostic_display.rs
@@ -1,7 +1,7 @@
 //! Displaying Naga IR terms in diagnostic output.
 
 use crate::proc::{GlobalCtx, Rule, TypeResolution};
-use crate::{Handle, Scalar, Type, TypeInner};
+use crate::{Handle, Scalar, Type};
 
 #[cfg(any(feature = "wgsl-in", feature = "wgsl-out"))]
 use crate::common::wgsl::TypeContext;
@@ -23,13 +23,16 @@ use core::fmt;
 /// for a type like `DiagnosticDisplay<(Handle<Type>, GlobalCtx)>`, where
 /// the [`GlobalCtx`] type provides the necessary context.
 ///
+/// Do not implement this type for [`TypeInner`], as that does not
+/// have enough information to display struct types correctly.
+///
 /// If you only need debugging output, [`DiagnosticDebug`] uses
 /// easier-to-obtain context types but still does a good enough job
 /// for logging or debugging.
 ///
 /// [`Display`]: core::fmt::Display
-/// [`Scalar`]: crate::Scalar
 /// [`GlobalCtx`]: crate::proc::GlobalCtx
+/// [`TypeInner`]: crate::ir::TypeInner
 /// [`DiagnosticDebug`]: super::DiagnosticDebug
 ///
 /// ## Language-sensitive diagnostics
@@ -77,23 +80,6 @@ impl fmt::Display for DiagnosticDisplay<(Handle<Type>, GlobalCtx<'_>)> {
         {
             let _ = ctx;
             write!(f, "{handle:?}")?;
-        }
-
-        Ok(())
-    }
-}
-
-impl fmt::Display for DiagnosticDisplay<(&TypeInner, GlobalCtx<'_>)> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (inner, ref ctx) = self.0;
-
-        #[cfg(any(feature = "wgsl-in", feature = "wgsl-out"))]
-        ctx.write_type_inner(inner, f)?;
-
-        #[cfg(not(any(feature = "wgsl-in", feature = "wgsl-out")))]
-        {
-            let _ = ctx;
-            write!(f, "{inner:?}")?;
         }
 
         Ok(())

--- a/naga/src/common/wgsl/types.rs
+++ b/naga/src/common/wgsl/types.rs
@@ -170,12 +170,6 @@ pub trait TypeContext {
         buf
     }
 
-    fn type_inner_to_string(&self, inner: &TypeInner) -> String {
-        let mut buf = String::new();
-        self.write_type_inner(inner, &mut buf).unwrap();
-        buf
-    }
-
     fn type_resolution_to_string(&self, resolution: &TypeResolution) -> String {
         let mut buf = String::new();
         self.write_type_resolution(resolution, &mut buf).unwrap();

--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -550,8 +550,14 @@ impl<'source> Lowerer<'source, '_> {
             // ERRORS
 
             // Bad conversion (type cast)
-            (Components::One { span, ty_inner, .. }, constructor) => {
-                let from_type = ctx.type_inner_to_string(ty_inner);
+            (
+                Components::One {
+                    span, component, ..
+                },
+                constructor,
+            ) => {
+                let component_ty = &ctx.typifier()[component];
+                let from_type = ctx.type_resolution_to_string(component_ty);
                 return Err(Box::new(Error::BadTypeCast {
                     span,
                     from_type,

--- a/naga/src/front/wgsl/lower/conversion.rs
+++ b/naga/src/front/wgsl/lower/conversion.rs
@@ -311,17 +311,19 @@ impl<'source> super::ExpressionContext<'source, '_, '_> {
         I::IntoIter: Clone, // for debugging
     {
         let types = &self.module.types;
-        let mut inners = components
-            .into_iter()
-            .map(|&c| self.typifier()[c].inner_with(types));
+        let components_iter = components.into_iter();
         log::debug!(
             "wgsl automatic_conversion_consensus: {}",
-            inners
+            components_iter
                 .clone()
-                .map(|inner| self.type_inner_to_string(inner))
+                .map(|&expr| {
+                    let res = &self.typifier()[expr];
+                    self.type_resolution_to_string(res)
+                })
                 .collect::<Vec<String>>()
                 .join(", ")
         );
+        let mut inners = components_iter.map(|&c| self.typifier()[c].inner_with(types));
         let mut best = inners.next().unwrap().scalar().ok_or(0_usize)?;
         for (inner, i) in inners.zip(1..) {
             let scalar = inner.scalar().ok_or(i)?;

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -412,6 +412,14 @@ impl TypeContext for ExpressionContext<'_, '_, '_> {
             None => write!(out, "{{anonymous override {handle:?}}}"),
         }
     }
+
+    fn write_unnamed_struct<W: core::fmt::Write>(
+        &self,
+        _: &crate::TypeInner,
+        _: &mut W,
+    ) -> core::fmt::Result {
+        unreachable!("the WGSL front end should always know the type name");
+    }
 }
 
 impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1308,8 +1308,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 if !explicit_inner.equivalent(init_inner, &ectx.module.types) {
                     return Err(Box::new(Error::InitializationTypeMismatch {
                         name: name.span,
-                        expected: ectx.type_inner_to_string(explicit_inner),
-                        got: ectx.type_inner_to_string(init_inner),
+                        expected: ectx.type_to_string(explicit_ty),
+                        got: ectx.type_to_string(init_ty),
                     }));
                 }
                 ty = explicit_ty;

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -3411,3 +3411,24 @@ fn struct_names_in_conversion_errors() {
     assert!(variant("1i").is_ok());
     assert!(variant("A()").is_err());
 }
+
+/// Naga should not crash just because the type of a
+/// bad initializer is a struct.
+#[test]
+fn struct_names_in_init_errors() {
+    #[track_caller]
+    fn variant(init: &str) -> Result<naga::Module, naga::front::wgsl::ParseError> {
+        let input = format!(
+            r#"
+                struct A {{ x: i32, }};
+                fn f() {{ var y: i32 = {init}; }}
+            "#
+        );
+        naga::front::wgsl::parse_str(&input)
+    }
+
+    assert!(variant("1").is_ok());
+    assert!(variant("1i").is_ok());
+    assert!(variant("1.0").is_err());
+    assert!(variant("A()").is_err());
+}

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -3369,3 +3369,24 @@ fn more_inconsistent_type() {
     variant("clamp(1f, 1i, 1f)");
     variant("clamp(1f, 1f, 1i)");
 }
+
+/// Naga should not crash just because the type of a
+/// bad argument is a struct.
+#[test]
+fn struct_names_in_argument_errors() {
+    #[track_caller]
+    fn variant(argument: &str) -> Result<naga::Module, naga::front::wgsl::ParseError> {
+        let input = format!(
+            r#"
+                struct A {{ x: i32, }};
+                fn f() {{ _ = sin({argument}); }}
+            "#
+        );
+        naga::front::wgsl::parse_str(&input)
+    }
+
+    assert!(variant("1.0").is_ok());
+    assert!(variant("1").is_ok());
+    assert!(variant("1i").is_err());
+    assert!(variant("A()").is_err());
+}

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -3390,3 +3390,24 @@ fn struct_names_in_argument_errors() {
     assert!(variant("1i").is_err());
     assert!(variant("A()").is_err());
 }
+
+/// Naga should not crash just because the type of a
+/// bad conversion operand is a struct.
+#[test]
+fn struct_names_in_conversion_errors() {
+    #[track_caller]
+    fn variant(argument: &str) -> Result<naga::Module, naga::front::wgsl::ParseError> {
+        let input = format!(
+            r#"
+                struct A {{ x: i32, }};
+                fn f() {{ _ = i32({argument}); }}
+            "#
+        );
+        naga::front::wgsl::parse_str(&input)
+    }
+
+    assert!(variant("1.0").is_ok());
+    assert!(variant("1").is_ok());
+    assert!(variant("1i").is_ok());
+    assert!(variant("A()").is_err());
+}


### PR DESCRIPTION
Don't try to use `&TypeInner` values to generate error messages, since `&TypeInner` cannot represent struct types in WGSL - they must be referred to by name, and only `Type` knows the type's name. Using `Handle<Type>` or `TypeResolution` works fine, so use that instead.

Add a new `Display` impl for `DiagnosticDisplay` for `TypeResolution`.

Fixes #7495.
