### PR TITLE
Convert `as_hal` calls to use guards intead of callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ Bottom level categories:
 
 ## Unreleased
 
+### `as_hal` calls now return guards instead of using callbacks.
+
+Previously, if you wanted to get access to the wgpu-hal or underlying api types, you would call `as_hal` and get the hal type as a callback. Now the function returns a guard which dereferences to the hal type.
+
+```diff
+- device.as_hal::<hal::api::Vulkan>(|hal_device| {...});
++ let hal_device: impl Deref<Item = hal::vulkan::Device> = device.as_hal::<hal::api::Vulkan>();
+```
+
 ### New Features
 
 #### Naga

--- a/wgpu-core/src/as_hal.rs
+++ b/wgpu-core/src/as_hal.rs
@@ -1,0 +1,239 @@
+use crate::{
+    global::Global,
+    hal_api::HalApi,
+    id::{
+        AdapterId, BlasId, BufferId, CommandEncoderId, DeviceId, QueueId, SurfaceId, TextureId,
+        TextureViewId, TlasId,
+    },
+    resource::AccelerationStructure,
+};
+
+impl Global {
+    /// # Safety
+    ///
+    /// - The raw buffer handle must not be manually destroyed
+    pub unsafe fn buffer_as_hal<A: HalApi, F: FnOnce(Option<&A::Buffer>) -> R, R>(
+        &self,
+        id: BufferId,
+        hal_buffer_callback: F,
+    ) -> R {
+        profiling::scope!("Buffer::as_hal");
+
+        let hub = &self.hub;
+
+        if let Ok(buffer) = hub.buffers.get(id).get() {
+            let snatch_guard = buffer.device.snatchable_lock.read();
+            let hal_buffer = buffer
+                .raw(&snatch_guard)
+                .and_then(|b| b.as_any().downcast_ref());
+            hal_buffer_callback(hal_buffer)
+        } else {
+            hal_buffer_callback(None)
+        }
+    }
+
+    /// # Safety
+    ///
+    /// - The raw texture handle must not be manually destroyed
+    pub unsafe fn texture_as_hal<A: HalApi, F: FnOnce(Option<&A::Texture>) -> R, R>(
+        &self,
+        id: TextureId,
+        hal_texture_callback: F,
+    ) -> R {
+        profiling::scope!("Texture::as_hal");
+
+        let hub = &self.hub;
+
+        if let Ok(texture) = hub.textures.get(id).get() {
+            let snatch_guard = texture.device.snatchable_lock.read();
+            let hal_texture = texture.raw(&snatch_guard);
+            let hal_texture = hal_texture
+                .as_ref()
+                .and_then(|it| it.as_any().downcast_ref());
+            hal_texture_callback(hal_texture)
+        } else {
+            hal_texture_callback(None)
+        }
+    }
+
+    /// # Safety
+    ///
+    /// - The raw texture view handle must not be manually destroyed
+    pub unsafe fn texture_view_as_hal<A: HalApi, F: FnOnce(Option<&A::TextureView>) -> R, R>(
+        &self,
+        id: TextureViewId,
+        hal_texture_view_callback: F,
+    ) -> R {
+        profiling::scope!("TextureView::as_hal");
+
+        let hub = &self.hub;
+
+        if let Ok(texture_view) = hub.texture_views.get(id).get() {
+            let snatch_guard = texture_view.device.snatchable_lock.read();
+            let hal_texture_view = texture_view.raw(&snatch_guard);
+            let hal_texture_view = hal_texture_view
+                .as_ref()
+                .and_then(|it| it.as_any().downcast_ref());
+            hal_texture_view_callback(hal_texture_view)
+        } else {
+            hal_texture_view_callback(None)
+        }
+    }
+
+    /// # Safety
+    ///
+    /// - The raw adapter handle must not be manually destroyed
+    pub unsafe fn adapter_as_hal<A: HalApi, F: FnOnce(Option<&A::Adapter>) -> R, R>(
+        &self,
+        id: AdapterId,
+        hal_adapter_callback: F,
+    ) -> R {
+        profiling::scope!("Adapter::as_hal");
+
+        let hub = &self.hub;
+        let adapter = hub.adapters.get(id);
+        let hal_adapter = adapter.raw.adapter.as_any().downcast_ref();
+
+        hal_adapter_callback(hal_adapter)
+    }
+
+    /// # Safety
+    ///
+    /// - The raw device handle must not be manually destroyed
+    pub unsafe fn device_as_hal<A: HalApi, F: FnOnce(Option<&A::Device>) -> R, R>(
+        &self,
+        id: DeviceId,
+        hal_device_callback: F,
+    ) -> R {
+        profiling::scope!("Device::as_hal");
+
+        let device = self.hub.devices.get(id);
+        let hal_device = device.raw().as_any().downcast_ref();
+
+        hal_device_callback(hal_device)
+    }
+
+    /// # Safety
+    ///
+    /// - The raw fence handle must not be manually destroyed
+    pub unsafe fn device_fence_as_hal<A: HalApi, F: FnOnce(Option<&A::Fence>) -> R, R>(
+        &self,
+        id: DeviceId,
+        hal_fence_callback: F,
+    ) -> R {
+        profiling::scope!("Device::fence_as_hal");
+
+        let device = self.hub.devices.get(id);
+        let fence = device.fence.read();
+        hal_fence_callback(fence.as_any().downcast_ref())
+    }
+
+    /// # Safety
+    /// - The raw surface handle must not be manually destroyed
+    pub unsafe fn surface_as_hal<A: HalApi, F: FnOnce(Option<&A::Surface>) -> R, R>(
+        &self,
+        id: SurfaceId,
+        hal_surface_callback: F,
+    ) -> R {
+        profiling::scope!("Surface::as_hal");
+
+        let surface = self.surfaces.get(id);
+        let hal_surface = surface
+            .raw(A::VARIANT)
+            .and_then(|surface| surface.as_any().downcast_ref());
+
+        hal_surface_callback(hal_surface)
+    }
+
+    /// # Safety
+    ///
+    /// - The raw command encoder handle must not be manually destroyed
+    pub unsafe fn command_encoder_as_hal_mut<
+        A: HalApi,
+        F: FnOnce(Option<&mut A::CommandEncoder>) -> R,
+        R,
+    >(
+        &self,
+        id: CommandEncoderId,
+        hal_command_encoder_callback: F,
+    ) -> R {
+        profiling::scope!("CommandEncoder::as_hal");
+
+        let hub = &self.hub;
+
+        let cmd_buf = hub.command_buffers.get(id.into_command_buffer_id());
+        let mut cmd_buf_data = cmd_buf.data.lock();
+        cmd_buf_data.record_as_hal_mut(|opt_cmd_buf| -> R {
+            hal_command_encoder_callback(opt_cmd_buf.and_then(|cmd_buf| {
+                cmd_buf
+                    .encoder
+                    .open()
+                    .ok()
+                    .and_then(|encoder| encoder.as_any_mut().downcast_mut())
+            }))
+        })
+    }
+
+    /// # Safety
+    ///
+    /// - The raw queue handle must not be manually destroyed
+    pub unsafe fn queue_as_hal<A: HalApi, F, R>(&self, id: QueueId, hal_queue_callback: F) -> R
+    where
+        F: FnOnce(Option<&A::Queue>) -> R,
+    {
+        profiling::scope!("Queue::as_hal");
+
+        let queue = self.hub.queues.get(id);
+        let hal_queue = queue.raw().as_any().downcast_ref();
+
+        hal_queue_callback(hal_queue)
+    }
+
+    /// # Safety
+    ///
+    /// - The raw blas handle must not be manually destroyed
+    pub unsafe fn blas_as_hal<A: HalApi, F: FnOnce(Option<&A::AccelerationStructure>) -> R, R>(
+        &self,
+        id: BlasId,
+        hal_blas_callback: F,
+    ) -> R {
+        profiling::scope!("Blas::as_hal");
+
+        let hub = &self.hub;
+
+        if let Ok(blas) = hub.blas_s.get(id).get() {
+            let snatch_guard = blas.device.snatchable_lock.read();
+            let hal_blas = blas
+                .try_raw(&snatch_guard)
+                .ok()
+                .and_then(|b| b.as_any().downcast_ref());
+            hal_blas_callback(hal_blas)
+        } else {
+            hal_blas_callback(None)
+        }
+    }
+
+    /// # Safety
+    ///
+    /// - The raw tlas handle must not be manually destroyed
+    pub unsafe fn tlas_as_hal<A: HalApi, F: FnOnce(Option<&A::AccelerationStructure>) -> R, R>(
+        &self,
+        id: TlasId,
+        hal_tlas_callback: F,
+    ) -> R {
+        profiling::scope!("Blas::as_hal");
+
+        let hub = &self.hub;
+
+        if let Ok(tlas) = hub.tlas_s.get(id).get() {
+            let snatch_guard = tlas.device.snatchable_lock.read();
+            let hal_tlas = tlas
+                .try_raw(&snatch_guard)
+                .ok()
+                .and_then(|t| t.as_any().downcast_ref());
+            hal_tlas_callback(hal_tlas)
+        } else {
+            hal_tlas_callback(None)
+        }
+    }
+}

