### PR TITLE
Add support for miri to the codebase

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,6 +6,10 @@ slow-timeout = { period = "45s", terminate-after = 2 }
 fail-fast = false
 retries = 0
 
+[profile.default-miri]
+# Miri is very very slow, so give it a much longer timeout.
+slow-timeout = { period = "120s", terminate-after = 4 }
+
 # Use two threads for tests with "2 threads" in their name
 [[profile.default.overrides]]
 filter = 'test(~2_threads) | test(~2 threads)'

--- a/examples/features/src/big_compute_buffers/mod.rs
+++ b/examples/features/src/big_compute_buffers/mod.rs
@@ -248,4 +248,4 @@ pub fn main() {
 
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]
-mod tests;
+pub mod tests;

--- a/examples/features/src/big_compute_buffers/tests.rs
+++ b/examples/features/src/big_compute_buffers/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
 
 #[gpu_test]
-static TWO_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
+pub static TWO_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .features(

--- a/examples/features/src/boids/mod.rs
+++ b/examples/features/src/boids/mod.rs
@@ -323,7 +323,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "boids",
     // Generated on 1080ti on Vk/Windows
     image_path: "/examples/features/src/boids/screenshot.png",

--- a/examples/features/src/bunnymark/mod.rs
+++ b/examples/features/src/bunnymark/mod.rs
@@ -434,7 +434,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "bunnymark",
     image_path: "/examples/features/src/bunnymark/screenshot.png",
     width: 1024,

--- a/examples/features/src/conservative_raster/mod.rs
+++ b/examples/features/src/conservative_raster/mod.rs
@@ -317,7 +317,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "conservative-raster",
     image_path: "/examples/features/src/conservative_raster/screenshot.png",
     width: 1024,

--- a/examples/features/src/cube/mod.rs
+++ b/examples/features/src/cube/mod.rs
@@ -381,7 +381,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "cube",
     // Generated on 1080ti on Vk/Windows
     image_path: "/examples/features/src/cube/screenshot.png",
@@ -397,7 +397,7 @@ static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTest
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST_LINES: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST_LINES: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "cube-lines",
     // Generated on 1080ti on Vk/Windows
     image_path: "/examples/features/src/cube/screenshot-lines.png",

--- a/examples/features/src/hello_synchronization/mod.rs
+++ b/examples/features/src/hello_synchronization/mod.rs
@@ -208,4 +208,4 @@ pub fn main() {
 }
 
 #[cfg(test)]
-mod tests;
+pub mod tests;

--- a/examples/features/src/hello_synchronization/tests.rs
+++ b/examples/features/src/hello_synchronization/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
 
 #[gpu_test]
-static SYNC: GpuTestConfiguration = GpuTestConfiguration::new()
+pub static SYNC: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         // Taken from hello-compute tests.
         TestParameters::default()

--- a/examples/features/src/lib.rs
+++ b/examples/features/src/lib.rs
@@ -36,4 +36,52 @@ pub mod uniform_values;
 pub mod water;
 
 #[cfg(test)]
-wgpu_test::gpu_test_main!();
+fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(unused_mut, reason = "non-wasm32 needs this mutable")
+    )]
+    let mut test_list = vec![
+        boids::TEST,
+        bunnymark::TEST,
+        conservative_raster::TEST,
+        cube::TEST,
+        cube::TEST_LINES,
+        hello_synchronization::tests::SYNC,
+        mipmap::TEST,
+        mipmap::TEST_QUERY,
+        msaa_line::TEST,
+        multiple_render_targets::TEST,
+        ray_cube_compute::TEST,
+        ray_cube_fragment::TEST,
+        ray_cube_normals::TEST,
+        ray_scene::TEST,
+        ray_shadows::TEST,
+        ray_traced_triangle::TEST,
+        shadow::TEST,
+        skybox::TEST,
+        skybox::TEST_ASTC,
+        skybox::TEST_BCN,
+        skybox::TEST_ETC2,
+        srgb_blend::TEST_LINEAR,
+        srgb_blend::TEST_SRGB,
+        stencil_triangles::TEST,
+        texture_arrays::TEST,
+        texture_arrays::TEST_NON_UNIFORM,
+        texture_arrays::TEST_UNIFORM,
+        timestamp_queries::tests::TIMESTAMPS_ENCODER,
+        timestamp_queries::tests::TIMESTAMPS_PASSES,
+        timestamp_queries::tests::TIMESTAMPS_PASS_BOUNDARIES,
+        water::TEST,
+    ];
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        test_list.push(big_compute_buffers::tests::TWO_BUFFERS);
+    }
+
+    test_list
+}
+
+#[cfg(test)]
+wgpu_test::gpu_test_main!(all_tests());

--- a/examples/features/src/mipmap/mod.rs
+++ b/examples/features/src/mipmap/mod.rs
@@ -508,7 +508,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "mipmap",
     image_path: "/examples/features/src/mipmap/screenshot.png",
     width: 1024,
@@ -521,7 +521,7 @@ static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTest
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST_QUERY: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST_QUERY: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "mipmap-query",
     image_path: "/examples/features/src/mipmap/screenshot_query.png",
     width: 1024,

--- a/examples/features/src/msaa_line/mod.rs
+++ b/examples/features/src/msaa_line/mod.rs
@@ -321,7 +321,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "msaa-line",
     image_path: "/examples/features/src/msaa_line/screenshot.png",
     width: 1024,

--- a/examples/features/src/multiple_render_targets/mod.rs
+++ b/examples/features/src/multiple_render_targets/mod.rs
@@ -536,7 +536,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: EXAMPLE_NAME,
     image_path: "/examples/features/src/multiple_render_targets/screenshot.png",
     width: 1024,

--- a/examples/features/src/ray_cube_compute/mod.rs
+++ b/examples/features/src/ray_cube_compute/mod.rs
@@ -486,7 +486,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "ray_cube_compute",
     image_path: "/examples/features/src/ray_cube_compute/screenshot.png",
     width: 1024,

--- a/examples/features/src/ray_cube_fragment/mod.rs
+++ b/examples/features/src/ray_cube_fragment/mod.rs
@@ -372,7 +372,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "ray_cube_fragment",
     image_path: "/examples/features/src/ray_cube_fragment/screenshot.png",
     width: 1024,

--- a/examples/features/src/ray_cube_normals/mod.rs
+++ b/examples/features/src/ray_cube_normals/mod.rs
@@ -472,7 +472,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "ray_cube_normals",
     image_path: "/examples/features/src/ray_cube_normals/screenshot.png",
     width: 1024,

--- a/examples/features/src/ray_scene/mod.rs
+++ b/examples/features/src/ray_scene/mod.rs
@@ -552,7 +552,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "ray_scene",
     image_path: "/examples/features/src/ray_scene/screenshot.png",
     width: 1024,

--- a/examples/features/src/ray_shadows/mod.rs
+++ b/examples/features/src/ray_shadows/mod.rs
@@ -370,7 +370,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "ray_shadows",
     image_path: "/examples/features/src/ray_shadows/screenshot.png",
     width: 1024,

--- a/examples/features/src/ray_traced_triangle/mod.rs
+++ b/examples/features/src/ray_traced_triangle/mod.rs
@@ -431,7 +431,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "ray_traced_triangle",
     image_path: "/examples/features/src/ray_traced_triangle/screenshot.png",
     width: 1024,

--- a/examples/features/src/shadow/mod.rs
+++ b/examples/features/src/shadow/mod.rs
@@ -839,7 +839,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "shadow",
     image_path: "/examples/features/src/shadow/screenshot.png",
     width: 1024,

--- a/examples/features/src/skybox/mod.rs
+++ b/examples/features/src/skybox/mod.rs
@@ -470,7 +470,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "skybox",
     image_path: "/examples/features/src/skybox/screenshot.png",
     width: 1024,
@@ -485,7 +485,7 @@ static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTest
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST_BCN: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST_BCN: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "skybox-bc7",
     image_path: "/examples/features/src/skybox/screenshot_bc7.png",
     width: 1024,
@@ -498,7 +498,7 @@ static TEST_BCN: crate::framework::ExampleTestParams = crate::framework::Example
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST_ETC2: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST_ETC2: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "skybox-etc2",
     image_path: "/examples/features/src/skybox/screenshot_etc2.png",
     width: 1024,
@@ -511,7 +511,7 @@ static TEST_ETC2: crate::framework::ExampleTestParams = crate::framework::Exampl
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST_ASTC: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST_ASTC: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "skybox-astc",
     image_path: "/examples/features/src/skybox/screenshot_astc.png",
     width: 1024,

--- a/examples/features/src/srgb_blend/mod.rs
+++ b/examples/features/src/srgb_blend/mod.rs
@@ -223,7 +223,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST_SRGB: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST_SRGB: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "srgb-blend-srg",
     // Generated on WARP/Windows
     image_path: "/examples/features/src/srgb_blend/screenshot-srgb.png",
@@ -237,7 +237,7 @@ static TEST_SRGB: crate::framework::ExampleTestParams = crate::framework::Exampl
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST_LINEAR: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST_LINEAR: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "srgb-blend-linear",
     // Generated on WARP/Windows
     image_path: "/examples/features/src/srgb_blend/screenshot-linear.png",

--- a/examples/features/src/stencil_triangles/mod.rs
+++ b/examples/features/src/stencil_triangles/mod.rs
@@ -245,7 +245,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "stencil-triangles",
     image_path: "/examples/features/src/stencil_triangles/screenshot.png",
     width: 1024,

--- a/examples/features/src/texture_arrays/mod.rs
+++ b/examples/features/src/texture_arrays/mod.rs
@@ -431,7 +431,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "texture-arrays",
     image_path: "/examples/features/src/texture_arrays/screenshot.png",
     width: 1024,
