### PR TITLE
Allow copying one layer of depth/stencil textures

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -6,6 +6,7 @@ webgpu:api,operation,compute,basic:memcpy:*
 webgpu:api,operation,compute_pipeline,overrides:*
 webgpu:api,operation,device,lost:*
 // This is all the storeOp tests, but some of them fail if run in a single invocation.
+// https://github.com/gfx-rs/wgpu/issues/8021
 webgpu:api,operation,render_pass,storeOp:render_pass_store_op,color_attachment_with_depth_stencil_attachment:*
 webgpu:api,operation,render_pass,storeOp:render_pass_store_op,color_attachment_only:*
 webgpu:api,operation,render_pass,storeOp:render_pass_store_op,multiple_color_attachments:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -5,6 +5,7 @@ webgpu:api,operation,compute,basic:memcpy:*
 //FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute_pipeline,overrides:*
 webgpu:api,operation,device,lost:*
+webgpu:api,operation,render_pass,storeOp:*
 webgpu:api,validation,encoding,beginComputePass:*
 webgpu:api,validation,encoding,beginRenderPass:*
 webgpu:api,validation,encoding,cmds,clearBuffer:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -5,7 +5,11 @@ webgpu:api,operation,compute,basic:memcpy:*
 //FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute_pipeline,overrides:*
 webgpu:api,operation,device,lost:*
-webgpu:api,operation,render_pass,storeOp:*
+// This is all the storeOp tests, but some of them fail if run in a single invocation.
+webgpu:api,operation,render_pass,storeOp:render_pass_store_op,color_attachment_with_depth_stencil_attachment:*
+webgpu:api,operation,render_pass,storeOp:render_pass_store_op,color_attachment_only:*
+webgpu:api,operation,render_pass,storeOp:render_pass_store_op,multiple_color_attachments:*
+webgpu:api,operation,render_pass,storeOp:render_pass_store_op,depth_stencil_attachment_only:*
 webgpu:api,validation,encoding,beginComputePass:*
 webgpu:api,validation,encoding,beginRenderPass:*
 webgpu:api,validation,encoding,cmds,clearBuffer:*

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -455,7 +455,7 @@ pub(crate) fn validate_texture_copy_range<T>(
     let extent = extent_virtual.physical_size(desc.format);
 
     // Multisampled and depth-stencil formats do not support partial copies
-    // on x and y dimensions, but do support copying a single mip level.
+    // on x and y dimensions, but do support copying a subset of layers.
     let requires_exact_size = desc.format.is_depth_stencil_format() || desc.sample_count > 1;
 
     // Return `Ok` if a run `size` texels long starting at `start_offset` is
@@ -510,7 +510,7 @@ pub(crate) fn validate_texture_copy_range<T>(
         texture_copy_view.origin.z,
         copy_size.depth_or_array_layers,
         extent.depth_or_array_layers,
-        false, // partial copy always allowed on Z/mip dimension
+        false, // partial copy always allowed on Z/layer dimension
     )?;
 
     if texture_copy_view.origin.x % block_width != 0 {

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -454,7 +454,8 @@ pub(crate) fn validate_texture_copy_range<T>(
     // physical size can be larger than the virtual
     let extent = extent_virtual.physical_size(desc.format);
 
-    // Multisampled and depth-stencil formats do not support partial copies.
+    // Multisampled and depth-stencil formats do not support partial copies
+    // on x and y dimensions, but do support copying a single mip level.
     let requires_exact_size = desc.format.is_depth_stencil_format() || desc.sample_count > 1;
 
     // Return `Ok` if a run `size` texels long starting at `start_offset` is
@@ -462,7 +463,8 @@ pub(crate) fn validate_texture_copy_range<T>(
     let check_dimension = |dimension: TextureErrorDimension,
                            start_offset: u32,
                            size: u32,
-                           texture_size: u32|
+                           texture_size: u32,
+                           requires_exact_size: bool|
      -> Result<(), TransferError> {
         if requires_exact_size && (start_offset != 0 || size != texture_size) {
             Err(TransferError::UnsupportedPartialTransfer {
@@ -494,18 +496,21 @@ pub(crate) fn validate_texture_copy_range<T>(
         texture_copy_view.origin.x,
         copy_size.width,
         extent.width,
+        requires_exact_size,
     )?;
     check_dimension(
         TextureErrorDimension::Y,
         texture_copy_view.origin.y,
         copy_size.height,
         extent.height,
+        requires_exact_size,
     )?;
     check_dimension(
         TextureErrorDimension::Z,
         texture_copy_view.origin.z,
         copy_size.depth_or_array_layers,
         extent.depth_or_array_layers,
+        false, // partial copy always allowed on Z/mip dimension
     )?;
 
     if texture_copy_view.origin.x % block_width != 0 {


### PR DESCRIPTION
This fixes a regression introduced by #7935.

Multisampled and depth/stencil textures require copying an entire surface, but should not require copying all layers.

**Testing**
Enables the CTS test that caught the regression in Firefox.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
