### PR TITLE
wgpu-hal: Expose vulkan::PhysicalDeviceFeatures

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -18,6 +18,7 @@ const INDEXING_FEATURES: wgt::Features = wgt::Features::TEXTURE_BINDING_ARRAY
     .union(wgt::Features::UNIFORM_BUFFER_BINDING_ARRAYS)
     .union(wgt::Features::PARTIALLY_BOUND_BINDING_ARRAY);
 
+#[expect(rustdoc::private_intra_doc_links)]
 /// Features supported by a [`vk::PhysicalDevice`] and its extensions.
 ///
 /// This is used in two phases:

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -32,6 +32,8 @@ mod drm;
 mod instance;
 mod sampler;
 
+pub use adapter::PhysicalDeviceFeatures;
+
 use alloc::{boxed::Box, ffi::CString, sync::Arc, vec::Vec};
 use core::{borrow::Borrow, ffi::CStr, fmt, mem, num::NonZeroU32, ops::DerefMut};
 
@@ -455,7 +457,7 @@ pub struct Adapter {
     //queue_families: Vec<vk::QueueFamilyProperties>,
     known_memory_flags: vk::MemoryPropertyFlags,
     phd_capabilities: adapter::PhysicalDeviceProperties,
-    phd_features: adapter::PhysicalDeviceFeatures,
+    phd_features: PhysicalDeviceFeatures,
     downlevel_flags: wgt::DownlevelFlags,
     private_caps: PrivateCapabilities,
     workarounds: Workarounds,


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/7681

**Description**
`PhysicalDeviceFeatures` is currently accessible through [`vulkan::Adapter::physical_device_features`](https://docs.rs/wgpu-hal/latest/wgpu_hal/vulkan/struct.Adapter.html#method.physical_device_features) which is a public function. This structure seems required to be able to tell what Vulkan device features wgpu needs so it would be nice if it was accessible externally as otherwise it's impossible to create a wgpu `Device` from Vulkan objects safely.

Re-exporting the type is the workaround I used just to get what I was doing to succeed, alternatively the whole `adapter` module could be made public or glob re-exported, this would also expose `PhysicalDeviceProperties` which appears to have the same issue.

**Testing**
Call `Adapter::physical_device_features`, notice that you can't name this type due to it being private.

**Squash or Rebase?**
Any

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