@@ -444,20 +444,21 @@ static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTest
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST_UNIFORM: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
-    name: "texture-arrays-uniform",
-    image_path: "/examples/features/src/texture_arrays/screenshot.png",
-    width: 1024,
-    height: 768,
-    optional_features: wgpu::Features::empty(),
-    base_test_parameters: wgpu_test::TestParameters::default(),
-    comparisons: &[wgpu_test::ComparisonType::Mean(0.0)],
-    _phantom: std::marker::PhantomData::<Example>,
-};
+pub static TEST_UNIFORM: crate::framework::ExampleTestParams =
+    crate::framework::ExampleTestParams {
+        name: "texture-arrays-uniform",
+        image_path: "/examples/features/src/texture_arrays/screenshot.png",
+        width: 1024,
+        height: 768,
+        optional_features: wgpu::Features::empty(),
+        base_test_parameters: wgpu_test::TestParameters::default(),
+        comparisons: &[wgpu_test::ComparisonType::Mean(0.0)],
+        _phantom: std::marker::PhantomData::<Example>,
+    };
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST_NON_UNIFORM: crate::framework::ExampleTestParams =
+pub static TEST_NON_UNIFORM: crate::framework::ExampleTestParams =
     crate::framework::ExampleTestParams {
         name: "texture-arrays-non-uniform",
         image_path: "/examples/features/src/texture_arrays/screenshot.png",

--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -426,13 +426,13 @@ pub fn main() {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration};
 
     use super::{submit_render_and_compute_pass_with_queries, QueryResults};
 
     #[gpu_test]
-    static TIMESTAMPS_PASS_BOUNDARIES: GpuTestConfiguration = GpuTestConfiguration::new()
+    pub static TIMESTAMPS_PASS_BOUNDARIES: GpuTestConfiguration = GpuTestConfiguration::new()
         .parameters(
             wgpu_test::TestParameters::default()
                 .limits(wgpu::Limits::downlevel_defaults())
@@ -441,7 +441,7 @@ mod tests {
         .run_sync(|ctx| test_timestamps(ctx, false, false));
 
     #[gpu_test]
-    static TIMESTAMPS_ENCODER: GpuTestConfiguration = GpuTestConfiguration::new()
+    pub static TIMESTAMPS_ENCODER: GpuTestConfiguration = GpuTestConfiguration::new()
         .parameters(
             wgpu_test::TestParameters::default()
                 .limits(wgpu::Limits::downlevel_defaults())
@@ -455,7 +455,7 @@ mod tests {
         .run_sync(|ctx| test_timestamps(ctx, true, false));
 
     #[gpu_test]
-    static TIMESTAMPS_PASSES: GpuTestConfiguration = GpuTestConfiguration::new()
+    pub static TIMESTAMPS_PASSES: GpuTestConfiguration = GpuTestConfiguration::new()
         .parameters(
             wgpu_test::TestParameters::default()
                 .limits(wgpu::Limits::downlevel_defaults())

--- a/examples/features/src/water/mod.rs
+++ b/examples/features/src/water/mod.rs
@@ -823,7 +823,7 @@ pub fn main() {
 
 #[cfg(test)]
 #[wgpu_test::gpu_test]
-static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
+pub static TEST: crate::framework::ExampleTestParams = crate::framework::ExampleTestParams {
     name: "water",
     image_path: "/examples/features/src/water/screenshot.png",
     width: 1024,

--- a/naga/tests/naga/example_wgsl.rs
+++ b/naga/tests/naga/example_wgsl.rs
@@ -4,6 +4,9 @@ use naga::{front::wgsl, valid::Validator};
 use std::{ffi::OsStr, fs, path::Path};
 
 /// Runs through all example shaders and ensures they are valid wgsl.
+// While we _can_ run this test under miri, it is extremely slow (>5 minutes),
+// and naga isn't the primary target for miri testing, so we disable it.
+#[cfg(not(miri))]
 #[test]
 pub fn parse_example_wgsl() {
     let example_path = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/naga/tests/naga/example_wgsl.rs
+++ b/naga/tests/naga/example_wgsl.rs
@@ -6,7 +6,7 @@ use std::{ffi::OsStr, fs, path::Path};
 /// Runs through all example shaders and ensures they are valid wgsl.
 // While we _can_ run this test under miri, it is extremely slow (>5 minutes),
 // and naga isn't the primary target for miri testing, so we disable it.
-#[cfg(not(miri))]
+#[cfg_attr(miri, ignore)]
 #[test]
 pub fn parse_example_wgsl() {
     let example_path = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/naga/tests/naga/snapshots.rs
+++ b/naga/tests/naga/snapshots.rs
@@ -818,7 +818,9 @@ fn write_output_wgsl(
     input.write_output_file("wgsl", "wgsl", string);
 }
 
-#[cfg(feature = "wgsl-in")]
+// While we _can_ run this test under miri, it is extremely slow (>5 minutes),
+// and naga isn't the primary target for miri testing, so we disable it.
+#[cfg(all(feature = "wgsl-in", not(miri)))]
 #[test]
 fn convert_snapshots_wgsl() {
     let _ = env_logger::try_init();
@@ -843,7 +845,8 @@ fn convert_snapshots_wgsl() {
     }
 }
 
-#[cfg(feature = "spv-in")]
+// miri doesn't allow us to shell out to `spirv-as`
+#[cfg(all(feature = "spv-in", not(miri)))]
 #[test]
 fn convert_snapshots_spv() {
     use std::process::Command;
@@ -892,7 +895,9 @@ fn convert_snapshots_spv() {
     }
 }
 
-#[cfg(feature = "glsl-in")]
+// While we _can_ run this test under miri, it is extremely slow (>5 minutes),
+// and naga isn't the primary target for miri testing, so we disable it.
+#[cfg(all(feature = "glsl-in", not(miri)))]
 #[allow(unused_variables)]
 #[test]
 fn convert_snapshots_glsl() {

--- a/naga/tests/naga/snapshots.rs
+++ b/naga/tests/naga/snapshots.rs
@@ -820,7 +820,8 @@ fn write_output_wgsl(
 
 // While we _can_ run this test under miri, it is extremely slow (>5 minutes),
 // and naga isn't the primary target for miri testing, so we disable it.
-#[cfg(all(feature = "wgsl-in", not(miri)))]
+#[cfg(feature = "wgsl-in")]
+#[cfg_attr(miri, ignore)]
 #[test]
 fn convert_snapshots_wgsl() {
     let _ = env_logger::try_init();
@@ -846,7 +847,8 @@ fn convert_snapshots_wgsl() {
 }
 
 // miri doesn't allow us to shell out to `spirv-as`
-#[cfg(all(feature = "spv-in", not(miri)))]
+#[cfg(feature = "spv-in")]
+#[cfg_attr(miri, ignore)]
 #[test]
 fn convert_snapshots_spv() {
     use std::process::Command;
@@ -897,7 +899,8 @@ fn convert_snapshots_spv() {
 
 // While we _can_ run this test under miri, it is extremely slow (>5 minutes),
 // and naga isn't the primary target for miri testing, so we disable it.
-#[cfg(all(feature = "glsl-in", not(miri)))]
+#[cfg(feature = "glsl-in")]
+#[cfg_attr(miri, ignore)]
 #[allow(unused_variables)]
 #[test]
 fn convert_snapshots_glsl() {

--- a/player/tests/player/main.rs
+++ b/player/tests/player/main.rs
@@ -245,7 +245,7 @@ impl Corpus {
     }
 }
 
-#[cfg(not(miri))]
+#[cfg_attr(miri, ignore)]
 #[test]
 fn test_api() {
     env_logger::init();

--- a/player/tests/player/main.rs
+++ b/player/tests/player/main.rs
@@ -245,6 +245,7 @@ impl Corpus {
     }
 }
 
+#[cfg(not(miri))]
 #[test]
 fn test_api() {
     env_logger::init();

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -67,8 +67,10 @@ trybuild.workspace = true
 # Cargo-metadata doesn't compile on wasm due to old cargo-util-schemas dependency.
 cargo_metadata.workspace = true
 env_logger.workspace = true
-nv-flip.workspace = true
 parking_lot = { workspace = true, features = ["deadlock_detection"] }
+
+[target.'cfg(not(any(target_arch = "wasm32", miri)))'.dependencies]
+nv-flip.workspace = true
 
 # Webassembly
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/tests/src/config.rs
+++ b/tests/src/config.rs
@@ -118,3 +118,5 @@ impl Default for GpuTestConfiguration {
         Self::new()
     }
 }
+
+pub type GpuTestInitializer = fn() -> GpuTestConfiguration;

--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -36,7 +36,7 @@ use core::fmt;
 /// [skip]: super::TestParameters::skip
 /// [expect_fail]: super::TestParameters::expect_fail
 /// [`AdapterInfo`]: wgpu::AdapterInfo
-#[derive(Default, Clone)]
+#[derive(Default, Clone, PartialEq)]
 pub struct FailureCase {
     /// Backends expected to fail, or `None` for any backend.
     ///
@@ -334,7 +334,7 @@ impl FailureReason {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, PartialEq)]
 pub enum FailureBehavior {
     /// Assert that the test fails for the given reason.
     ///

--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -7,7 +7,7 @@ use wgpu::*;
 
 use crate::TestingContext;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", miri)))]
 async fn read_png(path: impl AsRef<Path>, width: u32, height: u32) -> Option<Vec<u8>> {
     let data = match std::fs::read(&path) {
         Ok(f) => f,
@@ -45,7 +45,7 @@ async fn read_png(path: impl AsRef<Path>, width: u32, height: u32) -> Option<Vec
     Some(buffer)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", miri)))]
 async fn write_png(
     path: impl AsRef<Path>,
     width: u32,
@@ -64,7 +64,7 @@ async fn write_png(
     writer.write_image_data(data).unwrap();
 }
 
-#[cfg_attr(target_arch = "wasm32", allow(unused))]
+#[cfg_attr(any(target_arch = "wasm32", miri), allow(unused))]
 fn add_alpha(input: &[u8]) -> Vec<u8> {
     input
         .chunks_exact(3)
@@ -72,7 +72,7 @@ fn add_alpha(input: &[u8]) -> Vec<u8> {
         .collect()
 }
 
-#[cfg_attr(target_arch = "wasm32", allow(unused))]
+#[cfg_attr(any(target_arch = "wasm32", miri), allow(unused))]
 fn remove_alpha(input: &[u8]) -> Vec<u8> {
     input
         .chunks_exact(4)
@@ -81,7 +81,7 @@ fn remove_alpha(input: &[u8]) -> Vec<u8> {
         .collect()
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", miri)))]
 fn print_flip(pool: &mut nv_flip::FlipPool) {
     println!("\tMean: {:.6}", pool.mean());
     println!("\tMin Value: {:.6}", pool.min_value());
@@ -115,7 +115,7 @@ pub enum ComparisonType {
 }
 
 impl ComparisonType {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(any(target_arch = "wasm32", miri)))]
     fn check(&self, pool: &mut nv_flip::FlipPool) -> bool {
         match *self {
             ComparisonType::Mean(v) => {
@@ -148,7 +148,7 @@ impl ComparisonType {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", miri)))]
 pub async fn compare_image_output(
     path: impl AsRef<Path> + AsRef<OsStr>,
     adapter_info: &wgpu::AdapterInfo,
@@ -250,7 +250,7 @@ pub async fn compare_image_output(
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", miri))]
 pub async fn compare_image_output(
     path: impl AsRef<Path> + AsRef<OsStr>,
     adapter_info: &wgpu::AdapterInfo,
@@ -259,13 +259,13 @@ pub async fn compare_image_output(
     test_with_alpha: &[u8],
     checks: &[ComparisonType],
 ) {
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(target_arch = "wasm32", miri))]
     {
         let _ = (path, adapter_info, width, height, test_with_alpha, checks);
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", allow(unused))]
+#[cfg_attr(any(target_arch = "wasm32", miri), allow(unused))]
 fn sanitize_for_path(s: &str) -> String {
     s.chars()
         .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -65,8 +65,15 @@ pub fn initialize_instance(backends: wgpu::Backends, params: &TestParameters) ->
                 ..Default::default()
             }
             .with_env(),
-            // TODO(https://github.com/gfx-rs/wgpu/issues/7119): Enable noop backend?
-            noop: wgpu::NoopBackendOptions::default(),
+            // Allow the noop backend to be used in tests. This will not be used unless
+            // WGPU_GPU_TESTS_USE_NOOP_BACKEND env var is set, because wgpu-info will not
+            // enumerate the noop backend.
+            //
+            // However, we use wasm_bindgen_test to run tests on wasm, and wgpu
+            // will chose the noop on wasm32 for some reason.
+            noop: wgpu::NoopBackendOptions {
+                enable: !cfg!(target_arch = "wasm32"),
+            },
         },
     })
 }

--- a/tests/src/params.rs
+++ b/tests/src/params.rs
@@ -41,7 +41,9 @@ impl Default for TestParameters {
             required_limits: Limits::downlevel_webgl2_defaults(),
             required_instance_flags: InstanceFlags::empty(),
             force_fxc: false,
-            skips: Vec::new(),
+            // By default we skip the noop backend, and enable it if the test
+            // parameters ask us to remove it.
+            skips: vec![FailureCase::backend(wgpu::Backends::NOOP)],
             failures: Vec::new(),
         }
     }
@@ -92,6 +94,16 @@ impl TestParameters {
     /// Mark the test as always failing, and needing to be skipped.
     pub fn skip(mut self, when: FailureCase) -> Self {
         self.skips.push(when);
+        self
+    }
+
+    /// Enable testing against the noop backend and miri.
+    ///
+    /// The noop backend does not execute any operations, but allows us to test
+    /// validation and memory safety.
+    pub fn enable_noop(mut self) -> Self {
+        self.skips
+            .retain(|case| *case != FailureCase::backend(wgpu::Backends::NOOP));
         self
     }
 }

--- a/tests/src/report.rs
+++ b/tests/src/report.rs
@@ -15,6 +15,20 @@ pub(crate) struct GpuReport {
 }
 
 impl GpuReport {
+    #[cfg(not(target_arch = "wasm32"))]
+    /// Creates a new GpuReport with a single noop adapter.
+    pub(crate) fn noop_only() -> Self {
+        GpuReport {
+            devices: vec![AdapterReport {
+                info: wgpu::hal::noop::adapter_info(),
+                features: Features::all(),
+                limits: wgpu::hal::noop::CAPABILITIES.limits,
+                downlevel_caps: wgpu::hal::noop::CAPABILITIES.downlevel,
+                texture_format_features: HashMap::new(), // todo
+            }],
+        }
+    }
+
     #[cfg_attr(target_arch = "wasm32", allow(unused))]
     pub(crate) fn from_json(file: &str) -> serde_json::Result<Self> {
         profiling::scope!("Parsing .gpuconfig");

--- a/tests/tests/wgpu-compile/main.rs
+++ b/tests/tests/wgpu-compile/main.rs
@@ -1,3 +1,4 @@
+#![cfg(not(miri))]
 // Tests that ensure that various constructs that should not compile do not compile.
 
 #[test]

--- a/tests/tests/wgpu-compile/main.rs
+++ b/tests/tests/wgpu-compile/main.rs
@@ -1,6 +1,7 @@
 #![cfg(not(miri))]
 // Tests that ensure that various constructs that should not compile do not compile.
 
+#[cfg_attr(miri, ignore)]
 #[test]
 fn compile_fail() {
     let t = trybuild::TestCases::new();

--- a/tests/tests/wgpu-dependency/main.rs
+++ b/tests/tests/wgpu-dependency/main.rs
@@ -1,6 +1,6 @@
 // Cargo-metadata doesn't compile on wasm due to old cargo-util-schemas dependency.
 // Since this test isn't dependent on the current architecture, we can just skip it on wasm without any issues.
-#![cfg(not(target_arch = "wasm32"))]
+#![cfg(not(any(target_arch = "wasm32", miri)))]
 
 use std::process::Command;
 

--- a/tests/tests/wgpu-gpu/bgra8unorm_storage.rs
+++ b/tests/tests/wgpu-gpu/bgra8unorm_storage.rs
@@ -2,7 +2,11 @@
 
 use std::borrow::Cow;
 
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(BGRA8_UNORM_STORAGE);
+}
 
 const SHADER_SRC: &str = "
 @group(0) @binding(0) var tex: texture_storage_2d<bgra8unorm, write>;

--- a/tests/tests/wgpu-gpu/bind_group_layout_dedup.rs
+++ b/tests/tests/wgpu-gpu/bind_group_layout_dedup.rs
@@ -40,7 +40,11 @@ const ENTRY: wgpu::BindGroupLayoutEntry = wgpu::BindGroupLayoutEntry {
 
 #[gpu_test]
 static BIND_GROUP_LAYOUT_DEDUPLICATION: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits())
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop(),
+    )
     .run_async(bgl_dedupe);
 
 async fn bgl_dedupe(ctx: TestingContext) {
@@ -120,7 +124,11 @@ async fn bgl_dedupe(ctx: TestingContext) {
 #[gpu_test]
 static BIND_GROUP_LAYOUT_DEDUPLICATION_WITH_DROPPED_USER_HANDLE: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default().test_features_limits())
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .enable_noop(),
+        )
         .run_sync(bgl_dedupe_with_dropped_user_handle);
 
 // https://github.com/gfx-rs/wgpu/issues/4824
@@ -203,7 +211,11 @@ fn bgl_dedupe_with_dropped_user_handle(ctx: TestingContext) {
 
 #[gpu_test]
 static GET_DERIVED_BGL: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits())
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop(),
+    )
     .run_sync(get_derived_bgl);
 
 fn get_derived_bgl(ctx: TestingContext) {
@@ -277,7 +289,11 @@ fn get_derived_bgl(ctx: TestingContext) {
 #[gpu_test]
 static SEPARATE_PIPELINES_HAVE_INCOMPATIBLE_DERIVED_BGLS: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default().test_features_limits())
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .enable_noop(),
+        )
         .run_sync(separate_pipelines_have_incompatible_derived_bgls);
 
 fn separate_pipelines_have_incompatible_derived_bgls(ctx: TestingContext) {
@@ -341,7 +357,11 @@ fn separate_pipelines_have_incompatible_derived_bgls(ctx: TestingContext) {
 #[gpu_test]
 static DERIVED_BGLS_INCOMPATIBLE_WITH_REGULAR_BGLS: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default().test_features_limits())
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .enable_noop(),
+        )
         .run_sync(derived_bgls_incompatible_with_regular_bgls);
 
 fn derived_bgls_incompatible_with_regular_bgls(ctx: TestingContext) {
@@ -412,7 +432,11 @@ fn derived_bgls_incompatible_with_regular_bgls(ctx: TestingContext) {
 
 #[gpu_test]
 static BIND_GROUP_LAYOUT_DEDUPLICATION_DERIVED: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits())
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop(),
+    )
     .run_sync(bgl_dedupe_derived);
 
 fn bgl_dedupe_derived(ctx: TestingContext) {

--- a/tests/tests/wgpu-gpu/bind_group_layout_dedup.rs
+++ b/tests/tests/wgpu-gpu/bind_group_layout_dedup.rs
@@ -1,6 +1,19 @@
 use std::num::NonZeroU64;
 
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        BIND_GROUP_LAYOUT_DEDUPLICATION,
+        BIND_GROUP_LAYOUT_DEDUPLICATION_WITH_DROPPED_USER_HANDLE,
+        GET_DERIVED_BGL,
+        SEPARATE_PIPELINES_HAVE_INCOMPATIBLE_DERIVED_BGLS,
+        DERIVED_BGLS_INCOMPATIBLE_WITH_REGULAR_BGLS,
+        BIND_GROUP_LAYOUT_DEDUPLICATION_DERIVED,
+    ]);
+}
 
 const SHADER_SRC: &str = "
 @group(0) @binding(0)

--- a/tests/tests/wgpu-gpu/bind_groups.rs
+++ b/tests/tests/wgpu-gpu/bind_groups.rs
@@ -1,7 +1,19 @@
 use std::num::NonZeroU64;
 
 use wgpu::{BufferUsages, PollType};
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        MULTIPLE_BINDINGS_WITH_DIFFERENT_SIZES,
+        BIND_GROUP_NONFILTERING_LAYOUT_NONFILTERING_SAMPLER,
+        BIND_GROUP_NONFILTERING_LAYOUT_MIN_SAMPLER,
+        BIND_GROUP_NONFILTERING_LAYOUT_MAG_SAMPLER,
+        BIND_GROUP_NONFILTERING_LAYOUT_MIPMAP_SAMPLER,
+    ]);
+}
 
 /// Create two bind groups against the same bind group layout, in the same
 /// compute pass, but against two different shaders that have different binding

--- a/tests/tests/wgpu-gpu/bind_groups.rs
+++ b/tests/tests/wgpu-gpu/bind_groups.rs
@@ -176,14 +176,15 @@ static MULTIPLE_BINDINGS_WITH_DIFFERENT_SIZES: GpuTestConfiguration = GpuTestCon
     .parameters(
         TestParameters::default()
             .limits(wgpu::Limits::downlevel_defaults())
-            .expect_fail(FailureCase::always()), // https://github.com/gfx-rs/wgpu/issues/7359
+            .expect_fail(FailureCase::always())
+            .enable_noop(), // https://github.com/gfx-rs/wgpu/issues/7359
     )
     .run_sync(multiple_bindings_with_differing_sizes);
 
 #[gpu_test]
 static BIND_GROUP_NONFILTERING_LAYOUT_NONFILTERING_SAMPLER: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default())
+        .parameters(TestParameters::default().enable_noop())
         .run_sync(|ctx| {
             try_sampler_nonfiltering_layout(
                 ctx,
@@ -201,7 +202,7 @@ static BIND_GROUP_NONFILTERING_LAYOUT_NONFILTERING_SAMPLER: GpuTestConfiguration
 #[gpu_test]
 static BIND_GROUP_NONFILTERING_LAYOUT_MIN_SAMPLER: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default())
+        .parameters(TestParameters::default().enable_noop())
         .run_sync(|ctx| {
             try_sampler_nonfiltering_layout(
                 ctx,
@@ -219,7 +220,7 @@ static BIND_GROUP_NONFILTERING_LAYOUT_MIN_SAMPLER: GpuTestConfiguration =
 #[gpu_test]
 static BIND_GROUP_NONFILTERING_LAYOUT_MAG_SAMPLER: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default())
+        .parameters(TestParameters::default().enable_noop())
         .run_sync(|ctx| {
             try_sampler_nonfiltering_layout(
                 ctx,
@@ -237,7 +238,7 @@ static BIND_GROUP_NONFILTERING_LAYOUT_MAG_SAMPLER: GpuTestConfiguration =
 #[gpu_test]
 static BIND_GROUP_NONFILTERING_LAYOUT_MIPMAP_SAMPLER: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default())
+        .parameters(TestParameters::default().enable_noop())
         .run_sync(|ctx| {
             try_sampler_nonfiltering_layout(
                 ctx,

--- a/tests/tests/wgpu-gpu/binding_array/buffers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/buffers.rs
@@ -1,7 +1,18 @@
 use std::num::{NonZeroU32, NonZeroU64};
 
 use wgpu::*;
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.extend([
+        BINDING_ARRAY_UNIFORM_BUFFERS,
+        PARTIAL_BINDING_ARRAY_UNIFORM_BUFFERS,
+        BINDING_ARRAY_STORAGE_BUFFERS,
+        PARTIAL_BINDING_ARRAY_STORAGE_BUFFERS,
+    ]);
+}
 
 #[gpu_test]
 static BINDING_ARRAY_UNIFORM_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/binding_array/mod.rs
+++ b/tests/tests/wgpu-gpu/binding_array/mod.rs
@@ -2,3 +2,10 @@ mod buffers;
 mod sampled_textures;
 mod samplers;
 mod storage_textures;
+
+pub fn all_tests(tests: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    buffers::all_tests(tests);
+    sampled_textures::all_tests(tests);
+    samplers::all_tests(tests);
+    storage_textures::all_tests(tests);
+}

--- a/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
@@ -2,8 +2,16 @@ use std::num::NonZeroU32;
 
 use wgpu::*;
 use wgpu_test::{
-    gpu_test, image::ReadbackBuffers, GpuTestConfiguration, TestParameters, TestingContext,
+    gpu_test, image::ReadbackBuffers, GpuTestConfiguration, GpuTestInitializer, TestParameters,
+    TestingContext,
 };
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.extend([
+        BINDING_ARRAY_SAMPLED_TEXTURES,
+        PARTIAL_BINDING_ARRAY_SAMPLED_TEXTURES,
+    ]);
+}
 
 #[gpu_test]
 static BINDING_ARRAY_SAMPLED_TEXTURES: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/binding_array/samplers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/samplers.rs
@@ -1,7 +1,13 @@
 use std::num::{NonZeroU32, NonZeroU64};
 
 use wgpu::*;
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.extend([BINDING_ARRAY_SAMPLERS, PARTIAL_BINDING_ARRAY_SAMPLERS]);
+}
 
 #[gpu_test]
 static BINDING_ARRAY_SAMPLERS: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/binding_array/storage_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/storage_textures.rs
@@ -2,9 +2,16 @@ use std::num::NonZeroU32;
 
 use wgpu::*;
 use wgpu_test::{
-    gpu_test, image::ReadbackBuffers, FailureCase, GpuTestConfiguration, TestParameters,
-    TestingContext,
+    gpu_test, image::ReadbackBuffers, FailureCase, GpuTestConfiguration, GpuTestInitializer,
+    TestParameters, TestingContext,
 };
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.extend([
+        BINDING_ARRAY_STORAGE_TEXTURES,
+        PARTIAL_BINDING_ARRAY_STORAGE_TEXTURES,
+    ]);
+}
 
 #[gpu_test]
 static BINDING_ARRAY_STORAGE_TEXTURES: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/buffer.rs
+++ b/tests/tests/wgpu-gpu/buffer.rs
@@ -95,78 +95,84 @@ async fn test_empty_buffer_range(ctx: &TestingContext, buffer_size: u64, label: 
 
 #[gpu_test]
 static EMPTY_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().expect_fail(FailureCase::always()))
+    .parameters(
+        TestParameters::default()
+            .expect_fail(FailureCase::always())
+            .enable_noop(),
+    )
     .run_async(|ctx| async move {
         test_empty_buffer_range(&ctx, 2048, "regular buffer").await;
         test_empty_buffer_range(&ctx, 0, "zero-sized buffer").await;
     });
 
 #[gpu_test]
-static MAP_OFFSET: GpuTestConfiguration = GpuTestConfiguration::new().run_async(|ctx| async move {
-    // This test writes 16 bytes at the beginning of buffer mapped mapped with
-    // an offset of 32 bytes. Then the buffer is copied into another buffer that
-    // is read back and we check that the written bytes are correctly placed at
-    // offset 32..48.
-    // The goal is to check that get_mapped_range did not accidentally double-count
-    // the mapped offset.
+static MAP_OFFSET: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
+        // This test writes 16 bytes at the beginning of buffer mapped mapped with
+        // an offset of 32 bytes. Then the buffer is copied into another buffer that
+        // is read back and we check that the written bytes are correctly placed at
+        // offset 32..48.
+        // The goal is to check that get_mapped_range did not accidentally double-count
+        // the mapped offset.
 
-    let write_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
-        label: None,
-        size: 256,
-        usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
-        mapped_at_creation: false,
-    });
-    let read_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
-        label: None,
-        size: 256,
-        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
-        mapped_at_creation: false,
-    });
-
-    write_buf
-        .slice(32..)
-        .map_async(wgpu::MapMode::Write, move |result| {
-            result.unwrap();
+        let write_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 256,
+            usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let read_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 256,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
         });
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        write_buf
+            .slice(32..)
+            .map_async(wgpu::MapMode::Write, move |result| {
+                result.unwrap();
+            });
 
-    {
-        let slice = write_buf.slice(32..48);
-        let mut view = slice.get_mapped_range_mut();
-        for byte in &mut view[..] {
-            *byte = 2;
+        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+
+        {
+            let slice = write_buf.slice(32..48);
+            let mut view = slice.get_mapped_range_mut();
+            for byte in &mut view[..] {
+                *byte = 2;
+            }
         }
-    }
 
-    write_buf.unmap();
+        write_buf.unmap();
 
-    let mut encoder = ctx
-        .device
-        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
 
-    encoder.copy_buffer_to_buffer(&write_buf, 0, &read_buf, 0, 256);
+        encoder.copy_buffer_to_buffer(&write_buf, 0, &read_buf, 0, 256);
 
-    ctx.queue.submit(Some(encoder.finish()));
+        ctx.queue.submit(Some(encoder.finish()));
 
-    read_buf
-        .slice(..)
-        .map_async(wgpu::MapMode::Read, Result::unwrap);
+        read_buf
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, Result::unwrap);
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
 
-    let slice = read_buf.slice(..);
-    let view = slice.get_mapped_range();
-    for byte in &view[0..32] {
-        assert_eq!(*byte, 0);
-    }
-    for byte in &view[32..48] {
-        assert_eq!(*byte, 2);
-    }
-    for byte in &view[48..] {
-        assert_eq!(*byte, 0);
-    }
-});
+        let slice = read_buf.slice(..);
+        let view = slice.get_mapped_range();
+        for byte in &view[0..32] {
+            assert_eq!(*byte, 0);
+        }
+        for byte in &view[32..48] {
+            assert_eq!(*byte, 2);
+        }
+        for byte in &view[48..] {
+            assert_eq!(*byte, 0);
+        }
+    });
 
 /// The WebGPU algorithm [validating shader binding][vsb] requires
 /// implementations to check that buffer bindings are large enough to
@@ -177,7 +183,7 @@ static MAP_OFFSET: GpuTestConfiguration = GpuTestConfiguration::new().run_async(
 /// 16 for that variable's group/index. Pipeline creation should fail.
 #[gpu_test]
 static MINIMUM_BUFFER_BINDING_SIZE_LAYOUT: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits())
+    .parameters(TestParameters::default().test_features_limits().enable_noop())
     .run_sync(|ctx| {
         // Create a shader module that statically uses a storage buffer.
         let shader_module = ctx
@@ -247,7 +253,7 @@ static MINIMUM_BUFFER_BINDING_SIZE_LAYOUT: GpuTestConfiguration = GpuTestConfigu
 /// binding. Command recording should fail.
 #[gpu_test]
 static MINIMUM_BUFFER_BINDING_SIZE_DISPATCH: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits())
+    .parameters(TestParameters::default().test_features_limits().enable_noop())
     .run_sync(|ctx| {
         // This test tries to use a bindgroup layout with a
         // min_binding_size of 16 to an index whose WGSL type requires 32
@@ -344,7 +350,7 @@ static MINIMUM_BUFFER_BINDING_SIZE_DISPATCH: GpuTestConfiguration = GpuTestConfi
 
 #[gpu_test]
 static CLEAR_OFFSET_OUTSIDE_RESOURCE_BOUNDS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         let size = 16;
 
@@ -370,7 +376,7 @@ static CLEAR_OFFSET_OUTSIDE_RESOURCE_BOUNDS: GpuTestConfiguration = GpuTestConfi
 #[gpu_test]
 static CLEAR_OFFSET_PLUS_SIZE_OUTSIDE_U64_BOUNDS: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default())
+        .parameters(TestParameters::default().enable_noop())
         .run_sync(|ctx| {
             let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
                 label: None,

--- a/tests/tests/wgpu-gpu/buffer.rs
+++ b/tests/tests/wgpu-gpu/buffer.rs
@@ -1,4 +1,17 @@
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        EMPTY_BUFFER,
+        MAP_OFFSET,
+        MINIMUM_BUFFER_BINDING_SIZE_LAYOUT,
+        MINIMUM_BUFFER_BINDING_SIZE_DISPATCH,
+        CLEAR_OFFSET_OUTSIDE_RESOURCE_BOUNDS,
+        CLEAR_OFFSET_PLUS_SIZE_OUTSIDE_U64_BOUNDS,
+    ]);
+}
 
 async fn test_empty_buffer_range(ctx: &TestingContext, buffer_size: u64, label: &str) {
     let r = wgpu::BufferUsages::MAP_READ;

--- a/tests/tests/wgpu-gpu/buffer_copy.rs
+++ b/tests/tests/wgpu-gpu/buffer_copy.rs
@@ -2,7 +2,11 @@
 
 use wgpu::BufferAddress;
 
-use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration};
+use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, GpuTestInitializer};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(COPY_ALIGNMENT);
+}
 
 fn try_copy(
     ctx: &wgpu_test::TestingContext,

--- a/tests/tests/wgpu-gpu/buffer_copy.rs
+++ b/tests/tests/wgpu-gpu/buffer_copy.rs
@@ -2,7 +2,7 @@
 
 use wgpu::BufferAddress;
 
-use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.push(COPY_ALIGNMENT);
@@ -26,49 +26,51 @@ fn try_copy(
 }
 
 #[gpu_test]
-static COPY_ALIGNMENT: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {
-    try_copy(&ctx, 0, 0, None);
-    try_copy(
-        &ctx,
-        4,
-        16 + 1,
-        Some("copy size 17 does not respect `copy_buffer_alignment`"),
-    );
-    try_copy(
-        &ctx,
-        64,
-        20 + 2,
-        Some("copy size 22 does not respect `copy_buffer_alignment`"),
-    );
-    try_copy(
-        &ctx,
-        256,
-        44 + 3,
-        Some("copy size 47 does not respect `copy_buffer_alignment`"),
-    );
-    try_copy(&ctx, 1024, 8 + 4, None);
+static COPY_ALIGNMENT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
+        try_copy(&ctx, 0, 0, None);
+        try_copy(
+            &ctx,
+            4,
+            16 + 1,
+            Some("copy size 17 does not respect `copy_buffer_alignment`"),
+        );
+        try_copy(
+            &ctx,
+            64,
+            20 + 2,
+            Some("copy size 22 does not respect `copy_buffer_alignment`"),
+        );
+        try_copy(
+            &ctx,
+            256,
+            44 + 3,
+            Some("copy size 47 does not respect `copy_buffer_alignment`"),
+        );
+        try_copy(&ctx, 1024, 8 + 4, None);
 
-    try_copy(&ctx, 0, 4, None);
-    try_copy(
-        &ctx,
-        4 + 1,
-        8,
-        Some("buffer offset 5 is not aligned to block size or `copy_buffer_alignment`"),
-    );
-    try_copy(
-        &ctx,
-        64 + 2,
-        12,
-        Some("buffer offset 66 is not aligned to block size or `copy_buffer_alignment`"),
-    );
-    try_copy(
-        &ctx,
-        256 + 3,
-        16,
-        Some("buffer offset 259 is not aligned to block size or `copy_buffer_alignment`"),
-    );
-    try_copy(&ctx, 1024 + 4, 4, None);
-});
+        try_copy(&ctx, 0, 4, None);
+        try_copy(
+            &ctx,
+            4 + 1,
+            8,
+            Some("buffer offset 5 is not aligned to block size or `copy_buffer_alignment`"),
+        );
+        try_copy(
+            &ctx,
+            64 + 2,
+            12,
+            Some("buffer offset 66 is not aligned to block size or `copy_buffer_alignment`"),
+        );
+        try_copy(
+            &ctx,
+            256 + 3,
+            16,
+            Some("buffer offset 259 is not aligned to block size or `copy_buffer_alignment`"),
+        );
+        try_copy(&ctx, 1024 + 4, 4, None);
+    });
 
 const BUFFER_SIZE: BufferAddress = 1234;
 

--- a/tests/tests/wgpu-gpu/buffer_usages.rs
+++ b/tests/tests/wgpu-gpu/buffer_usages.rs
@@ -2,7 +2,17 @@
 
 use wgpu::BufferAddress;
 use wgpu::{BufferUsages as Bu, MapMode as Ma};
-use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    fail_if, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        BUFFER_USAGE,
+        BUFFER_USAGE_MAPPABLE_PRIMARY_BUFFERS,
+        BUFFER_MAP_ASYNC_MAP_STATE,
+    ]);
+}
 
 const BUFFER_SIZE: BufferAddress = 1234;
 

--- a/tests/tests/wgpu-gpu/buffer_usages.rs
+++ b/tests/tests/wgpu-gpu/buffer_usages.rs
@@ -59,20 +59,26 @@ fn try_create(ctx: TestingContext, usages: &[(bool, &[wgpu::BufferUsages])]) {
 }
 
 #[gpu_test]
-static BUFFER_USAGE: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {
-    try_create(
-        ctx,
-        &[
-            (false, ALWAYS_VALID),
-            (true, NEEDS_MAPPABLE_PRIMARY_BUFFERS),
-            (true, ALWAYS_FAIL),
-        ],
-    );
-});
+static BUFFER_USAGE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
+        try_create(
+            ctx,
+            &[
+                (false, ALWAYS_VALID),
+                (true, NEEDS_MAPPABLE_PRIMARY_BUFFERS),
+                (true, ALWAYS_FAIL),
+            ],
+        );
+    });
 
 #[gpu_test]
 static BUFFER_USAGE_MAPPABLE_PRIMARY_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS))
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS)
+            .enable_noop(),
+    )
     .run_sync(|ctx| {
         try_create(
             ctx,
@@ -169,7 +175,11 @@ async fn map_test(
 
 #[gpu_test]
 static BUFFER_MAP_ASYNC_MAP_STATE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS))
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS)
+            .enable_noop(),
+    )
     .run_async(move |ctx| async move {
         for usage_type in ["invalid", "read", "write"] {
             for map_mode_type in [Ma::Read, Ma::Write] {

--- a/tests/tests/wgpu-gpu/clear_texture.rs
+++ b/tests/tests/wgpu-gpu/clear_texture.rs
@@ -1,7 +1,19 @@
 use wgpu_test::{
-    gpu_test, image::ReadbackBuffers, FailureCase, GpuTestConfiguration, TestParameters,
-    TestingContext,
+    gpu_test, image::ReadbackBuffers, FailureCase, GpuTestConfiguration, GpuTestInitializer,
+    TestParameters, TestingContext,
 };
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        CLEAR_TEXTURE_UNCOMPRESSED_GLES,
+        CLEAR_TEXTURE_UNCOMPRESSED,
+        CLEAR_TEXTURE_DEPTH,
+        CLEAR_TEXTURE_DEPTH32_STENCIL8,
+        CLEAR_TEXTURE_COMPRESSED_BCN,
+        CLEAR_TEXTURE_COMPRESSED_ASTC,
+        CLEAR_TEXTURE_COMPRESSED_ETC2,
+    ]);
+}
 
 static TEXTURE_FORMATS_UNCOMPRESSED_GLES_COMPAT: &[wgpu::TextureFormat] = &[
     wgpu::TextureFormat::R8Unorm,

--- a/tests/tests/wgpu-gpu/clip_distances.rs
+++ b/tests/tests/wgpu-gpu/clip_distances.rs
@@ -1,4 +1,10 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(CLIP_DISTANCES);
+}
 
 #[gpu_test]
 static CLIP_DISTANCES: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/cloneable_types.rs
+++ b/tests/tests/wgpu-gpu/cloneable_types.rs
@@ -1,12 +1,13 @@
-use wgpu_test::{gpu_test, GpuTestInitializer, TestingContext};
+use wgpu_test::{gpu_test, GpuTestInitializer, TestParameters, TestingContext};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.push(CLONEABLE_BUFFERS);
 }
 
 #[gpu_test]
-static CLONEABLE_BUFFERS: GpuTestConfiguration =
-    wgpu_test::GpuTestConfiguration::new().run_sync(cloneable_buffers);
+static CLONEABLE_BUFFERS: GpuTestConfiguration = wgpu_test::GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(cloneable_buffers);
 
 // Test a basic case of cloneable types where you clone the buffer to be able
 // to access the buffer inside the callback as well as outside.

--- a/tests/tests/wgpu-gpu/cloneable_types.rs
+++ b/tests/tests/wgpu-gpu/cloneable_types.rs
@@ -1,4 +1,8 @@
-use wgpu_test::{gpu_test, TestingContext};
+use wgpu_test::{gpu_test, GpuTestInitializer, TestingContext};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(CLONEABLE_BUFFERS);
+}
 
 #[gpu_test]
 static CLONEABLE_BUFFERS: GpuTestConfiguration =

--- a/tests/tests/wgpu-gpu/compute_pass_ownership.rs
+++ b/tests/tests/wgpu-gpu/compute_pass_ownership.rs
@@ -175,7 +175,11 @@ async fn compute_pass_query_set_ownership_timestamps(ctx: TestingContext) {
 
 #[gpu_test]
 static COMPUTE_PASS_KEEP_ENCODER_ALIVE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits())
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop(),
+    )
     .run_async(compute_pass_keep_encoder_alive);
 
 async fn compute_pass_keep_encoder_alive(ctx: TestingContext) {

--- a/tests/tests/wgpu-gpu/compute_pass_ownership.rs
+++ b/tests/tests/wgpu-gpu/compute_pass_ownership.rs
@@ -4,7 +4,18 @@
 use std::num::NonZeroU64;
 
 use wgpu::util::DeviceExt as _;
-use wgpu_test::{gpu_test, valid, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, valid, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        COMPUTE_PASS_RESOURCE_OWNERSHIP,
+        COMPUTE_PASS_QUERY_SET_OWNERSHIP_PIPELINE_STATISTICS,
+        COMPUTE_PASS_QUERY_SET_OWNERSHIP_TIMESTAMPS,
+        COMPUTE_PASS_KEEP_ENCODER_ALIVE,
+    ]);
+}
 
 const SHADER_SRC: &str = "
 @group(0) @binding(0)

--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -1,6 +1,28 @@
 use std::sync::atomic::AtomicBool;
 
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        CROSS_DEVICE_BIND_GROUP_USAGE,
+        DEVICE_DESTROY_THEN_MORE,
+        DEVICE_DESTROY_THEN_LOST,
+        DIFFERENT_BGL_ORDER_BW_SHADER_AND_API,
+        DEVICE_DESTROY_THEN_BUFFER_CLEANUP,
+        DEVICE_AND_QUEUE_HAVE_DIFFERENT_IDS,
+    ]);
+
+    #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+    {
+        vec.extend([
+            DEVICE_LIFETIME_CHECK,
+            MULTIPLE_DEVICES,
+            REQUEST_DEVICE_ERROR_MESSAGE_NATIVE,
+        ]);
+    }
+}
 
 #[gpu_test]
 static CROSS_DEVICE_BIND_GROUP_USAGE: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -26,7 +26,11 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 
 #[gpu_test]
 static CROSS_DEVICE_BIND_GROUP_USAGE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().expect_fail(FailureCase::always()))
