### PR TITLE
Fix initialization tracking for the destination of `copyTextureToBuffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ By @cwfitzgerald in [#8162](https://github.com/gfx-rs/wgpu/pull/8162).
   - Copies within the same texture must not overlap.
   - Copies of multisampled or depth/stencil formats must span an entire subresource (layer).
   - Copies of depth/stencil formats must be 4B aligned.
+  - For texture-buffer copies, `bytes_per_row` on the buffer side must be 256B-aligned, even if the transfer is a single row.
 - The offset for `set_vertex_buffer` and `set_index_buffer` must be 4B aligned. By @andyleiserson in [#7929](https://github.com/gfx-rs/wgpu/pull/7929).
 - The offset and size of bindings are validated as fitting within the underlying buffer in more cases. By @andyleiserson in [#7911](https://github.com/gfx-rs/wgpu/pull/7911).
 - The function you pass to `Device::on_uncaptured_error()` must now implement `Sync` in addition to `Send`, and be wrapped in `Arc` instead of `Box`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ By @cwfitzgerald in [#8162](https://github.com/gfx-rs/wgpu/pull/8162).
 - Improve errors when buffer mapping is done incorrectly. Allow aliasing immutable [`BufferViews`]. By @cwfitzgerald in [#8150](https://github.com/gfx-rs/wgpu/pull/8150).
 - Require new `F16_IN_F32` downlevel flag for `quantizeToF16`, `pack2x16float`, and `unpack2x16float` in WGSL input. By @aleiserson in [#8130](https://github.com/gfx-rs/wgpu/pull/8130).
 - The error message for non-copyable depth/stencil formats no longer mentions the aspect when it is not relevant. By @reima in [#8156](https://github.com/gfx-rs/wgpu/pull/8156).
+- Track the initialization status of buffer memory correctly when `copy_texture_to_buffer` skips over padding space between rows or layers, or when the start/end of a texture-buffer transfer is not 4B aligned. By @andyleiserson in [#8099](https://github.com/gfx-rs/wgpu/pull/8099).
 
 #### naga
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -13,12 +13,9 @@ webgpu:api,operation,compute,basic:memcpy:*
 //FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute_pipeline,overrides:*
 webgpu:api,operation,device,lost:*
-// This is all the storeOp tests, but some of them fail if run in a single invocation.
-// https://github.com/gfx-rs/wgpu/issues/8021
-webgpu:api,operation,render_pass,storeOp:render_pass_store_op,color_attachment_with_depth_stencil_attachment:*
-webgpu:api,operation,render_pass,storeOp:render_pass_store_op,color_attachment_only:*
-webgpu:api,operation,render_pass,storeOp:render_pass_store_op,multiple_color_attachments:*
-webgpu:api,operation,render_pass,storeOp:render_pass_store_op,depth_stencil_attachment_only:*
+webgpu:api,operation,render_pass,storeOp:*
+// Presumably vertex pulling, revisit after https://github.com/gfx-rs/wgpu/issues/7981 is fixed.
+fails-if(metal) webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribute_offset:*
 fails-if(dx12) webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
 webgpu:api,validation,createBindGroup:buffer,effective_buffer_binding_size:*
 webgpu:api,validation,encoding,beginComputePass:*
@@ -74,14 +71,18 @@ webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validat
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
 // image_copy depth/stencil failures on dx12: https://github.com/gfx-rs/wgpu/issues/8133
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyB2T"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyT2B"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth32float";aspect="depth-only";copyType="CopyT2B"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyB2T"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyT2B"
 //mix of PASS and FAIL: other subtests of copy_buffer_offset. Related bugs:
-// https://github.com/gfx-rs/wgpu/issues/7946, https://github.com/gfx-rs/wgpu/issues/7947
+// https://github.com/gfx-rs/wgpu/issues/7946
 webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*
 webgpu:api,validation,image_copy,buffer_texture_copies:texture_buffer_usages:*
 webgpu:api,validation,image_copy,buffer_texture_copies:device_mismatch:*
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="r8uint";copyType="CopyB2T";dimension="1d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="r8uint";copyType="CopyT2B";dimension="1d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba32float";copyType="CopyB2T";dimension="1d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba32float";copyType="CopyT2B";dimension="1d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="2d"
@@ -95,7 +96,7 @@ fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="3d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="3d"
 //mix of PASS and FAIL: other subtests of offset_and_bytesPerRow. Related bugs:
-// https://github.com/gfx-rs/wgpu/issues/7946, https://github.com/gfx-rs/wgpu/issues/7947
+// https://github.com/gfx-rs/wgpu/issues/7946
 webgpu:api,validation,image_copy,layout_related:copy_end_overflows_u64:*
 // Fails with OOM in CI.
 fails-if(dx12) webgpu:api,validation,image_copy,layout_related:offset_alignment:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -82,6 +82,8 @@ fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_sten
 webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*
 webgpu:api,validation,image_copy,buffer_texture_copies:texture_buffer_usages:*
 webgpu:api,validation,image_copy,buffer_texture_copies:device_mismatch:*
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba32float";copyType="CopyB2T";dimension="1d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba32float";copyType="CopyT2B";dimension="1d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="2d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="2d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="3d"

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -288,7 +288,6 @@ pub(crate) fn validate_linear_texture_data(
     buffer_size: BufferAddress,
     buffer_side: CopySide,
     copy_size: &Extent3d,
-    need_copy_aligned_rows: bool,
 ) -> Result<(BufferAddress, BufferAddress), TransferError> {
     let wgt::BufferTextureCopyInfo {
         copy_width,
@@ -297,7 +296,7 @@ pub(crate) fn validate_linear_texture_data(
 
         offset,
 
-        block_size_bytes,
+        block_size_bytes: _,
         block_width_texels,
         block_height_texels,
 
@@ -337,24 +336,6 @@ pub(crate) fn validate_linear_texture_data(
     if layout.rows_per_image.is_none() && requires_multiple_images {
         return Err(TransferError::UnspecifiedRowsPerImage);
     };
-
-    if need_copy_aligned_rows {
-        let bytes_per_row_alignment = wgt::COPY_BYTES_PER_ROW_ALIGNMENT as BufferAddress;
-
-        let mut offset_alignment = block_size_bytes;
-        if format.is_depth_stencil_format() {
-            offset_alignment = 4
-        }
-        if offset % offset_alignment != 0 {
-            return Err(TransferError::UnalignedBufferOffset(offset));
-        }
-
-        // The alignment of row_stride_bytes is only required if there are
-        // multiple rows
-        if requires_multiple_rows && row_stride_bytes % bytes_per_row_alignment != 0 {
-            return Err(TransferError::UnalignedBytesPerRow);
-        }
-    }
 
     // Avoid underflow in the subtraction by checking bytes_in_copy against buffer_size first.
     if bytes_in_copy > buffer_size || offset > buffer_size - bytes_in_copy {
@@ -425,7 +406,15 @@ pub(crate) fn validate_texture_copy_dst_format(
 ///  * The copy must be from/to a single aspect of the texture.
 ///  * If `aligned` is true, the buffer offset must be aligned appropriately.
 ///
-/// The following steps in the algorithm are implemented elsewhere:
+/// And implements the following check from WebGPU's [validating GPUTexelCopyBufferInfo][vtcbi]
+/// algorithm:
+///  * If `aligned` is true, `bytesPerRow` must be a multiple of 256.
+///
+/// Note that the `bytesPerRow` alignment check is enforced whenever
+/// `bytesPerRow` is specified, even if the transfer is not multiple rows and
+/// `bytesPerRow` could have been omitted.
+///
+/// The following steps in [validating texture buffer copy][vtbc] are implemented elsewhere:
 ///  * Invocation of other validation algorithms.
 ///  * The texture usage (COPY_DST / COPY_SRC) check.
 ///  * The check for non-copyable depth/stencil formats. The caller must perform
@@ -435,11 +424,12 @@ pub(crate) fn validate_texture_copy_dst_format(
 ///    non-copyable format.
 ///
 /// [vtbc]: https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-texture-buffer-copy
+/// [vtcbi]: https://www.w3.org/TR/webgpu/#abstract-opdef-validating-gputexelcopybufferinfo
 pub(crate) fn validate_texture_buffer_copy<T>(
     texture_copy_view: &wgt::TexelCopyTextureInfo<T>,
     aspect: hal::FormatAspects,
     desc: &wgt::TextureDescriptor<(), Vec<wgt::TextureFormat>>,
-    offset: BufferAddress,
+    layout: &wgt::TexelCopyBufferLayout,
     aligned: bool,
 ) -> Result<(), TransferError> {
     if desc.sample_count != 1 {
@@ -464,8 +454,14 @@ pub(crate) fn validate_texture_buffer_copy<T>(
             .expect("non-copyable formats should have been rejected previously")
     };
 
-    if aligned && offset % u64::from(offset_alignment) != 0 {
-        return Err(TransferError::UnalignedBufferOffset(offset));
+    if aligned && layout.offset % u64::from(offset_alignment) != 0 {
+        return Err(TransferError::UnalignedBufferOffset(layout.offset));
+    }
+
+    if let Some(bytes_per_row) = layout.bytes_per_row {
+        if aligned && bytes_per_row % wgt::COPY_BYTES_PER_ROW_ALIGNMENT != 0 {
+            return Err(TransferError::UnalignedBytesPerRow);
+        }
     }
 
     Ok(())
@@ -1004,7 +1000,7 @@ impl Global {
                 destination,
                 dst_base.aspect,
                 &dst_texture.desc,
-                source.layout.offset,
+                &source.layout,
                 true, // alignment required for buffer offset
             )?;
 
@@ -1016,7 +1012,6 @@ impl Global {
                     src_buffer.size,
                     CopySide::Source,
                     copy_size,
-                    true,
                 )?;
 
             if dst_texture.desc.format.is_depth_stencil_format() {
@@ -1125,7 +1120,7 @@ impl Global {
                 source,
                 src_base.aspect,
                 &src_texture.desc,
-                destination.layout.offset,
+                &destination.layout,
                 true, // alignment required for buffer offset
             )?;
 
@@ -1137,7 +1132,6 @@ impl Global {
                     dst_buffer.size,
                     CopySide::Destination,
                     copy_size,
-                    true,
                 )?;
 
             if src_texture.desc.format.is_depth_stencil_format() {

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -21,7 +21,7 @@ use crate::{
         TextureInitTrackerAction,
     },
     resource::{
-        MissingBufferUsageError, MissingTextureUsageError, ParentDevice, RawResourceAccess,
+        Buffer, MissingBufferUsageError, MissingTextureUsageError, ParentDevice, RawResourceAccess,
         Texture, TextureErrorDimension,
     },
     snatch::SnatchGuard,
@@ -33,7 +33,7 @@ pub type TexelCopyBufferInfo = wgt::TexelCopyBufferInfo<BufferId>;
 pub type TexelCopyTextureInfo = wgt::TexelCopyTextureInfo<TextureId>;
 pub type CopyExternalImageDestInfo = wgt::CopyExternalImageDestInfo<TextureId>;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CopySide {
     Source,
     Destination,
@@ -276,9 +276,11 @@ pub(crate) fn extract_texture_selector<T>(
 ///
 /// Copied with some modifications from WebGPU standard.
 ///
-/// If successful, returns a pair `(bytes, stride)`, where:
+/// If successful, returns a tuple `(bytes, stride, is_contiguous)`, where:
 /// - `bytes` is the number of buffer bytes required for this copy, and
 /// - `stride` number of bytes between array layers.
+/// - `is_contiguous` is true if the linear texture data does not have padding
+///   between rows or between images.
 ///
 /// [vltd]: https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-linear-texture-data
 pub(crate) fn validate_linear_texture_data(
@@ -288,7 +290,7 @@ pub(crate) fn validate_linear_texture_data(
     buffer_size: BufferAddress,
     buffer_side: CopySide,
     copy_size: &Extent3d,
-) -> Result<(BufferAddress, BufferAddress), TransferError> {
+) -> Result<(BufferAddress, BufferAddress, bool), TransferError> {
     let wgt::BufferTextureCopyInfo {
         copy_width,
         copy_height,
@@ -303,14 +305,14 @@ pub(crate) fn validate_linear_texture_data(
         width_blocks: _,
         height_blocks,
 
-        row_bytes_dense: _,
+        row_bytes_dense,
         row_stride_bytes,
 
         image_stride_rows: _,
         image_stride_bytes,
 
         image_rows_dense: _,
-        image_bytes_dense: _,
+        image_bytes_dense,
 
         bytes_in_copy,
     } = layout.get_buffer_texture_copy_info(format, aspect, copy_size)?;
@@ -347,7 +349,10 @@ pub(crate) fn validate_linear_texture_data(
         });
     }
 
-    Ok((bytes_in_copy, image_stride_bytes))
+    let is_contiguous = (row_stride_bytes == row_bytes_dense || !requires_multiple_rows)
+        && (image_stride_bytes == image_bytes_dense || !requires_multiple_images);
+
+    Ok((bytes_in_copy, image_stride_bytes, is_contiguous))
 }
 
 /// Validate the source format of a texture copy.
@@ -733,6 +738,90 @@ fn handle_dst_texture_init(
     Ok(())
 }
 
+/// Handle initialization tracking for a transfer's source or destination buffer.
+///
+/// Ensures that the transfer will not read from uninitialized memory, and updates
+/// the initialization state information to reflect the transfer.
+fn handle_buffer_init(
+    cmd_buf_data: &mut CommandBufferMutable,
+    info: &TexelCopyBufferInfo,
+    buffer: &Arc<Buffer>,
+    direction: CopySide,
+    required_buffer_bytes_in_copy: BufferAddress,
+    is_contiguous: bool,
+) {
+    const ALIGN_SIZE: BufferAddress = wgt::COPY_BUFFER_ALIGNMENT;
+    const ALIGN_MASK: BufferAddress = wgt::COPY_BUFFER_ALIGNMENT - 1;
+
+    let start = info.layout.offset;
+    let end = info.layout.offset + required_buffer_bytes_in_copy;
+    if !is_contiguous || direction == CopySide::Source {
+        // If the transfer will read the buffer, then the whole region needs to
+        // be initialized.
+        //
+        // If the transfer will not write a contiguous region of the buffer,
+        // then we need to make sure the padding areas are initialized. For now,
+        // initialize the whole region, although this could be improved to
+        // initialize only the necessary parts if doing so is likely to be
+        // faster than initializing the whole thing.
+        //
+        // Adjust the start/end outwards to 4B alignment.
+        let aligned_start = start & !ALIGN_MASK;
+        let aligned_end = (end + ALIGN_MASK) & !ALIGN_MASK;
+        cmd_buf_data.buffer_memory_init_actions.extend(
+            buffer.initialization_status.read().create_action(
+                buffer,
+                aligned_start..aligned_end,
+                MemoryInitKind::NeedsInitializedMemory,
+            ),
+        );
+    } else {
+        // If the transfer will write a contiguous region of the buffer, then we
+        // don't need to initialize that region.
+        //
+        // However, if the start and end are not 4B aligned, we need to make
+        // sure that we don't end up trying to initialize non-4B-aligned regions
+        // later.
+        //
+        // Adjust the start/end inwards to 4B alignment, we will handle the
+        // first/last pieces differently.
+        let aligned_start = (start + ALIGN_MASK) & !ALIGN_MASK;
+        let aligned_end = end & !ALIGN_MASK;
+        if aligned_start != start {
+            cmd_buf_data.buffer_memory_init_actions.extend(
+                buffer.initialization_status.read().create_action(
+                    buffer,
+                    aligned_start - ALIGN_SIZE..aligned_start,
+                    MemoryInitKind::NeedsInitializedMemory,
+                ),
+            );
+        }
+        if aligned_start != aligned_end {
+            cmd_buf_data.buffer_memory_init_actions.extend(
+                buffer.initialization_status.read().create_action(
+                    buffer,
+                    aligned_start..aligned_end,
+                    MemoryInitKind::ImplicitlyInitialized,
+                ),
+            );
+        }
+        if aligned_end != end {
+            // It is possible that `aligned_end + ALIGN_SIZE > dst_buffer.size`,
+            // because `dst_buffer.size` is the user-requested size, not the
+            // final size of the buffer. The final size of the buffer is not
+            // readily available, but was rounded up to COPY_BUFFER_ALIGNMENT,
+            // so no overrun is possible.
+            cmd_buf_data.buffer_memory_init_actions.extend(
+                buffer.initialization_status.read().create_action(
+                    buffer,
+                    aligned_end..aligned_end + ALIGN_SIZE,
+                    MemoryInitKind::NeedsInitializedMemory,
+                ),
+            );
+        }
+    }
+}
+
 impl Global {
     pub fn command_encoder_copy_buffer_to_buffer(
         &self,
@@ -1004,7 +1093,7 @@ impl Global {
                 true, // alignment required for buffer offset
             )?;
 
-            let (required_buffer_bytes_in_copy, bytes_per_array_layer) =
+            let (required_buffer_bytes_in_copy, bytes_per_array_layer, is_contiguous) =
                 validate_linear_texture_data(
                     &source.layout,
                     dst_texture.desc.format,
@@ -1020,12 +1109,13 @@ impl Global {
                     .map_err(TransferError::from)?;
             }
 
-            cmd_buf_data.buffer_memory_init_actions.extend(
-                src_buffer.initialization_status.read().create_action(
-                    &src_buffer,
-                    source.layout.offset..(source.layout.offset + required_buffer_bytes_in_copy),
-                    MemoryInitKind::NeedsInitializedMemory,
-                ),
+            handle_buffer_init(
+                cmd_buf_data,
+                source,
+                &src_buffer,
+                CopySide::Source,
+                required_buffer_bytes_in_copy,
+                is_contiguous,
             );
 
             let regions = (0..array_layer_count)
@@ -1124,7 +1214,7 @@ impl Global {
                 true, // alignment required for buffer offset
             )?;
 
-            let (required_buffer_bytes_in_copy, bytes_per_array_layer) =
+            let (required_buffer_bytes_in_copy, bytes_per_array_layer, is_contiguous) =
                 validate_linear_texture_data(
                     &destination.layout,
                     src_texture.desc.format,
@@ -1180,13 +1270,13 @@ impl Global {
             let dst_barrier =
                 dst_pending.map(|pending| pending.into_hal(&dst_buffer, &snatch_guard));
 
-            cmd_buf_data.buffer_memory_init_actions.extend(
-                dst_buffer.initialization_status.read().create_action(
-                    &dst_buffer,
-                    destination.layout.offset
-                        ..(destination.layout.offset + required_buffer_bytes_in_copy),
-                    MemoryInitKind::ImplicitlyInitialized,
-                ),
+            handle_buffer_init(
+                cmd_buf_data,
+                destination,
+                &dst_buffer,
+                CopySide::Destination,
+                required_buffer_bytes_in_copy,
+                is_contiguous,
             );
 
             let regions = (0..array_layer_count)

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -763,8 +763,8 @@ impl Queue {
             &destination,
             dst_base.aspect,
             &dst.desc,
-            data_layout.offset,
-            false, // alignment not required for buffer offset
+            &data_layout,
+            false, // alignment not required for buffer offset or bytes per row
         )?;
 
         // Note: `_source_bytes_per_array_layer` is ignored since we
@@ -776,7 +776,6 @@ impl Queue {
             data.len() as wgt::BufferAddress,
             CopySide::Source,
             size,
-            false,
         )?;
 
         if dst.desc.format.is_depth_stencil_format() {

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -763,20 +763,21 @@ impl Queue {
             &destination,
             dst_base.aspect,
             &dst.desc,
-            &data_layout,
+            data_layout,
             false, // alignment not required for buffer offset or bytes per row
         )?;
 
         // Note: `_source_bytes_per_array_layer` is ignored since we
         // have a staging copy, and it can have a different value.
-        let (required_bytes_in_copy, _source_bytes_per_array_layer) = validate_linear_texture_data(
-            data_layout,
-            dst.desc.format,
-            destination.aspect,
-            data.len() as wgt::BufferAddress,
-            CopySide::Source,
-            size,
-        )?;
+        let (required_bytes_in_copy, _source_bytes_per_array_layer, _) =
+            validate_linear_texture_data(
+                data_layout,
+                dst.desc.format,
+                destination.aspect,
+                data.len() as wgt::BufferAddress,
+                CopySide::Source,
+                size,
+            )?;
 
         if dst.desc.format.is_depth_stencil_format() {
             self.device


### PR DESCRIPTION
The main goal of this PR was to fix initialization tracking for buffers that are the destination of a copyT2B operation (#8097). This fixes some CTS tests whose intermittent failure was causing false positives with other changes. I believe it will fix #8021. There is a risk of performance regressions from this change. It would be more performant to use a shader to initialize only the padding areas instead of unnecessarily initializing the entire destination range, but this would be a more involved change.

It was easy to fix the problem with non-4B-aligned initializations (#7947) at the same time, so I did.

There is one additional tweak to the 256B alignment check `bytes_per_row` that was needed to get the `offset_and_bytesPerRow` test fully passing, at least on Linux.

**Testing**
Enables some CTS tests. A directed test might be reasonable too, but I wanted to go ahead and open this so I can see what CI thinks.

**Squash or Rebase?** Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
