### PR TITLE
MVP `no_std` for `wgpu`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,11 +303,13 @@ jobs:
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p naga --no-default-features
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-hal --no-default-features
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu --no-default-features
 
           # Check with all compatible features
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features --features strict_asserts,fragile-send-sync-non-atomic-wasm,serde,counters
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p naga --no-default-features --features dot-out,compact
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-hal --no-default-features --features fragile-send-sync-non-atomic-wasm
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu --no-default-features --features serde
 
       # Building for native platforms with standard tests.
       - name: Check native

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4754,6 +4754,7 @@ dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
  "bytemuck",
+ "cfg-if",
  "cfg_aliases 0.2.1",
  "document-features",
  "hashbrown",

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -164,7 +164,7 @@ fragile-send-sync-non-atomic-wasm = [
 ## context around the WASM VM, e.g., when the WASM binary is used in a browser.
 web = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "wgpu-types/web"]
 
-std = ["raw-window-handle/std", "wgpu-types/std", "wgpu-core/std"]
+std = ["raw-window-handle/std", "wgpu-types/std", "wgpu-core?/std"]
 
 parking_lot = ["dep:parking_lot"]
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -29,7 +29,16 @@ ignored = ["cfg_aliases"]
 [lib]
 
 [features]
-default = ["std", "dx12", "metal", "gles", "vulkan", "wgsl", "webgpu"]
+default = [
+    "std",
+    "parking_lot",
+    "dx12",
+    "metal",
+    "gles",
+    "vulkan",
+    "wgsl",
+    "webgpu",
+]
 
 #! ### Backends
 # --------------------------------------------------------------------

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -164,8 +164,18 @@ fragile-send-sync-non-atomic-wasm = [
 ## context around the WASM VM, e.g., when the WASM binary is used in a browser.
 web = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "wgpu-types/web"]
 
+## Enables use of the standard library within `wgpu` and its dependencies.
+##
+## This can allow for better error reporting and for improved multithreading
+## support.
 std = ["raw-window-handle/std", "wgpu-types/std", "wgpu-core?/std"]
 
+## Uses `parking_lot` as the implementation for locking primitives.
+##
+## This is a recommended feature for most users and should only be disabled when
+## required, e.g., for `no_std` support.
+## If disabled, either `std::sync::Mutex` or `core::cell::RefCell` will be used,
+## based on whether `std` is enabled or not.
 parking_lot = ["dep:parking_lot"]
 
 #########################

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -29,7 +29,7 @@ ignored = ["cfg_aliases"]
 [lib]
 
 [features]
-default = ["dx12", "metal", "gles", "vulkan", "wgsl", "webgpu"]
+default = ["std", "dx12", "metal", "gles", "vulkan", "wgsl", "webgpu"]
 
 #! ### Backends
 # --------------------------------------------------------------------
@@ -155,6 +155,9 @@ fragile-send-sync-non-atomic-wasm = [
 ## context around the WASM VM, e.g., when the WASM binary is used in a browser.
 web = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "wgpu-types/web"]
 
+std = ["raw-window-handle/std", "wgpu-types/std", "wgpu-core/std"]
+
+parking_lot = ["dep:parking_lot"]
 
 #########################
 # Standard Dependencies #
@@ -168,12 +171,13 @@ wgpu-types.workspace = true
 # Needed for both wgpu-core and webgpu
 arrayvec.workspace = true
 bitflags.workspace = true
+cfg-if.workspace = true
 document-features.workspace = true
 hashbrown.workspace = true
 log.workspace = true
-parking_lot.workspace = true
+parking_lot = { workspace = true, optional = true }
 profiling.workspace = true
