### PR TITLE
[d3d12 wgl] Upgrade to `windows 0.62` crates

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -22,13 +22,11 @@ skip = [
     # Deno uses an old version
     { name = "which", version = "6.0.3" },
 
-    # Loom uses a new windows version
-    { name = "windows", version = "0.61.1" },
-    { name = "windows-core", version = "0.61.2" },
-    { name = "windows-implement", version = "0.60.0" },
-    { name = "windows-interface", version = "0.59.1" },
-    { name = "windows-result", version = "0.3.4" },
-    { name = "windows-strings", version = "0.4.2" },
+    # Temporarily allow older Windows version until updates make it through
+    { name = "windows", version = "0.59" },
+    { name = "windows-core", version = "0.59" },
+    { name = "windows-implement", version = "0.59" },
+    { name = "windows-strings", version = "0.3" },
 
     # cargo-metadata uses old version. Only used for infrastructure.
     { name = "toml", version = "0.8.23" },
@@ -76,6 +74,3 @@ allow-git = [
 unknown-registry = "deny"
 unknown-git = "deny"
 required-git-spec = "rev"
-
-[sources.allow-org]
-github = ["gfx-rs"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -746,6 +746,7 @@ jobs:
         with:
           command: check advisories
           arguments: --all-features --workspace
+          command-arguments: -Dwarnings
           rust-version: ${{ env.REPO_MSRV }}
 
   cargo-deny-check-rest:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -1869,7 +1869,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.16",
- "windows 0.59.0",
+ "windows",
 ]
 
 [[package]]
@@ -5099,8 +5099,8 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows 0.59.0",
- "windows-core 0.59.0",
+ "windows",
+ "windows-core",
  "winit 0.29.15",
 ]
 
@@ -5250,22 +5250,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
-dependencies = [
- "windows-core 0.59.0",
- "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -5277,20 +5267,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface",
- "windows-result",
- "windows-strings 0.3.1",
- "windows-targets 0.53.3",
+ "windows-core",
 ]
 
 [[package]]
@@ -5299,11 +5276,11 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.0",
+ "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result",
- "windows-strings 0.4.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5312,20 +5289,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -5368,7 +5334,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -5377,15 +5343,6 @@ name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link 0.1.3",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,14 +1861,15 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "hashbrown 0.16.0",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
+ "thiserror 2.0.16",
+ "windows 0.59.0",
 ]
 
 [[package]]
@@ -1931,6 +1932,8 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
 ]
@@ -5096,8 +5099,8 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.59.0",
+ "windows-core 0.59.0",
  "winit 0.29.15",
 ]
 
@@ -5247,12 +5250,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
+ "windows-core 0.59.0",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -5279,15 +5282,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-implement 0.59.0",
+ "windows-interface",
+ "windows-result",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -5297,9 +5300,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-result",
  "windows-strings 0.4.2",
 ]
 
@@ -5316,9 +5319,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5330,17 +5333,6 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5382,15 +5374,6 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -5400,12 +5383,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,15 +791,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1431,12 +1431,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1684,8 +1684,7 @@ dependencies = [
 [[package]]
 name = "generator"
 version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
+source = "git+https://github.com/Xudong-Huang/generator-rs?rev=70b89fdabcc0e82fe84ca17f65cc52ff25e8e6de#70b89fdabcc0e82fe84ca17f65cc52ff25e8e6de"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1701,7 +1700,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -2348,9 +2347,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -3283,7 +3282,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-sys 0.60.2",
 ]
 
@@ -3634,15 +3633,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4714,7 +4713,7 @@ checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -4727,7 +4726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags 2.9.4",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -4749,7 +4748,7 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "wayland-client",
  "xcursor",
 ]
@@ -5213,7 +5212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "winsafe",
 ]
 
