### PR TITLE
[deno] Don't report support for native-only features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,11 +715,11 @@ jobs:
       - name: Check for typos
         uses: crate-ci/typos@v1.33.1
 
-  cts-runner:
+  check-cts-runner:
     # runtime is normally 2 minutes
     timeout-minutes: 10
 
-    name: cts_runner
+    name: Clippy cts_runner
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -746,13 +746,9 @@ jobs:
         with:
           key: cts-runner-${{ env.CACHE_SUFFIX }}
 
-      - name: Build and Clippy
+      - name: Build Deno
         run: |
           cargo clippy --manifest-path cts_runner/Cargo.toml
-
-      - name: Tests
-        run: |
-          cargo test --manifest-path cts_runner/Cargo.toml
 
   # Separate job so that new advisories don't block CI.
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,11 +715,11 @@ jobs:
       - name: Check for typos
         uses: crate-ci/typos@v1.33.1
 
-  check-cts-runner:
+  cts-runner:
     # runtime is normally 2 minutes
     timeout-minutes: 10
 
-    name: Clippy cts_runner
+    name: cts_runner
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -746,9 +746,13 @@ jobs:
         with:
           key: cts-runner-${{ env.CACHE_SUFFIX }}
 
-      - name: Build Deno
+      - name: Build and Clippy
         run: |
           cargo clippy --manifest-path cts_runner/Cargo.toml
+
+      - name: Tests
+        run: |
+          cargo test --manifest-path cts_runner/Cargo.toml
 
   # Separate job so that new advisories don't block CI.
   #

