### PR TITLE
Remove security issue type; github adds it automatically

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,8 +3,3 @@ contact_links:
   - name: Question about wgpu
     url: https://github.com/gfx-rs/wgpu/discussions/new/choose
     about: Any questions about how to use wgpu should go here.
-  - name: Security concerns
-    url: https://github.com/gfx-rs/wgpu/security
-    about: >
-      If you have found a possible vulnerability in wgpu, please read this
-      security policy for information about reporting it confidentially.


### PR DESCRIPTION
In the security policy PR, I added an option in the issue type selection for security issues, but it turns out GitHub does that automatically. So remove the duplicated item.

<img width="1367" height="491" alt="Screenshot 2025-08-23 at 2 16 26 PM" src="https://github.com/user-attachments/assets/ae5ae004-51b2-4829-8209-45e038da9af9" />

**Squash or Rebase?** Squash