### PR TITLE
Updated mesh shader limits to be llvmpipe compatible

### DIFF
--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -979,8 +979,10 @@ impl Limits {
             // This very likely is never a real limiter
             max_task_workgroup_total_count: 65536,
             max_task_workgroups_per_dimension: 256,
-            max_mesh_multiview_count: 1,
-            max_mesh_output_layers: 1024,
+            // llvmpipe reports 0 multiview count, which just means no multiview is allowed
+            max_mesh_multiview_count: 0,
+            // llvmpipe once again requires this to be 8. My 3060 supports well over 1024 which is what I originally planned
+            max_mesh_output_layers: 8,
             ..self
         }
     }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -981,7 +981,7 @@ impl Limits {
             max_task_workgroups_per_dimension: 256,
             // llvmpipe reports 0 multiview count, which just means no multiview is allowed
             max_mesh_multiview_count: 0,
-            // llvmpipe once again requires this to be 8. My 3060 supports well over 1024 which is what I originally planned
+            // llvmpipe once again requires this to be 8. An RTX 3060 supports well over 1024.
             max_mesh_output_layers: 8,
             ..self
         }


### PR DESCRIPTION
**Connections**
Immediate tweak to #7345 

**Description**
I never checked to make sure that my arbitrary default limits worked on llvmpipe. My GPU gave such absurdly high limits so I just set fairly high limits for everything. This updates the defaults so that mesh shader tests failing can actually be caught by CI

**Squash or Rebase?**
Rebase is fine

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
