### PR TITLE
[naga]: Remove `indexmap/std` from `wgsl-in`

### DIFF
--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -58,13 +58,7 @@ arbitrary = [
 ]
 spv-in = ["dep:petgraph", "dep:spirv"]
 spv-out = ["dep:spirv"]
-wgsl-in = [
-    "dep:hexf-parse",
-    "dep:strum",
-    "dep:unicode-ident",
-    "indexmap/std",
-    "compact",
-]
+wgsl-in = ["dep:hexf-parse", "dep:strum", "dep:unicode-ident", "compact"]
 wgsl-out = []
 
 ## Enables outputting to HLSL (Microsoft's High-Level Shader Language).

--- a/naga/src/diagnostic_filter.rs
+++ b/naga/src/diagnostic_filter.rs
@@ -5,11 +5,11 @@ use alloc::boxed::Box;
 use crate::{Arena, Handle};
 
 #[cfg(feature = "wgsl-in")]
+use crate::FastIndexMap;
+#[cfg(feature = "wgsl-in")]
 use crate::Span;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "wgsl-in")]
-use indexmap::IndexMap;
 #[cfg(feature = "deserialize")]
 use serde::Deserialize;
 #[cfg(feature = "serialize")]
@@ -133,7 +133,7 @@ pub(crate) enum ShouldConflictOnFullDuplicate {
 /// [`add`]: DiagnosticFilterMap::add
 #[derive(Clone, Debug, Default)]
 #[cfg(feature = "wgsl-in")]
-pub(crate) struct DiagnosticFilterMap(IndexMap<FilterableTriggeringRule, (Severity, Span)>);
+pub(crate) struct DiagnosticFilterMap(FastIndexMap<FilterableTriggeringRule, (Severity, Span)>);
 
 #[cfg(feature = "wgsl-in")]
 impl DiagnosticFilterMap {


### PR DESCRIPTION
**Connections**
- Contributes to #6826

**Description**
Reduces blockers to `no_std` support in `wgsl-in` feature

**Testing**
CI

**Squash or Rebase?**

Squash

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [X] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ N/A

**Notes**

`DiagnosticFilterMap` will now be less resilient to DoS attacks since it uses `FastIndexMap` instead of `IndexMap`. I don't believe this is a substantial issue, but I'm calling it out here in case my assumption there is incorrect.