### PR TITLE
hal/vulkan: generate separate hash identity for Texture/TextureViews

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -2162,6 +2162,9 @@ impl super::Adapter {
                 self.private_caps.maximum_samplers,
             )),
             memory_allocations_counter: Default::default(),
+
+            texture_identity_factory: super::ResourceIdentityFactory::new(),
+            texture_view_identity_factory: super::ResourceIdentityFactory::new(),
         });
 
         let relay_semaphores = super::RelaySemaphores::new(&shared)?;

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -61,7 +61,8 @@ impl super::CommandEncoder {
             Entry::Vacant(e) => {
                 let super::FramebufferKey {
                     raw_pass,
-                    ref attachments,
+                    ref attachment_views,
+                    attachment_identities: _,
                     extent,
                 } = *e.key();
 
@@ -70,7 +71,7 @@ impl super::CommandEncoder {
                     .width(extent.width)
                     .height(extent.height)
                     .layers(extent.depth_or_array_layers)
-                    .attachments(attachments);
+                    .attachments(attachment_views);
 
                 let raw = unsafe { self.device.raw.create_framebuffer(&vk_info, None).unwrap() };
                 *e.insert(raw)
@@ -81,12 +82,13 @@ impl super::CommandEncoder {
     fn make_temp_texture_view(
         &mut self,
         key: super::TempTextureViewKey,
-    ) -> Result<vk::ImageView, crate::DeviceError> {
+    ) -> Result<super::IdentifiedTextureView, crate::DeviceError> {
         Ok(match self.temp_texture_views.entry(key) {
             Entry::Occupied(e) => *e.get(),
             Entry::Vacant(e) => {
                 let super::TempTextureViewKey {
                     texture,
+                    texture_identity: _,
                     format,
                     mip_level,
                     depth_slice,
@@ -105,7 +107,10 @@ impl super::CommandEncoder {
                     });
                 let raw = unsafe { self.device.raw.create_image_view(&vk_info, None) }
                     .map_err(super::map_host_device_oom_and_ioca_err)?;
-                *e.insert(raw)
+
+                let identity = self.device.texture_view_identity_factory.next();
+
+                *e.insert(super::IdentifiedTextureView { raw, identity })
             }
         })
     }
@@ -779,7 +784,8 @@ impl crate::CommandEncoder for super::CommandEncoder {
         };
         let mut fb_key = super::FramebufferKey {
             raw_pass: vk::RenderPass::null(),
-            attachments: ArrayVec::default(),
+            attachment_views: ArrayVec::default(),
+            attachment_identities: ArrayVec::default(),
             extent: desc.extent,
         };
 
@@ -788,13 +794,14 @@ impl crate::CommandEncoder for super::CommandEncoder {
                 let color_view = if cat.target.view.dimension == wgt::TextureViewDimension::D3 {
                     let key = super::TempTextureViewKey {
                         texture: cat.target.view.raw_texture,
+                        texture_identity: cat.target.view.texture_identity,
                         format: cat.target.view.raw_format,
                         mip_level: cat.target.view.base_mip_level,
                         depth_slice: cat.depth_slice.unwrap(),
                     };
                     self.make_temp_texture_view(key)?
                 } else {
-                    cat.target.view.raw
+                    cat.target.view.identified_raw_view()
                 };
 
                 vk_clear_values.push(vk::ClearValue {
@@ -809,10 +816,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
                 };
 
                 rp_key.colors.push(Some(color));
-                fb_key.attachments.push(color_view);
+                fb_key.push_view(color_view);
                 if let Some(ref at) = cat.resolve_target {
                     vk_clear_values.push(unsafe { mem::zeroed() });
-                    fb_key.attachments.push(at.view.raw);
+                    fb_key.push_view(at.view.identified_raw_view());
                 }
 
                 // Assert this attachment is valid for the detected multiview, as a sanity check
@@ -838,7 +845,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                 base: ds.target.make_attachment_key(ds.depth_ops),
                 stencil_ops: ds.stencil_ops,
             });
-            fb_key.attachments.push(ds.target.view.raw);
+            fb_key.push_view(ds.target.view.identified_raw_view());
 
             // Assert this attachment is valid for the detected multiview, as a sanity check
             // The driver crash for this is really bad on AMD, so the check is worth it

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -1139,6 +1139,8 @@ impl crate::Surface for super::Surface {
             return Err(crate::SurfaceError::Outdated);
         }
 
+        let identity = swapchain.device.texture_identity_factory.next();
+
         let texture = super::SurfaceTexture {
             index,
             texture: super::Texture {
@@ -1152,6 +1154,7 @@ impl crate::Surface for super::Surface {
                     height: swapchain.config.extent.height,
                     depth: 1,
                 },
+                identity,
             },
             surface_semaphores: swapchain_semaphores_arc,
         };


### PR DESCRIPTION
**Connections**

Closes #7922
Closes #7956

**Description**

Previously we used the raw handle for equality/hash value for textures and texture views. This worked fine as long as the handles we are given are unique. However, if the implementation re-uses handles after we delete the views, as it has full right to do, we will use an old VkFramebuffer, causing a use-after-free.

**Testing**
Ran against renderdoc and against the reproduction provided in #7922.

**Squash or Rebase?**

Squabase

Going to add a changelog entry on backport,