### PR TITLE
[metal] allow access to command buffer

### DIFF
--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -33,6 +33,10 @@ impl Default for super::CommandState {
 }
 
 impl super::CommandEncoder {
+    pub fn raw_command_buffer(&self) -> Option<&metal::CommandBuffer> {
+        self.raw_cmd_buf.as_ref()
+    }
+
     fn enter_blit(&mut self) -> &metal::BlitCommandEncoderRef {
         if self.state.blit.is_none() {
             debug_assert!(self.state.render.is_none() && self.state.compute.is_none());


### PR DESCRIPTION
**Description**
Allow HAL access to the metal `MTLCommandBuffer` of a command encoder.

**Testing**
Tested manually on iOS.

**Checklist**

- [x] Run `cargo fmt`.
- [x] ~~Run `taplo format`.~~
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] ~~`--target wasm32-unknown-unknown`~~
- [x] Run `cargo xtask test` to run tests.
- [x] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ <!-- See instructions at the top of `CHANGELOG.md`. -->
