### PR TITLE
[Naga msl-out] Add padding to end of structs. And run some textureSample CTS tests that now pass

### DIFF
--- a/cts_runner/src/bootstrap.js
+++ b/cts_runner/src/bootstrap.js
@@ -200,6 +200,7 @@ const windowOrWorkerGlobalScope = {
   GPUTextureUsage: util.nonEnumerable(webgpu.GPUTextureUsage),
   GPUTexture: util.nonEnumerable(webgpu.GPUTexture),
   GPUTextureView: util.nonEnumerable(webgpu.GPUTextureView),
+  GPUExternalTexture: util.nonEnumerable(webgpu.GPUExternalTexture),
   GPUSampler: util.nonEnumerable(webgpu.GPUSampler),
   GPUBindGroupLayout: util.nonEnumerable(webgpu.GPUBindGroupLayout),
   GPUPipelineLayout: util.nonEnumerable(webgpu.GPUPipelineLayout),

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -31,6 +31,7 @@ webgpu:api,operation,uncapturederror:iff_uncaptured:*
 //FAIL: webgpu:api,operation,uncapturederror:onuncapturederror_order_wrt_addEventListener
 // There are also two unimplemented SKIPs in uncapturederror not enumerated here.
 webgpu:api,validation,encoding,queries,general:occlusion_query,query_type:*
+webgpu:shader,execution,expression,call,builtin,textureSample:sampled_1d_coords:*
 webgpu:shader,execution,flow_control,return:*
 webgpu:shader,validation,expression,call,builtin,max:values:*
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break"

--- a/deno_webgpu/01_webgpu.js
+++ b/deno_webgpu/01_webgpu.js
@@ -35,6 +35,7 @@ import {
   GPUSupportedLimits,
   GPUTexture,
   GPUTextureView,
+  GPUExternalTexture,
   op_create_gpu,
 } from "ext:core/ops";
 const {
@@ -866,6 +867,7 @@ export {
   GPUTexture,
   GPUTextureUsage,
   GPUTextureView,
+  GPUExternalTexture,
   GPUUncapturedErrorEvent,
   GPUValidationError,
   initGPU,

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -93,6 +93,7 @@ deno_core::extension!(
         adapter::GPUSupportedLimits,
         texture::GPUTexture,
         texture::GPUTextureView,
+        texture::GPUExternalTexture,
         byow::UnsafeWindowSurface,
         surface::GPUCanvasContext,
     ],

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -660,3 +660,14 @@ impl From<GPUTextureFormat> for TextureFormat {
         }
     }
 }
+
+pub struct GPUExternalTexture {}
+
+impl WebIdlInterfaceConverter for GPUExternalTexture {
+    const NAME: &'static str = "GPUExternalTexture";
+}
+
+impl GarbageCollected for GPUExternalTexture {}
+
+#[op2]
+impl GPUExternalTexture {}

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -4470,6 +4470,16 @@ impl<W: Write> Writer<W> {
                             }
                         }
                     }