+    .parameters(
+        TestParameters::default()
+            .expect_fail(FailureCase::always())
+            .enable_noop(),
+    )
     .run_async(|ctx| async move {
         // Create a bind group using a layout from another device. This should be a validation
         // error but currently crashes.
@@ -53,7 +57,7 @@ static CROSS_DEVICE_BIND_GROUP_USAGE: GpuTestConfiguration = GpuTestConfiguratio
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
 #[gpu_test]
 static DEVICE_LIFETIME_CHECK: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         ctx.instance.poll_all(false);
 
@@ -80,7 +84,7 @@ static DEVICE_LIFETIME_CHECK: GpuTestConfiguration = GpuTestConfiguration::new()
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
 #[gpu_test]
 static MULTIPLE_DEVICES: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         use pollster::FutureExt as _;
         ctx.adapter
@@ -162,7 +166,11 @@ async fn request_device_error_message() {
 // should turn into no-ops, per spec.
 #[gpu_test]
 static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::CLEAR_TEXTURE))
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::CLEAR_TEXTURE)
+            .enable_noop(),
+    )
     .run_sync(|ctx| {
         // Create some resources on the device that we will attempt to use *after* losing
         // the device.
@@ -474,7 +482,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
 
 #[gpu_test]
 static DEVICE_DESTROY_THEN_LOST: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_async(|ctx| async move {
         // This test checks that when device.destroy is called, the provided
         // DeviceLostClosure is called with reason DeviceLostReason::Destroyed.
@@ -509,7 +517,7 @@ static DEVICE_DESTROY_THEN_LOST: GpuTestConfiguration = GpuTestConfiguration::ne
 
 #[gpu_test]
 static DIFFERENT_BGL_ORDER_BW_SHADER_AND_API: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         // This test addresses a bug found in multiple backends where `wgpu_core` and `wgpu_hal`
         // backends made different assumptions about the element order of vectors of bind group
@@ -636,7 +644,7 @@ static DIFFERENT_BGL_ORDER_BW_SHADER_AND_API: GpuTestConfiguration = GpuTestConf
 
 #[gpu_test]
 static DEVICE_DESTROY_THEN_BUFFER_CLEANUP: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         // When a device is destroyed, its resources should be released,
         // without causing a deadlock.
@@ -675,7 +683,7 @@ static DEVICE_DESTROY_THEN_BUFFER_CLEANUP: GpuTestConfiguration = GpuTestConfigu
 
 #[gpu_test]
 static DEVICE_AND_QUEUE_HAVE_DIFFERENT_IDS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_async(|ctx| async move {
         let TestingContext {
             adapter,

--- a/tests/tests/wgpu-gpu/dispatch_workgroups_indirect.rs
+++ b/tests/tests/wgpu-gpu/dispatch_workgroups_indirect.rs
@@ -74,7 +74,7 @@ static RESET_BIND_GROUPS: GpuTestConfiguration = GpuTestConfiguration::new()
             .limits(wgpu::Limits {
                 max_push_constant_size: 4,
                 ..wgpu::Limits::downlevel_defaults()
-            }),
+            }).enable_noop(),
     )
     .run_async(|ctx| async move {
         ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
@@ -116,7 +116,8 @@ static ZERO_SIZED_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
             .limits(wgpu::Limits {
                 max_push_constant_size: 4,
                 ..wgpu::Limits::downlevel_defaults()
-            }),
+            })
+            .enable_noop(),
     )
     .run_async(|ctx| async move {
         ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);

--- a/tests/tests/wgpu-gpu/dispatch_workgroups_indirect.rs
+++ b/tests/tests/wgpu-gpu/dispatch_workgroups_indirect.rs
@@ -1,4 +1,15 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        NUM_WORKGROUPS_BUILTIN,
+        DISCARD_DISPATCH,
+        RESET_BIND_GROUPS,
+        ZERO_SIZED_BUFFER,
+    ]);
+}
 
 /// Make sure that the num_workgroups builtin works properly (it requires a workaround on D3D12).
 #[gpu_test]

--- a/tests/tests/wgpu-gpu/draw_indirect.rs
+++ b/tests/tests/wgpu-gpu/draw_indirect.rs
@@ -2,7 +2,33 @@ use wgpu::{
     util::{BufferInitDescriptor, DeviceExt},
     vertex_attr_array,
 };
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend(&[
+        DRAW,
+        DRAW_OOB_START,
+        DRAW_OOB_COUNT,
+        INSTANCED_DRAW,
+        INSTANCED_DRAW_OOB_START,
+        INSTANCED_DRAW_OOB_COUNT,
+        INSTANCED_DRAW_OOB_INSTANCE_START,
+        INSTANCED_DRAW_OOB_INSTANCE_COUNT,
+        INSTANCED_DRAW_WITH_NON_ZERO_FIRST_INSTANCE,
+        INSTANCED_DRAW_WITH_NON_ZERO_FIRST_INSTANCE_MISSING_FEATURE,
+        INDEXED_DRAW,
+        INDEXED_DRAW_OOB_START,
+        INDEXED_DRAW_OOB_COUNT,
+        INSTANCED_INDEXED_DRAW,
+        INSTANCED_INDEXED_DRAW_OOB_START,
+        INSTANCED_INDEXED_DRAW_OOB_COUNT,
+        INSTANCED_INDEXED_DRAW_OOB_INSTANCE_START,
+        INSTANCED_INDEXED_DRAW_OOB_INSTANCE_COUNT,
+        INDIRECT_BUFFER_OFFSETS,
+    ]);
+}
 
 struct TestData {
     kind: Kind,

--- a/tests/tests/wgpu-gpu/draw_indirect.rs
+++ b/tests/tests/wgpu-gpu/draw_indirect.rs
@@ -343,12 +343,18 @@ macro_rules! make_test {
     ($name:ident, $test_data:expr, $expect_noop:expr, $features:expr) => {
         #[gpu_test]
         static $name: GpuTestConfiguration = GpuTestConfiguration::new()
-            .parameters(
-                TestParameters::default()
+            .parameters({
+                let params = TestParameters::default()
                     .downlevel_flags(wgpu::DownlevelFlags::INDIRECT_EXECUTION)
                     .features($features)
-                    .limits(wgpu::Limits::downlevel_defaults()),
-            )
+                    .limits(wgpu::Limits::downlevel_defaults());
+
+                if $expect_noop {
+                    params.enable_noop()
+                } else {
+                    params
+                }
+            })
             .run_async(|ctx| run_test(ctx, $test_data, $expect_noop));
     };
 }

--- a/tests/tests/wgpu-gpu/dual_source_blending.rs
+++ b/tests/tests/wgpu-gpu/dual_source_blending.rs
@@ -1,5 +1,14 @@
 use wgpu::*;
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        DUAL_SOURCE_BLENDING_FEATURE_DISABLED,
+        DUAL_SOURCE_BLENDING_FEATURE_ENABLED,
+    ]);
+}
 
 const VERTEX_SHADER: &str = r#"
 @vertex