-raw-window-handle = { workspace = true, features = ["std"] }
+raw-window-handle = { workspace = true, features = ["alloc"] }
 static_assertions.workspace = true
 
 ########################################

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -44,16 +44,16 @@ default = [
 # --------------------------------------------------------------------
 
 ## Enables the DX12 backend on Windows.
-dx12 = ["wgpu-core?/dx12"]
+dx12 = ["wgpu-core?/dx12", "std"]
 
 ## Enables the Metal backend on macOS & iOS.
-metal = ["wgpu-core?/metal"]
+metal = ["wgpu-core?/metal", "std"]
 
 ## Enables the Vulkan backend on Windows, Linux, and Android.
-vulkan = ["wgpu-core?/vulkan"]
+vulkan = ["wgpu-core?/vulkan", "std"]
 
 ## Enables the OpenGL/GLES backend on Windows, Linux, Android, and Emscripten.
-gles = ["wgpu-core?/gles"]
+gles = ["wgpu-core?/gles", "std"]
 
 ## Enables the WebGPU backend on WebAssembly.
 webgpu = [
@@ -67,18 +67,19 @@ webgpu = [
     "web-sys/Window",
     "web-sys/WorkerGlobalScope",
     "web-sys/WorkerNavigator",
+    "std",
 ]
 
 #! ### Conditional Backends
 
 ## Enables the GLES backend on macOS only for use with [ANGLE](https://github.com/google/angle).
-angle = ["wgpu-core?/angle"]
+angle = ["wgpu-core?/angle", "std"]
 
 ## Enables the Vulkan backend on macOS & iOS only for use with [MoltenVK](https://github.com/KhronosGroup/MoltenVK).
-vulkan-portability = ["wgpu-core?/vulkan-portability"]
+vulkan-portability = ["wgpu-core?/vulkan-portability", "std"]
 
 ## Enables the GLES backend on WebAssembly only.
-webgl = ["web", "wgpu-core/webgl", "dep:wgpu-hal", "dep:smallvec"]
+webgl = ["web", "wgpu-core/webgl", "dep:wgpu-hal", "dep:smallvec", "std"]
 
 ## Enables the noop backend for testing.
 ##
@@ -86,13 +87,13 @@ webgl = ["web", "wgpu-core/webgl", "dep:wgpu-hal", "dep:smallvec"]
 ## but performs no computation.
 ## Because it lacks basic functionality, it is only actually used if explicitly enabled
 ## through `NoopBackendOptions`.
-noop = ["wgpu-core/noop", "dep:wgpu-hal", "dep:smallvec"]
+noop = ["wgpu-core/noop", "dep:wgpu-hal", "dep:smallvec", "std"]
 
 #! **Note:** In the documentation, if you see that an item depends on a backend,
 #! it means that the item is only available when that backend is enabled _and_ the backend
 #! is supported on the current platform.
 
-custom = []
+custom = ["std"]
 
 #! ### Shading language support
 # --------------------------------------------------------------------
@@ -100,16 +101,16 @@ custom = []
 #! We will translate the input language to whatever the backend requires.
 
 ## Enable accepting SPIR-V shaders as input.
-spirv = ["naga/spv-in", "wgpu-core?/spirv"]
+spirv = ["naga/spv-in", "wgpu-core?/spirv", "std"]
 
 ## Enable accepting GLSL shaders as input.
-glsl = ["naga/glsl-in", "wgpu-core?/glsl"]
+glsl = ["naga/glsl-in", "wgpu-core?/glsl", "std"]
 
 ## Enable accepting WGSL shaders as input.
-wgsl = ["wgpu-core?/wgsl"]
+wgsl = ["wgpu-core?/wgsl", "std"]
 
 ## Enable accepting naga IR shaders as input.
-naga-ir = ["dep:naga"]
+naga-ir = ["dep:naga", "std"]
 
 #! ### Assertions and Serialization
 # --------------------------------------------------------------------
@@ -162,7 +163,7 @@ fragile-send-sync-non-atomic-wasm = [
 ##
 ## Those libraties (wasm-bindgen, web-sys, js-sys) can only be used when there is a JavaScript
 ## context around the WASM VM, e.g., when the WASM binary is used in a browser.
-web = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "wgpu-types/web"]
+web = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "wgpu-types/web", "std"]
 
 std = ["raw-window-handle/std", "wgpu-types/std", "wgpu-core/std"]
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -44,16 +44,16 @@ default = [
 # --------------------------------------------------------------------
 
 ## Enables the DX12 backend on Windows.
-dx12 = ["wgpu-core?/dx12", "std"]
+dx12 = ["wgpu-core?/dx12"]
 
 ## Enables the Metal backend on macOS & iOS.
-metal = ["wgpu-core?/metal", "std"]
+metal = ["wgpu-core?/metal"]
 
 ## Enables the Vulkan backend on Windows, Linux, and Android.
-vulkan = ["wgpu-core?/vulkan", "std"]
+vulkan = ["wgpu-core?/vulkan"]
 
 ## Enables the OpenGL/GLES backend on Windows, Linux, Android, and Emscripten.
-gles = ["wgpu-core?/gles", "std"]
+gles = ["wgpu-core?/gles"]
 
 ## Enables the WebGPU backend on WebAssembly.
 webgpu = [
@@ -67,19 +67,18 @@ webgpu = [
     "web-sys/Window",
     "web-sys/WorkerGlobalScope",
     "web-sys/WorkerNavigator",
-    "std",
 ]
 
 #! ### Conditional Backends
 
 ## Enables the GLES backend on macOS only for use with [ANGLE](https://github.com/google/angle).
-angle = ["wgpu-core?/angle", "std"]
+angle = ["wgpu-core?/angle"]
 
 ## Enables the Vulkan backend on macOS & iOS only for use with [MoltenVK](https://github.com/KhronosGroup/MoltenVK).
-vulkan-portability = ["wgpu-core?/vulkan-portability", "std"]
+vulkan-portability = ["wgpu-core?/vulkan-portability"]
 
 ## Enables the GLES backend on WebAssembly only.
-webgl = ["web", "wgpu-core/webgl", "dep:wgpu-hal", "dep:smallvec", "std"]
+webgl = ["web", "wgpu-core/webgl", "dep:wgpu-hal", "dep:smallvec"]
 
 ## Enables the noop backend for testing.
 ##
@@ -87,13 +86,13 @@ webgl = ["web", "wgpu-core/webgl", "dep:wgpu-hal", "dep:smallvec", "std"]
 ## but performs no computation.
 ## Because it lacks basic functionality, it is only actually used if explicitly enabled
 ## through `NoopBackendOptions`.
-noop = ["wgpu-core/noop", "dep:wgpu-hal", "dep:smallvec", "std"]
+noop = ["wgpu-core/noop", "dep:wgpu-hal", "dep:smallvec"]
 
 #! **Note:** In the documentation, if you see that an item depends on a backend,
 #! it means that the item is only available when that backend is enabled _and_ the backend
 #! is supported on the current platform.
 
-custom = ["std"]
+custom = []
 
 #! ### Shading language support
 # --------------------------------------------------------------------
@@ -101,16 +100,16 @@ custom = ["std"]
 #! We will translate the input language to whatever the backend requires.
 
 ## Enable accepting SPIR-V shaders as input.
-spirv = ["naga/spv-in", "wgpu-core?/spirv", "std"]
+spirv = ["naga/spv-in", "wgpu-core?/spirv"]
 
 ## Enable accepting GLSL shaders as input.
-glsl = ["naga/glsl-in", "wgpu-core?/glsl", "std"]
+glsl = ["naga/glsl-in", "wgpu-core?/glsl"]
 
 ## Enable accepting WGSL shaders as input.
-wgsl = ["wgpu-core?/wgsl", "std"]
+wgsl = ["wgpu-core?/wgsl"]
 
 ## Enable accepting naga IR shaders as input.
-naga-ir = ["dep:naga", "std"]
+naga-ir = ["dep:naga"]
 
 #! ### Assertions and Serialization
 # --------------------------------------------------------------------
@@ -163,7 +162,7 @@ fragile-send-sync-non-atomic-wasm = [
 ##
 ## Those libraties (wasm-bindgen, web-sys, js-sys) can only be used when there is a JavaScript
 ## context around the WASM VM, e.g., when the WASM binary is used in a browser.
-web = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "wgpu-types/web", "std"]
+web = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "wgpu-types/web"]
 
 std = ["raw-window-handle/std", "wgpu-types/std", "wgpu-core/std"]
 

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -47,6 +47,14 @@ fn main() {
         // ⚠️ Keep in sync with target.cfg() definition in wgpu-hal/Cargo.toml and cfg_alias in `wgpu-hal` crate ⚠️
         static_dxc: { all(target_os = "windows", feature = "static-dxc", not(target_arch = "aarch64")) },
         supports_64bit_atomics: { target_has_atomic = "64" },
-        custom: {any(feature = "custom")}
+        custom: {any(feature = "custom")},
+        std: { any(
+            feature = "std",
+            // TODO: Remove this when an alternative Mutex implementation is available for `no_std`.
+            // send_sync requires an appropriate Mutex implementation, which is only currently
+            // possible with `std` enabled.
+            send_sync
+        ) },
+        no_std: { not(std) }
     }
 }

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -53,7 +53,9 @@ fn main() {
             // TODO: Remove this when an alternative Mutex implementation is available for `no_std`.
             // send_sync requires an appropriate Mutex implementation, which is only currently
             // possible with `std` enabled.
-            send_sync
+            send_sync,
+            // Unwinding panics necessitate access to `std` to determine if a thread is panicking
+            panic = "unwind"
         ) },
         no_std: { not(std) }
     }

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -4,8 +4,7 @@ use core::{
     ops::{Bound, Deref, DerefMut, Range, RangeBounds},
 };
 
