### PR TITLE
Expose raw_factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Bottom level categories:
 #### D3D12
 
 - Remove the need for dxil.dll. By @teoxoy in [#7566](https://github.com/gfx-rs/wgpu/pull/7566)
+- Ability to get the raw `IDXGIFactory4` from `Instance`. By @MendyBerger in [#7827](https://github.com/gfx-rs/wgpu/pull/7827)
 
 #### Vulkan
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -469,6 +469,7 @@ impl Instance {
     pub unsafe fn raw_factory4(&self) -> &Dxgi::IDXGIFactory4 {
         self.factory.deref()
     }
+
     pub unsafe fn create_surface_from_visual(&self, visual: *mut ffi::c_void) -> Surface {
         let visual = unsafe { DirectComposition::IDCompositionVisual::from_raw_borrowed(&visual) }
             .expect("COM pointer should not be NULL");

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -465,6 +465,10 @@ pub struct Instance {
 }
 
 impl Instance {
+    /// Get the raw DXGI factory associated with this instance.
+    pub unsafe fn raw_factory4(&self) -> &Dxgi::IDXGIFactory4 {
+        self.factory.deref()
+    }
     pub unsafe fn create_surface_from_visual(&self, visual: *mut ffi::c_void) -> Surface {
         let visual = unsafe { DirectComposition::IDCompositionVisual::from_raw_borrowed(&visual) }
             .expect("COM pointer should not be NULL");


### PR DESCRIPTION
**Connections**
Works towards #4067

We have a case where we need access to the dxgi factory. Device, adapter, and texture already expose their underlying objects.

**Description**
Added ability to get the raw `IDXGIFactory4` from `Instance`.

There wasn't any prier convention how to expose a dx12 object with a version number, so wasn't sure if I should also add a version number to the method, like `raw_factory4`.
I did end up adding the version in the method name, that way it can be deprecated in favor of a newer method without being a breaking change. But happy to change it to just be `raw_factory` if that's preferred.

**Testing**
_Explain how this change is tested._

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
