### PR TITLE
Additional validation of buffer-texture copies

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -34,6 +34,28 @@ webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bind_grou
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:buffer_binding,render_pipeline:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:sampler_binding,render_pipeline:*
 webgpu:api,validation,encoding,queries,general:occlusion_query,query_index:*
+webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
+webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
+webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth32float";aspect="depth-only";copyType="CopyT2B"
+webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyB2T"
+webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyT2B"
+//mix of PASS and FAIL: other subtests of copy_buffer_offset
+// https://github.com/gfx-rs/wgpu/issues/7947
+webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*
+webgpu:api,validation,image_copy,buffer_texture_copies:texture_buffer_usages:*
+webgpu:api,validation,image_copy,buffer_texture_copies:device_mismatch:*
+webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="2d"
+webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="2d"
+webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="3d"
+webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="3d"
+webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="bgra8unorm";copyType="CopyB2T";dimension="2d"
+webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="bgra8unorm";copyType="CopyT2B";dimension="2d"
+webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="2d"
+webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="2d"
+webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="3d"
+webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="3d"
+//mix of PASS and FAIL: other subtests of offset_and_bytesPerRow
+// https://github.com/gfx-rs/wgpu/issues/7947
 webgpu:api,validation,image_copy,layout_related:copy_end_overflows_u64:*
 webgpu:api,validation,image_copy,texture_related:format:dimension="1d";*
 webgpu:api,validation,queue,submit:command_buffer,device_mismatch:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -36,26 +36,26 @@ webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:sampler_b
 webgpu:api,validation,encoding,queries,general:occlusion_query,query_index:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
-webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth32float";aspect="depth-only";copyType="CopyT2B"
-webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyB2T"
-webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyT2B"
-//mix of PASS and FAIL: other subtests of copy_buffer_offset
-// https://github.com/gfx-rs/wgpu/issues/7947
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth32float";aspect="depth-only";copyType="CopyT2B"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyB2T"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyT2B"
+//mix of PASS and FAIL: other subtests of copy_buffer_offset. Related bugs:
+// https://github.com/gfx-rs/wgpu/issues/7946, https://github.com/gfx-rs/wgpu/issues/7947
 webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*
 webgpu:api,validation,image_copy,buffer_texture_copies:texture_buffer_usages:*
 webgpu:api,validation,image_copy,buffer_texture_copies:device_mismatch:*
-webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="2d"
-webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="2d"
-webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="3d"
-webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="3d"
-webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="bgra8unorm";copyType="CopyB2T";dimension="2d"
-webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="bgra8unorm";copyType="CopyT2B";dimension="2d"
-webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="2d"
-webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="2d"
-webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="3d"
-webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="3d"
-//mix of PASS and FAIL: other subtests of offset_and_bytesPerRow
-// https://github.com/gfx-rs/wgpu/issues/7947
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="2d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="2d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="3d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="3d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="bgra8unorm";copyType="CopyB2T";dimension="2d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="bgra8unorm";copyType="CopyT2B";dimension="2d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="2d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="2d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="3d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="3d"
+//mix of PASS and FAIL: other subtests of offset_and_bytesPerRow. Related bugs:
+// https://github.com/gfx-rs/wgpu/issues/7946, https://github.com/gfx-rs/wgpu/issues/7947
 webgpu:api,validation,image_copy,layout_related:copy_end_overflows_u64:*
 webgpu:api,validation,image_copy,texture_related:format:dimension="1d";*
 webgpu:api,validation,queue,submit:command_buffer,device_mismatch:*

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -371,7 +371,14 @@ pub(crate) fn validate_linear_texture_data(
 ///  * The copy must be from/to a single aspect of the texture.
 ///  * If `aligned` is true, the buffer offset must be aligned appropriately.
 ///
-/// Other checks in this algorithm are enforced elsewhere.
+/// The following steps in the algorithm are implemented elsewhere:
+///  * Invocation of other validation algorithms.
+///  * The texture usage (COPY_DST / COPY_SRC) check.
+///  * The check for non-copyable depth/stencil formats. The caller must perform
+///    this check using `is_valid_copy_src_format` / `is_valid_copy_dst_format`
+///    before calling this function. This function will panic if
+///    [`wgt::TextureFormat::block_copy_size`] returns `None` due to a
+///    non-copyable format.
 ///
 /// [vtbc]: https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-texture-buffer-copy
 pub(crate) fn validate_texture_buffer_copy<T>(
@@ -394,9 +401,13 @@ pub(crate) fn validate_texture_buffer_copy<T>(
     let mut offset_alignment = if desc.format.is_depth_stencil_format() {
         4
     } else {
+        // The case where `block_copy_size` returns `None` is currently
+        // unreachable both for the reason in the expect message, and also
+        // because the currently-defined non-copyable formats are depth/stencil
+        // formats so would take the `if` branch.
         desc.format
             .block_copy_size(Some(texture_copy_view.aspect))
-            .unwrap_or(1)
+            .expect("non-copyable formats should have been rejected previously")
     };
 
     // TODO(https://github.com/gfx-rs/wgpu/issues/7947): This does not match the spec.

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -363,6 +363,59 @@ pub(crate) fn validate_linear_texture_data(
     Ok((bytes_in_copy, image_stride_bytes))
 }
 
+/// Validation for texture/buffer copies.
+///
+/// This implements the following checks from WebGPU's [validating texture buffer copy][vtbc]
+/// algorithm:
+///  * The texture must not be multisampled.
+///  * The copy must be from/to a single aspect of the texture.
+///  * If `aligned` is true, the buffer offset must be aligned appropriately.
+///
+/// Other checks in this algorithm are enforced elsewhere.
+///
+/// [vtbc]: https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-texture-buffer-copy
+pub(crate) fn validate_texture_buffer_copy<T>(
+    texture_copy_view: &wgt::TexelCopyTextureInfo<T>,
+    aspect: hal::FormatAspects,
+    desc: &wgt::TextureDescriptor<(), Vec<wgt::TextureFormat>>,
+    offset: BufferAddress,
+    aligned: bool,
+) -> Result<(), TransferError> {
+    if desc.sample_count != 1 {
+        return Err(TransferError::InvalidSampleCount {
+            sample_count: desc.sample_count,
+        });
+    }
+
+    if !aspect.is_one() {
+        return Err(TransferError::CopyAspectNotOne);
+    }
+
+    let mut offset_alignment = if desc.format.is_depth_stencil_format() {
+        4
+    } else {
+        desc.format
+            .block_copy_size(Some(texture_copy_view.aspect))
+            .unwrap_or(1)
+    };
+
+    // TODO(https://github.com/gfx-rs/wgpu/issues/7947): This does not match the spec.
+    // The spec imposes no alignment requirement if `!aligned`, and otherwise
+    // imposes only the `offset_alignment` as calculated above. wgpu currently
+    // can panic on alignments <4B, so we reject them here to avoid a panic.
+    if aligned {
+        offset_alignment = offset_alignment.max(4);
+    } else {
+        offset_alignment = 4;
+    }
+
+    if offset % u64::from(offset_alignment) != 0 {
+        return Err(TransferError::UnalignedBufferOffset(offset));
+    }
+
+    Ok(())
+}
+
 /// Validate the extent and alignment of a texture copy.
 ///
 /// Copied with minor modifications from WebGPU standard. This mostly follows
@@ -884,10 +937,6 @@ impl Global {
                 .map(|pending| pending.into_hal(dst_raw))
                 .collect::<Vec<_>>();
 
-            if !dst_base.aspect.is_one() {
-                return Err(TransferError::CopyAspectNotOne.into());
-            }
-
             if !conv::is_valid_copy_dst_texture_format(dst_texture.desc.format, destination.aspect)
             {
                 return Err(TransferError::CopyToForbiddenTextureFormat {
@@ -896,6 +945,14 @@ impl Global {
                 }
                 .into());
             }
+
+            validate_texture_buffer_copy(
+                destination,
+                dst_base.aspect,
+                &dst_texture.desc,
+                source.layout.offset,
+                true, // alignment required for buffer offset
+            )?;
 
             let (required_buffer_bytes_in_copy, bytes_per_array_layer) =
                 validate_linear_texture_data(
@@ -999,22 +1056,13 @@ impl Global {
             src_texture
                 .check_usage(TextureUsages::COPY_SRC)
                 .map_err(TransferError::MissingTextureUsage)?;
-            if src_texture.desc.sample_count != 1 {
-                return Err(TransferError::InvalidSampleCount {
-                    sample_count: src_texture.desc.sample_count,
-                }
-                .into());
-            }
+
             if source.mip_level >= src_texture.desc.mip_level_count {
                 return Err(TransferError::InvalidMipLevel {
                     requested: source.mip_level,
                     count: src_texture.desc.mip_level_count,
                 }
                 .into());
-            }
-
-            if !src_base.aspect.is_one() {
-                return Err(TransferError::CopyAspectNotOne.into());
             }
 
             if !conv::is_valid_copy_src_texture_format(src_texture.desc.format, source.aspect) {
@@ -1024,6 +1072,14 @@ impl Global {
                 }
                 .into());
             }
+
+            validate_texture_buffer_copy(
+                source,
+                src_base.aspect,
+                &src_texture.desc,
+                destination.layout.offset,
+                true, // alignment required for buffer offset
+            )?;
 
             let (required_buffer_bytes_in_copy, bytes_per_array_layer) =
                 validate_linear_texture_data(

--- a/wgpu-core/src/conv.rs
+++ b/wgpu-core/src/conv.rs
@@ -2,6 +2,9 @@ use wgt::TextureFormatFeatures;
 
 use crate::resource::{self, TextureDescriptor};
 
+// Some core-only texture format helpers. The helper methods on `TextureFormat`
+// defined in wgpu-types may need to be modified along with the ones here.
+
 pub fn is_valid_copy_src_texture_format(
     format: wgt::TextureFormat,
     aspect: wgt::TextureAspect,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -2608,6 +2608,8 @@ impl TextureAspect {
     }
 }
 
+// There are some additional texture format helpers in `wgpu-core/src/conv.rs`,
+// that may need to be modified along with the ones here.
 impl TextureFormat {
     /// Returns the aspect-specific format of the original format
     ///


### PR DESCRIPTION
Adds some more buffer-texture copy validation. I am declaring that this fixes #7936, although there are still problems with buffer-texture copies, see #7946 and #7947.

This PR enforces:
* Offset for copies to/from compressed formats must be aligned to the block size
* Offset for copies to/from depth stencil formats must be 4B aligned.
* Temporarily enforces that all buffer-texture copies be 4B aligned, pending a fix for #7947.
* Disallows multisampled textures for both T2B and B2T (previously only one checked for multisampled textures)

**Testing**
Enables a sampling of relevant CTS tests, but some of the tests still have a mix of passing and failing variants and I didn't try to exhaustively list every passing case in `test.lst`.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
