### PR TITLE
[hal][egl] Fix robust context creation failing on some devices

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -580,7 +580,6 @@ impl Inner {
         })
         .unwrap();
 
-        let needs_robustness = true;
         let mut khr_context_flags = 0;
         let supports_khr_context = display_extensions.contains("EGL_KHR_create_context");
 
@@ -617,53 +616,108 @@ impl Inner {
                 log::debug!("\tEGL context: -debug");
             }
         }
-        if needs_robustness {
-            //Note: the core version can fail if robustness is not supported
-            // (regardless of whether the extension is supported!).
-            // In fact, Angle does precisely that awful behavior, so we don't try it there.
-            if version >= (1, 5) && !display_extensions.contains("EGL_ANGLE_") {
-                log::debug!("\tEGL context: +robust access");
-                context_attributes.push(khronos_egl::CONTEXT_OPENGL_ROBUST_ACCESS);
-                context_attributes.push(khronos_egl::TRUE as _);
-            } else if display_extensions.contains("EGL_EXT_create_context_robustness") {
-                log::debug!("\tEGL context: +robust access EXT");
-                context_attributes.push(EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT);
-                context_attributes.push(khronos_egl::TRUE as _);
-            } else {
-                //Note: we aren't trying `EGL_CONTEXT_OPENGL_ROBUST_ACCESS_BIT_KHR`
-                // because it's for desktop GL only, not GLES.
-                log::warn!("\tEGL context: -robust access");
-            }
-        }
+
         if khr_context_flags != 0 {
             context_attributes.push(EGL_CONTEXT_FLAGS_KHR);
             context_attributes.push(khr_context_flags);
         }
-        context_attributes.push(khronos_egl::NONE);
 
         gl_context_attributes.extend(&context_attributes);
         gles_context_attributes.extend(&context_attributes);
 
