### PR TITLE
[deno] Return undefined instead of null from Queue.submit

### DIFF
--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use deno_core::cppgc::Ptr;
 use deno_core::futures::channel::oneshot;
 use deno_core::op2;
+use deno_core::v8;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use deno_error::JsErrorBox;
@@ -53,8 +54,9 @@ impl GPUQueue {
     #[required(1)]
     fn submit(
         &self,
+        scope: &mut v8::HandleScope,
         #[webidl] command_buffers: Vec<Ptr<GPUCommandBuffer>>,
-    ) -> Result<(), JsErrorBox> {
+    ) -> Result<v8::Local<v8::Value>, JsErrorBox> {
         let ids = command_buffers
             .into_iter()
             .enumerate()
@@ -75,7 +77,7 @@ impl GPUQueue {
             self.error_handler.push_error(Some(err));
         }
 
-        Ok(())
+        Ok(v8::undefined(scope).into())
     }
 
     #[async_method]


### PR DESCRIPTION
Many WebGPU APIs are specified as returning `undefined`. The deno rust object wrapping maps `()` to `null`.

This fixes the problem only for `Queue.submit`, which the CTS is sensitive to. As discussed in https://github.com/denoland/deno/issues/29603, there is a better way of doing this (`#[undefined]` attribute), but it requires a newer version of Deno that we can't easily adopt because it uses Rust 2024. So I have left the rest of the APIs for later. [This branch](https://github.com/gfx-rs/wgpu/compare/trunk...andyleiserson:wgpu:deno-undefined) has the version with the `#[undefined]` attributes.

**Testing**
This is covered (incidentally) by the CTS, but additional fixes for #7391 are required before the tests can be enabled.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
