### PR TITLE
Allow obtaining custom implementation from wgpu api types

### DIFF
--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -3,9 +3,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use wgpu::custom::{
-    AdapterInterface, DeviceInterface, DispatchAdapter, DispatchDevice, DispatchQueue,
-    DispatchShaderModule, DispatchSurface, InstanceInterface, QueueInterface, RequestAdapterFuture,
-    ShaderModuleInterface,
+    AdapterInterface, ComputePipelineInterface, DeviceInterface, DispatchAdapter, DispatchDevice,
+    DispatchQueue, DispatchShaderModule, DispatchSurface, InstanceInterface, QueueInterface,
+    RequestAdapterFuture, ShaderModuleInterface,
 };
 
 #[derive(Debug, Clone)]
@@ -163,9 +163,10 @@ impl DeviceInterface for CustomDevice {
 
     fn create_compute_pipeline(
         &self,
-        _desc: &wgpu::ComputePipelineDescriptor<'_>,
+        desc: &wgpu::ComputePipelineDescriptor<'_>,
     ) -> wgpu::custom::DispatchComputePipeline {
-        unimplemented!()
+        let module = desc.module.as_custom::<CustomShaderModule>().unwrap();
+        wgpu::custom::DispatchComputePipeline::custom(CustomComputePipeline(module.0.clone()))
     }
 
     unsafe fn create_pipeline_cache(
@@ -262,7 +263,7 @@ impl DeviceInterface for CustomDevice {
 }
 
 #[derive(Debug)]
-struct CustomShaderModule(Counter);
+pub struct CustomShaderModule(pub Counter);
 
 impl ShaderModuleInterface for CustomShaderModule {
     fn get_compilation_info(&self) -> Pin<Box<dyn wgpu::custom::ShaderCompilationInfoFuture>> {
@@ -340,6 +341,15 @@ impl QueueInterface for CustomQueue {
         _dest: wgpu::CopyExternalImageDestInfo<&wgpu::Texture>,
         _size: wgpu::Extent3d,
     ) {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug)]
+pub struct CustomComputePipeline(pub Counter);
+
+impl ComputePipelineInterface for CustomComputePipeline {
+    fn get_bind_group_layout(&self, _index: u32) -> wgpu::custom::DispatchBindGroupLayout {
         unimplemented!()
     }
 }

--- a/examples/standalone/custom_backend/src/main.rs
+++ b/examples/standalone/custom_backend/src/main.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use custom::Counter;
+use custom::{Counter, CustomShaderModule};
 use wgpu::{DeviceDescriptor, RequestAdapterOptions};
 
 mod custom;
@@ -31,12 +31,26 @@ async fn main() {
             .unwrap();
         assert_eq!(counter.count(), 5);
 
-        let _module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("shader"),
             source: wgpu::ShaderSource::Dummy(PhantomData),
         });
 
+        let custom_module = module.as_custom::<CustomShaderModule>().unwrap();
+        assert_eq!(custom_module.0.count(), 6);
+        let _module_clone = module.clone();
         assert_eq!(counter.count(), 6);
+
+        let _pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: None,
+            module: &module,
+            entry_point: None,
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        assert_eq!(counter.count(), 7);
     }
     assert_eq!(counter.count(), 1);
 }

