### PR TITLE
hal/vulkan: Accurately map all formats except fp16 to use the non-linear sRGB color space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,10 @@ By @cwfitzgerald in [#8162](https://github.com/gfx-rs/wgpu/pull/8162).
 
 - Fixed unwrap failed in context creation for some Android devices. By @uael in [#8024](https://github.com/gfx-rs/wgpu/pull/8024).
 
+##### Vulkan
+
+- Fixed wrong color format+space being reported versus what is hardcoded in `create_swapchain()`. By @MarijnS95 in [#8226](https://github.com/gfx-rs/wgpu/pull/8226).
+
 #### naga
 
 - [wgsl-in] Allow a trailing comma in `@blend_src(…)` attributes. By @ErichDonGubler in [#8137](https://github.com/gfx-rs/wgpu/pull/8137).

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -161,7 +161,8 @@ impl super::PrivateCapabilities {
 pub fn map_vk_surface_formats(sf: vk::SurfaceFormatKHR) -> Option<wgt::TextureFormat> {
     use ash::vk::Format as F;
     use wgt::TextureFormat as Tf;
-    // List we care about pulled from https://vulkan.gpuinfo.org/listsurfaceformats.php
+    // List we care about pulled from https://vulkan.gpuinfo.org/listsurfaceformats.php.
+    // Device::create_swapchain() hardcodes linear scRGB for fp16, non-linear sRGB otherwise.
     Some(match sf.color_space {
         vk::ColorSpaceKHR::SRGB_NONLINEAR => match sf.format {
             F::B8G8R8A8_UNORM => Tf::Bgra8Unorm,
@@ -169,13 +170,13 @@ pub fn map_vk_surface_formats(sf: vk::SurfaceFormatKHR) -> Option<wgt::TextureFo
             F::R8G8B8A8_SNORM => Tf::Rgba8Snorm,
             F::R8G8B8A8_UNORM => Tf::Rgba8Unorm,
             F::R8G8B8A8_SRGB => Tf::Rgba8UnormSrgb,
+            F::R16G16B16A16_SNORM => Tf::Rgba16Snorm,
+            F::R16G16B16A16_UNORM => Tf::Rgba16Unorm,
+            F::A2B10G10R10_UNORM_PACK32 => Tf::Rgb10a2Unorm,
             _ => return None,
         },
         vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT => match sf.format {
             F::R16G16B16A16_SFLOAT => Tf::Rgba16Float,
-            F::R16G16B16A16_SNORM => Tf::Rgba16Snorm,
-            F::R16G16B16A16_UNORM => Tf::Rgba16Unorm,
-            F::A2B10G10R10_UNORM_PACK32 => Tf::Rgb10a2Unorm,
             _ => return None,
         },
         _ => return None,


### PR DESCRIPTION

**Connections**
Fixes #8076

**Description**

In a quest to deduplicate reported texture formats in #3227 this was hacked in to be based on color spaces (having the same format listed for multiple color spaces is how duplicates exist to begin with), following [a link to some swapchain code] that forcibly uses linear scRGB (extended sRGB) for a surface configuration with fp16 texture format.  By accident it seems also 16-bit UNORM/SNORM formats and even the `A2R10G10B10_UNORM_PACK32` format were placed inside the linear scRGB match arm.  Besides mismatching with the forced color space used at swapchain creation, this disallows using higher bit-depth in regular non-linear sRGB output.  In particular 10-bit is popular for modern monitors, which remain in (non-linear) sRGB while HDR output is disabled.

According to the **linked** Vulkan reports database the existing format pairs with `EXTENDED_SRGB_LINEAR_EXT` have *barely any coverage*, to the point where `R16G16B16A16_SNORM` doesn't seem to be supported at all with anything other than `SRGB_NONLINEAR_KHR`.

[a link to some swapchain code]: https://github.com/gfx-rs/wgpu/blob/f41a1c294bf09c4ab7e523f6c9aff5119044a097/wgpu-hal/src/vulkan/device.rs#L542-L548

**Testing**
No testing yet.

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
