### PR TITLE
Backport new version of buffer size fixes

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -9,6 +9,8 @@ webgpu:api,operation,compute,basic:memcpy:*
 //FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute_pipeline,overrides:*
 webgpu:api,operation,device,lost:*
+webgpu:api,validation,encoding,cmds,render,draw:index_buffer_OOB:*
+webgpu:api,validation,encoding,cmds,render,draw:unused_buffer_bound:*
 webgpu:api,validation,queue,submit:command_buffer,device_mismatch:*
 webgpu:api,validation,queue,submit:command_buffer,duplicate_buffers:*
 webgpu:api,validation,queue,submit:command_buffer,submit_invalidates:*

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -680,29 +680,26 @@ impl GPUDevice {
                     .buffers
                     .into_iter()
                     .map(|b| {
-                        let layout = b.into_option().ok_or_else(|| {
-                            JsErrorBox::type_error(
-                                "Nullable GPUVertexBufferLayouts are currently not supported",
-                            )
-                        })?;
-
-                        Ok(wgpu_core::pipeline::VertexBufferLayout {
-                            array_stride: layout.array_stride,
-                            step_mode: layout.step_mode.into(),
-                            attributes: Cow::Owned(
-                                layout
-                                    .attributes
-                                    .into_iter()
-                                    .map(|attr| wgpu_types::VertexAttribute {
-                                        format: attr.format.into(),
-                                        offset: attr.offset,
-                                        shader_location: attr.shader_location,
-                                    })
-                                    .collect(),
-                            ),
-                        })
+                        b.into_option().map_or_else(
+                            wgpu_core::pipeline::VertexBufferLayout::default,
+                            |layout| wgpu_core::pipeline::VertexBufferLayout {
+                                array_stride: layout.array_stride,
+                                step_mode: layout.step_mode.into(),
+                                attributes: Cow::Owned(
+                                    layout
+                                        .attributes
+                                        .into_iter()
+                                        .map(|attr| wgpu_types::VertexAttribute {
+                                            format: attr.format.into(),
+                                            offset: attr.offset,
+                                            shader_location: attr.shader_location,
+                                        })
+                                        .collect(),
+                                ),
+                            },
+                        )
                     })
-                    .collect::<Result<_, JsErrorBox>>()?,
+                    .collect(),
             ),
         };
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -501,7 +501,7 @@ impl RenderBundleEncoder {
             buffer_id,
             index_format,
             offset,
-            size: size.map(NonZeroU64::get),
+            size,
         });
     }
 }
