### PR TITLE
use `wgt::PollType<u64>` in device interface instead of `wgt::PollType<SubmissionIndex>`

### DIFF
--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -244,7 +244,10 @@ impl DeviceInterface for CustomDevice {
         unimplemented!()
     }
 
-    fn poll(&self, _maintain: wgpu::PollType) -> Result<wgpu::PollStatus, wgpu::PollError> {
+    fn poll(
+        &self,
+        _maintain: wgpu::wgt::PollType<u64>,
+    ) -> Result<wgpu::PollStatus, wgpu::PollError> {
         unimplemented!()
     }
 

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -86,7 +86,7 @@ impl Device {
     ///
     /// When running on WebGPU, this is a no-op. `Device`s are automatically polled.
     pub fn poll(&self, poll_type: PollType) -> Result<crate::PollStatus, crate::PollError> {
-        self.inner.poll(poll_type)
+        self.inner.poll(poll_type.map_index(|s| s.index))
     }
 
     /// The features which can be used on this device.

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -27,7 +27,6 @@ crate::cmp::impl_eq_ord_hash_proxy!(Queue => .inner);
 /// There is no analogue in the WebGPU specification.
 #[derive(Debug, Clone)]
 pub struct SubmissionIndex {
-    #[cfg_attr(not(wgpu_core), expect(dead_code))]
     pub(crate) index: u64,
 }
 #[cfg(send_sync)]

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2402,7 +2402,7 @@ impl dispatch::DeviceInterface for WebDevice {
         // No capturing api in webgpu
     }
 
-    fn poll(&self, _poll_type: crate::PollType) -> Result<crate::PollStatus, crate::PollError> {
+    fn poll(&self, _poll_type: wgt::PollType<u64>) -> Result<crate::PollStatus, crate::PollError> {
         // Device is polled automatically
         Ok(crate::PollStatus::QueueEmpty)
     }

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1680,9 +1680,8 @@ impl dispatch::DeviceInterface for CoreDevice {
         };
     }
 
-    fn poll(&self, poll_type: crate::PollType) -> Result<crate::PollStatus, crate::PollError> {
-        let maintain_inner = poll_type.map_index(|i| i.index);
-        match self.context.0.device_poll(self.id, maintain_inner) {
+    fn poll(&self, poll_type: wgt::PollType<u64>) -> Result<crate::PollStatus, crate::PollError> {
+        match self.context.0.device_poll(self.id, poll_type) {
             Ok(status) => Ok(status),
             Err(err) => {
                 if let Some(poll_error) = err.to_poll_error() {

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -166,7 +166,7 @@ pub trait DeviceInterface: CommonTraits {
     unsafe fn start_graphics_debugger_capture(&self);
     unsafe fn stop_graphics_debugger_capture(&self);
 
-    fn poll(&self, poll_type: crate::PollType) -> Result<crate::PollStatus, crate::PollError>;
+    fn poll(&self, poll_type: wgt::PollType<u64>) -> Result<crate::PollStatus, crate::PollError>;
 
     fn get_internal_counters(&self) -> crate::InternalCounters;
     fn generate_allocator_report(&self) -> Option<crate::AllocatorReport>;


### PR DESCRIPTION
**Description**
Use `wgt::PollType<u64>` in `DeviceInterface` instead of `wgt::PollType<SubmissionIndex>`, this will allow obtaining submission indexes in custom backends.

**Testing**
No 

**Squash or Rebase?** Squash.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
