### PR TITLE
Port changes from Deno's copy of deno_webgpu and update deno crates

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -50,10 +50,6 @@ ignore = [
     # It's a dependency of `metal` (which is to be replaced with `objc2-metal`), and a
     # transitive dependency of `deno`. https://github.com/gfx-rs/wgpu/issues/7873
     "RUSTSEC-2024-0436",
-    # `adler` crate is no longer maintained https://rustsec.org/advisories/RUSTSEC-2025-0056
-    # It's a dependency of `miniz_oxide` 0.7.4, and a transitive dependency of `deno`.
-    # https://github.com/gfx-rs/wgpu/issues/7961
-    "RUSTSEC-2025-0056",
 ]
 
 [licenses]

--- a/.deny.toml
+++ b/.deny.toml
@@ -5,6 +5,7 @@ skip-tree = [
     { name = "winit", version = "0.29" },
     { name = "rustc_version", version = "0.2.3" },
     { name = "miniz_oxide", version = "0.7.4" },
+    { name = "rustc-hash", version = "1.1.0" },
 
     # introduced by Deno, to be investigated
     { name = "strum_macros", version = "0.25.3" },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,20 +318,11 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
-dependencies = [
- "simd-abstraction",
-]
-
-[[package]]
-name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
 dependencies = [
- "outref 0.5.2",
+ "outref",
  "vsimd",
 ]
 
@@ -366,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags 2.9.4",
  "cexpr",
@@ -379,18 +370,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
 ]
 
 [[package]]
@@ -399,14 +381,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -577,15 +553,6 @@ dependencies = [
 
 [[package]]
 name = "capacity_builder"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ec49028cb308564429cd8fac4ef21290067a0afe8f5955330a8d487d0d790c"
-dependencies = [
- "itoa",
-]
-
-[[package]]
-name = "capacity_builder"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f2d24a6dcf0cd402a21b65d35340f3a49ff3475dc5fdac91d22d2733e6641c6"
@@ -619,7 +586,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dc1a6f7b5651af85774ae5a34b4e8be397d9cf4bc063b7e6dbd99a841837830"
 dependencies = [
- "semver 1.0.26",
+ "semver",
  "serde",
  "serde-untagged",
  "serde-value",
@@ -638,7 +605,7 @@ dependencies = [
  "camino",
  "cargo-platform",
  "cargo-util-schemas",
- "semver 1.0.26",
+ "semver",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -770,7 +737,7 @@ version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -1055,26 +1022,26 @@ dependencies = [
 
 [[package]]
 name = "deno_console"
-version = "0.192.0"
+version = "0.203.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca40d9ecd49a0320c058eff8ad8b53c83b1b743e3087001afe2e14ec50197d34"
+checksum = "999171b0fc7255971eec7adfc49b2bf18832e86e4a86746c3c58633373d16cdb"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.338.0"
+version = "0.343.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113f3f08bd5daf99f1a7876c0f99cd8c3c609439fa0b808311ec856a253e95f0"
+checksum = "167ae63972f6de58e4a548327f363ebc449930b62a44d9bbd80197564d2c755d"
 dependencies = [
  "anyhow",
  "az",
  "bincode 1.3.3",
- "bit-set 0.5.3",
- "bit-vec 0.6.3",
+ "bit-set",
+ "bit-vec",
  "bytes",
- "capacity_builder 0.1.3",
+ "capacity_builder",
  "cooked-waker",
  "deno_core_icudata",
  "deno_error",
@@ -1084,7 +1051,6 @@ dependencies = [
  "futures",
  "indexmap",
  "libc",
- "memoffset",
  "parking_lot",
  "percent-encoding",
  "pin-project",
@@ -1109,9 +1075,9 @@ checksum = "fe4dccb6147bb3f3ba0c7a48e993bfeb999d2c2e47a81badee80e2b370c8d695"
 
 [[package]]
 name = "deno_error"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c23dbc46d5804814b08b4675838f9884e3a52916987ec5105af36d42f9911b5"
+checksum = "19fae9fe305307b5ef3ee4e8244c79cffcca421ab0ce8634dea0c6b1342f220f"
 dependencies = [
  "deno_error_macro",
  "libc",
@@ -1123,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error_macro"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babccedee31ce7e57c3e6dff2cb3ab8d68c49d0df8222fe0d11d628e65192790"
+checksum = "5abb2556e91848b66f562451fcbcdee2a3b7c88281828908dcf7cca355f5d997"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1134,17 +1100,17 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.214.0"
+version = "0.219.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad885bf882be535f7714c713042129acba6f31a8efb5e6b2298f6e40cab9b16"
+checksum = "188e48d180244dae157d8a5126b8fbcecf6458f26a425f1c2f57b5952a1b5ee1"
 dependencies = [
  "indexmap",
  "proc-macro-rules",
  "proc-macro2",
  "quote",
  "stringcase",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum",
+ "strum_macros",
  "syn",
  "thiserror 2.0.16",
 ]
@@ -1164,11 +1130,11 @@ dependencies = [
 
 [[package]]
 name = "deno_permissions"
-version = "0.52.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ff15740ddc4626cc7f5d66a113e0f825073476d1e83af9fa693426516d07b7"
+checksum = "f7c3c0785bcb458cd010c47d7f77cae26594a5160ebfc4fecb6f9e5ea36483fc"
 dependencies = [
- "capacity_builder 0.5.0",
+ "capacity_builder",
  "deno_core",
  "deno_error",
  "deno_path_util",
@@ -1207,24 +1173,23 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.192.0"
+version = "0.203.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a705094c7fbbb01338e89c12367da939cf831dd5b202e3a521f75a614a6082"
+checksum = "0961e3e844191cac261eba5efdf52e2a5dd3aeeac7ebb09c1bbe3f8b04ef31cd"
 dependencies = [
  "deno_core",
  "deno_error",
- "thiserror 2.0.16",
  "urlpattern",
 ]
 
 [[package]]
 name = "deno_web"
-version = "0.224.0"
+version = "0.234.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae1ba442b2c4b6116eb75e6e46968840693f2036d035bd45421c4a9beda6186"
+checksum = "2ec73d866d485bed1bd520f3a413a94b5c9a69de09d8561697d2bd83a79c795c"
 dependencies = [
  "async-trait",
- "base64-simd 0.8.0",
+ "base64-simd",
  "bytes",
  "deno_core",
  "deno_error",
@@ -1240,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webgpu"
-version = "0.157.0"
+version = "0.170.0"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1257,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.192.0"
+version = "0.203.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d2d820d865651e0ce4eca898176577c8693bf2694af32545ab4b9ffb9934fa"
+checksum = "cb50836af90d078b1f30f4df0e3398d557a74633b9b4740e10a299a83f12d054"
 dependencies = [
  "deno_core",
 ]
@@ -1388,9 +1353,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -1948,12 +1913,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -2447,15 +2406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "metal"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,7 +2482,7 @@ version = "26.0.0"
 dependencies = [
  "arbitrary",
  "arrayvec",
- "bit-set 0.8.0",
+ "bit-set",
  "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases 0.2.1",
@@ -2554,10 +2504,10 @@ dependencies = [
  "pp-rs",
  "ron",
  "rspirv",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "spirv",
- "strum 0.27.2",
+ "strum",
  "thiserror 2.0.16",
  "unicode-ident",
  "walkdir",
@@ -3107,12 +3057,6 @@ dependencies = [
 
 [[package]]
 name = "outref"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
-
-[[package]]
-name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
@@ -3609,7 +3553,7 @@ version = "0.12.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cf3a93856b6e5946537278df0d3075596371b1950ccff012f02b0f7eafec8d"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
 ]
 
@@ -3632,13 +3576,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
+name = "rustc-hash"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -3727,27 +3668,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -3833,9 +3759,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.247.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bbfafb7b707cbed49d1eaf48f4aa41b5ff57f813d1a80f77244e6e2fa4507e"
+checksum = "84b2d85f46747fad18bbf98ad4b9b13c59e01c85bf8c73182a71fdf638372dfd"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -3873,15 +3799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "simd-abstraction"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
-dependencies = [
- "outref 0.1.0",
 ]
 
 [[package]]
@@ -3982,17 +3899,16 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "8.0.1"
+version = "9.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208d40b9e8cad9f93613778ea295ed8f3c2b1824217c6cfc7219d3f6f45b96d4"
+checksum = "e22afbcb92ce02d23815b9795523c005cb9d3c214f8b7a66318541c240ea7935"
 dependencies = [
- "base64-simd 0.7.0",
+ "base64-simd",
  "bitvec",
  "data-encoding",
  "debugid",
  "if_chain",
- "rustc-hash",
- "rustc_version",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "unicode-id-start",
@@ -4038,9 +3954,9 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "stringcase"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04028eeb851ed08af6aba5caa29f2d59a13ed168cee4d6bd753aeefcf1d636b0"
+checksum = "72abeda133c49d7bddece6c154728f83eec8172380c80ab7096da9487e20d27c"
 
 [[package]]
 name = "strsim"
@@ -4050,33 +3966,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4085,7 +3979,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -4605,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "134.5.0"
+version = "135.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c7a224a7eaf3f98c1bad772fbaee56394dce185ef7b19a2e0ca5e3d274165d"
+checksum = "171c7d65c2c71e7e02cbef7762787614cab3e9043d58b433ef65b4baa2f4614d"
 dependencies = [
  "bindgen",
  "bitflags 2.9.4",
@@ -4615,7 +4509,6 @@ dependencies = [
  "gzip-header",
  "home",
  "miniz_oxide 0.7.4",
- "once_cell",
  "paste",
  "which 6.0.3",
 ]
@@ -5002,8 +4895,8 @@ name = "wgpu-core"
 version = "26.0.0"
 dependencies = [
  "arrayvec",
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.9.4",
  "bytemuck",
  "cfg_aliases 0.2.1",
@@ -5018,7 +4911,7 @@ dependencies = [
  "profiling",
  "raw-window-handle 0.6.2",
  "ron",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "smallvec",
  "thiserror 2.0.16",
@@ -5125,7 +5018,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.8.0",
+ "bit-set",
  "bitflags 2.9.4",
  "block",
  "bytemuck",
@@ -5162,7 +5055,7 @@ dependencies = [
  "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
  "renderdoc-sys",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.16",
  "wasm-bindgen",
@@ -5191,7 +5084,7 @@ dependencies = [
 name = "wgpu-macros"
 version = "26.0.0"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "quote",
  "syn",
 ]
@@ -5226,7 +5119,7 @@ dependencies = [
  "profiling",
  "serde",
  "serde_json",
- "strum 0.27.2",
+ "strum",
  "trybuild",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,12 +28,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,7 +298,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
@@ -989,6 +983,7 @@ version = "26.0.0"
 dependencies = [
  "deno_console",
  "deno_core",
+ "deno_features",
  "deno_url",
  "deno_web",
  "deno_webgpu",
@@ -1022,18 +1017,18 @@ dependencies = [
 
 [[package]]
 name = "deno_console"
-version = "0.203.0"
+version = "0.205.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999171b0fc7255971eec7adfc49b2bf18832e86e4a86746c3c58633373d16cdb"
+checksum = "f18e4a73bc0dd2a30dfbc14d8c2eb9b7347b7616acb6810d71e7912385c34f89"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.343.0"
+version = "0.347.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ae63972f6de58e4a548327f363ebc449930b62a44d9bbd80197564d2c755d"
+checksum = "d75ae5562f6ad750bc2007e7b1032ae37115a83fe58b6fbc77331c47744956cc"
 dependencies = [
  "anyhow",
  "az",
@@ -1099,10 +1094,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno_ops"
-version = "0.219.0"
+name = "deno_features"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188e48d180244dae157d8a5126b8fbcecf6458f26a425f1c2f57b5952a1b5ee1"
+checksum = "cf0bffbb52e0ad53c50225cdf0c20b24501036c3948264a049487fc5e5c40f57"
+dependencies = [
+ "deno_core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "deno_ops"
+version = "0.223.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5adc7f0795c7547f1b560a07aaea484e8f9cd035318348c6bfd084e0c42dce8"
 dependencies = [
  "indexmap",
  "proc-macro-rules",
@@ -1130,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "deno_permissions"
-version = "0.62.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c3c0785bcb458cd010c47d7f77cae26594a5160ebfc4fecb6f9e5ea36483fc"
+checksum = "501f5bb2f44b977eb682c42909df35b980edf5144d3b5f00796e96a67df0055c"
 dependencies = [
  "capacity_builder",
  "deno_core",
@@ -1173,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.203.0"
+version = "0.205.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0961e3e844191cac261eba5efdf52e2a5dd3aeeac7ebb09c1bbe3f8b04ef31cd"
+checksum = "af2813696e113b21c288558151c86a0f60d1afda3458bc76e5d29173fe288c22"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1184,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.234.0"
+version = "0.236.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec73d866d485bed1bd520f3a413a94b5c9a69de09d8561697d2bd83a79c795c"
+checksum = "8b0885564bfade3284b26a29cb32a67ba7b75fe329b7f12bc0e26815acf7ae1c"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -1205,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webgpu"
-version = "0.170.0"
+version = "0.171.0"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1222,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.203.0"
+version = "0.205.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb50836af90d078b1f30f4df0e3398d557a74633b9b4740e10a299a83f12d054"
+checksum = "7e4f3a7a4672a071d25e93b5598f4a8a4bfc20f2a8d6900a7a6a7d02264bc6f2"
 dependencies = [
  "deno_core",
 ]
@@ -1470,7 +1476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2438,15 +2444,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
@@ -3232,7 +3229,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3759,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.252.0"
+version = "0.256.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b2d85f46747fad18bbf98ad4b9b13c59e01c85bf8c73182a71fdf638372dfd"
+checksum = "69d69b4e574a9ec6bd0222463e50cf8531986d9c657543888e029d54d909b283"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -4499,16 +4496,16 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "135.1.1"
+version = "137.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171c7d65c2c71e7e02cbef7762787614cab3e9043d58b433ef65b4baa2f4614d"
+checksum = "33995a1fee055ff743281cde33a41f0d618ee0bdbe8bdf6859e11864499c2595"
 dependencies = [
  "bindgen",
  "bitflags 2.9.4",
  "fslock",
  "gzip-header",
  "home",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "paste",
  "which 6.0.3",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxed_error"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d4f95e880cfd28c4ca5a006cf7f6af52b4bcb7b5866f573b2faa126fb7affb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,24 +1027,25 @@ dependencies = [
 
 [[package]]
 name = "deno_console"
-version = "0.205.0"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18e4a73bc0dd2a30dfbc14d8c2eb9b7347b7616acb6810d71e7912385c34f89"
+checksum = "74189b98d1245bcef3a7565cbfe5cad4ab3d2ad9393aa48067fab89efe85a99b"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.347.0"
+version = "0.355.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75ae5562f6ad750bc2007e7b1032ae37115a83fe58b6fbc77331c47744956cc"
+checksum = "775d2fde80a2ec3116d179703b38346a931bb9626f4a826148d5fe8631cab29f"
 dependencies = [
  "anyhow",
  "az",
  "bincode 1.3.3",
  "bit-set",
  "bit-vec",
+ "boxed_error",
  "bytes",
  "capacity_builder",
  "cooked-waker",
@@ -1070,9 +1081,9 @@ checksum = "fe4dccb6147bb3f3ba0c7a48e993bfeb999d2c2e47a81badee80e2b370c8d695"
 
 [[package]]
 name = "deno_error"
-version = "0.5.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fae9fe305307b5ef3ee4e8244c79cffcca421ab0ce8634dea0c6b1342f220f"
+checksum = "dde60bd153886964234c5012d3d9caf788287f28d81fb24a884436904101ef10"
 dependencies = [
  "deno_error_macro",
  "libc",
@@ -1084,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error_macro"
-version = "0.5.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5abb2556e91848b66f562451fcbcdee2a3b7c88281828908dcf7cca355f5d997"
+checksum = "409f265785bd946d3006756955aaf40b0e4deb25752eae6a990afe54a31cfd83"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1095,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "deno_features"
-version = "0.2.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf0bffbb52e0ad53c50225cdf0c20b24501036c3948264a049487fc5e5c40f57"
+checksum = "ea79a01229bd5f8ee4ba784811f421a90a1ac241da4dc015a3f58380167c9944"
 dependencies = [
  "deno_core",
  "serde",
@@ -1106,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.223.0"
+version = "0.231.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5adc7f0795c7547f1b560a07aaea484e8f9cd035318348c6bfd084e0c42dce8"
+checksum = "9ca530772bbcbc9ad389ad7bcd86623b2ec555f68a2d062d23cc008915cbe781"
 dependencies = [
  "indexmap",
  "proc-macro-rules",
@@ -1123,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "deno_path_util"
-version = "0.3.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c238a664a0a6f1ce0ff2b73c6854811526d00f442a12f878cb8555b23fe13aa3"
+checksum = "bfe02936964b2910719bd488841f6e884349360113c7abf6f4c6b28ca9cd7a19"
 dependencies = [
  "deno_error",
  "percent-encoding",
@@ -1136,24 +1147,31 @@ dependencies = [
 
 [[package]]
 name = "deno_permissions"
-version = "0.64.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501f5bb2f44b977eb682c42909df35b980edf5144d3b5f00796e96a67df0055c"
+checksum = "656d8cc364ca906e12fb83d379202983052c6aa3e7420e385559e903d2773f61"
 dependencies = [
  "capacity_builder",
- "deno_core",
  "deno_error",
  "deno_path_util",
  "deno_terminal",
+ "deno_unsync",
  "fqdn",
+ "ipnetwork",
  "libc",
  "log",
+ "nix",
  "once_cell",
+ "parking_lot",
  "percent-encoding",
  "serde",
+ "serde_json",
+ "sys_traits",
  "thiserror 2.0.16",
- "which 6.0.3",
+ "url",
+ "which 8.0.0",
  "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1179,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.205.0"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2813696e113b21c288558151c86a0f60d1afda3458bc76e5d29173fe288c22"
+checksum = "a4f02fd80dda41f1e278c69170b802004c0094ceef2dde68bc117a69dc5702cf"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1190,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.236.0"
+version = "0.245.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0885564bfade3284b26a29cb32a67ba7b75fe329b7f12bc0e26815acf7ae1c"
+checksum = "56fbbfb92fa76a4e0873d1b02f5e9947562e70ac7ec065ba794b08aca3760564"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -1211,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webgpu"
-version = "0.171.0"
+version = "0.181.0"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1228,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.205.0"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4f3a7a4672a071d25e93b5598f4a8a4bfc20f2a8d6900a7a6a7d02264bc6f2"
+checksum = "b29a947a96dc0f672741669470f0260eba20d198436143b40afb9bda97723f07"
 dependencies = [
  "deno_core",
 ]
@@ -2127,6 +2145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,6 +2679,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -3756,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.256.0"
+version = "0.264.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d69b4e574a9ec6bd0222463e50cf8531986d9c657543888e029d54d909b283"
+checksum = "c34707712f3815e73e1c8319bba06e5bc105bb65fe812ea2e7279ffb905f6312"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -4657,9 +4695,9 @@ dependencies = [
 
 [[package]]
 name = "wasm_dep_analyzer"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eeee3bdea6257cc36d756fa745a70f9d393571e47d69e0ed97581676a5369ca"
+checksum = "a10e6b67c951a84de7029487e0e0a496860dae49f6699edd279d5ff35b8fbf54"
 dependencies = [
  "deno_error",
  "thiserror 2.0.16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ pp-rs = "0.2.1"
 profiling = { version = "1.0.1", default-features = false }
 quote = "1.0.38"
 raw-window-handle = { version = "0.6.2", default-features = false }
-rwh_05 = { version = "0.5.2", package = "raw-window-handle" } # temporary compatibility for glutin-winit               
+rwh_05 = { version = "0.5.2", package = "raw-window-handle" } # temporary compatibility for glutin-winit
 rayon = "1.3"
 regex-lite = "0.1"
 renderdoc-sys = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ indicatif = "0.18"
 itertools = { version = "0.14" }
 jobserver = "0.1"
 ktx2 = "0.4"
-libc = { version = "0.2.168", default-features = false }
+libc = { version = "0.2.171", default-features = false }
 # See https://github.com/rust-fuzz/libfuzzer/issues/126
 libfuzzer-sys = ">0.4.0,<=0.4.7"
 libloading = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ hashbrown = { version = "0.16", default-features = false, features = [
 heck = "0.5"
 hexf-parse = "0.2"
 image = { version = "0.25", default-features = false, features = ["png"] }
-indexmap = { version = "2.7", default-features = false }
+indexmap = { version = "2.8", default-features = false }
 indicatif = "0.18"
 itertools = { version = "0.14" }
 jobserver = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ rustc-hash = { version = "1.1", default-features = false }
 serde_json = "1.0.143"
 serde = { version = "1.0.219", default-features = false }
 shell-words = "1"
-smallvec = "1.13.1"
+smallvec = "1.14"
 spirv = "0.3"
 static_assertions = "1.1"
 strum = { version = "0.27", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ deno_webidl = "0.192.0"
 deno_webgpu = { version = "0.157.0", path = "./deno_webgpu" }
 deno_unsync = "0.4.2"
 deno_error = "0.5.5"
-tokio = "1.39"
+tokio = "1.45.1"
 termcolor = "1.1.3"
 
 # android dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,14 +236,14 @@ web-sys = { version = "0.3.77", default-features = false }
 web-time = "1.1.0"
 
 # deno dependencies
-deno_console = "0.192.0"
-deno_core = "0.338.0"
-deno_url = "0.192.0"
-deno_web = "0.224.0"
-deno_webidl = "0.192.0"
-deno_webgpu = { version = "0.157.0", path = "./deno_webgpu" }
+deno_console = "0.203.0"
+deno_core = "0.343.0"
+deno_url = "0.203.0"
+deno_web = "0.234.0"
+deno_webidl = "0.203.0"
+deno_webgpu = { version = "0.170.0", path = "./deno_webgpu" }
 deno_unsync = "0.4.2"
-deno_error = "0.5.5"
+deno_error = "0.5.6"
 tokio = "1.45.1"
 termcolor = "1.1.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ shell-words = "1"
 smallvec = "1.14"
 spirv = "0.3"
 static_assertions = "1.1"
-strum = { version = "0.27", default-features = false, features = ["derive"] }
+strum = { version = "0.27.1", default-features = false, features = ["derive"] }
 syn = "2.0.98"
 toml = "0.9.0"
 trybuild = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,15 +236,15 @@ web-sys = { version = "0.3.77", default-features = false }
 web-time = "1.1.0"
 
 # deno dependencies
-deno_console = "0.205.0"
-deno_core = "0.347.0"
-deno_features = "0.2.0"
-deno_url = "0.205.0"
-deno_web = "0.236.0"
-deno_webidl = "0.205.0"
-deno_webgpu = { version = "0.171.0", path = "./deno_webgpu" }
-deno_unsync = "0.4.2"
-deno_error = "0.5.6"
+deno_console = "0.214.0"
+deno_core = "0.355.0"
+deno_features = "0.11.0"
+deno_url = "0.214.0"
+deno_web = "0.245.0"
+deno_webidl = "0.214.0"
+deno_webgpu = { version = "0.181.0", path = "./deno_webgpu" }
+deno_unsync = "0.4.4"
+deno_error = "0.7.0"
 tokio = "1.45.1"
 termcolor = "1.1.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,12 +236,13 @@ web-sys = { version = "0.3.77", default-features = false }
 web-time = "1.1.0"
 
 # deno dependencies
-deno_console = "0.203.0"
-deno_core = "0.343.0"
-deno_url = "0.203.0"
-deno_web = "0.234.0"
-deno_webidl = "0.203.0"
-deno_webgpu = { version = "0.170.0", path = "./deno_webgpu" }
+deno_console = "0.205.0"
+deno_core = "0.347.0"
+deno_features = "0.2.0"
+deno_url = "0.205.0"
+deno_web = "0.236.0"
+deno_webidl = "0.205.0"
+deno_webgpu = { version = "0.171.0", path = "./deno_webgpu" }
 deno_unsync = "0.4.2"
 deno_error = "0.5.6"
 tokio = "1.45.1"

--- a/cts_runner/Cargo.toml
+++ b/cts_runner/Cargo.toml
@@ -15,6 +15,7 @@ env_logger.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 deno_console.workspace = true
 deno_core.workspace = true
+deno_features.workspace = true
 deno_url.workspace = true
 deno_web.workspace = true
 deno_webidl.workspace = true

--- a/cts_runner/src/bootstrap.js
+++ b/cts_runner/src/bootstrap.js
@@ -138,10 +138,6 @@ class Navigator {
   constructor() {
     webidl.illegalConstructor();
   }
-
-  [Symbol.for("Deno.customInspect")](inspect) {
-    return `${this.constructor.name} ${inspect({})}`;
-  }
 }
 const NavigatorPrototype = Navigator.prototype;
 

--- a/cts_runner/src/main.rs
+++ b/cts_runner/src/main.rs
@@ -36,10 +36,7 @@ pub async fn run() -> Result<(), AnyError> {
             deno_webidl::deno_webidl::init(),
             deno_console::deno_console::init(),
             deno_url::deno_url::init(),
-            deno_web::deno_web::init::<Permissions>(
-                Arc::new(BlobStore::default()),
-                None,
-            ),
+            deno_web::deno_web::init::<Permissions>(Arc::new(BlobStore::default()), None),
             deno_webgpu::deno_webgpu::init(),
             cts_runner::init(),
         ],

--- a/cts_runner/src/main.rs
+++ b/cts_runner/src/main.rs
@@ -30,23 +30,19 @@ pub async fn run() -> Result<(), AnyError> {
         .ok_or_else(|| anyhow!("missing specifier in first command line argument"))?;
     let specifier = resolve_url_or_path(&url, &env::current_dir()?)?;
 
-    let mut feature_checker = deno_core::FeatureChecker::default();
-    feature_checker.enable_feature(deno_webgpu::UNSTABLE_FEATURE_NAME);
-
     let options = RuntimeOptions {
         module_loader: Some(Rc::new(deno_core::FsModuleLoader)),
         extensions: vec![
-            deno_webidl::deno_webidl::init_ops_and_esm(),
-            deno_console::deno_console::init_ops_and_esm(),
-            deno_url::deno_url::init_ops_and_esm(),
-            deno_web::deno_web::init_ops_and_esm::<Permissions>(
+            deno_webidl::deno_webidl::init(),
+            deno_console::deno_console::init(),
+            deno_url::deno_url::init(),
+            deno_web::deno_web::init::<Permissions>(
                 Arc::new(BlobStore::default()),
                 None,
             ),
-            deno_webgpu::deno_webgpu::init_ops_and_esm(),
-            cts_runner::init_ops_and_esm(),
+            deno_webgpu::deno_webgpu::init(),
+            cts_runner::init(),
         ],
-        feature_checker: Some(Arc::new(feature_checker)),
         ..Default::default()
     };
     let mut js_runtime = JsRuntime::new(options);
@@ -84,6 +80,9 @@ deno_core::extension!(
     esm_entry_point = "ext:cts_runner/src/bootstrap.js",
     esm = ["src/bootstrap.js"],
     state = |state| {
+        let mut feature_checker = deno_features::FeatureChecker::default();
+        feature_checker.enable_feature(deno_webgpu::UNSTABLE_FEATURE_NAME);
+        state.put(feature_checker);
         state.put(Permissions {});
     }
 );

--- a/deno_webgpu/01_webgpu.js
+++ b/deno_webgpu/01_webgpu.js
@@ -37,6 +37,8 @@ import {
   GPUTextureView,
   GPUExternalTexture,
   op_create_gpu,
+  op_webgpu_device_start_capture,
+  op_webgpu_device_stop_capture,
 } from "ext:core/ops";
 const {
   ObjectDefineProperty,
@@ -884,6 +886,19 @@ webidl.converters["GPUUncapturedErrorEventInit"] = webidl
     dictMembersGPUUncapturedErrorEventInit,
   );
 
+function deviceStartCapture(device) {
+  op_webgpu_device_start_capture(device);
+}
+
+function deviceStopCapture(device) {
+  op_webgpu_device_stop_capture(device);
+}
+
+const denoNsWebGPU = {
+  deviceStartCapture,
+  deviceStopCapture,
+};
+
 let gpu;
 function initGPU() {
   if (!gpu) {
@@ -896,6 +911,7 @@ function initGPU() {
 }
 
 export {
+  denoNsWebGPU,
   GPU,
   gpu,
   GPUAdapter,

--- a/deno_webgpu/01_webgpu.js
+++ b/deno_webgpu/01_webgpu.js
@@ -57,9 +57,10 @@ import {
 import { DOMException } from "ext:deno_web/01_dom_exception.js";
 import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
 
-const customInspect = SymbolFor("Deno.privateCustomInspect");
+const privateCustomInspect = SymbolFor("Deno.privateCustomInspect");
 const _message = Symbol("[[message]]");
 const illegalConstructorKey = Symbol("illegalConstructorKey");
+
 class GPUError {
   constructor(key = null) {
     if (key !== illegalConstructorKey) {
@@ -73,7 +74,7 @@ class GPUError {
     return this[_message];
   }
 
-  [customInspect](inspect, inspectOptions) {
+  [privateCustomInspect](inspect, inspectOptions) {
     return inspect(
       createFilteredInspectProxy({
         object: this,
@@ -170,14 +171,16 @@ class GPUUncapturedErrorEvent extends Event {
 }
 const GPUUncapturedErrorEventPrototype = GPUUncapturedErrorEvent.prototype;
 
-ObjectDefineProperty(GPU, customInspect, {
+const GPUPrototype = GPU.prototype;
+ObjectDefineProperty(GPUPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return `${this.constructor.name} ${inspect({}, inspectOptions)}`;
   },
 });
 
-ObjectDefineProperty(GPUAdapter, customInspect, {
+const GPUAdapterPrototype = GPUAdapter.prototype;
+ObjectDefineProperty(GPUAdapterPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -188,16 +191,15 @@ ObjectDefineProperty(GPUAdapter, customInspect, {
           "features",
           "limits",
           "info",
-          "isFallbackAdapter",
         ],
       }),
       inspectOptions,
     );
   },
 });
-const GPUAdapterPrototype = GPUAdapter.prototype;
 
-ObjectDefineProperty(GPUAdapterInfo, customInspect, {
+const GPUAdapterInfoPrototype = GPUAdapterInfo.prototype;
+ObjectDefineProperty(GPUAdapterInfoPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -209,15 +211,19 @@ ObjectDefineProperty(GPUAdapterInfo, customInspect, {
           "architecture",
           "device",
           "description",
+          "subgroupMinSize",
+          "subgroupMaxSize",
+          "isFallbackAdapter",
         ],
       }),
       inspectOptions,
     );
   },
 });
-const GPUAdapterInfoPrototype = GPUAdapterInfo.prototype;
 
-ObjectDefineProperty(GPUSupportedFeatures, customInspect, {
+const GPUSupportedFeaturesPrototype = GPUSupportedFeatures.prototype;
+webidl.setlikeObjectWrap(GPUSupportedFeaturesPrototype, true);
+ObjectDefineProperty(GPUSupportedFeaturesPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     if (ObjectPrototypeIsPrototypeOf(GPUSupportedFeaturesPrototype, this)) {
@@ -229,10 +235,61 @@ ObjectDefineProperty(GPUSupportedFeatures, customInspect, {
     }
   },
 });
-const GPUSupportedFeaturesPrototype = GPUSupportedFeatures.prototype;
-webidl.setlikeObjectWrap(GPUSupportedFeaturesPrototype, true);
 
-ObjectDefineProperty(GPUDeviceLostInfo, customInspect, {
+const GPUSupportedLimitsPrototype = GPUSupportedLimits.prototype;
+ObjectDefineProperty(GPUSupportedLimitsPrototype, privateCustomInspect, {
+  __proto__: null,
+  value(inspect, inspectOptions) {
+    return inspect(
+      createFilteredInspectProxy({
+        object: this,
+        evaluate: ObjectPrototypeIsPrototypeOf(
+          GPUSupportedLimitsPrototype,
+          this,
+        ),
+        keys: [
+          "maxTextureDimension1D",
+          "maxTextureDimension2D",
+          "maxTextureDimension3D",
+          "maxTextureArrayLayers",
+          "maxBindGroups",
+          // TODO(@crowlKats): support max_bind_groups_plus_vertex_buffers
+          // "maxBindGroupsPlusVertexBuffers",
+          "maxBindingsPerBindGroup",
+          "maxDynamicUniformBuffersPerPipelineLayout",
+          "maxDynamicStorageBuffersPerPipelineLayout",
+          "maxSampledTexturesPerShaderStage",
+          "maxSamplersPerShaderStage",
+          "maxStorageBuffersPerShaderStage",
+          "maxStorageTexturesPerShaderStage",
+          "maxUniformBuffersPerShaderStage",
+          "maxUniformBufferBindingSize",
+          "maxStorageBufferBindingSize",
+          "minUniformBufferOffsetAlignment",
+          "minStorageBufferOffsetAlignment",
+          "maxVertexBuffers",
+          "maxBufferSize",
+          "maxVertexAttributes",
+          "maxVertexBufferArrayStride",
+          // TODO(@crowlKats): support max_inter_stage_shader_variables
+          // "maxInterStageShaderVariables",
+          "maxColorAttachments",
+          "maxColorAttachmentBytesPerSample",
+          "maxComputeWorkgroupStorageSize",
+          "maxComputeInvocationsPerWorkgroup",
+          "maxComputeWorkgroupSizeX",
+          "maxComputeWorkgroupSizeY",
+          "maxComputeWorkgroupSizeZ",
+          "maxComputeWorkgroupsPerDimension",
+        ],
+      }),
+      inspectOptions,
+    );
+  },
+});
+
+const GPUDeviceLostInfoPrototype = GPUDeviceLostInfo.prototype;
+ObjectDefineProperty(GPUDeviceLostInfoPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -251,9 +308,11 @@ ObjectDefineProperty(GPUDeviceLostInfo, customInspect, {
     );
   },
 });
-const GPUDeviceLostInfoPrototype = GPUDeviceLostInfo.prototype;
 
-ObjectDefineProperty(GPUDevice, customInspect, {
+const GPUDevicePrototype = GPUDevice.prototype;
+ObjectSetPrototypeOf(GPUDevicePrototype, EventTargetPrototype);
+defineEventHandler(GPUDevicePrototype, "uncapturederror");
+ObjectDefineProperty(GPUDevicePrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -274,11 +333,9 @@ ObjectDefineProperty(GPUDevice, customInspect, {
     );
   },
 });
-const GPUDevicePrototype = GPUDevice.prototype;
-ObjectSetPrototypeOf(GPUDevicePrototype, EventTargetPrototype);
-defineEventHandler(GPUDevice.prototype, "uncapturederror");
 
-ObjectDefineProperty(GPUQueue, customInspect, {
+const GPUQueuePrototype = GPUQueue.prototype;
+ObjectDefineProperty(GPUQueuePrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -293,9 +350,9 @@ ObjectDefineProperty(GPUQueue, customInspect, {
     );
   },
 });
-const GPUQueuePrototype = GPUQueue.prototype;
 
-ObjectDefineProperty(GPUBuffer, customInspect, {
+const GPUBufferPrototype = GPUBuffer.prototype;
+ObjectDefineProperty(GPUBufferPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -313,7 +370,6 @@ ObjectDefineProperty(GPUBuffer, customInspect, {
     );
   },
 });
-const GPUBufferPrototype = GPUBuffer.prototype;
 
 class GPUBufferUsage {
   constructor() {
@@ -365,7 +421,8 @@ class GPUMapMode {
   }
 }
 
-ObjectDefineProperty(GPUTexture, customInspect, {
+const GPUTexturePrototype = GPUTexture.prototype;
+ObjectDefineProperty(GPUTexturePrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -388,7 +445,6 @@ ObjectDefineProperty(GPUTexture, customInspect, {
     );
   },
 });
-const GPUTexturePrototype = GPUTexture.prototype;
 
 class GPUTextureUsage {
   constructor() {
@@ -412,7 +468,8 @@ class GPUTextureUsage {
   }
 }
 
-ObjectDefineProperty(GPUTextureView, customInspect, {
+const GPUTextureViewPrototype = GPUTextureView.prototype;
+ObjectDefineProperty(GPUTextureViewPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -427,20 +484,29 @@ ObjectDefineProperty(GPUTextureView, customInspect, {
     );
   },
 });
-const GPUTextureViewPrototype = GPUTextureView.prototype;
 
-ObjectDefineProperty(GPUSampler, customInspect, {
+const GPUSamplerPrototype = GPUSampler.prototype;
+ObjectDefineProperty(GPUSamplerPrototype, privateCustomInspect, {
   __proto__: null,
-  value(inspect) {
-    return `${this.constructor.name} ${
-      inspect({
-        label: this.label,
-      })
-    }`;
+  value(inspect, inspectOptions) {
+    return inspect(
+      createFilteredInspectProxy({
+        object: this,
+        evaluate: ObjectPrototypeIsPrototypeOf(
+          GPUSamplerPrototype,
+          this,
+        ),
+        keys: [
+          "label",
+        ],
+      }),
+      inspectOptions,
+    );
   },
 });
 
-ObjectDefineProperty(GPUBindGroupLayout, customInspect, {
+const GPUBindGroupLayoutPrototype = GPUBindGroupLayout.prototype;
+ObjectDefineProperty(GPUBindGroupLayout, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -458,9 +524,9 @@ ObjectDefineProperty(GPUBindGroupLayout, customInspect, {
     );
   },
 });
-const GPUBindGroupLayoutPrototype = GPUBindGroupLayout.prototype;
 
-ObjectDefineProperty(GPUPipelineLayout, customInspect, {
+const GPUPipelineLayoutPrototype = GPUPipelineLayout.prototype;
+ObjectDefineProperty(GPUPipelineLayoutPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -478,9 +544,9 @@ ObjectDefineProperty(GPUPipelineLayout, customInspect, {
     );
   },
 });
-const GPUPipelineLayoutPrototype = GPUPipelineLayout.prototype;
 
-ObjectDefineProperty(GPUBindGroup, customInspect, {
+const GPUBindGroupPrototype = GPUBindGroup.prototype;
+ObjectDefineProperty(GPUBindGroupPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -495,9 +561,9 @@ ObjectDefineProperty(GPUBindGroup, customInspect, {
     );
   },
 });
-const GPUBindGroupPrototype = GPUBindGroup.prototype;
 
-ObjectDefineProperty(GPUShaderModule, customInspect, {
+const GPUShaderModulePrototype = GPUShaderModule.prototype;
+ObjectDefineProperty(GPUShaderModulePrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -512,9 +578,8 @@ ObjectDefineProperty(GPUShaderModule, customInspect, {
     );
   },
 });
-const GPUShaderModulePrototype = GPUShaderModule.prototype;
 
-ObjectDefineProperty(GPUCompilationInfo, customInspect, {
+ObjectDefineProperty(GPUCompilationInfo, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -534,7 +599,7 @@ ObjectDefineProperty(GPUCompilationInfo, customInspect, {
 });
 const GPUCompilationInfoPrototype = GPUCompilationInfo.prototype;
 
-ObjectDefineProperty(GPUCompilationMessage, customInspect, {
+ObjectDefineProperty(GPUCompilationMessage, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -584,7 +649,8 @@ class GPUShaderStage {
   }
 }
 
-ObjectDefineProperty(GPUComputePipeline, customInspect, {
+const GPUComputePipelinePrototype = GPUComputePipeline.prototype;
+ObjectDefineProperty(GPUComputePipelinePrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -602,9 +668,9 @@ ObjectDefineProperty(GPUComputePipeline, customInspect, {
     );
   },
 });
-const GPUComputePipelinePrototype = GPUComputePipeline.prototype;
 
-ObjectDefineProperty(GPURenderPipeline, customInspect, {
+const GPURenderPipelinePrototype = GPURenderPipeline.prototype;
+ObjectDefineProperty(GPURenderPipelinePrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -622,7 +688,6 @@ ObjectDefineProperty(GPURenderPipeline, customInspect, {
     );
   },
 });
-const GPURenderPipelinePrototype = GPURenderPipeline.prototype;
 
 class GPUColorWrite {
   constructor() {
@@ -646,7 +711,8 @@ class GPUColorWrite {
   }
 }
 
-ObjectDefineProperty(GPUCommandEncoder, customInspect, {
+const GPUCommandEncoderPrototype = GPUCommandEncoder.prototype;
+ObjectDefineProperty(GPUCommandEncoderPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -664,9 +730,9 @@ ObjectDefineProperty(GPUCommandEncoder, customInspect, {
     );
   },
 });
-const GPUCommandEncoderPrototype = GPUCommandEncoder.prototype;
 
-ObjectDefineProperty(GPURenderPassEncoder, customInspect, {
+const GPURenderPassEncoderPrototype = GPURenderPassEncoder.prototype;
+ObjectDefineProperty(GPURenderPassEncoderPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -684,9 +750,9 @@ ObjectDefineProperty(GPURenderPassEncoder, customInspect, {
     );
   },
 });
-const GPURenderPassEncoderPrototype = GPURenderPassEncoder.prototype;
 
-ObjectDefineProperty(GPUComputePassEncoder, customInspect, {
+const GPUComputePassEncoderPrototype = GPUComputePassEncoder.prototype;
+ObjectDefineProperty(GPUComputePassEncoderPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -704,9 +770,9 @@ ObjectDefineProperty(GPUComputePassEncoder, customInspect, {
     );
   },
 });
-const GPUComputePassEncoderPrototype = GPUComputePassEncoder.prototype;
 
-ObjectDefineProperty(GPUCommandBuffer, customInspect, {
+const GPUCommandBufferPrototype = GPUCommandBuffer.prototype;
+ObjectDefineProperty(GPUCommandBufferPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -721,9 +787,9 @@ ObjectDefineProperty(GPUCommandBuffer, customInspect, {
     );
   },
 });
-const GPUCommandBufferPrototype = GPUCommandBuffer.prototype;
 
-ObjectDefineProperty(GPURenderBundleEncoder, customInspect, {
+const GPURenderBundleEncoderPrototype = GPURenderBundleEncoder.prototype;
+ObjectDefineProperty(GPURenderBundleEncoderPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -741,9 +807,9 @@ ObjectDefineProperty(GPURenderBundleEncoder, customInspect, {
     );
   },
 });
-const GPURenderBundleEncoderPrototype = GPURenderBundleEncoder.prototype;
 
-ObjectDefineProperty(GPURenderBundle, customInspect, {
+const GPURenderBundlePrototype = GPURenderBundle.prototype;
+ObjectDefineProperty(GPURenderBundlePrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -758,9 +824,9 @@ ObjectDefineProperty(GPURenderBundle, customInspect, {
     );
   },
 });
-const GPURenderBundlePrototype = GPURenderBundle.prototype;
 
-ObjectDefineProperty(GPUQuerySet, customInspect, {
+const GPUQuerySetPrototype = GPUQuerySet.prototype;
+ObjectDefineProperty(GPUQuerySetPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     return inspect(
@@ -777,7 +843,6 @@ ObjectDefineProperty(GPUQuerySet, customInspect, {
     );
   },
 });
-const GPUQuerySetPrototype = GPUQuerySet.prototype;
 // Naming it `type` or `r#type` in Rust does not work.
 // https://github.com/gfx-rs/wgpu/issues/7778
 ObjectDefineProperty(GPUQuerySet.prototype, "type", {

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webgpu"
-version = "0.170.0"
+version = "0.171.0"
 authors = ["the Deno authors"]
 edition.workspace = true
 license = "MIT"

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webgpu"
-version = "0.157.0"
+version = "0.170.0"
 authors = ["the Deno authors"]
 edition.workspace = true
 license = "MIT"

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webgpu"
-version = "0.171.0"
+version = "0.181.0"
 authors = ["the Deno authors"]
 edition.workspace = true
 license = "MIT"

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -60,7 +60,11 @@ impl Drop for GPUAdapter {
   }
 }
 
-impl GarbageCollected for GPUAdapter {}
+impl GarbageCollected for GPUAdapter {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUAdapter"
+  }
+}
 
 #[op2]
 impl GPUAdapter {
@@ -211,7 +215,11 @@ pub enum CreateDeviceError {
 
 pub struct GPUSupportedLimits(pub wgpu_types::Limits);
 
-impl GarbageCollected for GPUSupportedLimits {}
+impl GarbageCollected for GPUSupportedLimits {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUSupportedLimits"
+  }
+}
 
 #[op2]
 impl GPUSupportedLimits {
@@ -368,7 +376,11 @@ impl GPUSupportedLimits {
 
 pub struct GPUSupportedFeatures(v8::Global<v8::Value>);
 
-impl GarbageCollected for GPUSupportedFeatures {}
+impl GarbageCollected for GPUSupportedFeatures {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUSupportedFeatures"
+  }
+}
 
 impl GPUSupportedFeatures {
   #[allow(clippy::disallowed_types)]
@@ -402,7 +414,11 @@ pub struct GPUAdapterInfo {
   pub subgroup_max_size: u32,
 }
 
-impl GarbageCollected for GPUAdapterInfo {}
+impl GarbageCollected for GPUAdapterInfo {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUAdapterInfo"
+  }
+}
 
 #[op2]
 impl GPUAdapterInfo {

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -20,194 +20,197 @@ use crate::Instance;
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPURequestAdapterOptions {
-    pub power_preference: Option<GPUPowerPreference>,
-    #[webidl(default = false)]
-    pub force_fallback_adapter: bool,
+  pub power_preference: Option<GPUPowerPreference>,
+  #[webidl(default = false)]
+  pub force_fallback_adapter: bool,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUPowerPreference {
-    LowPower,
-    HighPerformance,
+  LowPower,
+  HighPerformance,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 struct GPUDeviceDescriptor {
-    #[webidl(default = String::new())]
-    label: String,
+  #[webidl(default = String::new())]
+  label: String,
 
-    #[webidl(default = vec![])]
-    required_features: Vec<GPUFeatureName>,
-    #[webidl(default = Default::default())]
-    #[options(enforce_range = true)]
-    required_limits: indexmap::IndexMap<String, Option<u64>>,
+  #[webidl(default = vec![])]
+  required_features: Vec<GPUFeatureName>,
+  #[webidl(default = Default::default())]
+  #[options(enforce_range = true)]
+  required_limits: indexmap::IndexMap<String, Option<u64>>,
 }
 
 pub struct GPUAdapter {
-    pub instance: Instance,
-    pub id: wgpu_core::id::AdapterId,
+  pub instance: Instance,
+  pub id: wgpu_core::id::AdapterId,
 
-    pub features: SameObject<GPUSupportedFeatures>,
-    pub limits: SameObject<GPUSupportedLimits>,
-    pub info: Rc<SameObject<GPUAdapterInfo>>,
+  pub features: SameObject<GPUSupportedFeatures>,
+  pub limits: SameObject<GPUSupportedLimits>,
+  pub info: Rc<SameObject<GPUAdapterInfo>>,
 }
 
 impl Drop for GPUAdapter {
-    fn drop(&mut self) {
-        self.instance.adapter_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.adapter_drop(self.id);
+  }
 }
 
 impl GarbageCollected for GPUAdapter {}
 
 #[op2]
 impl GPUAdapter {
-    #[getter]
-    #[global]
-    fn info(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
-        self.info.get(scope, |_| {
-            let info = self.instance.adapter_get_info(self.id);
-            let limits = self.instance.adapter_limits(self.id);
+  #[getter]
+  #[global]
+  fn info(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
+    self.info.get(scope, |_| {
+      let info = self.instance.adapter_get_info(self.id);
+      let limits = self.instance.adapter_limits(self.id);
 
-            GPUAdapterInfo {
-                info,
-                subgroup_min_size: limits.min_subgroup_size,
-                subgroup_max_size: limits.max_subgroup_size,
-            }
-        })
+      GPUAdapterInfo {
+        info,
+        subgroup_min_size: limits.min_subgroup_size,
+        subgroup_max_size: limits.max_subgroup_size,
+      }
+    })
+  }
+
+  #[getter]
+  #[global]
+  fn features(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
+    self.features.get(scope, |scope| {
+      let features = self.instance.adapter_features(self.id);
+      // Only expose WebGPU features, not wgpu native-only features
+      let features = features & wgpu_types::Features::all_webgpu_mask();
+      let features = features_to_feature_names(features);
+      GPUSupportedFeatures::new(scope, features)
+    })
+  }
+  #[getter]
+  #[global]
+  fn limits(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
+    self.limits.get(scope, |_| {
+      let adapter_limits = self.instance.adapter_limits(self.id);
+      GPUSupportedLimits(adapter_limits)
+    })
+  }
+  #[getter]
+  fn is_fallback_adapter(&self) -> bool {
+    // TODO(lucacasonato): report correctly from wgpu
+    false
+  }
+
+  #[async_method(fake)]
+  #[global]
+  fn request_device(
+    &self,
+    state: &mut OpState,
+    scope: &mut v8::HandleScope,
+    #[webidl] descriptor: GPUDeviceDescriptor,
+  ) -> Result<v8::Global<v8::Value>, CreateDeviceError> {
+    let features = self.instance.adapter_features(self.id);
+    let supported_features = features_to_feature_names(features);
+    #[allow(clippy::disallowed_types)]
+    let required_features = descriptor
+      .required_features
+      .iter()
+      .cloned()
+      .collect::<HashSet<_>>();
+
+    if !required_features.is_subset(&supported_features) {
+      return Err(CreateDeviceError::RequiredFeaturesNotASubset);
     }
 
-    #[getter]
-    #[global]
-    fn features(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
-        self.features.get(scope, |scope| {
-            let features = self.instance.adapter_features(self.id);
-            // Only expose WebGPU features, not wgpu native-only features
-            let features = features & wgpu_types::Features::all_webgpu_mask();
-            let features = features_to_feature_names(features);
-            GPUSupportedFeatures::new(scope, features)
-        })
-    }
-    #[getter]
-    #[global]
-    fn limits(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
-        self.limits.get(scope, |_| {
-            let adapter_limits = self.instance.adapter_limits(self.id);
-            GPUSupportedLimits(adapter_limits)
-        })
-    }
-    #[getter]
-    fn is_fallback_adapter(&self) -> bool {
-        // TODO(lucacasonato): report correctly from wgpu
-        false
-    }
+    // When support for compatibility mode is added, this will need to look
+    // at whether the adapter is "compatibility-defaulting" or
+    // "core-defaulting", and choose the appropriate set of defaults.
+    //
+    // Support for compatibility mode is tracked in
+    // https://github.com/gfx-rs/wgpu/issues/8124.
+    let required_limits = serde_json::from_value::<wgpu_types::Limits>(
+      serde_json::to_value(descriptor.required_limits)?,
+    )?
+    .or_better_values_from(&wgpu_types::Limits::default());
 
-    #[async_method(fake)]
-    #[global]
-    fn request_device(
-        &self,
-        state: &mut OpState,
-        scope: &mut v8::HandleScope,
-        #[webidl] descriptor: GPUDeviceDescriptor,
-    ) -> Result<v8::Global<v8::Value>, CreateDeviceError> {
-        let features = self.instance.adapter_features(self.id);
-        let supported_features = features_to_feature_names(features);
-        #[allow(clippy::disallowed_types)]
-        let required_features = descriptor
-            .required_features
-            .iter()
-            .cloned()
-            .collect::<HashSet<_>>();
+    let trace = std::env::var_os("DENO_WEBGPU_TRACE")
+      .map(|path| wgpu_types::Trace::Directory(std::path::PathBuf::from(path)))
+      .unwrap_or_default();
 
-        if !required_features.is_subset(&supported_features) {
-            return Err(CreateDeviceError::RequiredFeaturesNotASubset);
-        }
+    let wgpu_descriptor = wgpu_types::DeviceDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      required_features: super::webidl::feature_names_to_features(
+        descriptor.required_features,
+      ),
+      required_limits,
+      experimental_features: wgpu_types::ExperimentalFeatures::disabled(),
+      memory_hints: Default::default(),
+      trace,
+    };
 
-        // When support for compatibility mode is added, this will need to look
-        // at whether the adapter is "compatibility-defaulting" or
-        // "core-defaulting", and choose the appropriate set of defaults.
-        //
-        // Support for compatibility mode is tracked in
-        // https://github.com/gfx-rs/wgpu/issues/8124.
-        let required_limits = serde_json::from_value::<wgpu_types::Limits>(serde_json::to_value(
-            descriptor.required_limits,
-        )?)?
-        .or_better_values_from(&wgpu_types::Limits::default());
+    let (device, queue) = self.instance.adapter_request_device(
+      self.id,
+      &wgpu_descriptor,
+      None,
+      None,
+    )?;
 
-        let trace = std::env::var_os("DENO_WEBGPU_TRACE")
-            .map(|path| wgpu_types::Trace::Directory(std::path::PathBuf::from(path)))
-            .unwrap_or_default();
+    let spawner = state.borrow::<V8TaskSpawner>().clone();
+    let lost_resolver = v8::PromiseResolver::new(scope).unwrap();
+    let lost_promise = lost_resolver.get_promise(scope);
+    let device = GPUDevice {
+      instance: self.instance.clone(),
+      id: device,
+      queue,
+      label: descriptor.label,
+      queue_obj: SameObject::new(),
+      adapter_info: self.info.clone(),
+      error_handler: Rc::new(super::error::DeviceErrorHandler::new(
+        v8::Global::new(scope, lost_resolver),
+        spawner,
+      )),
+      adapter: self.id,
+      lost_promise: v8::Global::new(scope, lost_promise),
+      limits: SameObject::new(),
+      features: SameObject::new(),
+    };
+    let device = deno_core::cppgc::make_cppgc_object(scope, device);
+    let weak_device = v8::Weak::new(scope, device);
+    let event_target_setup = state.borrow::<crate::EventTargetSetup>();
+    let webidl_brand = v8::Local::new(scope, event_target_setup.brand.clone());
+    device.set(scope, webidl_brand, webidl_brand);
+    let set_event_target_data =
+      v8::Local::new(scope, event_target_setup.set_event_target_data.clone())
+        .cast::<v8::Function>();
+    let null = v8::null(scope);
+    set_event_target_data.call(scope, null.into(), &[device.into()]);
 
-        let wgpu_descriptor = wgpu_types::DeviceDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            required_features: super::webidl::feature_names_to_features(
-                descriptor.required_features,
-            ),
-            required_limits,
-            experimental_features: wgpu_types::ExperimentalFeatures::disabled(),
-            memory_hints: Default::default(),
-            trace,
-        };
+    // Now that the device is fully constructed, give the error handler a
+    // weak reference to it.
+    let device = device.cast::<v8::Value>();
+    deno_core::cppgc::try_unwrap_cppgc_object::<GPUDevice>(scope, device)
+      .unwrap()
+      .error_handler
+      .set_device(weak_device);
 
-        let (device, queue) =
-            self.instance
-                .adapter_request_device(self.id, &wgpu_descriptor, None, None)?;
-
-        let spawner = state.borrow::<V8TaskSpawner>().clone();
-        let lost_resolver = v8::PromiseResolver::new(scope).unwrap();
-        let lost_promise = lost_resolver.get_promise(scope);
-        let device = GPUDevice {
-            instance: self.instance.clone(),
-            id: device,
-            queue,
-            label: descriptor.label,
-            queue_obj: SameObject::new(),
-            adapter_info: self.info.clone(),
-            error_handler: Rc::new(super::error::DeviceErrorHandler::new(
-                v8::Global::new(scope, lost_resolver),
-                spawner,
-            )),
-            adapter: self.id,
-            lost_promise: v8::Global::new(scope, lost_promise),
-            limits: SameObject::new(),
-            features: SameObject::new(),
-        };
-        let device = deno_core::cppgc::make_cppgc_object(scope, device);
-        let weak_device = v8::Weak::new(scope, device);
-        let event_target_setup = state.borrow::<crate::EventTargetSetup>();
-        let webidl_brand = v8::Local::new(scope, event_target_setup.brand.clone());
-        device.set(scope, webidl_brand, webidl_brand);
-        let set_event_target_data =
-            v8::Local::new(scope, event_target_setup.set_event_target_data.clone())
-                .cast::<v8::Function>();
-        let null = v8::null(scope);
-        set_event_target_data.call(scope, null.into(), &[device.into()]);
-
-        // Now that the device is fully constructed, give the error handler a
-        // weak reference to it.
-        let device = device.cast::<v8::Value>();
-        deno_core::cppgc::try_unwrap_cppgc_object::<GPUDevice>(scope, device)
-            .unwrap()
-            .error_handler
-            .set_device(weak_device);
-
-        Ok(v8::Global::new(scope, device))
-    }
+    Ok(v8::Global::new(scope, device))
+  }
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum CreateDeviceError {
-    #[class(type)]
-    #[error("requiredFeatures must be a subset of the adapter features")]
-    RequiredFeaturesNotASubset,
-    #[class(inherit)]
-    #[error(transparent)]
-    Serde(#[from] serde_json::Error),
-    #[class("DOMExceptionOperationError")]
-    #[error(transparent)]
-    Device(#[from] wgpu_core::instance::RequestDeviceError),
+  #[class(type)]
+  #[error("requiredFeatures must be a subset of the adapter features")]
+  RequiredFeaturesNotASubset,
+  #[class(inherit)]
+  #[error(transparent)]
+  Serde(#[from] serde_json::Error),
+  #[class("DOMExceptionOperationError")]
+  #[error(transparent)]
+  Device(#[from] wgpu_core::instance::RequestDeviceError),
 }
 
 pub struct GPUSupportedLimits(pub wgpu_types::Limits);
@@ -216,155 +219,155 @@ impl GarbageCollected for GPUSupportedLimits {}
 
 #[op2]
 impl GPUSupportedLimits {
-    #[getter]
-    fn maxTextureDimension1D(&self) -> u32 {
-        self.0.max_texture_dimension_1d
-    }
+  #[getter]
+  fn maxTextureDimension1D(&self) -> u32 {
+    self.0.max_texture_dimension_1d
+  }
 
-    #[getter]
-    fn maxTextureDimension2D(&self) -> u32 {
-        self.0.max_texture_dimension_2d
-    }
+  #[getter]
+  fn maxTextureDimension2D(&self) -> u32 {
+    self.0.max_texture_dimension_2d
+  }
 
-    #[getter]
-    fn maxTextureDimension3D(&self) -> u32 {
-        self.0.max_texture_dimension_3d
-    }
+  #[getter]
+  fn maxTextureDimension3D(&self) -> u32 {
+    self.0.max_texture_dimension_3d
+  }
 
-    #[getter]
-    fn maxTextureArrayLayers(&self) -> u32 {
-        self.0.max_texture_array_layers
-    }
+  #[getter]
+  fn maxTextureArrayLayers(&self) -> u32 {
+    self.0.max_texture_array_layers
+  }
 
-    #[getter]
-    fn maxBindGroups(&self) -> u32 {
-        self.0.max_bind_groups
-    }
+  #[getter]
+  fn maxBindGroups(&self) -> u32 {
+    self.0.max_bind_groups
+  }
 
-    // TODO(@crowlKats): support max_bind_groups_plus_vertex_buffers
+  // TODO(@crowlKats): support max_bind_groups_plus_vertex_buffers
 
-    #[getter]
-    fn maxBindingsPerBindGroup(&self) -> u32 {
-        self.0.max_bindings_per_bind_group
-    }
+  #[getter]
+  fn maxBindingsPerBindGroup(&self) -> u32 {
+    self.0.max_bindings_per_bind_group
+  }
 
-    #[getter]
-    fn maxDynamicUniformBuffersPerPipelineLayout(&self) -> u32 {
-        self.0.max_dynamic_uniform_buffers_per_pipeline_layout
-    }
+  #[getter]
+  fn maxDynamicUniformBuffersPerPipelineLayout(&self) -> u32 {
+    self.0.max_dynamic_uniform_buffers_per_pipeline_layout
+  }
 
-    #[getter]
-    fn maxDynamicStorageBuffersPerPipelineLayout(&self) -> u32 {
-        self.0.max_dynamic_storage_buffers_per_pipeline_layout
-    }
+  #[getter]
+  fn maxDynamicStorageBuffersPerPipelineLayout(&self) -> u32 {
+    self.0.max_dynamic_storage_buffers_per_pipeline_layout
+  }
 
-    #[getter]
-    fn maxSampledTexturesPerShaderStage(&self) -> u32 {
-        self.0.max_sampled_textures_per_shader_stage
-    }
+  #[getter]
+  fn maxSampledTexturesPerShaderStage(&self) -> u32 {
+    self.0.max_sampled_textures_per_shader_stage
+  }
 
-    #[getter]
-    fn maxSamplersPerShaderStage(&self) -> u32 {
-        self.0.max_samplers_per_shader_stage
-    }
+  #[getter]
+  fn maxSamplersPerShaderStage(&self) -> u32 {
+    self.0.max_samplers_per_shader_stage
+  }
 
-    #[getter]
-    fn maxStorageBuffersPerShaderStage(&self) -> u32 {
-        self.0.max_storage_buffers_per_shader_stage
-    }
+  #[getter]
+  fn maxStorageBuffersPerShaderStage(&self) -> u32 {
+    self.0.max_storage_buffers_per_shader_stage
+  }
 
-    #[getter]
-    fn maxStorageTexturesPerShaderStage(&self) -> u32 {
-        self.0.max_storage_textures_per_shader_stage
-    }
+  #[getter]
+  fn maxStorageTexturesPerShaderStage(&self) -> u32 {
+    self.0.max_storage_textures_per_shader_stage
+  }
 
-    #[getter]
-    fn maxUniformBuffersPerShaderStage(&self) -> u32 {
-        self.0.max_uniform_buffers_per_shader_stage
-    }
+  #[getter]
+  fn maxUniformBuffersPerShaderStage(&self) -> u32 {
+    self.0.max_uniform_buffers_per_shader_stage
+  }
 
-    #[getter]
-    fn maxUniformBufferBindingSize(&self) -> u32 {
-        self.0.max_uniform_buffer_binding_size
-    }
+  #[getter]
+  fn maxUniformBufferBindingSize(&self) -> u32 {
+    self.0.max_uniform_buffer_binding_size
+  }
 
-    #[getter]
-    fn maxStorageBufferBindingSize(&self) -> u32 {
-        self.0.max_storage_buffer_binding_size
-    }
+  #[getter]
+  fn maxStorageBufferBindingSize(&self) -> u32 {
+    self.0.max_storage_buffer_binding_size
+  }
 
-    #[getter]
-    fn minUniformBufferOffsetAlignment(&self) -> u32 {
-        self.0.min_uniform_buffer_offset_alignment
-    }
+  #[getter]
+  fn minUniformBufferOffsetAlignment(&self) -> u32 {
+    self.0.min_uniform_buffer_offset_alignment
+  }
 
-    #[getter]
-    fn minStorageBufferOffsetAlignment(&self) -> u32 {
-        self.0.min_storage_buffer_offset_alignment
-    }
+  #[getter]
+  fn minStorageBufferOffsetAlignment(&self) -> u32 {
+    self.0.min_storage_buffer_offset_alignment
+  }
 
-    #[getter]
-    fn maxVertexBuffers(&self) -> u32 {
-        self.0.max_vertex_buffers
-    }
+  #[getter]
+  fn maxVertexBuffers(&self) -> u32 {
+    self.0.max_vertex_buffers
+  }
 
-    #[getter]
-    #[number]
-    fn maxBufferSize(&self) -> u64 {
-        self.0.max_buffer_size
-    }
+  #[getter]
+  #[number]
+  fn maxBufferSize(&self) -> u64 {
+    self.0.max_buffer_size
+  }
 
-    #[getter]
-    fn maxVertexAttributes(&self) -> u32 {
-        self.0.max_vertex_attributes
-    }
+  #[getter]
+  fn maxVertexAttributes(&self) -> u32 {
+    self.0.max_vertex_attributes
+  }
 
-    #[getter]
-    fn maxVertexBufferArrayStride(&self) -> u32 {
-        self.0.max_vertex_buffer_array_stride
-    }
+  #[getter]
+  fn maxVertexBufferArrayStride(&self) -> u32 {
+    self.0.max_vertex_buffer_array_stride
+  }
 
-    // TODO(@crowlKats): support max_inter_stage_shader_variables
+  // TODO(@crowlKats): support max_inter_stage_shader_variables
 
-    #[getter]
-    fn maxColorAttachments(&self) -> u32 {
-        self.0.max_color_attachments
-    }
+  #[getter]
+  fn maxColorAttachments(&self) -> u32 {
+    self.0.max_color_attachments
+  }
 
-    #[getter]
-    fn maxColorAttachmentBytesPerSample(&self) -> u32 {
-        self.0.max_color_attachment_bytes_per_sample
-    }
+  #[getter]
+  fn maxColorAttachmentBytesPerSample(&self) -> u32 {
+    self.0.max_color_attachment_bytes_per_sample
+  }
 
-    #[getter]
-    fn maxComputeWorkgroupStorageSize(&self) -> u32 {
-        self.0.max_compute_workgroup_storage_size
-    }
+  #[getter]
+  fn maxComputeWorkgroupStorageSize(&self) -> u32 {
+    self.0.max_compute_workgroup_storage_size
+  }
 
-    #[getter]
-    fn maxComputeInvocationsPerWorkgroup(&self) -> u32 {
-        self.0.max_compute_invocations_per_workgroup
-    }
+  #[getter]
+  fn maxComputeInvocationsPerWorkgroup(&self) -> u32 {
+    self.0.max_compute_invocations_per_workgroup
+  }
 
-    #[getter]
-    fn maxComputeWorkgroupSizeX(&self) -> u32 {
-        self.0.max_compute_workgroup_size_x
-    }
+  #[getter]
+  fn maxComputeWorkgroupSizeX(&self) -> u32 {
+    self.0.max_compute_workgroup_size_x
+  }
 
-    #[getter]
-    fn maxComputeWorkgroupSizeY(&self) -> u32 {
-        self.0.max_compute_workgroup_size_y
-    }
+  #[getter]
+  fn maxComputeWorkgroupSizeY(&self) -> u32 {
+    self.0.max_compute_workgroup_size_y
+  }
 
-    #[getter]
-    fn maxComputeWorkgroupSizeZ(&self) -> u32 {
-        self.0.max_compute_workgroup_size_z
-    }
+  #[getter]
+  fn maxComputeWorkgroupSizeZ(&self) -> u32 {
+    self.0.max_compute_workgroup_size_z
+  }
 
-    #[getter]
-    fn maxComputeWorkgroupsPerDimension(&self) -> u32 {
-        self.0.max_compute_workgroups_per_dimension
-    }
+  #[getter]
+  fn maxComputeWorkgroupsPerDimension(&self) -> u32 {
+    self.0.max_compute_workgroups_per_dimension
+  }
 }
 
 pub struct GPUSupportedFeatures(v8::Global<v8::Value>);
@@ -372,69 +375,72 @@ pub struct GPUSupportedFeatures(v8::Global<v8::Value>);
 impl GarbageCollected for GPUSupportedFeatures {}
 
 impl GPUSupportedFeatures {
-    #[allow(clippy::disallowed_types)]
-    pub fn new(scope: &mut v8::HandleScope, features: HashSet<GPUFeatureName>) -> Self {
-        let set = v8::Set::new(scope);
+  #[allow(clippy::disallowed_types)]
+  pub fn new(
+    scope: &mut v8::HandleScope,
+    features: HashSet<GPUFeatureName>,
+  ) -> Self {
+    let set = v8::Set::new(scope);
 
-        for feature in features {
-            let key = v8::String::new(scope, feature.as_str()).unwrap();
-            set.add(scope, key.into());
-        }
-
-        Self(v8::Global::new(scope, <v8::Local<v8::Value>>::from(set)))
+    for feature in features {
+      let key = v8::String::new(scope, feature.as_str()).unwrap();
+      set.add(scope, key.into());
     }
+
+    Self(v8::Global::new(scope, <v8::Local<v8::Value>>::from(set)))
+  }
 }
 
 #[op2]
 impl GPUSupportedFeatures {
-    #[global]
-    #[symbol("setlike_set")]
-    fn set(&self) -> v8::Global<v8::Value> {
-        self.0.clone()
-    }
+  #[global]
+  #[symbol("setlike_set")]
+  fn set(&self) -> v8::Global<v8::Value> {
+    self.0.clone()
+  }
 }
 
 pub struct GPUAdapterInfo {
-    pub info: wgpu_types::AdapterInfo,
-    pub subgroup_min_size: u32,
-    pub subgroup_max_size: u32,
+  pub info: wgpu_types::AdapterInfo,
+  pub subgroup_min_size: u32,
+  pub subgroup_max_size: u32,
 }
 
 impl GarbageCollected for GPUAdapterInfo {}
 
 #[op2]
 impl GPUAdapterInfo {
-    #[getter]
-    #[string]
-    fn vendor(&self) -> String {
-        self.info.vendor.to_string()
-    }
+  #[getter]
+  #[string]
+  fn vendor(&self) -> String {
+    self.info.vendor.to_string()
+  }
 
-    #[getter]
-    #[string]
-    fn architecture(&self) -> &'static str {
-        "" // TODO: wgpu#2170
-    }
+  #[getter]
+  #[string]
+  fn architecture(&self) -> &'static str {
+    "" // TODO: wgpu#2170
+  }
 
-    #[getter]
-    #[string]
-    fn device(&self) -> String {
-        self.info.device.to_string()
-    }
+  #[getter]
+  #[string]
+  fn device(&self) -> String {
+    self.info.device.to_string()
+  }
 
-    #[getter]
-    #[string]
-    fn description(&self) -> String {
-        self.info.name.clone()
-    }
+  #[getter]
+  #[string]
+  fn description(&self) -> String {
+    self.info.name.clone()
+  }
 
-    #[getter]
-    fn subgroup_min_size(&self) -> u32 {
-        self.subgroup_min_size
-    }
+  #[getter]
+  fn subgroup_min_size(&self) -> u32 {
+    self.subgroup_min_size
+  }
 
-    #[getter]
-    fn subgroup_max_size(&self) -> u32 {
-        self.subgroup_max_size
-    }
+  #[getter]
+  fn subgroup_max_size(&self) -> u32 {
+    self.subgroup_max_size
+  }
 }

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -13,6 +13,7 @@ use deno_core::V8TaskSpawner;
 use deno_core::WebIDL;
 
 use super::device::GPUDevice;
+use crate::error::GPUGenericError;
 use crate::webidl::features_to_feature_names;
 use crate::webidl::GPUFeatureName;
 use crate::Instance;
@@ -68,6 +69,12 @@ impl GarbageCollected for GPUAdapter {
 
 #[op2]
 impl GPUAdapter {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUAdapter, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[global]
   fn info(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
@@ -223,6 +230,12 @@ impl GarbageCollected for GPUSupportedLimits {
 
 #[op2]
 impl GPUSupportedLimits {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUSupportedLimits, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   fn maxTextureDimension1D(&self) -> u32 {
     self.0.max_texture_dimension_1d
@@ -401,6 +414,12 @@ impl GPUSupportedFeatures {
 
 #[op2]
 impl GPUSupportedFeatures {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUSupportedFeatures, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[global]
   #[symbol("setlike_set")]
   fn set(&self) -> v8::Global<v8::Value> {
@@ -422,6 +441,12 @@ impl GarbageCollected for GPUAdapterInfo {
 
 #[op2]
 impl GPUAdapterInfo {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUAdapterInfo, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn vendor(&self) -> String {

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -90,6 +90,7 @@ impl GPUAdapter {
       GPUSupportedFeatures::new(scope, features)
     })
   }
+
   #[getter]
   #[global]
   fn limits(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
@@ -97,11 +98,6 @@ impl GPUAdapter {
       let adapter_limits = self.instance.adapter_limits(self.id);
       GPUSupportedLimits(adapter_limits)
     })
-  }
-  #[getter]
-  fn is_fallback_adapter(&self) -> bool {
-    // TODO(lucacasonato): report correctly from wgpu
-    false
   }
 
   #[async_method(fake)]
@@ -442,5 +438,11 @@ impl GPUAdapterInfo {
   #[getter]
   fn subgroup_max_size(&self) -> u32 {
     self.subgroup_max_size
+  }
+
+  #[getter]
+  fn is_fallback_adapter(&self) -> bool {
+    // TODO(lucacasonato): report correctly from wgpu
+    false
   }
 }

--- a/deno_webgpu/bind_group.rs
+++ b/deno_webgpu/bind_group.rs
@@ -35,7 +35,11 @@ impl WebIdlInterfaceConverter for GPUBindGroup {
   const NAME: &'static str = "GPUBindGroup";
 }
 
-impl GarbageCollected for GPUBindGroup {}
+impl GarbageCollected for GPUBindGroup {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUBindGroup"
+  }
+}
 
 #[op2]
 impl GPUBindGroup {

--- a/deno_webgpu/bind_group.rs
+++ b/deno_webgpu/bind_group.rs
@@ -15,6 +15,7 @@ use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 
 use crate::buffer::GPUBuffer;
+use crate::error::GPUGenericError;
 use crate::sampler::GPUSampler;
 use crate::texture::GPUTextureView;
 use crate::Instance;
@@ -43,6 +44,12 @@ impl GarbageCollected for GPUBindGroup {
 
 #[op2]
 impl GPUBindGroup {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUBindGroup, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/bind_group.rs
+++ b/deno_webgpu/bind_group.rs
@@ -20,97 +20,103 @@ use crate::texture::GPUTextureView;
 use crate::Instance;
 
 pub struct GPUBindGroup {
-    pub instance: Instance,
-    pub id: wgpu_core::id::BindGroupId,
-    pub label: String,
+  pub instance: Instance,
+  pub id: wgpu_core::id::BindGroupId,
+  pub label: String,
 }
 
 impl Drop for GPUBindGroup {
-    fn drop(&mut self) {
-        self.instance.bind_group_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.bind_group_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPUBindGroup {
-    const NAME: &'static str = "GPUBindGroup";
+  const NAME: &'static str = "GPUBindGroup";
 }
 
 impl GarbageCollected for GPUBindGroup {}
 
 #[op2]
 impl GPUBindGroup {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUBindGroupDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub layout: Ptr<super::bind_group_layout::GPUBindGroupLayout>,
-    pub entries: Vec<GPUBindGroupEntry>,
+  pub layout: Ptr<super::bind_group_layout::GPUBindGroupLayout>,
+  pub entries: Vec<GPUBindGroupEntry>,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUBindGroupEntry {
-    #[options(enforce_range = true)]
-    pub binding: u32,
-    pub resource: GPUBindingResource,
+  #[options(enforce_range = true)]
+  pub binding: u32,
+  pub resource: GPUBindingResource,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUBufferBinding {
-    pub buffer: Ptr<GPUBuffer>,
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    pub offset: u64,
-    #[options(enforce_range = true)]
-    pub size: Option<u64>,
+  pub buffer: Ptr<GPUBuffer>,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  pub offset: u64,
+  #[options(enforce_range = true)]
+  pub size: Option<u64>,
 }
 
 pub(crate) enum GPUBindingResource {
-    Sampler(Ptr<GPUSampler>),
-    TextureView(Ptr<GPUTextureView>),
-    BufferBinding(GPUBufferBinding),
+  Sampler(Ptr<GPUSampler>),
+  TextureView(Ptr<GPUTextureView>),
+  BufferBinding(GPUBufferBinding),
 }
 
 impl<'a> WebIdlConverter<'a> for GPUBindingResource {
-    type Options = ();
+  type Options = ();
 
-    fn convert<'b>(
-        scope: &mut HandleScope<'a>,
-        value: Local<'a, Value>,
-        prefix: Cow<'static, str>,
-        context: ContextFn<'b>,
-        options: &Self::Options,
-    ) -> Result<Self, WebIdlError> {
-        <Ptr<GPUSampler>>::convert(scope, value, prefix.clone(), context.borrowed(), options)
-            .map(Self::Sampler)
-            .or_else(|_| {
-                <Ptr<GPUTextureView>>::convert(
-                    scope,
-                    value,
-                    prefix.clone(),
-                    context.borrowed(),
-                    options,
-                )
-                .map(Self::TextureView)
-            })
-            .or_else(|_| {
-                GPUBufferBinding::convert(scope, value, prefix, context, options)
-                    .map(Self::BufferBinding)
-            })
-    }
+  fn convert<'b>(
+    scope: &mut HandleScope<'a>,
+    value: Local<'a, Value>,
+    prefix: Cow<'static, str>,
+    context: ContextFn<'b>,
+    options: &Self::Options,
+  ) -> Result<Self, WebIdlError> {
+    <Ptr<GPUSampler>>::convert(
+      scope,
+      value,
+      prefix.clone(),
+      context.borrowed(),
+      options,
+    )
+    .map(Self::Sampler)
+    .or_else(|_| {
+      <Ptr<GPUTextureView>>::convert(
+        scope,
+        value,
+        prefix.clone(),
+        context.borrowed(),
+        options,
+      )
+      .map(Self::TextureView)
+    })
+    .or_else(|_| {
+      GPUBufferBinding::convert(scope, value, prefix, context, options)
+        .map(Self::BufferBinding)
+    })
+  }
 }

--- a/deno_webgpu/bind_group_layout.rs
+++ b/deno_webgpu/bind_group_layout.rs
@@ -23,7 +23,11 @@ impl deno_core::webidl::WebIdlInterfaceConverter for GPUBindGroupLayout {
   const NAME: &'static str = "GPUBindGroupLayout";
 }
 
-impl GarbageCollected for GPUBindGroupLayout {}
+impl GarbageCollected for GPUBindGroupLayout {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUBindGroupLayout"
+  }
+}
 
 #[op2]
 impl GPUBindGroupLayout {

--- a/deno_webgpu/bind_group_layout.rs
+++ b/deno_webgpu/bind_group_layout.rs
@@ -8,169 +8,173 @@ use crate::texture::GPUTextureViewDimension;
 use crate::Instance;
 
 pub struct GPUBindGroupLayout {
-    pub instance: Instance,
-    pub id: wgpu_core::id::BindGroupLayoutId,
-    pub label: String,
+  pub instance: Instance,
+  pub id: wgpu_core::id::BindGroupLayoutId,
+  pub label: String,
 }
 
 impl Drop for GPUBindGroupLayout {
-    fn drop(&mut self) {
-        self.instance.bind_group_layout_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.bind_group_layout_drop(self.id);
+  }
 }
 
 impl deno_core::webidl::WebIdlInterfaceConverter for GPUBindGroupLayout {
-    const NAME: &'static str = "GPUBindGroupLayout";
+  const NAME: &'static str = "GPUBindGroupLayout";
 }
 
 impl GarbageCollected for GPUBindGroupLayout {}
 
 #[op2]
 impl GPUBindGroupLayout {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUBindGroupLayoutDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
-    pub entries: Vec<GPUBindGroupLayoutEntry>,
+  #[webidl(default = String::new())]
+  pub label: String,
+  pub entries: Vec<GPUBindGroupLayoutEntry>,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUBindGroupLayoutEntry {
-    #[options(enforce_range = true)]
-    pub binding: u32,
-    #[options(enforce_range = true)]
-    pub visibility: u32,
-    pub buffer: Option<GPUBufferBindingLayout>,
-    pub sampler: Option<GPUSamplerBindingLayout>,
-    pub texture: Option<GPUTextureBindingLayout>,
-    pub storage_texture: Option<GPUStorageTextureBindingLayout>,
+  #[options(enforce_range = true)]
+  pub binding: u32,
+  #[options(enforce_range = true)]
+  pub visibility: u32,
+  pub buffer: Option<GPUBufferBindingLayout>,
+  pub sampler: Option<GPUSamplerBindingLayout>,
+  pub texture: Option<GPUTextureBindingLayout>,
+  pub storage_texture: Option<GPUStorageTextureBindingLayout>,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUBufferBindingLayout {
-    #[webidl(default = GPUBufferBindingType::Uniform)]
-    pub r#type: GPUBufferBindingType,
-    #[webidl(default = false)]
-    pub has_dynamic_offset: bool,
-    #[webidl(default = 0)]
-    pub min_binding_size: u64,
+  #[webidl(default = GPUBufferBindingType::Uniform)]
+  pub r#type: GPUBufferBindingType,
+  #[webidl(default = false)]
+  pub has_dynamic_offset: bool,
+  #[webidl(default = 0)]
+  pub min_binding_size: u64,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUBufferBindingType {
-    Uniform,
-    Storage,
-    ReadOnlyStorage,
+  Uniform,
+  Storage,
+  ReadOnlyStorage,
 }
 
 impl From<GPUBufferBindingType> for wgpu_types::BufferBindingType {
-    fn from(value: GPUBufferBindingType) -> Self {
-        match value {
-            GPUBufferBindingType::Uniform => Self::Uniform,
-            GPUBufferBindingType::Storage => Self::Storage { read_only: false },
-            GPUBufferBindingType::ReadOnlyStorage => Self::Storage { read_only: true },
-        }
+  fn from(value: GPUBufferBindingType) -> Self {
+    match value {
+      GPUBufferBindingType::Uniform => Self::Uniform,
+      GPUBufferBindingType::Storage => Self::Storage { read_only: false },
+      GPUBufferBindingType::ReadOnlyStorage => {
+        Self::Storage { read_only: true }
+      }
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUSamplerBindingLayout {
-    #[webidl(default = GPUSamplerBindingType::Filtering)]
-    pub r#type: GPUSamplerBindingType,
+  #[webidl(default = GPUSamplerBindingType::Filtering)]
+  pub r#type: GPUSamplerBindingType,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUSamplerBindingType {
-    Filtering,
-    NonFiltering,
-    Comparison,
+  Filtering,
+  NonFiltering,
+  Comparison,
 }
 
 impl From<GPUSamplerBindingType> for wgpu_types::SamplerBindingType {
-    fn from(value: GPUSamplerBindingType) -> Self {
-        match value {
-            GPUSamplerBindingType::Filtering => Self::Filtering,
-            GPUSamplerBindingType::NonFiltering => Self::NonFiltering,
-            GPUSamplerBindingType::Comparison => Self::Comparison,
-        }
+  fn from(value: GPUSamplerBindingType) -> Self {
+    match value {
+      GPUSamplerBindingType::Filtering => Self::Filtering,
+      GPUSamplerBindingType::NonFiltering => Self::NonFiltering,
+      GPUSamplerBindingType::Comparison => Self::Comparison,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUTextureBindingLayout {
-    #[webidl(default = GPUTextureSampleType::Float)]
-    pub sample_type: GPUTextureSampleType,
-    #[webidl(default = GPUTextureViewDimension::D2)]
-    pub view_dimension: GPUTextureViewDimension,
-    #[webidl(default = false)]
-    pub multisampled: bool,
+  #[webidl(default = GPUTextureSampleType::Float)]
+  pub sample_type: GPUTextureSampleType,
+  #[webidl(default = GPUTextureViewDimension::D2)]
+  pub view_dimension: GPUTextureViewDimension,
+  #[webidl(default = false)]
+  pub multisampled: bool,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUTextureSampleType {
-    Float,
-    UnfilterableFloat,
-    Depth,
-    Sint,
-    Uint,
+  Float,
+  UnfilterableFloat,
+  Depth,
+  Sint,
+  Uint,
 }
 
 impl From<GPUTextureSampleType> for wgpu_types::TextureSampleType {
-    fn from(value: GPUTextureSampleType) -> Self {
-        match value {
-            GPUTextureSampleType::Float => Self::Float { filterable: true },
-            GPUTextureSampleType::UnfilterableFloat => Self::Float { filterable: false },
-            GPUTextureSampleType::Depth => Self::Depth,
-            GPUTextureSampleType::Sint => Self::Sint,
-            GPUTextureSampleType::Uint => Self::Uint,
-        }
+  fn from(value: GPUTextureSampleType) -> Self {
+    match value {
+      GPUTextureSampleType::Float => Self::Float { filterable: true },
+      GPUTextureSampleType::UnfilterableFloat => {
+        Self::Float { filterable: false }
+      }
+      GPUTextureSampleType::Depth => Self::Depth,
+      GPUTextureSampleType::Sint => Self::Sint,
+      GPUTextureSampleType::Uint => Self::Uint,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUStorageTextureBindingLayout {
-    #[webidl(default = GPUStorageTextureAccess::WriteOnly)]
-    pub access: GPUStorageTextureAccess,
-    pub format: super::texture::GPUTextureFormat,
-    #[webidl(default = GPUTextureViewDimension::D2)]
-    pub view_dimension: GPUTextureViewDimension,
+  #[webidl(default = GPUStorageTextureAccess::WriteOnly)]
+  pub access: GPUStorageTextureAccess,
+  pub format: super::texture::GPUTextureFormat,
+  #[webidl(default = GPUTextureViewDimension::D2)]
+  pub view_dimension: GPUTextureViewDimension,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUStorageTextureAccess {
-    WriteOnly,
-    ReadOnly,
-    ReadWrite,
+  WriteOnly,
+  ReadOnly,
+  ReadWrite,
 }
 
 impl From<GPUStorageTextureAccess> for wgpu_types::StorageTextureAccess {
-    fn from(value: GPUStorageTextureAccess) -> Self {
-        match value {
-            GPUStorageTextureAccess::WriteOnly => Self::WriteOnly,
-            GPUStorageTextureAccess::ReadOnly => Self::ReadOnly,
-            GPUStorageTextureAccess::ReadWrite => Self::ReadWrite,
-        }
+  fn from(value: GPUStorageTextureAccess) -> Self {
+    match value {
+      GPUStorageTextureAccess::WriteOnly => Self::WriteOnly,
+      GPUStorageTextureAccess::ReadOnly => Self::ReadOnly,
+      GPUStorageTextureAccess::ReadWrite => Self::ReadWrite,
     }
+  }
 }

--- a/deno_webgpu/bind_group_layout.rs
+++ b/deno_webgpu/bind_group_layout.rs
@@ -4,6 +4,7 @@ use deno_core::op2;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 
+use crate::error::GPUGenericError;
 use crate::texture::GPUTextureViewDimension;
 use crate::Instance;
 
@@ -31,6 +32,12 @@ impl GarbageCollected for GPUBindGroupLayout {
 
 #[op2]
 impl GPUBindGroupLayout {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUBindGroupLayout, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -72,7 +72,11 @@ impl WebIdlInterfaceConverter for GPUBuffer {
   const NAME: &'static str = "GPUBuffer";
 }
 
-impl GarbageCollected for GPUBuffer {}
+impl GarbageCollected for GPUBuffer {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUBuffer"
+  }
+}
 
 #[op2]
 impl GPUBuffer {

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -13,6 +13,7 @@ use deno_core::WebIDL;
 use deno_error::JsErrorBox;
 use wgpu_core::device::HostMap as MapMode;
 
+use crate::error::GPUGenericError;
 use crate::Instance;
 
 #[derive(WebIDL)]
@@ -80,6 +81,12 @@ impl GarbageCollected for GPUBuffer {
 
 #[op2]
 impl GPUBuffer {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUBuffer, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -18,240 +18,245 @@ use crate::Instance;
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUBufferDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub size: u64,
-    #[options(enforce_range = true)]
-    pub usage: u32,
-    #[webidl(default = false)]
-    pub mapped_at_creation: bool,
+  pub size: u64,
+  #[options(enforce_range = true)]
+  pub usage: u32,
+  #[webidl(default = false)]
+  pub mapped_at_creation: bool,
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum BufferError {
-    #[class(generic)]
-    #[error(transparent)]
-    Canceled(#[from] oneshot::Canceled),
-    #[class("DOMExceptionOperationError")]
-    #[error(transparent)]
-    Access(#[from] wgpu_core::resource::BufferAccessError),
-    #[class("DOMExceptionOperationError")]
-    #[error("{0}")]
-    Operation(&'static str),
-    #[class(inherit)]
-    #[error(transparent)]
-    Other(#[from] JsErrorBox),
+  #[class(generic)]
+  #[error(transparent)]
+  Canceled(#[from] oneshot::Canceled),
+  #[class("DOMExceptionOperationError")]
+  #[error(transparent)]
+  Access(#[from] wgpu_core::resource::BufferAccessError),
+  #[class("DOMExceptionOperationError")]
+  #[error("{0}")]
+  Operation(&'static str),
+  #[class(inherit)]
+  #[error(transparent)]
+  Other(#[from] JsErrorBox),
 }
 
 pub struct GPUBuffer {
-    pub instance: Instance,
-    pub error_handler: super::error::ErrorHandler,
+  pub instance: Instance,
+  pub error_handler: super::error::ErrorHandler,
 
-    pub id: wgpu_core::id::BufferId,
-    pub device: wgpu_core::id::DeviceId,
+  pub id: wgpu_core::id::BufferId,
+  pub device: wgpu_core::id::DeviceId,
 
-    pub label: String,
+  pub label: String,
 
-    pub size: u64,
-    pub usage: u32,
+  pub size: u64,
+  pub usage: u32,
 
-    pub map_state: RefCell<&'static str>,
-    pub map_mode: RefCell<Option<MapMode>>,
+  pub map_state: RefCell<&'static str>,
+  pub map_mode: RefCell<Option<MapMode>>,
 
-    pub mapped_js_buffers: RefCell<Vec<v8::Global<v8::ArrayBuffer>>>,
+  pub mapped_js_buffers: RefCell<Vec<v8::Global<v8::ArrayBuffer>>>,
 }
 
 impl Drop for GPUBuffer {
-    fn drop(&mut self) {
-        self.instance.buffer_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.buffer_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPUBuffer {
-    const NAME: &'static str = "GPUBuffer";
+  const NAME: &'static str = "GPUBuffer";
 }
 
 impl GarbageCollected for GPUBuffer {}
 
 #[op2]
 impl GPUBuffer {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
+
+  #[getter]
+  #[number]
+  fn size(&self) -> u64 {
+    self.size
+  }
+  #[getter]
+  fn usage(&self) -> u32 {
+    self.usage
+  }
+
+  #[getter]
+  #[string]
+  fn map_state(&self) -> &'static str {
+    *self.map_state.borrow()
+  }
+
+  #[async_method]
+  async fn map_async(
+    &self,
+    #[webidl(options(enforce_range = true))] mode: u32,
+    #[webidl(default = 0)] offset: u64,
+    #[webidl] size: Option<u64>,
+  ) -> Result<(), BufferError> {
+    let read_mode = (mode & 0x0001) == 0x0001;
+    let write_mode = (mode & 0x0002) == 0x0002;
+    if (read_mode && write_mode) || (!read_mode && !write_mode) {
+      return Err(BufferError::Operation(
+        "exactly one of READ or WRITE map mode must be set",
+      ));
     }
 
-    #[getter]
-    #[number]
-    fn size(&self) -> u64 {
-        self.size
-    }
-    #[getter]
-    fn usage(&self) -> u32 {
-        self.usage
-    }
+    let mode = if read_mode {
+      MapMode::Read
+    } else {
+      assert!(write_mode);
+      MapMode::Write
+    };
 
-    #[getter]
-    #[string]
-    fn map_state(&self) -> &'static str {
-        *self.map_state.borrow()
+    {
+      *self.map_state.borrow_mut() = "pending";
     }
 
-    #[async_method]
-    async fn map_async(
-        &self,
-        #[webidl(options(enforce_range = true))] mode: u32,
-        #[webidl(default = 0)] offset: u64,
-        #[webidl] size: Option<u64>,
-    ) -> Result<(), BufferError> {
-        let read_mode = (mode & 0x0001) == 0x0001;
-        let write_mode = (mode & 0x0002) == 0x0002;
-        if (read_mode && write_mode) || (!read_mode && !write_mode) {
-            return Err(BufferError::Operation(
-                "exactly one of READ or WRITE map mode must be set",
-            ));
-        }
+    let (sender, receiver) =
+      oneshot::channel::<wgpu_core::resource::BufferAccessResult>();
 
-        let mode = if read_mode {
-            MapMode::Read
-        } else {
-            assert!(write_mode);
-            MapMode::Write
-        };
+    {
+      let callback = Box::new(move |status| {
+        sender.send(status).unwrap();
+      });
 
+      let err = self
+        .instance
+        .buffer_map_async(
+          self.id,
+          offset,
+          size,
+          wgpu_core::resource::BufferMapOperation {
+            host: mode,
+            callback: Some(callback),
+          },
+        )
+        .err();
+
+      if err.is_some() {
+        self.error_handler.push_error(err);
+        return Err(BufferError::Operation("validation error occurred"));
+      }
+    }
+
+    let done = Rc::new(RefCell::new(false));
+    let done_ = done.clone();
+    let device_poll_fut = async move {
+      while !*done.borrow() {
         {
-            *self.map_state.borrow_mut() = "pending";
-        }
-
-        let (sender, receiver) = oneshot::channel::<wgpu_core::resource::BufferAccessResult>();
-
-        {
-            let callback = Box::new(move |status| {
-                sender.send(status).unwrap();
-            });
-
-            let err = self
-                .instance
-                .buffer_map_async(
-                    self.id,
-                    offset,
-                    size,
-                    wgpu_core::resource::BufferMapOperation {
-                        host: mode,
-                        callback: Some(callback),
-                    },
-                )
-                .err();
-
-            if err.is_some() {
-                self.error_handler.push_error(err);
-                return Err(BufferError::Operation("validation error occurred"));
-            }
-        }
-
-        let done = Rc::new(RefCell::new(false));
-        let done_ = done.clone();
-        let device_poll_fut = async move {
-            while !*done.borrow() {
-                {
-                    self.instance
-                        .device_poll(self.device, wgpu_types::PollType::wait())
-                        .unwrap();
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-            Ok::<(), BufferError>(())
-        };
-
-        let receiver_fut = async move {
-            receiver.await??;
-            let mut done = done_.borrow_mut();
-            *done = true;
-            Ok::<(), BufferError>(())
-        };
-
-        tokio::try_join!(device_poll_fut, receiver_fut)?;
-
-        *self.map_state.borrow_mut() = "mapped";
-        *self.map_mode.borrow_mut() = Some(mode);
-
-        Ok(())
-    }
-
-    fn get_mapped_range<'s>(
-        &self,
-        scope: &mut v8::HandleScope<'s>,
-        #[webidl(default = 0)] offset: u64,
-        #[webidl] size: Option<u64>,
-    ) -> Result<v8::Local<'s, v8::ArrayBuffer>, BufferError> {
-        let (slice_pointer, range_size) = self
+          self
             .instance
-            .buffer_get_mapped_range(self.id, offset, size)
-            .map_err(BufferError::Access)?;
-
-        let mode = self.map_mode.borrow();
-        let mode = mode.as_ref().unwrap();
-
-        let bs = if mode == &MapMode::Write {
-            unsafe extern "C" fn noop_deleter_callback(
-                _data: *mut std::ffi::c_void,
-                _byte_length: usize,
-                _deleter_data: *mut std::ffi::c_void,
-            ) {
-            }
-
-            // SAFETY: creating a backing store from the pointer and length provided by wgpu
-            unsafe {
-                v8::ArrayBuffer::new_backing_store_from_ptr(
-                    slice_pointer.as_ptr() as _,
-                    range_size as usize,
-                    noop_deleter_callback,
-                    std::ptr::null_mut(),
-                )
-            }
-        } else {
-            // SAFETY: creating a vector from the pointer and length provided by wgpu
-            let slice =
-                unsafe { std::slice::from_raw_parts(slice_pointer.as_ptr(), range_size as usize) };
-            v8::ArrayBuffer::new_backing_store_from_vec(slice.to_vec())
-        };
-
-        let shared_bs = bs.make_shared();
-        let ab = v8::ArrayBuffer::with_backing_store(scope, &shared_bs);
-
-        if mode == &MapMode::Write {
-            self.mapped_js_buffers
-                .borrow_mut()
-                .push(v8::Global::new(scope, ab));
+            .device_poll(self.device, wgpu_types::PollType::wait())
+            .unwrap();
         }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+      }
+      Ok::<(), BufferError>(())
+    };
 
-        Ok(ab)
+    let receiver_fut = async move {
+      receiver.await??;
+      let mut done = done_.borrow_mut();
+      *done = true;
+      Ok::<(), BufferError>(())
+    };
+
+    tokio::try_join!(device_poll_fut, receiver_fut)?;
+
+    *self.map_state.borrow_mut() = "mapped";
+    *self.map_mode.borrow_mut() = Some(mode);
+
+    Ok(())
+  }
+
+  fn get_mapped_range<'s>(
+    &self,
+    scope: &mut v8::HandleScope<'s>,
+    #[webidl(default = 0)] offset: u64,
+    #[webidl] size: Option<u64>,
+  ) -> Result<v8::Local<'s, v8::ArrayBuffer>, BufferError> {
+    let (slice_pointer, range_size) = self
+      .instance
+      .buffer_get_mapped_range(self.id, offset, size)
+      .map_err(BufferError::Access)?;
+
+    let mode = self.map_mode.borrow();
+    let mode = mode.as_ref().unwrap();
+
+    let bs = if mode == &MapMode::Write {
+      unsafe extern "C" fn noop_deleter_callback(
+        _data: *mut std::ffi::c_void,
+        _byte_length: usize,
+        _deleter_data: *mut std::ffi::c_void,
+      ) {
+      }
+
+      // SAFETY: creating a backing store from the pointer and length provided by wgpu
+      unsafe {
+        v8::ArrayBuffer::new_backing_store_from_ptr(
+          slice_pointer.as_ptr() as _,
+          range_size as usize,
+          noop_deleter_callback,
+          std::ptr::null_mut(),
+        )
+      }
+    } else {
+      // SAFETY: creating a vector from the pointer and length provided by wgpu
+      let slice = unsafe {
+        std::slice::from_raw_parts(slice_pointer.as_ptr(), range_size as usize)
+      };
+      v8::ArrayBuffer::new_backing_store_from_vec(slice.to_vec())
+    };
+
+    let shared_bs = bs.make_shared();
+    let ab = v8::ArrayBuffer::with_backing_store(scope, &shared_bs);
+
+    if mode == &MapMode::Write {
+      self
+        .mapped_js_buffers
+        .borrow_mut()
+        .push(v8::Global::new(scope, ab));
     }
 
-    #[nofast]
-    fn unmap(&self, scope: &mut v8::HandleScope) -> Result<(), BufferError> {
-        for ab in self.mapped_js_buffers.replace(vec![]) {
-            let ab = ab.open(scope);
-            ab.detach(None);
-        }
+    Ok(ab)
+  }
 
-        self.instance
-            .buffer_unmap(self.id)
-            .map_err(BufferError::Access)?;
-
-        *self.map_state.borrow_mut() = "unmapped";
-
-        Ok(())
+  #[nofast]
+  fn unmap(&self, scope: &mut v8::HandleScope) -> Result<(), BufferError> {
+    for ab in self.mapped_js_buffers.replace(vec![]) {
+      let ab = ab.open(scope);
+      ab.detach(None);
     }
 
-    #[fast]
-    fn destroy(&self) {
-        self.instance.buffer_destroy(self.id);
-    }
+    self
+      .instance
+      .buffer_unmap(self.id)
+      .map_err(BufferError::Access)?;
+
+    *self.map_state.borrow_mut() = "unmapped";
+
+    Ok(())
+  }
+
+  #[fast]
+  fn destroy(&self) {
+    self.instance.buffer_destroy(self.id);
+  }
 }

--- a/deno_webgpu/byow.rs
+++ b/deno_webgpu/byow.rs
@@ -24,6 +24,16 @@ use crate::surface::GPUCanvasContext;
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum ByowError {
+  #[cfg(not(any(
+    target_os = "macos",
+    target_os = "windows",
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+  )))]
+  #[class(type)]
+  #[error("Unsupported platform")]
+  Unsupported,
   #[class(type)]
   #[error(
     "Cannot create surface outside of WebGPU context. Did you forget to call `navigator.gpu.requestAdapter()`?"
@@ -360,6 +370,6 @@ fn raw_window(
   _system: UnsafeWindowSurfaceSystem,
   _window: *const c_void,
   _display: *const c_void,
-) -> Result<RawHandles, deno_error::JsErrorBox> {
-  Err(deno_error::JsErrorBox::type_error("Unsupported platform"))
+) -> Result<RawHandles, ByowError> {
+  Err(ByowError::Unsupported)
 }

--- a/deno_webgpu/byow.rs
+++ b/deno_webgpu/byow.rs
@@ -83,7 +83,11 @@ pub struct UnsafeWindowSurface {
   pub context: SameObject<GPUCanvasContext>,
 }
 
-impl GarbageCollected for UnsafeWindowSurface {}
+impl GarbageCollected for UnsafeWindowSurface {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"UnsafeWindowSurface"
+  }
+}
 
 #[op2]
 impl UnsafeWindowSurface {

--- a/deno_webgpu/byow.rs
+++ b/deno_webgpu/byow.rs
@@ -163,6 +163,18 @@ impl UnsafeWindowSurface {
 
     context.present().map_err(JsErrorBox::from_err)
   }
+
+  #[fast]
+  fn resize(&self, width: u32, height: u32, scope: &mut v8::HandleScope) {
+    self.width.replace(width);
+    self.height.replace(height);
+
+    let Some(context) = self.context.try_unwrap(scope) else {
+      return;
+    };
+
+    context.resize_configure(width, height);
+  }
 }
 
 struct UnsafeWindowSurfaceOptions {

--- a/deno_webgpu/byow.rs
+++ b/deno_webgpu/byow.rs
@@ -3,10 +3,10 @@
 use std::cell::RefCell;
 use std::ffi::c_void;
 #[cfg(any(
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "freebsd",
-    target_os = "openbsd"
+  target_os = "linux",
+  target_os = "macos",
+  target_os = "freebsd",
+  target_os = "openbsd"
 ))]
 use std::ptr::NonNull;
 
@@ -24,305 +24,326 @@ use crate::surface::GPUCanvasContext;
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum ByowError {
-    #[class(type)]
-    #[error("Cannot create surface outside of WebGPU context. Did you forget to call `navigator.gpu.requestAdapter()`?")]
-    WebGPUNotInitiated,
-    #[class(type)]
-    #[error("Invalid parameters")]
-    InvalidParameters,
-    #[class(generic)]
-    #[error(transparent)]
-    CreateSurface(wgpu_core::instance::CreateSurfaceError),
-    #[cfg(target_os = "windows")]
-    #[class(type)]
-    #[error("Invalid system on Windows")]
-    InvalidSystem,
-    #[cfg(target_os = "macos")]
-    #[class(type)]
-    #[error("Invalid system on macOS")]
-    InvalidSystem,
-    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
-    #[class(type)]
-    #[error("Invalid system on Linux/BSD")]
-    InvalidSystem,
-    #[cfg(any(
-        target_os = "windows",
-        target_os = "linux",
-        target_os = "freebsd",
-        target_os = "openbsd"
-    ))]
-    #[class(type)]
-    #[error("window is null")]
-    NullWindow,
-    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
-    #[class(type)]
-    #[error("display is null")]
-    NullDisplay,
-    #[cfg(target_os = "macos")]
-    #[class(type)]
-    #[error("ns_view is null")]
-    NSViewDisplay,
+  #[class(type)]
+  #[error(
+    "Cannot create surface outside of WebGPU context. Did you forget to call `navigator.gpu.requestAdapter()`?"
+  )]
+  WebGPUNotInitiated,
+  #[class(type)]
+  #[error("Invalid parameters")]
+  InvalidParameters,
+  #[class(generic)]
+  #[error(transparent)]
+  CreateSurface(wgpu_core::instance::CreateSurfaceError),
+  #[cfg(target_os = "windows")]
+  #[class(type)]
+  #[error("Invalid system on Windows")]
+  InvalidSystem,
+  #[cfg(target_os = "macos")]
+  #[class(type)]
+  #[error("Invalid system on macOS")]
+  InvalidSystem,
+  #[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd"
+  ))]
+  #[class(type)]
+  #[error("Invalid system on Linux/BSD")]
+  InvalidSystem,
+  #[cfg(any(
+    target_os = "windows",
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd"
+  ))]
+  #[class(type)]
+  #[error("window is null")]
+  NullWindow,
+  #[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd"
+  ))]
+  #[class(type)]
+  #[error("display is null")]
+  NullDisplay,
+  #[cfg(target_os = "macos")]
+  #[class(type)]
+  #[error("ns_view is null")]
+  NSViewDisplay,
 }
 
 // TODO(@littledivy): This will extend `OffscreenCanvas` when we add it.
 pub struct UnsafeWindowSurface {
-    pub id: wgpu_core::id::SurfaceId,
-    pub width: RefCell<u32>,
-    pub height: RefCell<u32>,
+  pub id: wgpu_core::id::SurfaceId,
+  pub width: RefCell<u32>,
+  pub height: RefCell<u32>,
 
-    pub context: SameObject<GPUCanvasContext>,
+  pub context: SameObject<GPUCanvasContext>,
 }
 
 impl GarbageCollected for UnsafeWindowSurface {}
 
 #[op2]
 impl UnsafeWindowSurface {
-    #[constructor]
-    #[cppgc]
-    fn new(
-        state: &mut OpState,
-        #[from_v8] options: UnsafeWindowSurfaceOptions,
-    ) -> Result<UnsafeWindowSurface, ByowError> {
-        let instance = state
-            .try_borrow::<super::Instance>()
-            .ok_or(ByowError::WebGPUNotInitiated)?;
+  #[constructor]
+  #[cppgc]
+  fn new(
+    state: &mut OpState,
+    #[from_v8] options: UnsafeWindowSurfaceOptions,
+  ) -> Result<UnsafeWindowSurface, ByowError> {
+    let instance = state
+      .try_borrow::<super::Instance>()
+      .ok_or(ByowError::WebGPUNotInitiated)?;
 
-        // Security note:
-        //
-        // The `window_handle` and `display_handle` options are pointers to
-        // platform-specific window handles.
-        //
-        // The code below works under the assumption that:
-        //
-        // - handles can only be created by the FFI interface which
-        // enforces --allow-ffi.
-        //
-        // - `*const c_void` deserizalizes null and v8::External.
-        //
-        // - Only FFI can export v8::External to user code.
-        if options.window_handle.is_null() {
-            return Err(ByowError::InvalidParameters);
-        }
-
-        let (win_handle, display_handle) = raw_window(
-            options.system,
-            options.window_handle,
-            options.display_handle,
-        )?;
-
-        // SAFETY: see above comment
-        let id = unsafe {
-            instance
-                .instance_create_surface(display_handle, win_handle, None)
-                .map_err(ByowError::CreateSurface)?
-        };
-
-        Ok(UnsafeWindowSurface {
-            id,
-            width: RefCell::new(options.width),
-            height: RefCell::new(options.height),
-            context: SameObject::new(),
-        })
+    // Security note:
+    //
+    // The `window_handle` and `display_handle` options are pointers to
+    // platform-specific window handles.
+    //
+    // The code below works under the assumption that:
+    //
+    // - handles can only be created by the FFI interface which
+    // enforces --allow-ffi.
+    //
+    // - `*const c_void` deserizalizes null and v8::External.
+    //
+    // - Only FFI can export v8::External to user code.
+    if options.window_handle.is_null() {
+      return Err(ByowError::InvalidParameters);
     }
 
-    #[global]
-    fn get_context(
-        &self,
-        #[this] this: v8::Global<v8::Object>,
-        scope: &mut v8::HandleScope,
-    ) -> v8::Global<v8::Object> {
-        self.context.get(scope, |_| GPUCanvasContext {
-            surface_id: self.id,
-            width: self.width.clone(),
-            height: self.height.clone(),
-            config: RefCell::new(None),
-            texture: RefCell::new(None),
-            canvas: this,
-        })
-    }
+    let (win_handle, display_handle) = raw_window(
+      options.system,
+      options.window_handle,
+      options.display_handle,
+    )?;
 
-    #[nofast]
-    fn present(&self, scope: &mut v8::HandleScope) -> Result<(), JsErrorBox> {
-        let Some(context) = self.context.try_unwrap(scope) else {
-            return Err(JsErrorBox::type_error("getContext was never called"));
-        };
+    // SAFETY: see above comment
+    let id = unsafe {
+      instance
+        .instance_create_surface(display_handle, win_handle, None)
+        .map_err(ByowError::CreateSurface)?
+    };
 
-        context.present().map_err(JsErrorBox::from_err)
-    }
+    Ok(UnsafeWindowSurface {
+      id,
+      width: RefCell::new(options.width),
+      height: RefCell::new(options.height),
+      context: SameObject::new(),
+    })
+  }
+
+  #[global]
+  fn get_context(
+    &self,
+    #[this] this: v8::Global<v8::Object>,
+    scope: &mut v8::HandleScope,
+  ) -> v8::Global<v8::Object> {
+    self.context.get(scope, |_| GPUCanvasContext {
+      surface_id: self.id,
+      width: self.width.clone(),
+      height: self.height.clone(),
+      config: RefCell::new(None),
+      texture: RefCell::new(None),
+      canvas: this,
+    })
+  }
+
+  #[nofast]
+  fn present(&self, scope: &mut v8::HandleScope) -> Result<(), JsErrorBox> {
+    let Some(context) = self.context.try_unwrap(scope) else {
+      return Err(JsErrorBox::type_error("getContext was never called"));
+    };
+
+    context.present().map_err(JsErrorBox::from_err)
+  }
 }
 
 struct UnsafeWindowSurfaceOptions {
-    system: UnsafeWindowSurfaceSystem,
-    window_handle: *const c_void,
-    display_handle: *const c_void,
-    width: u32,
-    height: u32,
+  system: UnsafeWindowSurfaceSystem,
+  window_handle: *const c_void,
+  display_handle: *const c_void,
+  width: u32,
+  height: u32,
 }
 
 #[derive(Eq, PartialEq)]
 enum UnsafeWindowSurfaceSystem {
-    Cocoa,
-    Win32,
-    X11,
-    Wayland,
+  Cocoa,
+  Win32,
+  X11,
+  Wayland,
 }
 
 impl<'a> FromV8<'a> for UnsafeWindowSurfaceOptions {
-    type Error = JsErrorBox;
+  type Error = JsErrorBox;
 
-    fn from_v8(
-        scope: &mut v8::HandleScope<'a>,
-        value: Local<'a, Value>,
-    ) -> Result<Self, Self::Error> {
-        let obj = value
-            .try_cast::<v8::Object>()
-            .map_err(|_| JsErrorBox::type_error("is not an object"))?;
+  fn from_v8(
+    scope: &mut v8::HandleScope<'a>,
+    value: Local<'a, Value>,
+  ) -> Result<Self, Self::Error> {
+    let obj = value
+      .try_cast::<v8::Object>()
+      .map_err(|_| JsErrorBox::type_error("is not an object"))?;
 
-        let key = v8::String::new(scope, "system").unwrap();
-        let val = obj
-            .get(scope, key.into())
-            .ok_or_else(|| JsErrorBox::type_error("missing field 'system'"))?;
-        let s = String::from_v8(scope, val).unwrap();
-        let system = match s.as_str() {
-            "cocoa" => UnsafeWindowSurfaceSystem::Cocoa,
-            "win32" => UnsafeWindowSurfaceSystem::Win32,
-            "x11" => UnsafeWindowSurfaceSystem::X11,
-            "wayland" => UnsafeWindowSurfaceSystem::Wayland,
-            _ => return Err(JsErrorBox::type_error(format!("Invalid system kind '{s}'"))),
-        };
+    let key = v8::String::new(scope, "system").unwrap();
+    let val = obj
+      .get(scope, key.into())
+      .ok_or_else(|| JsErrorBox::type_error("missing field 'system'"))?;
+    let s = String::from_v8(scope, val).unwrap();
+    let system = match s.as_str() {
+      "cocoa" => UnsafeWindowSurfaceSystem::Cocoa,
+      "win32" => UnsafeWindowSurfaceSystem::Win32,
+      "x11" => UnsafeWindowSurfaceSystem::X11,
+      "wayland" => UnsafeWindowSurfaceSystem::Wayland,
+      _ => {
+        return Err(JsErrorBox::type_error(format!(
+          "Invalid system kind '{s}'"
+        )));
+      }
+    };
 
-        let key = v8::String::new(scope, "windowHandle").unwrap();
-        let val = obj
-            .get(scope, key.into())
-            .ok_or_else(|| JsErrorBox::type_error("missing field 'windowHandle'"))?;
-        let Some(window_handle) = deno_core::_ops::to_external_option(&val) else {
-            return Err(JsErrorBox::type_error("expected external"));
-        };
+    let key = v8::String::new(scope, "windowHandle").unwrap();
+    let val = obj
+      .get(scope, key.into())
+      .ok_or_else(|| JsErrorBox::type_error("missing field 'windowHandle'"))?;
+    let Some(window_handle) = deno_core::_ops::to_external_option(&val) else {
+      return Err(JsErrorBox::type_error("expected external"));
+    };
 
-        let key = v8::String::new(scope, "displayHandle").unwrap();
-        let val = obj
-            .get(scope, key.into())
-            .ok_or_else(|| JsErrorBox::type_error("missing field 'displayHandle'"))?;
-        let Some(display_handle) = deno_core::_ops::to_external_option(&val) else {
-            return Err(JsErrorBox::type_error("expected external"));
-        };
+    let key = v8::String::new(scope, "displayHandle").unwrap();
+    let val = obj
+      .get(scope, key.into())
+      .ok_or_else(|| JsErrorBox::type_error("missing field 'displayHandle'"))?;
+    let Some(display_handle) = deno_core::_ops::to_external_option(&val) else {
+      return Err(JsErrorBox::type_error("expected external"));
+    };
 
-        let key = v8::String::new(scope, "width").unwrap();
-        let val = obj
-            .get(scope, key.into())
-            .ok_or_else(|| JsErrorBox::type_error("missing field 'width'"))?;
-        let width = deno_core::convert::Number::<u32>::from_v8(scope, val)?.0;
+    let key = v8::String::new(scope, "width").unwrap();
+    let val = obj
+      .get(scope, key.into())
+      .ok_or_else(|| JsErrorBox::type_error("missing field 'width'"))?;
+    let width = deno_core::convert::Number::<u32>::from_v8(scope, val)?.0;
 
-        let key = v8::String::new(scope, "height").unwrap();
-        let val = obj
-            .get(scope, key.into())
-            .ok_or_else(|| JsErrorBox::type_error("missing field 'height'"))?;
-        let height = deno_core::convert::Number::<u32>::from_v8(scope, val)?.0;
+    let key = v8::String::new(scope, "height").unwrap();
+    let val = obj
+      .get(scope, key.into())
+      .ok_or_else(|| JsErrorBox::type_error("missing field 'height'"))?;
+    let height = deno_core::convert::Number::<u32>::from_v8(scope, val)?.0;
 
-        Ok(Self {
-            system,
-            window_handle,
-            display_handle,
-            width,
-            height,
-        })
-    }
+    Ok(Self {
+      system,
+      window_handle,
+      display_handle,
+      width,
+      height,
+    })
+  }
 }
 
 type RawHandles = (
-    raw_window_handle::RawWindowHandle,
-    raw_window_handle::RawDisplayHandle,
+  raw_window_handle::RawWindowHandle,
+  raw_window_handle::RawDisplayHandle,
 );
 
 #[cfg(target_os = "macos")]
 fn raw_window(
-    system: UnsafeWindowSurfaceSystem,
-    _ns_window: *const c_void,
-    ns_view: *const c_void,
+  system: UnsafeWindowSurfaceSystem,
+  _ns_window: *const c_void,
+  ns_view: *const c_void,
 ) -> Result<RawHandles, ByowError> {
-    if system != UnsafeWindowSurfaceSystem::Cocoa {
-        return Err(ByowError::InvalidSystem);
-    }
+  if system != UnsafeWindowSurfaceSystem::Cocoa {
+    return Err(ByowError::InvalidSystem);
+  }
 
-    let win_handle =
-        raw_window_handle::RawWindowHandle::AppKit(raw_window_handle::AppKitWindowHandle::new(
-            NonNull::new(ns_view as *mut c_void).ok_or(ByowError::NSViewDisplay)?,
-        ));
+  let win_handle = raw_window_handle::RawWindowHandle::AppKit(
+    raw_window_handle::AppKitWindowHandle::new(
+      NonNull::new(ns_view as *mut c_void).ok_or(ByowError::NSViewDisplay)?,
+    ),
+  );
 
-    let display_handle =
-        raw_window_handle::RawDisplayHandle::AppKit(raw_window_handle::AppKitDisplayHandle::new());
-    Ok((win_handle, display_handle))
+  let display_handle = raw_window_handle::RawDisplayHandle::AppKit(
+    raw_window_handle::AppKitDisplayHandle::new(),
+  );
+  Ok((win_handle, display_handle))
 }
 
 #[cfg(target_os = "windows")]
 fn raw_window(
-    system: UnsafeWindowSurfaceSystem,
-    window: *const c_void,
-    hinstance: *const c_void,
+  system: UnsafeWindowSurfaceSystem,
+  window: *const c_void,
+  hinstance: *const c_void,
 ) -> Result<RawHandles, ByowError> {
-    use raw_window_handle::WindowsDisplayHandle;
-    if system != UnsafeWindowSurfaceSystem::Win32 {
-        return Err(ByowError::InvalidSystem);
-    }
+  use raw_window_handle::WindowsDisplayHandle;
+  if system != UnsafeWindowSurfaceSystem::Win32 {
+    return Err(ByowError::InvalidSystem);
+  }
 
-    let win_handle = {
-        let mut handle = raw_window_handle::Win32WindowHandle::new(
-            std::num::NonZeroIsize::new(window as isize).ok_or(ByowError::NullWindow)?,
-        );
-        handle.hinstance = std::num::NonZeroIsize::new(hinstance as isize);
+  let win_handle = {
+    let mut handle = raw_window_handle::Win32WindowHandle::new(
+      std::num::NonZeroIsize::new(window as isize)
+        .ok_or(ByowError::NullWindow)?,
+    );
+    handle.hinstance = std::num::NonZeroIsize::new(hinstance as isize);
 
-        raw_window_handle::RawWindowHandle::Win32(handle)
-    };
+    raw_window_handle::RawWindowHandle::Win32(handle)
+  };
 
-    let display_handle = raw_window_handle::RawDisplayHandle::Windows(WindowsDisplayHandle::new());
-    Ok((win_handle, display_handle))
+  let display_handle =
+    raw_window_handle::RawDisplayHandle::Windows(WindowsDisplayHandle::new());
+  Ok((win_handle, display_handle))
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
 fn raw_window(
-    system: UnsafeWindowSurfaceSystem,
-    window: *const c_void,
-    display: *const c_void,
+  system: UnsafeWindowSurfaceSystem,
+  window: *const c_void,
+  display: *const c_void,
 ) -> Result<RawHandles, ByowError> {
-    let (win_handle, display_handle);
-    if system == UnsafeWindowSurfaceSystem::X11 {
-        win_handle = raw_window_handle::RawWindowHandle::Xlib(
-            raw_window_handle::XlibWindowHandle::new(window as *mut c_void as _),
-        );
+  let (win_handle, display_handle);
+  if system == UnsafeWindowSurfaceSystem::X11 {
+    win_handle = raw_window_handle::RawWindowHandle::Xlib(
+      raw_window_handle::XlibWindowHandle::new(window as *mut c_void as _),
+    );
 
-        display_handle = raw_window_handle::RawDisplayHandle::Xlib(
-            raw_window_handle::XlibDisplayHandle::new(NonNull::new(display as *mut c_void), 0),
-        );
-    } else if system == UnsafeWindowSurfaceSystem::Wayland {
-        win_handle = raw_window_handle::RawWindowHandle::Wayland(
-            raw_window_handle::WaylandWindowHandle::new(
-                NonNull::new(window as *mut c_void).ok_or(ByowError::NullWindow)?,
-            ),
-        );
+    display_handle = raw_window_handle::RawDisplayHandle::Xlib(
+      raw_window_handle::XlibDisplayHandle::new(
+        NonNull::new(display as *mut c_void),
+        0,
+      ),
+    );
+  } else if system == UnsafeWindowSurfaceSystem::Wayland {
+    win_handle = raw_window_handle::RawWindowHandle::Wayland(
+      raw_window_handle::WaylandWindowHandle::new(
+        NonNull::new(window as *mut c_void).ok_or(ByowError::NullWindow)?,
+      ),
+    );
 
-        display_handle = raw_window_handle::RawDisplayHandle::Wayland(
-            raw_window_handle::WaylandDisplayHandle::new(
-                NonNull::new(display as *mut c_void).ok_or(ByowError::NullDisplay)?,
-            ),
-        );
-    } else {
-        return Err(ByowError::InvalidSystem);
-    }
+    display_handle = raw_window_handle::RawDisplayHandle::Wayland(
+      raw_window_handle::WaylandDisplayHandle::new(
+        NonNull::new(display as *mut c_void).ok_or(ByowError::NullDisplay)?,
+      ),
+    );
+  } else {
+    return Err(ByowError::InvalidSystem);
+  }
 
-    Ok((win_handle, display_handle))
+  Ok((win_handle, display_handle))
 }
 
 #[cfg(not(any(
-    target_os = "macos",
-    target_os = "windows",
-    target_os = "linux",
-    target_os = "freebsd",
-    target_os = "openbsd",
+  target_os = "macos",
+  target_os = "windows",
+  target_os = "linux",
+  target_os = "freebsd",
+  target_os = "openbsd",
 )))]
 fn raw_window(
-    _system: UnsafeWindowSurfaceSystem,
-    _window: *const c_void,
-    _display: *const c_void,
+  _system: UnsafeWindowSurfaceSystem,
+  _window: *const c_void,
+  _display: *const c_void,
 ) -> Result<RawHandles, deno_error::JsErrorBox> {
-    Err(deno_error::JsErrorBox::type_error("Unsupported platform"))
+  Err(deno_error::JsErrorBox::type_error("Unsupported platform"))
 }

--- a/deno_webgpu/command_buffer.rs
+++ b/deno_webgpu/command_buffer.rs
@@ -4,6 +4,7 @@ use deno_core::op2;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 
+use crate::error::GPUGenericError;
 use crate::Instance;
 
 pub struct GPUCommandBuffer {
@@ -30,6 +31,12 @@ impl GarbageCollected for GPUCommandBuffer {
 
 #[op2]
 impl GPUCommandBuffer {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUCommandBuffer, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/command_buffer.rs
+++ b/deno_webgpu/command_buffer.rs
@@ -7,40 +7,40 @@ use deno_core::WebIDL;
 use crate::Instance;
 
 pub struct GPUCommandBuffer {
-    pub instance: Instance,
-    pub id: wgpu_core::id::CommandBufferId,
-    pub label: String,
+  pub instance: Instance,
+  pub id: wgpu_core::id::CommandBufferId,
+  pub label: String,
 }
 
 impl Drop for GPUCommandBuffer {
-    fn drop(&mut self) {
-        self.instance.command_buffer_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.command_buffer_drop(self.id);
+  }
 }
 
 impl deno_core::webidl::WebIdlInterfaceConverter for GPUCommandBuffer {
-    const NAME: &'static str = "GPUCommandBuffer";
+  const NAME: &'static str = "GPUCommandBuffer";
 }
 
 impl GarbageCollected for GPUCommandBuffer {}
 
 #[op2]
 impl GPUCommandBuffer {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUCommandBufferDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 }

--- a/deno_webgpu/command_buffer.rs
+++ b/deno_webgpu/command_buffer.rs
@@ -22,7 +22,11 @@ impl deno_core::webidl::WebIdlInterfaceConverter for GPUCommandBuffer {
   const NAME: &'static str = "GPUCommandBuffer";
 }
 
-impl GarbageCollected for GPUCommandBuffer {}
+impl GarbageCollected for GPUCommandBuffer {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUCommandBuffer"
+  }
+}
 
 #[op2]
 impl GPUCommandBuffer {

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -23,61 +23,61 @@ use crate::webidl::GPUExtent3D;
 use crate::Instance;
 
 pub struct GPUCommandEncoder {
-    pub instance: Instance,
-    pub error_handler: super::error::ErrorHandler,
+  pub instance: Instance,
+  pub error_handler: super::error::ErrorHandler,
 
-    pub id: wgpu_core::id::CommandEncoderId,
-    pub label: String,
+  pub id: wgpu_core::id::CommandEncoderId,
+  pub label: String,
 }
 
 impl Drop for GPUCommandEncoder {
-    fn drop(&mut self) {
-        self.instance.command_encoder_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.command_encoder_drop(self.id);
+  }
 }
 
 impl GarbageCollected for GPUCommandEncoder {}
 
 #[op2]
 impl GPUCommandEncoder {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 
-    #[required(1)]
-    #[cppgc]
-    fn begin_render_pass(
-        &self,
-        #[webidl] descriptor: crate::render_pass::GPURenderPassDescriptor,
-    ) -> Result<GPURenderPassEncoder, JsErrorBox> {
-        let color_attachments = Cow::Owned(
-            descriptor
-                .color_attachments
-                .into_iter()
-                .map(|attachment| {
-                    attachment.into_option().map(|attachment| {
-                        wgpu_core::command::RenderPassColorAttachment {
-                            view: attachment.view.id,
-                            depth_slice: attachment.depth_slice,
-                            resolve_target: attachment.resolve_target.map(|target| target.id),
-                            load_op: attachment
-                                .load_op
-                                .with_default_value(attachment.clear_value.map(Into::into)),
-                            store_op: attachment.store_op.into(),
-                        }
-                    })
-                })
-                .collect::<Vec<_>>(),
-        );
+  #[required(1)]
+  #[cppgc]
+  fn begin_render_pass(
+    &self,
+    #[webidl] descriptor: crate::render_pass::GPURenderPassDescriptor,
+  ) -> Result<GPURenderPassEncoder, JsErrorBox> {
+    let color_attachments = Cow::Owned(
+      descriptor
+        .color_attachments
+        .into_iter()
+        .map(|attachment| {
+          attachment.into_option().map(|attachment| {
+            wgpu_core::command::RenderPassColorAttachment {
+              view: attachment.view.id,
+              depth_slice: attachment.depth_slice,
+              resolve_target: attachment.resolve_target.map(|target| target.id),
+              load_op: attachment
+                .load_op
+                .with_default_value(attachment.clear_value.map(Into::into)),
+              store_op: attachment.store_op.into(),
+            }
+          })
+        })
+        .collect::<Vec<_>>(),
+    );
 
-        let depth_stencil_attachment = descriptor
+    let depth_stencil_attachment = descriptor
             .depth_stencil_attachment
             .map(|attachment| {
                 if attachment
@@ -111,359 +111,366 @@ impl GPUCommandEncoder {
             })
             .transpose()?;
 
-        let timestamp_writes = descriptor.timestamp_writes.map(|timestamp_writes| {
-            wgpu_core::command::PassTimestampWrites {
-                query_set: timestamp_writes.query_set.id,
-                beginning_of_pass_write_index: timestamp_writes.beginning_of_pass_write_index,
-                end_of_pass_write_index: timestamp_writes.end_of_pass_write_index,
-            }
-        });
-
-        let wgpu_descriptor = wgpu_core::command::RenderPassDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            color_attachments,
-            depth_stencil_attachment: depth_stencil_attachment.as_ref(),
-            timestamp_writes: timestamp_writes.as_ref(),
-            occlusion_query_set: descriptor.occlusion_query_set.map(|query_set| query_set.id),
-        };
-
-        let (render_pass, err) = self
-            .instance
-            .command_encoder_begin_render_pass(self.id, &wgpu_descriptor);
-
-        self.error_handler.push_error(err);
-
-        Ok(GPURenderPassEncoder {
-            instance: self.instance.clone(),
-            error_handler: self.error_handler.clone(),
-            render_pass: RefCell::new(render_pass),
-            label: descriptor.label,
-        })
-    }
-
-    #[cppgc]
-    fn begin_compute_pass(
-        &self,
-        #[webidl] descriptor: crate::compute_pass::GPUComputePassDescriptor,
-    ) -> GPUComputePassEncoder {
-        let timestamp_writes = descriptor.timestamp_writes.map(|timestamp_writes| {
-            wgpu_core::command::PassTimestampWrites {
-                query_set: timestamp_writes.query_set.id,
-                beginning_of_pass_write_index: timestamp_writes.beginning_of_pass_write_index,
-                end_of_pass_write_index: timestamp_writes.end_of_pass_write_index,
-            }
-        });
-
-        let wgpu_descriptor = wgpu_core::command::ComputePassDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            timestamp_writes,
-        };
-
-        let (compute_pass, err) = self
-            .instance
-            .command_encoder_begin_compute_pass(self.id, &wgpu_descriptor);
-
-        self.error_handler.push_error(err);
-
-        GPUComputePassEncoder {
-            instance: self.instance.clone(),
-            error_handler: self.error_handler.clone(),
-            compute_pass: RefCell::new(compute_pass),
-            label: descriptor.label,
+    let timestamp_writes =
+      descriptor.timestamp_writes.map(|timestamp_writes| {
+        wgpu_core::command::PassTimestampWrites {
+          query_set: timestamp_writes.query_set.id,
+          beginning_of_pass_write_index: timestamp_writes
+            .beginning_of_pass_write_index,
+          end_of_pass_write_index: timestamp_writes.end_of_pass_write_index,
         }
-    }
+      });
 
-    #[required(2)]
-    fn copy_buffer_to_buffer<'a>(
-        &self,
-        scope: &mut v8::HandleScope<'a>,
-        #[webidl] source: Ptr<GPUBuffer>,
-        arg2: v8::Local<'a, v8::Value>,
-        arg3: v8::Local<'a, v8::Value>,
-        arg4: v8::Local<'a, v8::Value>,
-        arg5: v8::Local<'a, v8::Value>,
-    ) -> Result<(), WebIdlError> {
-        let prefix = "Failed to execute 'GPUCommandEncoder.copyBufferToBuffer'";
-        let int_options = IntOptions {
-            clamp: false,
-            enforce_range: true,
-        };
+    let wgpu_descriptor = wgpu_core::command::RenderPassDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      color_attachments,
+      depth_stencil_attachment: depth_stencil_attachment.as_ref(),
+      timestamp_writes: timestamp_writes.as_ref(),
+      occlusion_query_set: descriptor
+        .occlusion_query_set
+        .map(|query_set| query_set.id),
+    };
 
-        let source_offset: BufferAddress;
-        let destination: Ptr<GPUBuffer>;
-        let destination_offset: BufferAddress;
-        let size: Option<BufferAddress>;
-        // Note that the last argument to either overload of `copy_buffer_to_buffer`
-        // is optional, so `arg5.is_undefined()` would not work here.
-        if arg4.is_undefined() {
-            // 3-argument overload
-            source_offset = 0;
-            destination = Ptr::<GPUBuffer>::convert(
-                scope,
-                arg2,
-                Cow::Borrowed(prefix),
-                (|| Cow::Borrowed("destination")).into(),
-                &(),
-            )?;
-            destination_offset = 0;
-            size = <Option<u64>>::convert(
-                scope,
-                arg3,
-                Cow::Borrowed(prefix),
-                (|| Cow::Borrowed("size")).into(),
-                &int_options,
-            )?;
-        } else {
-            // 5-argument overload
-            source_offset = u64::convert(
-                scope,
-                arg2,
-                Cow::Borrowed(prefix),
-                (|| Cow::Borrowed("sourceOffset")).into(),
-                &int_options,
-            )?;
-            destination = Ptr::<GPUBuffer>::convert(
-                scope,
-                arg3,
-                Cow::Borrowed(prefix),
-                (|| Cow::Borrowed("destination")).into(),
-                &(),
-            )?;
-            destination_offset = u64::convert(
-                scope,
-                arg4,
-                Cow::Borrowed(prefix),
-                (|| Cow::Borrowed("destinationOffset")).into(),
-                &int_options,
-            )?;
-            size = <Option<u64>>::convert(
-                scope,
-                arg5,
-                Cow::Borrowed(prefix),
-                (|| Cow::Borrowed("size")).into(),
-                &int_options,
-            )?;
+    let (render_pass, err) = self
+      .instance
+      .command_encoder_begin_render_pass(self.id, &wgpu_descriptor);
+
+    self.error_handler.push_error(err);
+
+    Ok(GPURenderPassEncoder {
+      instance: self.instance.clone(),
+      error_handler: self.error_handler.clone(),
+      render_pass: RefCell::new(render_pass),
+      label: descriptor.label,
+    })
+  }
+
+  #[cppgc]
+  fn begin_compute_pass(
+    &self,
+    #[webidl] descriptor: crate::compute_pass::GPUComputePassDescriptor,
+  ) -> GPUComputePassEncoder {
+    let timestamp_writes =
+      descriptor.timestamp_writes.map(|timestamp_writes| {
+        wgpu_core::command::PassTimestampWrites {
+          query_set: timestamp_writes.query_set.id,
+          beginning_of_pass_write_index: timestamp_writes
+            .beginning_of_pass_write_index,
+          end_of_pass_write_index: timestamp_writes.end_of_pass_write_index,
         }
+      });
 
-        let err = self
-            .instance
-            .command_encoder_copy_buffer_to_buffer(
-                self.id,
-                source.id,
-                source_offset,
-                destination.id,
-                destination_offset,
-                size,
-            )
-            .err();
+    let wgpu_descriptor = wgpu_core::command::ComputePassDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      timestamp_writes,
+    };
 
-        self.error_handler.push_error(err);
+    let (compute_pass, err) = self
+      .instance
+      .command_encoder_begin_compute_pass(self.id, &wgpu_descriptor);
 
-        Ok(())
+    self.error_handler.push_error(err);
+
+    GPUComputePassEncoder {
+      instance: self.instance.clone(),
+      error_handler: self.error_handler.clone(),
+      compute_pass: RefCell::new(compute_pass),
+      label: descriptor.label,
+    }
+  }
+
+  #[required(2)]
+  fn copy_buffer_to_buffer<'a>(
+    &self,
+    scope: &mut v8::HandleScope<'a>,
+    #[webidl] source: Ptr<GPUBuffer>,
+    arg2: v8::Local<'a, v8::Value>,
+    arg3: v8::Local<'a, v8::Value>,
+    arg4: v8::Local<'a, v8::Value>,
+    arg5: v8::Local<'a, v8::Value>,
+  ) -> Result<(), WebIdlError> {
+    let prefix = "Failed to execute 'GPUCommandEncoder.copyBufferToBuffer'";
+    let int_options = IntOptions {
+      clamp: false,
+      enforce_range: true,
+    };
+
+    let source_offset: BufferAddress;
+    let destination: Ptr<GPUBuffer>;
+    let destination_offset: BufferAddress;
+    let size: Option<BufferAddress>;
+    // Note that the last argument to either overload of `copy_buffer_to_buffer`
+    // is optional, so `arg5.is_undefined()` would not work here.
+    if arg4.is_undefined() {
+      // 3-argument overload
+      source_offset = 0;
+      destination = Ptr::<GPUBuffer>::convert(
+        scope,
+        arg2,
+        Cow::Borrowed(prefix),
+        (|| Cow::Borrowed("destination")).into(),
+        &(),
+      )?;
+      destination_offset = 0;
+      size = <Option<u64>>::convert(
+        scope,
+        arg3,
+        Cow::Borrowed(prefix),
+        (|| Cow::Borrowed("size")).into(),
+        &int_options,
+      )?;
+    } else {
+      // 5-argument overload
+      source_offset = u64::convert(
+        scope,
+        arg2,
+        Cow::Borrowed(prefix),
+        (|| Cow::Borrowed("sourceOffset")).into(),
+        &int_options,
+      )?;
+      destination = Ptr::<GPUBuffer>::convert(
+        scope,
+        arg3,
+        Cow::Borrowed(prefix),
+        (|| Cow::Borrowed("destination")).into(),
+        &(),
+      )?;
+      destination_offset = u64::convert(
+        scope,
+        arg4,
+        Cow::Borrowed(prefix),
+        (|| Cow::Borrowed("destinationOffset")).into(),
+        &int_options,
+      )?;
+      size = <Option<u64>>::convert(
+        scope,
+        arg5,
+        Cow::Borrowed(prefix),
+        (|| Cow::Borrowed("size")).into(),
+        &int_options,
+      )?;
     }
 
-    #[required(3)]
-    fn copy_buffer_to_texture(
-        &self,
-        #[webidl] source: GPUTexelCopyBufferInfo,
-        #[webidl] destination: GPUTexelCopyTextureInfo,
-        #[webidl] copy_size: GPUExtent3D,
-    ) {
-        let source = TexelCopyBufferInfo {
-            buffer: source.buffer.id,
-            layout: wgpu_types::TexelCopyBufferLayout {
-                offset: source.offset,
-                bytes_per_row: source.bytes_per_row,
-                rows_per_image: source.rows_per_image,
-            },
-        };
-        let destination = wgpu_types::TexelCopyTextureInfo {
-            texture: destination.texture.id,
-            mip_level: destination.mip_level,
-            origin: destination.origin.into(),
-            aspect: destination.aspect.into(),
-        };
+    let err = self
+      .instance
+      .command_encoder_copy_buffer_to_buffer(
+        self.id,
+        source.id,
+        source_offset,
+        destination.id,
+        destination_offset,
+        size,
+      )
+      .err();
 
-        let err = self
-            .instance
-            .command_encoder_copy_buffer_to_texture(
-                self.id,
-                &source,
-                &destination,
-                &copy_size.into(),
-            )
-            .err();
+    self.error_handler.push_error(err);
 
-        self.error_handler.push_error(err);
+    Ok(())
+  }
+
+  #[required(3)]
+  fn copy_buffer_to_texture(
+    &self,
+    #[webidl] source: GPUTexelCopyBufferInfo,
+    #[webidl] destination: GPUTexelCopyTextureInfo,
+    #[webidl] copy_size: GPUExtent3D,
+  ) {
+    let source = TexelCopyBufferInfo {
+      buffer: source.buffer.id,
+      layout: wgpu_types::TexelCopyBufferLayout {
+        offset: source.offset,
+        bytes_per_row: source.bytes_per_row,
+        rows_per_image: source.rows_per_image,
+      },
+    };
+    let destination = wgpu_types::TexelCopyTextureInfo {
+      texture: destination.texture.id,
+      mip_level: destination.mip_level,
+      origin: destination.origin.into(),
+      aspect: destination.aspect.into(),
+    };
+
+    let err = self
+      .instance
+      .command_encoder_copy_buffer_to_texture(
+        self.id,
+        &source,
+        &destination,
+        &copy_size.into(),
+      )
+      .err();
+
+    self.error_handler.push_error(err);
+  }
+
+  #[required(3)]
+  fn copy_texture_to_buffer(
+    &self,
+    #[webidl] source: GPUTexelCopyTextureInfo,
+    #[webidl] destination: GPUTexelCopyBufferInfo,
+    #[webidl] copy_size: GPUExtent3D,
+  ) {
+    let source = wgpu_types::TexelCopyTextureInfo {
+      texture: source.texture.id,
+      mip_level: source.mip_level,
+      origin: source.origin.into(),
+      aspect: source.aspect.into(),
+    };
+    let destination = TexelCopyBufferInfo {
+      buffer: destination.buffer.id,
+      layout: wgpu_types::TexelCopyBufferLayout {
+        offset: destination.offset,
+        bytes_per_row: destination.bytes_per_row,
+        rows_per_image: destination.rows_per_image,
+      },
+    };
+
+    let err = self
+      .instance
+      .command_encoder_copy_texture_to_buffer(
+        self.id,
+        &source,
+        &destination,
+        &copy_size.into(),
+      )
+      .err();
+
+    self.error_handler.push_error(err);
+  }
+
+  #[required(3)]
+  fn copy_texture_to_texture(
+    &self,
+    #[webidl] source: GPUTexelCopyTextureInfo,
+    #[webidl] destination: GPUTexelCopyTextureInfo,
+    #[webidl] copy_size: GPUExtent3D,
+  ) {
+    let source = wgpu_types::TexelCopyTextureInfo {
+      texture: source.texture.id,
+      mip_level: source.mip_level,
+      origin: source.origin.into(),
+      aspect: source.aspect.into(),
+    };
+    let destination = wgpu_types::TexelCopyTextureInfo {
+      texture: destination.texture.id,
+      mip_level: destination.mip_level,
+      origin: destination.origin.into(),
+      aspect: destination.aspect.into(),
+    };
+
+    let err = self
+      .instance
+      .command_encoder_copy_texture_to_texture(
+        self.id,
+        &source,
+        &destination,
+        &copy_size.into(),
+      )
+      .err();
+
+    self.error_handler.push_error(err);
+  }
+
+  #[required(1)]
+  fn clear_buffer(
+    &self,
+    #[webidl] buffer: Ptr<GPUBuffer>,
+    #[webidl(default = 0, options(enforce_range = true))] offset: u64,
+    #[webidl(options(enforce_range = true))] size: Option<u64>,
+  ) {
+    let err = self
+      .instance
+      .command_encoder_clear_buffer(self.id, buffer.id, offset, size)
+      .err();
+    self.error_handler.push_error(err);
+  }
+
+  #[required(5)]
+  fn resolve_query_set(
+    &self,
+    #[webidl] query_set: Ptr<super::query_set::GPUQuerySet>,
+    #[webidl(options(enforce_range = true))] first_query: u32,
+    #[webidl(options(enforce_range = true))] query_count: u32,
+    #[webidl] destination: Ptr<GPUBuffer>,
+    #[webidl(options(enforce_range = true))] destination_offset: u64,
+  ) {
+    let err = self
+      .instance
+      .command_encoder_resolve_query_set(
+        self.id,
+        query_set.id,
+        first_query,
+        query_count,
+        destination.id,
+        destination_offset,
+      )
+      .err();
+
+    self.error_handler.push_error(err);
+  }
+
+  #[cppgc]
+  fn finish(
+    &self,
+    #[webidl] descriptor: crate::command_buffer::GPUCommandBufferDescriptor,
+  ) -> GPUCommandBuffer {
+    let wgpu_descriptor = wgpu_types::CommandBufferDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+    };
+
+    let (id, err) =
+      self
+        .instance
+        .command_encoder_finish(self.id, &wgpu_descriptor, None);
+
+    self.error_handler.push_error(err);
+
+    GPUCommandBuffer {
+      instance: self.instance.clone(),
+      id,
+      label: descriptor.label,
     }
+  }
 
-    #[required(3)]
-    fn copy_texture_to_buffer(
-        &self,
-        #[webidl] source: GPUTexelCopyTextureInfo,
-        #[webidl] destination: GPUTexelCopyBufferInfo,
-        #[webidl] copy_size: GPUExtent3D,
-    ) {
-        let source = wgpu_types::TexelCopyTextureInfo {
-            texture: source.texture.id,
-            mip_level: source.mip_level,
-            origin: source.origin.into(),
-            aspect: source.aspect.into(),
-        };
-        let destination = TexelCopyBufferInfo {
-            buffer: destination.buffer.id,
-            layout: wgpu_types::TexelCopyBufferLayout {
-                offset: destination.offset,
-                bytes_per_row: destination.bytes_per_row,
-                rows_per_image: destination.rows_per_image,
-            },
-        };
+  fn push_debug_group(&self, #[webidl] group_label: String) {
+    let err = self
+      .instance
+      .command_encoder_push_debug_group(self.id, &group_label)
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-        let err = self
-            .instance
-            .command_encoder_copy_texture_to_buffer(
-                self.id,
-                &source,
-                &destination,
-                &copy_size.into(),
-            )
-            .err();
+  #[fast]
+  fn pop_debug_group(&self) {
+    let err = self.instance.command_encoder_pop_debug_group(self.id).err();
+    self.error_handler.push_error(err);
+  }
 
-        self.error_handler.push_error(err);
-    }
-
-    #[required(3)]
-    fn copy_texture_to_texture(
-        &self,
-        #[webidl] source: GPUTexelCopyTextureInfo,
-        #[webidl] destination: GPUTexelCopyTextureInfo,
-        #[webidl] copy_size: GPUExtent3D,
-    ) {
-        let source = wgpu_types::TexelCopyTextureInfo {
-            texture: source.texture.id,
-            mip_level: source.mip_level,
-            origin: source.origin.into(),
-            aspect: source.aspect.into(),
-        };
-        let destination = wgpu_types::TexelCopyTextureInfo {
-            texture: destination.texture.id,
-            mip_level: destination.mip_level,
-            origin: destination.origin.into(),
-            aspect: destination.aspect.into(),
-        };
-
-        let err = self
-            .instance
-            .command_encoder_copy_texture_to_texture(
-                self.id,
-                &source,
-                &destination,
-                &copy_size.into(),
-            )
-            .err();
-
-        self.error_handler.push_error(err);
-    }
-
-    #[required(1)]
-    fn clear_buffer(
-        &self,
-        #[webidl] buffer: Ptr<GPUBuffer>,
-        #[webidl(default = 0, options(enforce_range = true))] offset: u64,
-        #[webidl(options(enforce_range = true))] size: Option<u64>,
-    ) {
-        let err = self
-            .instance
-            .command_encoder_clear_buffer(self.id, buffer.id, offset, size)
-            .err();
-        self.error_handler.push_error(err);
-    }
-
-    #[required(5)]
-    fn resolve_query_set(
-        &self,
-        #[webidl] query_set: Ptr<super::query_set::GPUQuerySet>,
-        #[webidl(options(enforce_range = true))] first_query: u32,
-        #[webidl(options(enforce_range = true))] query_count: u32,
-        #[webidl] destination: Ptr<GPUBuffer>,
-        #[webidl(options(enforce_range = true))] destination_offset: u64,
-    ) {
-        let err = self
-            .instance
-            .command_encoder_resolve_query_set(
-                self.id,
-                query_set.id,
-                first_query,
-                query_count,
-                destination.id,
-                destination_offset,
-            )
-            .err();
-
-        self.error_handler.push_error(err);
-    }
-
-    #[cppgc]
-    fn finish(
-        &self,
-        #[webidl] descriptor: crate::command_buffer::GPUCommandBufferDescriptor,
-    ) -> GPUCommandBuffer {
-        let wgpu_descriptor = wgpu_types::CommandBufferDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-        };
-
-        let (id, err) = self
-            .instance
-            .command_encoder_finish(self.id, &wgpu_descriptor, None);
-
-        self.error_handler.push_error(err);
-
-        GPUCommandBuffer {
-            instance: self.instance.clone(),
-            id,
-            label: descriptor.label,
-        }
-    }
-
-    fn push_debug_group(&self, #[webidl] group_label: String) {
-        let err = self
-            .instance
-            .command_encoder_push_debug_group(self.id, &group_label)
-            .err();
-        self.error_handler.push_error(err);
-    }
-
-    #[fast]
-    fn pop_debug_group(&self) {
-        let err = self.instance.command_encoder_pop_debug_group(self.id).err();
-        self.error_handler.push_error(err);
-    }
-
-    fn insert_debug_marker(&self, #[webidl] marker_label: String) {
-        let err = self
-            .instance
-            .command_encoder_insert_debug_marker(self.id, &marker_label)
-            .err();
-        self.error_handler.push_error(err);
-    }
+  fn insert_debug_marker(&self, #[webidl] marker_label: String) {
+    let err = self
+      .instance
+      .command_encoder_insert_debug_marker(self.id, &marker_label)
+      .err();
+    self.error_handler.push_error(err);
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUCommandEncoderDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUTexelCopyBufferInfo {
-    pub buffer: Ptr<GPUBuffer>,
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    offset: u64,
-    #[options(enforce_range = true)]
-    bytes_per_row: Option<u32>,
-    #[options(enforce_range = true)]
-    rows_per_image: Option<u32>,
+  pub buffer: Ptr<GPUBuffer>,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  offset: u64,
+  #[options(enforce_range = true)]
+  bytes_per_row: Option<u32>,
+  #[options(enforce_range = true)]
+  rows_per_image: Option<u32>,
 }

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -36,7 +36,11 @@ impl Drop for GPUCommandEncoder {
   }
 }
 
-impl GarbageCollected for GPUCommandEncoder {}
+impl GarbageCollected for GPUCommandEncoder {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUCommandEncoder"
+  }
+}
 
 #[op2]
 impl GPUCommandEncoder {

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -16,6 +16,7 @@ use wgpu_types::{BufferAddress, TexelCopyBufferInfo};
 use crate::buffer::GPUBuffer;
 use crate::command_buffer::GPUCommandBuffer;
 use crate::compute_pass::GPUComputePassEncoder;
+use crate::error::GPUGenericError;
 use crate::queue::GPUTexelCopyTextureInfo;
 use crate::render_pass::GPULoadOp;
 use crate::render_pass::GPURenderPassEncoder;
@@ -44,6 +45,12 @@ impl GarbageCollected for GPUCommandEncoder {
 
 #[op2]
 impl GPUCommandEncoder {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUCommandEncoder, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/compute_pass.rs
+++ b/deno_webgpu/compute_pass.rs
@@ -23,7 +23,11 @@ pub struct GPUComputePassEncoder {
   pub label: String,
 }
 
-impl GarbageCollected for GPUComputePassEncoder {}
+impl GarbageCollected for GPUComputePassEncoder {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUComputePassEncoder"
+  }
+}
 
 #[op2]
 impl GPUComputePassEncoder {

--- a/deno_webgpu/compute_pass.rs
+++ b/deno_webgpu/compute_pass.rs
@@ -16,205 +16,218 @@ use deno_core::WebIDL;
 use crate::Instance;
 
 pub struct GPUComputePassEncoder {
-    pub instance: Instance,
-    pub error_handler: super::error::ErrorHandler,
+  pub instance: Instance,
+  pub error_handler: super::error::ErrorHandler,
 
-    pub compute_pass: RefCell<wgpu_core::command::ComputePass>,
-    pub label: String,
+  pub compute_pass: RefCell<wgpu_core::command::ComputePass>,
+  pub label: String,
 }
 
 impl GarbageCollected for GPUComputePassEncoder {}
 
 #[op2]
 impl GPUComputePassEncoder {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 
-    fn set_pipeline(&self, #[webidl] pipeline: Ptr<crate::compute_pipeline::GPUComputePipeline>) {
-        let err = self
-            .instance
-            .compute_pass_set_pipeline(&mut self.compute_pass.borrow_mut(), pipeline.id)
-            .err();
-        self.error_handler.push_error(err);
-    }
+  fn set_pipeline(
+    &self,
+    #[webidl] pipeline: Ptr<crate::compute_pipeline::GPUComputePipeline>,
+  ) {
+    let err = self
+      .instance
+      .compute_pass_set_pipeline(
+        &mut self.compute_pass.borrow_mut(),
+        pipeline.id,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    fn dispatch_workgroups(
-        &self,
-        #[webidl(options(enforce_range = true))] work_group_count_x: u32,
-        #[webidl(default = 1, options(enforce_range = true))] work_group_count_y: u32,
-        #[webidl(default = 1, options(enforce_range = true))] work_group_count_z: u32,
-    ) {
-        let err = self
-            .instance
-            .compute_pass_dispatch_workgroups(
-                &mut self.compute_pass.borrow_mut(),
-                work_group_count_x,
-                work_group_count_y,
-                work_group_count_z,
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  fn dispatch_workgroups(
+    &self,
+    #[webidl(options(enforce_range = true))] work_group_count_x: u32,
+    #[webidl(default = 1, options(enforce_range = true))]
+    work_group_count_y: u32,
+    #[webidl(default = 1, options(enforce_range = true))]
+    work_group_count_z: u32,
+  ) {
+    let err = self
+      .instance
+      .compute_pass_dispatch_workgroups(
+        &mut self.compute_pass.borrow_mut(),
+        work_group_count_x,
+        work_group_count_y,
+        work_group_count_z,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    fn dispatch_workgroups_indirect(
-        &self,
-        #[webidl] indirect_buffer: Ptr<crate::buffer::GPUBuffer>,
-        #[webidl(options(enforce_range = true))] indirect_offset: u64,
-    ) {
-        let err = self
-            .instance
-            .compute_pass_dispatch_workgroups_indirect(
-                &mut self.compute_pass.borrow_mut(),
-                indirect_buffer.id,
-                indirect_offset,
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  fn dispatch_workgroups_indirect(
+    &self,
+    #[webidl] indirect_buffer: Ptr<crate::buffer::GPUBuffer>,
+    #[webidl(options(enforce_range = true))] indirect_offset: u64,
+  ) {
+    let err = self
+      .instance
+      .compute_pass_dispatch_workgroups_indirect(
+        &mut self.compute_pass.borrow_mut(),
+        indirect_buffer.id,
+        indirect_offset,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[fast]
-    fn end(&self) {
-        let err = self
-            .instance
-            .compute_pass_end(&mut self.compute_pass.borrow_mut())
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[fast]
+  fn end(&self) {
+    let err = self
+      .instance
+      .compute_pass_end(&mut self.compute_pass.borrow_mut())
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    fn push_debug_group(&self, #[webidl] group_label: String) {
-        let err = self
-            .instance
-            .compute_pass_push_debug_group(
-                &mut self.compute_pass.borrow_mut(),
-                &group_label,
-                0, // wgpu#975
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  fn push_debug_group(&self, #[webidl] group_label: String) {
+    let err = self
+      .instance
+      .compute_pass_push_debug_group(
+        &mut self.compute_pass.borrow_mut(),
+        &group_label,
+        0, // wgpu#975
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[fast]
-    fn pop_debug_group(&self) {
-        let err = self
-            .instance
-            .compute_pass_pop_debug_group(&mut self.compute_pass.borrow_mut())
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[fast]
+  fn pop_debug_group(&self) {
+    let err = self
+      .instance
+      .compute_pass_pop_debug_group(&mut self.compute_pass.borrow_mut())
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    fn insert_debug_marker(&self, #[webidl] marker_label: String) {
-        let err = self
-            .instance
-            .compute_pass_insert_debug_marker(
-                &mut self.compute_pass.borrow_mut(),
-                &marker_label,
-                0, // wgpu#975
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  fn insert_debug_marker(&self, #[webidl] marker_label: String) {
+    let err = self
+      .instance
+      .compute_pass_insert_debug_marker(
+        &mut self.compute_pass.borrow_mut(),
+        &marker_label,
+        0, // wgpu#975
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    fn set_bind_group<'a>(
-        &self,
-        scope: &mut v8::HandleScope<'a>,
-        #[webidl(options(enforce_range = true))] index: u32,
-        #[webidl] bind_group: Nullable<Ptr<crate::bind_group::GPUBindGroup>>,
-        dynamic_offsets: v8::Local<'a, v8::Value>,
-        dynamic_offsets_data_start: v8::Local<'a, v8::Value>,
-        dynamic_offsets_data_length: v8::Local<'a, v8::Value>,
-    ) -> Result<(), WebIdlError> {
-        const PREFIX: &str = "Failed to execute 'setBindGroup' on 'GPUComputePassEncoder'";
-        let err = if let Ok(uint_32) = dynamic_offsets.try_cast::<v8::Uint32Array>() {
-            let start = u64::convert(
-                scope,
-                dynamic_offsets_data_start,
-                Cow::Borrowed(PREFIX),
-                (|| Cow::Borrowed("Argument 4")).into(),
-                &IntOptions {
-                    clamp: false,
-                    enforce_range: true,
-                },
-            )? as usize;
-            let len = u32::convert(
-                scope,
-                dynamic_offsets_data_length,
-                Cow::Borrowed(PREFIX),
-                (|| Cow::Borrowed("Argument 5")).into(),
-                &IntOptions {
-                    clamp: false,
-                    enforce_range: true,
-                },
-            )? as usize;
+  fn set_bind_group<'a>(
+    &self,
+    scope: &mut v8::HandleScope<'a>,
+    #[webidl(options(enforce_range = true))] index: u32,
+    #[webidl] bind_group: Nullable<Ptr<crate::bind_group::GPUBindGroup>>,
+    dynamic_offsets: v8::Local<'a, v8::Value>,
+    dynamic_offsets_data_start: v8::Local<'a, v8::Value>,
+    dynamic_offsets_data_length: v8::Local<'a, v8::Value>,
+  ) -> Result<(), WebIdlError> {
+    const PREFIX: &str =
+      "Failed to execute 'setBindGroup' on 'GPUComputePassEncoder'";
+    let err = if let Ok(uint_32) = dynamic_offsets.try_cast::<v8::Uint32Array>()
+    {
+      let start = u64::convert(
+        scope,
+        dynamic_offsets_data_start,
+        Cow::Borrowed(PREFIX),
+        (|| Cow::Borrowed("Argument 4")).into(),
+        &IntOptions {
+          clamp: false,
+          enforce_range: true,
+        },
+      )? as usize;
+      let len = u32::convert(
+        scope,
+        dynamic_offsets_data_length,
+        Cow::Borrowed(PREFIX),
+        (|| Cow::Borrowed("Argument 5")).into(),
+        &IntOptions {
+          clamp: false,
+          enforce_range: true,
+        },
+      )? as usize;
 
-            let ab = uint_32.buffer(scope).unwrap();
-            let ptr = ab.data().unwrap();
-            let ab_len = ab.byte_length() / 4;
+      let ab = uint_32.buffer(scope).unwrap();
+      let ptr = ab.data().unwrap();
+      let ab_len = ab.byte_length() / 4;
 
-            // SAFETY: compute_pass_set_bind_group internally calls extend_from_slice with this slice
-            let data = unsafe { std::slice::from_raw_parts(ptr.as_ptr() as _, ab_len) };
+      // SAFETY: compute_pass_set_bind_group internally calls extend_from_slice with this slice
+      let data =
+        unsafe { std::slice::from_raw_parts(ptr.as_ptr() as _, ab_len) };
 
-            let offsets = &data[start..(start + len)];
+      let offsets = &data[start..(start + len)];
 
-            self.instance
-                .compute_pass_set_bind_group(
-                    &mut self.compute_pass.borrow_mut(),
-                    index,
-                    bind_group.into_option().map(|bind_group| bind_group.id),
-                    offsets,
-                )
-                .err()
-        } else {
-            let offsets = <Option<Vec<u32>>>::convert(
-                scope,
-                dynamic_offsets,
-                Cow::Borrowed(PREFIX),
-                (|| Cow::Borrowed("Argument 3")).into(),
-                &IntOptions {
-                    clamp: false,
-                    enforce_range: true,
-                },
-            )?
-            .unwrap_or_default();
+      self
+        .instance
+        .compute_pass_set_bind_group(
+          &mut self.compute_pass.borrow_mut(),
+          index,
+          bind_group.into_option().map(|bind_group| bind_group.id),
+          offsets,
+        )
+        .err()
+    } else {
+      let offsets = <Option<Vec<u32>>>::convert(
+        scope,
+        dynamic_offsets,
+        Cow::Borrowed(PREFIX),
+        (|| Cow::Borrowed("Argument 3")).into(),
+        &IntOptions {
+          clamp: false,
+          enforce_range: true,
+        },
+      )?
+      .unwrap_or_default();
 
-            self.instance
-                .compute_pass_set_bind_group(
-                    &mut self.compute_pass.borrow_mut(),
-                    index,
-                    bind_group.into_option().map(|bind_group| bind_group.id),
-                    &offsets,
-                )
-                .err()
-        };
+      self
+        .instance
+        .compute_pass_set_bind_group(
+          &mut self.compute_pass.borrow_mut(),
+          index,
+          bind_group.into_option().map(|bind_group| bind_group.id),
+          &offsets,
+        )
+        .err()
+    };
 
-        self.error_handler.push_error(err);
+    self.error_handler.push_error(err);
 
-        Ok(())
-    }
+    Ok(())
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUComputePassDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub timestamp_writes: Option<GPUComputePassTimestampWrites>,
+  pub timestamp_writes: Option<GPUComputePassTimestampWrites>,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUComputePassTimestampWrites {
-    pub query_set: Ptr<crate::query_set::GPUQuerySet>,
-    #[options(enforce_range = true)]
-    pub beginning_of_pass_write_index: Option<u32>,
-    #[options(enforce_range = true)]
-    pub end_of_pass_write_index: Option<u32>,
+  pub query_set: Ptr<crate::query_set::GPUQuerySet>,
+  #[options(enforce_range = true)]
+  pub beginning_of_pass_write_index: Option<u32>,
+  #[options(enforce_range = true)]
+  pub end_of_pass_write_index: Option<u32>,
 }

--- a/deno_webgpu/compute_pass.rs
+++ b/deno_webgpu/compute_pass.rs
@@ -13,6 +13,7 @@ use deno_core::webidl::WebIdlError;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 
+use crate::error::GPUGenericError;
 use crate::Instance;
 
 pub struct GPUComputePassEncoder {
@@ -31,6 +32,12 @@ impl GarbageCollected for GPUComputePassEncoder {
 
 #[op2]
 impl GPUComputePassEncoder {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUComputePassEncoder, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/compute_pipeline.rs
+++ b/deno_webgpu/compute_pipeline.rs
@@ -30,7 +30,11 @@ impl WebIdlInterfaceConverter for GPUComputePipeline {
   const NAME: &'static str = "GPUComputePipeline";
 }
 
-impl GarbageCollected for GPUComputePipeline {}
+impl GarbageCollected for GPUComputePipeline {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUComputePipeline"
+  }
+}
 
 #[op2]
 impl GPUComputePipeline {

--- a/deno_webgpu/compute_pipeline.rs
+++ b/deno_webgpu/compute_pipeline.rs
@@ -13,70 +13,70 @@ use crate::webidl::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use crate::Instance;
 
 pub struct GPUComputePipeline {
-    pub instance: Instance,
-    pub error_handler: super::error::ErrorHandler,
+  pub instance: Instance,
+  pub error_handler: super::error::ErrorHandler,
 
-    pub id: wgpu_core::id::ComputePipelineId,
-    pub label: String,
+  pub id: wgpu_core::id::ComputePipelineId,
+  pub label: String,
 }
 
 impl Drop for GPUComputePipeline {
-    fn drop(&mut self) {
-        self.instance.compute_pipeline_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.compute_pipeline_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPUComputePipeline {
-    const NAME: &'static str = "GPUComputePipeline";
+  const NAME: &'static str = "GPUComputePipeline";
 }
 
 impl GarbageCollected for GPUComputePipeline {}
 
 #[op2]
 impl GPUComputePipeline {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 
-    #[cppgc]
-    fn get_bind_group_layout(&self, #[webidl] index: u32) -> GPUBindGroupLayout {
-        let (id, err) = self
-            .instance
-            .compute_pipeline_get_bind_group_layout(self.id, index, None);
+  #[cppgc]
+  fn get_bind_group_layout(&self, #[webidl] index: u32) -> GPUBindGroupLayout {
+    let (id, err) = self
+      .instance
+      .compute_pipeline_get_bind_group_layout(self.id, index, None);
 
-        self.error_handler.push_error(err);
+    self.error_handler.push_error(err);
 
-        // TODO(wgpu): needs to support retrieving the label
-        GPUBindGroupLayout {
-            instance: self.instance.clone(),
-            id,
-            label: "".to_string(),
-        }
+    // TODO(wgpu): needs to support retrieving the label
+    GPUBindGroupLayout {
+      instance: self.instance.clone(),
+      id,
+      label: "".to_string(),
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUComputePipelineDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub compute: GPUProgrammableStage,
-    pub layout: GPUPipelineLayoutOrGPUAutoLayoutMode,
+  pub compute: GPUProgrammableStage,
+  pub layout: GPUPipelineLayoutOrGPUAutoLayoutMode,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUProgrammableStage {
-    pub module: Ptr<GPUShaderModule>,
-    pub entry_point: Option<String>,
-    #[webidl(default = Default::default())]
-    pub constants: IndexMap<String, f64>,
+  pub module: Ptr<GPUShaderModule>,
+  pub entry_point: Option<String>,
+  #[webidl(default = Default::default())]
+  pub constants: IndexMap<String, f64>,
 }

--- a/deno_webgpu/compute_pipeline.rs
+++ b/deno_webgpu/compute_pipeline.rs
@@ -8,6 +8,7 @@ use deno_core::WebIDL;
 use indexmap::IndexMap;
 
 use crate::bind_group_layout::GPUBindGroupLayout;
+use crate::error::GPUGenericError;
 use crate::shader::GPUShaderModule;
 use crate::webidl::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use crate::Instance;
@@ -38,6 +39,12 @@ impl GarbageCollected for GPUComputePipeline {
 
 #[op2]
 impl GPUComputePipeline {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUComputePipeline, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -917,3 +917,21 @@ impl GPUDeviceLostInfo {
     "device was lost"
   }
 }
+
+#[op2(fast)]
+pub fn op_webgpu_device_start_capture(#[cppgc] device: &GPUDevice) {
+  unsafe {
+    device
+      .instance
+      .device_start_graphics_debugger_capture(device.id);
+  }
+}
+
+#[op2(fast)]
+pub fn op_webgpu_device_stop_capture(#[cppgc] device: &GPUDevice) {
+  unsafe {
+    device
+      .instance
+      .device_stop_graphics_debugger_capture(device.id);
+  }
+}

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -66,7 +66,11 @@ impl WebIdlInterfaceConverter for GPUDevice {
   const NAME: &'static str = "GPUDevice";
 }
 
-impl GarbageCollected for GPUDevice {}
+impl GarbageCollected for GPUDevice {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUDevice"
+  }
+}
 
 // EventTarget is extended in JS
 #[op2]
@@ -897,7 +901,11 @@ pub struct GPUDeviceLostInfo {
   pub reason: GPUDeviceLostReason,
 }
 
-impl GarbageCollected for GPUDeviceLostInfo {}
+impl GarbageCollected for GPUDeviceLostInfo {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUDeviceLostInfo"
+  }
+}
 
 #[op2]
 impl GPUDeviceLostInfo {

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -39,31 +39,31 @@ use crate::webidl::features_to_feature_names;
 use crate::Instance;
 
 pub struct GPUDevice {
-    pub instance: Instance,
-    pub id: wgpu_core::id::DeviceId,
-    pub adapter: wgpu_core::id::AdapterId,
-    pub queue: wgpu_core::id::QueueId,
+  pub instance: Instance,
+  pub id: wgpu_core::id::DeviceId,
+  pub adapter: wgpu_core::id::AdapterId,
+  pub queue: wgpu_core::id::QueueId,
 
-    pub label: String,
+  pub label: String,
 
-    pub features: SameObject<GPUSupportedFeatures>,
-    pub limits: SameObject<GPUSupportedLimits>,
-    pub adapter_info: Rc<SameObject<GPUAdapterInfo>>,
+  pub features: SameObject<GPUSupportedFeatures>,
+  pub limits: SameObject<GPUSupportedLimits>,
+  pub adapter_info: Rc<SameObject<GPUAdapterInfo>>,
 
-    pub queue_obj: SameObject<GPUQueue>,
+  pub queue_obj: SameObject<GPUQueue>,
 
-    pub error_handler: super::error::ErrorHandler,
-    pub lost_promise: v8::Global<v8::Promise>,
+  pub error_handler: super::error::ErrorHandler,
+  pub lost_promise: v8::Global<v8::Promise>,
 }
 
 impl Drop for GPUDevice {
-    fn drop(&mut self) {
-        self.instance.device_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.device_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPUDevice {
-    const NAME: &'static str = "GPUDevice";
+  const NAME: &'static str = "GPUDevice";
 }
 
 impl GarbageCollected for GPUDevice {}
@@ -71,803 +71,849 @@ impl GarbageCollected for GPUDevice {}
 // EventTarget is extended in JS
 #[op2]
 impl GPUDevice {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
+
+  #[getter]
+  #[global]
+  fn features(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
+    self.features.get(scope, |scope| {
+      let features = self.instance.device_features(self.id);
+      let features = features_to_feature_names(features);
+      GPUSupportedFeatures::new(scope, features)
+    })
+  }
+
+  #[getter]
+  #[global]
+  fn limits(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
+    self.limits.get(scope, |_| {
+      let limits = self.instance.device_limits(self.id);
+      GPUSupportedLimits(limits)
+    })
+  }
+
+  #[getter]
+  #[global]
+  fn adapter_info(
+    &self,
+    scope: &mut v8::HandleScope,
+  ) -> v8::Global<v8::Object> {
+    self.adapter_info.get(scope, |_| {
+      let info = self.instance.adapter_get_info(self.adapter);
+      let limits = self.instance.adapter_limits(self.adapter);
+
+      GPUAdapterInfo {
+        info,
+        subgroup_min_size: limits.min_subgroup_size,
+        subgroup_max_size: limits.max_subgroup_size,
+      }
+    })
+  }
+
+  #[getter]
+  #[global]
+  fn queue(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
+    self.queue_obj.get(scope, |_| GPUQueue {
+      id: self.queue,
+      device: self.id,
+      error_handler: self.error_handler.clone(),
+      instance: self.instance.clone(),
+      label: self.label.clone(),
+    })
+  }
+
+  #[fast]
+  fn destroy(&self) {
+    self.instance.device_destroy(self.id);
+    self
+      .error_handler
+      .push_error(Some(GPUError::Lost(GPUDeviceLostReason::Destroyed)));
+  }
+
+  #[required(1)]
+  #[cppgc]
+  fn create_buffer(
+    &self,
+    #[webidl] descriptor: super::buffer::GPUBufferDescriptor,
+  ) -> GPUBuffer {
+    // Validation of the usage needs to happen on the device timeline, so
+    // don't raise an error immediately if it isn't valid. wgpu will
+    // reject `BufferUsages::empty()`.
+    let usage = wgpu_types::BufferUsages::from_bits(descriptor.usage)
+      .unwrap_or(wgpu_types::BufferUsages::empty());
+
+    let wgpu_descriptor = wgpu_core::resource::BufferDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      size: descriptor.size,
+      usage,
+      mapped_at_creation: descriptor.mapped_at_creation,
+    };
+
+    let (id, err) =
+      self
+        .instance
+        .device_create_buffer(self.id, &wgpu_descriptor, None);
+
+    self.error_handler.push_error(err);
+
+    GPUBuffer {
+      instance: self.instance.clone(),
+      error_handler: self.error_handler.clone(),
+      id,
+      device: self.id,
+      label: descriptor.label,
+      size: descriptor.size,
+      usage: descriptor.usage,
+      map_state: RefCell::new(if descriptor.mapped_at_creation {
+        "mapped"
+      } else {
+        "unmapped"
+      }),
+      map_mode: RefCell::new(if descriptor.mapped_at_creation {
+        Some(wgpu_core::device::HostMap::Write)
+      } else {
+        None
+      }),
+      mapped_js_buffers: RefCell::new(vec![]),
     }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  }
 
-    #[getter]
-    #[global]
-    fn features(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
-        self.features.get(scope, |scope| {
-            let features = self.instance.device_features(self.id);
-            let features = features_to_feature_names(features);
-            GPUSupportedFeatures::new(scope, features)
-        })
-    }
+  #[required(1)]
+  #[cppgc]
+  fn create_texture(
+    &self,
+    #[webidl] descriptor: super::texture::GPUTextureDescriptor,
+  ) -> Result<GPUTexture, JsErrorBox> {
+    let wgpu_descriptor = wgpu_core::resource::TextureDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      size: descriptor.size.into(),
+      mip_level_count: descriptor.mip_level_count,
+      sample_count: descriptor.sample_count,
+      dimension: descriptor.dimension.clone().into(),
+      format: descriptor.format.clone().into(),
+      usage: wgpu_types::TextureUsages::from_bits(descriptor.usage)
+        .ok_or_else(|| JsErrorBox::type_error("usage is not valid"))?,
+      view_formats: descriptor
+        .view_formats
+        .into_iter()
+        .map(Into::into)
+        .collect(),
+    };
 
-    #[getter]
-    #[global]
-    fn limits(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
-        self.limits.get(scope, |_| {
-            let limits = self.instance.device_limits(self.id);
-            GPUSupportedLimits(limits)
-        })
-    }
+    let (id, err) =
+      self
+        .instance
+        .device_create_texture(self.id, &wgpu_descriptor, None);
 
-    #[getter]
-    #[global]
-    fn adapter_info(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
-        self.adapter_info.get(scope, |_| {
-            let info = self.instance.adapter_get_info(self.adapter);
-            let limits = self.instance.adapter_limits(self.adapter);
+    self.error_handler.push_error(err);
 
-            GPUAdapterInfo {
-                info,
-                subgroup_min_size: limits.min_subgroup_size,
-                subgroup_max_size: limits.max_subgroup_size,
-            }
-        })
-    }
+    Ok(GPUTexture {
+      instance: self.instance.clone(),
+      error_handler: self.error_handler.clone(),
+      id,
+      label: descriptor.label,
+      size: wgpu_descriptor.size,
+      mip_level_count: wgpu_descriptor.mip_level_count,
+      sample_count: wgpu_descriptor.sample_count,
+      dimension: descriptor.dimension,
+      format: descriptor.format,
+      usage: descriptor.usage,
+    })
+  }
 
-    #[getter]
-    #[global]
-    fn queue(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
-        self.queue_obj.get(scope, |_| GPUQueue {
-            id: self.queue,
-            device: self.id,
-            error_handler: self.error_handler.clone(),
-            instance: self.instance.clone(),
-            label: self.label.clone(),
-        })
-    }
+  #[cppgc]
+  fn create_sampler(
+    &self,
+    #[webidl] descriptor: super::sampler::GPUSamplerDescriptor,
+  ) -> Result<GPUSampler, JsErrorBox> {
+    let wgpu_descriptor = wgpu_core::resource::SamplerDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      address_modes: [
+        descriptor.address_mode_u.into(),
+        descriptor.address_mode_v.into(),
+        descriptor.address_mode_w.into(),
+      ],
+      mag_filter: descriptor.mag_filter.into(),
+      min_filter: descriptor.min_filter.into(),
+      mipmap_filter: descriptor.mipmap_filter.into(),
+      lod_min_clamp: descriptor.lod_min_clamp,
+      lod_max_clamp: descriptor.lod_max_clamp,
+      compare: descriptor.compare.map(Into::into),
+      anisotropy_clamp: descriptor.max_anisotropy,
+      border_color: None,
+    };
 
-    #[fast]
-    fn destroy(&self) {
-        self.instance.device_destroy(self.id);
-        self.error_handler
-            .push_error(Some(GPUError::Lost(GPUDeviceLostReason::Destroyed)));
-    }
+    let (id, err) =
+      self
+        .instance
+        .device_create_sampler(self.id, &wgpu_descriptor, None);
 
-    #[required(1)]
-    #[cppgc]
-    fn create_buffer(&self, #[webidl] descriptor: super::buffer::GPUBufferDescriptor) -> GPUBuffer {
-        // Validation of the usage needs to happen on the device timeline, so
-        // don't raise an error immediately if it isn't valid. wgpu will
-        // reject `BufferUsages::empty()`.
-        let usage = wgpu_types::BufferUsages::from_bits(descriptor.usage)
-            .unwrap_or(wgpu_types::BufferUsages::empty());
+    self.error_handler.push_error(err);
 
-        let wgpu_descriptor = wgpu_core::resource::BufferDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            size: descriptor.size,
-            usage,
-            mapped_at_creation: descriptor.mapped_at_creation,
-        };
+    Ok(GPUSampler {
+      instance: self.instance.clone(),
+      id,
+      label: descriptor.label,
+    })
+  }
 
-        let (id, err) = self
-            .instance
-            .device_create_buffer(self.id, &wgpu_descriptor, None);
+  #[required(1)]
+  #[cppgc]
+  fn create_bind_group_layout(
+    &self,
+    #[webidl]
+    descriptor: super::bind_group_layout::GPUBindGroupLayoutDescriptor,
+  ) -> Result<GPUBindGroupLayout, JsErrorBox> {
+    let mut entries = Vec::with_capacity(descriptor.entries.len());
 
-        self.error_handler.push_error(err);
+    for entry in descriptor.entries {
+      let n_entries = [
+        entry.buffer.is_some(),
+        entry.sampler.is_some(),
+        entry.texture.is_some(),
+        entry.storage_texture.is_some(),
+      ]
+      .into_iter()
+      .filter(|t| *t)
+      .count();
 
-        GPUBuffer {
-            instance: self.instance.clone(),
-            error_handler: self.error_handler.clone(),
-            id,
-            device: self.id,
-            label: descriptor.label,
-            size: descriptor.size,
-            usage: descriptor.usage,
-            map_state: RefCell::new(if descriptor.mapped_at_creation {
-                "mapped"
-            } else {
-                "unmapped"
-            }),
-            map_mode: RefCell::new(if descriptor.mapped_at_creation {
-                Some(wgpu_core::device::HostMap::Write)
-            } else {
-                None
-            }),
-            mapped_js_buffers: RefCell::new(vec![]),
+      if n_entries != 1 {
+        return Err(JsErrorBox::type_error(
+          "Only one of 'buffer', 'sampler', 'texture' and 'storageTexture' may be specified",
+        ));
+      }
+
+      let ty = if let Some(buffer) = entry.buffer {
+        BindingType::Buffer {
+          ty: buffer.r#type.into(),
+          has_dynamic_offset: buffer.has_dynamic_offset,
+          min_binding_size: NonZeroU64::new(buffer.min_binding_size),
         }
-    }
-
-    #[required(1)]
-    #[cppgc]
-    fn create_texture(
-        &self,
-        #[webidl] descriptor: super::texture::GPUTextureDescriptor,
-    ) -> Result<GPUTexture, JsErrorBox> {
-        let wgpu_descriptor = wgpu_core::resource::TextureDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            size: descriptor.size.into(),
-            mip_level_count: descriptor.mip_level_count,
-            sample_count: descriptor.sample_count,
-            dimension: descriptor.dimension.clone().into(),
-            format: descriptor.format.clone().into(),
-            usage: wgpu_types::TextureUsages::from_bits(descriptor.usage)
-                .ok_or_else(|| JsErrorBox::type_error("usage is not valid"))?,
-            view_formats: descriptor
-                .view_formats
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-        };
-
-        let (id, err) = self
-            .instance
-            .device_create_texture(self.id, &wgpu_descriptor, None);
-
-        self.error_handler.push_error(err);
-
-        Ok(GPUTexture {
-            instance: self.instance.clone(),
-            error_handler: self.error_handler.clone(),
-            id,
-            label: descriptor.label,
-            size: wgpu_descriptor.size,
-            mip_level_count: wgpu_descriptor.mip_level_count,
-            sample_count: wgpu_descriptor.sample_count,
-            dimension: descriptor.dimension,
-            format: descriptor.format,
-            usage: descriptor.usage,
-        })
-    }
-
-    #[cppgc]
-    fn create_sampler(
-        &self,
-        #[webidl] descriptor: super::sampler::GPUSamplerDescriptor,
-    ) -> Result<GPUSampler, JsErrorBox> {
-        let wgpu_descriptor = wgpu_core::resource::SamplerDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            address_modes: [
-                descriptor.address_mode_u.into(),
-                descriptor.address_mode_v.into(),
-                descriptor.address_mode_w.into(),
-            ],
-            mag_filter: descriptor.mag_filter.into(),
-            min_filter: descriptor.min_filter.into(),
-            mipmap_filter: descriptor.mipmap_filter.into(),
-            lod_min_clamp: descriptor.lod_min_clamp,
-            lod_max_clamp: descriptor.lod_max_clamp,
-            compare: descriptor.compare.map(Into::into),
-            anisotropy_clamp: descriptor.max_anisotropy,
-            border_color: None,
-        };
-
-        let (id, err) = self
-            .instance
-            .device_create_sampler(self.id, &wgpu_descriptor, None);
-
-        self.error_handler.push_error(err);
-
-        Ok(GPUSampler {
-            instance: self.instance.clone(),
-            id,
-            label: descriptor.label,
-        })
-    }
-
-    #[required(1)]
-    #[cppgc]
-    fn create_bind_group_layout(
-        &self,
-        #[webidl] descriptor: super::bind_group_layout::GPUBindGroupLayoutDescriptor,
-    ) -> Result<GPUBindGroupLayout, JsErrorBox> {
-        let mut entries = Vec::with_capacity(descriptor.entries.len());
-
-        for entry in descriptor.entries {
-            let n_entries = [
-                entry.buffer.is_some(),
-                entry.sampler.is_some(),
-                entry.texture.is_some(),
-                entry.storage_texture.is_some(),
-            ]
-            .into_iter()
-            .filter(|t| *t)
-            .count();
-
-            if n_entries != 1 {
-                return Err(JsErrorBox::type_error("Only one of 'buffer', 'sampler', 'texture' and 'storageTexture' may be specified"));
-            }
-
-            let ty = if let Some(buffer) = entry.buffer {
-                BindingType::Buffer {
-                    ty: buffer.r#type.into(),
-                    has_dynamic_offset: buffer.has_dynamic_offset,
-                    min_binding_size: NonZeroU64::new(buffer.min_binding_size),
-                }
-            } else if let Some(sampler) = entry.sampler {
-                BindingType::Sampler(sampler.r#type.into())
-            } else if let Some(texture) = entry.texture {
-                BindingType::Texture {
-                    sample_type: texture.sample_type.into(),
-                    view_dimension: texture.view_dimension.into(),
-                    multisampled: texture.multisampled,
-                }
-            } else if let Some(storage_texture) = entry.storage_texture {
-                BindingType::StorageTexture {
-                    access: storage_texture.access.into(),
-                    format: storage_texture.format.into(),
-                    view_dimension: storage_texture.view_dimension.into(),
-                }
-            } else {
-                unreachable!()
-            };
-
-            entries.push(wgpu_types::BindGroupLayoutEntry {
-                binding: entry.binding,
-                visibility: wgpu_types::ShaderStages::from_bits(entry.visibility)
-                    .ok_or_else(|| JsErrorBox::type_error("usage is not valid"))?,
-                ty,
-                count: None, // native-only
-            });
+      } else if let Some(sampler) = entry.sampler {
+        BindingType::Sampler(sampler.r#type.into())
+      } else if let Some(texture) = entry.texture {
+        BindingType::Texture {
+          sample_type: texture.sample_type.into(),
+          view_dimension: texture.view_dimension.into(),
+          multisampled: texture.multisampled,
         }
-
-        let wgpu_descriptor = wgpu_core::binding_model::BindGroupLayoutDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            entries: Cow::Owned(entries),
-        };
-
-        let (id, err) =
-            self.instance
-                .device_create_bind_group_layout(self.id, &wgpu_descriptor, None);
-
-        self.error_handler.push_error(err);
-
-        Ok(GPUBindGroupLayout {
-            instance: self.instance.clone(),
-            id,
-            label: descriptor.label,
-        })
-    }
-
-    #[required(1)]
-    #[cppgc]
-    fn create_pipeline_layout(
-        &self,
-        #[webidl] descriptor: super::pipeline_layout::GPUPipelineLayoutDescriptor,
-    ) -> GPUPipelineLayout {
-        let bind_group_layouts = descriptor
-            .bind_group_layouts
-            .into_iter()
-            .map(|bind_group_layout| bind_group_layout.id)
-            .collect();
-
-        let wgpu_descriptor = wgpu_core::binding_model::PipelineLayoutDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            bind_group_layouts: Cow::Owned(bind_group_layouts),
-            push_constant_ranges: Default::default(),
-        };
-
-        let (id, err) =
-            self.instance
-                .device_create_pipeline_layout(self.id, &wgpu_descriptor, None);
-
-        self.error_handler.push_error(err);
-
-        GPUPipelineLayout {
-            instance: self.instance.clone(),
-            id,
-            label: descriptor.label,
+      } else if let Some(storage_texture) = entry.storage_texture {
+        BindingType::StorageTexture {
+          access: storage_texture.access.into(),
+          format: storage_texture.format.into(),
+          view_dimension: storage_texture.view_dimension.into(),
         }
+      } else {
+        unreachable!()
+      };
+
+      entries.push(wgpu_types::BindGroupLayoutEntry {
+        binding: entry.binding,
+        visibility: wgpu_types::ShaderStages::from_bits(entry.visibility)
+          .ok_or_else(|| JsErrorBox::type_error("usage is not valid"))?,
+        ty,
+        count: None, // native-only
+      });
     }
 
-    #[required(1)]
-    #[cppgc]
-    fn create_bind_group(
-        &self,
-        #[webidl] descriptor: super::bind_group::GPUBindGroupDescriptor,
-    ) -> GPUBindGroup {
-        let entries = descriptor
-            .entries
-            .into_iter()
-            .map(|entry| wgpu_core::binding_model::BindGroupEntry {
-                binding: entry.binding,
-                resource: match entry.resource {
-                    GPUBindingResource::Sampler(sampler) => BindingResource::Sampler(sampler.id),
-                    GPUBindingResource::TextureView(texture_view) => {
-                        BindingResource::TextureView(texture_view.id)
-                    }
-                    GPUBindingResource::BufferBinding(buffer_binding) => {
-                        BindingResource::Buffer(wgpu_core::binding_model::BufferBinding {
-                            buffer: buffer_binding.buffer.id,
-                            offset: buffer_binding.offset,
-                            size: buffer_binding.size.and_then(NonZeroU64::new),
-                        })
-                    }
-                },
+    let wgpu_descriptor = wgpu_core::binding_model::BindGroupLayoutDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      entries: Cow::Owned(entries),
+    };
+
+    let (id, err) = self.instance.device_create_bind_group_layout(
+      self.id,
+      &wgpu_descriptor,
+      None,
+    );
+
+    self.error_handler.push_error(err);
+
+    Ok(GPUBindGroupLayout {
+      instance: self.instance.clone(),
+      id,
+      label: descriptor.label,
+    })
+  }
+
+  #[required(1)]
+  #[cppgc]
+  fn create_pipeline_layout(
+    &self,
+    #[webidl] descriptor: super::pipeline_layout::GPUPipelineLayoutDescriptor,
+  ) -> GPUPipelineLayout {
+    let bind_group_layouts = descriptor
+      .bind_group_layouts
+      .into_iter()
+      .map(|bind_group_layout| bind_group_layout.id)
+      .collect();
+
+    let wgpu_descriptor = wgpu_core::binding_model::PipelineLayoutDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      bind_group_layouts: Cow::Owned(bind_group_layouts),
+      push_constant_ranges: Default::default(),
+    };
+
+    let (id, err) = self.instance.device_create_pipeline_layout(
+      self.id,
+      &wgpu_descriptor,
+      None,
+    );
+
+    self.error_handler.push_error(err);
+
+    GPUPipelineLayout {
+      instance: self.instance.clone(),
+      id,
+      label: descriptor.label,
+    }
+  }
+
+  #[required(1)]
+  #[cppgc]
+  fn create_bind_group(
+    &self,
+    #[webidl] descriptor: super::bind_group::GPUBindGroupDescriptor,
+  ) -> GPUBindGroup {
+    let entries = descriptor
+      .entries
+      .into_iter()
+      .map(|entry| wgpu_core::binding_model::BindGroupEntry {
+        binding: entry.binding,
+        resource: match entry.resource {
+          GPUBindingResource::Sampler(sampler) => {
+            BindingResource::Sampler(sampler.id)
+          }
+          GPUBindingResource::TextureView(texture_view) => {
+            BindingResource::TextureView(texture_view.id)
+          }
+          GPUBindingResource::BufferBinding(buffer_binding) => {
+            BindingResource::Buffer(wgpu_core::binding_model::BufferBinding {
+              buffer: buffer_binding.buffer.id,
+              offset: buffer_binding.offset,
+              size: buffer_binding.size.and_then(NonZeroU64::new),
             })
-            .collect::<Vec<_>>();
+          }
+        },
+      })
+      .collect::<Vec<_>>();
 
-        let wgpu_descriptor = wgpu_core::binding_model::BindGroupDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            layout: descriptor.layout.id,
-            entries: Cow::Owned(entries),
-        };
+    let wgpu_descriptor = wgpu_core::binding_model::BindGroupDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      layout: descriptor.layout.id,
+      entries: Cow::Owned(entries),
+    };
 
-        let (id, err) = self
-            .instance
-            .device_create_bind_group(self.id, &wgpu_descriptor, None);
+    let (id, err) =
+      self
+        .instance
+        .device_create_bind_group(self.id, &wgpu_descriptor, None);
 
-        self.error_handler.push_error(err);
+    self.error_handler.push_error(err);
 
-        GPUBindGroup {
-            instance: self.instance.clone(),
-            id,
-            label: descriptor.label,
+    GPUBindGroup {
+      instance: self.instance.clone(),
+      id,
+      label: descriptor.label,
+    }
+  }
+
+  #[required(1)]
+  #[cppgc]
+  fn create_shader_module(
+    &self,
+    scope: &mut v8::HandleScope<'_>,
+    #[webidl] descriptor: super::shader::GPUShaderModuleDescriptor,
+  ) -> GPUShaderModule {
+    let wgpu_descriptor = wgpu_core::pipeline::ShaderModuleDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      runtime_checks: wgpu_types::ShaderRuntimeChecks::default(),
+    };
+
+    let (id, err) = self.instance.device_create_shader_module(
+      self.id,
+      &wgpu_descriptor,
+      wgpu_core::pipeline::ShaderModuleSource::Wgsl(Cow::Borrowed(
+        &descriptor.code,
+      )),
+      None,
+    );
+
+    let compilation_info =
+      GPUCompilationInfo::new(scope, err.iter(), &descriptor.code);
+    let compilation_info = make_cppgc_object(scope, compilation_info);
+    let compilation_info = v8::Global::new(scope, compilation_info);
+    self.error_handler.push_error(err);
+
+    GPUShaderModule {
+      instance: self.instance.clone(),
+      id,
+      label: descriptor.label,
+      compilation_info,
+    }
+  }
+
+  #[required(1)]
+  #[cppgc]
+  fn create_compute_pipeline(
+    &self,
+    #[webidl] descriptor: super::compute_pipeline::GPUComputePipelineDescriptor,
+  ) -> GPUComputePipeline {
+    self.new_compute_pipeline(descriptor)
+  }
+
+  #[required(1)]
+  #[cppgc]
+  fn create_render_pipeline(
+    &self,
+    #[webidl] descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
+  ) -> Result<GPURenderPipeline, JsErrorBox> {
+    self.new_render_pipeline(descriptor)
+  }
+
+  #[async_method]
+  #[required(1)]
+  #[cppgc]
+  async fn create_compute_pipeline_async(
+    &self,
+    #[webidl] descriptor: super::compute_pipeline::GPUComputePipelineDescriptor,
+  ) -> GPUComputePipeline {
+    self.new_compute_pipeline(descriptor)
+  }
+
+  #[async_method]
+  #[required(1)]
+  #[cppgc]
+  async fn create_render_pipeline_async(
+    &self,
+    #[webidl] descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
+  ) -> Result<GPURenderPipeline, JsErrorBox> {
+    self.new_render_pipeline(descriptor)
+  }
+
+  #[cppgc]
+  fn create_command_encoder(
+    &self,
+    #[webidl] descriptor: Option<
+      super::command_encoder::GPUCommandEncoderDescriptor,
+    >,
+  ) -> GPUCommandEncoder {
+    let label = descriptor.map(|d| d.label).unwrap_or_default();
+    let wgpu_descriptor = wgpu_types::CommandEncoderDescriptor {
+      label: Some(Cow::Owned(label.clone())),
+    };
+
+    let (id, err) = self.instance.device_create_command_encoder(
+      self.id,
+      &wgpu_descriptor,
+      None,
+    );
+
+    self.error_handler.push_error(err);
+
+    GPUCommandEncoder {
+      instance: self.instance.clone(),
+      error_handler: self.error_handler.clone(),
+      id,
+      label,
+    }
+  }
+
+  #[required(1)]
+  #[cppgc]
+  fn create_render_bundle_encoder(
+    &self,
+    #[webidl]
+    descriptor: super::render_bundle::GPURenderBundleEncoderDescriptor,
+  ) -> GPURenderBundleEncoder {
+    let wgpu_descriptor = wgpu_core::command::RenderBundleEncoderDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      color_formats: Cow::Owned(
+        descriptor
+          .color_formats
+          .into_iter()
+          .map(|format| format.into_option().map(Into::into))
+          .collect::<Vec<_>>(),
+      ),
+      depth_stencil: descriptor.depth_stencil_format.map(|format| {
+        wgpu_types::RenderBundleDepthStencil {
+          format: format.into(),
+          depth_read_only: descriptor.depth_read_only,
+          stencil_read_only: descriptor.stencil_read_only,
         }
+      }),
+      sample_count: descriptor.sample_count,
+      multiview: None,
+    };
+
+    let res = wgpu_core::command::RenderBundleEncoder::new(
+      &wgpu_descriptor,
+      self.id,
+      None,
+    );
+    let (encoder, err) = match res {
+      Ok(encoder) => (encoder, None),
+      Err(e) => (
+        wgpu_core::command::RenderBundleEncoder::dummy(self.id),
+        Some(e),
+      ),
+    };
+
+    self.error_handler.push_error(err);
+
+    GPURenderBundleEncoder {
+      instance: self.instance.clone(),
+      error_handler: self.error_handler.clone(),
+      encoder: RefCell::new(Some(encoder)),
+      label: descriptor.label,
+    }
+  }
+
+  #[required(1)]
+  #[cppgc]
+  fn create_query_set(
+    &self,
+    #[webidl] descriptor: crate::query_set::GPUQuerySetDescriptor,
+  ) -> GPUQuerySet {
+    let wgpu_descriptor = wgpu_core::resource::QuerySetDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      ty: descriptor.r#type.clone().into(),
+      count: descriptor.count,
+    };
+
+    let (id, err) =
+      self
+        .instance
+        .device_create_query_set(self.id, &wgpu_descriptor, None);
+
+    self.error_handler.push_error(err);
+
+    GPUQuerySet {
+      instance: self.instance.clone(),
+      id,
+      r#type: descriptor.r#type,
+      count: descriptor.count,
+      label: descriptor.label,
+    }
+  }
+
+  #[getter]
+  #[global]
+  fn lost(&self) -> v8::Global<v8::Promise> {
+    self.lost_promise.clone()
+  }
+
+  #[required(1)]
+  fn push_error_scope(&self, #[webidl] filter: super::error::GPUErrorFilter) {
+    self
+      .error_handler
+      .scopes
+      .lock()
+      .unwrap()
+      .push((filter, vec![]));
+  }
+
+  #[async_method(fake)]
+  #[global]
+  fn pop_error_scope(
+    &self,
+    scope: &mut v8::HandleScope,
+  ) -> Result<v8::Global<v8::Value>, JsErrorBox> {
+    if self.error_handler.is_lost.get().is_some() {
+      let val = v8::null(scope).cast::<v8::Value>();
+      return Ok(v8::Global::new(scope, val));
     }
 
-    #[required(1)]
-    #[cppgc]
-    fn create_shader_module(
-        &self,
-        scope: &mut v8::HandleScope<'_>,
-        #[webidl] descriptor: super::shader::GPUShaderModuleDescriptor,
-    ) -> GPUShaderModule {
-        let wgpu_descriptor = wgpu_core::pipeline::ShaderModuleDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            runtime_checks: wgpu_types::ShaderRuntimeChecks::default(),
-        };
+    let Some((_, errors)) = self.error_handler.scopes.lock().unwrap().pop()
+    else {
+      return Err(JsErrorBox::new(
+        "DOMExceptionOperationError",
+        "There are no error scopes on the error scope stack",
+      ));
+    };
 
-        let (id, err) = self.instance.device_create_shader_module(
-            self.id,
-            &wgpu_descriptor,
-            wgpu_core::pipeline::ShaderModuleSource::Wgsl(Cow::Borrowed(&descriptor.code)),
-            None,
-        );
+    let val = if let Some(err) = errors.into_iter().next() {
+      deno_core::error::to_v8_error(scope, &err)
+    } else {
+      v8::null(scope).into()
+    };
 
-        let compilation_info = GPUCompilationInfo::new(scope, err.iter(), &descriptor.code);
-        let compilation_info = make_cppgc_object(scope, compilation_info);
-        let compilation_info = v8::Global::new(scope, compilation_info);
-        self.error_handler.push_error(err);
+    Ok(v8::Global::new(scope, val))
+  }
 
-        GPUShaderModule {
-            instance: self.instance.clone(),
-            id,
-            label: descriptor.label,
-            compilation_info,
-        }
-    }
-
-    #[required(1)]
-    #[cppgc]
-    fn create_compute_pipeline(
-        &self,
-        #[webidl] descriptor: super::compute_pipeline::GPUComputePipelineDescriptor,
-    ) -> GPUComputePipeline {
-        self.new_compute_pipeline(descriptor)
-    }
-
-    #[required(1)]
-    #[cppgc]
-    fn create_render_pipeline(
-        &self,
-        #[webidl] descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
-    ) -> Result<GPURenderPipeline, JsErrorBox> {
-        self.new_render_pipeline(descriptor)
-    }
-
-    #[async_method]
-    #[required(1)]
-    #[cppgc]
-    async fn create_compute_pipeline_async(
-        &self,
-        #[webidl] descriptor: super::compute_pipeline::GPUComputePipelineDescriptor,
-    ) -> GPUComputePipeline {
-        self.new_compute_pipeline(descriptor)
-    }
-
-    #[async_method]
-    #[required(1)]
-    #[cppgc]
-    async fn create_render_pipeline_async(
-        &self,
-        #[webidl] descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
-    ) -> Result<GPURenderPipeline, JsErrorBox> {
-        self.new_render_pipeline(descriptor)
-    }
-
-    #[cppgc]
-    fn create_command_encoder(
-        &self,
-        #[webidl] descriptor: Option<super::command_encoder::GPUCommandEncoderDescriptor>,
-    ) -> GPUCommandEncoder {
-        let label = descriptor.map(|d| d.label).unwrap_or_default();
-        let wgpu_descriptor = wgpu_types::CommandEncoderDescriptor {
-            label: Some(Cow::Owned(label.clone())),
-        };
-
-        let (id, err) =
-            self.instance
-                .device_create_command_encoder(self.id, &wgpu_descriptor, None);
-
-        self.error_handler.push_error(err);
-
-        GPUCommandEncoder {
-            instance: self.instance.clone(),
-            error_handler: self.error_handler.clone(),
-            id,
-            label,
-        }
-    }
-
-    #[required(1)]
-    #[cppgc]
-    fn create_render_bundle_encoder(
-        &self,
-        #[webidl] descriptor: super::render_bundle::GPURenderBundleEncoderDescriptor,
-    ) -> GPURenderBundleEncoder {
-        let wgpu_descriptor = wgpu_core::command::RenderBundleEncoderDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            color_formats: Cow::Owned(
-                descriptor
-                    .color_formats
-                    .into_iter()
-                    .map(|format| format.into_option().map(Into::into))
-                    .collect::<Vec<_>>(),
-            ),
-            depth_stencil: descriptor.depth_stencil_format.map(|format| {
-                wgpu_types::RenderBundleDepthStencil {
-                    format: format.into(),
-                    depth_read_only: descriptor.depth_read_only,
-                    stencil_read_only: descriptor.stencil_read_only,
-                }
-            }),
-            sample_count: descriptor.sample_count,
-            multiview: None,
-        };
-
-        let res = wgpu_core::command::RenderBundleEncoder::new(&wgpu_descriptor, self.id, None);
-        let (encoder, err) = match res {
-            Ok(encoder) => (encoder, None),
-            Err(e) => (
-                wgpu_core::command::RenderBundleEncoder::dummy(self.id),
-                Some(e),
-            ),
-        };
-
-        self.error_handler.push_error(err);
-
-        GPURenderBundleEncoder {
-            instance: self.instance.clone(),
-            error_handler: self.error_handler.clone(),
-            encoder: RefCell::new(Some(encoder)),
-            label: descriptor.label,
-        }
-    }
-
-    #[required(1)]
-    #[cppgc]
-    fn create_query_set(
-        &self,
-        #[webidl] descriptor: crate::query_set::GPUQuerySetDescriptor,
-    ) -> GPUQuerySet {
-        let wgpu_descriptor = wgpu_core::resource::QuerySetDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            ty: descriptor.r#type.clone().into(),
-            count: descriptor.count,
-        };
-
-        let (id, err) = self
-            .instance
-            .device_create_query_set(self.id, &wgpu_descriptor, None);
-
-        self.error_handler.push_error(err);
-
-        GPUQuerySet {
-            instance: self.instance.clone(),
-            id,
-            r#type: descriptor.r#type,
-            count: descriptor.count,
-            label: descriptor.label,
-        }
-    }
-
-    #[getter]
-    #[global]
-    fn lost(&self) -> v8::Global<v8::Promise> {
-        self.lost_promise.clone()
-    }
-
-    #[required(1)]
-    fn push_error_scope(&self, #[webidl] filter: super::error::GPUErrorFilter) {
-        self.error_handler
-            .scopes
-            .lock()
-            .unwrap()
-            .push((filter, vec![]));
-    }
-
-    #[async_method(fake)]
-    #[global]
-    fn pop_error_scope(
-        &self,
-        scope: &mut v8::HandleScope,
-    ) -> Result<v8::Global<v8::Value>, JsErrorBox> {
-        if self.error_handler.is_lost.get().is_some() {
-            let val = v8::null(scope).cast::<v8::Value>();
-            return Ok(v8::Global::new(scope, val));
-        }
-
-        let Some((_, errors)) = self.error_handler.scopes.lock().unwrap().pop() else {
-            return Err(JsErrorBox::new(
-                "DOMExceptionOperationError",
-                "There are no error scopes on the error scope stack",
-            ));
-        };
-
-        let val = if let Some(err) = errors.into_iter().next() {
-            deno_core::error::to_v8_error(scope, &err)
-        } else {
-            v8::null(scope).into()
-        };
-
-        Ok(v8::Global::new(scope, val))
-    }
-
-    #[fast]
-    fn start_capture(&self) {
-        unsafe {
-            self.instance
-                .device_start_graphics_debugger_capture(self.id)
-        };
-    }
-    #[fast]
-    fn stop_capture(&self) {
-        self.instance
-            .device_poll(self.id, wgpu_types::PollType::wait())
-            .unwrap();
-        unsafe { self.instance.device_stop_graphics_debugger_capture(self.id) };
-    }
+  #[fast]
+  fn start_capture(&self) {
+    unsafe {
+      self
+        .instance
+        .device_start_graphics_debugger_capture(self.id)
+    };
+  }
+  #[fast]
+  fn stop_capture(&self) {
+    self
+      .instance
+      .device_poll(self.id, wgpu_types::PollType::wait())
+      .unwrap();
+    unsafe { self.instance.device_stop_graphics_debugger_capture(self.id) };
+  }
 }
 
 impl GPUDevice {
-    fn new_compute_pipeline(
-        &self,
-        descriptor: super::compute_pipeline::GPUComputePipelineDescriptor,
-    ) -> GPUComputePipeline {
-        let wgpu_descriptor = wgpu_core::pipeline::ComputePipelineDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            layout: descriptor.layout.into(),
-            stage: ProgrammableStageDescriptor {
-                module: descriptor.compute.module.id,
-                entry_point: descriptor.compute.entry_point.map(Into::into),
-                constants: descriptor.compute.constants.into_iter().collect(),
-                zero_initialize_workgroup_memory: true,
-            },
-            cache: None,
-        };
+  fn new_compute_pipeline(
+    &self,
+    descriptor: super::compute_pipeline::GPUComputePipelineDescriptor,
+  ) -> GPUComputePipeline {
+    let wgpu_descriptor = wgpu_core::pipeline::ComputePipelineDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      layout: descriptor.layout.into(),
+      stage: ProgrammableStageDescriptor {
+        module: descriptor.compute.module.id,
+        entry_point: descriptor.compute.entry_point.map(Into::into),
+        constants: descriptor.compute.constants.into_iter().collect(),
+        zero_initialize_workgroup_memory: true,
+      },
+      cache: None,
+    };
 
-        let (id, err) =
-            self.instance
-                .device_create_compute_pipeline(self.id, &wgpu_descriptor, None);
+    let (id, err) = self.instance.device_create_compute_pipeline(
+      self.id,
+      &wgpu_descriptor,
+      None,
+    );
 
-        self.error_handler.push_error(err);
+    self.error_handler.push_error(err);
 
-        GPUComputePipeline {
-            instance: self.instance.clone(),
-            error_handler: self.error_handler.clone(),
-            id,
-            label: descriptor.label.clone(),
-        }
+    GPUComputePipeline {
+      instance: self.instance.clone(),
+      error_handler: self.error_handler.clone(),
+      id,
+      label: descriptor.label.clone(),
     }
+  }
 
-    fn new_render_pipeline(
-        &self,
-        descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
-    ) -> Result<GPURenderPipeline, JsErrorBox> {
-        let vertex = wgpu_core::pipeline::VertexState {
-            stage: ProgrammableStageDescriptor {
-                module: descriptor.vertex.module.id,
-                entry_point: descriptor.vertex.entry_point.map(Into::into),
-                constants: descriptor.vertex.constants.into_iter().collect(),
-                zero_initialize_workgroup_memory: true,
-            },
-            buffers: Cow::Owned(
-                descriptor
-                    .vertex
-                    .buffers
+  fn new_render_pipeline(
+    &self,
+    descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
+  ) -> Result<GPURenderPipeline, JsErrorBox> {
+    let vertex = wgpu_core::pipeline::VertexState {
+      stage: ProgrammableStageDescriptor {
+        module: descriptor.vertex.module.id,
+        entry_point: descriptor.vertex.entry_point.map(Into::into),
+        constants: descriptor.vertex.constants.into_iter().collect(),
+        zero_initialize_workgroup_memory: true,
+      },
+      buffers: Cow::Owned(
+        descriptor
+          .vertex
+          .buffers
+          .into_iter()
+          .map(|b| {
+            b.into_option().map_or_else(
+              wgpu_core::pipeline::VertexBufferLayout::default,
+              |layout| wgpu_core::pipeline::VertexBufferLayout {
+                array_stride: layout.array_stride,
+                step_mode: layout.step_mode.into(),
+                attributes: Cow::Owned(
+                  layout
+                    .attributes
                     .into_iter()
-                    .map(|b| {
-                        b.into_option().map_or_else(
-                            wgpu_core::pipeline::VertexBufferLayout::default,
-                            |layout| wgpu_core::pipeline::VertexBufferLayout {
-                                array_stride: layout.array_stride,
-                                step_mode: layout.step_mode.into(),
-                                attributes: Cow::Owned(
-                                    layout
-                                        .attributes
-                                        .into_iter()
-                                        .map(|attr| wgpu_types::VertexAttribute {
-                                            format: attr.format.into(),
-                                            offset: attr.offset,
-                                            shader_location: attr.shader_location,
-                                        })
-                                        .collect(),
-                                ),
-                            },
-                        )
+                    .map(|attr| wgpu_types::VertexAttribute {
+                      format: attr.format.into(),
+                      offset: attr.offset,
+                      shader_location: attr.shader_location,
                     })
                     .collect(),
-            ),
-        };
+                ),
+              },
+            )
+          })
+          .collect(),
+      ),
+    };
 
-        let primitive = wgpu_types::PrimitiveState {
-            topology: descriptor.primitive.topology.into(),
-            strip_index_format: descriptor.primitive.strip_index_format.map(Into::into),
-            front_face: descriptor.primitive.front_face.into(),
-            cull_mode: descriptor.primitive.cull_mode.into(),
-            unclipped_depth: descriptor.primitive.unclipped_depth,
-            polygon_mode: Default::default(),
-            conservative: false,
-        };
+    let primitive = wgpu_types::PrimitiveState {
+      topology: descriptor.primitive.topology.into(),
+      strip_index_format: descriptor
+        .primitive
+        .strip_index_format
+        .map(Into::into),
+      front_face: descriptor.primitive.front_face.into(),
+      cull_mode: descriptor.primitive.cull_mode.into(),
+      unclipped_depth: descriptor.primitive.unclipped_depth,
+      polygon_mode: Default::default(),
+      conservative: false,
+    };
 
-        let depth_stencil = descriptor.depth_stencil.map(|depth_stencil| {
-            let front = wgpu_types::StencilFaceState {
-                compare: depth_stencil.stencil_front.compare.into(),
-                fail_op: depth_stencil.stencil_front.fail_op.into(),
-                depth_fail_op: depth_stencil.stencil_front.depth_fail_op.into(),
-                pass_op: depth_stencil.stencil_front.pass_op.into(),
-            };
-            let back = wgpu_types::StencilFaceState {
-                compare: depth_stencil.stencil_back.compare.into(),
-                fail_op: depth_stencil.stencil_back.fail_op.into(),
-                depth_fail_op: depth_stencil.stencil_back.depth_fail_op.into(),
-                pass_op: depth_stencil.stencil_back.pass_op.into(),
-            };
+    let depth_stencil = descriptor.depth_stencil.map(|depth_stencil| {
+      let front = wgpu_types::StencilFaceState {
+        compare: depth_stencil.stencil_front.compare.into(),
+        fail_op: depth_stencil.stencil_front.fail_op.into(),
+        depth_fail_op: depth_stencil.stencil_front.depth_fail_op.into(),
+        pass_op: depth_stencil.stencil_front.pass_op.into(),
+      };
+      let back = wgpu_types::StencilFaceState {
+        compare: depth_stencil.stencil_back.compare.into(),
+        fail_op: depth_stencil.stencil_back.fail_op.into(),
+        depth_fail_op: depth_stencil.stencil_back.depth_fail_op.into(),
+        pass_op: depth_stencil.stencil_back.pass_op.into(),
+      };
 
-            wgpu_types::DepthStencilState {
-                format: depth_stencil.format.into(),
-                depth_write_enabled: depth_stencil.depth_write_enabled.unwrap_or_default(),
-                depth_compare: depth_stencil
-                    .depth_compare
-                    .map(Into::into)
-                    .unwrap_or(wgpu_types::CompareFunction::Never), // TODO(wgpu): should be optional here
-                stencil: wgpu_types::StencilState {
-                    front,
-                    back,
-                    read_mask: depth_stencil.stencil_read_mask,
-                    write_mask: depth_stencil.stencil_write_mask,
-                },
-                bias: wgpu_types::DepthBiasState {
-                    constant: depth_stencil.depth_bias,
-                    slope_scale: depth_stencil.depth_bias_slope_scale,
-                    clamp: depth_stencil.depth_bias_clamp,
-                },
-            }
-        });
+      wgpu_types::DepthStencilState {
+        format: depth_stencil.format.into(),
+        depth_write_enabled: depth_stencil
+          .depth_write_enabled
+          .unwrap_or_default(),
+        depth_compare: depth_stencil
+          .depth_compare
+          .map(Into::into)
+          .unwrap_or(wgpu_types::CompareFunction::Never), // TODO(wgpu): should be optional here
+        stencil: wgpu_types::StencilState {
+          front,
+          back,
+          read_mask: depth_stencil.stencil_read_mask,
+          write_mask: depth_stencil.stencil_write_mask,
+        },
+        bias: wgpu_types::DepthBiasState {
+          constant: depth_stencil.depth_bias,
+          slope_scale: depth_stencil.depth_bias_slope_scale,
+          clamp: depth_stencil.depth_bias_clamp,
+        },
+      }
+    });
 
-        let multisample = wgpu_types::MultisampleState {
-            count: descriptor.multisample.count,
-            mask: descriptor.multisample.mask as u64,
-            alpha_to_coverage_enabled: descriptor.multisample.alpha_to_coverage_enabled,
-        };
+    let multisample = wgpu_types::MultisampleState {
+      count: descriptor.multisample.count,
+      mask: descriptor.multisample.mask as u64,
+      alpha_to_coverage_enabled: descriptor
+        .multisample
+        .alpha_to_coverage_enabled,
+    };
 
-        let fragment = descriptor
-            .fragment
-            .map(|fragment| {
-                Ok::<_, JsErrorBox>(wgpu_core::pipeline::FragmentState {
-                    stage: ProgrammableStageDescriptor {
-                        module: fragment.module.id,
-                        entry_point: fragment.entry_point.map(Into::into),
-                        constants: fragment.constants.into_iter().collect(),
-                        zero_initialize_workgroup_memory: true,
-                    },
-                    targets: Cow::Owned(
-                        fragment
-                            .targets
-                            .into_iter()
-                            .map(|target| {
-                                target
-                                    .into_option()
-                                    .map(|target| {
-                                        Ok(wgpu_types::ColorTargetState {
-                                            format: target.format.into(),
-                                            blend: target.blend.map(|blend| {
-                                                wgpu_types::BlendState {
-                                                    color: wgpu_types::BlendComponent {
-                                                        src_factor: blend.color.src_factor.into(),
-                                                        dst_factor: blend.color.dst_factor.into(),
-                                                        operation: blend.color.operation.into(),
-                                                    },
-                                                    alpha: wgpu_types::BlendComponent {
-                                                        src_factor: blend.alpha.src_factor.into(),
-                                                        dst_factor: blend.alpha.dst_factor.into(),
-                                                        operation: blend.alpha.operation.into(),
-                                                    },
-                                                }
-                                            }),
-                                            write_mask: wgpu_types::ColorWrites::from_bits(
-                                                target.write_mask,
-                                            )
-                                            .ok_or_else(|| {
-                                                JsErrorBox::type_error("usage is not valid")
-                                            })?,
-                                        })
-                                    })
-                                    .transpose()
-                            })
-                            .collect::<Result<_, JsErrorBox>>()?,
-                    ),
-                })
-            })
-            .transpose()?;
-
-        let wgpu_descriptor = wgpu_core::pipeline::RenderPipelineDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            layout: descriptor.layout.into(),
-            vertex,
-            primitive,
-            depth_stencil,
-            multisample,
-            fragment,
-            cache: None,
-            multiview: None,
-        };
-
-        let (id, err) =
-            self.instance
-                .device_create_render_pipeline(self.id, &wgpu_descriptor, None);
-
-        self.error_handler.push_error(err);
-
-        Ok(GPURenderPipeline {
-            instance: self.instance.clone(),
-            error_handler: self.error_handler.clone(),
-            id,
-            label: descriptor.label,
+    let fragment = descriptor
+      .fragment
+      .map(|fragment| {
+        Ok::<_, JsErrorBox>(wgpu_core::pipeline::FragmentState {
+          stage: ProgrammableStageDescriptor {
+            module: fragment.module.id,
+            entry_point: fragment.entry_point.map(Into::into),
+            constants: fragment.constants.into_iter().collect(),
+            zero_initialize_workgroup_memory: true,
+          },
+          targets: Cow::Owned(
+            fragment
+              .targets
+              .into_iter()
+              .map(|target| {
+                target
+                  .into_option()
+                  .map(|target| {
+                    Ok(wgpu_types::ColorTargetState {
+                      format: target.format.into(),
+                      blend: target.blend.map(|blend| wgpu_types::BlendState {
+                        color: wgpu_types::BlendComponent {
+                          src_factor: blend.color.src_factor.into(),
+                          dst_factor: blend.color.dst_factor.into(),
+                          operation: blend.color.operation.into(),
+                        },
+                        alpha: wgpu_types::BlendComponent {
+                          src_factor: blend.alpha.src_factor.into(),
+                          dst_factor: blend.alpha.dst_factor.into(),
+                          operation: blend.alpha.operation.into(),
+                        },
+                      }),
+                      write_mask: wgpu_types::ColorWrites::from_bits(
+                        target.write_mask,
+                      )
+                      .ok_or_else(|| {
+                        JsErrorBox::type_error("usage is not valid")
+                      })?,
+                    })
+                  })
+                  .transpose()
+              })
+              .collect::<Result<_, JsErrorBox>>()?,
+          ),
         })
-    }
+      })
+      .transpose()?;
+
+    let wgpu_descriptor = wgpu_core::pipeline::RenderPipelineDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      layout: descriptor.layout.into(),
+      vertex,
+      primitive,
+      depth_stencil,
+      multisample,
+      fragment,
+      cache: None,
+      multiview: None,
+    };
+
+    let (id, err) = self.instance.device_create_render_pipeline(
+      self.id,
+      &wgpu_descriptor,
+      None,
+    );
+
+    self.error_handler.push_error(err);
+
+    Ok(GPURenderPipeline {
+      instance: self.instance.clone(),
+      error_handler: self.error_handler.clone(),
+      id,
+      label: descriptor.label,
+    })
+  }
 }
 
 #[derive(Clone, Debug, Default, Hash, Eq, PartialEq)]
 pub enum GPUDeviceLostReason {
-    #[default]
-    Unknown,
-    Destroyed,
+  #[default]
+  Unknown,
+  Destroyed,
 }
 
 impl From<wgpu_types::DeviceLostReason> for GPUDeviceLostReason {
-    fn from(value: wgpu_types::DeviceLostReason) -> Self {
-        match value {
-            wgpu_types::DeviceLostReason::Unknown => Self::Unknown,
-            wgpu_types::DeviceLostReason::Destroyed => Self::Destroyed,
-        }
+  fn from(value: wgpu_types::DeviceLostReason) -> Self {
+    match value {
+      wgpu_types::DeviceLostReason::Unknown => Self::Unknown,
+      wgpu_types::DeviceLostReason::Destroyed => Self::Destroyed,
     }
+  }
 }
 
 #[derive(Default)]
 pub struct GPUDeviceLostInfo {
-    pub reason: GPUDeviceLostReason,
+  pub reason: GPUDeviceLostReason,
 }
 
 impl GarbageCollected for GPUDeviceLostInfo {}
 
 #[op2]
 impl GPUDeviceLostInfo {
-    #[getter]
-    #[string]
-    fn reason(&self) -> &'static str {
-        use GPUDeviceLostReason::*;
-        match self.reason {
-            Unknown => "unknown",
-            Destroyed => "destroyed",
-        }
+  #[getter]
+  #[string]
+  fn reason(&self) -> &'static str {
+    use GPUDeviceLostReason::*;
+    match self.reason {
+      Unknown => "unknown",
+      Destroyed => "destroyed",
     }
+  }
 
-    #[getter]
-    #[string]
-    fn message(&self) -> &'static str {
-        "device was lost"
-    }
+  #[getter]
+  #[string]
+  fn message(&self) -> &'static str {
+    "device was lost"
+  }
 }

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -30,7 +30,7 @@ use crate::adapter::GPUAdapterInfo;
 use crate::adapter::GPUSupportedFeatures;
 use crate::adapter::GPUSupportedLimits;
 use crate::command_encoder::GPUCommandEncoder;
-use crate::error::GPUError;
+use crate::error::{GPUError, GPUGenericError};
 use crate::query_set::GPUQuerySet;
 use crate::render_bundle::GPURenderBundleEncoder;
 use crate::render_pipeline::GPURenderPipeline;
@@ -75,6 +75,12 @@ impl GarbageCollected for GPUDevice {
 // EventTarget is extended in JS
 #[op2]
 impl GPUDevice {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUDevice, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {
@@ -909,6 +915,12 @@ impl GarbageCollected for GPUDeviceLostInfo {
 
 #[op2]
 impl GPUDeviceLostInfo {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUDeviceLostInfo, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn reason(&self) -> &'static str {

--- a/deno_webgpu/error.rs
+++ b/deno_webgpu/error.rs
@@ -372,3 +372,10 @@ impl From<ConfigureSurfaceError> for GPUError {
     GPUError::from_webgpu(err)
   }
 }
+
+#[derive(Debug, thiserror::Error, deno_error::JsError)]
+pub enum GPUGenericError {
+  #[class(type)]
+  #[error("Illegal constructor")]
+  InvalidConstructor,
+}

--- a/deno_webgpu/error.rs
+++ b/deno_webgpu/error.rs
@@ -44,324 +44,331 @@ use crate::device::GPUDeviceLostReason;
 pub type ErrorHandler = std::rc::Rc<DeviceErrorHandler>;
 
 pub struct DeviceErrorHandler {
-    pub is_lost: OnceLock<()>,
-    pub scopes: Mutex<Vec<(GPUErrorFilter, Vec<GPUError>)>>,
-    lost_resolver: Mutex<Option<v8::Global<v8::PromiseResolver>>>,
-    spawner: V8TaskSpawner,
+  pub is_lost: OnceLock<()>,
+  pub scopes: Mutex<Vec<(GPUErrorFilter, Vec<GPUError>)>>,
+  lost_resolver: Mutex<Option<v8::Global<v8::PromiseResolver>>>,
+  spawner: V8TaskSpawner,
 
-    // The error handler is constructed before the device. A weak
-    // reference to the device is placed here with `set_device`
-    // after the device is constructed.
-    device: OnceLock<v8::Weak<v8::Object>>,
+  // The error handler is constructed before the device. A weak
+  // reference to the device is placed here with `set_device`
+  // after the device is constructed.
+  device: OnceLock<v8::Weak<v8::Object>>,
 }
 
 impl DeviceErrorHandler {
-    pub fn new(lost_resolver: v8::Global<v8::PromiseResolver>, spawner: V8TaskSpawner) -> Self {
-        Self {
-            is_lost: Default::default(),
-            scopes: Mutex::new(vec![]),
-            lost_resolver: Mutex::new(Some(lost_resolver)),
-            device: OnceLock::new(),
-            spawner,
-        }
+  pub fn new(
+    lost_resolver: v8::Global<v8::PromiseResolver>,
+    spawner: V8TaskSpawner,
+  ) -> Self {
+    Self {
+      is_lost: Default::default(),
+      scopes: Mutex::new(vec![]),
+      lost_resolver: Mutex::new(Some(lost_resolver)),
+      device: OnceLock::new(),
+      spawner,
+    }
+  }
+
+  pub fn set_device(&self, device: v8::Weak<v8::Object>) {
+    self.device.set(device).unwrap()
+  }
+
+  pub fn push_error<E: Into<GPUError>>(&self, err: Option<E>) {
+    let Some(err) = err else {
+      return;
+    };
+
+    if self.is_lost.get().is_some() {
+      return;
     }
 
-    pub fn set_device(&self, device: v8::Weak<v8::Object>) {
-        self.device.set(device).unwrap()
+    let err = err.into();
+
+    if let GPUError::Lost(reason) = err {
+      let _ = self.is_lost.set(());
+      if let Some(resolver) = self.lost_resolver.lock().unwrap().take() {
+        self.spawner.spawn(move |scope| {
+          let resolver = v8::Local::new(scope, resolver);
+          let info = make_cppgc_object(scope, GPUDeviceLostInfo { reason });
+          let info = v8::Local::new(scope, info);
+          resolver.resolve(scope, info.into());
+        });
+      }
+
+      return;
     }
 
-    pub fn push_error<E: Into<GPUError>>(&self, err: Option<E>) {
-        let Some(err) = err else {
-            return;
+    let error_filter = match err {
+      GPUError::Lost(_) => unreachable!(),
+      GPUError::Validation(_) => GPUErrorFilter::Validation,
+      GPUError::OutOfMemory => GPUErrorFilter::OutOfMemory,
+      GPUError::Internal => GPUErrorFilter::Internal,
+    };
+
+    let mut scopes = self.scopes.lock().unwrap();
+    let scope = scopes
+      .iter_mut()
+      .rfind(|(filter, _)| filter == &error_filter);
+
+    if let Some(scope) = scope {
+      scope.1.push(err);
+    } else {
+      let device = self
+        .device
+        .get()
+        .expect("set_device was not called")
+        .clone();
+      self.spawner.spawn(move |scope| {
+        let state = JsRuntime::op_state_from(&*scope);
+        let Some(device) = device.to_local(scope) else {
+          // The device has already gone away, so we don't have
+          // anywhere to report the error.
+          return;
         };
+        let key = v8::String::new(scope, "dispatchEvent").unwrap();
+        let val = device.get(scope, key.into()).unwrap();
+        let func =
+          v8::Global::new(scope, val.try_cast::<v8::Function>().unwrap());
+        let device = v8::Global::new(scope, device.cast::<v8::Value>());
+        let error_event_class =
+          state.borrow().borrow::<crate::ErrorEventClass>().0.clone();
 
-        if self.is_lost.get().is_some() {
-            return;
-        }
+        let error = deno_core::error::to_v8_error(scope, &err);
 
-        let err = err.into();
+        let error_event_class =
+          v8::Local::new(scope, error_event_class.clone());
+        let constructor =
+          v8::Local::<v8::Function>::try_from(error_event_class).unwrap();
+        let kind = v8::String::new(scope, "uncapturederror").unwrap();
 
-        if let GPUError::Lost(reason) = err {
-            let _ = self.is_lost.set(());
-            if let Some(resolver) = self.lost_resolver.lock().unwrap().take() {
-                self.spawner.spawn(move |scope| {
-                    let resolver = v8::Local::new(scope, resolver);
-                    let info = make_cppgc_object(scope, GPUDeviceLostInfo { reason });
-                    let info = v8::Local::new(scope, info);
-                    resolver.resolve(scope, info.into());
-                });
-            }
+        let obj = v8::Object::new(scope);
+        let key = v8::String::new(scope, "error").unwrap();
+        obj.set(scope, key.into(), error);
 
-            return;
-        }
+        let event = constructor
+          .new_instance(scope, &[kind.into(), obj.into()])
+          .unwrap();
 
-        let error_filter = match err {
-            GPUError::Lost(_) => unreachable!(),
-            GPUError::Validation(_) => GPUErrorFilter::Validation,
-            GPUError::OutOfMemory => GPUErrorFilter::OutOfMemory,
-            GPUError::Internal => GPUErrorFilter::Internal,
-        };
-
-        let mut scopes = self.scopes.lock().unwrap();
-        let scope = scopes
-            .iter_mut()
-            .rfind(|(filter, _)| filter == &error_filter);
-
-        if let Some(scope) = scope {
-            scope.1.push(err);
-        } else {
-            let device = self
-                .device
-                .get()
-                .expect("set_device was not called")
-                .clone();
-            self.spawner.spawn(move |scope| {
-                let state = JsRuntime::op_state_from(&*scope);
-                let Some(device) = device.to_local(scope) else {
-                    // The device has already gone away, so we don't have
-                    // anywhere to report the error.
-                    return;
-                };
-                let key = v8::String::new(scope, "dispatchEvent").unwrap();
-                let val = device.get(scope, key.into()).unwrap();
-                let func = v8::Global::new(scope, val.try_cast::<v8::Function>().unwrap());
-                let device = v8::Global::new(scope, device.cast::<v8::Value>());
-                let error_event_class = state.borrow().borrow::<crate::ErrorEventClass>().0.clone();
-
-                let error = deno_core::error::to_v8_error(scope, &err);
-
-                let error_event_class = v8::Local::new(scope, error_event_class.clone());
-                let constructor = v8::Local::<v8::Function>::try_from(error_event_class).unwrap();
-                let kind = v8::String::new(scope, "uncapturederror").unwrap();
-
-                let obj = v8::Object::new(scope);
-                let key = v8::String::new(scope, "error").unwrap();
-                obj.set(scope, key.into(), error);
-
-                let event = constructor
-                    .new_instance(scope, &[kind.into(), obj.into()])
-                    .unwrap();
-
-                let recv = v8::Local::new(scope, device);
-                func.open(scope).call(scope, recv, &[event.into()]);
-            });
-        }
+        let recv = v8::Local::new(scope, device);
+        func.open(scope).call(scope, recv, &[event.into()]);
+      });
     }
+  }
 }
 
 #[derive(deno_core::WebIDL, Eq, PartialEq)]
 #[webidl(enum)]
 pub enum GPUErrorFilter {
-    Validation,
-    OutOfMemory,
-    Internal,
+  Validation,
+  OutOfMemory,
+  Internal,
 }
 
 #[derive(Debug, deno_error::JsError)]
 pub enum GPUError {
-    // TODO(@crowlKats): consider adding an unreachable value that uses unreachable!()
-    #[class("UNREACHABLE")]
-    Lost(GPUDeviceLostReason),
-    #[class("GPUValidationError")]
-    Validation(String),
-    #[class("GPUOutOfMemoryError")]
-    OutOfMemory,
-    #[class("GPUInternalError")]
-    Internal,
+  // TODO(@crowlKats): consider adding an unreachable value that uses unreachable!()
+  #[class("UNREACHABLE")]
+  Lost(GPUDeviceLostReason),
+  #[class("GPUValidationError")]
+  Validation(String),
+  #[class("GPUOutOfMemoryError")]
+  OutOfMemory,
+  #[class("GPUInternalError")]
+  Internal,
 }
 
 impl Display for GPUError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            GPUError::Lost(_) => Ok(()),
-            GPUError::Validation(s) => f.write_str(s),
-            GPUError::OutOfMemory => f.write_str("not enough memory left"),
-            GPUError::Internal => Ok(()),
-        }
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    match self {
+      GPUError::Lost(_) => Ok(()),
+      GPUError::Validation(s) => f.write_str(s),
+      GPUError::OutOfMemory => f.write_str("not enough memory left"),
+      GPUError::Internal => Ok(()),
     }
+  }
 }
 
 impl std::error::Error for GPUError {}
 
 impl GPUError {
-    fn from_webgpu(e: impl WebGpuError) -> Self {
-        match e.webgpu_error_type() {
-            ErrorType::Internal => GPUError::Internal,
-            ErrorType::DeviceLost => GPUError::Lost(GPUDeviceLostReason::Unknown), // TODO: this variant should be ignored, register the lost callback instead.
-            ErrorType::OutOfMemory => GPUError::OutOfMemory,
-            ErrorType::Validation => GPUError::Validation(fmt_err(&e)),
-        }
+  fn from_webgpu(e: impl WebGpuError) -> Self {
+    match e.webgpu_error_type() {
+      ErrorType::Internal => GPUError::Internal,
+      ErrorType::DeviceLost => GPUError::Lost(GPUDeviceLostReason::Unknown), // TODO: this variant should be ignored, register the lost callback instead.
+      ErrorType::OutOfMemory => GPUError::OutOfMemory,
+      ErrorType::Validation => GPUError::Validation(fmt_err(&e)),
     }
+  }
 }
 
 fn fmt_err(err: &(dyn std::error::Error + 'static)) -> String {
-    let mut output = err.to_string();
+  let mut output = err.to_string();
 
-    let mut e = err.source();
-    while let Some(source) = e {
-        output.push_str(&format!(": {source}"));
-        e = source.source();
-    }
+  let mut e = err.source();
+  while let Some(source) = e {
+    output.push_str(&format!(": {source}"));
+    e = source.source();
+  }
 
-    if output.is_empty() {
-        output.push_str("validation error");
-    }
+  if output.is_empty() {
+    output.push_str("validation error");
+  }
 
-    output
+  output
 }
 
 impl From<EncoderStateError> for GPUError {
-    fn from(err: EncoderStateError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: EncoderStateError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<PassStateError> for GPUError {
-    fn from(err: PassStateError) -> Self {
-        GPUError::Validation(fmt_err(&err))
-    }
+  fn from(err: PassStateError) -> Self {
+    GPUError::Validation(fmt_err(&err))
+  }
 }
 
 impl From<CreateBufferError> for GPUError {
-    fn from(err: CreateBufferError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateBufferError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<DeviceError> for GPUError {
-    fn from(err: DeviceError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: DeviceError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<BufferAccessError> for GPUError {
-    fn from(err: BufferAccessError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: BufferAccessError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreateBindGroupLayoutError> for GPUError {
-    fn from(err: CreateBindGroupLayoutError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateBindGroupLayoutError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreatePipelineLayoutError> for GPUError {
-    fn from(err: CreatePipelineLayoutError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreatePipelineLayoutError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreateBindGroupError> for GPUError {
-    fn from(err: CreateBindGroupError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateBindGroupError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<RenderBundleError> for GPUError {
-    fn from(err: RenderBundleError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: RenderBundleError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreateRenderBundleError> for GPUError {
-    fn from(err: CreateRenderBundleError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateRenderBundleError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CommandEncoderError> for GPUError {
-    fn from(err: CommandEncoderError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CommandEncoderError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<QueryError> for GPUError {
-    fn from(err: QueryError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: QueryError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<ComputePassError> for GPUError {
-    fn from(err: ComputePassError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: ComputePassError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreateComputePipelineError> for GPUError {
-    fn from(err: CreateComputePipelineError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateComputePipelineError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<GetBindGroupLayoutError> for GPUError {
-    fn from(err: GetBindGroupLayoutError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: GetBindGroupLayoutError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreateRenderPipelineError> for GPUError {
-    fn from(err: CreateRenderPipelineError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateRenderPipelineError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<RenderPassError> for GPUError {
-    fn from(err: RenderPassError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: RenderPassError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreateSamplerError> for GPUError {
-    fn from(err: CreateSamplerError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateSamplerError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreateShaderModuleError> for GPUError {
-    fn from(err: CreateShaderModuleError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateShaderModuleError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreateTextureError> for GPUError {
-    fn from(err: CreateTextureError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateTextureError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreateTextureViewError> for GPUError {
-    fn from(err: CreateTextureViewError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateTextureViewError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<CreateQuerySetError> for GPUError {
-    fn from(err: CreateQuerySetError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: CreateQuerySetError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<QueueSubmitError> for GPUError {
-    fn from(err: QueueSubmitError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: QueueSubmitError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<QueueWriteError> for GPUError {
-    fn from(err: QueueWriteError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: QueueWriteError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<ClearError> for GPUError {
-    fn from(err: ClearError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: ClearError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }
 
 impl From<ConfigureSurfaceError> for GPUError {
-    fn from(err: ConfigureSurfaceError) -> Self {
-        GPUError::from_webgpu(err)
-    }
+  fn from(err: ConfigureSurfaceError) -> Self {
+    GPUError::from_webgpu(err)
+  }
 }

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -64,7 +64,11 @@ pub type Instance = Arc<wgpu_core::global::Global>;
 deno_core::extension!(
   deno_webgpu,
   deps = [deno_webidl, deno_web],
-  ops = [op_create_gpu],
+  ops = [
+    op_create_gpu,
+    device::op_webgpu_device_start_capture,
+    device::op_webgpu_device_stop_capture,
+  ],
   objects = [
     GPU,
     adapter::GPUAdapter,

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -130,7 +130,11 @@ struct ErrorEventClass(v8::Global<v8::Value>);
 
 pub struct GPU;
 
-impl GarbageCollected for GPU {}
+impl GarbageCollected for GPU {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPU"
+  }
+}
 
 #[op2]
 impl GPU {

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -42,85 +42,85 @@ pub const UNSTABLE_FEATURE_NAME: &str = "webgpu";
 
 #[allow(clippy::print_stdout)]
 pub fn print_linker_flags(name: &str) {
-    if cfg!(windows) {
-        // these dls load slowly, so delay loading them
-        let dlls = [
-            // webgpu
-            "d3dcompiler_47",
-            "OPENGL32",
-            // network related functions
-            "iphlpapi",
-        ];
-        for dll in dlls {
-            println!("cargo:rustc-link-arg-bin={name}=/delayload:{dll}.dll");
-        }
-        // enable delay loading
-        println!("cargo:rustc-link-arg-bin={name}=delayimp.lib");
+  if cfg!(windows) {
+    // these dls load slowly, so delay loading them
+    let dlls = [
+      // webgpu
+      "d3dcompiler_47",
+      "OPENGL32",
+      // network related functions
+      "iphlpapi",
+    ];
+    for dll in dlls {
+      println!("cargo:rustc-link-arg-bin={name}=/delayload:{dll}.dll");
     }
+    // enable delay loading
+    println!("cargo:rustc-link-arg-bin={name}=delayimp.lib");
+  }
 }
 
 pub type Instance = Arc<wgpu_core::global::Global>;
 
 deno_core::extension!(
-    deno_webgpu,
-    deps = [deno_webidl, deno_web],
-    ops = [op_create_gpu],
-    objects = [
-        GPU,
-        adapter::GPUAdapter,
-        adapter::GPUAdapterInfo,
-        bind_group::GPUBindGroup,
-        bind_group_layout::GPUBindGroupLayout,
-        buffer::GPUBuffer,
-        command_buffer::GPUCommandBuffer,
-        command_encoder::GPUCommandEncoder,
-        compute_pass::GPUComputePassEncoder,
-        compute_pipeline::GPUComputePipeline,
-        device::GPUDevice,
-        device::GPUDeviceLostInfo,
-        pipeline_layout::GPUPipelineLayout,
-        query_set::GPUQuerySet,
-        queue::GPUQueue,
-        render_bundle::GPURenderBundle,
-        render_bundle::GPURenderBundleEncoder,
-        render_pass::GPURenderPassEncoder,
-        render_pipeline::GPURenderPipeline,
-        sampler::GPUSampler,
-        shader::GPUCompilationInfo,
-        shader::GPUCompilationMessage,
-        shader::GPUShaderModule,
-        adapter::GPUSupportedFeatures,
-        adapter::GPUSupportedLimits,
-        texture::GPUTexture,
-        texture::GPUTextureView,
-        texture::GPUExternalTexture,
-        byow::UnsafeWindowSurface,
-        surface::GPUCanvasContext,
-    ],
-    esm = ["00_init.js", "02_surface.js"],
-    lazy_loaded_esm = ["01_webgpu.js"],
+  deno_webgpu,
+  deps = [deno_webidl, deno_web],
+  ops = [op_create_gpu],
+  objects = [
+    GPU,
+    adapter::GPUAdapter,
+    adapter::GPUAdapterInfo,
+    bind_group::GPUBindGroup,
+    bind_group_layout::GPUBindGroupLayout,
+    buffer::GPUBuffer,
+    command_buffer::GPUCommandBuffer,
+    command_encoder::GPUCommandEncoder,
+    compute_pass::GPUComputePassEncoder,
+    compute_pipeline::GPUComputePipeline,
+    device::GPUDevice,
+    device::GPUDeviceLostInfo,
+    pipeline_layout::GPUPipelineLayout,
+    query_set::GPUQuerySet,
+    queue::GPUQueue,
+    render_bundle::GPURenderBundle,
+    render_bundle::GPURenderBundleEncoder,
+    render_pass::GPURenderPassEncoder,
+    render_pipeline::GPURenderPipeline,
+    sampler::GPUSampler,
+    shader::GPUCompilationInfo,
+    shader::GPUCompilationMessage,
+    shader::GPUShaderModule,
+    adapter::GPUSupportedFeatures,
+    adapter::GPUSupportedLimits,
+    texture::GPUTexture,
+    texture::GPUTextureView,
+    texture::GPUExternalTexture,
+    byow::UnsafeWindowSurface,
+    surface::GPUCanvasContext,
+  ],
+  esm = ["00_init.js", "02_surface.js"],
+  lazy_loaded_esm = ["01_webgpu.js"],
 );
 
 #[op2]
 #[cppgc]
 pub fn op_create_gpu(
-    state: &mut OpState,
-    scope: &mut v8::HandleScope,
-    webidl_brand: v8::Local<v8::Value>,
-    set_event_target_data: v8::Local<v8::Value>,
-    error_event_class: v8::Local<v8::Value>,
+  state: &mut OpState,
+  scope: &mut v8::HandleScope,
+  webidl_brand: v8::Local<v8::Value>,
+  set_event_target_data: v8::Local<v8::Value>,
+  error_event_class: v8::Local<v8::Value>,
 ) -> GPU {
-    state.put(EventTargetSetup {
-        brand: v8::Global::new(scope, webidl_brand),
-        set_event_target_data: v8::Global::new(scope, set_event_target_data),
-    });
-    state.put(ErrorEventClass(v8::Global::new(scope, error_event_class)));
-    GPU
+  state.put(EventTargetSetup {
+    brand: v8::Global::new(scope, webidl_brand),
+    set_event_target_data: v8::Global::new(scope, set_event_target_data),
+  });
+  state.put(ErrorEventClass(v8::Global::new(scope, error_event_class)));
+  GPU
 }
 
 struct EventTargetSetup {
-    brand: v8::Global<v8::Value>,
-    set_event_target_data: v8::Global<v8::Value>,
+  brand: v8::Global<v8::Value>,
+  set_event_target_data: v8::Global<v8::Value>,
 }
 struct ErrorEventClass(v8::Global<v8::Value>);
 
@@ -130,83 +130,83 @@ impl GarbageCollected for GPU {}
 
 #[op2]
 impl GPU {
-    #[async_method]
-    #[cppgc]
-    async fn request_adapter(
-        &self,
-        state: Rc<RefCell<OpState>>,
-        #[webidl] options: adapter::GPURequestAdapterOptions,
-    ) -> Option<adapter::GPUAdapter> {
-        let mut state = state.borrow_mut();
+  #[async_method]
+  #[cppgc]
+  async fn request_adapter(
+    &self,
+    state: Rc<RefCell<OpState>>,
+    #[webidl] options: adapter::GPURequestAdapterOptions,
+  ) -> Option<adapter::GPUAdapter> {
+    let mut state = state.borrow_mut();
 
-        let backends = std::env::var("DENO_WEBGPU_BACKEND").map_or_else(
-            |_| wgpu_types::Backends::all(),
-            |s| wgpu_types::Backends::from_comma_list(&s),
-        );
-        let instance = if let Some(instance) = state.try_borrow::<Instance>() {
-            instance
-        } else {
-            state.put(Arc::new(wgpu_core::global::Global::new(
-                "webgpu",
-                &wgpu_types::InstanceDescriptor {
-                    backends,
-                    flags: wgpu_types::InstanceFlags::from_build_config(),
-                    memory_budget_thresholds: wgpu_types::MemoryBudgetThresholds {
-                        for_resource_creation: Some(97),
-                        for_device_loss: Some(99),
-                    },
-                    backend_options: wgpu_types::BackendOptions {
-                        dx12: wgpu_types::Dx12BackendOptions {
-                            shader_compiler: wgpu_types::Dx12Compiler::Fxc,
-                            ..Default::default()
-                        },
-                        gl: wgpu_types::GlBackendOptions::default(),
-                        noop: wgpu_types::NoopBackendOptions::default(),
-                    },
-                },
-            )));
-            state.borrow::<Instance>()
-        };
+    let backends = std::env::var("DENO_WEBGPU_BACKEND").map_or_else(
+      |_| wgpu_types::Backends::all(),
+      |s| wgpu_types::Backends::from_comma_list(&s),
+    );
+    let instance = if let Some(instance) = state.try_borrow::<Instance>() {
+      instance
+    } else {
+      state.put(Arc::new(wgpu_core::global::Global::new(
+        "webgpu",
+        &wgpu_types::InstanceDescriptor {
+          backends,
+          flags: wgpu_types::InstanceFlags::from_build_config(),
+          memory_budget_thresholds: wgpu_types::MemoryBudgetThresholds {
+            for_resource_creation: Some(97),
+            for_device_loss: Some(99),
+          },
+          backend_options: wgpu_types::BackendOptions {
+            dx12: wgpu_types::Dx12BackendOptions {
+              shader_compiler: wgpu_types::Dx12Compiler::Fxc,
+              ..Default::default()
+            },
+            gl: wgpu_types::GlBackendOptions::default(),
+            noop: wgpu_types::NoopBackendOptions::default(),
+          },
+        },
+      )));
+      state.borrow::<Instance>()
+    };
 
-        let descriptor = wgpu_core::instance::RequestAdapterOptions {
-            power_preference: options
-                .power_preference
-                .map(|pp| match pp {
-                    adapter::GPUPowerPreference::LowPower => PowerPreference::LowPower,
-                    adapter::GPUPowerPreference::HighPerformance => {
-                        PowerPreference::HighPerformance
-                    }
-                })
-                .unwrap_or_default(),
-            force_fallback_adapter: options.force_fallback_adapter,
-            compatible_surface: None, // windowless
-        };
-        let id = instance.request_adapter(&descriptor, backends, None).ok()?;
-
-        Some(adapter::GPUAdapter {
-            instance: instance.clone(),
-            features: SameObject::new(),
-            limits: SameObject::new(),
-            info: Rc::new(SameObject::new()),
-            id,
+    let descriptor = wgpu_core::instance::RequestAdapterOptions {
+      power_preference: options
+        .power_preference
+        .map(|pp| match pp {
+          adapter::GPUPowerPreference::LowPower => PowerPreference::LowPower,
+          adapter::GPUPowerPreference::HighPerformance => {
+            PowerPreference::HighPerformance
+          }
         })
-    }
+        .unwrap_or_default(),
+      force_fallback_adapter: options.force_fallback_adapter,
+      compatible_surface: None, // windowless
+    };
+    let id = instance.request_adapter(&descriptor, backends, None).ok()?;
 
-    #[string]
-    fn getPreferredCanvasFormat(&self) -> &'static str {
-        // https://github.com/mozilla/gecko-dev/blob/b75080bb8b11844d18cb5f9ac6e68a866ef8e243/dom/webgpu/Instance.h#L42-L47
-        if cfg!(target_os = "android") {
-            texture::GPUTextureFormat::Rgba8unorm.as_str()
-        } else {
-            texture::GPUTextureFormat::Bgra8unorm.as_str()
-        }
+    Some(adapter::GPUAdapter {
+      instance: instance.clone(),
+      features: SameObject::new(),
+      limits: SameObject::new(),
+      info: Rc::new(SameObject::new()),
+      id,
+    })
+  }
+
+  #[string]
+  fn getPreferredCanvasFormat(&self) -> &'static str {
+    // https://github.com/mozilla/gecko-dev/blob/b75080bb8b11844d18cb5f9ac6e68a866ef8e243/dom/webgpu/Instance.h#L42-L47
+    if cfg!(target_os = "android") {
+      texture::GPUTextureFormat::Rgba8unorm.as_str()
+    } else {
+      texture::GPUTextureFormat::Bgra8unorm.as_str()
     }
+  }
 }
 
 fn transform_label<'a>(label: String) -> Option<std::borrow::Cow<'a, str>> {
-    if label.is_empty() {
-        None
-    } else {
-        Some(std::borrow::Cow::Owned(label))
-    }
+  if label.is_empty() {
+    None
+  } else {
+    Some(std::borrow::Cow::Owned(label))
+  }
 }

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -15,6 +15,8 @@ pub use wgpu_core;
 pub use wgpu_types;
 use wgpu_types::PowerPreference;
 
+use crate::error::GPUGenericError;
+
 mod adapter;
 mod bind_group;
 mod bind_group_layout;
@@ -138,6 +140,12 @@ impl GarbageCollected for GPU {
 
 #[op2]
 impl GPU {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPU, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[async_method]
   #[cppgc]
   async fn request_adapter(

--- a/deno_webgpu/pipeline_layout.rs
+++ b/deno_webgpu/pipeline_layout.rs
@@ -24,7 +24,11 @@ impl WebIdlInterfaceConverter for GPUPipelineLayout {
   const NAME: &'static str = "GPUPipelineLayout";
 }
 
-impl GarbageCollected for GPUPipelineLayout {}
+impl GarbageCollected for GPUPipelineLayout {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUPipelineLayout"
+  }
+}
 
 #[op2]
 impl GPUPipelineLayout {

--- a/deno_webgpu/pipeline_layout.rs
+++ b/deno_webgpu/pipeline_layout.rs
@@ -9,42 +9,43 @@ use deno_core::WebIDL;
 use crate::Instance;
 
 pub struct GPUPipelineLayout {
-    pub instance: Instance,
-    pub id: wgpu_core::id::PipelineLayoutId,
-    pub label: String,
+  pub instance: Instance,
+  pub id: wgpu_core::id::PipelineLayoutId,
+  pub label: String,
 }
 
 impl Drop for GPUPipelineLayout {
-    fn drop(&mut self) {
-        self.instance.pipeline_layout_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.pipeline_layout_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPUPipelineLayout {
-    const NAME: &'static str = "GPUPipelineLayout";
+  const NAME: &'static str = "GPUPipelineLayout";
 }
 
 impl GarbageCollected for GPUPipelineLayout {}
 
 #[op2]
 impl GPUPipelineLayout {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUPipelineLayoutDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub bind_group_layouts: Vec<Ptr<super::bind_group_layout::GPUBindGroupLayout>>,
+  pub bind_group_layouts:
+    Vec<Ptr<super::bind_group_layout::GPUBindGroupLayout>>,
 }

--- a/deno_webgpu/pipeline_layout.rs
+++ b/deno_webgpu/pipeline_layout.rs
@@ -6,6 +6,7 @@ use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 
+use crate::error::GPUGenericError;
 use crate::Instance;
 
 pub struct GPUPipelineLayout {
@@ -32,6 +33,12 @@ impl GarbageCollected for GPUPipelineLayout {
 
 #[op2]
 impl GPUPipelineLayout {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUPipelineLayout, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -26,7 +26,11 @@ impl WebIdlInterfaceConverter for GPUQuerySet {
   const NAME: &'static str = "GPUQuerySet";
 }
 
-impl GarbageCollected for GPUQuerySet {}
+impl GarbageCollected for GPUQuerySet {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUQuerySet"
+  }
+}
 
 #[op2]
 impl GPUQuerySet {

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -6,6 +6,7 @@ use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use deno_error::JsErrorBox;
 
+use crate::error::GPUGenericError;
 use crate::Instance;
 
 pub struct GPUQuerySet {
@@ -34,6 +35,12 @@ impl GarbageCollected for GPUQuerySet {
 
 #[op2]
 impl GPUQuerySet {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUQuerySet, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -9,82 +9,82 @@ use deno_error::JsErrorBox;
 use crate::Instance;
 
 pub struct GPUQuerySet {
-    pub instance: Instance,
-    pub id: wgpu_core::id::QuerySetId,
-    pub r#type: GPUQueryType,
-    pub count: u32,
-    pub label: String,
+  pub instance: Instance,
+  pub id: wgpu_core::id::QuerySetId,
+  pub r#type: GPUQueryType,
+  pub count: u32,
+  pub label: String,
 }
 
 impl Drop for GPUQuerySet {
-    fn drop(&mut self) {
-        self.instance.query_set_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.query_set_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPUQuerySet {
-    const NAME: &'static str = "GPUQuerySet";
+  const NAME: &'static str = "GPUQuerySet";
 }
 
 impl GarbageCollected for GPUQuerySet {}
 
 #[op2]
 impl GPUQuerySet {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 
-    #[fast]
-    fn destroy(&self) -> Result<(), JsErrorBox> {
-        // TODO(https://github.com/gfx-rs/wgpu/issues/6495): Destroy the query
-        // set. Until that is supported, it is okay to do nothing here, the
-        // query set will be garbage collected and dropped eventually.
-        Ok(())
-    }
+  #[fast]
+  fn destroy(&self) -> Result<(), JsErrorBox> {
+    // TODO(https://github.com/gfx-rs/wgpu/issues/6495): Destroy the query
+    // set. Until that is supported, it is okay to do nothing here, the
+    // query set will be garbage collected and dropped eventually.
+    Ok(())
+  }
 
-    // Naming this `type` or `r#type` does not work.
-    // https://github.com/gfx-rs/wgpu/issues/7778
-    #[getter]
-    #[string]
-    fn ty(&self) -> &'static str {
-        self.r#type.as_str()
-    }
+  // Naming this `type` or `r#type` does not work.
+  // https://github.com/gfx-rs/wgpu/issues/7778
+  #[getter]
+  #[string]
+  fn ty(&self) -> &'static str {
+    self.r#type.as_str()
+  }
 
-    #[getter]
-    fn count(&self) -> u32 {
-        self.count
-    }
+  #[getter]
+  fn count(&self) -> u32 {
+    self.count
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUQuerySetDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub r#type: GPUQueryType,
-    #[options(enforce_range = true)]
-    pub count: u32,
+  pub r#type: GPUQueryType,
+  #[options(enforce_range = true)]
+  pub count: u32,
 }
 
 #[derive(WebIDL, Clone)]
 #[webidl(enum)]
 pub(crate) enum GPUQueryType {
-    Occlusion,
-    Timestamp,
+  Occlusion,
+  Timestamp,
 }
 impl From<GPUQueryType> for wgpu_types::QueryType {
-    fn from(value: GPUQueryType) -> Self {
-        match value {
-            GPUQueryType::Occlusion => Self::Occlusion,
-            GPUQueryType::Timestamp => Self::Timestamp,
-        }
+  fn from(value: GPUQueryType) -> Self {
+    match value {
+      GPUQueryType::Occlusion => Self::Occlusion,
+      GPUQueryType::Timestamp => Self::Timestamp,
     }
+  }
 }

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -21,168 +21,178 @@ use crate::webidl::GPUOrigin3D;
 use crate::Instance;
 
 pub struct GPUQueue {
-    pub instance: Instance,
-    pub error_handler: super::error::ErrorHandler,
+  pub instance: Instance,
+  pub error_handler: super::error::ErrorHandler,
 
-    pub label: String,
+  pub label: String,
 
-    pub id: wgpu_core::id::QueueId,
-    pub device: wgpu_core::id::DeviceId,
+  pub id: wgpu_core::id::QueueId,
+  pub device: wgpu_core::id::DeviceId,
 }
 
 impl Drop for GPUQueue {
-    fn drop(&mut self) {
-        self.instance.queue_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.queue_drop(self.id);
+  }
 }
 
 impl GarbageCollected for GPUQueue {}
 
 #[op2]
 impl GPUQueue {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
+
+  #[required(1)]
+  fn submit(
+    &self,
+    scope: &mut v8::HandleScope,
+    #[webidl] command_buffers: Vec<Ptr<GPUCommandBuffer>>,
+  ) -> Result<v8::Local<v8::Value>, JsErrorBox> {
+    let ids = command_buffers
+      .into_iter()
+      .map(|cb| cb.id)
+      .collect::<Vec<_>>();
+
+    let err = self.instance.queue_submit(self.id, &ids).err();
+
+    if let Some((_, err)) = err {
+      self.error_handler.push_error(Some(err));
     }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
 
-    #[required(1)]
-    fn submit(
-        &self,
-        scope: &mut v8::HandleScope,
-        #[webidl] command_buffers: Vec<Ptr<GPUCommandBuffer>>,
-    ) -> Result<v8::Local<v8::Value>, JsErrorBox> {
-        let ids = command_buffers
-            .into_iter()
-            .map(|cb| cb.id)
-            .collect::<Vec<_>>();
+    Ok(v8::undefined(scope).into())
+  }
 
-        let err = self.instance.queue_submit(self.id, &ids).err();
+  #[async_method]
+  async fn on_submitted_work_done(&self) -> Result<(), JsErrorBox> {
+    let (sender, receiver) = oneshot::channel::<()>();
 
-        if let Some((_, err)) = err {
-            self.error_handler.push_error(Some(err));
+    let callback = Box::new(move || {
+      sender.send(()).unwrap();
+    });
+
+    self
+      .instance
+      .queue_on_submitted_work_done(self.id, callback);
+
+    let done = Rc::new(RefCell::new(false));
+    let done_ = done.clone();
+    let device_poll_fut = async move {
+      while !*done.borrow() {
+        {
+          self
+            .instance
+            .device_poll(self.device, wgpu_types::PollType::wait())
+            .unwrap();
         }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+      }
+      Ok::<(), JsErrorBox>(())
+    };
 
-        Ok(v8::undefined(scope).into())
-    }
+    let receiver_fut = async move {
+      receiver
+        .await
+        .map_err(|e| JsErrorBox::generic(e.to_string()))?;
+      let mut done = done_.borrow_mut();
+      *done = true;
+      Ok::<(), JsErrorBox>(())
+    };
 
-    #[async_method]
-    async fn on_submitted_work_done(&self) -> Result<(), JsErrorBox> {
-        let (sender, receiver) = oneshot::channel::<()>();
+    tokio::try_join!(device_poll_fut, receiver_fut)?;
 
-        let callback = Box::new(move || {
-            sender.send(()).unwrap();
-        });
+    Ok(())
+  }
 
-        self.instance
-            .queue_on_submitted_work_done(self.id, callback);
+  #[required(3)]
+  fn write_buffer(
+    &self,
+    #[webidl] buffer: Ptr<GPUBuffer>,
+    #[webidl(options(enforce_range = true))] buffer_offset: u64,
+    #[anybuffer] buf: &[u8],
+    #[webidl(default = 0, options(enforce_range = true))] data_offset: u64,
+    #[webidl(options(enforce_range = true))] size: Option<u64>,
+  ) {
+    let data = match size {
+      Some(size) => {
+        &buf[(data_offset as usize)..((data_offset + size) as usize)]
+      }
+      None => &buf[(data_offset as usize)..],
+    };
 
-        let done = Rc::new(RefCell::new(false));
-        let done_ = done.clone();
-        let device_poll_fut = async move {
-            while !*done.borrow() {
-                {
-                    self.instance
-                        .device_poll(self.device, wgpu_types::PollType::wait())
-                        .unwrap();
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-            Ok::<(), JsErrorBox>(())
-        };
+    let err = self
+      .instance
+      .queue_write_buffer(self.id, buffer.id, buffer_offset, data)
+      .err();
 
-        let receiver_fut = async move {
-            receiver
-                .await
-                .map_err(|e| JsErrorBox::generic(e.to_string()))?;
-            let mut done = done_.borrow_mut();
-            *done = true;
-            Ok::<(), JsErrorBox>(())
-        };
+    self.error_handler.push_error(err);
+  }
 
-        tokio::try_join!(device_poll_fut, receiver_fut)?;
+  #[required(4)]
+  fn write_texture(
+    &self,
+    #[webidl] destination: GPUTexelCopyTextureInfo,
+    #[anybuffer] buf: &[u8],
+    #[webidl] data_layout: GPUTexelCopyBufferLayout,
+    #[webidl] size: GPUExtent3D,
+  ) {
+    let destination = wgpu_types::TexelCopyTextureInfo {
+      texture: destination.texture.id,
+      mip_level: destination.mip_level,
+      origin: destination.origin.into(),
+      aspect: destination.aspect.into(),
+    };
 
-        Ok(())
-    }
+    let data_layout = wgpu_types::TexelCopyBufferLayout {
+      offset: data_layout.offset,
+      bytes_per_row: data_layout.bytes_per_row,
+      rows_per_image: data_layout.rows_per_image,
+    };
 
-    #[required(3)]
-    fn write_buffer(
-        &self,
-        #[webidl] buffer: Ptr<GPUBuffer>,
-        #[webidl(options(enforce_range = true))] buffer_offset: u64,
-        #[anybuffer] buf: &[u8],
-        #[webidl(default = 0, options(enforce_range = true))] data_offset: u64,
-        #[webidl(options(enforce_range = true))] size: Option<u64>,
-    ) {
-        let data = match size {
-            Some(size) => &buf[(data_offset as usize)..((data_offset + size) as usize)],
-            None => &buf[(data_offset as usize)..],
-        };
+    let err = self
+      .instance
+      .queue_write_texture(
+        self.id,
+        &destination,
+        buf,
+        &data_layout,
+        &size.into(),
+      )
+      .err();
 
-        let err = self
-            .instance
-            .queue_write_buffer(self.id, buffer.id, buffer_offset, data)
-            .err();
-
-        self.error_handler.push_error(err);
-    }
-
-    #[required(4)]
-    fn write_texture(
-        &self,
-        #[webidl] destination: GPUTexelCopyTextureInfo,
-        #[anybuffer] buf: &[u8],
-        #[webidl] data_layout: GPUTexelCopyBufferLayout,
-        #[webidl] size: GPUExtent3D,
-    ) {
-        let destination = wgpu_types::TexelCopyTextureInfo {
-            texture: destination.texture.id,
-            mip_level: destination.mip_level,
-            origin: destination.origin.into(),
-            aspect: destination.aspect.into(),
-        };
-
-        let data_layout = wgpu_types::TexelCopyBufferLayout {
-            offset: data_layout.offset,
-            bytes_per_row: data_layout.bytes_per_row,
-            rows_per_image: data_layout.rows_per_image,
-        };
-
-        let err = self
-            .instance
-            .queue_write_texture(self.id, &destination, buf, &data_layout, &size.into())
-            .err();
-
-        self.error_handler.push_error(err);
-    }
+    self.error_handler.push_error(err);
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUTexelCopyTextureInfo {
-    pub texture: Ptr<GPUTexture>,
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    pub mip_level: u32,
-    #[webidl(default = Default::default())]
-    pub origin: GPUOrigin3D,
-    #[webidl(default = GPUTextureAspect::All)]
-    pub aspect: GPUTextureAspect,
+  pub texture: Ptr<GPUTexture>,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  pub mip_level: u32,
+  #[webidl(default = Default::default())]
+  pub origin: GPUOrigin3D,
+  #[webidl(default = GPUTextureAspect::All)]
+  pub aspect: GPUTextureAspect,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 struct GPUTexelCopyBufferLayout {
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    offset: u64,
-    #[options(enforce_range = true)]
-    bytes_per_row: Option<u32>,
-    #[options(enforce_range = true)]
-    rows_per_image: Option<u32>,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  offset: u64,
+  #[options(enforce_range = true)]
+  bytes_per_row: Option<u32>,
+  #[options(enforce_range = true)]
+  rows_per_image: Option<u32>,
 }

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -36,7 +36,11 @@ impl Drop for GPUQueue {
   }
 }
 
-impl GarbageCollected for GPUQueue {}
+impl GarbageCollected for GPUQueue {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUQueue"
+  }
+}
 
 #[op2]
 impl GPUQueue {

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -14,6 +14,7 @@ use deno_error::JsErrorBox;
 
 use crate::buffer::GPUBuffer;
 use crate::command_buffer::GPUCommandBuffer;
+use crate::error::GPUGenericError;
 use crate::texture::GPUTexture;
 use crate::texture::GPUTextureAspect;
 use crate::webidl::GPUExtent3D;
@@ -44,6 +45,12 @@ impl GarbageCollected for GPUQueue {
 
 #[op2]
 impl GPUQueue {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUQueue, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -17,6 +17,7 @@ use deno_core::WebIDL;
 use deno_error::JsErrorBox;
 
 use crate::buffer::GPUBuffer;
+use crate::error::GPUGenericError;
 use crate::texture::GPUTextureFormat;
 use crate::Instance;
 
@@ -45,6 +46,12 @@ impl GarbageCollected for GPURenderBundleEncoder {
 
 #[op2]
 impl GPURenderBundleEncoder {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPURenderBundleEncoder, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {
@@ -419,6 +426,12 @@ impl GarbageCollected for GPURenderBundle {
 
 #[op2]
 impl GPURenderBundle {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPURenderBundle, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -20,396 +20,412 @@ use crate::buffer::GPUBuffer;
 use crate::texture::GPUTextureFormat;
 use crate::Instance;
 
-fn c_string_truncated_at_first_nul<T: Into<Vec<u8>>>(src: T) -> std::ffi::CString {
-    std::ffi::CString::new(src).unwrap_or_else(|err| {
-        let nul_pos = err.nul_position();
-        std::ffi::CString::new(err.into_vec().split_at(nul_pos).0).unwrap()
-    })
+fn c_string_truncated_at_first_nul<T: Into<Vec<u8>>>(
+  src: T,
+) -> std::ffi::CString {
+  std::ffi::CString::new(src).unwrap_or_else(|err| {
+    let nul_pos = err.nul_position();
+    std::ffi::CString::new(err.into_vec().split_at(nul_pos).0).unwrap()
+  })
 }
 
 pub struct GPURenderBundleEncoder {
-    pub instance: Instance,
-    pub error_handler: super::error::ErrorHandler,
+  pub instance: Instance,
+  pub error_handler: super::error::ErrorHandler,
 
-    pub encoder: RefCell<Option<wgpu_core::command::RenderBundleEncoder>>,
-    pub label: String,
+  pub encoder: RefCell<Option<wgpu_core::command::RenderBundleEncoder>>,
+  pub label: String,
 }
 
 impl GarbageCollected for GPURenderBundleEncoder {}
 
 #[op2]
 impl GPURenderBundleEncoder {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
+
+  #[cppgc]
+  fn finish(
+    &self,
+    #[webidl] descriptor: GPURenderBundleDescriptor,
+  ) -> GPURenderBundle {
+    let wgpu_descriptor = wgpu_core::command::RenderBundleDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+    };
+
+    let (id, err) = self.instance.render_bundle_encoder_finish(
+      self.encoder.borrow_mut().take().unwrap(),
+      &wgpu_descriptor,
+      None,
+    );
+
+    self.error_handler.push_error(err);
+
+    GPURenderBundle {
+      instance: self.instance.clone(),
+      id,
+      label: descriptor.label.clone(),
     }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
+
+  fn push_debug_group(
+    &self,
+    #[webidl] group_label: String,
+  ) -> Result<(), JsErrorBox> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
+
+    let label = c_string_truncated_at_first_nul(group_label);
+    // SAFETY: the string the raw pointer points to lives longer than the below
+    // function invocation.
+    unsafe {
+      wgpu_core::command::bundle_ffi::wgpu_render_bundle_push_debug_group(
+        encoder,
+        label.as_ptr(),
+      );
     }
 
-    #[cppgc]
-    fn finish(&self, #[webidl] descriptor: GPURenderBundleDescriptor) -> GPURenderBundle {
-        let wgpu_descriptor = wgpu_core::command::RenderBundleDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-        };
+    Ok(())
+  }
 
-        let (id, err) = self.instance.render_bundle_encoder_finish(
-            self.encoder.borrow_mut().take().unwrap(),
-            &wgpu_descriptor,
-            None,
+  #[fast]
+  fn pop_debug_group(&self) -> Result<(), JsErrorBox> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
+    wgpu_core::command::bundle_ffi::wgpu_render_bundle_pop_debug_group(encoder);
+    Ok(())
+  }
+
+  fn insert_debug_marker(
+    &self,
+    #[webidl] marker_label: String,
+  ) -> Result<(), JsErrorBox> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
+
+    let label = c_string_truncated_at_first_nul(marker_label);
+    // SAFETY: the string the raw pointer points to lives longer than the below
+    // function invocation.
+    unsafe {
+      wgpu_core::command::bundle_ffi::wgpu_render_bundle_insert_debug_marker(
+        encoder,
+        label.as_ptr(),
+      );
+    }
+    Ok(())
+  }
+
+  fn set_bind_group<'a>(
+    &self,
+    scope: &mut v8::HandleScope<'a>,
+    #[webidl(options(enforce_range = true))] index: u32,
+    #[webidl] bind_group: Nullable<Ptr<crate::bind_group::GPUBindGroup>>,
+    dynamic_offsets: v8::Local<'a, v8::Value>,
+    dynamic_offsets_data_start: v8::Local<'a, v8::Value>,
+    dynamic_offsets_data_length: v8::Local<'a, v8::Value>,
+  ) -> Result<(), SetBindGroupError> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
+
+    const PREFIX: &str =
+      "Failed to execute 'setBindGroup' on 'GPUComputePassEncoder'";
+    if let Ok(uint_32) = dynamic_offsets.try_cast::<v8::Uint32Array>() {
+      let start = u64::convert(
+        scope,
+        dynamic_offsets_data_start,
+        Cow::Borrowed(PREFIX),
+        (|| Cow::Borrowed("Argument 4")).into(),
+        &IntOptions {
+          clamp: false,
+          enforce_range: true,
+        },
+      )? as usize;
+      let len = u32::convert(
+        scope,
+        dynamic_offsets_data_length,
+        Cow::Borrowed(PREFIX),
+        (|| Cow::Borrowed("Argument 5")).into(),
+        &IntOptions {
+          clamp: false,
+          enforce_range: true,
+        },
+      )? as usize;
+
+      let ab = uint_32.buffer(scope).unwrap();
+      let ptr = ab.data().unwrap();
+      let ab_len = ab.byte_length() / 4;
+
+      // SAFETY: created from an array buffer, slice is dropped at end of function call
+      let data =
+        unsafe { std::slice::from_raw_parts(ptr.as_ptr() as _, ab_len) };
+
+      let offsets = &data[start..(start + len)];
+
+      // SAFETY: wgpu FFI call
+      unsafe {
+        wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_bind_group(
+          encoder,
+          index,
+          bind_group.into_option().map(|bind_group| bind_group.id),
+          offsets.as_ptr(),
+          offsets.len(),
         );
+      }
+    } else {
+      let offsets = <Option<Vec<u32>>>::convert(
+        scope,
+        dynamic_offsets,
+        Cow::Borrowed(PREFIX),
+        (|| Cow::Borrowed("Argument 3")).into(),
+        &IntOptions {
+          clamp: false,
+          enforce_range: true,
+        },
+      )?
+      .unwrap_or_default();
 
-        self.error_handler.push_error(err);
-
-        GPURenderBundle {
-            instance: self.instance.clone(),
-            id,
-            label: descriptor.label.clone(),
-        }
-    }
-
-    fn push_debug_group(&self, #[webidl] group_label: String) -> Result<(), JsErrorBox> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
-
-        let label = c_string_truncated_at_first_nul(group_label);
-        // SAFETY: the string the raw pointer points to lives longer than the below
-        // function invocation.
-        unsafe {
-            wgpu_core::command::bundle_ffi::wgpu_render_bundle_push_debug_group(
-                encoder,
-                label.as_ptr(),
-            );
-        }
-
-        Ok(())
-    }
-
-    #[fast]
-    fn pop_debug_group(&self) -> Result<(), JsErrorBox> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
-        wgpu_core::command::bundle_ffi::wgpu_render_bundle_pop_debug_group(encoder);
-        Ok(())
-    }
-
-    fn insert_debug_marker(&self, #[webidl] marker_label: String) -> Result<(), JsErrorBox> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
-
-        let label = c_string_truncated_at_first_nul(marker_label);
-        // SAFETY: the string the raw pointer points to lives longer than the below
-        // function invocation.
-        unsafe {
-            wgpu_core::command::bundle_ffi::wgpu_render_bundle_insert_debug_marker(
-                encoder,
-                label.as_ptr(),
-            );
-        }
-        Ok(())
-    }
-
-    fn set_bind_group<'a>(
-        &self,
-        scope: &mut v8::HandleScope<'a>,
-        #[webidl(options(enforce_range = true))] index: u32,
-        #[webidl] bind_group: Nullable<Ptr<crate::bind_group::GPUBindGroup>>,
-        dynamic_offsets: v8::Local<'a, v8::Value>,
-        dynamic_offsets_data_start: v8::Local<'a, v8::Value>,
-        dynamic_offsets_data_length: v8::Local<'a, v8::Value>,
-    ) -> Result<(), SetBindGroupError> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
-
-        const PREFIX: &str = "Failed to execute 'setBindGroup' on 'GPUComputePassEncoder'";
-        if let Ok(uint_32) = dynamic_offsets.try_cast::<v8::Uint32Array>() {
-            let start = u64::convert(
-                scope,
-                dynamic_offsets_data_start,
-                Cow::Borrowed(PREFIX),
-                (|| Cow::Borrowed("Argument 4")).into(),
-                &IntOptions {
-                    clamp: false,
-                    enforce_range: true,
-                },
-            )? as usize;
-            let len = u32::convert(
-                scope,
-                dynamic_offsets_data_length,
-                Cow::Borrowed(PREFIX),
-                (|| Cow::Borrowed("Argument 5")).into(),
-                &IntOptions {
-                    clamp: false,
-                    enforce_range: true,
-                },
-            )? as usize;
-
-            let ab = uint_32.buffer(scope).unwrap();
-            let ptr = ab.data().unwrap();
-            let ab_len = ab.byte_length() / 4;
-
-            // SAFETY: created from an array buffer, slice is dropped at end of function call
-            let data = unsafe { std::slice::from_raw_parts(ptr.as_ptr() as _, ab_len) };
-
-            let offsets = &data[start..(start + len)];
-
-            // SAFETY: wgpu FFI call
-            unsafe {
-                wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_bind_group(
-                    encoder,
-                    index,
-                    bind_group.into_option().map(|bind_group| bind_group.id),
-                    offsets.as_ptr(),
-                    offsets.len(),
-                );
-            }
-        } else {
-            let offsets = <Option<Vec<u32>>>::convert(
-                scope,
-                dynamic_offsets,
-                Cow::Borrowed(PREFIX),
-                (|| Cow::Borrowed("Argument 3")).into(),
-                &IntOptions {
-                    clamp: false,
-                    enforce_range: true,
-                },
-            )?
-            .unwrap_or_default();
-
-            // SAFETY: wgpu FFI call
-            unsafe {
-                wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_bind_group(
-                    encoder,
-                    index,
-                    bind_group.into_option().map(|bind_group| bind_group.id),
-                    offsets.as_ptr(),
-                    offsets.len(),
-                );
-            }
-        }
-
-        Ok(())
-    }
-
-    fn set_pipeline(
-        &self,
-        #[webidl] pipeline: Ptr<crate::render_pipeline::GPURenderPipeline>,
-    ) -> Result<(), JsErrorBox> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
-
-        wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_pipeline(encoder, pipeline.id);
-        Ok(())
-    }
-
-    #[required(2)]
-    fn set_index_buffer(
-        &self,
-        #[webidl] buffer: Ptr<GPUBuffer>,
-        #[webidl] index_format: crate::render_pipeline::GPUIndexFormat,
-        #[webidl(default = 0, options(enforce_range = true))] offset: u64,
-        #[webidl(options(enforce_range = true))] size: Option<u64>,
-    ) -> Result<(), JsErrorBox> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
-
-        encoder.set_index_buffer(
-            buffer.id,
-            index_format.into(),
-            offset,
-            size.and_then(NonZeroU64::new),
+      // SAFETY: wgpu FFI call
+      unsafe {
+        wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_bind_group(
+          encoder,
+          index,
+          bind_group.into_option().map(|bind_group| bind_group.id),
+          offsets.as_ptr(),
+          offsets.len(),
         );
-        Ok(())
+      }
     }
 
-    #[required(2)]
-    fn set_vertex_buffer(
-        &self,
-        #[webidl(options(enforce_range = true))] slot: u32,
-        #[webidl] buffer: Ptr<GPUBuffer>, // TODO(wgpu): support nullable buffer
-        #[webidl(default = 0, options(enforce_range = true))] offset: u64,
-        #[webidl(options(enforce_range = true))] size: Option<u64>,
-    ) -> Result<(), JsErrorBox> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
+    Ok(())
+  }
 
-        wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_vertex_buffer(
-            encoder,
-            slot,
-            buffer.id,
-            offset,
-            size.and_then(NonZeroU64::new),
-        );
-        Ok(())
-    }
+  fn set_pipeline(
+    &self,
+    #[webidl] pipeline: Ptr<crate::render_pipeline::GPURenderPipeline>,
+  ) -> Result<(), JsErrorBox> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
 
-    #[required(1)]
-    fn draw(
-        &self,
-        #[webidl(options(enforce_range = true))] vertex_count: u32,
-        #[webidl(default = 1, options(enforce_range = true))] instance_count: u32,
-        #[webidl(default = 0, options(enforce_range = true))] first_vertex: u32,
-        #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
-    ) -> Result<(), JsErrorBox> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
+    wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_pipeline(
+      encoder,
+      pipeline.id,
+    );
+    Ok(())
+  }
 
-        wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw(
-            encoder,
-            vertex_count,
-            instance_count,
-            first_vertex,
-            first_instance,
-        );
-        Ok(())
-    }
+  #[required(2)]
+  fn set_index_buffer(
+    &self,
+    #[webidl] buffer: Ptr<GPUBuffer>,
+    #[webidl] index_format: crate::render_pipeline::GPUIndexFormat,
+    #[webidl(default = 0, options(enforce_range = true))] offset: u64,
+    #[webidl(options(enforce_range = true))] size: Option<u64>,
+  ) -> Result<(), JsErrorBox> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
 
-    #[required(1)]
-    fn draw_indexed(
-        &self,
-        #[webidl(options(enforce_range = true))] index_count: u32,
-        #[webidl(default = 1, options(enforce_range = true))] instance_count: u32,
-        #[webidl(default = 0, options(enforce_range = true))] first_index: u32,
-        #[webidl(default = 0, options(enforce_range = true))] base_vertex: i32,
-        #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
-    ) -> Result<(), JsErrorBox> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
+    encoder.set_index_buffer(
+      buffer.id,
+      index_format.into(),
+      offset,
+      size.and_then(NonZeroU64::new),
+    );
+    Ok(())
+  }
 
-        wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indexed(
-            encoder,
-            index_count,
-            instance_count,
-            first_index,
-            base_vertex,
-            first_instance,
-        );
-        Ok(())
-    }
+  #[required(2)]
+  fn set_vertex_buffer(
+    &self,
+    #[webidl(options(enforce_range = true))] slot: u32,
+    #[webidl] buffer: Ptr<GPUBuffer>, // TODO(wgpu): support nullable buffer
+    #[webidl(default = 0, options(enforce_range = true))] offset: u64,
+    #[webidl(options(enforce_range = true))] size: Option<u64>,
+  ) -> Result<(), JsErrorBox> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
 
-    #[required(2)]
-    fn draw_indirect(
-        &self,
-        #[webidl] indirect_buffer: Ptr<GPUBuffer>,
-        #[webidl(options(enforce_range = true))] indirect_offset: u64,
-    ) -> Result<(), JsErrorBox> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
+    wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_vertex_buffer(
+      encoder,
+      slot,
+      buffer.id,
+      offset,
+      size.and_then(NonZeroU64::new),
+    );
+    Ok(())
+  }
 
-        wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indirect(
-            encoder,
-            indirect_buffer.id,
-            indirect_offset,
-        );
-        Ok(())
-    }
+  #[required(1)]
+  fn draw(
+    &self,
+    #[webidl(options(enforce_range = true))] vertex_count: u32,
+    #[webidl(default = 1, options(enforce_range = true))] instance_count: u32,
+    #[webidl(default = 0, options(enforce_range = true))] first_vertex: u32,
+    #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
+  ) -> Result<(), JsErrorBox> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
 
-    #[required(2)]
-    fn draw_indexed_indirect(
-        &self,
-        #[webidl] indirect_buffer: Ptr<GPUBuffer>,
-        #[webidl(options(enforce_range = true))] indirect_offset: u64,
-    ) -> Result<(), JsErrorBox> {
-        let mut encoder = self.encoder.borrow_mut();
-        let encoder = encoder
-            .as_mut()
-            .ok_or_else(|| JsErrorBox::generic("Encoder has already been finished"))?;
+    wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw(
+      encoder,
+      vertex_count,
+      instance_count,
+      first_vertex,
+      first_instance,
+    );
+    Ok(())
+  }
 
-        wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indexed_indirect(
-            encoder,
-            indirect_buffer.id,
-            indirect_offset,
-        );
-        Ok(())
-    }
+  #[required(1)]
+  fn draw_indexed(
+    &self,
+    #[webidl(options(enforce_range = true))] index_count: u32,
+    #[webidl(default = 1, options(enforce_range = true))] instance_count: u32,
+    #[webidl(default = 0, options(enforce_range = true))] first_index: u32,
+    #[webidl(default = 0, options(enforce_range = true))] base_vertex: i32,
+    #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
+  ) -> Result<(), JsErrorBox> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
+
+    wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indexed(
+      encoder,
+      index_count,
+      instance_count,
+      first_index,
+      base_vertex,
+      first_instance,
+    );
+    Ok(())
+  }
+
+  #[required(2)]
+  fn draw_indirect(
+    &self,
+    #[webidl] indirect_buffer: Ptr<GPUBuffer>,
+    #[webidl(options(enforce_range = true))] indirect_offset: u64,
+  ) -> Result<(), JsErrorBox> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
+
+    wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indirect(
+      encoder,
+      indirect_buffer.id,
+      indirect_offset,
+    );
+    Ok(())
+  }
+
+  #[required(2)]
+  fn draw_indexed_indirect(
+    &self,
+    #[webidl] indirect_buffer: Ptr<GPUBuffer>,
+    #[webidl(options(enforce_range = true))] indirect_offset: u64,
+  ) -> Result<(), JsErrorBox> {
+    let mut encoder = self.encoder.borrow_mut();
+    let encoder = encoder.as_mut().ok_or_else(|| {
+      JsErrorBox::generic("Encoder has already been finished")
+    })?;
+
+    wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indexed_indirect(
+      encoder,
+      indirect_buffer.id,
+      indirect_offset,
+    );
+    Ok(())
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPURenderBundleEncoderDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub color_formats: Vec<Nullable<GPUTextureFormat>>,
-    pub depth_stencil_format: Option<GPUTextureFormat>,
-    #[webidl(default = 1)]
-    #[options(enforce_range = true)]
-    pub sample_count: u32,
+  pub color_formats: Vec<Nullable<GPUTextureFormat>>,
+  pub depth_stencil_format: Option<GPUTextureFormat>,
+  #[webidl(default = 1)]
+  #[options(enforce_range = true)]
+  pub sample_count: u32,
 
-    #[webidl(default = false)]
-    pub depth_read_only: bool,
-    #[webidl(default = false)]
-    pub stencil_read_only: bool,
+  #[webidl(default = false)]
+  pub depth_read_only: bool,
+  #[webidl(default = false)]
+  pub stencil_read_only: bool,
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 enum SetBindGroupError {
-    #[class(inherit)]
-    #[error(transparent)]
-    WebIDL(#[from] WebIdlError),
-    #[class(inherit)]
-    #[error(transparent)]
-    Other(#[from] JsErrorBox),
+  #[class(inherit)]
+  #[error(transparent)]
+  WebIDL(#[from] WebIdlError),
+  #[class(inherit)]
+  #[error(transparent)]
+  Other(#[from] JsErrorBox),
 }
 
 pub struct GPURenderBundle {
-    pub instance: Instance,
-    pub id: wgpu_core::id::RenderBundleId,
-    pub label: String,
+  pub instance: Instance,
+  pub id: wgpu_core::id::RenderBundleId,
+  pub label: String,
 }
 
 impl Drop for GPURenderBundle {
-    fn drop(&mut self) {
-        self.instance.render_bundle_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.render_bundle_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPURenderBundle {
-    const NAME: &'static str = "GPURenderBundle";
+  const NAME: &'static str = "GPURenderBundle";
 }
 
 impl GarbageCollected for GPURenderBundle {}
 
 #[op2]
 impl GPURenderBundle {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPURenderBundleDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 }

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -37,7 +37,11 @@ pub struct GPURenderBundleEncoder {
   pub label: String,
 }
 
-impl GarbageCollected for GPURenderBundleEncoder {}
+impl GarbageCollected for GPURenderBundleEncoder {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPURenderBundleEncoder"
+  }
+}
 
 #[op2]
 impl GPURenderBundleEncoder {
@@ -407,7 +411,11 @@ impl WebIdlInterfaceConverter for GPURenderBundle {
   const NAME: &'static str = "GPURenderBundle";
 }
 
-impl GarbageCollected for GPURenderBundle {}
+impl GarbageCollected for GPURenderBundle {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPURenderBundle"
+  }
+}
 
 #[op2]
 impl GPURenderBundle {

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -28,7 +28,11 @@ pub struct GPURenderPassEncoder {
   pub label: String,
 }
 
-impl GarbageCollected for GPURenderPassEncoder {}
+impl GarbageCollected for GPURenderPassEncoder {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPURenderPassEncoder"
+  }
+}
 
 #[op2]
 impl GPURenderPassEncoder {

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -15,6 +15,7 @@ use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 
 use crate::buffer::GPUBuffer;
+use crate::error::GPUGenericError;
 use crate::render_bundle::GPURenderBundle;
 use crate::texture::GPUTextureView;
 use crate::webidl::GPUColor;
@@ -36,6 +37,12 @@ impl GarbageCollected for GPURenderPassEncoder {
 
 #[op2]
 impl GPURenderPassEncoder {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPURenderPassEncoder, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -21,456 +21,490 @@ use crate::webidl::GPUColor;
 use crate::Instance;
 
 pub struct GPURenderPassEncoder {
-    pub instance: Instance,
-    pub error_handler: super::error::ErrorHandler,
+  pub instance: Instance,
+  pub error_handler: super::error::ErrorHandler,
 
-    pub render_pass: RefCell<wgpu_core::command::RenderPass>,
-    pub label: String,
+  pub render_pass: RefCell<wgpu_core::command::RenderPass>,
+  pub label: String,
 }
 
 impl GarbageCollected for GPURenderPassEncoder {}
 
 #[op2]
 impl GPURenderPassEncoder {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 
-    #[required(6)]
-    fn set_viewport(
-        &self,
-        #[webidl] x: f32,
-        #[webidl] y: f32,
-        #[webidl] width: f32,
-        #[webidl] height: f32,
-        #[webidl] min_depth: f32,
-        #[webidl] max_depth: f32,
-    ) {
-        let err = self
-            .instance
-            .render_pass_set_viewport(
-                &mut self.render_pass.borrow_mut(),
-                x,
-                y,
-                width,
-                height,
-                min_depth,
-                max_depth,
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(6)]
+  fn set_viewport(
+    &self,
+    #[webidl] x: f32,
+    #[webidl] y: f32,
+    #[webidl] width: f32,
+    #[webidl] height: f32,
+    #[webidl] min_depth: f32,
+    #[webidl] max_depth: f32,
+  ) {
+    let err = self
+      .instance
+      .render_pass_set_viewport(
+        &mut self.render_pass.borrow_mut(),
+        x,
+        y,
+        width,
+        height,
+        min_depth,
+        max_depth,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(4)]
-    fn set_scissor_rect(
-        &self,
-        #[webidl(options(enforce_range = true))] x: u32,
-        #[webidl(options(enforce_range = true))] y: u32,
-        #[webidl(options(enforce_range = true))] width: u32,
-        #[webidl(options(enforce_range = true))] height: u32,
-    ) {
-        let err = self
-            .instance
-            .render_pass_set_scissor_rect(&mut self.render_pass.borrow_mut(), x, y, width, height)
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(4)]
+  fn set_scissor_rect(
+    &self,
+    #[webidl(options(enforce_range = true))] x: u32,
+    #[webidl(options(enforce_range = true))] y: u32,
+    #[webidl(options(enforce_range = true))] width: u32,
+    #[webidl(options(enforce_range = true))] height: u32,
+  ) {
+    let err = self
+      .instance
+      .render_pass_set_scissor_rect(
+        &mut self.render_pass.borrow_mut(),
+        x,
+        y,
+        width,
+        height,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(1)]
-    fn set_blend_constant(&self, #[webidl] color: GPUColor) {
-        let err = self
-            .instance
-            .render_pass_set_blend_constant(&mut self.render_pass.borrow_mut(), color.into())
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(1)]
+  fn set_blend_constant(&self, #[webidl] color: GPUColor) {
+    let err = self
+      .instance
+      .render_pass_set_blend_constant(
+        &mut self.render_pass.borrow_mut(),
+        color.into(),
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(1)]
-    fn set_stencil_reference(&self, #[webidl(options(enforce_range = true))] reference: u32) {
-        let err = self
-            .instance
-            .render_pass_set_stencil_reference(&mut self.render_pass.borrow_mut(), reference)
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(1)]
+  fn set_stencil_reference(
+    &self,
+    #[webidl(options(enforce_range = true))] reference: u32,
+  ) {
+    let err = self
+      .instance
+      .render_pass_set_stencil_reference(
+        &mut self.render_pass.borrow_mut(),
+        reference,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(1)]
-    fn begin_occlusion_query(&self, #[webidl(options(enforce_range = true))] query_index: u32) {
-        let err = self
-            .instance
-            .render_pass_begin_occlusion_query(&mut self.render_pass.borrow_mut(), query_index)
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(1)]
+  fn begin_occlusion_query(
+    &self,
+    #[webidl(options(enforce_range = true))] query_index: u32,
+  ) {
+    let err = self
+      .instance
+      .render_pass_begin_occlusion_query(
+        &mut self.render_pass.borrow_mut(),
+        query_index,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[fast]
-    fn end_occlusion_query(&self) {
-        let err = self
-            .instance
-            .render_pass_end_occlusion_query(&mut self.render_pass.borrow_mut())
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[fast]
+  fn end_occlusion_query(&self) {
+    let err = self
+      .instance
+      .render_pass_end_occlusion_query(&mut self.render_pass.borrow_mut())
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(1)]
-    fn execute_bundles(&self, #[webidl] bundles: Vec<Ptr<GPURenderBundle>>) {
-        let err = self
-            .instance
-            .render_pass_execute_bundles(
-                &mut self.render_pass.borrow_mut(),
-                &bundles
-                    .into_iter()
-                    .map(|bundle| bundle.id)
-                    .collect::<Vec<_>>(),
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(1)]
+  fn execute_bundles(&self, #[webidl] bundles: Vec<Ptr<GPURenderBundle>>) {
+    let err = self
+      .instance
+      .render_pass_execute_bundles(
+        &mut self.render_pass.borrow_mut(),
+        &bundles
+          .into_iter()
+          .map(|bundle| bundle.id)
+          .collect::<Vec<_>>(),
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[fast]
-    fn end(&self) {
-        let err = self
-            .instance
-            .render_pass_end(&mut self.render_pass.borrow_mut())
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[fast]
+  fn end(&self) {
+    let err = self
+      .instance
+      .render_pass_end(&mut self.render_pass.borrow_mut())
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    fn push_debug_group(&self, #[webidl] group_label: String) {
-        let err = self
-            .instance
-            .render_pass_push_debug_group(
-                &mut self.render_pass.borrow_mut(),
-                &group_label,
-                0, // wgpu#975
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  fn push_debug_group(&self, #[webidl] group_label: String) {
+    let err = self
+      .instance
+      .render_pass_push_debug_group(
+        &mut self.render_pass.borrow_mut(),
+        &group_label,
+        0, // wgpu#975
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[fast]
-    fn pop_debug_group(&self) {
-        let err = self
-            .instance
-            .render_pass_pop_debug_group(&mut self.render_pass.borrow_mut())
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[fast]
+  fn pop_debug_group(&self) {
+    let err = self
+      .instance
+      .render_pass_pop_debug_group(&mut self.render_pass.borrow_mut())
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    fn insert_debug_marker(&self, #[webidl] marker_label: String) {
-        let err = self
-            .instance
-            .render_pass_insert_debug_marker(
-                &mut self.render_pass.borrow_mut(),
-                &marker_label,
-                0, // wgpu#975
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  fn insert_debug_marker(&self, #[webidl] marker_label: String) {
+    let err = self
+      .instance
+      .render_pass_insert_debug_marker(
+        &mut self.render_pass.borrow_mut(),
+        &marker_label,
+        0, // wgpu#975
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    fn set_bind_group<'a>(
-        &self,
-        scope: &mut v8::HandleScope<'a>,
-        #[webidl(options(enforce_range = true))] index: u32,
-        #[webidl] bind_group: Nullable<Ptr<crate::bind_group::GPUBindGroup>>,
-        dynamic_offsets: v8::Local<'a, v8::Value>,
-        dynamic_offsets_data_start: v8::Local<'a, v8::Value>,
-        dynamic_offsets_data_length: v8::Local<'a, v8::Value>,
-    ) -> Result<(), WebIdlError> {
-        const PREFIX: &str = "Failed to execute 'setBindGroup' on 'GPUComputePassEncoder'";
+  fn set_bind_group<'a>(
+    &self,
+    scope: &mut v8::HandleScope<'a>,
+    #[webidl(options(enforce_range = true))] index: u32,
+    #[webidl] bind_group: Nullable<Ptr<crate::bind_group::GPUBindGroup>>,
+    dynamic_offsets: v8::Local<'a, v8::Value>,
+    dynamic_offsets_data_start: v8::Local<'a, v8::Value>,
+    dynamic_offsets_data_length: v8::Local<'a, v8::Value>,
+  ) -> Result<(), WebIdlError> {
+    const PREFIX: &str =
+      "Failed to execute 'setBindGroup' on 'GPUComputePassEncoder'";
 
-        let err = if let Ok(uint_32) = dynamic_offsets.try_cast::<v8::Uint32Array>() {
-            let start = u64::convert(
-                scope,
-                dynamic_offsets_data_start,
-                Cow::Borrowed(PREFIX),
-                (|| Cow::Borrowed("Argument 4")).into(),
-                &IntOptions {
-                    clamp: false,
-                    enforce_range: true,
-                },
-            )? as usize;
-            let len = u32::convert(
-                scope,
-                dynamic_offsets_data_length,
-                Cow::Borrowed(PREFIX),
-                (|| Cow::Borrowed("Argument 5")).into(),
-                &IntOptions {
-                    clamp: false,
-                    enforce_range: true,
-                },
-            )? as usize;
+    let err = if let Ok(uint_32) = dynamic_offsets.try_cast::<v8::Uint32Array>()
+    {
+      let start = u64::convert(
+        scope,
+        dynamic_offsets_data_start,
+        Cow::Borrowed(PREFIX),
+        (|| Cow::Borrowed("Argument 4")).into(),
+        &IntOptions {
+          clamp: false,
+          enforce_range: true,
+        },
+      )? as usize;
+      let len = u32::convert(
+        scope,
+        dynamic_offsets_data_length,
+        Cow::Borrowed(PREFIX),
+        (|| Cow::Borrowed("Argument 5")).into(),
+        &IntOptions {
+          clamp: false,
+          enforce_range: true,
+        },
+      )? as usize;
 
-            let ab = uint_32.buffer(scope).unwrap();
-            let ptr = ab.data().unwrap();
-            let ab_len = ab.byte_length() / 4;
+      let ab = uint_32.buffer(scope).unwrap();
+      let ptr = ab.data().unwrap();
+      let ab_len = ab.byte_length() / 4;
 
-            // SAFETY: created from an array buffer, slice is dropped at end of function call
-            let data = unsafe { std::slice::from_raw_parts(ptr.as_ptr() as _, ab_len) };
+      // SAFETY: created from an array buffer, slice is dropped at end of function call
+      let data =
+        unsafe { std::slice::from_raw_parts(ptr.as_ptr() as _, ab_len) };
 
-            let offsets = &data[start..(start + len)];
+      let offsets = &data[start..(start + len)];
 
-            self.instance
-                .render_pass_set_bind_group(
-                    &mut self.render_pass.borrow_mut(),
-                    index,
-                    bind_group.into_option().map(|bind_group| bind_group.id),
-                    offsets,
-                )
-                .err()
-        } else {
-            let offsets = <Option<Vec<u32>>>::convert(
-                scope,
-                dynamic_offsets,
-                Cow::Borrowed(PREFIX),
-                (|| Cow::Borrowed("Argument 3")).into(),
-                &IntOptions {
-                    clamp: false,
-                    enforce_range: true,
-                },
-            )?
-            .unwrap_or_default();
+      self
+        .instance
+        .render_pass_set_bind_group(
+          &mut self.render_pass.borrow_mut(),
+          index,
+          bind_group.into_option().map(|bind_group| bind_group.id),
+          offsets,
+        )
+        .err()
+    } else {
+      let offsets = <Option<Vec<u32>>>::convert(
+        scope,
+        dynamic_offsets,
+        Cow::Borrowed(PREFIX),
+        (|| Cow::Borrowed("Argument 3")).into(),
+        &IntOptions {
+          clamp: false,
+          enforce_range: true,
+        },
+      )?
+      .unwrap_or_default();
 
-            self.instance
-                .render_pass_set_bind_group(
-                    &mut self.render_pass.borrow_mut(),
-                    index,
-                    bind_group.into_option().map(|bind_group| bind_group.id),
-                    &offsets,
-                )
-                .err()
-        };
+      self
+        .instance
+        .render_pass_set_bind_group(
+          &mut self.render_pass.borrow_mut(),
+          index,
+          bind_group.into_option().map(|bind_group| bind_group.id),
+          &offsets,
+        )
+        .err()
+    };
 
-        self.error_handler.push_error(err);
+    self.error_handler.push_error(err);
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    fn set_pipeline(&self, #[webidl] pipeline: Ptr<crate::render_pipeline::GPURenderPipeline>) {
-        let err = self
-            .instance
-            .render_pass_set_pipeline(&mut self.render_pass.borrow_mut(), pipeline.id)
-            .err();
-        self.error_handler.push_error(err);
-    }
+  fn set_pipeline(
+    &self,
+    #[webidl] pipeline: Ptr<crate::render_pipeline::GPURenderPipeline>,
+  ) {
+    let err = self
+      .instance
+      .render_pass_set_pipeline(&mut self.render_pass.borrow_mut(), pipeline.id)
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(2)]
-    fn set_index_buffer(
-        &self,
-        #[webidl] buffer: Ptr<GPUBuffer>,
-        #[webidl] index_format: crate::render_pipeline::GPUIndexFormat,
-        #[webidl(default = 0, options(enforce_range = true))] offset: u64,
-        #[webidl(options(enforce_range = true))] size: Option<u64>,
-    ) {
-        let err = self
-            .instance
-            .render_pass_set_index_buffer(
-                &mut self.render_pass.borrow_mut(),
-                buffer.id,
-                index_format.into(),
-                offset,
-                size.and_then(NonZeroU64::new),
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(2)]
+  fn set_index_buffer(
+    &self,
+    #[webidl] buffer: Ptr<GPUBuffer>,
+    #[webidl] index_format: crate::render_pipeline::GPUIndexFormat,
+    #[webidl(default = 0, options(enforce_range = true))] offset: u64,
+    #[webidl(options(enforce_range = true))] size: Option<u64>,
+  ) {
+    let err = self
+      .instance
+      .render_pass_set_index_buffer(
+        &mut self.render_pass.borrow_mut(),
+        buffer.id,
+        index_format.into(),
+        offset,
+        size.and_then(NonZeroU64::new),
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(2)]
-    fn set_vertex_buffer(
-        &self,
-        #[webidl(options(enforce_range = true))] slot: u32,
-        #[webidl] buffer: Ptr<GPUBuffer>, // TODO(wgpu): support nullable buffer
-        #[webidl(default = 0, options(enforce_range = true))] offset: u64,
-        #[webidl(options(enforce_range = true))] size: Option<u64>,
-    ) {
-        let err = self
-            .instance
-            .render_pass_set_vertex_buffer(
-                &mut self.render_pass.borrow_mut(),
-                slot,
-                buffer.id,
-                offset,
-                size.and_then(NonZeroU64::new),
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(2)]
+  fn set_vertex_buffer(
+    &self,
+    #[webidl(options(enforce_range = true))] slot: u32,
+    #[webidl] buffer: Ptr<GPUBuffer>, // TODO(wgpu): support nullable buffer
+    #[webidl(default = 0, options(enforce_range = true))] offset: u64,
+    #[webidl(options(enforce_range = true))] size: Option<u64>,
+  ) {
+    let err = self
+      .instance
+      .render_pass_set_vertex_buffer(
+        &mut self.render_pass.borrow_mut(),
+        slot,
+        buffer.id,
+        offset,
+        size.and_then(NonZeroU64::new),
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(1)]
-    fn draw(
-        &self,
-        #[webidl(options(enforce_range = true))] vertex_count: u32,
-        #[webidl(default = 1, options(enforce_range = true))] instance_count: u32,
-        #[webidl(default = 0, options(enforce_range = true))] first_vertex: u32,
-        #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
-    ) {
-        let err = self
-            .instance
-            .render_pass_draw(
-                &mut self.render_pass.borrow_mut(),
-                vertex_count,
-                instance_count,
-                first_vertex,
-                first_instance,
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(1)]
+  fn draw(
+    &self,
+    #[webidl(options(enforce_range = true))] vertex_count: u32,
+    #[webidl(default = 1, options(enforce_range = true))] instance_count: u32,
+    #[webidl(default = 0, options(enforce_range = true))] first_vertex: u32,
+    #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
+  ) {
+    let err = self
+      .instance
+      .render_pass_draw(
+        &mut self.render_pass.borrow_mut(),
+        vertex_count,
+        instance_count,
+        first_vertex,
+        first_instance,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(1)]
-    fn draw_indexed(
-        &self,
-        #[webidl(options(enforce_range = true))] index_count: u32,
-        #[webidl(default = 1, options(enforce_range = true))] instance_count: u32,
-        #[webidl(default = 0, options(enforce_range = true))] first_index: u32,
-        #[webidl(default = 0, options(enforce_range = true))] base_vertex: i32,
-        #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
-    ) {
-        let err = self
-            .instance
-            .render_pass_draw_indexed(
-                &mut self.render_pass.borrow_mut(),
-                index_count,
-                instance_count,
-                first_index,
-                base_vertex,
-                first_instance,
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(1)]
+  fn draw_indexed(
+    &self,
+    #[webidl(options(enforce_range = true))] index_count: u32,
+    #[webidl(default = 1, options(enforce_range = true))] instance_count: u32,
+    #[webidl(default = 0, options(enforce_range = true))] first_index: u32,
+    #[webidl(default = 0, options(enforce_range = true))] base_vertex: i32,
+    #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
+  ) {
+    let err = self
+      .instance
+      .render_pass_draw_indexed(
+        &mut self.render_pass.borrow_mut(),
+        index_count,
+        instance_count,
+        first_index,
+        base_vertex,
+        first_instance,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(2)]
-    fn draw_indirect(
-        &self,
-        #[webidl] indirect_buffer: Ptr<GPUBuffer>,
-        #[webidl(options(enforce_range = true))] indirect_offset: u64,
-    ) {
-        let err = self
-            .instance
-            .render_pass_draw_indirect(
-                &mut self.render_pass.borrow_mut(),
-                indirect_buffer.id,
-                indirect_offset,
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(2)]
+  fn draw_indirect(
+    &self,
+    #[webidl] indirect_buffer: Ptr<GPUBuffer>,
+    #[webidl(options(enforce_range = true))] indirect_offset: u64,
+  ) {
+    let err = self
+      .instance
+      .render_pass_draw_indirect(
+        &mut self.render_pass.borrow_mut(),
+        indirect_buffer.id,
+        indirect_offset,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 
-    #[required(2)]
-    fn draw_indexed_indirect(
-        &self,
-        #[webidl] indirect_buffer: Ptr<GPUBuffer>,
-        #[webidl(options(enforce_range = true))] indirect_offset: u64,
-    ) {
-        let err = self
-            .instance
-            .render_pass_draw_indexed_indirect(
-                &mut self.render_pass.borrow_mut(),
-                indirect_buffer.id,
-                indirect_offset,
-            )
-            .err();
-        self.error_handler.push_error(err);
-    }
+  #[required(2)]
+  fn draw_indexed_indirect(
+    &self,
+    #[webidl] indirect_buffer: Ptr<GPUBuffer>,
+    #[webidl(options(enforce_range = true))] indirect_offset: u64,
+  ) {
+    let err = self
+      .instance
+      .render_pass_draw_indexed_indirect(
+        &mut self.render_pass.borrow_mut(),
+        indirect_buffer.id,
+        indirect_offset,
+      )
+      .err();
+    self.error_handler.push_error(err);
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPURenderPassDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub color_attachments: Vec<Nullable<GPURenderPassColorAttachment>>,
-    pub depth_stencil_attachment: Option<GPURenderPassDepthStencilAttachment>,
-    pub occlusion_query_set: Option<Ptr<crate::query_set::GPUQuerySet>>,
-    pub timestamp_writes: Option<GPURenderPassTimestampWrites>,
-    /*#[webidl(default = 50000000)]
-    #[options(enforce_range = true)]
-    pub max_draw_count: u64,*/
+  pub color_attachments: Vec<Nullable<GPURenderPassColorAttachment>>,
+  pub depth_stencil_attachment: Option<GPURenderPassDepthStencilAttachment>,
+  pub occlusion_query_set: Option<Ptr<crate::query_set::GPUQuerySet>>,
+  pub timestamp_writes: Option<GPURenderPassTimestampWrites>,
+  /*#[webidl(default = 50000000)]
+  #[options(enforce_range = true)]
+  pub max_draw_count: u64,*/
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPURenderPassColorAttachment {
-    pub view: Ptr<GPUTextureView>,
-    #[options(enforce_range = true)]
-    pub depth_slice: Option<u32>,
-    pub resolve_target: Option<Ptr<GPUTextureView>>,
-    pub clear_value: Option<GPUColor>,
-    pub load_op: GPULoadOp,
-    pub store_op: GPUStoreOp,
+  pub view: Ptr<GPUTextureView>,
+  #[options(enforce_range = true)]
+  pub depth_slice: Option<u32>,
+  pub resolve_target: Option<Ptr<GPUTextureView>>,
+  pub clear_value: Option<GPUColor>,
+  pub load_op: GPULoadOp,
+  pub store_op: GPUStoreOp,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPULoadOp {
-    Load,
-    Clear,
+  Load,
+  Clear,
 }
 impl GPULoadOp {
-    pub fn with_default_value<V: Default>(self, val: Option<V>) -> wgpu_core::command::LoadOp<V> {
-        match self {
-            GPULoadOp::Load => wgpu_core::command::LoadOp::Load,
-            GPULoadOp::Clear => wgpu_core::command::LoadOp::Clear(val.unwrap_or_default()),
-        }
+  pub fn with_default_value<V: Default>(
+    self,
+    val: Option<V>,
+  ) -> wgpu_core::command::LoadOp<V> {
+    match self {
+      GPULoadOp::Load => wgpu_core::command::LoadOp::Load,
+      GPULoadOp::Clear => {
+        wgpu_core::command::LoadOp::Clear(val.unwrap_or_default())
+      }
     }
+  }
 
-    pub fn with_value<V>(self, val: V) -> wgpu_core::command::LoadOp<V> {
-        match self {
-            GPULoadOp::Load => wgpu_core::command::LoadOp::Load,
-            GPULoadOp::Clear => wgpu_core::command::LoadOp::Clear(val),
-        }
+  pub fn with_value<V>(self, val: V) -> wgpu_core::command::LoadOp<V> {
+    match self {
+      GPULoadOp::Load => wgpu_core::command::LoadOp::Load,
+      GPULoadOp::Clear => wgpu_core::command::LoadOp::Clear(val),
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUStoreOp {
-    Store,
-    Discard,
+  Store,
+  Discard,
 }
 impl From<GPUStoreOp> for wgpu_core::command::StoreOp {
-    fn from(value: GPUStoreOp) -> Self {
-        match value {
-            GPUStoreOp::Store => Self::Store,
-            GPUStoreOp::Discard => Self::Discard,
-        }
+  fn from(value: GPUStoreOp) -> Self {
+    match value {
+      GPUStoreOp::Store => Self::Store,
+      GPUStoreOp::Discard => Self::Discard,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPURenderPassDepthStencilAttachment {
-    pub view: Ptr<GPUTextureView>,
-    pub depth_clear_value: Option<f32>,
-    pub depth_load_op: Option<GPULoadOp>,
-    pub depth_store_op: Option<GPUStoreOp>,
-    #[webidl(default = false)]
-    pub depth_read_only: bool,
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    pub stencil_clear_value: u32,
-    pub stencil_load_op: Option<GPULoadOp>,
-    pub stencil_store_op: Option<GPUStoreOp>,
-    #[webidl(default = false)]
-    pub stencil_read_only: bool,
+  pub view: Ptr<GPUTextureView>,
+  pub depth_clear_value: Option<f32>,
+  pub depth_load_op: Option<GPULoadOp>,
+  pub depth_store_op: Option<GPUStoreOp>,
+  #[webidl(default = false)]
+  pub depth_read_only: bool,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  pub stencil_clear_value: u32,
+  pub stencil_load_op: Option<GPULoadOp>,
+  pub stencil_store_op: Option<GPUStoreOp>,
+  #[webidl(default = false)]
+  pub stencil_read_only: bool,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPURenderPassTimestampWrites {
-    pub query_set: Ptr<crate::query_set::GPUQuerySet>,
-    #[options(enforce_range = true)]
-    pub beginning_of_pass_write_index: Option<u32>,
-    #[options(enforce_range = true)]
-    pub end_of_pass_write_index: Option<u32>,
+  pub query_set: Ptr<crate::query_set::GPUQuerySet>,
+  #[options(enforce_range = true)]
+  pub beginning_of_pass_write_index: Option<u32>,
+  #[options(enforce_range = true)]
+  pub end_of_pass_write_index: Option<u32>,
 }

--- a/deno_webgpu/render_pipeline.rs
+++ b/deno_webgpu/render_pipeline.rs
@@ -33,7 +33,11 @@ impl WebIdlInterfaceConverter for GPURenderPipeline {
   const NAME: &'static str = "GPURenderPipeline";
 }
 
-impl GarbageCollected for GPURenderPipeline {}
+impl GarbageCollected for GPURenderPipeline {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPURenderPipeline"
+  }
+}
 
 #[op2]
 impl GPURenderPipeline {

--- a/deno_webgpu/render_pipeline.rs
+++ b/deno_webgpu/render_pipeline.rs
@@ -16,535 +16,535 @@ use crate::webidl::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use crate::Instance;
 
 pub struct GPURenderPipeline {
-    pub instance: Instance,
-    pub error_handler: super::error::ErrorHandler,
+  pub instance: Instance,
+  pub error_handler: super::error::ErrorHandler,
 
-    pub id: wgpu_core::id::RenderPipelineId,
-    pub label: String,
+  pub id: wgpu_core::id::RenderPipelineId,
+  pub label: String,
 }
 
 impl Drop for GPURenderPipeline {
-    fn drop(&mut self) {
-        self.instance.render_pipeline_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.render_pipeline_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPURenderPipeline {
-    const NAME: &'static str = "GPURenderPipeline";
+  const NAME: &'static str = "GPURenderPipeline";
 }
 
 impl GarbageCollected for GPURenderPipeline {}
 
 #[op2]
 impl GPURenderPipeline {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 
-    #[cppgc]
-    fn get_bind_group_layout(&self, #[webidl] index: u32) -> GPUBindGroupLayout {
-        let (id, err) = self
-            .instance
-            .render_pipeline_get_bind_group_layout(self.id, index, None);
+  #[cppgc]
+  fn get_bind_group_layout(&self, #[webidl] index: u32) -> GPUBindGroupLayout {
+    let (id, err) = self
+      .instance
+      .render_pipeline_get_bind_group_layout(self.id, index, None);
 
-        self.error_handler.push_error(err);
+    self.error_handler.push_error(err);
 
-        // TODO(wgpu): needs to add a way to retrieve the label
-        GPUBindGroupLayout {
-            instance: self.instance.clone(),
-            id,
-            label: "".to_string(),
-        }
+    // TODO(wgpu): needs to add a way to retrieve the label
+    GPUBindGroupLayout {
+      instance: self.instance.clone(),
+      id,
+      label: "".to_string(),
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPURenderPipelineDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub layout: GPUPipelineLayoutOrGPUAutoLayoutMode,
-    pub vertex: GPUVertexState,
-    pub primitive: GPUPrimitiveState,
-    pub depth_stencil: Option<GPUDepthStencilState>,
-    pub multisample: GPUMultisampleState,
-    pub fragment: Option<GPUFragmentState>,
+  pub layout: GPUPipelineLayoutOrGPUAutoLayoutMode,
+  pub vertex: GPUVertexState,
+  pub primitive: GPUPrimitiveState,
+  pub depth_stencil: Option<GPUDepthStencilState>,
+  pub multisample: GPUMultisampleState,
+  pub fragment: Option<GPUFragmentState>,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUMultisampleState {
-    #[webidl(default = 1)]
-    #[options(enforce_range = true)]
-    pub count: u32,
-    #[webidl(default = 0xFFFFFFFF)]
-    #[options(enforce_range = true)]
-    pub mask: u32,
-    #[webidl(default = false)]
-    pub alpha_to_coverage_enabled: bool,
+  #[webidl(default = 1)]
+  #[options(enforce_range = true)]
+  pub count: u32,
+  #[webidl(default = 0xFFFFFFFF)]
+  #[options(enforce_range = true)]
+  pub mask: u32,
+  #[webidl(default = false)]
+  pub alpha_to_coverage_enabled: bool,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUDepthStencilState {
-    pub format: GPUTextureFormat,
-    pub depth_write_enabled: Option<bool>,
-    pub depth_compare: Option<GPUCompareFunction>,
-    pub stencil_front: GPUStencilFaceState,
-    pub stencil_back: GPUStencilFaceState,
-    #[webidl(default = 0xFFFFFFFF)]
-    #[options(enforce_range = true)]
-    pub stencil_read_mask: u32,
-    #[webidl(default = 0xFFFFFFFF)]
-    #[options(enforce_range = true)]
-    pub stencil_write_mask: u32,
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    pub depth_bias: i32,
-    #[webidl(default = 0.0)]
-    pub depth_bias_slope_scale: f32,
-    #[webidl(default = 0.0)]
-    pub depth_bias_clamp: f32,
+  pub format: GPUTextureFormat,
+  pub depth_write_enabled: Option<bool>,
+  pub depth_compare: Option<GPUCompareFunction>,
+  pub stencil_front: GPUStencilFaceState,
+  pub stencil_back: GPUStencilFaceState,
+  #[webidl(default = 0xFFFFFFFF)]
+  #[options(enforce_range = true)]
+  pub stencil_read_mask: u32,
+  #[webidl(default = 0xFFFFFFFF)]
+  #[options(enforce_range = true)]
+  pub stencil_write_mask: u32,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  pub depth_bias: i32,
+  #[webidl(default = 0.0)]
+  pub depth_bias_slope_scale: f32,
+  #[webidl(default = 0.0)]
+  pub depth_bias_clamp: f32,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUStencilFaceState {
-    #[webidl(default = GPUCompareFunction::Always)]
-    pub compare: GPUCompareFunction,
-    #[webidl(default = GPUStencilOperation::Keep)]
-    pub fail_op: GPUStencilOperation,
-    #[webidl(default = GPUStencilOperation::Keep)]
-    pub depth_fail_op: GPUStencilOperation,
-    #[webidl(default = GPUStencilOperation::Keep)]
-    pub pass_op: GPUStencilOperation,
+  #[webidl(default = GPUCompareFunction::Always)]
+  pub compare: GPUCompareFunction,
+  #[webidl(default = GPUStencilOperation::Keep)]
+  pub fail_op: GPUStencilOperation,
+  #[webidl(default = GPUStencilOperation::Keep)]
+  pub depth_fail_op: GPUStencilOperation,
+  #[webidl(default = GPUStencilOperation::Keep)]
+  pub pass_op: GPUStencilOperation,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUStencilOperation {
-    Keep,
-    Zero,
-    Replace,
-    Invert,
-    IncrementClamp,
-    DecrementClamp,
-    IncrementWrap,
-    DecrementWrap,
+  Keep,
+  Zero,
+  Replace,
+  Invert,
+  IncrementClamp,
+  DecrementClamp,
+  IncrementWrap,
+  DecrementWrap,
 }
 
 impl From<GPUStencilOperation> for wgpu_types::StencilOperation {
-    fn from(value: GPUStencilOperation) -> Self {
-        match value {
-            GPUStencilOperation::Keep => Self::Keep,
-            GPUStencilOperation::Zero => Self::Zero,
-            GPUStencilOperation::Replace => Self::Replace,
-            GPUStencilOperation::Invert => Self::Invert,
-            GPUStencilOperation::IncrementClamp => Self::IncrementClamp,
-            GPUStencilOperation::DecrementClamp => Self::DecrementClamp,
-            GPUStencilOperation::IncrementWrap => Self::IncrementWrap,
-            GPUStencilOperation::DecrementWrap => Self::DecrementWrap,
-        }
+  fn from(value: GPUStencilOperation) -> Self {
+    match value {
+      GPUStencilOperation::Keep => Self::Keep,
+      GPUStencilOperation::Zero => Self::Zero,
+      GPUStencilOperation::Replace => Self::Replace,
+      GPUStencilOperation::Invert => Self::Invert,
+      GPUStencilOperation::IncrementClamp => Self::IncrementClamp,
+      GPUStencilOperation::DecrementClamp => Self::DecrementClamp,
+      GPUStencilOperation::IncrementWrap => Self::IncrementWrap,
+      GPUStencilOperation::DecrementWrap => Self::DecrementWrap,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUVertexState {
-    pub module: Ptr<GPUShaderModule>,
-    pub entry_point: Option<String>,
-    #[webidl(default = Default::default())]
-    pub constants: IndexMap<String, f64>,
-    #[webidl(default = vec![])]
-    pub buffers: Vec<Nullable<GPUVertexBufferLayout>>,
+  pub module: Ptr<GPUShaderModule>,
+  pub entry_point: Option<String>,
+  #[webidl(default = Default::default())]
+  pub constants: IndexMap<String, f64>,
+  #[webidl(default = vec![])]
+  pub buffers: Vec<Nullable<GPUVertexBufferLayout>>,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUFragmentState {
-    pub module: Ptr<GPUShaderModule>,
-    pub entry_point: Option<String>,
-    #[webidl(default = Default::default())]
-    pub constants: IndexMap<String, f64>,
-    pub targets: Vec<Nullable<GPUColorTargetState>>,
+  pub module: Ptr<GPUShaderModule>,
+  pub entry_point: Option<String>,
+  #[webidl(default = Default::default())]
+  pub constants: IndexMap<String, f64>,
+  pub targets: Vec<Nullable<GPUColorTargetState>>,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUColorTargetState {
-    pub format: GPUTextureFormat,
-    pub blend: Option<GPUBlendState>,
-    #[webidl(default = 0xF)]
-    #[options(enforce_range = true)]
-    pub write_mask: u32,
+  pub format: GPUTextureFormat,
+  pub blend: Option<GPUBlendState>,
+  #[webidl(default = 0xF)]
+  #[options(enforce_range = true)]
+  pub write_mask: u32,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUBlendState {
-    pub color: GPUBlendComponent,
-    pub alpha: GPUBlendComponent,
+  pub color: GPUBlendComponent,
+  pub alpha: GPUBlendComponent,
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUBlendComponent {
-    #[webidl(default = GPUBlendOperation::Add)]
-    pub operation: GPUBlendOperation,
-    #[webidl(default = GPUBlendFactor::One)]
-    pub src_factor: GPUBlendFactor,
-    #[webidl(default = GPUBlendFactor::Zero)]
-    pub dst_factor: GPUBlendFactor,
+  #[webidl(default = GPUBlendOperation::Add)]
+  pub operation: GPUBlendOperation,
+  #[webidl(default = GPUBlendFactor::One)]
+  pub src_factor: GPUBlendFactor,
+  #[webidl(default = GPUBlendFactor::Zero)]
+  pub dst_factor: GPUBlendFactor,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUBlendOperation {
-    Add,
-    Subtract,
-    ReverseSubtract,
-    Min,
-    Max,
+  Add,
+  Subtract,
+  ReverseSubtract,
+  Min,
+  Max,
 }
 
 impl From<GPUBlendOperation> for wgpu_types::BlendOperation {
-    fn from(value: GPUBlendOperation) -> Self {
-        match value {
-            GPUBlendOperation::Add => Self::Add,
-            GPUBlendOperation::Subtract => Self::Subtract,
-            GPUBlendOperation::ReverseSubtract => Self::ReverseSubtract,
-            GPUBlendOperation::Min => Self::Min,
-            GPUBlendOperation::Max => Self::Max,
-        }
+  fn from(value: GPUBlendOperation) -> Self {
+    match value {
+      GPUBlendOperation::Add => Self::Add,
+      GPUBlendOperation::Subtract => Self::Subtract,
+      GPUBlendOperation::ReverseSubtract => Self::ReverseSubtract,
+      GPUBlendOperation::Min => Self::Min,
+      GPUBlendOperation::Max => Self::Max,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUBlendFactor {
-    #[webidl(rename = "zero")]
-    Zero,
-    #[webidl(rename = "one")]
-    One,
-    #[webidl(rename = "src")]
-    Src,
-    #[webidl(rename = "one-minus-src")]
-    OneMinusSrc,
-    #[webidl(rename = "src-alpha")]
-    SrcAlpha,
-    #[webidl(rename = "one-minus-src-alpha")]
-    OneMinusSrcAlpha,
-    #[webidl(rename = "dst")]
-    Dst,
-    #[webidl(rename = "one-minus-dst")]
-    OneMinusDst,
-    #[webidl(rename = "dst-alpha")]
-    DstAlpha,
-    #[webidl(rename = "one-minus-dst-alpha")]
-    OneMinusDstAlpha,
-    #[webidl(rename = "src-alpha-saturated")]
-    SrcAlphaSaturated,
-    #[webidl(rename = "constant")]
-    Constant,
-    #[webidl(rename = "one-minus-constant")]
-    OneMinusConstant,
-    #[webidl(rename = "src1")]
-    Src1,
-    #[webidl(rename = "one-minus-src1")]
-    OneMinusSrc1,
-    #[webidl(rename = "src1-alpha")]
-    Src1Alpha,
-    #[webidl(rename = "one-minus-src1-alpha")]
-    OneMinusSrc1Alpha,
+  #[webidl(rename = "zero")]
+  Zero,
+  #[webidl(rename = "one")]
+  One,
+  #[webidl(rename = "src")]
+  Src,
+  #[webidl(rename = "one-minus-src")]
+  OneMinusSrc,
+  #[webidl(rename = "src-alpha")]
+  SrcAlpha,
+  #[webidl(rename = "one-minus-src-alpha")]
+  OneMinusSrcAlpha,
+  #[webidl(rename = "dst")]
+  Dst,
+  #[webidl(rename = "one-minus-dst")]
+  OneMinusDst,
+  #[webidl(rename = "dst-alpha")]
+  DstAlpha,
+  #[webidl(rename = "one-minus-dst-alpha")]
+  OneMinusDstAlpha,
+  #[webidl(rename = "src-alpha-saturated")]
+  SrcAlphaSaturated,
+  #[webidl(rename = "constant")]
+  Constant,
+  #[webidl(rename = "one-minus-constant")]
+  OneMinusConstant,
+  #[webidl(rename = "src1")]
+  Src1,
+  #[webidl(rename = "one-minus-src1")]
+  OneMinusSrc1,
+  #[webidl(rename = "src1-alpha")]
+  Src1Alpha,
+  #[webidl(rename = "one-minus-src1-alpha")]
+  OneMinusSrc1Alpha,
 }
 
 impl From<GPUBlendFactor> for wgpu_types::BlendFactor {
-    fn from(value: GPUBlendFactor) -> Self {
-        match value {
-            GPUBlendFactor::Zero => Self::Zero,
-            GPUBlendFactor::One => Self::One,
-            GPUBlendFactor::Src => Self::Src,
-            GPUBlendFactor::OneMinusSrc => Self::OneMinusSrc,
-            GPUBlendFactor::SrcAlpha => Self::SrcAlpha,
-            GPUBlendFactor::OneMinusSrcAlpha => Self::OneMinusSrcAlpha,
-            GPUBlendFactor::Dst => Self::Dst,
-            GPUBlendFactor::OneMinusDst => Self::OneMinusDst,
-            GPUBlendFactor::DstAlpha => Self::DstAlpha,
-            GPUBlendFactor::OneMinusDstAlpha => Self::OneMinusDstAlpha,
-            GPUBlendFactor::SrcAlphaSaturated => Self::SrcAlphaSaturated,
-            GPUBlendFactor::Constant => Self::Constant,
-            GPUBlendFactor::OneMinusConstant => Self::OneMinusConstant,
-            GPUBlendFactor::Src1 => Self::Src1,
-            GPUBlendFactor::OneMinusSrc1 => Self::OneMinusSrc1,
-            GPUBlendFactor::Src1Alpha => Self::Src1Alpha,
-            GPUBlendFactor::OneMinusSrc1Alpha => Self::OneMinusSrc1Alpha,
-        }
+  fn from(value: GPUBlendFactor) -> Self {
+    match value {
+      GPUBlendFactor::Zero => Self::Zero,
+      GPUBlendFactor::One => Self::One,
+      GPUBlendFactor::Src => Self::Src,
+      GPUBlendFactor::OneMinusSrc => Self::OneMinusSrc,
+      GPUBlendFactor::SrcAlpha => Self::SrcAlpha,
+      GPUBlendFactor::OneMinusSrcAlpha => Self::OneMinusSrcAlpha,
+      GPUBlendFactor::Dst => Self::Dst,
+      GPUBlendFactor::OneMinusDst => Self::OneMinusDst,
+      GPUBlendFactor::DstAlpha => Self::DstAlpha,
+      GPUBlendFactor::OneMinusDstAlpha => Self::OneMinusDstAlpha,
+      GPUBlendFactor::SrcAlphaSaturated => Self::SrcAlphaSaturated,
+      GPUBlendFactor::Constant => Self::Constant,
+      GPUBlendFactor::OneMinusConstant => Self::OneMinusConstant,
+      GPUBlendFactor::Src1 => Self::Src1,
+      GPUBlendFactor::OneMinusSrc1 => Self::OneMinusSrc1,
+      GPUBlendFactor::Src1Alpha => Self::Src1Alpha,
+      GPUBlendFactor::OneMinusSrc1Alpha => Self::OneMinusSrc1Alpha,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUPrimitiveState {
-    #[webidl(default = GPUPrimitiveTopology::TriangleList)]
-    pub topology: GPUPrimitiveTopology,
-    pub strip_index_format: Option<GPUIndexFormat>,
-    #[webidl(default = GPUFrontFace::Ccw)]
-    pub front_face: GPUFrontFace,
-    #[webidl(default = GPUCullMode::None)]
-    pub cull_mode: GPUCullMode,
-    #[webidl(default = false)]
-    pub unclipped_depth: bool,
+  #[webidl(default = GPUPrimitiveTopology::TriangleList)]
+  pub topology: GPUPrimitiveTopology,
+  pub strip_index_format: Option<GPUIndexFormat>,
+  #[webidl(default = GPUFrontFace::Ccw)]
+  pub front_face: GPUFrontFace,
+  #[webidl(default = GPUCullMode::None)]
+  pub cull_mode: GPUCullMode,
+  #[webidl(default = false)]
+  pub unclipped_depth: bool,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUPrimitiveTopology {
-    PointList,
-    LineList,
-    LineStrip,
-    TriangleList,
-    TriangleStrip,
+  PointList,
+  LineList,
+  LineStrip,
+  TriangleList,
+  TriangleStrip,
 }
 
 impl From<GPUPrimitiveTopology> for wgpu_types::PrimitiveTopology {
-    fn from(value: GPUPrimitiveTopology) -> Self {
-        match value {
-            GPUPrimitiveTopology::PointList => Self::PointList,
-            GPUPrimitiveTopology::LineList => Self::LineList,
-            GPUPrimitiveTopology::LineStrip => Self::LineStrip,
-            GPUPrimitiveTopology::TriangleList => Self::TriangleList,
-            GPUPrimitiveTopology::TriangleStrip => Self::TriangleStrip,
-        }
+  fn from(value: GPUPrimitiveTopology) -> Self {
+    match value {
+      GPUPrimitiveTopology::PointList => Self::PointList,
+      GPUPrimitiveTopology::LineList => Self::LineList,
+      GPUPrimitiveTopology::LineStrip => Self::LineStrip,
+      GPUPrimitiveTopology::TriangleList => Self::TriangleList,
+      GPUPrimitiveTopology::TriangleStrip => Self::TriangleStrip,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUIndexFormat {
-    #[webidl(rename = "uint16")]
-    Uint16,
-    #[webidl(rename = "uint32")]
-    Uint32,
+  #[webidl(rename = "uint16")]
+  Uint16,
+  #[webidl(rename = "uint32")]
+  Uint32,
 }
 
 impl From<GPUIndexFormat> for wgpu_types::IndexFormat {
-    fn from(value: GPUIndexFormat) -> Self {
-        match value {
-            GPUIndexFormat::Uint16 => Self::Uint16,
-            GPUIndexFormat::Uint32 => Self::Uint32,
-        }
+  fn from(value: GPUIndexFormat) -> Self {
+    match value {
+      GPUIndexFormat::Uint16 => Self::Uint16,
+      GPUIndexFormat::Uint32 => Self::Uint32,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUFrontFace {
-    Ccw,
-    Cw,
+  Ccw,
+  Cw,
 }
 
 impl From<GPUFrontFace> for wgpu_types::FrontFace {
-    fn from(value: GPUFrontFace) -> Self {
-        match value {
-            GPUFrontFace::Ccw => Self::Ccw,
-            GPUFrontFace::Cw => Self::Cw,
-        }
+  fn from(value: GPUFrontFace) -> Self {
+    match value {
+      GPUFrontFace::Ccw => Self::Ccw,
+      GPUFrontFace::Cw => Self::Cw,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUCullMode {
-    None,
-    Front,
-    Back,
+  None,
+  Front,
+  Back,
 }
 
 impl From<GPUCullMode> for Option<wgpu_types::Face> {
-    fn from(value: GPUCullMode) -> Self {
-        match value {
-            GPUCullMode::None => None,
-            GPUCullMode::Front => Some(wgpu_types::Face::Front),
-            GPUCullMode::Back => Some(wgpu_types::Face::Back),
-        }
+  fn from(value: GPUCullMode) -> Self {
+    match value {
+      GPUCullMode::None => None,
+      GPUCullMode::Front => Some(wgpu_types::Face::Front),
+      GPUCullMode::Back => Some(wgpu_types::Face::Back),
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUVertexBufferLayout {
-    #[options(enforce_range = true)]
-    pub array_stride: u64,
-    #[webidl(default = GPUVertexStepMode::Vertex)]
-    pub step_mode: GPUVertexStepMode,
-    pub attributes: Vec<GPUVertexAttribute>,
+  #[options(enforce_range = true)]
+  pub array_stride: u64,
+  #[webidl(default = GPUVertexStepMode::Vertex)]
+  pub step_mode: GPUVertexStepMode,
+  pub attributes: Vec<GPUVertexAttribute>,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUVertexStepMode {
-    Vertex,
-    Instance,
+  Vertex,
+  Instance,
 }
 
 impl From<GPUVertexStepMode> for wgpu_types::VertexStepMode {
-    fn from(value: GPUVertexStepMode) -> Self {
-        match value {
-            GPUVertexStepMode::Vertex => Self::Vertex,
-            GPUVertexStepMode::Instance => Self::Instance,
-        }
+  fn from(value: GPUVertexStepMode) -> Self {
+    match value {
+      GPUVertexStepMode::Vertex => Self::Vertex,
+      GPUVertexStepMode::Instance => Self::Instance,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUVertexAttribute {
-    pub format: GPUVertexFormat,
-    #[options(enforce_range = true)]
-    pub offset: u64,
-    #[options(enforce_range = true)]
-    pub shader_location: u32,
+  pub format: GPUVertexFormat,
+  #[options(enforce_range = true)]
+  pub offset: u64,
+  #[options(enforce_range = true)]
+  pub shader_location: u32,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUVertexFormat {
-    #[webidl(rename = "uint8")]
-    Uint8,
-    #[webidl(rename = "uint8x2")]
-    Uint8x2,
-    #[webidl(rename = "uint8x4")]
-    Uint8x4,
-    #[webidl(rename = "sint8")]
-    Sint8,
-    #[webidl(rename = "sint8x2")]
-    Sint8x2,
-    #[webidl(rename = "sint8x4")]
-    Sint8x4,
-    #[webidl(rename = "unorm8")]
-    Unorm8,
-    #[webidl(rename = "unorm8x2")]
-    Unorm8x2,
-    #[webidl(rename = "unorm8x4")]
-    Unorm8x4,
-    #[webidl(rename = "snorm8")]
-    Snorm8,
-    #[webidl(rename = "snorm8x2")]
-    Snorm8x2,
-    #[webidl(rename = "snorm8x4")]
-    Snorm8x4,
-    #[webidl(rename = "uint16")]
-    Uint16,
-    #[webidl(rename = "uint16x2")]
-    Uint16x2,
-    #[webidl(rename = "uint16x4")]
-    Uint16x4,
-    #[webidl(rename = "sint16")]
-    Sint16,
-    #[webidl(rename = "sint16x2")]
-    Sint16x2,
-    #[webidl(rename = "sint16x4")]
-    Sint16x4,
-    #[webidl(rename = "unorm16")]
-    Unorm16,
-    #[webidl(rename = "unorm16x2")]
-    Unorm16x2,
-    #[webidl(rename = "unorm16x4")]
-    Unorm16x4,
-    #[webidl(rename = "snorm16")]
-    Snorm16,
-    #[webidl(rename = "snorm16x2")]
-    Snorm16x2,
-    #[webidl(rename = "snorm16x4")]
-    Snorm16x4,
-    #[webidl(rename = "float16")]
-    Float16,
-    #[webidl(rename = "float16x2")]
-    Float16x2,
-    #[webidl(rename = "float16x4")]
-    Float16x4,
-    #[webidl(rename = "float32")]
-    Float32,
-    #[webidl(rename = "float32x2")]
-    Float32x2,
-    #[webidl(rename = "float32x3")]
-    Float32x3,
-    #[webidl(rename = "float32x4")]
-    Float32x4,
-    #[webidl(rename = "uint32")]
-    Uint32,
-    #[webidl(rename = "uint32x2")]
-    Uint32x2,
-    #[webidl(rename = "uint32x3")]
-    Uint32x3,
-    #[webidl(rename = "uint32x4")]
-    Uint32x4,
-    #[webidl(rename = "sint32")]
-    Sint32,
-    #[webidl(rename = "sint32x2")]
-    Sint32x2,
-    #[webidl(rename = "sint32x3")]
-    Sint32x3,
-    #[webidl(rename = "sint32x4")]
-    Sint32x4,
-    #[webidl(rename = "unorm10-10-10-2")]
-    Unorm1010102,
-    #[webidl(rename = "unorm8x4-bgra")]
-    Unorm8x4Bgra,
+  #[webidl(rename = "uint8")]
+  Uint8,
+  #[webidl(rename = "uint8x2")]
+  Uint8x2,
+  #[webidl(rename = "uint8x4")]
+  Uint8x4,
+  #[webidl(rename = "sint8")]
+  Sint8,
+  #[webidl(rename = "sint8x2")]
+  Sint8x2,
+  #[webidl(rename = "sint8x4")]
+  Sint8x4,
+  #[webidl(rename = "unorm8")]
+  Unorm8,
+  #[webidl(rename = "unorm8x2")]
+  Unorm8x2,
+  #[webidl(rename = "unorm8x4")]
+  Unorm8x4,
+  #[webidl(rename = "snorm8")]
+  Snorm8,
+  #[webidl(rename = "snorm8x2")]
+  Snorm8x2,
+  #[webidl(rename = "snorm8x4")]
+  Snorm8x4,
+  #[webidl(rename = "uint16")]
+  Uint16,
+  #[webidl(rename = "uint16x2")]
+  Uint16x2,
+  #[webidl(rename = "uint16x4")]
+  Uint16x4,
+  #[webidl(rename = "sint16")]
+  Sint16,
+  #[webidl(rename = "sint16x2")]
+  Sint16x2,
+  #[webidl(rename = "sint16x4")]
+  Sint16x4,
+  #[webidl(rename = "unorm16")]
+  Unorm16,
+  #[webidl(rename = "unorm16x2")]
+  Unorm16x2,
+  #[webidl(rename = "unorm16x4")]
+  Unorm16x4,
+  #[webidl(rename = "snorm16")]
+  Snorm16,
+  #[webidl(rename = "snorm16x2")]
+  Snorm16x2,
+  #[webidl(rename = "snorm16x4")]
+  Snorm16x4,
+  #[webidl(rename = "float16")]
+  Float16,
+  #[webidl(rename = "float16x2")]
+  Float16x2,
+  #[webidl(rename = "float16x4")]
+  Float16x4,
+  #[webidl(rename = "float32")]
+  Float32,
+  #[webidl(rename = "float32x2")]
+  Float32x2,
+  #[webidl(rename = "float32x3")]
+  Float32x3,
+  #[webidl(rename = "float32x4")]
+  Float32x4,
+  #[webidl(rename = "uint32")]
+  Uint32,
+  #[webidl(rename = "uint32x2")]
+  Uint32x2,
+  #[webidl(rename = "uint32x3")]
+  Uint32x3,
+  #[webidl(rename = "uint32x4")]
+  Uint32x4,
+  #[webidl(rename = "sint32")]
+  Sint32,
+  #[webidl(rename = "sint32x2")]
+  Sint32x2,
+  #[webidl(rename = "sint32x3")]
+  Sint32x3,
+  #[webidl(rename = "sint32x4")]
+  Sint32x4,
+  #[webidl(rename = "unorm10-10-10-2")]
+  Unorm1010102,
+  #[webidl(rename = "unorm8x4-bgra")]
+  Unorm8x4Bgra,
 }
 
 impl From<GPUVertexFormat> for wgpu_types::VertexFormat {
-    fn from(value: GPUVertexFormat) -> Self {
-        match value {
-            GPUVertexFormat::Uint8 => Self::Uint8,
-            GPUVertexFormat::Uint8x2 => Self::Uint8x2,
-            GPUVertexFormat::Uint8x4 => Self::Uint8x4,
-            GPUVertexFormat::Sint8 => Self::Sint8,
-            GPUVertexFormat::Sint8x2 => Self::Sint8x2,
-            GPUVertexFormat::Sint8x4 => Self::Sint8x4,
-            GPUVertexFormat::Unorm8 => Self::Unorm8,
-            GPUVertexFormat::Unorm8x2 => Self::Unorm8x2,
-            GPUVertexFormat::Unorm8x4 => Self::Unorm8x4,
-            GPUVertexFormat::Snorm8 => Self::Snorm8,
-            GPUVertexFormat::Snorm8x2 => Self::Snorm8x2,
-            GPUVertexFormat::Snorm8x4 => Self::Snorm8x4,
-            GPUVertexFormat::Uint16 => Self::Uint16,
-            GPUVertexFormat::Uint16x2 => Self::Uint16x2,
-            GPUVertexFormat::Uint16x4 => Self::Uint16x4,
-            GPUVertexFormat::Sint16 => Self::Sint16,
-            GPUVertexFormat::Sint16x2 => Self::Sint16x2,
-            GPUVertexFormat::Sint16x4 => Self::Sint16x4,
-            GPUVertexFormat::Unorm16 => Self::Unorm16,
-            GPUVertexFormat::Unorm16x2 => Self::Unorm16x2,
-            GPUVertexFormat::Unorm16x4 => Self::Unorm16x4,
-            GPUVertexFormat::Snorm16 => Self::Snorm16,
-            GPUVertexFormat::Snorm16x2 => Self::Snorm16x2,
-            GPUVertexFormat::Snorm16x4 => Self::Snorm16x4,
-            GPUVertexFormat::Float16 => Self::Float16,
-            GPUVertexFormat::Float16x2 => Self::Float16x2,
-            GPUVertexFormat::Float16x4 => Self::Float16x4,
-            GPUVertexFormat::Float32 => Self::Float32,
-            GPUVertexFormat::Float32x2 => Self::Float32x2,
-            GPUVertexFormat::Float32x3 => Self::Float32x3,
-            GPUVertexFormat::Float32x4 => Self::Float32x4,
-            GPUVertexFormat::Uint32 => Self::Uint32,
-            GPUVertexFormat::Uint32x2 => Self::Uint32x2,
-            GPUVertexFormat::Uint32x3 => Self::Uint32x3,
-            GPUVertexFormat::Uint32x4 => Self::Uint32x4,
-            GPUVertexFormat::Sint32 => Self::Sint32,
-            GPUVertexFormat::Sint32x2 => Self::Sint32x2,
-            GPUVertexFormat::Sint32x3 => Self::Sint32x3,
-            GPUVertexFormat::Sint32x4 => Self::Sint32x4,
-            GPUVertexFormat::Unorm1010102 => Self::Unorm10_10_10_2,
-            GPUVertexFormat::Unorm8x4Bgra => Self::Unorm8x4Bgra,
-        }
+  fn from(value: GPUVertexFormat) -> Self {
+    match value {
+      GPUVertexFormat::Uint8 => Self::Uint8,
+      GPUVertexFormat::Uint8x2 => Self::Uint8x2,
+      GPUVertexFormat::Uint8x4 => Self::Uint8x4,
+      GPUVertexFormat::Sint8 => Self::Sint8,
+      GPUVertexFormat::Sint8x2 => Self::Sint8x2,
+      GPUVertexFormat::Sint8x4 => Self::Sint8x4,
+      GPUVertexFormat::Unorm8 => Self::Unorm8,
+      GPUVertexFormat::Unorm8x2 => Self::Unorm8x2,
+      GPUVertexFormat::Unorm8x4 => Self::Unorm8x4,
+      GPUVertexFormat::Snorm8 => Self::Snorm8,
+      GPUVertexFormat::Snorm8x2 => Self::Snorm8x2,
+      GPUVertexFormat::Snorm8x4 => Self::Snorm8x4,
+      GPUVertexFormat::Uint16 => Self::Uint16,
+      GPUVertexFormat::Uint16x2 => Self::Uint16x2,
+      GPUVertexFormat::Uint16x4 => Self::Uint16x4,
+      GPUVertexFormat::Sint16 => Self::Sint16,
+      GPUVertexFormat::Sint16x2 => Self::Sint16x2,
+      GPUVertexFormat::Sint16x4 => Self::Sint16x4,
+      GPUVertexFormat::Unorm16 => Self::Unorm16,
+      GPUVertexFormat::Unorm16x2 => Self::Unorm16x2,
+      GPUVertexFormat::Unorm16x4 => Self::Unorm16x4,
+      GPUVertexFormat::Snorm16 => Self::Snorm16,
+      GPUVertexFormat::Snorm16x2 => Self::Snorm16x2,
+      GPUVertexFormat::Snorm16x4 => Self::Snorm16x4,
+      GPUVertexFormat::Float16 => Self::Float16,
+      GPUVertexFormat::Float16x2 => Self::Float16x2,
+      GPUVertexFormat::Float16x4 => Self::Float16x4,
+      GPUVertexFormat::Float32 => Self::Float32,
+      GPUVertexFormat::Float32x2 => Self::Float32x2,
+      GPUVertexFormat::Float32x3 => Self::Float32x3,
+      GPUVertexFormat::Float32x4 => Self::Float32x4,
+      GPUVertexFormat::Uint32 => Self::Uint32,
+      GPUVertexFormat::Uint32x2 => Self::Uint32x2,
+      GPUVertexFormat::Uint32x3 => Self::Uint32x3,
+      GPUVertexFormat::Uint32x4 => Self::Uint32x4,
+      GPUVertexFormat::Sint32 => Self::Sint32,
+      GPUVertexFormat::Sint32x2 => Self::Sint32x2,
+      GPUVertexFormat::Sint32x3 => Self::Sint32x3,
+      GPUVertexFormat::Sint32x4 => Self::Sint32x4,
+      GPUVertexFormat::Unorm1010102 => Self::Unorm10_10_10_2,
+      GPUVertexFormat::Unorm8x4Bgra => Self::Unorm8x4Bgra,
     }
+  }
 }

--- a/deno_webgpu/render_pipeline.rs
+++ b/deno_webgpu/render_pipeline.rs
@@ -9,6 +9,7 @@ use deno_core::WebIDL;
 use indexmap::IndexMap;
 
 use crate::bind_group_layout::GPUBindGroupLayout;
+use crate::error::GPUGenericError;
 use crate::sampler::GPUCompareFunction;
 use crate::shader::GPUShaderModule;
 use crate::texture::GPUTextureFormat;
@@ -41,6 +42,12 @@ impl GarbageCollected for GPURenderPipeline {
 
 #[op2]
 impl GPURenderPipeline {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPURenderPipeline, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/rustfmt.toml
+++ b/deno_webgpu/rustfmt.toml
@@ -1,0 +1,3 @@
+max_width = 80
+tab_spaces = 2
+edition = "2021"

--- a/deno_webgpu/sampler.rs
+++ b/deno_webgpu/sampler.rs
@@ -23,7 +23,11 @@ impl WebIdlInterfaceConverter for GPUSampler {
   const NAME: &'static str = "GPUSampler";
 }
 
-impl GarbageCollected for GPUSampler {}
+impl GarbageCollected for GPUSampler {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUSampler"
+  }
+}
 
 #[op2]
 impl GPUSampler {

--- a/deno_webgpu/sampler.rs
+++ b/deno_webgpu/sampler.rs
@@ -5,6 +5,7 @@ use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 
+use crate::error::GPUGenericError;
 use crate::Instance;
 
 pub struct GPUSampler {
@@ -31,6 +32,12 @@ impl GarbageCollected for GPUSampler {
 
 #[op2]
 impl GPUSampler {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUSampler, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/sampler.rs
+++ b/deno_webgpu/sampler.rs
@@ -8,127 +8,127 @@ use deno_core::WebIDL;
 use crate::Instance;
 
 pub struct GPUSampler {
-    pub instance: Instance,
-    pub id: wgpu_core::id::SamplerId,
-    pub label: String,
+  pub instance: Instance,
+  pub id: wgpu_core::id::SamplerId,
+  pub label: String,
 }
 
 impl Drop for GPUSampler {
-    fn drop(&mut self) {
-        self.instance.sampler_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.sampler_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPUSampler {
-    const NAME: &'static str = "GPUSampler";
+  const NAME: &'static str = "GPUSampler";
 }
 
 impl GarbageCollected for GPUSampler {}
 
 #[op2]
 impl GPUSampler {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(super) struct GPUSamplerDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    #[webidl(default = GPUAddressMode::ClampToEdge)]
-    pub address_mode_u: GPUAddressMode,
-    #[webidl(default = GPUAddressMode::ClampToEdge)]
-    pub address_mode_v: GPUAddressMode,
-    #[webidl(default = GPUAddressMode::ClampToEdge)]
-    pub address_mode_w: GPUAddressMode,
-    #[webidl(default = GPUFilterMode::Nearest)]
-    pub mag_filter: GPUFilterMode,
-    #[webidl(default = GPUFilterMode::Nearest)]
-    pub min_filter: GPUFilterMode,
-    #[webidl(default = GPUFilterMode::Nearest)]
-    pub mipmap_filter: GPUFilterMode,
+  #[webidl(default = GPUAddressMode::ClampToEdge)]
+  pub address_mode_u: GPUAddressMode,
+  #[webidl(default = GPUAddressMode::ClampToEdge)]
+  pub address_mode_v: GPUAddressMode,
+  #[webidl(default = GPUAddressMode::ClampToEdge)]
+  pub address_mode_w: GPUAddressMode,
+  #[webidl(default = GPUFilterMode::Nearest)]
+  pub mag_filter: GPUFilterMode,
+  #[webidl(default = GPUFilterMode::Nearest)]
+  pub min_filter: GPUFilterMode,
+  #[webidl(default = GPUFilterMode::Nearest)]
+  pub mipmap_filter: GPUFilterMode,
 
-    #[webidl(default = 0.0)]
-    pub lod_min_clamp: f32,
-    #[webidl(default = 32.0)]
-    pub lod_max_clamp: f32,
+  #[webidl(default = 0.0)]
+  pub lod_min_clamp: f32,
+  #[webidl(default = 32.0)]
+  pub lod_max_clamp: f32,
 
-    pub compare: Option<GPUCompareFunction>,
+  pub compare: Option<GPUCompareFunction>,
 
-    #[webidl(default = 1)]
-    #[options(clamp = true)]
-    pub max_anisotropy: u16,
+  #[webidl(default = 1)]
+  #[options(clamp = true)]
+  pub max_anisotropy: u16,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUAddressMode {
-    ClampToEdge,
-    Repeat,
-    MirrorRepeat,
+  ClampToEdge,
+  Repeat,
+  MirrorRepeat,
 }
 
 impl From<GPUAddressMode> for wgpu_types::AddressMode {
-    fn from(value: GPUAddressMode) -> Self {
-        match value {
-            GPUAddressMode::ClampToEdge => Self::ClampToEdge,
-            GPUAddressMode::Repeat => Self::Repeat,
-            GPUAddressMode::MirrorRepeat => Self::MirrorRepeat,
-        }
+  fn from(value: GPUAddressMode) -> Self {
+    match value {
+      GPUAddressMode::ClampToEdge => Self::ClampToEdge,
+      GPUAddressMode::Repeat => Self::Repeat,
+      GPUAddressMode::MirrorRepeat => Self::MirrorRepeat,
     }
+  }
 }
 
 // Same as GPUMipmapFilterMode
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUFilterMode {
-    Nearest,
-    Linear,
+  Nearest,
+  Linear,
 }
 
 impl From<GPUFilterMode> for wgpu_types::FilterMode {
-    fn from(value: GPUFilterMode) -> Self {
-        match value {
-            GPUFilterMode::Nearest => Self::Nearest,
-            GPUFilterMode::Linear => Self::Linear,
-        }
+  fn from(value: GPUFilterMode) -> Self {
+    match value {
+      GPUFilterMode::Nearest => Self::Nearest,
+      GPUFilterMode::Linear => Self::Linear,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUCompareFunction {
-    Never,
-    Less,
-    Equal,
-    LessEqual,
-    Greater,
-    NotEqual,
-    GreaterEqual,
-    Always,
+  Never,
+  Less,
+  Equal,
+  LessEqual,
+  Greater,
+  NotEqual,
+  GreaterEqual,
+  Always,
 }
 
 impl From<GPUCompareFunction> for wgpu_types::CompareFunction {
-    fn from(value: GPUCompareFunction) -> Self {
-        match value {
-            GPUCompareFunction::Never => Self::Never,
-            GPUCompareFunction::Less => Self::Less,
-            GPUCompareFunction::Equal => Self::Equal,
-            GPUCompareFunction::LessEqual => Self::LessEqual,
-            GPUCompareFunction::Greater => Self::Greater,
-            GPUCompareFunction::NotEqual => Self::NotEqual,
-            GPUCompareFunction::GreaterEqual => Self::GreaterEqual,
-            GPUCompareFunction::Always => Self::Always,
-        }
+  fn from(value: GPUCompareFunction) -> Self {
+    match value {
+      GPUCompareFunction::Never => Self::Never,
+      GPUCompareFunction::Less => Self::Less,
+      GPUCompareFunction::Equal => Self::Equal,
+      GPUCompareFunction::LessEqual => Self::LessEqual,
+      GPUCompareFunction::Greater => Self::Greater,
+      GPUCompareFunction::NotEqual => Self::NotEqual,
+      GPUCompareFunction::GreaterEqual => Self::GreaterEqual,
+      GPUCompareFunction::Always => Self::Always,
     }
+  }
 }

--- a/deno_webgpu/shader.rs
+++ b/deno_webgpu/shader.rs
@@ -27,7 +27,11 @@ impl WebIdlInterfaceConverter for GPUShaderModule {
   const NAME: &'static str = "GPUShaderModule";
 }
 
-impl GarbageCollected for GPUShaderModule {}
+impl GarbageCollected for GPUShaderModule {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUShaderModule"
+  }
+}
 
 #[op2]
 impl GPUShaderModule {
@@ -71,7 +75,11 @@ pub struct GPUCompilationMessage {
   length: u64,
 }
 
-impl GarbageCollected for GPUCompilationMessage {}
+impl GarbageCollected for GPUCompilationMessage {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUCompilationMessage"
+  }
+}
 
 #[op2]
 impl GPUCompilationMessage {
@@ -162,7 +170,11 @@ pub struct GPUCompilationInfo {
   messages: v8::Global<v8::Object>,
 }
 
-impl GarbageCollected for GPUCompilationInfo {}
+impl GarbageCollected for GPUCompilationInfo {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUCompilationInfo"
+  }
+}
 
 #[op2]
 impl GPUCompilationInfo {

--- a/deno_webgpu/shader.rs
+++ b/deno_webgpu/shader.rs
@@ -11,193 +11,198 @@ use wgpu_core::pipeline;
 use crate::Instance;
 
 pub struct GPUShaderModule {
-    pub instance: Instance,
-    pub id: wgpu_core::id::ShaderModuleId,
-    pub label: String,
-    pub compilation_info: v8::Global<v8::Object>,
+  pub instance: Instance,
+  pub id: wgpu_core::id::ShaderModuleId,
+  pub label: String,
+  pub compilation_info: v8::Global<v8::Object>,
 }
 
 impl Drop for GPUShaderModule {
-    fn drop(&mut self) {
-        self.instance.shader_module_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.shader_module_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPUShaderModule {
-    const NAME: &'static str = "GPUShaderModule";
+  const NAME: &'static str = "GPUShaderModule";
 }
 
 impl GarbageCollected for GPUShaderModule {}
 
 #[op2]
 impl GPUShaderModule {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 
-    fn get_compilation_info<'a>(
-        &self,
-        scope: &mut v8::HandleScope<'a>,
-    ) -> v8::Local<'a, v8::Promise> {
-        let resolver = v8::PromiseResolver::new(scope).unwrap();
-        let info = v8::Local::new(scope, self.compilation_info.clone());
-        resolver.resolve(scope, info.into()).unwrap();
-        resolver.get_promise(scope)
-    }
+  fn get_compilation_info<'a>(
+    &self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> v8::Local<'a, v8::Promise> {
+    let resolver = v8::PromiseResolver::new(scope).unwrap();
+    let info = v8::Local::new(scope, self.compilation_info.clone());
+    resolver.resolve(scope, info.into()).unwrap();
+    resolver.get_promise(scope)
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUShaderModuleDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub code: String,
+  pub code: String,
 }
 
 pub struct GPUCompilationMessage {
-    message: String,
-    r#type: GPUCompilationMessageType,
-    line_num: u64,
-    line_pos: u64,
-    offset: u64,
-    length: u64,
+  message: String,
+  r#type: GPUCompilationMessageType,
+  line_num: u64,
+  line_pos: u64,
+  offset: u64,
+  length: u64,
 }
 
 impl GarbageCollected for GPUCompilationMessage {}
 
 #[op2]
 impl GPUCompilationMessage {
-    #[getter]
-    #[string]
-    fn message(&self) -> String {
-        self.message.clone()
-    }
+  #[getter]
+  #[string]
+  fn message(&self) -> String {
+    self.message.clone()
+  }
 
-    // Naming this `type` or `r#type` does not work.
-    // https://github.com/gfx-rs/wgpu/issues/7778
-    #[getter]
-    #[string]
-    fn ty(&self) -> &'static str {
-        self.r#type.as_str()
-    }
+  // Naming this `type` or `r#type` does not work.
+  // https://github.com/gfx-rs/wgpu/issues/7778
+  #[getter]
+  #[string]
+  fn ty(&self) -> &'static str {
+    self.r#type.as_str()
+  }
 
-    #[getter]
-    #[number]
-    fn line_num(&self) -> u64 {
-        self.line_num
-    }
+  #[getter]
+  #[number]
+  fn line_num(&self) -> u64 {
+    self.line_num
+  }
 
-    #[getter]
-    #[number]
-    fn line_pos(&self) -> u64 {
-        self.line_pos
-    }
+  #[getter]
+  #[number]
+  fn line_pos(&self) -> u64 {
+    self.line_pos
+  }
 
-    #[getter]
-    #[number]
-    fn offset(&self) -> u64 {
-        self.offset
-    }
+  #[getter]
+  #[number]
+  fn offset(&self) -> u64 {
+    self.offset
+  }
 
-    #[getter]
-    #[number]
-    fn length(&self) -> u64 {
-        self.length
-    }
+  #[getter]
+  #[number]
+  fn length(&self) -> u64 {
+    self.length
+  }
 }
 
 impl GPUCompilationMessage {
-    fn new(error: &pipeline::CreateShaderModuleError, source: &str) -> Self {
-        let message = error.to_string();
+  fn new(error: &pipeline::CreateShaderModuleError, source: &str) -> Self {
+    let message = error.to_string();
 
-        let loc = match error {
-            pipeline::CreateShaderModuleError::Parsing(e) => e.inner.location(source),
-            pipeline::CreateShaderModuleError::Validation(e) => e.inner.location(source),
-            _ => None,
-        };
+    let loc = match error {
+      pipeline::CreateShaderModuleError::Parsing(e) => e.inner.location(source),
+      pipeline::CreateShaderModuleError::Validation(e) => {
+        e.inner.location(source)
+      }
+      _ => None,
+    };
 
-        match loc {
-            Some(loc) => {
-                let len_utf16 = |s: &str| s.chars().map(|c| c.len_utf16() as u64).sum();
+    match loc {
+      Some(loc) => {
+        let len_utf16 = |s: &str| s.chars().map(|c| c.len_utf16() as u64).sum();
 
-                let start = loc.offset as usize;
+        let start = loc.offset as usize;
 
-                // Naga reports a `line_pos` using UTF-8 bytes, so we cannot use it.
-                let line_start = source[0..start].rfind('\n').map(|pos| pos + 1).unwrap_or(0);
-                let line_pos = len_utf16(&source[line_start..start]) + 1;
+        // Naga reports a `line_pos` using UTF-8 bytes, so we cannot use it.
+        let line_start =
+          source[0..start].rfind('\n').map(|pos| pos + 1).unwrap_or(0);
+        let line_pos = len_utf16(&source[line_start..start]) + 1;
 
-                Self {
-                    message,
-                    r#type: GPUCompilationMessageType::Error,
-                    line_num: loc.line_number.into(),
-                    line_pos,
-                    offset: len_utf16(&source[0..start]),
-                    length: len_utf16(&source[start..start + loc.length as usize]),
-                }
-            }
-            _ => Self {
-                message,
-                r#type: GPUCompilationMessageType::Error,
-                line_num: 0,
-                line_pos: 0,
-                offset: 0,
-                length: 0,
-            },
+        Self {
+          message,
+          r#type: GPUCompilationMessageType::Error,
+          line_num: loc.line_number.into(),
+          line_pos,
+          offset: len_utf16(&source[0..start]),
+          length: len_utf16(&source[start..start + loc.length as usize]),
         }
+      }
+      _ => Self {
+        message,
+        r#type: GPUCompilationMessageType::Error,
+        line_num: 0,
+        line_pos: 0,
+        offset: 0,
+        length: 0,
+      },
     }
+  }
 }
 
 pub struct GPUCompilationInfo {
-    messages: v8::Global<v8::Object>,
+  messages: v8::Global<v8::Object>,
 }
 
 impl GarbageCollected for GPUCompilationInfo {}
 
 #[op2]
 impl GPUCompilationInfo {
-    #[getter]
-    #[global]
-    fn messages(&self) -> v8::Global<v8::Object> {
-        self.messages.clone()
-    }
+  #[getter]
+  #[global]
+  fn messages(&self) -> v8::Global<v8::Object> {
+    self.messages.clone()
+  }
 }
 
 impl GPUCompilationInfo {
-    pub fn new<'args, 'scope>(
-        scope: &mut v8::HandleScope<'scope>,
-        messages: impl ExactSizeIterator<Item = &'args pipeline::CreateShaderModuleError>,
-        source: &'args str,
-    ) -> Self {
-        let array = v8::Array::new(scope, messages.len().try_into().unwrap());
-        for (i, message) in messages.enumerate() {
-            let message_object =
-                make_cppgc_object(scope, GPUCompilationMessage::new(message, source));
-            array.set_index(scope, i.try_into().unwrap(), message_object.into());
-        }
-
-        let object: v8::Local<v8::Object> = array.into();
-        object
-            .set_integrity_level(scope, v8::IntegrityLevel::Frozen)
-            .unwrap();
-
-        Self {
-            messages: v8::Global::new(scope, object),
-        }
+  pub fn new<'args, 'scope>(
+    scope: &mut v8::HandleScope<'scope>,
+    messages: impl ExactSizeIterator<
+      Item = &'args pipeline::CreateShaderModuleError,
+    >,
+    source: &'args str,
+  ) -> Self {
+    let array = v8::Array::new(scope, messages.len().try_into().unwrap());
+    for (i, message) in messages.enumerate() {
+      let message_object =
+        make_cppgc_object(scope, GPUCompilationMessage::new(message, source));
+      array.set_index(scope, i.try_into().unwrap(), message_object.into());
     }
+
+    let object: v8::Local<v8::Object> = array.into();
+    object
+      .set_integrity_level(scope, v8::IntegrityLevel::Frozen)
+      .unwrap();
+
+    Self {
+      messages: v8::Global::new(scope, object),
+    }
+  }
 }
 
 #[derive(WebIDL, Clone)]
 #[webidl(enum)]
 pub(crate) enum GPUCompilationMessageType {
-    Error,
-    Warning,
-    Info,
+  Error,
+  Warning,
+  Info,
 }

--- a/deno_webgpu/shader.rs
+++ b/deno_webgpu/shader.rs
@@ -8,6 +8,7 @@ use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use wgpu_core::pipeline;
 
+use crate::error::GPUGenericError;
 use crate::Instance;
 
 pub struct GPUShaderModule {
@@ -35,6 +36,12 @@ impl GarbageCollected for GPUShaderModule {
 
 #[op2]
 impl GPUShaderModule {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUShaderModule, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -12,6 +12,7 @@ use deno_error::JsErrorBox;
 use wgpu_types::SurfaceStatus;
 
 use crate::device::GPUDevice;
+use crate::error::GPUGenericError;
 use crate::texture::GPUTexture;
 use crate::texture::GPUTextureFormat;
 
@@ -55,6 +56,12 @@ impl GarbageCollected for GPUCanvasContext {
 
 #[op2]
 impl GPUCanvasContext {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUCanvasContext, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[global]
   fn canvas(&self) -> v8::Global<v8::Object> {

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -45,7 +45,11 @@ pub struct GPUCanvasContext {
   pub canvas: v8::Global<v8::Object>,
 }
 
-impl GarbageCollected for GPUCanvasContext {}
+impl GarbageCollected for GPUCanvasContext {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUCanvasContext"
+  }
+}
 
 #[op2]
 impl GPUCanvasContext {

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -164,6 +164,9 @@ impl GPUCanvasContext {
 
     config.device.instance.surface_present(self.surface_id)?;
 
+    // next `get_current_texture` call would get a new texture
+    *self.texture.borrow_mut() = None;
+
     Ok(())
   }
 }

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -32,6 +32,8 @@ pub struct Configuration {
   pub device: Ptr<GPUDevice>,
   pub usage: u32,
   pub format: GPUTextureFormat,
+  pub surface_config:
+    wgpu_types::SurfaceConfiguration<Vec<wgpu_types::TextureFormat>>,
 }
 
 pub struct GPUCanvasContext {
@@ -97,6 +99,7 @@ impl GPUCanvasContext {
       device,
       usage: configuration.usage,
       format: configuration.format,
+      surface_config: conf,
     });
 
     Ok(())
@@ -172,6 +175,27 @@ impl GPUCanvasContext {
     *self.texture.borrow_mut() = None;
 
     Ok(())
+  }
+
+  pub fn resize_configure(&self, width: u32, height: u32) {
+    self.width.replace(width);
+    self.height.replace(height);
+
+    let mut config = self.config.borrow_mut();
+    let Some(config) = &mut *config else {
+      return;
+    };
+
+    config.surface_config.width = width;
+    config.surface_config.height = height;
+
+    let err = config.device.instance.surface_configure(
+      self.surface_id,
+      config.device.id,
+      &config.surface_config,
+    );
+
+    config.device.error_handler.push_error(err);
   }
 }
 

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -2,12 +2,12 @@
 
 use std::cell::RefCell;
 
-use deno_core::op2;
-use deno_core::v8;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use deno_core::_ops::make_cppgc_object;
 use deno_core::cppgc::Ptr;
+use deno_core::op2;
+use deno_core::v8;
 use deno_error::JsErrorBox;
 use wgpu_types::SurfaceStatus;
 
@@ -17,213 +17,217 @@ use crate::texture::GPUTextureFormat;
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum SurfaceError {
-    #[class("DOMExceptionInvalidStateError")]
-    #[error("Context is not configured")]
-    UnconfiguredContext,
-    #[class(generic)]
-    #[error("Invalid Surface Status")]
-    InvalidStatus,
-    #[class(generic)]
-    #[error(transparent)]
-    Surface(#[from] wgpu_core::present::SurfaceError),
+  #[class("DOMExceptionInvalidStateError")]
+  #[error("Context is not configured")]
+  UnconfiguredContext,
+  #[class(generic)]
+  #[error("Invalid Surface Status")]
+  InvalidStatus,
+  #[class(generic)]
+  #[error(transparent)]
+  Surface(#[from] wgpu_core::present::SurfaceError),
 }
 
 pub struct Configuration {
-    pub device: Ptr<GPUDevice>,
-    pub usage: u32,
-    pub format: GPUTextureFormat,
+  pub device: Ptr<GPUDevice>,
+  pub usage: u32,
+  pub format: GPUTextureFormat,
 }
 
 pub struct GPUCanvasContext {
-    pub surface_id: wgpu_core::id::SurfaceId,
-    pub width: RefCell<u32>,
-    pub height: RefCell<u32>,
+  pub surface_id: wgpu_core::id::SurfaceId,
+  pub width: RefCell<u32>,
+  pub height: RefCell<u32>,
 
-    pub config: RefCell<Option<Configuration>>,
-    pub texture: RefCell<Option<v8::Global<v8::Object>>>,
+  pub config: RefCell<Option<Configuration>>,
+  pub texture: RefCell<Option<v8::Global<v8::Object>>>,
 
-    pub canvas: v8::Global<v8::Object>,
+  pub canvas: v8::Global<v8::Object>,
 }
 
 impl GarbageCollected for GPUCanvasContext {}
 
 #[op2]
 impl GPUCanvasContext {
-    #[getter]
-    #[global]
-    fn canvas(&self) -> v8::Global<v8::Object> {
-        self.canvas.clone()
+  #[getter]
+  #[global]
+  fn canvas(&self) -> v8::Global<v8::Object> {
+    self.canvas.clone()
+  }
+
+  fn configure(
+    &self,
+    #[webidl] configuration: GPUCanvasConfiguration,
+  ) -> Result<(), JsErrorBox> {
+    let usage = wgpu_types::TextureUsages::from_bits(configuration.usage)
+      .ok_or_else(|| JsErrorBox::type_error("usage is not valid"))?;
+    let format = configuration.format.clone().into();
+    let conf = wgpu_types::SurfaceConfiguration {
+      usage,
+      format,
+      width: *self.width.borrow(),
+      height: *self.height.borrow(),
+      present_mode: configuration
+        .present_mode
+        .map(Into::into)
+        .unwrap_or_default(),
+      alpha_mode: configuration.alpha_mode.into(),
+      view_formats: configuration
+        .view_formats
+        .into_iter()
+        .map(Into::into)
+        .collect(),
+      desired_maximum_frame_latency: 2,
+    };
+
+    let device = configuration.device;
+
+    let err =
+      device
+        .instance
+        .surface_configure(self.surface_id, device.id, &conf);
+
+    device.error_handler.push_error(err);
+
+    self.config.borrow_mut().replace(Configuration {
+      device,
+      usage: configuration.usage,
+      format: configuration.format,
+    });
+
+    Ok(())
+  }
+
+  #[fast]
+  fn unconfigure(&self) {
+    *self.config.borrow_mut() = None;
+  }
+
+  #[global]
+  fn get_current_texture(
+    &self,
+    scope: &mut v8::HandleScope,
+  ) -> Result<v8::Global<v8::Object>, SurfaceError> {
+    let config = self.config.borrow();
+    let Some(config) = config.as_ref() else {
+      return Err(SurfaceError::UnconfiguredContext);
+    };
+
+    {
+      if let Some(obj) = self.texture.borrow().as_ref() {
+        return Ok(obj.clone());
+      }
     }
 
-    fn configure(&self, #[webidl] configuration: GPUCanvasConfiguration) -> Result<(), JsErrorBox> {
-        let usage = wgpu_types::TextureUsages::from_bits(configuration.usage)
-            .ok_or_else(|| JsErrorBox::type_error("usage is not valid"))?;
-        let format = configuration.format.clone().into();
-        let conf = wgpu_types::SurfaceConfiguration {
-            usage,
-            format,
+    let output = config
+      .device
+      .instance
+      .surface_get_current_texture(self.surface_id, None)?;
+
+    match output.status {
+      SurfaceStatus::Good | SurfaceStatus::Suboptimal => {
+        let id = output.texture.unwrap();
+
+        let texture = GPUTexture {
+          instance: config.device.instance.clone(),
+          error_handler: config.device.error_handler.clone(),
+          id,
+          label: "".to_string(),
+          size: wgpu_types::Extent3d {
             width: *self.width.borrow(),
             height: *self.height.borrow(),
-            present_mode: configuration
-                .present_mode
-                .map(Into::into)
-                .unwrap_or_default(),
-            alpha_mode: configuration.alpha_mode.into(),
-            view_formats: configuration
-                .view_formats
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-            desired_maximum_frame_latency: 2,
+            depth_or_array_layers: 1,
+          },
+          mip_level_count: 0,
+          sample_count: 0,
+          dimension: crate::texture::GPUTextureDimension::D2,
+          format: config.format.clone(),
+          usage: config.usage,
         };
+        let obj = make_cppgc_object(scope, texture);
+        let obj = v8::Global::new(scope, obj);
+        *self.texture.borrow_mut() = Some(obj.clone());
 
-        let device = configuration.device;
-
-        let err = device
-            .instance
-            .surface_configure(self.surface_id, device.id, &conf);
-
-        device.error_handler.push_error(err);
-
-        self.config.borrow_mut().replace(Configuration {
-            device,
-            usage: configuration.usage,
-            format: configuration.format,
-        });
-
-        Ok(())
+        Ok(obj)
+      }
+      _ => Err(SurfaceError::InvalidStatus),
     }
-
-    #[fast]
-    fn unconfigure(&self) {
-        *self.config.borrow_mut() = None;
-    }
-
-    #[global]
-    fn get_current_texture(
-        &self,
-        scope: &mut v8::HandleScope,
-    ) -> Result<v8::Global<v8::Object>, SurfaceError> {
-        let config = self.config.borrow();
-        let Some(config) = config.as_ref() else {
-            return Err(SurfaceError::UnconfiguredContext);
-        };
-
-        {
-            if let Some(obj) = self.texture.borrow().as_ref() {
-                return Ok(obj.clone());
-            }
-        }
-
-        let output = config
-            .device
-            .instance
-            .surface_get_current_texture(self.surface_id, None)?;
-
-        match output.status {
-            SurfaceStatus::Good | SurfaceStatus::Suboptimal => {
-                let id = output.texture.unwrap();
-
-                let texture = GPUTexture {
-                    instance: config.device.instance.clone(),
-                    error_handler: config.device.error_handler.clone(),
-                    id,
-                    label: "".to_string(),
-                    size: wgpu_types::Extent3d {
-                        width: *self.width.borrow(),
-                        height: *self.height.borrow(),
-                        depth_or_array_layers: 1,
-                    },
-                    mip_level_count: 0,
-                    sample_count: 0,
-                    dimension: crate::texture::GPUTextureDimension::D2,
-                    format: config.format.clone(),
-                    usage: config.usage,
-                };
-                let obj = make_cppgc_object(scope, texture);
-                let obj = v8::Global::new(scope, obj);
-                *self.texture.borrow_mut() = Some(obj.clone());
-
-                Ok(obj)
-            }
-            _ => Err(SurfaceError::InvalidStatus),
-        }
-    }
+  }
 }
 
 impl GPUCanvasContext {
-    pub fn present(&self) -> Result<(), SurfaceError> {
-        let config = self.config.borrow();
-        let Some(config) = config.as_ref() else {
-            return Err(SurfaceError::UnconfiguredContext);
-        };
+  pub fn present(&self) -> Result<(), SurfaceError> {
+    let config = self.config.borrow();
+    let Some(config) = config.as_ref() else {
+      return Err(SurfaceError::UnconfiguredContext);
+    };
 
-        config.device.instance.surface_present(self.surface_id)?;
+    config.device.instance.surface_present(self.surface_id)?;
 
-        Ok(())
-    }
+    Ok(())
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 struct GPUCanvasConfiguration {
-    device: Ptr<GPUDevice>,
-    format: GPUTextureFormat,
-    #[webidl(default = wgpu_types::TextureUsages::RENDER_ATTACHMENT.bits())]
-    #[options(enforce_range = true)]
-    usage: u32,
-    #[webidl(default = GPUCanvasAlphaMode::Opaque)]
-    alpha_mode: GPUCanvasAlphaMode,
+  device: Ptr<GPUDevice>,
+  format: GPUTextureFormat,
+  #[webidl(default = wgpu_types::TextureUsages::RENDER_ATTACHMENT.bits())]
+  #[options(enforce_range = true)]
+  usage: u32,
+  #[webidl(default = GPUCanvasAlphaMode::Opaque)]
+  alpha_mode: GPUCanvasAlphaMode,
 
-    // Extended from spec
-    present_mode: Option<GPUPresentMode>,
-    #[webidl(default = vec![])]
-    view_formats: Vec<GPUTextureFormat>,
+  // Extended from spec
+  present_mode: Option<GPUPresentMode>,
+  #[webidl(default = vec![])]
+  view_formats: Vec<GPUTextureFormat>,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 enum GPUCanvasAlphaMode {
-    Opaque,
-    Premultiplied,
+  Opaque,
+  Premultiplied,
 }
 
 impl From<GPUCanvasAlphaMode> for wgpu_types::CompositeAlphaMode {
-    fn from(value: GPUCanvasAlphaMode) -> Self {
-        match value {
-            GPUCanvasAlphaMode::Opaque => Self::Opaque,
-            GPUCanvasAlphaMode::Premultiplied => Self::PreMultiplied,
-        }
+  fn from(value: GPUCanvasAlphaMode) -> Self {
+    match value {
+      GPUCanvasAlphaMode::Opaque => Self::Opaque,
+      GPUCanvasAlphaMode::Premultiplied => Self::PreMultiplied,
     }
+  }
 }
 
 // Extended from spec
 #[derive(WebIDL)]
 #[webidl(enum)]
 enum GPUPresentMode {
-    #[webidl(rename = "autoVsync")]
-    AutoVsync,
-    #[webidl(rename = "autoNoVsync")]
-    AutoNoVsync,
-    #[webidl(rename = "fifo")]
-    Fifo,
-    #[webidl(rename = "fifoRelaxed")]
-    FifoRelaxed,
-    #[webidl(rename = "immediate")]
-    Immediate,
-    #[webidl(rename = "mailbox")]
-    Mailbox,
+  #[webidl(rename = "autoVsync")]
+  AutoVsync,
+  #[webidl(rename = "autoNoVsync")]
+  AutoNoVsync,
+  #[webidl(rename = "fifo")]
+  Fifo,
+  #[webidl(rename = "fifoRelaxed")]
+  FifoRelaxed,
+  #[webidl(rename = "immediate")]
+  Immediate,
+  #[webidl(rename = "mailbox")]
+  Mailbox,
 }
 
 impl From<GPUPresentMode> for wgpu_types::PresentMode {
-    fn from(value: GPUPresentMode) -> Self {
-        match value {
-            GPUPresentMode::AutoVsync => Self::AutoVsync,
-            GPUPresentMode::AutoNoVsync => Self::AutoNoVsync,
-            GPUPresentMode::Fifo => Self::Fifo,
-            GPUPresentMode::FifoRelaxed => Self::FifoRelaxed,
-            GPUPresentMode::Immediate => Self::Immediate,
-            GPUPresentMode::Mailbox => Self::Mailbox,
-        }
+  fn from(value: GPUPresentMode) -> Self {
+    match value {
+      GPUPresentMode::AutoVsync => Self::AutoVsync,
+      GPUPresentMode::AutoNoVsync => Self::AutoNoVsync,
+      GPUPresentMode::Fifo => Self::Fifo,
+      GPUPresentMode::FifoRelaxed => Self::FifoRelaxed,
+      GPUPresentMode::Immediate => Self::Immediate,
+      GPUPresentMode::Mailbox => Self::Mailbox,
     }
+  }
 }

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -13,6 +13,7 @@ use wgpu_types::TextureDimension;
 use wgpu_types::TextureFormat;
 use wgpu_types::TextureViewDimension;
 
+use crate::error::GPUGenericError;
 use crate::Instance;
 
 #[derive(WebIDL)]
@@ -71,6 +72,12 @@ impl GarbageCollected for GPUTexture {
 
 #[op2]
 impl GPUTexture {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUTexture, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {
@@ -256,6 +263,12 @@ impl GarbageCollected for GPUTextureView {
 
 #[op2]
 impl GPUTextureView {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<GPUTextureView, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
   #[getter]
   #[string]
   fn label(&self) -> String {

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -18,228 +18,229 @@ use crate::Instance;
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUTextureDescriptor {
-    #[webidl(default = String::new())]
-    pub label: String,
+  #[webidl(default = String::new())]
+  pub label: String,
 
-    pub size: super::webidl::GPUExtent3D,
-    #[webidl(default = 1)]
-    #[options(enforce_range = true)]
-    pub mip_level_count: u32,
-    #[webidl(default = 1)]
-    #[options(enforce_range = true)]
-    pub sample_count: u32,
-    #[webidl(default = GPUTextureDimension::D2)]
-    pub dimension: GPUTextureDimension,
-    pub format: GPUTextureFormat,
-    #[options(enforce_range = true)]
-    pub usage: u32,
-    #[webidl(default = vec![])]
-    pub view_formats: Vec<GPUTextureFormat>,
+  pub size: super::webidl::GPUExtent3D,
+  #[webidl(default = 1)]
+  #[options(enforce_range = true)]
+  pub mip_level_count: u32,
+  #[webidl(default = 1)]
+  #[options(enforce_range = true)]
+  pub sample_count: u32,
+  #[webidl(default = GPUTextureDimension::D2)]
+  pub dimension: GPUTextureDimension,
+  pub format: GPUTextureFormat,
+  #[options(enforce_range = true)]
+  pub usage: u32,
+  #[webidl(default = vec![])]
+  pub view_formats: Vec<GPUTextureFormat>,
 }
 
 pub struct GPUTexture {
-    pub instance: Instance,
-    pub error_handler: super::error::ErrorHandler,
+  pub instance: Instance,
+  pub error_handler: super::error::ErrorHandler,
 
-    pub id: wgpu_core::id::TextureId,
+  pub id: wgpu_core::id::TextureId,
 
-    pub label: String,
+  pub label: String,
 
-    pub size: Extent3d,
-    pub mip_level_count: u32,
-    pub sample_count: u32,
-    pub dimension: GPUTextureDimension,
-    pub format: GPUTextureFormat,
-    pub usage: u32,
+  pub size: Extent3d,
+  pub mip_level_count: u32,
+  pub sample_count: u32,
+  pub dimension: GPUTextureDimension,
+  pub format: GPUTextureFormat,
+  pub usage: u32,
 }
 
 impl Drop for GPUTexture {
-    fn drop(&mut self) {
-        self.instance.texture_drop(self.id);
-    }
+  fn drop(&mut self) {
+    self.instance.texture_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPUTexture {
-    const NAME: &'static str = "GPUTexture";
+  const NAME: &'static str = "GPUTexture";
 }
 
 impl GarbageCollected for GPUTexture {}
 
 #[op2]
 impl GPUTexture {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 
-    #[getter]
-    fn width(&self) -> u32 {
-        self.size.width
-    }
-    #[getter]
-    fn height(&self) -> u32 {
-        self.size.height
-    }
-    #[getter]
-    fn depth_or_array_layers(&self) -> u32 {
-        self.size.depth_or_array_layers
-    }
-    #[getter]
-    fn mip_level_count(&self) -> u32 {
-        self.mip_level_count
-    }
-    #[getter]
-    fn sample_count(&self) -> u32 {
-        self.sample_count
-    }
-    #[getter]
-    #[string]
-    fn dimension(&self) -> &'static str {
-        self.dimension.as_str()
-    }
-    #[getter]
-    #[string]
-    fn format(&self) -> &'static str {
-        self.format.as_str()
-    }
-    #[getter]
-    fn usage(&self) -> u32 {
-        self.usage
-    }
-    #[fast]
-    fn destroy(&self) {
-        self.instance.texture_destroy(self.id);
-    }
+  #[getter]
+  fn width(&self) -> u32 {
+    self.size.width
+  }
+  #[getter]
+  fn height(&self) -> u32 {
+    self.size.height
+  }
+  #[getter]
+  fn depth_or_array_layers(&self) -> u32 {
+    self.size.depth_or_array_layers
+  }
+  #[getter]
+  fn mip_level_count(&self) -> u32 {
+    self.mip_level_count
+  }
+  #[getter]
+  fn sample_count(&self) -> u32 {
+    self.sample_count
+  }
+  #[getter]
+  #[string]
+  fn dimension(&self) -> &'static str {
+    self.dimension.as_str()
+  }
+  #[getter]
+  #[string]
+  fn format(&self) -> &'static str {
+    self.format.as_str()
+  }
+  #[getter]
+  fn usage(&self) -> u32 {
+    self.usage
+  }
+  #[fast]
+  fn destroy(&self) {
+    self.instance.texture_destroy(self.id);
+  }
 
-    #[cppgc]
-    fn create_view(
-        &self,
-        #[webidl] descriptor: GPUTextureViewDescriptor,
-    ) -> Result<GPUTextureView, JsErrorBox> {
-        let wgpu_descriptor = wgpu_core::resource::TextureViewDescriptor {
-            label: crate::transform_label(descriptor.label.clone()),
-            format: descriptor.format.map(Into::into),
-            dimension: descriptor.dimension.map(Into::into),
-            usage: Some(
-                wgpu_types::TextureUsages::from_bits(descriptor.usage)
-                    .ok_or_else(|| JsErrorBox::type_error("usage is not valid"))?,
-            ),
-            range: wgpu_types::ImageSubresourceRange {
-                aspect: descriptor.aspect.into(),
-                base_mip_level: descriptor.base_mip_level,
-                mip_level_count: descriptor.mip_level_count,
-                base_array_layer: descriptor.base_array_layer,
-                array_layer_count: descriptor.array_layer_count,
-            },
-        };
+  #[cppgc]
+  fn create_view(
+    &self,
+    #[webidl] descriptor: GPUTextureViewDescriptor,
+  ) -> Result<GPUTextureView, JsErrorBox> {
+    let wgpu_descriptor = wgpu_core::resource::TextureViewDescriptor {
+      label: crate::transform_label(descriptor.label.clone()),
+      format: descriptor.format.map(Into::into),
+      dimension: descriptor.dimension.map(Into::into),
+      usage: Some(
+        wgpu_types::TextureUsages::from_bits(descriptor.usage)
+          .ok_or_else(|| JsErrorBox::type_error("usage is not valid"))?,
+      ),
+      range: wgpu_types::ImageSubresourceRange {
+        aspect: descriptor.aspect.into(),
+        base_mip_level: descriptor.base_mip_level,
+        mip_level_count: descriptor.mip_level_count,
+        base_array_layer: descriptor.base_array_layer,
+        array_layer_count: descriptor.array_layer_count,
+      },
+    };
 
-        let (id, err) = self
-            .instance
-            .texture_create_view(self.id, &wgpu_descriptor, None);
+    let (id, err) =
+      self
+        .instance
+        .texture_create_view(self.id, &wgpu_descriptor, None);
 
-        self.error_handler.push_error(err);
+    self.error_handler.push_error(err);
 
-        Ok(GPUTextureView {
-            instance: self.instance.clone(),
-            id,
-            label: descriptor.label,
-        })
-    }
+    Ok(GPUTextureView {
+      instance: self.instance.clone(),
+      id,
+      label: descriptor.label,
+    })
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 struct GPUTextureViewDescriptor {
-    #[webidl(default = String::new())]
-    label: String,
+  #[webidl(default = String::new())]
+  label: String,
 
-    format: Option<GPUTextureFormat>,
-    dimension: Option<GPUTextureViewDimension>,
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    usage: u32,
-    #[webidl(default = GPUTextureAspect::All)]
-    aspect: GPUTextureAspect,
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    base_mip_level: u32,
-    #[options(enforce_range = true)]
-    mip_level_count: Option<u32>,
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    base_array_layer: u32,
-    #[options(enforce_range = true)]
-    array_layer_count: Option<u32>,
+  format: Option<GPUTextureFormat>,
+  dimension: Option<GPUTextureViewDimension>,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  usage: u32,
+  #[webidl(default = GPUTextureAspect::All)]
+  aspect: GPUTextureAspect,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  base_mip_level: u32,
+  #[options(enforce_range = true)]
+  mip_level_count: Option<u32>,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  base_array_layer: u32,
+  #[options(enforce_range = true)]
+  array_layer_count: Option<u32>,
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUTextureViewDimension {
-    #[webidl(rename = "1d")]
-    D1,
-    #[webidl(rename = "2d")]
-    D2,
-    #[webidl(rename = "2d-array")]
-    D2Array,
-    #[webidl(rename = "cube")]
-    Cube,
-    #[webidl(rename = "cube-array")]
-    CubeArray,
-    #[webidl(rename = "3d")]
-    D3,
+  #[webidl(rename = "1d")]
+  D1,
+  #[webidl(rename = "2d")]
+  D2,
+  #[webidl(rename = "2d-array")]
+  D2Array,
+  #[webidl(rename = "cube")]
+  Cube,
+  #[webidl(rename = "cube-array")]
+  CubeArray,
+  #[webidl(rename = "3d")]
+  D3,
 }
 
 impl From<GPUTextureViewDimension> for TextureViewDimension {
-    fn from(value: GPUTextureViewDimension) -> Self {
-        match value {
-            GPUTextureViewDimension::D1 => Self::D1,
-            GPUTextureViewDimension::D2 => Self::D2,
-            GPUTextureViewDimension::D3 => Self::D3,
-            GPUTextureViewDimension::D2Array => Self::D2Array,
-            GPUTextureViewDimension::Cube => Self::Cube,
-            GPUTextureViewDimension::CubeArray => Self::CubeArray,
-        }
+  fn from(value: GPUTextureViewDimension) -> Self {
+    match value {
+      GPUTextureViewDimension::D1 => Self::D1,
+      GPUTextureViewDimension::D2 => Self::D2,
+      GPUTextureViewDimension::D3 => Self::D3,
+      GPUTextureViewDimension::D2Array => Self::D2Array,
+      GPUTextureViewDimension::Cube => Self::Cube,
+      GPUTextureViewDimension::CubeArray => Self::CubeArray,
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub enum GPUTextureAspect {
-    All,
-    StencilOnly,
-    DepthOnly,
+  All,
+  StencilOnly,
+  DepthOnly,
 }
 
 impl From<GPUTextureAspect> for TextureAspect {
-    fn from(value: GPUTextureAspect) -> Self {
-        match value {
-            GPUTextureAspect::All => Self::All,
-            GPUTextureAspect::StencilOnly => Self::StencilOnly,
-            GPUTextureAspect::DepthOnly => Self::DepthOnly,
-        }
+  fn from(value: GPUTextureAspect) -> Self {
+    match value {
+      GPUTextureAspect::All => Self::All,
+      GPUTextureAspect::StencilOnly => Self::StencilOnly,
+      GPUTextureAspect::DepthOnly => Self::DepthOnly,
     }
+  }
 }
 
 pub struct GPUTextureView {
-    pub instance: Instance,
-    pub id: wgpu_core::id::TextureViewId,
-    pub label: String,
+  pub instance: Instance,
+  pub id: wgpu_core::id::TextureViewId,
+  pub label: String,
 }
 
 impl Drop for GPUTextureView {
-    fn drop(&mut self) {
-        let _ = self.instance.texture_view_drop(self.id);
-    }
+  fn drop(&mut self) {
+    let _ = self.instance.texture_view_drop(self.id);
+  }
 }
 
 impl WebIdlInterfaceConverter for GPUTextureView {
-    const NAME: &'static str = "GPUTextureView";
+  const NAME: &'static str = "GPUTextureView";
 }
 
 impl GarbageCollected for GPUTextureView {}
@@ -247,424 +248,424 @@ impl GarbageCollected for GPUTextureView {}
 
 #[op2]
 impl GPUTextureView {
-    #[getter]
-    #[string]
-    fn label(&self) -> String {
-        self.label.clone()
-    }
-    #[setter]
-    #[string]
-    fn label(&self, #[webidl] _label: String) {
-        // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
-    }
+  #[getter]
+  #[string]
+  fn label(&self) -> String {
+    self.label.clone()
+  }
+  #[setter]
+  #[string]
+  fn label(&self, #[webidl] _label: String) {
+    // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
+  }
 }
 
 #[derive(WebIDL, Clone)]
 #[webidl(enum)]
 pub enum GPUTextureDimension {
-    #[webidl(rename = "1d")]
-    D1,
-    #[webidl(rename = "2d")]
-    D2,
-    #[webidl(rename = "3d")]
-    D3,
+  #[webidl(rename = "1d")]
+  D1,
+  #[webidl(rename = "2d")]
+  D2,
+  #[webidl(rename = "3d")]
+  D3,
 }
 
 impl From<GPUTextureDimension> for TextureDimension {
-    fn from(value: GPUTextureDimension) -> Self {
-        match value {
-            GPUTextureDimension::D1 => Self::D1,
-            GPUTextureDimension::D2 => Self::D2,
-            GPUTextureDimension::D3 => Self::D3,
-        }
+  fn from(value: GPUTextureDimension) -> Self {
+    match value {
+      GPUTextureDimension::D1 => Self::D1,
+      GPUTextureDimension::D2 => Self::D2,
+      GPUTextureDimension::D3 => Self::D3,
     }
+  }
 }
 
 #[derive(WebIDL, Clone)]
 #[webidl(enum)]
 pub(crate) enum GPUTextureFormat {
-    #[webidl(rename = "r8unorm")]
-    R8unorm,
-    #[webidl(rename = "r8snorm")]
-    R8snorm,
-    #[webidl(rename = "r8uint")]
-    R8uint,
-    #[webidl(rename = "r8sint")]
-    R8sint,
-    #[webidl(rename = "r16uint")]
-    R16uint,
-    #[webidl(rename = "r16sint")]
-    R16sint,
-    #[webidl(rename = "r16float")]
-    R16float,
-    #[webidl(rename = "rg8unorm")]
-    Rg8unorm,
-    #[webidl(rename = "rg8snorm")]
-    Rg8snorm,
-    #[webidl(rename = "rg8uint")]
-    Rg8uint,
-    #[webidl(rename = "rg8sint")]
-    Rg8sint,
-    #[webidl(rename = "r32uint")]
-    R32uint,
-    #[webidl(rename = "r32sint")]
-    R32sint,
-    #[webidl(rename = "r32float")]
-    R32float,
-    #[webidl(rename = "rg16uint")]
-    Rg16uint,
-    #[webidl(rename = "rg16sint")]
-    Rg16sint,
-    #[webidl(rename = "rg16float")]
-    Rg16float,
-    #[webidl(rename = "rgba8unorm")]
-    Rgba8unorm,
-    #[webidl(rename = "rgba8unorm-srgb")]
-    Rgba8unormSrgb,
-    #[webidl(rename = "rgba8snorm")]
-    Rgba8snorm,
-    #[webidl(rename = "rgba8uint")]
-    Rgba8uint,
-    #[webidl(rename = "rgba8sint")]
-    Rgba8sint,
-    #[webidl(rename = "bgra8unorm")]
-    Bgra8unorm,
-    #[webidl(rename = "bgra8unorm-srgb")]
-    Bgra8unormSrgb,
-    #[webidl(rename = "rgb9e5ufloat")]
-    Rgb9e5ufloat,
-    #[webidl(rename = "rgb10a2uint")]
-    Rgb10a2uint,
-    #[webidl(rename = "rgb10a2unorm")]
-    Rgb10a2unorm,
-    #[webidl(rename = "rg11b10ufloat")]
-    Rg11b10ufloat,
-    #[webidl(rename = "rg32uint")]
-    Rg32uint,
-    #[webidl(rename = "rg32sint")]
-    Rg32sint,
-    #[webidl(rename = "rg32float")]
-    Rg32float,
-    #[webidl(rename = "rgba16uint")]
-    Rgba16uint,
-    #[webidl(rename = "rgba16sint")]
-    Rgba16sint,
-    #[webidl(rename = "rgba16float")]
-    Rgba16float,
-    #[webidl(rename = "rgba32uint")]
-    Rgba32uint,
-    #[webidl(rename = "rgba32sint")]
-    Rgba32sint,
-    #[webidl(rename = "rgba32float")]
-    Rgba32float,
-    #[webidl(rename = "stencil8")]
-    Stencil8,
-    #[webidl(rename = "depth16unorm")]
-    Depth16unorm,
-    #[webidl(rename = "depth24plus")]
-    Depth24plus,
-    #[webidl(rename = "depth24plus-stencil8")]
-    Depth24plusStencil8,
-    #[webidl(rename = "depth32float")]
-    Depth32float,
-    #[webidl(rename = "depth32float-stencil8")]
-    Depth32floatStencil8,
-    #[webidl(rename = "bc1-rgba-unorm")]
-    Bc1RgbaUnorm,
-    #[webidl(rename = "bc1-rgba-unorm-srgb")]
-    Bc1RgbaUnormSrgb,
-    #[webidl(rename = "bc2-rgba-unorm")]
-    Bc2RgbaUnorm,
-    #[webidl(rename = "bc2-rgba-unorm-srgb")]
-    Bc2RgbaUnormSrgb,
-    #[webidl(rename = "bc3-rgba-unorm")]
-    Bc3RgbaUnorm,
-    #[webidl(rename = "bc3-rgba-unorm-srgb")]
-    Bc3RgbaUnormSrgb,
-    #[webidl(rename = "bc4-r-unorm")]
-    Bc4RUnorm,
-    #[webidl(rename = "bc4-r-snorm")]
-    Bc4RSnorm,
-    #[webidl(rename = "bc5-rg-unorm")]
-    Bc5RgUnorm,
-    #[webidl(rename = "bc5-rg-snorm")]
-    Bc5RgSnorm,
-    #[webidl(rename = "bc6h-rgb-ufloat")]
-    Bc6hRgbUfloat,
-    #[webidl(rename = "bc6h-rgb-float")]
-    Bc6hRgbFloat,
-    #[webidl(rename = "bc7-rgba-unorm")]
-    Bc7RgbaUnorm,
-    #[webidl(rename = "bc7-rgba-unorm-srgb")]
-    Bc7RgbaUnormSrgb,
-    #[webidl(rename = "etc2-rgb8unorm")]
-    Etc2Rgb8unorm,
-    #[webidl(rename = "etc2-rgb8unorm-srgb")]
-    Etc2Rgb8unormSrgb,
-    #[webidl(rename = "etc2-rgb8a1unorm")]
-    Etc2Rgb8a1unorm,
-    #[webidl(rename = "etc2-rgb8a1unorm-srgb")]
-    Etc2Rgb8a1unormSrgb,
-    #[webidl(rename = "etc2-rgba8unorm")]
-    Etc2Rgba8unorm,
-    #[webidl(rename = "etc2-rgba8unorm-srgb")]
-    Etc2Rgba8unormSrgb,
-    #[webidl(rename = "eac-r11unorm")]
-    EacR11unorm,
-    #[webidl(rename = "eac-r11snorm")]
-    EacR11snorm,
-    #[webidl(rename = "eac-rg11unorm")]
-    EacRg11unorm,
-    #[webidl(rename = "eac-rg11snorm")]
-    EacRg11snorm,
-    #[webidl(rename = "astc-4x4-unorm")]
-    Astc4x4Unorm,
-    #[webidl(rename = "astc-4x4-unorm-srgb")]
-    Astc4x4UnormSrgb,
-    #[webidl(rename = "astc-5x4-unorm")]
-    Astc5x4Unorm,
-    #[webidl(rename = "astc-5x4-unorm-srgb")]
-    Astc5x4UnormSrgb,
-    #[webidl(rename = "astc-5x5-unorm")]
-    Astc5x5Unorm,
-    #[webidl(rename = "astc-5x5-unorm-srgb")]
-    Astc5x5UnormSrgb,
-    #[webidl(rename = "astc-6x5-unorm")]
-    Astc6x5Unorm,
-    #[webidl(rename = "astc-6x5-unorm-srgb")]
-    Astc6x5UnormSrgb,
-    #[webidl(rename = "astc-6x6-unorm")]
-    Astc6x6Unorm,
-    #[webidl(rename = "astc-6x6-unorm-srgb")]
-    Astc6x6UnormSrgb,
-    #[webidl(rename = "astc-8x5-unorm")]
-    Astc8x5Unorm,
-    #[webidl(rename = "astc-8x5-unorm-srgb")]
-    Astc8x5UnormSrgb,
-    #[webidl(rename = "astc-8x6-unorm")]
-    Astc8x6Unorm,
-    #[webidl(rename = "astc-8x6-unorm-srgb")]
-    Astc8x6UnormSrgb,
-    #[webidl(rename = "astc-8x8-unorm")]
-    Astc8x8Unorm,
-    #[webidl(rename = "astc-8x8-unorm-srgb")]
-    Astc8x8UnormSrgb,
-    #[webidl(rename = "astc-10x5-unorm")]
-    Astc10x5Unorm,
-    #[webidl(rename = "astc-10x5-unorm-srgb")]
-    Astc10x5UnormSrgb,
-    #[webidl(rename = "astc-10x6-unorm")]
-    Astc10x6Unorm,
-    #[webidl(rename = "astc-10x6-unorm-srgb")]
-    Astc10x6UnormSrgb,
-    #[webidl(rename = "astc-10x8-unorm")]
-    Astc10x8Unorm,
-    #[webidl(rename = "astc-10x8-unorm-srgb")]
-    Astc10x8UnormSrgb,
-    #[webidl(rename = "astc-10x10-unorm")]
-    Astc10x10Unorm,
-    #[webidl(rename = "astc-10x10-unorm-srgb")]
-    Astc10x10UnormSrgb,
-    #[webidl(rename = "astc-12x10-unorm")]
-    Astc12x10Unorm,
-    #[webidl(rename = "astc-12x10-unorm-srgb")]
-    Astc12x10UnormSrgb,
-    #[webidl(rename = "astc-12x12-unorm")]
-    Astc12x12Unorm,
-    #[webidl(rename = "astc-12x12-unorm-srgb")]
-    Astc12x12UnormSrgb,
+  #[webidl(rename = "r8unorm")]
+  R8unorm,
+  #[webidl(rename = "r8snorm")]
+  R8snorm,
+  #[webidl(rename = "r8uint")]
+  R8uint,
+  #[webidl(rename = "r8sint")]
+  R8sint,
+  #[webidl(rename = "r16uint")]
+  R16uint,
+  #[webidl(rename = "r16sint")]
+  R16sint,
+  #[webidl(rename = "r16float")]
+  R16float,
+  #[webidl(rename = "rg8unorm")]
+  Rg8unorm,
+  #[webidl(rename = "rg8snorm")]
+  Rg8snorm,
+  #[webidl(rename = "rg8uint")]
+  Rg8uint,
+  #[webidl(rename = "rg8sint")]
+  Rg8sint,
+  #[webidl(rename = "r32uint")]
+  R32uint,
+  #[webidl(rename = "r32sint")]
+  R32sint,
+  #[webidl(rename = "r32float")]
+  R32float,
+  #[webidl(rename = "rg16uint")]
+  Rg16uint,
+  #[webidl(rename = "rg16sint")]
+  Rg16sint,
+  #[webidl(rename = "rg16float")]
+  Rg16float,
+  #[webidl(rename = "rgba8unorm")]
+  Rgba8unorm,
+  #[webidl(rename = "rgba8unorm-srgb")]
+  Rgba8unormSrgb,
+  #[webidl(rename = "rgba8snorm")]
+  Rgba8snorm,
+  #[webidl(rename = "rgba8uint")]
+  Rgba8uint,
+  #[webidl(rename = "rgba8sint")]
+  Rgba8sint,
+  #[webidl(rename = "bgra8unorm")]
+  Bgra8unorm,
+  #[webidl(rename = "bgra8unorm-srgb")]
+  Bgra8unormSrgb,
+  #[webidl(rename = "rgb9e5ufloat")]
+  Rgb9e5ufloat,
+  #[webidl(rename = "rgb10a2uint")]
+  Rgb10a2uint,
+  #[webidl(rename = "rgb10a2unorm")]
+  Rgb10a2unorm,
+  #[webidl(rename = "rg11b10ufloat")]
+  Rg11b10ufloat,
+  #[webidl(rename = "rg32uint")]
+  Rg32uint,
+  #[webidl(rename = "rg32sint")]
+  Rg32sint,
+  #[webidl(rename = "rg32float")]
+  Rg32float,
+  #[webidl(rename = "rgba16uint")]
+  Rgba16uint,
+  #[webidl(rename = "rgba16sint")]
+  Rgba16sint,
+  #[webidl(rename = "rgba16float")]
+  Rgba16float,
+  #[webidl(rename = "rgba32uint")]
+  Rgba32uint,
+  #[webidl(rename = "rgba32sint")]
+  Rgba32sint,
+  #[webidl(rename = "rgba32float")]
+  Rgba32float,
+  #[webidl(rename = "stencil8")]
+  Stencil8,
+  #[webidl(rename = "depth16unorm")]
+  Depth16unorm,
+  #[webidl(rename = "depth24plus")]
+  Depth24plus,
+  #[webidl(rename = "depth24plus-stencil8")]
+  Depth24plusStencil8,
+  #[webidl(rename = "depth32float")]
+  Depth32float,
+  #[webidl(rename = "depth32float-stencil8")]
+  Depth32floatStencil8,
+  #[webidl(rename = "bc1-rgba-unorm")]
+  Bc1RgbaUnorm,
+  #[webidl(rename = "bc1-rgba-unorm-srgb")]
+  Bc1RgbaUnormSrgb,
+  #[webidl(rename = "bc2-rgba-unorm")]
+  Bc2RgbaUnorm,
+  #[webidl(rename = "bc2-rgba-unorm-srgb")]
+  Bc2RgbaUnormSrgb,
+  #[webidl(rename = "bc3-rgba-unorm")]
+  Bc3RgbaUnorm,
+  #[webidl(rename = "bc3-rgba-unorm-srgb")]
+  Bc3RgbaUnormSrgb,
+  #[webidl(rename = "bc4-r-unorm")]
+  Bc4RUnorm,
+  #[webidl(rename = "bc4-r-snorm")]
+  Bc4RSnorm,
+  #[webidl(rename = "bc5-rg-unorm")]
+  Bc5RgUnorm,
+  #[webidl(rename = "bc5-rg-snorm")]
+  Bc5RgSnorm,
+  #[webidl(rename = "bc6h-rgb-ufloat")]
+  Bc6hRgbUfloat,
+  #[webidl(rename = "bc6h-rgb-float")]
+  Bc6hRgbFloat,
+  #[webidl(rename = "bc7-rgba-unorm")]
+  Bc7RgbaUnorm,
+  #[webidl(rename = "bc7-rgba-unorm-srgb")]
+  Bc7RgbaUnormSrgb,
+  #[webidl(rename = "etc2-rgb8unorm")]
+  Etc2Rgb8unorm,
+  #[webidl(rename = "etc2-rgb8unorm-srgb")]
+  Etc2Rgb8unormSrgb,
+  #[webidl(rename = "etc2-rgb8a1unorm")]
+  Etc2Rgb8a1unorm,
+  #[webidl(rename = "etc2-rgb8a1unorm-srgb")]
+  Etc2Rgb8a1unormSrgb,
+  #[webidl(rename = "etc2-rgba8unorm")]
+  Etc2Rgba8unorm,
+  #[webidl(rename = "etc2-rgba8unorm-srgb")]
+  Etc2Rgba8unormSrgb,
+  #[webidl(rename = "eac-r11unorm")]
+  EacR11unorm,
+  #[webidl(rename = "eac-r11snorm")]
+  EacR11snorm,
+  #[webidl(rename = "eac-rg11unorm")]
+  EacRg11unorm,
+  #[webidl(rename = "eac-rg11snorm")]
+  EacRg11snorm,
+  #[webidl(rename = "astc-4x4-unorm")]
+  Astc4x4Unorm,
+  #[webidl(rename = "astc-4x4-unorm-srgb")]
+  Astc4x4UnormSrgb,
+  #[webidl(rename = "astc-5x4-unorm")]
+  Astc5x4Unorm,
+  #[webidl(rename = "astc-5x4-unorm-srgb")]
+  Astc5x4UnormSrgb,
+  #[webidl(rename = "astc-5x5-unorm")]
+  Astc5x5Unorm,
+  #[webidl(rename = "astc-5x5-unorm-srgb")]
+  Astc5x5UnormSrgb,
+  #[webidl(rename = "astc-6x5-unorm")]
+  Astc6x5Unorm,
+  #[webidl(rename = "astc-6x5-unorm-srgb")]
+  Astc6x5UnormSrgb,
+  #[webidl(rename = "astc-6x6-unorm")]
+  Astc6x6Unorm,
+  #[webidl(rename = "astc-6x6-unorm-srgb")]
+  Astc6x6UnormSrgb,
+  #[webidl(rename = "astc-8x5-unorm")]
+  Astc8x5Unorm,
+  #[webidl(rename = "astc-8x5-unorm-srgb")]
+  Astc8x5UnormSrgb,
+  #[webidl(rename = "astc-8x6-unorm")]
+  Astc8x6Unorm,
+  #[webidl(rename = "astc-8x6-unorm-srgb")]
+  Astc8x6UnormSrgb,
+  #[webidl(rename = "astc-8x8-unorm")]
+  Astc8x8Unorm,
+  #[webidl(rename = "astc-8x8-unorm-srgb")]
+  Astc8x8UnormSrgb,
+  #[webidl(rename = "astc-10x5-unorm")]
+  Astc10x5Unorm,
+  #[webidl(rename = "astc-10x5-unorm-srgb")]
+  Astc10x5UnormSrgb,
+  #[webidl(rename = "astc-10x6-unorm")]
+  Astc10x6Unorm,
+  #[webidl(rename = "astc-10x6-unorm-srgb")]
+  Astc10x6UnormSrgb,
+  #[webidl(rename = "astc-10x8-unorm")]
+  Astc10x8Unorm,
+  #[webidl(rename = "astc-10x8-unorm-srgb")]
+  Astc10x8UnormSrgb,
+  #[webidl(rename = "astc-10x10-unorm")]
+  Astc10x10Unorm,
+  #[webidl(rename = "astc-10x10-unorm-srgb")]
+  Astc10x10UnormSrgb,
+  #[webidl(rename = "astc-12x10-unorm")]
+  Astc12x10Unorm,
+  #[webidl(rename = "astc-12x10-unorm-srgb")]
+  Astc12x10UnormSrgb,
+  #[webidl(rename = "astc-12x12-unorm")]
+  Astc12x12Unorm,
+  #[webidl(rename = "astc-12x12-unorm-srgb")]
+  Astc12x12UnormSrgb,
 }
 
 impl From<GPUTextureFormat> for TextureFormat {
-    fn from(value: GPUTextureFormat) -> Self {
-        match value {
-            GPUTextureFormat::R8unorm => Self::R8Unorm,
-            GPUTextureFormat::R8snorm => Self::R8Snorm,
-            GPUTextureFormat::R8uint => Self::R8Uint,
-            GPUTextureFormat::R8sint => Self::R8Sint,
-            GPUTextureFormat::R16uint => Self::R16Uint,
-            GPUTextureFormat::R16sint => Self::R16Sint,
-            GPUTextureFormat::R16float => Self::R16Float,
-            GPUTextureFormat::Rg8unorm => Self::Rg8Unorm,
-            GPUTextureFormat::Rg8snorm => Self::Rg8Snorm,
-            GPUTextureFormat::Rg8uint => Self::Rg8Uint,
-            GPUTextureFormat::Rg8sint => Self::Rg8Sint,
-            GPUTextureFormat::R32uint => Self::R32Uint,
-            GPUTextureFormat::R32sint => Self::R32Sint,
-            GPUTextureFormat::R32float => Self::R32Float,
-            GPUTextureFormat::Rg16uint => Self::Rg16Uint,
-            GPUTextureFormat::Rg16sint => Self::Rg16Sint,
-            GPUTextureFormat::Rg16float => Self::Rg16Float,
-            GPUTextureFormat::Rgba8unorm => Self::Rgba8Unorm,
-            GPUTextureFormat::Rgba8unormSrgb => Self::Rgba8UnormSrgb,
-            GPUTextureFormat::Rgba8snorm => Self::Rgba8Snorm,
-            GPUTextureFormat::Rgba8uint => Self::Rgba8Uint,
-            GPUTextureFormat::Rgba8sint => Self::Rgba8Sint,
-            GPUTextureFormat::Bgra8unorm => Self::Bgra8Unorm,
-            GPUTextureFormat::Bgra8unormSrgb => Self::Bgra8UnormSrgb,
-            GPUTextureFormat::Rgb9e5ufloat => Self::Rgb9e5Ufloat,
-            GPUTextureFormat::Rgb10a2uint => Self::Rgb10a2Uint,
-            GPUTextureFormat::Rgb10a2unorm => Self::Rgb10a2Unorm,
-            GPUTextureFormat::Rg11b10ufloat => Self::Rg11b10Ufloat,
-            GPUTextureFormat::Rg32uint => Self::Rg32Uint,
-            GPUTextureFormat::Rg32sint => Self::Rg32Sint,
-            GPUTextureFormat::Rg32float => Self::Rg32Float,
-            GPUTextureFormat::Rgba16uint => Self::Rgba16Uint,
-            GPUTextureFormat::Rgba16sint => Self::Rgba16Sint,
-            GPUTextureFormat::Rgba16float => Self::Rgba16Float,
-            GPUTextureFormat::Rgba32uint => Self::Rgba32Uint,
-            GPUTextureFormat::Rgba32sint => Self::Rgba32Sint,
-            GPUTextureFormat::Rgba32float => Self::Rgba32Float,
-            GPUTextureFormat::Stencil8 => Self::Stencil8,
-            GPUTextureFormat::Depth16unorm => Self::Depth16Unorm,
-            GPUTextureFormat::Depth24plus => Self::Depth24Plus,
-            GPUTextureFormat::Depth24plusStencil8 => Self::Depth24PlusStencil8,
-            GPUTextureFormat::Depth32float => Self::Depth32Float,
-            GPUTextureFormat::Depth32floatStencil8 => Self::Depth32FloatStencil8,
-            GPUTextureFormat::Bc1RgbaUnorm => Self::Bc1RgbaUnorm,
-            GPUTextureFormat::Bc1RgbaUnormSrgb => Self::Bc1RgbaUnormSrgb,
-            GPUTextureFormat::Bc2RgbaUnorm => Self::Bc2RgbaUnorm,
-            GPUTextureFormat::Bc2RgbaUnormSrgb => Self::Bc2RgbaUnormSrgb,
-            GPUTextureFormat::Bc3RgbaUnorm => Self::Bc3RgbaUnorm,
-            GPUTextureFormat::Bc3RgbaUnormSrgb => Self::Bc3RgbaUnormSrgb,
-            GPUTextureFormat::Bc4RUnorm => Self::Bc4RUnorm,
-            GPUTextureFormat::Bc4RSnorm => Self::Bc4RSnorm,
-            GPUTextureFormat::Bc5RgUnorm => Self::Bc5RgUnorm,
-            GPUTextureFormat::Bc5RgSnorm => Self::Bc5RgSnorm,
-            GPUTextureFormat::Bc6hRgbUfloat => Self::Bc6hRgbUfloat,
-            GPUTextureFormat::Bc6hRgbFloat => Self::Bc6hRgbFloat,
-            GPUTextureFormat::Bc7RgbaUnorm => Self::Bc7RgbaUnorm,
-            GPUTextureFormat::Bc7RgbaUnormSrgb => Self::Bc7RgbaUnormSrgb,
-            GPUTextureFormat::Etc2Rgb8unorm => Self::Etc2Rgb8Unorm,
-            GPUTextureFormat::Etc2Rgb8unormSrgb => Self::Etc2Rgb8UnormSrgb,
-            GPUTextureFormat::Etc2Rgb8a1unorm => Self::Etc2Rgb8A1Unorm,
-            GPUTextureFormat::Etc2Rgb8a1unormSrgb => Self::Etc2Rgb8A1UnormSrgb,
-            GPUTextureFormat::Etc2Rgba8unorm => Self::Etc2Rgba8Unorm,
-            GPUTextureFormat::Etc2Rgba8unormSrgb => Self::Etc2Rgba8UnormSrgb,
-            GPUTextureFormat::EacR11unorm => Self::EacR11Unorm,
-            GPUTextureFormat::EacR11snorm => Self::EacR11Snorm,
-            GPUTextureFormat::EacRg11unorm => Self::EacRg11Unorm,
-            GPUTextureFormat::EacRg11snorm => Self::EacRg11Snorm,
-            GPUTextureFormat::Astc4x4Unorm => Self::Astc {
-                block: AstcBlock::B4x4,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc4x4UnormSrgb => Self::Astc {
-                block: AstcBlock::B4x4,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc5x4Unorm => Self::Astc {
-                block: AstcBlock::B5x4,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc5x4UnormSrgb => Self::Astc {
-                block: AstcBlock::B5x4,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc5x5Unorm => Self::Astc {
-                block: AstcBlock::B5x5,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc5x5UnormSrgb => Self::Astc {
-                block: AstcBlock::B5x5,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc6x5Unorm => Self::Astc {
-                block: AstcBlock::B6x5,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc6x5UnormSrgb => Self::Astc {
-                block: AstcBlock::B6x5,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc6x6Unorm => Self::Astc {
-                block: AstcBlock::B6x6,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc6x6UnormSrgb => Self::Astc {
-                block: AstcBlock::B6x6,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc8x5Unorm => Self::Astc {
-                block: AstcBlock::B8x5,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc8x5UnormSrgb => Self::Astc {
-                block: AstcBlock::B8x5,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc8x6Unorm => Self::Astc {
-                block: AstcBlock::B8x6,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc8x6UnormSrgb => Self::Astc {
-                block: AstcBlock::B8x6,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc8x8Unorm => Self::Astc {
-                block: AstcBlock::B8x8,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc8x8UnormSrgb => Self::Astc {
-                block: AstcBlock::B8x8,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc10x5Unorm => Self::Astc {
-                block: AstcBlock::B10x5,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc10x5UnormSrgb => Self::Astc {
-                block: AstcBlock::B10x5,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc10x6Unorm => Self::Astc {
-                block: AstcBlock::B10x6,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc10x6UnormSrgb => Self::Astc {
-                block: AstcBlock::B10x6,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc10x8Unorm => Self::Astc {
-                block: AstcBlock::B10x8,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc10x8UnormSrgb => Self::Astc {
-                block: AstcBlock::B10x8,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc10x10Unorm => Self::Astc {
-                block: AstcBlock::B10x10,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc10x10UnormSrgb => Self::Astc {
-                block: AstcBlock::B10x10,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc12x10Unorm => Self::Astc {
-                block: AstcBlock::B12x10,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc12x10UnormSrgb => Self::Astc {
-                block: AstcBlock::B12x10,
-                channel: AstcChannel::UnormSrgb,
-            },
-            GPUTextureFormat::Astc12x12Unorm => Self::Astc {
-                block: AstcBlock::B12x12,
-                channel: AstcChannel::Unorm,
-            },
-            GPUTextureFormat::Astc12x12UnormSrgb => Self::Astc {
-                block: AstcBlock::B12x12,
-                channel: AstcChannel::UnormSrgb,
-            },
-        }
+  fn from(value: GPUTextureFormat) -> Self {
+    match value {
+      GPUTextureFormat::R8unorm => Self::R8Unorm,
+      GPUTextureFormat::R8snorm => Self::R8Snorm,
+      GPUTextureFormat::R8uint => Self::R8Uint,
+      GPUTextureFormat::R8sint => Self::R8Sint,
+      GPUTextureFormat::R16uint => Self::R16Uint,
+      GPUTextureFormat::R16sint => Self::R16Sint,
+      GPUTextureFormat::R16float => Self::R16Float,
+      GPUTextureFormat::Rg8unorm => Self::Rg8Unorm,
+      GPUTextureFormat::Rg8snorm => Self::Rg8Snorm,
+      GPUTextureFormat::Rg8uint => Self::Rg8Uint,
+      GPUTextureFormat::Rg8sint => Self::Rg8Sint,
+      GPUTextureFormat::R32uint => Self::R32Uint,
+      GPUTextureFormat::R32sint => Self::R32Sint,
+      GPUTextureFormat::R32float => Self::R32Float,
+      GPUTextureFormat::Rg16uint => Self::Rg16Uint,
+      GPUTextureFormat::Rg16sint => Self::Rg16Sint,
+      GPUTextureFormat::Rg16float => Self::Rg16Float,
+      GPUTextureFormat::Rgba8unorm => Self::Rgba8Unorm,
+      GPUTextureFormat::Rgba8unormSrgb => Self::Rgba8UnormSrgb,
+      GPUTextureFormat::Rgba8snorm => Self::Rgba8Snorm,
+      GPUTextureFormat::Rgba8uint => Self::Rgba8Uint,
+      GPUTextureFormat::Rgba8sint => Self::Rgba8Sint,
+      GPUTextureFormat::Bgra8unorm => Self::Bgra8Unorm,
+      GPUTextureFormat::Bgra8unormSrgb => Self::Bgra8UnormSrgb,
+      GPUTextureFormat::Rgb9e5ufloat => Self::Rgb9e5Ufloat,
+      GPUTextureFormat::Rgb10a2uint => Self::Rgb10a2Uint,
+      GPUTextureFormat::Rgb10a2unorm => Self::Rgb10a2Unorm,
+      GPUTextureFormat::Rg11b10ufloat => Self::Rg11b10Ufloat,
+      GPUTextureFormat::Rg32uint => Self::Rg32Uint,
+      GPUTextureFormat::Rg32sint => Self::Rg32Sint,
+      GPUTextureFormat::Rg32float => Self::Rg32Float,
+      GPUTextureFormat::Rgba16uint => Self::Rgba16Uint,
+      GPUTextureFormat::Rgba16sint => Self::Rgba16Sint,
+      GPUTextureFormat::Rgba16float => Self::Rgba16Float,
+      GPUTextureFormat::Rgba32uint => Self::Rgba32Uint,
+      GPUTextureFormat::Rgba32sint => Self::Rgba32Sint,
+      GPUTextureFormat::Rgba32float => Self::Rgba32Float,
+      GPUTextureFormat::Stencil8 => Self::Stencil8,
+      GPUTextureFormat::Depth16unorm => Self::Depth16Unorm,
+      GPUTextureFormat::Depth24plus => Self::Depth24Plus,
+      GPUTextureFormat::Depth24plusStencil8 => Self::Depth24PlusStencil8,
+      GPUTextureFormat::Depth32float => Self::Depth32Float,
+      GPUTextureFormat::Depth32floatStencil8 => Self::Depth32FloatStencil8,
+      GPUTextureFormat::Bc1RgbaUnorm => Self::Bc1RgbaUnorm,
+      GPUTextureFormat::Bc1RgbaUnormSrgb => Self::Bc1RgbaUnormSrgb,
+      GPUTextureFormat::Bc2RgbaUnorm => Self::Bc2RgbaUnorm,
+      GPUTextureFormat::Bc2RgbaUnormSrgb => Self::Bc2RgbaUnormSrgb,
+      GPUTextureFormat::Bc3RgbaUnorm => Self::Bc3RgbaUnorm,
+      GPUTextureFormat::Bc3RgbaUnormSrgb => Self::Bc3RgbaUnormSrgb,
+      GPUTextureFormat::Bc4RUnorm => Self::Bc4RUnorm,
+      GPUTextureFormat::Bc4RSnorm => Self::Bc4RSnorm,
+      GPUTextureFormat::Bc5RgUnorm => Self::Bc5RgUnorm,
+      GPUTextureFormat::Bc5RgSnorm => Self::Bc5RgSnorm,
+      GPUTextureFormat::Bc6hRgbUfloat => Self::Bc6hRgbUfloat,
+      GPUTextureFormat::Bc6hRgbFloat => Self::Bc6hRgbFloat,
+      GPUTextureFormat::Bc7RgbaUnorm => Self::Bc7RgbaUnorm,
+      GPUTextureFormat::Bc7RgbaUnormSrgb => Self::Bc7RgbaUnormSrgb,
+      GPUTextureFormat::Etc2Rgb8unorm => Self::Etc2Rgb8Unorm,
+      GPUTextureFormat::Etc2Rgb8unormSrgb => Self::Etc2Rgb8UnormSrgb,
+      GPUTextureFormat::Etc2Rgb8a1unorm => Self::Etc2Rgb8A1Unorm,
+      GPUTextureFormat::Etc2Rgb8a1unormSrgb => Self::Etc2Rgb8A1UnormSrgb,
+      GPUTextureFormat::Etc2Rgba8unorm => Self::Etc2Rgba8Unorm,
+      GPUTextureFormat::Etc2Rgba8unormSrgb => Self::Etc2Rgba8UnormSrgb,
+      GPUTextureFormat::EacR11unorm => Self::EacR11Unorm,
+      GPUTextureFormat::EacR11snorm => Self::EacR11Snorm,
+      GPUTextureFormat::EacRg11unorm => Self::EacRg11Unorm,
+      GPUTextureFormat::EacRg11snorm => Self::EacRg11Snorm,
+      GPUTextureFormat::Astc4x4Unorm => Self::Astc {
+        block: AstcBlock::B4x4,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc4x4UnormSrgb => Self::Astc {
+        block: AstcBlock::B4x4,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc5x4Unorm => Self::Astc {
+        block: AstcBlock::B5x4,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc5x4UnormSrgb => Self::Astc {
+        block: AstcBlock::B5x4,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc5x5Unorm => Self::Astc {
+        block: AstcBlock::B5x5,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc5x5UnormSrgb => Self::Astc {
+        block: AstcBlock::B5x5,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc6x5Unorm => Self::Astc {
+        block: AstcBlock::B6x5,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc6x5UnormSrgb => Self::Astc {
+        block: AstcBlock::B6x5,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc6x6Unorm => Self::Astc {
+        block: AstcBlock::B6x6,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc6x6UnormSrgb => Self::Astc {
+        block: AstcBlock::B6x6,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc8x5Unorm => Self::Astc {
+        block: AstcBlock::B8x5,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc8x5UnormSrgb => Self::Astc {
+        block: AstcBlock::B8x5,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc8x6Unorm => Self::Astc {
+        block: AstcBlock::B8x6,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc8x6UnormSrgb => Self::Astc {
+        block: AstcBlock::B8x6,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc8x8Unorm => Self::Astc {
+        block: AstcBlock::B8x8,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc8x8UnormSrgb => Self::Astc {
+        block: AstcBlock::B8x8,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc10x5Unorm => Self::Astc {
+        block: AstcBlock::B10x5,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc10x5UnormSrgb => Self::Astc {
+        block: AstcBlock::B10x5,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc10x6Unorm => Self::Astc {
+        block: AstcBlock::B10x6,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc10x6UnormSrgb => Self::Astc {
+        block: AstcBlock::B10x6,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc10x8Unorm => Self::Astc {
+        block: AstcBlock::B10x8,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc10x8UnormSrgb => Self::Astc {
+        block: AstcBlock::B10x8,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc10x10Unorm => Self::Astc {
+        block: AstcBlock::B10x10,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc10x10UnormSrgb => Self::Astc {
+        block: AstcBlock::B10x10,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc12x10Unorm => Self::Astc {
+        block: AstcBlock::B12x10,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc12x10UnormSrgb => Self::Astc {
+        block: AstcBlock::B12x10,
+        channel: AstcChannel::UnormSrgb,
+      },
+      GPUTextureFormat::Astc12x12Unorm => Self::Astc {
+        block: AstcBlock::B12x12,
+        channel: AstcChannel::Unorm,
+      },
+      GPUTextureFormat::Astc12x12UnormSrgb => Self::Astc {
+        block: AstcBlock::B12x12,
+        channel: AstcChannel::UnormSrgb,
+      },
     }
+  }
 }
 
 pub struct GPUExternalTexture {}
 
 impl WebIdlInterfaceConverter for GPUExternalTexture {
-    const NAME: &'static str = "GPUExternalTexture";
+  const NAME: &'static str = "GPUExternalTexture";
 }
 
 impl GarbageCollected for GPUExternalTexture {}

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -63,7 +63,11 @@ impl WebIdlInterfaceConverter for GPUTexture {
   const NAME: &'static str = "GPUTexture";
 }
 
-impl GarbageCollected for GPUTexture {}
+impl GarbageCollected for GPUTexture {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUTexture"
+  }
+}
 
 #[op2]
 impl GPUTexture {
@@ -243,7 +247,11 @@ impl WebIdlInterfaceConverter for GPUTextureView {
   const NAME: &'static str = "GPUTextureView";
 }
 
-impl GarbageCollected for GPUTextureView {}
+impl GarbageCollected for GPUTextureView {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUTextureView"
+  }
+}
 // TODO(@crowlKats): weakref in texture for view
 
 #[op2]
@@ -668,7 +676,11 @@ impl WebIdlInterfaceConverter for GPUExternalTexture {
   const NAME: &'static str = "GPUExternalTexture";
 }
 
-impl GarbageCollected for GPUExternalTexture {}
+impl GarbageCollected for GPUExternalTexture {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"GPUExternalTexture"
+  }
+}
 
 #[op2]
 impl GPUExternalTexture {}

--- a/deno_webgpu/webidl.rs
+++ b/deno_webgpu/webidl.rs
@@ -17,428 +17,459 @@ use deno_error::JsErrorBox;
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUExtent3DDict {
-    #[options(enforce_range = true)]
-    width: u32,
-    #[webidl(default = 1)]
-    #[options(enforce_range = true)]
-    height: u32,
-    #[webidl(default = 1)]
-    #[options(enforce_range = true)]
-    depth_or_array_layers: u32,
+  #[options(enforce_range = true)]
+  width: u32,
+  #[webidl(default = 1)]
+  #[options(enforce_range = true)]
+  height: u32,
+  #[webidl(default = 1)]
+  #[options(enforce_range = true)]
+  depth_or_array_layers: u32,
 }
 
 pub(crate) enum GPUExtent3D {
-    Dict(GPUExtent3DDict),
-    Sequence((u32, u32, u32)),
+  Dict(GPUExtent3DDict),
+  Sequence((u32, u32, u32)),
 }
 
 impl<'a> WebIdlConverter<'a> for GPUExtent3D {
-    type Options = ();
+  type Options = ();
 
-    fn convert<'b>(
-        scope: &mut v8::HandleScope<'a>,
-        value: v8::Local<'a, v8::Value>,
-        prefix: Cow<'static, str>,
-        context: ContextFn<'b>,
-        options: &Self::Options,
-    ) -> Result<Self, WebIdlError> {
-        if value.is_null_or_undefined() {
-            return Ok(GPUExtent3D::Dict(GPUExtent3DDict::convert(
-                scope,
-                value,
-                prefix,
-                context.borrowed(),
-                options,
-            )?));
-        }
-        if let Ok(obj) = value.try_cast::<v8::Object>() {
-            let iter = v8::Symbol::get_iterator(scope);
-            if let Some(iter) = obj.get(scope, iter.into()) {
-                if !iter.is_undefined() {
-                    let conv = <Vec<u32>>::convert(
-                        scope,
-                        value,
-                        prefix.clone(),
-                        context.borrowed(),
-                        &IntOptions {
-                            clamp: false,
-                            enforce_range: true,
-                        },
-                    )?;
-                    if conv.is_empty() || conv.len() > 3 {
-                        return Err(WebIdlError::other(prefix, context, JsErrorBox::type_error(format!("A sequence of number used as a GPUExtent3D must have between 1 and 3 elements, received {} elements", conv.len()))));
-                    }
-
-                    let mut iter = conv.into_iter();
-                    return Ok(GPUExtent3D::Sequence((
-                        iter.next().unwrap(),
-                        iter.next().unwrap_or(1),
-                        iter.next().unwrap_or(1),
-                    )));
-                }
-            }
-
-            return Ok(GPUExtent3D::Dict(GPUExtent3DDict::convert(
-                scope, value, prefix, context, options,
-            )?));
-        }
-
-        Err(WebIdlError::new(
-            prefix,
-            context,
-            WebIdlErrorKind::ConvertToConverterType(
-                "sequence<GPUIntegerCoordinate> or GPUExtent3DDict",
-            ),
-        ))
+  fn convert<'b>(
+    scope: &mut v8::HandleScope<'a>,
+    value: v8::Local<'a, v8::Value>,
+    prefix: Cow<'static, str>,
+    context: ContextFn<'b>,
+    options: &Self::Options,
+  ) -> Result<Self, WebIdlError> {
+    if value.is_null_or_undefined() {
+      return Ok(GPUExtent3D::Dict(GPUExtent3DDict::convert(
+        scope,
+        value,
+        prefix,
+        context.borrowed(),
+        options,
+      )?));
     }
+    if let Ok(obj) = value.try_cast::<v8::Object>() {
+      let iter = v8::Symbol::get_iterator(scope);
+      if let Some(iter) = obj.get(scope, iter.into()) {
+        if !iter.is_undefined() {
+          let conv = <Vec<u32>>::convert(
+            scope,
+            value,
+            prefix.clone(),
+            context.borrowed(),
+            &IntOptions {
+              clamp: false,
+              enforce_range: true,
+            },
+          )?;
+          if conv.is_empty() || conv.len() > 3 {
+            return Err(WebIdlError::other(
+              prefix,
+              context,
+              JsErrorBox::type_error(format!(
+                "A sequence of number used as a GPUExtent3D must have between 1 and 3 elements, received {} elements",
+                conv.len()
+              )),
+            ));
+          }
+
+          let mut iter = conv.into_iter();
+          return Ok(GPUExtent3D::Sequence((
+            iter.next().unwrap(),
+            iter.next().unwrap_or(1),
+            iter.next().unwrap_or(1),
+          )));
+        }
+      }
+
+      return Ok(GPUExtent3D::Dict(GPUExtent3DDict::convert(
+        scope, value, prefix, context, options,
+      )?));
+    }
+
+    Err(WebIdlError::new(
+      prefix,
+      context,
+      WebIdlErrorKind::ConvertToConverterType(
+        "sequence<GPUIntegerCoordinate> or GPUExtent3DDict",
+      ),
+    ))
+  }
 }
 
 impl From<GPUExtent3D> for wgpu_types::Extent3d {
-    fn from(value: GPUExtent3D) -> Self {
-        match value {
-            GPUExtent3D::Dict(dict) => Self {
-                width: dict.width,
-                height: dict.height,
-                depth_or_array_layers: dict.depth_or_array_layers,
-            },
-            GPUExtent3D::Sequence((width, height, depth)) => Self {
-                width,
-                height,
-                depth_or_array_layers: depth,
-            },
-        }
+  fn from(value: GPUExtent3D) -> Self {
+    match value {
+      GPUExtent3D::Dict(dict) => Self {
+        width: dict.width,
+        height: dict.height,
+        depth_or_array_layers: dict.depth_or_array_layers,
+      },
+      GPUExtent3D::Sequence((width, height, depth)) => Self {
+        width,
+        height,
+        depth_or_array_layers: depth,
+      },
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUOrigin3DDict {
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    x: u32,
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    y: u32,
-    #[webidl(default = 0)]
-    #[options(enforce_range = true)]
-    z: u32,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  x: u32,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  y: u32,
+  #[webidl(default = 0)]
+  #[options(enforce_range = true)]
+  z: u32,
 }
 
 pub(crate) enum GPUOrigin3D {
-    Dict(GPUOrigin3DDict),
-    Sequence((u32, u32, u32)),
+  Dict(GPUOrigin3DDict),
+  Sequence((u32, u32, u32)),
 }
 
 impl Default for GPUOrigin3D {
-    fn default() -> Self {
-        GPUOrigin3D::Sequence((0, 0, 0))
-    }
+  fn default() -> Self {
+    GPUOrigin3D::Sequence((0, 0, 0))
+  }
 }
 
 impl<'a> WebIdlConverter<'a> for GPUOrigin3D {
-    type Options = ();
+  type Options = ();
 
-    fn convert<'b>(
-        scope: &mut v8::HandleScope<'a>,
-        value: v8::Local<'a, v8::Value>,
-        prefix: Cow<'static, str>,
-        context: ContextFn<'b>,
-        options: &Self::Options,
-    ) -> Result<Self, WebIdlError> {
-        if value.is_null_or_undefined() {
-            return Ok(GPUOrigin3D::Dict(GPUOrigin3DDict::convert(
-                scope,
-                value,
-                prefix,
-                context.borrowed(),
-                options,
-            )?));
-        }
-        if let Ok(obj) = value.try_cast::<v8::Object>() {
-            let iter = v8::Symbol::get_iterator(scope);
-            if let Some(iter) = obj.get(scope, iter.into()) {
-                if !iter.is_undefined() {
-                    let conv = <Vec<u32>>::convert(
-                        scope,
-                        value,
-                        prefix.clone(),
-                        context.borrowed(),
-                        &IntOptions {
-                            clamp: false,
-                            enforce_range: true,
-                        },
-                    )?;
-                    if conv.len() > 3 {
-                        return Err(WebIdlError::other(prefix, context, JsErrorBox::type_error(format!("A sequence of number used as a GPUOrigin3D must have at most 3 elements, received {} elements", conv.len()))));
-                    }
-
-                    let mut iter = conv.into_iter();
-                    return Ok(GPUOrigin3D::Sequence((
-                        iter.next().unwrap_or(0),
-                        iter.next().unwrap_or(0),
-                        iter.next().unwrap_or(0),
-                    )));
-                }
-            }
-
-            return Ok(GPUOrigin3D::Dict(GPUOrigin3DDict::convert(
-                scope, value, prefix, context, options,
-            )?));
-        }
-
-        Err(WebIdlError::new(
-            prefix,
-            context,
-            WebIdlErrorKind::ConvertToConverterType(
-                "sequence<GPUIntegerCoordinate> or GPUOrigin3DDict",
-            ),
-        ))
+  fn convert<'b>(
+    scope: &mut v8::HandleScope<'a>,
+    value: v8::Local<'a, v8::Value>,
+    prefix: Cow<'static, str>,
+    context: ContextFn<'b>,
+    options: &Self::Options,
+  ) -> Result<Self, WebIdlError> {
+    if value.is_null_or_undefined() {
+      return Ok(GPUOrigin3D::Dict(GPUOrigin3DDict::convert(
+        scope,
+        value,
+        prefix,
+        context.borrowed(),
+        options,
+      )?));
     }
+    if let Ok(obj) = value.try_cast::<v8::Object>() {
+      let iter = v8::Symbol::get_iterator(scope);
+      if let Some(iter) = obj.get(scope, iter.into()) {
+        if !iter.is_undefined() {
+          let conv = <Vec<u32>>::convert(
+            scope,
+            value,
+            prefix.clone(),
+            context.borrowed(),
+            &IntOptions {
+              clamp: false,
+              enforce_range: true,
+            },
+          )?;
+          if conv.len() > 3 {
+            return Err(WebIdlError::other(
+              prefix,
+              context,
+              JsErrorBox::type_error(format!(
+                "A sequence of number used as a GPUOrigin3D must have at most 3 elements, received {} elements",
+                conv.len()
+              )),
+            ));
+          }
+
+          let mut iter = conv.into_iter();
+          return Ok(GPUOrigin3D::Sequence((
+            iter.next().unwrap_or(0),
+            iter.next().unwrap_or(0),
+            iter.next().unwrap_or(0),
+          )));
+        }
+      }
+
+      return Ok(GPUOrigin3D::Dict(GPUOrigin3DDict::convert(
+        scope, value, prefix, context, options,
+      )?));
+    }
+
+    Err(WebIdlError::new(
+      prefix,
+      context,
+      WebIdlErrorKind::ConvertToConverterType(
+        "sequence<GPUIntegerCoordinate> or GPUOrigin3DDict",
+      ),
+    ))
+  }
 }
 
 impl From<GPUOrigin3D> for wgpu_types::Origin3d {
-    fn from(value: GPUOrigin3D) -> Self {
-        match value {
-            GPUOrigin3D::Dict(dict) => Self {
-                x: dict.x,
-                y: dict.y,
-                z: dict.z,
-            },
-            GPUOrigin3D::Sequence((x, y, z)) => Self { x, y, z },
-        }
+  fn from(value: GPUOrigin3D) -> Self {
+    match value {
+      GPUOrigin3D::Dict(dict) => Self {
+        x: dict.x,
+        y: dict.y,
+        z: dict.z,
+      },
+      GPUOrigin3D::Sequence((x, y, z)) => Self { x, y, z },
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPUColorDict {
-    r: f64,
-    g: f64,
-    b: f64,
-    a: f64,
+  r: f64,
+  g: f64,
+  b: f64,
+  a: f64,
 }
 
 pub(crate) enum GPUColor {
-    Dict(GPUColorDict),
-    Sequence((f64, f64, f64, f64)),
+  Dict(GPUColorDict),
+  Sequence((f64, f64, f64, f64)),
 }
 
 impl<'a> WebIdlConverter<'a> for GPUColor {
-    type Options = ();
+  type Options = ();
 
-    fn convert<'b>(
-        scope: &mut v8::HandleScope<'a>,
-        value: v8::Local<'a, v8::Value>,
-        prefix: Cow<'static, str>,
-        context: ContextFn<'b>,
-        options: &Self::Options,
-    ) -> Result<Self, WebIdlError> {
-        if value.is_null_or_undefined() {
-            return Ok(GPUColor::Dict(GPUColorDict::convert(
-                scope,
-                value,
-                prefix,
-                context.borrowed(),
-                options,
-            )?));
-        }
-        if let Ok(obj) = value.try_cast::<v8::Object>() {
-            let iter = v8::Symbol::get_iterator(scope);
-            if let Some(iter) = obj.get(scope, iter.into()) {
-                if !iter.is_undefined() {
-                    let conv = <Vec<f64>>::convert(
-                        scope,
-                        value,
-                        prefix.clone(),
-                        context.borrowed(),
-                        options,
-                    )?;
-                    if conv.len() != 4 {
-                        return Err(WebIdlError::other(prefix, context, JsErrorBox::type_error(format!("A sequence of number used as a GPUColor must have exactly 4 elements, received {} elements", conv.len()))));
-                    }
-
-                    let mut iter = conv.into_iter();
-                    return Ok(GPUColor::Sequence((
-                        iter.next().unwrap(),
-                        iter.next().unwrap(),
-                        iter.next().unwrap(),
-                        iter.next().unwrap(),
-                    )));
-                }
-            }
-
-            return Ok(GPUColor::Dict(GPUColorDict::convert(
-                scope, value, prefix, context, options,
-            )?));
-        }
-
-        Err(WebIdlError::new(
-            prefix,
-            context,
-            WebIdlErrorKind::ConvertToConverterType(
-                "sequence<GPUIntegerCoordinate> or GPUOrigin3DDict",
-            ),
-        ))
+  fn convert<'b>(
+    scope: &mut v8::HandleScope<'a>,
+    value: v8::Local<'a, v8::Value>,
+    prefix: Cow<'static, str>,
+    context: ContextFn<'b>,
+    options: &Self::Options,
+  ) -> Result<Self, WebIdlError> {
+    if value.is_null_or_undefined() {
+      return Ok(GPUColor::Dict(GPUColorDict::convert(
+        scope,
+        value,
+        prefix,
+        context.borrowed(),
+        options,
+      )?));
     }
+    if let Ok(obj) = value.try_cast::<v8::Object>() {
+      let iter = v8::Symbol::get_iterator(scope);
+      if let Some(iter) = obj.get(scope, iter.into()) {
+        if !iter.is_undefined() {
+          let conv = <Vec<f64>>::convert(
+            scope,
+            value,
+            prefix.clone(),
+            context.borrowed(),
+            options,
+          )?;
+          if conv.len() != 4 {
+            return Err(WebIdlError::other(
+              prefix,
+              context,
+              JsErrorBox::type_error(format!(
+                "A sequence of number used as a GPUColor must have exactly 4 elements, received {} elements",
+                conv.len()
+              )),
+            ));
+          }
+
+          let mut iter = conv.into_iter();
+          return Ok(GPUColor::Sequence((
+            iter.next().unwrap(),
+            iter.next().unwrap(),
+            iter.next().unwrap(),
+            iter.next().unwrap(),
+          )));
+        }
+      }
+
+      return Ok(GPUColor::Dict(GPUColorDict::convert(
+        scope, value, prefix, context, options,
+      )?));
+    }
+
+    Err(WebIdlError::new(
+      prefix,
+      context,
+      WebIdlErrorKind::ConvertToConverterType(
+        "sequence<GPUIntegerCoordinate> or GPUOrigin3DDict",
+      ),
+    ))
+  }
 }
 
 impl From<GPUColor> for wgpu_types::Color {
-    fn from(value: GPUColor) -> Self {
-        match value {
-            GPUColor::Dict(dict) => Self {
-                r: dict.r,
-                g: dict.g,
-                b: dict.b,
-                a: dict.a,
-            },
-            GPUColor::Sequence((r, g, b, a)) => Self { r, g, b, a },
-        }
+  fn from(value: GPUColor) -> Self {
+    match value {
+      GPUColor::Dict(dict) => Self {
+        r: dict.r,
+        g: dict.g,
+        b: dict.b,
+        a: dict.a,
+      },
+      GPUColor::Sequence((r, g, b, a)) => Self { r, g, b, a },
     }
+  }
 }
 
 #[derive(WebIDL)]
 #[webidl(enum)]
 pub(crate) enum GPUAutoLayoutMode {
-    Auto,
+  Auto,
 }
 
 pub(crate) enum GPUPipelineLayoutOrGPUAutoLayoutMode {
-    PipelineLayout(Ptr<crate::pipeline_layout::GPUPipelineLayout>),
-    AutoLayoutMode(GPUAutoLayoutMode),
+  PipelineLayout(Ptr<crate::pipeline_layout::GPUPipelineLayout>),
+  AutoLayoutMode(GPUAutoLayoutMode),
 }
 
-impl From<GPUPipelineLayoutOrGPUAutoLayoutMode> for Option<wgpu_core::id::PipelineLayoutId> {
-    fn from(value: GPUPipelineLayoutOrGPUAutoLayoutMode) -> Self {
-        match value {
-            GPUPipelineLayoutOrGPUAutoLayoutMode::PipelineLayout(layout) => Some(layout.id),
-            GPUPipelineLayoutOrGPUAutoLayoutMode::AutoLayoutMode(GPUAutoLayoutMode::Auto) => None,
-        }
+impl From<GPUPipelineLayoutOrGPUAutoLayoutMode>
+  for Option<wgpu_core::id::PipelineLayoutId>
+{
+  fn from(value: GPUPipelineLayoutOrGPUAutoLayoutMode) -> Self {
+    match value {
+      GPUPipelineLayoutOrGPUAutoLayoutMode::PipelineLayout(layout) => {
+        Some(layout.id)
+      }
+      GPUPipelineLayoutOrGPUAutoLayoutMode::AutoLayoutMode(
+        GPUAutoLayoutMode::Auto,
+      ) => None,
     }
+  }
 }
 
 impl<'a> WebIdlConverter<'a> for GPUPipelineLayoutOrGPUAutoLayoutMode {
-    type Options = ();
+  type Options = ();
 
-    fn convert<'b>(
-        scope: &mut v8::HandleScope<'a>,
-        value: v8::Local<'a, v8::Value>,
-        prefix: Cow<'static, str>,
-        context: ContextFn<'b>,
-        options: &Self::Options,
-    ) -> Result<Self, WebIdlError> {
-        if value.is_object() {
-            Ok(Self::PipelineLayout(WebIdlConverter::convert(
-                scope, value, prefix, context, options,
-            )?))
-        } else {
-            Ok(Self::AutoLayoutMode(WebIdlConverter::convert(
-                scope, value, prefix, context, options,
-            )?))
-        }
+  fn convert<'b>(
+    scope: &mut v8::HandleScope<'a>,
+    value: v8::Local<'a, v8::Value>,
+    prefix: Cow<'static, str>,
+    context: ContextFn<'b>,
+    options: &Self::Options,
+  ) -> Result<Self, WebIdlError> {
+    if value.is_object() {
+      Ok(Self::PipelineLayout(WebIdlConverter::convert(
+        scope, value, prefix, context, options,
+      )?))
+    } else {
+      Ok(Self::AutoLayoutMode(WebIdlConverter::convert(
+        scope, value, prefix, context, options,
+      )?))
     }
+  }
 }
 
 #[derive(WebIDL, Clone, Hash, Eq, PartialEq)]
 #[webidl(enum)]
 pub enum GPUFeatureName {
-    #[webidl(rename = "depth-clip-control")]
-    DepthClipControl,
-    #[webidl(rename = "timestamp-query")]
-    TimestampQuery,
-    #[webidl(rename = "indirect-first-instance")]
-    IndirectFirstInstance,
-    #[webidl(rename = "shader-f16")]
-    ShaderF16,
-    #[webidl(rename = "depth32float-stencil8")]
-    Depth32floatStencil8,
-    #[webidl(rename = "texture-compression-bc")]
-    TextureCompressionBc,
-    #[webidl(rename = "texture-compression-bc-sliced-3d")]
-    TextureCompressionBcSliced3d,
-    #[webidl(rename = "texture-compression-etc2")]
-    TextureCompressionEtc2,
-    #[webidl(rename = "texture-compression-astc")]
-    TextureCompressionAstc,
-    #[webidl(rename = "texture-compression-astc-sliced-3d")]
-    TextureCompressionAstcSliced3d,
-    #[webidl(rename = "rg11b10ufloat-renderable")]
-    Rg11b10ufloatRenderable,
-    #[webidl(rename = "bgra8unorm-storage")]
-    Bgra8unormStorage,
-    #[webidl(rename = "float32-filterable")]
-    Float32Filterable,
-    #[webidl(rename = "dual-source-blending")]
-    DualSourceBlending,
-    #[webidl(rename = "subgroups")]
-    Subgroups,
+  #[webidl(rename = "depth-clip-control")]
+  DepthClipControl,
+  #[webidl(rename = "timestamp-query")]
+  TimestampQuery,
+  #[webidl(rename = "indirect-first-instance")]
+  IndirectFirstInstance,
+  #[webidl(rename = "shader-f16")]
+  ShaderF16,
+  #[webidl(rename = "depth32float-stencil8")]
+  Depth32floatStencil8,
+  #[webidl(rename = "texture-compression-bc")]
+  TextureCompressionBc,
+  #[webidl(rename = "texture-compression-bc-sliced-3d")]
+  TextureCompressionBcSliced3d,
+  #[webidl(rename = "texture-compression-etc2")]
+  TextureCompressionEtc2,
+  #[webidl(rename = "texture-compression-astc")]
+  TextureCompressionAstc,
+  #[webidl(rename = "texture-compression-astc-sliced-3d")]
+  TextureCompressionAstcSliced3d,
+  #[webidl(rename = "rg11b10ufloat-renderable")]
+  Rg11b10ufloatRenderable,
+  #[webidl(rename = "bgra8unorm-storage")]
+  Bgra8unormStorage,
+  #[webidl(rename = "float32-filterable")]
+  Float32Filterable,
+  #[webidl(rename = "dual-source-blending")]
+  DualSourceBlending,
+  #[webidl(rename = "subgroups")]
+  Subgroups,
 
-    // extended from spec
-    #[webidl(rename = "texture-format-16-bit-norm")]
-    TextureFormat16BitNorm,
-    #[webidl(rename = "texture-compression-astc-hdr")]
-    TextureCompressionAstcHdr,
-    #[webidl(rename = "texture-adapter-specific-format-features")]
-    TextureAdapterSpecificFormatFeatures,
-    #[webidl(rename = "pipeline-statistics-query")]
-    PipelineStatisticsQuery,
-    #[webidl(rename = "timestamp-query-inside-passes")]
-    TimestampQueryInsidePasses,
-    #[webidl(rename = "mappable-primary-buffers")]
-    MappablePrimaryBuffers,
-    #[webidl(rename = "texture-binding-array")]
-    TextureBindingArray,
-    #[webidl(rename = "buffer-binding-array")]
-    BufferBindingArray,
-    #[webidl(rename = "storage-resource-binding-array")]
-    StorageResourceBindingArray,
-    #[webidl(rename = "sampled-texture-and-storage-buffer-array-non-uniform-indexing")]
-    SampledTextureAndStorageBufferArrayNonUniformIndexing,
-    #[webidl(rename = "storage-texture-array-non-uniform-indexing")]
-    StorageTextureArrayNonUniformIndexing,
-    #[webidl(rename = "uniform-buffer-binding-arrays")]
-    UniformBufferBindingArrays,
-    #[webidl(rename = "partially-bound-binding-array")]
-    PartiallyBoundBindingArray,
-    #[webidl(rename = "multi-draw-indirect-count")]
-    MultiDrawIndirectCount,
-    #[webidl(rename = "push-constants")]
-    PushConstants,
-    #[webidl(rename = "address-mode-clamp-to-zero")]
-    AddressModeClampToZero,
-    #[webidl(rename = "address-mode-clamp-to-border")]
-    AddressModeClampToBorder,
-    #[webidl(rename = "polygon-mode-line")]
-    PolygonModeLine,
-    #[webidl(rename = "polygon-mode-point")]
-    PolygonModePoint,
-    #[webidl(rename = "conservative-rasterization")]
-    ConservativeRasterization,
-    #[webidl(rename = "vertex-writable-storage")]
-    VertexWritableStorage,
-    #[webidl(rename = "clear-texture")]
-    ClearTexture,
-    #[webidl(rename = "multiview")]
-    Multiview,
-    #[webidl(rename = "vertex-attribute-64-bit")]
-    VertexAttribute64Bit,
-    #[webidl(rename = "shader-f64")]
-    ShaderF64,
-    #[webidl(rename = "shader-i16")]
-    ShaderI16,
-    #[webidl(rename = "shader-primitive-index")]
-    ShaderPrimitiveIndex,
-    #[webidl(rename = "shader-early-depth-test")]
-    ShaderEarlyDepthTest,
-    #[webidl(rename = "passthrough-shaders")]
-    PassthroughShaders,
+  // extended from spec
+  #[webidl(rename = "texture-format-16-bit-norm")]
+  TextureFormat16BitNorm,
+  #[webidl(rename = "texture-compression-astc-hdr")]
+  TextureCompressionAstcHdr,
+  #[webidl(rename = "texture-adapter-specific-format-features")]
+  TextureAdapterSpecificFormatFeatures,
+  #[webidl(rename = "pipeline-statistics-query")]
+  PipelineStatisticsQuery,
+  #[webidl(rename = "timestamp-query-inside-passes")]
+  TimestampQueryInsidePasses,
+  #[webidl(rename = "mappable-primary-buffers")]
+  MappablePrimaryBuffers,
+  #[webidl(rename = "texture-binding-array")]
+  TextureBindingArray,
+  #[webidl(rename = "buffer-binding-array")]
+  BufferBindingArray,
+  #[webidl(rename = "storage-resource-binding-array")]
+  StorageResourceBindingArray,
+  #[webidl(
+    rename = "sampled-texture-and-storage-buffer-array-non-uniform-indexing"
+  )]
+  SampledTextureAndStorageBufferArrayNonUniformIndexing,
+  #[webidl(rename = "storage-texture-array-non-uniform-indexing")]
+  StorageTextureArrayNonUniformIndexing,
+  #[webidl(rename = "uniform-buffer-binding-arrays")]
+  UniformBufferBindingArrays,
+  #[webidl(rename = "partially-bound-binding-array")]
+  PartiallyBoundBindingArray,
+  #[webidl(rename = "multi-draw-indirect-count")]
+  MultiDrawIndirectCount,
+  #[webidl(rename = "push-constants")]
+  PushConstants,
+  #[webidl(rename = "address-mode-clamp-to-zero")]
+  AddressModeClampToZero,
+  #[webidl(rename = "address-mode-clamp-to-border")]
+  AddressModeClampToBorder,
+  #[webidl(rename = "polygon-mode-line")]
+  PolygonModeLine,
+  #[webidl(rename = "polygon-mode-point")]
+  PolygonModePoint,
+  #[webidl(rename = "conservative-rasterization")]
+  ConservativeRasterization,
+  #[webidl(rename = "vertex-writable-storage")]
+  VertexWritableStorage,
+  #[webidl(rename = "clear-texture")]
+  ClearTexture,
+  #[webidl(rename = "multiview")]
+  Multiview,
+  #[webidl(rename = "vertex-attribute-64-bit")]
+  VertexAttribute64Bit,
+  #[webidl(rename = "shader-f64")]
+  ShaderF64,
+  #[webidl(rename = "shader-i16")]
+  ShaderI16,
+  #[webidl(rename = "shader-primitive-index")]
+  ShaderPrimitiveIndex,
+  #[webidl(rename = "shader-early-depth-test")]
+  ShaderEarlyDepthTest,
+  #[webidl(rename = "passthrough-shaders")]
+  PassthroughShaders,
 }
 
-pub fn feature_names_to_features(names: Vec<GPUFeatureName>) -> wgpu_types::Features {
-    use wgpu_types::Features;
-    let mut features = Features::empty();
+pub fn feature_names_to_features(
+  names: Vec<GPUFeatureName>,
+) -> wgpu_types::Features {
+  use wgpu_types::Features;
+  let mut features = Features::empty();
 
-    for name in names {
-        #[rustfmt::skip]
+  for name in names {
+    #[rustfmt::skip]
     let feature = match name {
       GPUFeatureName::DepthClipControl => Features::DEPTH_CLIP_CONTROL,
       GPUFeatureName::TimestampQuery => Features::TIMESTAMP_QUERY,
@@ -485,160 +516,167 @@ pub fn feature_names_to_features(names: Vec<GPUFeatureName>) -> wgpu_types::Feat
       GPUFeatureName::ShaderEarlyDepthTest => Features::SHADER_EARLY_DEPTH_TEST,
       GPUFeatureName::PassthroughShaders => Features::EXPERIMENTAL_PASSTHROUGH_SHADERS,
     };
-        features.set(feature, true);
-    }
+    features.set(feature, true);
+  }
 
-    features
+  features
 }
 
 #[allow(clippy::disallowed_types)]
-pub fn features_to_feature_names(features: wgpu_types::Features) -> HashSet<GPUFeatureName> {
-    use GPUFeatureName::*;
-    let mut return_features = HashSet::new();
+pub fn features_to_feature_names(
+  features: wgpu_types::Features,
+) -> HashSet<GPUFeatureName> {
+  use GPUFeatureName::*;
+  let mut return_features = HashSet::new();
 
-    // api
-    if features.contains(wgpu_types::Features::DEPTH_CLIP_CONTROL) {
-        return_features.insert(DepthClipControl);
-    }
-    if features.contains(wgpu_types::Features::TIMESTAMP_QUERY) {
-        return_features.insert(TimestampQuery);
-    }
-    if features.contains(wgpu_types::Features::INDIRECT_FIRST_INSTANCE) {
-        return_features.insert(IndirectFirstInstance);
-    }
-    // shader
-    if features.contains(wgpu_types::Features::SHADER_F16) {
-        return_features.insert(ShaderF16);
-    }
-    // texture formats
-    if features.contains(wgpu_types::Features::DEPTH32FLOAT_STENCIL8) {
-        return_features.insert(Depth32floatStencil8);
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_BC) {
-        return_features.insert(TextureCompressionBc);
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_BC_SLICED_3D) {
-        return_features.insert(TextureCompressionBcSliced3d);
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ETC2) {
-        return_features.insert(TextureCompressionEtc2);
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC) {
-        return_features.insert(TextureCompressionAstc);
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D) {
-        return_features.insert(TextureCompressionAstcSliced3d);
-    }
-    if features.contains(wgpu_types::Features::RG11B10UFLOAT_RENDERABLE) {
-        return_features.insert(Rg11b10ufloatRenderable);
-    }
-    if features.contains(wgpu_types::Features::BGRA8UNORM_STORAGE) {
-        return_features.insert(Bgra8unormStorage);
-    }
-    if features.contains(wgpu_types::Features::FLOAT32_FILTERABLE) {
-        return_features.insert(Float32Filterable);
-    }
-    if features.contains(wgpu_types::Features::DUAL_SOURCE_BLENDING) {
-        return_features.insert(DualSourceBlending);
-    }
-    if features.contains(wgpu_types::Features::SUBGROUP) {
-        return_features.insert(Subgroups);
-    }
+  // api
+  if features.contains(wgpu_types::Features::DEPTH_CLIP_CONTROL) {
+    return_features.insert(DepthClipControl);
+  }
+  if features.contains(wgpu_types::Features::TIMESTAMP_QUERY) {
+    return_features.insert(TimestampQuery);
+  }
+  if features.contains(wgpu_types::Features::INDIRECT_FIRST_INSTANCE) {
+    return_features.insert(IndirectFirstInstance);
+  }
+  // shader
+  if features.contains(wgpu_types::Features::SHADER_F16) {
+    return_features.insert(ShaderF16);
+  }
+  // texture formats
+  if features.contains(wgpu_types::Features::DEPTH32FLOAT_STENCIL8) {
+    return_features.insert(Depth32floatStencil8);
+  }
+  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_BC) {
+    return_features.insert(TextureCompressionBc);
+  }
+  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_BC_SLICED_3D) {
+    return_features.insert(TextureCompressionBcSliced3d);
+  }
+  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ETC2) {
+    return_features.insert(TextureCompressionEtc2);
+  }
+  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC) {
+    return_features.insert(TextureCompressionAstc);
+  }
+  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D)
+  {
+    return_features.insert(TextureCompressionAstcSliced3d);
+  }
+  if features.contains(wgpu_types::Features::RG11B10UFLOAT_RENDERABLE) {
+    return_features.insert(Rg11b10ufloatRenderable);
+  }
+  if features.contains(wgpu_types::Features::BGRA8UNORM_STORAGE) {
+    return_features.insert(Bgra8unormStorage);
+  }
+  if features.contains(wgpu_types::Features::FLOAT32_FILTERABLE) {
+    return_features.insert(Float32Filterable);
+  }
+  if features.contains(wgpu_types::Features::DUAL_SOURCE_BLENDING) {
+    return_features.insert(DualSourceBlending);
+  }
+  if features.contains(wgpu_types::Features::SUBGROUP) {
+    return_features.insert(Subgroups);
+  }
 
-    // extended from spec
+  // extended from spec
 
-    // texture formats
-    if features.contains(wgpu_types::Features::TEXTURE_FORMAT_16BIT_NORM) {
-        return_features.insert(TextureFormat16BitNorm);
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_HDR) {
-        return_features.insert(TextureCompressionAstcHdr);
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES) {
-        return_features.insert(TextureAdapterSpecificFormatFeatures);
-    }
-    // api
-    if features.contains(wgpu_types::Features::PIPELINE_STATISTICS_QUERY) {
-        return_features.insert(PipelineStatisticsQuery);
-    }
-    if features.contains(wgpu_types::Features::TIMESTAMP_QUERY_INSIDE_PASSES) {
-        return_features.insert(TimestampQueryInsidePasses);
-    }
-    if features.contains(wgpu_types::Features::MAPPABLE_PRIMARY_BUFFERS) {
-        return_features.insert(MappablePrimaryBuffers);
-    }
-    if features.contains(wgpu_types::Features::TEXTURE_BINDING_ARRAY) {
-        return_features.insert(TextureBindingArray);
-    }
-    if features.contains(wgpu_types::Features::BUFFER_BINDING_ARRAY) {
-        return_features.insert(BufferBindingArray);
-    }
-    if features.contains(wgpu_types::Features::STORAGE_RESOURCE_BINDING_ARRAY) {
-        return_features.insert(StorageResourceBindingArray);
-    }
-    if features.contains(
+  // texture formats
+  if features.contains(wgpu_types::Features::TEXTURE_FORMAT_16BIT_NORM) {
+    return_features.insert(TextureFormat16BitNorm);
+  }
+  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_HDR) {
+    return_features.insert(TextureCompressionAstcHdr);
+  }
+  if features
+    .contains(wgpu_types::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES)
+  {
+    return_features.insert(TextureAdapterSpecificFormatFeatures);
+  }
+  // api
+  if features.contains(wgpu_types::Features::PIPELINE_STATISTICS_QUERY) {
+    return_features.insert(PipelineStatisticsQuery);
+  }
+  if features.contains(wgpu_types::Features::TIMESTAMP_QUERY_INSIDE_PASSES) {
+    return_features.insert(TimestampQueryInsidePasses);
+  }
+  if features.contains(wgpu_types::Features::MAPPABLE_PRIMARY_BUFFERS) {
+    return_features.insert(MappablePrimaryBuffers);
+  }
+  if features.contains(wgpu_types::Features::TEXTURE_BINDING_ARRAY) {
+    return_features.insert(TextureBindingArray);
+  }
+  if features.contains(wgpu_types::Features::BUFFER_BINDING_ARRAY) {
+    return_features.insert(BufferBindingArray);
+  }
+  if features.contains(wgpu_types::Features::STORAGE_RESOURCE_BINDING_ARRAY) {
+    return_features.insert(StorageResourceBindingArray);
+  }
+  if features.contains(
         wgpu_types::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
     ) {
         return_features.insert(SampledTextureAndStorageBufferArrayNonUniformIndexing);
     }
-    if features.contains(wgpu_types::Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING) {
-        return_features.insert(StorageTextureArrayNonUniformIndexing);
-    }
-    if features.contains(wgpu_types::Features::UNIFORM_BUFFER_BINDING_ARRAYS) {
-        return_features.insert(UniformBufferBindingArrays);
-    }
-    if features.contains(wgpu_types::Features::PARTIALLY_BOUND_BINDING_ARRAY) {
-        return_features.insert(PartiallyBoundBindingArray);
-    }
-    if features.contains(wgpu_types::Features::MULTI_DRAW_INDIRECT_COUNT) {
-        return_features.insert(MultiDrawIndirectCount);
-    }
-    if features.contains(wgpu_types::Features::PUSH_CONSTANTS) {
-        return_features.insert(PushConstants);
-    }
-    if features.contains(wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_ZERO) {
-        return_features.insert(AddressModeClampToZero);
-    }
-    if features.contains(wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_BORDER) {
-        return_features.insert(AddressModeClampToBorder);
-    }
-    if features.contains(wgpu_types::Features::POLYGON_MODE_LINE) {
-        return_features.insert(PolygonModeLine);
-    }
-    if features.contains(wgpu_types::Features::POLYGON_MODE_POINT) {
-        return_features.insert(PolygonModePoint);
-    }
-    if features.contains(wgpu_types::Features::CONSERVATIVE_RASTERIZATION) {
-        return_features.insert(ConservativeRasterization);
-    }
-    if features.contains(wgpu_types::Features::VERTEX_WRITABLE_STORAGE) {
-        return_features.insert(VertexWritableStorage);
-    }
-    if features.contains(wgpu_types::Features::CLEAR_TEXTURE) {
-        return_features.insert(ClearTexture);
-    }
-    if features.contains(wgpu_types::Features::MULTIVIEW) {
-        return_features.insert(Multiview);
-    }
-    if features.contains(wgpu_types::Features::VERTEX_ATTRIBUTE_64BIT) {
-        return_features.insert(VertexAttribute64Bit);
-    }
-    // shader
-    if features.contains(wgpu_types::Features::SHADER_F64) {
-        return_features.insert(ShaderF64);
-    }
-    if features.contains(wgpu_types::Features::SHADER_I16) {
-        return_features.insert(ShaderI16);
-    }
-    if features.contains(wgpu_types::Features::SHADER_PRIMITIVE_INDEX) {
-        return_features.insert(ShaderPrimitiveIndex);
-    }
-    if features.contains(wgpu_types::Features::SHADER_EARLY_DEPTH_TEST) {
-        return_features.insert(ShaderEarlyDepthTest);
-    }
-    if features.contains(wgpu_types::Features::EXPERIMENTAL_PASSTHROUGH_SHADERS) {
-        return_features.insert(PassthroughShaders);
-    }
+  if features
+    .contains(wgpu_types::Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING)
+  {
+    return_features.insert(StorageTextureArrayNonUniformIndexing);
+  }
+  if features.contains(wgpu_types::Features::UNIFORM_BUFFER_BINDING_ARRAYS) {
+    return_features.insert(UniformBufferBindingArrays);
+  }
+  if features.contains(wgpu_types::Features::PARTIALLY_BOUND_BINDING_ARRAY) {
+    return_features.insert(PartiallyBoundBindingArray);
+  }
+  if features.contains(wgpu_types::Features::MULTI_DRAW_INDIRECT_COUNT) {
+    return_features.insert(MultiDrawIndirectCount);
+  }
+  if features.contains(wgpu_types::Features::PUSH_CONSTANTS) {
+    return_features.insert(PushConstants);
+  }
+  if features.contains(wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_ZERO) {
+    return_features.insert(AddressModeClampToZero);
+  }
+  if features.contains(wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_BORDER) {
+    return_features.insert(AddressModeClampToBorder);
+  }
+  if features.contains(wgpu_types::Features::POLYGON_MODE_LINE) {
+    return_features.insert(PolygonModeLine);
+  }
+  if features.contains(wgpu_types::Features::POLYGON_MODE_POINT) {
+    return_features.insert(PolygonModePoint);
+  }
+  if features.contains(wgpu_types::Features::CONSERVATIVE_RASTERIZATION) {
+    return_features.insert(ConservativeRasterization);
+  }
+  if features.contains(wgpu_types::Features::VERTEX_WRITABLE_STORAGE) {
+    return_features.insert(VertexWritableStorage);
+  }
+  if features.contains(wgpu_types::Features::CLEAR_TEXTURE) {
+    return_features.insert(ClearTexture);
+  }
+  if features.contains(wgpu_types::Features::MULTIVIEW) {
+    return_features.insert(Multiview);
+  }
+  if features.contains(wgpu_types::Features::VERTEX_ATTRIBUTE_64BIT) {
+    return_features.insert(VertexAttribute64Bit);
+  }
+  // shader
+  if features.contains(wgpu_types::Features::SHADER_F64) {
+    return_features.insert(ShaderF64);
+  }
+  if features.contains(wgpu_types::Features::SHADER_I16) {
+    return_features.insert(ShaderI16);
+  }
+  if features.contains(wgpu_types::Features::SHADER_PRIMITIVE_INDEX) {
+    return_features.insert(ShaderPrimitiveIndex);
+  }
+  if features.contains(wgpu_types::Features::SHADER_EARLY_DEPTH_TEST) {
+    return_features.insert(ShaderEarlyDepthTest);
+  }
+  if features.contains(wgpu_types::Features::EXPERIMENTAL_PASSTHROUGH_SHADERS) {
+    return_features.insert(PassthroughShaders);
+  }
 
-    return_features
+  return_features
 }


### PR DESCRIPTION
This cherry-picks changes that have been made in Deno's copy of deno_webgpu, and updates deno crates to more recent versions. (Not quite the latest, I stopped before a V8 major version update.)

I have added a rustfmt.toml in the `deno_webgpu` directory and reformatted to match Deno's formatting (2 space indent), to make it easier to transfer changes between the repos.

**Testing**
Relying on cts_runner.

**Squash or Rebase?** Rebase

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
