### PR TITLE
[naga] Ensure validation rejects invalid sample operations of `ImageClass::External` images.

### DIFF
--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -590,6 +590,11 @@ impl super::Validator {
                     }
                 }
 
+                // External textures can only be sampled using clamp_to_edge.
+                if matches!(class, crate::ImageClass::External) && !clamp_to_edge {
+                    return Err(ExpressionError::InvalidImageClass(class));
+                }
+
                 // check level properties
                 match level {
                     crate::SampleLevel::Auto => ShaderStages::FRAGMENT,


### PR DESCRIPTION
textureSampleBaseClampToEdge() is valid when called on a `texture_external` texture, but all other sample operations are invalid. Previously validation was succeeding for these operations on an external texture in cases where the same operation on a `texture_2d<f32>` would be allowed. We must therefore explicitly check for ImageClass::External and disallow invalid sample operations.

**Testing**
In firefox, this makes the following CTS tests pass:
* webgpu:shader,validation,expression,call,builtin,textureGather:texture_type:testTextureType="texture_external";*
* webgpu:shader,validation,expression,call,builtin,textureSample:texture_type:testTextureType="texture_external";*
* webgpu:shader,validation,expression,call,builtin,textureSampleGrad:texture_type:testTextureType="texture_external";*

...on platforms where external textures are enabled (ie currently nowhere, very soon Windows/DX12). Other platforms actually already pass because these tests expect validation errors, which we currently raise because `Feature::EXTERNAL_TEXTURE` is not enabled..). But without this change, enabling that feature will cause the tests to fail.

Unfortunately we cannot test this in wgpu's CTS CI, because deno also doesn't enable the external texture feature. Once we've added external texture support for metal and vulkan we can remove the feature and have it enabled by default, then run these tests in wgpu's CI.

**Squash or Rebase?**

Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
