### PR TITLE
Fix `initialize_adapter_from_env` under no_std.

### DIFF
--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -5,20 +5,23 @@ use crate::Backends;
 
 /// Initialize the adapter obeying the `WGPU_ADAPTER_NAME` environment variable.
 #[cfg(wgpu_core)]
+#[cfg_attr(not(std), expect(unused_variables, unreachable_code))]
 pub fn initialize_adapter_from_env(
     instance: &Instance,
     compatible_surface: Option<&Surface<'_>>,
 ) -> Result<Adapter, wgt::RequestAdapterError> {
-    cfg_if::cfg_if! {
-        if #[cfg(std)] {
-            let desired_adapter_name = std::env::var("WGPU_ADAPTER_NAME")
-                .as_deref()
-                .map(str::to_lowercase)
-                .map_err(|_| wgt::RequestAdapterError::EnvNotSet)?;
-        } else {
-            return Err(wgt::RequestAdapterError::EnvNotSet);
+    let desired_adapter_name: alloc::string::String = {
+        cfg_if::cfg_if! {
+            if #[cfg(std)] {
+                std::env::var("WGPU_ADAPTER_NAME")
+                    .as_deref()
+                    .map(str::to_lowercase)
+                    .map_err(|_| wgt::RequestAdapterError::EnvNotSet)?
+            } else {
+                return Err(wgt::RequestAdapterError::EnvNotSet)
+            }
         }
-    }
+    };
 
     let adapters = instance.enumerate_adapters(crate::Backends::all());
 


### PR DESCRIPTION
**Connections**
Fixes #7917.

This change should be backported to v26.

**Description**
Without this change, `desired_adapter_name` is an undeclared variable.

**Testing**
Tested with `cargo check -p wgpu --no-default-features  --features webgl --target wasm32-unknown-unknown`

**Squash or Rebase?**
N/A

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
