### PR TITLE
[deno] Make QuerySet.destroy a no-op for now

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -19,4 +19,5 @@ webgpu:api,operation,rendering,draw:*
 webgpu:api,operation,uncapturederror:iff_uncaptured:*
 //FAIL: webgpu:api,operation,uncapturederror:onuncapturederror_order_wrt_addEventListener
 // There are also two unimplemented SKIPs in uncapturederror not enumerated here.
+webgpu:api,validation,encoding,queries,general:occlusion_query,query_type:*
 webgpu:shader,execution,flow_control,return:*

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -43,9 +43,10 @@ impl GPUQuerySet {
 
     #[fast]
     fn destroy(&self) -> Result<(), JsErrorBox> {
-        Err(JsErrorBox::generic(
-            "This operation is currently not supported",
-        ))
+        // TODO(#6495): Destroy the query set. Until that is supported, it is
+        // okay to do nothing here, the query set will be garbage collected
+        // and dropped eventually.
+        Ok(())
     }
 
     #[getter]

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -43,9 +43,9 @@ impl GPUQuerySet {
 
     #[fast]
     fn destroy(&self) -> Result<(), JsErrorBox> {
-        // TODO(#6495): Destroy the query set. Until that is supported, it is
-        // okay to do nothing here, the query set will be garbage collected
-        // and dropped eventually.
+        // TODO(https://github.com/gfx-rs/wgpu/issues/6495): Destroy the query
+        // set. Until that is supported, it is okay to do nothing here, the
+        // query set will be garbage collected and dropped eventually.
         Ok(())
     }
 


### PR DESCRIPTION
Implementing `destroy` for query sets is tracked by https://github.com/gfx-rs/wgpu/issues/6495. In the mean time it is okay for it to be a no-op. `destroy` just recovers the resources earlier than garbage collection might, doing nothing is not a leak. It is also a no-op in Firefox.

I am doing this because query sets are also used by some of the encoder state tests relevant to #7391.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] Run `cargo xtask cts` to run the CTS.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
