### PR TITLE
[d3d12] get `vertex_index` & `instance_index` builtins working for indirect draws

### DIFF
--- a/examples/features/src/ray_shadows/shader.wgsl
+++ b/examples/features/src/ray_shadows/shader.wgsl
@@ -33,7 +33,10 @@ var<uniform> uniforms: Uniforms;
 @group(0) @binding(1)
 var acc_struct: acceleration_structure;
 
-var<push_constant> light: vec3<f32>;
+struct PushConstants {
+    light: vec3<f32>,
+}
+var<push_constant> pc: PushConstants;
 
 const SURFACE_BRIGHTNESS = 0.5;
 
@@ -45,7 +48,7 @@ fn fs_main(vertex: VertexOutput) -> @location(0) vec4<f32> {
 	let d = vertex.tex_coords * 2.0 - 1.0;
 
 	let origin = vertex.world_position;
-	let direction = normalize(light - vertex.world_position);
+	let direction = normalize(pc.light - vertex.world_position);
 
 	var normal: vec3<f32>;
 	let dir_cam = normalize(camera - vertex.world_position);

--- a/tests/tests/wgpu-gpu/vertex_indices/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_indices/mod.rs
@@ -183,32 +183,12 @@ impl Test {
             .contains(wgpu::Features::INDIRECT_FIRST_INSTANCE)
             || !is_indirect;
 
-        // If this is false, it won't be ignored, but it won't show up in the shader
-        //
-        // If the IdSource is buffers, this doesn't apply
-        let first_vert_instance_supported = ctx.adapter_downlevel_capabilities.flags.contains(
-            wgpu::DownlevelFlags::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW,
-        ) || matches!(self.id_source, IdSource::Buffers)
-            || !is_indirect;
-
         match self.case {
-            TestCase::DrawBaseVertex => {
-                if !first_vert_instance_supported {
-                    return &[0, 1, 2, 3, 4, 5];
-                }
-
-                &[0, 0, 0, 3, 4, 5, 6, 7, 8]
-            }
+            TestCase::DrawBaseVertex => &[0, 0, 0, 3, 4, 5, 6, 7, 8],
             TestCase::Draw | TestCase::DrawInstanced => &[0, 1, 2, 3, 4, 5],
-            TestCase::DrawNonZeroFirstVertex => {
-                if !first_vert_instance_supported {
-                    return &[0, 1, 2, 0, 0, 0];
-                }
-
-                &[0, 1, 2, 3, 4, 5]
-            }
+            TestCase::DrawNonZeroFirstVertex => &[0, 1, 2, 3, 4, 5],
             TestCase::DrawNonZeroFirstInstance => {
-                if !first_vert_instance_supported || !non_zero_first_instance_supported {
+                if !non_zero_first_instance_supported {
                     return &[0, 1, 2, 0, 0, 0];
                 }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -268,6 +268,7 @@ impl Device {
                 raw_device.as_ref(),
                 &desc.required_limits,
                 &desc.required_features,
+                adapter.backend(),
             )?)
         } else {
             None

--- a/wgpu-core/src/indirect_validation/mod.rs
+++ b/wgpu-core/src/indirect_validation/mod.rs
@@ -33,6 +33,7 @@ impl IndirectValidation {
         device: &dyn hal::DynDevice,
         required_limits: &wgt::Limits,
         required_features: &wgt::Features,
+        backend: wgt::Backend,
     ) -> Result<Self, DeviceError> {
         let dispatch = match Dispatch::new(device, required_limits) {
             Ok(dispatch) => dispatch,
@@ -41,7 +42,7 @@ impl IndirectValidation {
                 return Err(DeviceError::Lost);
             }
         };
-        let draw = match Draw::new(device, required_features) {
+        let draw = match Draw::new(device, required_features, backend) {
             Ok(draw) => draw,
             Err(e) => {
                 log::error!("indirect-draw-validation error: {e:?}");

--- a/wgpu-core/src/indirect_validation/validate_draw.wgsl
+++ b/wgpu-core/src/indirect_validation/validate_draw.wgsl
@@ -1,4 +1,5 @@
 override supports_indirect_first_instance: bool;
+override write_d3d12_special_constants: bool;
 
 struct MetadataEntry {
     // bits 0..30 are an offset into `src`
@@ -66,21 +67,32 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3u) {
         failed |= first_instance != 0u;
     }
 
+    let dst_offset = select(0u, 3u, write_d3d12_special_constants);
     if failed {
-        dst[dst_base_offset + 0] = 0u;
-        dst[dst_base_offset + 1] = 0u;
-        dst[dst_base_offset + 2] = 0u;
-        dst[dst_base_offset + 3] = 0u;
+        if write_d3d12_special_constants {
+            dst[dst_base_offset + 0] = 0u;
+            dst[dst_base_offset + 1] = 0u;
+            dst[dst_base_offset + 2] = 0u;
+        }
+        dst[dst_base_offset + dst_offset + 0] = 0u;
+        dst[dst_base_offset + dst_offset + 1] = 0u;
+        dst[dst_base_offset + dst_offset + 2] = 0u;
+        dst[dst_base_offset + dst_offset + 3] = 0u;
         if (is_indexed) {
-            dst[dst_base_offset + 4] = 0u;
+            dst[dst_base_offset + dst_offset + 4] = 0u;
         }
     } else {
-        dst[dst_base_offset + 0] = src[src_base_offset + 0];
-        dst[dst_base_offset + 1] = src[src_base_offset + 1];
-        dst[dst_base_offset + 2] = src[src_base_offset + 2];
-        dst[dst_base_offset + 3] = src[src_base_offset + 3];
+        if write_d3d12_special_constants {
+            dst[dst_base_offset + 0] = src[src_base_offset + 2 + u32(is_indexed)];
+            dst[dst_base_offset + 1] = src[src_base_offset + 3 + u32(is_indexed)];
+            dst[dst_base_offset + 2] = 0u;
+        }
+        dst[dst_base_offset + dst_offset + 0] = src[src_base_offset + 0];
+        dst[dst_base_offset + dst_offset + 1] = src[src_base_offset + 1];
+        dst[dst_base_offset + dst_offset + 2] = src[src_base_offset + 2];
+        dst[dst_base_offset + dst_offset + 3] = src[src_base_offset + 3];
         if (is_indexed) {
-            dst[dst_base_offset + 4] = src[src_base_offset + 4];
+            dst[dst_base_offset + dst_offset + 4] = src[src_base_offset + 4];
         }
     }
 }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -500,10 +500,7 @@ impl super::Adapter {
 
         let base = wgt::Limits::default();
 
-        let mut downlevel = wgt::DownlevelCapabilities::default();
-        // https://github.com/gfx-rs/wgpu/issues/2471
-        downlevel.flags -=
-            wgt::DownlevelFlags::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW;
+        let downlevel = wgt::DownlevelCapabilities::default();
 
         // See https://learn.microsoft.com/en-us/windows/win32/direct3d12/hardware-feature-levels#feature-level-support
         let max_color_attachments = 8;

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -384,8 +384,7 @@ impl super::Adapter {
         let mut downlevel_flags = wgt::DownlevelFlags::empty()
             | wgt::DownlevelFlags::NON_POWER_OF_TWO_MIPMAPPED_TEXTURES
             | wgt::DownlevelFlags::CUBE_ARRAY_TEXTURES
-            | wgt::DownlevelFlags::COMPARISON_SAMPLERS
-            | wgt::DownlevelFlags::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW;
+            | wgt::DownlevelFlags::COMPARISON_SAMPLERS;
         downlevel_flags.set(wgt::DownlevelFlags::COMPUTE_SHADERS, supports_compute);
         downlevel_flags.set(
             wgt::DownlevelFlags::FRAGMENT_WRITABLE_STORAGE,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -62,8 +62,6 @@ in shaders, getting buffers and builtins to work correctly is a bit tricky.
 We never emulate `base_vertex` and gl_VertexID behaves as `@builtin(vertex_index)` does, so we
 never need to do anything about that.
 
-We always advertise support for `VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW`.
-
 ### GL 4.2+ with ARB_shader_draw_parameters
 
 - `@builtin(instance_index)` translates to `gl_InstanceID + gl_BaseInstance`

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -559,8 +559,7 @@ impl PhysicalDeviceFeatures {
             | Df::INDIRECT_EXECUTION
             | Df::VIEW_FORMATS
             | Df::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES
-            | Df::NONBLOCKING_QUERY_RESOLVE
-            | Df::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW;
+            | Df::NONBLOCKING_QUERY_RESOLVE;
 
         dl_flags.set(
             Df::SURFACE_VIEW_FORMATS,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1079,34 +1079,6 @@ bitflags::bitflags! {
         /// Not Supported by:
         /// - GL ES / WebGL
         const NONBLOCKING_QUERY_RESOLVE = 1 << 22;
-
-        /// If this is true, use of `@builtin(vertex_index)` and `@builtin(instance_index)` will properly take into consideration
-        /// the `first_vertex` and `first_instance` parameters of indirect draw calls.
-        ///
-        /// If this is false, `@builtin(vertex_index)` and `@builtin(instance_index)` will start by counting from 0, ignoring the
-        /// `first_vertex` and `first_instance` parameters.
-        ///
-        /// For example, if you had a draw call like this:
-        /// - `first_vertex: 4,`
-        /// - `vertex_count: 12,`
-        ///
-        /// When this flag is present, `@builtin(vertex_index)` will start at 4 and go up to 15 (12 invocations).
-        ///
-        /// When this flag is not present, `@builtin(vertex_index)` will start at 0 and go up to 11 (12 invocations).
-        ///
-        /// This only affects the builtins in the shaders,
-        /// vertex buffers and instance rate vertex buffers will behave like expected with this flag disabled.
-        ///
-        /// See also [`Features::`]
-        ///
-        /// Supported By:
-        /// - Vulkan
-        /// - Metal
-        /// - OpenGL
-        ///
-        /// Will be implemented in the future by:
-        /// - DX12 ([#2471](https://github.com/gfx-rs/wgpu/issues/2471))
-        const VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW = 1 << 23;
     }
 }
 

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -230,15 +230,6 @@ impl RenderPass<'_> {
     ///
     /// This is like calling [`RenderPass::draw`] but the contents of the call are specified in the `indirect_buffer`.
     /// The structure expected in `indirect_buffer` must conform to [`DrawIndirectArgs`](crate::util::DrawIndirectArgs).
-    ///
-    /// Indirect drawing has some caveats depending on the features available. We are not currently able to validate
-    /// these and issue an error.
-    /// - If [`Features::INDIRECT_FIRST_INSTANCE`] is not present on the adapter,
-    ///   [`DrawIndirectArgs::first_instance`](crate::util::DrawIndirectArgs::first_instance) will be ignored.
-    /// - If [`DownlevelFlags::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW`] is not present on the adapter,
-    ///   any use of `@builtin(vertex_index)` or `@builtin(instance_index)` in the vertex shader will have different values.
-    ///
-    /// See details on the individual flags for more information.
     pub fn draw_indirect(&mut self, indirect_buffer: &Buffer, indirect_offset: BufferAddress) {
         self.inner
             .draw_indirect(&indirect_buffer.inner, indirect_offset);
@@ -249,15 +240,6 @@ impl RenderPass<'_> {
     ///
     /// This is like calling [`RenderPass::draw_indexed`] but the contents of the call are specified in the `indirect_buffer`.
     /// The structure expected in `indirect_buffer` must conform to [`DrawIndexedIndirectArgs`](crate::util::DrawIndexedIndirectArgs).
-    ///
-    /// Indirect drawing has some caveats depending on the features available. We are not currently able to validate
-    /// these and issue an error.
-    /// - If [`Features::INDIRECT_FIRST_INSTANCE`] is not present on the adapter,
-    ///   [`DrawIndexedIndirectArgs::first_instance`](crate::util::DrawIndexedIndirectArgs::first_instance) will be ignored.
-    /// - If [`DownlevelFlags::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW`] is not present on the adapter,
-    ///   any use of `@builtin(vertex_index)` or `@builtin(instance_index)` in the vertex shader will have different values.
-    ///
-    /// See details on the individual flags for more information.
     pub fn draw_indexed_indirect(
         &mut self,
         indirect_buffer: &Buffer,


### PR DESCRIPTION
**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/2471

**Description**
Gets the `vertex_index` & `instance_index` builtins working for indirect draws by updating the existing root constants (using the validation shader; same strategy as in https://github.com/gfx-rs/wgpu/pull/5730).

**Testing**
Existing `wgpu_gpu::vertex_indices` test.

**Squash or Rebase?**
Rebase