### PR TITLE
Fix warnings for unrecognized Vulkan present mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Bottom level categories:
 #### Vulkan
 
 - Fix OpenBSD compilation of `wgpu_hal::vulkan::drm`. By @ErichDonGubler in [#7810](https://github.com/gfx-rs/wgpu/pull/7810).
+- Fix warnings for unrecognized present mode. By @Wumpf in [#7850](https://github.com/gfx-rs/wgpu/pull/7850).
 
 #### Metal
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5011,7 +5011,6 @@ dependencies = [
  "naga",
  "ndk-sys 0.6.0+11769913",
  "objc",
- "once_cell",
  "ordered-float 5.0.0",
  "parking_lot",
  "portable-atomic",

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -468,17 +468,25 @@ pub fn map_present_mode(mode: wgt::PresentMode) -> vk::PresentModeKHR {
 }
 
 pub fn map_vk_present_mode(mode: vk::PresentModeKHR) -> Option<wgt::PresentMode> {
-    if mode == vk::PresentModeKHR::IMMEDIATE {
-        Some(wgt::PresentMode::Immediate)
-    } else if mode == vk::PresentModeKHR::MAILBOX {
-        Some(wgt::PresentMode::Mailbox)
-    } else if mode == vk::PresentModeKHR::FIFO {
-        Some(wgt::PresentMode::Fifo)
-    } else if mode == vk::PresentModeKHR::FIFO_RELAXED {
-        Some(wgt::PresentMode::FifoRelaxed)
-    } else {
-        log::warn!("Unrecognized present mode {:?}", mode);
-        None
+    // Not exposed in Ash yet.
+    const FIFO_LATEST_READY: vk::PresentModeKHR = vk::PresentModeKHR::from_raw(1_000_361_000);
+
+    // See https://registry.khronos.org/vulkan/specs/latest/man/html/VkPresentModeKHR.html
+    match mode {
+        vk::PresentModeKHR::IMMEDIATE => Some(wgt::PresentMode::Immediate),
+        vk::PresentModeKHR::MAILBOX => Some(wgt::PresentMode::Mailbox),
+        vk::PresentModeKHR::FIFO => Some(wgt::PresentMode::Fifo),
+        vk::PresentModeKHR::FIFO_RELAXED => Some(wgt::PresentMode::FifoRelaxed),
+
+        // Modes that aren't exposed yet.
+        vk::PresentModeKHR::SHARED_DEMAND_REFRESH => None,
+        vk::PresentModeKHR::SHARED_CONTINUOUS_REFRESH => None,
+        FIFO_LATEST_READY => None,
+
+        _ => {
+            log::debug!("Unrecognized present mode {:?}", mode);
+            None
+        }
     }
 }
 


### PR DESCRIPTION
**Connections**
* https://github.com/rerun-io/rerun/issues/10286
* https://github.com/gfx-rs/wgpu/issues/3206

**Description**
Got a lot of log spam on windows
```
Unrecognized present mode 1000361000
```

Encountering a present mode we don't support isn't worth a warning in the first place imho (surprise there's feature that aren't covere!), but also we should explicitly handle the present modes we _can_ know. PR does both!

**Testing**
ran example with logs enabled before/after

**Squash or Rebase?**
Squash 

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
