### PR TITLE
Remove `MaintainBase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Changes
+
+#### General
+
+- Removed `MaintainBase` in favor of using `PollType`. By @waywardmonkeys in [#7508](https://github.com/gfx-rs/wgpu/pull/7508).
+
 ## v25.0.0 (2025-04-10)
 
 ### Major Features

--- a/tests/tests/wgpu-gpu/regression/issue_4024.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4024.rs
@@ -74,7 +74,7 @@ static QUEUE_SUBMITTED_CALLBACK_ORDERING: GpuTestConfiguration = GpuTestConfigur
         });
 
         // No GPU work is happening at this point, but we want to process callbacks.
-        ctx.async_poll(MaintainBase::Poll).await.unwrap();
+        ctx.async_poll(PollType::Poll).await.unwrap();
 
         // Extract the ordering out of the arc.
         let ordering = Arc::into_inner(ordering).unwrap().into_inner();

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -33,7 +33,6 @@ pub struct SubmissionIndex {
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(SubmissionIndex: Send, Sync);
 
-pub use wgt::PollType as MaintainBase;
 /// Passed to [`Device::poll`] to control how and if it should block.
 pub type PollType = wgt::PollType<SubmissionIndex>;
 #[cfg(send_sync)]


### PR DESCRIPTION

**Description**
`Maintain` was renamed to `PollType`, but `MaintainBase` was left around. This isn't actually used within the code, so seems safe to remove.

**Testing**
Built.

**Squash or Rebase?**
One commit, doesn't matter.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
