### PR TITLE
Destroy texture views in clear_mode when destroying texture

### DIFF
--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -272,7 +272,7 @@ pub(crate) fn clear_texture<T: TextureTrackerSetSingle>(
     let dst_raw = dst_texture.try_raw(snatch_guard)?;
 
     // Issue the right barrier.
-    let clear_usage = match *dst_texture.clear_mode.lock() {
+    let clear_usage = match *dst_texture.clear_mode.read() {
         TextureClearMode::BufferCopy => wgt::TextureUses::COPY_DST,
         TextureClearMode::RenderPass {
             is_color: false, ..
@@ -314,7 +314,7 @@ pub(crate) fn clear_texture<T: TextureTrackerSetSingle>(
     }
 
     // Record actual clearing
-    let clear_mode = dst_texture.clear_mode.lock();
+    let clear_mode = dst_texture.clear_mode.read();
     match *clear_mode {
         TextureClearMode::BufferCopy => clear_texture_via_buffer_copies(
             &dst_texture.desc,
@@ -449,7 +449,7 @@ fn clear_texture_via_render_passes(
         depth_or_array_layers: 1, // Only one layer is cleared at a time.
     };
 
-    let clear_mode = dst_texture.clear_mode.lock();
+    let clear_mode = dst_texture.clear_mode.read();
 
     for mip_level in range.mip_range {
         let extent = extent_base.mip_level_size(mip_level, dst_texture.desc.dimension);

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -272,7 +272,7 @@ pub(crate) fn clear_texture<T: TextureTrackerSetSingle>(
     let dst_raw = dst_texture.try_raw(snatch_guard)?;
 
     // Issue the right barrier.
-    let clear_usage = match dst_texture.clear_mode {
+    let clear_usage = match *dst_texture.clear_mode.lock() {
         TextureClearMode::BufferCopy => wgt::TextureUses::COPY_DST,
         TextureClearMode::RenderPass {
             is_color: false, ..
@@ -314,7 +314,8 @@ pub(crate) fn clear_texture<T: TextureTrackerSetSingle>(
     }
 
     // Record actual clearing
-    match dst_texture.clear_mode {
+    let clear_mode = dst_texture.clear_mode.lock();
+    match *clear_mode {
         TextureClearMode::BufferCopy => clear_texture_via_buffer_copies(
             &dst_texture.desc,
             alignments,
@@ -324,9 +325,11 @@ pub(crate) fn clear_texture<T: TextureTrackerSetSingle>(
             dst_raw,
         ),
         TextureClearMode::Surface { .. } => {
+            drop(clear_mode);
             clear_texture_via_render_passes(dst_texture, range, true, encoder)?
         }
         TextureClearMode::RenderPass { is_color, .. } => {
+            drop(clear_mode);
             clear_texture_via_render_passes(dst_texture, range, is_color, encoder)?
         }
         TextureClearMode::None => {
@@ -446,6 +449,8 @@ fn clear_texture_via_render_passes(
         depth_or_array_layers: 1, // Only one layer is cleared at a time.
     };
 
+    let clear_mode = dst_texture.clear_mode.lock();
+
     for mip_level in range.mip_range {
         let extent = extent_base.mip_level_size(mip_level, dst_texture.desc.dimension);
         for depth_or_layer in range.layer_range.clone() {
@@ -454,7 +459,7 @@ fn clear_texture_via_render_passes(
                 color_attachments_tmp = [Some(hal::ColorAttachment {
                     target: hal::Attachment {
                         view: Texture::get_clear_view(
-                            &dst_texture.clear_mode,
+                            &clear_mode,
                             &dst_texture.desc,
                             mip_level,
                             depth_or_layer,
@@ -473,7 +478,7 @@ fn clear_texture_via_render_passes(
                     Some(hal::DepthStencilAttachment {
                         target: hal::Attachment {
                             view: Texture::get_clear_view(
-                                &dst_texture.clear_mode,
+                                &clear_mode,
                                 &dst_texture.desc,
                                 mip_level,
                                 depth_or_layer,

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -145,6 +145,7 @@ define_lock_ranks! {
     rank SURFACE_PRESENTATION "Surface::presentation" followed by { }
     rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { }
     rank TEXTURE_INITIALIZATION_STATUS "Texture::initialization_status" followed by { }
+    rank TEXTURE_CLEAR_MODE "Texture::clear_mode" followed by { }
     rank TEXTURE_VIEWS "Texture::views" followed by { }
     rank BLAS_BUILT_INDEX "Blas::built_index" followed by { }
     rank TLAS_BUILT_INDEX "Tlas::built_index" followed by { }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1029,7 +1029,7 @@ pub struct Texture {
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
     pub(crate) tracking_data: TrackingData,
-    pub(crate) clear_mode: TextureClearMode,
+    pub(crate) clear_mode: Mutex<TextureClearMode>,
     pub(crate) views: Mutex<WeakVec<TextureView>>,
     pub(crate) bind_groups: Mutex<WeakVec<BindGroup>>,
 }
@@ -1064,7 +1064,7 @@ impl Texture {
             },
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(device.tracker_indices.textures.clone()),
-            clear_mode,
+            clear_mode: Mutex::new(rank::TEXTURE_CLEAR_MODE, clear_mode),
             views: Mutex::new(rank::TEXTURE_VIEWS, WeakVec::new()),
             bind_groups: Mutex::new(rank::TEXTURE_BIND_GROUPS, WeakVec::new()),
         }
@@ -1090,7 +1090,7 @@ impl Texture {
 
 impl Drop for Texture {
     fn drop(&mut self) {
-        match self.clear_mode {
+        match *self.clear_mode.lock() {
             TextureClearMode::Surface {
                 ref mut clear_view, ..
             } => {
@@ -1208,6 +1208,7 @@ impl Texture {
             queue::TempResource::DestroyedTexture(DestroyedTexture {
                 raw: ManuallyDrop::new(raw),
                 views,
+                clear_mode: mem::replace(&mut *self.clear_mode.lock(), TextureClearMode::None),
                 bind_groups,
                 device: Arc::clone(&self.device),
                 label: self.label().to_owned(),
@@ -1471,6 +1472,7 @@ impl Global {
 pub struct DestroyedTexture {
     raw: ManuallyDrop<Box<dyn hal::DynTexture>>,
     views: WeakVec<TextureView>,
+    clear_mode: TextureClearMode,
     bind_groups: WeakVec<BindGroup>,
     device: Arc<Device>,
     label: String,
@@ -1492,6 +1494,20 @@ impl Drop for DestroyedTexture {
             &mut self.bind_groups,
         )));
         drop(deferred);
+
+        match mem::replace(&mut self.clear_mode, TextureClearMode::None) {
+            TextureClearMode::RenderPass { clear_views, .. } => {
+                for clear_view in clear_views {
+                    let raw = ManuallyDrop::into_inner(clear_view);
+                    unsafe { self.device.raw().destroy_texture_view(raw) };
+                }
+            }
+            TextureClearMode::Surface { clear_view } => {
+                let raw = ManuallyDrop::into_inner(clear_view);
+                unsafe { self.device.raw().destroy_texture_view(raw) };
+            }
+            _ => (),
+        }
 
         resource_log!("Destroy raw Texture (destroyed) {:?}", self.label());
         // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1029,7 +1029,7 @@ pub struct Texture {
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
     pub(crate) tracking_data: TrackingData,
-    pub(crate) clear_mode: Mutex<TextureClearMode>,
+    pub(crate) clear_mode: RwLock<TextureClearMode>,
     pub(crate) views: Mutex<WeakVec<TextureView>>,
     pub(crate) bind_groups: Mutex<WeakVec<BindGroup>>,
 }
@@ -1064,7 +1064,7 @@ impl Texture {
             },
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(device.tracker_indices.textures.clone()),
-            clear_mode: Mutex::new(rank::TEXTURE_CLEAR_MODE, clear_mode),
+            clear_mode: RwLock::new(rank::TEXTURE_CLEAR_MODE, clear_mode),
             views: Mutex::new(rank::TEXTURE_VIEWS, WeakVec::new()),
             bind_groups: Mutex::new(rank::TEXTURE_BIND_GROUPS, WeakVec::new()),
         }
@@ -1090,7 +1090,7 @@ impl Texture {
 
 impl Drop for Texture {
     fn drop(&mut self) {
-        match *self.clear_mode.lock() {
+        match *self.clear_mode.write() {
             TextureClearMode::Surface {
                 ref mut clear_view, ..
             } => {
@@ -1208,7 +1208,7 @@ impl Texture {
             queue::TempResource::DestroyedTexture(DestroyedTexture {
                 raw: ManuallyDrop::new(raw),
                 views,
-                clear_mode: mem::replace(&mut *self.clear_mode.lock(), TextureClearMode::None),
+                clear_mode: mem::replace(&mut *self.clear_mode.write(), TextureClearMode::None),
                 bind_groups,
                 device: Arc::clone(&self.device),
                 label: self.label().to_owned(),


### PR DESCRIPTION
**Connections**

Fixes #7697 

**Description**

Texture views held by `TextureClearMode` can prevent texture memory from being deallocated on graphics APIs that use reference counting. These changes ensure `clear_mode` views get destroyed after `Texture::destroy` instead of waiting for the whole `Texture` to be dropped. This might also fix a [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1922992), but I haven't rebuilt Firefox to check for sure.

**Testing**

This was tested on a project replicating the online [resizeCanvas sample](https://webgpu.github.io/webgpu-samples/?sample=resizeCanvas). Before, GPU memory continuously grew when textures were destroyed but not dropped. With these changes, memory remains stable.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
