### PR TITLE
[wgpu-core]: Remove `x_instead_of_y` exceptions

### DIFF
--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -82,7 +82,7 @@ impl<T> Mutex<T> {
     }
 }
 
-impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
+impl<'a, T> core::ops::Deref for MutexGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -90,14 +90,14 @@ impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::DerefMut for MutexGuard<'a, T> {
+impl<'a, T> core::ops::DerefMut for MutexGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.deref_mut()
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for Mutex<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: core::fmt::Debug> core::fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.inner.fmt(f)
     }
 }
@@ -171,13 +171,13 @@ impl<'a, T> RwLockWriteGuard<'a, T> {
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for RwLock<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: core::fmt::Debug> core::fmt::Debug for RwLock<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.inner.fmt(f)
     }
 }
 
-impl<'a, T> std::ops::Deref for RwLockReadGuard<'a, T> {
+impl<'a, T> core::ops::Deref for RwLockReadGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -185,7 +185,7 @@ impl<'a, T> std::ops::Deref for RwLockReadGuard<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::Deref for RwLockWriteGuard<'a, T> {
+impl<'a, T> core::ops::Deref for RwLockWriteGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -193,7 +193,7 @@ impl<'a, T> std::ops::Deref for RwLockWriteGuard<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::DerefMut for RwLockWriteGuard<'a, T> {
+impl<'a, T> core::ops::DerefMut for RwLockWriteGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.deref_mut()
     }
@@ -271,7 +271,7 @@ fn acquire(new_rank: LockRank, location: &'static Location<'static>) -> Option<H
                 log.write_acquisition(held_lock, new_rank, location);
             }
 
-            std::mem::replace(
+            core::mem::replace(
                 held_lock,
                 Some(HeldLock {
                     rank: new_rank,
@@ -478,7 +478,7 @@ impl LockRankSet {
     }
 }
 
-/// Convenience for `std::ptr::from_ref(t) as usize`.
+/// Convenience for `core::ptr::from_ref(t) as usize`.
 fn addr<T>(t: &T) -> usize {
-    std::ptr::from_ref(t) as usize
+    core::ptr::from_ref(t) as usize
 }

--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -28,15 +28,11 @@
 //!
 //! [`lock/rank.rs`]: ../../../src/wgpu_core/lock/rank.rs.html
 
-#![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
-
+use alloc::{format, string::String};
+use core::{cell::RefCell, panic::Location};
 use std::{
-    cell::RefCell,
-    format,
     fs::File,
-    panic::Location,
     path::{Path, PathBuf},
-    string::String,
 };
 
 use super::rank::{LockRank, LockRankSet};


### PR DESCRIPTION
**Connections**
- Contributes to #6826

**Description**
- Remove `x_instead_of_y` lint exceptions in `wgpu-core`. Minimal refactoring required to properly address the lint, and consistency is preferable IMO.

**Testing**
- CI

**Squash or Rebase?**

Squash

**Checklist**

- [X] Run `cargo fmt`.
- [X] ~~Run `taplo format`.~~ N/A
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [X] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ N/A
