### PR TITLE
Accept configuration from the environment for the trace player

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -68,7 +68,8 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let global = wgc::global::Global::new("player", &wgt::InstanceDescriptor::default());
+    let global =
+        wgc::global::Global::new("player", &wgt::InstanceDescriptor::from_env_or_default());
     let mut command_encoder_id_manager = IdentityManager::new();
     let mut command_buffer_id_manager = IdentityManager::new();
 


### PR DESCRIPTION
This makes the trace player honor the `WGPU_*` environment variables.

**Testing**
Tested manually.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
