### PR TITLE
[naga]: Switch off of `LazyLock` to `once_cell::racy::OnceBox`

### DIFF
--- a/naga/build.rs
+++ b/naga/build.rs
@@ -6,5 +6,7 @@ fn main() {
         msl_out: { any(feature = "msl-out", all(target_vendor = "apple", feature = "msl-out-if-target-apple")) },
         spv_out: { feature = "spv-out" },
         wgsl_out: { feature = "wgsl-out" },
+        std: { any(test, spv_out, feature = "spv-in", feature = "wgsl-in", feature = "stderr") },
+        no_std: { not(std) },
     }
 }

--- a/naga/src/back/glsl/keywords.rs
+++ b/naga/src/back/glsl/keywords.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use crate::racy_lock::RacyLock;
 
 use hashbrown::HashSet;
 
@@ -499,7 +499,7 @@ pub const RESERVED_KEYWORDS: &[&str] = &[
 /// significant time during [`Namer::reset`](crate::proc::Namer::reset).
 ///
 /// See <https://github.com/gfx-rs/wgpu/pull/7338> for benchmarks.
-pub static RESERVED_KEYWORD_SET: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+pub static RESERVED_KEYWORD_SET: RacyLock<HashSet<&'static str>> = RacyLock::new(|| {
     let mut set = HashSet::default();
     set.reserve(RESERVED_KEYWORDS.len());
     for &word in RESERVED_KEYWORDS {

--- a/naga/src/back/hlsl/keywords.rs
+++ b/naga/src/back/hlsl/keywords.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use crate::racy_lock::RacyLock;
 
 use hashbrown::HashSet;
 
@@ -924,7 +924,7 @@ pub const TYPES: &[&str] = &{
 /// significant time during [`Namer::reset`](crate::proc::Namer::reset).
 ///
 /// See <https://github.com/gfx-rs/wgpu/pull/7338> for benchmarks.
-pub static RESERVED_SET: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+pub static RESERVED_SET: RacyLock<HashSet<&'static str>> = RacyLock::new(|| {
     let mut set = HashSet::default();
     set.reserve(RESERVED.len() + TYPES.len());
     for &word in RESERVED {

--- a/naga/src/back/msl/keywords.rs
+++ b/naga/src/back/msl/keywords.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use crate::racy_lock::RacyLock;
 
 use hashbrown::HashSet;
 
@@ -360,7 +360,7 @@ pub const RESERVED: &[&str] = &[
 /// significant time during [`Namer::reset`](crate::proc::Namer::reset).
 ///
 /// See <https://github.com/gfx-rs/wgpu/pull/7338> for benchmarks.
-pub static RESERVED_SET: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+pub static RESERVED_SET: RacyLock<HashSet<&'static str>> = RacyLock::new(|| {
     let mut set = HashSet::default();
     set.reserve(RESERVED.len());
     for &word in RESERVED {

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -16,6 +16,9 @@ use crate::{
     Span, Statement, TypeInner, WithSpan,
 };
 
+#[cfg(no_std)]
+use num_traits::float::FloatCore as _;
+
 #[derive(Error, Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum PipelineConstantError {
@@ -905,7 +908,7 @@ fn map_value_to_literal(value: f64, scalar: Scalar) -> Result<Literal, PipelineC
                 return Err(PipelineConstantError::SrcNeedsToBeFinite);
             }
 
-            let value = <f64 as num_traits::float::FloatCore>::trunc(value);
+            let value = value.trunc();
             if value < f64::from(i32::MIN) || value > f64::from(i32::MAX) {
                 return Err(PipelineConstantError::DstRangeTooSmall);
             }
@@ -919,7 +922,7 @@ fn map_value_to_literal(value: f64, scalar: Scalar) -> Result<Literal, PipelineC
                 return Err(PipelineConstantError::SrcNeedsToBeFinite);
             }
 
-            let value = <f64 as num_traits::float::FloatCore>::trunc(value);
+            let value = value.trunc();
             if value < f64::from(u32::MIN) || value > f64::from(u32::MAX) {
                 return Err(PipelineConstantError::DstRangeTooSmall);
             }

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -905,7 +905,7 @@ fn map_value_to_literal(value: f64, scalar: Scalar) -> Result<Literal, PipelineC
                 return Err(PipelineConstantError::SrcNeedsToBeFinite);
             }
 
-            let value = value.trunc();
+            let value = <f64 as num_traits::float::FloatCore>::trunc(value);
             if value < f64::from(i32::MIN) || value > f64::from(i32::MAX) {
                 return Err(PipelineConstantError::DstRangeTooSmall);
             }
@@ -919,7 +919,7 @@ fn map_value_to_literal(value: f64, scalar: Scalar) -> Result<Literal, PipelineC
                 return Err(PipelineConstantError::SrcNeedsToBeFinite);
             }
 
-            let value = value.trunc();
+            let value = <f64 as num_traits::float::FloatCore>::trunc(value);
             if value < f64::from(u32::MIN) || value > f64::from(u32::MAX) {
                 return Err(PipelineConstantError::DstRangeTooSmall);
             }

--- a/naga/src/common/wgsl/to_wgsl.rs
+++ b/naga/src/common/wgsl/to_wgsl.rs
@@ -14,7 +14,7 @@ use alloc::string::{String, ToString};
 ///
 /// - If a type's WGSL form requires dynamic formatting, so that
 ///   returning a `&'static str` isn't feasible, consider implementing
-///   [`std::fmt::Display`] on some wrapper type instead.
+///   [`core::fmt::Display`] on some wrapper type instead.
 pub trait ToWgsl: Sized {
     /// Return WGSL source code representation of `self`.
     fn to_wgsl(self) -> &'static str;
@@ -32,7 +32,7 @@ pub trait ToWgsl: Sized {
 ///
 /// - If a type's WGSL form requires dynamic formatting, so that
 ///   returning a `&'static str` isn't feasible, consider implementing
-///   [`std::fmt::Display`] on some wrapper type instead.
+///   [`core::fmt::Display`] on some wrapper type instead.
 pub trait TryToWgsl: Sized {
     /// Return the WGSL form of `self` as a `'static` string.
     ///

--- a/naga/src/keywords/wgsl.rs
+++ b/naga/src/keywords/wgsl.rs
@@ -4,7 +4,7 @@ Keywords for [WGSL][wgsl] (WebGPU Shading Language).
 [wgsl]: https://gpuweb.github.io/gpuweb/wgsl.html
 */
 
-use std::sync::LazyLock;
+use crate::racy_lock::RacyLock;
 
 use hashbrown::HashSet;
 
@@ -238,7 +238,7 @@ pub const RESERVED: &[&str] = &[
 /// significant time during [`Namer::reset`](crate::proc::Namer::reset).
 ///
 /// See <https://github.com/gfx-rs/wgpu/pull/7338> for benchmarks.
-pub static RESERVED_SET: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+pub static RESERVED_SET: RacyLock<HashSet<&'static str>> = RacyLock::new(|| {
     let mut set = HashSet::default();
     set.reserve(RESERVED.len());
     for &word in RESERVED {

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -104,11 +104,6 @@ void main() {
     test,
     spv_out,
 
-    // Need OnceLock
-    hlsl_out,
-    msl_out,
-    wgsl_out,
-
     feature = "spv-in",
     feature = "wgsl-in",
 
@@ -130,6 +125,7 @@ pub mod ir;
 pub mod keywords;
 mod non_max_u32;
 pub mod proc;
+mod racy_lock;
 mod span;
 pub mod valid;
 

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -103,10 +103,8 @@ void main() {
 #[cfg(any(
     test,
     spv_out,
-
     feature = "spv-in",
     feature = "wgsl-in",
-
     feature = "stderr",
 ))]
 extern crate std;

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -100,13 +100,7 @@ void main() {
 )]
 #![no_std]
 
-#[cfg(any(
-    test,
-    spv_out,
-    feature = "spv-in",
-    feature = "wgsl-in",
-    feature = "stderr",
-))]
+#[cfg(std)]
 extern crate std;
 
 extern crate alloc;

--- a/naga/src/racy_lock.rs
+++ b/naga/src/racy_lock.rs
@@ -1,0 +1,73 @@
+#![cfg_attr(
+    not(any(hlsl_out, msl_out, wgsl_out, glsl_out)),
+    allow(dead_code, reason = "RacyLock is only required for the above configurations")
+)]
+
+use alloc::boxed::Box;
+use core::sync::atomic::{AtomicPtr, Ordering};
+
+/// An alternative to [`LazyLock`] which will race to initialize rather than blocking.
+/// This makes it suitable for `no_std` environments, at the expense of possibly leaking
+/// memory during initialization.
+///
+/// [`LazyLock`]: https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html
+pub struct RacyLock<T: 'static> {
+    inner: AtomicPtr<T>,
+    init: fn() -> T,
+}
+
+impl<T: 'static> RacyLock<T> {
+    /// Creates a new [`RacyLock`], which will initialize using the provided `init` function.
+    pub const fn new(init: fn() -> T) -> Self {
+        Self {
+            inner: AtomicPtr::new(core::ptr::null_mut()),
+            init,
+        }
+    }
+
+    /// Attempts to load the internal value, returning [`None`] if it is not yet initialized.
+    pub fn try_get(&self) -> Option<&T> {
+        let ptr = self.inner.load(Ordering::Acquire);
+
+        if ptr.is_null() {
+            None
+        } else {
+            // SAFETY: ptr can only ever be null, or a static-valid value from Box::leak,
+            // as it is private.
+            // The above check ensures ptr is not null, so it must be a valid pointer.
+            unsafe { Some(&*ptr) }
+        }
+    }
+
+    /// Loads the internal value, initializing it if required.
+    pub fn get(&self) -> &T {
+        self.try_get().unwrap_or_else(|| {
+            let value = (self.init)();
+
+            // Refresh the static value just before leaking to minimize leaked memory.
+            let ptr = self.inner.load(Ordering::Acquire);
+
+            if ptr.is_null() {
+                // Explicit type used to assert the returned reference is 'static.
+                let ptr: &'static mut T = Box::leak(Box::new(value));
+
+                self.inner.store(ptr, Ordering::Release);
+
+                ptr
+            } else {
+                // SAFETY: ptr can only ever be null, or a static-valid value from Box::leak,
+                // as it is private.
+                // The above check ensures ptr is not null, so it must be a valid pointer.
+                unsafe { &*ptr }
+            }
+        })
+    }
+}
+
+impl<T: 'static> core::ops::Deref for RacyLock<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.get()
+    }
+}