-        let context = if supports_opengl {
-            egl.create_context(display, config, None, &gl_context_attributes)
-                .or_else(|_| {
-                    egl.bind_api(khronos_egl::OPENGL_ES_API).unwrap();
+        let context = {
+            enum Robustness {
+                Core,
+                Ext,
+            }
+
+            let mut robustness = if version >= (1, 5) {
+                Some(Robustness::Core)
+            } else if display_extensions.contains("EGL_EXT_create_context_robustness") {
+                Some(Robustness::Ext)
+            } else {
+                None
+            };
+
+            loop {
+                let robustness_attributes = match robustness {
+                    Some(Robustness::Core) => {
+                        vec![
+                            khronos_egl::CONTEXT_OPENGL_ROBUST_ACCESS,
+                            khronos_egl::TRUE as _,
+                            khronos_egl::NONE,
+                        ]
+                    }
+                    Some(Robustness::Ext) => {
+                        vec![
+                            EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT,
+                            khronos_egl::TRUE as _,
+                            khronos_egl::NONE,
+                        ]
+                    }
+                    None => vec![khronos_egl::NONE],
+                };
+
+                let mut gl_context_attributes = gl_context_attributes.clone();
+                gl_context_attributes.extend(&robustness_attributes);
+
+                let mut gles_context_attributes = gles_context_attributes.clone();
+                gles_context_attributes.extend(&robustness_attributes);
+
+                let result = if supports_opengl {
+                    egl.create_context(display, config, None, &gl_context_attributes)
+                        .or_else(|_| {
+                            egl.bind_api(khronos_egl::OPENGL_ES_API).unwrap();
+                            egl.create_context(display, config, None, &gles_context_attributes)
+                        })
+                } else {
                     egl.create_context(display, config, None, &gles_context_attributes)
-                })
-                .map_err(|e| {
-                    crate::InstanceError::with_source(
-                        String::from("unable to create OpenGL or GLES 3.x context"),
-                        e,
-                    )
-                })
-        } else {
-            egl.create_context(display, config, None, &gles_context_attributes)
-                .map_err(|e| {
-                    crate::InstanceError::with_source(
-                        String::from("unable to create GLES 3.x context"),
-                        e,
-                    )
-                })
+                };
+
+                match (result, robustness) {
+                    // We have a context at the requested robustness level
+                    (Ok(_), robustness) => {
+                        match robustness {
+                            Some(Robustness::Core) => {
+                                log::debug!("\tEGL context: +robust access");
+                            }
+                            Some(Robustness::Ext) => {
+                                log::debug!("\tEGL context: +robust access EXT");
+                            }
+                            None => {
+                                log::debug!("\tEGL context: -robust access");
+                            }
+                        }
+
+                        break result;
+                    }
+
+                    // BadAttribute could mean that context creation is not supported at the requested robustness level
+                    // We try the next robustness level.
+                    (Err(khronos_egl::Error::BadAttribute), Some(r)) => {
+                        // Trying EXT robustness if Core robustness is not working
+                        // and EXT robustness is supported.
+                        robustness = if matches!(r, Robustness::Core)
+                            && display_extensions.contains("EGL_EXT_create_context_robustness")
+                        {
+                            Some(Robustness::Ext)
+                        } else {
+                            None
+                        };
+
+                        continue;
+                    }
+
+                    // Any other error, or depleted robustness levels, we give up.
+                    _ => break result,
+                }
+            }
+            .map_err(|e| {
+                crate::InstanceError::with_source(
+                    String::from("unable to create OpenGL or GLES 3.x context"),
+                    e,
+                )
+            })
         }?;
 
         // Testing if context can be binded without surface


### PR DESCRIPTION
**What**

On certain devices, context creation would fail with the following log message: 
`Instance::new: failed to create Gl backend: InstanceError { message: "unable to create GLES 3.x context", source: Some(BadAttribute) }`

This would surface up to the client as a `RequestAdapterError::NotFound`

Typically, this would happen predominantly on Motorola devices (Moto G54 5G and Moto G73 5G) but also on some Samsung devices (Galaxy S24+), under both Android 14 and 15. 

**Why**

The root of the issue seem to be a misunderstanding of how robust context creation interplays with the EGL 1.5 specification. 
The current code assumes that if the EGL version is >= 1.5, then robustness must be supported (except for ANGLE specifically which apparently was already identified as being problematic and so was hardcoded to go to Ext directly).

However, from [the spec](https://registry.khronos.org/EGL/specs/eglspec.1.5.pdf) (section 3.7.1.5, emphasis mine)

> If the EGL_CONTEXT_OPENGL_ROBUST_ACCESS attribute is set to EGL_TRUE, a
context supporting robust buffer access will be created. OpenGL contexts must
support the GL_ARB_robustness extension, or equivalent core API functional-
ity. OpenGL ES contexts must support the GL_EXT_robustness extension, or
equivalent core API functionality. [...] **If the implementation does not support robust buffer access, context creation will fail.**

**How the fix works**

Unfortunately this is a bit of a cat-and-mouse game: we need to check the context extensions to know if the robustness parameter will be supported, and we need the robustness parameter to create the context...

The proposed fix simply tries Core -> Ext -> No robustness, in this order, starting from which makes the most sense (aka. Core if we have EGL >= 1.5, and then Ext if the EGL extension is defined), only retrying if the returned error is the specified `BAD_ATTRIBUTE`. 

Note: this eliminates the need for the hardcoded ANGLE IOP as it will fail with "Core" and go to "Ext", at which point it will supposedly succeed. In fact, the comment already had identified the correct underlying issue but simply built a specific IOP instead of a generic solution. 

Note 2: in practice it seems that most devices I am encountering the issue with fail with "Core" and succeed with "Ext" (just as ANGLE, which is a strange behavior admittedly). One could possibly exchange the Ext then Core checks as [it was done in a previous version of the code](https://github.com/gfx-rs/wgpu/commit/e867a7434ce7b2b84a4a7fe8e552589eb3511e37#diff-2c0fdad21ae97e53894aacfdce5561fa69a0f975b5af3188c98eeacd7d6fe815). It is not clear to me why the check was inverted in the linked commit, I'll let @kvark chime in. In any case, I believe this proposed solution is more robust (🥁)

**Testing**

Manually tested on some devices and rolled out to a subset of users for which the previous method was failing. 

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [x] ~`--target wasm32-unknown-unknown`~
- [X] Run `cargo xtask test` to run tests.
- [x] ~If this contains user-facing changes, add a `CHANGELOG.md` entry.~
