### PR TITLE
[d3d12] remove the need for dxil.dll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,7 +547,7 @@ jobs:
           set -e
 
           curl.exe -L --retry 5 https://github.com/microsoft/DirectXShaderCompiler/releases/download/$DXC_RELEASE/$DXC_FILENAME -o dxc.zip
-          7z.exe e dxc.zip -odxc bin/x64/{dxc.exe,dxcompiler.dll,dxil.dll}
+          7z.exe e dxc.zip -odxc bin/x64/{dxc.exe,dxcompiler.dll}
 
           # We need to use cygpath to convert PWD to a windows path as we're using bash.
           cygpath --windows "$PWD/dxc" >> "$GITHUB_PATH"

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -64,7 +64,7 @@ jobs:
           set -e
 
           curl.exe -L --retry 5 https://github.com/microsoft/DirectXShaderCompiler/releases/download/$DXC_RELEASE/$DXC_FILENAME -o dxc.zip
-          7z.exe e dxc.zip -odxc bin/x64/{dxc.exe,dxcompiler.dll,dxil.dll}
+          7z.exe e dxc.zip -odxc bin/x64/{dxc.exe,dxcompiler.dll}
 
           # We need to use cygpath to convert PWD to a windows path as we're using bash.
           cygpath --windows "$PWD/dxc" >> "$GITHUB_PATH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ Naga now infers the correct binding layout when a resource appears only in an as
 
 - Mark `readonly_and_readwrite_storage_textures` & `packed_4x8_integer_dot_product` language extensions as implemented. By @teoxoy in [#7543](https://github.com/gfx-rs/wgpu/pull/7543)
 
+#### D3D12
+
+- Remove the need for dxil.dll. By @teoxoy in [#7566](https://github.com/gfx-rs/wgpu/pull/7566)
+
 ### Bug Fixes
 
 #### Naga

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ All testing and example infrastructure share the same set of environment variabl
 - `WGPU_ADAPTER_NAME` with a substring of the name of the adapter you want to use (ex. `1080` will match `NVIDIA GeForce 1080ti`).
 - `WGPU_BACKEND` with a comma-separated list of the backends you want to use (`vulkan`, `metal`, `dx12`, or `gl`).
 - `WGPU_POWER_PREF` with the power preference to choose when a specific adapter name isn't specified (`high`, `low` or `none`)
-- `WGPU_DX12_COMPILER` with the DX12 shader compiler you wish to use (`dxc`, `static-dxc`, or `fxc`). Note that `dxc` requires `dxil.dll` and `dxcompiler.dll` to be in the working directory, and `static-dxc` requires the `static-dxc` crate feature to be enabled. Otherwise, it will fall back to `fxc`.
+- `WGPU_DX12_COMPILER` with the DX12 shader compiler you wish to use (`dxc`, `static-dxc`, or `fxc`). Note that `dxc` requires `dxcompiler.dll` (min v1.8.2502) to be in the working directory, and `static-dxc` requires the `static-dxc` crate feature to be enabled. Otherwise, it will fall back to `fxc`.
 - `WGPU_GLES_MINOR_VERSION` with the minor OpenGL ES 3 version number to request (`0`, `1`, `2` or `automatic`).
 - `WGPU_ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER` with a boolean whether non-compliant drivers are enumerated (`0` for false, `1` for true).
 

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -69,13 +69,11 @@ impl crate::Instance for super::Instance {
         // Initialize DXC shader compiler
         let dxc_container = match desc.backend_options.dx12.shader_compiler.clone() {
             wgt::Dx12Compiler::DynamicDxc {
-                dxil_path,
                 dxc_path,
                 max_shader_model,
             } => {
                 let container = super::shader_compilation::get_dynamic_dxc_container(
                     dxc_path.into(),
-                    dxil_path.into(),
                     max_shader_model,
                 )
                 .map_err(|e| {

--- a/wgpu-types/src/instance.rs
+++ b/wgpu-types/src/instance.rs
@@ -394,9 +394,6 @@ pub enum DxcShaderModel {
 }
 
 /// Selects which DX12 shader compiler to use.
-///
-/// If the `DynamicDxc` option is selected, but `dxcompiler.dll` and `dxil.dll` files aren't found,
-/// then this will fall back to the Fxc compiler at runtime and log an error.
 #[derive(Clone, Debug, Default)]
 pub enum Dx12Compiler {
     /// The Fxc compiler (default) is old, slow and unmaintained.
@@ -406,17 +403,15 @@ pub enum Dx12Compiler {
     Fxc,
     /// The Dxc compiler is new, fast and maintained.
     ///
-    /// However, it requires both `dxcompiler.dll` and `dxil.dll` to be shipped with the application.
+    /// However, it requires `dxcompiler.dll` to be shipped with the application.
     /// These files can be downloaded from <https://github.com/microsoft/DirectXShaderCompiler/releases>.
     ///
-    /// Minimum supported version: [v1.5.2010](https://github.com/microsoft/DirectXShaderCompiler/releases/tag/v1.5.2010)
+    /// Minimum supported version: [v1.8.2502](https://github.com/microsoft/DirectXShaderCompiler/releases/tag/v1.8.2502)
     ///
     /// It also requires WDDM 2.1 (Windows 10 version 1607).
     DynamicDxc {
         /// Path to `dxcompiler.dll`.
         dxc_path: String,
-        /// Path to `dxil.dll`.
-        dxil_path: String,
         /// Maximum shader model the given dll supports.
         max_shader_model: DxcShaderModel,
     },
@@ -430,12 +425,11 @@ pub enum Dx12Compiler {
 impl Dx12Compiler {
     /// Helper function to construct a `DynamicDxc` variant with default paths.
     ///
-    /// The dll must support at least shader model 6.5.
+    /// The dll must support at least shader model 6.8.
     pub fn default_dynamic_dxc() -> Self {
         Self::DynamicDxc {
             dxc_path: String::from("dxcompiler.dll"),
-            dxil_path: String::from("dxil.dll"),
-            max_shader_model: DxcShaderModel::V6_5,
+            max_shader_model: DxcShaderModel::V6_7, // should be 6.8 but the variant is missing
         }
     }
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -121,7 +121,7 @@ serde = ["wgpu-core?/serde", "wgpu-types/serde"]
 ## Enables statically linking DXC.
 ##
 ## Normally, to use the modern DXC shader compiler with WGPU, the final application
-## must be shipped alongside `dxcompiler.dll` and `dxil.dll` (which can be downloaded from [Microsoft's GitHub][dxc]).
+## must be shipped alongside `dxcompiler.dll` (min v1.8.2502) (which can be downloaded from [Microsoft's GitHub][dxc]).
 ## This feature statically links a version of DXC so that no external binaries are required
 ## to compile DX12 shaders.
 ##


### PR DESCRIPTION
**Connections**
Resolve https://github.com/gfx-rs/wgpu/issues/7434.

**Description**
Removes the need for dxil.dll since the signing is now done by dxcompiler.dll.

**Testing**
Manually tested this works with dxcompiler.dll v1.8.2502 (it's also tested in CI).

**Squash or Rebase?**
n/a