### PR TITLE
Update naga span.rs: fix potential buffer overflow (panic) in span.rs where start happens to get an unexpected high value

### DIFF
--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -78,7 +78,11 @@ impl Span {
 
     /// Return a [`SourceLocation`] for this span in the provided source.
     pub fn location(&self, source: &str) -> SourceLocation {
-        let prefix = &source[..self.start as usize];
+        let prefix = if self.start < source.len() as u32 {
+          &source[..self.start as usize]
+        } else {
+          ""
+        };
         let line_number = prefix.matches('\n').count() as u32 + 1;
         let line_start = prefix.rfind('\n').map(|pos| pos + 1).unwrap_or(0) as u32;
         let line_position = self.start - line_start + 1;

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -81,7 +81,7 @@ impl Span {
         let prefix = if self.start < source.len() as u32 {
           &source[..self.start as usize]
         } else {
-          ""
+          "UNKNOWN_PREFIX"
         };
         let line_number = prefix.matches('\n').count() as u32 + 1;
         let line_start = prefix.rfind('\n').map(|pos| pos + 1).unwrap_or(0) as u32;

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -79,9 +79,9 @@ impl Span {
     /// Return a [`SourceLocation`] for this span in the provided source.
     pub fn location(&self, source: &str) -> SourceLocation {
         let prefix = if self.start < source.len() as u32 {
-          &source[..self.start as usize]
+            &source[..self.start as usize]
         } else {
-          "UNKNOWN_PREFIX"
+            "UNKNOWN_PREFIX"
         };
         let line_number = prefix.matches('\n').count() as u32 + 1;
         let line_start = prefix.rfind('\n').map(|pos| pos + 1).unwrap_or(0) as u32;


### PR DESCRIPTION
fix Span potential buffer overflow


**Description**
I got situations where start gets an unexpected high value on Android emulators (Android Studio,BlueStacks and LDPlayer) , but not on real devices. Didn't investigated why start gets such a value, just fixed that to let it work...

**Testing**
the panic doesn't occur any more
