### PR TITLE
Include FreeBSD in conditional compile attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,13 @@ jobs:
             tier: 1
             kind: native
 
+          # FreeBSD
+          - name: FreeBSD x86_64
+            os: ubuntu-24.04
+            target: x86_64-unknown-freebsd
+            tier: 2
+            kind: wgpu-only
+
           # Android
           - name: Android aarch64
             os: ubuntu-24.04

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -161,7 +161,7 @@ wgpu-core-deps-apple = { workspace = true, optional = true }
 wgpu-core-deps-emscripten = { workspace = true, optional = true }
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 wgpu-core-deps-wasm = { workspace = true, optional = true }
-[target.'cfg(any(windows, target_os = "linux", target_os = "android"))'.dependencies]
+[target.'cfg(any(windows, target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
 wgpu-core-deps-windows-linux-android = { workspace = true, optional = true }
 
 [dependencies]

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
-        windows_linux_android: { any(windows, target_os = "linux", target_os = "android") },
+        windows_linux_android: { any(windows, target_os = "linux", target_os = "android", target_os = "freebsd") },
         send_sync: { all(
             feature = "std",
             any(

--- a/wgpu-core/platform-deps/windows-linux-android/Cargo.toml
+++ b/wgpu-core/platform-deps/windows-linux-android/Cargo.toml
@@ -23,5 +23,5 @@ dx12 = ["wgpu-hal/dx12"]
 renderdoc = ["wgpu-hal/renderdoc"]
 
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
-[target.'cfg(any(windows, target_os = "linux", target_os = "android"))'.dependencies]
+[target.'cfg(any(windows, target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
 wgpu-hal.workspace = true

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -16,7 +16,7 @@ fn main() {
         metal: { all(target_vendor = "apple", feature = "metal") },
         vulkan: { any(
             // The `vulkan` feature enables the Vulkan backend only on "native Vulkan" platforms, i.e. Windows/Linux/Android
-            all(any(windows, target_os = "linux", target_os = "android"), feature = "vulkan"),
+            all(any(windows, target_os = "linux", target_os = "android", target_os = "freebsd"), feature = "vulkan"),
             // On Apple platforms, however, we require the `vulkan-portability` feature
             // to explicitly opt-in to Vulkan since it's meant to be used with MoltenVK.
             all(target_vendor = "apple", feature = "vulkan-portability")
@@ -24,7 +24,7 @@ fn main() {
         gles: { any(
             // The `gles` feature enables the OpenGL/GLES backend only on "native OpenGL" platforms, i.e. Windows, Linux, Android, and Emscripten.
             // (Note that WebGL is also not included here!)
-            all(any(windows, target_os = "linux", target_os = "android", Emscripten), feature = "gles"),
+            all(any(windows, target_os = "linux", target_os = "android", target_os = "freebsd", Emscripten), feature = "gles"),
             // On Apple platforms, however, we require the `angle` feature to explicitly opt-in to OpenGL
             // since its meant to be used with ANGLE.
             all(target_vendor = "apple", feature = "angle")


### PR DESCRIPTION
**Connections**
Fixes #8175

**Description**
Changes from #7076 cause the Vulkan and GLES backends to not build for FreeBSD. I have added FreeBSD to the conditional build attributes introduced in this change. 

**Testing**
Tested by running the examples in the example directory. These are now able to find a GPU adapter and run. Most tests refuse to run prior to making this change due to lack of an adapter.

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
