### PR TITLE
[core] fix missing applies of `DISCARD_HAL_LABELS`

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -756,7 +756,10 @@ impl Global {
             //
             // Use that buffer to insert barriers and clear discarded images.
             let transit = encoder
-                .open_pass(Some("(wgpu internal) Pre Pass"))
+                .open_pass(hal_label(
+                    Some("(wgpu internal) Pre Pass"),
+                    self.instance.flags,
+                ))
                 .map_pass_err(pass_scope)?;
             fixup_discarded_surfaces(
                 pending_discard_init_fixups.into_iter(),

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -149,6 +149,7 @@ pub(crate) fn fixup_discarded_surfaces<InitIter: Iterator<Item = TextureSurfaceD
             &device.alignments,
             device.zero_buffer.as_ref(),
             snatch_guard,
+            device.instance_flags,
         )
         .unwrap();
     }
@@ -304,6 +305,7 @@ impl BakedCommands {
                     &device.alignments,
                     device.zero_buffer.as_ref(),
                     snatch_guard,
+                    device.instance_flags,
                 );
 
                 // A Texture can be destroyed between the command recording

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -565,7 +565,7 @@ impl InnerCommandEncoder {
     pub(crate) fn open(&mut self) -> Result<&mut dyn hal::DynCommandEncoder, DeviceError> {
         if !self.is_open {
             self.is_open = true;
-            let hal_label = hal_label(Some(&self.label), self.device.instance_flags);
+            let hal_label = hal_label(Some(self.label.as_str()), self.device.instance_flags);
             unsafe { self.raw.begin_encoding(hal_label) }
                 .map_err(|e| self.device.handle_hal_error(e))?;
         }

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -554,6 +554,7 @@ fn handle_texture_init(
                 &device.alignments,
                 device.zero_buffer.as_ref(),
                 snatch_guard,
+                device.instance_flags,
             )?;
         }
     }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -27,6 +27,7 @@ use crate::{
     device::{DeviceError, WaitIdleError},
     get_lowest_common_denom,
     global::Global,
+    hal_label,
     id::{self, BlasId, QueueId},
     init_tracker::{has_copy_partial_init_tracker_coverage, TextureInitRange},
     lock::{rank, Mutex, MutexGuard, RwLock, RwLockWriteGuard},
@@ -57,6 +58,7 @@ impl Queue {
     pub(crate) fn new(
         device: Arc<Device>,
         raw: Box<dyn hal::DynQueue>,
+        instance_flags: wgt::InstanceFlags,
     ) -> Result<Self, DeviceError> {
         let pending_encoder = device
             .command_allocator
@@ -70,7 +72,7 @@ impl Queue {
             }
         };
 
-        let mut pending_writes = PendingWrites::new(pending_encoder);
+        let mut pending_writes = PendingWrites::new(pending_encoder, instance_flags);
 
         let zero_buffer = device.zero_buffer.as_ref();
         pending_writes.activate();
@@ -328,10 +330,14 @@ pub(crate) struct PendingWrites {
     dst_buffers: FastHashMap<TrackerIndex, Arc<Buffer>>,
     dst_textures: FastHashMap<TrackerIndex, Arc<Texture>>,
     copied_blas_s: FastHashMap<TrackerIndex, Arc<Blas>>,
+    instance_flags: wgt::InstanceFlags,
 }
 
 impl PendingWrites {
-    pub fn new(command_encoder: Box<dyn hal::DynCommandEncoder>) -> Self {
+    pub fn new(
+        command_encoder: Box<dyn hal::DynCommandEncoder>,
+        instance_flags: wgt::InstanceFlags,
+    ) -> Self {
         Self {
             command_encoder,
             is_recording: false,
@@ -339,6 +345,7 @@ impl PendingWrites {
             dst_buffers: FastHashMap::default(),
             dst_textures: FastHashMap::default(),
             copied_blas_s: FastHashMap::default(),
+            instance_flags,
         }
     }
 
@@ -423,7 +430,10 @@ impl PendingWrites {
         if !self.is_recording {
             unsafe {
                 self.command_encoder
-                    .begin_encoding(Some("(wgpu internal) PendingWrites"))
+                    .begin_encoding(hal_label(
+                        Some("(wgpu internal) PendingWrites"),
+                        self.instance_flags,
+                    ))
                     .unwrap();
             }
             self.is_recording = true;
@@ -812,6 +822,7 @@ impl Queue {
                         &self.device.alignments,
                         self.device.zero_buffer.as_ref(),
                         &snatch_guard,
+                        self.device.instance_flags,
                     )
                     .map_err(QueueWriteError::from)?;
                 }
@@ -1064,6 +1075,7 @@ impl Queue {
                         &self.device.alignments,
                         self.device.zero_buffer.as_ref(),
                         &self.device.snatchable_lock.read(),
+                        self.device.instance_flags,
                     )
                     .map_err(QueueWriteError::from)?;
                 }
@@ -1217,7 +1229,10 @@ impl Queue {
                         };
 
                         // execute resource transitions
-                        if let Err(e) = baked.encoder.open_pass(Some("(wgpu internal) Transit")) {
+                        if let Err(e) = baked.encoder.open_pass(hal_label(
+                            Some("(wgpu internal) Transit"),
+                            self.device.instance_flags,
+                        )) {
                             break 'error Err(e.into());
                         }
 
@@ -1252,8 +1267,10 @@ impl Queue {
                         // Note: we could technically do it after all of the command buffers,
                         // but here we have a command encoder by hand, so it's easier to use it.
                         if !used_surface_textures.is_empty() {
-                            if let Err(e) = baked.encoder.open_pass(Some("(wgpu internal) Present"))
-                            {
+                            if let Err(e) = baked.encoder.open_pass(hal_label(
+                                Some("(wgpu internal) Present"),
+                                self.device.instance_flags,
+                            )) {
                                 break 'error Err(e.into());
                             }
                             let texture_barriers = trackers

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -8,6 +8,7 @@ use crate::{
     api_log,
     device::Device,
     global::Global,
+    hal_label,
     id::{self, BlasId, TlasId},
     lock::RwLock,
     lock::{rank, Mutex},
@@ -231,7 +232,7 @@ impl Device {
             self.alignments.raw_tlas_instance_size * desc.max_instances.max(1) as usize;
         let instance_buffer = unsafe {
             self.raw().create_buffer(&hal::BufferDescriptor {
-                label: Some("(wgpu-core) instances_buffer"),
+                label: hal_label(Some("(wgpu-core) instances_buffer"), self.instance_flags),
                 size: instance_buffer_size as u64,
                 usage: wgt::BufferUses::COPY_DST
                     | wgt::BufferUses::TOP_LEVEL_ACCELERATION_STRUCTURE_INPUT,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -776,7 +776,7 @@ impl Adapter {
         let device = Device::new(hal_device.device, self, desc, instance_flags)?;
         let device = Arc::new(device);
 
-        let queue = Queue::new(device.clone(), hal_device.queue)?;
+        let queue = Queue::new(device.clone(), hal_device.queue, instance_flags)?;
         let queue = Arc::new(queue);
 
         device.set_queue(&queue);

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -141,7 +141,7 @@ impl<'a> LabelHelpers<'a> for Label<'a> {
     }
 }
 
-pub fn hal_label(opt: Option<&str>, flags: wgt::InstanceFlags) -> Option<&str> {
+pub fn hal_label<T: AsRef<str>>(opt: Option<T>, flags: wgt::InstanceFlags) -> Option<T> {
     if flags.contains(wgt::InstanceFlags::DISCARD_HAL_LABELS) {
         return None;
     }

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -177,7 +177,10 @@ impl Surface {
                 drop(fence);
 
                 let texture_desc = wgt::TextureDescriptor {
-                    label: Some(alloc::borrow::Cow::Borrowed("<Surface Texture>")),
+                    label: hal_label(
+                        Some(alloc::borrow::Cow::Borrowed("<Surface Texture>")),
+                        device.instance_flags,
+                    ),
                     size: wgt::Extent3d {
                         width: config.width,
                         height: config.height,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -22,6 +22,7 @@ use crate::{
         queue, resource::DeferredDestroy, BufferMapPendingClosure, Device, DeviceError,
         DeviceMismatch, HostMap, MissingDownlevelFlags, MissingFeatures,
     },
+    hal_label,
     init_tracker::{BufferInitTracker, TextureInitTracker},
     lock::{rank, Mutex, RwLock},
     ray_tracing::{BlasCompactReadyPendingClosure, BlasPrepareCompactError},
@@ -1017,7 +1018,7 @@ impl StagingBuffer {
     pub(crate) fn new(device: &Arc<Device>, size: wgt::BufferSize) -> Result<Self, DeviceError> {
         profiling::scope!("StagingBuffer::new");
         let stage_desc = hal::BufferDescriptor {
-            label: crate::hal_label(Some("(wgpu internal) Staging"), device.instance_flags),
+            label: hal_label(Some("(wgpu internal) Staging"), device.instance_flags),
             size: size.get(),
             usage: wgt::BufferUses::MAP_WRITE | wgt::BufferUses::COPY_SRC,
             memory_flags: hal::MemoryFlags::TRANSIENT,

--- a/wgpu-core/src/scratch.rs
+++ b/wgpu-core/src/scratch.rs
@@ -4,7 +4,7 @@ use core::mem::ManuallyDrop;
 use wgt::BufferUses;
 
 use crate::device::{Device, DeviceError};
-use crate::resource_log;
+use crate::{hal_label, resource_log};
 
 #[derive(Debug)]
 pub struct ScratchBuffer {
@@ -18,7 +18,7 @@ impl ScratchBuffer {
             device
                 .raw()
                 .create_buffer(&hal::BufferDescriptor {
-                    label: Some("(wgpu) scratch buffer"),
+                    label: hal_label(Some("(wgpu) scratch buffer"), device.instance_flags),
                     size: size.get(),
                     usage: BufferUses::ACCELERATION_STRUCTURE_SCRATCH,
                     memory_flags: hal::MemoryFlags::empty(),

--- a/wgpu-core/src/timestamp_normalization/mod.rs
+++ b/wgpu-core/src/timestamp_normalization/mod.rs
@@ -36,6 +36,7 @@ use wgt::PushConstantRange;
 
 use crate::{
     device::{Device, DeviceError},
+    hal_label,
     pipeline::{CreateComputePipelineError, CreateShaderModuleError},
     resource::Buffer,
     snatch::SnatchGuard,
@@ -112,7 +113,10 @@ impl TimestampNormalizer {
             let temporary_bind_group_layout = device
                 .raw()
                 .create_bind_group_layout(&hal::BindGroupLayoutDescriptor {
-                    label: Some("Timestamp Normalization Bind Group Layout"),
+                    label: hal_label(
+                        Some("Timestamp Normalization Bind Group Layout"),
+                        device.instance_flags,
+                    ),
                     flags: hal::BindGroupLayoutFlags::empty(),
                     entries: &[wgt::BindGroupLayoutEntry {
                         binding: 0,
@@ -283,7 +287,7 @@ impl TimestampNormalizer {
             let bg = device
                 .raw()
                 .create_bind_group(&hal::BindGroupDescriptor {
-                    label: Some(label),
+                    label: hal_label(Some(label), device.instance_flags),
                     layout: &*state.temporary_bind_group_layout,
                     buffers: &[hal::BufferBinding::new_unchecked(buffer, 0, buffer_size)],
                     samplers: &[],
@@ -331,7 +335,10 @@ impl TimestampNormalizer {
         unsafe {
             encoder.transition_buffers(barrier.as_slice());
             encoder.begin_compute_pass(&hal::ComputePassDescriptor {
-                label: Some("Timestamp normalization pass"),
+                label: hal_label(
+                    Some("Timestamp normalization pass"),
+                    buffer.device.instance_flags,
+                ),
                 timestamp_writes: None,
             });
             encoder.set_compute_pipeline(&*state.pipeline);


### PR DESCRIPTION
**Description**

The `DISCARD_HAL_LABELS` wasn't checked everywhere in core leading to labels being passed to hal. This was an issue on Android where some gles divers segfault in `glPushDebugGroup` for an obscure reason.

**Testing**

Manually.

**Checklist**

- [x] Run `cargo fmt`.
- [x] ~~Run `taplo format`.~~
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] ~~`--target wasm32-unknown-unknown`~~
- [x] Run `cargo xtask test` to run tests.
- [x] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~
