### PR TITLE
[core] check that indirect buffers have not been destroyed

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -865,6 +865,7 @@ fn dispatch_indirect(
         .require_downlevel_flags(wgt::DownlevelFlags::INDIRECT_EXECUTION)?;
 
     buffer.check_usage(wgt::BufferUsages::INDIRECT)?;
+    buffer.check_destroyed(&state.snatch_guard)?;
 
     if offset % 4 != 0 {
         return Err(ComputePassErrorInner::UnalignedIndirectBufferOffset(offset));

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2523,6 +2523,7 @@ fn multi_draw_indirect(
 
     indirect_buffer.same_device_as(cmd_buf.as_ref())?;
     indirect_buffer.check_usage(BufferUsages::INDIRECT)?;
+    indirect_buffer.check_destroyed(state.snatch_guard)?;
 
     if offset % 4 != 0 {
         return Err(RenderPassErrorInner::UnalignedIndirectBufferOffset(offset));


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/7528
Fixes https://github.com/gfx-rs/wgpu/issues/7529

**Description**
 We should check that indirect buffers have not been destroyed. It's not spec compliant to emit those errors on `pass.end()` but our whole destroyed-check mechanism is not. We need to emit those errors only on submit (similarly to: https://github.com/gfx-rs/wgpu/issues/7391).

**Testing**
WebGPU CTS