-use parking_lot::Mutex;
-
+use crate::util::Mutex;
 use crate::*;
 
 /// Handle to a GPU-accessible buffer.

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -1,10 +1,9 @@
 use alloc::{boxed::Box, string::String, sync::Arc};
 use core::{error, fmt, future::Future};
 
-use parking_lot::Mutex;
-
 use crate::api::blas::{Blas, BlasGeometrySizeDescriptors, CreateBlasDescriptor};
 use crate::api::tlas::{CreateTlasDescriptor, Tlas};
+use crate::util::Mutex;
 use crate::*;
 
 /// Open connection to a graphics and/or compute device.

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -2,7 +2,7 @@
 use alloc::vec::Vec;
 use core::future::Future;
 
-use crate::{util::Mutex, dispatch::InstanceInterface, *};
+use crate::{dispatch::InstanceInterface, util::Mutex, *};
 
 bitflags::bitflags! {
     /// WGSL language extensions.

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -2,9 +2,7 @@
 use alloc::vec::Vec;
 use core::future::Future;
 
-use parking_lot::Mutex;
-
-use crate::{dispatch::InstanceInterface, *};
+use crate::{util::Mutex, dispatch::InstanceInterface, *};
 
 bitflags::bitflags! {
     /// WGSL language extensions.

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -413,9 +413,9 @@ impl error::Error for CreateSurfaceError {
             #[cfg(wgpu_core)]
             CreateSurfaceErrorKind::Hal(e) => e.source(),
             CreateSurfaceErrorKind::Web(_) => None,
-            #[cfg(feature = "std")]
+            #[cfg(std)]
             CreateSurfaceErrorKind::RawHandle(e) => e.source(),
-            #[cfg(not(feature = "std"))]
+            #[cfg(no_std)]
             CreateSurfaceErrorKind::RawHandle(_) => None,
         }
     }

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -413,7 +413,7 @@ impl error::Error for CreateSurfaceError {
             #[cfg(wgpu_core)]
             CreateSurfaceErrorKind::Hal(e) => e.source(),
             CreateSurfaceErrorKind::Web(_) => None,
-            #[cfg(std)]
+            #[cfg(feature = "std")]
             CreateSurfaceErrorKind::RawHandle(e) => e.source(),
             #[cfg(no_std)]
             CreateSurfaceErrorKind::RawHandle(_) => None,

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -1,9 +1,9 @@
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
 use core::{error, fmt};
 
-use parking_lot::Mutex;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 
+use crate::util::Mutex;
 use crate::*;
 
 /// Describes a [`Surface`].
@@ -413,7 +413,10 @@ impl error::Error for CreateSurfaceError {
             #[cfg(wgpu_core)]
             CreateSurfaceErrorKind::Hal(e) => e.source(),
             CreateSurfaceErrorKind::Web(_) => None,
+            #[cfg(feature = "std")]
             CreateSurfaceErrorKind::RawHandle(e) => e.source(),
+            #[cfg(not(feature = "std"))]
+            CreateSurfaceErrorKind::RawHandle(e) => None,
         }
     }
 }

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -416,7 +416,7 @@ impl error::Error for CreateSurfaceError {
             #[cfg(feature = "std")]
             CreateSurfaceErrorKind::RawHandle(e) => e.source(),
             #[cfg(not(feature = "std"))]
-            CreateSurfaceErrorKind::RawHandle(e) => None,
+            CreateSurfaceErrorKind::RawHandle(_) => None,
         }
     }
 }

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -415,7 +415,7 @@ impl error::Error for CreateSurfaceError {
             CreateSurfaceErrorKind::Web(_) => None,
             #[cfg(feature = "std")]
             CreateSurfaceErrorKind::RawHandle(e) => e.source(),
-            #[cfg(no_std)]
+            #[cfg(not(feature = "std"))]
             CreateSurfaceErrorKind::RawHandle(_) => None,
         }
     }

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -84,19 +84,20 @@ impl fmt::Display for SurfaceError {
 impl error::Error for SurfaceError {}
 
 fn thread_panicking() -> bool {
-    #[cfg(feature = "std")]
-    return std::thread::panicking();
-
-    // If `panic = "abort"` then a thread _cannot_ be observably panicking by definition.
-    #[cfg(all(not(feature = "std"), panic = "abort"))]
-    return false;
-
-    // TODO: This is potentially overly pessimistic; it may be appropriate to instead allow a
-    // texture to not be discarded.
-    // Alternatively, this could _also_ be a `panic!`, since we only care if the thread is panicking
-    // when the surface has not been presented.
-    #[cfg(all(not(feature = "std"), not(panic = "abort")))]
-    compile_error!(
-        "cannot determine if a thread is panicking without either `panic = \"abort\"` or `std`"
-    );
+    cfg_if::cfg_if! {
+        if #[cfg(std)] {
+            std::thread::panicking()
+        } else if #[cfg(panic = "abort")] {
+            // If `panic = "abort"` then a thread _cannot_ be observably panicking by definition.
+            false
+        } else {
+            // TODO: This is potentially overly pessimistic; it may be appropriate to instead allow a
+            // texture to not be discarded.
+            // Alternatively, this could _also_ be a `panic!`, since we only care if the thread is panicking
+            // when the surface has not been presented.
+            compile_error!(
+                "cannot determine if a thread is panicking without either `panic = \"abort\"` or `std`"
+            );
+        }
+    }
 }

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -1,5 +1,4 @@
 use core::{error, fmt};
