### PR TITLE
Check the parent texture in `TextureView::try_raw`

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -458,9 +458,9 @@ impl Buffer {
             .ok_or_else(|| DestroyedResourceError(self.error_ident()))
     }
 
-    pub(crate) fn check_destroyed<'a>(
-        &'a self,
-        guard: &'a SnatchGuard,
+    pub(crate) fn check_destroyed(
+        &self,
+        guard: &SnatchGuard,
     ) -> Result<(), DestroyedResourceError> {
         self.raw
             .get(guard)
@@ -1217,6 +1217,16 @@ impl Texture {
             .ok_or_else(|| DestroyedResourceError(self.error_ident()))
     }
 
+    pub(crate) fn check_destroyed(
+        &self,
+        guard: &SnatchGuard,
+    ) -> Result<(), DestroyedResourceError> {
+        self.inner
+            .get(guard)
+            .map(|_| ())
+            .ok_or_else(|| DestroyedResourceError(self.error_ident()))
+    }
+
     pub(crate) fn get_clear_view<'a>(
         clear_mode: &'a TextureClearMode,
         desc: &'a wgt::TextureDescriptor<(), Vec<wgt::TextureFormat>>,
@@ -1810,6 +1820,7 @@ impl TextureView {
         &'a self,
         guard: &'a SnatchGuard,
     ) -> Result<&'a dyn hal::DynTextureView, DestroyedResourceError> {
+        self.parent.check_destroyed(guard)?;
         self.raw
             .get(guard)
             .map(|it| it.as_ref())


### PR DESCRIPTION
When we access an inner texture view, also check that the parent texture is not destroyed.

**Testing**
Passes existing tests, and makes the behavior with texture and buffers the same for the test `webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:*`. This test still fails for other reasons so I haven't added it to the regression.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
