### PR TITLE
[hal] Do not expose dependency on `metal` and `objc` crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ Naga now infers the correct binding layout when a resource appears only in an as
 
 - Remove the need for dxil.dll. By @teoxoy in [#7566](https://github.com/gfx-rs/wgpu/pull/7566)
 
+#### HAL
+
+- Do not expose the Metal backend's dependency on the `metal` and `objc` crates. By @madsmtm in [#7649](https://github.com/gfx-rs/wgpu/pull/7649)
+
 ### Bug Fixes
 
 #### Naga

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -303,34 +303,28 @@ impl Instance {
         }
     }
 
+    /// Construct a surface from a pointer to a `CAMetalLayer`.
+    ///
     /// # Safety
     ///
-    /// `layer` must be a valid pointer.
+    /// The given layer pointer must point to a valid, non-NULL, initialized
+    /// instance of `CAMetalLayer`.
     #[cfg(metal)]
     pub unsafe fn create_surface_metal(
         &self,
         layer: *mut core::ffi::c_void,
     ) -> Result<Surface, CreateSurfaceError> {
+        use core::ptr::NonNull;
+
         profiling::scope!("Instance::create_surface_metal");
 
-        let instance = unsafe { self.as_hal::<hal::api::Metal>() }
+        let _instance = unsafe { self.as_hal::<hal::api::Metal>() }
             .ok_or(CreateSurfaceError::BackendNotEnabled(Backend::Metal))?;
 
-        let layer = layer.cast();
-        // SAFETY: We do this cast and deref. (rather than using `metal` to get the
-        // object we want) to avoid direct coupling on the `metal` crate.
-        //
-        // To wit, this pointer…
-        //
-        // - …is properly aligned.
-        // - …is dereferenceable to a `MetalLayerRef` as an invariant of the `metal`
-        //   field.
-        // - …points to an _initialized_ `MetalLayerRef`.
-        // - …is only ever aliased via an immutable reference that lives within this
-        //   lexical scope.
-        let layer = unsafe { &*layer };
-        let raw_surface: Box<dyn hal::DynSurface> =
-            Box::new(instance.create_surface_from_layer(layer));
+        let layer = NonNull::new(layer).expect("layer pointer must not be NULL");
+        // SAFETY: Upheld by caller.
+        let raw_surface = unsafe { hal::metal::Surface::from_layer(layer) };
+        let raw_surface: Box<dyn hal::DynSurface> = Box::new(raw_surface);
 
         let surface = Surface {
             presentation: Mutex::new(rank::SURFACE_PRESENTATION, None),

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -103,12 +103,6 @@ crate::impl_dyn_resource!(
 
 pub struct Instance {}
 
-impl Instance {
-    pub fn create_surface_from_layer(&self, layer: &metal::MetalLayerRef) -> Surface {
-        unsafe { Surface::from_layer(layer) }
-    }
-}
-
 impl crate::Instance for Instance {
     type A = Api;
 
@@ -127,11 +121,11 @@ impl crate::Instance for Instance {
         match window_handle {
             #[cfg(any(target_os = "ios", target_os = "visionos"))]
             raw_window_handle::RawWindowHandle::UiKit(handle) => {
-                Ok(unsafe { Surface::from_view(handle.ui_view.cast()) })
+                Ok(unsafe { Surface::from_ui_view(handle.ui_view) })
             }
             #[cfg(target_os = "macos")]
             raw_window_handle::RawWindowHandle::AppKit(handle) => {
-                Ok(unsafe { Surface::from_view(handle.ns_view.cast()) })
+                Ok(unsafe { Surface::from_ns_view(handle.ns_view) })
             }
             _ => Err(crate::InstanceError::new(format!(
                 "window handle {window_handle:?} is not a Metal-compatible handle"

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::let_unit_value)] // `let () =` being used to constrain result type
 
 use alloc::borrow::ToOwned as _;
-use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
+use core::{ffi::c_void, mem::ManuallyDrop};
 use std::thread;
 
 use core_graphics_types::{
@@ -34,10 +34,18 @@ impl super::Surface {
         }
     }
 
-    /// If not called on the main thread, this will panic.
-    #[allow(clippy::transmute_ptr_to_ref)]
-    pub unsafe fn from_view(view: NonNull<Object>) -> Self {
-        let layer = unsafe { Self::get_metal_layer(view) };
+    /// Construct a surface from a pointer to a `NSView`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called from a thread that is not the main thread.
+    ///
+    /// # Safety
+    ///
+    /// The given view pointer must be a valid instance of `NSView`.
+    pub unsafe fn from_ns_view(view: NonNull<c_void>) -> Self {
+        // SAFETY: Upheld by caller.
+        let layer = unsafe { Self::get_metal_layer(view.cast()) };
         let layer = ManuallyDrop::new(layer);
         // SAFETY: The layer is an initialized instance of `CAMetalLayer`, and
         // we transfer the retain count to `MetalLayer` using `ManuallyDrop`.
@@ -45,9 +53,38 @@ impl super::Surface {
         Self::new(layer)
     }
 
-    pub unsafe fn from_layer(layer: &metal::MetalLayerRef) -> Self {
+    /// Construct a surface from a pointer to a `UIView`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called from a thread that is not the main thread.
+    ///
+    /// # Safety
+    ///
+    /// The given view pointer must be a valid instance of `UIView`.
+    pub unsafe fn from_ui_view(view: NonNull<c_void>) -> Self {
+        // SAFETY: Upheld by caller.
+        let layer = unsafe { Self::get_metal_layer(view.cast()) };
+        let layer = ManuallyDrop::new(layer);
+        // SAFETY: The layer is an initialized instance of `CAMetalLayer`, and
+        // we transfer the retain count to `MetalLayer` using `ManuallyDrop`.
+        let layer = unsafe { metal::MetalLayer::from_ptr(layer.cast()) };
+        Self::new(layer)
+    }
+
+    /// Construct a surface from a pointer to a `CAMetalLayer`.
+    ///
+    /// # Safety
+    ///
+    /// The given view pointer must be a valid instance of `CAMetalLayer`.
+    pub unsafe fn from_layer(layer: NonNull<c_void>) -> Self {
+        // SAFETY: Validity of the pointer is upheld by the caller.
+        //
+        // We extend the lifetime of the layer with `to_owned` below.
+        let layer = unsafe { layer.cast::<metal::MetalLayerRef>().as_ref() };
+
         let class = class!(CAMetalLayer);
-        let proper_kind: BOOL = msg_send![layer, isKindOfClass: class];
+        let proper_kind: BOOL = unsafe { msg_send![layer, isKindOfClass: class] };
         assert_eq!(proper_kind, YES);
         Self::new(layer.to_owned())
     }


### PR DESCRIPTION
**Connections**
Allows https://github.com/gfx-rs/wgpu/pull/5641 to not contain breaking changes.

**Description**
`wgpu-hal`'s dependency on the `metal` and `objc` crates is currently indirectly exposed via. the parameter types on `hal::metal::Surface::from_view`, `hal::metal::Surface::from_layer` and `hal::metal::Instance::create_surface_from_layer`.

This is unfortunate, since it ties `wgpu-hal` to specific dependencies, and specific versions of said dependencies. Instead, this PR changes these methods to use `NonNull<c_void>`, and prefers to instead document which type the user is expected to pass here. This mirrors the top-level API already exposed in `Instance::create_surface_metal`.

Additionally, this PR removes `metal::Instance::create_surface_from_layer`, since it was only a simple wrapper, and splits `metal::Surface::from_view` into `from_ns_view` and `from_ui_view` to make it clearer/easier to document what the requirements are for the given type. This matches [`raw_window_metal::Layer`](https://docs.rs/raw-window-metal/1.1.0/raw_window_metal/struct.Layer.html)'s methods.

**Testing**
Tested using:
```sh
# macOS
cargo run --bin wgpu-examples -- cube

# iOS on Mac Catalyst using Cargo Bundle
echo "[package.metadata.bundle]" >> examples/features/Cargo.toml
cargo bundle --format=ios --target=aarch64-apple-ios-macabi --bin wgpu-examples
./target/aarch64-apple-ios-macabi/debug/bundle/ios/wgpu-examples.app/wgpu-examples cube
```

I believe this should suffice, as this mostly modifies the entry point to surface creation.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry.