-use std::thread;
 
 use crate::*;
 
@@ -48,7 +47,7 @@ impl SurfaceTexture {
 
 impl Drop for SurfaceTexture {
     fn drop(&mut self) {
-        if !self.presented && !thread::panicking() {
+        if !self.presented && !thread_panicking() {
             self.detail.texture_discard();
         }
     }
@@ -83,3 +82,21 @@ impl fmt::Display for SurfaceError {
 }
 
 impl error::Error for SurfaceError {}
+
+fn thread_panicking() -> bool {
+    #[cfg(feature = "std")]
+    return std::thread::panicking();
+
+    // If `panic = "abort"` then a thread _cannot_ be observably panicking by definition.
+    #[cfg(all(not(feature = "std"), panic = "abort"))]
+    return false;
+
+    // TODO: This is potentially overly pessimistic; it may be appropriate to instead allow a
+    // texture to not be discarded.
+    // Alternatively, this could _also_ be a `panic!`, since we only care if the thread is panicking
+    // when the surface has not been presented.
+    #[cfg(all(not(feature = "std"), not(panic = "abort")))]
+    compile_error!(
+        "cannot determine if a thread is panicking without either `panic = \"abort\"` or `std`"
+    );
+}

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -10,11 +10,11 @@ use alloc::{
 use core::{error::Error, fmt, future::ready, ops::Range, pin::Pin, ptr::NonNull, slice};
 
 use arrayvec::ArrayVec;
-use parking_lot::Mutex;
 use smallvec::SmallVec;
 use wgc::{command::bundle_ffi::*, error::ContextErrorSource, pipeline::CreateShaderModuleError};
 use wgt::WasmNotSendSync;
 
+use crate::util::Mutex;
 use crate::{
     api,
     dispatch::{self, BufferMappedRangeInterface},

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -31,7 +31,7 @@
 #![cfg_attr(not(any(wgpu_core, webgpu)), allow(unused))]
 
 extern crate alloc;
-#[cfg(feature = "std")]
+#[cfg(std)]
 extern crate std;
 #[cfg(wgpu_core)]
 pub extern crate wgpu_core as wgc;

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -31,6 +31,7 @@
 #![cfg_attr(not(any(wgpu_core, webgpu)), allow(unused))]
 
 extern crate alloc;
+#[cfg(feature = "std")]
 extern crate std;
 #[cfg(wgpu_core)]
 pub extern crate wgpu_core as wgc;

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -9,10 +9,16 @@ pub fn initialize_adapter_from_env(
     instance: &Instance,
     compatible_surface: Option<&Surface<'_>>,
 ) -> Result<Adapter, wgt::RequestAdapterError> {
-    let desired_adapter_name = std::env::var("WGPU_ADAPTER_NAME")
-        .as_deref()
-        .map(str::to_lowercase)
-        .map_err(|_| wgt::RequestAdapterError::EnvNotSet)?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "std")] {
+            let desired_adapter_name = std::env::var("WGPU_ADAPTER_NAME")
+                .as_deref()
+                .map(str::to_lowercase)
+                .map_err(|_| wgt::RequestAdapterError::EnvNotSet)?;
+        } else {
+            return Err(wgt::RequestAdapterError::EnvNotSet);
+        }
+    }
 
     let adapters = instance.enumerate_adapters(crate::Backends::all());
 

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -10,7 +10,7 @@ pub fn initialize_adapter_from_env(
     compatible_surface: Option<&Surface<'_>>,
 ) -> Result<Adapter, wgt::RequestAdapterError> {
     cfg_if::cfg_if! {
-        if #[cfg(feature = "std")] {
+        if #[cfg(std)] {
             let desired_adapter_name = std::env::var("WGPU_ADAPTER_NAME")
                 .as_deref()
                 .map(str::to_lowercase)

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -7,7 +7,7 @@
 ///
 /// Allow [`belt::StagingBelt`] in `no_std` by replacing usage of [`std::sync::mpsc`] with an
 /// appropriate alternative.
-#[cfg(feature = "std")]
+#[cfg(std)]
 mod belt;
 mod device;
 mod encoder;
@@ -18,7 +18,7 @@ mod texture_blitter;
 use alloc::{borrow::Cow, format, string::String, vec};
 use core::ptr::copy_nonoverlapping;
 
-#[cfg(feature = "std")]
+#[cfg(std)]
 pub use belt::StagingBelt;
 pub use device::{BufferInitDescriptor, DeviceExt};
 pub use encoder::RenderEncoder;

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -3,15 +3,22 @@
 //! Nothing in this module is a part of the WebGPU API specification;
 //! they are unique to the `wgpu` library.
 
+/// # TODO
+///
+/// Allow [`belt::StagingBelt`] in `no_std` by replacing usage of [`std::sync::mpsc`] with an
+/// appropriate alternative.
+#[cfg(feature = "std")]
 mod belt;
 mod device;
 mod encoder;
 mod init;
+mod mutex;
 mod texture_blitter;
 
 use alloc::{borrow::Cow, format, string::String, vec};
 use core::ptr::copy_nonoverlapping;
 
+#[cfg(feature = "std")]
 pub use belt::StagingBelt;
 pub use device::{BufferInitDescriptor, DeviceExt};
 pub use encoder::RenderEncoder;
@@ -21,6 +28,8 @@ pub use texture_blitter::{TextureBlitter, TextureBlitterBuilder};
 pub use wgt::{
     math::*, DispatchIndirectArgs, DrawIndexedIndirectArgs, DrawIndirectArgs, TextureDataOrder,
 };
+
+pub(crate) use mutex::Mutex;
 
 use crate::dispatch;
 

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -3,10 +3,8 @@
 //! Nothing in this module is a part of the WebGPU API specification;
 //! they are unique to the `wgpu` library.
 
-/// # TODO
-///
-/// Allow [`belt::StagingBelt`] in `no_std` by replacing usage of [`std::sync::mpsc`] with an
-/// appropriate alternative.
+// TODO: For [`belt::StagingBelt`] to be available in `no_std` its usage of [`std::sync::mpsc`]
+// must be replaced with an appropriate alternative.
 #[cfg(std)]
 mod belt;
 mod device;

--- a/wgpu/src/util/mutex.rs
+++ b/wgpu/src/util/mutex.rs
@@ -1,0 +1,51 @@
+//! Provides a [`Mutex`] for internal use based on what features are available.
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "parking_lot")] {
+        use parking_lot::Mutex as MutexInner;
+    } else if #[cfg(feature = "std")] {
+        use std::sync::Mutex as MutexInner;
+    } else {
+        use core::cell::RefCell as MutexInner;
+    }
+}
+
+pub(crate) struct Mutex<T: ?Sized> {
+    inner: MutexInner<T>,
+}
+
+impl<T: ?Sized + core::fmt::Debug> core::fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        <MutexInner<T> as core::fmt::Debug>::fmt(&self.inner, f)
+    }
+}
+
+impl<T> Mutex<T> {
+    pub const fn new(value: T) -> Self {
+        Self {
+            inner: MutexInner::new(value),
+        }
+    }
+}
+
+impl<T: ?Sized> Mutex<T> {
+    pub fn lock(&self) -> impl core::ops::DerefMut<Target = T> + '_ {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "parking_lot")] {
+                return self.inner.lock();
+            } else if #[cfg(feature = "std")] {
+                return self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            } else {
+                loop {
+                    let Ok(lock) = self.inner.try_borrow_mut() else {
+                        // Without `std` all we can do is spin until the current lock is released
+                        core::hint::spin_loop();
+                        continue;
+                    };
+
+                    return lock;
+                }
+            }
+        }
+    }
+}