--- a/cts_runner/examples/hello-compute.js
+++ b/cts_runner/examples/hello-compute.js
@@ -112,8 +112,8 @@ function isTypedArrayEqual(a, b) {
 const actual = new Uint32Array(data);
 const expected = new Uint32Array([0, 2, 7, 55]);
 
-console.error("actual", actual);
-console.error("expected", expected);
+console.log("actual", actual);
+console.log("expected", expected);
 
 if (!isTypedArrayEqual(actual, expected)) {
   throw new TypeError("Actual does not equal expected!");

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -5,14 +5,7 @@ webgpu:api,operation,compute,basic:memcpy:*
 //FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute_pipeline,overrides:*
 webgpu:api,operation,device,lost:*
-webgpu:api,validation,encoding,cmds,clearBuffer:buffer_state:*
-webgpu:api,validation,encoding,cmds,clearBuffer:buffer,device_mismatch:*
-webgpu:api,validation,encoding,cmds,clearBuffer:default_args:*
-webgpu:api,validation,encoding,cmds,clearBuffer:buffer_usage:*
-webgpu:api,validation,encoding,cmds,clearBuffer:size_alignment:*
-webgpu:api,validation,encoding,cmds,clearBuffer:offset_alignment:*
-webgpu:api,validation,encoding,cmds,clearBuffer:overflow:*
-webgpu:api,validation,encoding,cmds,clearBuffer:out_of_bounds:*
+webgpu:api,validation,encoding,cmds,clearBuffer:*
 webgpu:api,validation,encoding,cmds,compute_pass:set_pipeline:*
 webgpu:api,validation,encoding,cmds,compute_pass:dispatch_sizes:*
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_with_invalid_or_destroyed_texture:*
@@ -36,6 +29,7 @@ webgpu:api,validation,encoding,encoder_state:*
 webgpu:api,validation,encoding,encoder_open_state:non_pass_commands:*
 webgpu:api,validation,encoding,encoder_open_state:render_pass_commands:*
 //FAIL: webgpu:api,validation,encoding,encoder_open_state:render_bundle_commands:*
+// https://github.com/gfx-rs/wgpu/issues/7857
 webgpu:api,validation,encoding,encoder_open_state:compute_pass_commands:*
 webgpu:api,validation,encoding,beginComputePass:*
 webgpu:api,validation,encoding,beginRenderPass:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -5,10 +5,7 @@ webgpu:api,operation,compute,basic:memcpy:*
 //FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute_pipeline,overrides:*
 webgpu:api,operation,device,lost:*
-webgpu:api,validation,encoding,cmds,clearBuffer:buffer_state:bufferState="valid"
-//FAIL: webgpu:api,validation,encoding,cmds,clearBuffer:buffer_state:bufferState="invalid"
-// https://github.com/gfx-rs/wgpu/issues/7796 (Mac only)
-webgpu:api,validation,encoding,cmds,clearBuffer:buffer_state:bufferState="destroyed"
+webgpu:api,validation,encoding,cmds,clearBuffer:buffer_state:*
 webgpu:api,validation,encoding,cmds,clearBuffer:buffer,device_mismatch:*
 webgpu:api,validation,encoding,cmds,clearBuffer:default_args:*
 webgpu:api,validation,encoding,cmds,clearBuffer:buffer_usage:*

--- a/cts_runner/tests/features.js
+++ b/cts_runner/tests/features.js
@@ -1,0 +1,5 @@
+const adapter = await navigator.gpu.requestAdapter();
+
+if (adapter.features.has("mappable-primary-buffers")) {
+    throw new TypeError("Adapter should not report support for wgpu native-only features");
+}

--- a/cts_runner/tests/integration.rs
+++ b/cts_runner/tests/integration.rs
@@ -1,4 +1,9 @@
-use std::path::PathBuf;
+use std::{
+    fmt::{self, Debug, Display},
+    path::PathBuf,
+    process::Command,
+    str,
+};
 
 pub fn target_dir() -> PathBuf {
     let current_exe = std::env::current_exe().unwrap();
@@ -15,13 +20,38 @@ pub fn cts_runner_exe_path() -> PathBuf {
     p
 }
 
-#[test]
-fn hello_compute_example() {
-    let output = std::process::Command::new(cts_runner_exe_path())
-        .arg("examples/hello-compute.js")
-        .spawn()
-        .unwrap()
-        .wait_with_output()
+pub struct JsError;
+
+impl Display for JsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "JavaScript test returned an error")
+    }
+}
+
+impl Debug for JsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+type JsResult = Result<(), JsError>;
+
+fn exec_js_test(script: &str) -> JsResult {
+    let output = Command::new(cts_runner_exe_path())
+        .arg(script)
+        .output()
         .unwrap();
-    assert!(output.status.success())
+    println!("{}", str::from_utf8(&output.stdout).unwrap());
+    eprintln!("{}", str::from_utf8(&output.stderr).unwrap());
+    output.status.success().then_some(()).ok_or(JsError)
+}
+
+#[test]
+fn hello_compute_example() -> JsResult {
+    exec_js_test("examples/hello-compute.js")
+}
+
+#[test]
+fn features() -> JsResult {
+    exec_js_test("tests/features.js")
 }

--- a/cts_runner/tests/integration.rs
+++ b/cts_runner/tests/integration.rs
@@ -1,3 +1,7 @@
+// Tests for cts_runner
+//
+// As of June 2025, these tests are not run in CI.
+
 use std::{
     fmt::{self, Debug, Display},
     path::PathBuf,

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -84,6 +84,8 @@ impl GPUAdapter {
     fn features(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
         self.features.get(scope, |scope| {
             let features = self.instance.adapter_features(self.id);
+            // Only expose WebGPU features, not wgpu native-only features
+            let features = features & wgpu_types::Features::all_webgpu_mask();
             let features = features_to_feature_names(features);
             GPUSupportedFeatures::new(scope, features)
         })


### PR DESCRIPTION
Fixes #7796

Mask the adapter-supported features returned by wgpu before returning them to Javascript, to include only WebGPU-defined features.

This fixes the CTS test referenced in #7796, and adds it to CI. I've also added a dedicated test to cts_runner.

**Squash or Rebase?** Squash.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