--- a/wgpu/src/api/adapter.rs
+++ b/wgpu/src/api/adapter.rs
@@ -136,7 +136,7 @@ impl Adapter {
     #[cfg(custom)]
     /// Returns custom implementation of adapter (if custom backend and is internally T)
     pub fn as_custom<T: custom::AdapterInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 
     #[cfg(custom)]

--- a/wgpu/src/api/adapter.rs
+++ b/wgpu/src/api/adapter.rs
@@ -134,6 +134,12 @@ impl Adapter {
     }
 
     #[cfg(custom)]
+    /// Returns custom implementation of adapter (if custom backend and is internally T)
+    pub fn as_custom<T: custom::AdapterInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+
+    #[cfg(custom)]
     /// Creates Adapter from custom implementation
     pub fn from_custom<T: custom::AdapterInterface>(adapter: T) -> Self {
         Self {

--- a/wgpu/src/api/bind_group.rs
+++ b/wgpu/src/api/bind_group.rs
@@ -21,7 +21,7 @@ impl BindGroup {
     #[cfg(custom)]
     /// Returns custom implementation of BindGroup (if custom backend and is internally T)
     pub fn as_custom<T: custom::BindGroupInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/bind_group.rs
+++ b/wgpu/src/api/bind_group.rs
@@ -17,6 +17,14 @@ static_assertions::assert_impl_all!(BindGroup: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(BindGroup => .inner);
 
+impl BindGroup {
+    #[cfg(custom)]
+    /// Returns custom implementation of BindGroup (if custom backend and is internally T)
+    pub fn as_custom<T: custom::BindGroupInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
 /// Resource to be bound by a [`BindGroup`] for use with a pipeline.
 ///
 /// The pipeline’s [`BindGroupLayout`] must contain a matching [`BindingType`].

--- a/wgpu/src/api/bind_group_layout.rs
+++ b/wgpu/src/api/bind_group_layout.rs
@@ -18,6 +18,8 @@ pub struct BindGroupLayout {
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(BindGroupLayout: Send, Sync);
 
+crate::cmp::impl_eq_ord_hash_proxy!(BindGroupLayout => .inner);
+
 impl BindGroupLayout {
     #[cfg(custom)]
     /// Returns custom implementation of BindGroupLayout (if custom backend and is internally T)
@@ -25,8 +27,6 @@ impl BindGroupLayout {
         self.inner.as_custom()
     }
 }
-
-crate::cmp::impl_eq_ord_hash_proxy!(BindGroupLayout => .inner);
 
 /// Describes a [`BindGroupLayout`].
 ///

--- a/wgpu/src/api/bind_group_layout.rs
+++ b/wgpu/src/api/bind_group_layout.rs
@@ -18,6 +18,14 @@ pub struct BindGroupLayout {
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(BindGroupLayout: Send, Sync);
 
+impl BindGroupLayout {
+    #[cfg(custom)]
+    /// Returns custom implementation of BindGroupLayout (if custom backend and is internally T)
+    pub fn as_custom<T: custom::BindGroupLayoutInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
 crate::cmp::impl_eq_ord_hash_proxy!(BindGroupLayout => .inner);
 
 /// Describes a [`BindGroupLayout`].

--- a/wgpu/src/api/bind_group_layout.rs
+++ b/wgpu/src/api/bind_group_layout.rs
@@ -22,7 +22,7 @@ impl BindGroupLayout {
     #[cfg(custom)]
     /// Returns custom implementation of BindGroupLayout (if custom backend and is internally T)
     pub fn as_custom<T: custom::BindGroupLayoutInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -174,6 +174,12 @@ impl Blas {
             hal_blas_callback(None)
         }
     }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of Blas (if custom backend and is internally T)
+    pub fn as_custom<T: crate::custom::BlasInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
 }
 
 /// Context version of [BlasTriangleGeometry].

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -178,7 +178,7 @@ impl Blas {
     #[cfg(custom)]
     /// Returns custom implementation of Blas (if custom backend and is internally T)
     pub fn as_custom<T: crate::custom::BlasInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -390,7 +390,7 @@ impl Buffer {
     #[cfg(custom)]
     /// Returns custom implementation of Buffer (if custom backend and is internally T)
     pub fn as_custom<T: custom::BufferInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -386,6 +386,12 @@ impl Buffer {
     ) -> BufferViewMut<'_> {
         self.slice(bounds).get_mapped_range_mut()
     }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of Buffer (if custom backend and is internally T)
+    pub fn as_custom<T: custom::BufferInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
 }
 
 /// A slice of a [`Buffer`], to be mapped, used for vertex or index data, or the like.

--- a/wgpu/src/api/command_buffer.rs
+++ b/wgpu/src/api/command_buffer.rs
@@ -18,6 +18,6 @@ impl CommandBuffer {
     #[cfg(custom)]
     /// Returns custom implementation of CommandBuffer (if custom backend and is internally T)
     pub fn as_custom<T: custom::CommandBufferInterface>(&self) -> Option<&T> {
-        self.buffer.as_custom_opt().and_then(|c| c.downcast())
+        self.buffer.as_custom()
     }
 }

--- a/wgpu/src/api/command_buffer.rs
+++ b/wgpu/src/api/command_buffer.rs
@@ -13,3 +13,11 @@ pub struct CommandBuffer {
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(CommandBuffer: Send, Sync);
+
+impl CommandBuffer {
+    #[cfg(custom)]
+    /// Returns custom implementation of CommandBuffer (if custom backend and is internally T)
+    pub fn as_custom<T: custom::CommandBufferInterface>(&self) -> Option<&T> {
+        self.buffer.as_custom_opt().and_then(|c| c.downcast())
+    }
+}

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -26,6 +26,14 @@ static_assertions::assert_impl_all!(CommandEncoder: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(CommandEncoder => .inner);
 
+impl CommandEncoder {
+    #[cfg(custom)]
+    /// Returns custom implementation of CommandEncoder (if custom backend and is internally T)
+    pub fn as_custom<T: custom::CommandEncoderInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
 /// Describes a [`CommandEncoder`].
 ///
 /// For use with [`Device::create_command_encoder`].

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -26,14 +26,6 @@ static_assertions::assert_impl_all!(CommandEncoder: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(CommandEncoder => .inner);
 
-impl CommandEncoder {
-    #[cfg(custom)]
-    /// Returns custom implementation of CommandEncoder (if custom backend and is internally T)
-    pub fn as_custom<T: custom::CommandEncoderInterface>(&self) -> Option<&T> {
-        self.inner.as_custom()
-    }
-}
-
 /// Describes a [`CommandEncoder`].
 ///
 /// For use with [`Device::create_command_encoder`].
@@ -269,6 +261,12 @@ impl CommandEncoder {
         } else {
             hal_command_encoder_callback(None)
         }
+    }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of CommandEncoder (if custom backend and is internally T)
+    pub fn as_custom<T: custom::CommandEncoderInterface>(&self) -> Option<&T> {
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -30,7 +30,7 @@ impl CommandEncoder {
     #[cfg(custom)]
     /// Returns custom implementation of CommandEncoder (if custom backend and is internally T)
     pub fn as_custom<T: custom::CommandEncoderInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/compute_pass.rs
+++ b/wgpu/src/api/compute_pass.rs
@@ -98,7 +98,7 @@ impl ComputePass<'_> {
     #[cfg(custom)]
     /// Returns custom implementation of ComputePass (if custom backend and is internally T)
     pub fn as_custom<T: custom::ComputePassInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/compute_pass.rs
+++ b/wgpu/src/api/compute_pass.rs
@@ -94,6 +94,12 @@ impl ComputePass<'_> {
         self.inner
             .dispatch_workgroups_indirect(&indirect_buffer.inner, indirect_offset);
     }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of ComputePass (if custom backend and is internally T)
+    pub fn as_custom<T: custom::ComputePassInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
 }
 
 /// [`Features::PUSH_CONSTANTS`] must be enabled on the device in order to call these functions.

--- a/wgpu/src/api/compute_pipeline.rs
+++ b/wgpu/src/api/compute_pipeline.rs
@@ -16,6 +16,14 @@ static_assertions::assert_impl_all!(ComputePipeline: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(ComputePipeline => .inner);
 
 impl ComputePipeline {
+    #[cfg(custom)]
+    /// Returns custom implementation of ComputePipeline (if custom backend and is internally T)
+    pub fn as_custom<T: custom::ComputePipelineInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
+impl ComputePipeline {
     /// Get an object representing the bind group layout at a given index.
     ///
     /// If this pipeline was created with a [default layout][ComputePipelineDescriptor::layout],

--- a/wgpu/src/api/compute_pipeline.rs
+++ b/wgpu/src/api/compute_pipeline.rs
@@ -16,14 +16,6 @@ static_assertions::assert_impl_all!(ComputePipeline: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(ComputePipeline => .inner);
 
 impl ComputePipeline {
-    #[cfg(custom)]
-    /// Returns custom implementation of ComputePipeline (if custom backend and is internally T)
-    pub fn as_custom<T: custom::ComputePipelineInterface>(&self) -> Option<&T> {
-        self.inner.as_custom()
-    }
-}
-
-impl ComputePipeline {
     /// Get an object representing the bind group layout at a given index.
     ///
     /// If this pipeline was created with a [default layout][ComputePipelineDescriptor::layout],
@@ -34,6 +26,12 @@ impl ComputePipeline {
     pub fn get_bind_group_layout(&self, index: u32) -> BindGroupLayout {
         let bind_group = self.inner.get_bind_group_layout(index);
         BindGroupLayout { inner: bind_group }
+    }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of ComputePipeline (if custom backend and is internally T)
+    pub fn as_custom<T: custom::ComputePipelineInterface>(&self) -> Option<&T> {
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/compute_pipeline.rs
+++ b/wgpu/src/api/compute_pipeline.rs
@@ -19,7 +19,7 @@ impl ComputePipeline {
     #[cfg(custom)]
     /// Returns custom implementation of ComputePipeline (if custom backend and is internally T)
     pub fn as_custom<T: custom::ComputePipelineInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -35,6 +35,12 @@ static_assertions::assert_impl_all!(DeviceDescriptor<'_>: Send, Sync);
 
 impl Device {
     #[cfg(custom)]
+    /// Returns custom implementation of Device (if custom backend and is internally T)
+    pub fn as_custom<T: custom::DeviceInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+
+    #[cfg(custom)]
     /// Creates Device from custom implementation
     pub fn from_custom<T: custom::DeviceInterface>(device: T) -> Self {
         Self {

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -37,7 +37,7 @@ impl Device {
     #[cfg(custom)]
     /// Returns custom implementation of Device (if custom backend and is internally T)
     pub fn as_custom<T: custom::DeviceInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 
     #[cfg(custom)]

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -208,6 +208,12 @@ impl Instance {
         }
     }
 
+    #[cfg(custom)]
+    /// Returns custom implementation of Instance (if custom backend and is internally T)
+    pub fn as_custom<T: custom::InstanceInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+
     /// Retrieves all available [`Adapter`]s that match the given [`Backends`].
     ///
     /// # Arguments

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -211,7 +211,7 @@ impl Instance {
     #[cfg(custom)]
     /// Returns custom implementation of Instance (if custom backend and is internally T)
     pub fn as_custom<T: custom::InstanceInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 
     /// Retrieves all available [`Adapter`]s that match the given [`Backends`].

--- a/wgpu/src/api/pipeline_cache.rs
+++ b/wgpu/src/api/pipeline_cache.rs
@@ -91,6 +91,6 @@ impl PipelineCache {
     #[cfg(custom)]
     /// Returns custom implementation of PipelineCache (if custom backend and is internally T)
     pub fn as_custom<T: custom::PipelineCacheInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }

--- a/wgpu/src/api/pipeline_cache.rs
+++ b/wgpu/src/api/pipeline_cache.rs
@@ -87,4 +87,10 @@ impl PipelineCache {
     pub fn get_data(&self) -> Option<Vec<u8>> {
         self.inner.get_data()
     }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of PipelineCache (if custom backend and is internally T)
+    pub fn as_custom<T: custom::PipelineCacheInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
 }

--- a/wgpu/src/api/pipeline_layout.rs
+++ b/wgpu/src/api/pipeline_layout.rs
@@ -19,7 +19,7 @@ impl PipelineLayout {
     #[cfg(custom)]
     /// Returns custom implementation of PipelineLayout (if custom backend and is internally T)
     pub fn as_custom<T: custom::PipelineLayoutInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/pipeline_layout.rs
+++ b/wgpu/src/api/pipeline_layout.rs
@@ -15,6 +15,14 @@ static_assertions::assert_impl_all!(PipelineLayout: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(PipelineLayout => .inner);
 
+impl PipelineLayout {
+    #[cfg(custom)]
+    /// Returns custom implementation of PipelineLayout (if custom backend and is internally T)
+    pub fn as_custom<T: custom::PipelineLayoutInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
 /// Describes a [`PipelineLayout`].
 ///
 /// For use with [`Device::create_pipeline_layout`].

--- a/wgpu/src/api/query_set.rs
+++ b/wgpu/src/api/query_set.rs
@@ -15,6 +15,14 @@ static_assertions::assert_impl_all!(QuerySet: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(QuerySet => .inner);
 
+impl QuerySet {
+    #[cfg(custom)]
+    /// Returns custom implementation of QuerySet (if custom backend and is internally T)
+    pub fn as_custom<T: custom::QuerySetInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
 /// Describes a [`QuerySet`].
 ///
 /// For use with [`Device::create_query_set`].

--- a/wgpu/src/api/query_set.rs
+++ b/wgpu/src/api/query_set.rs
@@ -19,7 +19,7 @@ impl QuerySet {
     #[cfg(custom)]
     /// Returns custom implementation of QuerySet (if custom backend and is internally T)
     pub fn as_custom<T: custom::QuerySetInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -23,7 +23,7 @@ impl Queue {
     #[cfg(custom)]
     /// Returns custom implementation of Queue (if custom backend and is internally T)
     pub fn as_custom<T: custom::QueueInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 
     #[cfg(custom)]
@@ -72,7 +72,7 @@ impl QueueWriteBufferView<'_> {
     #[cfg(custom)]
     /// Returns custom implementation of QueueWriteBufferView (if custom backend and is internally T)
     pub fn as_custom<T: custom::QueueWriteBufferInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -19,6 +19,22 @@ static_assertions::assert_impl_all!(Queue: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(Queue => .inner);
 
+impl Queue {
+    #[cfg(custom)]
+    /// Returns custom implementation of Queue (if custom backend and is internally T)
+    pub fn as_custom<T: custom::QueueInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+
+    #[cfg(custom)]
+    /// Creates Queue from custom implementation
+    pub fn from_custom<T: custom::QueueInterface>(queue: T) -> Self {
+        Self {
+            inner: dispatch::DispatchQueue::custom(queue),
+        }
+    }
+}
+
 /// Identifier for a particular call to [`Queue::submit`]. Can be used
 /// as part of an argument to [`Device::poll`] to block for a particular
 /// submission to finish.
@@ -52,6 +68,14 @@ pub struct QueueWriteBufferView<'a> {
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(QueueWriteBufferView<'_>: Send, Sync);
 
+impl QueueWriteBufferView<'_> {
+    #[cfg(custom)]
+    /// Returns custom implementation of QueueWriteBufferView (if custom backend and is internally T)
+    pub fn as_custom<T: custom::QueueWriteBufferInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
 impl Deref for QueueWriteBufferView<'_> {
     type Target = [u8];
 
@@ -82,14 +106,6 @@ impl Drop for QueueWriteBufferView<'_> {
 }
 
 impl Queue {
-    #[cfg(custom)]
-    /// Creates Queue from custom implementation
-    pub fn from_custom<T: custom::QueueInterface>(queue: T) -> Self {
-        Self {
-            inner: dispatch::DispatchQueue::custom(queue),
-        }
-    }
-
     /// Copies the bytes of `data` into `buffer` starting at `offset`.
     ///
     /// The data must be written fully in-bounds, that is, `offset + data.len() <= buffer.len()`.

--- a/wgpu/src/api/render_bundle.rs
+++ b/wgpu/src/api/render_bundle.rs
@@ -22,7 +22,7 @@ impl RenderBundle {
     #[cfg(custom)]
     /// Returns custom implementation of RenderBundle (if custom backend and is internally T)
     pub fn as_custom<T: custom::RenderBundleInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/render_bundle.rs
+++ b/wgpu/src/api/render_bundle.rs
@@ -18,6 +18,14 @@ static_assertions::assert_impl_all!(RenderBundle: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(RenderBundle => .inner);
 
+impl RenderBundle {
+    #[cfg(custom)]
+    /// Returns custom implementation of RenderBundle (if custom backend and is internally T)
+    pub fn as_custom<T: custom::RenderBundleInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
 /// Describes a [`RenderBundle`].
 ///
 /// For use with [`RenderBundleEncoder::finish`].

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -25,14 +25,6 @@ static_assertions::assert_not_impl_any!(RenderBundleEncoder<'_>: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(RenderBundleEncoder<'_> => .inner);
 
-impl RenderBundleEncoder<'_> {
-    #[cfg(custom)]
-    /// Returns custom implementation of RenderBundleEncoder (if custom backend and is internally T)
-    pub fn as_custom<T: custom::RenderBundleEncoderInterface>(&self) -> Option<&T> {
-        self.inner.as_custom()
-    }
-}
-
 /// Describes a [`RenderBundleEncoder`].
 ///
 /// For use with [`Device::create_render_bundle_encoder`].
@@ -195,6 +187,12 @@ impl<'a> RenderBundleEncoder<'a> {
     ) {
         self.inner
             .draw_indexed_indirect(&indirect_buffer.inner, indirect_offset);
+    }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of RenderBundleEncoder (if custom backend and is internally T)
+    pub fn as_custom<T: custom::RenderBundleEncoderInterface>(&self) -> Option<&T> {
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -29,7 +29,7 @@ impl RenderBundleEncoder<'_> {
     #[cfg(custom)]
     /// Returns custom implementation of RenderBundleEncoder (if custom backend and is internally T)
     pub fn as_custom<T: custom::RenderBundleEncoderInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -25,6 +25,14 @@ static_assertions::assert_not_impl_any!(RenderBundleEncoder<'_>: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(RenderBundleEncoder<'_> => .inner);
 
+impl RenderBundleEncoder<'_> {
+    #[cfg(custom)]
+    /// Returns custom implementation of RenderBundleEncoder (if custom backend and is internally T)
+    pub fn as_custom<T: custom::RenderBundleEncoderInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
 /// Describes a [`RenderBundleEncoder`].
 ///
 /// For use with [`Device::create_render_bundle_encoder`].

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -40,7 +40,7 @@ impl RenderPass<'_> {
     #[cfg(custom)]
     /// Returns custom implementation of RenderPass (if custom backend and is internally T)
     pub fn as_custom<T: custom::RenderPassInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -37,6 +37,14 @@ static_assertions::assert_impl_all!(RenderPass<'_>: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(RenderPass<'_> => .inner);
 
 impl RenderPass<'_> {
+    #[cfg(custom)]
+    /// Returns custom implementation of RenderPass (if custom backend and is internally T)
+    pub fn as_custom<T: custom::RenderPassInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
+impl RenderPass<'_> {
     /// Drops the lifetime relationship to the parent command encoder, making usage of
     /// the encoder while this pass is recorded a run-time error instead.
     ///

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -37,14 +37,6 @@ static_assertions::assert_impl_all!(RenderPass<'_>: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(RenderPass<'_> => .inner);
 
 impl RenderPass<'_> {
-    #[cfg(custom)]
-    /// Returns custom implementation of RenderPass (if custom backend and is internally T)
-    pub fn as_custom<T: custom::RenderPassInterface>(&self) -> Option<&T> {
-        self.inner.as_custom()
-    }
-}
-
-impl RenderPass<'_> {
     /// Drops the lifetime relationship to the parent command encoder, making usage of
     /// the encoder while this pass is recorded a run-time error instead.
     ///
@@ -331,6 +323,12 @@ impl RenderPass<'_> {
     ) {
         self.inner
             .multi_draw_indexed_indirect(&indirect_buffer.inner, indirect_offset, count);
+    }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of RenderPass (if custom backend and is internally T)
+    pub fn as_custom<T: custom::RenderPassInterface>(&self) -> Option<&T> {
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/render_pipeline.rs
+++ b/wgpu/src/api/render_pipeline.rs
@@ -21,7 +21,7 @@ impl RenderPipeline {
     #[cfg(custom)]
     /// Returns custom implementation of RenderPipeline (if custom backend and is internally T)
     pub fn as_custom<T: custom::RenderPipelineInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/render_pipeline.rs
+++ b/wgpu/src/api/render_pipeline.rs
@@ -18,14 +18,6 @@ static_assertions::assert_impl_all!(RenderPipeline: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(RenderPipeline => .inner);
 
 impl RenderPipeline {
-    #[cfg(custom)]
-    /// Returns custom implementation of RenderPipeline (if custom backend and is internally T)
-    pub fn as_custom<T: custom::RenderPipelineInterface>(&self) -> Option<&T> {
-        self.inner.as_custom()
-    }
-}
-
-impl RenderPipeline {
     /// Get an object representing the bind group layout at a given index.
     ///
     /// If this pipeline was created with a [default layout][RenderPipelineDescriptor::layout], then
@@ -35,6 +27,12 @@ impl RenderPipeline {
     pub fn get_bind_group_layout(&self, index: u32) -> BindGroupLayout {
         let layout = self.inner.get_bind_group_layout(index);
         BindGroupLayout { inner: layout }
+    }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of RenderPipeline (if custom backend and is internally T)
+    pub fn as_custom<T: custom::RenderPipelineInterface>(&self) -> Option<&T> {
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/render_pipeline.rs
+++ b/wgpu/src/api/render_pipeline.rs
@@ -18,6 +18,14 @@ static_assertions::assert_impl_all!(RenderPipeline: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(RenderPipeline => .inner);
 
 impl RenderPipeline {
+    #[cfg(custom)]
+    /// Returns custom implementation of RenderPipeline (if custom backend and is internally T)
+    pub fn as_custom<T: custom::RenderPipelineInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
+impl RenderPipeline {
     /// Get an object representing the bind group layout at a given index.
     ///
     /// If this pipeline was created with a [default layout][RenderPipelineDescriptor::layout], then

--- a/wgpu/src/api/sampler.rs
+++ b/wgpu/src/api/sampler.rs
@@ -18,6 +18,14 @@ static_assertions::assert_impl_all!(Sampler: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(Sampler => .inner);
 
+impl Sampler {
+    #[cfg(custom)]
+    /// Returns custom implementation of Sampler (if custom backend and is internally T)
+    pub fn as_custom<T: custom::SamplerInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
 /// Describes a [`Sampler`].
 ///
 /// For use with [`Device::create_sampler`].

--- a/wgpu/src/api/sampler.rs
+++ b/wgpu/src/api/sampler.rs
@@ -22,7 +22,7 @@ impl Sampler {
     #[cfg(custom)]
     /// Returns custom implementation of Sampler (if custom backend and is internally T)
     pub fn as_custom<T: custom::SamplerInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -25,17 +25,15 @@ static_assertions::assert_impl_all!(ShaderModule: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(ShaderModule => .inner);
 
 impl ShaderModule {
+    /// Get the compilation info for the shader module.
+    pub fn get_compilation_info(&self) -> impl Future<Output = CompilationInfo> + WasmNotSend {
+        self.inner.get_compilation_info()
+    }
+
     #[cfg(custom)]
     /// Returns custom implementation of ShaderModule (if custom backend and is internally T)
     pub fn as_custom<T: custom::ShaderModuleInterface>(&self) -> Option<&T> {
         self.inner.as_custom()
-    }
-}
-
-impl ShaderModule {
-    /// Get the compilation info for the shader module.
-    pub fn get_compilation_info(&self) -> impl Future<Output = CompilationInfo> + WasmNotSend {
-        self.inner.get_compilation_info()
     }
 }
 

--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -25,6 +25,14 @@ static_assertions::assert_impl_all!(ShaderModule: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(ShaderModule => .inner);
 
 impl ShaderModule {
+    #[cfg(custom)]
+    /// Returns custom implementation of ShaderModule (if custom backend and is internally T)
+    pub fn as_custom<T: custom::ShaderModuleInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
+impl ShaderModule {
     /// Get the compilation info for the shader module.
     pub fn get_compilation_info(&self) -> impl Future<Output = CompilationInfo> + WasmNotSend {
         self.inner.get_compilation_info()

--- a/wgpu/src/api/shader_module.rs
+++ b/wgpu/src/api/shader_module.rs
@@ -28,7 +28,7 @@ impl ShaderModule {
     #[cfg(custom)]
     /// Returns custom implementation of ShaderModule (if custom backend and is internally T)
     pub fn as_custom<T: custom::ShaderModuleInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -171,6 +171,12 @@ impl Surface<'_> {
             hal_surface_callback(None)
         }
     }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of Surface (if custom backend and is internally T)
+    pub fn as_custom<T: custom::SurfaceInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
 }
 
 // This custom implementation is required because [`Surface::_surface`] doesn't

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -175,7 +175,7 @@ impl Surface<'_> {
     #[cfg(custom)]
     /// Returns custom implementation of Surface (if custom backend and is internally T)
     pub fn as_custom<T: custom::SurfaceInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -42,7 +42,7 @@ impl SurfaceTexture {
     #[cfg(custom)]
     /// Returns custom implementation of SurfaceTexture (if custom backend and is internally T)
     pub fn as_custom<T: crate::custom::SurfaceOutputDetailInterface>(&self) -> Option<&T> {
-        self.detail.as_custom_opt().and_then(|c| c.downcast())
+        self.detail.as_custom()
     }
 }
 

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -38,6 +38,12 @@ impl SurfaceTexture {
         self.presented = true;
         self.detail.present();
     }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of SurfaceTexture (if custom backend and is internally T)
+    pub fn as_custom<T: crate::custom::SurfaceOutputDetailInterface>(&self) -> Option<&T> {
+        self.detail.as_custom_opt().and_then(|c| c.downcast())
+    }
 }
 
 impl Drop for SurfaceTexture {

--- a/wgpu/src/api/texture.rs
+++ b/wgpu/src/api/texture.rs
@@ -19,7 +19,7 @@ impl Texture {
     #[cfg(custom)]
     /// Returns custom implementation of Texture (if custom backend and is internally T)
     pub fn as_custom<T: custom::TextureInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/texture.rs
+++ b/wgpu/src/api/texture.rs
@@ -16,6 +16,14 @@ static_assertions::assert_impl_all!(Texture: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(Texture => .inner);
 
 impl Texture {
+    #[cfg(custom)]
+    /// Returns custom implementation of Texture (if custom backend and is internally T)
+    pub fn as_custom<T: custom::TextureInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
+impl Texture {
     /// Returns the inner hal Texture using a callback. The hal texture will be `None` if the
     /// backend type argument does not match with this wgpu Texture
     ///

--- a/wgpu/src/api/texture.rs
+++ b/wgpu/src/api/texture.rs
@@ -16,14 +16,6 @@ static_assertions::assert_impl_all!(Texture: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(Texture => .inner);
 
 impl Texture {
-    #[cfg(custom)]
-    /// Returns custom implementation of Texture (if custom backend and is internally T)
-    pub fn as_custom<T: custom::TextureInterface>(&self) -> Option<&T> {
-        self.inner.as_custom()
-    }
-}
-
-impl Texture {
     /// Returns the inner hal Texture using a callback. The hal texture will be `None` if the
     /// backend type argument does not match with this wgpu Texture
     ///
@@ -43,6 +35,12 @@ impl Texture {
         } else {
             hal_texture_callback(None)
         }
+    }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of Texture (if custom backend and is internally T)
+    pub fn as_custom<T: custom::TextureInterface>(&self) -> Option<&T> {
+        self.inner.as_custom()
     }
 
     /// Creates a view of this texture, specifying an interpretation of its texels and

--- a/wgpu/src/api/texture_view.rs
+++ b/wgpu/src/api/texture_view.rs
@@ -19,14 +19,6 @@ static_assertions::assert_impl_all!(TextureView: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(TextureView => .inner);
 
 impl TextureView {
-    #[cfg(custom)]
-    /// Returns custom implementation of TextureView (if custom backend and is internally T)
-    pub fn as_custom<T: custom::TextureViewInterface>(&self) -> Option<&T> {
-        self.inner.as_custom()
-    }
-}
-
-impl TextureView {
     /// Returns the inner hal `TextureView` using a callback. The hal texture will be `None` if the
     /// backend type argument does not match with this wgpu Texture
     ///
@@ -47,6 +39,12 @@ impl TextureView {
         } else {
             hal_texture_view_callback(None)
         }
+    }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of TextureView (if custom backend and is internally T)
+    pub fn as_custom<T: custom::TextureViewInterface>(&self) -> Option<&T> {
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/texture_view.rs
+++ b/wgpu/src/api/texture_view.rs
@@ -19,6 +19,14 @@ static_assertions::assert_impl_all!(TextureView: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(TextureView => .inner);
 
 impl TextureView {
+    #[cfg(custom)]
+    /// Returns custom implementation of TextureView (if custom backend and is internally T)
+    pub fn as_custom<T: custom::TextureViewInterface>(&self) -> Option<&T> {
+        self.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
+}
+
+impl TextureView {
     /// Returns the inner hal `TextureView` using a callback. The hal texture will be `None` if the
     /// backend type argument does not match with this wgpu Texture
     ///

--- a/wgpu/src/api/texture_view.rs
+++ b/wgpu/src/api/texture_view.rs
@@ -22,7 +22,7 @@ impl TextureView {
     #[cfg(custom)]
     /// Returns custom implementation of TextureView (if custom backend and is internally T)
     pub fn as_custom<T: custom::TextureViewInterface>(&self) -> Option<&T> {
-        self.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/tlas.rs
+++ b/wgpu/src/api/tlas.rs
@@ -61,7 +61,7 @@ impl Tlas {
     #[cfg(custom)]
     /// Returns custom implementation of Tlas (if custom backend and is internally T)
     pub fn as_custom<T: crate::custom::TlasInterface>(&self) -> Option<&T> {
-        self.shared.inner.as_custom_opt().and_then(|c| c.downcast())
+        self.shared.inner.as_custom()
     }
 }
 

--- a/wgpu/src/api/tlas.rs
+++ b/wgpu/src/api/tlas.rs
@@ -57,6 +57,12 @@ impl Tlas {
             hal_tlas_callback(None)
         }
     }
+
+    #[cfg(custom)]
+    /// Returns custom implementation of Tlas (if custom backend and is internally T)
+    pub fn as_custom<T: crate::custom::TlasInterface>(&self) -> Option<&T> {
+        self.shared.inner.as_custom_opt().and_then(|c| c.downcast())
+    }
 }
 
 /// Entry for a top level acceleration structure build.

--- a/wgpu/src/backend/custom.rs
+++ b/wgpu/src/backend/custom.rs
@@ -18,6 +18,11 @@ macro_rules! dyn_type {
             pub(crate) fn new<T: $interface>(t: T) -> Self {
                 Self(Arc::new(t))
             }
+
+            #[allow(clippy::allow_attributes, dead_code)]
+            pub(crate) fn downcast<T: $interface>(&self) -> Option<&T> {
+                self.0.as_ref().as_any().downcast_ref()
+            }
         }
 
         impl core::ops::Deref for $name {
@@ -45,6 +50,10 @@ macro_rules! dyn_type {
         impl $name {
             pub(crate) fn new<T: $interface>(t: T) -> Self {
                 Self(Arc::new(t))
+            }
+
+            pub(crate) fn downcast<T: $interface>(&self) -> Option<&T> {
+                self.0.as_ref().as_any().downcast_ref()
             }
         }
 

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -590,9 +590,9 @@ macro_rules! dispatch_types {
             #[cfg(custom)]
             #[inline]
             #[allow(clippy::allow_attributes, unused)]
-            pub(crate) fn as_custom_opt(&self) -> Option<&$custom_type> {
+            pub fn as_custom<T: $interface>(&self) -> Option<&T> {
                 match self {
-                    Self::Custom(value) => Some(value),
+                    Self::Custom(value) => value.downcast(),
                     _ => None,
                 }
             }
@@ -718,9 +718,9 @@ macro_rules! dispatch_types {
             #[cfg(custom)]
             #[inline]
             #[allow(clippy::allow_attributes, unused)]
-            pub(crate) fn as_custom_opt(&self) -> Option<&$custom_type> {
+            pub fn as_custom<T: $interface>(&self) -> Option<&T> {
                 match self {
-                    Self::Custom(value) => Some(value),
+                    Self::Custom(value) => value.downcast(),
                     _ => None,
                 }
             }

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -54,8 +54,20 @@ pub type BufferMapCallback = Box<dyn FnOnce(Result<(), crate::BufferAsyncError>)
 #[cfg(not(send_sync))]
 pub type BufferMapCallback = Box<dyn FnOnce(Result<(), crate::BufferAsyncError>) + 'static>;
 
+// remove when rust 1.86
+#[cfg_attr(not(custom), expect(dead_code))]
+pub trait AsAny {
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: 'static> AsAny for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
 // Common traits on all the interface traits
-trait_alias!(CommonTraits: Any + Debug + WasmNotSendSync);
+trait_alias!(CommonTraits: AsAny + Any + Debug + WasmNotSendSync);
 
 pub trait InstanceInterface: CommonTraits {
     fn new(desc: &crate::InstanceDescriptor) -> Self

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -587,6 +587,16 @@ macro_rules! dispatch_types {
                 }
             }
 
+            #[cfg(custom)]
+            #[inline]
+            #[allow(clippy::allow_attributes, unused)]
+            pub(crate) fn as_custom_opt(&self) -> Option<&$custom_type> {
+                match self {
+                    Self::Custom(value) => Some(value),
+                    _ => None,
+                }
+            }
+
             #[cfg(webgpu)]
             #[inline]
             #[allow(clippy::allow_attributes, unused)]
@@ -701,6 +711,16 @@ macro_rules! dispatch_types {
             ) -> Option<&mut $core_type> {
                 match self {
                     Self::Core(value) => Some(value),
+                    _ => None,
+                }
+            }
+
+            #[cfg(custom)]
+            #[inline]
+            #[allow(clippy::allow_attributes, unused)]
+            pub(crate) fn as_custom_opt(&self) -> Option<&$custom_type> {
+                match self {
+                    Self::Custom(value) => Some(value),
                     _ => None,
                 }
             }


### PR DESCRIPTION
**Connections**
Fixes #7533

**Description**
When implementing custom beckend, one was not be able to extract actual custom type from descriptors. This is now possible by introducing `as_custom` method on each wgpu API type (and `Dispatch*` type) that are analogues to `as_hal`. They try to return actual concrete custom type that is stored inside custom backend and return None if backend is not custom (or user wanted wrong T).

**Testing**
Example is modified to cover obtaining original custom type from dynamic custom backend type.

**Squash or Rebase?** Squash, but it's reviewable per commit.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
