### PR TITLE
Implement webgpu textureBindingViewDimension proposal to resolve texture view heuristics errors

### DIFF
--- a/benches/benches/wgpu-benchmark/bind_groups.rs
+++ b/benches/benches/wgpu-benchmark/bind_groups.rs
@@ -64,6 +64,7 @@ pub fn run_bench(ctx: BenchmarkContext) -> anyhow::Result<Vec<SubBenchResult>> {
                 format: wgpu::TextureFormat::Rgba8UnormSrgb,
                 usage: wgpu::TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
         texture_views.push(texture.create_view(&wgpu::TextureViewDescriptor {
             label: Some(&format!("Texture View {i}")),

--- a/benches/benches/wgpu-benchmark/computepass.rs
+++ b/benches/benches/wgpu-benchmark/computepass.rs
@@ -150,6 +150,7 @@ impl ComputepassState {
                     format: wgpu::TextureFormat::Rgba8UnormSrgb,
                     usage: wgpu::TextureUsages::TEXTURE_BINDING,
                     view_formats: &[],
+                    texture_binding_view_dimension: None,
                 });
             texture_views.push(texture.create_view(&wgpu::TextureViewDescriptor {
                 label: Some(&format!("Texture View {i}")),
@@ -176,6 +177,7 @@ impl ComputepassState {
                     format: wgpu::TextureFormat::R32Float,
                     usage: wgpu::TextureUsages::STORAGE_BINDING,
                     view_formats: &[],
+                    texture_binding_view_dimension: None,
                 });
             storage_texture_views.push(texture.create_view(&wgpu::TextureViewDescriptor {
                 label: Some(&format!("StorageTexture View {i}")),

--- a/benches/benches/wgpu-benchmark/renderpass.rs
+++ b/benches/benches/wgpu-benchmark/renderpass.rs
@@ -107,6 +107,7 @@ impl RenderpassState {
                     format: wgpu::TextureFormat::Rgba8UnormSrgb,
                     usage: wgpu::TextureUsages::TEXTURE_BINDING,
                     view_formats: &[],
+                    texture_binding_view_dimension: None,
                 });
             texture_views.push(texture.create_view(&wgpu::TextureViewDescriptor {
                 label: Some(&format!("Texture View {i}")),
@@ -242,6 +243,7 @@ impl RenderpassState {
                 format: wgpu::TextureFormat::Rgba8UnormSrgb,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             })
             .create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -223,6 +223,7 @@ impl GPUDevice {
         .into_iter()
         .map(Into::into)
         .collect(),
+      texture_binding_view_dimension: None,
     };
 
     let (wgpu_texture, err) = self.wgpu_device.create_texture(&wgpu_descriptor);

--- a/examples/bug-repro/01_texture_atomic_bug/src/main.rs
+++ b/examples/bug-repro/01_texture_atomic_bug/src/main.rs
@@ -154,6 +154,7 @@ impl State {
             format: wgpu::TextureFormat::R32Uint,
             usage: wgpu::TextureUsages::STORAGE_ATOMIC | wgpu::TextureUsages::STORAGE_BINDING,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let storage_view = storage_texture.create_view(&Default::default());
 
@@ -166,6 +167,7 @@ impl State {
             format: wgpu::TextureFormat::R8Uint,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let dummy_view = dummy_texture.create_view(&Default::default());
 

--- a/examples/features/src/bunnymark/mod.rs
+++ b/examples/features/src/bunnymark/mod.rs
@@ -261,6 +261,7 @@ impl crate::framework::Example for Example {
                 format: wgpu::TextureFormat::Rgba8UnormSrgb,
                 usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
             queue.write_texture(
                 texture.as_image_copy(),

--- a/examples/features/src/conservative_raster/mod.rs
+++ b/examples/features/src/conservative_raster/mod.rs
@@ -32,6 +32,7 @@ impl Example {
                 usage: wgpu::TextureUsages::TEXTURE_BINDING
                     | wgpu::TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             })
             .create_view(&Default::default());
 

--- a/examples/features/src/cube/mod.rs
+++ b/examples/features/src/cube/mod.rs
@@ -178,6 +178,7 @@ impl crate::framework::Example for Example {
             format: wgpu::TextureFormat::R8Uint,
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         queue.write_texture(

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -674,6 +674,7 @@ impl<E: Example + wgpu::WasmNotSendSync> From<ExampleTestParams<E>>
                     format,
                     usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
                     view_formats: &[],
+                    texture_binding_view_dimension: None,
                 });
 
                 let dst_view = dst_texture.create_view(&wgpu::TextureViewDescriptor::default());

--- a/examples/features/src/mipmap/mod.rs
+++ b/examples/features/src/mipmap/mod.rs
@@ -239,6 +239,7 @@ impl crate::framework::Example for Example {
                 | wgpu::TextureUsages::COPY_DST,
             label: None,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         //Note: we could use queue.write_texture instead, and this is what other

--- a/examples/features/src/msaa_line/mod.rs
+++ b/examples/features/src/msaa_line/mod.rs
@@ -116,6 +116,7 @@ impl Example {
                 | wgpu::TextureUsages::TRANSIENT_ATTACHMENT,
             label: None,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         };
 
         device

--- a/examples/features/src/multiple_render_targets/mod.rs
+++ b/examples/features/src/multiple_render_targets/mod.rs
@@ -45,6 +45,7 @@ impl MultiTargetRenderer {
             format: wgpu::TextureFormat::R8Unorm, // we need only the red channel for black/white image,
             usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let ball_texture_data = &create_ball_texture_data(WIDTH, HEIGHT);
@@ -397,6 +398,7 @@ impl TextureTargets {
                 | wgpu::TextureUsages::TEXTURE_BINDING
                 | wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[format],
+            texture_binding_view_dimension: None,
         });
         let green_texture = device.create_texture(&wgpu::TextureDescriptor {
             label: None,
@@ -409,6 +411,7 @@ impl TextureTargets {
                 | wgpu::TextureUsages::TEXTURE_BINDING
                 | wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[format],
+            texture_binding_view_dimension: None,
         });
         let red_view = red_texture.create_view(&wgpu::TextureViewDescriptor {
             format: Some(format),

--- a/examples/features/src/multiview/mod.rs
+++ b/examples/features/src/multiview/mod.rs
@@ -70,6 +70,8 @@ impl crate::framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Rgba8Unorm,
+            // This example in particular is not compatible with 'compatibility mode/glsl'
+            texture_binding_view_dimension: None,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT
                 | wgpu::TextureUsages::COPY_SRC
                 | wgpu::TextureUsages::TEXTURE_BINDING,

--- a/examples/features/src/ray_aabb_compute/mod.rs
+++ b/examples/features/src/ray_aabb_compute/mod.rs
@@ -118,6 +118,7 @@ impl crate::framework::Example for Example {
             format: wgpu::TextureFormat::Rgba8Unorm,
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::STORAGE_BINDING,
             view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
+            texture_binding_view_dimension: None,
         });
 
         let rt_view = rt_target.create_view(&wgpu::TextureViewDescriptor {

--- a/examples/features/src/ray_cube_compute/mod.rs
+++ b/examples/features/src/ray_cube_compute/mod.rs
@@ -157,6 +157,7 @@ impl crate::framework::Example for Example {
             format: wgpu::TextureFormat::Rgba8Unorm,
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::STORAGE_BINDING,
             view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
+            texture_binding_view_dimension: None,
         });
 
         let rt_view = rt_target.create_view(&wgpu::TextureViewDescriptor {

--- a/examples/features/src/ray_cube_normals/mod.rs
+++ b/examples/features/src/ray_cube_normals/mod.rs
@@ -146,6 +146,7 @@ impl crate::framework::Example for Example {
             format: wgpu::TextureFormat::Rgba8Unorm,
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::STORAGE_BINDING,
             view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
+            texture_binding_view_dimension: None,
         });
 
         let rt_view = rt_target.create_view(&wgpu::TextureViewDescriptor {

--- a/examples/features/src/ray_traced_triangle/mod.rs
+++ b/examples/features/src/ray_traced_triangle/mod.rs
@@ -248,6 +248,7 @@ impl crate::framework::Example for Example {
             format: wgpu::TextureFormat::Rgba8Unorm,
             usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let sampler = device.create_sampler(&SamplerDescriptor {

--- a/examples/features/src/render_to_texture/mod.rs
+++ b/examples/features/src/render_to_texture/mod.rs
@@ -42,6 +42,7 @@ async fn run(_path: Option<String>) {
         format: wgpu::TextureFormat::Rgba8UnormSrgb,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[wgpu::TextureFormat::Rgba8UnormSrgb],
+        texture_binding_view_dimension: None,
     });
     let output_staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: None,

--- a/examples/features/src/render_with_compute/mod.rs
+++ b/examples/features/src/render_with_compute/mod.rs
@@ -183,6 +183,7 @@ fn create_tv_and_bg(
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::TEXTURE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let view = texture.create_view(&Default::default());
     let bg = device.create_bind_group(&wgpu::BindGroupDescriptor {

--- a/examples/features/src/shadow/mod.rs
+++ b/examples/features/src/shadow/mod.rs
@@ -196,6 +196,7 @@ impl Example {
                 | wgpu::TextureUsages::TRANSIENT_ATTACHMENT,
             label: None,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         depth_texture.create_view(&wgpu::TextureViewDescriptor::default())
@@ -381,6 +382,7 @@ impl crate::framework::Example for Example {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
             label: None,
             view_formats: &[],
+            texture_binding_view_dimension: Some(wgpu::TextureViewDimension::D2Array),
         });
         let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/examples/features/src/skybox/mod.rs
+++ b/examples/features/src/skybox/mod.rs
@@ -84,6 +84,7 @@ impl Example {
                 | wgpu::TextureUsages::TRANSIENT_ATTACHMENT,
             label: None,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         depth_texture.create_view(&wgpu::TextureViewDescriptor::default())
@@ -333,6 +334,7 @@ impl crate::framework::Example for Example {
                 usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                 label: None,
                 view_formats: &[],
+                texture_binding_view_dimension: Some(wgpu::TextureViewDimension::Cube),
             },
             // KTX2 stores mip levels in mip major order.
             wgpu::util::TextureDataOrder::MipMajor,

--- a/examples/features/src/stencil_triangles/mod.rs
+++ b/examples/features/src/stencil_triangles/mod.rs
@@ -147,6 +147,7 @@ impl crate::framework::Example for Example {
             format: wgpu::TextureFormat::Stencil8,
             view_formats: &[],
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            texture_binding_view_dimension: None,
         });
 
         // Done
@@ -182,6 +183,7 @@ impl crate::framework::Example for Example {
             format: wgpu::TextureFormat::Stencil8,
             view_formats: &[],
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            texture_binding_view_dimension: None,
         });
     }
 

--- a/examples/features/src/storage_texture/mod.rs
+++ b/examples/features/src/storage_texture/mod.rs
@@ -56,6 +56,7 @@ async fn run(_path: Option<String>) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let storage_texture_view = storage_texture.create_view(&wgpu::TextureViewDescriptor::default());
     let output_staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {

--- a/examples/features/src/texture_arrays/mod.rs
+++ b/examples/features/src/texture_arrays/mod.rs
@@ -170,6 +170,7 @@ impl crate::framework::Example for Example {
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
             label: None,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         };
         let red_texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("red"),

--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -375,6 +375,7 @@ fn render_pass(
         format,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[format],
+        texture_binding_view_dimension: None,
     });
     let render_target_view = render_target.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/examples/features/src/water/mod.rs
+++ b/examples/features/src/water/mod.rs
@@ -195,6 +195,7 @@ impl Example {
                 | wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let draw_depth_buffer = device.create_texture(&wgpu::TextureDescriptor {
@@ -208,6 +209,7 @@ impl Example {
                 | wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let color_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
@@ -834,13 +836,17 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     base_test_parameters: wgpu_test::TestParameters::default()
         .downlevel_flags(wgpu::DownlevelFlags::READ_ONLY_DEPTH_STENCIL)
         // To be fixed in <https://github.com/gfx-rs/wgpu/issues/5231>.
-        .expect_fail(wgpu_test::FailureCase {
-            backends: Some(wgpu::Backends::VULKAN),
-            reasons: vec![wgpu_test::FailureReason::validation_error()
-                .with_message("WRITE_AFTER_WRITE hazard detected.")],
-            behavior: wgpu_test::FailureBehavior::AssertFailure,
-            ..Default::default()
-        }),
+        // Flaky: doesn't reproduce on all Vulkan driver versions.
+        .expect_fail(
+            wgpu_test::FailureCase {
+                backends: Some(wgpu::Backends::VULKAN),
+                reasons: vec![wgpu_test::FailureReason::validation_error()
+                    .with_message("WRITE_AFTER_WRITE hazard detected.")],
+                behavior: wgpu_test::FailureBehavior::AssertFailure,
+                ..Default::default()
+            }
+            .flaky(),
+        ),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.018)], // Bounded by Apple A9
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/tests/tests/wgpu-gpu/bgra8unorm_storage.rs
+++ b/tests/tests/wgpu-gpu/bgra8unorm_storage.rs
@@ -42,6 +42,7 @@ static BGRA8_UNORM_STORAGE: GpuTestConfiguration = GpuTestConfiguration::new()
             format: wgpu::TextureFormat::Bgra8Unorm,
             usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::COPY_SRC,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let view = texture.create_view(&wgpu::TextureViewDescriptor {

--- a/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
@@ -119,6 +119,7 @@ async fn binding_array_sampled_textures(ctx: TestingContext, partially_bound: bo
             format: TextureFormat::Rgba8UnormSrgb,
             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         ctx.queue.write_texture(
@@ -157,6 +158,7 @@ async fn binding_array_sampled_textures(ctx: TestingContext, partially_bound: bo
         format: TextureFormat::Rgba8UnormSrgb,
         usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let output_view = output_texture.create_view(&TextureViewDescriptor::default());
@@ -341,6 +343,7 @@ async fn partial_binding_array_followed_by_storage_buffer(ctx: TestingContext) {
         format: TextureFormat::Rgba8Unorm,
         usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let input_view = input_texture.create_view(&TextureViewDescriptor::default());
 
@@ -368,6 +371,7 @@ async fn partial_binding_array_followed_by_storage_buffer(ctx: TestingContext) {
         format: TextureFormat::Rgba8Unorm,
         usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let output_view = output_texture.create_view(&TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/binding_array/samplers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/samplers.rs
@@ -103,6 +103,7 @@ async fn binding_array_samplers(ctx: TestingContext, partially_bound: bool) {
         format: TextureFormat::Rgba8Unorm,
         usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     ctx.queue.write_texture(

--- a/tests/tests/wgpu-gpu/binding_array/storage_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/storage_textures.rs
@@ -98,6 +98,7 @@ async fn binding_array_storage_textures(ctx: TestingContext, partially_bound: bo
             format: TextureFormat::Rgba8Unorm,
             usage: TextureUsages::STORAGE_BINDING | TextureUsages::COPY_DST,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         ctx.queue.write_texture(
@@ -136,6 +137,7 @@ async fn binding_array_storage_textures(ctx: TestingContext, partially_bound: bo
         format: TextureFormat::Rgba8Unorm,
         usage: TextureUsages::STORAGE_BINDING | TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let output_view = output_texture.create_view(&TextureViewDescriptor::default());

--- a/tests/tests/wgpu-gpu/clear_texture.rs
+++ b/tests/tests/wgpu-gpu/clear_texture.rs
@@ -244,6 +244,7 @@ async fn single_texture_clear_test(
         format,
         usage: wgpu::TextureUsages::COPY_SRC | extra_usages,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let mut encoder = ctx
         .device
@@ -350,12 +351,14 @@ static CLEAR_TEXTURE_UNCOMPRESSED_GLES: GpuTestConfiguration = GpuTestConfigurat
 static CLEAR_TEXTURE_UNCOMPRESSED: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            // Flaky: doesn't reproduce on all GL driver versions.
             .expect_fail(
                 FailureCase::backend(wgpu::Backends::GL)
                     .panic("texture with format Rg8Snorm was not fully cleared")
                     .panic("texture with format Rgb9e5Ufloat was not fully cleared")
                     .validation_error("GL_INVALID_FRAMEBUFFER_OPERATION")
-                    .validation_error("GL_INVALID_OPERATION"),
+                    .validation_error("GL_INVALID_OPERATION")
+                    .flaky(),
             )
             .features(wgpu::Features::CLEAR_TEXTURE),
     )

--- a/tests/tests/wgpu-gpu/clip_distances.rs
+++ b/tests/tests/wgpu-gpu/clip_distances.rs
@@ -77,6 +77,7 @@ async fn clip_distances(ctx: TestingContext) {
         format: wgpu::TextureFormat::R8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     // Perform render

--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -167,6 +167,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
             format: wgpu::TextureFormat::Rg8Uint,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let target_view = texture_for_view.create_view(&wgpu::TextureViewDescriptor::default());
 
@@ -179,6 +180,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
             format: wgpu::TextureFormat::Rg8Uint,
             usage: wgpu::TextureUsages::COPY_SRC,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let texture_for_write = ctx.device.create_texture(&wgpu::TextureDescriptor {
@@ -190,6 +192,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
             format: wgpu::TextureFormat::Rg8Uint,
             usage: wgpu::TextureUsages::COPY_DST,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         // Create some buffers.
@@ -281,6 +284,7 @@ static DEVICE_DESTROY_THEN_MORE: GpuTestConfiguration = GpuTestConfiguration::ne
             format: wgpu::TextureFormat::Rg8Uint,
             usage: wgpu::TextureUsages::COPY_SRC,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         encoder_for_clear.clear_texture(
@@ -550,6 +554,7 @@ static DIFFERENT_BGL_ORDER_BW_SHADER_AND_API: GpuTestConfiguration = GpuTestConf
             format: wgpu::TextureFormat::Rgba8Unorm,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let my_texture_view = my_texture.create_view(&wgpu::TextureViewDescriptor {
@@ -650,6 +655,7 @@ static DEVICE_DESTROY_THEN_BUFFER_CLEANUP: GpuTestConfiguration = GpuTestConfigu
             format: wgpu::TextureFormat::Rg8Uint,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         // Destroy the device.

--- a/tests/tests/wgpu-gpu/draw_indirect.rs
+++ b/tests/tests/wgpu-gpu/draw_indirect.rs
@@ -236,6 +236,7 @@ async fn run_test_inner(
         format: wgpu::TextureFormat::R8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let out_texture_view = out_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
@@ -735,6 +736,7 @@ async fn indirect_buffer_offsets(ctx: TestingContext) {
         format: wgpu::TextureFormat::R8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let out_texture_view = out_texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/encoder.rs
+++ b/tests/tests/wgpu-gpu/encoder.rs
@@ -63,6 +63,7 @@ static DROP_ENCODER_AFTER_ERROR: GpuTestConfiguration = GpuTestConfiguration::ne
             format: wgpu::TextureFormat::R8Unorm,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let target_view = target_tex.create_view(&wgpu::TextureViewDescriptor::default());
 
@@ -125,6 +126,7 @@ fn encoder_operations_fail_while_pass_alive(ctx: TestingContext) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::COPY_DST,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     };
     let texture_dst = ctx.device.create_texture(&texture_desc);
     let texture_src = ctx.device.create_texture(&wgpu::TextureDescriptor {
@@ -150,6 +152,7 @@ fn encoder_operations_fail_while_pass_alive(ctx: TestingContext) {
         format: wgpu::TextureFormat::Bgra8UnormSrgb,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[wgpu::TextureFormat::Bgra8UnormSrgb],
+        texture_binding_view_dimension: None,
     };
     let target_tex = ctx.device.create_texture(&target_desc);
     let color_attachment_view = target_tex.create_view(&wgpu::TextureViewDescriptor::default());

--- a/tests/tests/wgpu-gpu/external_texture/mod.rs
+++ b/tests/tests/wgpu-gpu/external_texture/mod.rs
@@ -150,6 +150,7 @@ fn create_texture_and_view(
         format,
         usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     if let Some(data) = data {
         ctx.queue.write_texture(

--- a/tests/tests/wgpu-gpu/float32_filterable.rs
+++ b/tests/tests/wgpu-gpu/float32_filterable.rs
@@ -23,6 +23,7 @@ fn create_texture_binding(device: &wgpu::Device, format: wgpu::TextureFormat, fi
         format,
         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());

--- a/tests/tests/wgpu-gpu/image_atomics/mod.rs
+++ b/tests/tests/wgpu-gpu/image_atomics/mod.rs
@@ -126,6 +126,7 @@ async fn test_format(
         mip_level_count: 1,
         sample_count: 1,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let view = tex.create_view(&wgpu::TextureViewDescriptor {
         format: Some(format),
@@ -192,6 +193,7 @@ static IMAGE_ATOMICS_NOT_ENABLED: GpuTestConfiguration = GpuTestConfiguration::n
                     mip_level_count: 1,
                     sample_count: 1,
                     view_formats: &[],
+                    texture_binding_view_dimension: None,
                 });
             },
             Some("Texture usages TextureUsages(STORAGE_ATOMIC) are not allowed on a texture of type R32Uint"),
@@ -220,6 +222,7 @@ static IMAGE_ATOMICS_NOT_SUPPORTED: GpuTestConfiguration = GpuTestConfiguration:
                     mip_level_count: 1,
                     sample_count: 1,
                     view_formats: &[],
+                    texture_binding_view_dimension: None,
                 });
             },
             Some("Texture usages TextureUsages(STORAGE_ATOMIC) are not allowed on a texture of type R8Uint"),

--- a/tests/tests/wgpu-gpu/immediates.rs
+++ b/tests/tests/wgpu-gpu/immediates.rs
@@ -240,6 +240,7 @@ async fn render_pass_test(ctx: &TestingContext, use_render_bundle: bool) {
         usage: TextureUsages::RENDER_ATTACHMENT,
         label: Some("Output Texture"),
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let output_texture_view = output_texture.create_view(&Default::default());
 

--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -114,6 +114,7 @@ static TEXTURE_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
             format: wgpu::TextureFormat::Rgba8Snorm,
             usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         texture.destroy();
@@ -213,6 +214,7 @@ fn create_render_target(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureV
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
     (texture, view)
@@ -512,6 +514,7 @@ fn test_texture_destroy_before_submit(ctx: &TestingContext, usage: UsageKind) {
             format: wgpu::TextureFormat::Rgba8Snorm,
             usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         };
 
         let texture_1 = ctx.device.create_texture(&descriptor);
@@ -567,6 +570,7 @@ fn test_texture_destroy_before_submit(ctx: &TestingContext, usage: UsageKind) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::TEXTURE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
@@ -620,6 +624,7 @@ fn test_texture_destroy_after_submit(ctx: &TestingContext, usage: UsageKind) {
             format: wgpu::TextureFormat::Rgba8Snorm,
             usage: wgpu::TextureUsages::COPY_SRC | wgpu::TextureUsages::COPY_DST,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         };
 
         let texture_1 = ctx.device.create_texture(&descriptor);
@@ -671,6 +676,7 @@ fn test_texture_destroy_after_submit(ctx: &TestingContext, usage: UsageKind) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::TEXTURE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
@@ -721,6 +727,7 @@ fn test_external_texture_destroy_before_submit(ctx: &TestingContext, usage: Usag
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::TEXTURE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let external_texture = ctx.device.create_external_texture(

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -10,6 +10,7 @@ mod regression {
     pub mod issue_6317;
     pub mod issue_6467;
     pub mod issue_6827;
+    pub mod issue_7428;
     pub mod issue_9115;
 }
 
@@ -145,6 +146,7 @@ fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     regression::issue_6317::all_tests(&mut tests);
     regression::issue_6467::all_tests(&mut tests);
     regression::issue_6827::all_tests(&mut tests);
+    regression::issue_7428::all_tests(&mut tests);
     regression::issue_9115::all_tests(&mut tests);
     render_pass_ownership::all_tests(&mut tests);
     render_target::all_tests(&mut tests);

--- a/tests/tests/wgpu-gpu/mesh_shader/mod.rs
+++ b/tests/tests/wgpu-gpu/mesh_shader/mod.rs
@@ -37,6 +37,7 @@ fn create_depth(
         format: wgpu::TextureFormat::Depth32Float,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let depth_view = depth_texture.create_view(&Default::default());
     let state = wgpu::DepthStencilState {

--- a/tests/tests/wgpu-gpu/multiview/mod.rs
+++ b/tests/tests/wgpu-gpu/multiview/mod.rs
@@ -134,6 +134,7 @@ async fn run_test(ctx: TestingContext, layer_mask: u32, sample_count: u32) {
         format: wgpu::TextureFormat::R8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     };
     let texture = ctx.device.create_texture(&texture_desc);
     let texture_view_desc = wgpu::TextureViewDescriptor {

--- a/tests/tests/wgpu-gpu/occlusion_query/mod.rs
+++ b/tests/tests/wgpu-gpu/occlusion_query/mod.rs
@@ -30,6 +30,7 @@ static OCCLUSION_QUERY: GpuTestConfiguration = GpuTestConfiguration::new()
             format: wgpu::TextureFormat::Depth32Float,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let depth_texture_view = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/oom.rs
+++ b/tests/tests/wgpu-gpu/oom.rs
@@ -60,6 +60,7 @@ static TEXTURE_OOM_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
                 format: TextureFormat::Rgba16Float,
                 usage: TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
             if let Some(err) = scope.pop().await {
                 match err {

--- a/tests/tests/wgpu-gpu/pass_ops/mod.rs
+++ b/tests/tests/wgpu-gpu/pass_ops/mod.rs
@@ -79,6 +79,7 @@ async fn dont_care(ctx: TestingContext) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let readbacks = ReadbackBuffers::new(&ctx.device, &out_texture);
@@ -136,6 +137,7 @@ static DONT_CARE_COLOR_STRICT_WEBGPU_COMPLIANCE: GpuTestConfiguration = GpuTestC
             format: wgpu::TextureFormat::Rgba8Unorm,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
         let mut encoder = ctx
@@ -181,6 +183,7 @@ static DONT_CARE_DEPTH_STRICT_WEBGPU_COMPLIANCE: GpuTestConfiguration = GpuTestC
             format: wgpu::TextureFormat::Depth16Unorm,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
         let mut encoder = ctx
@@ -226,6 +229,7 @@ static DONT_CARE_STENCIL_STRICT_WEBGPU_COMPLIANCE: GpuTestConfiguration =
                 format: wgpu::TextureFormat::Stencil8,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
             let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
             let mut encoder = ctx

--- a/tests/tests/wgpu-gpu/per_vertex/mod.rs
+++ b/tests/tests/wgpu-gpu/per_vertex/mod.rs
@@ -130,6 +130,7 @@ async fn per_vertex(ctx: TestingContext) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let color_view = color_texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/planar_texture/mod.rs
+++ b/tests/tests/wgpu-gpu/planar_texture/mod.rs
@@ -87,6 +87,7 @@ fn test_planar_texture_creation_sampling(
         format: target_format,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let target_view = target_tex.create_view(&wgpu::TextureViewDescriptor::default());
 
@@ -246,6 +247,7 @@ static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfigurati
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let y_view = tex.create_view(&wgpu::TextureViewDescriptor {
             format: Some(wgpu::TextureFormat::R8Unorm),
@@ -289,6 +291,7 @@ static P010_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfigurati
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let y_view = tex.create_view(&wgpu::TextureViewDescriptor {
             format: Some(wgpu::TextureFormat::R16Unorm),
@@ -329,6 +332,7 @@ static NV12_TEXTURE_RENDERING: GpuTestConfiguration = GpuTestConfiguration::new(
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let y_view = tex.create_view(&wgpu::TextureViewDescriptor {
             format: Some(wgpu::TextureFormat::R8Unorm),
@@ -373,6 +377,7 @@ static NV12_TEXTURE_COPYING: GpuTestConfiguration = GpuTestConfiguration::new()
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let output_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
@@ -383,6 +388,7 @@ static NV12_TEXTURE_COPYING: GpuTestConfiguration = GpuTestConfiguration::new()
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let mut command_encoder = ctx
@@ -430,6 +436,7 @@ static NV12_PLANE_TO_SINGLE_PLANE_COPY: GpuTestConfiguration = GpuTestConfigurat
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         // Distinct patterns per plane so a swap or plane-0-fallback would fail
@@ -492,6 +499,7 @@ static NV12_PLANE_TO_SINGLE_PLANE_COPY: GpuTestConfiguration = GpuTestConfigurat
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let rg8 = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: Some("rg8 dst"),
@@ -502,6 +510,7 @@ static NV12_PLANE_TO_SINGLE_PLANE_COPY: GpuTestConfiguration = GpuTestConfigurat
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let r8_readback = ctx.device.create_buffer(&wgpu::BufferDescriptor {
@@ -631,6 +640,7 @@ static P010_TEXTURE_COPYING: GpuTestConfiguration = GpuTestConfiguration::new()
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let output_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
@@ -641,6 +651,7 @@ static P010_TEXTURE_COPYING: GpuTestConfiguration = GpuTestConfiguration::new()
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let mut command_encoder = ctx

--- a/tests/tests/wgpu-gpu/queue_transfer.rs
+++ b/tests/tests/wgpu-gpu/queue_transfer.rs
@@ -28,6 +28,7 @@ static QUEUE_WRITE_TEXTURE_THEN_DESTROY: GpuTestConfiguration = GpuTestConfigura
             format: wgpu::TextureFormat::Rgba32Float,
             usage: wgpu::TextureUsages::COPY_DST,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let data = vec![255; 1024];
@@ -78,6 +79,7 @@ static QUEUE_WRITE_TEXTURE_OVERFLOW: GpuTestConfiguration = GpuTestConfiguration
             format: wgpu::TextureFormat::Rgba32Float,
             usage: wgpu::TextureUsages::COPY_DST,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let data = vec![255; 128];
@@ -129,6 +131,7 @@ static QUEUE_WRITE_TEXTURE_BUFFER_OOB: GpuTestConfiguration =
                 format: wgpu::TextureFormat::Rgba32Float,
                 usage: wgpu::TextureUsages::COPY_DST,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
 
             let data = vec![255; 128];

--- a/tests/tests/wgpu-gpu/regression/issue_3349.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_3349.rs
@@ -138,6 +138,7 @@ async fn multi_stage_data_binding_test(ctx: TestingContext) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::COPY_SRC | wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());

--- a/tests/tests/wgpu-gpu/regression/issue_3457.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_3457.rs
@@ -135,6 +135,7 @@ static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration = GpuTestConfiguration::ne
                 format: TextureFormat::Rgba8Unorm,
                 usage: TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             })
             .create_view(&TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/regression/issue_4485.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4485.rs
@@ -38,6 +38,7 @@ async fn test_impl(ctx: &TestingContext) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::COPY_SRC | wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/regression/issue_4514.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4514.rs
@@ -38,6 +38,7 @@ async fn test_impl(ctx: &TestingContext) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::COPY_SRC | wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/regression/issue_5231_9343.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_5231_9343.rs
@@ -79,6 +79,7 @@ fn read_only_depth_test(ctx: &TestingContext, sample_depth: bool) {
         format: TextureFormat::Rgba8Unorm,
         usage: TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let color_view = color_texture.create_view(&TextureViewDescriptor::default());
 
@@ -96,6 +97,7 @@ fn read_only_depth_test(ctx: &TestingContext, sample_depth: bool) {
         format: TextureFormat::Depth32Float,
         usage: depth_usage,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let depth_view = depth_texture.create_view(&TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/regression/issue_6827.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_6827.rs
@@ -53,6 +53,7 @@ async fn run_test(ctx: TestingContext, use_many_writes: bool) {
                 | wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::COPY_SRC,
             label: None,
+            texture_binding_view_dimension: None,
         })
     };
 

--- a/tests/tests/wgpu-gpu/regression/issue_7428.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_7428.rs
@@ -1,0 +1,176 @@
+use wgpu_test::{
+    apply, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.push(TEXTURE_BINDING_VIEW_DIM_D2_ARRAY);
+}
+
+/// On the GLES backend, if you need a texture view in a view dimension other than what is inferred,
+/// you must pass texture_binding_view_dimension. This tests that this happens on all backends properly.
+#[apply(gpu_test!)]
+static TEXTURE_BINDING_VIEW_DIM_D2_ARRAY: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(wgpu::Limits {
+                max_storage_buffers_per_shader_stage: 1,
+                ..wgpu::Limits::downlevel_defaults()
+            }),
+    )
+    .run_async(|ctx| async move { test_impl(&ctx).await });
+
+async fn test_impl(ctx: &TestingContext) {
+    const TEST_PIXEL: [u8; 4] = [255, 0, 0, 255];
+    const OUTPUT_SIZE: u64 = 4 * 4; // vec4f
+
+    let texture_d2_array = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: None,
+        size: wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+        texture_binding_view_dimension: Some(wgpu::TextureViewDimension::D2Array),
+    });
+
+    ctx.queue.write_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: &texture_d2_array,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        &TEST_PIXEL,
+        wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(4),
+            rows_per_image: Some(1),
+        },
+        texture_d2_array.size(),
+    );
+
+    let texture_view = texture_d2_array.create_view(&wgpu::TextureViewDescriptor {
+        dimension: Some(wgpu::TextureViewDimension::D2Array),
+        array_layer_count: Some(1),
+        base_array_layer: 0,
+        ..Default::default()
+    });
+
+    let output_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: OUTPUT_SIZE,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let readback_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: OUTPUT_SIZE,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let bind_group_layout = ctx
+        .device
+        .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: None,
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2Array,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: None,
+        layout: &bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&texture_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: output_buf.as_entire_binding(),
+            },
+        ],
+    });
+
+    let shader = ctx
+        .device
+        .create_shader_module(wgpu::include_wgsl!("issue_7428.wgsl"));
+
+    let pipeline_layout = ctx
+        .device
+        .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+    let pipeline = ctx
+        .device
+        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: Some(&pipeline_layout),
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: None,
+            timestamp_writes: None,
+        });
+
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups(1, 1, 1);
+    }
+
+    encoder.copy_buffer_to_buffer(&output_buf, 0, &readback_buf, 0, OUTPUT_SIZE);
+
+    ctx.queue.submit(Some(encoder.finish()));
+
+    readback_buf.map_async(wgpu::MapMode::Read, .., Result::unwrap);
+
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
+
+    let result = readback_buf.get_mapped_range(..).unwrap();
+    assert_eq!(
+        bytemuck::cast_slice::<u8, f32>(&result),
+        &[1.0, 0.0, 0.0, 1.0],
+    );
+}

--- a/tests/tests/wgpu-gpu/regression/issue_7428.wgsl
+++ b/tests/tests/wgpu-gpu/regression/issue_7428.wgsl
@@ -1,0 +1,10 @@
+@group(0) @binding(0)
+var tex: texture_2d_array<f32>;
+
+@group(0) @binding(1)
+var<storage, read_write> output: array<vec4f>;
+
+@compute @workgroup_size(1)
+fn main() {
+    output[0] = textureLoad(tex, vec2i(0, 0), 0, 0);
+}

--- a/tests/tests/wgpu-gpu/regression/issue_9115.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_9115.rs
@@ -120,6 +120,7 @@ async fn immediates_with_uniform_in_single_module(ctx: TestingContext) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::COPY_SRC | wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());

--- a/tests/tests/wgpu-gpu/render_pass_ownership.rs
+++ b/tests/tests/wgpu-gpu/render_pass_ownership.rs
@@ -485,6 +485,7 @@ fn resource_setup(ctx: &TestingContext) -> ResourceSetup {
         format: target_format,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[target_format],
+        texture_binding_view_dimension: None,
     };
     let target_tex = ctx.device.create_texture(&target_desc);
     let target_tex_resolve = ctx.device.create_texture(&wgpu::TextureDescriptor {

--- a/tests/tests/wgpu-gpu/render_target.rs
+++ b/tests/tests/wgpu-gpu/render_target.rs
@@ -139,6 +139,7 @@ async fn run_test(
         format: wgpu::TextureFormat::R8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let readback_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
@@ -167,6 +168,7 @@ async fn run_test(
                 format: wgpu::TextureFormat::R8Unorm,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
             let ms_texture_view = ms_texture.create_view(&wgpu::TextureViewDescriptor::default());
             Some(ms_texture_view)
@@ -361,6 +363,7 @@ async fn run_test_3d(ctx: TestingContext) {
         format: wgpu::TextureFormat::R8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let readback_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {

--- a/tests/tests/wgpu-gpu/resolve_query_set_init.rs
+++ b/tests/tests/wgpu-gpu/resolve_query_set_init.rs
@@ -72,6 +72,7 @@ static USED_EMPTY_OCCLUSION_RESOLVES_TO_ZERO: GpuTestConfiguration = GpuTestConf
                 format: TextureFormat::Rgba8Unorm,
                 usage: TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             })
             .create_view(&TextureViewDescriptor::default());
 
@@ -477,6 +478,7 @@ fn create_occlusion_render_resources(ctx: &TestingContext) -> (TextureView, Rend
             format: TextureFormat::Rgba8Unorm,
             usage: TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         })
         .create_view(&TextureViewDescriptor::default());
     let shader = ctx.device.create_shader_module(ShaderModuleDescriptor {

--- a/tests/tests/wgpu-gpu/resource_error.rs
+++ b/tests/tests/wgpu-gpu/resource_error.rs
@@ -59,6 +59,7 @@ static BAD_TEXTURE_CREATE_VIEW: GpuTestConfiguration = GpuTestConfiguration::new
                     format: wgpu::TextureFormat::Rgba8UnormSrgb,
                     usage: wgpu::TextureUsages::all(),
                     view_formats: &[],
+                    texture_binding_view_dimension: None,
                 })
             },
             Some("dimension x is zero"),
@@ -95,6 +96,7 @@ static BAD_TEXTURE_WRITE: GpuTestConfiguration = GpuTestConfiguration::new()
                     format: wgpu::TextureFormat::Rgba8Unorm,
                     usage: wgpu::TextureUsages::COPY_DST,
                     view_formats: &[],
+                    texture_binding_view_dimension: None,
                 })
             },
             Some("mip level count"),

--- a/tests/tests/wgpu-gpu/samplers.rs
+++ b/tests/tests/wgpu-gpu/samplers.rs
@@ -351,6 +351,7 @@ fn sampler_bind_group(ctx: TestingContext, group_type: GroupType) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let input_image_view = input_image.create_view(&wgpu::TextureViewDescriptor::default());

--- a/tests/tests/wgpu-gpu/scissor_tests/mod.rs
+++ b/tests/tests/wgpu-gpu/scissor_tests/mod.rs
@@ -38,6 +38,7 @@ async fn scissor_test_impl(
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::COPY_SRC | wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/shader_barycentric/mod.rs
+++ b/tests/tests/wgpu-gpu/shader_barycentric/mod.rs
@@ -129,6 +129,7 @@ async fn barycentric(ctx: TestingContext, no_perspective: bool) {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let color_view = color_texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/shader_primitive_index/mod.rs
+++ b/tests/tests/wgpu-gpu/shader_primitive_index/mod.rs
@@ -170,6 +170,7 @@ async fn pulling_common(
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let color_view = color_texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/shader_view_format/mod.rs
+++ b/tests/tests/wgpu-gpu/shader_view_format/mod.rs
@@ -81,6 +81,7 @@ async fn reinterpret(
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[reinterpret_to],
+            texture_binding_view_dimension: None,
         },
         wgpu::util::TextureDataOrder::LayerMajor,
         bytemuck::cast_slice(src_data),
@@ -134,6 +135,7 @@ async fn reinterpret(
         format: src_format,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let target_view = target_tex.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/texture_binding/mod.rs
+++ b/tests/tests/wgpu-gpu/texture_binding/mod.rs
@@ -38,6 +38,7 @@ fn texture_binding(ctx: TestingContext) {
         format: TextureFormat::Rg32Float,
         usage: TextureUsages::STORAGE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let shader = ctx
         .device
@@ -94,6 +95,7 @@ fn single_scalar_load(ctx: TestingContext) {
         format: TextureFormat::R32Float,
         usage: TextureUsages::STORAGE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let texture_write = ctx.device.create_texture(&TextureDescriptor {
         label: None,
@@ -108,6 +110,7 @@ fn single_scalar_load(ctx: TestingContext) {
         format: TextureFormat::Rgba32Float,
         usage: TextureUsages::STORAGE_BINDING | TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let buffer = ctx.device.create_buffer(&BufferDescriptor {
         label: None,

--- a/tests/tests/wgpu-gpu/texture_blit.rs
+++ b/tests/tests/wgpu-gpu/texture_blit.rs
@@ -24,6 +24,7 @@ static TEXTURE_BLIT_WITH_LINEAR_FILTER_TEST: GpuTestConfiguration = GpuTestConfi
             format: wgpu::TextureFormat::Rgba16Float,
             usage: wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let target = ctx.device.create_texture(&wgpu::TextureDescriptor {
@@ -39,6 +40,7 @@ static TEXTURE_BLIT_WITH_LINEAR_FILTER_TEST: GpuTestConfiguration = GpuTestConfi
             format: wgpu::TextureFormat::Rgba8UnormSrgb,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let blitter = wgpu::util::TextureBlitterBuilder::new(
@@ -76,6 +78,7 @@ static TEXTURE_BLIT_WITH_NEAREST_FILTER_TEST: GpuTestConfiguration = GpuTestConf
             format: wgpu::TextureFormat::Rgba16Float,
             usage: wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let target = ctx.device.create_texture(&wgpu::TextureDescriptor {
@@ -91,6 +94,7 @@ static TEXTURE_BLIT_WITH_NEAREST_FILTER_TEST: GpuTestConfiguration = GpuTestConf
             format: wgpu::TextureFormat::Rgba8UnormSrgb,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let blitter = wgpu::util::TextureBlitterBuilder::new(

--- a/tests/tests/wgpu-gpu/texture_bounds.rs
+++ b/tests/tests/wgpu-gpu/texture_bounds.rs
@@ -108,6 +108,7 @@ const TEXTURE_DESCRIPTOR: wgpu::TextureDescriptor = wgpu::TextureDescriptor {
     format: wgpu::TextureFormat::Rgba8UnormSrgb,
     usage: wgpu::TextureUsages::COPY_DST.union(wgpu::TextureUsages::COPY_SRC),
     view_formats: &[],
+    texture_binding_view_dimension: None,
 };
 
 const BYTES_PER_PIXEL: u32 = 4;

--- a/tests/tests/wgpu-gpu/texture_view_creation.rs
+++ b/tests/tests/wgpu-gpu/texture_view_creation.rs
@@ -36,6 +36,7 @@ static STENCIL_ONLY_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::
                     | TextureUsages::COPY_SRC
                     | TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
             let _view = texture.create_view(&TextureViewDescriptor {
                 aspect: TextureAspect::StencilOnly,
@@ -68,6 +69,7 @@ static DEPTH_ONLY_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::ne
                     | TextureUsages::COPY_SRC
                     | TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
             let _view = texture.create_view(&TextureViewDescriptor {
                 aspect: TextureAspect::DepthOnly,
@@ -103,6 +105,7 @@ static SHARED_USAGE_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::
                     | TextureUsages::TEXTURE_BINDING
                     | TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[TextureFormat::Rgba8UnormSrgb],
+                texture_binding_view_dimension: None,
             });
             let _view = texture.create_view(&TextureViewDescriptor {
                 aspect: TextureAspect::All,

--- a/tests/tests/wgpu-gpu/transfer.rs
+++ b/tests/tests/wgpu-gpu/transfer.rs
@@ -25,6 +25,7 @@ static COPY_OVERFLOW_Z: GpuTestConfiguration = GpuTestConfiguration::new()
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let t2 = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
@@ -39,6 +40,7 @@ static COPY_OVERFLOW_Z: GpuTestConfiguration = GpuTestConfiguration::new()
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         fail(

--- a/tests/tests/wgpu-gpu/transient.rs
+++ b/tests/tests/wgpu-gpu/transient.rs
@@ -79,6 +79,7 @@ static RESOLVE_WITH_TRANSIENT: GpuTestConfiguration = GpuTestConfiguration::new(
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT
                 | wgpu::TextureUsages::TRANSIENT_ATTACHMENT,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let target_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
@@ -90,6 +91,7 @@ static RESOLVE_WITH_TRANSIENT: GpuTestConfiguration = GpuTestConfiguration::new(
             format: wgpu::TextureFormat::Rgba8Unorm,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let readback_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {

--- a/tests/tests/wgpu-gpu/transition_resources.rs
+++ b/tests/tests/wgpu-gpu/transition_resources.rs
@@ -21,6 +21,7 @@ static TRANSITION_RESOURCES: GpuTestConfiguration = GpuTestConfiguration::new()
             format: wgpu::TextureFormat::Rgba8Unorm,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let mut encoder = ctx

--- a/tests/tests/wgpu-gpu/vertex_formats/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_formats/mod.rs
@@ -274,6 +274,7 @@ async fn vertex_formats_common(ctx: TestingContext, tests: &[Test<'_>]) {
                 format: wgpu::TextureFormat::Rgba8Unorm,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_DST,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             },
             wgpu::util::TextureDataOrder::LayerMajor,
             &[0, 0, 0, 1],

--- a/tests/tests/wgpu-gpu/vertex_indices/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_indices/mod.rs
@@ -296,6 +296,7 @@ async fn vertex_index_common(ctx: TestingContext) {
                 format: wgpu::TextureFormat::Rgba8Unorm,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_DST,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             },
             wgpu::util::TextureDataOrder::LayerMajor,
             &[0, 0, 0, 1],

--- a/tests/tests/wgpu-gpu/vertex_state.rs
+++ b/tests/tests/wgpu-gpu/vertex_state.rs
@@ -130,6 +130,7 @@ async fn set_array_stride_to_0(ctx: TestingContext) {
         format: wgpu::TextureFormat::R8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let out_texture_view = out_texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-gpu/write_texture.rs
+++ b/tests/tests/wgpu-gpu/write_texture.rs
@@ -36,6 +36,7 @@ static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let data = vec![1u8; width as usize * 2];
         // Write the first two rows
@@ -135,6 +136,7 @@ static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let data = vec![1u8; (width * height) as usize * 2];
         // Write the first two slices
@@ -231,6 +233,7 @@ static WRITE_TEXTURE_NO_OOB: GpuTestConfiguration = GpuTestConfiguration::new()
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         let data = vec![1u8; width as usize * 2 + 100]; // check that we don't attempt to copy OOB internally by adding 100 bytes here
         ctx.queue.write_texture(
@@ -278,6 +281,7 @@ static WRITE_TEXTURE_VIA_STAGING_BUFFER: GpuTestConfiguration = GpuTestConfigura
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         let write_width: u32 = 31;

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -208,6 +208,7 @@ impl<'ctx> DiscardTestCase<'ctx> {
                 | TextureUsages::RENDER_ATTACHMENT
                 | extra_usages,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
 
         // Clear using a write_texture operation. We could also clear using a render_pass clear.
@@ -460,6 +461,7 @@ static WRITE_TEXTURE_STENCIL_LEAVES_DEPTH_UNINIT_DEPTH24PLUS_STENCIL8: GpuTestCo
                     | TextureUsages::COPY_SRC
                     | TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
 
             let stencil_bytes_per_row = size.width;
@@ -746,6 +748,7 @@ async fn check_write_aspect_leaves_other_uninit(
         format,
         usage: TextureUsages::COPY_DST | TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let write_bytes_per_row = write.size.width * write.bpp;
@@ -1058,6 +1061,7 @@ fn create_3d_texture(ctx: &TestingContext, label: &str, depth: u32) -> Texture {
         format: TextureFormat::R8Uint,
         usage: TextureUsages::COPY_SRC | TextureUsages::COPY_DST,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     })
 }
 
@@ -1433,6 +1437,7 @@ async fn check_vertex_buffer_tail_init(
         format: TextureFormat::Rgba8UnormSrgb,
         usage: TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let output_view = output_texture.create_view(&Default::default());
 
@@ -1674,6 +1679,7 @@ async fn test_copy_texture_to_buffer_padding_init(
         format,
         usage: TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let readback = ctx.device.create_buffer(&BufferDescriptor {

--- a/tests/tests/wgpu-validation/api/device.rs
+++ b/tests/tests/wgpu-validation/api/device.rs
@@ -19,6 +19,7 @@ fn recursive_uncaptured_error() {
         format: wgpu::TextureFormat::Rgba8UnormSrgb,
         usage: wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     };
 
     let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());

--- a/tests/tests/wgpu-validation/api/external_texture.rs
+++ b/tests/tests/wgpu-validation/api/external_texture.rs
@@ -23,6 +23,7 @@ fn create_external_texture() {
         format: TextureFormat::Rgba8Unorm,
         usage: TextureUsages::TEXTURE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     };
 
     let r_texture = device.create_texture(&TextureDescriptor {
@@ -371,6 +372,7 @@ fn external_texture_binding() {
         format: TextureFormat::Rgba8Unorm,
         usage: TextureUsages::TEXTURE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     };
     let external_texture_descriptor = ExternalTextureDescriptor {
         label: None,
@@ -434,6 +436,7 @@ fn external_texture_binding_texture_view() {
         format: TextureFormat::Rgba8Unorm,
         usage: TextureUsages::TEXTURE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     };
 
     let texture = device.create_texture(&texture_descriptor);
@@ -584,6 +587,7 @@ fn destroyed_external_texture_plane() {
         format: TextureFormat::Rgba8Unorm,
         usage: TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let target_view = target_texture.create_view(&TextureViewDescriptor::default());
 
@@ -600,6 +604,7 @@ fn destroyed_external_texture_plane() {
         format: TextureFormat::Rgba8Unorm,
         usage: TextureUsages::TEXTURE_BINDING,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let plane_view = plane_texture.create_view(&TextureViewDescriptor::default());
 

--- a/tests/tests/wgpu-validation/api/immediates.rs
+++ b/tests/tests/wgpu-validation/api/immediates.rs
@@ -433,6 +433,7 @@ fn setup_render() -> (wgpu::Device, wgpu::Queue, wgpu::TextureView) {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         label: Some("Output Texture"),
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let output_texture_view = output_texture.create_view(&Default::default());
 

--- a/tests/tests/wgpu-validation/api/texture.rs
+++ b/tests/tests/wgpu-validation/api/texture.rs
@@ -24,6 +24,7 @@ fn destroyed_texture() {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let texture_dst = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("dst"),
@@ -34,6 +35,7 @@ fn destroyed_texture() {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::COPY_DST,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let mut encoder =
@@ -108,6 +110,7 @@ fn planar_texture_view_plane() {
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         valid(&device, || {
             let _ = tex.create_view(&wgpu::TextureViewDescriptor {
@@ -138,6 +141,7 @@ fn non_planar_texture_view_plane() {
         mip_level_count: 1,
         sample_count: 1,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     fail(
         &device,
@@ -190,6 +194,7 @@ fn planar_texture_view_plane_out_of_bounds() {
             mip_level_count: 1,
             sample_count: 1,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         });
         fail(
             &device,
@@ -240,6 +245,7 @@ fn planar_texture_bad_view_format() {
                     mip_level_count: 1,
                     sample_count: 1,
                     view_formats: &[view_format],
+                    texture_binding_view_dimension: None,
                 });
             },
             Some(&format!(
@@ -279,6 +285,7 @@ fn planar_texture_bad_size() {
                     mip_level_count: 1,
                     sample_count: 1,
                     view_formats: &[],
+                    texture_binding_view_dimension: None,
                 });
             },
             Some(&format!(
@@ -327,6 +334,7 @@ fn planar_texture_render_attachment() {
                 mip_level_count: 1,
                 sample_count: 1,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
 
             let _ = texture.create_view(&wgpu::TextureViewDescriptor {
@@ -367,6 +375,7 @@ fn planar_texture_render_attachment_unsupported() {
                 mip_level_count: 1,
                 sample_count: 1,
                 view_formats: &[],
+                texture_binding_view_dimension: None,
             });
         },
         Some("Texture usages TextureUsages(RENDER_ATTACHMENT) are not allowed on a texture of type P010"),
@@ -396,6 +405,7 @@ fn encode_copy_texture_to_buffer(
         format,
         usage: wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let buffer = device.create_buffer(&wgpu::BufferDescriptor {
@@ -495,6 +505,7 @@ fn encode_copy_buffer_to_texture(
         format,
         usage: wgpu::TextureUsages::COPY_DST,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     let buffer = device.create_buffer(&wgpu::BufferDescriptor {
@@ -612,6 +623,7 @@ fn transient_invalid_usage() {
             format: wgpu::TextureFormat::Rgba8Unorm,
             usage,
             view_formats: &[],
+            texture_binding_view_dimension: None,
         };
         fail(
             &device,
@@ -629,6 +641,7 @@ fn transient_invalid_usage() {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::TRANSIENT_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     };
     fail(
         &device,
@@ -658,6 +671,7 @@ fn transient_invalid_storeop() {
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TRANSIENT_ATTACHMENT,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
 
     fail(
@@ -709,6 +723,7 @@ fn no_overflow_in_texture_selector() {
         format: wgpu::TextureFormat::R8Unorm,
         usage: wgpu::TextureUsages::COPY_DST,
         view_formats: &[],
+        texture_binding_view_dimension: None,
     });
     let _view = texture.create_view(&wgpu::TextureViewDescriptor {
         base_array_layer: 3385121660,

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -191,6 +191,7 @@ fn trace_texture_test() {
         format: wgt::TextureFormat::Rgba8Unorm,
         usage: wgt::TextureUsages::COPY_DST | wgt::TextureUsages::TEXTURE_BINDING,
         view_formats: Vec::new(),
+        texture_binding_view_dimension: None,
     };
 
     let (texture, error) = device.create_texture(&desc);

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2030,6 +2030,7 @@ impl Device {
             usage: hal_usage,
             memory_flags: hal::MemoryFlags::empty(),
             view_formats: hal_view_formats,
+            texture_binding_view_dimension: desc.texture_binding_view_dimension,
         };
 
         let raw_texture = unsafe { self.raw().create_texture(&hal_desc) }

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -207,6 +207,7 @@ impl Surface {
                     mip_level_count: 1,
                     format: config.format,
                     dimension: wgt::TextureDimension::D2,
+                    texture_binding_view_dimension: None,
                     usage: config.usage,
                     view_formats: config.view_formats,
                 };

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -327,6 +327,7 @@ impl<A: hal::Api> Example<A> {
             format: wgpu_types::TextureFormat::Rgba8UnormSrgb,
             usage: wgpu_types::TextureUses::COPY_DST | wgpu_types::TextureUses::RESOURCE,
             memory_flags: hal::MemoryFlags::empty(),
+            texture_binding_view_dimension: None,
             view_formats: vec![],
         };
         let texture = unsafe { device.create_texture(&texture_desc).unwrap() };

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -667,6 +667,7 @@ impl<A: hal::Api> Example<A> {
             usage: wgpu_types::TextureUses::STORAGE_READ_WRITE | wgpu_types::TextureUses::COPY_SRC,
             memory_flags: hal::MemoryFlags::empty(),
             view_formats: vec![wgpu_types::TextureFormat::Rgba8Unorm],
+            texture_binding_view_dimension: None,
         };
         let texture = unsafe { device.create_texture(&texture_desc).unwrap() };
 

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -316,7 +316,7 @@ pub(super) fn map_primitive_state(state: &wgt::PrimitiveState) -> super::Primiti
     }
 }
 
-pub fn _map_view_dimension(dim: wgt::TextureViewDimension) -> u32 {
+pub fn map_view_dimension(dim: wgt::TextureViewDimension) -> u32 {
     use wgt::TextureViewDimension as Tvd;
     match dim {
         Tvd::D1 | Tvd::D2 => glow::TEXTURE_2D,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -508,35 +508,30 @@ impl Texture {
 
     /// Returns the `target`, whether the image is 3d and whether the image is a cubemap.
     fn get_info_from_desc(desc: &TextureDescriptor) -> u32 {
-        match desc.dimension {
-            // WebGL (1 and 2) as well as some GLES versions do not have 1D textures, so we are
-            // doing `TEXTURE_2D` instead
-            wgt::TextureDimension::D1 => glow::TEXTURE_2D,
-            wgt::TextureDimension::D2 => {
-                // HACK: detect a cube map; forces cube compatible textures to be cube textures
-                match (desc.is_cube_compatible(), desc.size.depth_or_array_layers) {
-                    (false, 1) => glow::TEXTURE_2D,
-                    (false, _) => glow::TEXTURE_2D_ARRAY,
-                    (true, 6) => glow::TEXTURE_CUBE_MAP,
-                    (true, _) => glow::TEXTURE_CUBE_MAP_ARRAY,
+        if let Some(dim) = desc.texture_binding_view_dimension {
+            conv::map_view_dimension(dim)
+        } else {
+            match desc.dimension {
+                // WebGL (1 and 2) as well as some GLES versions do not have 1D textures, so we are
+                // doing `TEXTURE_2D` instead
+                wgt::TextureDimension::D1 => glow::TEXTURE_2D,
+                wgt::TextureDimension::D2 => {
+                    // HACK: detect a cube map; forces cube compatible textures to be cube textures
+                    match (desc.is_cube_compatible(), desc.size.depth_or_array_layers) {
+                        (false, 1) => glow::TEXTURE_2D,
+                        (false, _) => glow::TEXTURE_2D_ARRAY,
+                        (true, 6) => glow::TEXTURE_CUBE_MAP,
+                        (true, _) => glow::TEXTURE_CUBE_MAP_ARRAY,
+                    }
                 }
+                wgt::TextureDimension::D3 => glow::TEXTURE_3D,
             }
-            wgt::TextureDimension::D3 => glow::TEXTURE_3D,
         }
     }
 
-    /// More information can be found in issues #1614 and #1574
+    /// More information can be found in issues #1614, #7428 and #1574
     fn log_failing_target_heuristics(view_dimension: wgt::TextureViewDimension, target: u32) {
-        let expected_target = match view_dimension {
-            wgt::TextureViewDimension::D1 => glow::TEXTURE_2D,
-            wgt::TextureViewDimension::D2 => glow::TEXTURE_2D,
-            wgt::TextureViewDimension::D2Array => glow::TEXTURE_2D_ARRAY,
-            wgt::TextureViewDimension::Cube => glow::TEXTURE_CUBE_MAP,
-            wgt::TextureViewDimension::CubeArray => glow::TEXTURE_CUBE_MAP_ARRAY,
-            wgt::TextureViewDimension::D3 => glow::TEXTURE_3D,
-        };
-
-        if expected_target == target {
+        if conv::map_view_dimension(view_dimension) == target {
             return;
         }
 
@@ -569,6 +564,8 @@ impl Texture {
                 "`D2` textures with ",
                 "`depth_or_array_layers > 6 && depth_or_array_layers % 6 == 0` ",
                 "are assumed to have view dimension `CubeArray`\n",
+                "Specify texture_binding_view_dimension in TextureDescriptor ",
+                "to select the target explicitly.\n",
             ),
             got,
             view_dimension,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2206,6 +2206,8 @@ pub struct TextureDescriptor<'a> {
     pub format: wgt::TextureFormat,
     pub usage: wgt::TextureUses,
     pub memory_flags: MemoryFlags,
+    /// For compatibility mode (#8124), views created from this texture must have this as their `dimension`.
+    pub texture_binding_view_dimension: Option<wgt::TextureViewDimension>,
     /// Allows views of this texture to have a different format
     /// than the texture does.
     pub view_formats: Vec<wgt::TextureFormat>,

--- a/wgpu-info/src/texture.rs
+++ b/wgpu-info/src/texture.rs
@@ -16,6 +16,7 @@ fn test_compute_render_extent() {
             format,
             usage: wgpu::TextureUsages::empty(),
             view_formats: &[],
+            texture_binding_view_dimension: None,
         };
 
         if format.is_multi_planar_format() {
@@ -39,6 +40,7 @@ fn test_compute_render_extent() {
             format,
             usage: wgpu::TextureUsages::empty(),
             view_formats: &[],
+            texture_binding_view_dimension: None,
         };
 
         assert_eq!(

--- a/wgpu-types/src/texture.rs
+++ b/wgpu-types/src/texture.rs
@@ -528,6 +528,8 @@ pub struct TextureDescriptor<L, V> {
     ///
     /// Note: currently, only the srgb-ness is allowed to change. (ex: `Rgba8Unorm` texture + `Rgba8UnormSrgb` view)
     pub view_formats: V,
+    /// For compatibility mode/gles (#8124), views created from this texture must have this as their `dimension`.
+    pub texture_binding_view_dimension: Option<TextureViewDimension>,
 }
 
 impl<L, V> TextureDescriptor<L, V> {
@@ -546,6 +548,7 @@ impl<L, V> TextureDescriptor<L, V> {
             format: self.format,
             usage: self.usage,
             view_formats: self.view_formats.clone(),
+            texture_binding_view_dimension: self.texture_binding_view_dimension,
         }
     }
 
@@ -565,6 +568,7 @@ impl<L, V> TextureDescriptor<L, V> {
             format: self.format,
             usage: self.usage,
             view_formats: v_fun(&self.view_formats),
+            texture_binding_view_dimension: self.texture_binding_view_dimension,
         }
     }
 
@@ -587,6 +591,7 @@ impl<L, V> TextureDescriptor<L, V> {
     ///   format: wgpu::TextureFormat::Rgba8Sint,
     ///   usage: wgpu::TextureUsages::empty(),
     ///   view_formats: &[],
+    ///   texture_binding_view_dimension: None,
     /// };
     ///
     /// assert_eq!(desc.mip_level_size(0), Some(wgpu::Extent3d { width: 100, height: 60, depth_or_array_layers: 1 }));

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -175,6 +175,7 @@ impl Surface<'_> {
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
+            texture_binding_view_dimension: None,
             view_formats: &[],
         };
 


### PR DESCRIPTION
**Connections**
- Based on: https://github.com/teoxoy/wgpu/tree/texture_binding_view_dimension
- Based on: https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md
- Works around #7428

**Description**
- GLES backend currently spams the console with this error (https://github.com/gfx-rs/wgpu/blob/trunk/wgpu-hal/src/gles/mod.rs#L498) in bevy examples (https://github.com/bevyengine/bevy/issues/13115) and doesn't have a good way to use texture views as GLES 3 doesn't support texture views.

> Fundamental issue is that webgpu's textures and texture views are incompatible with opengl's textures and texture views because they are mappings of vulkan's images and image views.

 _Originally posted by @tasogare3710 in [#7428](https://github.com/gfx-rs/wgpu/issues/7428#issuecomment-2817209315)_

**Testing**
- Regression test added: `issue_7428.rs` which exercises the d2array type which would otherwise be inferred wrong.
- Need to test js/wasm

**Squash or Rebase?**
- Not ready to be merged yet, undecided.

**Checklist**
(keeping, as draft)
- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
