### PR TITLE
[naga]: Remove unused features from `petgraph`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,7 +3000,6 @@ dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown",
  "indexmap",
- "serde",
 ]
 
 [[package]]

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -56,7 +56,7 @@ arbitrary = [
     "half/arbitrary",
     "half/std",
 ]
-spv-in = ["dep:petgraph", "dep:spirv"]
+spv-in = ["dep:petgraph", "petgraph/graphmap", "dep:spirv"]
 spv-out = ["dep:spirv"]
 wgsl-in = ["dep:hexf-parse", "dep:strum", "dep:unicode-ident", "compact"]
 wgsl-out = []
@@ -102,7 +102,7 @@ serde = { version = "1.0.219", features = [
     "default",
     "derive",
 ], optional = true }
-petgraph = { version = "0.8", optional = true }
+petgraph = { version = "0.8", optional = true, default-features = false }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
 unicode-ident = { version = "1.0", optional = true }

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -617,7 +617,12 @@ pub struct Frontend<I> {
     // Graph of all function calls through the module.
     // It's used to sort the functions (as nodes) topologically,
     // so that in the IR any called function is already known.
-    function_call_graph: GraphMap<spirv::Word, (), petgraph::Directed>,
+    function_call_graph: GraphMap<
+        spirv::Word,
+        (),
+        petgraph::Directed,
+        core::hash::BuildHasherDefault<rustc_hash::FxHasher>,
+    >,
     options: Options,
 
     /// Maps for a switch from a case target to the respective body and associated literals that


### PR DESCRIPTION
**Connections**
- Contributes to #6826

**Description**
- Remove unused features from `petgraph` in Naga, improving `no_std` compatibility

**Testing**
- CI

**Squash or Rebase?**

Squash

**Checklist**

- [X] ~~Run `cargo fmt`.~~ N/A
- [X] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [X] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ N/A
