### PR TITLE
Tweaks to CTS xtask, useful when running a modified CTS.

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,8 +16,11 @@ const HELP: &str = "\
 Usage: xtask <COMMAND>
 
 Commands:
-  cts [<test selector> | -f <test list file>]...
+  cts [--skip-checkout] [<test selector> | -f <test list file>]...
     Check out, build, and run CTS tests
+
+    --skip-checkout     Don't check out the pinned CTS version, use whatever is
+                        already checked out.
 
   run-wasm
     Build and run web examples


### PR DESCRIPTION
Adds a `--skip-checkout` option to run whatever is already present, rather than check out the version pinned by `cts_runner/revision.txt`. Canonicalizes path to Cargo.toml in case `cts` is a symlink.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] Run `cargo xtask cts` to run the CTS.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
