### PR TITLE
Fix OpenBSD compilation of `wgpu_hal::vulkan::drm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ Bottom level categories:
 
 - Get `vertex_index` & `instance_index` builtins working for indirect draws. By @teoxoy in [#7535](https://github.com/gfx-rs/wgpu/pull/7535)
 
+#### Vulkan
+
+- Fix OpenBSD compilation of `wgpu_hal::vulkan::drm`. By @ErichDonGubler in [#7810](https://github.com/gfx-rs/wgpu/pull/7810).
+
 #### Metal
 
 - Remove extraneous main thread warning in `fn surface_capabilities()`. By @jamesordner in [#7692](https://github.com/gfx-rs/wgpu/pull/7692)


### PR DESCRIPTION
**Connections**

- [Firefox's bug 1972160 - thunderbird fails to build wgpu-hal crate with mismatching trait on src/vulkan/drm.rs](https://bugzilla.mozilla.org/show_bug.cgi?id=1972160)
 	- Basically, more platforms are experiencing problems similar to <https://github.com/gfx-rs/wgpu/pull/7290>.

**Description**

Normally, `libc::stat::st_rdev`'s type and `libc::makedev`'s return type are the same: a `dev_t`. _However_, we've needed to work around cases where this isn't true in the past, breaking comparisons between them in the `wgpu_hal::vulkan::drm` module until a fix was put in place. In #7290, for instance, we needed to work around a weird case in Android where this wasn't true, but converting the `*_devid` side of the comparison to `u64` first worked.

Now, we've discovered another case (OpenBSD) where both sides of the comparison are `dev_t`, but _signed_. We've only dealt with unsigned integers until now, so our workaround to convert the `*_devid` side of the comparison breaks down because `i32` is not convertible to `u64` using `From::from`. Sigh! Time to find something else that works.

I think the simplest solution is to use an `as` cast. 😱 So, do that here: make a `to_u64!(…)` macro that force-converts things, `assert`ing that we're not casting something bigger than a `u64`. Then, apply it to both sides of our comparison. Voilà!

Also, document this weirdness, so I don't have to write it out in the event of _yet another_ weird divergence for the types in this comparison. 😅

**Testing**

- [x] Confirm that this actually fixes a problem for OpenBSD builds.

For CI going forward, 🤷🏻‍♂️ this is not a configuration we normally care to test! I'm not sure what the right solution here is. My suggestion is that we treat this as a one-off, since this is (AFAIK) the first fix motivated by OpenBSD specifically.

**Squash or Rebase?**

squush plz

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
