### PR TITLE
Split EncoderStateError from CommandEncoderError

### DIFF
--- a/tests/tests/wgpu-gpu/encoder.rs
+++ b/tests/tests/wgpu-gpu/encoder.rs
@@ -308,23 +308,15 @@ fn encoder_operations_fail_while_pass_alive(ctx: TestingContext) {
             ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
 
             log::info!("Testing operation {op_name:?} on a locked command encoder while a {pass_type:?} pass is active");
-            fail(
-                &ctx.device,
-                || op(&mut encoder),
-                Some("Command encoder is locked"),
-            );
+            fail(&ctx.device, || op(&mut encoder), Some("encoder is locked"));
 
             // Drop the pass - this also fails now since the encoder is invalid:
-            fail(
-                &ctx.device,
-                || drop(pass),
-                Some("Command encoder is invalid"),
-            );
+            fail(&ctx.device, || drop(pass), Some("encoder is invalid"));
             // Also, it's not possible to create a new pass on the encoder:
             fail(
                 &ctx.device,
                 || encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default()),
-                Some("Command encoder is invalid"),
+                Some("encoder is invalid"),
             );
         }
 
@@ -334,16 +326,8 @@ fn encoder_operations_fail_while_pass_alive(ctx: TestingContext) {
                 .device
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
             let pass = create_pass(&mut encoder, pass_type);
-            fail(
-                &ctx.device,
-                || encoder.finish(),
-                Some("Command encoder is locked"),
-            );
-            fail(
-                &ctx.device,
-                || drop(pass),
-                Some("Command encoder is invalid"),
-            );
+            fail(&ctx.device, || encoder.finish(), Some("encoder is locked"));
+            fail(&ctx.device, || drop(pass), Some("encoder is invalid"));
         }
     }
 }

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -5,7 +5,7 @@ use core::ops::Range;
 use crate::device::trace::Command as TraceCommand;
 use crate::{
     api_log,
-    command::CommandEncoderError,
+    command::EncoderStateError,
     device::DeviceError,
     get_lowest_common_denom,
     global::Global,
@@ -74,7 +74,7 @@ whereas subesource range specified start {subresource_base_array_layer} and coun
     #[error(transparent)]
     Device(#[from] DeviceError),
     #[error(transparent)]
-    CommandEncoderError(#[from] CommandEncoderError),
+    EncoderState(#[from] EncoderStateError),
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
 }

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -4,6 +4,7 @@ use wgt::{BufferAddress, DynamicOffset};
 use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use core::{fmt, str};
 
+use crate::command::EncoderStateError;
 use crate::ray_tracing::AsAction;
 use crate::{
     binding_model::{
@@ -127,7 +128,7 @@ pub enum ComputePassErrorInner {
     #[error(transparent)]
     Device(#[from] DeviceError),
     #[error(transparent)]
-    Encoder(#[from] CommandEncoderError),
+    EncoderState(#[from] EncoderStateError),
     #[error("Parent encoder is invalid")]
     InvalidParentEncoder,
     #[error("Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
@@ -301,7 +302,7 @@ impl Global {
 
         match cmd_buf.data.lock().lock_encoder() {
             Ok(_) => {}
-            Err(e) => return make_err(e, arc_desc),
+            Err(e) => return make_err(e.into(), arc_desc),
         };
 
         arc_desc.timestamp_writes = match desc

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -4,7 +4,7 @@ use core::{iter, mem};
 #[cfg(feature = "trace")]
 use crate::device::trace::Command as TraceCommand;
 use crate::{
-    command::{CommandBuffer, CommandEncoderError},
+    command::{CommandBuffer, EncoderStateError},
     device::{DeviceError, MissingFeatures},
     global::Global,
     id,
@@ -96,7 +96,7 @@ pub enum QueryError {
     #[error(transparent)]
     Device(#[from] DeviceError),
     #[error(transparent)]
-    Encoder(#[from] CommandEncoderError),
+    EncoderState(#[from] EncoderStateError),
     #[error(transparent)]
     MissingFeature(#[from] MissingFeatures),
     #[error("Error encountered while trying to use queries")]

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -11,6 +11,7 @@ use wgt::{
 use crate::binding_model::BindGroup;
 use crate::command::{
     validate_and_begin_occlusion_query, validate_and_begin_pipeline_statistics_query,
+    EncoderStateError,
 };
 use crate::init_tracker::BufferInitTrackerAction;
 use crate::pipeline::{RenderPipeline, VertexStep};
@@ -662,7 +663,7 @@ pub enum RenderPassErrorInner {
     #[error(transparent)]
     ColorAttachment(#[from] ColorAttachmentError),
     #[error(transparent)]
-    Encoder(#[from] CommandEncoderError),
+    EncoderState(#[from] EncoderStateError),
     #[error("Parent encoder is invalid")]
     InvalidParentEncoder,
     #[error("The format of the {location} ({format:?}) is not resolvable")]
@@ -1610,7 +1611,7 @@ impl Global {
 
         match cmd_buf.data.lock().lock_encoder() {
             Ok(_) => {}
-            Err(e) => return make_err(e, arc_desc),
+            Err(e) => return make_err(e.into(), arc_desc),
         };
 
         let err = fill_arc_desc(hub, desc, &mut arc_desc, &cmd_buf.device).err();

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -8,7 +8,7 @@ use wgt::{BufferAddress, BufferUsages, Extent3d, TextureSelector, TextureUsages}
 use crate::device::trace::Command as TraceCommand;
 use crate::{
     api_log,
-    command::{clear_texture, CommandEncoderError},
+    command::{clear_texture, EncoderStateError},
     conv,
     device::{Device, DeviceError, MissingDownlevelFlags},
     global::Global,
@@ -161,19 +161,15 @@ pub enum TransferError {
 #[non_exhaustive]
 pub enum CopyError {
     #[error(transparent)]
-    Encoder(#[from] CommandEncoderError),
+    EncoderState(#[from] EncoderStateError),
+    #[error(transparent)]
+    Device(#[from] DeviceError),
     #[error("Copy error")]
     Transfer(#[from] TransferError),
     #[error(transparent)]
     DestroyedResource(#[from] DestroyedResourceError),
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
-}
-
-impl From<DeviceError> for CopyError {
-    fn from(err: DeviceError) -> Self {
-        CopyError::Encoder(CommandEncoderError::Device(err))
-    }
 }
 
 pub(crate) fn extract_texture_selector<T>(

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -1,15 +1,13 @@
 use thiserror::Error;
 
 use crate::{
-    command::CommandBuffer,
+    command::{CommandBuffer, EncoderStateError},
     device::DeviceError,
     global::Global,
     id::{BufferId, CommandEncoderId, TextureId},
     resource::{InvalidResourceError, ParentDevice},
     track::ResourceUsageCompatibilityError,
 };
-
-use super::CommandEncoderError;
 
 impl Global {
     pub fn command_encoder_transition_resources(
@@ -85,7 +83,7 @@ pub enum TransitionResourcesError {
     #[error(transparent)]
     Device(#[from] DeviceError),
     #[error(transparent)]
-    Encoder(#[from] CommandEncoderError),
+    EncoderState(#[from] EncoderStateError),
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
     #[error(transparent)]

--- a/wgpu-core/src/ray_tracing.rs
+++ b/wgpu-core/src/ray_tracing.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use wgt::{AccelerationStructureGeometryFlags, BufferAddress, IndexFormat, VertexFormat};
 
 use crate::{
-    command::CommandEncoderError,
+    command::EncoderStateError,
     device::{DeviceError, MissingFeatures},
     id::{BlasId, BufferId, TlasId},
     resource::{
@@ -50,7 +50,7 @@ pub enum CreateTlasError {
 #[derive(Clone, Debug, Error)]
 pub enum BuildAccelerationStructureError {
     #[error(transparent)]
-    Encoder(#[from] CommandEncoderError),
+    EncoderState(#[from] EncoderStateError),
 
     #[error(transparent)]
     Device(#[from] DeviceError),


### PR DESCRIPTION
More work towards #7391. I posted a [comment](https://github.com/gfx-rs/wgpu/issues/7391#issuecomment-2956613558) summarizing the overall user-visible results I expect for that issue.

This PR splits the variants of `CommandEncoderError` for the encoder being in an incorrect state into a dedicated enum `EncoderStateError`. It changes several error enums that only need the state errors to use the latter rather than the former. In a future PR, many command encoding functions will return `EncoderStateError` because the only error they can raise immediately (vs. raise on a later call to `encoder.finish()`) is `EncoderStateError::Ended`.

I have tweaked the error messages slightly to generalize "command encoder" to "encoder" (either a command encoder, pass encoder, or render bundle encoder), and I have renamed the `NotRecording` variant to `Ended` because it seems clearer to call it as the spec does -- i.e. "this encoder can't be used because it is in the "ended" state".

**Testing**
Just a refactor, relying on existing test coverage.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