--- a/naga/src/racy_lock.rs
+++ b/naga/src/racy_lock.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(
     not(any(hlsl_out, msl_out, wgsl_out, glsl_out)),
-    allow(
+    expect(
         dead_code,
         reason = "RacyLock is only required for the above configurations"
     )

--- a/naga/src/racy_lock.rs
+++ b/naga/src/racy_lock.rs
@@ -9,9 +9,7 @@
 use alloc::boxed::Box;
 use once_cell::race::OnceBox;
 
-/// An alternative to [`LazyLock`] which will race to initialize rather than blocking.
-/// This makes it suitable for `no_std` environments, at the expense of possibly leaking
-/// memory during initialization.
+/// An alternative to [`LazyLock`] based on [`OnceBox`].
 ///
 /// [`LazyLock`]: https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html
 pub struct RacyLock<T: 'static> {

--- a/naga/src/racy_lock.rs
+++ b/naga/src/racy_lock.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(
     not(any(hlsl_out, msl_out, wgsl_out, glsl_out)),
-    allow(dead_code, reason = "RacyLock is only required for the above configurations")
+    allow(
+        dead_code,
+        reason = "RacyLock is only required for the above configurations"
+    )
 )]
 
 use alloc::boxed::Box;

--- a/naga/src/racy_lock.rs
+++ b/naga/src/racy_lock.rs
@@ -28,11 +28,6 @@ impl<T: 'static> RacyLock<T> {
         }
     }
 
