### PR TITLE
Make `strum` a dev-only dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Naga now infers the correct binding layout when a resource appears only in an as
 - Mark `readonly_and_readwrite_storage_textures` & `packed_4x8_integer_dot_product` language extensions as implemented. By @teoxoy in [#7543](https://github.com/gfx-rs/wgpu/pull/7543)
 - `naga::back::hlsl::Writer::new` has a new `pipeline_options` argument. `hlsl::PipelineOptions::default()` can be passed as a default. The `shader_stage` and `entry_point` members of `pipeline_options` can be used to write only a single entry point when using the HLSL and MSL backends (GLSL and SPIR-V already had this functionality). The Metal and DX12 HALs now write only a single entry point when loading shaders. By @andyleiserson in [#7626](https://github.com/gfx-rs/wgpu/pull/7626).
 - Implemented `early_depth_test` for SPIR-V backend, enabling `SHADER_EARLY_DEPTH_TEST` for Vulkan. Additionally, fixed conservative depth optimizations when using `early_depth_test`. The syntax for forcing early depth tests is now `@early_depth_test(force)` instead of `@early_depth_test`. By @dzamkov in [#7676](https://github.com/gfx-rs/wgpu/pull/7676).
+- `ImplementedLanguageExtension::VARIANTS` is now implemented manually rather than derived using `strum` (allowing `strum` to become a dev-only dependency) so it is no longer a member of the `strum::VARIANTS` trait. Unless you are using this trait as a bound this should have no effect.
 
 #### D3D12
 

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -58,7 +58,7 @@ arbitrary = [
 ]
 spv-in = ["dep:petgraph", "petgraph/graphmap", "dep:spirv"]
 spv-out = ["dep:spirv"]
-wgsl-in = ["dep:hexf-parse", "dep:strum", "dep:unicode-ident", "compact"]
+wgsl-in = ["dep:hexf-parse", "dep:unicode-ident", "compact"]
 wgsl-out = []
 
 ## Enables outputting to HLSL (Microsoft's High-Level Shader Language).
@@ -95,7 +95,6 @@ libm = { workspace = true, default-features = false }
 log.workspace = true
 num-traits.workspace = true
 once_cell = { workspace = true, features = ["alloc", "race"] }
-strum = { workspace = true, optional = true }
 spirv = { workspace = true, optional = true }
 thiserror.workspace = true
 serde = { workspace = true, features = ["alloc", "derive"], optional = true }
@@ -117,6 +116,7 @@ ron.workspace = true
 rspirv.workspace = true
 serde = { workspace = true, features = ["default", "derive"] }
 spirv = { workspace = true, features = ["deserialize"] }
+strum = { workspace = true }
 toml.workspace = true
 walkdir.workspace = true
 

--- a/naga/src/front/wgsl/parse/directive/language_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/language_extension.rs
@@ -2,8 +2,6 @@
 //!
 //! The focal point of this module is the [`LanguageExtension`] API.
 
-use strum::VariantArray;
-
 /// A language extension recognized by Naga, but not guaranteed to be present in all environments.
 ///
 /// WGSL spec.: <https://www.w3.org/TR/WGSL/#language-extensions-sec>
@@ -54,7 +52,8 @@ impl LanguageExtension {
 }
 
 /// A variant of [`LanguageExtension::Implemented`].
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, VariantArray)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(test, derive(strum::VariantArray))]
 pub enum ImplementedLanguageExtension {
     ReadOnlyAndReadWriteStorageTextures,
     Packed4x8IntegerDotProduct,
@@ -62,6 +61,13 @@ pub enum ImplementedLanguageExtension {
 }
 
 impl ImplementedLanguageExtension {
+    /// A slice of all variants of [`ImplementedLanguageExtension`].
+    pub const VARIANTS: &'static [Self] = &[
+        Self::ReadOnlyAndReadWriteStorageTextures,
+        Self::Packed4x8IntegerDotProduct,
+        Self::PointerCompositeAccess,
+    ];
+
     /// Returns slice of all variants of [`ImplementedLanguageExtension`].
     pub const fn all() -> &'static [Self] {
         Self::VARIANTS
@@ -81,6 +87,16 @@ impl ImplementedLanguageExtension {
             }
         }
     }
+}
+
+#[test]
+/// Asserts that the manual implementation of VARIANTS is the same as the derived strum version would be
+/// while still allowing strum to be a dev-only dependency
+fn test_manual_variants_array_is_correct() {
+    assert_eq!(
+        <ImplementedLanguageExtension as strum::VariantArray>::VARIANTS,
+        ImplementedLanguageExtension::VARIANTS
+    );
 }
 
 /// A variant of [`LanguageExtension::Unimplemented`].


### PR DESCRIPTION
**Description**
This reduces the number of dependencies that users of naga need to install by replacing a `strum` derive with a manual impl. Strum is still included a dev-dependency to verify that the manual impl is correct in a test.

**Testing**
Everything still builds correctly. This is very unlikely to affect runtime behaviour.

**Squash or Rebase?**
Either: there is only one commit.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
