### PR TITLE
[deno] Return `undefined` instead of `null` from WebGPU APIs

### DIFF
--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -114,6 +114,9 @@ impl GPUBuffer {
     *self.map_state.borrow()
   }
 
+  // In the successful case, the promise should resolve to undefined, but
+  // `#[undefined]` does not seem to work here.
+  // https://github.com/denoland/deno/issues/29603
   #[async_method]
   async fn map_async(
     &self,
@@ -250,6 +253,7 @@ impl GPUBuffer {
   }
 
   #[nofast]
+  #[undefined]
   fn unmap(&self, scope: &mut v8::HandleScope) -> Result<(), BufferError> {
     for ab in self.mapped_js_buffers.replace(vec![]) {
       let ab = ab.open(scope);
@@ -267,6 +271,7 @@ impl GPUBuffer {
   }
 
   #[fast]
+  #[undefined]
   fn destroy(&self) {
     self.instance.buffer_destroy(self.id);
   }

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -191,6 +191,7 @@ impl GPUCommandEncoder {
   }
 
   #[required(2)]
+  #[undefined]
   fn copy_buffer_to_buffer<'a>(
     &self,
     scope: &mut v8::HandleScope<'a>,
@@ -280,6 +281,7 @@ impl GPUCommandEncoder {
   }
 
   #[required(3)]
+  #[undefined]
   fn copy_buffer_to_texture(
     &self,
     #[webidl] source: GPUTexelCopyBufferInfo,
@@ -315,6 +317,7 @@ impl GPUCommandEncoder {
   }
 
   #[required(3)]
+  #[undefined]
   fn copy_texture_to_buffer(
     &self,
     #[webidl] source: GPUTexelCopyTextureInfo,
@@ -350,6 +353,7 @@ impl GPUCommandEncoder {
   }
 
   #[required(3)]
+  #[undefined]
   fn copy_texture_to_texture(
     &self,
     #[webidl] source: GPUTexelCopyTextureInfo,
@@ -383,6 +387,7 @@ impl GPUCommandEncoder {
   }
 
   #[required(1)]
+  #[undefined]
   fn clear_buffer(
     &self,
     #[webidl] buffer: Ptr<GPUBuffer>,
@@ -397,6 +402,7 @@ impl GPUCommandEncoder {
   }
 
   #[required(5)]
+  #[undefined]
   fn resolve_query_set(
     &self,
     #[webidl] query_set: Ptr<super::query_set::GPUQuerySet>,

--- a/deno_webgpu/compute_pass.rs
+++ b/deno_webgpu/compute_pass.rs
@@ -49,6 +49,7 @@ impl GPUComputePassEncoder {
     // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
   }
 
+  #[undefined]
   fn set_pipeline(
     &self,
     #[webidl] pipeline: Ptr<crate::compute_pipeline::GPUComputePipeline>,
@@ -63,6 +64,7 @@ impl GPUComputePassEncoder {
     self.error_handler.push_error(err);
   }
 
+  #[undefined]
   fn dispatch_workgroups(
     &self,
     #[webidl(options(enforce_range = true))] work_group_count_x: u32,
@@ -83,6 +85,7 @@ impl GPUComputePassEncoder {
     self.error_handler.push_error(err);
   }
 
+  #[undefined]
   fn dispatch_workgroups_indirect(
     &self,
     #[webidl] indirect_buffer: Ptr<crate::buffer::GPUBuffer>,
@@ -100,6 +103,7 @@ impl GPUComputePassEncoder {
   }
 
   #[fast]
+  #[undefined]
   fn end(&self) {
     let err = self
       .instance
@@ -108,6 +112,7 @@ impl GPUComputePassEncoder {
     self.error_handler.push_error(err);
   }
 
+  #[undefined]
   fn push_debug_group(&self, #[webidl] group_label: String) {
     let err = self
       .instance
@@ -121,6 +126,7 @@ impl GPUComputePassEncoder {
   }
 
   #[fast]
+  #[undefined]
   fn pop_debug_group(&self) {
     let err = self
       .instance
@@ -129,6 +135,7 @@ impl GPUComputePassEncoder {
     self.error_handler.push_error(err);
   }
 
+  #[undefined]
   fn insert_debug_marker(&self, #[webidl] marker_label: String) {
     let err = self
       .instance
@@ -141,6 +148,7 @@ impl GPUComputePassEncoder {
     self.error_handler.push_error(err);
   }
 
+  #[undefined]
   fn set_bind_group<'a>(
     &self,
     scope: &mut v8::HandleScope<'a>,

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -142,6 +142,7 @@ impl GPUDevice {
   }
 
   #[fast]
+  #[undefined]
   fn destroy(&self) {
     self.instance.device_destroy(self.id);
     self
@@ -623,6 +624,7 @@ impl GPUDevice {
   }
 
   #[required(1)]
+  #[undefined]
   fn push_error_scope(&self, #[webidl] filter: super::error::GPUErrorFilter) {
     self
       .error_handler

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -53,6 +53,7 @@ impl GPUQuerySet {
   }
 
   #[fast]
+  #[undefined]
   fn destroy(&self) -> Result<(), JsErrorBox> {
     // TODO(https://github.com/gfx-rs/wgpu/issues/6495): Destroy the query
     // set. Until that is supported, it is okay to do nothing here, the

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use deno_core::cppgc::Ptr;
 use deno_core::futures::channel::oneshot;
 use deno_core::op2;
-use deno_core::v8;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use deno_error::JsErrorBox;
@@ -63,11 +62,11 @@ impl GPUQueue {
   }
 
   #[required(1)]
+  #[undefined]
   fn submit(
     &self,
-    scope: &mut v8::HandleScope,
     #[webidl] command_buffers: Vec<Ptr<GPUCommandBuffer>>,
-  ) -> Result<v8::Local<v8::Value>, JsErrorBox> {
+  ) -> Result<(), JsErrorBox> {
     let ids = command_buffers
       .into_iter()
       .map(|cb| cb.id)
@@ -79,9 +78,12 @@ impl GPUQueue {
       self.error_handler.push_error(Some(err));
     }
 
-    Ok(v8::undefined(scope).into())
+    Ok(())
   }
 
+  // In the successful case, the promise should resolve to undefined, but
+  // `#[undefined]` does not seem to work here.
+  // https://github.com/denoland/deno/issues/29603
   #[async_method]
   async fn on_submitted_work_done(&self) -> Result<(), JsErrorBox> {
     let (sender, receiver) = oneshot::channel::<()>();
@@ -124,6 +126,7 @@ impl GPUQueue {
   }
 
   #[required(3)]
+  #[undefined]
   fn write_buffer(
     &self,
     #[webidl] buffer: Ptr<GPUBuffer>,
@@ -148,6 +151,7 @@ impl GPUQueue {
   }
 
   #[required(4)]
+  #[undefined]
   fn write_texture(
     &self,
     #[webidl] destination: GPUTexelCopyTextureInfo,

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -87,6 +87,7 @@ impl GPURenderBundleEncoder {
     }
   }
 
+  #[undefined]
   fn push_debug_group(
     &self,
     #[webidl] group_label: String,
@@ -110,6 +111,7 @@ impl GPURenderBundleEncoder {
   }
 
   #[fast]
+  #[undefined]
   fn pop_debug_group(&self) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut().ok_or_else(|| {
@@ -119,6 +121,7 @@ impl GPURenderBundleEncoder {
     Ok(())
   }
 
+  #[undefined]
   fn insert_debug_marker(
     &self,
     #[webidl] marker_label: String,
@@ -140,6 +143,7 @@ impl GPURenderBundleEncoder {
     Ok(())
   }
 
+  #[undefined]
   fn set_bind_group<'a>(
     &self,
     scope: &mut v8::HandleScope<'a>,
@@ -226,6 +230,7 @@ impl GPURenderBundleEncoder {
     Ok(())
   }
 
+  #[undefined]
   fn set_pipeline(
     &self,
     #[webidl] pipeline: Ptr<crate::render_pipeline::GPURenderPipeline>,
@@ -243,6 +248,7 @@ impl GPURenderBundleEncoder {
   }
 
   #[required(2)]
+  #[undefined]
   fn set_index_buffer(
     &self,
     #[webidl] buffer: Ptr<GPUBuffer>,
@@ -265,6 +271,7 @@ impl GPURenderBundleEncoder {
   }
 
   #[required(2)]
+  #[undefined]
   fn set_vertex_buffer(
     &self,
     #[webidl(options(enforce_range = true))] slot: u32,
@@ -288,6 +295,7 @@ impl GPURenderBundleEncoder {
   }
 
   #[required(1)]
+  #[undefined]
   fn draw(
     &self,
     #[webidl(options(enforce_range = true))] vertex_count: u32,
@@ -311,6 +319,7 @@ impl GPURenderBundleEncoder {
   }
 
   #[required(1)]
+  #[undefined]
   fn draw_indexed(
     &self,
     #[webidl(options(enforce_range = true))] index_count: u32,
@@ -336,6 +345,7 @@ impl GPURenderBundleEncoder {
   }
 
   #[required(2)]
+  #[undefined]
   fn draw_indirect(
     &self,
     #[webidl] indirect_buffer: Ptr<GPUBuffer>,
@@ -355,6 +365,7 @@ impl GPURenderBundleEncoder {
   }
 
   #[required(2)]
+  #[undefined]
   fn draw_indexed_indirect(
     &self,
     #[webidl] indirect_buffer: Ptr<GPUBuffer>,

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -55,6 +55,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(6)]
+  #[undefined]
   fn set_viewport(
     &self,
     #[webidl] x: f32,
@@ -80,6 +81,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(4)]
+  #[undefined]
   fn set_scissor_rect(
     &self,
     #[webidl(options(enforce_range = true))] x: u32,
@@ -101,6 +103,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(1)]
+  #[undefined]
   fn set_blend_constant(&self, #[webidl] color: GPUColor) {
     let err = self
       .instance
@@ -113,6 +116,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(1)]
+  #[undefined]
   fn set_stencil_reference(
     &self,
     #[webidl(options(enforce_range = true))] reference: u32,
@@ -128,6 +132,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(1)]
+  #[undefined]
   fn begin_occlusion_query(
     &self,
     #[webidl(options(enforce_range = true))] query_index: u32,
@@ -143,6 +148,7 @@ impl GPURenderPassEncoder {
   }
 
   #[fast]
+  #[undefined]
   fn end_occlusion_query(&self) {
     let err = self
       .instance
@@ -152,6 +158,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(1)]
+  #[undefined]
   fn execute_bundles(&self, #[webidl] bundles: Vec<Ptr<GPURenderBundle>>) {
     let err = self
       .instance
@@ -167,6 +174,7 @@ impl GPURenderPassEncoder {
   }
 
   #[fast]
+  #[undefined]
   fn end(&self) {
     let err = self
       .instance
@@ -175,6 +183,7 @@ impl GPURenderPassEncoder {
     self.error_handler.push_error(err);
   }
 
+  #[undefined]
   fn push_debug_group(&self, #[webidl] group_label: String) {
     let err = self
       .instance
@@ -188,6 +197,7 @@ impl GPURenderPassEncoder {
   }
 
   #[fast]
+  #[undefined]
   fn pop_debug_group(&self) {
     let err = self
       .instance
@@ -196,6 +206,7 @@ impl GPURenderPassEncoder {
     self.error_handler.push_error(err);
   }
 
+  #[undefined]
   fn insert_debug_marker(&self, #[webidl] marker_label: String) {
     let err = self
       .instance
@@ -208,6 +219,7 @@ impl GPURenderPassEncoder {
     self.error_handler.push_error(err);
   }
 
+  #[undefined]
   fn set_bind_group<'a>(
     &self,
     scope: &mut v8::HandleScope<'a>,
@@ -291,6 +303,7 @@ impl GPURenderPassEncoder {
     Ok(())
   }
 
+  #[undefined]
   fn set_pipeline(
     &self,
     #[webidl] pipeline: Ptr<crate::render_pipeline::GPURenderPipeline>,
@@ -303,6 +316,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(2)]
+  #[undefined]
   fn set_index_buffer(
     &self,
     #[webidl] buffer: Ptr<GPUBuffer>,
@@ -324,6 +338,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(2)]
+  #[undefined]
   fn set_vertex_buffer(
     &self,
     #[webidl(options(enforce_range = true))] slot: u32,
@@ -345,6 +360,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(1)]
+  #[undefined]
   fn draw(
     &self,
     #[webidl(options(enforce_range = true))] vertex_count: u32,
@@ -366,6 +382,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(1)]
+  #[undefined]
   fn draw_indexed(
     &self,
     #[webidl(options(enforce_range = true))] index_count: u32,
@@ -389,6 +406,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(2)]
+  #[undefined]
   fn draw_indirect(
     &self,
     #[webidl] indirect_buffer: Ptr<GPUBuffer>,
@@ -406,6 +424,7 @@ impl GPURenderPassEncoder {
   }
 
   #[required(2)]
+  #[undefined]
   fn draw_indexed_indirect(
     &self,
     #[webidl] indirect_buffer: Ptr<GPUBuffer>,

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -68,6 +68,7 @@ impl GPUCanvasContext {
     self.canvas.clone()
   }
 
+  #[undefined]
   fn configure(
     &self,
     #[webidl] configuration: GPUCanvasConfiguration,
@@ -113,6 +114,7 @@ impl GPUCanvasContext {
   }
 
   #[fast]
+  #[undefined]
   fn unconfigure(&self) {
     *self.config.borrow_mut() = None;
   }

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -124,6 +124,7 @@ impl GPUTexture {
     self.usage
   }
   #[fast]
+  #[undefined]
   fn destroy(&self) {
     self.instance.texture_destroy(self.id);
   }


### PR DESCRIPTION
See denoland/deno#29603

The `#[undefined]` attribute does not seem to work for the async methods `GPUBuffer::map_async` and `GPUQueue::on_submitted_work_done`, so those are not fixed.

**Testing**
The CTS is sensitive to the difference for `Queue.submit()`, which is why it previously returned undefined manually. No testing for the other functions.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
