### PR TITLE
[naga hlsl-out] Fix odd name for a Handle<GlobalVariable>.

### DIFF
--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -392,8 +392,8 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         }
 
         // Write all globals
-        for (ty, _) in module.global_variables.iter() {
-            self.write_global(module, ty)?;
+        for (global, _) in module.global_variables.iter() {
+            self.write_global(module, global)?;
         }
 
         if !module.global_variables.is_empty() {


### PR DESCRIPTION
In `naga::back::hlsl::writer`, rename the variable bound by the `for` loop in `Writer::write` iterating over global variables from `ty` to `global`. The old name must have been a typo; that value has nothing to do with types.
