### PR TITLE
feat(naga): allow `u32` for sample index arg. of texture loads

### DIFF
--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -660,7 +660,7 @@ impl super::Validator {
                 match (sample, class.is_multisampled()) {
                     (None, false) => {}
                     (Some(sample), true) => {
-                        if resolver[sample].scalar_kind() != Some(Sk::Sint) {
+                        if !matches!(resolver[sample].scalar_kind(), Some(Sk::Sint | Sk::Uint)) {
                             return Err(ExpressionError::InvalidImageOtherIndexType(sample));
                         }
                     }


### PR DESCRIPTION
**Description**

We currently don't permit `u32` for the sample index arguments to texture loads. However, the WGSL spec. demands this.

**Testing**

TODO: Snapshots tests!

**Squash or Rebase?**

If multiple, then rebase.

**Checklist**
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