--- a/tests/tests/wgpu-gpu/dual_source_blending.rs
+++ b/tests/tests/wgpu-gpu/dual_source_blending.rs
@@ -55,7 +55,7 @@ fn blend_state_with_dual_source_blending() -> BlendState {
 
 #[gpu_test]
 static DUAL_SOURCE_BLENDING_FEATURE_DISABLED: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_async(dual_source_blending_disabled);
 
 async fn dual_source_blending_disabled(ctx: TestingContext) {
@@ -118,7 +118,11 @@ async fn dual_source_blending_disabled(ctx: TestingContext) {
 
 #[gpu_test]
 static DUAL_SOURCE_BLENDING_FEATURE_ENABLED: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::DUAL_SOURCE_BLENDING))
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::DUAL_SOURCE_BLENDING)
+            .enable_noop(),
+    )
     .run_async(dual_source_blending_enabled);
 
 async fn dual_source_blending_enabled(ctx: TestingContext) {

--- a/tests/tests/wgpu-gpu/encoder.rs
+++ b/tests/tests/wgpu-gpu/encoder.rs
@@ -1,8 +1,18 @@
 use wgpu::util::DeviceExt;
 use wgpu::CommandEncoder;
 use wgpu_test::{
-    fail, gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext,
+    fail, gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters,
+    TestingContext,
 };
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        DROP_ENCODER,
+        DROP_QUEUE_BEFORE_CREATING_COMMAND_ENCODER,
+        DROP_ENCODER_AFTER_ERROR,
+        ENCODER_OPERATIONS_FAIL_WHILE_PASS_ALIVE,
+    ]);
+}
 
 #[gpu_test]
 static DROP_ENCODER: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {

--- a/tests/tests/wgpu-gpu/encoder.rs
+++ b/tests/tests/wgpu-gpu/encoder.rs
@@ -15,17 +15,23 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 }
 
 #[gpu_test]
-static DROP_ENCODER: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {
-    let encoder = ctx
-        .device
-        .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-    drop(encoder);
-});
+static DROP_ENCODER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
+        let encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        drop(encoder);
+    });
 
 #[gpu_test]
 static DROP_QUEUE_BEFORE_CREATING_COMMAND_ENCODER: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default().expect_fail(FailureCase::always()))
+        .parameters(
+            TestParameters::default()
+                .expect_fail(FailureCase::always())
+                .enable_noop(),
+        )
         .run_sync(|ctx| {
             // Use the device after the queue is dropped. Currently this panics
             // but it probably shouldn't.
@@ -38,7 +44,7 @@ static DROP_QUEUE_BEFORE_CREATING_COMMAND_ENCODER: GpuTestConfiguration =
 
 #[gpu_test]
 static DROP_ENCODER_AFTER_ERROR: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         let mut encoder = ctx
             .device
@@ -82,11 +88,15 @@ static DROP_ENCODER_AFTER_ERROR: GpuTestConfiguration = GpuTestConfiguration::ne
 
 #[gpu_test]
 static ENCODER_OPERATIONS_FAIL_WHILE_PASS_ALIVE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(
-        wgpu::Features::CLEAR_TEXTURE
-            | wgpu::Features::TIMESTAMP_QUERY
-            | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS,
-    ))
+    .parameters(
+        TestParameters::default()
+            .features(
+                wgpu::Features::CLEAR_TEXTURE
+                    | wgpu::Features::TIMESTAMP_QUERY
+                    | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS,
+            )
+            .enable_noop(),
+    )
     .run_sync(encoder_operations_fail_while_pass_alive);
 
 fn encoder_operations_fail_while_pass_alive(ctx: TestingContext) {

--- a/tests/tests/wgpu-gpu/float32_filterable.rs
+++ b/tests/tests/wgpu-gpu/float32_filterable.rs
@@ -1,6 +1,13 @@
 //! Tests for FLOAT32_FILTERABLE feature.
 
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        FLOAT32_FILTERABLE_WITHOUT_FEATURE,
+        FLOAT32_FILTERABLE_WITH_FEATURE,
+    ]);
+}
 
 fn create_texture_binding(device: &wgpu::Device, format: wgpu::TextureFormat, filterable: bool) {
     let texture = device.create_texture(&wgpu::TextureDescriptor {

--- a/tests/tests/wgpu-gpu/float32_filterable.rs
+++ b/tests/tests/wgpu-gpu/float32_filterable.rs
@@ -53,7 +53,7 @@ fn create_texture_binding(device: &wgpu::Device, format: wgpu::TextureFormat, fi
 
 #[gpu_test]
 static FLOAT32_FILTERABLE_WITHOUT_FEATURE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         let device = &ctx.device;
         // Unorm textures are always filterable
@@ -80,7 +80,11 @@ static FLOAT32_FILTERABLE_WITHOUT_FEATURE: GpuTestConfiguration = GpuTestConfigu
 
 #[gpu_test]
 static FLOAT32_FILTERABLE_WITH_FEATURE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::FLOAT32_FILTERABLE))
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::FLOAT32_FILTERABLE)
+            .enable_noop(),
+    )
     .run_sync(|ctx| {
         let device = &ctx.device;
         // With the feature enabled, it does work!

--- a/tests/tests/wgpu-gpu/image_atomics/mod.rs
+++ b/tests/tests/wgpu-gpu/image_atomics/mod.rs
@@ -172,7 +172,7 @@ async fn test_format(
 
 #[gpu_test]
 static IMAGE_ATOMICS_NOT_ENABLED: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         let size = wgpu::Extent3d {
             width: 256,
@@ -200,7 +200,7 @@ static IMAGE_ATOMICS_NOT_ENABLED: GpuTestConfiguration = GpuTestConfiguration::n
 
 #[gpu_test]
 static IMAGE_ATOMICS_NOT_SUPPORTED: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_ATOMIC))
+    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_ATOMIC).enable_noop())
     .run_sync(|ctx| {
         let size = wgpu::Extent3d {
             width: 256,

--- a/tests/tests/wgpu-gpu/image_atomics/mod.rs
+++ b/tests/tests/wgpu-gpu/image_atomics/mod.rs
@@ -2,8 +2,18 @@
 
 use wgpu::ShaderModuleDescriptor;
 use wgpu_test::{
-    fail, gpu_test, image::ReadbackBuffers, GpuTestConfiguration, TestParameters, TestingContext,
+    fail, gpu_test, image::ReadbackBuffers, GpuTestConfiguration, GpuTestInitializer,
+    TestParameters, TestingContext,
 };
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.extend([
+        IMAGE_64_ATOMICS,
+        IMAGE_32_ATOMICS,
+        IMAGE_ATOMICS_NOT_ENABLED,
+        IMAGE_ATOMICS_NOT_SUPPORTED,
+    ]);
+}
 
 #[gpu_test]
 static IMAGE_64_ATOMICS: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/instance.rs
+++ b/tests/tests/wgpu-gpu/instance.rs
@@ -1,8 +1,10 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.push(INITIALIZE);
 }
 
 #[gpu_test]
-static INITIALIZE: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|_ctx| {});
+static INITIALIZE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|_ctx| {});

--- a/tests/tests/wgpu-gpu/instance.rs
+++ b/tests/tests/wgpu-gpu/instance.rs
@@ -1,4 +1,8 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(INITIALIZE);
+}
 
 #[gpu_test]
 static INITIALIZE: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|_ctx| {});

--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -1,5 +1,16 @@
 use wgpu::{util::DeviceExt, Backends};
-use wgpu_test::{fail, gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
+use wgpu_test::{
+    fail, gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        BUFFER_DESTROY,
+        TEXTURE_DESTROY,
+        BUFFER_DESTROY_BEFORE_SUBMIT,
+        TEXTURE_DESTROY_BEFORE_SUBMIT,
+    ]);
+}
 
 #[gpu_test]
 static BUFFER_DESTROY: GpuTestConfiguration =

--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -13,8 +13,9 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 }
 
 #[gpu_test]
-static BUFFER_DESTROY: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static BUFFER_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
         let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("buffer"),
             size: 256,
@@ -80,8 +81,9 @@ static BUFFER_DESTROY: GpuTestConfiguration =
     });
 
 #[gpu_test]
-static TEXTURE_DESTROY: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static TEXTURE_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
         let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
             size: wgpu::Extent3d {
@@ -118,7 +120,9 @@ static TEXTURE_DESTROY: GpuTestConfiguration =
 static BUFFER_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         // https://github.com/gfx-rs/wgpu/issues/7854
-        TestParameters::default().skip(FailureCase::backend_adapter(Backends::VULKAN, "llvmpipe")),
+        TestParameters::default()
+            .skip(FailureCase::backend_adapter(Backends::VULKAN, "llvmpipe"))
+            .enable_noop(),
     )
     .run_sync(|ctx| {
         let buffer_source = ctx
@@ -158,7 +162,9 @@ static BUFFER_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration
 static TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         // https://github.com/gfx-rs/wgpu/issues/7854
-        TestParameters::default().skip(FailureCase::backend_adapter(Backends::VULKAN, "llvmpipe")),
+        TestParameters::default()
+            .skip(FailureCase::backend_adapter(Backends::VULKAN, "llvmpipe"))
+            .enable_noop(),
     )
     .run_sync(|ctx| {
         let descriptor = wgpu::TextureDescriptor {

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -1,14 +1,14 @@
 mod regression {
-    mod issue_3349;
-    mod issue_3457;
-    mod issue_4024;
-    mod issue_4122;
-    mod issue_4485;
-    mod issue_4514;
-    mod issue_5553;
-    mod issue_6317;
-    mod issue_6467;
-    mod issue_6827;
+    pub mod issue_3349;
+    pub mod issue_3457;
+    pub mod issue_4024;
+    pub mod issue_4122;
+    pub mod issue_4485;
+    pub mod issue_4514;
+    pub mod issue_5553;
+    pub mod issue_6317;
+    pub mod issue_6467;
+    pub mod issue_6827;
 }
 
 mod bgra8unorm_storage;
@@ -69,4 +69,76 @@ mod vertex_indices;
 mod write_texture;
 mod zero_init_texture_after_discard;
 
-wgpu_test::gpu_test_main!();
+fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
+    let mut tests = Vec::new();
+
+    bgra8unorm_storage::all_tests(&mut tests);
+    bind_group_layout_dedup::all_tests(&mut tests);
+    bind_groups::all_tests(&mut tests);
+    binding_array::all_tests(&mut tests);
+    buffer_copy::all_tests(&mut tests);
+    buffer_usages::all_tests(&mut tests);
+    buffer::all_tests(&mut tests);
+    clear_texture::all_tests(&mut tests);
+    clip_distances::all_tests(&mut tests);
+    cloneable_types::all_tests(&mut tests);
+    compute_pass_ownership::all_tests(&mut tests);
+    device::all_tests(&mut tests);
+    dispatch_workgroups_indirect::all_tests(&mut tests);
+    draw_indirect::all_tests(&mut tests);
+    dual_source_blending::all_tests(&mut tests);
+    encoder::all_tests(&mut tests);
+    float32_filterable::all_tests(&mut tests);
+    image_atomics::all_tests(&mut tests);
+    instance::all_tests(&mut tests);
+    life_cycle::all_tests(&mut tests);
+    mem_leaks::all_tests(&mut tests);
+    mesh_shader::all_tests(&mut tests);
+    nv12_texture::all_tests(&mut tests);
+    occlusion_query::all_tests(&mut tests);
+    oob_indexing::all_tests(&mut tests);
+    oom::all_tests(&mut tests);
+    pipeline_cache::all_tests(&mut tests);
+    pipeline::all_tests(&mut tests);
+    poll::all_tests(&mut tests);
+    push_constants::all_tests(&mut tests);
+    query_set::all_tests(&mut tests);
+    queue_transfer::all_tests(&mut tests);
+    ray_tracing::all_tests(&mut tests);
+    regression::issue_3349::all_tests(&mut tests);
+    regression::issue_3457::all_tests(&mut tests);
+    regression::issue_4024::all_tests(&mut tests);
+    regression::issue_4122::all_tests(&mut tests);
+    regression::issue_4485::all_tests(&mut tests);
+    regression::issue_4514::all_tests(&mut tests);
+    regression::issue_5553::all_tests(&mut tests);
+    regression::issue_6317::all_tests(&mut tests);
+    regression::issue_6467::all_tests(&mut tests);
+    regression::issue_6827::all_tests(&mut tests);
+    render_pass_ownership::all_tests(&mut tests);
+    render_target::all_tests(&mut tests);
+    resource_descriptor_accessor::all_tests(&mut tests);
+    resource_error::all_tests(&mut tests);
+    samplers::all_tests(&mut tests);
+    scissor_tests::all_tests(&mut tests);
+    shader_primitive_index::all_tests(&mut tests);
+    shader_view_format::all_tests(&mut tests);
+    shader::all_tests(&mut tests);
+    subgroup_operations::all_tests(&mut tests);
+    texture_binding::all_tests(&mut tests);
+    texture_blit::all_tests(&mut tests);
+    texture_bounds::all_tests(&mut tests);
+    texture_view_creation::all_tests(&mut tests);
+    timestamp_normalization::all_tests(&mut tests);
+    timestamp_query::all_tests(&mut tests);
+    transfer::all_tests(&mut tests);
+    transition_resources::all_tests(&mut tests);
+    vertex_formats::all_tests(&mut tests);
+    vertex_indices::all_tests(&mut tests);
+    write_texture::all_tests(&mut tests);
+    zero_init_texture_after_discard::all_tests(&mut tests);
+
+    tests
+}
+
+wgpu_test::gpu_test_main!(all_tests());

--- a/tests/tests/wgpu-gpu/mem_leaks.rs
+++ b/tests/tests/wgpu-gpu/mem_leaks.rs
@@ -1,3 +1,17 @@
+#[allow(
+    clippy::allow_attributes,
+    reason = "Using expect is going to be much more verbose"
+)]
+#[allow(clippy::ptr_arg)]
+pub fn all_tests(_vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        target_os = "emscripten",
+        feature = "webgl"
+    ))]
+    _vec.push(SIMPLE_DRAW_CHECK_MEM_LEAKS);
+}
+
 #[cfg(any(
     not(target_arch = "wasm32"),
     target_os = "emscripten",

