### PR TITLE
Add cbindgen:ignore directives

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -59,8 +59,11 @@ use thiserror::Error;
 #[cfg(feature = "trace")]
 type TraceCommand = Command;
 
+/// cbindgen:ignore
 pub type TexelCopyBufferInfo = ffi::TexelCopyBufferInfo;
+/// cbindgen:ignore
 pub type TexelCopyTextureInfo = ffi::TexelCopyTextureInfo;
+/// cbindgen:ignore
 pub type CopyExternalImageDestInfo = ffi::CopyExternalImageDestInfo;
 
 const PUSH_CONSTANT_CLEAR_ARRAY: &[u32] = &[0_u32; 64];


### PR DESCRIPTION
cbindgen generates nonsensical typedefs from these.

**Squash or Rebase?** Squash