### PR TITLE
fix(deno_webgpu): add `std` feature to `wgpu` dep.

### DIFF
--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -24,6 +24,7 @@ wgpu-core = { workspace = true, features = [
     "strict_asserts",
     "wgsl",
     "gles",
+    "std",
 ] }
 wgpu-types = { workspace = true, features = ["serde", "std"] }
 


### PR DESCRIPTION
There seems to be no reason not to do this, unless Deno is supposed to work in `no_std` environments. This fixes an issue where `WGPU*` environment variables weren't working when trying to use them to change how CTS tests were executing via `cargo xtask cts`, i.e., `WGPU_BACKEND=dx12`.