--- a/tests/tests/wgpu-gpu/mem_leaks.rs
+++ b/tests/tests/wgpu-gpu/mem_leaks.rs
@@ -310,7 +310,8 @@ static SIMPLE_DRAW_CHECK_MEM_LEAKS: wgpu_test::GpuTestConfiguration =
         .parameters(
             wgpu_test::TestParameters::default()
                 .test_features_limits()
-                .features(wgpu::Features::VERTEX_WRITABLE_STORAGE),
+                .features(wgpu::Features::VERTEX_WRITABLE_STORAGE)
+                .enable_noop(),
         )
         .run_async(|ctx| {
             draw_test_with_reports(ctx, &[0, 1, 2, 3, 4, 5], |cmb| {

--- a/tests/tests/wgpu-gpu/mesh_shader/mod.rs
+++ b/tests/tests/wgpu-gpu/mesh_shader/mod.rs
@@ -1,7 +1,21 @@
 use std::{io::Write, process::Stdio};
 
 use wgpu::util::DeviceExt;
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.extend([
+        MESH_PIPELINE_BASIC_MESH,
+        MESH_PIPELINE_BASIC_TASK_MESH,
+        MESH_PIPELINE_BASIC_MESH_FRAG,
+        MESH_PIPELINE_BASIC_TASK_MESH_FRAG,
+        MESH_DRAW_INDIRECT,
+        MESH_MULTI_DRAW_INDIRECT,
+        MESH_MULTI_DRAW_INDIRECT_COUNT,
+    ]);
+}
 
 // Same as in mesh shader example
 fn compile_glsl(

--- a/tests/tests/wgpu-gpu/nv12_texture/mod.rs
+++ b/tests/tests/wgpu-gpu/nv12_texture/mod.rs
@@ -14,7 +14,11 @@ pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
 
 #[gpu_test]
 static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
+            .enable_noop(),
+    )
     .run_sync(|ctx| {
         let size = wgpu::Extent3d {
             width: 256,
@@ -135,7 +139,11 @@ static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfigurati
 #[gpu_test]
 static NV12_TEXTURE_VIEW_PLANE_ON_NON_PLANAR_FORMAT: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
+        .parameters(
+            TestParameters::default()
+                .features(wgpu::Features::TEXTURE_FORMAT_NV12)
+                .enable_noop(),
+        )
         .run_sync(|ctx| {
             let size = wgpu::Extent3d {
                 width: 256,
@@ -166,7 +174,11 @@ static NV12_TEXTURE_VIEW_PLANE_ON_NON_PLANAR_FORMAT: GpuTestConfiguration =
 
 #[gpu_test]
 static NV12_TEXTURE_VIEW_PLANE_OUT_OF_BOUNDS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
+            .enable_noop(),
+    )
     .run_sync(|ctx| {
         let size = wgpu::Extent3d {
             width: 256,
@@ -198,7 +210,11 @@ static NV12_TEXTURE_VIEW_PLANE_OUT_OF_BOUNDS: GpuTestConfiguration = GpuTestConf
 
 #[gpu_test]
 static NV12_TEXTURE_BAD_FORMAT_VIEW_PLANE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
+            .enable_noop(),
+    )
     .run_sync(|ctx| {
         let size = wgpu::Extent3d {
             width: 256,
@@ -230,7 +246,11 @@ static NV12_TEXTURE_BAD_FORMAT_VIEW_PLANE: GpuTestConfiguration = GpuTestConfigu
 
 #[gpu_test]
 static NV12_TEXTURE_BAD_SIZE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::TEXTURE_FORMAT_NV12))
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
+            .enable_noop(),
+    )
     .run_sync(|ctx| {
         let size = wgpu::Extent3d {
             width: 255,

--- a/tests/tests/wgpu-gpu/nv12_texture/mod.rs
+++ b/tests/tests/wgpu-gpu/nv12_texture/mod.rs
@@ -1,6 +1,16 @@
 //! Tests for nv12 texture creation and sampling.
 
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.extend([
+        NV12_TEXTURE_CREATION_SAMPLING,
+        NV12_TEXTURE_VIEW_PLANE_ON_NON_PLANAR_FORMAT,
+        NV12_TEXTURE_VIEW_PLANE_OUT_OF_BOUNDS,
+        NV12_TEXTURE_BAD_FORMAT_VIEW_PLANE,
+        NV12_TEXTURE_BAD_SIZE,
+    ]);
+}
 
 #[gpu_test]
 static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/occlusion_query/mod.rs
+++ b/tests/tests/wgpu-gpu/occlusion_query/mod.rs
@@ -1,5 +1,9 @@
 use wgpu::InstanceFlags;
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(OCCLUSION_QUERY);
+}
 
 #[gpu_test]
 static OCCLUSION_QUERY: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/oob_indexing.rs
+++ b/tests/tests/wgpu-gpu/oob_indexing.rs
@@ -1,6 +1,13 @@
 use wgpu::{Backend, Backends};
 use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    vec.extend([
+        RESTRICT_WORKGROUP_PRIVATE_FUNCTION_LET,
+        D3D12_RESTRICT_DYNAMIC_BUFFERS,
+    ]);
+}
+
 /// Tests that writing and reading to the max length of a container (vec, mat, array)
 /// in the workgroup, private and function address spaces + let declarations
 /// will instead write to and read from the last element.

--- a/tests/tests/wgpu-gpu/oom.rs
+++ b/tests/tests/wgpu-gpu/oom.rs
@@ -5,7 +5,19 @@ use wgpu::{
     CreateTlasDescriptor, Error, ErrorFilter, Extent3d, Features, QuerySetDescriptor, QueryType,
     TextureDescriptor, TextureDimension, TextureFormat, TextureUsages, VertexFormat,
 };
+use wgpu_test::GpuTestInitializer;
 use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        TEXTURE_OOM_TEST,
+        BUFFER_OOM_TEST,
+        MAPPING_BUFFER_OOM_TEST,
+        QUERY_SET_OOM_TEST,
+        BLAS_OOM_TEST,
+        TLAS_OOM_TEST,
+    ]);
+}
 
 // Tests in this file must all end with "OOM_TEST" so that nextest doesn't run any other tests while it runs one of the OOM tests.
 // This is done so that other tests that create resources will not fail with OOM errors due to the OOM tests running in parallel.

--- a/tests/tests/wgpu-gpu/pipeline.rs
+++ b/tests/tests/wgpu-gpu/pipeline.rs
@@ -42,7 +42,7 @@ const TRIVIAL_FRAGMENT_SHADER_DESC: wgpu::ShaderModuleDescriptor = wgpu::ShaderM
 #[gpu_test]
 static COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default())
+        .parameters(TestParameters::default().enable_noop())
         .run_sync(|ctx| {
             ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
 
@@ -72,7 +72,11 @@ static COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE: GpuTestConfiguration =
 #[gpu_test]
 static COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default().test_features_limits())
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .enable_noop(),
+        )
         .run_sync(|ctx| {
             ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
 
@@ -101,7 +105,7 @@ static COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX: GpuTestConfiguration =
 #[gpu_test]
 static RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default())
+        .parameters(TestParameters::default().enable_noop())
         .run_sync(|ctx| {
             ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
 
@@ -138,7 +142,11 @@ static RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE: GpuTestConfiguration =
 #[gpu_test]
 static RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default().test_features_limits())
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .enable_noop(),
+        )
         .run_sync(|ctx| {
             ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
 
@@ -186,7 +194,7 @@ static RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX: GpuTestConfiguration =
 
 #[gpu_test]
 static NO_TARGETLESS_RENDER: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         fail(
             &ctx.device,

--- a/tests/tests/wgpu-gpu/pipeline.rs
+++ b/tests/tests/wgpu-gpu/pipeline.rs
@@ -1,4 +1,14 @@
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE,
+        COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX,
+        RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE,
+        RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX,
+        NO_TARGETLESS_RENDER,
+    ]);
+}
 
 const INVALID_SHADER_DESC: wgpu::ShaderModuleDescriptor = wgpu::ShaderModuleDescriptor {
     label: Some("invalid shader"),

--- a/tests/tests/wgpu-gpu/pipeline_cache.rs
+++ b/tests/tests/wgpu-gpu/pipeline_cache.rs
@@ -2,6 +2,10 @@ use std::{fmt::Write, num::NonZeroU64};
 
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    vec.push(PIPELINE_CACHE);
+}
+
 /// We want to test that using a pipeline cache doesn't cause failure
 ///
 /// It would be nice if we could also assert that reusing a pipeline cache would make compilation

--- a/tests/tests/wgpu-gpu/poll.rs
+++ b/tests/tests/wgpu-gpu/poll.rs
@@ -6,7 +6,18 @@ use wgpu::{
     CommandEncoderDescriptor, ComputePassDescriptor, PollType, ShaderStages,
 };
 
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestingContext};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestingContext};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        WAIT,
+        DOUBLE_WAIT,
+        WAIT_ON_SUBMISSION,
+        DOUBLE_WAIT_ON_SUBMISSION,
+        WAIT_OUT_OF_ORDER,
+        WAIT_AFTER_BAD_SUBMISSION,
+    ]);
+}
 
 fn generate_dummy_work(ctx: &TestingContext) -> CommandBuffer {
     let buffer = ctx.device.create_buffer(&BufferDescriptor {

--- a/tests/tests/wgpu-gpu/poll.rs
+++ b/tests/tests/wgpu-gpu/poll.rs
@@ -6,7 +6,9 @@ use wgpu::{
     CommandEncoderDescriptor, ComputePassDescriptor, PollType, ShaderStages,
 };
 
-use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestingContext};
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
@@ -64,16 +66,19 @@ fn generate_dummy_work(ctx: &TestingContext) -> CommandBuffer {
 }
 
 #[gpu_test]
-static WAIT: GpuTestConfiguration = GpuTestConfiguration::new().run_async(|ctx| async move {
-    let cmd_buf = generate_dummy_work(&ctx);
+static WAIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
+        let cmd_buf = generate_dummy_work(&ctx);
 
-    ctx.queue.submit(Some(cmd_buf));
-    ctx.async_poll(PollType::wait()).await.unwrap();
-});
+        ctx.queue.submit(Some(cmd_buf));
+        ctx.async_poll(PollType::wait()).await.unwrap();
+    });
 
 #[gpu_test]
-static DOUBLE_WAIT: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static DOUBLE_WAIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
         let cmd_buf = generate_dummy_work(&ctx);
 
         ctx.queue.submit(Some(cmd_buf));
@@ -82,8 +87,9 @@ static DOUBLE_WAIT: GpuTestConfiguration =
     });
 
 #[gpu_test]
-static WAIT_ON_SUBMISSION: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static WAIT_ON_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
         let cmd_buf = generate_dummy_work(&ctx);
 
         let index = ctx.queue.submit(Some(cmd_buf));
@@ -91,8 +97,9 @@ static WAIT_ON_SUBMISSION: GpuTestConfiguration =
     });
 
 #[gpu_test]
-static DOUBLE_WAIT_ON_SUBMISSION: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static DOUBLE_WAIT_ON_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
         let cmd_buf = generate_dummy_work(&ctx);
 
         let index = ctx.queue.submit(Some(cmd_buf));
@@ -103,8 +110,9 @@ static DOUBLE_WAIT_ON_SUBMISSION: GpuTestConfiguration =
     });
 
 #[gpu_test]
-static WAIT_OUT_OF_ORDER: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static WAIT_OUT_OF_ORDER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
         let cmd_buf1 = generate_dummy_work(&ctx);
         let cmd_buf2 = generate_dummy_work(&ctx);
 
@@ -120,7 +128,11 @@ static WAIT_OUT_OF_ORDER: GpuTestConfiguration =
 /// console.
 #[gpu_test]
 static WAIT_AFTER_BAD_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(wgpu_test::TestParameters::default().skip(wgpu_test::FailureCase::webgl2()))
+    .parameters(
+        wgpu_test::TestParameters::default()
+            .skip(wgpu_test::FailureCase::webgl2())
+            .enable_noop(),
+    )
     .run_async(wait_after_bad_submission);
 
 async fn wait_after_bad_submission(ctx: TestingContext) {

--- a/tests/tests/wgpu-gpu/push_constants.rs
+++ b/tests/tests/wgpu-gpu/push_constants.rs
@@ -3,7 +3,13 @@ use std::num::NonZeroU64;
 
 use wgpu::util::RenderEncoder;
 use wgpu::*;
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([PARTIAL_UPDATE, RENDER_PASS_TEST]);
+}
 
 /// We want to test that partial updates to push constants work as expected.
 ///

--- a/tests/tests/wgpu-gpu/query_set.rs
+++ b/tests/tests/wgpu-gpu/query_set.rs
@@ -1,4 +1,8 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(DROP_FAILED_TIMESTAMP_QUERY_SET);
+}
 
 #[gpu_test]
 static DROP_FAILED_TIMESTAMP_QUERY_SET: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/query_set.rs
+++ b/tests/tests/wgpu-gpu/query_set.rs
@@ -6,7 +6,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 
 #[gpu_test]
 static DROP_FAILED_TIMESTAMP_QUERY_SET: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         // Enter an error scope, so the validation catch-all doesn't
         // report the error too early.

--- a/tests/tests/wgpu-gpu/queue_transfer.rs
+++ b/tests/tests/wgpu-gpu/queue_transfer.rs
@@ -1,7 +1,7 @@
 //! Tests for buffer copy validation.
 
 use wgpu::PollType;
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
@@ -13,6 +13,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 
 #[gpu_test]
 static QUEUE_WRITE_TEXTURE_THEN_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
@@ -61,8 +62,9 @@ static QUEUE_WRITE_TEXTURE_THEN_DESTROY: GpuTestConfiguration = GpuTestConfigura
     });
 
 #[gpu_test]
-static QUEUE_WRITE_TEXTURE_OVERFLOW: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_sync(|ctx| {
+static QUEUE_WRITE_TEXTURE_OVERFLOW: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
         let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
             size: wgpu::Extent3d {

--- a/tests/tests/wgpu-gpu/queue_transfer.rs
+++ b/tests/tests/wgpu-gpu/queue_transfer.rs
@@ -1,7 +1,15 @@
 //! Tests for buffer copy validation.
 
 use wgpu::PollType;
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration};
+use wgpu_test::{fail, gpu_test, GpuTestConfiguration, GpuTestInitializer};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        QUEUE_WRITE_TEXTURE_THEN_DESTROY,
+        QUEUE_WRITE_TEXTURE_OVERFLOW,
+        QUEUE_WRITE_TEXTURE_BUFFER_OOB,
+    ]);
+}
 
 #[gpu_test]
 static QUEUE_WRITE_TEXTURE_THEN_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
@@ -3,7 +3,29 @@ use std::iter;
 use crate::ray_tracing::{acceleration_structure_limits, AsBuildContext};
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu::*;
-use wgpu_test::{fail, fail_if, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    fail, fail_if, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters,
+    TestingContext,
+};
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.extend([
+        UNBUILT_BLAS,
+        UNBUILT_BLAS_COMPACTION,
+        BLAS_COMPACTION_WITHOUT_FLAGS,
+        UNPREPARED_BLAS_COMPACTION,
+        BLAS_COMPACTION,
+        OUT_OF_ORDER_AS_BUILD,
+        OUT_OF_ORDER_AS_BUILD_USE,
+        EMPTY_BUILD,
+        BUILD_WITH_TRANSFORM,
+        ONLY_BLAS_VERTEX_RETURN,
+        ONLY_TLAS_VERTEX_RETURN,
+        EXTRA_FORMAT_BUILD,
+        MISALIGNED_BUILD,
+        TOO_SMALL_STRIDE_BUILD,
+    ]);
+}
 
 #[gpu_test]
 static UNBUILT_BLAS: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
@@ -66,7 +66,8 @@ static UNBUILT_BLAS_COMPACTION: GpuTestConfiguration = GpuTestConfiguration::new
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     .run_sync(unbuilt_blas_compaction);
 
@@ -128,7 +129,8 @@ static UNPREPARED_BLAS_COMPACTION: GpuTestConfiguration = GpuTestConfiguration::
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     .run_sync(unprepared_blas_compaction);
 
@@ -295,7 +297,8 @@ static OUT_OF_ORDER_AS_BUILD_USE: GpuTestConfiguration = GpuTestConfiguration::n
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     .run_sync(out_of_order_as_build_use);
 
@@ -477,7 +480,8 @@ static EMPTY_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     .run_sync(empty_build);
 fn empty_build(ctx: TestingContext) {
@@ -498,7 +502,8 @@ static BUILD_WITH_TRANSFORM: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     .run_sync(build_with_transform);
 
@@ -710,7 +715,8 @@ static ONLY_TLAS_VERTEX_RETURN: GpuTestConfiguration = GpuTestConfiguration::new
             .features(
                 wgpu::Features::EXPERIMENTAL_RAY_QUERY
                     | wgpu::Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN,
-            ),
+            )
+            .enable_noop(),
     )
     .run_sync(only_tlas_vertex_return);
 
@@ -749,7 +755,8 @@ static EXTRA_FORMAT_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
             .features(
                 wgpu::Features::EXPERIMENTAL_RAY_QUERY
                     | wgpu::Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS,
-            ),
+            )
+            .enable_noop(),
     )
     .run_sync(|ctx| test_as_build_format_stride(ctx, VertexFormat::Snorm16x4, 6, false));
 
@@ -759,7 +766,8 @@ static MISALIGNED_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     // Larger than the minimum size, but not aligned as required
     .run_sync(|ctx| test_as_build_format_stride(ctx, VertexFormat::Float32x3, 13, true));
