### PR TITLE
Remove bufferslice lifetime

### DIFF
--- a/examples/features/src/bunnymark/mod.rs
+++ b/examples/features/src/bunnymark/mod.rs
@@ -331,7 +331,7 @@ impl crate::framework::Example for Example {
             entries: &[wgpu::BindGroupEntry {
                 binding: 0,
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &local_buffer,
+                    buffer: local_buffer.clone(),
                     offset: 0,
                     size: wgpu::BufferSize::new(size_of::<Bunny>() as _),
                 }),

--- a/examples/features/src/shadow/mod.rs
+++ b/examples/features/src/shadow/mod.rs
@@ -350,7 +350,7 @@ impl crate::framework::Example for Example {
             entries: &[wgpu::BindGroupEntry {
                 binding: 0,
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &entity_uniform_buf,
+                    buffer: entity_uniform_buf.clone(),
                     offset: 0,
                     size: wgpu::BufferSize::new(entity_uniform_size),
                 }),

--- a/examples/features/src/texture_arrays/mod.rs
+++ b/examples/features/src/texture_arrays/mod.rs
@@ -316,7 +316,7 @@ impl crate::framework::Example for Example {
             entries: &[wgpu::BindGroupEntry {
                 binding: 0,
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &texture_index_buffer,
+                    buffer: texture_index_buffer.clone(),
                     offset: 0,
                     size: Some(NonZeroU64::new(4).unwrap()),
                 }),

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -150,7 +150,7 @@ impl WgpuContext {
             entries: &[wgpu::BindGroupEntry {
                 binding: 0,
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &uniform_buffer,
+                    buffer: uniform_buffer.clone(),
                     offset: 0,
                     size: None,
                 }),

--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -333,7 +333,7 @@ fn copy_via_compute(
             BindGroupEntry {
                 binding: 1,
                 resource: BindingResource::Buffer(BufferBinding {
-                    buffer: &output_buffer,
+                    buffer: output_buffer.clone(),
                     offset: 0,
                     size: None,
                 }),

--- a/tests/tests/wgpu-gpu/bind_group_layout_dedup.rs
+++ b/tests/tests/wgpu-gpu/bind_group_layout_dedup.rs
@@ -448,7 +448,7 @@ fn bgl_dedupe_derived(ctx: TestingContext) {
         entries: &[wgpu::BindGroupEntry {
             binding: 0,
             resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                buffer: &buffer,
+                buffer: buffer.clone(),
                 offset: 0,
                 size: None,
             }),
@@ -460,7 +460,7 @@ fn bgl_dedupe_derived(ctx: TestingContext) {
         entries: &[wgpu::BindGroupEntry {
             binding: 0,
             resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                buffer: &buffer,
+                buffer: buffer.clone(),
                 offset: 0,
                 size: None,
             }),

--- a/tests/tests/wgpu-gpu/bind_groups.rs
+++ b/tests/tests/wgpu-gpu/bind_groups.rs
@@ -96,7 +96,7 @@ fn multiple_bindings_with_differing_sizes(ctx: TestingContext) {
             entries: &[wgpu::BindGroupEntry {
                 binding: 0,
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &buffer,
+                    buffer: buffer.clone(),
                     offset: 0,
                     size: Some(NonZeroU64::new(u64::try_from(8 - 4 * i).unwrap()).unwrap()),
                 }),

--- a/tests/tests/wgpu-gpu/oob_indexing.rs
+++ b/tests/tests/wgpu-gpu/oob_indexing.rs
@@ -396,7 +396,7 @@ async fn d3d12_restrict_dynamic_buffers(ctx: TestingContext) {
             wgpu::BindGroupEntry {
                 binding: 2,
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &in_data_uniform_buffer,
+                    buffer: in_data_uniform_buffer.clone(),
                     offset: 0,
                     size: Some(std::num::NonZeroU64::new(4 * 4).unwrap()),
                 }),
@@ -404,7 +404,7 @@ async fn d3d12_restrict_dynamic_buffers(ctx: TestingContext) {
             wgpu::BindGroupEntry {
                 binding: 3,
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &in_data_storage_buffer,
+                    buffer: in_data_storage_buffer.clone(),
                     offset: 0,
                     size: Some(std::num::NonZeroU64::new(4 * 4).unwrap()),
                 }),

--- a/tests/tests/wgpu-gpu/samplers.rs
+++ b/tests/tests/wgpu-gpu/samplers.rs
@@ -479,7 +479,7 @@ fn sampler_bind_group(ctx: TestingContext, group_type: GroupType) {
         entries: &[wgpu::BindGroupEntry {
             binding: 0,
             resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                buffer: &output_buffer,
+                buffer: output_buffer.clone(),
                 offset: 0,
                 size: None,
             }),

--- a/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
@@ -54,7 +54,7 @@ static ZERO_INIT_WORKGROUP_MEMORY: GpuTestConfiguration = GpuTestConfiguration::
             entries: &[BindGroupEntry {
                 binding: 0,
                 resource: BindingResource::Buffer(BufferBinding {
-                    buffer: &output_buffer,
+                    buffer: output_buffer.clone(),
                     offset: 0,
                     size: Some(NonZeroU64::new(BUFFER_BINDING_SIZE as u64).unwrap()),
                 }),

--- a/tests/tests/wgpu-gpu/timestamp_normalization/utils.rs
+++ b/tests/tests/wgpu-gpu/timestamp_normalization/utils.rs
@@ -279,7 +279,5 @@ fn process_shader(ctx: TestingContext, inputs: &[u8], entry_point_src: &str) -> 
 
     ctx.device.poll(wgpu::PollType::Wait).unwrap();
 
-    let value = pulldown_buffer.get_mapped_range(..).to_vec();
-
-    value
+    pulldown_buffer.get_mapped_range(..).to_vec()
 }

--- a/tests/tests/wgpu-validation/api/buffer_slice.rs
+++ b/tests/tests/wgpu-validation/api/buffer_slice.rs
@@ -36,7 +36,7 @@ fn getters() {
             slice_with_size.offset(),
             slice_with_size.size()
         ),
-        (&buffer, 10, NonZero::new(80).unwrap())
+        (buffer.clone(), 10, NonZero::new(80).unwrap())
     );
 
     let slice_without_size = buffer.slice(10..);
@@ -46,7 +46,7 @@ fn getters() {
             slice_without_size.offset(),
             slice_without_size.size()
         ),
-        (&buffer, 10, NonZero::new(90).unwrap())
+        (buffer.clone(), 10, NonZero::new(90).unwrap())
     );
 }
 
@@ -64,6 +64,6 @@ fn into_buffer_binding() {
     else {
         panic!("didn't match")
     };
-    assert_eq!(b, &buffer);
+    assert_eq!(b, buffer.clone());
     assert_eq!(size, NonZero::new(30).unwrap());
 }

--- a/wgpu/src/api/bind_group.rs
+++ b/wgpu/src/api/bind_group.rs
@@ -38,14 +38,14 @@ pub enum BindingResource<'a> {
     ///
     /// Corresponds to [`wgt::BufferBindingType::Uniform`] and [`wgt::BufferBindingType::Storage`]
     /// with [`BindGroupLayoutEntry::count`] set to None.
-    Buffer(BufferBinding<'a>),
+    Buffer(BufferBinding),
     /// Binding is backed by an array of buffers.
     ///
     /// [`Features::BUFFER_BINDING_ARRAY`] must be supported to use this feature.
     ///
     /// Corresponds to [`wgt::BufferBindingType::Uniform`] and [`wgt::BufferBindingType::Storage`]
     /// with [`BindGroupLayoutEntry::count`] set to Some.
-    BufferArray(&'a [BufferBinding<'a>]),
+    BufferArray(&'a [BufferBinding]),
     /// Binding is a sampler.
     ///
     /// Corresponds to [`wgt::BindingType::Sampler`] with [`BindGroupLayoutEntry::count`] set to None.
@@ -90,9 +90,9 @@ static_assertions::assert_impl_all!(BindingResource<'_>: Send, Sync);
 /// Corresponds to [WebGPU `GPUBufferBinding`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpubufferbinding).
 #[derive(Clone, Debug)]
-pub struct BufferBinding<'a> {
+pub struct BufferBinding {
     /// The buffer to bind.
-    pub buffer: &'a Buffer,
+    pub buffer: Buffer,
 
     /// Base offset of the buffer, in bytes.
     ///
@@ -115,7 +115,7 @@ pub struct BufferBinding<'a> {
     pub size: Option<BufferSize>,
 }
 #[cfg(send_sync)]
-static_assertions::assert_impl_all!(BufferBinding<'_>: Send, Sync);
+static_assertions::assert_impl_all!(BufferBinding: Send, Sync);
 
 /// An element of a [`BindGroupDescriptor`], consisting of a bindable resource
 /// and the slot to bind it to.

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -193,9 +193,9 @@ impl Buffer {
     }
 
     /// Return the binding view of the entire buffer.
-    pub fn as_entire_buffer_binding(&self) -> BufferBinding<'_> {
+    pub fn as_entire_buffer_binding(&self) -> BufferBinding {
         BufferBinding {
-            buffer: self,
+            buffer: self.clone(),
             offset: 0,
             size: None,
         }
@@ -241,11 +241,11 @@ impl Buffer {
     /// - If `bounds` is outside of the bounds of `self`.
     /// - If `bounds` has a length less than 1.
     #[track_caller]
-    pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice<'_> {
+    pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice {
         let (offset, size) = range_to_offset_size(bounds, self.size);
         check_buffer_bounds(self.size, offset, size);
         BufferSlice {
-            buffer: self,
+            buffer: self.clone(),
             offset,
             size,
         }
@@ -331,7 +331,7 @@ impl Buffer {
     /// - If you try to create overlapping views of a buffer, mutable or otherwise.
     ///
     /// [mapped]: Buffer#mapping-buffers
-    pub fn get_mapped_range<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferView<'_> {
+    pub fn get_mapped_range<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferView {
         self.slice(bounds).get_mapped_range()
     }
 
@@ -354,10 +354,7 @@ impl Buffer {
     /// - If you try to create overlapping views of a buffer, mutable or otherwise.
     ///
     /// [mapped]: Buffer#mapping-buffers
-    pub fn get_mapped_range_mut<S: RangeBounds<BufferAddress>>(
-        &self,
-        bounds: S,
-    ) -> BufferViewMut<'_> {
+    pub fn get_mapped_range_mut<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferViewMut {
         self.slice(bounds).get_mapped_range_mut()
     }
 
@@ -408,16 +405,16 @@ impl Buffer {
 /// working with the [`Buffer`], instead.
 ///
 /// [map]: Buffer#mapping-buffers
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct BufferSlice<'a> {
-    pub(crate) buffer: &'a Buffer,
+#[derive(Clone, Debug, PartialEq)]
+pub struct BufferSlice {
+    pub(crate) buffer: Buffer,
     pub(crate) offset: BufferAddress,
     pub(crate) size: BufferSize,
 }
 #[cfg(send_sync)]
-static_assertions::assert_impl_all!(BufferSlice<'_>: Send, Sync);
+static_assertions::assert_impl_all!(BufferSlice: Send, Sync);
 
-impl<'a> BufferSlice<'a> {
+impl BufferSlice {
     /// Return another [`BufferSlice`] referring to the portion of `self`'s contents
     /// indicated by `bounds`.
     ///
@@ -431,11 +428,11 @@ impl<'a> BufferSlice<'a> {
     /// - If `bounds` is outside of the bounds of `self`.
     /// - If `bounds` has a length less than 1.
     #[track_caller]
-    pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice<'a> {
+    pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice {
         let (offset, size) = range_to_offset_size(bounds, self.size.get());
         check_buffer_bounds(self.size.get(), offset, size);
         BufferSlice {
-            buffer: self.buffer,
+            buffer: self.buffer.clone(),
             offset: self.offset + offset, // check_buffer_bounds ensures this does not overflow
             size,                         // check_buffer_bounds ensures this is essentially min()
         }
@@ -495,11 +492,11 @@ impl<'a> BufferSlice<'a> {
     /// - If you try to create overlapping views of a buffer, mutable or otherwise.
     ///
     /// [mapped]: Buffer#mapping-buffers
-    pub fn get_mapped_range(&self) -> BufferView<'a> {
+    pub fn get_mapped_range(&self) -> BufferView {
         let end = self.buffer.map_context.lock().add(self.offset, self.size);
         let range = self.buffer.inner.get_mapped_range(self.offset..end);
         BufferView {
-            slice: *self,
+            slice: self.clone(),
             inner: range,
         }
     }
@@ -521,11 +518,11 @@ impl<'a> BufferSlice<'a> {
     /// - If you try to create overlapping views of a buffer, mutable or otherwise.
     ///
     /// [mapped]: Buffer#mapping-buffers
-    pub fn get_mapped_range_mut(&self) -> BufferViewMut<'a> {
+    pub fn get_mapped_range_mut(&self) -> BufferViewMut {
         let end = self.buffer.map_context.lock().add(self.offset, self.size);
         let range = self.buffer.inner.get_mapped_range(self.offset..end);
         BufferViewMut {
-            slice: *self,
+            slice: self.clone(),
             inner: range,
             readable: self.buffer.usage.contains(BufferUsages::MAP_READ),
         }
@@ -536,8 +533,8 @@ impl<'a> BufferSlice<'a> {
     /// You should usually not need to call this, and if you received the buffer from code you
     /// do not control, you should refrain from accessing the buffer outside the bounds of the
     /// slice. Nevertheless, it’s possible to get this access, so this method makes it simple.
-    pub fn buffer(&self) -> &'a Buffer {
-        self.buffer
+    pub fn buffer(&self) -> Buffer {
+        self.buffer.clone()
     }
 
     /// Returns the offset in [`Self::buffer()`] this slice starts at.
@@ -551,22 +548,22 @@ impl<'a> BufferSlice<'a> {
     }
 }
 
-impl<'a> From<BufferSlice<'a>> for crate::BufferBinding<'a> {
+impl From<BufferSlice> for crate::BufferBinding {
     /// Convert a [`BufferSlice`] to an equivalent [`BufferBinding`],
     /// provided that it will be used without a dynamic offset.
-    fn from(value: BufferSlice<'a>) -> Self {
+    fn from(value: BufferSlice) -> Self {
         BufferBinding {
-            buffer: value.buffer,
+            buffer: value.buffer.clone(),
             offset: value.offset,
             size: Some(value.size),
         }
     }
 }
 
-impl<'a> From<BufferSlice<'a>> for crate::BindingResource<'a> {
+impl From<BufferSlice> for crate::BindingResource<'_> {
     /// Convert a [`BufferSlice`] to an equivalent [`BindingResource::Buffer`],
     /// provided that it will be used without a dynamic offset.
-    fn from(value: BufferSlice<'a>) -> Self {
+    fn from(value: BufferSlice) -> Self {
         crate::BindingResource::Buffer(crate::BufferBinding::from(value))
     }
 }
@@ -702,8 +699,8 @@ static_assertions::assert_impl_all!(MapMode: Send, Sync);
 /// [map]: Buffer#mapping-buffers
 /// [`map_async`]: BufferSlice::map_async
 #[derive(Debug)]
-pub struct BufferView<'a> {
-    slice: BufferSlice<'a>,
+pub struct BufferView {
+    slice: BufferSlice,
     inner: dispatch::DispatchBufferMappedRange,
 }
 
@@ -717,7 +714,7 @@ impl BufferView<'_> {
     }
 }
 
-impl core::ops::Deref for BufferView<'_> {
+impl core::ops::Deref for BufferView {
     type Target = [u8];
 
     #[inline]
@@ -726,7 +723,7 @@ impl core::ops::Deref for BufferView<'_> {
     }
 }
 
-impl AsRef<[u8]> for BufferView<'_> {
+impl AsRef<[u8]> for BufferView {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.inner.slice()
@@ -752,20 +749,20 @@ impl AsRef<[u8]> for BufferView<'_> {
 ///
 /// [map]: Buffer#mapping-buffers
 #[derive(Debug)]
-pub struct BufferViewMut<'a> {
-    slice: BufferSlice<'a>,
+pub struct BufferViewMut {
+    slice: BufferSlice,
     inner: dispatch::DispatchBufferMappedRange,
     readable: bool,
 }
 
-impl AsMut<[u8]> for BufferViewMut<'_> {
+impl AsMut<[u8]> for BufferViewMut {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         self.inner.slice_mut()
     }
 }
 
-impl Deref for BufferViewMut<'_> {
+impl Deref for BufferViewMut {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -777,13 +774,13 @@ impl Deref for BufferViewMut<'_> {
     }
 }
 
-impl DerefMut for BufferViewMut<'_> {
+impl DerefMut for BufferViewMut {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.slice_mut()
     }
 }
 
-impl Drop for BufferView<'_> {
+impl Drop for BufferView {
     fn drop(&mut self) {
         self.slice
             .buffer
@@ -793,7 +790,7 @@ impl Drop for BufferView<'_> {
     }
 }
 
-impl Drop for BufferViewMut<'_> {
+impl Drop for BufferViewMut {
     fn drop(&mut self) {
         self.slice
             .buffer

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -705,7 +705,7 @@ pub struct BufferView {
 }
 
 #[cfg(webgpu)]
-impl BufferView<'_> {
+impl BufferView {
     /// Provides the same data as dereferencing the view, but as a `Uint8Array` in js.
     /// This can be MUCH faster than dereferencing the view which copies the data into
     /// the Rust / wasm heap.

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -88,7 +88,7 @@ impl<'a> RenderBundleEncoder<'a> {
     ///
     /// Subsequent calls to [`draw_indexed`](RenderBundleEncoder::draw_indexed) on this [`RenderBundleEncoder`] will
     /// use `buffer` as the source index buffer.
-    pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'a>, index_format: IndexFormat) {
+    pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice, index_format: IndexFormat) {
         self.inner.set_index_buffer(
             &buffer_slice.buffer.inner,
             index_format,
@@ -107,7 +107,7 @@ impl<'a> RenderBundleEncoder<'a> {
     ///
     /// [`draw`]: RenderBundleEncoder::draw
     /// [`draw_indexed`]: RenderBundleEncoder::draw_indexed
-    pub fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'a>) {
+    pub fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice) {
         self.inner.set_vertex_buffer(
             slot,
             &buffer_slice.buffer.inner,

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -95,7 +95,7 @@ impl RenderPass<'_> {
     ///
     /// Subsequent calls to [`draw_indexed`](RenderPass::draw_indexed) on this [`RenderPass`] will
     /// use `buffer` as the source index buffer.
-    pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'_>, index_format: IndexFormat) {
+    pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice, index_format: IndexFormat) {
         self.inner.set_index_buffer(
             &buffer_slice.buffer.inner,
             index_format,
@@ -116,7 +116,7 @@ impl RenderPass<'_> {
     ///
     /// [`draw`]: RenderPass::draw
     /// [`draw_indexed`]: RenderPass::draw_indexed
-    pub fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'_>) {
+    pub fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice) {
         self.inner.set_vertex_buffer(
             slot,
             &buffer_slice.buffer.inner,

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1964,7 +1964,7 @@ impl dispatch::DeviceInterface for WebDevice {
             .map(|binding| {
                 let mapped_resource = match binding.resource {
                     crate::BindingResource::Buffer(crate::BufferBinding {
-                        buffer,
+                        ref buffer,
                         offset,
                         size,
                     }) => {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1205,7 +1205,7 @@ impl dispatch::DeviceInterface for CoreDevice {
                 binding: entry.binding,
                 resource: match entry.resource {
                     BindingResource::Buffer(BufferBinding {
-                        buffer,
+                        ref buffer,
                         offset,
                         size,
                     }) => bm::BindingResource::Buffer(bm::BufferBinding {

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -77,14 +77,14 @@ impl StagingBelt {
         offset: BufferAddress,
         size: BufferSize,
         device: &Device,
-    ) -> BufferViewMut<'_> {
+    ) -> BufferViewMut {
         let slice_of_belt = self.allocate(
             size,
             const { BufferSize::new(crate::COPY_BUFFER_ALIGNMENT).unwrap() },
             device,
         );
         encoder.copy_buffer_to_buffer(
-            slice_of_belt.buffer(),
+            &slice_of_belt.buffer(),
             slice_of_belt.offset(),
             target,
             offset,
@@ -117,7 +117,7 @@ impl StagingBelt {
         size: BufferSize,
         alignment: BufferSize,
         device: &Device,
-    ) -> BufferSlice<'_> {
+    ) -> BufferSlice {
         assert!(
             alignment.get().is_power_of_two(),
             "alignment must be a power of two, not {alignment}"

--- a/wgpu/src/util/encoder.rs
+++ b/wgpu/src/util/encoder.rs
@@ -26,7 +26,7 @@ pub trait RenderEncoder<'a> {
     ///
     /// Subsequent calls to [`draw_indexed`](RenderEncoder::draw_indexed) on this [`RenderEncoder`] will
     /// use `buffer` as the source index buffer.
-    fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'a>, index_format: IndexFormat);
+    fn set_index_buffer(&mut self, buffer_slice: BufferSlice, index_format: IndexFormat);
 
     /// Assign a vertex buffer to a slot.
     ///
@@ -38,7 +38,7 @@ pub trait RenderEncoder<'a> {
     ///
     /// [`draw`]: RenderEncoder::draw
     /// [`draw_indexed`]: RenderEncoder::draw_indexed
-    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'a>);
+    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice);
 
     /// Draws primitives from the active vertex buffer(s).
     ///
@@ -121,12 +121,12 @@ impl<'a> RenderEncoder<'a> for RenderPass<'a> {
     }
 
     #[inline(always)]
-    fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'a>, index_format: IndexFormat) {
+    fn set_index_buffer(&mut self, buffer_slice: BufferSlice, index_format: IndexFormat) {
         Self::set_index_buffer(self, buffer_slice, index_format);
     }
 
     #[inline(always)]
-    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'a>) {
+    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice) {
         Self::set_vertex_buffer(self, slot, buffer_slice);
     }
 
@@ -177,12 +177,12 @@ impl<'a> RenderEncoder<'a> for RenderBundleEncoder<'a> {
     }
 
     #[inline(always)]
-    fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'a>, index_format: IndexFormat) {
+    fn set_index_buffer(&mut self, buffer_slice: BufferSlice, index_format: IndexFormat) {
         Self::set_index_buffer(self, buffer_slice, index_format);
     }
 
     #[inline(always)]
-    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'a>) {
+    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice) {
         Self::set_vertex_buffer(self, slot, buffer_slice);
     }
 

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -95,7 +95,7 @@ impl DownloadBuffer {
     pub fn read_buffer(
         device: &super::Device,
         queue: &super::Queue,
-        buffer: &super::BufferSlice<'_>,
+        buffer: &super::BufferSlice,
         callback: impl FnOnce(Result<Self, super::BufferAsyncError>) + Send + 'static,
     ) {
         let size = buffer.size.into();
@@ -109,7 +109,7 @@ impl DownloadBuffer {
 
         let mut encoder =
             device.create_command_encoder(&super::CommandEncoderDescriptor { label: None });
-        encoder.copy_buffer_to_buffer(buffer.buffer, buffer.offset, &download, 0, size);
+        encoder.copy_buffer_to_buffer(&buffer.buffer, buffer.offset, &download, 0, size);
         let command_buffer: super::CommandBuffer = encoder.finish();
         queue.submit(Some(command_buffer));
 


### PR DESCRIPTION
**Connections**
Related issue: #6974 

I'm also going to ping a few relevant people
* @kpreid - I understand they have contributed to past `BufferSlice` designs
* @sagudev  - They have voiced support for this change in the matrix chat


**Description**
Currently, BufferSlice is generic over a lifetime, but the lifetime is only used for a reference to a buffer. Since buffers are now Cloneable, it make sense to abandon this and instead have BufferSlice "own" a `Buffer`. I only see 2 issues with this:

1. Obviously, this would require calling `clone()` in many more places
2. Also, it would probably require making other types like `BufferBinding` similarly lose their lifetimes (`BufferBinding` because it needs to be castable from `BufferSlice`, unless we refactor that). This would mean that in cases where people are creating bind groups, they have to do `buffer.clone()` rather than `&buffer`, which is maybe slightly worse ergonomically. Other types like `BufferView` would also lose their lifetimes, though I think this is mostly for the better.

In general, I'm of the opinion that we should avoid lifetimes in public APIs like the plague in most cases, and that this should outweigh the tiny impact of a few more clones and of .

I just wanna leave 2 more notes here to address (possible) concerns
*  `BufferSlice` already isn't part of the WebGPU spec so this shouldn't cause worries about deviating from the spec
* The change is entirely in `wgpu` and not part of `wgpu-core` or `wgpu-types`. Since I understand most of the logic and heavy lifting occurs back there, the performance issues should be negligible.

**Testing**
No need.

**Squash or Rebase?**

Probably should be squashed.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
