### PR TITLE
Backport fix STATUS_HEAP_CORRUPTION crash in create_sampler (#8043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ Bottom level categories:
 
 ## Unreleased
 
+## v26.0.4 (2025-08-06)
+
+### Bug Fixes
+
+#### Vulkan
+
+Fix `STATUS_HEAP_CORRUPTION` crash when concurrently calling `create_sampler`. By @atlv24 in [#8043](https://github.com/gfx-rs/wgpu/pull/8043).
+
 ## v26.0.3 (2025-07-30)
 
 ### Bug Fixes

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1404,18 +1404,20 @@ impl crate::Device for super::Device {
             create_info = create_info.border_color(conv::map_border_color(color));
         }
 
-        let raw = self
-            .shared
-            .sampler_cache
-            .lock()
-            .create_sampler(&self.shared.raw, create_info)?;
+        let mut sampler_cache_guard = self.shared.sampler_cache.lock();
+
+        let raw = sampler_cache_guard.create_sampler(&self.shared.raw, create_info)?;
 
         // Note: Cached samplers will just continually overwrite the label
         //
         // https://github.com/gfx-rs/wgpu/issues/6867
         if let Some(label) = desc.label {
+            // SAFETY: we are holding a lock on the sampler cache,
+            // so we can only be setting the name from one thread.
             unsafe { self.shared.set_object_name(raw, label) };
         }
+
+        drop(sampler_cache_guard);
 
         self.counters.samplers.add(1);
 


### PR DESCRIPTION
Backport #8043 for v26.0.4 patch release