### PR TITLE
Fix detection of `local_invocation_id` for zero initialization of workgroup memory

### DIFF
--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -760,7 +760,7 @@ impl Writer {
                             .push(Instruction::load(type_id, id, varying_id, None));
                         constituent_ids.push(id);
 
-                        if binding == &crate::Binding::BuiltIn(crate::BuiltIn::GlobalInvocationId) {
+                        if binding == &crate::Binding::BuiltIn(crate::BuiltIn::LocalInvocationId) {
                             local_invocation_id = Some(id);
                         }
                     }


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/naga/pull/2259#discussion_r1557802159. Thanks @ErichDonGubler for reminding me! 😅 