### PR TITLE
[wgpu-hal]: Remove exceptions for `x_instead_of_y` lints

### DIFF
--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -1,4 +1,5 @@
-use std::{ffi::OsString, os::windows::ffi::OsStringExt, string::String};
+use alloc::string::String;
+use std::{ffi::OsString, os::windows::ffi::OsStringExt};
 
 use windows::Win32::Graphics::Dxgi;
 

--- a/wgpu-hal/src/auxil/dxgi/exception.rs
+++ b/wgpu-hal/src/auxil/dxgi/exception.rs
@@ -1,4 +1,4 @@
-use std::{
+use alloc::{
     borrow::Cow,
     string::{String, ToString as _},
 };

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -1,4 +1,5 @@
-use std::{ops::Deref, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
+use core::ops::Deref;
 
 use windows::{core::Interface as _, Win32::Graphics::Dxgi};
 

--- a/wgpu-hal/src/auxil/dxgi/mod.rs
+++ b/wgpu-hal/src/auxil/dxgi/mod.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
-
 pub mod conv;
 pub mod exception;
 pub mod factory;

--- a/wgpu-hal/src/auxil/dxgi/time.rs
+++ b/wgpu-hal/src/auxil/dxgi/time.rs
@@ -18,8 +18,8 @@ pub enum PresentationTimer {
     },
 }
 
-impl std::fmt::Debug for PresentationTimer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PresentationTimer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match *self {
             Self::Dxgi { frequency } => f
                 .debug_struct("DXGI")

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -1,4 +1,6 @@
-use std::{ptr, string::String, sync::Arc, thread, vec::Vec};
+use alloc::{string::String, sync::Arc, vec::Vec};
+use core::ptr;
+use std::thread;
 
 use parking_lot::Mutex;
 use windows::{

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1,4 +1,5 @@
-use std::{mem, ops::Range, vec::Vec};
+use alloc::vec::Vec;
+use core::{mem, ops::Range};
 
 use windows::Win32::{
     Foundation,
@@ -784,7 +785,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                 desc.color_attachments.len() as u32,
                 Some(color_views.as_ptr()),
                 false,
-                ds_view.as_ref().map(std::ptr::from_ref),
+                ds_view.as_ref().map(core::ptr::from_ref),
             )
         };
 
@@ -843,7 +844,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                             ds.clear_value.0,
                             ds.clear_value.1 as u8,
                             0,
-                            std::ptr::null(),
+                            core::ptr::null(),
                         )
                     }
                 }
@@ -864,8 +865,8 @@ impl crate::CommandEncoder for super::CommandEncoder {
             right: desc.extent.width as i32,
             bottom: desc.extent.height as i32,
         };