@@ -770,7 +778,8 @@ static TOO_SMALL_STRIDE_BUILD: GpuTestConfiguration = GpuTestConfiguration::new(
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     // Aligned as required, but smaller than minimum size
     .run_sync(|ctx| test_as_build_format_stride(ctx, VertexFormat::Float32x3, 8, true));

--- a/tests/tests/wgpu-gpu/ray_tracing/as_create.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_create.rs
@@ -18,7 +18,8 @@ static BLAS_INVALID_VERTEX_FORMAT: GpuTestConfiguration = GpuTestConfiguration::
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     .run_sync(invalid_vertex_format_blas_create);
 
@@ -59,7 +60,8 @@ static BLAS_MISMATCHED_INDEX: GpuTestConfiguration = GpuTestConfiguration::new()
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     .run_sync(mismatched_index_blas_create);
 

--- a/tests/tests/wgpu-gpu/ray_tracing/as_create.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_create.rs
@@ -8,6 +8,10 @@ use wgpu::{IndexFormat, VertexFormat};
 use wgpu_macros::gpu_test;
 use wgpu_test::{fail, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(tests: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    tests.extend([BLAS_INVALID_VERTEX_FORMAT, BLAS_MISMATCHED_INDEX]);
+}
+
 #[gpu_test]
 static BLAS_INVALID_VERTEX_FORMAT: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(

--- a/tests/tests/wgpu-gpu/ray_tracing/as_use_after_free.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_use_after_free.rs
@@ -13,6 +13,10 @@ use wgpu::{
 use wgpu_macros::gpu_test;
 use wgpu_test::{GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(tests: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    tests.push(ACCELERATION_STRUCTURE_USE_AFTER_FREE);
+}
+
 fn required_features() -> wgpu::Features {
     wgpu::Features::EXPERIMENTAL_RAY_QUERY
 }

--- a/tests/tests/wgpu-gpu/ray_tracing/limits.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/limits.rs
@@ -10,6 +10,10 @@ use wgpu::{
 use wgpu_macros::gpu_test;
 use wgpu_test::{fail, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(tests: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    tests.push(LIMITS_HIT);
+}
+
 #[gpu_test]
 static LIMITS_HIT: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(

--- a/tests/tests/wgpu-gpu/ray_tracing/limits.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/limits.rs
@@ -26,7 +26,8 @@ static LIMITS_HIT: GpuTestConfiguration = GpuTestConfiguration::new()
                 max_acceleration_structures_per_shader_stage: 1,
                 ..Limits::default()
             })
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     .run_sync(hit_limits);
 

--- a/tests/tests/wgpu-gpu/ray_tracing/mod.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/mod.rs
@@ -18,6 +18,15 @@ mod limits;
 mod scene;
 mod shader;
 
+pub fn all_tests(tests: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    as_build::all_tests(tests);
+    as_create::all_tests(tests);
+    as_use_after_free::all_tests(tests);
+    limits::all_tests(tests);
+    scene::all_tests(tests);
+    shader::all_tests(tests);
+}
+
 fn acceleration_structure_limits() -> wgpu::Limits {
     wgpu::Limits::default().using_minimum_supported_acceleration_structure_values()
 }

--- a/tests/tests/wgpu-gpu/ray_tracing/scene/mod.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/scene/mod.rs
@@ -9,6 +9,13 @@ use glam::{Affine3A, Quat, Vec3};
 
 mod mesh_gen;
 
+pub fn all_tests(tests: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    tests.extend([
+        ACCELERATION_STRUCTURE_BUILD_NO_INDEX,
+        ACCELERATION_STRUCTURE_BUILD_WITH_INDEX,
+    ]);
+}
+
 fn acceleration_structure_build(ctx: &TestingContext, use_index_buffer: bool) {
     let max_instances = 1000;
     let device = &ctx.device;

--- a/tests/tests/wgpu-gpu/ray_tracing/scene/mod.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/scene/mod.rs
@@ -110,7 +110,8 @@ static ACCELERATION_STRUCTURE_BUILD_NO_INDEX: GpuTestConfiguration = GpuTestConf
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     .run_sync(|ctx| {
         acceleration_structure_build(&ctx, false);
@@ -122,7 +123,8 @@ static ACCELERATION_STRUCTURE_BUILD_WITH_INDEX: GpuTestConfiguration = GpuTestCo
         TestParameters::default()
             .test_features_limits()
             .limits(acceleration_structure_limits())
-            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
+            .enable_noop(),
     )
     .run_sync(|ctx| {
         acceleration_structure_build(&ctx, true);

--- a/tests/tests/wgpu-gpu/ray_tracing/shader.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/shader.rs
@@ -5,9 +5,14 @@ use wgpu::{
 };
 use wgpu::{AccelerationStructureFlags, BufferUsages};
 use wgpu_macros::gpu_test;
+use wgpu_test::GpuTestInitializer;
 use wgpu_test::{GpuTestConfiguration, TestParameters, TestingContext};
 
 const STRUCT_SIZE: wgpu::BufferAddress = 176;
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.push(ACCESS_ALL_STRUCT_MEMBERS);
+}
 
 #[gpu_test]
 static ACCESS_ALL_STRUCT_MEMBERS: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/regression/issue_3349.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_3349.rs
@@ -1,7 +1,12 @@
 use wgpu::util::DeviceExt;
 use wgpu_test::{
-    gpu_test, image::ReadbackBuffers, GpuTestConfiguration, TestParameters, TestingContext,
+    gpu_test, image::ReadbackBuffers, GpuTestConfiguration, GpuTestInitializer, TestParameters,
+    TestingContext,
 };
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(MULTI_STAGE_DATA_BINDING);
+}
 
 /// We thought we had an OpenGL bug that, when running without explicit in-shader locations,
 /// we will not properly bind uniform buffers to both the vertex and fragment

--- a/tests/tests/wgpu-gpu/regression/issue_3457.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_3457.rs
@@ -1,4 +1,4 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 use wgpu::*;
 
@@ -19,8 +19,9 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 /// We use non-consecutive vertex attribute locations (0 and 5) in order to also test
 /// that we unset the correct locations (see PR #3706).
 #[gpu_test]
-static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
         let module = ctx
             .device
             .create_shader_module(include_wgsl!("issue_3457.wgsl"));

--- a/tests/tests/wgpu-gpu/regression/issue_3457.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_3457.rs
@@ -1,6 +1,10 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
 
 use wgpu::*;
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(PASS_RESET_VERTEX_BUFFER);
+}
 
 /// The core issue here was that we weren't properly disabling vertex attributes on GL
 /// when a renderpass ends. This ended up being rather tricky to test for as GL is remarkably

--- a/tests/tests/wgpu-gpu/regression/issue_4024.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4024.rs
@@ -1,9 +1,13 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use wgpu_test::{gpu_test, GpuTestConfiguration};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
 
 use wgpu::*;
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(QUEUE_SUBMITTED_CALLBACK_ORDERING);
+}
 
 /// The WebGPU specification has very specific requirements about the ordering of map_async
 /// and on_submitted_work_done callbacks. Specifically, all map_async callbacks that are initiated

--- a/tests/tests/wgpu-gpu/regression/issue_4024.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4024.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 use wgpu::*;
 
@@ -18,6 +18,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 /// to add them to. This is incorrect, as we do not immediately invoke map_async callbacks.
 #[gpu_test]
 static QUEUE_SUBMITTED_CALLBACK_ORDERING: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
     .run_async(|ctx| async move {
         // Create a mappable buffer
         let buffer = ctx.device.create_buffer(&BufferDescriptor {

--- a/tests/tests/wgpu-gpu/regression/issue_4122.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4122.rs
@@ -1,6 +1,12 @@
 use std::ops::Range;
 
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(CLEAR_BUFFER_RANGE_RESPECTED);
+}
 
 async fn fill_test(ctx: &TestingContext, range: Range<u64>, size: u64) -> bool {
     let gpu_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {

--- a/tests/tests/wgpu-gpu/regression/issue_4122.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4122.rs
@@ -91,7 +91,7 @@ async fn fill_test(ctx: &TestingContext, range: Range<u64>, size: u64) -> bool {
 /// This test will fail on nvidia if the bug is not properly worked around.
 #[gpu_test]
 static CLEAR_BUFFER_RANGE_RESPECTED: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_async(|ctx| async move {
         // This hits most of the cases in nvidia's clear buffer bug
         let mut succeeded = true;

--- a/tests/tests/wgpu-gpu/regression/issue_4485.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4485.rs
@@ -16,7 +16,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 /// This also tests that shaders generated with this fix execute correctly.
 #[gpu_test]
 static CONTINUE_SWITCH: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().force_fxc(true))
+    .parameters(TestParameters::default().force_fxc(true).enable_noop())
     .run_async(|ctx| async move { test_impl(&ctx).await });
 
 async fn test_impl(ctx: &TestingContext) {

--- a/tests/tests/wgpu-gpu/regression/issue_4485.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4485.rs
@@ -1,4 +1,10 @@
-use wgpu_test::{gpu_test, image, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, image, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(CONTINUE_SWITCH);
+}
 
 /// FXC doesn't accept `continue` inside a switch. Instead we store a flag for whether
 /// the loop should continue that is checked after the switch.

--- a/tests/tests/wgpu-gpu/regression/issue_4514.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4514.rs
@@ -1,4 +1,10 @@
-use wgpu_test::{gpu_test, image, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, image, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(DEGENERATE_SWITCH);
+}
 
 /// FXC and potentially some glsl consumers have a bug when handling switch statements on a constant
 /// with just a default case. (not sure if the constant part is relevant)

--- a/tests/tests/wgpu-gpu/regression/issue_4514.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4514.rs
@@ -16,7 +16,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 /// bug is avoided there.
 #[gpu_test]
 static DEGENERATE_SWITCH: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().force_fxc(true))
+    .parameters(TestParameters::default().force_fxc(true).enable_noop())
     .run_async(|ctx| async move { test_impl(&ctx).await });
 
 async fn test_impl(ctx: &TestingContext) {

--- a/tests/tests/wgpu-gpu/regression/issue_5553.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_5553.rs
@@ -1,6 +1,10 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
 
 use wgpu::*;
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(ALLOW_INPUT_NOT_CONSUMED);
+}
 
 /// Previously, for every user-defined vertex output a fragment shader had to have a corresponding
 /// user-defined input. This would generate `StageError::InputNotConsumed`.

--- a/tests/tests/wgpu-gpu/regression/issue_5553.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_5553.rs
@@ -1,4 +1,4 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 use wgpu::*;
 
@@ -14,8 +14,9 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 /// the fragment inputs. This is necessary for generating correct hlsl:
 /// https://github.com/gfx-rs/wgpu/issues/5553
 #[gpu_test]
-static ALLOW_INPUT_NOT_CONSUMED: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static ALLOW_INPUT_NOT_CONSUMED: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
         let module = ctx
             .device
             .create_shader_module(include_wgsl!("issue_5553.wgsl"));

--- a/tests/tests/wgpu-gpu/regression/issue_6317.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_6317.rs
@@ -11,7 +11,8 @@ static NON_FATAL_ERRORS_IN_QUEUE_SUBMIT: GpuTestConfiguration = GpuTestConfigura
     .parameters(
         TestParameters::default()
             .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
-            .limits(Limits::downlevel_defaults()),
+            .limits(Limits::downlevel_defaults())
+            .enable_noop(),
     )
     .run_sync(|ctx| {
         let shader_with_trivial_bind_group = concat!(

--- a/tests/tests/wgpu-gpu/regression/issue_6317.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_6317.rs
@@ -1,6 +1,10 @@
 use wgpu::{DownlevelFlags, Limits};
 use wgpu_macros::gpu_test;
-use wgpu_test::{fail, GpuTestConfiguration, TestParameters};
+use wgpu_test::{fail, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(NON_FATAL_ERRORS_IN_QUEUE_SUBMIT);
+}
 
 #[gpu_test]
 static NON_FATAL_ERRORS_IN_QUEUE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/regression/issue_6467.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_6467.rs
@@ -13,7 +13,11 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 /// The following test should successfully do nothing on all platforms.
 #[gpu_test]
 static ZERO_WORKGROUP_COUNT: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().limits(wgpu::Limits::default()))
+    .parameters(
+        TestParameters::default()
+            .limits(wgpu::Limits::default())
+            .enable_noop(),
+    )
     .run_async(|ctx| async move {
         let module = ctx
             .device

--- a/tests/tests/wgpu-gpu/regression/issue_6467.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_6467.rs
@@ -1,5 +1,9 @@
 use wgpu::util::DeviceExt;
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(ZERO_WORKGROUP_COUNT);
+}
 
 /// Running a compute shader with a total workgroup count of zero implies that no work
 /// should be done, and is a user error. Vulkan and DX12 accept this invalid input with grace, but

--- a/tests/tests/wgpu-gpu/regression/issue_6827.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_6827.rs
@@ -1,6 +1,12 @@
 use std::sync::Arc;
 
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.extend([TEST_SINGLE_WRITE, TEST_SCATTER]);
+}
 
 #[gpu_test]
 static TEST_SINGLE_WRITE: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/render_pass_ownership.rs
+++ b/tests/tests/wgpu-gpu/render_pass_ownership.rs
@@ -12,7 +12,18 @@
 use std::num::NonZeroU64;
 
 use wgpu::util::DeviceExt as _;
-use wgpu_test::{gpu_test, valid, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, valid, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        RENDER_PASS_RESOURCE_OWNERSHIP,
+        RENDER_PASS_QUERY_SET_OWNERSHIP_PIPELINE_STATISTICS,
+        RENDER_PASS_QUERY_SET_OWNERSHIP_TIMESTAMPS,
+        RENDER_PASS_KEEP_ENCODER_ALIVE,
+    ]);
+}
 
 // Minimal shader with buffer based side effect - only needed to check whether the render pass has executed at all.
 const SHADER_SRC: &str = "

--- a/tests/tests/wgpu-gpu/render_pass_ownership.rs
+++ b/tests/tests/wgpu-gpu/render_pass_ownership.rs
@@ -268,7 +268,11 @@ async fn render_pass_query_set_ownership_timestamps(ctx: TestingContext) {
 
 #[gpu_test]
 static RENDER_PASS_KEEP_ENCODER_ALIVE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits())
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop(),
+    )
     .run_async(render_pass_keep_encoder_alive);
 
 async fn render_pass_keep_encoder_alive(ctx: TestingContext) {

--- a/tests/tests/wgpu-gpu/render_target.rs
+++ b/tests/tests/wgpu-gpu/render_target.rs
@@ -2,7 +2,19 @@ use wgpu::{
     util::{BufferInitDescriptor, DeviceExt},
     vertex_attr_array,
 };
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        DRAW_TO_2D_VIEW,
+        DRAW_TO_2D_ARRAY_VIEW,
+        RESOLVE_TO_2D_VIEW,
+        RESOLVE_TO_2D_ARRAY_VIEW,
+        DRAW_TO_3D_VIEW,
+    ]);
+}
 
 #[gpu_test]
 static DRAW_TO_2D_VIEW: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/resource_descriptor_accessor.rs
+++ b/tests/tests/wgpu-gpu/resource_descriptor_accessor.rs
@@ -1,4 +1,8 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(BUFFER_SIZE_AND_USAGE);
+}
 
 #[gpu_test]
 static BUFFER_SIZE_AND_USAGE: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {

--- a/tests/tests/wgpu-gpu/resource_descriptor_accessor.rs
+++ b/tests/tests/wgpu-gpu/resource_descriptor_accessor.rs
@@ -1,21 +1,23 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.push(BUFFER_SIZE_AND_USAGE);
 }
 
 #[gpu_test]
-static BUFFER_SIZE_AND_USAGE: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {
-    let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
-        label: None,
-        size: 1234,
-        usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
-        mapped_at_creation: false,
-    });
+static BUFFER_SIZE_AND_USAGE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
+        let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 1234,
+            usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
 
-    assert_eq!(buffer.size(), 1234);
-    assert_eq!(
-        buffer.usage(),
-        wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST
-    );
-});
+        assert_eq!(buffer.size(), 1234);
+        assert_eq!(
+            buffer.usage(),
+            wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST
+        );
+    });

--- a/tests/tests/wgpu-gpu/resource_error.rs
+++ b/tests/tests/wgpu-gpu/resource_error.rs
@@ -1,70 +1,74 @@
-use wgpu_test::{fail, gpu_test, valid, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{fail, gpu_test, valid, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([BAD_BUFFER, BAD_TEXTURE]);
 }
 
 #[gpu_test]
-static BAD_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {
-    // Create a buffer with bad parameters and call a few methods.
-    // Validation should fail but there should be not panic.
-    let buffer = fail(
-        &ctx.device,
-        || {
-            ctx.device.create_buffer(&wgpu::BufferDescriptor {
-                label: None,
-                size: 99999999,
-                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::STORAGE,
-                mapped_at_creation: false,
-            })
-        },
-        Some("`map` usage can only be combined with the opposite `copy`"),
-    );
+static BAD_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
+        // Create a buffer with bad parameters and call a few methods.
+        // Validation should fail but there should be not panic.
+        let buffer = fail(
+            &ctx.device,
+            || {
+                ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                    label: None,
+                    size: 99999999,
+                    usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::STORAGE,
+                    mapped_at_creation: false,
+                })
+            },
+            Some("`map` usage can only be combined with the opposite `copy`"),
+        );
 
-    fail(
-        &ctx.device,
-        || buffer.slice(..).map_async(wgpu::MapMode::Write, |_| {}),
-        Some("Buffer with '' label is invalid"),
-    );
-    fail(
-        &ctx.device,
-        || buffer.unmap(),
-        Some("Buffer with '' label is invalid"),
-    );
-    valid(&ctx.device, || buffer.destroy());
-    valid(&ctx.device, || buffer.destroy());
-});
+        fail(
+            &ctx.device,
+            || buffer.slice(..).map_async(wgpu::MapMode::Write, |_| {}),
+            Some("Buffer with '' label is invalid"),
+        );
+        fail(
+            &ctx.device,
+            || buffer.unmap(),
+            Some("Buffer with '' label is invalid"),
+        );
+        valid(&ctx.device, || buffer.destroy());
+        valid(&ctx.device, || buffer.destroy());
+    });
 
 #[gpu_test]
