### PR TITLE
Use lockfileMaintence for non-breaking changes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,18 +5,29 @@
   "prConcurrentLimit": 20,
   "prHourlyLimit": 200,
   "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "recreateWhen": "always",
+    "rebaseStalePrs": true,
+    "branchTopic": "Cargo.lock update",
+    "commitMessageAction": "Update Cargo.lock",
+    "schedule": ["before 4am on monday"],
+    "prBodyDefinitions": {
+      "Change": "All locks refreshed"
+    }
+  },
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],
       "matchCurrentVersion": "<1.0.0",
-      "groupName": "Minor Updates",
-      "description": "Patch updates to 0.x.y crates are treated as compatible by cargo"
+      "enabled": false,
+      "description": "Patch updates to 0.x.y crates are compatible and handled by lockFileMaintenance"
     },
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": ">=1.0.0",
-      "groupName": "Minor Updates",
-      "description": "Minor and patch updates to x.y.z crates are treated as compatible by cargo"
+      "enabled": false,
+      "description": "Minor and patch updates to x.y.z crates are compatible and handled by lockFileMaintenance"
     },
     {
       "description": "IGNORE: Windows 0.59 is pending on https://github.com/gfx-rs/wgpu/pull/6876",


### PR DESCRIPTION
This will also update transitive dependencies (all things cargo update will)