-    /// Attempts to load the internal value, returning [`None`] if it is not yet initialized.
-    pub fn try_get(&self) -> Option<&T> {
-        self.inner.get()
-    }
-
     /// Loads the internal value, initializing it if required.
     pub fn get(&self) -> &T {
         self.inner.get_or_init(|| Box::new((self.init)()))

--- a/naga/src/racy_lock.rs
+++ b/naga/src/racy_lock.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(
-    not(any(hlsl_out, msl_out, wgsl_out, glsl_out)),
+    not(any(glsl_out, hlsl_out, msl_out, feature = "wgsl-in", wgsl_out)),
     expect(
         dead_code,
         reason = "RacyLock is only required for the above configurations"

--- a/naga/src/racy_lock.rs
+++ b/naga/src/racy_lock.rs
@@ -7,7 +7,7 @@
 )]
 
 use alloc::boxed::Box;
-use core::sync::atomic::{AtomicPtr, Ordering};
+use once_cell::race::OnceBox;
 
 /// An alternative to [`LazyLock`] which will race to initialize rather than blocking.
 /// This makes it suitable for `no_std` environments, at the expense of possibly leaking
@@ -15,7 +15,7 @@ use core::sync::atomic::{AtomicPtr, Ordering};
 ///
 /// [`LazyLock`]: https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html
 pub struct RacyLock<T: 'static> {
-    inner: AtomicPtr<T>,
+    inner: OnceBox<T>,
     init: fn() -> T,
 }
 
