### PR TITLE
Fix texture_from_d3d11_shared_handle compatibility on AMD/Nvidia GPUs

### DIFF
--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -769,6 +769,7 @@ impl super::Device {
         let mut import_memory_info = vk::ImportMemoryWin32HandleInfoKHR::default()
             .handle_type(vk::ExternalMemoryHandleTypeFlags::D3D11_TEXTURE)
             .handle(d3d11_shared_handle.0 as _);
+        // TODO: We should use `push_next` instead, but currently ash does not provide this method for the `ImportMemoryWin32HandleInfoKHR` type.
         #[allow(clippy::unnecessary_mut_passed)]
         {
             import_memory_info.p_next = <*const _>::cast(&mut dedicated_allocate_info);

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -761,9 +761,18 @@ impl super::Device {
         let image =
             self.create_image_without_memory(desc, Some(&mut external_memory_image_info))?;
 
+        // Some external memory types require dedicated allocation
+        // https://docs.vulkan.org/guide/latest/extensions/external.html#_importing_memory
+        let mut dedicated_allocate_info =
+            vk::MemoryDedicatedAllocateInfo::default().image(image.raw);
+
         let mut import_memory_info = vk::ImportMemoryWin32HandleInfoKHR::default()
             .handle_type(vk::ExternalMemoryHandleTypeFlags::D3D11_TEXTURE)
             .handle(d3d11_shared_handle.0 as _);
+        #[allow(clippy::unnecessary_mut_passed)]
+        {
+            import_memory_info.p_next = <*const _>::cast(&mut dedicated_allocate_info);
+        }
 
         let mem_type_index = self
             .find_memory_type_index(


### PR DESCRIPTION
**Description**
`texture_from_d3d11_shared_handle` may fail on some AMD/Nvidia GPUs, [it's recommended to use `VkMemoryDedicatedAllocateInfo`](https://docs.vulkan.org/guide/latest/extensions/external.html#_importing_memory).

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
