### PR TITLE
Tolerate destruction of textures used in immediate queue operations prior to submit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
  "deno_web",
  "deno_webgpu",
  "deno_webidl",
+ "env_logger",
  "termcolor",
  "tokio",
 ]

--- a/cts_runner/Cargo.toml
+++ b/cts_runner/Cargo.toml
@@ -7,6 +7,9 @@ description = "CTS runner for wgpu"
 license.workspace = true
 publish = false
 
+[dependencies]
+env_logger.workspace = true
+
 # We make all dependencies conditional on not being wasm,
 # so the whole workspace can built as wasm.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/cts_runner/src/main.rs
+++ b/cts_runner/src/main.rs
@@ -147,5 +147,6 @@ impl deno_web::TimersPermission for Permissions {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
+    env_logger::init();
     unwrap_or_exit(run().await)
 }

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -43,6 +43,7 @@ webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bind_grou
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bind_groups_and_pipeline_layout_mismatch:encoderType="render%20pass";*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:buffer_binding,render_pipeline:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:sampler_binding,render_pipeline:*
+webgpu:api,validation,image_copy,texture_related:format:dimension="1d";*
 webgpu:api,validation,queue,submit:command_buffer,device_mismatch:*
 webgpu:api,validation,queue,submit:command_buffer,duplicate_buffers:*
 webgpu:api,validation,queue,submit:command_buffer,submit_invalidates:*

--- a/tests/tests/wgpu-gpu/queue_transfer.rs
+++ b/tests/tests/wgpu-gpu/queue_transfer.rs
@@ -1,6 +1,56 @@
 //! Tests for buffer copy validation.
 
+use wgpu::PollType;
 use wgpu_test::{fail, gpu_test, GpuTestConfiguration};
+
+#[gpu_test]
+static QUEUE_WRITE_TEXTURE_THEN_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
+    .run_sync(|ctx| {
+        let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            size: wgpu::Extent3d {
+                width: 64,
+                height: 32,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba32Float,
+            usage: wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+
+        let data = vec![255; 1024];
+
+        ctx.queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d { x: 0, y: 0, z: 0 },
+                aspect: wgpu::TextureAspect::All,
+            },
+            &data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(1024),
+                rows_per_image: Some(32),
+            },
+            wgpu::Extent3d {
+                width: 64,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        // Unlike textures used in a command buffer, which must not be destroyed prior to calling
+        // submit, it is permissible to destroy a texture used in an immediate queue operation
+        // before calling submit.
+        texture.destroy();
+
+        ctx.queue.submit([]);
+        ctx.device.poll(PollType::wait()).unwrap();
+    });
 
 #[gpu_test]
 static QUEUE_WRITE_TEXTURE_OVERFLOW: GpuTestConfiguration =

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1279,7 +1279,11 @@ impl Queue {
                                     .unwrap()
                             };
                         }
-                        Err(e) => break 'error Err(e.into()),
+                        // The texture must not have been destroyed when its usage here was
+                        // encoded. If it was destroyed after that, then it was transferred
+                        // to `pending_writes.temp_resources` at the time of destruction, so
+                        // we are still okay to use it.
+                        Err(DestroyedResourceError(_)) => {}
                     }
                 }
 


### PR DESCRIPTION
Textures used in "immediate" operations on GPUQueue (e.g. `writeTexture`) must not be destroyed at the time that `writeTexture` is called, but it is okay to destroy the texture at any point after that. The actual commands effecting `writeTexture` will not be executed until the next submit, but my understanding is that that is our implementation detail.

Textures that are in use by a pending command buffer are held in `pending_writes` after `destroy` is called. Thus, it is safe to ignore a `DestroyedResourceError` accessing the texture.

I've also included a separate commit that adds `env_logger` to `cts_runner`.

**Testing**
This may fix a large number of CTS tests, I haven't tried to identify them all, but I did add one set. I also added a directed test.

**Squash or Rebase?** Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
