### PR TITLE
Fix unused warning in a specific feature config

### DIFF
--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -119,9 +119,8 @@ pub struct BindTarget {
     pub mutable: bool,
 }
 
-#[cfg(any(feature = "serialize", feature = "deserialize"))]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg(feature = "deserialize")]
+#[derive(serde::Deserialize)]
 struct BindingMapSerialization {
     resource_binding: crate::ResourceBinding,
     bind_target: BindTarget,


### PR DESCRIPTION
Appeared in the Firefox build, and reproducible by building naga with `--no-default-features --features serialize,msl-out`.

There were some changes to the version of `BindingMapSerialization` used for snapshot tests in #8108, but building with the command above produces the warning even before that. I didn't try to trace the origin farther back than that.