### PR TITLE
Merge shared functionality from render and compute passes

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1315,7 +1315,7 @@ impl State {
     fn pipeline(&self) -> Result<&PipelineState, RenderBundleErrorInner> {
         self.pipeline
             .as_ref()
-            .ok_or(DrawError::MissingPipeline.into())
+            .ok_or(DrawError::MissingPipeline(pass::MissingPipeline).into())
     }
 
     /// Mark all non-empty bind group table entries from `index` onwards as dirty.

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -118,6 +118,7 @@ use crate::{
 };
 
 use super::{
+    pass,
     render_command::{ArcRenderCommand, RenderCommand},
     DrawKind,
 };
@@ -527,11 +528,13 @@ fn set_bind_group(
 
     let max_bind_groups = state.device.limits.max_bind_groups;
     if index >= max_bind_groups {
-        return Err(RenderCommandError::BindGroupIndexOutOfRange {
-            index,
-            max: max_bind_groups,
-        }
-        .into());
+        return Err(
+            RenderCommandError::BindGroupIndexOutOfRange(pass::BindGroupIndexOutOfRange {
+                index,
+                max: max_bind_groups,
+            })
+            .into(),
+        );
     }
 
     // Identify the next `num_dynamic_offsets` entries from `dynamic_offsets`.

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -20,7 +20,7 @@ pub enum DrawError {
     #[error("Blend constant needs to be set")]
     MissingBlendConstant,
     #[error("Render pipeline must be set")]
-    MissingPipeline,
+    MissingPipeline(#[from] pass::MissingPipeline),
     #[error("Currently set {pipeline} requires vertex buffer {index} to be set")]
     MissingVertexBuffer {
         pipeline: ResourceErrorIdent,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -2,6 +2,8 @@ use alloc::boxed::Box;
 
 use thiserror::Error;
 
+use super::bind::BinderError;
+use crate::command::pass;
 use crate::{
     binding_model::{LateMinBufferBindingSizeMismatch, PushConstantUploadError},
     resource::{
@@ -10,8 +12,6 @@ use crate::{
     },
     track::ResourceUsageCompatibilityError,
 };
-
-use super::bind::BinderError;
 
 /// Error validating a draw call.
 #[derive(Clone, Debug, Error)]
@@ -61,8 +61,8 @@ pub enum DrawError {
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum RenderCommandError {
-    #[error("Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}")]
-    BindGroupIndexOutOfRange { index: u32, max: u32 },
+    #[error(transparent)]
+    BindGroupIndexOutOfRange(#[from] pass::BindGroupIndexOutOfRange),
     #[error("Vertex buffer index {index} is greater than the device's requested `max_vertex_buffers` limit {max}")]
     VertexBufferIndexOutOfRange { index: u32, max: u32 },
     #[error("Render pipeline targets are incompatible with render pass")]

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -6,6 +6,7 @@ mod compute;
 mod compute_command;
 mod draw;
 mod memory_init;
+mod pass;
 mod query;
 mod ray_tracing;
 mod render;

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -1,0 +1,159 @@
+//! Generic pass functions that both compute and render passes need.
+
+use crate::api_log;
+use crate::binding_model::{BindError, BindGroup};
+use crate::command::bind::Binder;
+use crate::command::memory_init::{CommandBufferTextureMemoryActions, SurfacesInDiscardState};
+use crate::command::CommandBuffer;
+use crate::device::{Device, DeviceError};
+use crate::init_tracker::BufferInitTrackerAction;
+use crate::ray_tracing::AsAction;
+use crate::resource::{DestroyedResourceError, Labeled, ParentDevice};
+use crate::snatch::SnatchGuard;
+use crate::track::{ResourceUsageCompatibilityError, Tracker, UsageScope};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use thiserror::Error;
+use wgt::DynamicOffset;
+
+#[derive(Clone, Debug, Error)]
+#[error(
+    "Bind group index {index} is greater than the device's requested `max_bind_group` limit {max}"
+)]
+pub struct BindGroupIndexOutOfRange {
+    pub index: u32,
+    pub max: u32,
+}
+
+pub(crate) struct BaseState<'scope, 'snatch_guard, 'cmd_buf, 'raw_encoder> {
+    pub(crate) device: &'cmd_buf Arc<Device>,
+
+    pub(crate) raw_encoder: &'raw_encoder mut dyn hal::DynCommandEncoder,
+
+    pub(crate) tracker: &'cmd_buf mut Tracker,
+    pub(crate) buffer_memory_init_actions: &'cmd_buf mut Vec<BufferInitTrackerAction>,
+    pub(crate) texture_memory_actions: &'cmd_buf mut CommandBufferTextureMemoryActions,
+    pub(crate) as_actions: &'cmd_buf mut Vec<AsAction>,
+
+    /// Immediate texture inits required because of prior discards. Need to
+    /// be inserted before texture reads.
+    pub(crate) pending_discard_init_fixups: SurfacesInDiscardState,
+
+    pub(crate) scope: UsageScope<'scope>,
+
+    pub(crate) binder: Binder,
+
+    pub(crate) temp_offsets: Vec<u32>,
+
+    pub(crate) dynamic_offset_count: usize,
+
+    pub(crate) snatch_guard: &'snatch_guard SnatchGuard<'snatch_guard>,
+}
+
+pub(crate) fn set_bind_group<E>(
+    state: &mut BaseState,
+    cmd_buf: &CommandBuffer,
+    dynamic_offsets: &[DynamicOffset],
+    index: u32,
+    num_dynamic_offsets: usize,
+    bind_group: Option<Arc<BindGroup>>,
+    merge_bind_groups: bool,
+) -> Result<(), E>
+where
+    E: From<DeviceError>
+        + From<BindGroupIndexOutOfRange>
+        + From<ResourceUsageCompatibilityError>
+        + From<DestroyedResourceError>
+        + From<BindError>,
+{
+    if bind_group.is_none() {
+        api_log!("Pass::set_bind_group {index} None");
+    } else {
+        api_log!(
+            "Pass::set_bind_group {index} {}",
+            bind_group.as_ref().unwrap().error_ident()
+        );
+    }
+
+    let max_bind_groups = state.device.limits.max_bind_groups;
+    if index >= max_bind_groups {
+        return Err(BindGroupIndexOutOfRange {
+            index,
+            max: max_bind_groups,
+        }
+        .into());
+    }
+
+    state.temp_offsets.clear();
+    state.temp_offsets.extend_from_slice(
+        &dynamic_offsets
+            [state.dynamic_offset_count..state.dynamic_offset_count + num_dynamic_offsets],
+    );
+    state.dynamic_offset_count += num_dynamic_offsets;
+
+    if bind_group.is_none() {
+        // TODO: Handle bind_group None.
+        return Ok(());
+    }
+
+    let bind_group = bind_group.unwrap();
+    let bind_group = state.tracker.bind_groups.insert_single(bind_group);
+
+    bind_group.same_device_as(cmd_buf)?;
+
+    bind_group.validate_dynamic_bindings(index, &state.temp_offsets)?;
+
+    if merge_bind_groups {
+        // merge the resource tracker in
+        unsafe {
+            state.scope.merge_bind_group(&bind_group.used)?;
+        }
+    }
+    //Note: stateless trackers are not merged: the lifetime reference
+    // is held to the bind group itself.
+
+    state
+        .buffer_memory_init_actions
+        .extend(bind_group.used_buffer_ranges.iter().filter_map(|action| {
+            action
+                .buffer
+                .initialization_status
+                .read()
+                .check_action(action)
+        }));
+    for action in bind_group.used_texture_ranges.iter() {
+        state
+            .pending_discard_init_fixups
+            .extend(state.texture_memory_actions.register_init_action(action));
+    }
+
+    let used_resource = bind_group
+        .used
+        .acceleration_structures
+        .into_iter()
+        .map(|tlas| AsAction::UseTlas(tlas.clone()));
+
+    state.as_actions.extend(used_resource);
+
+    let pipeline_layout = state.binder.pipeline_layout.clone();
+    let entries = state
+        .binder
+        .assign_group(index as usize, bind_group, &state.temp_offsets);
+    if !entries.is_empty() && pipeline_layout.is_some() {
+        let pipeline_layout = pipeline_layout.as_ref().unwrap().raw();
+        for (i, e) in entries.iter().enumerate() {
+            if let Some(group) = e.group.as_ref() {
+                let raw_bg = group.try_raw(state.snatch_guard)?;
+                unsafe {
+                    state.raw_encoder.set_bind_group(
+                        pipeline_layout,
+                        index + i as u32,
+                        Some(raw_bg),
+                        &e.dynamic_offsets,
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
**Connections**
Preparation for ray tracing pipelines (specifically the new pass that would be added).

**Description**
There were many duplicated functions, and some duplicated functionality between render and compute passes when actually recording the commands. This confused me, and I didn't realise there were two `set_bind_group` functions, and so some ray tracing validation was only in one. To implement ray tracing pipelines, a third pass would have to be introduced, which would cause a third duplication of this code.

Some things to note:
- ~~For some reason, compute passes used a tracker which took things from a usage scope, while render passes just used the usage scope directly. I couldn't find a reason this was necessary, but there might be a particular reason.~~ re-added this.
- Compute passes have an extra push constant field to reset push constants after indirect validation, there was a `todo` there, but I couldn't see why, and removed it as part of the refactor, but I can add it back if needed.

**Testing**
Tries to just keep all existing functionality.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`.
- [x] Run `cargo xtask test` to run tests.
  - There were a few failures on my machine, but none seem to be introduced by this. 
- [N/a] If this contains user-facing changes, add a `CHANGELOG.md` entry. Internal changes only.
