### PR TITLE
fix(core): validate `sample_count` is 1 in `Queue::write_texture`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ By @Vecvec in [#7913](https://github.com/gfx-rs/wgpu/pull/7913).
 
 Naga now requires that no type be larger than 1 GB. This limit may be lowered in the future; feedback on an appropriate value for the limit is welcome. By @andyleiserson in [#7950](https://github.com/gfx-rs/wgpu/pull/7950).
 
+### Bug Fixes
+
+#### General
+
+- Validate `sample_count` is 1 in `Queue::write_texture`. By @ErichDonGubler in [????](https://github.com/gfx-rs/wgpu/pull/????).
+
 ## v26.0.1 (2025-07-10)
 
 ### Bug Fixes

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -53,6 +53,7 @@ webgpu:api,validation,image_copy,texture_related:format:dimension="1d";*
 webgpu:api,validation,queue,submit:command_buffer,device_mismatch:*
 webgpu:api,validation,queue,submit:command_buffer,duplicate_buffers:*
 webgpu:api,validation,queue,submit:command_buffer,submit_invalidates:*
+webgpu:api,validation,queue,writeTexture:sample_count:*
 //FAIL: webgpu:api,validation,queue,submit:command_buffer,invalid_submit_invalidates:*
 // https://github.com/gfx-rs/wgpu/issues/3911#issuecomment-2972995675
 webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -732,6 +732,13 @@ impl Queue {
 
         self.same_device_as(dst.as_ref())?;
 
+        if dst.desc.sample_count != 1 {
+            return Err(TransferError::InvalidSampleCount {
+                sample_count: dst.desc.sample_count,
+            }
+            .into());
+        }
+
         dst.check_usage(wgt::TextureUsages::COPY_DST)
             .map_err(TransferError::MissingTextureUsage)?;
 


### PR DESCRIPTION
This is a missing piece of the ["validating texture buffer copy" routine](https://www.w3.org/TR/webgpu/#abstract-opdef-validating-texture-buffer-copy), which is currently not outlined in the same way as the WebGPU spec.

It's almost certainly better to refactor `writeTexture` and other copy commands so that we can capture the routine and properly share it between different standard operations. This commit leaves this as future work, only fixing the missing validation in `writeTexture.`

**Connections**

- This was detected by runs of Firefox against the [`webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*`](https://gpuweb.github.io/cts/standalone/?q=webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*) CTS test.

**Squash or Rebase?**

Squash.

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
