### PR TITLE
wgpu-types: Do not depend on "bitflags/serde" if feature "serde" is not enabled

### DIFF
--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -49,7 +49,7 @@ trace = ["std"]
 web = ["dep:js-sys", "dep:web-sys"]
 
 [dependencies]
-bitflags = { workspace = true, features = ["serde"] }
+bitflags.workspace = true
 bytemuck = { workspace = true, features = ["derive"] }
 log.workspace = true
 thiserror = { workspace = true, optional = true }


### PR DESCRIPTION
**Description**
Avoid unnecessary dependencies to enable compiling `bitflags` earlier


**Testing**
```sh
cargo check
cargo check --feature serde
```

**Squash or Rebase?**
squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry.
