### PR TITLE
[tests] Test destruction of a used resource before submission

### DIFF
--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -1,3 +1,4 @@
+use wgpu::util::DeviceExt;
 use wgpu_test::{fail, gpu_test, GpuTestConfiguration};
 
 #[gpu_test]
@@ -98,4 +99,100 @@ static TEXTURE_DESTROY: GpuTestConfiguration =
         texture.destroy();
 
         texture.destroy();
+    });
+
+// Test that destroying a buffer between command buffer recording and
+// submission fails gracefully.
+#[gpu_test]
+static BUFFER_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration =
+    GpuTestConfiguration::new().run_sync(|ctx| {
+        let buffer_source = ctx
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: None,
+                contents: &[0u8; 4],
+                usage: wgpu::BufferUsages::COPY_SRC,
+            });
+        let buffer_dest = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 4,
+            usage: wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        encoder.copy_buffer_to_buffer(&buffer_source, 0, &buffer_dest, 0, 4);
+
+        buffer_source.destroy();
+        buffer_dest.destroy();
+
+        let cmd_buffer = encoder.finish();
+
+        fail(
+            &ctx.device,
+            || ctx.queue.submit([cmd_buffer]),
+            Some("Buffer with '' label has been destroyed"),
+        );
+    });
+
+// Test that destroying a texture between command buffer recording and
+// submission fails gracefully.
+#[gpu_test]
+static TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration =
+    GpuTestConfiguration::new().run_sync(|ctx| {
+        let descriptor = wgpu::TextureDescriptor {
+            label: None,
+            size: wgpu::Extent3d {
+                width: 128,
+                height: 128,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1, // multisampling is not supported for clear
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Snorm,
+            usage: wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        };
+
+        let texture_1 = ctx.device.create_texture(&descriptor);
+        let texture_2 = ctx.device.create_texture(&descriptor);
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        encoder.copy_texture_to_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture_1,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture_2,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::Extent3d {
+                width: 128,
+                height: 128,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        texture_1.destroy();
+        texture_2.destroy();
+
+        let cmd_buffer = encoder.finish();
+
+        fail(
+            &ctx.device,
+            || ctx.queue.submit([cmd_buffer]),
+            Some("Texture with '' label has been destroyed"),
+        );
     });

--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -1,5 +1,5 @@
-use wgpu::util::DeviceExt;
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration};
+use wgpu::{util::DeviceExt, Backends};
+use wgpu_test::{fail, gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
 
 #[gpu_test]
 static BUFFER_DESTROY: GpuTestConfiguration =
@@ -104,8 +104,12 @@ static TEXTURE_DESTROY: GpuTestConfiguration =
 // Test that destroying a buffer between command buffer recording and
 // submission fails gracefully.
 #[gpu_test]
-static BUFFER_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_sync(|ctx| {
+static BUFFER_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        // https://github.com/gfx-rs/wgpu/issues/7854
+        TestParameters::default().skip(FailureCase::backend_adapter(Backends::VULKAN, "llvmpipe")),
+    )
+    .run_sync(|ctx| {
         let buffer_source = ctx
             .device
             .create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -140,8 +144,12 @@ static BUFFER_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration =
 // Test that destroying a texture between command buffer recording and
 // submission fails gracefully.
 #[gpu_test]
-static TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_sync(|ctx| {
+static TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        // https://github.com/gfx-rs/wgpu/issues/7854
+        TestParameters::default().skip(FailureCase::backend_adapter(Backends::VULKAN, "llvmpipe")),
+    )
+    .run_sync(|ctx| {
         let descriptor = wgpu::TextureDescriptor {
             label: None,
             size: wgpu::Extent3d {


### PR DESCRIPTION
I noticed the texture version of this test case was already written in #5031, and will work after the recent error reporting changes. I added the buffer version.

Fixes #5031

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
