### PR TITLE
Make DX12 backend actually expose DXIL/HLSL passthrough feature

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -363,7 +363,8 @@ impl super::Adapter {
             | wgt::Features::TEXTURE_FORMAT_NV12
             | wgt::Features::FLOAT32_FILTERABLE
             | wgt::Features::TEXTURE_ATOMIC
-            | wgt::Features::EXTERNAL_TEXTURE;
+            | wgt::Features::EXTERNAL_TEXTURE
+            | wgt::Features::HLSL_DXIL_SHADER_PASSTHROUGH;
 
         //TODO: in order to expose this, we need to run a compute shader
         // that extract the necessary statistics out of the D3D12 result.


### PR DESCRIPTION
**Connections**
Addresses #8089 
Obseleted by #7834 

**Description**
Previously, support for HLSL/DXIL passthrough wasn't actually exposed. This is a one-liner to fix that.

**Testing**
No testing unfortunately, but hopefully @jonahnm can verify this works

**Squash or Rebase?**
Squash probably cus commit is named dumb

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
