### PR TITLE
Update CTS job to run on trunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,13 @@ name: CI
 on:
   push:
     branches-ignore: [
-        # We don't need to run on renovate PRs.
+        # Renovate branches are always PRs, so they will be covered
+        # by the pull_request event.
         "renovate/**",
-        # This is the branch the merge queue creates.
+        # Branches with the `gh-readonly-queue` prefix are used by the
+        # merge queue, so they are already covered by the `merge_group` event.
         "gh-readonly-queue/**",
       ]
-    tags: [v0.*]
   pull_request:
   merge_group:
 

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -1,11 +1,17 @@
 name: CTS
 
 on:
+  push:
+    branches-ignore: [
+        # Renovate branches are always PRs, so they will be covered
+        # by the pull_request event.
+        "renovate/**",
+        # Branches with the `gh-readonly-queue` prefix are used by the
+        # merge queue, so they are already covered by the `merge_group` event.
+        "gh-readonly-queue/**",
+      ]
   pull_request:
-    types: [labeled, opened, synchronize]
-  schedule:
-    - cron: "33 2 * * *"
-  workflow_dispatch:
+  merge_group:
 
 env:
   CARGO_INCREMENTAL: false

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -2,8 +2,14 @@ name: cargo-generate
 
 on:
   push:
-    branches: ["*"]
-    tags: [v0.*]
+    branches-ignore: [
+        # Renovate branches are always PRs, so they will be covered
+        # by the pull_request event.
+        "renovate/**",
+        # Branches with the `gh-readonly-queue` prefix are used by the
+        # merge queue, so they are already covered by the `merge_group` event.
+        "gh-readonly-queue/**",
+      ]
   pull_request:
   merge_group:
 

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -3,12 +3,13 @@ name: Shaders
 on:
   push:
     branches-ignore: [
-        # We don't need to run on renovate PRs.
+        # Renovate branches are always PRs, so they will be covered
+        # by the pull_request event.
         "renovate/**",
-        # This is the branch the merge queue creates.
+        # Branches with the `gh-readonly-queue` prefix are used by the
+        # merge queue, so they are already covered by the `merge_group` event.
         "gh-readonly-queue/**",
       ]
-    tags: [v0.*]
   pull_request:
   merge_group:
 


### PR DESCRIPTION
Previously we had only run it on a cron, but we run it on every PR, so run it on every commit on trunk too.