### PR TITLE
fix STATUS_HEAP_CORRUPTION crash in create_sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ We have merged the acceleration structure feature into the `RayQuery` feature. T
 
 By @Vecvec in [#7913](https://github.com/gfx-rs/wgpu/pull/7913).
 
+### Bug Fixes
+
+#### Vulkan
+
+Fix `STATUS_HEAP_CORRUPTION` crash when concurrently calling `create_sampler`. By @atlv24 in [#8043](https://github.com/gfx-rs/wgpu/pull/8043).
+
 ### Changes
 
 #### Naga

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,17 +53,17 @@ We have merged the acceleration structure feature into the `RayQuery` feature. T
 
 By @Vecvec in [#7913](https://github.com/gfx-rs/wgpu/pull/7913).
 
-### Bug Fixes
-
-#### Vulkan
-
-Fix `STATUS_HEAP_CORRUPTION` crash when concurrently calling `create_sampler`. By @atlv24 in [#8043](https://github.com/gfx-rs/wgpu/pull/8043).
-
 ### Changes
 
 #### Naga
 
 Naga now requires that no type be larger than 1 GB. This limit may be lowered in the future; feedback on an appropriate value for the limit is welcome. By @andyleiserson in [#7950](https://github.com/gfx-rs/wgpu/pull/7950).
+
+### Bug Fixes
+
+#### Vulkan
+
+Fix `STATUS_HEAP_CORRUPTION` crash when concurrently calling `create_sampler`. By @atlv24 in [#8043](https://github.com/gfx-rs/wgpu/pull/8043).
 
 ## v26.0.2 (2025-07-23)
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1414,7 +1414,11 @@ impl crate::Device for super::Device {
         //
         // https://github.com/gfx-rs/wgpu/issues/6867
         if let Some(label) = desc.label {
+            let l = self.shared.sampler_cache.lock();
+            // SAFETY: we are holding a lock on the sampler cache,
+            // so we can only be setting the name from one thread.
             unsafe { self.shared.set_object_name(raw, label) };
+            drop(l);
         }
 
         self.counters.samplers.add(1);

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1404,22 +1404,20 @@ impl crate::Device for super::Device {
             create_info = create_info.border_color(conv::map_border_color(color));
         }
 
-        let raw = self
-            .shared
-            .sampler_cache
-            .lock()
-            .create_sampler(&self.shared.raw, create_info)?;
+        let mut sampler_cache_guard = self.shared.sampler_cache.lock();
+
+        let raw = sampler_cache_guard.create_sampler(&self.shared.raw, create_info)?;
 
         // Note: Cached samplers will just continually overwrite the label
         //
         // https://github.com/gfx-rs/wgpu/issues/6867
         if let Some(label) = desc.label {
-            let l = self.shared.sampler_cache.lock();
             // SAFETY: we are holding a lock on the sampler cache,
             // so we can only be setting the name from one thread.
             unsafe { self.shared.set_object_name(raw, label) };
-            drop(l);
         }
+
+        drop(sampler_cache_guard);
 
         self.counters.samplers.add(1);
 


### PR DESCRIPTION
**Connections**
Fixes https://github.com/bevyengine/bevy/issues/20379

**Description**
The unsafe in hal vk `create_sampler` is unsound.

**Testing**
Reproduction case:
```rs
use std::thread;
struct Example {}
impl crate::framework::Example for Example {
    fn init(
        _config: &wgpu::SurfaceConfiguration,
        _adapter: &wgpu::Adapter,
        device: &wgpu::Device,
        _queue: &wgpu::Queue,
    ) -> Self {
        thread::scope(move |s| {
            for i in 0..100 {
                s.spawn(|| {
                    for i in 0..100000 {
                        let _ = device.create_sampler(&wgpu::SamplerDescriptor {
                            label: Some("My Label"),
                            ..Default::default()
                        });
                    }
                });
            }
        });
        Self {}
    }
    fn resize(
        &mut self,
        _config: &wgpu::SurfaceConfiguration,
        _device: &wgpu::Device,
        _queue: &wgpu::Queue,
    ) {
    }
    fn update(&mut self, _event: winit::event::WindowEvent) {}
    fn render(&mut self, _view: &wgpu::TextureView, _device: &wgpu::Device, _queue: &wgpu::Queue) {}
}
```

**Squash or Rebase?**

squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
