### PR TITLE
Don't raise `AlreadyDestroyed` error on repeated `destroy()` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Naga now infers the correct binding layout when a resource appears only in an as
 #### General
 
 - Removed `MaintainBase` in favor of using `PollType`. By @waywardmonkeys in [#7508](https://github.com/gfx-rs/wgpu/pull/7508).
+- wgpu-core no longer raises an error if `destroy` is called multiple times for a buffer or texture. This only affects the wgpu-core API; the wgpu API already allowed multiple `destroy` calls. By @andyleiserson in [#7686](https://github.com/gfx-rs/wgpu/pull/7686).
 
 #### Naga
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -713,7 +713,8 @@ impl Buffer {
             let raw = match self.raw.snatch(&mut snatch_guard) {
                 Some(raw) => raw,
                 None => {
-                    return Err(DestroyError::AlreadyDestroyed);
+                    // Per spec, it is valid to call `destroy` multiple times.
+                    return Ok(());
                 }
             };
 
@@ -1189,7 +1190,8 @@ impl Texture {
                     return Ok(());
                 }
                 None => {
-                    return Err(DestroyError::AlreadyDestroyed);
+                    // Per spec, it is valid to call `destroy` multiple times.
+                    return Ok(());
                 }
             };
 
@@ -1953,8 +1955,6 @@ impl QuerySet {
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum DestroyError {
-    #[error("Resource is already destroyed")]
-    AlreadyDestroyed,
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
 }


### PR DESCRIPTION
The [spec](https://www.w3.org/TR/webgpu/#dom-gpubuffer-destroy) says that it is valid to destroy a buffer multiple times. This change removes the `AlreadyDestroyed` error that was raised if `destroy` was called multiple times for a buffer or texture. (The spec doesn't explicitly say that it is okay to destroy a texture multiple times, but it also doesn't specify an error.)

This error was already discarded within the Firefox wgpu bindings, and is discarded in the implementation of `CoreBuffer::destroy` and `CoreTexture::destroy`. However, the Deno webgpu bindings call `buffer_destroy` and `texture_destroy` directly, and the error on multiple destroy calls caused failures running the CTS under Deno. 

**Testing**
This fix resolved an issue in the CTS, but I haven't added a specific test for it.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