-        unsafe { list.RSSetViewports(std::slice::from_ref(&raw_vp)) };
-        unsafe { list.RSSetScissorRects(std::slice::from_ref(&raw_rect)) };
+        unsafe { list.RSSetViewports(core::slice::from_ref(&raw_vp)) };
+        unsafe { list.RSSetScissorRects(core::slice::from_ref(&raw_rect)) };
     }
 
     unsafe fn end_render_pass(&mut self) {
@@ -1127,7 +1128,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
             self.list
                 .as_ref()
                 .unwrap()
-                .RSSetViewports(std::slice::from_ref(&raw_vp))
+                .RSSetViewports(core::slice::from_ref(&raw_vp))
         }
     }
     unsafe fn set_scissor_rect(&mut self, rect: &crate::Rect<u32>) {
@@ -1141,7 +1142,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
             self.list
                 .as_ref()
                 .unwrap()
-                .RSSetScissorRects(std::slice::from_ref(&raw_rect))
+                .RSSetScissorRects(core::slice::from_ref(&raw_rect))
         }
     }
     unsafe fn set_stencil_reference(&mut self, value: u32) {

--- a/wgpu-hal/src/dx12/descriptor.rs
+++ b/wgpu-hal/src/dx12/descriptor.rs
@@ -1,4 +1,5 @@
-use std::{fmt, vec::Vec};
+use alloc::vec::Vec;
+use core::fmt;
 
 use bit_set::BitSet;
 use parking_lot::Mutex;

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1,13 +1,11 @@
-use std::{
+use alloc::{
     borrow::Cow,
-    ffi,
-    num::NonZeroU32,
-    ptr,
     string::{String, ToString as _},
     sync::Arc,
-    time::{Duration, Instant},
     vec::Vec,
 };
+use core::{ffi, num::NonZeroU32, ptr, time::Duration};
+use std::time::Instant;
 
 use bytemuck::TransparentWrapper;
 use parking_lot::Mutex;
@@ -868,7 +866,7 @@ impl crate::Device for super::Device {
             bind_cbv.space += 1;
         }
 
-        let mut dynamic_storage_buffer_offsets_targets = std::collections::BTreeMap::new();
+        let mut dynamic_storage_buffer_offsets_targets = alloc::collections::BTreeMap::new();
         let mut total_dynamic_storage_buffers = 0;
 
         // Collect the whole number of bindings we will create upfront.
@@ -1635,7 +1633,9 @@ impl crate::Device for super::Device {
     ) -> Result<super::ShaderModule, crate::ShaderError> {
         self.counters.shader_modules.add(1);
 
-        let raw_name = desc.label.and_then(|label| ffi::CString::new(label).ok());
+        let raw_name = desc
+            .label
+            .and_then(|label| alloc::ffi::CString::new(label).ok());
         match shader {
             crate::ShaderInput::Naga(naga) => Ok(super::ShaderModule {
                 naga,

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -1,4 +1,4 @@
-use std::{string::String, sync::Arc, vec::Vec};
+use alloc::{string::String, sync::Arc, vec::Vec};
 
 use parking_lot::RwLock;
 use windows::{

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -72,8 +72,6 @@ Otherwise, we pass a range corresponding only to the current bind group.
 
 !*/
 
-#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
-
 mod adapter;
 mod command;
 mod conv;
@@ -86,7 +84,8 @@ mod suballocation;
 mod types;
 mod view;
 
-use std::{borrow::ToOwned as _, ffi, fmt, mem, num::NonZeroU32, ops::Deref, sync::Arc, vec::Vec};
+use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
+use core::{ffi, fmt, mem, num::NonZeroU32, ops::Deref};
 
 use arrayvec::ArrayVec;
 use parking_lot::{Mutex, RwLock};
@@ -116,7 +115,7 @@ struct DynLib {
 impl DynLib {
     unsafe fn new<P>(filename: P) -> Result<Self, libloading::Error>
     where
-        P: AsRef<ffi::OsStr>,
+        P: AsRef<std::ffi::OsStr>,
     {
         unsafe { libloading::Library::new(filename) }.map(|inner| Self { inner })
     }
@@ -154,10 +153,10 @@ impl D3D12Lib {
     ) -> Result<Option<Direct3D12::ID3D12Device>, crate::DeviceError> {
         // Calls windows::Win32::Graphics::Direct3D12::D3D12CreateDevice on d3d12.dll
         type Fun = extern "system" fn(
-            padapter: *mut core::ffi::c_void,
+            padapter: *mut ffi::c_void,
             minimumfeaturelevel: Direct3D::D3D_FEATURE_LEVEL,
             riid: *const windows_core::GUID,
-            ppdevice: *mut *mut core::ffi::c_void,
+            ppdevice: *mut *mut ffi::c_void,
         ) -> windows_core::HRESULT;
         let func: libloading::Symbol<Fun> =
             unsafe { self.lib.get(c"D3D12CreateDevice".to_bytes()) }?;
@@ -197,8 +196,8 @@ impl D3D12Lib {
         type Fun = extern "system" fn(
             prootsignature: *const Direct3D12::D3D12_ROOT_SIGNATURE_DESC,
             version: Direct3D12::D3D_ROOT_SIGNATURE_VERSION,
-            ppblob: *mut *mut core::ffi::c_void,
-            pperrorblob: *mut *mut core::ffi::c_void,
+            ppblob: *mut *mut ffi::c_void,
+            pperrorblob: *mut *mut ffi::c_void,
         ) -> windows_core::HRESULT;
         let func: libloading::Symbol<Fun> =
             unsafe { self.lib.get(c"D3D12SerializeRootSignature".to_bytes()) }?;
@@ -238,7 +237,7 @@ impl D3D12Lib {
         // Calls windows::Win32::Graphics::Direct3D12::D3D12GetDebugInterface on d3d12.dll
         type Fun = extern "system" fn(
             riid: *const windows_core::GUID,
-            ppvdebug: *mut *mut core::ffi::c_void,
+            ppvdebug: *mut *mut ffi::c_void,
         ) -> windows_core::HRESULT;
         let func: libloading::Symbol<Fun> =
             unsafe { self.lib.get(c"D3D12GetDebugInterface".to_bytes()) }?;
@@ -276,7 +275,7 @@ impl DxgiLib {
         type Fun = extern "system" fn(
             flags: u32,
             riid: *const windows_core::GUID,
-            pdebug: *mut *mut core::ffi::c_void,
+            pdebug: *mut *mut ffi::c_void,
         ) -> windows_core::HRESULT;
         let func: libloading::Symbol<Fun> =
             unsafe { self.lib.get(c"DXGIGetDebugInterface1".to_bytes()) }?;
@@ -306,7 +305,7 @@ impl DxgiLib {
         type Fun = extern "system" fn(
             flags: Dxgi::DXGI_CREATE_FACTORY_FLAGS,
             riid: *const windows_core::GUID,
-            ppfactory: *mut *mut core::ffi::c_void,
+            ppfactory: *mut *mut ffi::c_void,
         ) -> windows_core::HRESULT;
         let func: libloading::Symbol<Fun> =
             unsafe { self.lib.get(c"CreateDXGIFactory2".to_bytes()) }?;
@@ -329,7 +328,7 @@ impl DxgiLib {
         // Calls windows::Win32::Graphics::Dxgi::CreateDXGIFactory1 on dxgi.dll
         type Fun = extern "system" fn(
             riid: *const windows_core::GUID,
-            ppfactory: *mut *mut core::ffi::c_void,
+            ppfactory: *mut *mut ffi::c_void,
         ) -> windows_core::HRESULT;
         let func: libloading::Symbol<Fun> =
             unsafe { self.lib.get(c"CreateDXGIFactory1".to_bytes()) }?;
@@ -385,7 +384,7 @@ impl Deref for D3DBlob {
 
 impl D3DBlob {
     unsafe fn as_slice(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.GetBufferPointer().cast(), self.GetBufferSize()) }
+        unsafe { core::slice::from_raw_parts(self.GetBufferPointer().cast(), self.GetBufferSize()) }
     }
 
     unsafe fn as_c_str(&self) -> Result<&ffi::CStr, ffi::FromBytesUntilNulError> {
@@ -883,7 +882,7 @@ impl Texture {
 impl crate::DynTexture for Texture {}
 impl crate::DynSurfaceTexture for Texture {}
 
-impl std::borrow::Borrow<dyn crate::DynTexture> for Texture {
+impl core::borrow::Borrow<dyn crate::DynTexture> for Texture {
     fn borrow(&self) -> &dyn crate::DynTexture {
         self
     }
@@ -1023,13 +1022,13 @@ struct BindGroupInfo {
 #[derive(Debug, Clone)]
 struct RootConstantInfo {
     root_index: RootIndex,
-    range: std::ops::Range<u32>,
+    range: core::ops::Range<u32>,
 }
 
 #[derive(Debug, Clone)]
 struct DynamicStorageBufferOffsets {
     root_index: RootIndex,
-    range: std::ops::Range<usize>,
+    range: core::ops::Range<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -1067,7 +1066,7 @@ impl crate::DynPipelineLayout for PipelineLayout {}
 #[derive(Debug)]
 pub struct ShaderModule {
     naga: crate::NagaShader,
-    raw_name: Option<ffi::CString>,
+    raw_name: Option<alloc::ffi::CString>,
     runtime_checks: wgt::ShaderRuntimeChecks,
 }
 
@@ -1140,7 +1139,7 @@ impl SwapChain {
 
     unsafe fn wait(
         &mut self,
-        timeout: Option<std::time::Duration>,
+        timeout: Option<core::time::Duration>,
     ) -> Result<bool, crate::SurfaceError> {
         let timeout_ms = match timeout {
             Some(duration) => duration.as_millis() as u32,
@@ -1362,7 +1361,7 @@ impl crate::Surface for Surface {
 
     unsafe fn acquire_texture(
         &self,
-        timeout: Option<std::time::Duration>,
+        timeout: Option<core::time::Duration>,
         _fence: &Fence,
     ) -> Result<Option<crate::AcquiredSurfaceTexture<Api>>, crate::SurfaceError> {
         let mut swapchain = self.swap_chain.write();

--- a/wgpu-hal/src/dx12/sampler.rs
+++ b/wgpu-hal/src/dx12/sampler.rs
@@ -2,7 +2,7 @@
 //!
 //! Nearly identical to the Vulkan sampler cache, with added descriptor heap management.
 
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 use hashbrown::{hash_map::Entry, HashMap};
 
@@ -43,8 +43,8 @@ impl PartialEq for HashableSamplerDesc {
 
 impl Eq for HashableSamplerDesc {}
 
-impl std::hash::Hash for HashableSamplerDesc {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl core::hash::Hash for HashableSamplerDesc {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.0.Filter.0.hash(state);
         self.0.AddressU.0.hash(state);
         self.0.AddressV.0.hash(state);

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -1,4 +1,6 @@
-use std::{ffi::CStr, path::PathBuf, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
+use core::ffi::CStr;
+use std::path::PathBuf;
 
 use crate::auxil::dxgi::result::HResult;
 use thiserror::Error;
@@ -27,8 +29,8 @@ pub(super) fn compile_fxc(
         compile_flags |= Fxc::D3DCOMPILE_DEBUG | Fxc::D3DCOMPILE_SKIP_OPTIMIZATION;
     }
 
-    let raw_ep = std::ffi::CString::new(raw_ep).unwrap();
-    let full_stage = std::ffi::CString::new(full_stage).unwrap();
+    let raw_ep = alloc::ffi::CString::new(raw_ep).unwrap();
+    let full_stage = alloc::ffi::CString::new(full_stage).unwrap();
 
     // If no name has been set, D3DCompile wants the null pointer.
     let source_name = source_name
@@ -62,9 +64,9 @@ pub(super) fn compile_fxc(
         Err(e) => {
             let mut full_msg = format!("FXC D3DCompile error ({e})");
             if let Some(error) = error {
-                use std::fmt::Write as _;
+                use core::fmt::Write as _;
                 let message = unsafe {
-                    std::slice::from_raw_parts(
+                    core::slice::from_raw_parts(
                         error.GetBufferPointer().cast(),
                         error.GetBufferSize(),
                     )

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -1,6 +1,6 @@
+use alloc::sync::Arc;
 use gpu_allocator::{d3d12::AllocationCreateDesc, MemoryLocation};
 use parking_lot::Mutex;
-use std::sync::Arc;
 use windows::Win32::Graphics::{Direct3D12, Dxgi};
 
 use crate::{
@@ -563,7 +563,7 @@ impl<'a> DeviceAllocationContext<'a> {
     ) -> Result<Direct3D12::D3D12_RESOURCE_ALLOCATION_INFO, crate::DeviceError> {
         let allocation_info = unsafe {
             self.raw
-                .GetResourceAllocationInfo(0, std::slice::from_ref(desc))
+                .GetResourceAllocationInfo(0, core::slice::from_ref(desc))
         };
 
         let Some(threshold) = self

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1,16 +1,6 @@
-#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
-
-use std::{
-    ffi,
-    mem::ManuallyDrop,
-    os::raw,
-    ptr,
-    rc::Rc,
-    string::String,
-    sync::{Arc, LazyLock},
-    time::Duration,
-    vec::Vec,
-};
+use alloc::{rc::Rc, string::String, sync::Arc, vec::Vec};
+use core::{ffi, mem::ManuallyDrop, ptr, time::Duration};
+use std::{os::raw, sync::LazyLock};
 
 use glow::HasContext;
 use hashbrown::HashMap;
@@ -399,7 +389,7 @@ pub struct AdapterContextLock<'a> {
     egl: Option<EglContextLock<'a>>,
 }
 
-impl<'a> std::ops::Deref for AdapterContextLock<'a> {
+impl<'a> core::ops::Deref for AdapterContextLock<'a> {
     type Target = glow::Context;
 
     fn deref(&self) -> &Self::Target {
@@ -922,7 +912,7 @@ impl crate::Instance for Instance {
             log::debug!("Enabling EGL debug output");
             let function: EglDebugMessageControlFun = {
                 let addr = egl.get_proc_address("eglDebugMessageControlKHR").unwrap();
-                unsafe { std::mem::transmute(addr) }
+                unsafe { core::mem::transmute(addr) }
             };
             let attributes = [
                 EGL_DEBUG_MSG_CRITICAL_KHR as khronos_egl::Attrib,
@@ -1018,7 +1008,7 @@ impl crate::Instance for Instance {
                      */
                     log::warn!("Re-initializing Gles context due to Wayland window");
 
-                    use std::ops::DerefMut;
+                    use core::ops::DerefMut;
                     let display_attributes = [khronos_egl::ATTRIB_NONE];
 
                     let display = unsafe {
@@ -1042,7 +1032,7 @@ impl crate::Instance for Instance {
                         inner.force_gles_minor_version,
                     )?;
 
-                    let old_inner = std::mem::replace(inner.deref_mut(), new_inner);
+                    let old_inner = core::mem::replace(inner.deref_mut(), new_inner);
                     inner.wl_display = Some(display_handle.display.as_ptr());
 
                     drop(old_inner);

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -1,19 +1,17 @@
-#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
-
-use std::{
-    borrow::ToOwned as _,
-    ffi::{c_void, CStr, CString},
+use alloc::{borrow::ToOwned as _, ffi::CString, string::String, sync::Arc, vec::Vec};
+use core::{
+    ffi::{c_void, CStr},
     mem::{self, ManuallyDrop},
-    os::raw::c_int,
     ptr,
-    string::String,
+    time::Duration,
+};
+use std::{
+    os::raw::c_int,
     sync::{
         mpsc::{sync_channel, SyncSender},
-        Arc, LazyLock,
+        LazyLock,
     },
     thread,
-    time::Duration,
-    vec::Vec,
 };
 
 use glow::HasContext;
@@ -102,7 +100,7 @@ pub struct AdapterContextLock<'a> {
     inner: MutexGuard<'a, Inner>,
 }
 
-impl<'a> std::ops::Deref for AdapterContextLock<'a> {
+impl<'a> core::ops::Deref for AdapterContextLock<'a> {
     type Target = glow::Context;
 
     fn deref(&self) -> &Self::Target {

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -3,7 +3,8 @@ use objc::{class, msg_send, sel, sel_impl};
 use parking_lot::Mutex;
 use wgt::{AstcBlock, AstcChannel};
 
-use std::{sync::Arc, thread};
+use alloc::sync::Arc;
+use std::thread;
 
 use super::TimestampQuerySupport;
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1,10 +1,10 @@
 use super::{conv, AsNative, TimestampQuerySupport};
 use crate::CommandEncoder as _;
-use std::{
+use alloc::{
     borrow::{Cow, ToOwned as _},
-    ops::Range,
     vec::Vec,
 };
+use core::ops::Range;
 
 // has to match `Temp::binding_sizes`
 const WORD_SIZE: usize = 4;
@@ -972,7 +972,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         if buffer_size > 0 {
             self.state.vertex_buffer_size_map.insert(
                 buffer_index,
-                std::num::NonZeroU64::new(buffer_size).unwrap(),
+                core::num::NonZeroU64::new(buffer_size).unwrap(),
             );
         } else {
             self.state.vertex_buffer_size_map.remove(&buffer_index);

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -853,7 +853,10 @@ impl crate::Device for super::Device {
                         );
 
                         let contents: &mut [metal::MTLResourceID] = unsafe {
-                            std::slice::from_raw_parts_mut(buffer.contents().cast(), count as usize)
+                            core::slice::from_raw_parts_mut(
+                                buffer.contents().cast(),
+                                count as usize,
+                            )
                         };
 
                         match layout.ty {
@@ -1541,7 +1544,7 @@ impl crate::Device for super::Device {
             if start.elapsed().as_millis() >= timeout_ms as u128 {
                 return Ok(false);
             }
-            thread::sleep(time::Duration::from_millis(1));
+            thread::sleep(core::time::Duration::from_millis(1));
         }
     }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -13,8 +13,6 @@ end of the VS buffer table.
 
 !*/
 
-#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
-
 // `MTLFeatureSet` is superseded by `MTLGpuFamily`.
 // However, `MTLGpuFamily` is only supported starting MacOS 10.15, whereas our minimum target is MacOS 10.13,
 // See https://github.com/gpuweb/gpuweb/issues/1069 for minimum spec.
@@ -28,15 +26,9 @@ mod layer_observer;
 mod surface;
 mod time;
 
-use std::{
-    borrow::ToOwned as _,
-    fmt, iter, ops,
-    ptr::NonNull,
-    string::String,
-    sync::{atomic, Arc},
-    thread,
-    vec::Vec,
-};
+use alloc::{borrow::ToOwned as _, string::String, sync::Arc, vec::Vec};
+use core::{fmt, iter, ops, ptr::NonNull, sync::atomic};
+use std::thread;
 
 use arrayvec::ArrayVec;
 use bitflags::bitflags;
@@ -396,13 +388,13 @@ pub struct SurfaceTexture {
 
 impl crate::DynSurfaceTexture for SurfaceTexture {}
 
-impl std::borrow::Borrow<Texture> for SurfaceTexture {
+impl core::borrow::Borrow<Texture> for SurfaceTexture {
     fn borrow(&self) -> &Texture {
         &self.texture
     }
 }
 
-impl std::borrow::Borrow<dyn crate::DynTexture> for SurfaceTexture {
+impl core::borrow::Borrow<dyn crate::DynTexture> for SurfaceTexture {
     fn borrow(&self) -> &dyn crate::DynTexture {
         &self.texture
     }

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::let_unit_value)] // `let () =` being used to constrain result type
 
-use std::borrow::ToOwned as _;
-use std::mem::ManuallyDrop;
-use std::ptr::NonNull;
+use alloc::borrow::ToOwned as _;
+use core::mem::ManuallyDrop;
+use core::ptr::NonNull;
 use std::thread;
 
 use core_graphics_types::{
@@ -186,7 +186,7 @@ impl crate::Surface for super::Surface {
 
     unsafe fn acquire_texture(
         &self,
-        _timeout_ms: Option<std::time::Duration>, //TODO
+        _timeout_ms: Option<core::time::Duration>, //TODO
         _fence: &super::Fence,
     ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
         let render_layer = self.render_layer.lock();

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1,4 +1,5 @@
-use std::{borrow::ToOwned as _, collections::BTreeMap, ffi::CStr, sync::Arc, vec::Vec};
+use alloc::{borrow::ToOwned as _, collections::BTreeMap, sync::Arc, vec::Vec};
+use core::ffi::CStr;
 
 use ash::{amd, ext, google, khr, vk};
 use parking_lot::Mutex;

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -3,7 +3,7 @@ use super::conv;
 use arrayvec::ArrayVec;
 use ash::vk;
 
-use std::{mem, ops::Range};
+use core::{mem, ops::Range};
 
 const ALLOCATION_GRANULARITY: u32 = 16;
 const DST_IMAGE_LAYOUT: vk::ImageLayout = vk::ImageLayout::TRANSFER_DST_OPTIMAL;
@@ -1277,7 +1277,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                     self.active,
                     &vk::CopyAccelerationStructureInfoKHR {
                         s_type: vk::StructureType::COPY_ACCELERATION_STRUCTURE_INFO_KHR,
-                        p_next: std::ptr::null(),
+                        p_next: core::ptr::null(),
                         src: src.raw,
                         dst: dst.raw,
                         mode,

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -1,4 +1,4 @@
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 use ash::vk;
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1,12 +1,15 @@
-use std::{
+use alloc::{
     borrow::{Cow, ToOwned as _},
     collections::BTreeMap,
-    ffi::{CStr, CString},
+    ffi::CString,
+    sync::Arc,
+    vec::Vec,
+};
+use core::{
+    ffi::CStr,
     mem::{self, MaybeUninit},
     num::NonZeroU32,
     ptr,
-    sync::Arc,
-    vec::Vec,
 };
 
 use arrayvec::ArrayVec;
@@ -49,7 +52,7 @@ impl super::DeviceShared {
                 .as_bytes()
                 .iter()
                 .cloned()
-                .chain(std::iter::once(0))
+                .chain(core::iter::once(0))
                 .collect();
             &buffer_vec
         };

--- a/wgpu-hal/src/vulkan/drm.rs
+++ b/wgpu-hal/src/vulkan/drm.rs
@@ -1,7 +1,7 @@
 #![cfg(all(unix, not(target_vendor = "apple"), not(target_family = "wasm")))]
 
+use alloc::{string::ToString, vec::Vec};
 use core::mem::MaybeUninit;
-use std::{string::ToString, vec::Vec};
 
 use ash::{ext, khr, vk};
 

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -1,14 +1,17 @@
-use std::{
+use alloc::{
     borrow::ToOwned as _,
     boxed::Box,
-    ffi::{c_void, CStr, CString},
-    slice,
-    str::FromStr,
+    ffi::CString,
     string::{String, ToString as _},
     sync::Arc,
-    thread,
     vec::Vec,
 };
+use core::{
+    ffi::{c_void, CStr},
+    slice,
+    str::FromStr,
+};
+use std::thread;
 
 use arrayvec::ArrayVec;
 use ash::{ext, khr, vk};
@@ -20,7 +23,7 @@ unsafe extern "system" fn debug_utils_messenger_callback(
     callback_data_ptr: *const vk::DebugUtilsMessengerCallbackDataEXT,
     user_data: *mut c_void,
 ) -> vk::Bool32 {
-    use std::borrow::Cow;
+    use alloc::borrow::Cow;
 
     if thread::panicking() {
         return vk::FALSE;
@@ -539,7 +542,7 @@ impl super::Instance {
     #[cfg(metal)]
     fn create_surface_from_view(
         &self,
-        view: std::ptr::NonNull<c_void>,
+        view: core::ptr::NonNull<c_void>,
     ) -> Result<super::Surface, crate::InstanceError> {
         if !self.shared.extensions.contains(&ext::metal_surface::NAME) {
             return Err(crate::InstanceError::new(String::from(
@@ -1016,7 +1019,7 @@ impl crate::Surface for super::Surface {
 
     unsafe fn acquire_texture(
         &self,
-        timeout: Option<std::time::Duration>,
+        timeout: Option<core::time::Duration>,
         fence: &super::Fence,
     ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
         let mut swapchain = self.swapchain.write();

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -24,8 +24,6 @@ Otherwise, we manage a pool of `VkFence` objects behind each `hal::Fence`.
 
 !*/
 
-#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
-
 mod adapter;
 mod command;
 mod conv;
@@ -34,16 +32,8 @@ mod drm;
 mod instance;
 mod sampler;
 
-use std::{
-    borrow::Borrow,
-    boxed::Box,
-    ffi::{CStr, CString},
-    fmt, mem,
-    num::NonZeroU32,
-    ops::DerefMut,
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::{boxed::Box, ffi::CString, sync::Arc, vec::Vec};
+use core::{borrow::Borrow, ffi::CStr, fmt, mem, num::NonZeroU32, ops::DerefMut};
 
 use arrayvec::ArrayVec;
 use ash::{ext, khr, vk};

--- a/wgpu-hal/src/vulkan/sampler.rs
+++ b/wgpu-hal/src/vulkan/sampler.rs
@@ -39,8 +39,8 @@ impl PartialEq for HashableSamplerCreateInfo {
 
 impl Eq for HashableSamplerCreateInfo {}
 
-impl std::hash::Hash for HashableSamplerCreateInfo {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl core::hash::Hash for HashableSamplerCreateInfo {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.0.flags.hash(state);
         self.0.mag_filter.hash(state);
         self.0.min_filter.hash(state);


### PR DESCRIPTION
**Connections**
- Contributes to #6826

**Description**

There are exceptions within `wgpu-hal` to permit using `std` redundantly in certain modules. This adds a level of inconsistency to developing in `wgpu-hal` without (IMO) meaningful benefit. This PR removes those exceptions and addresses the warnings raised.

**Testing**
- CI

**Squash or Rebase?**

Squash

**Checklist**

- [X] Run `cargo fmt`.
- [X] ~~Run `taplo format`.~~ N/A
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [X] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ N/A
