### PR TITLE
[naga] Allow Scalar for MathFunction::Distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ Bottom level categories:
 
 - Removed `MaintainBase` in favor of using `PollType`. By @waywardmonkeys in [#7508](https://github.com/gfx-rs/wgpu/pull/7508).
 
+### Bug Fixes
+
+#### Naga
+
+- Allow scalars as the first argument of the `distance` built-in function. By @bernhl in [#7530](https://github.com/gfx-rs/wgpu/pull/7530).
+
 ## v25.0.1 (2025-04-11)
 
 ### Bug Fixes

--- a/naga/src/proc/overloads/mathfunction.rs
+++ b/naga/src/proc/overloads/mathfunction.rs
@@ -92,7 +92,9 @@ impl ir::MathFunction {
             Mf::Ldexp => ldexp().into(),
             Mf::Outer => outer().into(),
             Mf::Cross => regular!(2, VEC3 of FLOAT).into(),
-            Mf::Distance => regular!(2, VECN of FLOAT_ABSTRACT_UNIMPLEMENTED -> Scalar).into(),
+            Mf::Distance => {
+                regular!(2, SCALAR|VECN of FLOAT_ABSTRACT_UNIMPLEMENTED -> Scalar).into()
+            }
             Mf::Length => regular!(1, SCALAR|VECN of FLOAT_ABSTRACT_UNIMPLEMENTED -> Scalar).into(),
             Mf::Normalize => regular!(1, VECN of FLOAT_ABSTRACT_UNIMPLEMENTED).into(),
             Mf::FaceForward => regular!(3, VECN of FLOAT_ABSTRACT_UNIMPLEMENTED).into(),

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -3419,6 +3419,9 @@ fn too_many_arguments_2() {
   │                    ^^^^^^^^              ^^ argument #2 has type `i32`
   │
   = note: `distance` accepts the following types for argument #2:
+  = note: allowed type: f32
+  = note: allowed type: f16
+  = note: allowed type: f64
   = note: allowed type: vec2<f32>
   = note: allowed type: vec2<f16>
   = note: allowed type: vec2<f64>


### PR DESCRIPTION
**Description**
As per https://www.w3.org/TR/WGSL/#distance-builtin the distance function should allow float scalars.

**Checklist**
- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->