### PR TITLE
[hal metal] ray tracing acceleration structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ Naga now infers the correct binding layout when a resource appears only in an as
 
 - Use highest SPIR-V version supported by Vulkan API version. By @robamler in [#7595](https://github.com/gfx-rs/wgpu/pull/7595)
 
+#### Metal
+
+- Implements ray-tracing acceleration structures for metal backend. By @lichtso in [#7660](https://github.com/gfx-rs/wgpu/pull/7660)
+
 ### Bug Fixes
 
 #### Naga

--- a/examples/features/src/ray_shadows/mod.rs
+++ b/examples/features/src/ray_shadows/mod.rs
@@ -116,7 +116,7 @@ impl crate::framework::Example for Example {
 
     fn required_limits() -> wgpu::Limits {
         wgpu::Limits {
-            max_push_constant_size: 12,
+            max_push_constant_size: 16,
             ..wgpu::Limits::default()
         }
     }
@@ -209,7 +209,7 @@ impl crate::framework::Example for Example {
             bind_group_layouts: &[&bind_group_layout],
             push_constant_ranges: &[wgpu::PushConstantRange {
                 stages: wgpu::ShaderStages::FRAGMENT,
-                range: 0..12,
+                range: 0..16,
             }],
         });
 

--- a/examples/features/src/ray_shadows/shader.wgsl
+++ b/examples/features/src/ray_shadows/shader.wgsl
@@ -35,6 +35,7 @@ var acc_struct: acceleration_structure;
 
 struct PushConstants {
     light: vec3<f32>,
+    padding: f32,
 }
 var<push_constant> pc: PushConstants;
 

--- a/examples/features/src/ray_traced_triangle/mod.rs
+++ b/examples/features/src/ray_traced_triangle/mod.rs
@@ -120,7 +120,7 @@ impl crate::framework::Example for Example {
         });
 
         let index_buffer = device.create_buffer_init(&BufferInitDescriptor {
-            label: Some("vertex buffer"),
+            label: Some("index buffer"),
             contents: bytemuck::cast_slice(&indices),
             usage: BufferUsages::BLAS_INPUT,
         });

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -1141,7 +1141,7 @@ fn iter_buffers<'a, 'b>(
         };
 
         let triangles = hal::AccelerationStructureTriangles {
-            vertex_buffer: Some(vertex_buffer),
+            vertex_buffer,
             vertex_format: mesh.size.vertex_format,
             first_vertex: mesh.first_vertex,
             vertex_count: mesh.size.vertex_count,

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -280,7 +280,7 @@ impl Global {
                 tlas,
                 entries: hal::AccelerationStructureEntries::Instances(
                     hal::AccelerationStructureInstances {
-                        buffer: Some(instance_buffer),
+                        buffer: instance_buffer,
                         offset: 0,
                         count: entry.instance_count,
                     },
@@ -602,7 +602,7 @@ impl Global {
                     tlas: tlas.clone(),
                     entries: hal::AccelerationStructureEntries::Instances(
                         hal::AccelerationStructureInstances {
-                            buffer: Some(tlas.instance_buffer.as_ref()),
+                            buffer: tlas.instance_buffer.as_ref(),
                             offset: 0,
                             count: instance_count,
                         },

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -1150,7 +1150,7 @@ fn iter_buffers<'a, 'b>(
                 let index_stride = mesh.size.index_format.unwrap().byte_size() as u32;
                 hal::AccelerationStructureTriangleIndices::<dyn hal::DynBuffer> {
                     format: mesh.size.index_format.unwrap(),
-                    buffer: Some(index_buffer),
+                    buffer: index_buffer,
                     offset: mesh.first_index.unwrap() * index_stride,
                     count: mesh.size.index_count.unwrap(),
                 }

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -584,6 +584,13 @@ impl Global {
                 dependencies.push(blas.clone());
             }
 
+            let dependencies_raw = dependencies
+                .iter()
+                .map(|blas| blas.try_raw(&snatch_guard).unwrap())
+                .collect::<Vec<_>>();
+            let tlas_raw = tlas.try_raw(&snatch_guard)?;
+            tlas_raw.set_dependencies(&dependencies_raw);
+
             build_command.tlas_s_built.push(TlasBuild {
                 tlas: tlas.clone(),
                 dependencies,

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -158,7 +158,7 @@ impl Device {
                 &hal::GetAccelerationStructureBuildSizesDescriptor {
                     entries: &hal::AccelerationStructureEntries::Instances(
                         hal::AccelerationStructureInstances {
-                            buffer: None,
+                            buffer: self.zero_buffer.as_ref(),
                             offset: 0,
                             count: desc.max_instances,
                         },

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -50,7 +50,7 @@ impl Device {
                                 dyn hal::DynBuffer,
                             > {
                                 format: desc.index_format.unwrap(),
-                                buffer: None,
+                                buffer: self.zero_buffer.as_ref(),
                                 offset: 0,
                                 count,
                             });

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -78,7 +78,7 @@ impl Device {
                     }
 
                     entries.push(hal::AccelerationStructureTriangles::<dyn hal::DynBuffer> {
-                        vertex_buffer: None,
+                        vertex_buffer: self.zero_buffer.as_ref(),
                         vertex_format: desc.vertex_format,
                         first_vertex: 0,
                         vertex_count: desc.vertex_count,

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -75,6 +75,7 @@ metal = [
     "naga/msl-out",
     "dep:arrayvec",
     "dep:block",
+    "dep:bytemuck",
     "dep:core-graphics-types",
     "dep:hashbrown",
     "dep:libc",

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -493,30 +493,11 @@ impl<A: hal::Api> Example<A> {
         }];
         let blas_entries = hal::AccelerationStructureEntries::Triangles(blas_triangles);
 
-        let mut tlas_entries =
-            hal::AccelerationStructureEntries::Instances(hal::AccelerationStructureInstances {
-                buffer: None,
-                count: 3,
-                offset: 0,
-            });
-
         let blas_sizes = unsafe {
             device.get_acceleration_structure_build_sizes(
                 &hal::GetAccelerationStructureBuildSizesDescriptor {
                     entries: &blas_entries,
                     flags: hal::AccelerationStructureBuildFlags::PREFER_FAST_TRACE,
-                },
-            )
-        };
-
-        let tlas_flags = hal::AccelerationStructureBuildFlags::PREFER_FAST_TRACE
-            | hal::AccelerationStructureBuildFlags::ALLOW_UPDATE;
-
-        let tlas_sizes = unsafe {
-            device.get_acceleration_structure_build_sizes(
-                &hal::GetAccelerationStructureBuildSizesDescriptor {
-                    entries: &tlas_entries,
-                    flags: tlas_flags,
                 },
             )
         };
@@ -530,6 +511,91 @@ impl<A: hal::Api> Example<A> {
             })
         }
         .unwrap();
+
+        let instances = [
+            AccelerationStructureInstance::new(
+                &Affine3A::from_translation(Vec3 {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                }),
+                0,
+                0xff,
+                0,
+                0,
+                unsafe { device.get_acceleration_structure_device_address(&blas) },
+            ),
+            AccelerationStructureInstance::new(
+                &Affine3A::from_translation(Vec3 {
+                    x: -1.0,
+                    y: -1.0,
+                    z: -2.0,
+                }),
+                0,
+                0xff,
+                0,
+                0,
+                unsafe { device.get_acceleration_structure_device_address(&blas) },
+            ),
+            AccelerationStructureInstance::new(
+                &Affine3A::from_translation(Vec3 {
+                    x: 1.0,
+                    y: -1.0,
+                    z: -2.0,
+                }),
+                0,
+                0xff,
+                0,
+                0,
+                unsafe { device.get_acceleration_structure_device_address(&blas) },
+            ),
+        ];
+
+        let instances_buffer_size = instances.len() * size_of::<AccelerationStructureInstance>();
+
+        let instances_buffer = unsafe {
+            let instances_buffer = device
+                .create_buffer(&hal::BufferDescriptor {
+                    label: Some("instances_buffer"),
+                    size: instances_buffer_size as u64,
+                    usage: wgpu_types::BufferUses::MAP_WRITE
+                        | wgpu_types::BufferUses::TOP_LEVEL_ACCELERATION_STRUCTURE_INPUT,
+                    memory_flags: hal::MemoryFlags::TRANSIENT | hal::MemoryFlags::PREFER_COHERENT,
+                })
+                .unwrap();
+
+            let mapping = device
+                .map_buffer(&instances_buffer, 0..instances_buffer_size as u64)
+                .unwrap();
+            ptr::copy_nonoverlapping(
+                instances.as_ptr() as *const u8,
+                mapping.ptr.as_ptr(),
+                instances_buffer_size,
+            );
+            device.unmap_buffer(&instances_buffer);
+            assert!(mapping.is_coherent);
+
+            instances_buffer
+        };
+
+        let tlas_entries =
+            hal::AccelerationStructureEntries::Instances(hal::AccelerationStructureInstances {
+                buffer: &instances_buffer,
+                count: 3,
+                offset: 0,
+            });
+
+        let tlas_flags = hal::AccelerationStructureBuildFlags::PREFER_FAST_TRACE
+            | hal::AccelerationStructureBuildFlags::ALLOW_UPDATE;
+
+        let tlas_sizes = unsafe {
+            device.get_acceleration_structure_build_sizes(
+                &hal::GetAccelerationStructureBuildSizesDescriptor {
+                    entries: &tlas_entries,
+                    flags: tlas_flags,
+                },
+            )
+        };
 
         let tlas = unsafe {
             device.create_acceleration_structure(&hal::AccelerationStructureDescriptor {
@@ -652,80 +718,6 @@ impl<A: hal::Api> Example<A> {
                 })
                 .unwrap()
         };
-
-        let instances = [
-            AccelerationStructureInstance::new(
-                &Affine3A::from_translation(Vec3 {
-                    x: 0.0,
-                    y: 0.0,
-                    z: 0.0,
-                }),
-                0,
-                0xff,
-                0,
-                0,
-                unsafe { device.get_acceleration_structure_device_address(&blas) },
-            ),
-            AccelerationStructureInstance::new(
-                &Affine3A::from_translation(Vec3 {
-                    x: -1.0,
-                    y: -1.0,
-                    z: -2.0,
-                }),
-                0,
-                0xff,
-                0,
-                0,
-                unsafe { device.get_acceleration_structure_device_address(&blas) },
-            ),
-            AccelerationStructureInstance::new(
-                &Affine3A::from_translation(Vec3 {
-                    x: 1.0,
-                    y: -1.0,
-                    z: -2.0,
-                }),
-                0,
-                0xff,
-                0,
-                0,
-                unsafe { device.get_acceleration_structure_device_address(&blas) },
-            ),
-        ];
-
-        let instances_buffer_size = instances.len() * size_of::<AccelerationStructureInstance>();
-
-        let instances_buffer = unsafe {
-            let instances_buffer = device
-                .create_buffer(&hal::BufferDescriptor {
-                    label: Some("instances_buffer"),
-                    size: instances_buffer_size as u64,
-                    usage: wgpu_types::BufferUses::MAP_WRITE
-                        | wgpu_types::BufferUses::TOP_LEVEL_ACCELERATION_STRUCTURE_INPUT,
-                    memory_flags: hal::MemoryFlags::TRANSIENT | hal::MemoryFlags::PREFER_COHERENT,
-                })
-                .unwrap();
-
-            let mapping = device
-                .map_buffer(&instances_buffer, 0..instances_buffer_size as u64)
-                .unwrap();
-            ptr::copy_nonoverlapping(
-                instances.as_ptr() as *const u8,
-                mapping.ptr.as_ptr(),
-                instances_buffer_size,
-            );
-            device.unmap_buffer(&instances_buffer);
-            assert!(mapping.is_coherent);
-
-            instances_buffer
-        };
-
-        if let hal::AccelerationStructureEntries::Instances(ref mut i) = tlas_entries {
-            i.buffer = Some(&instances_buffer);
-            assert!(
-                instances.len() <= i.count as usize,
-                "Tlas allocation to small"
-            );
-        }
 
         let cmd_encoder_desc = hal::CommandEncoderDescriptor {
             label: None,
@@ -903,7 +895,7 @@ impl<A: hal::Api> Example<A> {
             ctx.encoder.begin_encoding(Some("frame")).unwrap();
 
             let instances = hal::AccelerationStructureInstances {
-                buffer: Some(&self.instances_buffer),
+                buffer: &self.instances_buffer,
                 count: self.instances.len() as u32,
                 offset: 0,
             };

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -473,7 +473,7 @@ impl<A: hal::Api> Example<A> {
         };
 
         let blas_triangles = vec![hal::AccelerationStructureTriangles {
-            vertex_buffer: Some(&vertices_buffer),
+            vertex_buffer: &vertices_buffer,
             first_vertex: 0,
             vertex_format: wgpu_types::VertexFormat::Float32x3,
             // each vertex is 3 floats, and floats are stored raw in the array

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -479,9 +479,9 @@ impl<A: hal::Api> Example<A> {
             // each vertex is 3 floats, and floats are stored raw in the array
             vertex_count: vertices.len() as u32 / 3,
             vertex_stride: 3 * 4,
-            indices: indices_buffer.as_ref().map(|(buf, len)| {
+            indices: indices_buffer.as_ref().map(|(buffer, len)| {
                 hal::AccelerationStructureTriangleIndices {
-                    buffer: Some(buf),
+                    buffer,
                     format: wgpu_types::IndexFormat::Uint32,
                     offset: 0,
                     count: *len as u32,

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1508,12 +1508,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                         let index_count =
                             triangle.indices.as_ref().map_or(0, |indices| indices.count);
                         let index_address = triangle.indices.as_ref().map_or(0, |indices| unsafe {
-                            indices
-                                .buffer
-                                .expect("needs buffer to build")
-                                .resource
-                                .GetGPUVirtualAddress()
-                                + indices.offset as u64
+                            indices.buffer.resource.GetGPUVirtualAddress() + indices.offset as u64
                         });
                         let vertex_address = unsafe {
                             triangle

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1476,13 +1476,8 @@ impl crate::CommandEncoder for super::CommandEncoder {
             let num_desc;
             match descriptor.entries {
                 AccelerationStructureEntries::Instances(instances) => {
-                    let desc_address = unsafe {
-                        instances
-                            .buffer
-                            .expect("needs buffer to build")
-                            .resource
-                            .GetGPUVirtualAddress()
-                    } + instances.offset as u64;
+                    let desc_address = unsafe { instances.buffer.resource.GetGPUVirtualAddress() }
+                        + instances.offset as u64;
                     ty = Direct3D12::D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
                     inputs0 = Direct3D12::D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_0 {
                         InstanceDescs: desc_address,

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1546,10 +1546,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                     geometry_desc = Vec::with_capacity(aabbs.len());
                     for aabb in aabbs {
                         let aabb_address = unsafe {
-                            aabb.buffer
-                                .expect("needs buffer to build")
-                                .resource
-                                .GetGPUVirtualAddress()
+                            aabb.buffer.resource.GetGPUVirtualAddress()
                                 + (aabb.offset as u64 * aabb.stride)
                         };
 

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1511,11 +1511,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                             indices.buffer.resource.GetGPUVirtualAddress() + indices.offset as u64
                         });
                         let vertex_address = unsafe {
-                            triangle
-                                .vertex_buffer
-                                .expect("needs buffer to build")
-                                .resource
-                                .GetGPUVirtualAddress()
+                            triangle.vertex_buffer.resource.GetGPUVirtualAddress()
                                 + (triangle.first_vertex as u64 * triangle.vertex_stride)
                         };
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -1134,7 +1134,9 @@ pub struct AccelerationStructure {
     allocation: suballocation::Allocation,
 }
 
-impl crate::DynAccelerationStructure for AccelerationStructure {}
+impl crate::DynAccelerationStructure for AccelerationStructure {
+    fn set_dependencies(&self, _dependencies: &[&dyn crate::DynAccelerationStructure]) {}
+}
 
 impl SwapChain {
     unsafe fn release_resources(mut self) -> Dxgi::IDXGISwapChain3 {

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -169,7 +169,7 @@ impl<'a> AccelerationStructureEntries<'a, dyn DynBuffer> {
                     triangles
                         .iter()
                         .map(|t| AccelerationStructureTriangles {
-                            vertex_buffer: t.vertex_buffer.map(|b| b.expect_downcast_ref()),
+                            vertex_buffer: t.vertex_buffer.expect_downcast_ref(),
                             vertex_format: t.vertex_format,
                             first_vertex: t.first_vertex,
                             vertex_count: t.vertex_count,

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -51,7 +51,7 @@ macro_rules! impl_dyn_resource {
 pub(crate) use impl_dyn_resource;
 
 /// Extension trait for `DynResource` used by implementations of various dynamic resource traits.
-trait DynResourceExt {
+pub(crate) trait DynResourceExt {
     /// # Panics
     ///
     /// - Panics if `self` is not downcastable to `T`.
@@ -104,7 +104,9 @@ impl<R: DynResource + ?Sized> DynResourceExt for R {
     }
 }
 
-pub trait DynAccelerationStructure: DynResource + fmt::Debug {}
+pub trait DynAccelerationStructure: DynResource + fmt::Debug {
+    fn set_dependencies(&self, dependencies: &[&dyn DynAccelerationStructure]);
+}
 pub trait DynBindGroup: DynResource + fmt::Debug {}
 pub trait DynBindGroupLayout: DynResource + fmt::Debug {}
 pub trait DynBuffer: DynResource + fmt::Debug {}

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -176,7 +176,7 @@ impl<'a> AccelerationStructureEntries<'a, dyn DynBuffer> {
                             vertex_stride: t.vertex_stride,
                             indices: t.indices.as_ref().map(|i| {
                                 AccelerationStructureTriangleIndices {
-                                    buffer: i.buffer.map(|b| b.expect_downcast_ref()),
+                                    buffer: i.buffer.expect_downcast_ref(),
                                     format: i.format,
                                     offset: i.offset,
                                     count: i.count,

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -197,7 +197,7 @@ impl<'a> AccelerationStructureEntries<'a, dyn DynBuffer> {
                 entries
                     .iter()
                     .map(|e| AccelerationStructureAABBs {
-                        buffer: e.buffer.map(|b| b.expect_downcast_ref()),
+                        buffer: e.buffer.expect_downcast_ref(),
                         offset: e.offset,
                         count: e.count,
                         stride: e.stride,

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -159,7 +159,7 @@ impl<'a> AccelerationStructureEntries<'a, dyn DynBuffer> {
         match self {
             AccelerationStructureEntries::Instances(instances) => {
                 AccelerationStructureEntries::Instances(AccelerationStructureInstances {
-                    buffer: instances.buffer.map(|b| b.expect_downcast_ref()),
+                    buffer: instances.buffer.expect_downcast_ref(),
                     offset: instances.offset,
                     count: instances.count,
                 })

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -741,7 +741,9 @@ impl crate::DynQuerySet for QuerySet {}
 #[derive(Debug)]
 pub struct AccelerationStructure;
 
-impl crate::DynAccelerationStructure for AccelerationStructure {}
+impl crate::DynAccelerationStructure for AccelerationStructure {
+    fn set_dependencies(&self, _dependencies: &[&dyn crate::DynAccelerationStructure]) {}
+}
 
 #[derive(Debug)]
 pub struct PipelineCache;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2489,7 +2489,7 @@ pub enum AccelerationStructureEntries<'a, B: DynBuffer + ?Sized> {
 /// * `transform` - optional transform
 #[derive(Clone, Debug)]
 pub struct AccelerationStructureTriangles<'a, B: DynBuffer + ?Sized> {
-    pub vertex_buffer: Option<&'a B>,
+    pub vertex_buffer: &'a B,
     pub vertex_format: wgt::VertexFormat,
     pub first_vertex: u32,
     pub vertex_count: u32,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2526,7 +2526,7 @@ pub struct AccelerationStructureInstances<'a, B: DynBuffer + ?Sized> {
 #[derive(Clone, Debug)]
 pub struct AccelerationStructureTriangleIndices<'a, B: DynBuffer + ?Sized> {
     pub format: wgt::IndexFormat,
-    pub buffer: Option<&'a B>,
+    pub buffer: &'a B,
     pub offset: u32,
     pub count: u32,
 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2517,7 +2517,7 @@ pub struct AccelerationStructureCopy {
 /// * `offset` - offset in bytes
 #[derive(Clone, Debug)]
 pub struct AccelerationStructureInstances<'a, B: DynBuffer + ?Sized> {
-    pub buffer: Option<&'a B>,
+    pub buffer: &'a B,
     pub offset: u32,
     pub count: u32,
 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2502,7 +2502,7 @@ pub struct AccelerationStructureTriangles<'a, B: DynBuffer + ?Sized> {
 /// * `offset` - offset in bytes
 #[derive(Clone, Debug)]
 pub struct AccelerationStructureAABBs<'a, B: DynBuffer + ?Sized> {
-    pub buffer: Option<&'a B>,
+    pub buffer: &'a B,
     pub offset: u32,
     pub count: u32,
     pub stride: wgt::BufferAddress,

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1090,7 +1090,7 @@ impl super::PrivateCapabilities {
                 raw_tlas_instance_size: size_of::<
                     metal::MTLIndirectAccelerationStructureInstanceDescriptor,
                 >(),
-                ray_tracing_scratch_buffer_alignment: 0,
+                ray_tracing_scratch_buffer_alignment: 1,
             },
             downlevel,
         }

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1087,7 +1087,9 @@ impl super::PrivateCapabilities {
                 // Metal Shading Language it generates, so from `wgpu_hal`'s
                 // users' point of view, references are tightly checked.
                 uniform_bounds_check_alignment: wgt::BufferSize::new(1).unwrap(),
-                raw_tlas_instance_size: 0,
+                raw_tlas_instance_size: size_of::<
+                    metal::MTLIndirectAccelerationStructureInstanceDescriptor,
+                >(),
                 ray_tracing_scratch_buffer_alignment: 0,
             },
             downlevel,

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -892,6 +892,12 @@ impl super::PrivateCapabilities {
                 && (device.supports_family(MTLGPUFamily::Apple7)
                     || device.supports_family(MTLGPUFamily::Mac2)),
             supports_shared_event: version.at_least((10, 14), (12, 0), os_is_mac),
+            supports_raytracing: if version.at_least((14, 0), (17, 0), os_is_mac) {
+                // The Rust metal crate does not expose device.supports_raytracing_from_render() yet
+                device.supports_raytracing()
+            } else {
+                false
+            },
         }
     }
 
@@ -992,6 +998,11 @@ impl super::PrivateCapabilities {
         if self.supports_simd_scoped_operations {
             features.insert(F::SUBGROUP | F::SUBGROUP_BARRIER);
         }
+
+        features.set(
+            F::EXPERIMENTAL_RAY_QUERY | F::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE,
+            self.supports_raytracing,
+        );
 
         features
     }

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1417,10 +1417,16 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn read_acceleration_structure_compact_size(
         &mut self,
-        _acceleration_structure: &super::AccelerationStructure,
-        _buf: &super::Buffer,
+        acceleration_structure: &super::AccelerationStructure,
+        buffer: &super::Buffer,
     ) {
-        unimplemented!()
+        let command_encoder = self.enter_acceleration_structure_builder();
+        command_encoder.write_compacted_acceleration_structure_size_with_type(
+            &acceleration_structure.raw,
+            &buffer.raw,
+            0,
+            metal::MTLDataType::ULong,
+        );
     }
 }
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1413,7 +1413,6 @@ impl crate::CommandEncoder for super::CommandEncoder {
         &mut self,
         _barriers: crate::AccelerationStructureBarrier,
     ) {
-        unimplemented!()
     }
 
     unsafe fn read_acceleration_structure_compact_size(

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -720,23 +720,32 @@ impl crate::CommandEncoder for super::CommandEncoder {
         if let Some(ref encoder) = self.state.render {
             let mut changes_sizes_buffer = false;
             for index in 0..group.counters.vs.buffers {
-                let buf = &group.buffers[index as usize];
-                let mut offset = buf.offset;
-                if let Some(dyn_index) = buf.dynamic_index {
-                    offset += dynamic_offsets[dyn_index as usize] as wgt::BufferAddress;
-                }
-                encoder.set_vertex_buffer(
-                    (bg_info.base_resource_indices.vs.buffers + index) as u64,
-                    Some(buf.ptr.as_native()),
-                    offset,
-                );
-                if let Some(size) = buf.binding_size {
-                    let br = naga::ResourceBinding {
-                        group: group_index,
-                        binding: buf.binding_location,
-                    };
-                    self.state.storage_buffer_length_map.insert(br, size);
-                    changes_sizes_buffer = true;
+                match &group.buffers[index as usize] {
+                    super::BufferResource::Buffer(binding) => {
+                        let mut offset = binding.offset;
+                        if let Some(dyn_index) = binding.dynamic_index {
+                            offset += dynamic_offsets[dyn_index as usize] as wgt::BufferAddress;
+                        }
+                        encoder.set_vertex_buffer(
+                            (bg_info.base_resource_indices.vs.buffers + index) as u64,
+                            Some(binding.ptr.as_native()),
+                            offset,
+                        );
+                        if let Some(size) = binding.binding_size {
+                            let br = naga::ResourceBinding {
+                                group: group_index,
+                                binding: binding.binding_location,
+                            };
+                            self.state.storage_buffer_length_map.insert(br, size);
+                            changes_sizes_buffer = true;
+                        }
+                    }
+                    super::BufferResource::AccelerationStructure(ptr) => {
+                        encoder.set_vertex_acceleration_structure(
+                            (bg_info.base_resource_indices.vs.buffers + index) as u64,
+                            Some(ptr.as_native()),
+                        );
+                    }
                 }
             }
             if changes_sizes_buffer {
@@ -754,23 +763,32 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
             changes_sizes_buffer = false;
             for index in 0..group.counters.fs.buffers {
-                let buf = &group.buffers[(group.counters.vs.buffers + index) as usize];
-                let mut offset = buf.offset;
-                if let Some(dyn_index) = buf.dynamic_index {
-                    offset += dynamic_offsets[dyn_index as usize] as wgt::BufferAddress;
-                }
-                encoder.set_fragment_buffer(
-                    (bg_info.base_resource_indices.fs.buffers + index) as u64,
-                    Some(buf.ptr.as_native()),
-                    offset,
-                );
-                if let Some(size) = buf.binding_size {
-                    let br = naga::ResourceBinding {
-                        group: group_index,
-                        binding: buf.binding_location,
-                    };
-                    self.state.storage_buffer_length_map.insert(br, size);
-                    changes_sizes_buffer = true;
+                match &group.buffers[(group.counters.vs.buffers + index) as usize] {
+                    super::BufferResource::Buffer(binding) => {
+                        let mut offset = binding.offset;
+                        if let Some(dyn_index) = binding.dynamic_index {
+                            offset += dynamic_offsets[dyn_index as usize] as wgt::BufferAddress;
+                        }
+                        encoder.set_fragment_buffer(
+                            (bg_info.base_resource_indices.fs.buffers + index) as u64,
+                            Some(binding.ptr.as_native()),
+                            offset,
+                        );
+                        if let Some(size) = binding.binding_size {
+                            let br = naga::ResourceBinding {
+                                group: group_index,
+                                binding: binding.binding_location,
+                            };
+                            self.state.storage_buffer_length_map.insert(br, size);
+                            changes_sizes_buffer = true;
+                        }
+                    }
+                    super::BufferResource::AccelerationStructure(ptr) => {
+                        encoder.set_fragment_acceleration_structure(
+                            (bg_info.base_resource_indices.fs.buffers + index) as u64,
+                            Some(ptr.as_native()),
+                        );
+                    }
                 }
             }
             if changes_sizes_buffer {
@@ -832,22 +850,32 @@ impl crate::CommandEncoder for super::CommandEncoder {
             let mut changes_sizes_buffer = false;
             for index in 0..group.counters.cs.buffers {
                 let buf = &group.buffers[(index_base.buffers + index) as usize];
-                let mut offset = buf.offset;
-                if let Some(dyn_index) = buf.dynamic_index {
-                    offset += dynamic_offsets[dyn_index as usize] as wgt::BufferAddress;
-                }
-                encoder.set_buffer(
-                    (bg_info.base_resource_indices.cs.buffers + index) as u64,
-                    Some(buf.ptr.as_native()),
-                    offset,
-                );
-                if let Some(size) = buf.binding_size {
-                    let br = naga::ResourceBinding {
-                        group: group_index,
-                        binding: buf.binding_location,
-                    };
-                    self.state.storage_buffer_length_map.insert(br, size);
-                    changes_sizes_buffer = true;
+                match buf {
+                    super::BufferResource::Buffer(binding) => {
+                        let mut offset = binding.offset;
+                        if let Some(dyn_index) = binding.dynamic_index {
+                            offset += dynamic_offsets[dyn_index as usize] as wgt::BufferAddress;
+                        }
+                        encoder.set_buffer(
+                            (bg_info.base_resource_indices.cs.buffers + index) as u64,
+                            Some(binding.ptr.as_native()),
+                            offset,
+                        );
+                        if let Some(size) = binding.binding_size {
+                            let br = naga::ResourceBinding {
+                                group: group_index,
+                                binding: binding.binding_location,
+                            };
+                            self.state.storage_buffer_length_map.insert(br, size);
+                            changes_sizes_buffer = true;
+                        }
+                    }
+                    super::BufferResource::AccelerationStructure(ptr) => {
+                        encoder.set_acceleration_structure(
+                            (bg_info.base_resource_indices.cs.buffers + index) as u64,
+                            Some(ptr.as_native()),
+                        );
+                    }
                 }
             }
             if changes_sizes_buffer {

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -6,8 +6,8 @@ use alloc::{
 };
 use core::ops::Range;
 use metal::{
-    MTLIndexType, MTLLoadAction, MTLPrimitiveType, MTLScissorRect, MTLSize, MTLStoreAction,
-    MTLViewport, MTLVisibilityResultMode, NSRange,
+    MTLLoadAction, MTLPrimitiveType, MTLScissorRect, MTLSize, MTLStoreAction, MTLViewport,
+    MTLVisibilityResultMode, NSRange,
 };
 
 // has to match `Temp::binding_sizes`
@@ -956,10 +956,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         binding: crate::BufferBinding<'a, super::Buffer>,
         format: wgt::IndexFormat,
     ) {
-        let (stride, raw_type) = match format {
-            wgt::IndexFormat::Uint16 => (2, MTLIndexType::UInt16),
-            wgt::IndexFormat::Uint32 => (4, MTLIndexType::UInt32),
-        };
+        let (stride, raw_type) = conv::map_index_format(format);
         self.state.index = Some(super::IndexState {
             buffer_ptr: AsNative::from(binding.buffer.raw.as_ref()),
             offset: binding.offset,
@@ -1322,7 +1319,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     unsafe fn build_acceleration_structures<'a, T>(
         &mut self,
         _descriptor_count: u32,
-        _descriptors: T,
+        descriptors: T,
     ) where
         super::Api: 'a,
         T: IntoIterator<

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -740,11 +740,19 @@ impl crate::CommandEncoder for super::CommandEncoder {
                             changes_sizes_buffer = true;
                         }
                     }
-                    super::BufferResource::AccelerationStructure(ptr) => {
+                    super::BufferResource::AccelerationStructure(acceleration_structure) => {
                         encoder.set_vertex_acceleration_structure(
                             (bg_info.base_resource_indices.vs.buffers + index) as u64,
-                            Some(ptr.as_native()),
+                            Some(acceleration_structure.as_raw().as_native()),
                         );
+                        let dependencies = acceleration_structure.dependencies.read();
+                        for blas in dependencies.iter() {
+                            encoder.use_resource_at(
+                                blas,
+                                metal::MTLResourceUsage::Read,
+                                metal::MTLRenderStages::Vertex,
+                            );
+                        }
                     }
                 }
             }
@@ -783,11 +791,19 @@ impl crate::CommandEncoder for super::CommandEncoder {
                             changes_sizes_buffer = true;
                         }
                     }
-                    super::BufferResource::AccelerationStructure(ptr) => {
+                    super::BufferResource::AccelerationStructure(acceleration_structure) => {
                         encoder.set_fragment_acceleration_structure(
                             (bg_info.base_resource_indices.fs.buffers + index) as u64,
-                            Some(ptr.as_native()),
+                            Some(acceleration_structure.as_raw().as_native()),
                         );
+                        let dependencies = acceleration_structure.dependencies.read();
+                        for blas in dependencies.iter() {
+                            encoder.use_resource_at(
+                                blas,
+                                metal::MTLResourceUsage::Read,
+                                metal::MTLRenderStages::Fragment,
+                            );
+                        }
                     }
                 }
             }
@@ -870,11 +886,15 @@ impl crate::CommandEncoder for super::CommandEncoder {
                             changes_sizes_buffer = true;
                         }
                     }
-                    super::BufferResource::AccelerationStructure(ptr) => {
+                    super::BufferResource::AccelerationStructure(acceleration_structure) => {
                         encoder.set_acceleration_structure(
                             (bg_info.base_resource_indices.cs.buffers + index) as u64,
-                            Some(ptr.as_native()),
+                            Some(acceleration_structure.as_raw().as_native()),
                         );
+                        let dependencies = acceleration_structure.dependencies.read();
+                        for blas in dependencies.iter() {
+                            encoder.use_resource(blas, metal::MTLResourceUsage::Read);
+                        }
                     }
                 }
             }

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1373,7 +1373,40 @@ impl crate::CommandEncoder for super::CommandEncoder {
             >,
         >,
     {
-        unimplemented!()
+        let command_encoder = self.enter_acceleration_structure_builder();
+        for descriptor in descriptors {
+            let acceleration_structure_descriptor =
+                conv::map_acceleration_structure_descriptor(descriptor.entries);
+            /* The Rust metal crate does not expose metal::MTLAccelerationStructureUsage yet
+            let mut usage = metal::MTLAccelerationStructureUsage::None;
+            if descriptor.flags.contains(wgt::AccelerationStructureFlags::ALLOW_UPDATE) {
+                usage |= metal::MTLAccelerationStructureUsage::Refit;
+            }
+            if descriptor.flags.contains(wgt::AccelerationStructureFlags::PREFER_FAST_BUILD) {
+                usage |= metal::MTLAccelerationStructureUsage::PreferFastBuild;
+            }
+            acceleration_structure_descriptor.set_usage(usage);
+            */
+            match descriptor.mode {
+                crate::AccelerationStructureBuildMode::Build => {
+                    command_encoder.build_acceleration_structure(
+                        &descriptor.destination_acceleration_structure.raw,
+                        &acceleration_structure_descriptor,
+                        &descriptor.scratch_buffer.raw,
+                        descriptor.scratch_buffer_offset,
+                    );
+                }
+                crate::AccelerationStructureBuildMode::Update => {
+                    command_encoder.refit_acceleration_structure(
+                        &descriptor.source_acceleration_structure.unwrap().raw,
+                        &acceleration_structure_descriptor,
+                        Some(&descriptor.destination_acceleration_structure.raw),
+                        &descriptor.scratch_buffer.raw,
+                        descriptor.scratch_buffer_offset,
+                    );
+                }
+            }
+        }
     }
 
     unsafe fn place_acceleration_structure_barrier(

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -17,6 +17,7 @@ impl Default for super::CommandState {
     fn default() -> Self {
         Self {
             blit: None,
+            acceleration_structure_builder: None,
             render: None,
             compute: None,
             raw_primitive_type: MTLPrimitiveType::Point,
@@ -35,6 +36,7 @@ impl Default for super::CommandState {
 impl super::CommandEncoder {
     fn enter_blit(&mut self) -> &metal::BlitCommandEncoderRef {
         if self.state.blit.is_none() {
+            self.leave_acceleration_structure_builder();
             debug_assert!(self.state.render.is_none() && self.state.compute.is_none());
             let cmd_buf = self.raw_cmd_buf.as_ref().unwrap();
 
@@ -125,10 +127,40 @@ impl super::CommandEncoder {
         }
     }
 
+    fn enter_acceleration_structure_builder(
+        &mut self,
+    ) -> &metal::AccelerationStructureCommandEncoderRef {
+        if self.state.acceleration_structure_builder.is_none() {
+            self.leave_blit();
+            debug_assert!(
+                self.state.render.is_none()
+                    && self.state.compute.is_none()
+                    && self.state.blit.is_none()
+            );
+            let cmd_buf = self.raw_cmd_buf.as_ref().unwrap();
+            objc::rc::autoreleasepool(|| {
+                self.state.acceleration_structure_builder = Some(
+                    cmd_buf
+                        .new_acceleration_structure_command_encoder()
+                        .to_owned(),
+                );
+            });
+        }
+        self.state.acceleration_structure_builder.as_ref().unwrap()
+    }
+
+    pub(super) fn leave_acceleration_structure_builder(&mut self) {
+        if let Some(encoder) = self.state.acceleration_structure_builder.take() {
+            encoder.end_encoding();
+        }
+    }
+
     fn active_encoder(&mut self) -> Option<&metal::CommandEncoderRef> {
         if let Some(ref encoder) = self.state.render {
             Some(encoder)
         } else if let Some(ref encoder) = self.state.compute {
+            Some(encoder)
+        } else if let Some(ref encoder) = self.state.acceleration_structure_builder {
             Some(encoder)
         } else if let Some(ref encoder) = self.state.blit {
             Some(encoder)
@@ -140,6 +172,7 @@ impl super::CommandEncoder {
     fn begin_pass(&mut self) {
         self.state.reset();
         self.leave_blit();
+        self.leave_acceleration_structure_builder();
     }
 }
 
@@ -212,6 +245,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn discard_encoding(&mut self) {
         self.leave_blit();
+        self.leave_acceleration_structure_builder();
         // when discarding, we don't have a guarantee that
         // everything is in a good state, so check carefully
         if let Some(encoder) = self.state.render.take() {
@@ -231,6 +265,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         }
 
         self.leave_blit();
+        self.leave_acceleration_structure_builder();
         debug_assert!(self.state.render.is_none());
         debug_assert!(self.state.compute.is_none());
         debug_assert!(self.state.pending_timer_queries.is_empty());

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -437,11 +437,19 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn copy_acceleration_structure_to_acceleration_structure(
         &mut self,
-        _src: &super::AccelerationStructure,
-        _dst: &super::AccelerationStructure,
-        _copy: wgt::AccelerationStructureCopy,
+        src: &super::AccelerationStructure,
+        dst: &super::AccelerationStructure,
+        copy: wgt::AccelerationStructureCopy,
     ) {
-        unimplemented!()
+        let command_encoder = self.enter_acceleration_structure_builder();
+        match copy {
+            wgt::AccelerationStructureCopy::Clone => {
+                command_encoder.copy_acceleration_structure(&src.raw, &dst.raw);
+            }
+            wgt::AccelerationStructureCopy::Compact => {
+                command_encoder.copy_and_compact_acceleration_structure(&src.raw, &dst.raw);
+            }
+        };
     }
 
     unsafe fn begin_query(&mut self, set: &super::QuerySet, index: u32) {

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -1,9 +1,9 @@
 use metal::{
     MTLBlendFactor, MTLBlendOperation, MTLBlitOption, MTLClearColor, MTLColorWriteMask,
-    MTLCompareFunction, MTLCullMode, MTLOrigin, MTLPrimitiveTopologyClass, MTLPrimitiveType,
-    MTLRenderStages, MTLResourceUsage, MTLSamplerAddressMode, MTLSamplerBorderColor,
-    MTLSamplerMinMagFilter, MTLSize, MTLStencilOperation, MTLStoreAction, MTLTextureType,
-    MTLTextureUsage, MTLVertexFormat, MTLVertexStepFunction, MTLWinding, NSRange,
+    MTLCompareFunction, MTLCullMode, MTLIndexType, MTLOrigin, MTLPrimitiveTopologyClass,
+    MTLPrimitiveType, MTLRenderStages, MTLResourceUsage, MTLSamplerAddressMode,
+    MTLSamplerBorderColor, MTLSamplerMinMagFilter, MTLSize, MTLStencilOperation, MTLStoreAction,
+    MTLTextureType, MTLTextureUsage, MTLVertexFormat, MTLVertexStepFunction, MTLWinding, NSRange,
 };
 
 pub fn map_texture_usage(format: wgt::TextureFormat, usage: wgt::TextureUses) -> MTLTextureUsage {
@@ -231,6 +231,13 @@ pub fn map_vertex_format(format: wgt::VertexFormat) -> MTLVertexFormat {
         Vf::Unorm10_10_10_2 => MTL::UInt1010102Normalized,
         Vf::Unorm8x4Bgra => MTL::UChar4Normalized_BGRA,
         Vf::Float64 | Vf::Float64x2 | Vf::Float64x3 | Vf::Float64x4 => unimplemented!(),
+    }
+}
+
+pub fn map_index_format(format: wgt::IndexFormat) -> (u64, MTLIndexType) {
+    match format {
+        wgt::IndexFormat::Uint16 => (2, MTLIndexType::UInt16),
+        wgt::IndexFormat::Uint32 => (4, MTLIndexType::UInt32),
     }
 }
 

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -1,9 +1,10 @@
 use metal::{
-    MTLBlendFactor, MTLBlendOperation, MTLBlitOption, MTLClearColor, MTLColorWriteMask,
-    MTLCompareFunction, MTLCullMode, MTLIndexType, MTLOrigin, MTLPrimitiveTopologyClass,
-    MTLPrimitiveType, MTLRenderStages, MTLResourceUsage, MTLSamplerAddressMode,
-    MTLSamplerBorderColor, MTLSamplerMinMagFilter, MTLSize, MTLStencilOperation, MTLStoreAction,
-    MTLTextureType, MTLTextureUsage, MTLVertexFormat, MTLVertexStepFunction, MTLWinding, NSRange,
+    MTLAttributeFormat, MTLBlendFactor, MTLBlendOperation, MTLBlitOption, MTLClearColor,
+    MTLColorWriteMask, MTLCompareFunction, MTLCullMode, MTLIndexType, MTLOrigin,
+    MTLPrimitiveTopologyClass, MTLPrimitiveType, MTLRenderStages, MTLResourceUsage,
+    MTLSamplerAddressMode, MTLSamplerBorderColor, MTLSamplerMinMagFilter, MTLSize,
+    MTLStencilOperation, MTLStoreAction, MTLTextureType, MTLTextureUsage, MTLVertexFormat,
+    MTLVertexStepFunction, MTLWinding, NSRange,
 };
 
 pub fn map_texture_usage(format: wgt::TextureFormat, usage: wgt::TextureUses) -> MTLTextureUsage {
@@ -358,5 +359,95 @@ pub fn map_resource_usage(ty: &wgt::BindingType) -> MTLResourceUsage {
         },
         wgt::BindingType::Sampler(..) => MTLResourceUsage::empty(),
         _ => unreachable!(),
+    }
+}
+
+pub fn map_acceleration_structure_descriptor<'a>(
+    entries: &crate::AccelerationStructureEntries<'a, super::Buffer>,
+) -> metal::AccelerationStructureDescriptor {
+    match entries {
+        crate::AccelerationStructureEntries::Instances(instances) => {
+            let descriptor = metal::InstanceAccelerationStructureDescriptor::descriptor();
+            descriptor.set_instance_descriptor_type(
+                metal::MTLAccelerationStructureInstanceDescriptorType::Indirect,
+            );
+            descriptor.set_instance_count(instances.count as u64);
+            descriptor.set_instance_descriptor_buffer(&instances.buffer.raw);
+            descriptor.set_instance_descriptor_buffer_offset(instances.offset as u64);
+            metal::AccelerationStructureDescriptor::from(descriptor)
+        }
+        crate::AccelerationStructureEntries::Triangles(entries) => {
+            let geometry_descriptors = entries
+                .iter()
+                .map(|triangles| {
+                    let descriptor =
+                        metal::AccelerationStructureTriangleGeometryDescriptor::descriptor();
+                    if let Some(indices) = triangles.indices.as_ref() {
+                        descriptor.set_index_buffer(Some(&*indices.buffer.raw));
+                        descriptor.set_index_buffer_offset(indices.offset as u64);
+                        descriptor.set_index_type(map_index_format(indices.format).1);
+                        descriptor.set_triangle_count(indices.count as u64 / 3);
+                    } else {
+                        descriptor.set_triangle_count(triangles.vertex_count as u64 / 3);
+                    }
+                    descriptor.set_vertex_buffer(Some(&*triangles.vertex_buffer.raw));
+                    descriptor.set_vertex_buffer_offset(
+                        triangles.first_vertex as u64 * triangles.vertex_stride,
+                    );
+                    descriptor.set_vertex_stride(triangles.vertex_stride);
+                    // Safety: MTLVertexFormat and MTLAttributeFormat are identical.
+                    // https://docs.rs/metal/latest/metal/enum.MTLAttributeFormat.html
+                    // https://docs.rs/metal/latest/metal/enum.MTLVertexFormat.html
+                    descriptor.set_vertex_format(unsafe {
+                        core::mem::transmute::<MTLVertexFormat, MTLAttributeFormat>(
+                            map_vertex_format(triangles.vertex_format),
+                        )
+                    });
+                    if let Some(transform) = triangles.transform.as_ref() {
+                        descriptor.set_transformation_matrix_buffer(Some(&*transform.buffer.raw));
+                        descriptor.set_transformation_matrix_buffer_offset(transform.offset as u64);
+                    }
+                    descriptor.set_opaque(
+                        triangles
+                            .flags
+                            .contains(wgt::AccelerationStructureGeometryFlags::OPAQUE),
+                    );
+                    // wgt::AccelerationStructureGeometryFlags::NO_DUPLICATE_ANY_HIT_INVOCATION
+                    // descriptor.set_intersection_function_table_offset(offset);
+                    metal::AccelerationStructureGeometryDescriptor::from(descriptor)
+                })
+                .collect::<alloc::vec::Vec<_>>();
+            let descriptor = metal::PrimitiveAccelerationStructureDescriptor::descriptor();
+            descriptor.set_geometry_descriptors(metal::Array::from_owned_slice(
+                geometry_descriptors.as_slice(),
+            ));
+            metal::AccelerationStructureDescriptor::from(descriptor)
+        }
+        crate::AccelerationStructureEntries::AABBs(entries) => {
+            let geometry_descriptors = entries
+                .iter()
+                .map(|aabbs| {
+                    let descriptor =
+                        metal::AccelerationStructureBoundingBoxGeometryDescriptor::descriptor();
+                    descriptor.set_bounding_box_buffer(Some(&*aabbs.buffer.raw));
+                    descriptor.set_bounding_box_count(aabbs.count as u64);
+                    descriptor.set_bounding_box_stride(aabbs.stride);
+                    descriptor.set_bounding_box_buffer_offset(aabbs.offset as u64);
+                    descriptor.set_opaque(
+                        aabbs
+                            .flags
+                            .contains(wgt::AccelerationStructureGeometryFlags::OPAQUE),
+                    );
+                    // wgt::AccelerationStructureGeometryFlags::NO_DUPLICATE_ANY_HIT_INVOCATION
+                    // descriptor.set_intersection_function_table_offset(offset);
+                    metal::AccelerationStructureGeometryDescriptor::from(descriptor)
+                })
+                .collect::<alloc::vec::Vec<_>>();
+            let descriptor = metal::PrimitiveAccelerationStructureDescriptor::descriptor();
+            descriptor.set_geometry_descriptors(metal::Array::from_owned_slice(
+                geometry_descriptors.as_slice(),
+            ));
+            metal::AccelerationStructureDescriptor::from(descriptor)
+        }
     }
 }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -2,6 +2,7 @@ use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
 use core::{ptr::NonNull, sync::atomic};
 use std::{thread, time};
 
+use bytemuck::TransparentWrapper;
 use parking_lot::Mutex;
 
 use super::{conv, PassthroughShader};
@@ -1625,8 +1626,40 @@ impl crate::Device for super::Device {
         // self.counters.acceleration_structures.sub(1);
     }
 
-    fn tlas_instance_to_bytes(&self, _instance: TlasInstance) -> Vec<u8> {
-        unimplemented!()
+    fn tlas_instance_to_bytes(&self, instance: TlasInstance) -> Vec<u8> {
+        let temp = metal::MTLIndirectAccelerationStructureInstanceDescriptor {
+            transformation_matrix: [
+                [
+                    instance.transform[0],
+                    instance.transform[4],
+                    instance.transform[8],
+                ],
+                [
+                    instance.transform[1],
+                    instance.transform[5],
+                    instance.transform[9],
+                ],
+                [
+                    instance.transform[2],
+                    instance.transform[6],
+                    instance.transform[10],
+                ],
+                [
+                    instance.transform[3],
+                    instance.transform[7],
+                    instance.transform[11],
+                ],
+            ],
+            options: metal::MTLAccelerationStructureInstanceOptions::None,
+            mask: instance.mask as u32,
+            intersection_function_table_offset: 0,
+            acceleration_structure_id: instance.blas_address,
+            user_id: instance.custom_data,
+        };
+
+        wgt::bytemuck_wrapper!(unsafe struct Desc(metal::MTLIndirectAccelerationStructureInstanceDescriptor));
+
+        bytemuck::bytes_of(&Desc::wrap(temp)).to_vec()
     }
 
     fn get_internal_counters(&self) -> wgt::HalCounters {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1622,7 +1622,7 @@ impl crate::Device for super::Device {
         &self,
         _acceleration_structure: super::AccelerationStructure,
     ) {
-        unimplemented!()
+        // self.counters.acceleration_structures.sub(1);
     }
 
     fn tlas_instance_to_bytes(&self, _instance: TlasInstance) -> Vec<u8> {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1607,9 +1607,15 @@ impl crate::Device for super::Device {
 
     unsafe fn create_acceleration_structure(
         &self,
-        _desc: &crate::AccelerationStructureDescriptor,
+        descriptor: &crate::AccelerationStructureDescriptor,
     ) -> Result<super::AccelerationStructure, crate::DeviceError> {
-        unimplemented!()
+        // self.counters.acceleration_structures.add(1);
+        let device = self.shared.device.lock();
+        objc::rc::autoreleasepool(|| {
+            Ok(super::AccelerationStructure {
+                raw: device.new_acceleration_structure_with_size(descriptor.size),
+            })
+        })
     }
 
     unsafe fn destroy_acceleration_structure(

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1013,7 +1013,7 @@ impl crate::Device for super::Device {
                                     desc.acceleration_structures[start..end].iter().map(
                                         |acceleration_structure| {
                                             super::BufferResource::AccelerationStructure(
-                                                acceleration_structure.as_raw(),
+                                                (*acceleration_structure).clone(),
                                             )
                                         },
                                     ),
@@ -1656,6 +1656,7 @@ impl crate::Device for super::Device {
         objc::rc::autoreleasepool(|| {
             Ok(super::AccelerationStructure {
                 raw: device.new_acceleration_structure_with_size(descriptor.size),
+                dependencies: Arc::new(parking_lot::RwLock::new(Vec::new())),
             })
         })
     }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1600,9 +1600,9 @@ impl crate::Device for super::Device {
 
     unsafe fn get_acceleration_structure_device_address(
         &self,
-        _acceleration_structure: &super::AccelerationStructure,
+        acceleration_structure: &super::AccelerationStructure,
     ) -> wgt::BufferAddress {
-        unimplemented!()
+        acceleration_structure.raw.gpu_resource_id()._impl
     }
 
     unsafe fn create_acceleration_structure(

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -746,7 +746,10 @@ impl crate::Device for super::Device {
                                     wgt::StorageTextureAccess::Atomic => true,
                                 };
                             }
-                            wgt::BindingType::AccelerationStructure { .. } => unimplemented!(),
+                            wgt::BindingType::AccelerationStructure { .. } => {
+                                target.buffer = Some(info.counters.buffers as _);
+                                info.counters.buffers += 1;
+                            }
                         }
                     }
 
@@ -896,18 +899,41 @@ impl crate::Device for super::Device {
                                     // need to be passed to useResource
                                 }
                             }
+                            wgt::BindingType::AccelerationStructure { .. } => {
+                                let start = entry.resource_index as usize;
+                                let end = start + count as usize;
+                                let acceleration_structures =
+                                    &desc.acceleration_structures[start..end];
+
+                                for (idx, &acceleration_structure) in
+                                    acceleration_structures.iter().enumerate()
+                                {
+                                    contents[idx] = acceleration_structure.raw.gpu_resource_id();
+
+                                    let use_info = bg
+                                        .resources_to_use
+                                        .entry(acceleration_structure.as_raw().cast())
+                                        .or_default();
+                                    use_info.stages |= stages;
+                                    use_info.uses |= uses;
+                                    use_info.visible_in_compute |=
+                                        layout.visibility.contains(wgt::ShaderStages::COMPUTE);
+                                }
+                            }
                             _ => {
                                 unimplemented!();
                             }
                         }
 
-                        bg.buffers.push(super::BufferResource {
-                            ptr: unsafe { NonNull::new_unchecked(buffer.as_ptr()) },
-                            offset: 0,
-                            dynamic_index: None,
-                            binding_size: None,
-                            binding_location: layout.binding,
-                        });
+                        bg.buffers.push(super::BufferResource::Buffer(
+                            super::BufferResourceBinding {
+                                ptr: unsafe { NonNull::new_unchecked(buffer.as_ptr()) },
+                                offset: 0,
+                                dynamic_index: None,
+                                binding_size: None,
+                                binding_location: layout.binding,
+                            },
+                        ));
                         counter.buffers += 1;
 
                         bg.argument_buffers.push(buffer)
@@ -945,17 +971,19 @@ impl crate::Device for super::Device {
                                             }
                                             _ => None,
                                         };
-                                        super::BufferResource {
-                                            ptr: source.buffer.as_raw(),
-                                            offset: source.offset,
-                                            dynamic_index: if has_dynamic_offset {
-                                                Some(dynamic_offsets_count - 1)
-                                            } else {
-                                                None
+                                        super::BufferResource::Buffer(
+                                            super::BufferResourceBinding {
+                                                ptr: source.buffer.as_raw(),
+                                                offset: source.offset,
+                                                dynamic_index: if has_dynamic_offset {
+                                                    Some(dynamic_offsets_count - 1)
+                                                } else {
+                                                    None
+                                                },
+                                                binding_size,
+                                                binding_location: layout.binding,
                                             },
-                                            binding_size,
-                                            binding_location: layout.binding,
-                                        }
+                                        )
                                     }));
                                 counter.buffers += 1;
                             }
@@ -978,7 +1006,20 @@ impl crate::Device for super::Device {
                                 );
                                 counter.textures += 1;
                             }
-                            wgt::BindingType::AccelerationStructure { .. } => unimplemented!(),
+                            wgt::BindingType::AccelerationStructure { .. } => {
+                                let start = entry.resource_index as usize;
+                                let end = start + 1;
+                                bg.buffers.extend(
+                                    desc.acceleration_structures[start..end].iter().map(
+                                        |acceleration_structure| {
+                                            super::BufferResource::AccelerationStructure(
+                                                acceleration_structure.as_raw(),
+                                            )
+                                        },
+                                    ),
+                                );
+                                counter.buffers += 1;
+                            }
                         }
                     }
                 }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1574,9 +1574,28 @@ impl crate::Device for super::Device {
 
     unsafe fn get_acceleration_structure_build_sizes(
         &self,
-        _desc: &crate::GetAccelerationStructureBuildSizesDescriptor<super::Buffer>,
+        descriptor: &crate::GetAccelerationStructureBuildSizesDescriptor<super::Buffer>,
     ) -> crate::AccelerationStructureBuildSizes {
-        unimplemented!()
+        let acceleration_structure_descriptor =
+            conv::map_acceleration_structure_descriptor(descriptor.entries);
+        /* The Rust metal crate does not expose metal::MTLAccelerationStructureUsage yet
+        let mut usage = metal::MTLAccelerationStructureUsage::None;
+        if descriptor.flags.contains(wgt::AccelerationStructureFlags::ALLOW_UPDATE) {
+            usage |= metal::MTLAccelerationStructureUsage::Refit;
+        }
+        if descriptor.flags.contains(wgt::AccelerationStructureFlags::PREFER_FAST_BUILD) {
+            usage |= metal::MTLAccelerationStructureUsage::PreferFastBuild;
+        }
+        acceleration_structure_descriptor.set_usage(usage);
+        */
+        let device = self.shared.device.lock();
+        let info =
+            device.acceleration_structure_sizes_with_descriptor(&acceleration_structure_descriptor);
+        crate::AccelerationStructureBuildSizes {
+            acceleration_structure_size: info.acceleration_structure_size,
+            update_scratch_size: info.refit_scratch_buffer_size,
+            build_scratch_size: info.build_scratch_buffer_size,
+        }
     }
 
     unsafe fn get_acceleration_structure_device_address(

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -670,7 +670,7 @@ pub struct PipelineLayout {
 
 impl crate::DynPipelineLayout for PipelineLayout {}
 
-trait AsNative {
+pub(crate) trait AsNative {
     type Native;
     fn from(native: &Self::Native) -> Self;
     fn as_native(&self) -> &Self::Native;
@@ -764,7 +764,7 @@ struct BufferResourceBinding {
 #[derive(Debug)]
 enum BufferResource {
     Buffer(BufferResourceBinding),
-    AccelerationStructure(AccelerationStructurePtr),
+    AccelerationStructure(AccelerationStructure),
 }
 
 #[derive(Debug)]
@@ -1032,9 +1032,10 @@ pub struct PipelineCache;
 
 impl crate::DynPipelineCache for PipelineCache {}
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AccelerationStructure {
     raw: metal::AccelerationStructure,
+    dependencies: Arc<RwLock<Vec<metal::AccelerationStructure>>>,
 }
 
 impl AccelerationStructure {
@@ -1043,4 +1044,16 @@ impl AccelerationStructure {
     }
 }
 
-impl crate::DynAccelerationStructure for AccelerationStructure {}
+impl crate::DynAccelerationStructure for AccelerationStructure {
+    fn set_dependencies(&self, dependencies: &[&dyn crate::DynAccelerationStructure]) {
+        use crate::dynamic::DynResourceExt;
+        *self.dependencies.write() = dependencies
+            .iter()
+            .map(|blas| {
+                blas.expect_downcast_ref::<AccelerationStructure>()
+                    .raw
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+    }
+}

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -34,10 +34,11 @@ use arrayvec::ArrayVec;
 use bitflags::bitflags;
 use hashbrown::HashMap;
 use metal::{
-    foreign_types::ForeignTypeRef as _, MTLArgumentBuffersTier, MTLBuffer, MTLCommandBufferStatus,
-    MTLCullMode, MTLDepthClipMode, MTLIndexType, MTLLanguageVersion, MTLPrimitiveType,
-    MTLReadWriteTextureTier, MTLRenderStages, MTLResource, MTLResourceUsage, MTLSamplerState,
-    MTLSize, MTLTexture, MTLTextureType, MTLTriangleFillMode, MTLWinding,
+    foreign_types::ForeignTypeRef as _, MTLAccelerationStructure, MTLArgumentBuffersTier,
+    MTLBuffer, MTLCommandBufferStatus, MTLCullMode, MTLDepthClipMode, MTLIndexType,
+    MTLLanguageVersion, MTLPrimitiveType, MTLReadWriteTextureTier, MTLRenderStages, MTLResource,
+    MTLResourceUsage, MTLSamplerState, MTLSize, MTLTexture, MTLTextureType, MTLTriangleFillMode,
+    MTLWinding,
 };
 use naga::FastHashMap;
 use parking_lot::{Mutex, RwLock};
@@ -679,6 +680,7 @@ type ResourcePtr = NonNull<MTLResource>;
 type BufferPtr = NonNull<MTLBuffer>;
 type TexturePtr = NonNull<MTLTexture>;
 type SamplerPtr = NonNull<MTLSamplerState>;
+type AccelerationStructurePtr = NonNull<MTLAccelerationStructure>;
 
 impl AsNative for ResourcePtr {
     type Native = metal::ResourceRef;
@@ -718,6 +720,18 @@ impl AsNative for TexturePtr {
 
 impl AsNative for SamplerPtr {
     type Native = metal::SamplerStateRef;
+    #[inline]
+    fn from(native: &Self::Native) -> Self {
+        unsafe { NonNull::new_unchecked(native.as_ptr()) }
+    }
+    #[inline]
+    fn as_native(&self) -> &Self::Native {
+        unsafe { Self::Native::from_ptr(self.as_ptr()) }
+    }
+}
+
+impl AsNative for AccelerationStructurePtr {
+    type Native = metal::AccelerationStructureRef;
     #[inline]
     fn from(native: &Self::Native) -> Self {
         unsafe { NonNull::new_unchecked(native.as_ptr()) }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -952,6 +952,7 @@ struct Temp {
 
 struct CommandState {
     blit: Option<metal::BlitCommandEncoder>,
+    acceleration_structure_builder: Option<metal::AccelerationStructureCommandEncoder>,
     render: Option<metal::RenderCommandEncoder>,
     compute: Option<metal::ComputeCommandEncoder>,
     raw_primitive_type: MTLPrimitiveType,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -299,6 +299,7 @@ struct PrivateCapabilities {
     int64_atomics: bool,
     float_atomics: bool,
     supports_shared_event: bool,
+    supports_raytracing: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -743,7 +743,7 @@ impl AsNative for AccelerationStructurePtr {
 }
 
 #[derive(Debug)]
-struct BufferResource {
+struct BufferResourceBinding {
     ptr: BufferPtr,
     offset: wgt::BufferAddress,
     dynamic_index: Option<u32>,
@@ -759,6 +759,12 @@ struct BufferResource {
     binding_size: Option<wgt::BufferSize>,
 
     binding_location: u32,
+}
+
+#[derive(Debug)]
+enum BufferResource {
+    Buffer(BufferResourceBinding),
+    AccelerationStructure(AccelerationStructurePtr),
 }
 
 #[derive(Debug)]

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -1026,6 +1026,14 @@ pub struct PipelineCache;
 impl crate::DynPipelineCache for PipelineCache {}
 
 #[derive(Debug)]
-pub struct AccelerationStructure;
+pub struct AccelerationStructure {
+    raw: metal::AccelerationStructure,
+}
+
+impl AccelerationStructure {
+    fn as_raw(&self) -> AccelerationStructurePtr {
+        unsafe { NonNull::new_unchecked(self.raw.as_ptr()) }
+    }
+}
 
 impl crate::DynAccelerationStructure for AccelerationStructure {}

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -60,7 +60,9 @@ impl crate::Api for Api {
 
 crate::impl_dyn_resource!(Buffer, CommandBuffer, Context, Fence, Resource);
 
-impl crate::DynAccelerationStructure for Resource {}
+impl crate::DynAccelerationStructure for Resource {
+    fn set_dependencies(&self, _dependencies: &[&dyn crate::DynAccelerationStructure]) {}
+}
 impl crate::DynBindGroup for Resource {}
 impl crate::DynBindGroupLayout for Resource {}
 impl crate::DynBuffer for Buffer {}

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -668,7 +668,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                     for aabb in in_geometries {
                         let aabbs_data = vk::AccelerationStructureGeometryAabbsDataKHR::default()
                             .data(vk::DeviceOrHostAddressConstKHR {
-                                device_address: get_device_address(aabb.buffer),
+                                device_address: get_device_address(Some(aabb.buffer)),
                             })
                             .stride(aabb.stride);
 

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -600,7 +600,9 @@ impl crate::CommandEncoder for super::CommandEncoder {
                                 // index buffer we need to have IndexType::NONE_KHR as our index type.
                                 .index_type(vk::IndexType::NONE_KHR)
                                 .vertex_data(vk::DeviceOrHostAddressConstKHR {
-                                    device_address: get_device_address(triangles.vertex_buffer),
+                                    device_address: get_device_address(Some(
+                                        triangles.vertex_buffer,
+                                    )),
                                 })
                                 .vertex_format(conv::map_vertex_format(triangles.vertex_format))
                                 .max_vertex(triangles.vertex_count)

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -571,7 +571,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                     // TODO: Code is so large that rustfmt refuses to treat this... :(
                     )
                     .data(vk::DeviceOrHostAddressConstKHR {
-                        device_address: get_device_address(instances.buffer),
+                        device_address: get_device_address(Some(instances.buffer)),
                     });
 
                     let geometry = vk::AccelerationStructureGeometryKHR::default()

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -611,7 +611,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                         if let Some(ref indices) = triangles.indices {
                             triangle_data = triangle_data
                                 .index_data(vk::DeviceOrHostAddressConstKHR {
-                                    device_address: get_device_address(indices.buffer),
+                                    device_address: get_device_address(Some(indices.buffer)),
                                 })
                                 .index_type(conv::map_index_format(indices.format));
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -773,7 +773,9 @@ pub struct AccelerationStructure {
     compacted_size_query: Option<vk::QueryPool>,
 }
 
-impl crate::DynAccelerationStructure for AccelerationStructure {}
+impl crate::DynAccelerationStructure for AccelerationStructure {
+    fn set_dependencies(&self, _dependencies: &[&dyn crate::DynAccelerationStructure]) {}
+}
 
 #[derive(Debug)]
 pub struct Texture {


### PR DESCRIPTION
**Connections**
Fixes: #7402

**Description**
Implements the missing ray tracing acceleration structures in the HAL metal backend.

**Testing**
The examples ray_scene, ray_shadows, ray_cube_compute, ray_cube_fragment and ray_traced_triangle all work.
That is if invoked via `cargo run --bin wgpu-examples ray_traced_triangle`, but not via `cargo xtask test ray_traced_triangle`, still current CI runner is too old to catch that as it does not support hardware ray tracing.

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry.
