### PR TITLE
[naga]: Add `no_std` polyfill for `round_ties_even` for `f32` and `f64`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-hal --all-features
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu --all-features
 
-      # Building for no_std platforms where every feature is enabled except "std".
+      # Building for no_std platforms.
       - name: Check `no_std`
         if: matrix.kind == 'no_std'
         shell: bash
@@ -301,9 +301,11 @@ jobs:
 
           # check with no features
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p naga --no-default-features
 
-          # Check with all features except "std".
+          # Check with all compatible features
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features --features strict_asserts,fragile-send-sync-non-atomic-wasm,serde,counters
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p naga --no-default-features --features dot-out,compact
 
       # Building for native platforms with standard tests.
       - name: Check native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Bottom level categories:
 
 ### New Features
 
+#### Naga
+
+- Added `no_std` support with default features disabled. By @Bushrat011899 in [#7585](https://github.com/gfx-rs/wgpu/pull/7585).
+
 #### General
 
 - Add support for rendering to slices of 3D texture views and single layered 2D-Array texture views (this requires `VK_KHR_maintenance1` which should be widely available on newer drivers). By @teoxoy in [#7596](https://github.com/gfx-rs/wgpu/pull/7596)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,6 +2513,7 @@ dependencies = [
  "hlsl-snapshots",
  "indexmap",
  "itertools 0.14.0",
+ "libm",
  "log",
  "num-traits",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ libc = { version = "0.2.168", default-features = false }
 # See https://github.com/rust-fuzz/libfuzzer/issues/126
 libfuzzer-sys = ">0.4.0,<=0.4.7"
 libloading = "0.8"
+libm = { version = "0.2.6", default-features = false }
 libtest-mimic = "0.8"
 log = "0.4.21"
 nanoserde = "0.2"

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -91,7 +91,8 @@ hashbrown.workspace = true
 half = { workspace = true, features = ["num-traits"] }
 rustc-hash.workspace = true
 indexmap.workspace = true
-libm = { version = "0.2", default-features = false }
+# Earliest version of libm with rint and rintf
+libm = { version = "0.2.6", default-features = false }
 log.workspace = true
 num-traits.workspace = true
 once_cell = { workspace = true, features = ["alloc", "race"] }

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -91,8 +91,7 @@ hashbrown.workspace = true
 half = { workspace = true, features = ["num-traits"] }
 rustc-hash.workspace = true
 indexmap.workspace = true
-# Earliest version of libm with rint and rintf
-libm = { version = "0.2.6", default-features = false }
+libm = { workspace = true, default-features = false }
 log.workspace = true
 num-traits.workspace = true
 once_cell = { workspace = true, features = ["alloc", "race"] }

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -91,6 +91,7 @@ hashbrown.workspace = true
 half = { workspace = true, features = ["num-traits"] }
 rustc-hash.workspace = true
 indexmap.workspace = true
+libm = { version = "0.2", default-features = false }
 log.workspace = true
 num-traits.workspace = true
 once_cell = { workspace = true, features = ["alloc", "race"] }

--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -46,6 +46,13 @@ pub type NeedBakeExpressions = crate::FastHashSet<crate::Handle<crate::Expressio
 ///
 /// [`Expression`]: crate::Expression
 /// [`Handle`]: crate::Handle
+#[cfg_attr(
+    not(any(glsl_out, hlsl_out, msl_out, wgsl_out)),
+    allow(
+        dead_code,
+        reason = "shared helpers can be dead if none of the enabled backends need it"
+    )
+)]
 struct Baked(crate::Handle<crate::Expression>);
 
 impl core::fmt::Display for Baked {

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1172,8 +1172,8 @@ impl<'a> ConstantEvaluator<'a> {
             }
             crate::MathFunction::Round => {
                 component_wise_float(self, span, [arg], |e| match e {
-                    Float::Abstract([e]) => Ok(Float::Abstract([e.round_ties_even()])),
-                    Float::F32([e]) => Ok(Float::F32([e.round_ties_even()])),
+                    Float::Abstract([e]) => Ok(Float::Abstract([libm::rint(e)])),
+                    Float::F32([e]) => Ok(Float::F32([libm::rintf(e)])),
                     Float::F16([e]) => {
                         // TODO: `round_ties_even` is not available on `half::f16` yet.
                         //


### PR DESCRIPTION
**Connections**
- Contributes to #6826

**Description**
- Generalizes the `round_ties_even` `f16` polyfill for `f32` and `f64` using `num_traits::float::FloatCore`, specifically for `no_std` support
- Adds `naga` to the _Check `no_std`_ CI action now that it is MVP compatible

**Testing**
- CI

**Squash or Rebase?**

Squash

**Checklist**

- [X] Run `cargo fmt`.
- [X] ~~Run `taplo format`.~~ N/A
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry.

**Notes**

- I haven't added a feature to switch back to `f32::round_ties_even` or `f64::round_ties_even`, since I don't believe there is substantial value added with such a feature.
- I have not added tests for the implementation, since it is based on the existing `f16` polyfill. However, there are substantial tests for this exact method in [this num-traits PR I opened](https://github.com/rust-num/num-traits/pull/350). This PR would just allow us to continue working on `no_std` support while we wait for that PR to be accepted (or not).