### PR TITLE
Rg11b10ufloat should be resolvable when it is renderable

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -50,6 +50,8 @@ webgpu:api,validation,queue,submit:command_buffer,submit_invalidates:*
 //FAIL: webgpu:api,validation,queue,submit:command_buffer,invalid_submit_invalidates:*
 // https://github.com/gfx-rs/wgpu/issues/3911#issuecomment-2972995675
 webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*
+webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,*
+webgpu:api,validation,texture,rg11b10ufloat_renderable:*
 webgpu:api,operation,render_pipeline,overrides:*
 webgpu:api,operation,rendering,basic:clear:*
 webgpu:api,operation,rendering,basic:fullscreen_quad:*

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2958,11 +2958,12 @@ impl TextureFormat {
             storage | binding
         };
         let atomic = attachment | atomic_64;
-        let rg11b10f = if device_features.contains(Features::RG11B10UFLOAT_RENDERABLE) {
-            attachment
-        } else {
-            basic
-        };
+        let (rg11b10f_f, rg11b10f_u) =
+            if device_features.contains(Features::RG11B10UFLOAT_RENDERABLE) {
+                (msaa_resolve, attachment)
+            } else {
+                (msaa, basic)
+            };
         let (bgra8unorm_f, bgra8unorm) = if device_features.contains(Features::BGRA8UNORM_STORAGE) {
             (
                 msaa_resolve | TextureFormatFeatureFlags::STORAGE_WRITE_ONLY,
@@ -3003,7 +3004,7 @@ impl TextureFormat {
             Self::Bgra8UnormSrgb =>       (msaa_resolve, attachment),
             Self::Rgb10a2Uint =>          (        msaa, attachment),
             Self::Rgb10a2Unorm =>         (msaa_resolve, attachment),
-            Self::Rg11b10Ufloat =>        (        msaa,   rg11b10f),
+            Self::Rg11b10Ufloat =>        (  rg11b10f_f, rg11b10f_u),
             Self::R64Uint =>              (     s_ro_wo,  atomic_64),
             Self::Rg32Uint =>             (     s_ro_wo,  all_flags),
             Self::Rg32Sint =>             (     s_ro_wo,  all_flags),


### PR DESCRIPTION
As the title says. This is impacting at least one site in Firefox. https://bugzilla.mozilla.org/show_bug.cgi?id=1975285

**Testing**
Enables some relevant CTS tests.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
