### PR TITLE
[naga spv-in] Lay out entry point output structs correctly.

### DIFF
--- a/naga/tests/out/ir/spv-spec-constants.compact.ron
+++ b/naga/tests/out/ir/spv-spec-constants.compact.ron
@@ -160,10 +160,10 @@
                         binding: Some(BuiltIn(Position(
                             invariant: false,
                         ))),
-                        offset: 0,
+                        offset: 16,
                     ),
                 ],
-                span: 65535,
+                span: 32,
             ),
         ),
     ],

--- a/naga/tests/out/ir/spv-spec-constants.ron
+++ b/naga/tests/out/ir/spv-spec-constants.ron
@@ -251,10 +251,10 @@
                         binding: Some(BuiltIn(Position(
                             invariant: false,
                         ))),
-                        offset: 0,
+                        offset: 16,
                     ),
                 ],
-                span: 65535,
+                span: 32,
             ),
         ),
     ],

--- a/naga/tests/out/msl/spv-quad-vert.msl
+++ b/naga/tests/out/msl/spv-quad-vert.msl
@@ -15,6 +15,7 @@ struct gl_PerVertex {
 };
 struct VertexOutput {
     metal::float2 member;
+    char _pad1[8];
     metal::float4 gl_Position;
 };
 
@@ -53,6 +54,6 @@ vertex main_Output main_(
     main_1(v_uv, a_uv_1, unnamed, a_pos_1);
     metal::float2 _e7 = v_uv;
     metal::float4 _e8 = unnamed.gl_Position;
-    const auto _tmp = VertexOutput {_e7, _e8};
+    const auto _tmp = VertexOutput {_e7, {}, _e8};
     return main_Output { _tmp.member, _tmp.gl_Position };
 }


### PR DESCRIPTION
In the SPIR-V front end, when generating Naga IR `Struct` types to represent a SPIR-V entry point's `Output` variables, instead of saying "0xFFFF, // shouldn't matter", follow the usual rules in assigning struct member offsets and computing an overall size (`TypeInner::Struct::span`) for the resulting struct type.
