### PR TITLE
Fix misleading error message for read-only attachments with set load op

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -638,9 +638,9 @@ impl WebGpuError for ColorAttachmentError {
 pub enum AttachmentError {
     #[error("The format of the depth-stencil attachment ({0:?}) is not a depth-or-stencil format")]
     InvalidDepthStencilAttachmentFormat(wgt::TextureFormat),
-    #[error("Read-only attachment with load")]
+    #[error("LoadOp must be None for read-only attachments")]
     ReadOnlyWithLoad,
-    #[error("Read-only attachment with store")]
+    #[error("StoreOp must be None for read-only attachments")]
     ReadOnlyWithStore,
     #[error("Attachment without load")]
     NoLoad,


### PR DESCRIPTION
Fixes #8067

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->

**NB**: `cargo xtask test` reports
> `Summary [  29.520s] 950 tests run: 777 passed, 173 failed, 12 skipped`

both in trunk and in my branch, so I guess no new tests were broken.