### PR TITLE
Use backwards-compatible options to `git config`

### DIFF
--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -80,7 +80,7 @@ pub fn run_cts(shell: Shell, mut args: Arguments) -> anyhow::Result<()> {
         // clones may not have it. Eventually this can be removed.
         if shell
             .cmd("git")
-            .args(["config", "get", "remote.origin.fetch"])
+            .args(["config", "--get", "remote.origin.fetch"])
             .quiet()
             .ignore_stdout()
             .ignore_stderr()
@@ -91,7 +91,6 @@ pub fn run_cts(shell: Shell, mut args: Arguments) -> anyhow::Result<()> {
                 .cmd("git")
                 .args([
                     "config",
-                    "set",
                     "remote.origin.fetch",
                     "+refs/heads/gh-pages:refs/remotes/origin/gh-pages",
                 ])


### PR DESCRIPTION
Small fix to the CTS xtask.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