--- a/wgpu/src/util/mutex.rs
+++ b/wgpu/src/util/mutex.rs
@@ -41,9 +41,9 @@ impl<T: ?Sized> Mutex<T> {
     pub fn lock(&self) -> impl core::ops::DerefMut<Target = T> + '_ {
         cfg_if::cfg_if! {
             if #[cfg(feature = "parking_lot")] {
-                return self.inner.lock();
+                self.inner.lock()
             } else if #[cfg(feature = "std")] {
-                return self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
             } else {
                 loop {
                     let Ok(lock) = self.inner.try_borrow_mut() else {
@@ -52,7 +52,7 @@ impl<T: ?Sized> Mutex<T> {
                         continue;
                     };
 
-                    return lock;
+                    break lock;
                 }
             }
         }

--- a/wgpu/src/util/mutex.rs
+++ b/wgpu/src/util/mutex.rs
@@ -14,9 +14,18 @@ pub(crate) struct Mutex<T: ?Sized> {
     inner: MutexInner<T>,
 }
 
-impl<T: ?Sized + core::fmt::Debug> core::fmt::Debug for Mutex<T> {
+impl<T: ?Sized> core::fmt::Debug for Mutex<T>
+where
+    MutexInner<T>: core::fmt::Debug,
+{
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         <MutexInner<T> as core::fmt::Debug>::fmt(&self.inner, f)
+    }
+}
+
+impl<T: Default> Default for Mutex<T> {
+    fn default() -> Self {
+        Self::new(<T as Default>::default())
     }
 }
 