-static BAD_TEXTURE: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {
-    let texture = fail(
-        &ctx.device,
-        || {
-            ctx.device.create_texture(&wgpu::TextureDescriptor {
-                label: None,
-                size: wgpu::Extent3d {
-                    width: 0,
-                    height: 12345678,
-                    depth_or_array_layers: 9001,
-                },
-                mip_level_count: 2000,
-                sample_count: 27,
-                dimension: wgpu::TextureDimension::D2,
-                format: wgpu::TextureFormat::Rgba8UnormSrgb,
-                usage: wgpu::TextureUsages::all(),
-                view_formats: &[],
-            })
-        },
-        Some("dimension x is zero"),
-    );
+static BAD_TEXTURE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
+        let texture = fail(
+            &ctx.device,
+            || {
+                ctx.device.create_texture(&wgpu::TextureDescriptor {
+                    label: None,
+                    size: wgpu::Extent3d {
+                        width: 0,
+                        height: 12345678,
+                        depth_or_array_layers: 9001,
+                    },
+                    mip_level_count: 2000,
+                    sample_count: 27,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                    usage: wgpu::TextureUsages::all(),
+                    view_formats: &[],
+                })
+            },
+            Some("dimension x is zero"),
+        );
 
-    fail(
-        &ctx.device,
-        || {
-            let _ = texture.create_view(&wgpu::TextureViewDescriptor::default());
-        },
-        Some("Texture with '' label is invalid"),
-    );
-    valid(&ctx.device, || texture.destroy());
-    valid(&ctx.device, || texture.destroy());
-});
+        fail(
+            &ctx.device,
+            || {
+                let _ = texture.create_view(&wgpu::TextureViewDescriptor::default());
+            },
+            Some("Texture with '' label is invalid"),
+        );
+        valid(&ctx.device, || texture.destroy());
+        valid(&ctx.device, || texture.destroy());
+    });

--- a/tests/tests/wgpu-gpu/resource_error.rs
+++ b/tests/tests/wgpu-gpu/resource_error.rs
@@ -1,4 +1,8 @@
-use wgpu_test::{fail, gpu_test, valid, GpuTestConfiguration};
+use wgpu_test::{fail, gpu_test, valid, GpuTestConfiguration, GpuTestInitializer};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([BAD_BUFFER, BAD_TEXTURE]);
+}
 
 #[gpu_test]
 static BAD_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {

--- a/tests/tests/wgpu-gpu/samplers.rs
+++ b/tests/tests/wgpu-gpu/samplers.rs
@@ -2,7 +2,19 @@
 //!
 //! Do some tests to ensure things are working correctly and nothing gets mad.
 
-use wgpu_test::{did_oom, gpu_test, valid, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    did_oom, gpu_test, valid, GpuTestConfiguration, GpuTestInitializer, TestParameters,
+    TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        SAMPLER_DEDUPLICATION,
+        SAMPLER_CREATION_FAILURE,
+        SAMPLER_SINGLE_BIND_GROUP,
+        SAMPLER_MULTI_BIND_GROUP,
+    ]);
+}
 
 // A number large enough to likely cause sampler caches to run out of space
 // on some devices.

--- a/tests/tests/wgpu-gpu/samplers.rs
+++ b/tests/tests/wgpu-gpu/samplers.rs
@@ -21,8 +21,9 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 const PROBABLY_PROBLEMATIC_SAMPLER_COUNT: u32 = 8 * 1024;
 
 #[gpu_test]
-static SAMPLER_DEDUPLICATION: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_sync(sampler_deduplication);
+static SAMPLER_DEDUPLICATION: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(sampler_deduplication);
 
 // Create a large number of samplers from the same two descriptors.
 //
@@ -71,8 +72,9 @@ fn sampler_deduplication(ctx: TestingContext) {
 }
 
 #[gpu_test]
-static SAMPLER_CREATION_FAILURE: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_sync(sampler_creation_failure);
+static SAMPLER_CREATION_FAILURE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(sampler_creation_failure);
 
 /// We want to test that sampler creation properly fails when we hit internal sampler
 /// cache limits. As we don't actually know what the limit is, we first create as many

--- a/tests/tests/wgpu-gpu/scissor_tests/mod.rs
+++ b/tests/tests/wgpu-gpu/scissor_tests/mod.rs
@@ -1,4 +1,13 @@
-use wgpu_test::{gpu_test, image, GpuTestConfiguration, TestingContext};
+use wgpu_test::{gpu_test, image, GpuTestConfiguration, GpuTestInitializer, TestingContext};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        SCISSOR_TEST_FULL_RECT,
+        SCISSOR_TEST_EMPTY_RECT,
+        SCISSOR_TEST_EMPTY_RECT_WITH_OFFSET,
+        SCISSOR_TEST_CUSTOM_RECT,
+    ]);
+}
 
 struct Rect {
     x: u32,

--- a/tests/tests/wgpu-gpu/shader/array_size_overrides.rs
+++ b/tests/tests/wgpu-gpu/shader/array_size_overrides.rs
@@ -3,6 +3,10 @@ use wgpu::util::DeviceExt;
 use wgpu::{BufferDescriptor, BufferUsages, MapMode, PollType};
 use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    vec.push(ARRAY_SIZE_OVERRIDES);
+}
+
 const SHADER: &str = r#"
     const testing_shared: array<i32, 1> = array(8);
     override n = testing_shared[0u];

--- a/tests/tests/wgpu-gpu/shader/compilation_messages/mod.rs
+++ b/tests/tests/wgpu-gpu/shader/compilation_messages/mod.rs
@@ -8,7 +8,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 
 #[gpu_test]
 static SHADER_COMPILE_SUCCESS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_async(|ctx| async move {
         let sm = ctx
             .device
@@ -22,7 +22,7 @@ static SHADER_COMPILE_SUCCESS: GpuTestConfiguration = GpuTestConfiguration::new(
 
 #[gpu_test]
 static SHADER_COMPILE_ERROR: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default())
+    .parameters(TestParameters::default().enable_noop())
     .run_async(|ctx| async move {
         ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
         let sm = ctx

--- a/tests/tests/wgpu-gpu/shader/compilation_messages/mod.rs
+++ b/tests/tests/wgpu-gpu/shader/compilation_messages/mod.rs
@@ -1,6 +1,10 @@
 use wgpu::include_wgsl;
 
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([SHADER_COMPILE_SUCCESS, SHADER_COMPILE_ERROR]);
+}
 
 #[gpu_test]
 static SHADER_COMPILE_SUCCESS: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/shader/data_builtins.rs
+++ b/tests/tests/wgpu-gpu/shader/data_builtins.rs
@@ -1,7 +1,11 @@
 use wgpu::{DownlevelFlags, Limits};
 
 use crate::shader::{shader_input_output_test, InputStorageType, ShaderTest};
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([UNPACK4xU8, UNPACK4xI8, PACK4xU8, PACK4xI8]);
+}
 
 #[allow(non_snake_case)]
 fn create_unpack4xU8_test() -> Vec<ShaderTest> {

--- a/tests/tests/wgpu-gpu/shader/mod.rs
+++ b/tests/tests/wgpu-gpu/shader/mod.rs
@@ -13,7 +13,7 @@ use wgpu::{
     ShaderModuleDescriptor, ShaderSource, ShaderStages,
 };
 
-use wgpu_test::TestingContext;
+use wgpu_test::{GpuTestInitializer, TestingContext};
 
 pub mod array_size_overrides;
 pub mod compilation_messages;
@@ -22,6 +22,16 @@ pub mod numeric_builtins;
 pub mod struct_layout;
 pub mod workgroup_size_overrides;
 pub mod zero_init_workgroup_mem;
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    array_size_overrides::all_tests(tests);
+    compilation_messages::all_tests(tests);
+    data_builtins::all_tests(tests);
+    numeric_builtins::all_tests(tests);
+    struct_layout::all_tests(tests);
+    workgroup_size_overrides::all_tests(tests);
+    zero_init_workgroup_mem::all_tests(tests);
+}
 
 #[derive(Clone, Copy, PartialEq)]
 enum InputStorageType {

--- a/tests/tests/wgpu-gpu/shader/numeric_builtins.rs
+++ b/tests/tests/wgpu-gpu/shader/numeric_builtins.rs
@@ -1,7 +1,16 @@
 use wgpu::{DownlevelFlags, Limits};
 
 use crate::shader::{shader_input_output_test, InputStorageType, ShaderTest};
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        NUMERIC_BUILTINS,
+        INT64_ATOMIC_MIN_MAX,
+        INT64_ATOMIC_ALL_OPS,
+        FLOAT32_ATOMIC,
+    ]);
+}
 
 fn create_numeric_builtin_test() -> Vec<ShaderTest> {
     let mut tests = Vec::new();

--- a/tests/tests/wgpu-gpu/shader/struct_layout.rs
+++ b/tests/tests/wgpu-gpu/shader/struct_layout.rs
@@ -3,7 +3,20 @@ use std::fmt::Write;
 use wgpu::{Backends, DownlevelFlags, Features, Limits};
 
 use crate::shader::{shader_input_output_test, InputStorageType, ShaderTest, MAX_BUFFER_SIZE};
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        UNIFORM_INPUT,
+        STORAGE_INPUT,
+        PUSH_CONSTANT_INPUT,
+        UNIFORM_INPUT_INT64,
+        STORAGE_INPUT_INT64,
+        PUSH_CONSTANT_INPUT_INT64,
+        UNIFORM_INPUT_F16,
+        STORAGE_INPUT_F16,
+    ]);
+}
 
 #[gpu_test]
 static UNIFORM_INPUT: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/shader/workgroup_size_overrides.rs
+++ b/tests/tests/wgpu-gpu/shader/workgroup_size_overrides.rs
@@ -3,6 +3,10 @@ use wgpu::util::DeviceExt;
 use wgpu::{BufferDescriptor, BufferUsages, MapMode, PollType};
 use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    vec.push(WORKGROUP_SIZE_OVERRIDES);
+}
+
 const SHADER: &str = r#"
     override n = 3;
 

--- a/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
@@ -8,7 +8,11 @@ use wgpu::{
     ShaderStages,
 };
 
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(ZERO_INIT_WORKGROUP_MEMORY);
+}
 
 #[gpu_test]
 static ZERO_INIT_WORKGROUP_MEMORY: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/shader_primitive_index/mod.rs
+++ b/tests/tests/wgpu-gpu/shader_primitive_index/mod.rs
@@ -1,6 +1,10 @@
 use wgpu::util::DeviceExt;
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    vec.extend([DRAW, DRAW_INDEXED]);
+}
+
 //
 // These tests render two triangles to a 2x2 render target. The first triangle
 // in the vertex buffer covers the bottom-left pixel, the second triangle

--- a/tests/tests/wgpu-gpu/shader_view_format/mod.rs
+++ b/tests/tests/wgpu-gpu/shader_view_format/mod.rs
@@ -1,6 +1,10 @@
 use wgpu::{util::DeviceExt, DownlevelFlags, Limits, TextureFormat};
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    vec.push(REINTERPRET_SRGB);
+}
+
 #[gpu_test]
 static REINTERPRET_SRGB: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(

--- a/tests/tests/wgpu-gpu/subgroup_operations/mod.rs
+++ b/tests/tests/wgpu-gpu/subgroup_operations/mod.rs
@@ -1,6 +1,10 @@
 use std::num::NonZeroU64;
 
-use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(SUBGROUP_OPERATIONS);
+}
 
 const THREAD_COUNT: u64 = 128;
 const TEST_COUNT: u32 = 37;

--- a/tests/tests/wgpu-gpu/texture_binding/mod.rs
+++ b/tests/tests/wgpu-gpu/texture_binding/mod.rs
@@ -7,7 +7,11 @@ use wgpu::{
     TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
 use wgpu_macros::gpu_test;
-use wgpu_test::{GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([TEXTURE_BINDING, SINGLE_SCALAR_LOAD]);
+}
 
 #[gpu_test]
 static TEXTURE_BINDING: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/texture_binding/mod.rs
+++ b/tests/tests/wgpu-gpu/texture_binding/mod.rs
@@ -18,7 +18,8 @@ static TEXTURE_BINDING: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .downlevel_flags(DownlevelFlags::WEBGPU_TEXTURE_FORMAT_SUPPORT),
+            .downlevel_flags(DownlevelFlags::WEBGPU_TEXTURE_FORMAT_SUPPORT)
+            .enable_noop(),
     )
     .run_sync(texture_binding);
 

--- a/tests/tests/wgpu-gpu/texture_blit.rs
+++ b/tests/tests/wgpu-gpu/texture_blit.rs
@@ -1,4 +1,4 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
@@ -9,6 +9,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 
 #[gpu_test]
 static TEXTURE_BLIT_WITH_LINEAR_FILTER_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         let source = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
@@ -60,6 +61,7 @@ static TEXTURE_BLIT_WITH_LINEAR_FILTER_TEST: GpuTestConfiguration = GpuTestConfi
 
 #[gpu_test]
 static TEXTURE_BLIT_WITH_NEAREST_FILTER_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         let source = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,

--- a/tests/tests/wgpu-gpu/texture_blit.rs
+++ b/tests/tests/wgpu-gpu/texture_blit.rs
@@ -1,4 +1,11 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        TEXTURE_BLIT_WITH_LINEAR_FILTER_TEST,
+        TEXTURE_BLIT_WITH_NEAREST_FILTER_TEST,
+    ]);
+}
 
 #[gpu_test]
 static TEXTURE_BLIT_WITH_LINEAR_FILTER_TEST: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/texture_bounds.rs
+++ b/tests/tests/wgpu-gpu/texture_bounds.rs
@@ -1,95 +1,97 @@
 //! Tests for texture copy bounds checks.
 
-use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration};
+use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
     vec.push(BAD_COPY_ORIGIN_TEST);
 }
 
 #[gpu_test]
-static BAD_COPY_ORIGIN_TEST: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {
-    let try_origin = |origin, size, should_panic| {
-        let texture = ctx.device.create_texture(&TEXTURE_DESCRIPTOR);
-        let data = vec![255; BUFFER_SIZE as usize];
+static BAD_COPY_ORIGIN_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
+        let try_origin = |origin, size, should_panic| {
+            let texture = ctx.device.create_texture(&TEXTURE_DESCRIPTOR);
+            let data = vec![255; BUFFER_SIZE as usize];
 
-        fail_if(
-            &ctx.device,
-            should_panic,
-            || {
-                ctx.queue.write_texture(
-                    wgpu::TexelCopyTextureInfo {
-                        texture: &texture,
-                        mip_level: 0,
-                        origin,
-                        aspect: wgpu::TextureAspect::All,
-                    },
-                    &data,
-                    BUFFER_COPY_LAYOUT,
-                    size,
-                )
+            fail_if(
+                &ctx.device,
+                should_panic,
+                || {
+                    ctx.queue.write_texture(
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &texture,
+                            mip_level: 0,
+                            origin,
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        &data,
+                        BUFFER_COPY_LAYOUT,
+                        size,
+                    )
+                },
+                None,
+            );
+        };
+
+        try_origin(wgpu::Origin3d { x: 0, y: 0, z: 0 }, TEXTURE_SIZE, false);
+        try_origin(wgpu::Origin3d { x: 1, y: 0, z: 0 }, TEXTURE_SIZE, true);
+        try_origin(wgpu::Origin3d { x: 0, y: 1, z: 0 }, TEXTURE_SIZE, true);
+        try_origin(wgpu::Origin3d { x: 0, y: 0, z: 1 }, TEXTURE_SIZE, true);
+
+        try_origin(
+            wgpu::Origin3d {
+                x: TEXTURE_SIZE.width - 1,
+                y: TEXTURE_SIZE.height - 1,
+                z: TEXTURE_SIZE.depth_or_array_layers - 1,
             },
-            None,
+            wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            false,
         );
-    };
-
-    try_origin(wgpu::Origin3d { x: 0, y: 0, z: 0 }, TEXTURE_SIZE, false);
-    try_origin(wgpu::Origin3d { x: 1, y: 0, z: 0 }, TEXTURE_SIZE, true);
-    try_origin(wgpu::Origin3d { x: 0, y: 1, z: 0 }, TEXTURE_SIZE, true);
-    try_origin(wgpu::Origin3d { x: 0, y: 0, z: 1 }, TEXTURE_SIZE, true);
-
-    try_origin(
-        wgpu::Origin3d {
-            x: TEXTURE_SIZE.width - 1,
-            y: TEXTURE_SIZE.height - 1,
-            z: TEXTURE_SIZE.depth_or_array_layers - 1,
-        },
-        wgpu::Extent3d {
-            width: 1,
-            height: 1,
-            depth_or_array_layers: 1,
-        },
-        false,
-    );
-    try_origin(
-        wgpu::Origin3d {
-            x: u32::MAX,
-            y: 0,
-            z: 0,
-        },
-        wgpu::Extent3d {
-            width: 1,
-            height: 1,
-            depth_or_array_layers: 1,
-        },
-        true,
-    );
-    try_origin(
-        wgpu::Origin3d {
-            x: u32::MAX,
-            y: 0,
-            z: 0,
-        },
-        wgpu::Extent3d {
-            width: 1,
-            height: 1,
-            depth_or_array_layers: 1,
-        },
-        true,
-    );
-    try_origin(
-        wgpu::Origin3d {
-            x: u32::MAX,
-            y: 0,
-            z: 0,
-        },
-        wgpu::Extent3d {
-            width: 1,
-            height: 1,
-            depth_or_array_layers: 1,
-        },
-        true,
-    );
-});
+        try_origin(
+            wgpu::Origin3d {
+                x: u32::MAX,
+                y: 0,
+                z: 0,
+            },
+            wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            true,
+        );
+        try_origin(
+            wgpu::Origin3d {
+                x: u32::MAX,
+                y: 0,
+                z: 0,
+            },
+            wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            true,
+        );
+        try_origin(
+            wgpu::Origin3d {
+                x: u32::MAX,
+                y: 0,
+                z: 0,
+            },
+            wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            true,
+        );
+    });
 
 const TEXTURE_SIZE: wgpu::Extent3d = wgpu::Extent3d {
     width: 64,

--- a/tests/tests/wgpu-gpu/texture_bounds.rs
+++ b/tests/tests/wgpu-gpu/texture_bounds.rs
@@ -2,6 +2,10 @@
 
 use wgpu_test::{fail_if, gpu_test, GpuTestConfiguration};
 
+pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    vec.push(BAD_COPY_ORIGIN_TEST);
+}
+
 #[gpu_test]
 static BAD_COPY_ORIGIN_TEST: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {
     let try_origin = |origin, size, should_panic| {

--- a/tests/tests/wgpu-gpu/texture_view_creation.rs
+++ b/tests/tests/wgpu-gpu/texture_view_creation.rs
@@ -14,7 +14,8 @@ static STENCIL_ONLY_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::
     .parameters(
         TestParameters::default()
             .skip(FailureCase::webgl2()) // WebGL doesn't have stencil only views
-            .limits(wgpu::Limits::downlevel_defaults()),
+            .limits(wgpu::Limits::downlevel_defaults())
+            .enable_noop(),
     )
     .run_async(|ctx| async move {
         for format in [TextureFormat::Stencil8, TextureFormat::Depth24PlusStencil8] {
@@ -42,8 +43,9 @@ static STENCIL_ONLY_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::
     });
 
 #[gpu_test]
-static DEPTH_ONLY_VIEW_CREATION: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static DEPTH_ONLY_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
         for format in [
             TextureFormat::Depth16Unorm,
             TextureFormat::Depth24Plus,
@@ -74,7 +76,11 @@ static DEPTH_ONLY_VIEW_CREATION: GpuTestConfiguration =
 
 #[gpu_test]
 static SHARED_USAGE_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().downlevel_flags(DownlevelFlags::VIEW_FORMATS))
+    .parameters(
+        TestParameters::default()
+            .downlevel_flags(DownlevelFlags::VIEW_FORMATS)
+            .enable_noop(),
+    )
     .run_async(|ctx| async move {
         {
             let (texture_format, view_format) =

--- a/tests/tests/wgpu-gpu/texture_view_creation.rs
+++ b/tests/tests/wgpu-gpu/texture_view_creation.rs
@@ -1,5 +1,13 @@
 use wgpu::*;
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters};
+use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        STENCIL_ONLY_VIEW_CREATION,
+        DEPTH_ONLY_VIEW_CREATION,
+        SHARED_USAGE_VIEW_CREATION,
+    ]);
+}
 
 #[gpu_test]
 static STENCIL_ONLY_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::new()

--- a/tests/tests/wgpu-gpu/timestamp_normalization/mod.rs
+++ b/tests/tests/wgpu-gpu/timestamp_normalization/mod.rs
@@ -1,1 +1,5 @@
 mod utils;
+
+pub fn all_tests(tests: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    utils::all_tests(tests);
+}

--- a/tests/tests/wgpu-gpu/timestamp_normalization/utils.rs
+++ b/tests/tests/wgpu-gpu/timestamp_normalization/utils.rs
@@ -8,6 +8,10 @@ use nanorand::Rng;
 use wgpu::{util::DeviceExt, Limits};
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    vec.extend([U64_MUL_U32, SHIFT_RIGHT_U96]);
+}
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct Uint96(u32, u32, u32);

--- a/tests/tests/wgpu-gpu/timestamp_query.rs
+++ b/tests/tests/wgpu-gpu/timestamp_query.rs
@@ -2,7 +2,13 @@ use wgpu::{
     util::DeviceExt, ComputePassTimestampWrites, Features, InstanceFlags,
     QUERY_RESOLVE_BUFFER_ALIGNMENT,
 };
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{
+    gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(TIMESTAMP_QUERY);
+}
 
 const SHADER: &str = r#"
 @compute @workgroup_size(1)

--- a/tests/tests/wgpu-gpu/transfer.rs
+++ b/tests/tests/wgpu-gpu/transfer.rs
@@ -1,4 +1,8 @@
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration};
+use wgpu_test::{fail, gpu_test, GpuTestConfiguration, GpuTestInitializer};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(COPY_OVERFLOW_Z);
+}
 
 #[gpu_test]
 static COPY_OVERFLOW_Z: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {

--- a/tests/tests/wgpu-gpu/transfer.rs
+++ b/tests/tests/wgpu-gpu/transfer.rs
@@ -1,73 +1,75 @@
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.push(COPY_OVERFLOW_Z);
 }
 
 #[gpu_test]
