### PR TITLE
[d3d12] add a shader cache to avoid calling into DXC/FXC

### DIFF
--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -84,10 +84,11 @@ mod suballocation;
 mod types;
 mod view;
 
-use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
+use alloc::{borrow::ToOwned as _, string::String, sync::Arc, vec::Vec};
 use core::{ffi, fmt, mem, num::NonZeroU32, ops::Deref};
 
 use arrayvec::ArrayVec;
+use hashbrown::HashMap;
 use parking_lot::{Mutex, RwLock};
 use suballocation::Allocator;
 use windows::{
@@ -656,6 +657,7 @@ pub struct Device {
     null_rtv_handle: descriptor::Handle,
     mem_allocator: Allocator,
     compiler_container: Arc<shader_compilation::CompilerContainer>,
+    shader_cache: Mutex<ShaderCache>,
     counters: Arc<wgt::HalCounters>,
 }
 
@@ -1077,6 +1079,28 @@ pub struct ShaderModule {
 
 impl crate::DynShaderModule for ShaderModule {}
 
+#[derive(Default)]
+pub struct ShaderCache {
+    nr_of_shaders_compiled: u32,
+    entries: HashMap<ShaderCacheKey, ShaderCacheValue>,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+pub(super) struct ShaderCacheKey {
+    source: String,
+    entry_point: String,
+    stage: naga::ShaderStage,
+    shader_model: naga::back::hlsl::ShaderModel,
+}
+
+pub(super) struct ShaderCacheValue {
+    /// This is the value of [`ShaderCache::nr_of_shaders_compiled`]
+    /// at the time the cache entry was last used.
+    last_used: u32,
+    shader: CompiledShader,
+}
+
+#[derive(Clone)]
 pub(super) enum CompiledShader {
     Dxc(Direct3D::Dxc::IDxcBlob),
     Fxc(Direct3D::ID3DBlob),
@@ -1095,8 +1119,6 @@ impl CompiledShader {
             },
         }
     }
-
-    unsafe fn destroy(self) {}
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/7716.

**Description**
Adds a shader cache to the D3D12 backend so that we don't have to recompile shaders via DXC/FXC.
~Note that the cache is per device and so will get cleared when the device is dropped. I think this is fine for now.~

**Testing**
Tested manually.

**Squash or Rebase?**
n/a
