### PR TITLE
chore(cts): Fix parsing of Git for Windows version string

### DIFF
--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -161,6 +161,12 @@ fn parse_git_version_output(output: &str) -> anyhow::Result<GitVersion> {
     let raw_version = raw_version.trim_end(); // There should always be a newline at the end, but
                                               // we don't care if it's missing.
 
+    // Git for Windows suffixes the version with ".windows.<n>".
+    // Strip it if present.
+    let raw_version = raw_version
+        .split_once(".windows")
+        .map_or(raw_version, |(before, _after)| before);
+
     let parsed = GitVersion::try_from(
         raw_version
             .splitn(3, '.')
@@ -189,6 +195,7 @@ fn test_git_version_parsing() {
     test_ok!("git version 2.3.0", [2, 3, 0]);
     test_ok!("git version 0.255.0", [0, 255, 0]);
     test_ok!("git version 4.5.6", [4, 5, 6]);
+    test_ok!("git version 2.3.0.windows.1", [2, 3, 0]);
 
     macro_rules! test_err {
         ($input:expr, $msg:expr) => {


### PR DESCRIPTION
**Connections**
Regressed by #7800 

**Description**
Git for Windows adds an extra suffix to the version string. This is a follow up to #7800 that ensures we parse such git versions correctly rather than returning an error.

This is causing CTS runs to fail for me on CI. So I'm curious how it got through CI in the first place?

**Testing**
Added a test. CI now passes (presumably)

**Squash or Rebase?**

doesn't matter

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