-static COPY_OVERFLOW_Z: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {
-    let mut encoder = ctx
-        .device
-        .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+static COPY_OVERFLOW_Z: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
 
-    let t1 = ctx.device.create_texture(&wgpu::TextureDescriptor {
-        label: None,
-        dimension: wgpu::TextureDimension::D2,
-        size: wgpu::Extent3d {
-            width: 256,
-            height: 256,
-            depth_or_array_layers: 1,
-        },
-        format: wgpu::TextureFormat::Rgba8Uint,
-        usage: wgpu::TextureUsages::COPY_DST,
-        mip_level_count: 1,
-        sample_count: 1,
-        view_formats: &[],
-    });
-    let t2 = ctx.device.create_texture(&wgpu::TextureDescriptor {
-        label: None,
-        dimension: wgpu::TextureDimension::D2,
-        size: wgpu::Extent3d {
-            width: 256,
-            height: 256,
-            depth_or_array_layers: 1,
-        },
-        format: wgpu::TextureFormat::Rgba8Uint,
-        usage: wgpu::TextureUsages::COPY_DST,
-        mip_level_count: 1,
-        sample_count: 1,
-        view_formats: &[],
-    });
+        let t1 = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size: wgpu::Extent3d {
+                width: 256,
+                height: 256,
+                depth_or_array_layers: 1,
+            },
+            format: wgpu::TextureFormat::Rgba8Uint,
+            usage: wgpu::TextureUsages::COPY_DST,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[],
+        });
+        let t2 = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size: wgpu::Extent3d {
+                width: 256,
+                height: 256,
+                depth_or_array_layers: 1,
+            },
+            format: wgpu::TextureFormat::Rgba8Uint,
+            usage: wgpu::TextureUsages::COPY_DST,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[],
+        });
 
-    fail(
-        &ctx.device,
-        || {
-            // Validation should catch the silly selected z layer range without panicking.
-            encoder.copy_texture_to_texture(
-                wgpu::TexelCopyTextureInfo {
-                    texture: &t1,
-                    mip_level: 1,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::TexelCopyTextureInfo {
-                    texture: &t2,
-                    mip_level: 1,
-                    origin: wgpu::Origin3d {
-                        x: 0,
-                        y: 0,
-                        z: 3824276442,
+        fail(
+            &ctx.device,
+            || {
+                // Validation should catch the silly selected z layer range without panicking.
+                encoder.copy_texture_to_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &t1,
+                        mip_level: 1,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
                     },
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::Extent3d {
-                    width: 100,
-                    height: 3,
-                    depth_or_array_layers: 613286111,
-                },
-            );
-            ctx.queue.submit(Some(encoder.finish()));
-        },
-        Some("unable to select texture mip level"),
-    );
-});
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &t2,
+                        mip_level: 1,
+                        origin: wgpu::Origin3d {
+                            x: 0,
+                            y: 0,
+                            z: 3824276442,
+                        },
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::Extent3d {
+                        width: 100,
+                        height: 3,
+                        depth_or_array_layers: 613286111,
+                    },
+                );
+                ctx.queue.submit(Some(encoder.finish()));
+            },
+            Some("unable to select texture mip level"),
+        );
+    });

--- a/tests/tests/wgpu-gpu/transition_resources.rs
+++ b/tests/tests/wgpu-gpu/transition_resources.rs
@@ -1,4 +1,8 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(TRANSITION_RESOURCES);
+}
 
 #[gpu_test]
 static TRANSITION_RESOURCES: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {

--- a/tests/tests/wgpu-gpu/transition_resources.rs
+++ b/tests/tests/wgpu-gpu/transition_resources.rs
@@ -1,39 +1,41 @@
-use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.push(TRANSITION_RESOURCES);
 }
 
 #[gpu_test]
-static TRANSITION_RESOURCES: GpuTestConfiguration = GpuTestConfiguration::new().run_sync(|ctx| {
-    let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
-        label: None,
-        size: wgpu::Extent3d {
-            width: 32,
-            height: 32,
-            depth_or_array_layers: 1,
-        },
-        mip_level_count: 1,
-        sample_count: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::Rgba8Unorm,
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
-        view_formats: &[],
+static TRANSITION_RESOURCES: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
+        let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            size: wgpu::Extent3d {
+                width: 32,
+                height: 32,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+        encoder.transition_resources(
+            std::iter::empty(),
+            [wgpu::TextureTransition {
+                texture: &texture,
+                selector: None,
+                state: wgpu::TextureUses::COLOR_TARGET,
+            }]
+            .into_iter(),
+        );
+
+        ctx.queue.submit([encoder.finish()]);
     });
-
-    let mut encoder = ctx
-        .device
-        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-
-    encoder.transition_resources(
-        std::iter::empty(),
-        [wgpu::TextureTransition {
-            texture: &texture,
-            selector: None,
-            state: wgpu::TextureUses::COLOR_TARGET,
-        }]
-        .into_iter(),
-    );
-
-    ctx.queue.submit([encoder.finish()]);
-});

--- a/tests/tests/wgpu-gpu/vertex_formats/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_formats/mod.rs
@@ -6,6 +6,10 @@ use wgpu::util::{BufferInitDescriptor, DeviceExt};
 
 use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    vec.extend([VERTEX_FORMATS_ALL, VERTEX_FORMATS_10_10_10_2]);
+}
+
 #[derive(Debug, Copy, Clone)]
 enum TestCase {
     UnormsAndSnorms,

--- a/tests/tests/wgpu-gpu/vertex_indices/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_indices/mod.rs
@@ -11,6 +11,10 @@ use wgpu::util::{BufferInitDescriptor, DeviceExt, RenderEncoder};
 use wgpu::RenderBundleDescriptor;
 use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
+pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
+    vec.push(VERTEX_INDICES);
+}
+
 /// Generic struct representing a draw call
 struct Draw {
     vertex: Range<u32>,

--- a/tests/tests/wgpu-gpu/write_texture.rs
+++ b/tests/tests/wgpu-gpu/write_texture.rs
@@ -1,7 +1,7 @@
 //! Tests for texture copy
 
 use wgpu::*;
-use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
@@ -199,8 +199,9 @@ static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
     });
 
 #[gpu_test]
-static WRITE_TEXTURE_NO_OOB: GpuTestConfiguration =
-    GpuTestConfiguration::new().run_async(|ctx| async move {
+static WRITE_TEXTURE_NO_OOB: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
         let size = 256;
 
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {

--- a/tests/tests/wgpu-gpu/write_texture.rs
+++ b/tests/tests/wgpu-gpu/write_texture.rs
@@ -1,7 +1,16 @@
 //! Tests for texture copy
 
 use wgpu::*;
-use wgpu_test::{gpu_test, GpuTestConfiguration};
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        WRITE_TEXTURE_SUBSET_2D,
+        WRITE_TEXTURE_SUBSET_3D,
+        WRITE_TEXTURE_NO_OOB,
+        WRITE_TEXTURE_VIA_STAGING_BUFFER,
+    ]);
+}
 
 #[gpu_test]
 static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =

--- a/tests/tests/wgpu-gpu/zero_init_texture_after_discard.rs
+++ b/tests/tests/wgpu-gpu/zero_init_texture_after_discard.rs
@@ -1,8 +1,17 @@
 use wgpu::*;
 use wgpu_test::{
-    gpu_test, image::ReadbackBuffers, FailureCase, GpuTestConfiguration, TestParameters,
-    TestingContext,
+    gpu_test, image::ReadbackBuffers, FailureCase, GpuTestConfiguration, GpuTestInitializer,
+    TestParameters, TestingContext,
 };
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_AFTER_SUBMIT,
+        DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_IN_SAME_ENCODER,
+        DISCARDING_DEPTH_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_IN_SAME_ENCODER,
+        DISCARDING_EITHER_DEPTH_OR_STENCIL_ASPECT_TEST,
+    ]);
+}
 
 // Checks if discarding a color target resets its init state, causing a zero read of this texture when copied in after submit of the encoder.
 #[gpu_test]

--- a/tests/tests/wgpu-validation/api/instance.rs
+++ b/tests/tests/wgpu-validation/api/instance.rs
@@ -1,5 +1,5 @@
 mod multi_instance {
-    #![cfg(not(target_arch = "wasm32"))]
+    #![cfg(not(any(target_arch = "wasm32", miri)))]
 
     async fn get() -> wgpu::Adapter {
         let adapter = {

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -120,22 +120,34 @@ impl crate::Instance for Context {
     ) -> Vec<crate::ExposedAdapter<Api>> {
         vec![crate::ExposedAdapter {
             adapter: Context,
-            info: wgt::AdapterInfo {
-                name: String::from("noop wgpu backend"),
-                vendor: 0,
-                device: 0,
-                device_type: wgt::DeviceType::Cpu,
-                driver: String::from("wgpu"),
-                driver_info: String::new(),
-                backend: wgt::Backend::Noop,
-            },
+            info: adapter_info(),
             features: wgt::Features::all(),
             capabilities: CAPABILITIES,
         }]
     }
 }
 
-const CAPABILITIES: crate::Capabilities = {
+/// Returns the adapter info for the noop backend.
+///
+/// This is used in the test harness to construct info about
+/// the noop backend adapter without actually initializing wgpu.
+pub fn adapter_info() -> wgt::AdapterInfo {
+    wgt::AdapterInfo {
+        name: String::from("noop wgpu backend"),
+        vendor: 0,
+        device: 0,
+        device_type: wgt::DeviceType::Cpu,
+        driver: String::from("wgpu"),
+        driver_info: String::new(),
+        backend: wgt::Backend::Noop,
+    }
+}
+
+/// The capabilities of the noop backend.
+///
+/// This is used in the test harness to construct capabilities
+/// of the noop backend without actually initializing wgpu.
+pub const CAPABILITIES: crate::Capabilities = {
     /// Guaranteed to be no bigger than isize::MAX which is the maximum size of an allocation,
     /// except on 16-bit platforms which we certainly don’t fit in.
     const ALLOC_MAX_U32: u32 = i32::MAX as u32;

--- a/wgpu-macros/src/lib.rs
+++ b/wgpu-macros/src/lib.rs
@@ -9,29 +9,27 @@ use syn::Ident;
 #[proc_macro_attribute]
 pub fn gpu_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input_static = syn::parse_macro_input!(item as syn::ItemStatic);
+    let vis = input_static.vis;
     let expr = &input_static.expr;
     let ident = &input_static.ident;
     let ident_str = ident.to_string();
     let ident_lower = ident_str.to_snake_case();
 
-    let register_test_name = Ident::new(&format!("{ident_lower}_initializer"), ident.span());
+    let register_test_name = Ident::new(&format!("{ident}"), ident.span());
     let test_name_webgl = Ident::new(&format!("{ident_lower}_webgl"), ident.span());
 
     quote! {
-        #[cfg(not(target_arch = "wasm32"))]
-        #[::wgpu_test::ctor::ctor(crate_path = ::wgpu_test::ctor)]
-        fn #register_test_name() {
+        #[allow(non_snake_case)]
+        #vis fn #register_test_name() -> ::wgpu_test::GpuTestConfiguration {
             struct S;
 
-            ::wgpu_test::native::TEST_LIST.lock().push(
-                // Allow any type that can be converted to a GpuTestConfiguration
-                ::wgpu_test::GpuTestConfiguration::from(#expr).name_from_init_function_typename::<S>(#ident_lower)
-            )
+            // Allow any type that can be converted to a GpuTestConfiguration
+            ::wgpu_test::GpuTestConfiguration::from(#expr).name_from_init_function_typename::<S>(#ident_lower)
         }
 
         #[cfg(target_arch = "wasm32")]
         #[wasm_bindgen_test::wasm_bindgen_test]
-        async fn #test_name_webgl() {
+        #vis async fn #test_name_webgl() {
             struct S;
 
             // Allow any type that can be converted to a GpuTestConfiguration

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,7 @@ use anyhow::Context;
 use pico_args::Arguments;
 
 mod cts;
+mod miri;
 mod run_wasm;
 mod test;
 mod util;
@@ -36,6 +37,14 @@ Commands:
     --retries   Number of times to retry failing tests
 
     All extra arguments will be forwarded to cargo-nextest (NOT wgpu-info)
+
+  miri
+    Run all miri-compatible tests under miri. Requires a nightly toolchain
+    with the x86_64-unknown-linux-gnu target and miri component installed.
+
+    --toolchain <toolchain>   The toolchain to use for miri tests.
+                              Must be a nightly toolchain.
+                              Defaults to `nightly`.
 
   vendor-web-sys
     Re-vendor the WebGPU web-sys bindings.
@@ -85,6 +94,7 @@ fn main() -> anyhow::Result<ExitCode> {
     match subcommand.as_deref() {
         Some("cts") => cts::run_cts(shell, args)?,
         Some("run-wasm") => run_wasm::run_wasm(shell, args)?,
+        Some("miri") => miri::run_miri(shell, args)?,
         Some("test") => test::run_tests(shell, args)?,
         Some("vendor-web-sys") => vendor_web_sys::run_vendor_web_sys(shell, args)?,
         Some(subcommand) => {

--- a/xtask/src/miri.rs
+++ b/xtask/src/miri.rs
@@ -1,0 +1,29 @@
+use pico_args::Arguments;
+use xshell::Shell;
+
+pub fn run_miri(shell: Shell, mut args: Arguments) -> anyhow::Result<()> {
+    let toolchain: String = args
+        .opt_value_from_str("--toolchain")?
+        .unwrap_or_else(|| String::from("nightly"));
+
+    shell
+        .cmd("rustup")
+        .args([
+            "run",
+            &toolchain,
+            "cargo",
+            "miri",
+            "nextest",
+            "run",
+            "--target",
+            "x86_64-unknown-linux-gnu",
+        ])
+        .env(
+            "MIRIFLAGS",
+            "-Zmiri-disable-isolation -Zmiri-deterministic-floats",
+        )
+        .quiet()
+        .run()?;
+
+    Ok(())
+}

--- a/xtask/src/miri.rs
+++ b/xtask/src/miri.rs
@@ -22,6 +22,7 @@ pub fn run_miri(shell: Shell, mut args: Arguments) -> anyhow::Result<()> {
             "MIRIFLAGS",
             "-Zmiri-disable-isolation -Zmiri-deterministic-floats",
         )
+        .env("WGPU_GPU_TESTS_USE_NOOP_BACKEND", "1")
         .quiet()
         .run()?;
 


### PR DESCRIPTION
Wires in support for miri (and potentially ASAN) in the codebase.

Main transform was manually enumerating tests.