### PR TITLE
Fix warnings from the nightly Rust compiler

### DIFF
--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -247,7 +247,7 @@ impl SurfaceWrapper {
         }
     }
 
-    fn get(&self) -> Option<&Surface> {
+    fn get(&self) -> Option<&'_ Surface<'static>> {
         self.surface.as_ref()
     }
 

--- a/naga/src/arena/unique_arena.rs
+++ b/naga/src/arena/unique_arena.rs
@@ -72,7 +72,7 @@ impl<T> UniqueArena<T> {
             .unwrap_or(&Span::default())
     }
 
-    pub(crate) fn drain_all(&mut self) -> UniqueArenaDrain<T> {
+    pub(crate) fn drain_all(&mut self) -> UniqueArenaDrain<'_, T> {
         UniqueArenaDrain {
             inner_elts: self.set.drain(..),
             inner_spans: self.span_info.drain(..),

--- a/naga/src/compact/functions.rs
+++ b/naga/src/compact/functions.rs
@@ -56,7 +56,7 @@ impl FunctionTracer<'_> {
         self.as_expression().trace_expressions();
     }
 
-    fn as_expression(&mut self) -> super::expressions::ExpressionTracer {
+    fn as_expression(&mut self) -> super::expressions::ExpressionTracer<'_> {
         super::expressions::ExpressionTracer {
             constants: self.constants,
             overrides: self.overrides,

--- a/naga/src/compact/mod.rs
+++ b/naga/src/compact/mod.rs
@@ -460,7 +460,7 @@ impl<'module> ModuleTracer<'module> {
         }
     }
 
-    fn as_type(&mut self) -> types::TypeTracer {
+    fn as_type(&mut self) -> types::TypeTracer<'_> {
         types::TypeTracer {
             overrides: &self.module.overrides,
             types_used: &mut self.types_used,
@@ -469,7 +469,7 @@ impl<'module> ModuleTracer<'module> {
         }
     }
 
-    fn as_const_expression(&mut self) -> expressions::ExpressionTracer {
+    fn as_const_expression(&mut self) -> expressions::ExpressionTracer<'_> {
         expressions::ExpressionTracer {
             constants: &self.module.constants,
             overrides: &self.module.overrides,

--- a/naga/src/front/spv/function.rs
+++ b/naga/src/front/spv/function.rs
@@ -603,7 +603,7 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
 }
 
 impl BlockContext<'_> {
-    pub(super) fn gctx(&self) -> crate::proc::GlobalCtx {
+    pub(super) fn gctx(&self) -> crate::proc::GlobalCtx<'_> {
         crate::proc::GlobalCtx {
             types: &self.module.types,
             constants: &self.module.constants,

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -466,7 +466,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
         }
     }
 
-    fn as_const_evaluator(&mut self) -> proc::ConstantEvaluator {
+    fn as_const_evaluator(&mut self) -> proc::ConstantEvaluator<'_> {
         match self.expr_type {
             ExpressionContextType::Runtime(ref mut rctx) => {
                 proc::ConstantEvaluator::for_wgsl_function(
@@ -513,7 +513,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
     fn as_diagnostic_display<T>(
         &self,
         value: T,
-    ) -> crate::common::DiagnosticDisplay<(T, proc::GlobalCtx)> {
+    ) -> crate::common::DiagnosticDisplay<(T, proc::GlobalCtx<'_>)> {
         let ctx = self.module.to_ctx();
         crate::common::DiagnosticDisplay((value, ctx))
     }
@@ -982,7 +982,7 @@ impl Components {
         }
     }
 
-    fn single_component(name: &str, name_span: Span) -> Result<u32> {
+    fn single_component(name: &str, name_span: Span) -> Result<'_, u32> {
         let ch = name.chars().next().ok_or(Error::BadAccessor(name_span))?;
         match Self::letter_component(ch) {
             Some(sc) => Ok(sc as u32),
@@ -993,7 +993,7 @@ impl Components {
     /// Construct a `Components` value from a 'member' name, like `"wzy"` or `"x"`.
     ///
     /// Use `name_span` for reporting errors in parsing the component string.
-    fn new(name: &str, name_span: Span) -> Result<Self> {
+    fn new(name: &str, name_span: Span) -> Result<'_, Self> {
         let size = match name.len() {
             1 => return Ok(Components::Single(Self::single_component(name, name_span)?)),
             2 => ir::VectorSize::Bi,

--- a/naga/src/front/wgsl/parse/directive/enable_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/enable_extension.rs
@@ -73,7 +73,7 @@ impl EnableExtension {
     const SUBGROUPS: &'static str = "subgroups";
 
     /// Convert from a sentinel word in WGSL into its associated [`EnableExtension`], if possible.
-    pub(crate) fn from_ident(word: &str, span: Span) -> Result<Self> {
+    pub(crate) fn from_ident(word: &str, span: Span) -> Result<'_, Self> {
         Ok(match word {
             Self::F16 => Self::Implemented(ImplementedEnableExtension::F16),
             Self::CLIP_DISTANCES => Self::Implemented(ImplementedEnableExtension::ClipDistances),

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -703,7 +703,7 @@ impl<'a> ConstantEvaluator<'a> {
         }
     }
 
-    pub fn to_ctx(&self) -> crate::proc::GlobalCtx {
+    pub fn to_ctx(&self) -> crate::proc::GlobalCtx<'_> {
         crate::proc::GlobalCtx {
             types: self.types,
             constants: self.constants,

--- a/naga/src/proc/namer.rs
+++ b/naga/src/proc/namer.rs
@@ -201,7 +201,7 @@ impl Namer {
         self.keywords_case_insensitive.extend(
             reserved_keywords_case_insensitive
                 .iter()
-                .map(|string| (AsciiUniCase(*string))),
+                .map(|string| AsciiUniCase(*string)),
         );
 
         // Choose fallback names for anonymous entry point return types.

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -40,7 +40,7 @@ pub(crate) struct CommandBufferTextureMemoryActions {
 }
 
 impl CommandBufferTextureMemoryActions {
-    pub(crate) fn drain_init_actions(&mut self) -> Drain<TextureInitTrackerAction> {
+    pub(crate) fn drain_init_actions(&mut self) -> Drain<'_, TextureInitTrackerAction> {
         self.init_actions.drain(..)
     }
 

--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -221,7 +221,7 @@ where
     }
 
     // Returns an iterator over the uninitialized ranges in a query range.
-    pub(crate) fn uninitialized(&mut self, drain_range: Range<Idx>) -> UninitializedIter<Idx> {
+    pub(crate) fn uninitialized(&mut self, drain_range: Range<Idx>) -> UninitializedIter<'_, Idx> {
         let index = self
             .uninitialized_ranges
             .partition_point(|r| r.end <= drain_range.start);
@@ -233,7 +233,7 @@ where
     }
 
     // Drains uninitialized ranges in a query range.
-    pub(crate) fn drain(&mut self, drain_range: Range<Idx>) -> InitTrackerDrain<Idx> {
+    pub(crate) fn drain(&mut self, drain_range: Range<Idx>) -> InitTrackerDrain<'_, Idx> {
         let index = self
             .uninitialized_ranges
             .partition_point(|r| r.end <= drain_range.start);

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -185,7 +185,7 @@ impl<T> Mutex<T> {
     }
 
     #[track_caller]
-    pub fn lock(&self) -> MutexGuard<T> {
+    pub fn lock(&self) -> MutexGuard<'_, T> {
         let saved = acquire(self.rank, Location::caller());
         MutexGuard {
             inner: self.inner.lock(),
@@ -256,7 +256,7 @@ impl<T> RwLock<T> {
     }
 
     #[track_caller]
-    pub fn read(&self) -> RwLockReadGuard<T> {
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
         let saved = acquire(self.rank, Location::caller());
         RwLockReadGuard {
             inner: self.inner.read(),
@@ -265,7 +265,7 @@ impl<T> RwLock<T> {
     }
 
     #[track_caller]
-    pub fn write(&self) -> RwLockWriteGuard<T> {
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
         let saved = acquire(self.rank, Location::caller());
         RwLockWriteGuard {
             inner: self.inner.write(),

--- a/wgpu-core/src/lock/vanilla.rs
+++ b/wgpu-core/src/lock/vanilla.rs
@@ -31,7 +31,7 @@ impl<T> Mutex<T> {
         Mutex(parking_lot::Mutex::new(value))
     }
 
-    pub fn lock(&self) -> MutexGuard<T> {
+    pub fn lock(&self) -> MutexGuard<'_, T> {
         MutexGuard(self.0.lock())
     }
 
@@ -87,11 +87,11 @@ impl<T> RwLock<T> {
         RwLock(parking_lot::RwLock::new(value))
     }
 
-    pub fn read(&self) -> RwLockReadGuard<T> {
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
         RwLockReadGuard(self.0.read())
     }
 
-    pub fn write(&self) -> RwLockWriteGuard<T> {
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
         RwLockWriteGuard(self.0.write())
     }
 

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -70,7 +70,7 @@ impl<T: StorageItem> FutureId<'_, T> {
 }
 
 impl<T: StorageItem> Registry<T> {
-    pub(crate) fn prepare(&self, id_in: Option<Id<T::Marker>>) -> FutureId<T> {
+    pub(crate) fn prepare(&self, id_in: Option<Id<T::Marker>>) -> FutureId<'_, T> {
         FutureId {
             id: match id_in {
                 Some(id_in) => {

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -143,7 +143,7 @@ impl SnatchLock {
 
     /// Request read access to snatchable resources.
     #[track_caller]
-    pub fn read(&self) -> SnatchGuard {
+    pub fn read(&self) -> SnatchGuard<'_> {
         LockTrace::enter("read");
         SnatchGuard(self.lock.read())
     }
@@ -154,7 +154,7 @@ impl SnatchLock {
     /// a high risk of causing lock contention if called concurrently with other
     /// wgpu work.
     #[track_caller]
-    pub fn write(&self) -> ExclusiveSnatchGuard {
+    pub fn write(&self) -> ExclusiveSnatchGuard<'_> {
         LockTrace::enter("write");
         ExclusiveSnatchGuard(self.lock.write())
     }


### PR DESCRIPTION
Mostly adding `'_` lifetime annotations to return types (I will say that `Result<'_>` looks pretty weird). Remove redundant parens in a closure in `naga/src/proc/namer.rs`. One of the returned lifetimes is `'static` in the very first fix in `examples/.../framework.rs`.

**Testing**
No functional changes.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