@@ -5250,47 +5249,47 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
 dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "a90dd7a7b86859ec4cdf864658b311545ef19dbcf17a672b52ab7cefe80c336f"
 dependencies = [
  "windows-core",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "b2194dee901458cb79e1148a4e9aac2b164cc95fa431891e7b296ff0b2f1d8a6"
 dependencies = [
  "windows-core",
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
  "windows-threading",
 ]
 
@@ -5330,30 +5329,30 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "2ce3498fe0aba81e62e477408383196b4b0363db5e0c27646f932676283b43d8"
 dependencies = [
  "windows-core",
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -5475,11 +5474,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "ab47f085ad6932defa48855254c758cdd0e2f2d48e62a34118a268d8f345e118"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -5821,7 +5820,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "x11rb-protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ indicatif = "0.18"
 itertools = { version = "0.14" }
 jobserver = "0.1"
 ktx2 = "0.4"
-libc = { version = "0.2.171", default-features = false }
+libc = { version = "0.2.172", default-features = false }
 # See https://github.com/rust-fuzz/libfuzzer/issues/126
 libfuzzer-sys = ">0.4.0,<=0.4.7"
 libloading = "0.8"
@@ -210,10 +210,12 @@ gpu-alloc = "0.6"
 gpu-descriptor = "0.3.2"
 
 # DX12 dependencies
-gpu-allocator = { version = "0.27", default-features = false }
+gpu-allocator = { version = "0.28", default-features = false, features = [
+    "hashbrown",
+] }
 range-alloc = "0.1"
 mach-dxcompiler-rs = { version = "0.1.4", default-features = false } # remember to increase max_shader_model if applicable
-windows-core = { version = "0.58", default-features = false }
+windows-core = { version = "0.59", default-features = false }
 
 # Gles dependencies
 khronos-egl = "6"
@@ -223,7 +225,7 @@ glutin-winit = { version = "0.4", default-features = false }
 glutin_wgl_sys = "0.6"
 
 # DX12 and GLES dependencies
-windows = { version = "0.58", default-features = false }
+windows = { version = "0.59", default-features = false }
 
 # wasm32 dependencies
 console_error_panic_hook = "0.1.5"
@@ -245,7 +247,7 @@ deno_webidl = "0.214.0"
 deno_webgpu = { version = "0.181.0", path = "./deno_webgpu" }
 deno_unsync = "0.4.4"
 deno_error = "0.7.0"
-tokio = "1.45.1"
+tokio = "1.47"
 termcolor = "1.1.3"
 
 # android dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ gpu-allocator = { version = "0.28", default-features = false, features = [
 ] }
 range-alloc = "0.1"
 mach-dxcompiler-rs = { version = "0.1.4", default-features = false } # remember to increase max_shader_model if applicable
-windows-core = { version = "0.59", default-features = false }
+windows-core = { version = "0.61", default-features = false }
 
 # Gles dependencies
 khronos-egl = "6"
@@ -225,7 +225,7 @@ glutin-winit = { version = "0.4", default-features = false }
 glutin_wgl_sys = "0.6"
 
 # DX12 and GLES dependencies
-windows = { version = "0.59", default-features = false }
+windows = { version = "0.61", default-features = false }
 
 # wasm32 dependencies
 console_error_panic_hook = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ gpu-allocator = { version = "0.28", default-features = false, features = [
 ] }
 range-alloc = "0.1"
 mach-dxcompiler-rs = { version = "0.1.4", default-features = false } # remember to increase max_shader_model if applicable
-windows-core = { version = "0.61", default-features = false }
+windows-core = { version = ">=0.61, <=0.62", default-features = false }
 
 # Gles dependencies
 khronos-egl = "6"
@@ -225,7 +225,7 @@ glutin-winit = { version = "0.4", default-features = false }
 glutin_wgl_sys = "0.6"
 
 # DX12 and GLES dependencies
-windows = { version = "0.61", default-features = false }
+windows = { version = ">=0.61, <=0.62", default-features = false }
 
 # wasm32 dependencies
 console_error_panic_hook = "0.1.5"
@@ -256,6 +256,9 @@ ndk-sys = "0.6"
 # These overrides allow our examples to explicitly depend on release crates
 [patch.crates-io]
 wgpu = { path = "./wgpu" }
