### PR TITLE
[naga wgsl-in] add "texture_external" to reserved keyword list

### DIFF
--- a/naga/src/keywords/wgsl.rs
+++ b/naga/src/keywords/wgsl.rs
@@ -36,6 +36,7 @@ pub const RESERVED: &[&str] = &[
     "texture_3d",
     "texture_cube",
     "texture_cube_array",
+    "texture_external",
     "texture_multisampled_2d",
     "texture_storage_1d",
     "texture_storage_2d",


### PR DESCRIPTION
**Description**
This fixes the following CTS test when the EXTERNAL_TEXTURE feature is enabled:
```
webgpu:shader,validation,parse,shadow_builtins:shadow_hides_builtin_handle_type:inject="module"
```

The test expects a validation error due to the keyword being reserved. When the feature is _disabled_, the test test passes by accident because an error is raised due to the missing feature. 

**Testing**
Have verified it fixes the test locally if I force enable the external texture feature. Can't add it to the CTS test list which runs in CI as deno does not request the external texture feature.

**Squash or Rebase?**

Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.