### PR TITLE
Panic on errors in pass_end_with_unresolved_commands

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -102,8 +102,7 @@ impl GlobalPlay for wgc::global::Global {
                         encoder,
                         base,
                         timestamp_writes.as_ref(),
-                    )
-                    .unwrap();
+                    );
                 }
                 trace::Command::RunRenderPass {
                     base,
@@ -119,8 +118,7 @@ impl GlobalPlay for wgc::global::Global {
                         target_depth_stencil.as_ref(),
                         timestamp_writes.as_ref(),
                         occlusion_query_set_id,
-                    )
-                    .unwrap();
+                    );
                 }
                 trace::Command::BuildAccelerationStructuresUnsafeTlas { blas, tlas } => {
                     let blas_iter = blas.iter().map(|x| {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -108,10 +108,14 @@ impl CommandEncoderStatus {
     }
 
     #[cfg(feature = "trace")]
-    fn get_inner(&mut self) -> Result<&mut CommandBufferMutable, CommandEncoderError> {
+    fn get_inner(&mut self) -> &mut CommandBufferMutable {
         match self {
-            Self::Locked(inner) | Self::Finished(inner) | Self::Recording(inner) => Ok(inner),
-            Self::Error => Err(CommandEncoderError::Invalid),
+            Self::Locked(inner) | Self::Finished(inner) | Self::Recording(inner) => inner,
+            // This is unreachable because this function is only used when
+            // playing back a recorded trace. If only to avoid having to
+            // implement serialization for all the error types, we don't support
+            // storing the errors in a trace.
+            Self::Error => unreachable!("passes in a trace do not store errors"),
         }
     }
 

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -161,7 +161,7 @@ impl Global {
         #[cfg(feature = "trace")]
         let trace_tlas: Vec<TlasBuildEntry> = tlas_iter.collect();
         #[cfg(feature = "trace")]
-        if let Some(ref mut list) = cmd_buf.data.lock().get_inner()?.commands {
+        if let Some(ref mut list) = cmd_buf.data.lock().get_inner().commands {
             list.push(
                 crate::device::trace::Command::BuildAccelerationStructuresUnsafeTlas {
                     blas: trace_blas.clone(),
@@ -444,7 +444,7 @@ impl Global {
             .collect();
 
         #[cfg(feature = "trace")]
-        if let Some(ref mut list) = cmd_buf.data.lock().get_inner()?.commands {
+        if let Some(ref mut list) = cmd_buf.data.lock().get_inner().commands {
             list.push(crate::device::trace::Command::BuildAccelerationStructures {
                 blas: trace_blas.clone(),
                 tlas: trace_tlas.clone(),


### PR DESCRIPTION
For #7391, we need to store errors generated by command recording and raise them only when `CommandEncoder.finish` is called. My plan is to add a second type parameter `E` to `BasePass<C>` for the kind of errors raised by the pass (either `ComputePassError` or `RenderPassError`). But in the case of passes stored in a trace (`trace::Command::RunRenderPass` and `RunComputePass`), this type parameter needs to be `()`, because our errors types are not serializable.

This change modifies the functions `compute_pass_end_with_unresolved_commands` and `render_pass_end_with_unresolved_commands`, which are called from the trace player, to panic on any error. Previously, any error resulted in an immediate panic at the call sites for these functions, so this should not make any functional difference.

While having an error type `()` in the input traces isn't inconsistent with these functions still being able to return errors, it seemed less confusing to just make them panic, rather than have possible confusion around where errors are coming from in these functions, and where they are going (to the caller? to the command encoder?). 

It is not clear to me how these functions are used. It appears that historically they were called by the main `pass_end` functions, but that is no longer the case. As best I can tell, these functions might be called if playing an old trace, but aren't called within the current implementation or written to new traces.

**Testing**
Passes existing tests.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
