### PR TITLE
Remove deadlock potential from `UncapturedErrorHandler`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ By @Vecvec in [#7913](https://github.com/gfx-rs/wgpu/pull/7913).
   - Copies of depth/stencil formats must be 4B aligned.
 - The offset for `set_vertex_buffer` and `set_index_buffer` must be 4B aligned. By @andyleiserson in [#7929](https://github.com/gfx-rs/wgpu/pull/7929).
 - The offset and size of bindings are validated as fitting within the underlying buffer in more cases. By @andyleiserson in [#7911](https://github.com/gfx-rs/wgpu/pull/7911).
+- The function you pass to `Device::on_uncaptured_error()` must now implement `Sync` in addition to `Send`.
+  By @kpreid in [#8011](https://github.com/gfx-rs/wgpu/pull/8011).
 
 #### Naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ By @Vecvec in [#7913](https://github.com/gfx-rs/wgpu/pull/7913).
 - The offset for `set_vertex_buffer` and `set_index_buffer` must be 4B aligned. By @andyleiserson in [#7929](https://github.com/gfx-rs/wgpu/pull/7929).
 - The offset and size of bindings are validated as fitting within the underlying buffer in more cases. By @andyleiserson in [#7911](https://github.com/gfx-rs/wgpu/pull/7911).
 - The function you pass to `Device::on_uncaptured_error()` must now implement `Sync` in addition to `Send`, and be wrapped in `Arc` instead of `Box`.
+  In exchange for this, it is no longer possible for calling `wgpu` functions while in that callback to cause a deadlock (not that we encourage you to actually do that).
   By @kpreid in [#8011](https://github.com/gfx-rs/wgpu/pull/8011).
 
 #### Naga

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ By @Vecvec in [#7913](https://github.com/gfx-rs/wgpu/pull/7913).
   - Copies of depth/stencil formats must be 4B aligned.
 - The offset for `set_vertex_buffer` and `set_index_buffer` must be 4B aligned. By @andyleiserson in [#7929](https://github.com/gfx-rs/wgpu/pull/7929).
 - The offset and size of bindings are validated as fitting within the underlying buffer in more cases. By @andyleiserson in [#7911](https://github.com/gfx-rs/wgpu/pull/7911).
-- The function you pass to `Device::on_uncaptured_error()` must now implement `Sync` in addition to `Send`.
+- The function you pass to `Device::on_uncaptured_error()` must now implement `Sync` in addition to `Send`, and be wrapped in `Arc` instead of `Box`.
   By @kpreid in [#8011](https://github.com/gfx-rs/wgpu/pull/8011).
 
 #### Naga

--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -240,7 +240,7 @@ impl DeviceInterface for CustomDevice {
         unimplemented!()
     }
 
-    fn on_uncaptured_error(&self, _handler: Box<dyn wgpu::UncapturedErrorHandler>) {
+    fn on_uncaptured_error(&self, _handler: Arc<dyn wgpu::UncapturedErrorHandler>) {
         unimplemented!()
     }
 

--- a/tests/tests/wgpu-validation/api/device.rs
+++ b/tests/tests/wgpu-validation/api/device.rs
@@ -1,0 +1,44 @@
+/// Test that if another error occurs reentrantly in the [`wgpu::Device::on_uncaptured_error`]
+/// handler, this does not result in a deadlock (as a previous implementation would have had).
+#[cfg(not(target_family = "wasm"))] // test needs wgpu::Device: Send + Sync to achieve reentrance
+#[test]
+fn recursive_uncaptured_error() {
+    use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
+    use std::sync::Arc;
+
+    const ERRONEOUS_TEXTURE_DESC: wgpu::TextureDescriptor = wgpu::TextureDescriptor {
+        label: None,
+        size: wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 10,
+        },
+        mip_level_count: 0,
+        sample_count: 0,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8UnormSrgb,
+        usage: wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    };
+
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+
+    let errors_seen: Arc<AtomicU32> = Arc::default();
+    let handler = Arc::new({
+        let errors_seen = errors_seen.clone();
+        let device = device.clone();
+        move |_error| {
+            let previous_count = errors_seen.fetch_add(1, Relaxed);
+            if previous_count == 0 {
+                // Trigger another error recursively
+                _ = device.create_texture(&ERRONEOUS_TEXTURE_DESC);
+            }
+        }
+    });
+
+    // Trigger one error which will call the handler
+    device.on_uncaptured_error(handler);
+    _ = device.create_texture(&ERRONEOUS_TEXTURE_DESC);
+
+    assert_eq!(errors_seen.load(Relaxed), 2);
+}

--- a/tests/tests/wgpu-validation/api/mod.rs
+++ b/tests/tests/wgpu-validation/api/mod.rs
@@ -1,6 +1,7 @@
 mod binding_arrays;
 mod buffer;
 mod buffer_slice;
+mod device;
 mod external_texture;
 mod instance;
 mod texture;

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -714,9 +714,11 @@ impl From<wgc::instance::RequestDeviceError> for RequestDeviceError {
     }
 }
 
-/// Type for the callback of uncaptured error handler
-pub trait UncapturedErrorHandler: Fn(Error) + Send + 'static {}
-impl<T> UncapturedErrorHandler for T where T: Fn(Error) + Send + 'static {}
+/// The callback of [`Device::on_uncaptured_error()`].
+///
+/// It must be a function with this signature.
+pub trait UncapturedErrorHandler: Fn(Error) + Send + Sync + 'static {}
+impl<T> UncapturedErrorHandler for T where T: Fn(Error) + Send + Sync + 'static {}
 
 /// Kinds of [`Error`]s a [`Device::push_error_scope()`] may be configured to catch.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -407,8 +407,8 @@ impl Device {
         QuerySet { inner: query_set }
     }
 
-    /// Set a callback for errors that are not handled in error scopes.
-    pub fn on_uncaptured_error(&self, handler: Box<dyn UncapturedErrorHandler>) {
+    /// Set a callback which will be called for all errors that are not handled in error scopes.
+    pub fn on_uncaptured_error(&self, handler: Arc<dyn UncapturedErrorHandler>) {
         self.inner.on_uncaptured_error(handler)
     }
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -10,6 +10,7 @@ use alloc::{
     format,
     rc::Rc,
     string::{String, ToString as _},
+    sync::Arc,
     vec,
     vec::Vec,
 };
@@ -2409,7 +2410,7 @@ impl dispatch::DeviceInterface for WebDevice {
         closure.forget();
     }
 
-    fn on_uncaptured_error(&self, handler: Box<dyn crate::UncapturedErrorHandler>) {
+    fn on_uncaptured_error(&self, handler: Arc<dyn crate::UncapturedErrorHandler>) {
         let f = Closure::wrap(Box::new(move |event: webgpu_sys::GpuUncapturedErrorEvent| {
             let error = crate::Error::from_js(event.error().value_of());
             handler(error);

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -617,7 +617,7 @@ struct ErrorScope {
 
 struct ErrorSinkRaw {
     scopes: Vec<ErrorScope>,
-    uncaptured_handler: Option<Box<dyn crate::UncapturedErrorHandler>>,
+    uncaptured_handler: Option<Arc<dyn crate::UncapturedErrorHandler>>,
 }
 
 impl ErrorSinkRaw {
@@ -1757,7 +1757,7 @@ impl dispatch::DeviceInterface for CoreDevice {
             .device_set_device_lost_closure(self.id, device_lost_callback);
     }
 
-    fn on_uncaptured_error(&self, handler: Box<dyn crate::UncapturedErrorHandler>) {
+    fn on_uncaptured_error(&self, handler: Arc<dyn crate::UncapturedErrorHandler>) {
         let mut error_sink = self.error_sink.lock();
         error_sink.uncaptured_handler = Some(handler);
     }

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -185,7 +185,7 @@ pub trait DeviceInterface: CommonTraits {
 
     fn set_device_lost_callback(&self, device_lost_callback: BoxDeviceLostCallback);
 
-    fn on_uncaptured_error(&self, handler: Box<dyn crate::UncapturedErrorHandler>);
+    fn on_uncaptured_error(&self, handler: Arc<dyn crate::UncapturedErrorHandler>);
     fn push_error_scope(&self, filter: crate::ErrorFilter);
     fn pop_error_scope(&self) -> Pin<Box<dyn PopErrorScopeFuture>>;
 


### PR DESCRIPTION
**Connections**
Fixes #5395.

**Description**
Previously, the `Device::on_uncaptured_error()` callback was called with a device-wide mutex held. This provides synchronization we don’t actually promise to the user and which the user cannot take advantage of (because the callback signature is not `FnMut`), and allows a deadlock to occur via reentrancy.

Instead,
* Call the callback without the mutex held.
* To enable this, accept it wrapped in `Arc` instead of `Box`, and require it to be `Send + Sync` rather than just `Send`.

An alternative to the approach in this PR would be to explicitly document that the callback is called with a mutex held. In that case, the callback should be made `FnMut` to allow it to take advantage of this — the opposite of this PR's change to `Fn + Sync`.

**Testing**
Added a test case for the now-impossible deadlock.

**Squash or Rebase?**
Rebase.

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
