### PR TITLE
Report errors when `CommandEncoder.finish` is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,12 @@ Bottom level categories:
 #### WebGPU
 
 - The type of the `size` parameter to `copy_buffer_to_buffer` has changed from `BufferAddress` to `impl Into<Option<BufferAddress>>`. This achieves the spec-defined behavior of the value being optional, while still accepting existing calls without changes. By @andyleiserson in [#7659](https://github.com/gfx-rs/wgpu/pull/7659).
+- To bring wgpu's error reporting into compliance with the WebGPU specification, the error type returned from some functions has changed, and some errors may be raised at a different time than they were previously.
+  - The error type returned by many methods on `CommandEncoder`, `RenderPassEncoder`, `ComputePassEncoder`, and `RenderBundleEncoder` has changed to `EncoderStateError` or `PassStateError`. These functions will return the `Ended` variant of these errors if called on an encoder that is no longer active. Reporting of all other errors is deferred until a call to `finish()`.
+  - Variants holding a `CommandEncoderError` in the error enums `ClearError`, `ComputePassErrorInner`, `QueryError`, and `RenderPassErrorInner` have been replaced with variants holding an `EncoderStateError`.
+  - The definition of `enum CommandEncoderError` has changed significantly, to reflect which errors can be raised by `CommandEncoder.finish()`. There are also some errors that no longer appear directly in `CommandEncoderError`, and instead appear nested within the `RenderPass` or `ComputePass` variants.
+  - `CopyError` has been removed. Errors that were previously a `CopyError` are now a `CommandEncoderError` returned by `finish()`. (The detailed reasons for copies to fail were and still are described by `TransferError`, which was previously a variant of `CopyError`, and is now a variant of `CommandEncoderError`).
+
 
 #### HAL
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -1,14 +1,37 @@
 unittests:*
 webgpu:api,operation,command_buffer,basic:*
-webgpu:api,operation,command_buffer,copyBufferToBuffer:single:newSig=false;*
-// https://github.com/gfx-rs/wgpu/issues/7391
-//FAIL: webgpu:api,operation,command_buffer,copyBufferToBuffer:single:newSig=true;*
-webgpu:api,operation,command_buffer,copyBufferToBuffer:state_transitions:*
-webgpu:api,operation,command_buffer,copyBufferToBuffer:copy_order:*
+webgpu:api,operation,command_buffer,copyBufferToBuffer:*
 webgpu:api,operation,compute,basic:memcpy:*
 //FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute_pipeline,overrides:*
 webgpu:api,operation,device,lost:*
+webgpu:api,validation,encoding,cmds,clearBuffer:out_of_bounds,*
+webgpu:api,validation,encoding,cmds,compute_pass:set_pipeline:*
+webgpu:api,validation,encoding,cmds,compute_pass:dispatch_sizes:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_with_invalid_or_destroyed_texture:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture,device_mismatch:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:mipmap_level:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_usage:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:sample_count:*
+//FAIL: webgpu:api,validation,encoding,cmds,copyTextureToTexture:multisampled_copy_restrictions:*
+// texture_format_compatibility fails on Windows and Mac in CI.
+// It passes locally on Mac. It is also a relatively long test.
+//FAIL: webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_format_compatibility:*
+//FAIL: webgpu:api,validation,encoding,cmds,copyTextureToTexture:depth_stencil_copy_restrictions:*
+//FAIL: webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:*
+//FAIL: webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_within_same_texture:*
+//FAIL: webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_aspects:*
+// Fails on Windows, https://github.com/gfx-rs/wgpu/issues/7844.
+//FAIL: webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges_with_compressed_texture_formats:*
+webgpu:api,validation,encoding,cmds,index_access:*
+//FAIL: webgpu:api,validation,encoding,cmds,render,draw:*
+webgpu:api,validation,encoding,encoder_state:*
+webgpu:api,validation,encoding,encoder_open_state:non_pass_commands:*
+webgpu:api,validation,encoding,encoder_open_state:render_pass_commands:*
+//FAIL: webgpu:api,validation,encoding,encoder_open_state:render_bundle_commands:*
+webgpu:api,validation,encoding,encoder_open_state:compute_pass_commands:*
+webgpu:api,validation,encoding,beginComputePass:*
+webgpu:api,validation,encoding,beginRenderPass:*
 webgpu:api,validation,queue,submit:command_buffer,device_mismatch:*
 webgpu:api,validation,queue,submit:command_buffer,duplicate_buffers:*
 webgpu:api,validation,queue,submit:command_buffer,submit_invalidates:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -5,7 +5,17 @@ webgpu:api,operation,compute,basic:memcpy:*
 //FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute_pipeline,overrides:*
 webgpu:api,operation,device,lost:*
-webgpu:api,validation,encoding,cmds,clearBuffer:out_of_bounds,*
+webgpu:api,validation,encoding,cmds,clearBuffer:buffer_state:bufferState="valid"
+//FAIL: webgpu:api,validation,encoding,cmds,clearBuffer:buffer_state:bufferState="invalid"
+// https://github.com/gfx-rs/wgpu/issues/7796 (Mac only)
+webgpu:api,validation,encoding,cmds,clearBuffer:buffer_state:bufferState="destroyed"
+webgpu:api,validation,encoding,cmds,clearBuffer:buffer,device_mismatch:*
+webgpu:api,validation,encoding,cmds,clearBuffer:default_args:*
+webgpu:api,validation,encoding,cmds,clearBuffer:buffer_usage:*
+webgpu:api,validation,encoding,cmds,clearBuffer:size_alignment:*
+webgpu:api,validation,encoding,cmds,clearBuffer:offset_alignment:*
+webgpu:api,validation,encoding,cmds,clearBuffer:overflow:*
+webgpu:api,validation,encoding,cmds,clearBuffer:out_of_bounds:*
 webgpu:api,validation,encoding,cmds,compute_pass:set_pipeline:*
 webgpu:api,validation,encoding,cmds,compute_pass:dispatch_sizes:*
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_with_invalid_or_destroyed_texture:*

--- a/deno_webgpu/error.rs
+++ b/deno_webgpu/error.rs
@@ -19,6 +19,7 @@ use wgpu_core::command::CommandEncoderError;
 use wgpu_core::command::ComputePassError;
 use wgpu_core::command::CreateRenderBundleError;
 use wgpu_core::command::EncoderStateError;
+use wgpu_core::command::PassStateError;
 use wgpu_core::command::QueryError;
 use wgpu_core::command::RenderBundleError;
 use wgpu_core::command::RenderPassError;
@@ -200,6 +201,12 @@ fn fmt_err(err: &(dyn std::error::Error + 'static)) -> String {
 
 impl From<EncoderStateError> for GPUError {
     fn from(err: EncoderStateError) -> Self {
+        GPUError::Validation(fmt_err(&err))
+    }
+}
+
+impl From<PassStateError> for GPUError {
+    fn from(err: PassStateError) -> Self {
         GPUError::Validation(fmt_err(&err))
     }
 }

--- a/tests/tests/wgpu-gpu/bind_group_layout_dedup.rs
+++ b/tests/tests/wgpu-gpu/bind_group_layout_dedup.rs
@@ -316,11 +316,11 @@ fn separate_pipelines_have_incompatible_derived_bgls(ctx: TestingContext) {
     pass.set_bind_group(0, &bg2, &[]);
     pass.dispatch_workgroups(1, 1, 1);
 
+    drop(pass);
+
     fail(
         &ctx.device,
-        || {
-            drop(pass);
-        },
+        || encoder.finish(),
         Some("label at index 0 is not compatible with the corresponding bindgrouplayout"),
     );
 }
@@ -388,13 +388,13 @@ fn derived_bgls_incompatible_with_regular_bgls(ctx: TestingContext) {
     pass.set_bind_group(0, &bg, &[]);
     pass.dispatch_workgroups(1, 1, 1);
 
+    drop(pass);
+
     fail(
         &ctx.device,
-        || {
-            drop(pass);
-        },
+        || encoder.finish(),
         Some("label at index 0 is not compatible with the corresponding bindgrouplayout"),
-    )
+    );
 }
 
 #[gpu_test]

--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -347,34 +347,34 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
         );
 
         // Creating a compute pass should fail.
+        let pass = encoder_for_compute_pass.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: None,
+            timestamp_writes: None,
+        });
+        drop(pass);
         fail(
             &ctx.device,
-            || {
-                encoder_for_compute_pass.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                    label: None,
-                    timestamp_writes: None,
-                });
-            },
+            || encoder_for_compute_pass.finish(),
             Some("device with '' label is invalid"),
         );
 
         // Creating a render pass should fail.
