### PR TITLE
Fix build with `profiling` enabled

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -408,7 +408,7 @@ impl Instance {
         {
             // NOTE: We might be using `profiling` without any features. The empty backend of this
             // macro emits no code, so unused code linting changes depending on the backend.
-            profiling::scope!("enumerating", &*format!("{:?}", _backend));
+            profiling::scope!("enumerating", &*alloc::format!("{:?}", _backend));
 
             let hal_adapters = unsafe { instance.enumerate_adapters(None) };
             for raw in hal_adapters {


### PR DESCRIPTION
**Connections**
https://github.com/Wumpf/wgpu-profiler/pull/95

**Description**
When building with `profiling/profile-with-tracy` or similar enabled, then `alloc::format` must be in scope to compile some code.

This breaks the build for `wgpu-profiler` with wgpu 25.

**Testing**
Ran `cargo clippy --tests --features profiling/profile-with-tracy`

**Squash or Rebase?**
N/A

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
