### PR TITLE
add into_custom api for Instance Queue, and Device

### DIFF
--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -47,6 +47,15 @@ impl Device {
         }
     }
 
+    #[cfg(custom)]
+    /// Convert Device into custom implementation.
+    ///
+    /// This is useful for wrapping the an existing device implementation to
+    /// implement a new custom device interface
+    pub fn into_custom<T: custom::DeviceInterface>(self) -> crate::dispatch::DispatchDevice {
+        self.inner
+    }
+
     /// Constructs a stub device for testing using [`Backend::Noop`].
     ///
     /// This is a convenience function which avoids the configuration, `async`, and fallibility

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -52,7 +52,7 @@ impl Device {
     ///
     /// This is useful for wrapping the an existing device implementation to
     /// implement a new custom device interface
-    pub fn into_custom<T: custom::DeviceInterface>(self) -> crate::dispatch::DispatchDevice {
+    pub fn into_custom(self) -> crate::dispatch::DispatchDevice {
         self.inner
     }
 

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -207,6 +207,15 @@ impl Instance {
     }
 
     #[cfg(custom)]
+    /// Convert Instance into custom implementation.
+    ///
+    /// This is useful for wrapping the an existing instance implementation to
+    /// implement a new custom instance interface
+    pub fn into_custom<T: custom::InstanceInterface>(self) -> crate::dispatch::DispatchInstance {
+        self.inner
+    }
+
+    #[cfg(custom)]
     /// Returns custom implementation of Instance (if custom backend and is internally T)
     pub fn as_custom<T: custom::InstanceInterface>(&self) -> Option<&T> {
         self.inner.as_custom()

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -211,7 +211,7 @@ impl Instance {
     ///
     /// This is useful for wrapping the an existing instance implementation to
     /// implement a new custom instance interface
-    pub fn into_custom<T: custom::InstanceInterface>(self) -> crate::dispatch::DispatchInstance {
+    pub fn into_custom(self) -> crate::dispatch::DispatchInstance {
         self.inner
     }
 

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -33,6 +33,15 @@ impl Queue {
             inner: dispatch::DispatchQueue::custom(queue),
         }
     }
+
+    #[cfg(custom)]
+    /// Convert Queue into custom implementation.
+    ///
+    /// This is useful for wrapping the an existing queue implementation to
+    /// implement a new custom queue interface
+    pub fn into_custom<T: custom::QueueInterface>(self) -> crate::dispatch::DispatchQueue {
+        self.inner
+    }
 }
 
 /// Identifier for a particular call to [`Queue::submit`]. Can be used

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -39,7 +39,7 @@ impl Queue {
     ///
     /// This is useful for wrapping the an existing queue implementation to
     /// implement a new custom queue interface
-    pub fn into_custom<T: custom::QueueInterface>(self) -> crate::dispatch::DispatchQueue {
+    pub fn into_custom(self) -> crate::dispatch::DispatchQueue {
         self.inner
     }
 }


### PR DESCRIPTION
**Connections**

related issue: https://github.com/gfx-rs/wgpu/issues/7714 and specific discussion: https://github.com/gfx-rs/wgpu/issues/7714#issuecomment-2968876914

**Description**

This PR adds util methods to convert some wgpu-level api into its internal custom one. Currently, only for `Instance`, `Queue` and `Device`, as these are the most common places to inject custom logic.

**Testing**

The change is simple to verify.

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