+        let pass = encoder_for_render_pass.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: None,
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                ops: wgpu::Operations::default(),
+                resolve_target: None,
+                view: &target_view,
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+        drop(pass);
         fail(
             &ctx.device,
-            || {
-                encoder_for_render_pass.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: None,
-                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        ops: wgpu::Operations::default(),
-                        resolve_target: None,
-                        view: &target_view,
-                        depth_slice: None,
-                    })],
-                    depth_stencil_attachment: None,
-                    timestamp_writes: None,
-                    occlusion_query_set: None,
-                });
-            },
+            || encoder_for_render_pass.finish(),
             Some("device with '' label is invalid"),
         );
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -85,6 +85,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{
+    convert::Infallible,
     num::{NonZeroU32, NonZeroU64},
     ops::Range,
 };
@@ -153,7 +154,7 @@ pub struct RenderBundleEncoderDescriptor<'a> {
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RenderBundleEncoder {
-    base: BasePass<RenderCommand>,
+    base: BasePass<RenderCommand, Infallible>,
     parent_id: id::DeviceId,
     pub(crate) context: RenderPassContext,
     pub(crate) is_depth_read_only: bool,
@@ -170,7 +171,7 @@ impl RenderBundleEncoder {
     pub fn new(
         desc: &RenderBundleEncoderDescriptor,
         parent_id: id::DeviceId,
-        base: Option<BasePass<RenderCommand>>,
+        base: Option<BasePass<RenderCommand, Infallible>>,
     ) -> Result<Self, CreateRenderBundleError> {
         let (is_depth_read_only, is_stencil_read_only) = match desc.depth_stencil {
             Some(ds) => {
@@ -248,7 +249,7 @@ impl RenderBundleEncoder {
     }
 
     #[cfg(feature = "trace")]
-    pub(crate) fn to_base_pass(&self) -> BasePass<RenderCommand> {
+    pub(crate) fn to_base_pass(&self) -> BasePass<RenderCommand, Infallible> {
         self.base.clone()
     }
 
@@ -466,6 +467,7 @@ impl RenderBundleEncoder {
         let render_bundle = RenderBundle {
             base: BasePass {
                 label: desc.label.as_deref().map(str::to_owned),
+                error: None,
                 commands,
                 dynamic_offsets: flat_dynamic_offsets,
                 string_data: self.base.string_data,
@@ -863,7 +865,7 @@ pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
 pub struct RenderBundle {
     // Normalized command stream. It can be executed verbatim,
     // without re-binding anything on the pipeline change.
-    base: BasePass<ArcRenderCommand>,
+    base: BasePass<ArcRenderCommand, Infallible>,
     pub(super) is_depth_read_only: bool,
     pub(super) is_stencil_read_only: bool,
     pub(crate) device: Arc<Device>,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1162,6 +1162,17 @@ fn write_timestamp(
 }
 
 // Recording a compute pass.
+//
+// The only error that should be returned from these methods is
+// `EncoderStateError::Ended`, when the pass has already ended and an immediate
+// validation error is raised.
+//
+// All other errors should be stored in the pass for later reporting when
+// `CommandEncoder.finish()` is called.
+//
+// The `pass_try!` macro should be used to handle errors appropriately. Note
+// that the `pass_try!` and `pass_base!` macros may return early from the
+// function that invokes them, like the `?` operator.
 impl Global {
     pub fn compute_pass_set_bind_group(
         &self,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1577,7 +1577,7 @@ impl Global {
 
             arc_desc.timestamp_writes = desc
                 .timestamp_writes
-                .map(|tw| Global::validate_pass_timestamp_writes(device, &query_sets, tw))
+                .map(|tw| Global::validate_pass_timestamp_writes::<CommandEncoderError>(device, &query_sets, tw))
                 .transpose()?;
 
             arc_desc.occlusion_query_set =

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -3119,6 +3119,18 @@ fn execute_bundle(
     Ok(())
 }
 
+// Recording a render pass.
+//
+// The only error that should be returned from these methods is
+// `EncoderStateError::Ended`, when the pass has already ended and an immediate
+// validation error is raised.
+//
+// All other errors should be stored in the pass for later reporting when
+// `CommandEncoder.finish()` is called.
+//
+// The `pass_try!` macro should be used to handle errors appropriately. Note
+// that the `pass_try!` and `pass_base!` macros may return early from the
+// function that invokes them, like the `?` operator.
 impl Global {
     fn resolve_render_pass_buffer_id(
         &self,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -1,5 +1,5 @@
 use alloc::{string::String, vec::Vec};
-use core::ops::Range;
+use core::{convert::Infallible, ops::Range};
 
 #[cfg(feature = "trace")]
 use {alloc::borrow::Cow, std::io::Write as _};
@@ -109,7 +109,7 @@ pub enum Action<'a> {
     CreateRenderBundle {
         id: id::RenderBundleId,
         desc: crate::command::RenderBundleEncoderDescriptor<'a>,
-        base: crate::command::BasePass<crate::command::RenderCommand>,
+        base: crate::command::BasePass<crate::command::RenderCommand, Infallible>,
     },
     DestroyRenderBundle(id::RenderBundleId),
     CreateQuerySet {
@@ -192,11 +192,11 @@ pub enum Command {
     PopDebugGroup,
     InsertDebugMarker(String),
     RunComputePass {
-        base: crate::command::BasePass<crate::command::ComputeCommand>,
+        base: crate::command::BasePass<crate::command::ComputeCommand, Infallible>,
         timestamp_writes: Option<crate::command::PassTimestampWrites>,
     },
     RunRenderPass {
-        base: crate::command::BasePass<crate::command::RenderCommand>,
+        base: crate::command::BasePass<crate::command::RenderCommand, Infallible>,
         target_colors: Vec<Option<crate::command::RenderPassColorAttachment>>,
         target_depth_stencil: Option<crate::command::RenderPassDepthStencilAttachment>,
         timestamp_writes: Option<crate::command::PassTimestampWrites>,

--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -34,7 +34,7 @@ pub fn run_cts(shell: Shell, mut args: Arguments) -> anyhow::Result<()> {
         tests.extend(shell.read_file(file)?.lines().filter_map(|line| {
             let trimmed = line.trim();
             let is_comment = trimmed.starts_with("//") || trimmed.starts_with("#");
-            (!is_comment).then(|| OsString::from(trimmed))
+            (!trimmed.is_empty() && !is_comment).then(|| OsString::from(trimmed))
         }))
     }
 


### PR DESCRIPTION
This has the rest of the error reporting changes for #7391. I don't think there is urgency to get these changes in before the train leaves, but it's probably better to take either all of them or none of them than to take some of them, so here's a PR with all of them. It can be reviewed commit-by-commit if that's easier.

As in the other PRs, turning on the "hide whitespace" option will substantially reduce the diff.

**Testing**
Enables relevant CTS tests, and updates some wgpu tests that are sensitive to the timing of error reporting.

**Squash or Rebase?** Rebase, but check for fixups that should be squashed first.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] Add a `CHANGELOG.md` entry.
