### PR TITLE
Security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,6 @@ contact_links:
     about: Any questions about how to use wgpu should go here.
   - name: Security concerns
     url: https://github.com/gfx-rs/wgpu/security
-    about: Information about reporting possible vulnerabilities.
+    about: >
+      If you have found a possible vulnerability in wgpu, please read this
+      security policy for information about reporting it confidentially.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question about wgpu
-    url: https://github.com/gfx-rs/wgpu/discussions/new
+    url: https://github.com/gfx-rs/wgpu/discussions/new/choose
     about: Any questions about how to use wgpu should go here.
+  - name: Security concerns
+    url: https://github.com/gfx-rs/wgpu/security
+    about: Information about reporting possible vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,79 @@
+# WGPU Security Policy
+
+This document describes what is considered a security vulnerability in WGPU and
+how vulnerabilities should be reported.
+
+
+## Vulnerability Definition
+
+WebGPU introduces a different threat model than is sometimes applied to
+GPU-related software. Unlike typical gaming or high-performance computing
+applications, where the software accessing GPU APIs is proprietary or
+obtained from a trusted developer, WebGPU makes GPU APIs available to
+arbitrary web applications. In the threat model of the web, malicious
+content should not be able to use the GPU APIs to access data or interfaces
+outside the intended scope for interaction with web content.
+
+While the WGPU maintainers have discretion in assigning a severity to
+individual vulnerabilities, it is generally considered a security vulnerability
+in WGPU if Javascript or WebAssembly code running with privileges of ordinary
+web content is able to:
+
+- Access data associated with native applications other than the user agent,
+  or associated with other web origins.
+- Escape the applicable sandbox and run arbitrary code or call arbitrary system
+  APIs on the user agent host.
+- Consume system resources to the point that it is difficult to recover
+  (e.g. by closing the web page).
+
+The WGPU Rust API offers some functionality, both supported and experimental,
+that is not part of the WebGPU standard and is not made available in Javascript
+environments using WGPU. Associated vulnerabilities may be assigned lower
+severity than vulnerabilities that apply to a Javascript WebGPU implementation
+based on WGPU.
+
+
+## Supported Versions
+
+The WGPU project maintains security support for serious vulnerabilities in the
+[most recent major release](https://github.com/gfx-rs/wgpu/releases). Fixes for
+security vulnerabilities found shortly after the initial release of a major
+version may also be provided for the previous major release.
+
+Mozilla provides security support for versions of WGPU used in [current
+versions of Firefox](https://whattrainisitnow.com/).
+
+The version of WGPU that is active can be found in the Firefox repositories:
+
+- [release](https://github.com/mozilla-firefox/firefox/blob/release/gfx/wgpu_bindings/Cargo.toml),
+- [beta](https://github.com/mozilla-firefox/firefox/blob/beta/gfx/wgpu_bindings/Cargo.toml), and
+- [nightly](https://github.com/mozilla-firefox/firefox/blob/main/gfx/wgpu_bindings/Cargo.toml),
+
+We welcome reports of security vulnerabilities in any of these released
+versions or in the latest code on the `trunk` branch.
+
+
+## Reporting a Vulnerability
+
+Although not all vulnerabilities in WGPU will affect Firefox, Mozilla accepts
+all vulnerability reports for WGPU and directs them appropriately. Additionally,
+Mozilla serves as the CVE numbering authority for the WGPU project.
+
+To report a security problem with WGPU, create a bug in Mozilla's Bugzilla
+instance in the [Core ::
+Graphics :: WebGPU](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=Graphics%3A+WebGPU)
+component.
+
+**IMPORTANT: For security issues, please make sure that you check the box
+labelled "Many users could be harmed by this security problem".** We advise
+that you check this option for anything that is potentially
+security-relevant, including memory safety, crashes, race conditions, and
+handling of confidential information.
+
+Review Mozilla's [guides on bug
+reporting](https://bugzilla.mozilla.org/page.cgi?id=bug-writing.html) before
+you open a bug.
+
+Mozilla operates a [bug bounty
+program](https://www.mozilla.org/en-US/security/bug-bounty/). Some
+vulnerabilities in this project may be eligible.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,10 +14,11 @@ arbitrary web applications. In the threat model of the web, malicious
 content should not be able to use the GPU APIs to access data or interfaces
 outside the intended scope for interaction with web content.
 
-While the WGPU maintainers have discretion in assigning a severity to
-individual vulnerabilities, it is generally considered a high-severity vulnerability
-in WGPU if JavaScript or WebAssembly code running with privileges of ordinary
-web content, in a web browser that is using `wgpu` to provide the WebGPU API to that content, is able to:
+The WGPU maintainers have discretion in assigning a severity to individual
+vulnerabilities. It is generally considered a high-severity vulnerability in
+WGPU if JavaScript or WebAssembly code, running with privileges of ordinary web
+content in a browser that is using WGPU to provide the WebGPU API to that
+content, is able to:
 
 - Access data associated with native applications other than the user agent,
   or associated with other web origins.
@@ -27,10 +28,10 @@ web content, in a web browser that is using `wgpu` to provide the WebGPU API to 
   (e.g. by closing the web page).
 
 The WGPU Rust API offers some functionality, both supported and experimental,
-that is not part of the WebGPU standard and is not made available in Javascript
+that is not part of the WebGPU standard and is not made available in JavaScript
 environments using WGPU. Associated vulnerabilities may be assigned lower
-severity than vulnerabilities that apply to a WebGPU implementation exposed to JavaScript
-based on WGPU.
+severity than vulnerabilities that apply to a WGPU-based WebGPU implementation
+exposed to JavaScript.
 
 
 ## Supported Versions
@@ -60,8 +61,8 @@ all vulnerability reports for WGPU and directs them appropriately. Additionally,
 Mozilla serves as the CVE numbering authority for the WGPU project.
 
 To report a security problem with WGPU, create a bug in Mozilla's Bugzilla
-instance in the [Core ::
-Graphics :: WebGPU](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=Graphics%3A+WebGPU)
+instance in the
+[Core :: Graphics :: WebGPU](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=Graphics%3A+WebGPU&groups=core-security)
 component.
 
 **IMPORTANT: For security issues, please make sure that you check the box

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,11 @@ applications, where the software accessing GPU APIs is proprietary or
 obtained from a trusted developer, WebGPU makes GPU APIs available to
 arbitrary web applications. In the threat model of the web, malicious
 content should not be able to use the GPU APIs to access data or interfaces
-outside the intended scope for interaction with web content.
+outside the intended scope for interaction with web content. Therefore, `wgpu`
+seeks to prevent undefined behavior and data leaks even when its API is
+misused, and failures to do so may be considered vulnerabilities. (This is
+also in accordance with the Rust principle of safe vs. unsafe code, since the
+`wgpu` library exposes a safe API.)
 
 The WGPU maintainers have discretion in assigning a severity to individual
 vulnerabilities. It is generally considered a high-severity vulnerability in
@@ -62,7 +66,7 @@ Mozilla serves as the CVE numbering authority for the WGPU project.
 
 To report a security problem with WGPU, create a bug in Mozilla's Bugzilla
 instance in the
-[Core :: Graphics :: WebGPU](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=Graphics%3A+WebGPU&groups=core-security)
+[Core :: Graphics :: WebGPU](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=Graphics%3A+WebGPU&groups=core-security&groups=gfx-core-security)
 component.
 
 **IMPORTANT: For security issues, please make sure that you check the box

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,9 +15,9 @@ content should not be able to use the GPU APIs to access data or interfaces
 outside the intended scope for interaction with web content.
 
 While the WGPU maintainers have discretion in assigning a severity to
-individual vulnerabilities, it is generally considered a security vulnerability
-in WGPU if Javascript or WebAssembly code running with privileges of ordinary
-web content is able to:
+individual vulnerabilities, it is generally considered a high-severity vulnerability
+in WGPU if JavaScript or WebAssembly code running with privileges of ordinary
+web content, in a web browser that is using `wgpu` to provide the WebGPU API to that content, is able to:
 
 - Access data associated with native applications other than the user agent,
   or associated with other web origins.
@@ -29,7 +29,7 @@ web content is able to:
 The WGPU Rust API offers some functionality, both supported and experimental,
 that is not part of the WebGPU standard and is not made available in Javascript
 environments using WGPU. Associated vulnerabilities may be assigned lower
-severity than vulnerabilities that apply to a Javascript WebGPU implementation
+severity than vulnerabilities that apply to a WebGPU implementation exposed to JavaScript
 based on WGPU.
 
 


### PR DESCRIPTION
Proposal for a security policy. Would fix #6874.

This would appear in the security tab on GitHub. For an example of what the page would look like, see https://github.com/tc39/ecma262/security/. (Signed-in repository collaborators looking at the page for wgpu will see something different.)

Since the vulnerability reports will appear on that page adjacent to the policy, I haven't explicitly stated in the document where reports are published.