### PR TITLE
Loosen Viewport validation requirements to match the new specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Naga now infers the correct binding layout when a resource appears only in an as
 
 ### Changes
 
+- Loosen Viewport validation requirements to match the [new specs](https://github.com/gpuweb/gpuweb/pull/5025). By @ebbdrop in [#7564](https://github.com/gfx-rs/wgpu/pull/7564)
+
 #### General
 
 - Removed `MaintainBase` in favor of using `PollType`. By @waywardmonkeys in [#7508](https://github.com/gfx-rs/wgpu/pull/7508).

--- a/tests/tests/wgpu-gpu/encoder.rs
+++ b/tests/tests/wgpu-gpu/encoder.rs
@@ -68,7 +68,7 @@ static DROP_ENCODER_AFTER_ERROR: GpuTestConfiguration = GpuTestConfiguration::ne
                 renderpass.set_viewport(0.0, 0.0, -1.0, -1.0, 0.0, 1.0);
                 drop(renderpass);
             },
-            Some("viewport has invalid rect"),
+            Some("less than zero"),
         );
 
         // This is the actual interesting error condition. We've created

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -81,8 +81,10 @@ pub enum RenderCommandError {
     MissingTextureUsage(#[from] MissingTextureUsageError),
     #[error(transparent)]
     PushConstants(#[from] PushConstantUploadError),
-    #[error("Viewport has invalid rect {0:?}; origin and/or size is less than or equal to 0, and/or is not contained in the render target {1:?}")]
-    InvalidViewportRect(Rect<f32>, wgt::Extent3d),
+    #[error("Viewport size {{ w: {w}, h: {h} }} greater than device's requested `max_texture_dimension_2d` limit {max}, or less than zero")]
+    InvalidViewportRectSize { w: f32, h: f32, max: u32 },
+    #[error("Viewport has invalid rect {rect:?} for device's requested `max_texture_dimension_2d` limit; Origin less than -2 * `max_texture_dimension_2d` ({min}), or rect extends past 2 * `max_texture_dimension_2d` - 1 ({max})")]
+    InvalidViewportRectPosition { rect: Rect<f32>, min: f32, max: f32 },
     #[error("Viewport minDepth {0} and/or maxDepth {1} are not in [0, 1]")]
     InvalidViewportDepth(f32, f32),
     #[error("Scissor {0:?} is not contained in the render target {1:?}")]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2347,14 +2347,33 @@ fn set_viewport(
     depth_max: f32,
 ) -> Result<(), RenderPassErrorInner> {
     api_log!("RenderPass::set_viewport {rect:?}");
-    if rect.x < 0.0
-        || rect.y < 0.0
-        || rect.w <= 0.0
-        || rect.h <= 0.0
-        || rect.x + rect.w > state.info.extent.width as f32
-        || rect.y + rect.h > state.info.extent.height as f32
+
+    if rect.w < 0.0
+        || rect.h < 0.0
+        || rect.w > state.device.limits.max_texture_dimension_2d as f32
+        || rect.h > state.device.limits.max_texture_dimension_2d as f32
     {
-        return Err(RenderCommandError::InvalidViewportRect(rect, state.info.extent).into());
+        return Err(RenderCommandError::InvalidViewportRectSize {
+            w: rect.w,
+            h: rect.h,
+            max: state.device.limits.max_texture_dimension_2d,
+        }
+        .into());
+    }
+
+    let max_viewport_range = state.device.limits.max_texture_dimension_2d as f32 * 2.0;
+
+    if rect.x < -max_viewport_range
+        || rect.y < -max_viewport_range
+        || rect.x + rect.w > max_viewport_range - 1.0
+        || rect.y + rect.h > max_viewport_range - 1.0
+    {
+        return Err(RenderCommandError::InvalidViewportRectPosition {
+            rect,
+            min: -max_viewport_range,
+            max: max_viewport_range - 1.0,
+        }
+        .into());
     }
     if !(0.0..=1.0).contains(&depth_min) || !(0.0..=1.0).contains(&depth_max) {
         return Err(RenderCommandError::InvalidViewportDepth(depth_min, depth_max).into());


### PR DESCRIPTION
**Description**
Updates the set_viewport validation to match the new viewport validation introduced in
https://github.com/gpuweb/gpuweb/pull/5025.

**Testing**
Tested locally.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
