### PR TITLE
Fix `raw-window-handle` dependency being too lenient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ png = "0.17.16"
 pollster = "0.4"
 portable-atomic = "1"
 profiling = { version = "1", default-features = false }
-raw-window-handle = { version = "0.6", default-features = false }
+raw-window-handle = { version = "0.6.2", default-features = false }
 rayon = "1"
 renderdoc-sys = "1.1.0"
 ron = "0.9"


### PR DESCRIPTION
**Connections**
Based on a user report in chat.

**Description**
`wgpu-hal` mentions `RawWindowHandle::OhosNdk`, which was added in `raw-window-handle` version 0.6.2. Therefore the dependency must be on ^0.6.2 too, not ^0.6.

**Testing**
I'm keeping it simple and letting the CI do all the testing of this.

**Squash or Rebase?**
Just one commit.
