### PR TITLE
Two small vulkan changes

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1161,13 +1161,14 @@ impl PhysicalDeviceProperties {
             .min(limits.max_compute_work_group_count[1])
             .min(limits.max_compute_work_group_count[2]);
 
-        // Prevent very large buffers on mesa and most android devices.
+        // Prevent very large buffers on mesa and most android devices, and in all cases
+        // don't risk confusing JS by exceeding the range of a double.
         let is_nvidia = self.properties.vendor_id == crate::auxil::db::nvidia::VENDOR;
         let max_buffer_size =
             if (cfg!(target_os = "linux") || cfg!(target_os = "android")) && !is_nvidia {
                 i32::MAX as u64
             } else {
-                u64::MAX
+                1u64 << 52
             };
 
         let mut max_binding_array_elements = 0;

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -236,7 +236,7 @@ impl super::DeviceShared {
         &self,
         buffer: &'a super::Buffer,
         ranges: I,
-    ) -> Option<impl 'a + Iterator<Item = vk::MappedMemoryRange>> {
+    ) -> Option<impl 'a + Iterator<Item = vk::MappedMemoryRange<'a>>> {
         let block = buffer.block.as_ref()?.lock();
         let mask = self.private_caps.non_coherent_map_mask;
         Some(ranges.map(move |range| {


### PR DESCRIPTION
Fix one more nightly compile warning like the ones in #7964 that I didn't see before because I wasn't building Vulkan. (The compiler suggests the `'_` lifetime but `'a` seemed more appropriate, however, I don't claim to fully understand what's going on here.)

Reduce the value for an "unlimited" maximum buffer size from `u64::MAX` to `1 << 52` to avoid problems when the limit values are round-tripped through JS.

Although these changes both involve buffers, they are unrelated.

**Testing**
For the first change, just that it compiles. The second change resolves a problem running the CTS on Mac with the `vulkan-portability` feature enabled. (The problem might also be reproducible on Linux systems with NVIDIA GPUs.)

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
