### PR TITLE
Add TextureView::texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ Previously, if you wanted to get access to the wgpu-hal or underlying api types,
 
 ### New Features
 
+#### New method `TextureView::texture`
+
+You can now call `texture_view.texture()` to get access to the texture that
+a given texture view points to.
+
+By @cwfitzgerald in [#7907](https://github.com/gfx-rs/wgpu/pull/7907).
+
 #### Naga
 
 - Added `no_std` support with default features disabled. By @Bushrat011899 in [#7585](https://github.com/gfx-rs/wgpu/pull/7585).

--- a/tests/tests/wgpu-gpu/mem_leaks.rs
+++ b/tests/tests/wgpu-gpu/mem_leaks.rs
@@ -169,8 +169,9 @@ async fn draw_test_with_reports(
     assert_eq!(report.buffers.num_allocated, 1);
     assert_eq!(report.texture_views.num_allocated, 1);
     assert_eq!(report.texture_views.num_kept_from_user, 1);
-    assert_eq!(report.textures.num_allocated, 0);
-    assert_eq!(report.textures.num_kept_from_user, 0);
+    // TextureViews in `wgpu` have a reference to the texture.
+    assert_eq!(report.textures.num_allocated, 1);
+    assert_eq!(report.textures.num_kept_from_user, 1);
 
     let mut encoder = ctx
         .device
@@ -208,7 +209,7 @@ async fn draw_test_with_reports(
     assert_eq!(report.command_buffers.num_allocated, 1);
     assert_eq!(report.render_bundles.num_allocated, 0);
     assert_eq!(report.texture_views.num_allocated, 1);
-    assert_eq!(report.textures.num_allocated, 0);
+    assert_eq!(report.textures.num_allocated, 1);
 
     function(&mut rpass);
 

--- a/wgpu/src/api/texture.rs
+++ b/wgpu/src/api/texture.rs
@@ -70,7 +70,10 @@ impl Texture {
     pub fn create_view(&self, desc: &TextureViewDescriptor<'_>) -> TextureView {
         let view = self.inner.create_view(desc);
 
-        TextureView { inner: view }
+        TextureView {
+            inner: view,
+            texture: self.clone(),
+        }
     }
 
     /// Destroy the associated native resources as soon as possible.

--- a/wgpu/src/api/texture_view.rs
+++ b/wgpu/src/api/texture_view.rs
@@ -15,6 +15,7 @@ use crate::*;
 #[derive(Debug, Clone)]
 pub struct TextureView {
     pub(crate) inner: dispatch::DispatchTextureView,
+    pub(crate) texture: Texture,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(TextureView: Send, Sync);
@@ -22,6 +23,14 @@ static_assertions::assert_impl_all!(TextureView: Send, Sync);
 crate::cmp::impl_eq_ord_hash_proxy!(TextureView => .inner);
 
 impl TextureView {
+    /// Returns the [`Texture`] that this `TextureView` refers to.
+    ///
+    /// All wgpu resources are refcounted, so you can own the returned [`Texture`]
+    /// by cloning it.
+    pub fn texture(&self) -> &Texture {
+        &self.texture
+    }
+
     /// Get the [`wgpu_hal`] texture view from this `TextureView`.
     ///
     /// Find the Api struct corresponding to the active backend in [`wgpu_hal::api`],


### PR DESCRIPTION
Split out of #7895 to land in v26 while we figure out what to do with the descriptors.