### PR TITLE
fix(core): validate effective buf. binding size is aligned to 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ Naga now requires that no type be larger than 1 GB. This limit may be lowered in
 
 ### Bug Fixes
 
+#### General
+
+- Validate that effective buffer binding size is aligned to 4 when creating bind groups with buffer entries.. By @ErichDonGubler in [8041](https://github.com/gfx-rs/wgpu/pull/8041).
+
 #### Vulkan
 
 Fix `STATUS_HEAP_CORRUPTION` crash when concurrently calling `create_sampler`. By @atlv24 in [#8043](https://github.com/gfx-rs/wgpu/pull/8043).

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -19,6 +19,7 @@ webgpu:api,operation,render_pass,storeOp:render_pass_store_op,color_attachment_w
 webgpu:api,operation,render_pass,storeOp:render_pass_store_op,color_attachment_only:*
 webgpu:api,operation,render_pass,storeOp:render_pass_store_op,multiple_color_attachments:*
 webgpu:api,operation,render_pass,storeOp:render_pass_store_op,depth_stencil_attachment_only:*
+webgpu:api,validation,createBindGroup:buffer,effective_buffer_binding_size:*
 webgpu:api,validation,encoding,beginComputePass:*
 webgpu:api,validation,encoding,beginRenderPass:*
 webgpu:api,validation,encoding,cmds,clearBuffer:*

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -167,6 +167,8 @@ pub enum CreateBindGroupError {
     MissingTextureUsage(#[from] MissingTextureUsageError),
     #[error("Binding declared as a single item, but bind group is using it as an array")]
     SingleBindingExpected,
+    #[error("Effective buffer binding size {size} for storage buffers is expected to align to {alignment}, but size is {size}")]
+    UnalignedEffectiveBufferBindingSizeForStorage { alignment: u8, size: u64 },
     #[error("Buffer offset {0} does not respect device's requested `{1}` limit {2}")]
     UnalignedBufferOffset(wgt::BufferAddress, &'static str, u32),
     #[error(
@@ -275,6 +277,7 @@ impl WebGpuError for CreateBindGroupError {
             | Self::DuplicateBinding(_)
             | Self::MissingBindingDeclaration(_)
             | Self::SingleBindingExpected
+            | Self::UnalignedEffectiveBufferBindingSizeForStorage { .. }
             | Self::UnalignedBufferOffset(_, _, _)
             | Self::BufferRangeTooLarge { .. }
             | Self::WrongBindingType { .. }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2470,28 +2470,6 @@ impl Device {
             ),
         };
 
-        if matches!(binding_ty, wgt::BufferBindingType::Storage { .. }) {
-            // NOTE: We stay `Option`al here to avoid potentially overflowing ops with the offset
-            // and size. This overflow is checked later.
-            let effective_buffer_binding_size = bb
-                .size
-                .map(|s| s.get())
-                .or_else(|| bb.buffer.size.checked_sub(bb.offset));
-
-            if let Some(effective_buffer_binding_size) = effective_buffer_binding_size {
-                let storage_buf_size_alignment = 4;
-
-                let aligned =
-                    effective_buffer_binding_size % u64::from(storage_buf_size_alignment) == 0;
-                if !aligned {
-                    return Err(Error::UnalignedEffectiveBufferBindingSizeForStorage {
-                        alignment: storage_buf_size_alignment,
-                        size: effective_buffer_binding_size,
-                    });
-                }
-            }
-        }
-
         let (align, align_limit_name) =
             binding_model::buffer_binding_type_alignment(&self.limits, binding_ty);
         if bb.offset % align as u64 != 0 {
@@ -2511,6 +2489,19 @@ impl Device {
         buffer.check_usage(pub_usage)?;
 
         let (bb, bind_size) = buffer.binding(bb.offset, bb.size, snatch_guard)?;
+
+        if matches!(binding_ty, wgt::BufferBindingType::Storage { .. }) {
+            let storage_buf_size_alignment = 4;
+
+            let aligned = bind_size % u64::from(storage_buf_size_alignment) == 0;
+            if !aligned {
+                return Err(Error::UnalignedEffectiveBufferBindingSizeForStorage {
+                    alignment: storage_buf_size_alignment,
+                    size: bind_size,
+                });
+            }
+        }
+
         let bind_end = bb.offset + bind_size;
 
         if bind_size > range_limit as u64 {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2471,16 +2471,24 @@ impl Device {
         };
 
         if matches!(binding_ty, wgt::BufferBindingType::Storage { .. }) {
-            let storage_buf_size_alignment = 4;
+            // NOTE: We stay `Option`al here to avoid potentially overflowing ops with the offset
+            // and size. This overflow is checked later.
             let effective_buffer_binding_size = bb
                 .size
-                .map_or_else(|| bb.buffer.size - bb.offset, |s| s.get());
+                .map(|s| s.get())
+                .or_else(|| bb.buffer.size.checked_sub(bb.offset));
 
-            if effective_buffer_binding_size.get() % u64::from(storage_buf_size_alignment) != 0 {
-                return Err(Error::UnalignedEffectiveBufferBindingSizeForStorage {
-                    alignment: storage_buf_size_alignment,
-                    size: effective_buffer_binding_size,
-                });
+            if let Some(effective_buffer_binding_size) = effective_buffer_binding_size {
+                let storage_buf_size_alignment = 4;
+
+                let aligned =
+                    effective_buffer_binding_size % u64::from(storage_buf_size_alignment) == 0;
+                if !aligned {
+                    return Err(Error::UnalignedEffectiveBufferBindingSizeForStorage {
+                        alignment: storage_buf_size_alignment,
+                        size: effective_buffer_binding_size,
+                    });
+                }
             }
         }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2470,6 +2470,20 @@ impl Device {
             ),
         };
 
+        if matches!(binding_ty, wgt::BufferBindingType::Storage { .. }) {
+            let storage_buf_size_alignment = 4;
+            let effective_buffer_binding_size = bb
+                .size
+                .map_or_else(|| bb.buffer.size - bb.offset, |s| s.get());
+
+            if effective_buffer_binding_size.get() % u64::from(storage_buf_size_alignment) != 0 {
+                return Err(Error::UnalignedEffectiveBufferBindingSizeForStorage {
+                    alignment: storage_buf_size_alignment,
+                    size: effective_buffer_binding_size,
+                });
+            }
+        }
+
         let (align, align_limit_name) =
             binding_model::buffer_binding_type_alignment(&self.limits, binding_ty);
         if bb.offset % align as u64 != 0 {


### PR DESCRIPTION
The WebGPU spec. `createBindGroup` [states][spec-ref] (emphasis mine):

> Device timeline initialization steps:
>
> …
>
> 2. If any of the following conditions are unsatisfied generate a
>    validation error, invalidate _bindGroup_ and return.
>
>    …
>
>    For each `GPUBindGroupEntry` _bindingDescriptor_ in
>    _descriptor_.`entries`:
>
>    - …
>
>    - If the defined binding member for _layoutBinding_ is:
>
>      - …
>
>      - `buffer`
>
>        - …
>
>        - If _layoutBinding_.`buffer`.`type` is
>
>          - …
>
>          - `"storage"` or `"read-only-storage"`
>
>            - …
>
>            - effective buffer binding size(_bufferBinding_) is a multiple of 4.

[spec-ref]: https://www.w3.org/TR/webgpu/#dom-gpudevice-createbindgroup

We were not implementing this check of effective buffer binding size. Check that it's a multiple of 4, including
`webgpu:api,validation,createBindGroup:buffer,effective_buffer_binding_size:*` that this is now implemented as intended.

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
