### PR TITLE
Add storage for an error in `CommandEncoderStatus`

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -80,17 +80,22 @@ pub(crate) enum CommandEncoderStatus {
     /// [`Global::command_encoder_finish`] transitions a
     /// `CommandBuffer` from the `Recording` state into this state.
     ///
-    /// [`Global::queue_submit`] drops command buffers unless they are
+    /// [`Global::queue_submit`] requires that command buffers are
     /// in this state.
+    ///
+    /// This corresponds to WebGPU's "ended" state.
+    /// See <https://www.w3.org/TR/webgpu/#encoder-state-ended>
     Finished(CommandBufferMutable),
 
-    /// An error occurred while recording a compute or render pass.
+    /// The command encoder is invalid.
     ///
-    /// When a `CommandEncoder` is left in this state, we have also
-    /// returned an error result from the function that encountered
-    /// the problem. Future attempts to use the encoder (for example,
-    /// calls to [`Self::record`]) will also return errors.
-    Error,
+    /// The error that caused the invalidation is stored here, and will
+    /// be raised by `CommandEncoder.finish()`.
+    Error(CommandEncoderError),
+
+    /// Temporary state used by the functions below. Encoder should never be
+    /// left in this state.
+    Transitioning,
 }
 
 impl CommandEncoderStatus {
@@ -98,12 +103,10 @@ impl CommandEncoderStatus {
     pub(crate) fn record(&mut self) -> Result<RecordingGuard<'_>, EncoderStateError> {
         match self {
             Self::Recording(_) => Ok(RecordingGuard { inner: self }),
-            Self::Locked(_) => {
-                *self = Self::Error;
-                Err(EncoderStateError::Locked)
-            }
+            Self::Locked(_) => Err(self.invalidate(EncoderStateError::Locked)),
             Self::Finished(_) => Err(EncoderStateError::Ended),
-            Self::Error => Err(EncoderStateError::Invalid),
+            Self::Error(_) => Err(EncoderStateError::Invalid),
+            Self::Transitioning => unreachable!(),
         }
     }
 
@@ -115,7 +118,8 @@ impl CommandEncoderStatus {
             // playing back a recorded trace. If only to avoid having to
             // implement serialization for all the error types, we don't support
             // storing the errors in a trace.
-            Self::Error => unreachable!("passes in a trace do not store errors"),
+            Self::Error(_) => unreachable!("passes in a trace do not store errors"),
+            Self::Transitioning => unreachable!(),
         }
     }
 
