### PR TITLE
Small changes to facilitate fuzzing

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -435,16 +435,20 @@ impl RenderBundleEncoder {
                     .map_pass_err(scope)?;
                 }
                 RenderCommand::DrawIndirect { .. }
-                | RenderCommand::MultiDrawIndirectCount { .. } => unimplemented!(),
-                RenderCommand::PushDebugGroup { color: _, len: _ } => unimplemented!(),
-                RenderCommand::InsertDebugMarker { color: _, len: _ } => unimplemented!(),
-                RenderCommand::PopDebugGroup => unimplemented!(),
+                | RenderCommand::MultiDrawIndirectCount { .. }
+                | RenderCommand::PushDebugGroup { color: _, len: _ }
+                | RenderCommand::InsertDebugMarker { color: _, len: _ }
+                | RenderCommand::PopDebugGroup => {
+                    unimplemented!("not supported by a render bundle")
+                }
                 // Must check the TIMESTAMP_QUERY_INSIDE_PASSES feature
                 RenderCommand::WriteTimestamp { .. }
                 | RenderCommand::BeginOcclusionQuery { .. }
                 | RenderCommand::EndOcclusionQuery
                 | RenderCommand::BeginPipelineStatisticsQuery { .. }
-                | RenderCommand::EndPipelineStatisticsQuery => unimplemented!(),
+                | RenderCommand::EndPipelineStatisticsQuery => {
+                    unimplemented!("not supported by a render bundle")
+                }
                 RenderCommand::ExecuteBundle(_)
                 | RenderCommand::SetBlendConstant(_)
                 | RenderCommand::SetStencilReference(_)

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -34,16 +34,20 @@ const _: () = {
 #[cfg_attr(
     any(feature = "serde", feature = "replay"),
     derive(serde::Deserialize),
-    serde(from = "SerialId")
+    serde(try_from = "SerialId")
 )]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RawId(NonZeroU64);
 
 impl RawId {
     /// Zip together an identifier and return its raw underlying representation.
+    ///
+    /// # Panics
+    ///
+    /// If both ID components are zero.
     pub fn zip(index: Index, epoch: Epoch) -> RawId {
         let v = (index as u64) | ((epoch as u64) << 32);
-        Self(NonZeroU64::new(v).unwrap())
+        Self(NonZeroU64::new(v).expect("IDs may not be zero"))
     }
 
     /// Unzip a raw identifier into its components.
@@ -101,10 +105,22 @@ impl From<RawId> for SerialId {
     }
 }
 
-impl From<SerialId> for RawId {
-    fn from(id: SerialId) -> Self {
-        match id {
-            SerialId::Id(index, epoch) => RawId::zip(index, epoch),
+pub struct ZeroIdError;
+
+impl fmt::Display for ZeroIdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "IDs may not be zero")
+    }
+}
+
+impl TryFrom<SerialId> for RawId {
+    type Error = ZeroIdError;
+    fn try_from(id: SerialId) -> Result<Self, ZeroIdError> {
+        let SerialId::Id(index, epoch) = id;
+        if index == 0 && epoch == 0 {
+            Err(ZeroIdError)
+        } else {
+            Ok(RawId::zip(index, epoch))
         }
     }
 }

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -94,7 +94,11 @@ where
 
     pub(crate) fn remove(&mut self, id: Id<T::Marker>) -> T {
         let (index, epoch) = id.unzip();
-        match mem::replace(&mut self.map[index as usize], Element::Vacant) {
+        let stored = self
+            .map
+            .get_mut(index as usize)
+            .unwrap_or_else(|| panic!("{}[{:?}] does not exist", self.kind, id));
+        match mem::replace(stored, Element::Vacant) {
             Element::Occupied(value, storage_epoch) => {
                 assert_eq!(epoch, storage_epoch, "id epoch mismatch");
                 value


### PR DESCRIPTION
My fuzzing setup is still WIP and not in a condition to merge, but these changes are small and can stand alone.

* Avoid a crash if deserializing a zero ID from a trace
* Make some crash messages more distinctive so it's easier to catch and identify them.

**Testing**
Not a lot to test here but I have exercised it locally.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
