### PR TITLE
CI: Disallow all warnings in `cargo deny` and prune unmatched `skip`s

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -3,17 +3,10 @@ multiple-versions = "deny"
 skip-tree = [
     { name = "windows-sys", version = "0.45" },
     { name = "winit", version = "0.29" },
-    { name = "rustc_version", version = "0.2.3" },
-    { name = "miniz_oxide", version = "0.7.4" },
     { name = "rustc-hash", version = "1.1.0" },
 
     # introduced by Deno, to be investigated
-    { name = "strum_macros", version = "0.25.3" },
     { name = "petgraph", version = "0.6.5" },
-    { name = "base64-simd", version = "0.7.0" },
-    { name = "bit-set", version = "0.5.3" },
-    { name = "bit-vec", version = "0.6.3" },
-    { name = "capacity_builder", version = "0.1.3" },
 ]
 skip = [
     # Flume uses an old version
@@ -35,11 +28,8 @@ skip = [
     { name = "ordered-float", version = "2.10.1" },
     # bindgen (used by deno) uses old version
     { name = "itertools", version = "0.13.0" },
-    # Strum uses an old version
-    { name = "heck", version = "0.4.0" },
     # Deno uses an old version
     { name = "bincode", version = "1.3.3" },
-    { name = "strum", version = "0.25.0" },
 ]
 wildcards = "deny"
 allow-wildcard-paths = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -746,6 +746,7 @@ jobs:
         with:
           command: check advisories
           arguments: --all-features --workspace
+          command-arguments: -Dwarnings -Aunmatched-organization
           rust-version: ${{ env.REPO_MSRV }}
 
   cargo-deny-check-rest:
@@ -763,4 +764,5 @@ jobs:
         with:
           command: check bans licenses sources
           arguments: --all-features --workspace
+          command-arguments: -Dwarnings -Aunmatched-organization
           rust-version: ${{ env.REPO_MSRV }}


### PR DESCRIPTION
**Connections**
Split out from #6876

**Description**
The warnings right now all entail `unmatched-skip` / `unmatched-skip-root` that have (likely) gotten stale since various automated Renovate bumps where `Cargo.lock` changes don't require the corresponding unmatched duplicate to be removed from `.deny.toml` again.

An exception has been made for `unmatched-organization` since we don't always have a `git` dependency on a fork in `gfx-rs`, resulting in a warning about that orga being in `sources.allow-org.github`.

**Testing**
Locally:
```console
$ cargo deny --all-features --workspace check -Dwarnings -Aunmatched-organization
```

**Squash or Rebase?**

Rebase

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
