### PR TITLE
Remove another type of error that could be raised by `destroy`

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -11,5 +11,4 @@ webgpu:api,operation,rendering,color_target_state:blending,formats:*
 webgpu:api,operation,rendering,color_target_state:blend_constant,setting:*
 webgpu:api,operation,rendering,depth:*
 webgpu:api,operation,rendering,draw:*
-// https://github.com/gfx-rs/wgpu/issues/7391
-//FAIL: webgpu:api,operation,uncapturederror:*
+webgpu:api,operation,uncapturederror:*

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -251,9 +251,7 @@ impl GPUBuffer {
     }
 
     #[fast]
-    fn destroy(&self) -> Result<(), JsErrorBox> {
-        self.instance
-            .buffer_destroy(self.id)
-            .map_err(|e| JsErrorBox::generic(e.to_string()))
+    fn destroy(&self) {
+        self.instance.buffer_destroy(self.id);
     }
 }

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -113,10 +113,8 @@ impl GPUTexture {
         self.usage
     }
     #[fast]
-    fn destroy(&self) -> Result<(), JsErrorBox> {
-        self.instance
-            .texture_destroy(self.id)
-            .map_err(|e| JsErrorBox::generic(e.to_string()))
+    fn destroy(&self) {
+        self.instance.texture_destroy(self.id);
     }
 
     #[cppgc]

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -247,7 +247,7 @@ impl GlobalPlay for wgc::global::Global {
                 }
             }
             Action::FreeBuffer(id) => {
-                self.buffer_destroy(id).unwrap();
+                self.buffer_destroy(id);
             }
             Action::DestroyBuffer(id) => {
                 self.buffer_drop(id);
@@ -259,7 +259,7 @@ impl GlobalPlay for wgc::global::Global {
                 }
             }
             Action::FreeTexture(id) => {
-                self.texture_destroy(id).unwrap();
+                self.texture_destroy(id);
             }
             Action::DestroyTexture(id) => {
                 self.texture_drop(id);

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -252,13 +252,16 @@ impl Global {
         Ok(())
     }
 
-    pub fn buffer_destroy(&self, buffer_id: id::BufferId) -> Result<(), resource::DestroyError> {
+    pub fn buffer_destroy(&self, buffer_id: id::BufferId) {
         profiling::scope!("Buffer::destroy");
         api_log!("Buffer::destroy {buffer_id:?}");
 
         let hub = &self.hub;
 
-        let buffer = hub.buffers.get(buffer_id).get()?;
+        let Ok(buffer) = hub.buffers.get(buffer_id).get() else {
+            // If the buffer is already invalid, there's nothing to do.
+            return;
+        };
 
         #[cfg(feature = "trace")]
         if let Some(trace) = buffer.device.trace.lock().as_mut() {
@@ -270,7 +273,7 @@ impl Global {
             buffer_id,
         );
 
-        buffer.destroy()
+        buffer.destroy();
     }
 
     pub fn buffer_drop(&self, buffer_id: id::BufferId) {
@@ -409,20 +412,23 @@ impl Global {
         (id, err)
     }
 
-    pub fn texture_destroy(&self, texture_id: id::TextureId) -> Result<(), resource::DestroyError> {
+    pub fn texture_destroy(&self, texture_id: id::TextureId) {
         profiling::scope!("Texture::destroy");
         api_log!("Texture::destroy {texture_id:?}");
 
         let hub = &self.hub;
 
-        let texture = hub.textures.get(texture_id).get()?;
+        let Ok(texture) = hub.textures.get(texture_id).get() else {
+            // If the texture is already invalid, there's nothing to do.
+            return;
+        };
 
         #[cfg(feature = "trace")]
         if let Some(trace) = texture.device.trace.lock().as_mut() {
             trace.add(trace::Action::FreeTexture(texture_id));
         }
 
-        texture.destroy()
+        texture.destroy();
     }
 
     pub fn texture_drop(&self, texture_id: id::TextureId) {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3914,12 +3914,12 @@ impl Device {
         let trackers = self.trackers.lock();
         for buffer in trackers.buffers.used_resources() {
             if let Some(buffer) = Weak::upgrade(buffer) {
-                let _ = buffer.destroy();
+                buffer.destroy();
             }
         }
         for texture in trackers.textures.used_resources() {
             if let Some(texture) = Weak::upgrade(texture) {
-                let _ = texture.destroy();
+                texture.destroy();
             }
         }
     }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -704,7 +704,7 @@ impl Buffer {
         Ok(None)
     }
 
-    pub(crate) fn destroy(self: &Arc<Self>) -> Result<(), DestroyError> {
+    pub(crate) fn destroy(self: &Arc<Self>) {
         let device = &self.device;
 
         let temp = {
@@ -714,7 +714,7 @@ impl Buffer {
                 Some(raw) => raw,
                 None => {
                     // Per spec, it is valid to call `destroy` multiple times.
-                    return Ok(());
+                    return;
                 }
             };
 
@@ -755,8 +755,6 @@ impl Buffer {
                 }
             }
         }
-
-        Ok(())
     }
 }
 
@@ -1180,18 +1178,18 @@ impl Texture {
         }
     }
 
-    pub(crate) fn destroy(self: &Arc<Self>) -> Result<(), DestroyError> {
+    pub(crate) fn destroy(self: &Arc<Self>) {
         let device = &self.device;
 
         let temp = {
             let raw = match self.inner.snatch(&mut device.snatchable_lock.write()) {
                 Some(TextureInner::Native { raw }) => raw,
                 Some(TextureInner::Surface { .. }) => {
-                    return Ok(());
+                    return;
                 }
                 None => {
                     // Per spec, it is valid to call `destroy` multiple times.
-                    return Ok(());
+                    return;
                 }
             };
 
@@ -1227,8 +1225,6 @@ impl Texture {
                 }
             }
         }
-
-        Ok(())
     }
 }
 
@@ -1966,13 +1962,6 @@ impl QuerySet {
     pub(crate) fn raw(&self) -> &dyn hal::DynQuerySet {
         self.raw.as_ref()
     }
-}
-
-#[derive(Clone, Debug, Error)]
-#[non_exhaustive]
-pub enum DestroyError {
-    #[error(transparent)]
-    InvalidResource(#[from] InvalidResourceError),
 }
 
 pub type BlasDescriptor<'a> = wgt::CreateBlasDescriptor<Label<'a>>;

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -602,8 +602,10 @@ impl<'a> DeviceAllocationContext<'a> {
             }
         };
 
-        if info.CurrentUsage + allocation_info.SizeInBytes.max(memblock_size)
-            >= info.Budget / 100 * threshold as u64
+        if info
+            .CurrentUsage
+            .checked_add(allocation_info.SizeInBytes.max(memblock_size))
+            .is_none_or(|usage| usage >= info.Budget / 100 * threshold as u64)
         {
             return Err(crate::DeviceError::OutOfMemory);
         }

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2056,8 +2056,7 @@ impl dispatch::BufferInterface for CoreBuffer {
     }
 
     fn destroy(&self) {
-        // Per spec, no error to report. Even calling destroy multiple times is valid.
-        let _ = self.context.0.buffer_destroy(self.id);
+        self.context.0.buffer_destroy(self.id);
     }
 }
 
@@ -2101,8 +2100,7 @@ impl dispatch::TextureInterface for CoreTexture {
     }
 
     fn destroy(&self) {
-        // Per spec, no error to report. Even calling destroy multiple times is valid.
-        let _ = self.context.0.texture_destroy(self.id);
+        self.context.0.texture_destroy(self.id);
     }
 }
 


### PR DESCRIPTION
This fixes the `uncapturederror` CTS tests by removing another error raised by `destroy` (the previous one was in #7686).

Unfortunately, this is a breaking change to the `wgpu-core` API.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
