### PR TITLE
Do not depend on `document-features` by default

### DIFF
--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -159,6 +159,9 @@ renderdoc = ["wgpu-core-deps-windows-linux-android/renderdoc"]
 # TODO(https://github.com/gfx-rs/wgpu/issues/7120): there should be a hal feature
 noop = []
 
+# Add features documentation to docs
+_docs = ["dep:document-features"]
+
 # The target limitation here isn't needed, but prevents more than one of these
 # platform crates from being included in the build at a time, preventing users
 # from getting confused by seeing them in the list of crates.
@@ -181,7 +184,7 @@ bit-vec.workspace = true
 bit-set.workspace = true
 bitflags.workspace = true
 bytemuck = { workspace = true, optional = true }
-document-features.workspace = true
+document-features = { workspace = true, optional = true }
 hashbrown.workspace = true
 indexmap.workspace = true
 log.workspace = true

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -3,7 +3,7 @@
 //! into other language-specific user-friendly libraries.
 //!
 //! ## Feature flags
-#![doc = document_features::document_features!()]
+#![cfg_attr(feature = "_docs", doc = document_features::document_features!())]
 //!
 
 #![no_std]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -148,6 +148,9 @@ fragile-send-sync-non-atomic-wasm = [
     "wgpu-types/fragile-send-sync-non-atomic-wasm",
 ]
 
+# Add features documentation to docs
+_docs = ["dep:document-features"]
+
 #########################
 # Standard Dependencies #
 #########################
@@ -160,7 +163,7 @@ wgpu-types.workspace = true
 # Needed for both wgpu-core and webgpu
 arrayvec.workspace = true
 bitflags.workspace = true
-document-features.workspace = true
+document-features = { workspace = true, optional = true }
 hashbrown.workspace = true
 log.workspace = true
 parking_lot.workspace = true

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -3,7 +3,7 @@
 //! To start using the API, create an [`Instance`].
 //!
 //! ## Feature flags
-#![doc = document_features::document_features!()]
+#![cfg_attr(feature = "_docs", doc = document_features::document_features!())]
 //!
 //! ### Feature Aliases
 //!


### PR DESCRIPTION
**Description**
Avoid depending on `document-features` by default, only when building in docs.rs.

**Testing**
Built docs locally with and without `--all-features` flag.

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry
