### PR TITLE
Validate binding ranges against buffer size

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -94,8 +94,39 @@ impl WebGpuError for CreateBindGroupLayoutError {
     }
 }
 
-//TODO: refactor this to move out `enum BindingError`.
+#[derive(Clone, Debug, Error)]
+#[non_exhaustive]
+pub enum BindingError {
+    #[error(transparent)]
+    DestroyedResource(#[from] DestroyedResourceError),
+    #[error("Buffer {buffer}: Binding with size {binding_size} at offset {offset} would overflow buffer size of {buffer_size}")]
+    BindingRangeTooLarge {
+        buffer: ResourceErrorIdent,
+        offset: wgt::BufferAddress,
+        binding_size: u64,
+        buffer_size: u64,
+    },
+    #[error("Buffer {buffer}: Binding offset {offset} is greater than or equal to buffer size {buffer_size}")]
+    BindingOffsetTooLarge {
+        buffer: ResourceErrorIdent,
+        offset: wgt::BufferAddress,
+        buffer_size: u64,
+    },
+}
 
+impl WebGpuError for BindingError {
+    fn webgpu_error_type(&self) -> ErrorType {
+        match self {
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
+            Self::BindingRangeTooLarge { .. } | Self::BindingOffsetTooLarge { .. } => {
+                ErrorType::Validation
+            }
+        }
+    }
+}
+
+// TODO: there may be additional variants here that can be extracted into
+// `BindingError`.
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum CreateBindGroupError {
@@ -103,6 +134,8 @@ pub enum CreateBindGroupError {
     Device(#[from] DeviceError),
     #[error(transparent)]
     DestroyedResource(#[from] DestroyedResourceError),
+    #[error(transparent)]
+    BindingError(#[from] BindingError),
     #[error(
         "Binding count declared with at most {expected} items, but {actual} items were provided"
     )]
@@ -113,12 +146,6 @@ pub enum CreateBindGroupError {
     BindingArrayLengthMismatch { actual: usize, expected: usize },
     #[error("Array binding provided zero elements")]
     BindingArrayZeroLength,
-    #[error("The bound range {range:?} of {buffer} overflows its size ({size})")]
-    BindingRangeTooLarge {
-        buffer: ResourceErrorIdent,
-        range: Range<wgt::BufferAddress>,
-        size: u64,
-    },
     #[error("Binding size {actual} of {buffer} is less than minimum {min}")]
     BindingSizeTooSmall {
         buffer: ResourceErrorIdent,
@@ -233,6 +260,7 @@ impl WebGpuError for CreateBindGroupError {
         let e: &dyn WebGpuError = match self {
             Self::Device(e) => e,
             Self::DestroyedResource(e) => e,
+            Self::BindingError(e) => e,
             Self::MissingBufferUsage(e) => e,
             Self::MissingTextureUsage(e) => e,
             Self::ResourceUsageCompatibility(e) => e,
@@ -240,7 +268,6 @@ impl WebGpuError for CreateBindGroupError {
             Self::BindingArrayPartialLengthMismatch { .. }
             | Self::BindingArrayLengthMismatch { .. }
             | Self::BindingArrayZeroLength
-            | Self::BindingRangeTooLarge { .. }
             | Self::BindingSizeTooSmall { .. }
             | Self::BindingsNumMismatch { .. }
             | Self::BindingZeroSize(_)

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -106,7 +106,7 @@ pub enum BindingError {
         binding_size: u64,
         buffer_size: u64,
     },
-    #[error("Buffer {buffer}: Binding offset {offset} is greater than or equal to buffer size {buffer_size}")]
+    #[error("Buffer {buffer}: Binding offset {offset} is greater than buffer size {buffer_size}")]
     BindingOffsetTooLarge {
         buffer: ResourceErrorIdent,
         offset: wgt::BufferAddress,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -7,7 +7,7 @@ use wgt::error::{ErrorType, WebGpuError};
 use super::bind::BinderError;
 use crate::command::pass;
 use crate::{
-    binding_model::{LateMinBufferBindingSizeMismatch, PushConstantUploadError},
+    binding_model::{BindingError, LateMinBufferBindingSizeMismatch, PushConstantUploadError},
     resource::{
         DestroyedResourceError, MissingBufferUsageError, MissingTextureUsageError,
         ResourceErrorIdent,
@@ -89,6 +89,8 @@ pub enum RenderCommandError {
     MissingTextureUsage(#[from] MissingTextureUsageError),
     #[error(transparent)]
     PushConstants(#[from] PushConstantUploadError),
+    #[error(transparent)]
+    BindingError(#[from] BindingError),
     #[error("Viewport size {{ w: {w}, h: {h} }} greater than device's requested `max_texture_dimension_2d` limit {max}, or less than zero")]
     InvalidViewportRectSize { w: f32, h: f32, max: u32 },
     #[error("Viewport has invalid rect {rect:?} for device's requested `max_texture_dimension_2d` limit; Origin less than -2 * `max_texture_dimension_2d` ({min}), or rect extends past 2 * `max_texture_dimension_2d` - 1 ({max})")]
@@ -110,6 +112,7 @@ impl WebGpuError for RenderCommandError {
             Self::MissingBufferUsage(e) => e,
             Self::MissingTextureUsage(e) => e,
             Self::PushConstants(e) => e,
+            Self::BindingError(e) => e,
 
             Self::BindGroupIndexOutOfRange { .. }
             | Self::VertexBufferIndexOutOfRange { .. }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1,12 +1,17 @@
 use alloc::{borrow::Cow, sync::Arc, vec::Vec};
-use core::{fmt, num::NonZeroU32, str};
+use core::{
+    fmt,
+    num::{NonZeroU32, NonZeroU64},
+    str,
+};
+use hal::ShouldBeNonZeroExt;
 
 use arrayvec::ArrayVec;
 use thiserror::Error;
 use wgt::{
     error::{ErrorType, WebGpuError},
-    BufferAddress, BufferSize, BufferUsages, Color, DynamicOffset, IndexFormat, ShaderStages,
-    TextureSelector, TextureUsages, TextureViewDimension, VertexStepMode,
+    BufferAddress, BufferSize, BufferSizeOrZero, BufferUsages, Color, DynamicOffset, IndexFormat,
+    ShaderStages, TextureSelector, TextureUsages, TextureViewDimension, VertexStepMode,
 };
 
 use crate::command::{
@@ -2331,7 +2336,7 @@ fn set_index_buffer(
     buffer: Arc<crate::resource::Buffer>,
     index_format: IndexFormat,
     offset: u64,
-    size: Option<BufferSize>,
+    size: Option<BufferSizeOrZero>,
 ) -> Result<(), RenderPassErrorInner> {
     api_log!("RenderPass::set_index_buffer {}", buffer.error_ident());
 
@@ -2371,7 +2376,7 @@ fn set_vertex_buffer(
     slot: u32,
     buffer: Arc<crate::resource::Buffer>,
     offset: u64,
-    size: Option<BufferSize>,
+    size: Option<BufferSizeOrZero>,
 ) -> Result<(), RenderPassErrorInner> {
     api_log!(
         "RenderPass::set_vertex_buffer {slot} {}",
@@ -3082,7 +3087,7 @@ impl Global {
             buffer: pass_try!(base, scope, self.resolve_render_pass_buffer_id(buffer_id)),
             index_format,
             offset,
-            size,
+            size: size.map(NonZeroU64::get),
         });
 
         Ok(())
@@ -3103,7 +3108,7 @@ impl Global {
             slot,
             buffer: pass_try!(base, scope, self.resolve_render_pass_buffer_id(buffer_id)),
             offset,
-            size,
+            size: size.map(NonZeroU64::get),
         });
 
         Ok(())

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1,5 +1,5 @@
 use alloc::{borrow::Cow, sync::Arc, vec::Vec};
-use core::{fmt, num::NonZeroU32, ops::Range, str};
+use core::{fmt, num::NonZeroU32, str};
 
 use arrayvec::ArrayVec;
 use thiserror::Error;
@@ -356,13 +356,17 @@ struct IndexState {
 }
 
 impl IndexState {
-    fn update_buffer(&mut self, range: Range<BufferAddress>, format: IndexFormat) {
+    fn update_buffer<B: hal::DynBuffer + ?Sized>(
+        &mut self,
+        binding: &hal::BufferBinding<'_, B>,
+        format: IndexFormat,
+    ) {
         self.buffer_format = Some(format);
         let shift = match format {
             IndexFormat::Uint16 => 1,
             IndexFormat::Uint32 => 2,
         };
-        self.limit = (range.end - range.start) >> shift;
+        self.limit = binding.size.get() >> shift;
     }
 
     fn reset(&mut self) {
@@ -2320,6 +2324,7 @@ fn set_pipeline(
     Ok(())
 }
 
+// This function is duplicative of `bundle::set_index_buffer`.
 fn set_index_buffer(
     state: &mut State,
     cmd_buf: &Arc<CommandBuffer>,
@@ -2339,33 +2344,27 @@ fn set_index_buffer(
     buffer.same_device_as(cmd_buf.as_ref())?;
 
     buffer.check_usage(BufferUsages::INDEX)?;
-    let buf_raw = buffer.try_raw(state.general.snatch_guard)?;
 
-    let end = match size {
-        Some(s) => offset + s.get(),
-        None => buffer.size,
-    };
-    state.index.update_buffer(offset..end, index_format);
+    let binding = buffer
+        .binding(offset, size, state.general.snatch_guard)
+        .map_err(RenderCommandError::from)?;
+    state.index.update_buffer(&binding, index_format);
 
     state.general.buffer_memory_init_actions.extend(
         buffer.initialization_status.read().create_action(
             &buffer,
-            offset..end,
+            offset..(offset + binding.size.get()),
             MemoryInitKind::NeedsInitializedMemory,
         ),
     );
 
-    let bb = hal::BufferBinding {
-        buffer: buf_raw,
-        offset,
-        size,
-    };
     unsafe {
-        hal::DynCommandEncoder::set_index_buffer(state.general.raw_encoder, bb, index_format);
+        hal::DynCommandEncoder::set_index_buffer(state.general.raw_encoder, binding, index_format);
     }
     Ok(())
 }
 
+// This function is duplicative of `render::set_vertex_buffer`.
 fn set_vertex_buffer(
     state: &mut State,
     cmd_buf: &Arc<CommandBuffer>,
@@ -2397,30 +2396,22 @@ fn set_vertex_buffer(
     }
 
     buffer.check_usage(BufferUsages::VERTEX)?;
-    let buf_raw = buffer.try_raw(state.general.snatch_guard)?;
 
-    //TODO: where are we checking that the offset is in bound?
-    let buffer_size = match size {
-        Some(s) => s.get(),
-        None => buffer.size - offset,
-    };
-    state.vertex.buffer_sizes[slot as usize] = Some(buffer_size);
+    let binding = buffer
+        .binding(offset, size, state.general.snatch_guard)
+        .map_err(RenderCommandError::from)?;
+    state.vertex.buffer_sizes[slot as usize] = Some(binding.size.get());
 
     state.general.buffer_memory_init_actions.extend(
         buffer.initialization_status.read().create_action(
             &buffer,
-            offset..(offset + buffer_size),
+            offset..(offset + binding.size.get()),
             MemoryInitKind::NeedsInitializedMemory,
         ),
     );
 
-    let bb = hal::BufferBinding {
-        buffer: buf_raw,
-        offset,
-        size,
-    };
     unsafe {
-        hal::DynCommandEncoder::set_vertex_buffer(state.general.raw_encoder, slot, bb);
+        hal::DynCommandEncoder::set_vertex_buffer(state.general.raw_encoder, slot, binding);
     }
     if let Some(pipeline) = state.pipeline.as_ref() {
         state.vertex.update_limits(&pipeline.vertex_steps);

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -392,6 +392,17 @@ impl RenderCommand {
 }
 
 /// Equivalent to `RenderCommand` with the Ids resolved into resource Arcs.
+///
+/// In a render pass, commands are stored in this format between when they are
+/// added to the pass, and when the pass is `end()`ed and the commands are
+/// replayed to the HAL encoder. Validation occurs when the pass is ended, which
+/// means that parameters stored in an `ArcRenderCommand` for a pass operation
+/// have generally not been validated.
+///
+/// In a render bundle, commands are stored in this format between when the bundle
+/// is `finish()`ed and when the bundle is executed. Validation occurs when the
+/// bundle is finished, which means that parameters stored in an `ArcRenderCommand`
+/// for a render bundle operation must have been validated.
 #[doc(hidden)]
 #[derive(Clone, Debug)]
 pub enum ArcRenderCommand {
@@ -405,12 +416,22 @@ pub enum ArcRenderCommand {
         buffer: Arc<Buffer>,
         index_format: wgt::IndexFormat,
         offset: BufferAddress,
+
+        // For a render pass, this reflects the argument passed by the
+        // application, which may be `None`. For a render bundle, this reflects
+        // the validated size of the binding, and will be populated even in the
+        // case that the application omitted the size.
         size: Option<BufferSize>,
     },
     SetVertexBuffer {
         slot: u32,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
+
+        // For a render pass, this reflects the argument passed by the
+        // application, which may be `None`. For a render bundle, this reflects
+        // the validated size of the binding, and will be populated even in the
+        // case that the application omitted the size.
         size: Option<BufferSize>,
     },
     SetBlendConstant(Color),

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 
-use wgt::{BufferAddress, BufferSize, Color};
+use wgt::{BufferAddress, BufferSizeOrZero, Color};
 
 use super::{Rect, RenderBundle};
 use crate::{
@@ -24,13 +24,13 @@ pub enum RenderCommand {
         buffer_id: id::BufferId,
         index_format: wgt::IndexFormat,
         offset: BufferAddress,
-        size: Option<BufferSize>,
+        size: Option<BufferSizeOrZero>,
     },
     SetVertexBuffer {
         slot: u32,
         buffer_id: id::BufferId,
         offset: BufferAddress,
-        size: Option<BufferSize>,
+        size: Option<BufferSizeOrZero>,
     },
     SetBlendConstant(Color),
     SetStencilReference(u32),
@@ -418,21 +418,18 @@ pub enum ArcRenderCommand {
         offset: BufferAddress,
 
         // For a render pass, this reflects the argument passed by the
-        // application, which may be `None`. For a render bundle, this reflects
-        // the validated size of the binding, and will be populated even in the
-        // case that the application omitted the size.
-        size: Option<BufferSize>,
+        // application, which may be `None`. For a finished render bundle, this
+        // reflects the validated size of the binding, and will be populated
+        // even in the case that the application omitted the size.
+        size: Option<BufferSizeOrZero>,
     },
     SetVertexBuffer {
         slot: u32,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
 
-        // For a render pass, this reflects the argument passed by the
-        // application, which may be `None`. For a render bundle, this reflects
-        // the validated size of the binding, and will be populated even in the
-        // case that the application omitted the size.
-        size: Option<BufferSize>,
+        // See comment in `SetIndexBuffer`.
+        size: Option<BufferSizeOrZero>,
     },
     SetBlendConstant(Color),
     SetStencilReference(u32),

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -383,6 +383,7 @@ impl Global {
     /// - `hal_buffer` must be created from `device_id` corresponding raw handle.
     /// - `hal_buffer` must be created respecting `desc`
     /// - `hal_buffer` must be initialized
+    /// - `hal_buffer` must not have zero size.
     pub unsafe fn create_buffer_from_hal<A: HalApi>(
         &self,
         hal_buffer: A::Buffer,
@@ -404,7 +405,7 @@ impl Global {
             trace.add(trace::Action::CreateBuffer(fid.id(), desc.clone()));
         }
 
-        let (buffer, err) = device.create_buffer_from_hal(Box::new(hal_buffer), desc);
+        let (buffer, err) = unsafe { device.create_buffer_from_hal(Box::new(hal_buffer), desc) };
 
         let id = fid.assign(buffer);
         api_log!("Device::create_buffer -> {id:?}");

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -8,9 +8,10 @@ use alloc::{
 use core::{
     fmt,
     mem::{self, ManuallyDrop},
-    num::NonZeroU32,
+    num::{NonZeroU32, NonZeroU64},
     sync::atomic::{AtomicBool, Ordering},
 };
+use hal::ShouldBeNonZeroExt;
 
 use arrayvec::ArrayVec;
 use bitflags::Flags;
@@ -2198,7 +2199,7 @@ impl Device {
 
         buffer.check_usage(pub_usage)?;
 
-        let bb = buffer.binding(bb.offset, bb.size, snatch_guard)?;
+        let bb = buffer.binding(bb.offset, bb.size.map(NonZeroU64::get), snatch_guard)?;
         let bind_size = bb.size.get();
 
         if bind_size > range_limit as u64 {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -703,7 +703,8 @@ impl Device {
         let buffer = unsafe { self.raw().create_buffer(&hal_desc) }
             .map_err(|e| self.handle_hal_error_with_nonfatal_oom(e))?;
 
-        let timestamp_normalization_bind_group = Snatchable::new(
+        let timestamp_normalization_bind_group = Snatchable::new(unsafe {
+            // SAFETY: The size passed here must not overflow the buffer.
             self.timestamp_normalizer
                 .get()
                 .unwrap()
@@ -711,10 +712,10 @@ impl Device {
                     self,
                     &*buffer,
                     desc.label.as_deref(),
-                    desc.size,
+                    wgt::BufferSize::new(hal_desc.size).unwrap(),
                     desc.usage,
-                )?,
-        );
+                )
+        }?);
 
         let indirect_validation_bind_groups =
             self.create_indirect_validation_bind_groups(buffer.as_ref(), desc.size, desc.usage)?;
@@ -810,28 +811,36 @@ impl Device {
         Ok(texture)
     }
 
-    pub(crate) fn create_buffer_from_hal(
+    /// # Safety
+    ///
+    /// - `hal_buffer` must have been created on this device.
+    /// - `hal_buffer` must have been created respecting `desc` (in particular, the size).
+    /// - `hal_buffer` must be initialized.
+    /// - `hal_buffer` must not have zero size.
+    pub(crate) unsafe fn create_buffer_from_hal(
         self: &Arc<Self>,
         hal_buffer: Box<dyn hal::DynBuffer>,
         desc: &resource::BufferDescriptor,
     ) -> (Fallible<Buffer>, Option<resource::CreateBufferError>) {
-        let timestamp_normalization_bind_group = match self
-            .timestamp_normalizer
-            .get()
-            .unwrap()
-            .create_normalization_bind_group(
-                self,
-                &*hal_buffer,
-                desc.label.as_deref(),
-                desc.size,
-                desc.usage,
-            ) {
-            Ok(bg) => Snatchable::new(bg),
-            Err(e) => {
-                return (
-                    Fallible::Invalid(Arc::new(desc.label.to_string())),
-                    Some(e.into()),
-                )
+        let timestamp_normalization_bind_group = unsafe {
+            match self
+                .timestamp_normalizer
+                .get()
+                .unwrap()
+                .create_normalization_bind_group(
+                    self,
+                    &*hal_buffer,
+                    desc.label.as_deref(),
+                    wgt::BufferSize::new(desc.size).unwrap(),
+                    desc.usage,
+                ) {
+                Ok(bg) => Snatchable::new(bg),
+                Err(e) => {
+                    return (
+                        Fallible::Invalid(Arc::new(desc.label.to_string())),
+                        Some(e.into()),
+                    )
+                }
             }
         };
 
@@ -2188,31 +2197,9 @@ impl Device {
         buffer.same_device(self)?;
 
         buffer.check_usage(pub_usage)?;
-        let raw_buffer = buffer.try_raw(snatch_guard)?;
 
-        let (bind_size, bind_end) = match bb.size {
-            Some(size) => {
-                let end = bb.offset + size.get();
-                if end > buffer.size {
-                    return Err(Error::BindingRangeTooLarge {
-                        buffer: buffer.error_ident(),
-                        range: bb.offset..end,
-                        size: buffer.size,
-                    });
-                }
-                (size.get(), end)
-            }
-            None => {
-                if buffer.size < bb.offset {
-                    return Err(Error::BindingRangeTooLarge {
-                        buffer: buffer.error_ident(),
-                        range: bb.offset..bb.offset,
-                        size: buffer.size,
-                    });
-                }
-                (buffer.size - bb.offset, buffer.size)
-            }
-        };
+        let bb = buffer.binding(bb.offset, bb.size, snatch_guard)?;
+        let bind_size = bb.size.get();
 
         if bind_size > range_limit as u64 {
             return Err(Error::BufferRangeTooLarge {
@@ -2227,8 +2214,8 @@ impl Device {
             dynamic_binding_info.push(binding_model::BindGroupDynamicBindingData {
                 binding_idx: binding,
                 buffer_size: buffer.size,
-                binding_range: bb.offset..bind_end,
-                maximum_dynamic_offset: buffer.size - bind_end,
+                binding_range: bb.offset..bb.offset + bind_size,
+                maximum_dynamic_offset: buffer.size - bb.offset - bind_size,
                 binding_type: binding_ty,
             });
         }
@@ -2266,11 +2253,7 @@ impl Device {
             MemoryInitKind::NeedsInitializedMemory,
         ));
 
-        Ok(hal::BufferBinding {
-            buffer: raw_buffer,
-            offset: bb.offset,
-            size: bb.size,
-        })
+        Ok(bb)
     }
 
     fn create_sampler_binding<'a>(

--- a/wgpu-core/src/indirect_validation/dispatch.rs
+++ b/wgpu-core/src/indirect_validation/dispatch.rs
@@ -232,10 +232,9 @@ impl Dispatch {
                 resource_index: 0,
                 count: 1,
             }],
-            buffers: &[hal::BufferBinding {
-                buffer: dst_buffer.as_ref(),
-                offset: 0,
-                size: Some(DST_BUFFER_SIZE),
+            buffers: &[unsafe {
+                // SAFETY: We just created the buffer with this size.
+                hal::BufferBinding::new_unchecked(dst_buffer.as_ref(), 0, DST_BUFFER_SIZE)
             }],
             samplers: &[],
             textures: &[],
@@ -278,10 +277,9 @@ impl Dispatch {
                 resource_index: 0,
                 count: 1,
             }],
-            buffers: &[hal::BufferBinding {
-                buffer,
-                offset: 0,
-                size: Some(binding_size),
+            buffers: &[unsafe {
+                // SAFETY: We calculated the binding size to fit within the buffer.
+                hal::BufferBinding::new_unchecked(buffer, 0, binding_size)
             }],
             samplers: &[],
             textures: &[],

--- a/wgpu-core/src/indirect_validation/draw.rs
+++ b/wgpu-core/src/indirect_validation/draw.rs
@@ -135,10 +135,9 @@ impl Draw {
                 resource_index: 0,
                 count: 1,
             }],
-            buffers: &[hal::BufferBinding {
-                buffer,
-                offset: 0,
-                size: Some(binding_size),
+            buffers: &[unsafe {
+                // SAFETY: We calculated the binding size to fit within the buffer.
+                hal::BufferBinding::new_unchecked(buffer, 0, binding_size)
             }],
             samplers: &[],
             textures: &[],
@@ -684,10 +683,9 @@ fn create_buffer_and_bind_group(
             resource_index: 0,
             count: 1,
         }],
-        buffers: &[hal::BufferBinding {
-            buffer: buffer.as_ref(),
-            offset: 0,
-            size: Some(BUFFER_SIZE),
+        buffers: &[unsafe {
+            // SAFETY: We just created the buffer with this size.
+            hal::BufferBinding::new_unchecked(buffer.as_ref(), 0, BUFFER_SIZE)
         }],
         samplers: &[],
         textures: &[],

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -17,7 +17,7 @@ use wgt::{
 #[cfg(feature = "trace")]
 use crate::device::trace;
 use crate::{
-    binding_model::BindGroup,
+    binding_model::{BindGroup, BindingError},
     device::{
         queue, resource::DeferredDestroy, BufferMapPendingClosure, Device, DeviceError,
         DeviceMismatch, HostMap, MissingDownlevelFlags, MissingFeatures,
@@ -482,6 +482,76 @@ impl Buffer {
                 actual: self.usage,
                 expected,
             })
+        }
+    }
+
+    /// Resolve the size of a binding for buffer with `offset` and `size`.
+    ///
+    /// If `size` is `None`, then the remainder of the buffer starting from
+    /// `offset` is used.
+    ///
+    /// If the binding would overflow the buffer or is empty (see
+    /// [`hal::BufferBinding`]), then an error is returned.
+    pub fn resolve_binding_size(
+        &self,
+        offset: wgt::BufferAddress,
+        binding_size: Option<wgt::BufferSize>,
+    ) -> Result<wgt::BufferSize, BindingError> {
+        let buffer_size = self.size;
+
+        match binding_size {
+            Some(binding_size) => {
+                match offset.checked_add(binding_size.get()) {
+                    // `binding_size` is not zero which means `end == buffer_size` is ok.
+                    Some(end) if end <= buffer_size => Ok(binding_size),
+                    _ => Err(BindingError::BindingRangeTooLarge {
+                        buffer: self.error_ident(),
+                        offset,
+                        binding_size: binding_size.get(),
+                        buffer_size,
+                    }),
+                }
+            }
+            None => {
+                // We require that `buffer_size - offset` converts to
+                // `BufferSize` (`NonZeroU64`) because bindings must not be
+                // empty.
+                buffer_size
+                    .checked_sub(offset)
+                    .and_then(wgt::BufferSize::new)
+                    .ok_or_else(|| BindingError::BindingOffsetTooLarge {
+                        buffer: self.error_ident(),
+                        offset,
+                        buffer_size,
+                    })
+            }
+        }
+    }
+
+    /// Create a new [`hal::BufferBinding`] for the buffer with `offset` and
+    /// `size`.
+    ///
+    /// If `size` is `None`, then the remainder of the buffer starting from
+    /// `offset` is used.
+    ///
+    /// If the binding would overflow the buffer or is empty (see
+    /// [`hal::BufferBinding`]), then an error is returned.
+    pub fn binding<'a>(
+        &'a self,
+        offset: wgt::BufferAddress,
+        binding_size: Option<wgt::BufferSize>,
+        snatch_guard: &'a SnatchGuard,
+    ) -> Result<hal::BufferBinding<'a, dyn hal::DynBuffer>, BindingError> {
+        let buf_raw = self.try_raw(snatch_guard)?;
+        let resolved_size = self.resolve_binding_size(offset, binding_size)?;
+        unsafe {
+            // SAFETY: The offset and size passed to hal::BufferBinding::new_unchecked must
+            // define a binding contained within the buffer.
+            Ok(hal::BufferBinding::new_unchecked(
+                buf_raw,
+                offset,
+                resolved_size,
+            ))
         }
     }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -490,35 +490,32 @@ impl Buffer {
     /// If `size` is `None`, then the remainder of the buffer starting from
     /// `offset` is used.
     ///
-    /// If the binding would overflow the buffer or is empty (see
-    /// [`hal::BufferBinding`]), then an error is returned.
+    /// If the binding would overflow the buffer, then an error is returned.
+    ///
+    /// Zero-size bindings are permitted here for historical reasons. Although
+    /// zero-size bindings are permitted by WebGPU, they are not permitted by
+    /// some backends. See [`Buffer::binding`] and
+    /// [#3170](https://github.com/gfx-rs/wgpu/issues/3170).
     pub fn resolve_binding_size(
         &self,
         offset: wgt::BufferAddress,
-        binding_size: Option<wgt::BufferSize>,
-    ) -> Result<wgt::BufferSize, BindingError> {
+        binding_size: Option<wgt::BufferSizeOrZero>,
+    ) -> Result<wgt::BufferSizeOrZero, BindingError> {
         let buffer_size = self.size;
 
         match binding_size {
-            Some(binding_size) => {
-                match offset.checked_add(binding_size.get()) {
-                    // `binding_size` is not zero which means `end == buffer_size` is ok.
-                    Some(end) if end <= buffer_size => Ok(binding_size),
-                    _ => Err(BindingError::BindingRangeTooLarge {
-                        buffer: self.error_ident(),
-                        offset,
-                        binding_size: binding_size.get(),
-                        buffer_size,
-                    }),
-                }
-            }
+            Some(binding_size) => match offset.checked_add(binding_size) {
+                Some(end) if end <= buffer_size => Ok(binding_size),
+                _ => Err(BindingError::BindingRangeTooLarge {
+                    buffer: self.error_ident(),
+                    offset,
+                    binding_size,
+                    buffer_size,
+                }),
+            },
             None => {
-                // We require that `buffer_size - offset` converts to
-                // `BufferSize` (`NonZeroU64`) because bindings must not be
-                // empty.
                 buffer_size
                     .checked_sub(offset)
-                    .and_then(wgt::BufferSize::new)
                     .ok_or_else(|| BindingError::BindingOffsetTooLarge {
                         buffer: self.error_ident(),
                         offset,
@@ -534,12 +531,20 @@ impl Buffer {
     /// If `size` is `None`, then the remainder of the buffer starting from
     /// `offset` is used.
     ///
-    /// If the binding would overflow the buffer or is empty (see
-    /// [`hal::BufferBinding`]), then an error is returned.
+    /// If the binding would overflow the buffer, then an error is returned.
+    ///
+    /// Zero-size bindings are permitted here for historical reasons. Although
+    /// zero-size bindings are permitted by WebGPU, they are not permitted by
+    /// some backends. Previous documentation for `hal::BufferBinding`
+    /// disallowed zero-size bindings, but this restriction was not honored
+    /// elsewhere in the code. Zero-size bindings need to be quashed or remapped
+    /// to a non-zero size, either universally in wgpu-core, or in specific
+    /// backends that do not support them. See
+    /// [#3170](https://github.com/gfx-rs/wgpu/issues/3170).
     pub fn binding<'a>(
         &'a self,
         offset: wgt::BufferAddress,
-        binding_size: Option<wgt::BufferSize>,
+        binding_size: Option<wgt::BufferSizeOrZero>,
         snatch_guard: &'a SnatchGuard,
     ) -> Result<hal::BufferBinding<'a, dyn hal::DynBuffer>, BindingError> {
         let buf_raw = self.try_raw(snatch_guard)?;

--- a/wgpu-core/src/timestamp_normalization/mod.rs
+++ b/wgpu-core/src/timestamp_normalization/mod.rs
@@ -242,12 +242,16 @@ impl TimestampNormalizer {
         }
     }
 
-    pub fn create_normalization_bind_group(
+    /// Create a bind group for normalizing timestamps in `buffer`.
+    ///
+    /// This function is unsafe because it does not know that `buffer_size` is
+    /// the true size of the buffer.
+    pub unsafe fn create_normalization_bind_group(
         &self,
         device: &Device,
         buffer: &dyn hal::DynBuffer,
         buffer_label: Option<&str>,
-        buffer_size: u64,
+        buffer_size: wgt::BufferSize,
         buffer_usages: wgt::BufferUsages,
     ) -> Result<TimestampNormalizationBindGroup, DeviceError> {
         unsafe {
@@ -263,7 +267,7 @@ impl TimestampNormalizer {
             // at once to normalize the timestamps, we can't use it. We force the buffer to fail
             // to allocate. The lowest max binding size is 128MB, and query sets must be small
             // (no more than 4096), so this should never be hit in practice by sane programs.
-            if buffer_size > device.adapter.limits().max_storage_buffer_binding_size as u64 {
+            if buffer_size.get() > device.adapter.limits().max_storage_buffer_binding_size as u64 {
                 return Err(DeviceError::OutOfMemory);
             }
 
@@ -282,11 +286,7 @@ impl TimestampNormalizer {
                 .create_bind_group(&hal::BindGroupDescriptor {
                     label: Some(label),
                     layout: &*state.temporary_bind_group_layout,
-                    buffers: &[hal::BufferBinding {
-                        buffer,
-                        offset: 0,
-                        size: None,
-                    }],
+                    buffers: &[hal::BufferBinding::new_unchecked(buffer, 0, buffer_size)],
                     samplers: &[],
                     textures: &[],
                     acceleration_structures: &[],

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -447,11 +447,7 @@ impl<A: hal::Api> Example<A> {
         let global_group = {
             let global_buffer_binding = unsafe {
                 // SAFETY: This is the same size that was specified for buffer creation.
-                hal::BufferBinding::new_unchecked(
-                    &global_buffer,
-                    0,
-                    global_buffer_desc.size.try_into().unwrap(),
-                )
+                hal::BufferBinding::new_unchecked(&global_buffer, 0, global_buffer_desc.size)
             };
             let texture_binding = hal::TextureBinding {
                 view: &texture_view,

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -445,10 +445,13 @@ impl<A: hal::Api> Example<A> {
         let texture_view = unsafe { device.create_texture_view(&texture, &view_desc).unwrap() };
 
         let global_group = {
-            let global_buffer_binding = hal::BufferBinding {
-                buffer: &global_buffer,
-                offset: 0,
-                size: None,
+            let global_buffer_binding = unsafe {
+                // SAFETY: This is the same size that was specified for buffer creation.
+                hal::BufferBinding::new_unchecked(
+                    &global_buffer,
+                    0,
+                    global_buffer_desc.size.try_into().unwrap(),
+                )
             };
             let texture_binding = hal::TextureBinding {
                 view: &texture_view,
@@ -483,10 +486,13 @@ impl<A: hal::Api> Example<A> {
         };
 
         let local_group = {
-            let local_buffer_binding = hal::BufferBinding {
-                buffer: &local_buffer,
-                offset: 0,
-                size: wgpu_types::BufferSize::new(size_of::<Locals>() as _),
+            let local_buffer_binding = unsafe {
+                // SAFETY: The size must fit within the buffer.
+                hal::BufferBinding::new_unchecked(
+                    &local_buffer,
+                    0,
+                    wgpu_types::BufferSize::new(size_of::<Locals>() as _).unwrap(),
+                )
             };
             let local_group_desc = hal::BindGroupDescriptor {
                 label: Some("local"),

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -603,10 +603,13 @@ impl<A: hal::Api> Example<A> {
         let texture_view = unsafe { device.create_texture_view(&texture, &view_desc).unwrap() };
 
         let bind_group = {
-            let buffer_binding = hal::BufferBinding {
-                buffer: &uniform_buffer,
-                offset: 0,
-                size: None,
+            let buffer_binding = unsafe {
+                // SAFETY: The size matches the buffer allocation.
+                hal::BufferBinding::new_unchecked(
+                    &uniform_buffer,
+                    0,
+                    wgpu_types::BufferSize::new_unchecked(uniforms_size as u64),
+                )
             };
             let texture_binding = hal::TextureBinding {
                 view: &texture_view,

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1136,7 +1136,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     ) {
         let ibv = Direct3D12::D3D12_INDEX_BUFFER_VIEW {
             BufferLocation: binding.resolve_address(),
-            SizeInBytes: binding.resolve_size() as u32,
+            SizeInBytes: binding.size.try_into().unwrap(),
             Format: auxil::dxgi::conv::map_index_format(format),
         };
 
@@ -1149,7 +1149,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     ) {
         let vb = &mut self.pass.vertex_buffers[index as usize];
         vb.BufferLocation = binding.resolve_address();
-        vb.SizeInBytes = binding.resolve_size() as u32;
+        vb.SizeInBytes = binding.size.try_into().unwrap();
         self.pass.dirty_vertex_buffers |= 1 << index;
     }
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1442,7 +1442,7 @@ impl crate::Device for super::Device {
                     let end = start + entry.count as usize;
                     for data in &desc.buffers[start..end] {
                         let gpu_address = data.resolve_address();
-                        let mut size = data.resolve_size() as u32;
+                        let mut size = data.size.try_into().unwrap();
 
                         if has_dynamic_offset {
                             match ty {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -865,13 +865,6 @@ unsafe impl Sync for Buffer {}
 impl crate::DynBuffer for Buffer {}
 
 impl crate::BufferBinding<'_, Buffer> {
-    fn resolve_size(&self) -> wgt::BufferAddress {
-        match self.size {
-            Some(size) => size.get(),
-            None => self.buffer.size - self.offset,
-        }
-    }
-
     // TODO: Return GPU handle directly?
     fn resolve_address(&self) -> wgt::BufferAddress {
         (unsafe { self.buffer.resource.GetGPUVirtualAddress() }) + self.offset

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -534,7 +534,6 @@ impl crate::Device for super::Device {
             return Ok(super::Buffer {
                 raw: None,
                 target,
-                size: desc.size,
                 map_flags: 0,
                 data: Some(Arc::new(MaybeMutex::new(vec![0; desc.size as usize]))),
                 offset_of_current_mapping: Arc::new(MaybeMutex::new(0)),
@@ -634,7 +633,6 @@ impl crate::Device for super::Device {
         Ok(super::Buffer {
             raw,
             target,
-            size: desc.size,
             map_flags,
             data,
             offset_of_current_mapping: Arc::new(MaybeMutex::new(0)),
@@ -1265,11 +1263,8 @@ impl crate::Device for super::Device {
                     let bb = &desc.buffers[entry.resource_index as usize];
                     super::RawBinding::Buffer {
                         raw: bb.buffer.raw.unwrap(),
-                        offset: bb.offset as i32,
-                        size: match bb.size {
-                            Some(s) => s.get() as i32,
-                            None => (bb.buffer.size - bb.offset) as i32,
-                        },
+                        offset: bb.offset.try_into().unwrap(),
+                        size: bb.size.get().try_into().unwrap(),
                     }
                 }
                 wgt::BindingType::Sampler { .. } => {

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1261,10 +1261,11 @@ impl crate::Device for super::Device {
             let binding = match layout.ty {
                 wgt::BindingType::Buffer { .. } => {
                     let bb = &desc.buffers[entry.resource_index as usize];
+                    assert!(bb.size != 0, "zero-size bindings are not supported");
                     super::RawBinding::Buffer {
                         raw: bb.buffer.raw.unwrap(),
                         offset: bb.offset.try_into().unwrap(),
-                        size: bb.size.get().try_into().unwrap(),
+                        size: bb.size.try_into().unwrap(),
                     }
                 }
                 wgt::BindingType::Sampler { .. } => {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -342,7 +342,6 @@ impl Drop for Queue {
 pub struct Buffer {
     raw: Option<glow::Buffer>,
     target: BindTarget,
-    size: wgt::BufferAddress,
     map_flags: u32,
     data: Option<Arc<MaybeMutex<Vec<u8>>>>,
     offset_of_current_mapping: Arc<MaybeMutex<wgt::BufferAddress>>,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -297,7 +297,7 @@ use core::{
     borrow::Borrow,
     error::Error,
     fmt,
-    num::NonZeroU32,
+    num::{NonZeroU32, NonZeroU64},
     ops::{Range, RangeInclusive},
     ptr::NonNull,
 };
@@ -1981,7 +1981,7 @@ pub struct PipelineLayoutDescriptor<'a, B: DynBindGroupLayout + ?Sized> {
 ///
 /// `wgpu_hal` guarantees that shaders compiled with
 /// [`ShaderModuleDescriptor::runtime_checks`] set to `true` cannot read or
-/// write data via this binding outside the *accessible region* of [`buffer`]:
+/// write data via this binding outside the *accessible region* of a buffer:
 ///
 /// - The accessible region starts at [`offset`].
 ///
@@ -2006,14 +2006,14 @@ pub struct PipelineLayoutDescriptor<'a, B: DynBindGroupLayout + ?Sized> {
 /// Some back ends cannot tolerate zero-length regions; for example, see
 /// [VUID-VkDescriptorBufferInfo-offset-00340][340] and
 /// [VUID-VkDescriptorBufferInfo-range-00341][341], or the
-/// documentation for GLES's [glBindBufferRange][bbr]. For this reason, a valid
-/// `BufferBinding` must have `offset` strictly less than the size of the
-/// buffer.
+/// documentation for GLES's [glBindBufferRange][bbr]. This documentation
+/// previously stated that a `BufferBinding` must have `offset` strictly less
+/// than the size of the buffer, but this restriction was not honored elsewhere
+/// in the code, so has been removed. However, it remains the case that
+/// some backends do not support zero-length bindings, so additional
+/// logic is needed somewhere to handle this properly. See
+/// [#3170](https://github.com/gfx-rs/wgpu/issues/3170).
 ///
-/// WebGPU allows zero-length bindings, and there is not currently a mechanism
-/// in place
-///
-/// [`buffer`]: BufferBinding::buffer
 /// [`offset`]: BufferBinding::offset
 /// [`size`]: BufferBinding::size
 /// [`Storage`]: wgt::BufferBindingType::Storage
@@ -2033,12 +2033,11 @@ pub struct BufferBinding<'a, B: DynBuffer + ?Sized> {
 
     /// The offset at which the bound region starts.
     ///
-    /// Because zero-length bindings are not permitted (see above), this must be
-    /// strictly less than the size of the buffer.
+    /// This must be less or equal to the size of the buffer.
     pub offset: wgt::BufferAddress,
 
     /// The size of the region bound, in bytes.
-    pub size: wgt::BufferSize,
+    pub size: wgt::BufferSizeOrZero,
 }
 
 // We must implement this manually because `B` is not necessarily `Clone`.
@@ -2049,6 +2048,25 @@ impl<B: DynBuffer + ?Sized> Clone for BufferBinding<'_, B> {
             offset: self.offset,
             size: self.size,
         }
+    }
+}
+
+/// Temporary convenience trait to let us call `.get()` on `u64`s in code that
+/// really wants to be using `NonZeroU64`.
+/// TODO(<https://github.com/gfx-rs/wgpu/issues/3170>): remove this
+pub trait ShouldBeNonZeroExt {
+    fn get(&self) -> u64;
+}
+
+impl ShouldBeNonZeroExt for NonZeroU64 {
+    fn get(&self) -> u64 {
+        NonZeroU64::get(*self)
+    }
+}
+
+impl ShouldBeNonZeroExt for u64 {
+    fn get(&self) -> u64 {
+        *self
     }
 }
 
@@ -2064,15 +2082,20 @@ impl<'a, B: DynBuffer + ?Sized> BufferBinding<'a, B> {
     ///
     /// SAFETY: The caller is responsible for ensuring that a binding of `size`
     /// bytes starting at `offset` is contained within the buffer.
-    pub unsafe fn new_unchecked(
+    ///
+    /// The `S` type parameter is a temporary convenience to allow callers to
+    /// pass either a `u64` or a `NonZeroU64`. When the zero-size binding issue
+    /// is resolved, the argument should just match the type of the member.
+    /// TODO(<https://github.com/gfx-rs/wgpu/issues/3170>): remove the parameter
+    pub unsafe fn new_unchecked<S: Into<wgt::BufferSizeOrZero>>(
         buffer: &'a B,
         offset: wgt::BufferAddress,
-        size: wgt::BufferSize,
+        size: S,
     ) -> Self {
         Self {
             buffer,
             offset,
-            size,
+            size: size.into(),
         }
     }
 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1970,6 +1970,13 @@ pub struct PipelineLayoutDescriptor<'a, B: DynBindGroupLayout + ?Sized> {
 ///
 /// [`BindGroup`]: Api::BindGroup
 ///
+/// ## Construction
+///
+/// The recommended way to construct a `BufferBinding` is using the `binding`
+/// method on a wgpu-core `Buffer`, which will validate the binding size
+/// against the buffer size. An unsafe `new_unchecked` constructor is also
+/// provided for cases where direct construction is necessary.
+///
 /// ## Accessible region
 ///
 /// `wgpu_hal` guarantees that shaders compiled with
@@ -1994,44 +2001,78 @@ pub struct PipelineLayoutDescriptor<'a, B: DynBindGroupLayout + ?Sized> {
 /// parts of which buffers shaders might observe. This optimization is only
 /// sound if shader access is bounds-checked.
 ///
+/// ## Zero-length bindings
+///
+/// Some back ends cannot tolerate zero-length regions; for example, see
+/// [VUID-VkDescriptorBufferInfo-offset-00340][340] and
+/// [VUID-VkDescriptorBufferInfo-range-00341][341], or the
+/// documentation for GLES's [glBindBufferRange][bbr]. For this reason, a valid
+/// `BufferBinding` must have `offset` strictly less than the size of the
+/// buffer.
+///
+/// WebGPU allows zero-length bindings, and there is not currently a mechanism
+/// in place
+///
 /// [`buffer`]: BufferBinding::buffer
 /// [`offset`]: BufferBinding::offset
 /// [`size`]: BufferBinding::size
 /// [`Storage`]: wgt::BufferBindingType::Storage
 /// [`Uniform`]: wgt::BufferBindingType::Uniform
+/// [340]: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkDescriptorBufferInfo-offset-00340
+/// [341]: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkDescriptorBufferInfo-range-00341
+/// [bbr]: https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glBindBufferRange.xhtml
 /// [woob]: https://gpuweb.github.io/gpuweb/wgsl/#out-of-bounds-access-sec
 #[derive(Debug)]
 pub struct BufferBinding<'a, B: DynBuffer + ?Sized> {
     /// The buffer being bound.
-    pub buffer: &'a B,
+    ///
+    /// This is not fully `pub` to prevent direct construction of
+    /// `BufferBinding`s, while still allowing public read access to the `offset`
+    /// and `size` properties.
+    pub(crate) buffer: &'a B,
 
     /// The offset at which the bound region starts.
     ///
-    /// This must be less than the size of the buffer. Some back ends
-    /// cannot tolerate zero-length regions; for example, see
-    /// [VUID-VkDescriptorBufferInfo-offset-00340][340] and
-    /// [VUID-VkDescriptorBufferInfo-range-00341][341], or the
-    /// documentation for GLES's [glBindBufferRange][bbr].
-    ///
-    /// [340]: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkDescriptorBufferInfo-offset-00340
-    /// [341]: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkDescriptorBufferInfo-range-00341
-    /// [bbr]: https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glBindBufferRange.xhtml
+    /// Because zero-length bindings are not permitted (see above), this must be
+    /// strictly less than the size of the buffer.
     pub offset: wgt::BufferAddress,
 
     /// The size of the region bound, in bytes.
-    ///
-    /// If `None`, the region extends from `offset` to the end of the
-    /// buffer. Given the restrictions on `offset`, this means that
-    /// the size is always greater than zero.
-    pub size: Option<wgt::BufferSize>,
+    pub size: wgt::BufferSize,
 }
 
-impl<'a, T: DynBuffer + ?Sized> Clone for BufferBinding<'a, T> {
+// We must implement this manually because `B` is not necessarily `Clone`.
+impl<B: DynBuffer + ?Sized> Clone for BufferBinding<'_, B> {
     fn clone(&self) -> Self {
         BufferBinding {
             buffer: self.buffer,
             offset: self.offset,
             size: self.size,
+        }
+    }
+}
+
+impl<'a, B: DynBuffer + ?Sized> BufferBinding<'a, B> {
+    /// Construct a `BufferBinding` with the given contents.
+    ///
+    /// When possible, use the `binding` method on a wgpu-core `Buffer` instead
+    /// of this method. `Buffer::binding` validates the size of the binding
+    /// against the size of the buffer.
+    ///
+    /// It is more difficult to provide a validating constructor here, due to
+    /// not having direct access to the size of a `DynBuffer`.
+    ///
+    /// SAFETY: The caller is responsible for ensuring that a binding of `size`
+    /// bytes starting at `offset` is contained within the buffer.
+    pub unsafe fn new_unchecked(
+        buffer: &'a B,
+        offset: wgt::BufferAddress,
+        size: wgt::BufferSize,
+    ) -> Self {
+        Self {
+            buffer,
+            offset,
+            size,
         }
     }
 }

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -4,7 +4,7 @@ use alloc::{
     borrow::{Cow, ToOwned as _},
     vec::Vec,
 };
-use core::ops::Range;
+use core::{num::NonZeroU64, ops::Range};
 use metal::{
     MTLIndexType, MTLLoadAction, MTLPrimitiveType, MTLScissorRect, MTLSize, MTLStoreAction,
     MTLViewport, MTLVisibilityResultMode, NSRange,
@@ -977,9 +977,11 @@ impl crate::CommandEncoder for super::CommandEncoder {
         let encoder = self.state.render.as_ref().unwrap();
         encoder.set_vertex_buffer(buffer_index, Some(&binding.buffer.raw), binding.offset);
 
-        self.state
-            .vertex_buffer_size_map
-            .insert(buffer_index, binding.size);
+        // https://github.com/gfx-rs/wgpu/issues/3170
+        let size =
+            NonZeroU64::new(binding.size).expect("zero-size vertex buffers are not supported");
+
+        self.state.vertex_buffer_size_map.insert(buffer_index, size);
 
         if let Some((index, sizes)) = self
             .state

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -977,15 +977,9 @@ impl crate::CommandEncoder for super::CommandEncoder {
         let encoder = self.state.render.as_ref().unwrap();
         encoder.set_vertex_buffer(buffer_index, Some(&binding.buffer.raw), binding.offset);
 
-        let buffer_size = binding.resolve_size();
-        if buffer_size > 0 {
-            self.state.vertex_buffer_size_map.insert(
-                buffer_index,
-                core::num::NonZeroU64::new(buffer_size).unwrap(),
-            );
-        } else {
-            self.state.vertex_buffer_size_map.remove(&buffer_index);
-        }
+        self.state
+            .vertex_buffer_size_map
+            .insert(buffer_index, binding.size);
 
         if let Some((index, sizes)) = self
             .state

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1,5 +1,5 @@
 use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
-use core::{ptr::NonNull, sync::atomic};
+use core::{num::NonZeroU64, ptr::NonNull, sync::atomic};
 use std::{thread, time};
 
 use parking_lot::Mutex;
@@ -928,9 +928,12 @@ impl crate::Device for super::Device {
                                 let end = start + 1;
                                 bg.buffers
                                     .extend(desc.buffers[start..end].iter().map(|source| {
+                                        // https://github.com/gfx-rs/wgpu/issues/3170
+                                        let source_size = NonZeroU64::new(source.size)
+                                            .expect("zero-size bindings are not supported");
                                         let binding_size = match ty {
                                             wgt::BufferBindingType::Storage { .. } => {
-                                                Some(source.size)
+                                                Some(source_size)
                                             }
                                             _ => None,
                                         };

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -340,10 +340,6 @@ impl super::Device {
         }
     }
 
-    pub unsafe fn buffer_from_raw(raw: metal::Buffer, size: wgt::BufferAddress) -> super::Buffer {
-        super::Buffer { raw, size }
-    }
-
     pub fn raw_device(&self) -> &Mutex<metal::Device> {
         &self.shared.device
     }
@@ -373,10 +369,7 @@ impl crate::Device for super::Device {
                 raw.set_label(label);
             }
             self.counters.buffers.add(1);
-            Ok(super::Buffer {
-                raw,
-                size: desc.size,
-            })
+            Ok(super::Buffer { raw })
         })
     }
     unsafe fn destroy_buffer(&self, _buffer: super::Buffer) {
@@ -935,14 +928,9 @@ impl crate::Device for super::Device {
                                 let end = start + 1;
                                 bg.buffers
                                     .extend(desc.buffers[start..end].iter().map(|source| {
-                                        // Given the restrictions on `BufferBinding::offset`,
-                                        // this should never be `None`.
-                                        let remaining_size = wgt::BufferSize::new(
-                                            source.buffer.size - source.offset,
-                                        );
                                         let binding_size = match ty {
                                             wgt::BufferBindingType::Storage { .. } => {
-                                                source.size.or(remaining_size)
+                                                Some(source.size)
                                             }
                                             _ => None,
                                         };

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -502,7 +502,6 @@ impl crate::Queue for Queue {
 #[derive(Debug)]
 pub struct Buffer {
     raw: metal::Buffer,
-    size: wgt::BufferAddress,
 }
 
 unsafe impl Send for Buffer {}
@@ -513,15 +512,6 @@ impl crate::DynBuffer for Buffer {}
 impl Buffer {
     fn as_raw(&self) -> BufferPtr {
         unsafe { NonNull::new_unchecked(self.raw.as_ptr()) }
-    }
-}
-
-impl crate::BufferBinding<'_, Buffer> {
-    fn resolve_size(&self) -> wgt::BufferAddress {
-        match self.size {
-            Some(size) => size.get(),
-            None => self.buffer.size - self.offset,
-        }
     }
 }
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1802,9 +1802,7 @@ impl crate::Device for super::Device {
                                 vk::DescriptorBufferInfo::default()
                                     .buffer(binding.buffer.raw)
                                     .offset(binding.offset)
-                                    .range(
-                                        binding.size.map_or(vk::WHOLE_SIZE, wgt::BufferSize::get),
-                                    )
+                                    .range(binding.size.get())
                             },
                         ));
                     write.buffer_info(local_buffer_infos)

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1799,10 +1799,12 @@ impl crate::Device for super::Device {
                     (buffer_infos, local_buffer_infos) =
                         buffer_infos.extend(desc.buffers[start as usize..end as usize].iter().map(
                             |binding| {
+                                // https://github.com/gfx-rs/wgpu/issues/3170
+                                assert!(binding.size != 0, "zero-size bindings are not supported");
                                 vk::DescriptorBufferInfo::default()
                                     .buffer(binding.buffer.raw)
                                     .offset(binding.offset)
-                                    .range(binding.size.get())
+                                    .range(binding.size)
                             },
                         ));
                     write.buffer_info(local_buffer_infos)

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -61,6 +61,12 @@ pub type BufferAddress = u64;
 /// [`BufferSlice`]: ../wgpu/struct.BufferSlice.html
 pub type BufferSize = core::num::NonZeroU64;
 
+/// Integral type used for buffer sizes that may be zero.
+///
+/// Although the wgpu Rust API disallows zero-size `BufferSlice` and wgpu-hal
+/// disallows zero-size bindings, WebGPU permits zero-size buffers and bindings.
+pub type BufferSizeOrZero = u64;
+
 /// Integral type used for binding locations in shaders.
 ///
 /// Used in [`VertexAttribute`]s and errors.

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -322,6 +322,7 @@ impl Device {
     /// - `hal_buffer` must be created from this device internal handle
     /// - `hal_buffer` must be created respecting `desc`
     /// - `hal_buffer` must be initialized
+    /// - `hal_buffer` must not have zero size
     #[cfg(wgpu_core)]
     #[must_use]
     pub unsafe fn create_buffer_from_hal<A: wgc::hal_api::HalApi>(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -170,6 +170,12 @@ impl ContextWgpuCore {
         }
     }
 
+    /// # Safety
+    ///
+    /// - `hal_buffer` must be created from `device`.
+    /// - `hal_buffer` must be created respecting `desc`
+    /// - `hal_buffer` must be initialized
+    /// - `hal_buffer` must not have zero size.
     pub unsafe fn create_buffer_from_hal<A: wgc::hal_api::HalApi>(
         &self,
         hal_buffer: A::Buffer,


### PR DESCRIPTION
Fixes the issues noted in https://github.com/gfx-rs/wgpu/issues/1039#issuecomment-3010879202. Together with #7874, this addresses #1039.

This tightens up the validation of binding sizes. I have added a helper on the wgpu_core `Buffer` type to resolve implicit remainder-of-buffer sizes and validate the binding offset and size against the size of the buffer. This helper is now the preferred way of constructing a `hal::BufferBinding`. Direct construction is no longer allowed in wgpu_core. There is an unsafe `new_unchecked` helper for cases where direct construction is necessary.

~The more controversial and potentially risky part of this change is that the validation of binding size rejects zero-size bindings. Previously, zero-size bindings were allowed in `create_buffer_binding`, even though `hal::BufferBinding` was documented as not allowing zero-size bindings. So I think this version is safer, but it's possible that zero-size bindings were tolerated in some cases before that will no longer work.~ 

I have left support for zero-size bindings in approximately the same state as it was, since attempting to disallow them entirely caused test failures. #3170 

**Testing**
Tested locally using the following CTS tests:
```
webgpu:api,validation,encoding,cmds,render,setIndexBuffer:offset_and_size_oob:*
webgpu:api,validation,encoding,cmds,render,setVertexBuffer:offset_and_size_oob:*
```

The tests are still failing, due to #3170, but the situation is improved.

**Squash or Rebase?** Rebase (seems useful to keep the "validate binding ranges" and "restore zero-sized buffer" support commits separate, since it may be useful to revert the latter).

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
