### PR TITLE
Fix misleading error message about vertex attribute limits

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3697,7 +3697,7 @@ impl Device {
 
                     if attribute.shader_location >= self.limits.max_vertex_attributes {
                         return Err(
-                            pipeline::CreateRenderPipelineError::TooManyVertexAttributes {
+                            pipeline::CreateRenderPipelineError::VertexAttributeLocationTooLarge {
                                 given: attribute.shader_location,
                                 limit: self.limits.max_vertex_attributes,
                             },

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -624,6 +624,8 @@ pub enum CreateRenderPipelineError {
     TooManyVertexBuffers { given: u32, limit: u32 },
     #[error("The total number of vertex attributes {given} exceeds the limit {limit}")]
     TooManyVertexAttributes { given: u32, limit: u32 },
+    #[error("Vertex attribute location {given} must be less than limit {limit}")]
+    VertexAttributeLocationTooLarge { given: u32, limit: u32 },
     #[error("Vertex buffer {index} stride {given} exceeds the limit {limit}")]
     VertexStrideTooLarge { index: u32, given: u32, limit: u32 },
     #[error("Vertex attribute at location {location} stride {given} exceeds the limit {limit}")]
@@ -708,6 +710,7 @@ impl WebGpuError for CreateRenderPipelineError {
             | Self::InvalidSampleCount(_)
             | Self::TooManyVertexBuffers { .. }
             | Self::TooManyVertexAttributes { .. }
+            | Self::VertexAttributeLocationTooLarge { .. }
             | Self::VertexStrideTooLarge { .. }
             | Self::UnalignedVertexStride { .. }
             | Self::InvalidVertexAttributeOffset { .. }


### PR DESCRIPTION
Fixes #8064.
I wanted to just replace `attribute.shader_location` with `attribute.shader_location + 1`, but this might still be even more misleading in some cases, so I took the liberty of introducing another error type for this case specifically.

**Checklist**

- [x] Run cargo fmt.
- [x] Run taplo format.
- [x] Run cargo clippy --tests. If applicable, add:
  - [x] --target wasm32-unknown-unknown
- [x] Run cargo xtask test to run tests.

**NB**: `cargo xtask test` reports
> `Summary [  29.520s] 950 tests run: 777 passed, 173 failed, 12 skipped`

both in trunk and in my branch, so I guess no new tests were broken.