### PR TITLE
Skip `wgpu_gpu::oom::query_set_oom_test` on Vulkan.

### DIFF
--- a/tests/tests/wgpu-gpu/oom.rs
+++ b/tests/tests/wgpu-gpu/oom.rs
@@ -13,6 +13,9 @@ use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
 /// Backends for which OOM detection is implemented
 const OOM_DETECTION_IMPL: Backends = Backends::DX12.union(Backends::VULKAN);
 
+/// Backends for which query set OOM detection is implemented
+const QUERY_SET_OOM_DETECTION_IMPL: Backends = Backends::DX12;
+
 // All tests skip llvmpipe.
 // Even though llvmpipe supports VK_EXT_memory_budget it's happy to continue creating resources until
 // the process crashes with SIGABRT "memory allocation of X bytes failed" or the test times out.
@@ -125,7 +128,8 @@ static MAPPING_BUFFER_OOM_TEST: GpuTestConfiguration = GpuTestConfiguration::new
 static QUERY_SET_OOM_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .skip(FailureCase::backend(!OOM_DETECTION_IMPL))
+            // Vulkan: https://github.com/gfx-rs/wgpu/issues/7817
+            .skip(FailureCase::backend(!QUERY_SET_OOM_DETECTION_IMPL))
             // see comment at the top of the file
             .skip(FailureCase::backend_adapter(Backends::VULKAN, "llvmpipe")),
     )


### PR DESCRIPTION
Vulkan's `VK_EXT_memory_budget` extension doesn't cover query sets, so `wgpu_hal::vulkan::Device::error_if_would_oom_on_resource_allocation`'s tactic doesn't work to anticipate OOM errors from the Vulkan driver when creating query sets.

Without these checks, `wgpu_gpu::oom::query_set_oom_test` actually consumes a significant amount of memory and attracts the attention of the system's OOM killer. While it does get killed, the situation tends to adversely affect the stability of the rest of the system, and thus is not a friendly thing for a test run to do (#7817).

This change can be reverted once a suitable accounting method for query sets has been implemented on Vulkan.
