### PR TITLE
[ci] Configure renovate to update the CTS

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -104,6 +104,26 @@
         "deno_*"
       ],
       "enabled": false
+    },
+    {
+      "description": "CTS revision is pinned to a Git SHA.",
+      "matchPackageNames": [
+        "https://github.com/gpuweb/cts"
+      ],
+      "versioning": "git"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^cts_runner\\/revision\\.txt$/"],
+      "matchStrings": [
+        "(?<currentDigest>.{40})"
+      ],
+      "currentValueTemplate": "gh-pages",
+      "depNameTemplate": "cts",
+      "packageNameTemplate": "https://github.com/gpuweb/cts",
+      "datasourceTemplate": "git-refs"
     }
   ]
 }


### PR DESCRIPTION
Configure renovate to update the pinned Git SHA for the CTS.

**Testing**
Tested locally with the renovate CLI. There is also a way to have renovate test the changes in a PR by creating a branch with a particular name but I didn't attempt that.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
