### PR TITLE
[metal] `MTLDevice` is thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,7 @@ By @cwfitzgerald in [#8609](https://github.com/gfx-rs/wgpu/pull/8609).
 
 - Add support for mesh shaders. By @SupaMaggie70Incorporated in [#8139](https://github.com/gfx-rs/wgpu/pull/8139)
 - Expose render layer. By @xiaopengli89 in [#8707](https://github.com/gfx-rs/wgpu/pull/8707)
+- `MTLDevice` is thread-safe. By @uael in [#8168](https://github.com/gfx-rs/wgpu/pull/8168)
 
 #### Naga
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -50,11 +50,10 @@ impl crate::Adapter for super::Adapter {
         let queue = self
             .shared
             .device
-            .lock()
             .new_command_queue_with_max_command_buffer_count(MAX_COMMAND_BUFFERS);
 
         // Acquiring the meaning of timestamp ticks is hard with Metal!
-        // The only thing there is is a method correlating cpu & gpu timestamps (`device.sample_timestamps`).
+        // The only thing there is a method correlating cpu & gpu timestamps (`device.sample_timestamps`).
         // Users are supposed to call this method twice and calculate the difference,
         // see "Converting GPU Timestamps into CPU Time":
         // https://developer.apple.com/documentation/metal/gpu_counters_and_counter_sample_buffers/converting_gpu_timestamps_into_cpu_time
@@ -72,7 +71,7 @@ impl crate::Adapter for super::Adapter {
         // Based on:
         // * https://github.com/gfx-rs/wgpu/pull/2528
         // * https://github.com/gpuweb/gpuweb/issues/1325#issuecomment-761041326
-        let timestamp_period = if self.shared.device.lock().name().starts_with("Intel") {
+        let timestamp_period = if self.shared.device.name().starts_with("Intel") {
             83.333
         } else {
             // Known for Apple Silicon (at least M1 & M2, iPad Pro 2018) and AMD GPUs.
@@ -121,7 +120,7 @@ impl crate::Adapter for super::Adapter {
             Tfc::empty()
         };
         let is_not_apple1x = super::PrivateCapabilities::supports_any(
-            self.shared.device.lock().as_ref(),
+            self.shared.device.as_ref(),
             &[
                 MTLFeatureSet::iOS_GPUFamily2_v1,
                 MTLFeatureSet::macOS_GPUFamily1_v1,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -2,8 +2,6 @@ use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
 use core::{ptr::NonNull, sync::atomic};
 use std::{thread, time};
 
-use parking_lot::Mutex;
-
 use super::{conv, PassthroughShader};
 use crate::auxil::map_naga_stage;
 use crate::metal::ShaderModuleSource;
@@ -215,7 +213,6 @@ impl super::Device {
                 let library = self
                     .shared
                     .device
-                    .lock()
                     .new_library_with_source(source.as_ref(), &options)
                     .map_err(|err| {
                         log::debug!("Naga generated shader:\n{source}");
@@ -362,7 +359,7 @@ impl super::Device {
         super::Buffer { raw, size }
     }
 
-    pub fn raw_device(&self) -> &Mutex<metal::Device> {
+    pub fn raw_device(&self) -> &metal::Device {
         &self.shared.device
     }
 }
@@ -386,7 +383,7 @@ impl crate::Device for super::Device {
         //TODO: HazardTrackingModeUntracked
 
         objc::rc::autoreleasepool(|| {
-            let raw = self.shared.device.lock().new_buffer(desc.size, options);
+            let raw = self.shared.device.new_buffer(desc.size, options);
             if let Some(label) = desc.label {
                 raw.set_label(label);
             }
@@ -468,7 +465,7 @@ impl crate::Device for super::Device {
             descriptor.set_usage(conv::map_texture_usage(desc.format, desc.usage));
             descriptor.set_storage_mode(mtl_storage_mode);
 
-            let raw = self.shared.device.lock().new_texture(&descriptor);
+            let raw = self.shared.device.new_texture(&descriptor);
             if raw.as_ptr().is_null() {
                 return Err(crate::DeviceError::OutOfMemory);
             }
@@ -620,7 +617,7 @@ impl crate::Device for super::Device {
             if self.features.contains(wgt::Features::TEXTURE_BINDING_ARRAY) {
                 descriptor.set_support_argument_buffers(true);
             }
-            let raw = self.shared.device.lock().new_sampler(&descriptor);
+            let raw = self.shared.device.new_sampler(&descriptor);
 
             self.counters.samplers.add(1);
 
@@ -891,7 +888,7 @@ impl crate::Device for super::Device {
                         let uses = conv::map_resource_usage(&layout.ty);
 
                         // Create argument buffer for this array
-                        let buffer = self.shared.device.lock().new_buffer(
+                        let buffer = self.shared.device.new_buffer(
                             8 * count as u64,
                             MTLResourceOptions::HazardTrackingModeUntracked
                                 | MTLResourceOptions::StorageModeShared,
@@ -1073,8 +1070,8 @@ impl crate::Device for super::Device {
                 num_workgroups,
             } => {
                 let options = metal::CompileOptions::new();
-                // Obtain the locked device from shared
-                let device = self.shared.device.lock();
+                // Obtain the device from shared
+                let device = &self.shared.device;
                 let library = device
                     .new_library_with_source(source, &options)
                     .map_err(|e| crate::ShaderError::Compilation(format!("MSL: {e:?}")))?;
@@ -1459,11 +1456,7 @@ impl crate::Device for super::Device {
                     }
 
                     let ds_descriptor = create_depth_stencil_desc(ds);
-                    let raw = self
-                        .shared
-                        .device
-                        .lock()
-                        .new_depth_stencil_state(&ds_descriptor);
+                    let raw = self.shared.device.new_depth_stencil_state(&ds_descriptor);
                     Some((raw, ds.bias))
                 }
                 None => None,
@@ -1496,10 +1489,10 @@ impl crate::Device for super::Device {
             // Create the pipeline from descriptor
             let raw = match descriptor {
                 MetalGenericRenderPipelineDescriptor::Standard(d) => {
-                    self.shared.device.lock().new_render_pipeline_state(&d)
+                    self.shared.device.new_render_pipeline_state(&d)
                 }
                 MetalGenericRenderPipelineDescriptor::Mesh(d) => {
-                    self.shared.device.lock().new_mesh_render_pipeline_state(&d)
+                    self.shared.device.new_mesh_render_pipeline_state(&d)
                 }
             }
             .map_err(|e| {
@@ -1600,7 +1593,6 @@ impl crate::Device for super::Device {
             let raw = self
                 .shared
                 .device
-                .lock()
                 .new_compute_pipeline_state(&descriptor)
                 .map_err(|e| {
                     crate::PipelineError::Linkage(
@@ -1637,7 +1629,7 @@ impl crate::Device for super::Device {
                     let size = desc.count as u64 * crate::QUERY_SIZE;
                     let options = MTLResourceOptions::empty();
                     //TODO: HazardTrackingModeUntracked
-                    let raw_buffer = self.shared.device.lock().new_buffer(size, options);
+                    let raw_buffer = self.shared.device.new_buffer(size, options);
                     if let Some(label) = desc.label {
                         raw_buffer.set_label(label);
                     }
@@ -1649,7 +1641,7 @@ impl crate::Device for super::Device {
                 }
                 wgt::QueryType::Timestamp => {
                     let size = desc.count as u64 * crate::QUERY_SIZE;
-                    let device = self.shared.device.lock();
+                    let device = &self.shared.device;
                     let destination_buffer = device.new_buffer(size, MTLResourceOptions::empty());
 
                     let csb_desc = metal::CounterSampleBufferDescriptor::new();
@@ -1701,7 +1693,7 @@ impl crate::Device for super::Device {
     unsafe fn create_fence(&self) -> DeviceResult<super::Fence> {
         self.counters.fences.add(1);
         let shared_event = if self.shared.private_caps.supports_shared_event {
-            Some(self.shared.device.lock().new_shared_event())
+            Some(self.shared.device.new_shared_event())
         } else {
             None
         };
@@ -1765,9 +1757,9 @@ impl crate::Device for super::Device {
         if !self.shared.private_caps.supports_capture_manager {
             return false;
         }
-        let device = self.shared.device.lock();
+        let device = &self.shared.device;
         let shared_capture_manager = metal::CaptureManager::shared();
-        let default_capture_scope = shared_capture_manager.new_capture_scope_with_device(&device);
+        let default_capture_scope = shared_capture_manager.new_capture_scope_with_device(device);
         shared_capture_manager.set_default_capture_scope(&default_capture_scope);
         shared_capture_manager.start_capture_with_scope(&default_capture_scope);
         default_capture_scope.begin_scope();

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -337,7 +337,7 @@ impl Default for Settings {
 }
 
 struct AdapterShared {
-    device: Mutex<metal::Device>,
+    device: metal::Device,
     disabilities: PrivateDisabilities,
     private_caps: PrivateCapabilities,
     settings: Settings,
@@ -355,7 +355,7 @@ impl AdapterShared {
         Self {
             disabilities: PrivateDisabilities::new(&device),
             private_caps,
-            device: Mutex::new(device),
+            device,
             settings: Settings::default(),
             presentation_timer: time::PresentationTimer::new(),
         }

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -163,8 +163,8 @@ impl crate::Surface for super::Surface {
             _ => (),
         }
 
-        let device_raw = device.shared.device.lock();
-        render_layer.set_device(&device_raw);
+        let device_raw = &device.shared.device;
+        render_layer.set_device(device_raw);
         render_layer.set_pixel_format(caps.map_format(config.format));
         render_layer.set_framebuffer_only(framebuffer_only);
         // opt-in to Metal EDR


### PR DESCRIPTION
**Description**
`MTLDevice` **look like** is safe to access from different threads, this remove the `Mutex` around it. Feel free to close if it's actually not, the Apple documentation is very unclear about that and only notice about the [thread safety of the command queue](https://developer.apple.com/documentation/metal/mtlcommandqueue)

**Testing**
Tested manually on iOS.

**Checklist**

- [x] Run `cargo fmt`.
- [x] ~~Run `taplo format`.~~
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] ~~`--target wasm32-unknown-unknown`~~
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
