### PR TITLE
Prevent resources for acceleration structures being created if they are not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ By @Vecvec in [#7913](https://github.com/gfx-rs/wgpu/pull/7913).
 
 ### Changes
 
-#### Gemeral
+#### General
 
 - Prevent resources for acceleration structures being created if acceleration structures are not enabled. By @Vecvec in [#8036](https://github.com/gfx-rs/wgpu/pull/8036).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ By @Vecvec in [#7913](https://github.com/gfx-rs/wgpu/pull/7913).
 
 ### Changes
 
+#### Gemeral
+
+- Prevent resources for acceleration structures being created if acceleration structures are not enabled. By @Vecvec in [#8036](https://github.com/gfx-rs/wgpu/pull/8036).
+
 #### Naga
 
 Naga now requires that no type be larger than 1 GB. This limit may be lowered in the future; feedback on an appropriate value for the limit is welcome. By @andyleiserson in [#7950](https://github.com/gfx-rs/wgpu/pull/7950).

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -912,6 +912,8 @@ pub enum CreateBufferError {
     MaxBufferSize { requested: u64, maximum: u64 },
     #[error(transparent)]
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),
+    #[error(transparent)]
+    MissingFeatures(#[from] MissingFeatures),
     #[error("Failed to create bind group for indirect buffer validation: {0}")]
     IndirectValidationBindGroup(DeviceError),
 }
@@ -929,6 +931,7 @@ impl WebGpuError for CreateBufferError {
             Self::AccessError(e) => e,
             Self::MissingDownlevelFlags(e) => e,
             Self::IndirectValidationBindGroup(e) => e,
+            Self::MissingFeatures(e) => e,
 
             Self::UnalignedSize
             | Self::InvalidUsage(_)


### PR DESCRIPTION
**Connections**
Fixes #8008 

**Description**
Prevents buffers and bind group layouts from being created with usages that can only be used with acceleration structures.

**Testing**
Adds a test.

**Squash or Rebase?**
squash
<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. 
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
