### PR TITLE
Backport fix for a deadlock caused by locking the device's snatchable lock after locking the queue's pending writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+#### General
+- Fix a possible deadlock within `Queue::write_buffer`. By @RedMindZ in [#7582](https://github.com/gfx-rs/wgpu/pull/7582)
+
 ### v24.0.4 (2025-04-03)
 
 #### Metal

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -472,6 +472,8 @@ impl Queue {
             return Ok(());
         };
 
+        let snatch_guard = self.device.snatchable_lock.read();
+
         // Platform validation requires that the staging buffer always be
         // freed, even if an error occurs. All paths from here must call
         // `device.pending_writes.consume`.
@@ -485,6 +487,7 @@ impl Queue {
         };
 
         let result = self.write_staging_buffer_impl(
+            &snatch_guard,
             &mut pending_writes,
             &staging_buffer,
             buffer,
@@ -518,6 +521,7 @@ impl Queue {
 
         let buffer = buffer.get()?;
 
+        let snatch_guard = self.device.snatchable_lock.read();
         let mut pending_writes = self.pending_writes.lock();
 
         // At this point, we have taken ownership of the staging_buffer from the
@@ -527,6 +531,7 @@ impl Queue {
         let staging_buffer = staging_buffer.flush();
 
         let result = self.write_staging_buffer_impl(
+            &snatch_guard,
             &mut pending_writes,
             &staging_buffer,
             buffer,
@@ -579,6 +584,7 @@ impl Queue {
 
     fn write_staging_buffer_impl(
         &self,
+        snatch_guard: &SnatchGuard,
         pending_writes: &mut PendingWrites,
         staging_buffer: &FlushedStagingBuffer,
         buffer: Arc<Buffer>,
@@ -591,8 +597,7 @@ impl Queue {
                 .set_single(&buffer, hal::BufferUses::COPY_DST)
         };
 
-        let snatch_guard = self.device.snatchable_lock.read();
-        let dst_raw = buffer.try_raw(&snatch_guard)?;
+        let dst_raw = buffer.try_raw(snatch_guard)?;
 
         self.same_device_as(buffer.as_ref())?;
 
@@ -610,7 +615,7 @@ impl Queue {
                 to: hal::BufferUses::COPY_SRC,
             },
         })
-        .chain(transition.map(|pending| pending.into_hal(&buffer, &snatch_guard)))
+        .chain(transition.map(|pending| pending.into_hal(&buffer, snatch_guard)))
         .collect::<Vec<_>>();
         let encoder = pending_writes.activate();
         unsafe {


### PR DESCRIPTION
**Connections**
This is a backport of [#7582](https://github.com/gfx-rs/wgpu/pull/7582) to v24.

This bug was actually very similar to #7004 which was already backported. Since this is impacting and the root cause is the same, I think this makes sens to backport this fix too.

**Description**
Copied from the original issue:
> There is a deadlock in Queue::write_buffer and Queue::write_staging_buffer that is caused by taking the device's snatchable lock after locking the queue's pending writes. This violates the lock ranking, which states that the device's snatchable lock must be taken first. This is fixed by simply reversing the order in which the locking occurs.

I looked for other potential deadlocks but did not find any. I also added a reference to the original patch in the changelog.

**Testing**
This deadlock occurred when using wgpu v24.0.4 where I could reproduce it reliably. 
I identified its source as coming from `self.pending_writes.lock()`. A patch existing but for the v25 branch. After backporting it to the v24 I confirmed the decklock was no longer happening.

**Squash or Rebase?**
This is a single commit.

**Checklist**
- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo test`
- [ ] Run `cargo xtask test` to run tests.`
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
