### PR TITLE
[api] expose invalid submission index to `PollError`

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -138,6 +138,9 @@ impl WaitIdleError {
     pub fn to_poll_error(&self) -> Option<wgt::PollError> {
         match self {
             WaitIdleError::Timeout => Some(wgt::PollError::Timeout),
+            &WaitIdleError::WrongSubmissionIndex(a, b) => {
+                Some(wgt::PollError::WrongSubmissionIndex(a, b))
+            }
             _ => None,
         }
     }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4555,6 +4555,12 @@ pub enum PollError {
         error("The requested Wait timed out before the submission was completed.")
     )]
     Timeout,
+    /// The requested Wait was given a wrong submission index.
+    #[cfg_attr(
+        feature = "std",
+        error("Tried to wait using a submission index ({0}) that has not been returned by a successful submission (last successful submission: {1})")
+    )]
+    WrongSubmissionIndex(u64, u64),
 }
 
 /// Status of device poll operation.


### PR DESCRIPTION
**Description**
We are encountering a panic from time to time due to invalid submission index being passed to poll, our code literally being:
```rust
let idx = queue.submit(Some(command_buffer));
device.poll(wgpu::PollType::WaitForSubmissionIndex(idx));
```
In the meantime of a proper fix, prefer to handle the error more gracefully.

**Testing**
Manually on different plaforms.

**Checklist**

- [x] Run `cargo fmt`.
- [x] ~~Run `taplo format`.~~
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] ~~`--target wasm32-unknown-unknown`~~
- [x] Run `cargo xtask test` to run tests.
- [x] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ <!-- See instructions at the top of `CHANGELOG.md`. -->
