### PR TITLE
[naga] Ensure test functions in glsl snapshots are reachable from the entry point

### DIFF
--- a/naga/tests/in/glsl/931-constant-emitting.frag
+++ b/naga/tests/in/glsl/931-constant-emitting.frag
@@ -9,4 +9,6 @@ float function() {
     return 0.0;
 }
 
-void main() {}
+void main() {
+    function();
+}

--- a/naga/tests/in/glsl/constant-array-size.frag
+++ b/naga/tests/in/glsl/constant-array-size.frag
@@ -13,4 +13,6 @@ vec4 function() {
     return sum;
 }
 
-void main() {}
+void main() {
+    function();
+}

--- a/naga/tests/in/glsl/expressions.frag
+++ b/naga/tests/in/glsl/expressions.frag
@@ -159,6 +159,27 @@ void testSwizzleWrites(vec3 a) {
 
 out vec4 o_color;
 void main() {
+    testBinOpVecFloat(vec4(0), 1.0);
+    testBinOpFloatVec(vec4(0), 1.0);
+    testBinOpIVecInt(ivec4(0), 1);
+    testBinOpIntIVec(1, ivec4(0));
+    testBinOpUVecUint(uvec4(0), 1);
+    testBinOpUintUVec(1, uvec4(0));
+    testBinOpMatMat(mat3(0), mat3(1));
+    testBinOpMatFloat(1, mat3(1));
+    testUnaryOpMat(mat3(1));
+    testStructConstructor();
+    testNonScalarToScalarConstructor();
+    testArrayConstructor();
+    testFreestandingConstructor();
+    testNonImplicitCastVectorCast();
     privatePointer(global);
+    ternary(false);
+    testMatrixMultiplication(mat4x3(0), mat4x4(1));
+    testLength();
+    testConstantLength(float[4](0.0, 1.0, 2.0, 3.0));
+    indexConstantNonConstantIndex(1);
+    testSwizzleWrites(vec3(0));
+
     o_color.rgba = vec4(1.0);
 }

--- a/naga/tests/in/glsl/fma.frag
+++ b/naga/tests/in/glsl/fma.frag
@@ -5,5 +5,17 @@ void Fma(inout Mat4x3 d, Mat4x3 m, float s) { d.mx += m.mx * s; d.my += m.my * s
 
 out vec4 o_color;
 void main() {
+    Mat4x3 m1 = {
+        vec4(0),
+        vec4(1),
+        vec4(2),
+    };
+    Mat4x3 m2 = {
+        vec4(0),
+        vec4(1),
+        vec4(2),
+    };
+
+    Fma(m1, m2, 2.0);
     o_color.rgba = vec4(1.0);
 }

--- a/naga/tests/in/glsl/functions_call.frag
+++ b/naga/tests/in/glsl/functions_call.frag
@@ -18,4 +18,12 @@ void swizzleImplicitCastCaller(vec3 a) {
     swizzleImplicitCastCallee(a.xz);
 }
 
-void main() {}
+void main() {
+    swizzleCaller(vec3(0));
+    uint a;
+    outImplicitCastCallee(a);
+    outImplicitCastCaller(1.0);
+    uvec2 b;
+    swizzleImplicitCastCallee(b);
+    swizzleImplicitCastCaller(vec3(0));
+}

--- a/naga/tests/in/glsl/images.frag
+++ b/naga/tests/in/glsl/images.frag
@@ -70,4 +70,13 @@ void testImgWriteReadOnly(in ivec2 coord) {
     vec2 size = imageSize(imgWriteReadOnly);
 }
 
-void main() {}
+void main() {
+    testImg1D(1);
+    testImg1DArray(ivec2(0));
+    testImg2D(ivec2(0));
+    testImg2DArray(ivec3(0));
+    testImg3D(ivec3(0));
+    testImgReadOnly(ivec2(0));
+    testImgWriteOnly(ivec2(0));
+    testImgWriteReadOnly(ivec2(0));
+}

--- a/naga/tests/in/glsl/sampler-functions.frag
+++ b/naga/tests/in/glsl/sampler-functions.frag
@@ -1,6 +1,9 @@
 #version 440
 precision mediump float;
 
+layout(set = 1, binding = 0) uniform texture2D tex2D;
+layout(set = 1, binding = 1) uniform samplerShadow sampShadow;
+
 float CalcShadowPCF1(texture2D T_P_t_TextureDepth, samplerShadow S_P_t_TextureDepth, in vec3 t_ProjCoord) {
     float t_Res = 0.0f;
     t_Res += texture(sampler2DShadow(T_P_t_TextureDepth, S_P_t_TextureDepth), t_ProjCoord.xyz) * (1.0 / 5.0);
@@ -13,4 +16,6 @@ float CalcShadowPCF(texture2D T_P_t_TextureDepth, samplerShadow S_P_t_TextureDep
 }
 
 void main() {
+    CalcShadowPCF1(tex2D, sampShadow, vec3(0));
+    CalcShadowPCF(tex2D, sampShadow, vec3(0), 1.0);
 }

--- a/naga/tests/in/glsl/samplers.frag
+++ b/naga/tests/in/glsl/samplers.frag
@@ -296,4 +296,24 @@ void testTex2DMSArray(in vec3 coord) {
     c = texelFetch(sampler2DMSArray(tex2DMSArray, samp), ivec3(coord), 3);
 }
 
-void main() {}
+void main() {
+    testTex1D(1.0);
+#if HAS_1D_DEPTH_TEXTURES
+    testTex1DShadow(2.0);
+#endif
+    testTex1DArray(vec2(3.0));
+#if HAS_1D_DEPTH_TEXTURES
+    testTex1DArrayShadow(vec2(4.0));
+#endif
+    testTex2D(vec2(1.0));
+    testTex2DShadow(vec2(1.0));
+    testTex2DArray(vec3(1.0));
+    testTex2DArrayShadow(vec3(1.0));
+    testTexCube(vec3(1.0));
+    testTexCubeShadow(vec3(1.0));
+    testTexCubeArray(vec4(1.0));
+    testTexCubeArrayShadow(vec4(1.0));
+    testTex3D(vec3(1.0));
+    testTex2DMS(vec2(1.0));
+    testTex2DMSArray(vec3(1.0));
+}

--- a/naga/tests/in/glsl/statements.frag
+++ b/naga/tests/in/glsl/statements.frag
@@ -33,4 +33,9 @@ void switchNoLastBreak(int a) {
     return;
 }
 
-void main() {}
+void main() {
+    switchEmpty(1);
+    switchNoDefault(2);
+    switchCaseImplConv(3);
+    switchNoLastBreak(4);
+}

--- a/naga/tests/in/glsl/vector-functions.frag
+++ b/naga/tests/in/glsl/vector-functions.frag
@@ -44,4 +44,10 @@ void btest(bvec4 a, bvec4 b) {
 	bvec4 g = not(a);
 }
 
-void main() {}
+void main() {
+    ftest(vec4(0), vec4(0));
+    dtest(dvec4(0), dvec4(0));
+    itest(ivec4(0), ivec4(0));
+    utest(uvec4(0), uvec4(0));
+    btest(bvec4(false), bvec4(false));
+}

--- a/naga/tests/out/wgsl/glsl-931-constant-emitting.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-931-constant-emitting.frag.wgsl
@@ -5,6 +5,7 @@ fn function() -> f32 {
 }
 
 fn main_1() {
+    let _e0 = function();
     return;
 }
 

--- a/naga/tests/out/wgsl/glsl-constant-array-size.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-constant-array-size.frag.wgsl
@@ -32,6 +32,7 @@ fn function() -> vec4<f32> {
 }
 
 fn main_1() {
+    let _e0 = function();
     return;
 }
 

--- a/naga/tests/out/wgsl/glsl-expressions.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-expressions.frag.wgsl
@@ -427,11 +427,31 @@ fn testSwizzleWrites(a_27: vec3<f32>) {
 fn main_1() {
     var local_6: f32;
 
-    let _e2 = global;
-    local_6 = _e2;
+    testBinOpVecFloat(vec4(0f), 1f);
+    testBinOpFloatVec(vec4(0f), 1f);
+    testBinOpIVecInt(vec4(0i), 1i);
+    testBinOpIntIVec(1i, vec4(0i));
+    testBinOpUVecUint(vec4(0u), 1u);
+    testBinOpUintUVec(1u, vec4(0u));
+    testBinOpMatMat(mat3x3<f32>(vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f)), mat3x3<f32>(vec3<f32>(1f, 0f, 0f), vec3<f32>(0f, 1f, 0f), vec3<f32>(0f, 0f, 1f)));
+    testBinOpMatFloat(1f, mat3x3<f32>(vec3<f32>(1f, 0f, 0f), vec3<f32>(0f, 1f, 0f), vec3<f32>(0f, 0f, 1f)));
+    testUnaryOpMat(mat3x3<f32>(vec3<f32>(1f, 0f, 0f), vec3<f32>(0f, 1f, 0f), vec3<f32>(0f, 0f, 1f)));
+    testStructConstructor();
+    testNonScalarToScalarConstructor();
+    testArrayConstructor();
+    testFreestandingConstructor();
+    testNonImplicitCastVectorCast();
+    let _e45 = global;
+    local_6 = _e45;
     privatePointer((&local_6));
-    let _e4 = local_6;
-    global = _e4;
+    let _e47 = local_6;
+    global = _e47;
+    ternary(false);
+    testMatrixMultiplication(mat4x3<f32>(vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f)), mat4x4<f32>(vec4<f32>(1f, 0f, 0f, 0f), vec4<f32>(0f, 1f, 0f, 0f), vec4<f32>(0f, 0f, 1f, 0f), vec4<f32>(0f, 0f, 0f, 1f)));
+    testLength();
+    testConstantLength(array<f32, 4>(0f, 1f, 2f, 3f));
+    indexConstantNonConstantIndex(1i);
+    testSwizzleWrites(vec3(0f));
     o_color.x = 1f;
     o_color.y = 1f;
     o_color.z = 1f;

--- a/naga/tests/out/wgsl/glsl-fma.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-fma.frag.wgsl
@@ -32,6 +32,11 @@ fn Fma(d: ptr<function, Mat4x3_>, m: Mat4x3_, s: f32) {
 }
 
 fn main_1() {
+    var m1_: Mat4x3_ = Mat4x3_(vec4(0f), vec4(1f), vec4(2f));
+    var m2_: Mat4x3_ = Mat4x3_(vec4(0f), vec4(1f), vec4(2f));
+
+    let _e17 = m2_;
+    Fma((&m1_), _e17, 2f);
     o_color.x = 1f;
     o_color.y = 1f;
     o_color.z = 1f;

--- a/naga/tests/out/wgsl/glsl-functions_call.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-functions_call.frag.wgsl
@@ -50,6 +50,14 @@ fn swizzleImplicitCastCaller(a_7: vec3<f32>) {
 }
 
 fn main_1() {
+    var a_9: u32;
+    var b: vec2<u32>;
+
+    swizzleCaller(vec3(0f));
+    outImplicitCastCallee((&a_9));
+    outImplicitCastCaller(1f);
+    swizzleImplicitCastCallee((&b));
+    swizzleImplicitCastCaller(vec3(0f));
     return;
 }
 

--- a/naga/tests/out/wgsl/glsl-images.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-images.frag.wgsl
@@ -134,6 +134,14 @@ fn testImgWriteReadOnly(coord_14: vec2<i32>) {
 }
 
 fn main_1() {
+    testImg1D(1i);
+    testImg1DArray(vec2(0i));
+    testImg2D(vec2(0i));
+    testImg2DArray(vec3(0i));
+    testImg3D(vec3(0i));
+    testImgReadOnly(vec2(0i));
+    testImgWriteOnly(vec2(0i));
+    testImgWriteReadOnly(vec2(0i));
     return;
 }
 

--- a/naga/tests/out/wgsl/glsl-sampler-functions.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-sampler-functions.frag.wgsl
@@ -1,3 +1,8 @@
+@group(1) @binding(0) 
+var tex2D: texture_depth_2d;
+@group(1) @binding(1) 
+var sampShadow: sampler_comparison;
+
 fn CalcShadowPCF1_(T_P_t_TextureDepth: texture_depth_2d, S_P_t_TextureDepth: sampler_comparison, t_ProjCoord: vec3<f32>) -> f32 {
     var t_ProjCoord_1: vec3<f32>;
     var t_Res: f32 = 0f;
@@ -27,6 +32,8 @@ fn CalcShadowPCF(T_P_t_TextureDepth_1: texture_depth_2d, S_P_t_TextureDepth_1: s
 }
 
 fn main_1() {
+    let _e4 = CalcShadowPCF1_(tex2D, sampShadow, vec3(0f));
+    let _e8 = CalcShadowPCF(tex2D, sampShadow, vec3(0f), 1f);
     return;
 }
 

--- a/naga/tests/out/wgsl/glsl-samplers.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-samplers.frag.wgsl
@@ -628,6 +628,19 @@ fn testTex2DMSArray(coord_24: vec3<f32>) {
 }
 
 fn main_1() {
+    testTex1D(1f);
+    testTex1DArray(vec2(3f));
+    testTex2D(vec2(1f));
+    testTex2DShadow(vec2(1f));
+    testTex2DArray(vec3(1f));
+    testTex2DArrayShadow(vec3(1f));
+    testTexCube(vec3(1f));
+    testTexCubeShadow(vec3(1f));
+    testTexCubeArray(vec4(1f));
+    testTexCubeArrayShadow(vec4(1f));
+    testTex3D(vec3(1f));
+    testTex2DMS(vec2(1f));
+    testTex2DMSArray(vec3(1f));
     return;
 }
 

--- a/naga/tests/out/wgsl/glsl-statements.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-statements.frag.wgsl
@@ -54,6 +54,10 @@ fn switchNoLastBreak(a_6: i32) {
 }
 
 fn main_1() {
+    switchEmpty(1i);
+    switchNoDefault(2i);
+    switchCaseImplConv(3u);
+    switchNoLastBreak(4i);
     return;
 }
 

--- a/naga/tests/out/wgsl/glsl-vector-functions.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-vector-functions.frag.wgsl
@@ -157,6 +157,11 @@ fn btest(a_8: vec4<bool>, b_8: vec4<bool>) {
 }
 
 fn main_1() {
+    ftest(vec4(0f), vec4(0f));
+    dtest(vec4(0.0lf), vec4(0.0lf));
+    itest(vec4(0i), vec4(0i));
+    utest(vec4(0u), vec4(0u));
+    btest(vec4(false), vec4(false));
     return;
 }
 


### PR DESCRIPTION
For #5885, we are planning to change compaction to remove unreferenced functions.

This change ensures that test functions in GLSL snapshots are reachable from the entry point, so that when we start pruning unreachable functions, we do not lose test coverage.

This is the first of three similar changes to tests. The others are for the WGSL snapshot tests and for the non-snapshot naga tests.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
