### PR TITLE
Merge acceleration structure feature and ray query feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Bottom level categories:
 
 ## Unreleased
 
+### General
+
+- Merge `EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE` into `EXPERIMENTAL_RAY_QUERY`. By @Vecvec in [#7913](https://github.com/gfx-rs/wgpu/pull/7913).
+
 ## v26.0.0 (2025-07-09)
 
 ### Major Features

--- a/docs/api-specs/ray_tracing.md
+++ b/docs/api-specs/ray_tracing.md
@@ -19,7 +19,7 @@ The documentation and specific details of the functions and structures provided
 can be found with their definitions.
 
 Acceleration structures do not have a separate feature, instead they are enabled by `Features::EXPERIMENTAL_RAY_QUERY`, unlike vulkan.
-When ray tracing pipelines are added that feature will also enable acceleration structures.
+When ray tracing pipelines are added, that feature will also enable acceleration structures.
 
 A [`Blas`] can be created with [`Device::create_blas`].
 A [`Tlas`] can be created with [`Device::create_tlas`].

--- a/docs/api-specs/ray_tracing.md
+++ b/docs/api-specs/ray_tracing.md
@@ -3,7 +3,7 @@
 🧪Experimental🧪
 
 `wgpu` supports an experimental version of ray tracing which is subject to change. The extensions allow for acceleration structures to be created and built (with
-`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE` enabled) and interacted with in shaders. Currently `naga` only supports ray queries
+`Features::EXPERIMENTAL_RAY_QUERY` enabled) and interacted with in shaders. Currently `naga` only supports ray queries
 (accessible with `Features::EXPERIMENTAL_RAY_QUERY` enabled in wgpu).
 
 **Note**: The features documented here may have major bugs in them and are expected to be subject
