### PR TITLE
BADHACK: gles/egl: Require surface before creating instance / query adapter on Wayland

### DIFF
--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -141,10 +141,16 @@ impl SurfaceWrapper {
     /// On wasm, we need to create the surface here, as the WebGL backend needs
     /// a surface (and hence a canvas) to be present to create the adapter.
     ///
+    /// On Wayland our context creation (both inside the [`Instance`] and [`Adapter`]) requires
+    /// access to the `RawDisplayHandle`.  Since this is currently not provided, a compatible
+    /// context is set up via the surface instead.
+    ///
     /// We cannot unconditionally create a surface here, as Android requires
-    /// us to wait until we receive the `Resumed` event to do so.
+    /// us to wait until we receive [`Event::Resumed`] to do so.
     fn pre_adapter(&mut self, instance: &Instance, window: Arc<Window>) {
-        if cfg!(target_arch = "wasm32") {
+        // XXX: Also needed for EGL+Wayland!
+        // if cfg!(target_arch = "wasm32") {
+        if !cfg!(target_os = "android") {
             self.surface = Some(instance.create_surface(window).unwrap());
         }
     }
@@ -153,6 +159,8 @@ impl SurfaceWrapper {
     fn start_condition(e: &Event<()>) -> bool {
         match e {
             // On all other platforms, we can create the surface immediately.
+            // XXX: winit was improved to consistently emit a Resumed event on all platforms, which
+            // is the right place to create surfaces...  Most platforms emit it right after Init.
             Event::NewEvents(StartCause::Init) => !cfg!(target_os = "android"),
             // On android we need to wait for a resumed event to create the surface.
             Event::Resumed => cfg!(target_os = "android"),
@@ -174,13 +182,9 @@ impl SurfaceWrapper {
         log::info!("Surface resume {window_size:?}");
 
         // We didn't create the surface in pre_adapter, so we need to do so now.
-        if !cfg!(target_arch = "wasm32") {
-            self.surface = Some(context.instance.create_surface(window).unwrap());
-        }
-
-        // From here on, self.surface should be Some.
-
-        let surface = self.surface.as_ref().unwrap();
+        let surface = self
+            .surface
+            .get_or_insert_with(|| context.instance.create_surface(window).unwrap());
 
         // Get the default configuration,
         let mut config = surface

--- a/examples/features/src/utils.rs
+++ b/examples/features/src/utils.rs
@@ -203,23 +203,28 @@ pub(crate) async fn get_adapter_with_capabilities_or_from_env(
             );
         adapter
     } else {
-        let adapters = instance.enumerate_adapters(Backends::all());
-
         let mut chosen_adapter = None;
-        for adapter in adapters {
-            if let Some(surface) = surface {
-                if !adapter.is_surface_supported(surface) {
-                    continue;
-                }
-            }
 
-            let required_features = *required_features;
-            let adapter_features = adapter.features();
-            if !adapter_features.contains(required_features) {
-                continue;
-            } else {
-                chosen_adapter = Some(adapter);
-                break;
+        if let Some(surface) = surface {
+            chosen_adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptionsBase {
+                    compatible_surface: Some(surface),
+                    ..Default::default()
+                })
+                .await
+                .ok();
+        } else {
+            let adapters = instance.enumerate_adapters(Backends::all());
+
+            for adapter in adapters {
+                let required_features = *required_features;
+                let adapter_features = adapter.features();
+                if !adapter_features.contains(required_features) {
+                    continue;
+                } else {
+                    chosen_adapter = Some(adapter);
+                    break;
+                }
             }
         }
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -291,6 +291,12 @@ struct EglContext {
 
 impl EglContext {
     fn make_current(&self) {
+        log::trace!(
+            "Make current on {:?} {:?} {:?}",
+            self.display,
+            self.pbuffer,
+            self.raw
+        );
         self.instance
             .make_current(self.display, self.pbuffer, self.pbuffer, Some(self.raw))
             .unwrap();
@@ -697,6 +703,7 @@ impl Inner {
             version,
             supports_native_window,
             config,
+            // Will in some scenarios be overwritten by the caller after this function returns.
             wl_display: None,
             srgb_kind,
             force_gles_minor_version,
@@ -839,7 +846,10 @@ impl crate::Instance for Instance {
 
         let (display, display_owner, wsi_kind) =
             if let (Some(library), Some(egl)) = (wayland_library, egl1_5) {
-                log::info!("Using Wayland platform");
+                // XXX: Drop this code and convert `Inner` to an `Option` so that we can
+                // force-initialize this whenever the "RawDisplayHandle" is available (currently
+                // only via the surface)...
+                log::error!("Using Wayland platform, creating nonfunctional bogus display first");
                 let display_attributes = [khronos_egl::ATTRIB_NONE];
                 let display = unsafe {
                     egl.get_platform_display(
@@ -969,6 +979,7 @@ impl crate::Instance for Instance {
                     )
                     .unwrap();
 
+                // TODO: Why?
                 let ret = unsafe {
                     ndk_sys::ANativeWindow_setBuffersGeometry(
                         handle
@@ -1013,6 +1024,7 @@ impl crate::Instance for Instance {
                             .unwrap()
                             .get_platform_display(
                                 EGL_PLATFORM_WAYLAND_KHR,
+                                // khronos_egl::DEFAULT_DISPLAY,
                                 display_handle.display.as_ptr(),
                                 &display_attributes,
                             )
@@ -1056,9 +1068,22 @@ impl crate::Instance for Instance {
 
     unsafe fn enumerate_adapters(
         &self,
-        _surface_hint: Option<&Surface>,
+        surface_hint: Option<&Surface>,
     ) -> Vec<crate::ExposedAdapter<super::Api>> {
         let inner = self.inner.lock();
+
+        if let Some(surface) = surface_hint {
+            assert_eq!(surface.egl.raw, inner.egl.raw);
+        } else
+        // if inner.??? == Wayland
+        {
+            // This is a trick from Web, but it's too restrictive and not needed if the user
+            // initializes in the right order.
+            // TODO: We can probably also allow the user through if inner.wl_surface is not NULL?
+            log::info!("Returning zero adapters on Wayland unless a surface is passed");
+            return vec![];
+        }
+
         inner.egl.make_current();
 
         let mut gl = unsafe {
@@ -1313,6 +1338,7 @@ impl crate::Surface for Surface {
                         let wl_egl_window_create: libloading::Symbol<WlEglWindowCreateFun> =
                             unsafe { library.get(c"wl_egl_window_create".to_bytes()) }.unwrap();
                         let window =
+                        // XXX: Why hardcode a random size here, over using config.extent?
                             unsafe { wl_egl_window_create(handle.surface.as_ptr(), 640, 480) }
                                 .cast();
                         wl_window = Some(window);

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -361,7 +361,7 @@ pub struct RequestAdapterOptions<S> {
     pub force_fallback_adapter: bool,
     /// Surface that is required to be presentable with the requested adapter. This does not
     /// create the surface, only guarantees that the adapter can present to said surface.
-    /// For WebGL, this is strictly required, as an adapter can not be created without a surface.
+    /// For WebGL and Wayland, this is strictly required, as an adapter can not be created without a surface.
     pub compatible_surface: Option<S>,
 }
 


### PR DESCRIPTION
**Connections**
Fixes #5505
Could address #3176 if we make `Inner` an `Option`
Fixes https://github.com/gfx-rs/wgpu/discussions/7965

**Description**

In `egl`, `Inner` has been made `Clone` in #2350, and prior to that some EGL fields were copied into `AdapterContext` since #1729.

At the same time `wgpu` to this day doesn't seem to accept a `RawDisplayHandle` when **creating an `Instance`**, meaning that on Wayland at least we end up creating a bogus `EGLDisplay` (and respective GL context) that isn't compatible with the window/surface that the user later wants `wgpu` to present to (not to mention, the user/caller has _zero_ control over the Wayland or other connection to use, this is all hardcoded based on library detection and [connecting to the default Wayland socket](https://github.com/gfx-rs/wgpu/blob/96ef5ecaa449ee11af51c9469ec40f98452834a1/wgpu-hal/src/gles/egl.rs#L185)...).

Each time `wl_display_connect()` is called, which is likely also what happens internally when `EGL_DEFAULT_DISPLAY` is passed for `EGL_PLATFORM_WAYLAND_KHR`, a different and incompatible display connection is used. Even if `wgpu`'s `test_wayland_display()` would have connected to the same Wayland server as `eglGetPlatformDisplay(WAYLAND, DEFAULT_DISPLAY)` and the one the caller uses for its surface, these cannot be used interchangeably.

To patch up this bogus display, https://github.com/gfx-rs/gfx/pull/3545 inserted some logic to **replace the internal `EGLDisplay` and GL context** whenever a surface is created which _does receive a `RawDisplayHandle`_ with the correct `wl_display` handle to use to be compatible with the given `wl_surface`:

https://github.com/gfx-rs/wgpu/blob/96ef5ecaa449ee11af51c9469ec40f98452834a1/wgpu-hal/src/gles/egl.rs#L991-L1034

Now all the way back to the first sentence, about cloning a bunch of EGL handles. The problem mainly occurs when the user either enumerated `Adapter`s before this operation, and worse if they started creating resources on it. Because of this clone:

https://github.com/gfx-rs/wgpu/blob/96ef5ecaa449ee11af51c9469ec40f98452834a1/wgpu-hal/src/gles/egl.rs#L1100-L1103

Those adapters have the old `EGLDisplay` and old GL context. Which we **just closed** when replacing `Inner` with the "new `wl_display`-based" `EGLDisplay` and context:

https://github.com/gfx-rs/wgpu/blob/96ef5ecaa449ee11af51c9469ec40f98452834a1/wgpu-hal/src/gles/egl.rs#L707-L721

**Whenever the user now uses the adapter to make the context current, a `BadDisplay` / `BadContext` error is generated because the context and display handles are both destroyed.**

To solve that, one of the proposed solutions was to follow what Web does: require a surface when enumerating `Adapter`s so that the right `EGLDisplay` is copied over. This is however overly restrictive:
- After creating a surface, the internals are updated and a surface no longer needs to be passed when enumerating surfaces.
- A surface (typically from a window) shouldn't be needed at all, if merely the `RawDisplayHandle` could be passed.

For now, see if this unblocks folks while we work on a more likable solution. Stay tuned.

**Testing**
`amdgpu` with Wayland compositor, with e.g.;

```shell
WGPU_BACKEND=gl cargo r -p wgpu-examples -- shadow
```

**Squash or Rebase?**

rebase

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
