### PR TITLE
chore: add config. for `prettier`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+**/*.frag
+**/*.vert
+naga/tests/in/
+naga/tests/out/


### PR DESCRIPTION
`.prettierignore` is necessary for avoiding overwriting. ~~`.prettierrc.toml` seems like a natural (empty) file to add, to indicate in the future where configuration should go, if we need it.~~