### PR TITLE
fix(const_eval): allow `cast`s from `AbstractInt` to itself

### DIFF
--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1845,6 +1845,10 @@ impl<'a> ConstantEvaluator<'a> {
                         Literal::AbstractFloat(v) => v,
                         _ => return make_error(),
                     }),
+                    Sc::ABSTRACT_INT => Literal::AbstractInt(match literal {
+                        Literal::AbstractInt(v) => v,
+                        _ => return make_error(),
+                    }),
                     _ => {
                         log::debug!("Constant evaluator refused to convert value to {target:?}");
                         return make_error();


### PR DESCRIPTION
Found this while testing #7572 against WebGPU CTS, attempting to (reasonably) cast from a  `0x80000000` literal to an `AbstractInt` as part of `select`.

**Squash or Rebase?**

sqoosh

**Checklist**

- [x] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ I forewent doing this, because the issue doesn't seem to be exposed until #7572.
