### PR TITLE
fix(webgpu): Insert fragment constants into fragment descriptor

### DIFF
--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2130,7 +2130,7 @@ impl dispatch::DeviceInterface for WebDevice {
                 .collect::<js_sys::Array>();
             let module = frag.module.inner.as_webgpu();
             let mapped_fragment_desc = webgpu_sys::GpuFragmentState::new(&module.module, &targets);
-            insert_constants_map(&mapped_vertex_state, frag.compilation_options.constants);
+            insert_constants_map(&mapped_fragment_desc, frag.compilation_options.constants);
             if let Some(ep) = frag.entry_point {
                 mapped_fragment_desc.set_entry_point(ep);
             }


### PR DESCRIPTION
**Description**
In `create_render_pipeline`, the `frag.compilation_options.constants` were mistakenly inserted into `mapped_vertex_state` instead of `mapped_fragment_desc`, causing override constants to fail in the fragment shader.

**Testing**
A shader was used to conditionally sample a texture to use as color output, otherwise output white. Did not work before, but does now.

**Squash or Rebase?**

Not applicable.