### PR TITLE
Implement on_submitted_work_done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Bottom level categories:
 #### WebGPU
 
 - Fix setting unclipped_depth. By @atlv24 in [#7841](https://github.com/gfx-rs/wgpu/pull/7841)
+- Implement `on_submitted_work_done` for WebGPU backend. By @drewcrawford in [#7864](https://github.com/gfx-rs/wgpu/pull/7864)
 
 ### Changes
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2594,8 +2594,17 @@ impl dispatch::QueueInterface for WebQueue {
         1.0
     }
 
-    fn on_submitted_work_done(&self, _callback: dispatch::BoxSubmittedWorkDoneCallback) {
-        unimplemented!("on_submitted_work_done is not yet implemented");
+    fn on_submitted_work_done(&self, callback: dispatch::BoxSubmittedWorkDoneCallback) {
+        let promise = self.inner.on_submitted_work_done();
+        wasm_bindgen_futures::spawn_local(async move {
+            match wasm_bindgen_futures::JsFuture::from(promise).await {
+                Ok(_) => callback(),
+                Err(error) => {
+                    log::error!("on_submitted_work_done promise failed: {:?}", error);
+                    callback();
+                }
+            }
+        });
     }
 
     fn compact_blas(


### PR DESCRIPTION
**Connections**

See primarily
* https://github.com/gfx-rs/wgpu/issues/6395

_When one pull request builds on another_: This PR should not depend on any other PR.

**Description**

This unblocked a primary unimplemented check I encountered on wasm32.  This PR does not solve my problem but it represents some further progress on the underlying bug I continue to look into and is a bellwether for sending additional PRs.

**Testing**
This is tested through existing tests.  

**Squash or Rebase?**

This PR contains ought to fit into one commit, if not ask me to rebase.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [!] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [?] Run `cargo xtask test` to run tests:
```bash
% cargo xtask test
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/wgpu-xtask test`
[INFO  wgpu_xtask::test] Generating .gpuconfig file based on gpus on the system
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/wgpu-info --json -o .gpuconfig`
[INFO  wgpu_xtask::test] Found 1 gpu
[INFO  wgpu_xtask::test] Running cargo tests
error: no such command: `nextest`

	Did you mean `test`?

	View all installed commands with `cargo --list`
	Find a package to install `nextest` with `cargo search cargo-nextest`
Error: Tests failed

Caused by:
    command exited with non-zero code `cargo nextest run --benches --tests --all-features`: 101
```
- [?] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
