### PR TITLE
docs(vulkan): clarify safety contract for `DeviceShared::set_object_name`

### DIFF
--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -27,7 +27,17 @@ impl super::DeviceShared {
     ///
     /// # Safety
     ///
-    /// - It must be safe to mutate `object` from this thread.
+    /// This method inherits the safety contract from [`vkSetDebugUtilsObjectName`]. In particular:
+    ///
+    /// - `object` must be a valid handle for one of the following:
+    ///   - An instance-level object from the same instance as this device.
+    ///   - A physical-device-level object that descends from the same physical device as this
+    ///     device.
+    ///   - A device-level object that descends from this device.
+    /// - `object` must be externally synchronized—only the calling thread should access it during
+    ///   this call.
+    ///
+    /// [`vkSetDebugUtilsObjectName`]: https://registry.khronos.org/vulkan/specs/latest/man/html/vkSetDebugUtilsObjectNameEXT.html
     pub(super) unsafe fn set_object_name(&self, object: impl vk::Handle, name: &str) {
         let Some(extension) = self.extension_fns.debug_utils.as_ref() else {
             return;

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -27,7 +27,7 @@ impl super::DeviceShared {
     ///
     /// # Safety
     ///
-    /// It must be valid to set `object`'s debug name
+    /// - It must be safe to mutate `object` from this thread.
     pub(super) unsafe fn set_object_name(&self, object: impl vk::Handle, name: &str) {
         let Some(extension) = self.extension_fns.debug_utils.as_ref() else {
             return;


### PR DESCRIPTION
Motivated by [discussion in #8043](https://github.com/gfx-rs/wgpu/pull/8043#issuecomment-3155476579).
