### PR TITLE
[naga] Warn, rather than error, on unreachable statements

### DIFF
--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -4,6 +4,8 @@ use anyhow::{anyhow, Context as _};
 use std::fs;
 use std::{error::Error, fmt, io::Read, path::Path, str::FromStr};
 
+use naga::Diagnostic;
+
 /// Translate shaders to different formats.
 #[derive(argh::FromArgs, Debug, Clone)]
 struct Args {

--- a/naga/src/error.rs
+++ b/naga/src/error.rs
@@ -1,6 +1,8 @@
 use alloc::{boxed::Box, string::String};
 use core::{error::Error, fmt};
 
+use crate::span::Diagnostic;
+
 #[derive(Clone, Debug)]
 pub struct ShaderError<E> {
     /// The source code of the shader.

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -124,7 +124,7 @@ pub mod valid;
 use alloc::string::String;
 
 pub use crate::arena::{Arena, Handle, Range, UniqueArena};
-pub use crate::span::{SourceLocation, Span, SpanContext, WithSpan};
+pub use crate::span::{Diagnostic, SourceLocation, Span, SpanContext, WithSpan};
 
 // TODO: Eliminate this re-export and migrate uses of `crate::Foo` to `use crate::ir; ir::Foo`.
 pub use ir::*;

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -124,7 +124,7 @@ pub mod valid;
 use alloc::string::String;
 
 pub use crate::arena::{Arena, Handle, Range, UniqueArena};
-pub use crate::span::{Diagnostic, SourceLocation, Span, SpanContext, WithSpan};
+pub use crate::span::{Diagnostic, SourceLocation, Span, SpanContext, WithSpan, WithSpanBoxed};
 
 // TODO: Eliminate this re-export and migrate uses of `crate::Foo` to `use crate::ir; ir::Foo`.
 pub use ir::*;

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -1,5 +1,6 @@
 use alloc::{
     borrow::ToOwned,
+    boxed::Box,
     format,
     string::{String, ToString},
     vec::Vec,
@@ -140,6 +141,20 @@ pub struct WithSpan<E> {
     spans: Vec<SpanContext>,
 }
 
+/// Variant of [`WithSpan`] that holds a boxed [`Error`].
+///
+/// This is currently used to hold warnings from validation, and since we don't
+/// have severity information in [`WithSpan`] or in the error itself, the
+/// implementations of [`Diagnostic`] assume that any [`WithSpan`] is a
+/// [`codespan_reporting::diagnostic::Severity::Error`] and any
+/// [`WithSpanBoxed`] is a
+/// [`codespan_reporting::diagnostic::Severity::Warning`].
+#[derive(Debug)]
+pub struct WithSpanBoxed {
+    inner: Box<dyn Error>,
+    spans: Vec<SpanContext>,
+}
+
 impl<E> fmt::Display for WithSpan<E>
 where
     E: fmt::Display,
@@ -237,6 +252,17 @@ impl<E> WithSpan<E> {
         res
     }
 
+    /// Convert this [`WithSpan`] into a [`WithSpanBoxed`].
+    pub fn boxed(self) -> WithSpanBoxed
+    where
+        E: Error + 'static,
+    {
+        WithSpanBoxed {
+            inner: Box::new(self.inner),
+            spans: self.spans,
+        }
+    }
+
     /// Return a [`SourceLocation`] for our first span, if we have one.
     pub fn location(&self, source: &str) -> Option<SourceLocation> {
         if self.spans.is_empty() || source.is_empty() {
@@ -245,48 +271,63 @@ impl<E> WithSpan<E> {
 
         Some(self.spans[0].0.location(source))
     }
+}
 
-    pub(crate) fn diagnostic(&self) -> codespan_reporting::diagnostic::Diagnostic<()>
-    where
-        E: Error,
-    {
-        use codespan_reporting::diagnostic::{Diagnostic, Label};
-        let diagnostic = Diagnostic::error()
-            .with_message(self.inner.to_string())
-            .with_labels(
-                self.spans()
-                    .map(|&(span, ref desc)| {
-                        Label::primary((), span.to_range().unwrap()).with_message(desc.to_owned())
-                    })
-                    .collect(),
-            )
-            .with_notes({
-                let mut notes = Vec::new();
-                let mut source: &dyn Error = &self.inner;
-                while let Some(next) = Error::source(source) {
-                    notes.push(next.to_string());
-                    source = next;
-                }
-                notes
-            });
-        diagnostic
+fn diagnostic(
+    severity: codespan_reporting::diagnostic::Severity,
+    error: &dyn Error,
+    spans: &[SpanContext],
+) -> codespan_reporting::diagnostic::Diagnostic<()> {
+    use codespan_reporting::diagnostic::{Diagnostic, Label};
+    let diagnostic = Diagnostic::new(severity)
+        .with_message(error.to_string())
+        .with_labels(
+            spans
+                .iter()
+                .map(|&(span, ref desc)| {
+                    Label::primary((), span.to_range().unwrap()).with_message(desc.to_owned())
+                })
+                .collect(),
+        )
+        .with_notes({
+            let mut notes = Vec::new();
+            let mut source = error;
+            while let Some(next) = Error::source(source) {
+                notes.push(next.to_string());
+                source = next;
+            }
+            notes
+        });
+    diagnostic
+}
+
+impl<E: Error> Diagnostic for WithSpan<E> {
+    fn diagnostic(&self) -> codespan_reporting::diagnostic::Diagnostic<()> {
+        use codespan_reporting::diagnostic::Severity;
+        diagnostic(Severity::Error, &self.inner, &self.spans)
     }
+}
+
+impl Diagnostic for WithSpanBoxed {
+    fn diagnostic(&self) -> codespan_reporting::diagnostic::Diagnostic<()> {
+        /// We assume that `self` is a warning. See documentation for [`WithSpanBoxed`].
+        use codespan_reporting::diagnostic::Severity;
+        diagnostic(Severity::Warning, self.inner.as_ref(), &self.spans)
+    }
+}
+
+pub trait Diagnostic {
+    fn diagnostic(&self) -> codespan_reporting::diagnostic::Diagnostic<()>;
 
     /// Emits a summary of the error to standard error stream.
     #[cfg(feature = "stderr")]
-    pub fn emit_to_stderr(&self, source: &str)
-    where
-        E: Error,
-    {
+    fn emit_to_stderr(&self, source: &str) {
         self.emit_to_stderr_with_path(source, "wgsl")
     }
 
     /// Emits a summary of the error to standard error stream.
     #[cfg(feature = "stderr")]
-    pub fn emit_to_stderr_with_path(&self, source: &str, path: &str)
-    where
-        E: Error,
-    {
+    fn emit_to_stderr_with_path(&self, source: &str, path: &str) {
         use codespan_reporting::{files, term};
 
         let files = files::SimpleFile::new(path, source);
@@ -305,18 +346,12 @@ impl<E> WithSpan<E> {
     }
 
     /// Emits a summary of the error to a string.
-    pub fn emit_to_string(&self, source: &str) -> String
-    where
-        E: Error,
-    {
+    fn emit_to_string(&self, source: &str) -> String {
         self.emit_to_string_with_path(source, "wgsl")
     }
 
     /// Emits a summary of the error to a string.
-    pub fn emit_to_string_with_path(&self, source: &str, path: &str) -> String
-    where
-        E: Error,
-    {
+    fn emit_to_string_with_path(&self, source: &str, path: &str) -> String {
         use codespan_reporting::{files, term};
 
         let files = files::SimpleFile::new(path, source);

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -7,6 +7,7 @@ use super::{
 };
 use crate::arena::{Arena, UniqueArena};
 use crate::arena::{Handle, HandleSet};
+use crate::diagnostic_filter::Severity;
 use crate::proc::TypeResolution;
 use crate::span::WithSpan;
 use crate::span::{AddSpan as _, MapErrWithSpan as _};
@@ -112,8 +113,8 @@ pub enum FunctionError {
         name: String,
         space: crate::AddressSpace,
     },
-    #[error("There are instructions after `return`/`break`/`continue`")]
-    InstructionsAfterReturn,
+    #[error("Unreachable statement after `{after}`")]
+    UnreachableStatement { after: &'static str },
     #[error("The `break` is used outside of a `loop` or `switch` context")]
     BreakOutsideOfLoopOrSwitch,
     #[error("The `continue` is used outside of a `loop` context")]
@@ -232,9 +233,18 @@ bitflags::bitflags! {
     }
 }
 
+/// Return type of `validate_block`
 struct BlockInfo {
+    /// Shader stages for which the block is valid.
     stages: super::ShaderStages,
-    finished: bool,
+
+    /// Span for a control flow statement that terminated the block.
+    ///
+    /// If the block contained a statement like `return`, `break`, `continue`,
+    /// or `discard` that will cause further statements not to be executed, this
+    /// is set based on that statement. This is used for "unreachable statement"
+    /// diagnostics.
+    unreachable: Option<(&'static str, crate::Span)>,
 }
 
 struct BlockContext<'a> {
@@ -751,12 +761,29 @@ impl super::Validator {
         context: &BlockContext,
     ) -> Result<BlockInfo, WithSpan<FunctionError>> {
         use crate::{AddressSpace, Statement as S, TypeInner as Ti};
-        let mut finished = false;
+        // Information used for "unreachable statement" diagnostics. Upon
+        // diverging control flow like `return`, this is set to `Some(Some(_))`.
+        // After emitting a diagnostic, this is set to `Some(None)`, so that
+        // there is only one warning for each block containing unreachable
+        // statements.
+        let mut unreachable = None;
         let mut stages = super::ShaderStages::all();
         for (statement, &span) in statements.span_iter() {
-            if finished {
-                return Err(FunctionError::InstructionsAfterReturn
-                    .with_span_static(span, "instructions after return"));
+            if let Some(Some((prev_stmt, prev_span))) = unreachable {
+                Severity::Warning.report_diag(
+                    FunctionError::UnreachableStatement { after: prev_stmt }
+                        .with_span()
+                        .with_context((span, String::from("this statement is unreachable")))
+                        .with_context((
+                            prev_span,
+                            String::from("because it appears after this statement"),
+                        )),
+                    |e, level| {
+                        log::log!(level, "{e}");
+                        self.diagnostics.push(e.boxed());
+                    },
+                )?;
+                unreachable = Some(None);
             }
             match *statement {
                 S::Emit(ref range) => {
@@ -806,7 +833,7 @@ impl super::Validator {
                 S::Block(ref block) => {
                     let info = self.validate_block(block, context)?;
                     stages &= info.stages;
-                    finished = info.finished;
+                    unreachable.get_or_insert(info.unreachable);
                 }
                 S::If {
                     condition,
@@ -949,14 +976,14 @@ impl super::Validator {
                         return Err(FunctionError::BreakOutsideOfLoopOrSwitch
                             .with_span_static(span, "invalid break"));
                     }
-                    finished = true;
+                    unreachable.get_or_insert(Some(("break", span)));
                 }
                 S::Continue => {
                     if !context.abilities.contains(ControlFlowAbility::CONTINUE) {
                         return Err(FunctionError::ContinueOutsideOfLoop
                             .with_span_static(span, "invalid continue"));
                     }
-                    finished = true;
+                    unreachable.get_or_insert(Some(("continue", span)));
                 }
                 S::Return { value } => {
                     if !context.abilities.contains(ControlFlowAbility::RETURN) {
@@ -996,11 +1023,11 @@ impl super::Validator {
                             .with_span_static(span, "invalid return"));
                         }
                     }
-                    finished = true;
+                    unreachable.get_or_insert(Some(("return", span)));
                 }
                 S::Kill => {
                     stages &= super::ShaderStages::FRAGMENT;
-                    finished = true;
+                    unreachable.get_or_insert(Some(("discard", span)));
                 }
                 S::Barrier(barrier) => {
                     stages &= super::ShaderStages::COMPUTE;
@@ -1618,7 +1645,10 @@ impl super::Validator {
                 }
             }
         }
-        Ok(BlockInfo { stages, finished })
+        Ok(BlockInfo {
+            stages,
+            unreachable: unreachable.unwrap_or(None),
+        })
     }
 
     fn validate_block(

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -18,6 +18,7 @@ use bit_set::BitSet;
 use crate::{
     arena::{Handle, HandleSet},
     proc::{ExpressionKindTracker, LayoutError, Layouter, TypeResolution},
+    span::WithSpanBoxed,
     FastHashSet,
 };
 
@@ -283,6 +284,7 @@ pub struct Validator {
     switch_values: FastHashSet<crate::SwitchValue>,
     valid_expression_list: Vec<Handle<crate::Expression>>,
     valid_expression_set: HandleSet<crate::Expression>,
+    diagnostics: Vec<WithSpanBoxed>,
     override_ids: FastHashSet<u16>,
 
     /// Treat overrides whose initializers are not fully-evaluated
@@ -485,6 +487,7 @@ impl Validator {
             switch_values: FastHashSet::default(),
             valid_expression_list: Vec::new(),
             valid_expression_set: HandleSet::new(),
+            diagnostics: Vec::new(),
             override_ids: FastHashSet::default(),
             overrides_resolved: false,
             needs_visit: HandleSet::new(),
@@ -511,6 +514,7 @@ impl Validator {
         self.switch_values.clear();
         self.valid_expression_list.clear();
         self.valid_expression_set.clear();
+        self.diagnostics.clear();
         self.override_ids.clear();
     }
 
@@ -757,6 +761,13 @@ impl Validator {
         }
 
         Ok(mod_info)
+    }
+
+    /// Return any warnings produced during validation.
+    ///
+    /// The details of returned diagnostic messages are not a stable API.
+    pub fn diagnostics(&self) -> &[WithSpanBoxed] {
+        &self.diagnostics
     }
 }
 

--- a/naga/tests/naga/validation.rs
+++ b/naga/tests/naga/validation.rs
@@ -1,4 +1,4 @@
-use naga::{valid, Expression, Function, Scalar};
+use naga::{valid, Diagnostic, Expression, Function, Scalar};
 
 /// Validation should fail if `AtomicResult` expressions are not
 /// populated by `Atomic` statements.
@@ -922,4 +922,36 @@ fn main() {
         info.get_entry_point(0)[global],
         naga::valid::GlobalUse::QUERY
     );
+}
+
+#[cfg(feature = "wgsl-in")]
+#[test]
+fn global_use_unreachable() {
+    let source = "
+@group(0) @binding(0)
+var<storage, read_write> global: u32;
+
+@compute @workgroup_size(64)
+fn main() {
+    var used: u32;
+    return;
+    used = global;
+}
+    ";
+
+    let module = naga::front::wgsl::parse_str(source).expect("module should parse");
+    let mut validator = valid::Validator::new(Default::default(), valid::Capabilities::all());
+    let info = validator.validate(&module).unwrap();
+
+    let global = module.global_variables.iter().next().unwrap().0;
+    assert_eq!(
+        info.get_entry_point(0)[global],
+        naga::valid::GlobalUse::READ,
+    );
+
+    // But it should emit a diagnostic
+    assert_eq!(validator.diagnostics().len(), 1);
+    assert!(validator.diagnostics()[0]
+        .emit_to_string(source)
+        .contains("warning: Unreachable statement after `return`"));
 }

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -3,16 +3,12 @@ Tests for the WGSL front end.
 */
 #![cfg(feature = "wgsl-in")]
 
-use naga::valid::Capabilities;
+use naga::{valid::Capabilities, Diagnostic};
 
 #[track_caller]
-fn check(input: &str, snapshot: &str) {
-    let output = match naga::front::wgsl::parse_str(input) {
-        Ok(_) => panic!("expected parser error, but parsing succeeded!"),
-        Err(err) => err.emit_to_string(input),
-    };
-    if output != snapshot {
-        for diff in diff::lines(snapshot, &output) {
+fn check_msg(actual: &str, expected: &str) {
+    if actual != expected {
+        for diff in diff::lines(actual, expected) {
             match diff {
                 diff::Result::Left(l) => println!("-{l}"),
                 diff::Result::Both(l, _) => println!(" {l}"),
@@ -21,6 +17,15 @@ fn check(input: &str, snapshot: &str) {
         }
         panic!("Error snapshot failed");
     }
+}
+
+#[track_caller]
+fn check(input: &str, snapshot: &str) {
+    let output = match naga::front::wgsl::parse_str(input) {
+        Ok(_) => panic!("expected parser error, but parsing succeeded!"),
+        Err(err) => err.emit_to_string(input),
+    };
+    check_msg(&output, snapshot);
 }
 
 #[track_caller]
@@ -1980,7 +1985,8 @@ fn invalid_local_vars() {
 }
 
 #[test]
-fn dead_code() {
+fn unreachable_statement() {
+    // We don't analyze whether both sides of an if statement exit.
     check_validation! {
         "
         fn dead_code_after_if(condition: bool) -> i32 {
@@ -1994,20 +2000,172 @@ fn dead_code() {
         ":
         Ok(_)
     }
+
+    // Statements removed in lowering don't trigger the warning.
     check_validation! {
         "
+        fn dead_phony_assignment() -> i32 {
+            return 1;
+            _ = 2;
+        }
+        ":
+        Ok(_)
+    }
+
+    // But other statements do trigger the warning.
+    // Variant 1
+    let source = "
         fn dead_code_after_block() -> i32 {
             {
                 return 1;
             }
             return 2;
+            return 3;
         }
-        ":
-        Err(naga::valid::ValidationError::Function {
-            source: naga::valid::FunctionError::InstructionsAfterReturn,
-            ..
-        })
-    }
+        ";
+    let module = naga::front::wgsl::parse_str(source).unwrap();
+    let mut validator = naga::valid::Validator::new(
+        naga::valid::ValidationFlags::all(),
+        naga::valid::Capabilities::default(),
+    );
+    // Validation should succeed
+    validator.validate(&module).unwrap();
+
+    // It should produce one diagnostic, even though there are two unreachable
+    // statements.
+    assert_eq!(validator.diagnostics().len(), 1);
+    check_msg(
+        &validator.diagnostics()[0].emit_to_string(source),
+        "warning: Unreachable statement after `return`
+  ┌─ wgsl:4:17
+  │
+4 │                 return 1;
+  │                 ^^^^^^^^^ because it appears after this statement
+5 │             }
+6 │             return 2;
+  │             ^^^^^^^^^ this statement is unreachable
+
+",
+    );
+
+    // Variant 2
+    let source = "
+        fn dead_code_after_block() -> i32 {
+            {
+                return 1;
+                return 2;
+            }
+            return 3;
+        }
+        ";
+    let module = naga::front::wgsl::parse_str(source).unwrap();
+    let mut validator = naga::valid::Validator::new(
+        naga::valid::ValidationFlags::all(),
+        naga::valid::Capabilities::default(),
+    );
+    // Validation should succeed
+    validator.validate(&module).unwrap();
+
+    // It should produce one diagnostic, even though there are two unreachable
+    // statements.
+    assert_eq!(validator.diagnostics().len(), 1);
+    check_msg(
+        &validator.diagnostics()[0].emit_to_string(source),
+        "warning: Unreachable statement after `return`
+  ┌─ wgsl:4:17
+  │
+4 │                 return 1;
+  │                 ^^^^^^^^^ because it appears after this statement
+5 │                 return 2;
+  │                 ^^^^^^^^^ this statement is unreachable
+
+",
+    );
+
+    // Variant 3
+    let source = "
+        fn dead_code_after_block() -> i32 {
+            var x: i32;
+            {
+                return 1;
+                x = 2;
+            }
+            return 3;
+        }
+        ";
+    let module = naga::front::wgsl::parse_str(source).unwrap();
+    let mut validator = naga::valid::Validator::new(
+        naga::valid::ValidationFlags::all(),
+        naga::valid::Capabilities::default(),
+    );
+    // Validation should succeed
+    validator.validate(&module).unwrap();
+
+    // It should produce one diagnostic, even though there are two unreachable
+    // statements.
+    assert_eq!(validator.diagnostics().len(), 1);
+    check_msg(
+        &validator.diagnostics()[0].emit_to_string(source),
+        "warning: Unreachable statement after `return`
+  ┌─ wgsl:5:17
+  │
+5 │                 return 1;
+  │                 ^^^^^^^^^ because it appears after this statement
+6 │                 x = 2;
+  │                 ^^^^^ this statement is unreachable
+
+",
+    );
+
+    // Variant 4
+    let source = "
+        fn dead_code_after_block() -> i32 {
+            var x: i32;
+            return 1;
+            {
+                return 2;
+                x = 3;
+            }
+            return 4;
+        }
+        ";
+    let module = naga::front::wgsl::parse_str(source).unwrap();
+    let mut validator = naga::valid::Validator::new(
+        naga::valid::ValidationFlags::all(),
+        naga::valid::Capabilities::default(),
+    );
+    // Validation should succeed
+    validator.validate(&module).unwrap();
+
+    // This one produces two diagnostics, because it doesn't seem worth the
+    // extra effort to suppress one of them.
+    assert_eq!(validator.diagnostics().len(), 2);
+    check_msg(
+        &validator.diagnostics()[0].emit_to_string(source),
+        "warning: Unreachable statement after `return`
+  ┌─ wgsl:4:13
+  │\x20\x20
+4 │               return 1;
+  │               ^^^^^^^^^ because it appears after this statement
+5 │ ╭             {
+6 │ │                 return 2;
+7 │ │                 x = 3;
+  │ ╰──────────────────────^ this statement is unreachable
+
+",
+    );
+    check_msg(
+        &validator.diagnostics()[1].emit_to_string(source),
+        "warning: Unreachable statement after `return`
+  ┌─ wgsl:6:17
+  │
+6 │                 return 2;
+  │                 ^^^^^^^^^ because it appears after this statement
+7 │                 x = 3;
+  │                 ^^^^^ this statement is unreachable
+
+",
+    );
 }
 
 #[test]
@@ -3442,19 +3600,19 @@ fn inconsistent_type() {
         "fn foo() -> f32 {
             return dot(vec4<f32>(), vec3<f32>());
         }",
-        r#"error: inconsistent type passed as argument #2 to `dot`
+        "error: inconsistent type passed as argument #2 to `dot`
   ┌─ wgsl:2:20
   │
 2 │             return dot(vec4<f32>(), vec3<f32>());
   │                    ^^^ ^^^^^^^^^^   ^^^^^^^^^^ argument #2 has type vec3<f32>
-  │                        │             
+  │                        │\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20
   │                        this argument has type vec4<f32>, which constrains subsequent arguments
   │
   = note: Because argument #1 has type vec4<f32>, only the following types
   = note: (or types that automatically convert to them) are accepted for argument #2:
   = note: allowed type: vec4<f32>
 
-"#,
+",
     );
 }
 


### PR DESCRIPTION
Earlier versions of WGSL specified that unreachable code was an error, but that is no longer the case. This PR removes the error but retains a warning on unreachable statements. #7718 is an alternative that removes the associated logic entirely, not generating an error or warning.

Fixes #7536

I have added a mechanism to collect warnings during validation. Mostly to make them accessible to the tests, I add an API on `Validator` to retrieve the diagnostics. However, even with the warning that the diagnostics are not stable, I'm not sure if we really want this to be a public API. Another possibility is changing the tests to unit tests so they can retrieve the diagnostics without having a public API.

I also made some changes in the `Span` module to support boxed errors for the diagnostics. It would be better to just use `Vec<ValidationError>` for the diagnostics, but the difficulty with that is that creating a `ValidationError` from a `FunctionError` requires knowing the function name (not too bad) and the `Handle` for the function (harder), which aren't readily available at the point where the diagnostic is generated, because in error cases the conversion to a `ValidationError` happens as the error propagates upwards.

**Testing**
Added tests in the validation suite and added/updated tests in wgsl_errors.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
