### PR TITLE
Fix build with `profiling` active.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,10 @@ jobs:
           # Check with all features.
           cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} --tests --benches --all-features
 
+          # Check with all features and profiling macro code.
+          # If we don't check this then errors inside `profiling::scope!()` will not be caught.
+          cargo clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} --tests --benches --all-features --features test-build-with-profiling
+
           # build docs
           cargo doc --target ${{ matrix.target }} ${{ matrix.extra-flags }} --all-features --no-deps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fixed build error occurring when the `profiling` dependency is configured to have profiling active. By @kpreid in [#7916](https://github.com/gfx-rs/wgpu/pull/7916).
+
 ## v26.0.0 (2025-07-09)
 
 ### Major Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ pollster = "0.4"
 portable-atomic = "1.8"
 portable-atomic-util = "0.2.4"
 pp-rs = "0.2.1"
-profiling = { version = "1", default-features = false }
+profiling = { version = "1.0.1", default-features = false }
 quote = "1.0.38"
 raw-window-handle = { version = "0.6.2", default-features = false }
 rwh_05 = { version = "0.5.2", package = "raw-window-handle" } # temporary compatibility for glutin-winit               

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -29,6 +29,9 @@ harness = true
 
 [features]
 webgl = ["wgpu/webgl"]
+# This feature is not actually used by this package, but it being present somewhere in the workspace
+# allows us to force the build to have profiling code enabled so we can test that configuration.
+test-build-with-profiling = ["profiling/type-check"]
 
 [dependencies]
 wgpu = { workspace = true, features = ["noop"] }

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -492,7 +492,7 @@ impl Global {
         let pass_scope = PassErrorScope::Pass;
         profiling::scope!(
             "CommandEncoder::run_compute_pass {}",
-            base.label.as_deref().unwrap_or("")
+            pass.base.label.as_deref().unwrap_or("")
         );
 
         let cmd_buf = pass.parent.take().ok_or(EncoderStateError::Ended)?;

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1804,7 +1804,7 @@ impl Global {
         let pass_scope = PassErrorScope::Pass;
         profiling::scope!(
             "CommandEncoder::run_render_pass {}",
-            base.label.as_deref().unwrap_or("")
+            pass.base.label.as_deref().unwrap_or("")
         );
 
         let cmd_buf = pass.parent.take().ok_or(EncoderStateError::Ended)?;


### PR DESCRIPTION
**Connections**
Fixes #7914.

This change should be backported to v26.

**Description**
Code in `profiling::scope!()` referred to undeclared variables, and this was not caught since the code is normally not compiled.

**Testing**
Confirmed that the code now builds with `profiling/profile-with-tracing` enabled.
Added CI test for this configuration.

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
