### PR TITLE
ci: Make the install-{mesa,vulkan-sdk} action multiplatform

### DIFF
--- a/.github/actions/install-mesa/action.yml
+++ b/.github/actions/install-mesa/action.yml
@@ -1,16 +1,22 @@
 name: 'Install Mesa'
 description: 'Install Mesa'
+inputs:
+  # Sourced from https://archive.mesa3d.org/. Bumping this requires
+  # updating the mesa build in https://github.com/gfx-rs/ci-build and creating a new release.
+  version:
+    default: '24.3.4'
+  # Corresponds to https://github.com/gfx-rs/ci-build/releases
+  ci-binary-build:
+    default: 'build20'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
-    - name: Install Mesa
+    - name: (Linux) Install Mesa
+      if: runner.os == 'Linux'
       shell: bash
       env:
-        # Sourced from https://archive.mesa3d.org/. Bumping this requires
-        # updating the mesa build in https://github.com/gfx-rs/ci-build and creating a new release.
-        MESA_VERSION: "24.3.4"
-        # Corresponds to https://github.com/gfx-rs/ci-build/releases
-        CI_BINARY_BUILD: "build20"
+        MESA_VERSION: ${{ inputs.version }}
+        CI_BINARY_BUILD: ${{ inputs.ci-binary-build }}
       run: |
         set -e
 
@@ -34,3 +40,22 @@ runs:
         echo "VK_DRIVER_FILES=$PWD/icd.json" >> "$GITHUB_ENV"
         echo "LD_LIBRARY_PATH=$PWD/mesa/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
         echo "LIBGL_DRIVERS_PATH=$PWD/mesa/lib/x86_64-linux-gnu/dri" >> "$GITHUB_ENV"
