### PR TITLE
[wgpu-core] remove implicit PL & BGL IDs from pipeline creation

### DIFF
--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -651,7 +651,7 @@ impl GPUDevice {
 
         let (id, err) =
             self.instance
-                .device_create_compute_pipeline(self.id, &wgpu_descriptor, None, None);
+                .device_create_compute_pipeline(self.id, &wgpu_descriptor, None);
 
         self.error_handler.push_error(err);
 
@@ -818,7 +818,7 @@ impl GPUDevice {
 
         let (id, err) =
             self.instance
-                .device_create_render_pipeline(self.id, &wgpu_descriptor, None, None);
+                .device_create_render_pipeline(self.id, &wgpu_descriptor, None);
 
         self.error_handler.push_error(err);
 

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -298,20 +298,8 @@ impl GlobalPlay for wgc::global::Global {
             Action::DestroyShaderModule(id) => {
                 self.shader_module_drop(id);
             }
-            Action::CreateComputePipeline {
-                id,
-                desc,
-                implicit_context,
-            } => {
-                let implicit_ids =
-                    implicit_context
-                        .as_ref()
-                        .map(|ic| wgc::device::ImplicitPipelineIds {
-                            root_id: ic.root_id,
-                            group_ids: &ic.group_ids,
-                        });
-                let (_, error) =
-                    self.device_create_compute_pipeline(device, &desc, Some(id), implicit_ids);
+            Action::CreateComputePipeline { id, desc } => {
+                let (_, error) = self.device_create_compute_pipeline(device, &desc, Some(id));
                 if let Some(e) = error {
                     panic!("{e}");
                 }
@@ -319,20 +307,8 @@ impl GlobalPlay for wgc::global::Global {
             Action::DestroyComputePipeline(id) => {
                 self.compute_pipeline_drop(id);
             }
-            Action::CreateRenderPipeline {
-                id,
-                desc,
-                implicit_context,
-            } => {
-                let implicit_ids =
-                    implicit_context
-                        .as_ref()
-                        .map(|ic| wgc::device::ImplicitPipelineIds {
-                            root_id: ic.root_id,
-                            group_ids: &ic.group_ids,
-                        });
-                let (_, error) =
-                    self.device_create_render_pipeline(device, &desc, Some(id), implicit_ids);
+            Action::CreateRenderPipeline { id, desc } => {
+                let (_, error) = self.device_create_render_pipeline(device, &desc, Some(id));
                 if let Some(e) = error {
                     panic!("{e}");
                 }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -3,8 +3,6 @@ use core::{fmt, num::NonZeroU32};
 
 use crate::{
     binding_model,
-    hub::Hub,
-    id::{BindGroupLayoutId, PipelineLayoutId},
     ray_tracing::BlasCompactReadyPendingClosure,
     resource::{
         Buffer, BufferAccessError, BufferAccessResult, BufferMapOperation, Labeled,
@@ -382,31 +380,6 @@ pub struct MissingDownlevelFlags(pub wgt::DownlevelFlags);
 impl WebGpuError for MissingDownlevelFlags {
     fn webgpu_error_type(&self) -> ErrorType {
         ErrorType::Validation
-    }
-}
-
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ImplicitPipelineContext {
-    pub root_id: PipelineLayoutId,
-    pub group_ids: ArrayVec<BindGroupLayoutId, { hal::MAX_BIND_GROUPS }>,
-}
-
-pub struct ImplicitPipelineIds<'a> {
-    pub root_id: PipelineLayoutId,
-    pub group_ids: &'a [BindGroupLayoutId],
-}
-
-impl ImplicitPipelineIds<'_> {
-    fn prepare(self, hub: &Hub) -> ImplicitPipelineContext {
-        ImplicitPipelineContext {
-            root_id: hub.pipeline_layouts.prepare(Some(self.root_id)).id(),
-            group_ids: self
-                .group_ids
-                .iter()
-                .map(|id_in| hub.bind_group_layouts.prepare(Some(*id_in)).id())
-                .collect(),
-        }
     }
 }
 

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -90,15 +90,11 @@ pub enum Action<'a> {
     CreateComputePipeline {
         id: id::ComputePipelineId,
         desc: crate::pipeline::ComputePipelineDescriptor<'a>,
-        #[cfg_attr(feature = "replay", serde(default))]
-        implicit_context: Option<super::ImplicitPipelineContext>,
     },
     DestroyComputePipeline(id::ComputePipelineId),
     CreateRenderPipeline {
         id: id::RenderPipelineId,
         desc: crate::pipeline::RenderPipelineDescriptor<'a>,
-        #[cfg_attr(feature = "replay", serde(default))]
-        implicit_context: Option<super::ImplicitPipelineContext>,
     },
     DestroyRenderPipeline(id::RenderPipelineId),
     CreatePipelineCache {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -190,10 +190,6 @@ pub type ImplicitBindGroupCount = u8;
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum ImplicitLayoutError {
-    #[error("The implicit_pipeline_ids arg is required")]
-    MissingImplicitPipelineIds,
-    #[error("Missing IDs for deriving {0} bind groups")]
-    MissingIds(ImplicitBindGroupCount),
     #[error("Unable to reflect the shader {0:?} interface")]
     ReflectionError(wgt::ShaderStages),
     #[error(transparent)]
@@ -205,9 +201,7 @@ pub enum ImplicitLayoutError {
 impl WebGpuError for ImplicitLayoutError {
     fn webgpu_error_type(&self) -> ErrorType {
         let e: &dyn WebGpuError = match self {
-            Self::MissingImplicitPipelineIds | Self::MissingIds(_) | Self::ReflectionError(_) => {
-                return ErrorType::Validation
-            }
+            Self::ReflectionError(_) => return ErrorType::Validation,
             Self::BindGroup(e) => e,
             Self::Pipeline(e) => e,
         };

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -3,7 +3,7 @@ use alloc::sync::Arc;
 use crate::{
     id::Id,
     identity::IdentityManager,
-    lock::{rank, RwLock, RwLockReadGuard, RwLockWriteGuard},
+    lock::{rank, RwLock, RwLockReadGuard},
     storage::{Element, Storage, StorageItem},
 };
 
@@ -55,6 +55,7 @@ pub(crate) struct FutureId<'a, T: StorageItem> {
 }
 
 impl<T: StorageItem> FutureId<'_, T> {
+    #[cfg(feature = "trace")]
     pub fn id(&self) -> Id<T::Marker> {
         self.id
     }
@@ -86,10 +87,6 @@ impl<T: StorageItem> Registry<T> {
     #[track_caller]
     pub(crate) fn read<'a>(&'a self) -> RwLockReadGuard<'a, Storage<T>> {
         self.storage.read()
-    }
-    #[track_caller]
-    pub(crate) fn write<'a>(&'a self) -> RwLockWriteGuard<'a, Storage<T>> {
-        self.storage.write()
     }
     pub(crate) fn remove(&self, id: Id<T::Marker>) -> T {
         let value = self.storage.write().remove(id);

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1321,10 +1321,10 @@ impl dispatch::DeviceInterface for CoreDevice {
             cache: desc.cache.map(|cache| cache.inner.as_core().id),
         };
 
-        let (id, error) =
-            self.context
-                .0
-                .device_create_render_pipeline(self.id, &descriptor, None, None);
+        let (id, error) = self
+            .context
+            .0
+            .device_create_render_pipeline(self.id, &descriptor, None);
         if let Some(cause) = error {
             if let wgc::pipeline::CreateRenderPipelineError::Internal { stage, ref error } = cause {
                 log::error!("Shader translation error for stage {:?}: {}", stage, error);
@@ -1372,10 +1372,10 @@ impl dispatch::DeviceInterface for CoreDevice {
             cache: desc.cache.map(|cache| cache.inner.as_core().id),
         };
 
-        let (id, error) =
-            self.context
-                .0
-                .device_create_compute_pipeline(self.id, &descriptor, None, None);
+        let (id, error) = self
+            .context
+            .0
+            .device_create_compute_pipeline(self.id, &descriptor, None);
         if let Some(cause) = error {
             if let wgc::pipeline::CreateComputePipelineError::Internal(ref error) = cause {
                 log::error!(


### PR DESCRIPTION
These are no longer needed since wgpu-core can now create the PL & BGLs without needing IDs.