### PR TITLE
fix(webgpu): set_unclipped_depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,10 @@ Bottom level categories:
 
 - Remove extraneous main thread warning in `fn surface_capabilities()`. By @jamesordner in [#7692](https://github.com/gfx-rs/wgpu/pull/7692)
 
+#### WebGPU
+
+- Fix setting unclipped_depth. By @atlv24 in [#7841](https://github.com/gfx-rs/wgpu/pull/7841)
+
 ### Changes
 
 - Loosen Viewport validation requirements to match the [new specs](https://github.com/gpuweb/gpuweb/pull/5025). By @ebbdrop in [#7564](https://github.com/gfx-rs/wgpu/pull/7564)

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -380,8 +380,7 @@ fn map_primitive_state(primitive: &wgt::PrimitiveState) -> webgpu_sys::GpuPrimit
         PrimitiveTopology::TriangleStrip => pt::TriangleStrip,
     });
 
-    //TODO:
-    //mapped.unclipped_depth(primitive.unclipped_depth);
+    mapped.set_unclipped_depth(primitive.unclipped_depth);
 
     match primitive.polygon_mode {
         wgt::PolygonMode::Fill => {}


### PR DESCRIPTION
**Connections**
https://github.com/bevyengine/bevy/issues/19626

**Description**
At Bevy we've been dealing with shadows disappearing at certain view angles on WebGPU: https://github.com/bevyengine/bevy/issues/19626

One potential fix we found was ignoring the reported value of DEPTH_CLIP_CONTROL on WebGPU: https://github.com/bevyengine/bevy/pull/19785

This suggests that WebGPU is either incorrectly reporting support of the feature, or there is a wgpu bug. I scanned through the codebase and found this line:
https://github.com/gfx-rs/wgpu/blob/440b33f4c60dd5c014b7f6c9584c6736cd4e9158/wgpu/src/backend/webgpu.rs#L384

```rs
    //TODO:
    //mapped.unclipped_depth(primitive.unclipped_depth);
```

I went digging through git blame for an explanation, and it was moved around and renamed as a comment since but originated here: https://github.com/i509VCB/wgpu/commit/756ea0e51ff2a58b5edac910ba546f80ffba800e#diff-22b854c44dc9db01eda3ade5dee571eb22a526b759ce2a6da4739f28435faedb

I couldn't find a PR for this, seems like it was just commited directly to master and may have been an oversight, but I'm not sure.

So I uncommented the line, got it to compile by using the set_ variant, and tested it, and it fixes our problem.

**Testing**
Linked bevy issue has a repro case

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