--- a/wgpu/src/util/mutex.rs
+++ b/wgpu/src/util/mutex.rs
@@ -3,7 +3,7 @@
 cfg_if::cfg_if! {
     if #[cfg(feature = "parking_lot")] {
         use parking_lot::Mutex as MutexInner;
-    } else if #[cfg(feature = "std")] {
+    } else if #[cfg(std)] {
         use std::sync::Mutex as MutexInner;
     } else {
         use core::cell::RefCell as MutexInner;
@@ -42,7 +42,7 @@ impl<T: ?Sized> Mutex<T> {
         cfg_if::cfg_if! {
             if #[cfg(feature = "parking_lot")] {
                 self.inner.lock()
-            } else if #[cfg(feature = "std")] {
+            } else if #[cfg(std)] {
                 self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
             } else {
                 loop {


### PR DESCRIPTION
**Connections**

- Contributes to #6826

**Description**

- Adds `parking_lot` and `std` features to `wgpu`, allowing for compilation on `wasm32v1-none` with said features disabled.
- Added an internal `Mutex` wrapper to handle selecting a non-`parking_lot` implementation.
- Gated `StagingBelt` behind `std` as it requires access to a channel implementation (`std::sync::mpsc`) to function. This could be replaced with `ConcurrentQueue` but that will require adding a new dependency to `wgpu` (although it is already in the lockfile as a dev-dependency)
- Added `wgpu` to the `no_std` CI task

**Testing**

- CI

**Squash or Rebase?**

Squash

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry.
