### PR TITLE
fix(wgsl-in): accept trailing comma in `@blend_src(…)` attr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ By @Vecvec in [#7913](https://github.com/gfx-rs/wgpu/pull/7913).
 
 - Fixed a bug where access to matrices with 2 rows would not work in some cases. By @andyleiserson in [#7438](https://github.com/gfx-rs/wgpu/pull/7438).
 
+#### Naga
+
+- [wgsl-in] Allow a trailing comma in `@blend_src(…)` attributes. By @ErichDonGubler in [#8137](https://github.com/gfx-rs/wgpu/pull/8137).
+
 ## v26.0.4 (2025-08-07)
 
 ### Bug Fixes

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -57,6 +57,7 @@ webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bind_grou
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:buffer_binding,render_pipeline:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:sampler_binding,render_pipeline:*
 webgpu:api,validation,encoding,queries,general:occlusion_query,query_index:*
+webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth32float";aspect="depth-only";copyType="CopyT2B"

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -235,6 +235,7 @@ impl<'a> BindingParser<'a> {
                 lexer.expect(Token::Paren('('))?;
                 self.blend_src
                     .set(parser.general_expression(lexer, ctx)?, name_span)?;
+                lexer.skip(Token::Separator(','));
                 lexer.expect(Token::Paren(')'))?;
             }
             _ => return Err(Box::new(Error::UnknownAttribute(name_span))),


### PR DESCRIPTION
I discovered that [`webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*`](https://gpuweb.github.io/cts/standalone/?q=webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*) had some errors outstanding while investigating if our dual source blending is up-to-spec. This was an easy one to knock out.

**Squash or Rebase?**

squashplz

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