@@ -17,6 +17,9 @@ an [introduction](https://developer.nvidia.com/blog/introduction-nvidia-rtx-dire
 
 The documentation and specific details of the functions and structures provided
 can be found with their definitions.
+
+Acceleration structures do not have a separate feature, instead they are enabled by `Features::EXPERIMENTAL_RAY_QUERY`, unlike vulkan.
+When ray tracing pipelines are added that feature will also enable acceleration structures.
 
 A [`Blas`] can be created with [`Device::create_blas`].
 A [`Tlas`] can be created with [`Device::create_tlas`].

--- a/examples/features/src/ray_cube_compute/mod.rs
+++ b/examples/features/src/ray_cube_compute/mod.rs
@@ -145,7 +145,6 @@ impl crate::framework::Example for Example {
         wgpu::Features::TEXTURE_BINDING_ARRAY
             | wgpu::Features::VERTEX_WRITABLE_STORAGE
             | wgpu::Features::EXPERIMENTAL_RAY_QUERY
-            | wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
     }
 
     fn required_downlevel_capabilities() -> wgpu::DownlevelCapabilities {

--- a/examples/features/src/ray_cube_fragment/mod.rs
+++ b/examples/features/src/ray_cube_fragment/mod.rs
@@ -108,7 +108,6 @@ struct Example {
 impl crate::framework::Example for Example {
     fn required_features() -> wgpu::Features {
         wgpu::Features::EXPERIMENTAL_RAY_QUERY
-            | wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
     }
 
     fn required_downlevel_capabilities() -> wgpu::DownlevelCapabilities {

--- a/examples/features/src/ray_cube_normals/mod.rs
+++ b/examples/features/src/ray_cube_normals/mod.rs
@@ -133,9 +133,7 @@ impl crate::framework::Example for Example {
     // Don't want srgb, so normals show up better.
     const SRGB: bool = false;
     fn required_features() -> wgpu::Features {
-        wgpu::Features::EXPERIMENTAL_RAY_QUERY
-            | wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
-            | wgpu::Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN
+        wgpu::Features::EXPERIMENTAL_RAY_QUERY | wgpu::Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN
     }
 
     fn required_downlevel_capabilities() -> wgpu::DownlevelCapabilities {

--- a/examples/features/src/ray_scene/mod.rs
+++ b/examples/features/src/ray_scene/mod.rs
@@ -318,7 +318,6 @@ struct Example {
 impl crate::framework::Example for Example {
     fn required_features() -> wgpu::Features {
         wgpu::Features::EXPERIMENTAL_RAY_QUERY
-            | wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
     }
 
     fn required_downlevel_capabilities() -> wgpu::DownlevelCapabilities {

--- a/examples/features/src/ray_shadows/mod.rs
+++ b/examples/features/src/ray_shadows/mod.rs
@@ -104,9 +104,7 @@ fn create_matrix(config: &wgpu::SurfaceConfiguration) -> Uniforms {
 
 impl crate::framework::Example for Example {
     fn required_features() -> wgpu::Features {
-        wgpu::Features::EXPERIMENTAL_RAY_QUERY
-            | wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
-            | wgpu::Features::PUSH_CONSTANTS
+        wgpu::Features::EXPERIMENTAL_RAY_QUERY | wgpu::Features::PUSH_CONSTANTS
     }
 
     fn required_downlevel_capabilities() -> wgpu::DownlevelCapabilities {

--- a/examples/features/src/ray_traced_triangle/mod.rs
+++ b/examples/features/src/ray_traced_triangle/mod.rs
@@ -29,8 +29,7 @@ struct Uniforms {
 
 impl crate::framework::Example for Example {
     fn required_features() -> wgpu::Features {
-        wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
-            | wgpu::Features::EXPERIMENTAL_RAY_QUERY
+        wgpu::Features::EXPERIMENTAL_RAY_QUERY
     }
 
     fn required_limits() -> wgpu::Limits {

--- a/tests/tests/wgpu-gpu/oom.rs
+++ b/tests/tests/wgpu-gpu/oom.rs
@@ -159,10 +159,8 @@ static QUERY_SET_OOM_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
 static BLAS_OOM_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
+            .features(Features::EXPERIMENTAL_RAY_QUERY)
             .skip(FailureCase::backend(!OOM_DETECTION_IMPL))
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(Backends::VULKAN, "AMD"))
             // see comment at the top of the file
             .skip(FailureCase::backend_adapter(Backends::VULKAN, "llvmpipe")),
     )
@@ -203,10 +201,8 @@ static BLAS_OOM_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
 static TLAS_OOM_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
+            .features(Features::EXPERIMENTAL_RAY_QUERY)
             .skip(FailureCase::backend(!OOM_DETECTION_IMPL))
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(Backends::VULKAN, "AMD"))
             // see comment at the top of the file
             .skip(FailureCase::backend_adapter(Backends::VULKAN, "llvmpipe")),
     )

--- a/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
@@ -3,9 +3,7 @@ use std::iter;
 use crate::ray_tracing::{acceleration_structure_limits, AsBuildContext};
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu::*;
-use wgpu_test::{
-    fail, fail_if, gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext,
-};
+use wgpu_test::{fail, fail_if, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
 #[gpu_test]
 static UNBUILT_BLAS: GpuTestConfiguration = GpuTestConfiguration::new()
@@ -13,9 +11,7 @@ static UNBUILT_BLAS: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(unbuilt_blas);
 
@@ -48,9 +44,7 @@ static UNBUILT_BLAS_COMPACTION: GpuTestConfiguration = GpuTestConfiguration::new
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(unbuilt_blas_compaction);
 
@@ -77,9 +71,7 @@ static BLAS_COMPACTION_WITHOUT_FLAGS: GpuTestConfiguration = GpuTestConfiguratio
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(blas_compaction_without_flags);
 
@@ -114,9 +106,7 @@ static UNPREPARED_BLAS_COMPACTION: GpuTestConfiguration = GpuTestConfiguration::
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(unprepared_blas_compaction);
 
@@ -144,9 +134,7 @@ static BLAS_COMPACTION: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(blas_compaction);
 
@@ -203,9 +191,7 @@ static OUT_OF_ORDER_AS_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(out_of_order_as_build);
 
@@ -287,12 +273,7 @@ static OUT_OF_ORDER_AS_BUILD_USE: GpuTestConfiguration = GpuTestConfiguration::n
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(
-                wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
-                    | wgpu::Features::EXPERIMENTAL_RAY_QUERY,
-            )
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(out_of_order_as_build_use);
 
@@ -474,7 +455,7 @@ static EMPTY_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(empty_build);
 fn empty_build(ctx: TestingContext) {
@@ -495,9 +476,7 @@ static BUILD_WITH_TRANSFORM: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(build_with_transform);
 
@@ -583,12 +562,9 @@ static ONLY_BLAS_VERTEX_RETURN: GpuTestConfiguration = GpuTestConfiguration::new
             .test_features_limits()
             .limits(acceleration_structure_limits())
             .features(
-                wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
-                    | wgpu::Features::EXPERIMENTAL_RAY_QUERY
+                wgpu::Features::EXPERIMENTAL_RAY_QUERY
                     | wgpu::Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN,
-            )
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            ),
     )
     .run_sync(only_blas_vertex_return);
 
@@ -710,12 +686,9 @@ static ONLY_TLAS_VERTEX_RETURN: GpuTestConfiguration = GpuTestConfiguration::new
             .test_features_limits()
             .limits(acceleration_structure_limits())
             .features(
-                wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
-                    | wgpu::Features::EXPERIMENTAL_RAY_QUERY
+                wgpu::Features::EXPERIMENTAL_RAY_QUERY
                     | wgpu::Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN,
-            )
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            ),
     )
     .run_sync(only_tlas_vertex_return);
 
@@ -752,11 +725,9 @@ static EXTRA_FORMAT_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
             .test_features_limits()
             .limits(acceleration_structure_limits())
             .features(
-                wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
+                wgpu::Features::EXPERIMENTAL_RAY_QUERY
                     | wgpu::Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS,
-            )
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            ),
     )
     .run_sync(|ctx| test_as_build_format_stride(ctx, VertexFormat::Snorm16x4, 6, false));
 
@@ -766,9 +737,7 @@ static MISALIGNED_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     // Larger than the minimum size, but not aligned as required
     .run_sync(|ctx| test_as_build_format_stride(ctx, VertexFormat::Float32x3, 13, true));
@@ -779,9 +748,7 @@ static TOO_SMALL_STRIDE_BUILD: GpuTestConfiguration = GpuTestConfiguration::new(
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     // Aligned as required, but smaller than minimum size
     .run_sync(|ctx| test_as_build_format_stride(ctx, VertexFormat::Float32x3, 8, true));

--- a/tests/tests/wgpu-gpu/ray_tracing/as_create.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_create.rs
@@ -14,7 +14,7 @@ static BLAS_INVALID_VERTEX_FORMAT: GpuTestConfiguration = GpuTestConfiguration::
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(invalid_vertex_format_blas_create);
 
@@ -55,7 +55,7 @@ static BLAS_MISMATCHED_INDEX: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(mismatched_index_blas_create);
 

--- a/tests/tests/wgpu-gpu/ray_tracing/as_use_after_free.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_use_after_free.rs
@@ -11,11 +11,10 @@ use wgpu::{
     PollType, TlasInstance, VertexFormat,
 };
 use wgpu_macros::gpu_test;
-use wgpu_test::{FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{GpuTestConfiguration, TestParameters, TestingContext};
 
 fn required_features() -> wgpu::Features {
     wgpu::Features::EXPERIMENTAL_RAY_QUERY
-        | wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
 }
 
 /// This test creates a blas, puts a reference to it in a tlas instance inside a tlas package,
@@ -147,8 +146,6 @@ static ACCELERATION_STRUCTURE_USE_AFTER_FREE: GpuTestConfiguration = GpuTestConf
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(required_features())
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(required_features()),
     )
     .run_sync(acceleration_structure_use_after_free);

--- a/tests/tests/wgpu-gpu/ray_tracing/limits.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/limits.rs
@@ -8,7 +8,7 @@ use wgpu::{
     ShaderStages, VertexFormat,
 };
 use wgpu_macros::gpu_test;
-use wgpu_test::{fail, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{fail, GpuTestConfiguration, TestParameters, TestingContext};
 
 #[gpu_test]
 static LIMITS_HIT: GpuTestConfiguration = GpuTestConfiguration::new()
@@ -22,9 +22,7 @@ static LIMITS_HIT: GpuTestConfiguration = GpuTestConfiguration::new()
                 max_acceleration_structures_per_shader_stage: 1,
                 ..Limits::default()
             })
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(hit_limits);
 

--- a/tests/tests/wgpu-gpu/ray_tracing/scene/mod.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/scene/mod.rs
@@ -1,6 +1,6 @@
 use std::{iter, mem};
 
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
 use wgpu::util::DeviceExt;
 
@@ -103,9 +103,7 @@ static ACCELERATION_STRUCTURE_BUILD_NO_INDEX: GpuTestConfiguration = GpuTestConf
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(|ctx| {
         acceleration_structure_build(&ctx, false);
@@ -117,9 +115,7 @@ static ACCELERATION_STRUCTURE_BUILD_WITH_INDEX: GpuTestConfiguration = GpuTestCo
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-            // https://github.com/gfx-rs/wgpu/issues/6727
-            .skip(FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(|ctx| {
         acceleration_structure_build(&ctx, true);

--- a/tests/tests/wgpu-gpu/ray_tracing/shader.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/shader.rs
@@ -15,10 +15,7 @@ static ACCESS_ALL_STRUCT_MEMBERS: GpuTestConfiguration = GpuTestConfiguration::n
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(
-                wgpu::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
-                    | wgpu::Features::EXPERIMENTAL_RAY_QUERY,
-            ),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
     )
     .run_sync(access_all_struct_members);
 

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -76,8 +76,7 @@ impl Global {
             |cmd_buf_data| -> Result<(), BuildAccelerationStructureError> {
                 let device = &cmd_buf.device;
                 device.check_is_valid()?;
-                device
-                    .require_features(Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)?;
+                device.require_features(Features::EXPERIMENTAL_RAY_QUERY)?;
 
                 let mut build_command = AsBuild::default();
 
@@ -214,7 +213,7 @@ impl Global {
 
             let device = &cmd_buf.device;
             device.check_is_valid()?;
-            device.require_features(Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)?;
+            device.require_features(Features::EXPERIMENTAL_RAY_QUERY)?;
 
             let mut buf_storage = Vec::new();
             iter_blas(

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1691,9 +1691,7 @@ impl Global {
         // TODO: Tracing
 
         let error = 'error: {
-            match device.require_features(
-                wgpu_types::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE,
-            ) {
+            match device.require_features(wgpu_types::Features::EXPERIMENTAL_RAY_QUERY) {
                 Ok(_) => {}
                 Err(err) => break 'error err.into(),
             }

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -30,7 +30,7 @@ impl Device {
         sizes: wgt::BlasGeometrySizeDescriptors,
     ) -> Result<Arc<resource::Blas>, CreateBlasError> {
         self.check_is_valid()?;
-        self.require_features(Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)?;
+        self.require_features(Features::EXPERIMENTAL_RAY_QUERY)?;
 
         if blas_desc
             .flags
@@ -176,7 +176,7 @@ impl Device {
         desc: &resource::TlasDescriptor,
     ) -> Result<Arc<resource::Tlas>, CreateTlasError> {
         self.check_is_valid()?;
-        self.require_features(Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)?;
+        self.require_features(Features::EXPERIMENTAL_RAY_QUERY)?;
 
         if desc.max_instances > self.limits.max_tlas_instance_count {
             return Err(CreateTlasError::TooManyInstances(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -236,7 +236,7 @@ impl Device {
 
         let rt_uses = if desc
             .required_features
-            .contains(wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
+            .intersects(wgt::Features::EXPERIMENTAL_RAY_QUERY)
         {
             wgt::BufferUses::TOP_LEVEL_ACCELERATION_STRUCTURE_INPUT
         } else {

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -468,17 +468,15 @@ impl super::Adapter {
         }
         .is_ok();
 
-        // Since all features for raytracing pipeline (geometry index) and ray queries both come
-        // from here, there is no point in adding an extra call here given that there will be no
-        // feature using EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE if all these are not met.
         // Once ray tracing pipelines are supported they also will go here
+        let supports_ray_tracing = features5.RaytracingTier
+            == Direct3D12::D3D12_RAYTRACING_TIER_1_1
+            && shader_model >= naga::back::hlsl::ShaderModel::V6_5
+            && has_features5;
         features.set(
             wgt::Features::EXPERIMENTAL_RAY_QUERY
-                | wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
                 | wgt::Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS,
-            features5.RaytracingTier == Direct3D12::D3D12_RAYTRACING_TIER_1_1
-                && shader_model >= naga::back::hlsl::ShaderModel::V6_5
-                && has_features5,
+            supports_ray_tracing,
         );
 
         let atomic_int64_on_typed_resource_supported = {
@@ -519,12 +517,11 @@ impl super::Adapter {
         // If we also support acceleration structures these are shared so we must halve it.
         // It's unlikely that this affects anything because most devices that support ray tracing
         // probably have a higher binding tier than one.
-        let max_sampled_textures_per_shader_stage =
-            if !features.contains(wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE) {
-                max_srv_count
-            } else {
-                max_srv_count / 2
-            };
+        let max_sampled_textures_per_shader_stage = if !supports_ray_tracing {
+            max_srv_count
+        } else {
+            max_srv_count / 2
+        };
 
         Some(crate::ExposedAdapter {
             adapter: super::Adapter {
@@ -616,30 +613,22 @@ impl super::Adapter {
                     // store buffer sizes using 32 bit ints (a situation we have already encountered with vulkan).
                     max_buffer_size: i32::MAX as u64,
                     max_non_sampler_bindings: 1_000_000,
-                    max_blas_primitive_count: if features
-                        .contains(wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-                    {
+                    max_blas_primitive_count: if supports_ray_tracing {
                         1 << 29 // 2^29
                     } else {
                         0
                     },
-                    max_blas_geometry_count: if features
-                        .contains(wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-                    {
+                    max_blas_geometry_count: if supports_ray_tracing {
                         1 << 24 // 2^24
                     } else {
                         0
                     },
-                    max_tlas_instance_count: if features
-                        .contains(wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-                    {
+                    max_tlas_instance_count: if supports_ray_tracing {
                         1 << 24 // 2^24
                     } else {
                         0
                     },
-                    max_acceleration_structures_per_shader_stage: if features
-                        .contains(wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE)
-                    {
+                    max_acceleration_structures_per_shader_stage: if supports_ray_tracing {
                         max_srv_count / 2
                     } else {
                         0

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -984,18 +984,6 @@ bitflags_array! {
         ///
         /// [`TextureFormat::NV12`]: super::TextureFormat::NV12
         const TEXTURE_FORMAT_NV12 = 1 << 29;
-        /// ***THIS IS EXPERIMENTAL:*** Features enabled by this may have
-        /// major bugs in them and are expected to be subject to breaking changes, suggestions
-        /// for the API exposed by this should be posted on [the ray-tracing issue](https://github.com/gfx-rs/wgpu/issues/1040)
-        ///
-        /// Allows for the creation of ray-tracing acceleration structures. Currently,
-        /// ray-tracing acceleration structures are only useful when used with [Features::EXPERIMENTAL_RAY_QUERY]
-        ///
-        /// Supported platforms:
-        /// - Vulkan
-        ///
-        /// This is a native-only feature.
-        const EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE = 1 << 30;
 
         /// Allows for the creation and usage of `ExternalTexture`s, and bind
         /// group layouts containing external texture `BindingType`s.
@@ -1010,7 +998,7 @@ bitflags_array! {
         ///
         /// Supported platforms:
         /// - None
-        const EXTERNAL_TEXTURE = 1 << 31;
+        const EXTERNAL_TEXTURE = 1 << 30;
 
         // Shader:
 
@@ -1024,7 +1012,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native-only feature.
-        const EXPERIMENTAL_RAY_QUERY = 1 << 32;
+        const EXPERIMENTAL_RAY_QUERY = 1 << 31;
         /// Enables 64-bit floating point types in SPIR-V shaders.
         ///
         /// Note: even when supported by GPU hardware, 64-bit floating point operations are
@@ -1034,14 +1022,14 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const SHADER_F64 = 1 << 33;
+        const SHADER_F64 = 1 << 32;
         /// Allows shaders to use i16. Not currently supported in `naga`, only available through `spirv-passthrough`.
         ///
         /// Supported platforms:
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const SHADER_I16 = 1 << 34;
+        const SHADER_I16 = 1 << 33;
         /// Enables `builtin(primitive_index)` in fragment shaders.
         ///
         /// Note: enables geometry processing for pipelines using the builtin.
@@ -1055,7 +1043,7 @@ bitflags_array! {
         /// - OpenGL (some)
         ///
         /// This is a native only feature.
-        const SHADER_PRIMITIVE_INDEX = 1 << 35;
+        const SHADER_PRIMITIVE_INDEX = 1 << 34;
         /// Allows shaders to use the `early_depth_test` attribute.
         ///
         /// The attribute is applied to the fragment shader entry point. It can be used in two
@@ -1083,7 +1071,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [`EarlyDepthTest`]: https://docs.rs/naga/latest/naga/ir/enum.EarlyDepthTest.html
-        const SHADER_EARLY_DEPTH_TEST = 1 << 36;
+        const SHADER_EARLY_DEPTH_TEST = 1 << 35;
         /// Allows shaders to use i64 and u64.
         ///
         /// Supported platforms:
@@ -1092,7 +1080,7 @@ bitflags_array! {
         /// - Metal (with MSL 2.3+)
         ///
         /// This is a native only feature.
-        const SHADER_INT64 = 1 << 37;
+        const SHADER_INT64 = 1 << 36;
         /// Allows compute and fragment shaders to use the subgroup operation built-ins
         ///
         /// Supported Platforms:
@@ -1101,14 +1089,14 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const SUBGROUP = 1 << 38;
+        const SUBGROUP = 1 << 37;
         /// Allows vertex shaders to use the subgroup operation built-ins
         ///
         /// Supported Platforms:
         /// - Vulkan
         ///
         /// This is a native only feature.
-        const SUBGROUP_VERTEX = 1 << 39;
+        const SUBGROUP_VERTEX = 1 << 38;
         /// Allows shaders to use the subgroup barrier
         ///
         /// Supported Platforms:
@@ -1116,7 +1104,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const SUBGROUP_BARRIER = 1 << 40;
+        const SUBGROUP_BARRIER = 1 << 39;
         /// Allows the use of pipeline cache objects
         ///
         /// Supported platforms:
@@ -1125,7 +1113,7 @@ bitflags_array! {
         /// Unimplemented Platforms:
         /// - DX12
         /// - Metal
-        const PIPELINE_CACHE = 1 << 41;
+        const PIPELINE_CACHE = 1 << 40;
         /// Allows shaders to use i64 and u64 atomic min and max.
         ///
         /// Supported platforms:
@@ -1134,7 +1122,7 @@ bitflags_array! {
         /// - Metal (with MSL 2.4+)
         ///
         /// This is a native only feature.
-        const SHADER_INT64_ATOMIC_MIN_MAX = 1 << 42;
+        const SHADER_INT64_ATOMIC_MIN_MAX = 1 << 41;
         /// Allows shaders to use all i64 and u64 atomic operations.
         ///
         /// Supported platforms:
@@ -1142,7 +1130,7 @@ bitflags_array! {
         /// - DX12 (with SM 6.6+)
         ///
         /// This is a native only feature.
-        const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 43;
+        const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 42;
         /// Allows using the [VK_GOOGLE_display_timing] Vulkan extension.
         ///
         /// This is used for frame pacing to reduce latency, and is generally only available on Android.
@@ -1158,7 +1146,7 @@ bitflags_array! {
         ///
         /// [VK_GOOGLE_display_timing]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html
         /// [`Surface::as_hal()`]: https://docs.rs/wgpu/latest/wgpu/struct.Surface.html#method.as_hal
-        const VULKAN_GOOGLE_DISPLAY_TIMING = 1 << 44;
+        const VULKAN_GOOGLE_DISPLAY_TIMING = 1 << 43;
 
         /// Allows using the [VK_KHR_external_memory_win32] Vulkan extension.
         ///
@@ -1168,7 +1156,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [VK_KHR_external_memory_win32]: https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_external_memory_win32.html
-        const VULKAN_EXTERNAL_MEMORY_WIN32 = 1 << 45;
+        const VULKAN_EXTERNAL_MEMORY_WIN32 = 1 << 44;
 
         /// Enables R64Uint image atomic min and max.
         ///
@@ -1178,7 +1166,7 @@ bitflags_array! {
         /// - Metal (with MSL 3.1+)
         ///
         /// This is a native only feature.
-        const TEXTURE_INT64_ATOMIC = 1 << 46;
+        const TEXTURE_INT64_ATOMIC = 1 << 45;
 
         /// Allows uniform buffers to be bound as binding arrays.
         ///
@@ -1195,7 +1183,7 @@ bitflags_array! {
         /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s `shaderUniformBufferArrayNonUniformIndexing` feature)
         ///
         /// This is a native only feature.
-        const UNIFORM_BUFFER_BINDING_ARRAYS = 1 << 47;
+        const UNIFORM_BUFFER_BINDING_ARRAYS = 1 << 46;
 
         /// Enables mesh shaders and task shaders in mesh shader pipelines.
         ///
@@ -1207,7 +1195,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const EXPERIMENTAL_MESH_SHADER = 1 << 48;
+        const EXPERIMENTAL_MESH_SHADER = 1 << 47;
 
         /// ***THIS IS EXPERIMENTAL:*** Features enabled by this may have
         /// major bugs in them and are expected to be subject to breaking changes, suggestions
@@ -1222,7 +1210,7 @@ bitflags_array! {
         /// This is a native only feature
         ///
         /// [`AccelerationStructureFlags::ALLOW_RAY_HIT_VERTEX_RETURN`]: super::AccelerationStructureFlags::ALLOW_RAY_HIT_VERTEX_RETURN
-        const EXPERIMENTAL_RAY_HIT_VERTEX_RETURN = 1 << 49;
+        const EXPERIMENTAL_RAY_HIT_VERTEX_RETURN = 1 << 48;
 
         /// Enables multiview in mesh shader pipelines
         ///
@@ -1234,7 +1222,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
-        const EXPERIMENTAL_MESH_SHADER_MULTIVIEW = 1 << 50;
+        const EXPERIMENTAL_MESH_SHADER_MULTIVIEW = 1 << 49;
 
         /// Allows usage of additional vertex formats in [BlasTriangleGeometrySizeDescriptor::vertex_format]
         ///
@@ -1243,7 +1231,7 @@ bitflags_array! {
         /// - DX12
         ///
         /// [BlasTriangleGeometrySizeDescriptor::vertex_format]: super::BlasTriangleGeometrySizeDescriptor
-        const EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS = 1 << 51;
+        const EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS = 1 << 50;
 
         /// Enables creating shader modules from DirectX HLSL or DXIL shaders (unsafe)
         ///
@@ -1253,7 +1241,7 @@ bitflags_array! {
         /// - DX12
         ///
         /// This is a native only feature.
-        const HLSL_DXIL_SHADER_PASSTHROUGH = 1 << 53;
+        const HLSL_DXIL_SHADER_PASSTHROUGH = 1 << 51;
     }
 
     /// Features that are not guaranteed to be supported.
@@ -1529,7 +1517,7 @@ impl Features {
     #[must_use]
     pub fn allowed_vertex_formats_for_blas(&self) -> Vec<VertexFormat> {
         let mut formats = Vec::new();
-        if self.contains(Self::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE) {
+        if self.intersects(Self::EXPERIMENTAL_RAY_QUERY) {
             formats.push(VertexFormat::Float32x3);
         }
         if self.contains(Self::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS) {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -608,19 +608,19 @@ pub struct Limits {
     /// to create many bind groups at the cost of a large up-front allocation at device creation.
     pub max_non_sampler_bindings: u32,
     /// The maximum number of primitive (ex: triangles, aabbs) a BLAS is allowed to have. Requesting
-    /// more than 0 during device creation only makes sense if [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`]
+    /// more than 0 during device creation only makes sense if [`Features::EXPERIMENTAL_RAY_QUERY`]
     /// is enabled.
     pub max_blas_primitive_count: u32,
     /// The maximum number of geometry descriptors a BLAS is allowed to have. Requesting
-    /// more than 0 during device creation only makes sense if [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`]
+    /// more than 0 during device creation only makes sense if [`Features::EXPERIMENTAL_RAY_QUERY`]
     /// is enabled.
     pub max_blas_geometry_count: u32,
     /// The maximum number of instances a TLAS is allowed to have. Requesting more than 0 during
-    /// device creation only makes sense if [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`]
+    /// device creation only makes sense if [`Features::EXPERIMENTAL_RAY_QUERY`]
     /// is enabled.
     pub max_tlas_instance_count: u32,
     /// The maximum number of acceleration structures allowed to be used in a shader stage.
-    /// Requesting more than 0 during device creation only makes sense if [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`]
+    /// Requesting more than 0 during device creation only makes sense if [`Features::EXPERIMENTAL_RAY_QUERY`]
     /// is enabled.
     pub max_acceleration_structures_per_shader_stage: u32,
 }
@@ -895,7 +895,7 @@ impl Limits {
         }
     }
 
-    /// The minimum guaranteed limits for acceleration structures if you enable [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`]
+    /// The minimum guaranteed limits for acceleration structures if you enable [`Features::EXPERIMENTAL_RAY_QUERY`]
     #[must_use]
     pub const fn using_minimum_supported_acceleration_structure_values(self) -> Self {
         Self {
@@ -7506,7 +7506,7 @@ impl Default for ShaderRuntimeChecks {
 /// Descriptor for all size defining attributes of a single triangle geometry inside a bottom level acceleration structure.
 pub struct BlasTriangleGeometrySizeDescriptor {
     /// Format of a vertex position, must be [`VertexFormat::Float32x3`]
-    /// with just [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`]
+    /// with just [`Features::EXPERIMENTAL_RAY_QUERY`]
     /// but [`Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS`] adds more.
     pub vertex_format: VertexFormat,
     /// Number of vertices.

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -286,7 +286,7 @@ impl CommandEncoder {
     }
 }
 
-/// [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`] must be enabled on the device in order to call these functions.
+/// [`Features::EXPERIMENTAL_RAY_QUERY`] must be enabled on the device in order to call these functions.
 impl CommandEncoder {
     /// Mark acceleration structures as being built. ***Should only*** be used with wgpu-hal
     /// functions, all wgpu functions already mark acceleration structures as built.
@@ -323,7 +323,7 @@ impl CommandEncoder {
     ///   - Each BLAS in each TLAS instance must have been being built in the current call or in a previous call to `build_acceleration_structures` or `build_acceleration_structures_unsafe_tlas`
     ///   - The number of TLAS instances must be less than or equal to the max number of tlas instances when creating (if creating a package with `TlasPackage::new()` this is already satisfied)
     ///
-    /// If the device the command encoder is created from does not have [Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE] enabled then a validation error is generated
+    /// If the device the command encoder is created from does not have [Features::EXPERIMENTAL_RAY_QUERY] enabled then a validation error is generated
     ///
     /// A bottom level acceleration structure may be build and used as a reference in a top level acceleration structure in the same invocation of this function.
     ///
@@ -334,7 +334,7 @@ impl CommandEncoder {
     ///    - All the bottom level acceleration structures referenced by the top level acceleration structure are valid and have been built prior,
     ///      or at same time as the containing top level acceleration structure.
     ///
-    /// [Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE]: wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
+    /// [Features::EXPERIMENTAL_RAY_QUERY]: wgt::Features::EXPERIMENTAL_RAY_QUERY
     pub fn build_acceleration_structures<'a>(
         &mut self,
         blas: impl IntoIterator<Item = &'a BlasBuildEntry<'a>>,

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -554,7 +554,7 @@ impl Device {
     }
 }
 
-/// [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`] must be enabled on the device in order to call these functions.
+/// [`Features::EXPERIMENTAL_RAY_QUERY`] must be enabled on the device in order to call these functions.
 impl Device {
     /// Create a bottom level acceleration structure, used inside a top level acceleration structure for ray tracing.
     /// - `desc`: The descriptor of the acceleration structure.
@@ -563,14 +563,14 @@ impl Device {
     /// # Validation
     /// If any of the following is not satisfied a validation error is generated
     ///
-    /// The device ***must*** have [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`] enabled.
+    /// The device ***must*** have [`Features::EXPERIMENTAL_RAY_QUERY`] enabled.
     /// if `sizes` is [`BlasGeometrySizeDescriptors::Triangles`] then the following must be satisfied
     /// - For every geometry descriptor (for the purposes this is called `geo_desc`) of `sizes.descriptors` the following must be satisfied:
     ///     - `geo_desc.vertex_format` must be within allowed formats (allowed formats for a given feature set
     ///       may be queried with [`Features::allowed_vertex_formats_for_blas`]).
     ///     - Both or neither of `geo_desc.index_format` and `geo_desc.index_count` must be provided.
     ///
-    /// [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`]: wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
+    /// [`Features::EXPERIMENTAL_RAY_QUERY`]: wgt::Features::EXPERIMENTAL_RAY_QUERY
     /// [`Features::allowed_vertex_formats_for_blas`]: wgt::Features::allowed_vertex_formats_for_blas
     #[must_use]
     pub fn create_blas(
@@ -592,9 +592,9 @@ impl Device {
     /// # Validation
     /// If any of the following is not satisfied a validation error is generated
     ///
-    /// The device ***must*** have [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`] enabled.
+    /// The device ***must*** have [`Features::EXPERIMENTAL_RAY_QUERY`] enabled.
     ///
-    /// [`Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE`]: wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE
+    /// [`Features::EXPERIMENTAL_RAY_QUERY`]: wgt::Features::EXPERIMENTAL_RAY_QUERY
     #[must_use]
     pub fn create_tlas(&self, desc: &CreateTlasDescriptor<'_>) -> Tlas {
         let tlas = self.inner.create_tlas(desc);


### PR DESCRIPTION
**Connections**
Works around AMD driver bug so fixes #6727.
I don't know if it should be kept open to track the driver bug

**Description**
Merges `EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE` into `EXPERIMENTAL_RAY_QUERY`. Requesting `EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE` on its own seems to cause null pointer dereferences on AMD, and is likely a untested path on other drivers because it does not make sense to have `EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE` without either ray queries or rt pipelines (which aren't here yet).

**Testing**
No new issues, though @cwfitzgerald / someone else with an AMD GPU should make sure this actually fixes the issue.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [n/a] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
