### PR TITLE
test(cts): add `…,vertex_state,correctness:array_stride_zero:*`, expect fail on macOS

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -18,6 +18,7 @@ webgpu:api,operation,compute,basic:memcpy:*
 webgpu:api,operation,compute_pipeline,overrides:*
 webgpu:api,operation,device,lost:*
 webgpu:api,operation,render_pass,storeOp:*
+fails-if(metal,vulkan) webgpu:api,operation,vertex_state,correctness:array_stride_zero:*
 // Presumably vertex pulling, revisit after https://github.com/gfx-rs/wgpu/issues/7981 is fixed.
 fails-if(metal) webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribute_offset:*
 fails-if(dx12) webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*

--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -50,12 +50,6 @@ const CTS_GIT_URL: &str = "https://github.com/gpuweb/cts.git";
 /// Path to default CTS test list.
 const CTS_DEFAULT_TEST_LIST: &str = "cts_runner/test.lst";
 
-static TEST_LINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    RegexBuilder::new(r#"(?:fails-if\s*\(\s*(?<fails_if>\w+)\s*\)\s+)?(?<selector>.*)"#)
-        .build()
-        .unwrap()
-});
-
 #[derive(Default)]
 struct TestLine {
     pub selector: OsString,
@@ -103,6 +97,12 @@ pub fn run_cts(
 
     for file in list_files {
         tests.extend(shell.read_file(file)?.lines().filter_map(|line| {
+            static TEST_LINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+                RegexBuilder::new(r#"(?:fails-if\s*\(\s*(?<fails_if>\w+)\s*\)\s+)?(?<selector>.*)"#)
+                    .build()
+                    .unwrap()
+            });
+
             let trimmed = line.trim();
             let is_comment = trimmed.starts_with("//") || trimmed.starts_with("#");
             let captures = TEST_LINE_REGEX

--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -53,7 +53,7 @@ const CTS_DEFAULT_TEST_LIST: &str = "cts_runner/test.lst";
 #[derive(Default)]
 struct TestLine {
     pub selector: OsString,
-    pub fails_if: Option<String>,
+    pub fails_if: Vec<String>,
 }
 
 pub fn run_cts(
@@ -98,9 +98,11 @@ pub fn run_cts(
     for file in list_files {
         tests.extend(shell.read_file(file)?.lines().filter_map(|line| {
             static TEST_LINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-                RegexBuilder::new(r#"(?:fails-if\s*\(\s*(?<fails_if>\w+)\s*\)\s+)?(?<selector>.*)"#)
-                    .build()
-                    .unwrap()
+                RegexBuilder::new(
+                    r#"(?:fails-if\s*\(\s*(?<fails_if>\w+(?:,\w+)*?)\s*\)\s+)?(?<selector>.*)"#,
+                )
+                .build()
+                .unwrap()
             });
 
             let trimmed = line.trim();
@@ -110,7 +112,15 @@ pub fn run_cts(
                 .expect("Invalid test line: {trimmed}");
             (!trimmed.is_empty() && !is_comment).then(|| TestLine {
                 selector: OsString::from(&captures["selector"]),
-                fails_if: captures.name("fails_if").map(|m| m.as_str().to_string()),
+                fails_if: captures
+                    .name("fails_if")
+                    .map(|m| {
+                        m.as_str()
+                            .split_terminator(',')
+                            .map(|m| m.to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             })
         }))
     }
@@ -237,8 +247,8 @@ pub fn run_cts(
 
     log::info!("Running CTS");
     for test in &tests {
-        match (&test.fails_if, &running_on_backend) {
-            (Some(backend), Some(running_on_backend)) if backend == running_on_backend => {
+        if let Some(running_on_backend) = &running_on_backend {
+            if test.fails_if.contains(running_on_backend) {
                 log::info!(
                     "Skipping {} on {} backend",
                     test.selector.to_string_lossy(),
@@ -246,7 +256,6 @@ pub fn run_cts(
                 );
                 continue;
             }
-            _ => {}
         }
 
         log::info!("Running {}", test.selector.to_string_lossy());


### PR DESCRIPTION
Spurred on by #8260.