--- a/wgpu-core/src/as_hal.rs
+++ b/wgpu-core/src/as_hal.rs
@@ -5,7 +5,7 @@ use crate::{
         AdapterId, BlasId, BufferId, CommandEncoderId, DeviceId, QueueId, SurfaceId, TextureId,
         TextureViewId, TlasId,
     },
-    resource::AccelerationStructure,
+    resource::RawResourceAccess,
 };
 
 impl Global {

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -26,7 +26,8 @@ use crate::{
     pipeline::{ComputePipeline, RenderPipeline},
     resource::{
         Buffer, DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
-        MissingTextureUsageError, ResourceErrorIdent, Sampler, TextureView, Tlas, TrackingData,
+        MissingTextureUsageError, RawResourceAccess, ResourceErrorIdent, Sampler, TextureView,
+        Tlas, TrackingData,
     },
     resource_log,
     snatch::{SnatchGuard, Snatchable},

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -111,7 +111,7 @@ use crate::{
     pipeline::{PipelineFlags, RenderPipeline, VertexStep},
     resource::{
         Buffer, DestroyedResourceError, Fallible, InvalidResourceError, Labeled, ParentDevice,
-        TrackingData,
+        RawResourceAccess, TrackingData,
     },
     resource_log,
     snatch::SnatchGuard,

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -13,7 +13,7 @@ use crate::{
     init_tracker::{MemoryInitKind, TextureInitRange},
     resource::{
         DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
-        ParentDevice, ResourceErrorIdent, Texture, TextureClearMode,
+        ParentDevice, RawResourceAccess, ResourceErrorIdent, Texture, TextureClearMode,
     },
     snatch::SnatchGuard,
     track::TextureTrackerSetSingle,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -7,9 +7,9 @@ use wgt::{
 use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use core::{fmt, str};
 
-use crate::binding_model::BindError;
 use crate::command::{pass, EncoderStateError, PassStateError, TimestampWritesError};
 use crate::resource::DestroyedResourceError;
+use crate::{binding_model::BindError, resource::RawResourceAccess};
 use crate::{
     binding_model::{LateMinBufferBindingSizeMismatch, PushConstantUploadError},
     command::{

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -9,7 +9,7 @@ use hashbrown::hash_map::Entry;
 use crate::{
     device::Device,
     init_tracker::*,
-    resource::{DestroyedResourceError, ParentDevice, Texture, Trackable},
+    resource::{DestroyedResourceError, ParentDevice, RawResourceAccess, Texture, Trackable},
     snatch::SnatchGuard,
     track::{DeviceTracker, TextureTracker},
     FastHashMap,

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -11,7 +11,7 @@ use crate::{
     init_tracker::MemoryInitKind,
     resource::{
         DestroyedResourceError, InvalidResourceError, MissingBufferUsageError, ParentDevice,
-        QuerySet, Trackable,
+        QuerySet, RawResourceAccess, Trackable,
     },
     track::{StatelessTracker, TrackerIndex},
     FastHashMap,

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -7,7 +7,6 @@ use core::{
 
 use wgt::{math::align_to, BufferUsages, BufferUses, Features};
 
-use crate::lock::RwLockWriteGuard;
 use crate::ray_tracing::{AsAction, AsBuild, TlasBuild, ValidateAsActionsError};
 use crate::{
     command::CommandBufferMutable,
@@ -21,14 +20,13 @@ use crate::{
         TlasInstance, TlasPackage, TraceBlasBuildEntry, TraceBlasGeometries,
         TraceBlasTriangleGeometry, TraceTlasInstance, TraceTlasPackage,
     },
-    resource::{
-        AccelerationStructure, Blas, BlasCompactState, Buffer, Labeled, StagingBuffer, Tlas,
-    },
+    resource::{Blas, BlasCompactState, Buffer, Labeled, StagingBuffer, Tlas},
     scratch::ScratchBuffer,
     snatch::SnatchGuard,
     track::PendingTransition,
 };
 use crate::{command::EncoderStateError, device::resource::CommandIndices};
+use crate::{lock::RwLockWriteGuard, resource::RawResourceAccess};
 
 use crate::id::{BlasId, TlasId};
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -15,6 +15,7 @@ use crate::command::{
     TimestampWritesError,
 };
 use crate::pipeline::{RenderPipeline, VertexStep};
+use crate::resource::RawResourceAccess;
 use crate::resource::{InvalidResourceError, ResourceErrorIdent};
 use crate::snatch::SnatchGuard;
 use crate::{

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -22,8 +22,8 @@ use crate::{
         TextureInitTrackerAction,
     },
     resource::{
-        MissingBufferUsageError, MissingTextureUsageError, ParentDevice, Texture,
-        TextureErrorDimension,
+        MissingBufferUsageError, MissingTextureUsageError, ParentDevice, RawResourceAccess,
+        Texture, TextureErrorDimension,
     },
     snatch::SnatchGuard,
 };

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -207,6 +207,8 @@ impl Global {
         offset: BufferAddress,
         data: &[u8],
     ) -> BufferAccessResult {
+        use crate::resource::RawResourceAccess;
+
         let hub = &self.hub;
 
         let buffer = hub.buffers.get(buffer_id).get()?;

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     ray_tracing::BlasCompactReadyPendingClosure,
     resource::{
         Buffer, BufferAccessError, BufferAccessResult, BufferMapOperation, Labeled,
-        ResourceErrorIdent,
+        RawResourceAccess, ResourceErrorIdent,
     },
     snatch::SnatchGuard,
     Label, DOWNLEVEL_ERROR_MESSAGE,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -14,7 +14,6 @@ use wgt::{
 };
 
 use super::{life::LifetimeTracker, Device};
-use crate::device::resource::CommandIndices;
 #[cfg(feature = "trace")]
 use crate::device::trace::Action;
 use crate::{
@@ -33,8 +32,8 @@ use crate::{
     lock::{rank, Mutex, MutexGuard, RwLock, RwLockWriteGuard},
     ray_tracing::{BlasCompactReadyPendingClosure, CompactBlasError},
     resource::{
-        AccelerationStructure, Blas, BlasCompactState, Buffer, BufferAccessError, BufferMapState,
-        DestroyedBuffer, DestroyedResourceError, DestroyedTexture, Fallible, FlushedStagingBuffer,
+        Blas, BlasCompactState, Buffer, BufferAccessError, BufferMapState, DestroyedBuffer,
+        DestroyedResourceError, DestroyedTexture, Fallible, FlushedStagingBuffer,
         InvalidResourceError, Labeled, ParentDevice, ResourceErrorIdent, StagingBuffer, Texture,
         TextureInner, Trackable, TrackingData,
     },
@@ -44,6 +43,7 @@ use crate::{
     track::{self, Tracker, TrackerIndex},
     FastHashMap, SubmissionIndex,
 };
+use crate::{device::resource::CommandIndices, resource::RawResourceAccess};
 
 pub struct Queue {
     raw: Box<dyn hal::DynQueue>,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -40,7 +40,7 @@ use crate::{
     pipeline,
     pool::ResourcePool,
     resource::{
-        self, AccelerationStructure, Buffer, Fallible, Labeled, ParentDevice, QuerySet, Sampler,
+        self, Buffer, Fallible, Labeled, ParentDevice, QuerySet, RawResourceAccess, Sampler,
         StagingBuffer, Texture, TextureView, TextureViewNotRenderableReason, Tlas, TrackingData,
     },
     resource_log,

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -65,6 +65,7 @@ extern crate std;
 extern crate wgpu_hal as hal;
 extern crate wgpu_types as wgt;
 
+mod as_hal;
 pub mod binding_model;
 pub mod command;
 mod conv;

--- a/wgpu-core/src/lock/mod.rs
+++ b/wgpu-core/src/lock/mod.rs
@@ -52,4 +52,4 @@ use observing as chosen;
 #[cfg(not(any(wgpu_validate_locks, feature = "observe_locks")))]
 use vanilla as chosen;
 
-pub use chosen::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+pub use chosen::{Mutex, MutexGuard, RankData, RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -38,6 +38,8 @@ use std::{
 use super::rank::{LockRank, LockRankSet};
 use crate::FastHashSet;
 
+pub type RankData = Option<HeldLock>;
+
 /// A `Mutex` instrumented for lock acquisition order observation.
 ///
 /// This is just a wrapper around a [`parking_lot::Mutex`], along with
@@ -159,6 +161,27 @@ impl<T> RwLock<T> {
             inner: self.inner.write(),
             _state: LockStateGuard { saved },
         }
+    }
+
+    /// Force an read-unlock operation on this lock.
+    ///
+    /// Safety:
+    /// - A read lock must be held which is not held by a guard.
+    pub unsafe fn force_unlock_read(&self, data: RankData) {
+        release(data);
+        unsafe { self.inner.force_unlock_read() };
+    }
+}
+
+impl<'a, T> RwLockReadGuard<'a, T> {
+    // Forget the read guard, leaving the lock in a locked state with no guard.
+    //
+    // Equivalent to std::mem::forget, but preserves the information about the lock
+    // rank.
+    pub fn forget(this: Self) -> RankData {
+        core::mem::forget(this.inner);
+
+        this._state.saved
     }
 }
 
@@ -316,7 +339,7 @@ enum ThreadState {
 
 /// Information about a currently held lock.
 #[derive(Debug, Copy, Clone)]
-struct HeldLock {
+pub struct HeldLock {
     /// The lock's rank.
     rank: LockRank,
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -22,12 +22,6 @@ use crate::{
         queue, resource::DeferredDestroy, BufferMapPendingClosure, Device, DeviceError,
         DeviceMismatch, HostMap, MissingDownlevelFlags, MissingFeatures,
     },
-    global::Global,
-    hal_api::HalApi,
-    id::{
-        AdapterId, BufferId, CommandEncoderId, DeviceId, QueueId, SurfaceId, TextureId,
-        TextureViewId,
-    },
     init_tracker::{BufferInitTracker, TextureInitTracker},
     lock::{rank, Mutex, RwLock},
     ray_tracing::{BlasCompactReadyPendingClosure, BlasPrepareCompactError},
@@ -38,8 +32,6 @@ use crate::{
     weak_vec::WeakVec,
     Label, LabelHelpers, SubmissionIndex,
 };
-
-use crate::id::{BlasId, TlasId};
 
 /// Information about the wgpu-core resource.
 ///
@@ -647,7 +639,7 @@ impl Buffer {
     // Note: This must not be called while holding a lock.
     pub(crate) fn unmap(
         self: &Arc<Self>,
-        #[cfg(feature = "trace")] buffer_id: BufferId,
+        #[cfg(feature = "trace")] buffer_id: crate::id::BufferId,
     ) -> Result<(), BufferAccessError> {
         if let Some((mut operation, status)) = self.unmap_inner(
             #[cfg(feature = "trace")]
@@ -663,7 +655,7 @@ impl Buffer {
 
     fn unmap_inner(
         self: &Arc<Self>,
-        #[cfg(feature = "trace")] buffer_id: BufferId,
+        #[cfg(feature = "trace")] buffer_id: crate::id::BufferId,
     ) -> Result<Option<BufferMapPendingClosure>, BufferAccessError> {
         let device = &self.device;
         let snatch_guard = device.snatchable_lock.read();
@@ -915,9 +907,9 @@ unsafe impl Sync for StagingBuffer {}
 /// freed once their associated operation's queue submission has finished
 /// execution.
 ///
-/// [`queue_create_staging_buffer`]: Global::queue_create_staging_buffer
-/// [`queue_write_staging_buffer`]: Global::queue_write_staging_buffer
-/// [`queue_write_texture`]: Global::queue_write_texture
+/// [`queue_create_staging_buffer`]: crate::global::Global::queue_create_staging_buffer
+/// [`queue_write_staging_buffer`]: crate::global::Global::queue_write_staging_buffer
+/// [`queue_write_texture`]: crate::global::Global::queue_write_texture
 /// [`Device::pending_writes`]: crate::device::Device
 #[derive(Debug)]
 pub struct StagingBuffer {
@@ -1302,236 +1294,6 @@ impl Texture {
                     life_lock.schedule_resource_destruction(temp, last_submit_index);
                 }
             }
-        }
-    }
-}
-
-impl Global {
-    /// # Safety
-    ///
-    /// - The raw buffer handle must not be manually destroyed
-    pub unsafe fn buffer_as_hal<A: HalApi, F: FnOnce(Option<&A::Buffer>) -> R, R>(
-        &self,
-        id: BufferId,
-        hal_buffer_callback: F,
-    ) -> R {
-        profiling::scope!("Buffer::as_hal");
-
-        let hub = &self.hub;
-
-        if let Ok(buffer) = hub.buffers.get(id).get() {
-            let snatch_guard = buffer.device.snatchable_lock.read();
-            let hal_buffer = buffer
-                .raw(&snatch_guard)
-                .and_then(|b| b.as_any().downcast_ref());
-            hal_buffer_callback(hal_buffer)
-        } else {
-            hal_buffer_callback(None)
-        }
-    }
-
-    /// # Safety
-    ///
-    /// - The raw texture handle must not be manually destroyed
-    pub unsafe fn texture_as_hal<A: HalApi, F: FnOnce(Option<&A::Texture>) -> R, R>(
-        &self,
-        id: TextureId,
-        hal_texture_callback: F,
-    ) -> R {
-        profiling::scope!("Texture::as_hal");
-
-        let hub = &self.hub;
-
-        if let Ok(texture) = hub.textures.get(id).get() {
-            let snatch_guard = texture.device.snatchable_lock.read();
-            let hal_texture = texture.raw(&snatch_guard);
-            let hal_texture = hal_texture
-                .as_ref()
-                .and_then(|it| it.as_any().downcast_ref());
-            hal_texture_callback(hal_texture)
-        } else {
-            hal_texture_callback(None)
-        }
-    }
-
-    /// # Safety
-    ///
-    /// - The raw texture view handle must not be manually destroyed
-    pub unsafe fn texture_view_as_hal<A: HalApi, F: FnOnce(Option<&A::TextureView>) -> R, R>(
-        &self,
-        id: TextureViewId,
-        hal_texture_view_callback: F,
-    ) -> R {
-        profiling::scope!("TextureView::as_hal");
-
-        let hub = &self.hub;
-
-        if let Ok(texture_view) = hub.texture_views.get(id).get() {
-            let snatch_guard = texture_view.device.snatchable_lock.read();
-            let hal_texture_view = texture_view.raw(&snatch_guard);
-            let hal_texture_view = hal_texture_view
-                .as_ref()
-                .and_then(|it| it.as_any().downcast_ref());
-            hal_texture_view_callback(hal_texture_view)
-        } else {
-            hal_texture_view_callback(None)
-        }
-    }
-
-    /// # Safety
-    ///
-    /// - The raw adapter handle must not be manually destroyed
-    pub unsafe fn adapter_as_hal<A: HalApi, F: FnOnce(Option<&A::Adapter>) -> R, R>(
-        &self,
-        id: AdapterId,
-        hal_adapter_callback: F,
-    ) -> R {
-        profiling::scope!("Adapter::as_hal");
-
-        let hub = &self.hub;
-        let adapter = hub.adapters.get(id);
-        let hal_adapter = adapter.raw.adapter.as_any().downcast_ref();
-
-        hal_adapter_callback(hal_adapter)
-    }
-
-    /// # Safety
-    ///
-    /// - The raw device handle must not be manually destroyed
-    pub unsafe fn device_as_hal<A: HalApi, F: FnOnce(Option<&A::Device>) -> R, R>(
-        &self,
-        id: DeviceId,
-        hal_device_callback: F,
-    ) -> R {
-        profiling::scope!("Device::as_hal");
-
-        let device = self.hub.devices.get(id);
-        let hal_device = device.raw().as_any().downcast_ref();
-
-        hal_device_callback(hal_device)
-    }
-
-    /// # Safety
-    ///
-    /// - The raw fence handle must not be manually destroyed
-    pub unsafe fn device_fence_as_hal<A: HalApi, F: FnOnce(Option<&A::Fence>) -> R, R>(
-        &self,
-        id: DeviceId,
-        hal_fence_callback: F,
-    ) -> R {
-        profiling::scope!("Device::fence_as_hal");
-
-        let device = self.hub.devices.get(id);
-        let fence = device.fence.read();
-        hal_fence_callback(fence.as_any().downcast_ref())
-    }
-
-    /// # Safety
-    /// - The raw surface handle must not be manually destroyed
-    pub unsafe fn surface_as_hal<A: HalApi, F: FnOnce(Option<&A::Surface>) -> R, R>(
-        &self,
-        id: SurfaceId,
-        hal_surface_callback: F,
-    ) -> R {
-        profiling::scope!("Surface::as_hal");
-
-        let surface = self.surfaces.get(id);
-        let hal_surface = surface
-            .raw(A::VARIANT)
-            .and_then(|surface| surface.as_any().downcast_ref());
-
-        hal_surface_callback(hal_surface)
-    }
-
-    /// # Safety
-    ///
-    /// - The raw command encoder handle must not be manually destroyed
-    pub unsafe fn command_encoder_as_hal_mut<
-        A: HalApi,
-        F: FnOnce(Option<&mut A::CommandEncoder>) -> R,
-        R,
-    >(
-        &self,
-        id: CommandEncoderId,
-        hal_command_encoder_callback: F,
-    ) -> R {
-        profiling::scope!("CommandEncoder::as_hal");
-
-        let hub = &self.hub;
-
-        let cmd_buf = hub.command_buffers.get(id.into_command_buffer_id());
-        let mut cmd_buf_data = cmd_buf.data.lock();
-        cmd_buf_data.record_as_hal_mut(|opt_cmd_buf| -> R {
-            hal_command_encoder_callback(opt_cmd_buf.and_then(|cmd_buf| {
-                cmd_buf
-                    .encoder
-                    .open()
-                    .ok()
-                    .and_then(|encoder| encoder.as_any_mut().downcast_mut())
-            }))
-        })
-    }
-
-    /// # Safety
-    ///
-    /// - The raw queue handle must not be manually destroyed
-    pub unsafe fn queue_as_hal<A: HalApi, F, R>(&self, id: QueueId, hal_queue_callback: F) -> R
-    where
-        F: FnOnce(Option<&A::Queue>) -> R,
-    {
-        profiling::scope!("Queue::as_hal");
-
-        let queue = self.hub.queues.get(id);
-        let hal_queue = queue.raw().as_any().downcast_ref();
-
-        hal_queue_callback(hal_queue)
-    }
-
-    /// # Safety
-    ///
-    /// - The raw blas handle must not be manually destroyed
-    pub unsafe fn blas_as_hal<A: HalApi, F: FnOnce(Option<&A::AccelerationStructure>) -> R, R>(
-        &self,
-        id: BlasId,
-        hal_blas_callback: F,
-    ) -> R {
-        profiling::scope!("Blas::as_hal");
-
-        let hub = &self.hub;
-
-        if let Ok(blas) = hub.blas_s.get(id).get() {
-            let snatch_guard = blas.device.snatchable_lock.read();
-            let hal_blas = blas
-                .try_raw(&snatch_guard)
-                .ok()
-                .and_then(|b| b.as_any().downcast_ref());
-            hal_blas_callback(hal_blas)
-        } else {
-            hal_blas_callback(None)
-        }
-    }
-
-    /// # Safety
-    ///
-    /// - The raw tlas handle must not be manually destroyed
-    pub unsafe fn tlas_as_hal<A: HalApi, F: FnOnce(Option<&A::AccelerationStructure>) -> R, R>(
-        &self,
-        id: TlasId,
-        hal_tlas_callback: F,
-    ) -> R {
-        profiling::scope!("Blas::as_hal");
-
-        let hub = &self.hub;
-
-        if let Ok(tlas) = hub.tlas_s.get(id).get() {
-            let snatch_guard = tlas.device.snatchable_lock.read();
-            let hal_tlas = tlas
-                .try_raw(&snatch_guard)
-                .ok()
-                .and_then(|t| t.as_any().downcast_ref());
-            hal_tlas_callback(hal_tlas)
-        } else {
-            hal_tlas_callback(None)
         }
     }
 }

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -160,7 +160,6 @@ impl SnatchLock {
     }
 
     #[track_caller]
-    #[expect(unused)]
     pub unsafe fn force_unlock_read(&self, data: RankData) {
         // This is unsafe because it can cause deadlocks if the lock is held.
         // It should only be used in very specific cases, like when a resource

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,9 +1,9 @@
-use core::{cell::UnsafeCell, fmt};
+use core::{cell::UnsafeCell, fmt, mem::ManuallyDrop};
 
-use crate::lock::{rank, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use crate::lock::{rank, RankData, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// A guard that provides read access to snatchable data.
-pub struct SnatchGuard<'a>(#[expect(dead_code)] RwLockReadGuard<'a, ()>);
+pub struct SnatchGuard<'a>(RwLockReadGuard<'a, ()>);
 /// A guard that allows snatching the snatchable data.
 pub struct ExclusiveSnatchGuard<'a>(#[expect(dead_code)] RwLockWriteGuard<'a, ()>);
 
@@ -157,6 +157,34 @@ impl SnatchLock {
     pub fn write(&self) -> ExclusiveSnatchGuard {
         LockTrace::enter("write");
         ExclusiveSnatchGuard(self.lock.write())
+    }
+
+    #[track_caller]
+    #[expect(unused)]
+    pub unsafe fn force_unlock_read(&self, data: RankData) {
+        // This is unsafe because it can cause deadlocks if the lock is held.
+        // It should only be used in very specific cases, like when a resource
+        // needs to be snatched in a panic handler.
+        LockTrace::exit();
+        unsafe { self.lock.force_unlock_read(data) };
+    }
+}
+
+impl SnatchGuard<'_> {
+    /// Forget the guard, leaving the lock in a locked state with no guard.
+    ///
+    /// This is equivalent to `std::mem::forget`, but preserves the information about the lock
+    /// rank.
+    pub fn forget(this: Self) -> RankData {
+        // Cancel the drop implementation of the current guard.
+        let manually_drop = ManuallyDrop::new(this);
+
+        // As we are unable to destructure out of this guard due to the drop implementation,
+        // so we manually read the inner value.
+        // SAFETY: This is safe because we never access the original guard again.
+        let inner_guard = unsafe { core::ptr::read(&manually_drop.0) };
+
+        RwLockReadGuard::forget(inner_guard)
     }
 }
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -106,7 +106,7 @@ use crate::{
     binding_model, command,
     lock::{rank, Mutex},
     pipeline,
-    resource::{self, Labeled, ResourceErrorIdent},
+    resource::{self, Labeled, RawResourceAccess, ResourceErrorIdent},
     snatch::SnatchGuard,
     track::blas::BlasTracker,
 };

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -20,7 +20,7 @@
 
 use super::{range::RangedStates, PendingTransition, PendingTransitionList};
 use crate::{
-    resource::{Texture, TextureInner, TextureView, Trackable},
+    resource::{RawResourceAccess, Texture, TextureInner, TextureView, Trackable},
     snatch::SnatchGuard,
     track::{
         invalid_resource_state, skip_barrier, ResourceMetadata, ResourceMetadataProvider,

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -163,16 +163,28 @@ impl Instance {
         }
     }
 
-    /// Return a reference to a specific backend instance, if available.
+    /// Get the [`wgpu_hal`] instance from this `Instance`.
     ///
-    /// If this `Instance` has a wgpu-hal [`Instance`] for backend
-    /// `A`, return a reference to it. Otherwise, return `None`.
+    /// Find the Api struct corresponding to the active backend in [`wgpu_hal::api`],
+    /// and pass that struct to the to the `A` type parameter.
+    ///
+    /// Returns a guard that dereferences to the type of the hal backend
+    /// which implements [`A::Instance`].
+    ///
+    /// # Errors
+    ///
+    /// This method will return None if:
+    /// - The instance is not from the backend specified by `A`.
+    /// - The instance is from the `webgpu` or `custom` backend.
     ///
     /// # Safety
     ///
-    /// - The raw instance handle returned must not be manually destroyed.
+    /// - The returned resource must not be destroyed unless the guard
+    ///   is the last reference to it and it is not in use by the GPU.
+    ///   The guard and handle may be dropped at any time however.
+    /// - All the safety requirements of wgpu-hal must be upheld.
     ///
-    /// [`Instance`]: hal::Api::Instance
+    /// [`A::Instance`]: hal::Api::Instance
     #[cfg(wgpu_core)]
     pub unsafe fn as_hal<A: wgc::hal_api::HalApi>(&self) -> Option<&A::Instance> {
         self.inner

--- a/wgpu/src/api/tlas.rs
+++ b/wgpu/src/api/tlas.rs
@@ -1,6 +1,8 @@
 use crate::{api::blas::TlasInstance, dispatch};
 use crate::{BindingResource, Label};
 use alloc::vec::Vec;
+#[cfg(wgpu_core)]
+use core::ops::Deref;
 use core::ops::{Index, IndexMut, Range};
 use wgt::WasmNotSendSync;
 
@@ -28,29 +30,40 @@ static_assertions::assert_impl_all!(Tlas: WasmNotSendSync);
 crate::cmp::impl_eq_ord_hash_proxy!(Tlas => .inner);
 
 impl Tlas {
-    /// Returns the inner hal Acceleration Structure using a callback. The hal acceleration structure
-    /// will be `None` if the backend type argument does not match with this wgpu Tlas
+    /// Get the [`wgpu_hal`] acceleration structure from this `Tlas`.
     ///
-    /// This method will start the wgpu_core level command recording.
+    /// Find the Api struct corresponding to the active backend in [`wgpu_hal::api`],
+    /// and pass that struct to the to the `A` type parameter.
+    ///
+    /// Returns a guard that dereferences to the type of the hal backend
+    /// which implements [`A::AccelerationStructure`].
+    ///
+    /// # Deadlocks
+    ///
+    /// - The returned guard holds a read-lock on a device-local "destruction"
+    ///   lock, which will cause all calls to `destroy` to block until the
+    ///   guard is released.
+    ///
+    /// # Errors
+    ///
+    /// This method will return None if:
+    /// - The acceleration structure is not from the backend specified by `A`.
+    /// - The acceleration structure is from the `webgpu` or `custom` backend.
     ///
     /// # Safety
     ///
-    /// - The raw handle obtained from the hal Acceleration Structure must not be manually destroyed
-    /// - If the raw handle is build,
+    /// - The returned resource must not be destroyed unless the guard
+    ///   is the last reference to it and it is not in use by the GPU.
+    ///   The guard and handle may be dropped at any time however.
+    /// - All the safety requirements of wgpu-hal must be upheld.
+    ///
+    /// [`A::AccelerationStructure`]: hal::Api::AccelerationStructure
     #[cfg(wgpu_core)]
-    pub unsafe fn as_hal<
-        A: wgc::hal_api::HalApi,
-        F: FnOnce(Option<&A::AccelerationStructure>) -> R,
-        R,
-    >(
+    pub unsafe fn as_hal<A: wgc::hal_api::HalApi>(
         &mut self,
-        hal_tlas_callback: F,
-    ) -> R {
-        if let Some(tlas) = self.inner.as_core_opt() {
-            unsafe { tlas.context.tlas_as_hal::<A, F, R>(tlas, hal_tlas_callback) }
-        } else {
-            hal_tlas_callback(None)
-        }
+    ) -> Option<impl Deref<Target = A::AccelerationStructure>> {
+        let tlas = self.inner.as_core_opt()?;
+        unsafe { tlas.context.tlas_as_hal::<A>(tlas) }
     }
 
     #[cfg(custom)]


### PR DESCRIPTION
**Description**

This converts all `as_hal` calls (except CommandBuffers) from callbacks to guards. This will make the api signifigantly better.

I needed to add a few escape hatches in the locking infrastructure to allow dependent locks to exist in a single guard. All of the unsafe in this PR does not affect Mozilla.

**Review experience is commit by commit**

**Testing**

No current testing of the as_hal api at all. Working on it.

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
