### PR TITLE
Fix error message for sampler arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ Bottom level categories:
 
 ### Bug Fixes
 
+#### General
+
+- Fix error message for sampler array limit. By @LPGhatguy in [#7704](https://github.com/gfx-rs/wgpu/pull/7704).
+
 #### Naga
 
 Naga now infers the correct binding layout when a resource appears only in an assignment to `_`. By @andyleiserson in [#7540](https://github.com/gfx-rs/wgpu/pull/7540).

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -255,7 +255,7 @@ impl BindingTypeMaxCountErrorKind {
                 "max_binding_array_elements_per_shader_stage"
             }
             BindingTypeMaxCountErrorKind::BindingArraySamplerElements => {
-                "max_binding_array_elements_per_shader_stage"
+                "max_binding_array_sampler_elements_per_shader_stage"
             }
         }
     }


### PR DESCRIPTION
**Description**
The error message for the sampler array binding limit being too low refers to the wrong property. This was confusing as I'd already raised the property in the error message!

I was not able to run the xtask test suite as it did not build on my machine. I think it's a problem with my configuration.

**Checklist**

- [x] Run `cargo fmt`.
- ~Run `taplo format`.~
- [x] Run `cargo clippy --tests`. If applicable, add:
  - ~`--target wasm32-unknown-unknown`~
- ~Run `cargo xtask test` to run tests.~
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->