### PR TITLE
Fix minimal versions CI failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ wgpu-core-deps-emscripten = { version = "26.0.0", path = "./wgpu-core/platform-d
 
 anyhow = { version = "1.0.87", default-features = false }
 approx = "0.5"
-arbitrary = "1.4"
+arbitrary = "1.4.2"
 argh = "0.1.13"
 arrayvec = { version = "0.7.1", default-features = false }
 bincode = "2"


### PR DESCRIPTION
Attempting to fix [this](https://github.com/gfx-rs/wgpu/actions/runs/16996131534/job/48187165042) CI failure:  

```
error[E0433]: failed to resolve: could not find `details` in `arbitrary`
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/half-2.5.0/src/binary16.rs:46:42
   |
46 | #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
   |                                          ^^^^^^^^^^^^^^^^^^^^ could not find `details` in `arbitrary`
   |
   = note: this error originates in the derive macro `arbitrary::Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
```

I have not tracked down exactly what is wrong here, but I suspect it has to do with incompatibilities between the `arbitrary` and `derive_arbitrary` crates when they don't have matching versions.

**Squash or Rebase?** Squash