### PR TITLE
Normalize how the wgpu project is stylized in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Jujutsu
 #
-# When using the WGPU repository through [Jujutsu](https://github.com/martinvonz/jj), `.jj/` dirs.
+# When using the wgpu repository through [Jujutsu](https://github.com/martinvonz/jj), `.jj/` dirs.
 # are ignored because Jujutsu writes a `.jj/.gitignore` file containing `/*`. Some tools, like
 # `prettier`, don't handle nested `.gitgnore` properly, but they _do_ handle top-level `.gitignore`
 # patterns properly. So, include it here, even though we shouldn't need it. :cry:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Top level categories:
 
 Bottom level categories:
 
-- Naga
+- naga
 - General
 - DX12
 - Vulkan
@@ -101,10 +101,10 @@ This allows using precompiled shaders without manually checking which backend's 
 - Make a compacted hal acceleration structure inherit a label from the base BLAS. By @Vecvec in [#8103](https://github.com/gfx-rs/wgpu/pull/8103).
 - The limits requested for a device must now satisfy `min_subgroup_size <= max_subgroup_size`. By @andyleiserson in [#8085](https://github.com/gfx-rs/wgpu/pull/8085).
 
-#### Naga
+#### naga
 
-- Naga now requires that no type be larger than 1 GB. This limit may be lowered in the future; feedback on an appropriate value for the limit is welcome. By @andyleiserson in [#7950](https://github.com/gfx-rs/wgpu/pull/7950).
-- If the shader source contains control characters, Naga now replaces them with U+FFFD ("replacement character") in diagnostic output. By @andyleiserson in [#8049](https://github.com/gfx-rs/wgpu/pull/8049).
+- naga now requires that no type be larger than 1 GB. This limit may be lowered in the future; feedback on an appropriate value for the limit is welcome. By @andyleiserson in [#7950](https://github.com/gfx-rs/wgpu/pull/7950).
+- If the shader source contains control characters, naga now replaces them with U+FFFD ("replacement character") in diagnostic output. By @andyleiserson in [#8049](https://github.com/gfx-rs/wgpu/pull/8049).
 - Add f16 IO polyfill on Vulkan backend to enable SHADER_F16 use without requiring `storageInputOutput16`. By @cryvosh in [#7884](https://github.com/gfx-rs/wgpu/pull/7884).
 
 #### DX12
@@ -121,7 +121,7 @@ This allows using precompiled shaders without manually checking which backend's 
 
 - Fixed a bug where access to matrices with 2 rows would not work in some cases. By @andyleiserson in [#7438](https://github.com/gfx-rs/wgpu/pull/7438).
 
-#### Naga
+#### naga
 
 - [wgsl-in] Allow a trailing comma in `@blend_src(…)` attributes. By @ErichDonGubler in [#8137](https://github.com/gfx-rs/wgpu/pull/8137).
 
@@ -141,7 +141,7 @@ This allows using precompiled shaders without manually checking which backend's 
 
 ### Bug Fixes
 
-#### Naga
+#### naga
 
 - Fix empty `if` statements causing errors on spirv 1.6+. By @Vecvec in [#7883](https://github.com/gfx-rs/wgpu/pull/7883).
 
@@ -224,7 +224,7 @@ let (device, queue) = adapter
 
 By @Vecvec in [#7829](https://github.com/gfx-rs/wgpu/pull/7829).
 
-### Naga
+### naga
 
 - Added `no_std` support with default features disabled. By @Bushrat011899 in [#7585](https://github.com/gfx-rs/wgpu/pull/7585).
 - [wgsl-in,ir] Add support for parsing rust-style doc comments via `naga::front::glsl::Frontend::new_with_options`. By @Vrixyz in [#6364](https://github.com/gfx-rs/wgpu/pull/6364).
@@ -241,7 +241,7 @@ By @Vecvec in [#7829](https://github.com/gfx-rs/wgpu/pull/7829).
 - Add extra acceleration structure vertex formats. By @Vecvec in [#7580](https://github.com/gfx-rs/wgpu/pull/7580).
 - Add acceleration structure limits. By @Vecvec in [#7845](https://github.com/gfx-rs/wgpu/pull/7845).
 - Add support for clip-distances feature for Vulkan and GL backends. By @dzamkov in [#7730](https://github.com/gfx-rs/wgpu/pull/7730)
-- Added `wgpu_types::error::{ErrorType, WebGpuError}` for classification of errors according to WebGPU's [`GPUError`]'s classification scheme, and implement `WebGpuError` for existing errors. This allows users of `wgpu-core` to offload error classification onto the WGPU ecosystem, rather than having to do it themselves without sufficient information. By @ErichDonGubler in [#6547](https://github.com/gfx-rs/wgpu/pull/6547).
+- Added `wgpu_types::error::{ErrorType, WebGpuError}` for classification of errors according to WebGPU's [`GPUError`]'s classification scheme, and implement `WebGpuError` for existing errors. This allows users of `wgpu-core` to offload error classification onto the wgpu ecosystem, rather than having to do it themselves without sufficient information. By @ErichDonGubler in [#6547](https://github.com/gfx-rs/wgpu/pull/6547).
 
 [`GPUError`]: https://www.w3.org/TR/webgpu/#gpuerror
 
@@ -252,9 +252,9 @@ By @Vecvec in [#7829](https://github.com/gfx-rs/wgpu/pull/7829).
 - Fix error message for sampler array limit. By @LPGhatguy in [#7704](https://github.com/gfx-rs/wgpu/pull/7704).
 - Fix bug where using `BufferSlice::get_mapped_range_as_array_buffer()` on a buffer would prevent you from ever unmapping it. Note that this API has changed and is now `BufferView::as_uint8array()`.
 
-#### Naga
+#### naga
 
-- Naga now infers the correct binding layout when a resource appears only in an assignment to `_`. By @andyleiserson in [#7540](https://github.com/gfx-rs/wgpu/pull/7540).
+- naga now infers the correct binding layout when a resource appears only in an assignment to `_`. By @andyleiserson in [#7540](https://github.com/gfx-rs/wgpu/pull/7540).
 - Implement `dot4U8Packed` and `dot4I8Packed` for all backends, using specialized intrinsics on SPIR-V, HSLS, and Metal if available, and polyfills everywhere else. By @robamler in [#7494](https://github.com/gfx-rs/wgpu/pull/7494), [#7574](https://github.com/gfx-rs/wgpu/pull/7574), and [#7653](https://github.com/gfx-rs/wgpu/pull/7653).
 - Add polyfilled `pack4x{I,U}8Clamped` built-ins to all backends and WGSL frontend. By @ErichDonGubler in [#7546](https://github.com/gfx-rs/wgpu/pull/7546).
 - Allow textureLoad's sample index arg to be unsigned. By @jimblandy in [#7625](https://github.com/gfx-rs/wgpu/pull/7625).
@@ -305,7 +305,7 @@ By @Vecvec in [#7829](https://github.com/gfx-rs/wgpu/pull/7829).
   - The definition of `enum CommandEncoderError` has changed significantly, to reflect which errors can be raised by `CommandEncoder.finish()`. There are also some errors that no longer appear directly in `CommandEncoderError`, and instead appear nested within the `RenderPass` or `ComputePass` variants.
   - `CopyError` has been removed. Errors that were previously a `CopyError` are now a `CommandEncoderError` returned by `finish()`. (The detailed reasons for copies to fail were and still are described by `TransferError`, which was previously a variant of `CopyError`, and is now a variant of `CommandEncoderError`).
 
-#### Naga
+#### naga
 
 - Mark `readonly_and_readwrite_storage_textures` & `packed_4x8_integer_dot_product` language extensions as implemented. By @teoxoy in [#7543](https://github.com/gfx-rs/wgpu/pull/7543)
 - `naga::back::hlsl::Writer::new` has a new `pipeline_options` argument. `hlsl::PipelineOptions::default()` can be passed as a default. The `shader_stage` and `entry_point` members of `pipeline_options` can be used to write only a single entry point when using the HLSL and MSL backends (GLSL and SPIR-V already had this functionality). The Metal and DX12 HALs now write only a single entry point when loading shaders. By @andyleiserson in [#7626](https://github.com/gfx-rs/wgpu/pull/7626).
@@ -460,7 +460,7 @@ There is now documentation to describe how this maps to the various debuggers' a
 
 By @cwfitzgerald in [#7470](https://github.com/gfx-rs/wgpu/pull/7470)
 
-##### Ensure loops generated by SPIR-V and HLSL Naga backends are bounded
+##### Ensure loops generated by SPIR-V and HLSL naga backends are bounded
 
 Make sure that all loops in shaders generated by these naga backends are bounded
 to avoid undefined behaviour due to infinite loops. Note that this may have a
@@ -587,7 +587,7 @@ By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811), [#6815](h
 - new `Features::MSL_SHADER_PASSTHROUGH` run-time feature allows providing pass-through MSL Metal shaders. By @syl20bnr in [#7326](https://github.com/gfx-rs/wgpu/pull/7326).
 - Added mesh shader support to `wgpu_hal`. By @SupaMaggie70Incorporated in [#7089](https://github.com/gfx-rs/wgpu/pull/7089)
 
-#### Naga
+#### naga
 
 - Add support for unsigned types when calling textureLoad with the level parameter. By @ygdrasil-io in [#7058](https://github.com/gfx-rs/wgpu/pull/7058).
 - Support @must_use attribute on function declarations. By @turbocrime in [#6801](https://github.com/gfx-rs/wgpu/pull/6801).
@@ -612,15 +612,15 @@ By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811), [#6815](h
 - Rename `instance_id` and `instance_custom_index` to `instance_index` and `instance_custom_data` by @Vecvec in
   [#6780](https://github.com/gfx-rs/wgpu/pull/6780)
 
-#### Naga
+#### naga
 
-- Naga IR types are now available in the module `naga::ir` (e.g. `naga::ir::Module`).
+- naga IR types are now available in the module `naga::ir` (e.g. `naga::ir::Module`).
   The original names (e.g. `naga::Module`) remain present for compatibility.
   By @kpreid in [#7365](https://github.com/gfx-rs/wgpu/pull/7365).
 - Refactored `use` statements to simplify future `no_std` support. By @bushrat011899 in [#7256](https://github.com/gfx-rs/wgpu/pull/7256)
-- Naga's WGSL frontend no longer allows using the `&` operator to take the address of a component of a vector,
+- naga's WGSL frontend no longer allows using the `&` operator to take the address of a component of a vector,
   which is not permitted by the WGSL specification. By @andyleiserson in [#7284](https://github.com/gfx-rs/wgpu/pull/7284)
-- Naga's use of `termcolor` and `stderr` are now optional behind features of the same names. By @bushrat011899 in [#7482](https://github.com/gfx-rs/wgpu/pull/7482)
+- naga's use of `termcolor` and `stderr` are now optional behind features of the same names. By @bushrat011899 in [#7482](https://github.com/gfx-rs/wgpu/pull/7482)
 
 #### Vulkan
 
@@ -630,7 +630,7 @@ By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811), [#6815](h
 
 ### Bug Fixes
 
-#### Naga
+#### naga
 
 - Fix some instances of functions which have a return type but don't return a value being incorrectly validated. By @jamienicol in [#7013](https://github.com/gfx-rs/wgpu/pull/7013).
 - Allow abstract expressions to be used in WGSL function return statements. By @jamienicol in [#7035](https://github.com/gfx-rs/wgpu/pull/7035).
@@ -662,7 +662,7 @@ By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811), [#6815](h
 #### Vulkan
 
 - Stop naga causing undefined behavior when a ray query misses. By @Vecvec in [#6752](https://github.com/gfx-rs/wgpu/pull/6752).
-- In Naga's SPIR-V backend, avoid duplicating SPIR-V OpTypePointer instructions. By @jimblandy in [#7246](https://github.com/gfx-rs/wgpu/pull/7246).
+- In naga's SPIR-V backend, avoid duplicating SPIR-V OpTypePointer instructions. By @jimblandy in [#7246](https://github.com/gfx-rs/wgpu/pull/7246).
 
 #### Gles
 
@@ -682,7 +682,7 @@ By @cwfitzgerald in [#6811](https://github.com/gfx-rs/wgpu/pull/6811), [#6815](h
 
 ### Performance
 
-#### Naga
+#### naga
 
 - Replace `unicode-xid` with `unicode-ident`. By @CrazyboyQCD in [#7135](https://github.com/gfx-rs/wgpu/pull/7135)
 
@@ -855,7 +855,7 @@ By @cwfitzgerald in [#6895](https://github.com/gfx-rs/wgpu/pull/6895)
 
 #### The `diagnostic(…);` directive is now supported in WGSL
 
-Naga now parses `diagnostic(…);` directives according to the WGSL spec. This allows users to control certain lints, similar to Rust's `allow`, `warn`, and `deny` attributes. For example, in standard WGSL (but, notably, not Naga yet—see <https://github.com/gfx-rs/wgpu/issues/4369>) this snippet would emit a uniformity error:
+naga now parses `diagnostic(…);` directives according to the WGSL spec. This allows users to control certain lints, similar to Rust's `allow`, `warn`, and `deny` attributes. For example, in standard WGSL (but, notably, not naga yet—see <https://github.com/gfx-rs/wgpu/issues/4369>) this snippet would emit a uniformity error:
 
 ```wgsl
 @group(0) @binding(0) var s : sampler;
@@ -897,15 +897,15 @@ fn main(@builtin(position) p : vec4f) -> @location(0) vec4f {
 There are some limitations to keep in mind with this new functionality:
 
 - We support `@diagnostic(…)` rules as `fn` attributes, but prioritization for rules in statement positions (i.e., `if (…) @diagnostic(…) { … }` is unclear. If you are blocked by not being able to parse `diagnostic(…)` rules in statement positions, please let us know in <https://github.com/gfx-rs/wgpu/issues/5320>, so we can determine how to prioritize it!
-- Standard WGSL specifies `error`, `warning`, `info`, and `off` severity levels. These are all technically usable now! A caveat, though: warning- and info-level are only emitted to `stderr` via the `log` façade, rather than being reported through a `Result::Err` in Naga or the `CompilationInfo` interface in `wgpu{,-core}`. This will require breaking changes in Naga to fix, and is being tracked by <https://github.com/gfx-rs/wgpu/issues/6458>.
-- Not all lints can be controlled with `diagnostic(…)` rules. In fact, only the `derivative_uniformity` triggering rule exists in the WGSL standard. That said, Naga contributors are excited to see how this level of control unlocks a new ecosystem of configurable diagnostics.
+- Standard WGSL specifies `error`, `warning`, `info`, and `off` severity levels. These are all technically usable now! A caveat, though: warning- and info-level are only emitted to `stderr` via the `log` façade, rather than being reported through a `Result::Err` in naga or the `CompilationInfo` interface in `wgpu{,-core}`. This will require breaking changes in naga to fix, and is being tracked by <https://github.com/gfx-rs/wgpu/issues/6458>.
+- Not all lints can be controlled with `diagnostic(…)` rules. In fact, only the `derivative_uniformity` triggering rule exists in the WGSL standard. That said, naga contributors are excited to see how this level of control unlocks a new ecosystem of configurable diagnostics.
 - Finally, `diagnostic(…)` rules are not yet emitted in WGSL output. This means that `wgsl-in` → `wgsl-out` is currently a lossy process. We felt that it was important to unblock users who needed `diagnostic(…)` rules (i.e., <https://github.com/gfx-rs/wgpu/issues/3135>) before we took significant effort to fix this (tracked in <https://github.com/gfx-rs/wgpu/issues/6496>).
 
 By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148](https://github.com/gfx-rs/wgpu/pull/6148), [#6533](https://github.com/gfx-rs/wgpu/pull/6533), [#6353](https://github.com/gfx-rs/wgpu/pull/6353), [#6537](https://github.com/gfx-rs/wgpu/pull/6537).
 
 #### New Features
 
-##### Naga
+##### naga
 
 - Support atomic operations on fields of global structs in the SPIR-V frontend. By @schell in [#6693](https://github.com/gfx-rs/wgpu/pull/6693).
 - Clean up tests for atomic operations support in SPIR-V frontend. By @schell in [#6692](https://github.com/gfx-rs/wgpu/pull/6692)
@@ -951,7 +951,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 
 #### Changes
 
-##### Naga
+##### naga
 
 - Show types of LHS and RHS in binary operation type mismatch errors. By @ErichDonGubler in [#6450](https://github.com/gfx-rs/wgpu/pull/6450).
 - The GLSL parser now uses less expressions for function calls. By @magcius in [#6604](https://github.com/gfx-rs/wgpu/pull/6604).
@@ -1004,7 +1004,7 @@ By @ErichDonGubler in [#6456](https://github.com/gfx-rs/wgpu/pull/6456), [#6148]
 - Fix `wgpu-info` not showing dx12 adapters. By @wumpf in [#6844](https://github.com/gfx-rs/wgpu/pull/6844).
 - Use `transform_buffer_offset` when initialising `transform_buffer`. By @Vecvec in [#6864](https://github.com/gfx-rs/wgpu/pull/6864).
 
-#### Naga
+#### naga
 
 - Fix crash when a texture argument is missing. By @aedm in [#6486](https://github.com/gfx-rs/wgpu/pull/6486)
 - Emit an error in constant evaluation, rather than crash, in certain cases where `vecN` constructors have less than N arguments. By @ErichDonGubler in [#6508](https://github.com/gfx-rs/wgpu/pull/6508).
@@ -1058,7 +1058,7 @@ Below changes were cherry-picked from 24.0.0 development line.
 
 ### Themes of this release
 
-This release's theme is one that is likely to repeat for a few releases: convergence with the WebGPU specification! WGPU's design and base functionality are actually determined by two specifications: one for WebGPU, and one for the WebGPU Shading Language.
+This release's theme is one that is likely to repeat for a few releases: convergence with the WebGPU specification! wgpu's design and base functionality are actually determined by two specifications: one for WebGPU, and one for the WebGPU Shading Language.
 
 This may not sound exciting, but let us convince you otherwise! All major web browsers have committed to offering WebGPU in their environment. Even JS runtimes like [Node][nodejs-webgpu-interest] and [Deno][deno_webgpu-crate-manifest] have communities that are very interested in providing WebGPU! WebGPU is slowly [eating the world][eat-the-world-meaning], as it were. 😀 It's really important, then, that WebGPU implementations behave in ways that one would expect across all platforms. For example, if Firefox's WebGPU implementation were to break when running scripts and shaders that worked just fine in Chrome, that would mean sad users for both application authors _and_ browser authors.
 
@@ -1066,23 +1066,23 @@ This may not sound exciting, but let us convince you otherwise! All major web br
 [deno_webgpu-crate-manifest]: https://github.com/gfx-rs/wgpu/tree/64a61ee5c69569bbb3db03563997e88a229eba17/deno_webgpu#deno_webgpu
 [eat-the-world-meaning]: https://www.quora.com/What-did-Marc-Andreessen-mean-when-he-said-that-software-is-eating-the-world
 
-WGPU also benefits from standard, portable behavior in the same way as web browsers. Because of this behavior, it's generally fairly easy to port over usage of WebGPU in JavaScript to WGPU. It is also what lets WGPU go full circle: WGPU can be an implementation of WebGPU on native targets, but _also_ it can use _other implementations of WebGPU_ as a backend in JavaScript when compiled to WASM. Therefore, the same dynamic applies: if WGPU's own behavior were significantly different, then WGPU and end users would be _sad, sad humans_ as soon as they discover places where their nice apps are breaking, right?
+wgpu also benefits from standard, portable behavior in the same way as web browsers. Because of this behavior, it's generally fairly easy to port over usage of WebGPU in JavaScript to wgpu. It is also what lets wgpu go full circle: wgpu can be an implementation of WebGPU on native targets, but _also_ it can use _other implementations of WebGPU_ as a backend in JavaScript when compiled to WASM. Therefore, the same dynamic applies: if wgpu's own behavior were significantly different, then wgpu and end users would be _sad, sad humans_ as soon as they discover places where their nice apps are breaking, right?
 
-The answer is: yes, we _do_ have sad, sad humans that really want their WGPU code to work _everywhere_. As Firefox and others use WGPU to implement WebGPU, the above example of Firefox diverging from standard is, unfortunately, today's reality. It _mostly_ behaves the same as a standards-compliant WebGPU, but it still doesn't in many important ways. Of particular note is Naga, its implementation of the WebGPU Shader Language. Shaders are pretty much a black-and-white point of failure in GPU programming; if they don't compile, then you can't use the rest of the API! And yet, it's extremely easy to run into a case like that from <https://github.com/gfx-rs/wgpu/issues/4400>:
+The answer is: yes, we _do_ have sad, sad humans that really want their wgpu code to work _everywhere_. As Firefox and others use wgpu to implement WebGPU, the above example of Firefox diverging from standard is, unfortunately, today's reality. It _mostly_ behaves the same as a standards-compliant WebGPU, but it still doesn't in many important ways. Of particular note is naga, its implementation of the WebGPU Shader Language. Shaders are pretty much a black-and-white point of failure in GPU programming; if they don't compile, then you can't use the rest of the API! And yet, it's extremely easy to run into a case like that from <https://github.com/gfx-rs/wgpu/issues/4400>:
 
 ```wgsl
 fn gimme_a_float() -> f32 {
-  return 42; // fails in Naga, but standard WGSL happily converts to `f32`
+  return 42; // fails in naga, but standard WGSL happily converts to `f32`
 }
 ```
 
-We intend to continue making visible strides in converging with specifications for WebGPU and WGSL, as this release has. This is, unfortunately, one of the major reasons that WGPU has no plans to work hard at keeping a SemVer-stable interface for the foreseeable future; we have an entire platform of GPU programming functionality we have to catch up with, and SemVer stability is unfortunately in tension with that. So, for now, you're going to keep seeing major releases and breaking changes. Where possible, we'll try to make that painless, but compromises to do so don't always make sense with our limited resources.
+We intend to continue making visible strides in converging with specifications for WebGPU and WGSL, as this release has. This is, unfortunately, one of the major reasons that wgpu has no plans to work hard at keeping a SemVer-stable interface for the foreseeable future; we have an entire platform of GPU programming functionality we have to catch up with, and SemVer stability is unfortunately in tension with that. So, for now, you're going to keep seeing major releases and breaking changes. Where possible, we'll try to make that painless, but compromises to do so don't always make sense with our limited resources.
 
 This is also the last planned major version release of 2024; the next milestone is set for January 1st, 2025, according to our regular 12-week cadence (offset from the originally planned date of 2024-10-09 for _this_ release 😅). We'll see you next year!
 
 ### Contributor spotlight: @sagudev
 
-This release, we'd like to spotlight the work of @sagudev, who has made significant contributions to the WGPU ecosystem this release. Among other things, they contributed a particularly notable feature where runtime-known indices are finally allowed for use with `const` array values. For example, this WGSL shader previously wasn't allowed:
+This release, we'd like to spotlight the work of @sagudev, who has made significant contributions to the wgpu ecosystem this release. Among other things, they contributed a particularly notable feature where runtime-known indices are finally allowed for use with `const` array values. For example, this WGSL shader previously wasn't allowed:
 
 ```wgsl
 const arr: array<u32, 4> = array(1, 2, 3, 4);
@@ -1094,7 +1094,7 @@ fn what_number_should_i_use(idx: u32) -> u32 {
 
 …but now it works! This is significant because this sort of shader rejection was one of the most impactful issues we are aware of for converging with the WGSL specification. There are more still to go—some of which we expect to even more drastically change how folks author shaders—but we suspect that many more will come in the next few releases, including with @sagudev's help.
 
-We're excited for more of @sagudev's contributions via the Servo community. Oh, did we forget to mention that these contributions were motivated by their work on Servo? That's right, a _third_ well-known JavaScript runtime is now using WGPU to implement its WebGPU implementation. We're excited to support Servo to becoming another fully fledged browsing environment this way.
+We're excited for more of @sagudev's contributions via the Servo community. Oh, did we forget to mention that these contributions were motivated by their work on Servo? That's right, a _third_ well-known JavaScript runtime is now using wgpu to implement its WebGPU implementation. We're excited to support Servo to becoming another fully fledged browsing environment this way.
 
 ### Major Changes
 
@@ -1169,9 +1169,9 @@ fn fs_main() { /* … */ }
 
 [optional-entrypoint-in-spec]: https://github.com/gpuweb/gpuweb/issues/4342
 
-#### WGPU's DX12 backend is now based on the `windows` crate ecosystem, instead of the `d3d12` crate
+#### wgpu's DX12 backend is now based on the `windows` crate ecosystem, instead of the `d3d12` crate
 
-WGPU has retired the `d3d12` crate (based on `winapi`), and now uses the `windows` crate for interfacing with Windows. For many, this may not be a change that affects day-to-day work. However, for users who need to vet their dependencies, or who may vendor in dependencies, this may be a nontrivial migration.
+wgpu has retired the `d3d12` crate (based on `winapi`), and now uses the `windows` crate for interfacing with Windows. For many, this may not be a change that affects day-to-day work. However, for users who need to vet their dependencies, or who may vendor in dependencies, this may be a nontrivial migration.
 
 By @MarijnS95 in [#6006](https://github.com/gfx-rs/wgpu/pull/6006).
 
@@ -1181,7 +1181,7 @@ By @MarijnS95 in [#6006](https://github.com/gfx-rs/wgpu/pull/6006).
 
 - Added initial acceleration structure and ray query support into wgpu. By @expenses @daniel-keitel @Vecvec @JMS55 @atlv24 in [#6291](https://github.com/gfx-rs/wgpu/pull/6291)
 
-#### Naga
+#### naga
 
 - Support constant evaluation for `firstLeadingBit` and `firstTrailingBit` numeric built-ins in WGSL. Front-ends that translate to these built-ins also benefit from constant evaluation. By @ErichDonGubler in [#5101](https://github.com/gfx-rs/wgpu/pull/5101).
 - Add `first` and `either` sampling types for `@interpolate(flat, …)` in WGSL. By @ErichDonGubler in [#6181](https://github.com/gfx-rs/wgpu/pull/6181).
@@ -1191,7 +1191,7 @@ By @MarijnS95 in [#6006](https://github.com/gfx-rs/wgpu/pull/6006).
 - Support polyfilling `inverse` in WGSL. By @chyyran in [#6385](https://github.com/gfx-rs/wgpu/pull/6385).
 - Add base support for parsing `requires`, `enable`, and `diagnostic` directives. No extensions or diagnostic filters are yet supported, but diagnostics have improved dramatically. By @ErichDonGubler in [#6352](https://github.com/gfx-rs/wgpu/pull/6352), [#6424](https://github.com/gfx-rs/wgpu/pull/6424), [#6437](https://github.com/gfx-rs/wgpu/pull/6437).
 - Include error chain information as a message and notes in shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
-- Unify Naga CLI error output with the format of shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
+- Unify naga CLI error output with the format of shader compilation messages. By @ErichDonGubler in [#6436](https://github.com/gfx-rs/wgpu/pull/6436).
 
 #### General
 
@@ -1211,7 +1211,7 @@ By @MarijnS95 in [#6006](https://github.com/gfx-rs/wgpu/pull/6006).
 
 - Fix incorrect hlsl image output type conversion. By @atlv24 in [#6123](https://github.com/gfx-rs/wgpu/pull/6123).
 
-#### Naga
+#### naga
 
 - SPIR-V frontend splats depth texture sample and load results. Fixes [issue #4551](https://github.com/gfx-rs/wgpu/issues/4551). By @schell in [#6384](https://github.com/gfx-rs/wgpu/pull/6384).
 - Accept only `vec3` (not `vecN`) for the `cross` built-in. By @ErichDonGubler in [#6171](https://github.com/gfx-rs/wgpu/pull/6171).
@@ -1235,7 +1235,7 @@ By @MarijnS95 in [#6006](https://github.com/gfx-rs/wgpu/pull/6006).
 - Deduplicate bind group layouts that are created from pipelines with "auto" layouts. By @teoxoy [#6049](https://github.com/gfx-rs/wgpu/pull/6049).
 - Document `wgpu_hal` bounds-checking promises, and adapt `wgpu_core`'s lazy initialization logic to the slightly weaker-than-expected guarantees. By @jimblandy in [#6201](https://github.com/gfx-rs/wgpu/pull/6201).
 - Raise validation error instead of panicking in `{Render,Compute}Pipeline::get_bind_group_layout` on native / WebGL. By @bgr360 in [#6280](https://github.com/gfx-rs/wgpu/pull/6280).
-- **BREAKING**: Remove the last exposed C symbols in project, located in `wgpu_core::render::bundle::bundle_ffi`, to allow multiple versions of WGPU to compile together. By @ErichDonGubler in [#6272](https://github.com/gfx-rs/wgpu/pull/6272).
+- **BREAKING**: Remove the last exposed C symbols in project, located in `wgpu_core::render::bundle::bundle_ffi`, to allow multiple versions of wgpu to compile together. By @ErichDonGubler in [#6272](https://github.com/gfx-rs/wgpu/pull/6272).
 - Call `flush_mapped_ranges` when unmapping write-mapped buffers. By @teoxoy in [#6089](https://github.com/gfx-rs/wgpu/pull/6089).
 - When mapping buffers for reading, mark buffers as initialized only when they have `MAP_WRITE` usage. By @teoxoy in [#6178](https://github.com/gfx-rs/wgpu/pull/6178).
 - Add a separate pipeline constants error. By @teoxoy in [#6094](https://github.com/gfx-rs/wgpu/pull/6094).
@@ -1307,7 +1307,7 @@ This release includes `wgpu`, `wgpu-core` and `naga`. All other crates remain at
 
 ### Added
 
-#### Naga
+#### naga
 
 - Added back implementations of PartialEq for more IR types. By @teoxoy in [#6045](https://github.com/gfx-rs/wgpu/pull/6045)
 
@@ -1328,21 +1328,21 @@ This release includes `wgpu`, `wgpu-core` and `naga`. All other crates remain at
 
 ### Our first major version release!
 
-For the first time ever, WGPU is being released with a major version (i.e., 22.\* instead of 0.22.\*)! Maintainership has decided to fully adhere to [Semantic Versioning](https://semver.org/)'s recommendations for versioning production software. According to [SemVer 2.0.0's Q&A about when to use 1.0.0 versions (and beyond)](https://semver.org/spec/v2.0.0.html#how-do-i-know-when-to-release-100):
+For the first time ever, wgpu is being released with a major version (i.e., 22.\* instead of 0.22.\*)! Maintainership has decided to fully adhere to [Semantic Versioning](https://semver.org/)'s recommendations for versioning production software. According to [SemVer 2.0.0's Q&A about when to use 1.0.0 versions (and beyond)](https://semver.org/spec/v2.0.0.html#how-do-i-know-when-to-release-100):
 
 > ### How do I know when to release 1.0.0?
 >
 > If your software is being used in production, it should probably already be 1.0.0. If you have a stable API on which users have come to depend, you should be 1.0.0. If you’re worrying a lot about backward compatibility, you should probably already be 1.0.0.
 
-It is a well-known fact that WGPU has been used for applications and platforms already in production for years, at this point. We are often concerned with tracking breaking changes, and affecting these consumers' ability to ship. By releasing our first major version, we publicly acknowledge that this is the case. We encourage other projects in the Rust ecosystem to follow suit.
+It is a well-known fact that wgpu has been used for applications and platforms already in production for years, at this point. We are often concerned with tracking breaking changes, and affecting these consumers' ability to ship. By releasing our first major version, we publicly acknowledge that this is the case. We encourage other projects in the Rust ecosystem to follow suit.
 
-Note that while we start to use the major version number, WGPU is _not_ "going stable", as many Rust projects do. We anticipate many breaking changes before we fully comply with the WebGPU spec., which we expect to take a small number of years.
+Note that while we start to use the major version number, wgpu is _not_ "going stable", as many Rust projects do. We anticipate many breaking changes before we fully comply with the WebGPU spec., which we expect to take a small number of years.
 
 ### Overview
 
-A major ([pun intended](#our-first-major-version-release)) theme of this release is incremental improvement. Among the typically large set of bug fixes, new features, and other adjustments to WGPU by the many contributors listed below, @wumpf and @teoxoy have merged a series of many simplifications to WGPU's internals and, in one case, to the render and compute pass recording APIs. Many of these change WGPU to use atomically reference-counted resource tracking (i.e., `Arc<…>`), rather than using IDs to manage the lifetimes of platform-specific graphics resources in a registry of separate reference counts. This has led us to diagnose and fix many long-standing bugs, and net some neat performance improvements on the order of 40% or more of some workloads.
+A major ([pun intended](#our-first-major-version-release)) theme of this release is incremental improvement. Among the typically large set of bug fixes, new features, and other adjustments to wgpu by the many contributors listed below, @wumpf and @teoxoy have merged a series of many simplifications to wgpu's internals and, in one case, to the render and compute pass recording APIs. Many of these change wgpu to use atomically reference-counted resource tracking (i.e., `Arc<…>`), rather than using IDs to manage the lifetimes of platform-specific graphics resources in a registry of separate reference counts. This has led us to diagnose and fix many long-standing bugs, and net some neat performance improvements on the order of 40% or more of some workloads.
 
-While the above is exciting, we acknowledge already finding and fixing some (easy-to-fix) regressions from the above work. If you migrate to WGPU 22 and encounter such bugs, please engage us in the issue tracker right away!
+While the above is exciting, we acknowledge already finding and fixing some (easy-to-fix) regressions from the above work. If you migrate to wgpu 22 and encounter such bugs, please engage us in the issue tracker right away!
 
 ### Major Changes
 
@@ -1419,7 +1419,7 @@ Add the following flags to `wgpu_types::Features`:
   atomic operations available on Metal as of 3.1.
 
 Add corresponding flags to `naga::valid::Capabilities`. These are supported by the
-WGSL front end, and all Naga backends.
+WGSL front end, and all naga backends.
 
 Platform support:
 
@@ -1464,7 +1464,7 @@ By @teoxoy in [#5901](https://github.com/gfx-rs/wgpu/pull/5901)
   - These hints may be ignored by some backends. Currently only the Vulkan and D3D12 backends take them into account.
 - Add `HTMLImageElement` and `ImageData` as external source for copying images. By @Valaphee in [#5668](https://github.com/gfx-rs/wgpu/pull/5668)
 
-#### Naga
+#### naga
 
 - Added -D, --defines option to naga CLI to define preprocessor macros by @theomonnom in [#5859](https://github.com/gfx-rs/wgpu/pull/5859)
 - Added type upgrades to SPIR-V atomic support. Added related infrastructure. Tracking issue is [here](https://github.com/gfx-rs/wgpu/issues/4489). By @schell in [#5775](https://github.com/gfx-rs/wgpu/pull/5775).
@@ -1532,7 +1532,7 @@ By @teoxoy in [#5901](https://github.com/gfx-rs/wgpu/pull/5901)
 - Replace `glClear` with `glClearBufferF` because `glDrawBuffers` requires that the ith buffer must be `COLOR_ATTACHMENTi` or `NONE` [#5666](https://github.com/gfx-rs/wgpu/pull/5666)
 - Return the unmodified version in driver_info. By @Valaphee in [#5753](https://github.com/gfx-rs/wgpu/pull/5753)
 
-#### Naga
+#### naga
 
 - In spv-out don't decorate a `BindingArray`'s type with `Block` if the type is a struct with a runtime array by @Vecvec in [#5776](https://github.com/gfx-rs/wgpu/pull/5776)
 - Add `packed` as a keyword for GLSL by @kjarosh in [#5855](https://github.com/gfx-rs/wgpu/pull/5855)
@@ -1576,7 +1576,7 @@ This release fixes the validation errors whenever a surface is used with the vul
 
 - Fix regression on OpenGL (EGL) where non-sRGB still used sRGB [#5642](https://github.com/gfx-rs/wgpu/pull/5642)
 
-#### Naga
+#### naga
 
 - Work around shader consumers that have bugs handling `switch` statements with a single body for all cases. These are now written as `do {} while(false);` loops in hlsl-out and glsl-out. By @Imberflur in [#5654](https://github.com/gfx-rs/wgpu/pull/5654)
 - In hlsl-out, defer `continue` statements in switches by setting a flag and breaking from the switch. This allows such constructs to work with FXC which does not support `continue` within a switch. By @Imberflur in [#5654](https://github.com/gfx-rs/wgpu/pull/5654)
@@ -1675,9 +1675,9 @@ By @atlv24 and @cwfitzgerald in [#5154](https://github.com/gfx-rs/wgpu/pull/5154
   - Added `wgpu::TextureView::as_hal`
   - `wgpu::Texture::as_hal` now returns a user-defined type to match the other as_hal functions
 
-#### Naga
+#### naga
 
-- Allow user to select which MSL version to use via `--metal-version` with Naga CLI. By @pcleavelin in [#5392](https://github.com/gfx-rs/wgpu/pull/5392)
+- Allow user to select which MSL version to use via `--metal-version` with naga CLI. By @pcleavelin in [#5392](https://github.com/gfx-rs/wgpu/pull/5392)
 - Support `arrayLength` for runtime-sized arrays inside binding arrays (for WGSL input and SPIR-V output). By @kvark in [#5428](https://github.com/gfx-rs/wgpu/pull/5428)
 - Added `--shader-stage` and `--input-kind` options to naga-cli for specifying vertex/fragment/compute shaders, and frontend. by @ratmice in [#5411](https://github.com/gfx-rs/wgpu/pull/5411)
 - Added a `create_validator` function to wgpu_core `Device` to create naga `Validator`s. By @atlv24 [#5606](https://github.com/gfx-rs/wgpu/pull/5606)
@@ -1736,7 +1736,7 @@ By @atlv24 and @cwfitzgerald in [#5154](https://github.com/gfx-rs/wgpu/pull/5154
 - Remove exposed C symbols (`extern "C"` + [no_mangle]) from RenderPass & ComputePass recording. By @wumpf in [#5409](https://github.com/gfx-rs/wgpu/pull/5409).
 - Fix surfaces being only compatible with first backend enabled on an instance, causing failures when manually specifying an adapter. By @Wumpf in [#5535](https://github.com/gfx-rs/wgpu/pull/5535).
 
-#### Naga
+#### naga
 
 - In spv-in, remove unnecessary "gl_PerVertex" name check so unused builtins will always be skipped. Prevents validation errors caused by capability requirements of these builtins [#4915](https://github.com/gfx-rs/wgpu/issues/4915). By @Imberflur in [#5227](https://github.com/gfx-rs/wgpu/pull/5227).
 - In spv-out, check for acceleration and ray-query types when enabling ray-query extension to prevent validation error. By @Vecvec in [#5463](https://github.com/gfx-rs/wgpu/pull/5463)
@@ -2020,7 +2020,7 @@ Abstract types make numeric literals easier to use, by
 automatically converting literals and other constant expressions
 from abstract numeric types to concrete types when safe and
 necessary. For example, to build a vector of floating-point
-numbers, Naga previously made you write:
+numbers, naga previously made you write:
 
 ```rust
 vec3<f32>(1.0, 2.0, 3.0)
@@ -2032,7 +2032,7 @@ With this change, you can now simply write:
 vec3<f32>(1, 2, 3)
 ```
 
-Even though the literals are abstract integers, Naga recognizes
+Even though the literals are abstract integers, naga recognizes
 that it is safe and necessary to convert them to `f32` values in
 order to build the vector. You can also use abstract values as
 initializers for global constants and global and local variables,
@@ -2043,15 +2043,15 @@ var unit_x: vec2<f32> = vec2(1, 0);
 ```
 
 The literals `1` and `0` are abstract integers, and the expression
-`vec2(1, 0)` is an abstract vector. However, Naga recognizes that
+`vec2(1, 0)` is an abstract vector. However, naga recognizes that
 it can convert that to the concrete type `vec2<f32>` to satisfy
 the given type of `unit_x`.
 The WGSL specification permits abstract integers and
-floating-point values in almost all contexts, but Naga's support
+floating-point values in almost all contexts, but naga's support
 for this is still incomplete. Many WGSL operators and builtin
 functions are specified to produce abstract results when applied
-to abstract inputs, but for now Naga simply concretizes them all
-before applying the operation. We will expand Naga's abstract type
+to abstract inputs, but for now naga simply concretizes them all
+before applying the operation. We will expand naga's abstract type
 support in subsequent pull requests.
 As part of this work, the public types `naga::ScalarKind` and
 `naga::Literal` now have new variants, `AbstractInt` and `AbstractFloat`.
@@ -2103,15 +2103,15 @@ By @cwfitzgerald in [#5053](https://github.com/gfx-rs/wgpu/pull/5053)
 - `@builtin(instance_index)` now properly reflects the range provided in the draw call instead of always counting from 0. By @cwfitzgerald in [#4722](https://github.com/gfx-rs/wgpu/pull/4722).
 - Desktop GL now supports `POLYGON_MODE_LINE` and `POLYGON_MODE_POINT`. By @valaphee in [#4836](https://github.com/gfx-rs/wgpu/pull/4836).
 
-#### Naga
+#### naga
 
-- Naga's WGSL front end now allows operators to produce values with abstract types, rather than concretizing their operands. By @jimblandy in [#4850](https://github.com/gfx-rs/wgpu/pull/4850) and [#4870](https://github.com/gfx-rs/wgpu/pull/4870).
-- Naga's WGSL front and back ends now have experimental support for 64-bit floating-point literals: `1.0lf` denotes an `f64` value. There has been experimental support for an `f64` type for a while, but until now there was no syntax for writing literals with that type. As before, Naga module validation rejects `f64` values unless `naga::valid::Capabilities::FLOAT64` is requested. By @jimblandy in [#4747](https://github.com/gfx-rs/wgpu/pull/4747).
-- Naga constant evaluation can now process binary operators whose operands are both vectors. By @jimblandy in [#4861](https://github.com/gfx-rs/wgpu/pull/4861).
-- Add `--bulk-validate` option to Naga CLI. By @jimblandy in [#4871](https://github.com/gfx-rs/wgpu/pull/4871).
-- Naga's `cargo xtask validate` now runs validation jobs in parallel, using the [jobserver](https://crates.io/crates/jobserver) protocol to limit concurrency, and offers a `validate all` subcommand, which runs all available validation types. By @jimblandy in [#4902](https://github.com/gfx-rs/wgpu/pull/4902).
+- naga's WGSL front end now allows operators to produce values with abstract types, rather than concretizing their operands. By @jimblandy in [#4850](https://github.com/gfx-rs/wgpu/pull/4850) and [#4870](https://github.com/gfx-rs/wgpu/pull/4870).
+- naga's WGSL front and back ends now have experimental support for 64-bit floating-point literals: `1.0lf` denotes an `f64` value. There has been experimental support for an `f64` type for a while, but until now there was no syntax for writing literals with that type. As before, naga module validation rejects `f64` values unless `naga::valid::Capabilities::FLOAT64` is requested. By @jimblandy in [#4747](https://github.com/gfx-rs/wgpu/pull/4747).
+- naga constant evaluation can now process binary operators whose operands are both vectors. By @jimblandy in [#4861](https://github.com/gfx-rs/wgpu/pull/4861).
+- Add `--bulk-validate` option to naga CLI. By @jimblandy in [#4871](https://github.com/gfx-rs/wgpu/pull/4871).
+- naga's `cargo xtask validate` now runs validation jobs in parallel, using the [jobserver](https://crates.io/crates/jobserver) protocol to limit concurrency, and offers a `validate all` subcommand, which runs all available validation types. By @jimblandy in [#4902](https://github.com/gfx-rs/wgpu/pull/4902).
 - Remove `span` and `validate` features. Always fully validate shader modules, and always track source positions for use in error messages. By @teoxoy in [#4706](https://github.com/gfx-rs/wgpu/pull/4706).
-- Introduce a new `Scalar` struct type for use in Naga's IR, and update all frontend, middle, and backend code appropriately. By @jimblandy in [#4673](https://github.com/gfx-rs/wgpu/pull/4673).
+- Introduce a new `Scalar` struct type for use in naga's IR, and update all frontend, middle, and backend code appropriately. By @jimblandy in [#4673](https://github.com/gfx-rs/wgpu/pull/4673).
 - Add more metal keywords. By @fornwall in [#4707](https://github.com/gfx-rs/wgpu/pull/4707).
 - Add a new `naga::Literal` variant, `I64`, for signed 64-bit literals. [#4711](https://github.com/gfx-rs/wgpu/pull/4711).
 - Emit and init `struct` member padding always. By @ErichDonGubler in [#4701](https://github.com/gfx-rs/wgpu/pull/4701).
@@ -2145,14 +2145,14 @@ By @cwfitzgerald in [#5053](https://github.com/gfx-rs/wgpu/pull/5053)
 
 - Create a hidden window per `wgpu::Instance` instead of sharing a global one. By @Zoxc in [#4603](https://github.com/gfx-rs/wgpu/issues/4603)
 
-#### Naga
+#### naga
 
 - Make module compaction preserve the module's named types, even if they are unused. By @jimblandy in [#4734](https://github.com/gfx-rs/wgpu/pull/4734).
 - Improve algorithm used by module compaction. By @jimblandy in [#4662](https://github.com/gfx-rs/wgpu/pull/4662).
 - When reading GLSL, fix the argument types of the double-precision floating-point overloads of the `dot`, `reflect`, `distance`, and `ldexp` builtin functions. Correct the WGSL generated for constructing 64-bit floating-point matrices. Add tests for all the above. By @jimblandy in [#4684](https://github.com/gfx-rs/wgpu/pull/4684).
-- Allow Naga's IR types to represent matrices with elements elements of any scalar kind. This makes it possible for Naga IR types to represent WGSL abstract matrices. By @jimblandy in [#4735](https://github.com/gfx-rs/wgpu/pull/4735).
+- Allow naga's IR types to represent matrices with elements elements of any scalar kind. This makes it possible for naga IR types to represent WGSL abstract matrices. By @jimblandy in [#4735](https://github.com/gfx-rs/wgpu/pull/4735).
 - Preserve the source spans for constants and expressions correctly across module compaction. By @jimblandy in [#4696](https://github.com/gfx-rs/wgpu/pull/4696).
-- Record the names of WGSL `alias` declarations in Naga IR `Type`s. By @jimblandy in [#4733](https://github.com/gfx-rs/wgpu/pull/4733).
+- Record the names of WGSL `alias` declarations in naga IR `Type`s. By @jimblandy in [#4733](https://github.com/gfx-rs/wgpu/pull/4733).
 
 #### Metal
 
@@ -2170,7 +2170,7 @@ This release includes `naga` version 0.14.2. The crates `wgpu-core`, `wgpu-hal` 
 
 ### Bug Fixes
 
-#### Naga
+#### naga
 
 - When evaluating const-expressions and generating SPIR-V, properly handle `Compose` expressions whose operands are `Splat` expressions. Such expressions are created and marked as constant by the constant evaluator. By @jimblandy in [#4695](https://github.com/gfx-rs/wgpu/pull/4695).
 
@@ -2364,7 +2364,7 @@ By @teoxoy in [#4185](https://github.com/gfx-rs/wgpu/pull/4185)
 
 ### Added/New Features
 
-- Re-export Naga. By @exrook in [#4172](https://github.com/gfx-rs/wgpu/pull/4172)
+- Re-export naga. By @exrook in [#4172](https://github.com/gfx-rs/wgpu/pull/4172)
 - Add WinUI 3 SwapChainPanel support. By @ddrboxman in [#4191](https://github.com/gfx-rs/wgpu/pull/4191)
 
 ### Changes
@@ -3250,7 +3250,7 @@ both `raw_window_handle::HasRawWindowHandle` and `raw_window_handle::HasRawDispl
 #### Vulkan
 
 - Fix `astc_hdr` formats support by @jinleili in [#2971]](https://github.com/gfx-rs/wgpu/pull/2971)
-- Update to Naga b209d911 (2022-9-1) to avoid generating SPIR-V that
+- Update to naga b209d911 (2022-9-1) to avoid generating SPIR-V that
   violates Vulkan valid usage rules `VUID-StandaloneSpirv-Flat-06202`
   and `VUID-StandaloneSpirv-Flat-04744`. By @jimblandy in
   [#3008](https://github.com/gfx-rs/wgpu/pull/3008)
@@ -3278,7 +3278,7 @@ both `raw_window_handle::HasRawWindowHandle` and `raw_window_handle::HasRawDispl
 - Update Winit to version 0.27 and raw-window-handle to 0.5 by @wyatt-herkamp in [#2918](https://github.com/gfx-rs/wgpu/pull/2918)
 - Address Clippy 0.1.63 complaints. By @jimblandy in [#2977](https://github.com/gfx-rs/wgpu/pull/2977)
 - Don't use `PhantomData` for `IdentityManager`'s `Input` type. By @jimblandy in [#2972](https://github.com/gfx-rs/wgpu/pull/2972)
-- Changed Naga variant in ShaderSource to `Cow<'static, Module>`, to allow loading global variables by @daxpedda in [#2903](https://github.com/gfx-rs/wgpu/pull/2903)
+- Changed naga variant in ShaderSource to `Cow<'static, Module>`, to allow loading global variables by @daxpedda in [#2903](https://github.com/gfx-rs/wgpu/pull/2903)
 - Updated the maximum binding index to match the WebGPU specification by @nical in [#2957](https://github.com/gfx-rs/wgpu/pull/2957)
 - Add `unsafe_op_in_unsafe_fn` to Clippy lints in the entire workspace. By @ErichDonGubler in [#3044](https://github.com/gfx-rs/wgpu/pull/3044).
 
@@ -3611,7 +3611,7 @@ DeviceDescriptor {
 - [WebGL] Add a downlevel capability for rendering to floating point textures by @expenses in [#2729](https://github.com/gfx-rs/wgpu/pull/2729)
 - allow creating wgpu::Instance from wgpu_core::Instance by @i509VCB in [#2763](https://github.com/gfx-rs/wgpu/pull/2763)
 - Force binding sizes to be multiples of 16 on webgl by @cwfitzgerald in [#2808](https://github.com/gfx-rs/wgpu/pull/2808)
-- Add Naga variant to ShaderSource by @rttad in [#2801](https://github.com/gfx-rs/wgpu/pull/2801)
+- Add naga variant to ShaderSource by @rttad in [#2801](https://github.com/gfx-rs/wgpu/pull/2801)
 - Implement Queue::write_buffer_with by @teoxoy in [#2777](https://github.com/gfx-rs/wgpu/pull/2777)
 
 #### Vulkan
@@ -4048,7 +4048,7 @@ DeviceDescriptor {
     - new `PARTIALLY_BOUND_BINDING_ARRAY`
     - `NON_FILL_POLYGON_MODE` is split into `POLYGON_MODE_LINE` and `POLYGON_MODE_POINT`
 - fixes:
-  - many shader-related fixes in Naga-0.7
+  - many shader-related fixes in naga-0.7
   - fix a panic in resource cleanup happening when they are dropped on another thread
   - Vulkan:
     - create SPIR-V per entry point to work around driver bugs
@@ -4198,7 +4198,7 @@ DeviceDescriptor {
 
 ## v0.8 (2021-04-29)
 
-- Naga is used by default to translate shaders, SPIRV-Cross is optional behind `cross` feature
+- naga is used by default to translate shaders, SPIRV-Cross is optional behind `cross` feature
 - Features:
   - buffers are zero-initialized
   - downlevel limits for DX11/OpenGL support
@@ -4297,7 +4297,7 @@ DeviceDescriptor {
   - all transfer operations
   - all resource creation
   - bind group matching to the layout
-  - experimental shader interface matching with Naga
+  - experimental shader interface matching with naga
 
 ### wgpu-core-0.5.6 (2020-07-09)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,18 @@
-This document is a guide for contributions to the WGPU project.
+This document is a guide for contributions to the wgpu project.
 
 ## Welcome!
 
-First of all, welcome to the WGPU community! 👋 We're glad you want to
-contribute. If you are unfamiliar with the WGPU project, we recommend you read
+First of all, welcome to the wgpu community! 👋 We're glad you want to
+contribute. If you are unfamiliar with the wgpu project, we recommend you read
 [`GOVERNANCE.md`] for an overview of its goals, and how it's governed.
 
 ## Documentation Overview:
 
-- [`GOVERNANCE.md`]: An overview of the WGPU project's goals and governance.
-- [`CODE_OF_CONDUCT.md`]: The code of conduct for the WGPU project.
-- [`docs/release-checklist.md`]: Checklist for creating a new release of WGPU.
-- [`docs/review-checklist.md`]: Checklist for reviewing a pull request in WGPU.
-- [`docs/testing.md`]: Information on the test suites in WGPU and Naga.
+- [`GOVERNANCE.md`]: An overview of the wgpu project's goals and governance.
+- [`CODE_OF_CONDUCT.md`]: The code of conduct for the wgpu project.
+- [`docs/release-checklist.md`]: Checklist for creating a new release of wgpu.
+- [`docs/review-checklist.md`]: Checklist for reviewing a pull request in wgpu.
+- [`docs/testing.md`]: Information on the test suites in wgpu and naga.
 
 [`GOVERNANCE.md`]: ./GOVERNANCE.md
 [`CODE_OF_CONDUCT.md`]: ./CODE_OF_CONDUCT.md
@@ -20,9 +20,9 @@ contribute. If you are unfamiliar with the WGPU project, we recommend you read
 [`docs/review-checklist.md`]: ./docs/review-checklist.md
 [`docs/testing.md`]: ./docs/testing.md
 
-## Talking to other humans in the WGPU project
+## Talking to other humans in the wgpu project
 
-The WGPU project has multiple official platforms for community engagement:
+The wgpu project has multiple official platforms for community engagement:
 
 - The Matrix channel [`wgpu:matrix.org`](https://matrix.to/#/#wgpu:matrix.org)
   is dedicated to informal chat about contributions the project. It is
@@ -73,10 +73,10 @@ The WGPU project has multiple official platforms for community engagement:
 [Meeting Link]: https://meet.google.com/ubo-ztcw-gwf
 [`CODE_OF_CONDUCT.md`]: ./CODE_OF_CONDUCT.md
 
-## Contributing to WGPU
+## Contributing to wgpu
 
 Community response to contributions are, in general, prioritized based on their
-relevance to WGPU's mission and decision-making groups' interest (see
+relevance to wgpu's mission and decision-making groups' interest (see
 [`GOVERNANCE.md`]).
 
 ### "What can I work on?" as a new contributor
@@ -84,24 +84,24 @@ relevance to WGPU's mission and decision-making groups' interest (see
 TODO
 
 We discourage new contributors from submitting large changes or opinionated
-refactors unless they have been specifically validated by WGPU maintainership.
+refactors unless they have been specifically validated by wgpu maintainership.
 These are likely to be rejected on basis of needing discussion before a formal
 review.
 
-### Setting up a WGPU development environment
+### Setting up a wgpu development environment
 
-We use the following components in a WGPU development environment:
+We use the following components in a wgpu development environment:
 
 - [A Rust toolchain][install-rust] matching the version specified in
-  [`rust-toolchain.toml`](./rust-toolchain.toml), to compile WGPU's code. If you
+  [`rust-toolchain.toml`](./rust-toolchain.toml), to compile wgpu's code. If you
   use `rustup`, this will be automatically installed when you first run a
   `cargo` command in the repository.
 - [Taplo](https://taplo.tamasfe.dev/) to keep TOML files formatted.
 - [Vulkan SDK](https://vulkan.lunarg.com/) to provide Vulkan validation layers
   and other Vulkan/SPIR-V tools for testing.
 
-Once these are done, you should be ready to hack on WGPU! Drop into your
-favorite editor, make some changes to the repository's code, and test that WGPU
+Once these are done, you should be ready to hack on wgpu! Drop into your
+favorite editor, make some changes to the repository's code, and test that wgpu
 has been changed the way you expect. Take a look at [`docs/testing.md`] for more
 info on testing.
 
@@ -111,8 +111,8 @@ and a [`git` dependency][git-deps] pointing to your own fork to share changes
 with other contributors.
 
 Once you are ready to request a review of your changes so they become part of
-WGPU public history, create a pull request with your changes committed to a
-branch in your own fork of WGPU in GitHub. See documentation for that
+wgpu public history, create a pull request with your changes committed to a
+branch in your own fork of wgpu in GitHub. See documentation for that
 [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
 
 [install-rust]: https://www.rust-lang.org/tools/install
@@ -157,9 +157,9 @@ assignment is simply to ensure that pull requests don't get neglected.
 
 #### Designing new features
 
-As an open source project, WGPU wants to serve a broad audience. This
+As an open source project, wgpu wants to serve a broad audience. This
 helps us cast a wide net for contributors, and widens the impact of
-their work. However, WGPU does not promise to incorporate every
+their work. However, wgpu does not promise to incorporate every
 proposed feature.
 
 Large efforts that are ultimately rejected tend to burn contributors
@@ -176,11 +176,11 @@ Contributors should anticipate that the larger and more complex a pull
 request is, the less likely it is that reviewers will accept it,
 regardless of its merits.
 
-The WGPU project has had poor experiences with large, complex pull
+The wgpu project has had poor experiences with large, complex pull
 requests:
 
 - Complex pull requests are difficult to review effectively. It is
-  common for us to debug a problem in WGPU and find that it was
+  common for us to debug a problem in wgpu and find that it was
   introduced by some massive pull request that we had reviewed and
   accepted, showing that we obviously hadn't understood it as well as
   we'd thought.
@@ -190,7 +190,7 @@ requests:
   stressful to question its design decisions, knowing that changing
   them will require the author to essentially reimplement the project
   from scratch. Such pull requests make it hard for maintainers to
-  uphold their responsibility to keep WGPU maintainable. Incremental
+  uphold their responsibility to keep wgpu maintainable. Incremental
   changes are easier to discuss and revise without drama.
 
 These problems are serious enough that maintainers may choose to
@@ -199,7 +199,7 @@ feature or the technical merit of the code.
 
 The problem isn't really the *size* of the pull request: a simple
 rename, with no changes to functionality, might touch hundreds of
-files, but be easy to review. Or, a change to Naga might affect dozens
+files, but be easy to review. Or, a change to naga might affect dozens
 of snapshot test output files, without being hard to understand.
 
 Rather, the problem is the *complexity* of the pull request: how many

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,15 +1,15 @@
-The **WGPU project** is a set of open-source libraries that _enables application
+The **wgpu project** is a set of open-source libraries that _enables application
 authors to write portable and performant graphics programs_. It was originally
 conceived to provide an implementation of WebGPU for Firefox as the standard
 evolved, and settled into something that could be shipped on all web browsers.
-WGPU has also enjoyed much contribution and use from other projects that require
+wgpu has also enjoyed much contribution and use from other projects that require
 graphics programming. We expect that these sorts of users will continue for the
 lifetime of project, and we embrace these contributors' needs and effort as the
-lifeblood of WGPU.
+lifeblood of wgpu.
 
 ## Mission
 
-The WGPU community seeks to realize the following directives through the
+The wgpu community seeks to realize the following directives through the
 project: it…
 
 1. …provides libraries for the WebGPU API that…
@@ -28,7 +28,7 @@ project: it…
 
 ## Decision-making
 
-The WGPU community's decision-making is influenced by the following
+The wgpu community's decision-making is influenced by the following
 groups:
 
 * Community leadership:
@@ -38,18 +38,18 @@ groups:
 * Firefox's WebGPU team (@jimblandy, @nical, @teoxoy, @ErichDonGubler, and
   others)
 * Deno's WebGPU contributors (@crowlKats)
-* Other users that ship applications based on WGPU
+* Other users that ship applications based on wgpu
 
 It is no coincidence that these groups correspond to the historically most
-active and consistent contributors. In general, WGPU's community structure is
+active and consistent contributors. In general, wgpu's community structure is
 meritocratic: social influence is granted proportionate to groups' contribution
-to and stake in WGPU's mission.
+to and stake in wgpu's mission.
 
 These decision-making groups meet together regularly to discuss issues of
-importance to the community, with a focus on WGPU's [mission](#Mission).
+importance to the community, with a focus on wgpu's [mission](#Mission).
 
 ---
 
 NOTE: The above is a snapshot of a perpetually changing state of affairs in the
-WGPU community. It is not a binding contract between users and decision-makers
-of the WGPU project.
+wgpu community. It is not a binding contract between users and decision-makers
+of the wgpu project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
-# WGPU Security Policy
+# wgpu Security Policy
 
-This document describes what is considered a security vulnerability in WGPU and
+This document describes what is considered a security vulnerability in wgpu and
 how vulnerabilities should be reported.
 
 
@@ -18,10 +18,10 @@ misused, and failures to do so may be considered vulnerabilities. (This is
 also in accordance with the Rust principle of safe vs. unsafe code, since the
 `wgpu` library exposes a safe API.)
 
-The WGPU maintainers have discretion in assigning a severity to individual
+The wgpu maintainers have discretion in assigning a severity to individual
 vulnerabilities. It is generally considered a high-severity vulnerability in
-WGPU if JavaScript or WebAssembly code, running with privileges of ordinary web
-content in a browser that is using WGPU to provide the WebGPU API to that
+wgpu if JavaScript or WebAssembly code, running with privileges of ordinary web
+content in a browser that is using wgpu to provide the WebGPU API to that
 content, is able to:
 
 - Access data associated with native applications other than the user agent,
@@ -31,24 +31,24 @@ content, is able to:
 - Consume system resources to the point that it is difficult to recover
   (e.g. by closing the web page).
 
-The WGPU Rust API offers some functionality, both supported and experimental,
+The wgpu Rust API offers some functionality, both supported and experimental,
 that is not part of the WebGPU standard and is not made available in JavaScript
-environments using WGPU. Associated vulnerabilities may be assigned lower
-severity than vulnerabilities that apply to a WGPU-based WebGPU implementation
+environments using wgpu. Associated vulnerabilities may be assigned lower
+severity than vulnerabilities that apply to a wgpu-based WebGPU implementation
 exposed to JavaScript.
 
 
 ## Supported Versions
 
-The WGPU project maintains security support for serious vulnerabilities in the
+The wgpu project maintains security support for serious vulnerabilities in the
 [most recent major release](https://github.com/gfx-rs/wgpu/releases). Fixes for
 security vulnerabilities found shortly after the initial release of a major
 version may also be provided for the previous major release.
 
-Mozilla provides security support for versions of WGPU used in [current
+Mozilla provides security support for versions of wgpu used in [current
 versions of Firefox](https://whattrainisitnow.com/).
 
-The version of WGPU that is active can be found in the Firefox repositories:
+The version of wgpu that is active can be found in the Firefox repositories:
 
 - [release](https://github.com/mozilla-firefox/firefox/blob/release/gfx/wgpu_bindings/Cargo.toml),
 - [beta](https://github.com/mozilla-firefox/firefox/blob/beta/gfx/wgpu_bindings/Cargo.toml), and
@@ -60,11 +60,11 @@ versions or in the latest code on the `trunk` branch.
 
 ## Reporting a Vulnerability
 
-Although not all vulnerabilities in WGPU will affect Firefox, Mozilla accepts
-all vulnerability reports for WGPU and directs them appropriately. Additionally,
-Mozilla serves as the CVE numbering authority for the WGPU project.
+Although not all vulnerabilities in wgpu will affect Firefox, Mozilla accepts
+all vulnerability reports for wgpu and directs them appropriately. Additionally,
+Mozilla serves as the CVE numbering authority for the wgpu project.
 
-To report a security problem with WGPU, create a bug in Mozilla's Bugzilla
+To report a security problem with wgpu, create a bug in Mozilla's Bugzilla
 instance in the
 [Core :: Graphics :: WebGPU](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=Graphics%3A+WebGPU&groups=core-security&groups=gfx-core-security)
 component.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 # Examples
 
-If you are just starting your graphics programming journey entirely, we recommend going through [Learn-WGPU](https://sotrh.github.io/learn-wgpu/)
+If you are just starting your graphics programming journey entirely, we recommend going through [Learn-wgpu](https://sotrh.github.io/learn-wgpu/)
 for a mode guided tutorial, which will also teach you the basics of graphics programming.
 
 ## Standalone Examples
@@ -32,12 +32,12 @@ These examples use a common framework to handle wgpu init, window creation, and 
 
 #### Graphics
 
-- `hello_triangle` - Provides an example of a bare-bones WGPU workflow using the Winit crate that simply renders a red triangle on a green background.
+- `hello_triangle` - Provides an example of a bare-bones wgpu workflow using the Winit crate that simply renders a red triangle on a green background.
 - `uniform_values` - Demonstrates the basics of enabling shaders and the GPU, in general, to access app state through uniform variables. `uniform_values` also serves as an example of rudimentary app building as the app stores state and takes window-captured keyboard events. The app displays the Mandelbrot Set in grayscale (similar to `storage_texture`) but allows the user to navigate and explore it using their arrow keys and scroll wheel.
 - `cube` - Introduces the user to slightly more advanced models. The example creates a set of triangles to form a cube on the CPU and then uses a vertex and index buffer to send the generated model to the GPU for usage in rendering. It also uses a texture generated on the CPU to shade the sides of the cube and a uniform variable to apply a transformation matrix to the cube in the shader.
 - `bunnymark` - Demonstrates many things, but chief among them is performing numerous draw calls with different bind groups in one render pass. The example also uses textures for the icon and uniform buffers to transfer both global and per-particle states.
 - `skybox` - Shows off too many concepts to list here. The name comes from game development where a "skybox" acts as a background for rendering, usually to add a sky texture for immersion, although they can also be used for backdrops to give the idea of a world beyond the game scene. This example does so much more than this, though, as it uses a car model loaded from a file and uses the user's mouse to rotate the car model in 3d. `skybox` also makes use of depth textures and similar app patterns to `uniform_values`.
-- `shadow` - Likely by far the most complex example (certainly the largest in lines of code) of the official WGPU examples. `shadow` demonstrates basic scene rendering with the main attraction being lighting and shadows (as the name implies). It is recommended that any user looking into lighting be very familiar with the basic concepts of not only rendering with WGPU but also the primary mathematical ideas of computer graphics.
+- `shadow` - Likely by far the most complex example (certainly the largest in lines of code) of the official wgpu examples. `shadow` demonstrates basic scene rendering with the main attraction being lighting and shadows (as the name implies). It is recommended that any user looking into lighting be very familiar with the basic concepts of not only rendering with wgpu but also the primary mathematical ideas of computer graphics.
 - `multiple-render-targets` - Demonstrates how to render to two texture targets simultaneously from fragment shader.
 - `render_to_texture` - Renders to an image texture offscreen, demonstrating both off-screen rendering as well as how to add a sort of resolution-agnostic screenshot feature to an engine. This example either outputs an image file of your naming (pass command line arguments after specifying a `--` like `cargo run --bin wgpu-examples -- render_to_texture "test.png"`) or adds an `img` element containing the image to the page in WASM.
 - `ray_cube_fragment` - Demonstrates using ray queries with a fragment shader.

--- a/examples/features/src/storage_texture/mod.rs
+++ b/examples/features/src/storage_texture/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! Storage textures work like normal textures but they operate similar to storage buffers
 //! in that they can be written to. The issue is that as it stands, write-only is the
-//! only valid access mode for storage textures in WGSL and although there is a WGPU feature
+//! only valid access mode for storage textures in WGSL and although there is a wgpu feature
 //! to allow for read-write access, this is unfortunately a native-only feature and thus
 //! we won't be using it here. If we needed a reference texture, we would need to add a
 //! second texture to act as a reference and attach that as well. Luckily, we don't need

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -18,7 +18,7 @@
 
 use std::sync::Arc;
 // We won't bring StorageBuffer into scope as that might be too easy to confuse
-// with actual GPU-allocated WGPU storage buffers.
+// with actual GPU-allocated wgpu storage buffers.
 use encase::ShaderType;
 use winit::{
     event::{Event, KeyEvent, WindowEvent},

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -31,7 +31,7 @@ fn main() {
     // Other platforms don't really need one.
     let window_builder = cfg!(windows).then(|| {
         winit::window::WindowBuilder::new()
-            .with_title("WGPU raw GLES example (press Escape to exit)")
+            .with_title("wgpu raw GLES example (press Escape to exit)")
     });
 
     // The template will match only the configurations supporting rendering
@@ -70,7 +70,7 @@ fn main() {
 
     // Glutin tries to create an OpenGL context by default.  Force it to use any version of GLES.
     let context_attributes = glutin::context::ContextAttributesBuilder::new()
-        // WGPU expects GLES 3.0+.
+        // wgpu expects GLES 3.0+.
         .with_context_api(glutin::context::ContextApi::Gles(Some(Version::new(3, 0))))
         .build(raw_window_handle);
 
@@ -112,7 +112,7 @@ fn main() {
                 Event::Resumed => {
                     let window = window.take().unwrap_or_else(|| {
                         let window_builder = winit::window::WindowBuilder::new()
-                            .with_title("WGPU raw GLES example (press Escape to exit)");
+                            .with_title("wgpu raw GLES example (press Escape to exit)");
                         glutin_winit::finalize_window(window_target, window_builder, &gl_config)
                             .unwrap()
                     });

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -1190,7 +1190,7 @@ impl DownlevelCapabilities {
 bitflags::bitflags! {
     /// Binary flags listing features that may or may not be present on downlevel adapters.
     ///
-    /// A downlevel adapter is a GPU adapter that WGPU supports, but with potentially limited
+    /// A downlevel adapter is a GPU adapter that wgpu supports, but with potentially limited
     /// features, due to the lack of hardware feature support.
     ///
     /// Flags that are **not** present for a downlevel adapter or device usually indicates

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -130,7 +130,7 @@ serde = ["wgpu-core?/serde", "wgpu-types/serde"]
 
 ## Enables statically linking DXC.
 ##
-## Normally, to use the modern DXC shader compiler with WGPU, the final application
+## Normally, to use the modern DXC shader compiler with wgpu, the final application
 ## must be shipped alongside `dxcompiler.dll` (min v1.8.2502) (which can be downloaded from [Microsoft's GitHub][dxc]).
 ## This feature statically links a version of DXC so that no external binaries are required
 ## to compile DX12 shaders.

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1876,7 +1876,7 @@ impl dispatch::DeviceInterface for WebDevice {
             Err(crate::CompilationInfo {
                 messages: vec![crate::CompilationMessage {
                     message:
-                        "Passthrough shader not compiled for WGSL on WebGPU backend (WGPU error)"
+                        "Passthrough shader not compiled for WGSL on WebGPU backend (wgpu error)"
                             .to_string(),
                     location: None,
                     message_type: crate::CompilationMessageType::Error,


### PR DESCRIPTION
[Discussed in the meeting today.](https://docs.google.com/document/d/1Z3qjy3m7eAYaTsh2n-iKxLV4Hjc6wZxgukzdQOgVH1c/edit?tab=t.0#heading=h.pcvpqf4eg42c)

This normalizes how we talk about wgpu to always be wgpu or `wgpu` instead of WGPU.