+
+    - name: (Windows) Install Mesa
+      if: runner.os == 'Windows'
+      shell: bash
+      env:
+        MESA_VERSION: ${{ inputs.version }}
+        CI_BINARY_BUILD: ${{ inputs.ci-binary-build }}
+      run: |
+        set -e
+
+        curl.exe -L --retry 5 https://github.com/pal1000/mesa-dist-win/releases/download/$MESA_VERSION/mesa3d-$MESA_VERSION-release-msvc.7z -o mesa.7z
+        7z.exe e mesa.7z -omesa x64/{opengl32.dll,libgallium_wgl.dll,libglapi.dll,vulkan_lvp.dll,lvp_icd.x86_64.json}
+
+        cp -v mesa/* target/llvm-cov-target/debug/
+        cp -v mesa/* target/llvm-cov-target/debug/deps
+
+        # We need to use cygpath to convert PWD to a windows path as we're using bash.
+        echo "VK_DRIVER_FILES=`cygpath --windows $PWD/mesa/lvp_icd.x86_64.json`" >> "$GITHUB_ENV"
+        echo "GALLIUM_DRIVER=llvmpipe" >> "$GITHUB_ENV"

--- a/.github/actions/install-vulkan-sdk/action.yml
+++ b/.github/actions/install-vulkan-sdk/action.yml
@@ -1,14 +1,20 @@
-name: "Install Vulkan SDK"
-description: "Install Vulkan SDK"
+name: 'Install Vulkan SDK'
+description: 'Install Vulkan SDK'
+inputs:
+  # Sourced from https://vulkan.lunarg.com/sdk/home#linux
+  version:
+    default: '1.4.321'
+  full-version:
+    default: '1.4.321.0'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
-    - name: Install Vulkan SDK
+    - name: (Linux) Install Vulkan SDK
+      if: runner.os == 'Linux'
       shell: bash
       env:
-        # Sourced from https://vulkan.lunarg.com/sdk/home#linux
-        VULKAN_SDK_VERSION: "1.4.321"
-        VULKAN_FULL_SDK_VERSION: "1.4.321.0"
+        VULKAN_SDK_VERSION: ${{ inputs.version }}
+        VULKAN_FULL_SDK_VERSION: ${{ inputs.full-version }}
       run: |
         set -e
 
@@ -21,3 +27,36 @@ runs:
         echo "$HOME/VulkanSDK/x86_64/bin" >> "$GITHUB_PATH"
         echo "LD_LIBRARY_PATH=$HOME/VulkanSDK/x86_64/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
         echo "VK_ADD_LAYER_PATH=$HOME/VulkanSDK/x86_64/share/vulkan/explicit_layer.d" >> "$GITHUB_ENV"
+
+    - name: (Windows) Install Vulkan SDK
+      if: runner.os == 'Windows'
+      shell: bash
+      env:
+        VULKAN_SDK_VERSION: ${{ inputs.version }}
+        VULKAN_FULL_SDK_VERSION: ${{ inputs.full-version }}
+      run: |
+        set -e
+
+        curl.exe -L --retry 5 https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_FULL_SDK_VERSION }}/windows/vulkansdk-windows-X64-${{ env.VULKAN_FULL_SDK_VERSION }}.exe -o vulkan-sdk-installer.exe
+
+        ./vulkan-sdk-installer.exe --accept-licenses --default-answer --confirm-command install
+
+        echo "C:/VulkanSDK/${{ env.VULKAN_FULL_SDK_VERSION }}/Bin" >> "$GITHUB_PATH"
+
+
+    - name: (Mac) Install Vulkan SDK
+      if: runner.os == 'macOS'
+      shell: bash
+      env:
+        VULKAN_SDK_VERSION: ${{ inputs.version }}
+        VULKAN_FULL_SDK_VERSION: ${{ inputs.full-version }}
+      run: |
+        set -e
+
+        curl -L --retry 5 https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_FULL_SDK_VERSION }}/mac/vulkansdk-macos-${{ env.VULKAN_FULL_SDK_VERSION }}.zip -o vulkan-sdk.zip
+        unzip vulkan-sdk.zip -d vulkan-sdk
+
+        ls -l vulkan-sdk
+        sudo ./vulkan-sdk/vulkansdk-macOS-${{ env.VULKAN_FULL_SDK_VERSION }}.app/Contents/MacOS/vulkansdk-macOS-${{ env.VULKAN_FULL_SDK_VERSION }} --root "$HOME/VulkanSDK" --accept-licenses --default-answer --confirm-command install
+
+        echo "$HOME/VulkanSDK/macOS/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,6 @@ env:
   # Dependency versioning
   #
 
-  # Sourced from https://vulkan.lunarg.com/sdk/home#linux
-  # These Vulkan version definition is duplicated in the install-vulkan action.
-  VULKAN_SDK_VERSION: "1.4.321"
-  VULKAN_FULL_SDK_VERSION: "1.4.321.0"
-
-  # These Mesa version definition is duplicated in the install-mesa action.
-  MESA_VERSION: "24.3.4"
-
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
   REPO_MSRV: "1.88"
   # This is the MSRV used by the `wgpu-core`, `wgpu-hal`, and `wgpu-types` crates,
@@ -563,45 +555,15 @@ jobs:
 
       - name: (Windows) Install Mesa
         if: matrix.os == 'windows-2022'
-        shell: bash
-        run: |
-          set -e
-
-          curl.exe -L --retry 5 https://github.com/pal1000/mesa-dist-win/releases/download/$MESA_VERSION/mesa3d-$MESA_VERSION-release-msvc.7z -o mesa.7z
-          7z.exe e mesa.7z -omesa x64/{opengl32.dll,libgallium_wgl.dll,libglapi.dll,vulkan_lvp.dll,lvp_icd.x86_64.json}
-
-          cp -v mesa/* target/llvm-cov-target/debug/
-          cp -v mesa/* target/llvm-cov-target/debug/deps
-
-          # We need to use cygpath to convert PWD to a windows path as we're using bash.
-          echo "VK_DRIVER_FILES=`cygpath --windows $PWD/mesa/lvp_icd.x86_64.json`" >> "$GITHUB_ENV"
-          echo "GALLIUM_DRIVER=llvmpipe" >> "$GITHUB_ENV"
+        uses: ./.github/actions/install-mesa
 
       - name: (Windows) Install Vulkan SDK
         if: matrix.os == 'windows-2022'
-        shell: bash
-        run: |
-          set -e
-
-          curl.exe -L --retry 5 https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_FULL_SDK_VERSION }}/windows/vulkansdk-windows-X64-${{ env.VULKAN_FULL_SDK_VERSION }}.exe -o vulkan-sdk-installer.exe
-
-          ./vulkan-sdk-installer.exe --accept-licenses --default-answer --confirm-command install
-
-          echo "C:/VulkanSDK/${{ env.VULKAN_FULL_SDK_VERSION }}/Bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/install-vulkan-sdk
 
       - name: (Mac) Install Vulkan SDK
         if: matrix.os == 'macos-14'
-        shell: bash
-        run: |
-          set -e
-
-          curl -L --retry 5 https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_FULL_SDK_VERSION }}/mac/vulkansdk-macos-${{ env.VULKAN_FULL_SDK_VERSION }}.zip -o vulkan-sdk.zip
-          unzip vulkan-sdk.zip -d vulkan-sdk
-
-          ls -l vulkan-sdk
-          sudo ./vulkan-sdk/vulkansdk-macOS-${{ env.VULKAN_FULL_SDK_VERSION }}.app/Contents/MacOS/vulkansdk-macOS-${{ env.VULKAN_FULL_SDK_VERSION }} --root "$HOME/VulkanSDK" --accept-licenses --default-answer --confirm-command install
-
-          echo "$HOME/VulkanSDK/macOS/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/install-vulkan-sdk
 
       - name: (Linux) Install Vulkan SDK
         if: matrix.os == 'ubuntu-24.04'


### PR DESCRIPTION
**Description**

This also allow to remove the MESA_VERSION and VULKAN_SDK_VERSION duplication between the ci workflow and the install action.

To pass down the version in each steps, I added action inputs because there is no way as of today to define environments variables that are shared between steps in composite actions (no top level `env:` like for workflows).

**Squash or Rebase?**

rebase

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
