### PR TITLE
[hal] allow for `PreMultiplied` alpha mode on the web

### DIFF
--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -1232,7 +1232,10 @@ impl crate::Adapter for super::Adapter {
                 } else {
                     vec![wgt::PresentMode::Fifo] //TODO
                 },
-                composite_alpha_modes: vec![wgt::CompositeAlphaMode::Opaque], //TODO
+                composite_alpha_modes: vec![
+                    wgt::CompositeAlphaMode::Opaque,
+                    wgt::CompositeAlphaMode::PreMultiplied,
+                ], //TODO
                 maximum_frame_latency: 2..=2, //TODO, unused currently
                 current_extent: None,
                 usage: wgt::TextureUses::COLOR_TARGET,

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -3735,7 +3735,10 @@ impl dispatch::SurfaceInterface for WebSurface {
             formats,
             // Doesn't really have meaning on the web.
             present_modes: vec![wgt::PresentMode::Fifo],
-            alpha_modes: vec![wgt::CompositeAlphaMode::Opaque],
+            alpha_modes: vec![
+                wgt::CompositeAlphaMode::Opaque,
+                wgt::CompositeAlphaMode::PreMultiplied,
+            ],
             // Statically set to RENDER_ATTACHMENT for now. See https://gpuweb.github.io/gpuweb/#dom-gpucanvasconfiguration-usage
             usages: wgt::TextureUsages::RENDER_ATTACHMENT,
         }


### PR DESCRIPTION
**Description**
`CompositeAlphaMode::PreMultiplied` was missing in WebGPU and GLES supported `alpha_modes`

**Testing**
Manually for both Android (GLES) and the Web (WebGL and WebGPU)

**Checklist**

- [x] Run `cargo fmt`.
- [x] ~~Run `taplo format`.~~
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ <!-- See instructions at the top of `CHANGELOG.md`. -->
