### PR TITLE
[msl] vertex pulling: fix unpacking `snorm16x2` & `snorm16x4`

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -125,6 +125,7 @@ webgpu:api,operation,rendering,color_target_state:blend_constant,setting:*
 webgpu:api,operation,rendering,depth:*
 webgpu:api,operation,rendering,draw:*
 webgpu:api,operation,shader_module,compilation_info:*
+webgpu:api,operation,vertex_state,correctness:non_zero_array_stride_and_attribute_offset:*
 // Likely due to https://github.com/gfx-rs/wgpu/issues/7357.
 fails-if(metal) webgpu:api,operation,uncapturederror:iff_uncaptured:*
 //FAIL: webgpu:shader,execution,expression,call,builtin,select:*

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -5144,14 +5144,14 @@ template <typename A>
                 let name = self.namer.call("unpackSnorm16x2");
                 writeln!(
                     self.out,
-                    "metal::float2 {name}(metal::ushort b0, \
-                                          metal::ushort b1, \
-                                          metal::ushort b2, \
-                                          metal::ushort b3) {{"
+                    "metal::float2 {name}(uint b0, \
+                                          uint b1, \
+                                          uint b2, \
+                                          uint b3) {{"
                 )?;
                 writeln!(
                     self.out,
-                    "{}return metal::unpack_snorm2x16_to_float(b1 << 24 | b0 << 16 | b3 << 8 | b2);",
+                    "{}return metal::unpack_snorm2x16_to_float(b3 << 24 | b2 << 16 | b1 << 8 | b0);",
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
@@ -5161,19 +5161,19 @@ template <typename A>
                 let name = self.namer.call("unpackSnorm16x4");
                 writeln!(
                     self.out,
-                    "metal::float4 {name}(metal::ushort b0, \
-                                          metal::ushort b1, \
-                                          metal::ushort b2, \
-                                          metal::ushort b3, \
-                                          metal::ushort b4, \
-                                          metal::ushort b5, \
-                                          metal::ushort b6, \
-                                          metal::ushort b7) {{"
+                    "metal::float4 {name}(uint b0, \
+                                          uint b1, \
+                                          uint b2, \
+                                          uint b3, \
+                                          uint b4, \
+                                          uint b5, \
+                                          uint b6, \
+                                          uint b7) {{"
                 )?;
                 writeln!(
                     self.out,
-                    "{}return metal::float4(metal::unpack_snorm2x16_to_float(b1 << 24 | b0 << 16 | b3 << 8 | b2), \
-                                            metal::unpack_snorm2x16_to_float(b5 << 24 | b4 << 16 | b7 << 8 | b6));",
+                    "{}return metal::float4(metal::unpack_snorm2x16_to_float(b3 << 24 | b2 << 16 | b1 << 8 | b0), \
+                                            metal::unpack_snorm2x16_to_float(b7 << 24 | b6 << 16 | b5 << 8 | b4));",
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x1.msl
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x1.msl
@@ -120,11 +120,11 @@ metal::float4 unpackUnorm16x4_(metal::ushort b0, metal::ushort b1, metal::ushort
 float unpackSnorm16_(metal::ushort b0, metal::ushort b1) {
     return metal::unpack_snorm2x16_to_float(b1 << 8 | b0).x;
 }
-metal::float2 unpackSnorm16x2_(metal::ushort b0, metal::ushort b1, metal::ushort b2, metal::ushort b3) {
-    return metal::unpack_snorm2x16_to_float(b1 << 24 | b0 << 16 | b3 << 8 | b2);
+metal::float2 unpackSnorm16x2_(uint b0, uint b1, uint b2, uint b3) {
+    return metal::unpack_snorm2x16_to_float(b3 << 24 | b2 << 16 | b1 << 8 | b0);
 }
-metal::float4 unpackSnorm16x4_(metal::ushort b0, metal::ushort b1, metal::ushort b2, metal::ushort b3, metal::ushort b4, metal::ushort b5, metal::ushort b6, metal::ushort b7) {
-    return metal::float4(metal::unpack_snorm2x16_to_float(b1 << 24 | b0 << 16 | b3 << 8 | b2), metal::unpack_snorm2x16_to_float(b5 << 24 | b4 << 16 | b7 << 8 | b6));
+metal::float4 unpackSnorm16x4_(uint b0, uint b1, uint b2, uint b3, uint b4, uint b5, uint b6, uint b7) {
+    return metal::float4(metal::unpack_snorm2x16_to_float(b3 << 24 | b2 << 16 | b1 << 8 | b0), metal::unpack_snorm2x16_to_float(b7 << 24 | b6 << 16 | b5 << 8 | b4));
 }
 float unpackFloat16_(metal::ushort b0, metal::ushort b1) {
     return float(as_type<half>(metal::ushort(b1 << 8 | b0)));

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x2.msl
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x2.msl
@@ -120,11 +120,11 @@ metal::float4 unpackUnorm16x4_(metal::ushort b0, metal::ushort b1, metal::ushort
 float unpackSnorm16_(metal::ushort b0, metal::ushort b1) {
     return metal::unpack_snorm2x16_to_float(b1 << 8 | b0).x;
 }
-metal::float2 unpackSnorm16x2_(metal::ushort b0, metal::ushort b1, metal::ushort b2, metal::ushort b3) {
-    return metal::unpack_snorm2x16_to_float(b1 << 24 | b0 << 16 | b3 << 8 | b2);
+metal::float2 unpackSnorm16x2_(uint b0, uint b1, uint b2, uint b3) {
+    return metal::unpack_snorm2x16_to_float(b3 << 24 | b2 << 16 | b1 << 8 | b0);
 }
-metal::float4 unpackSnorm16x4_(metal::ushort b0, metal::ushort b1, metal::ushort b2, metal::ushort b3, metal::ushort b4, metal::ushort b5, metal::ushort b6, metal::ushort b7) {
-    return metal::float4(metal::unpack_snorm2x16_to_float(b1 << 24 | b0 << 16 | b3 << 8 | b2), metal::unpack_snorm2x16_to_float(b5 << 24 | b4 << 16 | b7 << 8 | b6));
+metal::float4 unpackSnorm16x4_(uint b0, uint b1, uint b2, uint b3, uint b4, uint b5, uint b6, uint b7) {
+    return metal::float4(metal::unpack_snorm2x16_to_float(b3 << 24 | b2 << 16 | b1 << 8 | b0), metal::unpack_snorm2x16_to_float(b7 << 24 | b6 << 16 | b5 << 8 | b4));
 }
 float unpackFloat16_(metal::ushort b0, metal::ushort b1) {
     return float(as_type<half>(metal::ushort(b1 << 8 | b0)));

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x3.msl
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x3.msl
@@ -120,11 +120,11 @@ metal::float4 unpackUnorm16x4_(metal::ushort b0, metal::ushort b1, metal::ushort
 float unpackSnorm16_(metal::ushort b0, metal::ushort b1) {
     return metal::unpack_snorm2x16_to_float(b1 << 8 | b0).x;
 }
-metal::float2 unpackSnorm16x2_(metal::ushort b0, metal::ushort b1, metal::ushort b2, metal::ushort b3) {
-    return metal::unpack_snorm2x16_to_float(b1 << 24 | b0 << 16 | b3 << 8 | b2);
+metal::float2 unpackSnorm16x2_(uint b0, uint b1, uint b2, uint b3) {
+    return metal::unpack_snorm2x16_to_float(b3 << 24 | b2 << 16 | b1 << 8 | b0);
 }
-metal::float4 unpackSnorm16x4_(metal::ushort b0, metal::ushort b1, metal::ushort b2, metal::ushort b3, metal::ushort b4, metal::ushort b5, metal::ushort b6, metal::ushort b7) {
-    return metal::float4(metal::unpack_snorm2x16_to_float(b1 << 24 | b0 << 16 | b3 << 8 | b2), metal::unpack_snorm2x16_to_float(b5 << 24 | b4 << 16 | b7 << 8 | b6));
+metal::float4 unpackSnorm16x4_(uint b0, uint b1, uint b2, uint b3, uint b4, uint b5, uint b6, uint b7) {
+    return metal::float4(metal::unpack_snorm2x16_to_float(b3 << 24 | b2 << 16 | b1 << 8 | b0), metal::unpack_snorm2x16_to_float(b7 << 24 | b6 << 16 | b5 << 8 | b4));
 }
 float unpackFloat16_(metal::ushort b0, metal::ushort b1) {
     return float(as_type<half>(metal::ushort(b1 << 8 | b0)));

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x4.msl
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x4.msl
@@ -120,11 +120,11 @@ metal::float4 unpackUnorm16x4_(metal::ushort b0, metal::ushort b1, metal::ushort
 float unpackSnorm16_(metal::ushort b0, metal::ushort b1) {
     return metal::unpack_snorm2x16_to_float(b1 << 8 | b0).x;
 }
-metal::float2 unpackSnorm16x2_(metal::ushort b0, metal::ushort b1, metal::ushort b2, metal::ushort b3) {
-    return metal::unpack_snorm2x16_to_float(b1 << 24 | b0 << 16 | b3 << 8 | b2);
+metal::float2 unpackSnorm16x2_(uint b0, uint b1, uint b2, uint b3) {
+    return metal::unpack_snorm2x16_to_float(b3 << 24 | b2 << 16 | b1 << 8 | b0);
 }
-metal::float4 unpackSnorm16x4_(metal::ushort b0, metal::ushort b1, metal::ushort b2, metal::ushort b3, metal::ushort b4, metal::ushort b5, metal::ushort b6, metal::ushort b7) {
-    return metal::float4(metal::unpack_snorm2x16_to_float(b1 << 24 | b0 << 16 | b3 << 8 | b2), metal::unpack_snorm2x16_to_float(b5 << 24 | b4 << 16 | b7 << 8 | b6));
+metal::float4 unpackSnorm16x4_(uint b0, uint b1, uint b2, uint b3, uint b4, uint b5, uint b6, uint b7) {
+    return metal::float4(metal::unpack_snorm2x16_to_float(b3 << 24 | b2 << 16 | b1 << 8 | b0), metal::unpack_snorm2x16_to_float(b7 << 24 | b6 << 16 | b5 << 8 | b4));
 }
 float unpackFloat16_(metal::ushort b0, metal::ushort b1) {
     return float(as_type<half>(metal::ushort(b1 << 8 | b0)));


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/wgpu/issues/7981.
