### PR TITLE
Allow using `Device::create_texture_with_data` correctly with mipmapped non-block aligned textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ Naga now infers the correct binding layout when a resource appears only in an as
 - Properly apply WGSL's automatic conversions to the arguments to texture sampling functions. By @jimblandy in [#7548](https://github.com/gfx-rs/wgpu/pull/7548).
 - Properly evaluate `abs(most negative abstract int)`. By @jimblandy in [#7507](https://github.com/gfx-rs/wgpu/pull/7507).
 
+#### General
+- Allow using `Device::create_texture_with_data` with mipmapped nPOT textures. By @atlv24 in [#7678](https://github.com/gfx-rs/wgpu/pull/7678).
+
 #### DX12
 
 - Get `vertex_index` & `instance_index` builtins working for indirect draws. By @teoxoy in [#7535](https://github.com/gfx-rs/wgpu/pull/7535)

--- a/wgpu/src/util/device.rs
+++ b/wgpu/src/util/device.rs
@@ -82,10 +82,14 @@ impl DeviceExt for crate::Device {
         order: TextureDataOrder,
         data: &[u8],
     ) -> crate::Texture {
-        // Implicitly add the COPY_DST usage
-        let mut desc = desc.to_owned();
-        desc.usage |= crate::TextureUsages::COPY_DST;
-        let texture = self.create_texture(&desc);
+        let texture = self.create_texture(&{
+            let mut desc = desc.to_owned();
+            // Implicitly add the COPY_DST usage
+            desc.usage |= crate::TextureUsages::COPY_DST;
+            // Implicitly expand to blocksize
+            desc.size = desc.size.physical_size(desc.format);
+            desc
+        });
 
         // Will return None only if it's a combined depth-stencil format
         // If so, default to 4, validation will fail later anyway since the depth or stencil


### PR DESCRIPTION
**Connections**
Fixes #7677
Bevy side of the fix: https://github.com/bevyengine/bevy/pull/19129

**Description**
Implicitly expand size to blocksize in create_texture_with_data to allow using logical size in mip size computations

**Testing**
Patch into bevy repro of the issue and it works

**Squash or Rebase?**
Any

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
