### PR TITLE
[naga spv-in] Update supported capabilities list

### DIFF
--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -74,6 +74,14 @@ pub const SUPPORTED_CAPABILITIES: &[spirv::Capability] = &[
     spirv::Capability::Float64,
     spirv::Capability::Geometry,
     spirv::Capability::MultiView,
+    spirv::Capability::StorageBuffer16BitAccess,
+    spirv::Capability::UniformAndStorageBuffer16BitAccess,
+    spirv::Capability::GroupNonUniform,
+    spirv::Capability::GroupNonUniformVote,
+    spirv::Capability::GroupNonUniformArithmetic,
+    spirv::Capability::GroupNonUniformBallot,
+    spirv::Capability::GroupNonUniformShuffle,
+    spirv::Capability::GroupNonUniformShuffleRelative,
     // tricky ones
     spirv::Capability::UniformBufferArrayDynamicIndexing,
     spirv::Capability::StorageBufferArrayDynamicIndexing,
@@ -380,7 +388,7 @@ impl Default for Options {
     fn default() -> Self {
         Options {
             adjust_coordinate_space: true,
-            strict_capabilities: false,
+            strict_capabilities: true,
             block_ctx_dump_prefix: None,
         }
     }

--- a/naga/tests/naga/snapshots.rs
+++ b/naga/tests/naga/snapshots.rs
@@ -853,7 +853,7 @@ fn convert_snapshots_spv() {
             &command.stdout,
             &naga::front::spv::Options {
                 adjust_coordinate_space,
-                strict_capabilities: false,
+                strict_capabilities: true,
                 block_ctx_dump_prefix: None,
             },
         )


### PR DESCRIPTION
**Description**
The list of supported capabilities for spv-in doesn't include GroupNonUNiform capabilities that were already implemented and had a shader for testing. With this PR, the tests will enforce the capability list be up to date with what is tested, and as such I have added the missing capabilities to the list.

**Testing**
The naga tests now use the `strict_capabilities` option, ensuring the capabilities list is up to date with tests.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