+
+# https://github.com/Xudong-Huang/generator-rs/pull/75
+generator = { git = "https://github.com/Xudong-Huang/generator-rs", rev = "70b89fdabcc0e82fe84ca17f65cc52ff25e8e6de" }
 
 [profile.release]
 lto = "thin"

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -1,17 +1,19 @@
 use alloc::vec::Vec;
 use core::{mem, ops::Range};
 
-use windows::Win32::{
-    Foundation,
-    Graphics::{Direct3D12, Dxgi},
+use windows::{
+    core::Interface as _,
+    Win32::{
+        Foundation,
+        Graphics::{Direct3D12, Dxgi},
+    },
 };
-use windows_core::Interface;
 
 use super::conv;
 use crate::{
     auxil::{
         self,
-        dxgi::{name::ObjectExt, result::HResult as _},
+        dxgi::{name::ObjectExt as _, result::HResult as _},
     },
     dx12::borrow_interface_temporarily,
     AccelerationStructureEntries,
@@ -864,23 +866,12 @@ impl crate::CommandEncoder for super::CommandEncoder {
             if let Some(ds_view) = ds_view {
                 if flags != Direct3D12::D3D12_CLEAR_FLAGS::default() {
                     unsafe {
-                        // list.ClearDepthStencilView(
-                        //     ds_view,
-                        //     flags,
-                        //     ds.clear_value.0,
-                        //     ds.clear_value.1 as u8,
-                        //     None,
-                        // )
-                        // TODO: Replace with the above in the next breaking windows-rs release,
-                        // when https://github.com/microsoft/win32metadata/pull/1971 is in.
-                        (Interface::vtable(list).ClearDepthStencilView)(
-                            Interface::as_raw(list),
+                        list.ClearDepthStencilView(
                             ds_view,
                             flags,
                             ds.clear_value.0,
                             ds.clear_value.1 as u8,
-                            0,
-                            core::ptr::null(),
+                            None,
                         )
                     }
                 }

--- a/wgpu-hal/src/dx12/dcomp.rs
+++ b/wgpu-hal/src/dx12/dcomp.rs
@@ -2,8 +2,10 @@ use alloc::sync::Arc;
 use core::{ffi, ptr};
 
 use once_cell::sync::Lazy;
-use windows::Win32::{Foundation::HWND, Graphics::DirectComposition};
-use windows_core::Interface;
+use windows::{
+    core::Interface as _,
+    Win32::{Foundation::HWND, Graphics::DirectComposition},
+};
 
 use super::DynLib;
 

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1875,8 +1875,8 @@ impl crate::Device for super::Device {
             DepthBias: bias.constant,
             DepthBiasClamp: bias.clamp,
             SlopeScaledDepthBias: bias.slope_scale,
-            DepthClipEnable: Foundation::BOOL::from(!desc.primitive.unclipped_depth),
-            MultisampleEnable: Foundation::BOOL::from(desc.multisample.count > 1),
+            DepthClipEnable: windows_core::BOOL::from(!desc.primitive.unclipped_depth),
+            MultisampleEnable: windows_core::BOOL::from(desc.multisample.count > 1),
             ForcedSampleCount: 0,
             AntialiasedLineEnable: false.into(),
             ConservativeRaster: if desc.primitive.conservative {
@@ -1905,7 +1905,7 @@ impl crate::Device for super::Device {
             RasterizedStream: 0,
         };
         let blend_state = Direct3D12::D3D12_BLEND_DESC {
-            AlphaToCoverageEnable: Foundation::BOOL::from(
+            AlphaToCoverageEnable: windows_core::BOOL::from(
                 desc.multisample.alpha_to_coverage_enabled,
             ),
             IndependentBlendEnable: true.into(),

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -23,7 +23,7 @@ use super::{conv, descriptor, D3D12Lib};
 use crate::{
     auxil::{
         self,
-        dxgi::{name::ObjectExt, result::HResult},
+        dxgi::{name::ObjectExt as _, result::HResult as _},
     },
     dx12::{
         borrow_optional_interface_temporarily, shader_compilation, suballocation, DCompLib,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -1330,7 +1330,7 @@ impl crate::Surface for Surface {
                                 .ok_or(crate::SurfaceError::Other("IDXGIFactoryMedia not found"))?
                                 .CreateSwapChainForCompositionSurfaceHandle(
                                     &device.present_queue,
-                                    handle,
+                                    Some(handle),
                                     &desc,
                                     None,
                                 )

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -93,7 +93,7 @@ use hashbrown::HashMap;
 use parking_lot::{Mutex, RwLock};
 use suballocation::Allocator;
 use windows::{
-    core::{Free, Interface},
+    core::{Free as _, Interface},
     Win32::{
         Foundation,
         Graphics::{Direct3D, Direct3D12, DirectComposition, Dxgi},

--- a/wgpu-hal/src/dx12/suballocation.rs
+++ b/wgpu-hal/src/dx12/suballocation.rs
@@ -1,10 +1,11 @@
 use alloc::sync::Arc;
+
 use gpu_allocator::{d3d12::AllocationCreateDesc, MemoryLocation};
 use parking_lot::Mutex;
 use windows::Win32::Graphics::{Direct3D12, Dxgi};
 
 use crate::{
-    auxil::dxgi::{name::ObjectExt, result::HResult as _},
+    auxil::dxgi::{name::ObjectExt as _, result::HResult as _},
     dx12::conv,
 };
 
@@ -143,7 +144,7 @@ impl Allocator {
             allocations,
             blocks,
             total_allocated_bytes: upstream.total_allocated_bytes,
-            total_reserved_bytes: upstream.total_reserved_bytes,
+            total_reserved_bytes: upstream.total_capacity_bytes,
         }
     }
 }

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -128,7 +128,7 @@ impl WglContext {
         if unsafe { OpenGL::wglGetCurrentContext() }.is_invalid() {
             return Ok(());
         }
-        unsafe { OpenGL::wglMakeCurrent(None, None) }
+        unsafe { OpenGL::wglMakeCurrent(Default::default(), Default::default()) }
     }
 }
 
@@ -382,7 +382,7 @@ fn create_instance_device() -> Result<InstanceDevice, crate::InstanceError> {
                         1,
                         None,
                         None,
-                        instance,
+                        Some(instance.into()),
                         None,
                     )
                 }
@@ -394,7 +394,7 @@ fn create_instance_device() -> Result<InstanceDevice, crate::InstanceError> {
                 })?;
                 let window = Window { window };
 
-                let dc = unsafe { Gdi::GetDC(window.window) };
+                let dc = unsafe { Gdi::GetDC(Some(window.window)) };
                 if dc.is_invalid() {
                     return Err(crate::InstanceError::with_source(
                         String::from("unable to create memory device"),
@@ -636,7 +636,7 @@ struct DeviceContextHandle {
 impl Drop for DeviceContextHandle {
     fn drop(&mut self) {
         unsafe {
-            Gdi::ReleaseDC(self.window, self.device);
+            Gdi::ReleaseDC(Some(self.window), self.device);
         };
     }
 }
@@ -672,7 +672,7 @@ impl Surface {
     ) -> Result<(), crate::SurfaceError> {
         let swapchain = self.swapchain.read();
         let sc = swapchain.as_ref().unwrap();
-        let dc = unsafe { Gdi::GetDC(self.window) };
+        let dc = unsafe { Gdi::GetDC(Some(self.window)) };
         if dc.is_invalid() {
             log::error!(
                 "unable to get the device context from window: {}",
@@ -750,7 +750,7 @@ impl crate::Surface for Surface {
         // Remove the old configuration.
         unsafe { self.unconfigure(device) };
 
-        let dc = unsafe { Gdi::GetDC(self.window) };
+        let dc = unsafe { Gdi::GetDC(Some(self.window)) };
         if dc.is_invalid() {
             log::error!(
                 "unable to get the device context from window: {}",

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -226,7 +226,7 @@ unsafe fn setup_pixel_format(dc: Gdi::HDC) -> Result<(), crate::InstanceError> {
         if index == 0 {
             return Err(crate::InstanceError::with_source(
                 String::from("unable to choose pixel format"),
-                Error::from_win32(),
+                Error::from_thread(),
             ));
         }
 
@@ -244,7 +244,7 @@ unsafe fn setup_pixel_format(dc: Gdi::HDC) -> Result<(), crate::InstanceError> {
         if index == 0 {
             return Err(crate::InstanceError::with_source(
                 String::from("unable to get pixel format index"),
-                Error::from_win32(),
+                Error::from_thread(),
             ));
         }
         let mut format = Default::default();
@@ -254,7 +254,7 @@ unsafe fn setup_pixel_format(dc: Gdi::HDC) -> Result<(), crate::InstanceError> {
         {
             return Err(crate::InstanceError::with_source(
                 String::from("unable to read pixel format"),
-                Error::from_win32(),
+                Error::from_thread(),
             ));
         }
 
@@ -311,7 +311,7 @@ fn create_global_window_class() -> Result<CString, crate::InstanceError> {
     if atom == 0 {
         return Err(crate::InstanceError::with_source(
             String::from("unable to register window class"),
-            Error::from_win32(),
+            Error::from_thread(),
         ));
     }
 
@@ -398,7 +398,7 @@ fn create_instance_device() -> Result<InstanceDevice, crate::InstanceError> {
                 if dc.is_invalid() {
                     return Err(crate::InstanceError::with_source(
                         String::from("unable to create memory device"),
-                        Error::from_win32(),
+                        Error::from_thread(),
                     ));
                 }
                 let dc = DeviceContextHandle {
@@ -484,7 +484,7 @@ impl crate::Instance for Instance {
             if context.is_null() {
                 return Err(crate::InstanceError::with_source(
                     String::from("unable to create OpenGL context"),
-                    Error::from_win32(),
+                    Error::from_thread(),
                 ));
             }
             WglContext {
@@ -676,7 +676,7 @@ impl Surface {
         if dc.is_invalid() {
             log::error!(
                 "unable to get the device context from window: {}",
-                Error::from_win32()
+                Error::from_thread()
             );
             return Err(crate::SurfaceError::Other(
                 "unable to get the device context from window",
@@ -754,7 +754,7 @@ impl crate::Surface for Surface {
         if dc.is_invalid() {
             log::error!(
                 "unable to get the device context from window: {}",
-                Error::from_win32()
+                Error::from_thread()
             );
             return Err(crate::SurfaceError::Other(
                 "unable to get the device context from window",
@@ -828,7 +828,7 @@ impl crate::Surface for Surface {
         };
 
         if unsafe { extra.SwapIntervalEXT(if vsync { 1 } else { 0 }) } == Foundation::FALSE.0 {
-            log::error!("unable to set swap interval: {}", Error::from_win32());
+            log::error!("unable to set swap interval: {}", Error::from_thread());
             return Err(crate::SurfaceError::Other("unable to set swap interval"));
         }
 

--- a/wgpu-types/src/counters.rs
+++ b/wgpu-types/src/counters.rs
@@ -181,6 +181,7 @@ pub struct AllocatorReport {
     /// Sum of the memory used by all allocations, in bytes.
     pub total_allocated_bytes: u64,
     /// Sum of the memory reserved by all memory blocks including unallocated regions, in bytes.
+    // XXX: Rename to total_capacity_bytes following the rename at https://github.com/Traverse-Research/gpu-allocator/pull/266?
     pub total_reserved_bytes: u64,
 }
 


### PR DESCRIPTION
**Connections**
Depends on https://github.com/gfx-rs/wgpu/pull/6876

**Description**
Uses the latest `windows 0.62` and `windows-core 0.62` releases.

https://github.com/microsoft/windows-rs/releases/tag/0.61.0
https://github.com/microsoft/windows-rs/releases/tag/63
https://github.com/microsoft/windows-rs/releases/tag/69

**Testing**
```sh
WGPU_BACKEND=d3d12 cargo r -p wgpu-examples hello_triangle
```

**Squash or Rebase?**
squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] Replaced crate patches with actual releases.
