### PR TITLE
[naga] mark `readonly_and_readwrite_storage_textures` & `packed_4x8_integer_dot_product` language extensions as implemented

### DIFF
--- a/naga/src/front/wgsl/parse/directive/language_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/language_extension.rs
@@ -24,11 +24,11 @@ impl LanguageExtension {
     /// Convert from a sentinel word in WGSL into its associated [`LanguageExtension`], if possible.
     pub fn from_ident(s: &str) -> Option<Self> {
         Some(match s {
-            Self::READONLY_AND_READWRITE_STORAGE_TEXTURES => Self::Unimplemented(
-                UnimplementedLanguageExtension::ReadOnlyAndReadWriteStorageTextures,
-            ),
+            Self::READONLY_AND_READWRITE_STORAGE_TEXTURES => {
+                Self::Implemented(ImplementedLanguageExtension::ReadOnlyAndReadWriteStorageTextures)
+            }
             Self::PACKED4X8_INTEGER_DOT_PRODUCT => {
-                Self::Unimplemented(UnimplementedLanguageExtension::Packed4x8IntegerDotProduct)
+                Self::Implemented(ImplementedLanguageExtension::Packed4x8IntegerDotProduct)
             }
             Self::UNRESTRICTED_POINTER_PARAMETERS => {
                 Self::Unimplemented(UnimplementedLanguageExtension::UnrestrictedPointerParameters)
@@ -45,12 +45,6 @@ impl LanguageExtension {
         match self {
             Self::Implemented(kind) => kind.to_ident(),
             Self::Unimplemented(kind) => match kind {
-                UnimplementedLanguageExtension::ReadOnlyAndReadWriteStorageTextures => {
-                    Self::READONLY_AND_READWRITE_STORAGE_TEXTURES
-                }
-                UnimplementedLanguageExtension::Packed4x8IntegerDotProduct => {
-                    Self::PACKED4X8_INTEGER_DOT_PRODUCT
-                }
                 UnimplementedLanguageExtension::UnrestrictedPointerParameters => {
                     Self::UNRESTRICTED_POINTER_PARAMETERS
                 }
@@ -62,6 +56,8 @@ impl LanguageExtension {
 /// A variant of [`LanguageExtension::Implemented`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, VariantArray)]
 pub enum ImplementedLanguageExtension {
+    ReadOnlyAndReadWriteStorageTextures,
+    Packed4x8IntegerDotProduct,
     PointerCompositeAccess,
 }
 
@@ -74,6 +70,12 @@ impl ImplementedLanguageExtension {
     /// Maps this [`ImplementedLanguageExtension`] into the sentinel word associated with it in WGSL.
     pub const fn to_ident(self) -> &'static str {
         match self {
+            ImplementedLanguageExtension::ReadOnlyAndReadWriteStorageTextures => {
+                LanguageExtension::READONLY_AND_READWRITE_STORAGE_TEXTURES
+            }
+            ImplementedLanguageExtension::Packed4x8IntegerDotProduct => {
+                LanguageExtension::PACKED4X8_INTEGER_DOT_PRODUCT
+            }
             ImplementedLanguageExtension::PointerCompositeAccess => {
                 LanguageExtension::POINTER_COMPOSITE_ACCESS
             }
@@ -84,16 +86,12 @@ impl ImplementedLanguageExtension {
 /// A variant of [`LanguageExtension::Unimplemented`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum UnimplementedLanguageExtension {
-    ReadOnlyAndReadWriteStorageTextures,
-    Packed4x8IntegerDotProduct,
     UnrestrictedPointerParameters,
 }
 
 impl UnimplementedLanguageExtension {
     pub(crate) const fn tracking_issue_num(self) -> u16 {
         match self {
-            Self::ReadOnlyAndReadWriteStorageTextures => 6204,
-            Self::Packed4x8IntegerDotProduct => 6445,
             Self::UnrestrictedPointerParameters => 5158,
         }
     }

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -888,6 +888,12 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
             crate::WgslLanguageFeatures::empty(),
             |acc, wle| {
                 acc | match wle {
+                    ImplementedLanguageExtension::ReadOnlyAndReadWriteStorageTextures => {
+                        crate::WgslLanguageFeatures::ReadOnlyAndReadWriteStorageTextures
+                    }
+                    ImplementedLanguageExtension::Packed4x8IntegerDotProduct => {
+                        crate::WgslLanguageFeatures::Packed4x8IntegerDotProduct
+                    }
                     ImplementedLanguageExtension::PointerCompositeAccess => {
                         crate::WgslLanguageFeatures::PointerCompositeAccess
                     }


### PR DESCRIPTION
Closes https://github.com/gfx-rs/wgpu/issues/6445 & last part of the already closed https://github.com/gfx-rs/wgpu/issues/6204.