### PR TITLE
fix(naga): don't panic on `f16`s in pipeline constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Bottom level categories:
 - Generate vectorized code for `[un]pack4x{I,U}8[Clamp]` on SPIR-V and MSL 2.1+. By @robamler in [#7664](https://github.com/gfx-rs/wgpu/pull/7664).
 - Fix typing for `select`, which had issues particularly with a lack of automatic type conversion. By @ErichDonGubler in [#7572](https://github.com/gfx-rs/wgpu/pull/7572).
 - Allow scalars as the first argument of the `distance` built-in function. By @bernhl in [#7530](https://github.com/gfx-rs/wgpu/pull/7530).
+- Don't panic when handling `f16` for pipeline constants, i.e., `override`s in WGSL. By @ErichDonGubler in [#7801](https://github.com/gfx-rs/wgpu/pull/7801).
 
 #### DX12
 
@@ -127,7 +128,6 @@ Bottom level categories:
 #### HAL
 
 - Added initial `no_std` support to `wgpu-hal`. By @bushrat011899 in [#7599](https://github.com/gfx-rs/wgpu/pull/7599)
-
 
 ### Documentation
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -27,6 +27,7 @@ webgpu:api,operation,uncapturederror:iff_uncaptured:*
 // There are also two unimplemented SKIPs in uncapturederror not enumerated here.
 webgpu:api,validation,encoding,queries,general:occlusion_query,query_type:*
 webgpu:shader,execution,flow_control,return:*
+webgpu:shader,validation,expression,call,builtin,max:values:*
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break_if"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="continue"

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -979,7 +979,10 @@ fn map_value_to_literal(value: f64, scalar: Scalar) -> Result<Literal, PipelineC
 
             Ok(Literal::F64(value))
         }
-        _ => unreachable!(),
+        Scalar::ABSTRACT_FLOAT | Scalar::ABSTRACT_INT => {
+            unreachable!("abstract values should not be validated out of override processing")
+        }
+        _ => unreachable!("unrecognized scalar type for override"),
     }
 }
 

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -945,6 +945,19 @@ fn map_value_to_literal(value: f64, scalar: Scalar) -> Result<Literal, PipelineC
             let value = value as u32;
             Ok(Literal::U32(value))
         }
+        Scalar::F16 => {
+            // https://webidl.spec.whatwg.org/#js-float
+            if !value.is_finite() {
+                return Err(PipelineConstantError::SrcNeedsToBeFinite);
+            }
+
+            let value = half::f16::from_f64(value);
+            if !value.is_finite() {
+                return Err(PipelineConstantError::DstRangeTooSmall);
+            }
+
+            Ok(Literal::F16(value))
+        }
         Scalar::F32 => {
             // https://webidl.spec.whatwg.org/#js-float
             if !value.is_finite() {


### PR DESCRIPTION
While looking at Firefox's CTS results for  `webgpu:shader,validation,expression,call,builtin,max:values:*`, I found an issue which, minimized as this small WGPU application:

```toml
# Cargo.toml

[package]
name = "tmp-a05txx"
version = "0.1.0"
edition = "2024"

[dependencies]
# wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "620c9d1e8bcdede08a76134692babd6ccc004ecb" }
wgpu = { path = "/Users/mozilla/workspace/wgpu/wgpu/" }
env_logger = "*"
pollster = "*"

```

```rust
// src/main.rs

use pollster::FutureExt as _;

fn main() {
    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
        backends: wgpu::Backends::PRIMARY, // & !wgpu::Backends::VULKAN,
        ..Default::default()
    });
    let adapter = instance
        .request_adapter(&Default::default())
        .block_on()
        .unwrap();

    let (device, _queue) = adapter
        .request_device(&wgpu::DeviceDescriptor {
            required_features: wgpu::Features::SHADER_F16,
            ..Default::default()
        })
        .block_on()
        .unwrap();

    let source = "enable f16;
override o0 : f16;
override o1 : f16;
var<private> v  = max(f16(o0), f16(o1));

@workgroup_size(1) @compute
fn main() {
    _ = o0;
    _ = o1;
    _ = v;
}";

    let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
        label: None,
        source: wgpu::ShaderSource::Wgsl(source.into()),
    });

    let _ = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
        label: None,
        layout: None,
        module: &module,
        entry_point: None,
        compilation_options: wgpu::PipelineCompilationOptions {
            constants: &[("o0", -65504.), ("o1", -65504.)],
            ..Default::default()
        },
        cache: None,
    });
}

```

…crashes like this:

```
thread 'main' panicked at <snip>/wgpu/naga/src/back/pipeline_constants.rs:969:14:
internal error: entered unreachable code
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/panicking.rs:75:14
   2: core::panicking::panic
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/panicking.rs:145:5
   3: naga::back::pipeline_constants::map_value_to_literal
             at <snip>/wgpu/naga/src/back/pipeline_constants.rs:969:14
   4: naga::back::pipeline_constants::process_override
             at <snip>/wgpu/naga/src/back/pipeline_constants.rs:307:42
   5: naga::back::pipeline_constants::process_overrides
             at <snip>/wgpu/naga/src/back/pipeline_constants.rs:145:38
   6: wgpu_hal::metal::device::<impl wgpu_hal::metal::Device>::load_shader
             at <snip>/wgpu/wgpu-hal/src/metal/device.rs:137:37
   7: wgpu_hal::metal::device::<impl wgpu_hal::Device for wgpu_hal::metal::Device>::create_compute_pipeline::{{closure}}
             at <snip>/wgpu/wgpu-hal/src/metal/device.rs:1358:17
   8: objc::rc::autorelease::autoreleasepool
             at <snip>/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc-0.2.7/src/rc/autorelease.rs:29:5
   9: wgpu_hal::metal::device::<impl wgpu_hal::Device for wgpu_hal::metal::Device>::create_compute_pipeline
             at <snip>/wgpu/wgpu-hal/src/metal/device.rs:1340:9
  10: <D as wgpu_hal::dynamic::device::DynDevice>::create_compute_pipeline
             at <snip>/wgpu/wgpu-hal/src/dynamic/device.rs:451:18
  11: wgpu_core::device::resource::Device::create_compute_pipeline
             at <snip>/wgpu/wgpu-core/src/device/resource.rs:3017:22
  12: wgpu_core::device::global::<impl wgpu_core::global::Global>::device_create_compute_pipeline
             at <snip>/wgpu/wgpu-core/src/device/global.rs:1513:34
  13: <wgpu::backend::wgpu_core::CoreDevice as wgpu::dispatch::DeviceInterface>::create_compute_pipeline
             at <snip>/wgpu/wgpu/src/backend/wgpu_core.rs:1436:13
  14: wgpu::api::device::Device::create_compute_pipeline
             at <snip>/wgpu/wgpu/src/api/device.rs:249:24
  15: tmp_a05txx::main
             at ./src/main.rs:38:13
  16: core::ops::function::FnOnce::call_once
             at <snip>/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

**Testing**

`webgpu:shader,validation,expression,call,builtin,max:values:*` crashes before this change, and `PASS`es afterwards. 😤

**Squash or Rebase?**

sqoosh

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
