### PR TITLE
hal/vulkan: Clear framebuffer cache during command buffer reset

### DIFF
--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -180,6 +180,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
         self.free
             .extend(cmd_bufs.into_iter().map(|cmd_buf| cmd_buf.raw));
         self.free.append(&mut self.discarded);
+        // Delete framebuffers from the framebuffer cache
+        for (_, framebuffer) in self.framebuffers.drain() {
+            unsafe { self.device.raw.destroy_framebuffer(framebuffer, None) };
+        }
         let _ = unsafe {
             self.device
                 .raw


### PR DESCRIPTION
**Connections**

Closes #7847 
Spawned https://github.com/gfx-rs/wgpu/issues/8032

**Description**

Cache grew without bounds, now that cache is cleared, now there's no leak

**Testing**

Stared at task manager

**Squash or Rebase?**

Yes