### PR TITLE
Add `-Zdirect-minimal-versions` compatibility and testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,32 +405,29 @@ jobs:
           # check `wgpu-core` with all features. This will also get `wgpu-hal` and `wgpu-types`.
           cargo check --target ${{ matrix.target }} --all-features -p wgpu-core
 
-  naga-minimal-versions:
+  # Check that the libraries build — but not that there are no warnings or that tests pass -
+  # with `-Zdirect-minimal-versions` which lowers all dependencies from the workspace packages
+  # to non-workspace packages to their minimum allowed version.
+  check-minimal-versions:
     # runtime is normally 2 minutes
     timeout-minutes: 10
 
-    name: MSRV naga Minimal Versions
+    name: MSRV Minimal Versions
     runs-on: ubuntu-22.04
+    env:
+      # Override flags to NOT include `-D warnings`, because warnings may be due to harmless problems in deps.
+      # Also, allow unexpected_cfgs because it is very common and spammy when using old deps.
+      RUSTFLAGS: -A unexpected_cfgs
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install core MSRV toolchain
-        run: |
-          rustup toolchain install ${{ env.CORE_MSRV }} --no-self-update --profile=minimal --component clippy
-          rustup override set ${{ env.CORE_MSRV }}
-          cargo -V
-
-      - name: Install Nightly toolchain
+      - name: Install toolchain
         run: |
           rustup toolchain install ${{ env.REPO_MSRV }} --no-self-update --profile=minimal
-          cargo +${{ env.REPO_MSRV }} -V
-
-      - name: Install `cargo-hack`
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-hack
+          rustup override set ${{ env.REPO_MSRV }}
+          cargo -V
 
       - name: Disable debug symbols
         shell: bash
@@ -445,16 +442,16 @@ jobs:
         run: |
           set -e
 
-          cargo +${{ env.REPO_MSRV }} hack generate-lockfile --remove-dev-deps -Z minimal-versions -p naga -p naga-cli
+          cargo +${{ env.REPO_MSRV }} update -Zdirect-minimal-versions
         env:
           RUSTC_BOOTSTRAP: 1
 
-      - name: Run Clippy
+      - name: Run cargo check
         shell: bash
         run: |
           set -e
 
-          cargo clippy --all-features -p naga -p naga-cli
+          cargo check --all-targets --all-features
 
   wasm-test:
     # runtime is normally 2 minutes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ codespan-reporting = { version = "0.12", default-features = false }
 ctor = "0.4"
 document-features = "0.2.11"
 encase = "0.11.0"
-env_logger = "0.11"
+env_logger = "0.11.8"
 fern = "0.7"
 flume = "0.11"
 futures-lite = "2"
@@ -116,10 +116,10 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 indexmap = { version = "2.7.1", default-features = false }
 itertools = { version = "0.14.0" }
 ktx2 = "0.4"
-libc = { version = "0.2", default-features = false }
+libc = { version = "0.2.168", default-features = false }
 libloading = "0.8"
 libtest-mimic = "0.8.1"
-log = "0.4"
+log = "0.4.21"
 nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
 noise = "0.9"
 nv-flip = "0.1"
@@ -128,7 +128,7 @@ obj = "0.10"
 once_cell = { version = "1.21.3", default-features = false }
 # Firefox has 3.4.0 vendored, so we allow that version in our dependencies
 ordered-float = { version = ">=3, <=5.0", default-features = false }
