### PR TITLE
Deferred error reporting for transfer commands

### DIFF
--- a/deno_webgpu/error.rs
+++ b/deno_webgpu/error.rs
@@ -17,7 +17,6 @@ use wgpu_core::binding_model::GetBindGroupLayoutError;
 use wgpu_core::command::ClearError;
 use wgpu_core::command::CommandEncoderError;
 use wgpu_core::command::ComputePassError;
-use wgpu_core::command::CopyError;
 use wgpu_core::command::CreateRenderBundleError;
 use wgpu_core::command::EncoderStateError;
 use wgpu_core::command::QueryError;
@@ -269,12 +268,6 @@ impl From<RenderBundleError> for GPUError {
 
 impl From<CreateRenderBundleError> for GPUError {
     fn from(err: CreateRenderBundleError) -> Self {
-        GPUError::Validation(fmt_err(&err))
-    }
-}
-
-impl From<CopyError> for GPUError {
-    fn from(err: CopyError) -> Self {
         GPUError::Validation(fmt_err(&err))
     }
 }

--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -380,70 +380,66 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
         );
 
         // Copying a buffer to a buffer should fail.
+        encoder_for_buffer_buffer_copy.copy_buffer_to_buffer(
+            &buffer_source,
+            0,
+            &buffer_dest,
+            0,
+            256,
+        );
         fail(
             &ctx.device,
-            || {
-                encoder_for_buffer_buffer_copy.copy_buffer_to_buffer(
-                    &buffer_source,
-                    0,
-                    &buffer_dest,
-                    0,
-                    256,
-                );
-            },
+            || encoder_for_buffer_buffer_copy.finish(),
             Some("device with '' label is invalid"),
         );
 
         // Copying a buffer to a texture should fail.
+        encoder_for_buffer_texture_copy.copy_buffer_to_texture(
+            wgpu::TexelCopyBufferInfo {
+                buffer: &buffer_source,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(4),
+                    rows_per_image: None,
+                },
+            },
+            texture_for_write.as_image_copy(),
+            texture_extent,
+        );
         fail(
             &ctx.device,
-            || {
-                encoder_for_buffer_texture_copy.copy_buffer_to_texture(
-                    wgpu::TexelCopyBufferInfo {
-                        buffer: &buffer_source,
-                        layout: wgpu::TexelCopyBufferLayout {
-                            offset: 0,
-                            bytes_per_row: Some(4),
-                            rows_per_image: None,
-                        },
-                    },
-                    texture_for_write.as_image_copy(),
-                    texture_extent,
-                );
-            },
+            || encoder_for_buffer_texture_copy.finish(),
             Some("device with '' label is invalid"),
         );
 
         // Copying a texture to a buffer should fail.
+        encoder_for_texture_buffer_copy.copy_texture_to_buffer(
+            texture_for_read.as_image_copy(),
+            wgpu::TexelCopyBufferInfo {
+                buffer: &buffer_source,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(4),
+                    rows_per_image: None,
+                },
+            },
+            texture_extent,
+        );
         fail(
             &ctx.device,
-            || {
-                encoder_for_texture_buffer_copy.copy_texture_to_buffer(
-                    texture_for_read.as_image_copy(),
-                    wgpu::TexelCopyBufferInfo {
-                        buffer: &buffer_source,
-                        layout: wgpu::TexelCopyBufferLayout {
-                            offset: 0,
-                            bytes_per_row: Some(4),
-                            rows_per_image: None,
-                        },
-                    },
-                    texture_extent,
-                );
-            },
+            || encoder_for_texture_buffer_copy.finish(),
             Some("device with '' label is invalid"),
         );
 
         // Copying a texture to a texture should fail.
+        encoder_for_texture_texture_copy.copy_texture_to_texture(
+            texture_for_read.as_image_copy(),
+            texture_for_write.as_image_copy(),
+            texture_extent,
+        );
         fail(
             &ctx.device,
-            || {
-                encoder_for_texture_texture_copy.copy_texture_to_texture(
-                    texture_for_read.as_image_copy(),
-                    texture_for_write.as_image_copy(),
-                    texture_extent,
-                );
-            },
+            || encoder_for_texture_texture_copy.finish(),
             Some("device with '' label is invalid"),
         );
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -30,6 +30,7 @@ pub use timestamp_writes::PassTimestampWrites;
 
 use self::memory_init::CommandBufferTextureMemoryActions;
 
+use crate::command::transition_resources::TransitionResourcesError;
 use crate::device::queue::TempResource;
 use crate::device::{Device, DeviceError, MissingFeatures};
 use crate::lock::{rank, Mutex};
@@ -37,9 +38,11 @@ use crate::snatch::SnatchGuard;
 
 use crate::init_tracker::BufferInitTrackerAction;
 use crate::ray_tracing::AsAction;
-use crate::resource::{Fallible, InvalidResourceError, Labeled, ParentDevice as _, QuerySet};
+use crate::resource::{
+    DestroyedResourceError, Fallible, InvalidResourceError, Labeled, ParentDevice as _, QuerySet,
+};
 use crate::storage::Storage;
-use crate::track::{DeviceTracker, Tracker, UsageScope};
+use crate::track::{DeviceTracker, ResourceUsageCompatibilityError, Tracker, UsageScope};
 use crate::{api_log, global::Global, id, resource_log, Label};
 use crate::{hal_label, LabelHelpers};
 
@@ -886,7 +889,17 @@ pub enum CommandEncoderError {
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
     #[error(transparent)]
+    DestroyedResource(#[from] DestroyedResourceError),
+    #[error(transparent)]
+    ResourceUsage(#[from] ResourceUsageCompatibilityError),
+    #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
+    #[error(transparent)]
+    Transfer(#[from] TransferError),
+    #[error(transparent)]
+    Clear(#[from] ClearError),
+    #[error(transparent)]
+    TransitionResources(#[from] TransitionResourcesError),
     #[error(
         "begin and end indices of pass timestamp writes are both set to {idx}, which is not allowed"
     )]


### PR DESCRIPTION
Next piece of #7391. This PR updates the command encoder data transfer commands to use `record_with` for deferred error reporting.

Turning on the "hide whitespace" option will substantially reduce the diff.

**Testing**
Small update to one gpu test, but most of the test coverage for this will be enabled later. 

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
