### PR TITLE
Another fix for texture copy validation

### DIFF
--- a/tests/tests/wgpu-gpu/queue_transfer.rs
+++ b/tests/tests/wgpu-gpu/queue_transfer.rs
@@ -99,3 +99,54 @@ static QUEUE_WRITE_TEXTURE_OVERFLOW: GpuTestConfiguration =
             Some("end up overrunning the bounds of the destination texture"),
         );
     });
+
+#[gpu_test]
+static QUEUE_WRITE_TEXTURE_BUFFER_OOB: GpuTestConfiguration =
+    GpuTestConfiguration::new().run_sync(|ctx| {
+        // Test that transfers overrunning the end of the source buffer, or
+        // where offset + size overflows a u64, are rejected.
+        for offset in [120, u64::MAX - 3] {
+            let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+                label: None,
+                size: wgpu::Extent3d {
+                    width: 146,
+                    height: 25,
+                    depth_or_array_layers: 192,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba32Float,
+                usage: wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            });
+
+            let data = vec![255; 128];
+
+            fail(
+                &ctx.device,
+                || {
+                    ctx.queue.write_texture(
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &texture,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d { x: 0, y: 0, z: 1 },
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        &data,
+                        wgpu::TexelCopyBufferLayout {
+                            offset,
+                            bytes_per_row: Some(16),
+                            rows_per_image: Some(1),
+                        },
+                        wgpu::Extent3d {
+                            width: 1,
+                            height: 1,
+                            depth_or_array_layers: 1,
+                        },
+                    );
+                },
+                Some("would end up overrunning the bounds of the source buffer"),
+            );
+        }
+    });

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -351,10 +351,11 @@ pub(crate) fn validate_linear_texture_data(
         }
     }
 
-    if offset + bytes_in_copy > buffer_size {
+    // Avoid underflow in the subtraction by checking bytes_in_copy against buffer_size first.
+    if bytes_in_copy > buffer_size || offset > buffer_size - bytes_in_copy {
         return Err(TransferError::BufferOverrun {
             start_offset: offset,
-            end_offset: offset + bytes_in_copy,
+            end_offset: offset.wrapping_add(bytes_in_copy),
             buffer_size,
             side: buffer_side,
         });


### PR DESCRIPTION
Fix another validation issue in texture copies.

**Testing**
Adds a directed test.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
