### PR TITLE
Fix shaderf16 support on vulkan/nvidia

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -387,7 +387,9 @@ impl PhysicalDeviceFeatures {
                 None
             },
             shader_float16: if requested_features.contains(wgt::Features::SHADER_F16) {
-                let supported_f16_features = _phd_features.shader_float16.map(|(_, s)| s)
+                let supported_f16_features = _phd_features
+                    .shader_float16
+                    .map(|(_, s)| s)
                     .unwrap_or_default();
 
                 Some((
@@ -395,14 +397,12 @@ impl PhysicalDeviceFeatures {
                     // Only enable the 16bit storage features that are actually supported by the hardware
                     vk::PhysicalDevice16BitStorageFeatures::default()
                         .storage_buffer16_bit_access(
-                            supported_f16_features.storage_buffer16_bit_access != 0
+                            supported_f16_features.storage_buffer16_bit_access != 0,
                         )
                         .uniform_and_storage_buffer16_bit_access(
-                            supported_f16_features.uniform_and_storage_buffer16_bit_access != 0
+                            supported_f16_features.uniform_and_storage_buffer16_bit_access != 0,
                         )
-                        .storage_input_output16(
-                            supported_f16_features.storage_input_output16 != 0
-                        ),
+                        .storage_input_output16(supported_f16_features.storage_input_output16 != 0),
                 ))
             } else {
                 None
@@ -732,7 +732,7 @@ impl PhysicalDeviceFeatures {
                 F::SHADER_F16,
                 f16_i8.shader_float16 != 0
                     && bit16.storage_buffer16_bit_access != 0
-                    && bit16.uniform_and_storage_buffer16_bit_access != 0
+                    && bit16.uniform_and_storage_buffer16_bit_access != 0,
             );
         }
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -387,12 +387,22 @@ impl PhysicalDeviceFeatures {
                 None
             },
             shader_float16: if requested_features.contains(wgt::Features::SHADER_F16) {
+                let supported_f16_features = _phd_features.shader_float16.map(|(_, s)| s)
+                    .unwrap_or_default();
+
                 Some((
                     vk::PhysicalDeviceShaderFloat16Int8Features::default().shader_float16(true),
+                    // Only enable the 16bit storage features that are actually supported by the hardware
                     vk::PhysicalDevice16BitStorageFeatures::default()
-                        .storage_buffer16_bit_access(true)
-                        .storage_input_output16(true)
-                        .uniform_and_storage_buffer16_bit_access(true),
+                        .storage_buffer16_bit_access(
+                            supported_f16_features.storage_buffer16_bit_access != 0
+                        )
+                        .uniform_and_storage_buffer16_bit_access(
+                            supported_f16_features.uniform_and_storage_buffer16_bit_access != 0
+                        )
+                        .storage_input_output16(
+                            supported_f16_features.storage_input_output16 != 0
+                        ),
                 ))
             } else {
                 None
@@ -723,7 +733,6 @@ impl PhysicalDeviceFeatures {
                 f16_i8.shader_float16 != 0
                     && bit16.storage_buffer16_bit_access != 0
                     && bit16.uniform_and_storage_buffer16_bit_access != 0
-                    && bit16.storage_input_output16 != 0,
             );
         }
 


### PR DESCRIPTION
**Connections**
N/A

**Description**
On my Laptop 4090, vulkaninfo reports:

```
VkPhysicalDeviceVulkan11Features:
---------------------------------
storageBuffer16BitAccess = true
uniformAndStorageBuffer16BitAccess = true
storagePushConstant16 = true
storageInputOutput16 = false
```
        
However the wgpu vulkan backend requires all four to be true for the SHADER_F16 feature to be supported.
This doesn't seem necessary, and as far as I can tell, `storage_input_output16` isn't even read anywhere in wgpu.

This is also how dawn handles f16 support checking [here](https://github.com/google/dawn/blob/50c8a69ed21cd299022d66d9a41e06094749ea00/src/dawn/native/vulkan/DeviceVk.cpp#L517).

**Testing**
My personal project using f16s (developed in chrome wasm which doesn't have this issue) was tested and works fine on Windows 11 native, Vulkan Backend.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