+                    if last_offset < span {
+                        let pad = span - last_offset;
+                        writeln!(
+                            self.out,
+                            "{}char _pad{}[{}];",
+                            back::INDENT,
+                            members.len(),
+                            pad
+                        )?;
+                    }
                     writeln!(self.out, "}};")?;
                 }
                 _ => {

--- a/naga/tests/out/msl/spv-quad-vert.msl
+++ b/naga/tests/out/msl/spv-quad-vert.msl
@@ -12,6 +12,7 @@ struct gl_PerVertex {
     float gl_PointSize;
     type_3 gl_ClipDistance;
     type_3 gl_CullDistance;
+    char _pad4[4];
 };
 struct VertexOutput {
     metal::float2 member;

--- a/naga/tests/out/msl/spv-unnamed-gl-per-vertex.msl
+++ b/naga/tests/out/msl/spv-unnamed-gl-per-vertex.msl
@@ -12,6 +12,7 @@ struct type_4 {
     float member_1;
     type_3 member_2;
     type_3 member_3;
+    char _pad4[4];
 };
 
 void function(

--- a/naga/tests/out/msl/wgsl-6438-conflicting-idents.msl
+++ b/naga/tests/out/msl/wgsl-6438-conflicting-idents.msl
@@ -7,6 +7,7 @@ using metal::uint;
 struct OurVertexShaderOutput {
     metal::float4 position;
     metal::float2 texcoord;
+    char _pad2[8];
 };
 
 struct vsInput {

--- a/naga/tests/out/msl/wgsl-access.msl
+++ b/naga/tests/out/msl/wgsl-access.msl
@@ -16,6 +16,7 @@ struct GlobalConst {
 };
 struct AlignedWrapper {
     int value;
+    char _pad1[4];
 };
 struct type_6 {
     metal::float2x2 inner[2];
@@ -35,6 +36,7 @@ struct Bar {
     char _pad4[4];
     type_10 arr;
     type_11 data;
+    char _pad6[8];
 };
 struct Baz {
     metal::float3x2 m;

--- a/naga/tests/out/msl/wgsl-atomicCompareExchange.msl
+++ b/naga/tests/out/msl/wgsl-atomicCompareExchange.msl
@@ -13,10 +13,12 @@ struct type_4 {
 struct _atomic_compare_exchange_resultSint4_ {
     int old_value;
     bool exchanged;
+    char _pad2[3];
 };
 struct _atomic_compare_exchange_resultUint4_ {
     uint old_value;
     bool exchanged;
+    char _pad2[3];
 };
 
 template <typename A>

--- a/naga/tests/out/msl/wgsl-atomicOps.msl
+++ b/naga/tests/out/msl/wgsl-atomicOps.msl
@@ -14,10 +14,12 @@ struct Struct {
 struct _atomic_compare_exchange_resultUint4_ {
     uint old_value;
     bool exchanged;
+    char _pad2[3];
 };
 struct _atomic_compare_exchange_resultSint4_ {
     int old_value;
     bool exchanged;
+    char _pad2[3];
 };
 
 template <typename A>

--- a/naga/tests/out/msl/wgsl-bounds-check-restrict.msl
+++ b/naga/tests/out/msl/wgsl-bounds-check-restrict.msl
@@ -18,6 +18,7 @@ struct Globals {
     metal::float4 v;
     metal::float3x4 m;
     type_4 d;
+    char _pad4[12];
 };
 
 float index_array(

--- a/naga/tests/out/msl/wgsl-bounds-check-zero.msl
+++ b/naga/tests/out/msl/wgsl-bounds-check-zero.msl
@@ -24,6 +24,7 @@ struct Globals {
     metal::float4 v;
     metal::float3x4 m;
     type_4 d;
+    char _pad4[12];
 };
 
 float index_array(

--- a/naga/tests/out/msl/wgsl-constructors.msl
+++ b/naga/tests/out/msl/wgsl-constructors.msl
@@ -7,6 +7,7 @@ using metal::uint;
 struct Foo {
     metal::float4 a;
     int b;
+    char _pad2[12];
 };
 struct type_6 {
     metal::float2x2 inner[1];

--- a/naga/tests/out/msl/wgsl-extra.msl
+++ b/naga/tests/out/msl/wgsl-extra.msl
@@ -12,6 +12,7 @@ struct PushConstants {
 struct FragmentIn {
     metal::float4 color;
     uint primitive_index;
+    char _pad2[12];
 };
 
 struct main_Input {

--- a/naga/tests/out/msl/wgsl-fragment-output.msl
+++ b/naga/tests/out/msl/wgsl-fragment-output.msl
@@ -19,6 +19,7 @@ struct FragmentOutputVec2Scalar {
     float scalarf;
     int scalari;
     uint scalaru;
+    char _pad6[4];
 };
 
 struct main_vec4vec3_Output {

--- a/naga/tests/out/msl/wgsl-int64.msl
+++ b/naga/tests/out/msl/wgsl-int64.msl
@@ -21,6 +21,7 @@ struct UniformCompatible {
     metal::long3 val_i64_3_;
     metal::long4 val_i64_4_;
     ulong final_value;
+    char _pad12[24];
 };
 struct type_11 {
     ulong inner[2];

--- a/naga/tests/out/msl/wgsl-interface.msl
+++ b/naga/tests/out/msl/wgsl-interface.msl
@@ -7,6 +7,7 @@ using metal::uint;
 struct VertexOutput {
     metal::float4 position;
     float _varying;
+    char _pad2[12];
 };
 struct FragmentOutput {
     float depth;

--- a/naga/tests/out/msl/wgsl-interpolate.msl
+++ b/naga/tests/out/msl/wgsl-interpolate.msl
@@ -18,6 +18,7 @@ struct FragmentInput {
     float perspective_centroid;
     float perspective_sample;
     float perspective_center;
+    char _pad12[4];
 };
 
 struct vert_mainOutput {

--- a/naga/tests/out/msl/wgsl-interpolate_compat.msl
+++ b/naga/tests/out/msl/wgsl-interpolate_compat.msl
@@ -18,6 +18,7 @@ struct FragmentInput {
     float perspective_centroid;
     float perspective_sample;
     float perspective_center;
+    char _pad11[4];
 };
 
 struct vert_mainOutput {

--- a/naga/tests/out/msl/wgsl-msl-vpt.msl
+++ b/naga/tests/out/msl/wgsl-msl-vpt.msl
@@ -13,11 +13,13 @@ struct VertexOutput {
     metal::float4 position;
     metal::float4 color;
     metal::float2 texcoord;
+    char _pad3[8];
 };
 struct VertexInput {
     metal::float4 position;
     metal::float3 normal;
     metal::float2 texcoord;
+    char _pad3[8];
 };
 float unpackFloat32_(uint b0, uint b1, uint b2, uint b3) {
     return as_type<float>(b3 << 24 | b2 << 16 | b1 << 8 | b0);

--- a/naga/tests/out/msl/wgsl-overrides-atomicCompareExchangeWeak.msl
+++ b/naga/tests/out/msl/wgsl-overrides-atomicCompareExchangeWeak.msl
@@ -7,6 +7,7 @@ using metal::uint;
 struct _atomic_compare_exchange_resultUint4_ {
     uint old_value;
     bool exchanged;
+    char _pad2[3];
 };
 
 template <typename A>

--- a/naga/tests/out/msl/wgsl-padding.msl
+++ b/naga/tests/out/msl/wgsl-padding.msl
@@ -10,6 +10,7 @@ struct S {
 struct Test {
     S a;
     float b;
+    char _pad2[12];
 };
 struct type_2 {
     metal::float3 inner[2];
@@ -17,10 +18,12 @@ struct type_2 {
 struct Test2_ {
     type_2 a;
     float b;
+    char _pad2[12];
 };
 struct Test3_ {
     metal::float4x3 a;
     float b;
+    char _pad2[12];
 };
 
 struct vertex_Output {

--- a/tests/tests/wgpu-gpu/shader/struct_layout.rs
+++ b/tests/tests/wgpu-gpu/shader/struct_layout.rs
@@ -211,7 +211,7 @@ fn create_struct_layout_tests(storage_type: InputStorageType) -> Vec<ShaderTest>
 
     // Test for https://github.com/gfx-rs/wgpu/issues/5262.
     //
-    // The struct is supposed to have a size of 32 and alignment of 16, but on metal, it has size 24.
+    // The struct is supposed to have a size of 32 and alignment of 16.
     for ty in ["f32", "u32", "i32"] {
         let header = format!("struct Inner {{ vec: vec3<{ty}>, scalar1: u32, scalar2: u32 }}");
         let members = String::from("arr: array<Inner, 2>");
@@ -238,8 +238,7 @@ fn create_struct_layout_tests(storage_type: InputStorageType) -> Vec<ShaderTest>
                 &input_values,
                 &[0, 1, 2, 3, 4, 8, 9, 10, 11, 12],
             )
-            .header(header)
-            .failures(Backends::METAL),
+            .header(header),
         );
     }
 


### PR DESCRIPTION
**Connections**
Fixes #7803
Depends on #7807 

The deno changes are copied from #7709. If this lands first I'll remove the changes from that PR.

**Description**
See #7803 

Note I've only enabled the 1d tests to run. In higher dimensions we use more exotic texture formats, some of which fail. They also take a very long time to run, so there's probably a discussion to be had about whether that's desirable.

**Testing**
Added CTS test to run

**Squash or Rebase?**

Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
