### PR TITLE
chore: update `gpu-descriptor` 0.3.1 → 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf29e94d6d243368b7a56caa16bc213e4f9f8ed38c4d9557069527b5d5281ca"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
  "bitflags 2.9.0",
  "gpu-descriptor-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ objc = "0.2.5"
 android_system_properties = "0.1.1"
 ash = "0.38"
 gpu-alloc = "0.6"
-gpu-descriptor = "0.3"
+gpu-descriptor = "0.3.2"
 
 # DX12 dependencies
 gpu-allocator = { version = "0.27", default-features = false }


### PR DESCRIPTION
Forces users to consume a fix for #7525.