@@ -123,17 +127,24 @@ impl CommandEncoderStatus {
     ///
     /// Call [`Self::unlock_encoder`] to put the [`CommandBuffer`] back into the [`Self::Recording`] state.
     fn lock_encoder(&mut self) -> Result<(), EncoderStateError> {
-        match mem::replace(self, Self::Error) {
+        match mem::replace(self, Self::Transitioning) {
             Self::Recording(inner) => {
                 *self = Self::Locked(inner);
                 Ok(())
             }
-            Self::Finished(inner) => {
-                *self = Self::Finished(inner);
+            st @ Self::Finished(_) => {
+                // Attempting to open a pass on a finished encoder raises a
+                // validation error but does not invalidate the encoder. This is
+                // related to https://github.com/gpuweb/gpuweb/issues/5207.
+                *self = st;
                 Err(EncoderStateError::Ended)
             }
-            Self::Locked(_) => Err(EncoderStateError::Locked),
-            Self::Error => Err(EncoderStateError::Invalid),
+            Self::Locked(_) => Err(self.invalidate(EncoderStateError::Locked)),
+            st @ Self::Error(_) => {
+                *self = st;
+                Err(EncoderStateError::Invalid)
+            }
+            Self::Transitioning => unreachable!(),
         }
     }
 
@@ -143,25 +154,32 @@ impl CommandEncoderStatus {
     ///
     /// It is only valid to call this function if the encoder is in the [`Self::Locked`] state.
     fn unlock_encoder(&mut self) -> Result<RecordingGuard<'_>, EncoderStateError> {
-        match mem::replace(self, Self::Error) {
+        match mem::replace(self, Self::Transitioning) {
             Self::Locked(inner) => {
                 *self = Self::Recording(inner);
                 Ok(RecordingGuard { inner: self })
             }
-            Self::Finished(inner) => {
-                *self = Self::Finished(inner);
+            st @ Self::Finished(_) => {
+                // Attempting to end a pass on a finished encoder raises a
+                // validation error but does not invalidate the encoder. This is
+                // related to https://github.com/gpuweb/gpuweb/issues/5207.
+                *self = st;
                 Err(EncoderStateError::Ended)
             }
-            Self::Recording(_) => Err(EncoderStateError::Invalid),
-            Self::Error => Err(EncoderStateError::Invalid),
+            Self::Recording(_) => Err(self.invalidate(EncoderStateError::Unlocked)),
+            st @ Self::Error(_) => {
+                *self = st;
+                Err(EncoderStateError::Invalid)
+            }
+            Self::Transitioning => unreachable!(),
         }
     }
 
     fn finish(&mut self) -> Result<(), CommandEncoderError> {
-        match mem::replace(self, Self::Error) {
+        match mem::replace(self, Self::Transitioning) {
             Self::Recording(mut inner) => {
                 if let Err(e) = inner.encoder.close_if_open() {
-                    Err(e.into())
+                    Err(self.invalidate(e.into()))
                 } else {
                     *self = Self::Finished(inner);
                     // Note: if we want to stop tracking the swapchain texture view,
@@ -169,13 +187,20 @@ impl CommandEncoderStatus {
                     Ok(())
                 }
             }
-            Self::Finished(inner) => {
-                *self = Self::Finished(inner);
-                Err(EncoderStateError::Ended.into())
-            }
-            Self::Locked(_) => Err(EncoderStateError::Locked.into()),
-            Self::Error => Err(EncoderStateError::Invalid.into()),
+            Self::Finished(_) => Err(self.invalidate(EncoderStateError::Ended.into())),
+            Self::Locked(_) => Err(self.invalidate(EncoderStateError::Locked.into())),
+            Self::Error(err) => Err(self.invalidate(err)),
+            Self::Transitioning => unreachable!(),
         }
+    }
+
+    // Invalidate the command encoder and store the error `err` causing the
+    // invalidation for diagnostic purposes.
+    //
+    // Note that this also unlocks the encoder.
+    fn invalidate<E: Clone + Into<CommandEncoderError>>(&mut self, err: E) -> E {
+        *self = Self::Error(err.clone().into());
+        err
     }
 }
 
@@ -203,7 +228,11 @@ impl<'a> RecordingGuard<'a> {
 
 impl<'a> Drop for RecordingGuard<'a> {
     fn drop(&mut self) {
-        *self.inner = CommandEncoderStatus::Error;
+        if matches!(*self.inner, CommandEncoderStatus::Error(_)) {
+            // Don't overwrite an error that is already present.
+            return;
+        }
+        self.inner.invalidate(EncoderStateError::Invalid);
     }
 }
 
@@ -571,12 +600,16 @@ impl CommandBuffer {
         }
     }
 
-    pub(crate) fn new_invalid(device: &Arc<Device>, label: &Label) -> Self {
+    pub(crate) fn new_invalid(
+        device: &Arc<Device>,
+        label: &Label,
+        err: CommandEncoderError,
+    ) -> Self {
         CommandBuffer {
             device: device.clone(),
             support_clear_texture: device.features.contains(wgt::Features::CLEAR_TEXTURE),
             label: label.to_string(),
-            data: Mutex::new(rank::COMMAND_BUFFER_DATA, CommandEncoderStatus::Error),
+            data: Mutex::new(rank::COMMAND_BUFFER_DATA, CommandEncoderStatus::Error(err)),
         }
     }
 
@@ -659,12 +692,16 @@ impl CommandBuffer {
 
 impl CommandBuffer {
     pub fn take_finished<'a>(&'a self) -> Result<CommandBufferMutable, InvalidResourceError> {
-        let status = mem::replace(&mut *self.data.lock(), CommandEncoderStatus::Error);
-        match status {
-            CommandEncoderStatus::Finished(command_buffer_mutable) => Ok(command_buffer_mutable),
-            CommandEncoderStatus::Recording(_)
-            | CommandEncoderStatus::Locked(_)
-            | CommandEncoderStatus::Error => Err(InvalidResourceError(self.error_ident())),
+        use CommandEncoderStatus as St;
+        match mem::replace(
+            &mut *self.data.lock(),
+            CommandEncoderStatus::Error(EncoderStateError::Submitted.into()),
+        ) {
+            St::Finished(command_buffer_mutable) => Ok(command_buffer_mutable),
+            St::Recording(_) | St::Locked(_) | St::Error(_) => {
+                Err(InvalidResourceError(self.error_ident()))
+            }
+            St::Transitioning => unreachable!(),
         }
     }
 }
@@ -726,6 +763,20 @@ impl<C: Clone> BasePass<C> {
 }
 
 /// Errors related to the state of a command or pass encoder.
+///
+/// `EncoderStateError::Ended` is returned immediately when an attempt is made
+/// to encode a command using an encoder that has already finished.
+///
+/// `EncoderStateError::Locked` is returned by a subsequent call to
+/// `encoder.finish()`, if there was an attempt to open a second pass on the
+/// encoder while a previous pass was still open.
+///
+/// `EncoderStateError::Invalid` is used internally by wgpu. It should usually
+/// not be seen by users of the API, since an effort should be made to provide
+/// the caller with a more specific reason for the encoder being invalid.
+///
+/// The exact behavior of these errors may change based on the resolution of
+/// <https://github.com/gpuweb/gpuweb/issues/5207>.
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum EncoderStateError {
@@ -737,6 +788,17 @@ pub enum EncoderStateError {
     /// Note: only command encoders can be locked (not pass encoders).
     #[error("Encoder is locked by a previously created render/compute pass. Before recording any new commands, the pass must be ended.")]
     Locked,
+    #[error(
+        "Encoder is not currently locked. A pass can only be ended while the recorder is locked."
+    )]
+    Unlocked,
+
+    /// The command buffer has already been submitted.
+    ///
+    /// Although command encoders and command buffers are distinct WebGPU
+    /// objects, we use `CommandEncoderStatus` for both.
+    #[error("This command buffer has already been submitted.")]
+    Submitted,
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -50,7 +50,11 @@ use crate::device::trace::Command as TraceCommand;
 
 const PUSH_CONSTANT_CLEAR_ARRAY: &[u32] = &[0_u32; 64];
 
-/// The current state of a [`CommandBuffer`].
+/// The current state of a command or pass encoder.
+///
+/// In the WebGPU spec, the state of an encoder (open, locked, or ended) is
+/// orthogonal to the validity of the encoder. However, this enum does not
+/// represent the state of an invalid encoder.
 pub(crate) enum CommandEncoderStatus {
     /// Ready to record commands. An encoder's initial state.
     ///
@@ -70,9 +74,9 @@ pub(crate) enum CommandEncoderStatus {
     /// This state is entered when a render/compute pass is created,
     /// and exited when the pass is ended.
     ///
-    /// As long as the command encoder is locked, any command building operation on it will fail
-    /// and put the encoder into the [`Self::Error`] state.
-    /// See <https://www.w3.org/TR/webgpu/#encoder-state-locked>
+    /// As long as the command encoder is locked, any command building operation
+    /// on it will fail and put the encoder into the [`Self::Error`] state. See
+    /// <https://www.w3.org/TR/webgpu/#encoder-state-locked>
     Locked(CommandBufferMutable),
 
     /// Command recording is complete, and the buffer is ready for submission.
@@ -93,8 +97,8 @@ pub(crate) enum CommandEncoderStatus {
     /// be raised by `CommandEncoder.finish()`.
     Error(CommandEncoderError),
 
-    /// Temporary state used by the functions below. Encoder should never be
-    /// left in this state.
+    /// Temporary state used internally by methods on `CommandEncoderStatus`.
+    /// Encoder should never be left in this state.
     Transitioning,
 }
 
@@ -125,7 +129,8 @@ impl CommandEncoderStatus {
 
     /// Locks the encoder by putting it in the [`Self::Locked`] state.
     ///
-    /// Call [`Self::unlock_encoder`] to put the [`CommandBuffer`] back into the [`Self::Recording`] state.
+    /// Call [`Self::unlock_encoder`] to put the [`CommandBuffer`] back into the
+    /// [`Self::Recording`] state.
     fn lock_encoder(&mut self) -> Result<(), EncoderStateError> {
         match mem::replace(self, Self::Transitioning) {
             Self::Recording(inner) => {
@@ -197,7 +202,8 @@ impl CommandEncoderStatus {
     // Invalidate the command encoder and store the error `err` causing the
     // invalidation for diagnostic purposes.
     //
-    // Note that this also unlocks the encoder.
+    // Since we do not track the state of an invalid encoder, it is not
+    // necessary to unlock an encoder that has been invalidated.
     fn invalidate<E: Clone + Into<CommandEncoderError>>(&mut self, err: E) -> E {
         *self = Self::Error(err.clone().into());
         err
@@ -764,32 +770,35 @@ impl<C: Clone> BasePass<C> {
 
 /// Errors related to the state of a command or pass encoder.
 ///
-/// `EncoderStateError::Ended` is returned immediately when an attempt is made
-/// to encode a command using an encoder that has already finished.
-///
-/// `EncoderStateError::Locked` is returned by a subsequent call to
-/// `encoder.finish()`, if there was an attempt to open a second pass on the
-/// encoder while a previous pass was still open.
-///
-/// `EncoderStateError::Invalid` is used internally by wgpu. It should usually
-/// not be seen by users of the API, since an effort should be made to provide
-/// the caller with a more specific reason for the encoder being invalid.
-///
 /// The exact behavior of these errors may change based on the resolution of
 /// <https://github.com/gpuweb/gpuweb/issues/5207>.
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum EncoderStateError {
+    /// Used internally by wgpu functions to indicate the encoder already
+    /// contained an error. This variant should usually not be seen by users of
+    /// the API, since an effort should be made to provide the caller with a
+    /// more specific reason for the encoder being invalid.
     #[error("Encoder is invalid")]
     Invalid,
+
+    /// Returned immediately when an attempt is made to encode a command using
+    /// an encoder that has already finished.
     #[error("Encoding must not have ended")]
     Ended,
 
+    /// Returned by a subsequent call to `encoder.finish()`, if there was an
+    /// attempt to open a second pass on the encoder while it was locked for
+    /// a first pass (i.e. the first pass was still open).
+    ///
     /// Note: only command encoders can be locked (not pass encoders).
     #[error("Encoder is locked by a previously created render/compute pass. Before recording any new commands, the pass must be ended.")]
     Locked,
+
+    /// Returned when attempting to end a pass if the parent encoder is not
+    /// locked. This can only happen if pass begin/end calls are mismatched.
     #[error(
-        "Encoder is not currently locked. A pass can only be ended while the recorder is locked."
+        "Encoder is not currently locked. A pass can only be ended while the encoder is locked."
     )]
     Unlocked,
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1046,7 +1046,11 @@ impl Global {
             return (id.into_command_encoder_id(), None);
         };
 
-        let id = fid.assign(Arc::new(CommandBuffer::new_invalid(&device, &desc.label)));
+        let id = fid.assign(Arc::new(CommandBuffer::new_invalid(
+            &device,
+            &desc.label,
+            error.clone().into(),
+        )));
         (id.into_command_encoder_id(), Some(error))
     }
 


### PR DESCRIPTION
This PR adds storage for an error in `CommandEncoderStatus`. Upcoming changes for #7391 will store errors that occur during command encoding in this spot, for deferred reporting by `CommandEncoder.finish()`.

**Testing**
No intended functional changes from this change by itself. Subsequent changes will enable additional CTS tests.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] I posted a draft changelog entry for the error reporting changes [here](https://github.com/gfx-rs/wgpu/issues/7391#issuecomment-2956613558), but I'm not planning to further carve it up and attach it to individual PRs.
