### PR TITLE
remove outdated docs for Adapter::request_device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,12 @@ Naga now infers the correct binding layout when a resource appears only in an as
 
 - Allow scalars as the first argument of the `distance` built-in function. By @bernhl in [#7530](https://github.com/gfx-rs/wgpu/pull/7530).
 
+### Documentation
+
+#### General
+
+- Remove outdated information about `Adapter::request_device`. By @tesselode in [#7768](https://github.com/gfx-rs/wgpu/pull/7768)
+
 ## v25.0.2 (2025-05-24)
 
 ### Bug Fixes

--- a/wgpu/src/api/adapter.rs
+++ b/wgpu/src/api/adapter.rs
@@ -43,11 +43,6 @@ impl Adapter {
     /// [`Adapter`].
     /// However, `wgpu` does not currently enforce this restriction.
     ///
-    /// # Arguments
-    ///
-    /// - `desc` - Description of the features and limits requested from the given device.
-    /// - `trace` - Can be used for API call tracing, if the feature is enabled.
-    ///
     /// # Panics
     ///
     /// - `request_device()` was already called on this `Adapter`.


### PR DESCRIPTION
**Connections**
#7767 

**Description**
The docs list two arguments to `Adapter::request_device`: `desc` and `trace`. As of wgpu v0.25, this is no longer correct, as the trace argument was moved into `DeviceDescriptor`.

I removed the entire arguments section for consistency with most other functions that take a `XDescriptor` argument and don't need to explain what it is.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