@@ -23,47 +23,19 @@ impl<T: 'static> RacyLock<T> {
     /// Creates a new [`RacyLock`], which will initialize using the provided `init` function.
     pub const fn new(init: fn() -> T) -> Self {
         Self {
-            inner: AtomicPtr::new(core::ptr::null_mut()),
+            inner: OnceBox::new(),
             init,
         }
     }
 
     /// Attempts to load the internal value, returning [`None`] if it is not yet initialized.
     pub fn try_get(&self) -> Option<&T> {
-        let ptr = self.inner.load(Ordering::Acquire);
-
-        if ptr.is_null() {
-            None
-        } else {
-            // SAFETY: ptr can only ever be null, or a static-valid value from Box::leak,
-            // as it is private.
-            // The above check ensures ptr is not null, so it must be a valid pointer.
-            unsafe { Some(&*ptr) }
-        }
+        self.inner.get()
     }
 
     /// Loads the internal value, initializing it if required.
     pub fn get(&self) -> &T {
-        self.try_get().unwrap_or_else(|| {
-            let value = (self.init)();
-
-            // Refresh the static value just before leaking to minimize leaked memory.
-            let ptr = self.inner.load(Ordering::Acquire);
-
-            if ptr.is_null() {
-                // Explicit type used to assert the returned reference is 'static.
-                let ptr: &'static mut T = Box::leak(Box::new(value));
-
-                self.inner.store(ptr, Ordering::Release);
-
-                ptr
-            } else {
-                // SAFETY: ptr can only ever be null, or a static-valid value from Box::leak,
-                // as it is private.
-                // The above check ensures ptr is not null, so it must be a valid pointer.
-                unsafe { &*ptr }
-            }
-        })
+        self.inner.get_or_init(|| Box::new((self.init)()))
     }
 }
 


### PR DESCRIPTION
**Connections**
- Contributes to #6826

**Description**
- Added a custom alternative to `LazyLock`, `RacyLock`, which uses `AtomicPtr` internally. This type is a drop-in replacement for `LazyLock`, but it trades in blocking for potentially leaking the initialized value in cases where multiple threads attempt to initialize. The type is public but in a private module to prevent external use.
- Removed instances of `LazyLock` and replaced them with `RacyLock`.
- Removed `hlsl_out`,  `wgsl_out`, and `msl_out` from the `extern crate std;` statement, decoupling those features from explicit `std` usage.

**Testing**
- CI

**Squash or Rebase?**

Squash

**Checklist**

- [X] Run `cargo fmt`.
- [X] ~~Run `taplo format`.~~ N/A
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [X] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ N/A

**Notes**

~~This addition includes two `unsafe` blocks in order to dereference the pointer stored within an internal `AtomicPtr`. I considered this preferable to bringing in a 3rd party dependency, such as [`spin`](https://crates.io/crates/spin).~~

I also chose to not offer a feature to switch back to `std::sync::LazyLock`, since such a feature would increase Naga's complexity, and risk stagnating `unsafe` code.