### PR TITLE
chore(deps): Update bitflags version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,7 @@ dependencies = [
 name = "naga-test"
 version = "26.0.0"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "env_logger",
  "naga",
  "ron",


### PR DESCRIPTION
My local builds have been making this change to Cargo.lock. I think what happened is that another reference to 2.9.3 was added to Cargo.lock in parallel with the renovate change that bumped the version to 2.9.4.