-parking_lot = "0.12.1"
+parking_lot = "0.12.3"
 pico-args = { version = "0.5.0", features = [
     "eq-separator",
     "short-space-opt",
@@ -136,30 +136,30 @@ pico-args = { version = "0.5.0", features = [
 ] }
 png = "0.17.16"
 pollster = "0.4"
-portable-atomic = "1"
+portable-atomic = "1.10.0"
 profiling = { version = "1", default-features = false }
 raw-window-handle = { version = "0.6.2", default-features = false }
-rayon = "1"
+rayon = "1.3.0"
 renderdoc-sys = "1.1.0"
 ron = "0.10"
 # NOTE: rustc-hash v2 is a completely different hasher with different performance characteristics
 # see discussion here (including with some other alternatives): https://github.com/gfx-rs/wgpu/issues/6999
 # (using default-features = false to support no-std build, avoiding any extra features that may require std::collections)
-rustc-hash = { version = "1", default-features = false }
+rustc-hash = { version = "1.1.0", default-features = false }
 serde_json = "1.0.140"
-serde = { version = "1", default-features = false }
-smallvec = "1"
+serde = { version = "1.0.219", default-features = false }
+smallvec = "1.9.0"
 static_assertions = "1.1.0"
 strum = { version = "0.27.1", default-features = false, features = ["derive"] }
 trybuild = "1"
 tracy-client = "0.18"
-thiserror = { version = "2", default-features = false }
-walkdir = "2"
+thiserror = { version = "2.0.3", default-features = false }
+walkdir = "2.3.0"
 winit = { version = "0.29", features = ["android-native-activity"] }
 
 # Metal dependencies
 metal = "0.32.0"
-block = "0.1"
+block = "0.1.6"
 core-graphics-types = "0.2"
 objc = "0.2.5"
 
@@ -188,11 +188,11 @@ windows = { version = "0.58", default-features = false }
 # wasm32 dependencies
 console_error_panic_hook = "0.1.7"
 console_log = "1"
-js-sys = { version = "0.3.70", default-features = false }
-wasm-bindgen = "0.2.97"
+js-sys = { version = "0.3.77", default-features = false }
+wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.45"
 wasm-bindgen-test = "0.3"
-web-sys = { version = "0.3.74", default-features = false }
+web-sys = { version = "0.3.77", default-features = false }
 web-time = "1.1.0"
 
 # deno dependencies

--- a/examples/standalone/01_hello_compute/Cargo.toml
+++ b/examples/standalone/01_hello_compute/Cargo.toml
@@ -5,7 +5,7 @@ rust-version = "1.84"
 publish = false
 
 [dependencies]
-bytemuck = "1"
+bytemuck = "1.22.0"
 env_logger = "0.11.8"
 pollster = "0.4"
 wgpu = "25.0.0"

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -81,7 +81,7 @@ termcolor = ["codespan-reporting/termcolor"]
 stderr = ["codespan-reporting/std"]
 
 [dependencies]
-arbitrary = { version = "1.4", features = ["derive"], optional = true }
+arbitrary = { version = "1.4.1", features = ["derive"], optional = true }
 arrayvec.workspace = true
 bitflags.workspace = true
 bit-set.workspace = true
@@ -91,7 +91,7 @@ hashbrown.workspace = true
 half = { workspace = true, default-features = false, features = ["num-traits"] }
 rustc-hash.workspace = true
 indexmap.workspace = true
-log = "0.4"
+log.workspace = true
 # `half` requires 0.2.16 for `FromBytes` and `ToBytes`.
 num-traits = { version = "0.2.16", default-features = false }
 once_cell = { workspace = true, features = ["alloc", "race"] }
@@ -105,7 +105,7 @@ serde = { version = "1.0.219", default-features = false, features = [
 petgraph = { version = "0.8", optional = true, default-features = false }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
-unicode-ident = { version = "1.0", optional = true }
+unicode-ident = { version = "1.0.5", optional = true }
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/naga/hlsl-snapshots/Cargo.toml
+++ b/naga/hlsl-snapshots/Cargo.toml
@@ -11,5 +11,5 @@ path = "src/lib.rs"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = "1.0.97"
 nanoserde = "0.2.1"

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -296,7 +296,7 @@ web-sys = { workspace = true, optional = true, features = [
     "WebGl2RenderingContext",
     "OffscreenCanvas",
 ] }
-js-sys = { workspace = true, optional = true, features = ["default"] }
+js-sys = { workspace = true, optional = true, default-features = true }
 
 ############################
 ### Platform: Emscripten ###
@@ -328,5 +328,5 @@ winit.workspace = true                                           # for "halmark"
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))'.dev-dependencies]
 glutin-winit = { workspace = true, features = ["egl", "wgl", "wayland", "x11"] }
 glutin = { workspace = true, features = ["egl", "wgl", "wayland", "x11"] }
-rwh_05 = { version = "0.5", package = "raw-window-handle" }                      # temporary compatibility for glutin-winit
+rwh_05 = { version = "0.5.2", package = "raw-window-handle" }                    # temporary compatibility for glutin-winit
 winit = { workspace = true, features = ["rwh_05"] }

--- a/wgpu-macros/Cargo.toml
+++ b/wgpu-macros/Cargo.toml
@@ -17,5 +17,5 @@ proc-macro = true
 
 [dependencies]
 heck = "0.5"
-quote = "1"
-syn = { version = "2", features = ["full"] }
+quote = "1.0.38"
+syn = { version = "2.0.98", features = ["full"] }


### PR DESCRIPTION
**Connections**
Prevents problems like the one described in #7526.

**Description**
This PR adds a CI job which confirms building with [`cargo update -Zdirect-minimal-versions`](https://doc.rust-lang.org/cargo/reference/unstable.html#direct-minimal-versions) on some platforms. This unstable feature updates all dependencies from the workspace packages to non-workspace packages to the minimum version allowed by the workspace’s dependency specifications, thus ensuring that the project will not build if it actually depends on items newer than its dependency specifications.

It also updates dependency versions to be compatible with `-Zdirect-minimal-versions`. Specifically, `cargo update -Zdirect-minimal-versions` will fail if any transitive dependency has a *higher* dependency requirement than the workspace. This should largely make no difference since those versions would have been required anyway; however, it may increase the minimum dependency requirement seen by users of a *single* package from crates.io (e.g. users of `naga` without `wgpu`). That could be a reason to reject this change.

Also, this change will increase the `Cargo.toml` maintenance burden, because increasing some dependency versions may require also increasing others even when that change is a noop for any normal build.

**Testing**
I confirmed that tests pass with the dependencies actually updated, except for `naga back::msl::writer::test_stack_size`. However, the added CI job does not run tests, only `cargo check`, to minimize the additional CI cost. Thus, CI will catch use of newer items, but not bugs in old dependencies.

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [X] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
