### PR TITLE
Remove `pending_query_resets` from `CommandBufferMutable`

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -645,8 +645,6 @@ pub struct CommandBufferMutable {
     buffer_memory_init_actions: Vec<BufferInitTrackerAction>,
     texture_memory_actions: CommandBufferTextureMemoryActions,
 
-    pub(crate) pending_query_resets: QueryResetMap,
-
     as_actions: Vec<AsAction>,
     temp_resources: Vec<TempResource>,
 
@@ -722,7 +720,6 @@ impl CommandEncoder {
                     trackers: Tracker::new(),
                     buffer_memory_init_actions: Default::default(),
                     texture_memory_actions: Default::default(),
-                    pending_query_resets: QueryResetMap::new(),
                     as_actions: Default::default(),
                     temp_resources: Default::default(),
                     indirect_draw_validation_resources:


### PR DESCRIPTION
It is emptied by `reset_queries` at the end of every render pass, so it's just keeping an allocation alive, not holding any state, outside of a render pass. It seems unlikely that there is sufficient performance gain from reusing the memory allocation to justify the complexity of additional state at higher layers.

For encoding on finish, there will be some additional code handing off state during encoding. Keeping this state locally within a render pass means one less piece of state that needs to be handed off.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
