### PR TITLE
[naga wgsl-in] Apply automatic conversions to sampling arguments.

### DIFF
--- a/naga/tests/in/wgsl/abstract-types-texture.toml
+++ b/naga/tests/in/wgsl/abstract-types-texture.toml
@@ -1,0 +1,1 @@
+targets = "METAL"

--- a/naga/tests/in/wgsl/abstract-types-texture.wgsl
+++ b/naga/tests/in/wgsl/abstract-types-texture.wgsl
@@ -1,0 +1,20 @@
+@group(0) @binding(0) var t: texture_2d<f32>;
+@group(0) @binding(1) var s: sampler;
+
+fn color() {
+  _ = textureSample(t, s, vec2(1,2));
+  _ = textureSample(t, s, vec2(1,2), vec2(3,4));
+  _ = textureSampleLevel(t, s, vec2(1,2), 0);
+  _ = textureSampleLevel(t, s, vec2(1,2), 0.0);
+  _ = textureSampleGrad(t, s, vec2(1,2), vec2(3,4), vec2(5,6));
+  _ = textureSampleBias(t, s, vec2(1,2), 1);
+}
+
+@group(0) @binding(2) var d: texture_depth_2d;
+@group(0) @binding(3) var c: sampler_comparison;
+
+fn depth() {
+  _ = textureSampleLevel(d, s, vec2(1,2), 1i);
+  _ = textureSampleCompare(d, c, vec2(1,2), 0);
+  _ = textureGatherCompare(d, c, vec2(1,2), 0);
+}

--- a/naga/tests/out/msl/wgsl-abstract-types-texture.msl
+++ b/naga/tests/out/msl/wgsl-abstract-types-texture.msl
@@ -1,0 +1,30 @@
+// language: metal1.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+
+void color(
+    metal::texture2d<float, metal::access::sample> t,
+    metal::sampler s
+) {
+    metal::float4 phony = t.sample(s, metal::float2(1.0, 2.0));
+    metal::float4 phony_1 = t.sample(s, metal::float2(1.0, 2.0), metal::int2(3, 4));
+    metal::float4 phony_2 = t.sample(s, metal::float2(1.0, 2.0), metal::level(0.0));
+    metal::float4 phony_3 = t.sample(s, metal::float2(1.0, 2.0), metal::level(0.0));
+    metal::float4 phony_4 = t.sample(s, metal::float2(1.0, 2.0), metal::gradient2d(metal::float2(3.0, 4.0), metal::float2(5.0, 6.0)));
+    metal::float4 phony_5 = t.sample(s, metal::float2(1.0, 2.0), metal::bias(1.0));
+    return;
+}
+
+void depth(
+    metal::sampler s,
+    metal::depth2d<float, metal::access::sample> d,
+    metal::sampler c
+) {
+    float phony_6 = d.sample(s, metal::float2(1.0, 2.0), metal::level(1));
+    float phony_7 = d.sample_compare(c, metal::float2(1.0, 2.0), 0.0);
+    metal::float4 phony_8 = d.gather_compare(c, metal::float2(1.0, 2.0), 0.0);
+    return;
+}


### PR DESCRIPTION
Depends on #7547 (but could be rebased if that's rejected).

Properly apply WGSL's automatic conversions to the arguments
to texture sampling functions.

Introduce helper function `Lowerer::expression_with_leaf_scalar`.

Although this can't affect behavior, use
`Lowerer::expression_for_abstract` for the `image` and `sampler`
arguments, simply because we want to move away from
`Lower::expression`'s automatic concretization, and move towards
having callers say explicitly what sort of conversions they need.

Although this can't affect behavior, use
`Lowerer::expression_with_leaf_scalar` for the `offset` argument, so
that the code spells out that this requires an `i32` value, rather
than depending on blind concretization giving it that.

Continue to use `Lowerer::expression` for `gather` and `array_index`,
since those happen to behave correctly with blind concretization, and
can be cleaned up later.

Fixes #7427.
