### PR TITLE
[deno] Remove kludge for `type` properties

### DIFF
--- a/deno_webgpu/01_webgpu.js
+++ b/deno_webgpu/01_webgpu.js
@@ -625,13 +625,6 @@ ObjectDefineProperty(GPUCompilationMessage, privateCustomInspect, {
   },
 });
 const GPUCompilationMessagePrototype = GPUCompilationMessage.prototype;
-// Naming it `type` or `r#type` in Rust does not work.
-// https://github.com/gfx-rs/wgpu/issues/7778
-ObjectDefineProperty(GPUCompilationMessage.prototype, "type", {
-  get() {
-    return this.ty;
-  }
-});
 
 class GPUShaderStage {
   constructor() {
@@ -844,13 +837,6 @@ ObjectDefineProperty(GPUQuerySetPrototype, privateCustomInspect, {
       inspectOptions,
     );
   },
-});
-// Naming it `type` or `r#type` in Rust does not work.
-// https://github.com/gfx-rs/wgpu/issues/7778
-ObjectDefineProperty(GPUQuerySet.prototype, "type", {
-  get() {
-    return this.ty;
-  }
 });
 
 // Converters

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -60,11 +60,10 @@ impl GPUQuerySet {
     Ok(())
   }
 
-  // Naming this `type` or `r#type` does not work.
-  // https://github.com/gfx-rs/wgpu/issues/7778
   #[getter]
   #[string]
-  fn ty(&self) -> &'static str {
+  #[rename("type")]
+  fn r#type(&self) -> &'static str {
     self.r#type.as_str()
   }
 

--- a/deno_webgpu/shader.rs
+++ b/deno_webgpu/shader.rs
@@ -96,11 +96,10 @@ impl GPUCompilationMessage {
     self.message.clone()
   }
 
-  // Naming this `type` or `r#type` does not work.
-  // https://github.com/gfx-rs/wgpu/issues/7778
   #[getter]
   #[string]
-  fn ty(&self) -> &'static str {
+  #[rename("type")]
+  fn r#type(&self) -> &'static str {
     self.r#type.as_str()
   }
 


### PR DESCRIPTION
The issue that interfered with this before was fixed in Deno.

Fixes #7778.

**Testing**
Access to `GPUCompilationMessage.type` is exercised by CTS tests that are enabled, and is what found this issue originally.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
