### PR TITLE
[naga] Track globals used directly by a named expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ Bottom level categories:
 
 #### Naga
 
+### Bux Fixes
+
+#### Naga
+
+Naga now infers the correct binding layout when a resource appears only in an assignment to `_`. By @andyleiserson in [#7540](https://github.com/gfx-rs/wgpu/pull/7540).
+
 - Add polyfills for `dot4U8Packed` and `dot4I8Packed` for all backends. By @robamler in [#7494](https://github.com/gfx-rs/wgpu/pull/7494).
 
 ### Changes

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1988,6 +1988,9 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 return Ok(());
             }
             ast::StatementKind::Phony(expr) => {
+                // Remembered the RHS of the phony assignment as a named expression. This
+                // is important (1) to preserve the RHS for validation, (2) to track any
+                // referenced globals.
                 let mut emitter = Emitter::default();
                 emitter.start(&ctx.function.expressions);
 


### PR DESCRIPTION
Modify naga validation to consider any global used directly by a named expression as used. The case where this was found to matter is phony expressions -- the spec explicitly suggests using a statement like `_ = &bound_global` to place  `bound_global` in the shader's resource interface even if it is otherwise unused. Omitting it from the resource interface can cause applications to fail with bind group layout mismatches.

Fixes #7524

**Testing**
Adds tests in `naga::validation` that check the module info produced by validation has the expected `GlobalUse` in this scenario.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] Added a `CHANGELOG.md` entry.