@@ -604,7 +604,7 @@ fn set_index_buffer(
     buffer_id: id::Id<id::markers::Buffer>,
     index_format: wgt::IndexFormat,
     offset: u64,
-    size: Option<wgt::BufferSizeOrZero>,
+    size: Option<NonZeroU64>,
 ) -> Result<(), RenderBundleErrorInner> {
     let buffer = buffer_guard.get(buffer_id).get()?;
 
@@ -636,7 +636,7 @@ fn set_vertex_buffer(
     slot: u32,
     buffer_id: id::Id<id::markers::Buffer>,
     offset: u64,
-    size: Option<wgt::BufferSizeOrZero>,
+    size: Option<NonZeroU64>,
 ) -> Result<(), RenderBundleErrorInner> {
     let max_vertex_buffers = state.device.limits.max_vertex_buffers;
     if slot >= max_vertex_buffers {
@@ -952,11 +952,7 @@ impl RenderBundle {
                     let bb = unsafe {
                         // SAFETY: The binding size was checked against the buffer size
                         // in `set_index_buffer` and again in `IndexState::flush`.
-                        hal::BufferBinding::new_unchecked(
-                            buffer,
-                            *offset,
-                            size.expect("size was resolved in `RenderBundleEncoder::finish`"),
-                        )
+                        hal::BufferBinding::new_unchecked(buffer, *offset, *size)
                     };
                     unsafe { raw.set_index_buffer(bb, *index_format) };
                 }
@@ -970,11 +966,7 @@ impl RenderBundle {
                     let bb = unsafe {
                         // SAFETY: The binding size was checked against the buffer size
                         // in `set_vertex_buffer` and again in `VertexState::flush`.
-                        hal::BufferBinding::new_unchecked(
-                            buffer,
-                            *offset,
-                            size.expect("size was resolved in `RenderBundleEncoder::finish`"),
-                        )
+                        hal::BufferBinding::new_unchecked(buffer, *offset, *size)
                     };
                     unsafe { raw.set_vertex_buffer(*slot, bb) };
                 }
@@ -1161,7 +1153,7 @@ impl IndexState {
                 buffer: self.buffer.clone(),
                 index_format: self.format,
                 offset: self.range.start,
-                size: Some(binding_size),
+                size: NonZeroU64::new(binding_size),
             })
         } else {
             None
@@ -1217,7 +1209,7 @@ impl VertexState {
                 slot,
                 buffer: self.buffer.clone(),
                 offset: self.range.start,
-                size: Some(binding_size),
+                size: NonZeroU64::new(binding_size),
             })
         } else {
             None
@@ -1566,7 +1558,7 @@ where
 pub mod bundle_ffi {
     use super::{RenderBundleEncoder, RenderCommand};
     use crate::{id, RawString};
-    use core::{convert::TryInto, num::NonZeroU64, slice};
+    use core::{convert::TryInto, slice};
     use wgt::{BufferAddress, BufferSize, DynamicOffset, IndexFormat};
 
     /// # Safety
@@ -1625,7 +1617,7 @@ pub mod bundle_ffi {
             slot,
             buffer_id,
             offset,
-            size: size.map(NonZeroU64::get),
+            size,
         });
     }
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -616,7 +616,7 @@ fn set_index_buffer(
     buffer.same_device(&state.device)?;
     buffer.check_usage(wgt::BufferUsages::INDEX)?;
 
-    let end = buffer.resolve_binding_size(offset, size)?;
+    let end = offset + buffer.resolve_binding_size(offset, size)?;
 
     state
         .buffer_memory_init_actions
@@ -657,7 +657,7 @@ fn set_vertex_buffer(
     buffer.same_device(&state.device)?;
     buffer.check_usage(wgt::BufferUsages::VERTEX)?;
 
-    let end = buffer.resolve_binding_size(offset, size)?;
+    let end = offset + buffer.resolve_binding_size(offset, size)?;
 
     state
         .buffer_memory_init_actions

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -949,11 +949,9 @@ impl RenderBundle {
                     size,
                 } => {
                     let buffer = buffer.try_raw(snatch_guard)?;
-                    let bb = unsafe {
-                        // SAFETY: The binding size was checked against the buffer size
-                        // in `set_index_buffer` and again in `IndexState::flush`.
-                        hal::BufferBinding::new_unchecked(buffer, *offset, *size)
-                    };
+                    // SAFETY: The binding size was checked against the buffer size
+                    // in `set_index_buffer` and again in `IndexState::flush`.
+                    let bb = hal::BufferBinding::new_unchecked(buffer, *offset, *size);
                     unsafe { raw.set_index_buffer(bb, *index_format) };
                 }
                 Cmd::SetVertexBuffer {
@@ -963,11 +961,9 @@ impl RenderBundle {
                     size,
                 } => {
                     let buffer = buffer.try_raw(snatch_guard)?;
-                    let bb = unsafe {
-                        // SAFETY: The binding size was checked against the buffer size
-                        // in `set_vertex_buffer` and again in `VertexState::flush`.
-                        hal::BufferBinding::new_unchecked(buffer, *offset, *size)
-                    };
+                    // SAFETY: The binding size was checked against the buffer size
+                    // in `set_vertex_buffer` and again in `VertexState::flush`.
+                    let bb = hal::BufferBinding::new_unchecked(buffer, *offset, *size);
                     unsafe { raw.set_vertex_buffer(*slot, bb) };
                 }
                 Cmd::SetPushConstant {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1,16 +1,11 @@
 use alloc::{borrow::Cow, sync::Arc, vec::Vec};
-use core::{
-    fmt,
-    num::{NonZeroU32, NonZeroU64},
-    str,
-};
-use hal::ShouldBeNonZeroExt;
+use core::{fmt, num::NonZeroU32, ops::Range, str};
 
 use arrayvec::ArrayVec;
 use thiserror::Error;
 use wgt::{
-    BufferAddress, BufferSize, BufferSizeOrZero, BufferUsages, Color, DynamicOffset, IndexFormat,
-    ShaderStages, TextureSelector, TextureUsages, TextureViewDimension, VertexStepMode,
+    BufferAddress, BufferSize, BufferUsages, Color, DynamicOffset, IndexFormat, ShaderStages,
+    TextureSelector, TextureUsages, TextureViewDimension, VertexStepMode,
 };
 
 use crate::binding_model::BindGroup;
@@ -362,17 +357,13 @@ struct IndexState {
 }
 
 impl IndexState {
-    fn update_buffer<B: hal::DynBuffer + ?Sized>(
-        &mut self,
-        binding: &hal::BufferBinding<'_, B>,
-        format: IndexFormat,
-    ) {
+    fn update_buffer(&mut self, range: Range<BufferAddress>, format: IndexFormat) {
         self.buffer_format = Some(format);
         let shift = match format {
             IndexFormat::Uint16 => 1,
             IndexFormat::Uint32 => 2,
         };
-        self.limit = binding.size.get() >> shift;
+        self.limit = (range.end - range.start) >> shift;
     }
 
     fn reset(&mut self) {
@@ -2304,7 +2295,7 @@ fn set_index_buffer(
     buffer: Arc<crate::resource::Buffer>,
     index_format: IndexFormat,
     offset: u64,
-    size: Option<BufferSizeOrZero>,
+    size: Option<BufferSize>,
 ) -> Result<(), RenderPassErrorInner> {
     api_log!("RenderPass::set_index_buffer {}", buffer.error_ident());
 
@@ -2318,16 +2309,17 @@ fn set_index_buffer(
 
     buffer.check_usage(BufferUsages::INDEX)?;
 
-    let binding = buffer
+    let (binding, resolved_size) = buffer
         .binding(offset, size, state.snatch_guard)
         .map_err(RenderCommandError::from)?;
-    state.index.update_buffer(&binding, index_format);
+    let end = offset + resolved_size;
+    state.index.update_buffer(offset..end, index_format);
 
     state
         .buffer_memory_init_actions
         .extend(buffer.initialization_status.read().create_action(
             &buffer,
-            offset..(offset + binding.size.get()),
+            offset..end,
             MemoryInitKind::NeedsInitializedMemory,
         ));
 
@@ -2344,7 +2336,7 @@ fn set_vertex_buffer(
     slot: u32,
     buffer: Arc<crate::resource::Buffer>,
     offset: u64,
-    size: Option<BufferSizeOrZero>,
+    size: Option<BufferSize>,
 ) -> Result<(), RenderPassErrorInner> {
     api_log!(
         "RenderPass::set_vertex_buffer {slot} {}",
@@ -2370,16 +2362,16 @@ fn set_vertex_buffer(
 
     buffer.check_usage(BufferUsages::VERTEX)?;
 
-    let binding = buffer
+    let (binding, buffer_size) = buffer
         .binding(offset, size, state.snatch_guard)
         .map_err(RenderCommandError::from)?;
-    state.vertex.buffer_sizes[slot as usize] = Some(binding.size.get());
+    state.vertex.buffer_sizes[slot as usize] = Some(buffer_size);
 
     state
         .buffer_memory_init_actions
         .extend(buffer.initialization_status.read().create_action(
             &buffer,
-            offset..(offset + binding.size.get()),
+            offset..(offset + buffer_size),
             MemoryInitKind::NeedsInitializedMemory,
         ));
 
@@ -3154,7 +3146,7 @@ impl Global {
             buffer: self.resolve_render_pass_buffer_id(scope, buffer_id)?,
             index_format,
             offset,
-            size: size.map(NonZeroU64::get),
+            size,
         });
 
         Ok(())
@@ -3175,7 +3167,7 @@ impl Global {
             slot,
             buffer: self.resolve_render_pass_buffer_id(scope, buffer_id)?,
             offset,
-            size: size.map(NonZeroU64::get),
+            size,
         });
 
         Ok(())

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 
-use wgt::{BufferAddress, BufferSizeOrZero, Color};
+use wgt::{BufferAddress, BufferSize, Color};
 
 use super::{Rect, RenderBundle};
 use crate::{
@@ -24,13 +24,13 @@ pub enum RenderCommand {
         buffer_id: id::BufferId,
         index_format: wgt::IndexFormat,
         offset: BufferAddress,
-        size: Option<BufferSizeOrZero>,
+        size: Option<BufferSize>,
     },
     SetVertexBuffer {
         slot: u32,
         buffer_id: id::BufferId,
         offset: BufferAddress,
-        size: Option<BufferSizeOrZero>,
+        size: Option<BufferSize>,
     },
     SetBlendConstant(Color),
     SetStencilReference(u32),
@@ -416,20 +416,13 @@ pub enum ArcRenderCommand {
         buffer: Arc<Buffer>,
         index_format: wgt::IndexFormat,
         offset: BufferAddress,
-
-        // For a render pass, this reflects the argument passed by the
-        // application, which may be `None`. For a finished render bundle, this
-        // reflects the validated size of the binding, and will be populated
-        // even in the case that the application omitted the size.
-        size: Option<BufferSizeOrZero>,
+        size: Option<BufferSize>,
     },
     SetVertexBuffer {
         slot: u32,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
-
-        // See comment in `SetIndexBuffer`.
-        size: Option<BufferSizeOrZero>,
+        size: Option<BufferSize>,
     },
     SetBlendConstant(Color),
     SetStencilReference(u32),

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -8,7 +8,7 @@ use alloc::{
 use core::{
     fmt,
     mem::{self, ManuallyDrop},
-    num::{NonZeroU32, NonZeroU64},
+    num::NonZeroU32,
     sync::atomic::{AtomicBool, Ordering},
 };
 use hal::ShouldBeNonZeroExt;
@@ -2183,8 +2183,8 @@ impl Device {
 
         buffer.check_usage(pub_usage)?;
 
-        let bb = buffer.binding(bb.offset, bb.size.map(NonZeroU64::get), snatch_guard)?;
-        let bind_size = bb.size.get();
+        let (bb, bind_size) = buffer.binding(bb.offset, bb.size, snatch_guard)?;
+        let bind_end = bb.offset + bind_size;
 
         if bind_size > range_limit as u64 {
             return Err(Error::BufferRangeTooLarge {
@@ -2199,8 +2199,8 @@ impl Device {
             dynamic_binding_info.push(binding_model::BindGroupDynamicBindingData {
                 binding_idx: binding,
                 buffer_size: buffer.size,
-                binding_range: bb.offset..bb.offset + bind_size,
-                maximum_dynamic_offset: buffer.size - bb.offset - bind_size,
+                binding_range: bb.offset..bind_end,
+                maximum_dynamic_offset: buffer.size - bind_end,
                 binding_type: binding_ty,
             });
         }

--- a/wgpu-core/src/indirect_validation/dispatch.rs
+++ b/wgpu-core/src/indirect_validation/dispatch.rs
@@ -234,7 +234,7 @@ impl Dispatch {
             }],
             buffers: &[unsafe {
                 // SAFETY: We just created the buffer with this size.
-                hal::BufferBinding::new_unchecked(dst_buffer.as_ref(), 0, DST_BUFFER_SIZE)
+                hal::BufferBinding::new_unchecked(dst_buffer.as_ref(), 0, Some(DST_BUFFER_SIZE))
             }],
             samplers: &[],
             textures: &[],

--- a/wgpu-core/src/indirect_validation/dispatch.rs
+++ b/wgpu-core/src/indirect_validation/dispatch.rs
@@ -232,10 +232,12 @@ impl Dispatch {
                 resource_index: 0,
                 count: 1,
             }],
-            buffers: &[unsafe {
-                // SAFETY: We just created the buffer with this size.
-                hal::BufferBinding::new_unchecked(dst_buffer.as_ref(), 0, Some(DST_BUFFER_SIZE))
-            }],
+            // SAFETY: We just created the buffer with this size.
+            buffers: &[hal::BufferBinding::new_unchecked(
+                dst_buffer.as_ref(),
+                0,
+                Some(DST_BUFFER_SIZE),
+            )],
             samplers: &[],
             textures: &[],
             acceleration_structures: &[],
@@ -277,10 +279,8 @@ impl Dispatch {
                 resource_index: 0,
                 count: 1,
             }],
-            buffers: &[unsafe {
-                // SAFETY: We calculated the binding size to fit within the buffer.
-                hal::BufferBinding::new_unchecked(buffer, 0, binding_size)
-            }],
+            // SAFETY: We calculated the binding size to fit within the buffer.
+            buffers: &[hal::BufferBinding::new_unchecked(buffer, 0, binding_size)],
             samplers: &[],
             textures: &[],
             acceleration_structures: &[],

--- a/wgpu-core/src/indirect_validation/draw.rs
+++ b/wgpu-core/src/indirect_validation/draw.rs
@@ -135,10 +135,8 @@ impl Draw {
                 resource_index: 0,
                 count: 1,
             }],
-            buffers: &[unsafe {
-                // SAFETY: We calculated the binding size to fit within the buffer.
-                hal::BufferBinding::new_unchecked(buffer, 0, binding_size)
-            }],
+            // SAFETY: We calculated the binding size to fit within the buffer.
+            buffers: &[hal::BufferBinding::new_unchecked(buffer, 0, binding_size)],
             samplers: &[],
             textures: &[],
             acceleration_structures: &[],
@@ -683,10 +681,12 @@ fn create_buffer_and_bind_group(
             resource_index: 0,
             count: 1,
         }],
-        buffers: &[unsafe {
-            // SAFETY: We just created the buffer with this size.
-            hal::BufferBinding::new_unchecked(buffer.as_ref(), 0, BUFFER_SIZE)
-        }],
+        // SAFETY: We just created the buffer with this size.
+        buffers: &[hal::BufferBinding::new_unchecked(
+            buffer.as_ref(),
+            0,
+            BUFFER_SIZE,
+        )],
         samplers: &[],
         textures: &[],
         acceleration_structures: &[],

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -311,6 +311,17 @@ pub struct VertexBufferLayout<'a> {
     pub attributes: Cow<'a, [wgt::VertexAttribute]>,
 }
 
+/// A null vertex buffer layout that may be placed in unused slots.
+impl Default for VertexBufferLayout<'_> {
+    fn default() -> Self {
+        Self {
+            array_stride: Default::default(),
+            step_mode: Default::default(),
+            attributes: Cow::Borrowed(&[]),
+        }
+    }
+}
+
 /// Describes the vertex process in a render pipeline.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -448,17 +448,17 @@ impl Buffer {
     pub fn resolve_binding_size(
         &self,
         offset: wgt::BufferAddress,
-        binding_size: Option<wgt::BufferSizeOrZero>,
-    ) -> Result<wgt::BufferSizeOrZero, BindingError> {
+        binding_size: Option<wgt::BufferSize>,
+    ) -> Result<u64, BindingError> {
         let buffer_size = self.size;
 
         match binding_size {
-            Some(binding_size) => match offset.checked_add(binding_size) {
-                Some(end) if end <= buffer_size => Ok(binding_size),
+            Some(binding_size) => match offset.checked_add(binding_size.get()) {
+                Some(end) if end <= buffer_size => Ok(binding_size.get()),
                 _ => Err(BindingError::BindingRangeTooLarge {
                     buffer: self.error_ident(),
                     offset,
-                    binding_size,
+                    binding_size: binding_size.get(),
                     buffer_size,
                 }),
             },
@@ -475,35 +475,38 @@ impl Buffer {
     }
 
     /// Create a new [`hal::BufferBinding`] for the buffer with `offset` and
-    /// `size`.
+    /// `binding_size`.
     ///
-    /// If `size` is `None`, then the remainder of the buffer starting from
-    /// `offset` is used.
+    /// If `binding_size` is `None`, then the remainder of the buffer starting
+    /// from `offset` is used.
     ///
     /// If the binding would overflow the buffer, then an error is returned.
     ///
-    /// Zero-size bindings are permitted here for historical reasons. Although
+    /// A zero-size binding at the end of the buffer is permitted here for historical reasons. Although
     /// zero-size bindings are permitted by WebGPU, they are not permitted by
-    /// some backends. Previous documentation for `hal::BufferBinding`
-    /// disallowed zero-size bindings, but this restriction was not honored
-    /// elsewhere in the code. Zero-size bindings need to be quashed or remapped
-    /// to a non-zero size, either universally in wgpu-core, or in specific
-    /// backends that do not support them. See
+    /// some backends. The zero-size binding need to be quashed or remapped to a
+    /// non-zero size, either universally in wgpu-core, or in specific backends
+    /// that do not support them. See
     /// [#3170](https://github.com/gfx-rs/wgpu/issues/3170).
+    ///
+    /// Although it seems like it would be simpler and safer to use the resolved
+    /// size in the returned [`hal::BufferBinding`], doing this (and removing
+    /// redundant logic in backends to resolve the implicit size) was observed
+    /// to cause problems in certain CTS tests, so an implicit size
+    /// specification is preserved in the output.
     pub fn binding<'a>(
         &'a self,
         offset: wgt::BufferAddress,
-        binding_size: Option<wgt::BufferSizeOrZero>,
+        binding_size: Option<wgt::BufferSize>,
         snatch_guard: &'a SnatchGuard,
-    ) -> Result<hal::BufferBinding<'a, dyn hal::DynBuffer>, BindingError> {
+    ) -> Result<(hal::BufferBinding<'a, dyn hal::DynBuffer>, u64), BindingError> {
         let buf_raw = self.try_raw(snatch_guard)?;
         let resolved_size = self.resolve_binding_size(offset, binding_size)?;
         unsafe {
             // SAFETY: The offset and size passed to hal::BufferBinding::new_unchecked must
             // define a binding contained within the buffer.
-            Ok(hal::BufferBinding::new_unchecked(
-                buf_raw,
-                offset,
+            Ok((
+                hal::BufferBinding::new_unchecked(buf_raw, offset, binding_size),
                 resolved_size,
             ))
         }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -502,14 +502,12 @@ impl Buffer {
     ) -> Result<(hal::BufferBinding<'a, dyn hal::DynBuffer>, u64), BindingError> {
         let buf_raw = self.try_raw(snatch_guard)?;
         let resolved_size = self.resolve_binding_size(offset, binding_size)?;
-        unsafe {
-            // SAFETY: The offset and size passed to hal::BufferBinding::new_unchecked must
-            // define a binding contained within the buffer.
-            Ok((
-                hal::BufferBinding::new_unchecked(buf_raw, offset, binding_size),
-                resolved_size,
-            ))
-        }
+        // SAFETY: The offset and size passed to hal::BufferBinding::new_unchecked must
+        // define a binding contained within the buffer.
+        Ok((
+            hal::BufferBinding::new_unchecked(buf_raw, offset, binding_size),
+            resolved_size,
+        ))
     }
 
     /// Returns the mapping callback in case of error so that the callback can be fired outside

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -447,14 +447,12 @@ impl<A: hal::Api> Example<A> {
         let texture_view = unsafe { device.create_texture_view(&texture, &view_desc).unwrap() };
 
         let global_group = {
-            let global_buffer_binding = unsafe {
-                // SAFETY: This is the same size that was specified for buffer creation.
-                hal::BufferBinding::new_unchecked(
-                    &global_buffer,
-                    0,
-                    NonZeroU64::new(global_buffer_desc.size),
-                )
-            };
+            // SAFETY: This is the same size that was specified for buffer creation.
+            let global_buffer_binding = hal::BufferBinding::new_unchecked(
+                &global_buffer,
+                0,
+                NonZeroU64::new(global_buffer_desc.size),
+            );
             let texture_binding = hal::TextureBinding {
                 view: &texture_view,
                 usage: wgpu_types::TextureUses::RESOURCE,
@@ -488,14 +486,12 @@ impl<A: hal::Api> Example<A> {
         };
 
         let local_group = {
-            let local_buffer_binding = unsafe {
-                // SAFETY: The size must fit within the buffer.
-                hal::BufferBinding::new_unchecked(
-                    &local_buffer,
-                    0,
-                    wgpu_types::BufferSize::new(size_of::<Locals>() as _),
-                )
-            };
+            // SAFETY: The size must fit within the buffer.
+            let local_buffer_binding = hal::BufferBinding::new_unchecked(
+                &local_buffer,
+                0,
+                wgpu_types::BufferSize::new(size_of::<Locals>() as _),
+            );
             let local_group_desc = hal::BindGroupDescriptor {
                 label: Some("local"),
                 layout: &local_group_layout,

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -14,7 +14,9 @@ use winit::{
 
 use std::{
     borrow::{Borrow, Cow},
-    iter, ptr,
+    iter,
+    num::NonZeroU64,
+    ptr,
     time::Instant,
 };
 
@@ -447,7 +449,11 @@ impl<A: hal::Api> Example<A> {
         let global_group = {
             let global_buffer_binding = unsafe {
                 // SAFETY: This is the same size that was specified for buffer creation.
-                hal::BufferBinding::new_unchecked(&global_buffer, 0, global_buffer_desc.size)
+                hal::BufferBinding::new_unchecked(
+                    &global_buffer,
+                    0,
+                    NonZeroU64::new(global_buffer_desc.size),
+                )
             };
             let texture_binding = hal::TextureBinding {
                 view: &texture_view,
@@ -487,7 +493,7 @@ impl<A: hal::Api> Example<A> {
                 hal::BufferBinding::new_unchecked(
                     &local_buffer,
                     0,
-                    wgpu_types::BufferSize::new(size_of::<Locals>() as _).unwrap(),
+                    wgpu_types::BufferSize::new(size_of::<Locals>() as _),
                 )
             };
             let local_group_desc = hal::BindGroupDescriptor {

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1136,7 +1136,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     ) {
         let ibv = Direct3D12::D3D12_INDEX_BUFFER_VIEW {
             BufferLocation: binding.resolve_address(),
-            SizeInBytes: binding.size.try_into().unwrap(),
+            SizeInBytes: binding.resolve_size().try_into().unwrap(),
             Format: auxil::dxgi::conv::map_index_format(format),
         };
 
@@ -1149,7 +1149,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     ) {
         let vb = &mut self.pass.vertex_buffers[index as usize];
         vb.BufferLocation = binding.resolve_address();
-        vb.SizeInBytes = binding.size.try_into().unwrap();
+        vb.SizeInBytes = binding.resolve_size().try_into().unwrap();
         self.pass.dirty_vertex_buffers |= 1 << index;
     }
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1417,7 +1417,7 @@ impl crate::Device for super::Device {
                     let end = start + entry.count as usize;
                     for data in &desc.buffers[start..end] {
                         let gpu_address = data.resolve_address();
-                        let mut size = data.size.try_into().unwrap();
+                        let mut size = data.resolve_size().try_into().unwrap();
 
                         if has_dynamic_offset {
                             match ty {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -854,6 +854,13 @@ unsafe impl Sync for Buffer {}
 impl crate::DynBuffer for Buffer {}
 
 impl crate::BufferBinding<'_, Buffer> {
+    fn resolve_size(&self) -> wgt::BufferAddress {
+        match self.size {
+            Some(size) => size.get(),
+            None => self.buffer.size - self.offset,
+        }
+    }
+
     // TODO: Return GPU handle directly?
     fn resolve_address(&self) -> wgt::BufferAddress {
         (unsafe { self.buffer.resource.GetGPUVirtualAddress() }) + self.offset

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -342,6 +342,7 @@ impl Drop for Queue {
 pub struct Buffer {
     raw: Option<glow::Buffer>,
     target: BindTarget,
+    size: wgt::BufferAddress,
     map_flags: u32,
     data: Option<Arc<MaybeMutex<Vec<u8>>>>,
     offset_of_current_mapping: Arc<MaybeMutex<wgt::BufferAddress>>,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1957,8 +1957,8 @@ pub struct PipelineLayoutDescriptor<'a, B: DynBindGroupLayout + ?Sized> {
 ///
 /// The recommended way to construct a `BufferBinding` is using the `binding`
 /// method on a wgpu-core `Buffer`, which will validate the binding size
-/// against the buffer size. An unsafe `new_unchecked` constructor is also
-/// provided for cases where direct construction is necessary.
+/// against the buffer size. A `new_unchecked` constructor is also provided for
+/// cases where direct construction is necessary.
 ///
 /// ## Accessible region
 ///
@@ -2020,7 +2020,11 @@ pub struct BufferBinding<'a, B: DynBuffer + ?Sized> {
     pub offset: wgt::BufferAddress,
 
     /// The size of the region bound, in bytes.
-    pub size: wgt::BufferSizeOrZero,
+    ///
+    /// If `None`, the region extends from `offset` to the end of the
+    /// buffer. Given the restrictions on `offset`, this means that
+    /// the size is always greater than zero.
+    pub size: Option<wgt::BufferSize>,
 }
 
 // We must implement this manually because `B` is not necessarily `Clone`.
@@ -2053,6 +2057,15 @@ impl ShouldBeNonZeroExt for u64 {
     }
 }
 
+impl ShouldBeNonZeroExt for Option<NonZeroU64> {
+    fn get(&self) -> u64 {
+        match *self {
+            Some(non_zero) => non_zero.get(),
+            None => 0,
+        }
+    }
+}
+
 impl<'a, B: DynBuffer + ?Sized> BufferBinding<'a, B> {
     /// Construct a `BufferBinding` with the given contents.
     ///
@@ -2067,10 +2080,10 @@ impl<'a, B: DynBuffer + ?Sized> BufferBinding<'a, B> {
     /// bytes starting at `offset` is contained within the buffer.
     ///
     /// The `S` type parameter is a temporary convenience to allow callers to
-    /// pass either a `u64` or a `NonZeroU64`. When the zero-size binding issue
-    /// is resolved, the argument should just match the type of the member.
+    /// pass a zero size. When the zero-size binding issue is resolved, the
+    /// argument should just match the type of the member.
     /// TODO(<https://github.com/gfx-rs/wgpu/issues/3170>): remove the parameter
-    pub unsafe fn new_unchecked<S: Into<wgt::BufferSizeOrZero>>(
+    pub unsafe fn new_unchecked<S: Into<Option<NonZeroU64>>>(
         buffer: &'a B,
         offset: wgt::BufferAddress,
         size: S,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2083,7 +2083,7 @@ impl<'a, B: DynBuffer + ?Sized> BufferBinding<'a, B> {
     /// pass a zero size. When the zero-size binding issue is resolved, the
     /// argument should just match the type of the member.
     /// TODO(<https://github.com/gfx-rs/wgpu/issues/3170>): remove the parameter
-    pub unsafe fn new_unchecked<S: Into<Option<NonZeroU64>>>(
+    pub fn new_unchecked<S: Into<Option<NonZeroU64>>>(
         buffer: &'a B,
         offset: wgt::BufferAddress,
         size: S,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -494,6 +494,7 @@ impl crate::Queue for Queue {
 #[derive(Debug)]
 pub struct Buffer {
     raw: metal::Buffer,
+    size: wgt::BufferAddress,
 }
 
 unsafe impl Send for Buffer {}
@@ -504,6 +505,15 @@ impl crate::DynBuffer for Buffer {}
 impl Buffer {
     fn as_raw(&self) -> BufferPtr {
         unsafe { NonNull::new_unchecked(self.raw.as_ptr()) }
+    }
+}
+
+impl crate::BufferBinding<'_, Buffer> {
+    fn resolve_size(&self) -> wgt::BufferAddress {
+        match self.size {
+            Some(size) => size.get(),
+            None => self.buffer.size - self.offset,
+        }
     }
 }
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1799,12 +1799,12 @@ impl crate::Device for super::Device {
                     (buffer_infos, local_buffer_infos) =
                         buffer_infos.extend(desc.buffers[start as usize..end as usize].iter().map(
                             |binding| {
-                                // https://github.com/gfx-rs/wgpu/issues/3170
-                                assert!(binding.size != 0, "zero-size bindings are not supported");
                                 vk::DescriptorBufferInfo::default()
                                     .buffer(binding.buffer.raw)
                                     .offset(binding.offset)
-                                    .range(binding.size)
+                                    .range(
+                                        binding.size.map_or(vk::WHOLE_SIZE, wgt::BufferSize::get),
+                                    )
                             },
                         ));
                     write.buffer_info(local_buffer_infos)

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -60,12 +60,6 @@ pub type BufferAddress = u64;
 /// [`BufferSlice`]: ../wgpu/struct.BufferSlice.html
 pub type BufferSize = core::num::NonZeroU64;
 
-/// Integral type used for buffer sizes that may be zero.
-///
-/// Although the wgpu Rust API disallows zero-size `BufferSlice` and wgpu-hal
-/// disallows zero-size bindings, WebGPU permits zero-size buffers and bindings.
-pub type BufferSizeOrZero = u64;
-
 /// Integral type used for binding locations in shaders.
 ///
 /// Used in [`VertexAttribute`]s and errors.


### PR DESCRIPTION
Applies #7911 to the firefox-141 branch. Since the original version of the change was not reverted on this branch, the commit that undoes the reversion is not included. The "fix for destroyed resource errors" commit is also not included, because it only makes sense with other error reporting changes that landed on trunk after the branch point. 

**Testing**
Enables a few CTS tests.

**Squash or Rebase?** Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
