### PR TITLE
Rework `wgpu::PollType` to only two enum variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,7 @@ To wait indefinitely on the latest submission, you can also use the `wait_indefi
 device.poll(wgpu::PollType::wait_indefinitely());
 ```
 
-By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282) & [#????](https://github.com/gfx-rs/wgpu/pull/????)
+By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282) & [#8285](https://github.com/gfx-rs/wgpu/pull/8285)
 
 ### New Features
 
@@ -203,7 +203,7 @@ By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282) & [#????](https:/
 - Added mesh shader support to `wgpu`, with examples. Requires passthrough. By @SupaMaggie70Incorporated in [#7345](https://github.com/gfx-rs/wgpu/pull/7345).
 
 - Added support for external textures based on WebGPU's [`GPUExternalTexture`](https://www.w3.org/TR/webgpu/#gpuexternaltexture). These allow shaders to transparently operate on potentially multiplanar source texture data in either RGB or YCbCr formats via WGSL's `texture_external` type. This is gated behind the `Features::EXTERNAL_TEXTURE` feature, which is currently only supported on DX12. By @jamienicol in [#4386](https://github.com/gfx-rs/wgpu/issues/4386).
-- `wgpu::Device::poll` can now specify a timeout via `wgpu::PollType::Wait`. By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282) & [#????](https://github.com/gfx-rs/wgpu/pull/????)
+- `wgpu::Device::poll` can now specify a timeout via `wgpu::PollType::Wait`. By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282) & [#8285](https://github.com/gfx-rs/wgpu/pull/8285)
 
 #### naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,44 @@ by if the `Feature::MULTI_DRAW_INDIRECT_COUNT` feature is available on the devic
 
 By @cwfitzgerald in [#8162](https://github.com/gfx-rs/wgpu/pull/8162).
 
+
+#### `wgpu::PollType::Wait` has now an optional timeout
+
+We removed `wgpu::PollType::WaitForSubmissionIndex` and added fields to `wgpu::PollType::Wait` in order to express timeouts.
+
+Before/after for `wgpu::PollType::Wait`:
+
+```diff
+-device.poll(wgpu::PollType::Wait).unwrap();
+-device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
++device.poll(wgpu::PollType::Wait {
++      submission_index: None, // Wait for most recent submission
++      timeout: Some(std::time::Duration::from_secs(60)), // Previous behavior, but more likely you want `None` instead.
++  })
++  .unwrap();
+```
+
+Before/after for `wgpu::PollType::WaitForSubmissionIndex`:
+
+```diff
+-device.poll(wgpu::PollType::WaitForSubmissionIndex(index_to_wait_on))
++device.poll(wgpu::PollType::Wait {
++      submission_index: Some(index_to_wait_on),
++      timeout: Some(std::time::Duration::from_secs(60)), // Previous behavior, but more likely you want `None` instead.
++  })
++  .unwrap();
+```
+
+⚠️ Previously, both `wgpu::PollType::WaitForSubmissionIndex` and `wgpu::PollType::Wait` had a hard-coded timeout of 60 seconds.
+
+
+To wait indefinitely on the latest submission, you can also use the `wait_indefinitely` convenience function:
+```rust
+device.poll(wgpu::PollType::wait_indefinitely());
+```
+
+By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282) & [#????](https://github.com/gfx-rs/wgpu/pull/????)
+
 ### New Features
 
 #### General
@@ -165,7 +203,7 @@ By @cwfitzgerald in [#8162](https://github.com/gfx-rs/wgpu/pull/8162).
 - Added mesh shader support to `wgpu`, with examples. Requires passthrough. By @SupaMaggie70Incorporated in [#7345](https://github.com/gfx-rs/wgpu/pull/7345).
 
 - Added support for external textures based on WebGPU's [`GPUExternalTexture`](https://www.w3.org/TR/webgpu/#gpuexternaltexture). These allow shaders to transparently operate on potentially multiplanar source texture data in either RGB or YCbCr formats via WGSL's `texture_external` type. This is gated behind the `Features::EXTERNAL_TEXTURE` feature, which is currently only supported on DX12. By @jamienicol in [#4386](https://github.com/gfx-rs/wgpu/issues/4386).
-- `wgpu::Device::poll` can now specify a timeout via `wgpu::PollType::WaitWithTimeout`/`wgpu::PollType::WaitForSubmissionIndexWithTimeout`. By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282)
+- `wgpu::Device::poll` can now specify a timeout via `wgpu::PollType::Wait`. By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282) & [#????](https://github.com/gfx-rs/wgpu/pull/????)
 
 #### naga
 
@@ -195,7 +233,6 @@ By @cwfitzgerald in [#8162](https://github.com/gfx-rs/wgpu/pull/8162).
 - Require new `F16_IN_F32` downlevel flag for `quantizeToF16`, `pack2x16float`, and `unpack2x16float` in WGSL input. By @aleiserson in [#8130](https://github.com/gfx-rs/wgpu/pull/8130).
 - The error message for non-copyable depth/stencil formats no longer mentions the aspect when it is not relevant. By @reima in [#8156](https://github.com/gfx-rs/wgpu/pull/8156).
 - Track the initialization status of buffer memory correctly when `copy_texture_to_buffer` skips over padding space between rows or layers, or when the start/end of a texture-buffer transfer is not 4B aligned. By @andyleiserson in [#8099](https://github.com/gfx-rs/wgpu/pull/8099).
-- `wgpu::PollType::Wait`/`wgpu::PollType::WaitForSubmissionIndex` will no longer timeout after 60 seconds, but instead wait indefinitely or (depending on backend implementation) until an error is encountered. Use `wgpu::PollType::WaitWithTimeout`/`wgpu::PollType::WaitForSubmissionIndexWithTimeout` if you need a timeout. By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282)
 
 #### naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,7 @@ To wait indefinitely on the latest submission, you can also use the `wait_indefi
 device.poll(wgpu::PollType::wait_indefinitely());
 ```
 
-By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282) & [#8285](https://github.com/gfx-rs/wgpu/pull/8285)
+By @wumpf in [#8282](https://github.com/gfx-rs/wgpu/pull/8282), [#8285](https://github.com/gfx-rs/wgpu/pull/8285)
 
 ### New Features
 

--- a/benches/benches/wgpu-benchmark/bind_groups.rs
+++ b/benches/benches/wgpu-benchmark/bind_groups.rs
@@ -155,7 +155,7 @@ fn run_bench(ctx: &mut Criterion) {
                         state
                             .device_state
                             .device
-                            .poll(wgpu::PollType::Wait)
+                            .poll(wgpu::PollType::wait_indefinitely())
                             .unwrap();
                     }
 

--- a/benches/benches/wgpu-benchmark/computepass.rs
+++ b/benches/benches/wgpu-benchmark/computepass.rs
@@ -489,7 +489,7 @@ fn run_bench(ctx: &mut Criterion) {
                             state
                                 .device_state
                                 .device
-                                .poll(wgpu::PollType::Wait)
+                                .poll(wgpu::PollType::wait_indefinitely())
                                 .unwrap();
                         }
 
@@ -538,7 +538,7 @@ fn run_bench(ctx: &mut Criterion) {
                         state
                             .device_state
                             .device
-                            .poll(wgpu::PollType::Wait)
+                            .poll(wgpu::PollType::wait_indefinitely())
                             .unwrap();
                     }
 
@@ -584,7 +584,7 @@ fn run_bench(ctx: &mut Criterion) {
                 state
                     .device_state
                     .device
-                    .poll(wgpu::PollType::Wait)
+                    .poll(wgpu::PollType::wait_indefinitely())
                     .unwrap();
             }
 

--- a/benches/benches/wgpu-benchmark/renderpass.rs
+++ b/benches/benches/wgpu-benchmark/renderpass.rs
@@ -497,7 +497,7 @@ fn run_bench(ctx: &mut Criterion) {
                             state
                                 .device_state
                                 .device
-                                .poll(wgpu::PollType::Wait)
+                                .poll(wgpu::PollType::wait_indefinitely())
                                 .unwrap();
                         }
 
@@ -544,7 +544,7 @@ fn run_bench(ctx: &mut Criterion) {
                     state
                         .device_state
                         .device
-                        .poll(wgpu::PollType::Wait)
+                        .poll(wgpu::PollType::wait_indefinitely())
                         .unwrap();
                 }
 
@@ -584,7 +584,7 @@ fn run_bench(ctx: &mut Criterion) {
                 state
                     .device_state
                     .device
-                    .poll(wgpu::PollType::Wait)
+                    .poll(wgpu::PollType::wait_indefinitely())
                     .unwrap();
             }
 

--- a/benches/benches/wgpu-benchmark/resource_creation.rs
+++ b/benches/benches/wgpu-benchmark/resource_creation.rs
@@ -61,7 +61,10 @@ fn run_bench(ctx: &mut Criterion) {
                         drop(buffers);
 
                         state.queue.submit([]);
-                        state.device.poll(wgpu::PollType::Wait).unwrap();
+                        state
+                            .device
+                            .poll(wgpu::PollType::wait_indefinitely())
+                            .unwrap();
                     }
 
                     duration

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -177,7 +177,7 @@ impl GPUBuffer {
         {
           self
             .instance
-            .device_poll(self.device, wgpu_types::PollType::wait())
+            .device_poll(self.device, wgpu_types::PollType::wait_indefinitely())
             .unwrap();
         }
         tokio::time::sleep(Duration::from_millis(10)).await;

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -685,7 +685,7 @@ impl GPUDevice {
   fn stop_capture(&self) {
     self
       .instance
-      .device_poll(self.id, wgpu_types::PollType::wait())
+      .device_poll(self.id, wgpu_types::PollType::wait_indefinitely())
       .unwrap();
     unsafe { self.instance.device_stop_graphics_debugger_capture(self.id) };
   }

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -103,7 +103,7 @@ impl GPUQueue {
         {
           self
             .instance
-            .device_poll(self.device, wgpu_types::PollType::wait())
+            .device_poll(self.device, wgpu_types::PollType::wait_indefinitely())
             .unwrap();
         }
         tokio::time::sleep(Duration::from_millis(10)).await;

--- a/examples/features/src/big_compute_buffers/mod.rs
+++ b/examples/features/src/big_compute_buffers/mod.rs
@@ -80,7 +80,7 @@ pub async fn execute_gpu_inner(
         slice.map_async(wgpu::MapMode::Read, |_| {});
     }
 
-    device.poll(wgpu::PollType::Wait).unwrap();
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
 
     let mut data = Vec::new();
     for staging_buffer in &staging_buffers {

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -597,7 +597,9 @@ impl<E: Example + wgpu::WasmNotSendSync> From<ExampleTestParams<E>>
 
                 let dst_buffer_slice = dst_buffer.slice(..);
                 dst_buffer_slice.map_async(wgpu::MapMode::Read, |_| ());
-                ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+                ctx.async_poll(wgpu::PollType::wait_indefinitely())
+                    .await
+                    .unwrap();
                 let bytes = dst_buffer_slice.get_mapped_range().to_vec();
 
                 wgpu_test::image::compare_image_output(

--- a/examples/features/src/hello_synchronization/mod.rs
+++ b/examples/features/src/hello_synchronization/mod.rs
@@ -182,7 +182,7 @@ async fn get_data<T: bytemuck::Pod>(
     let buffer_slice = staging_buffer.slice(..);
     let (sender, receiver) = flume::bounded(1);
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());
-    device.poll(wgpu::PollType::wait()).unwrap();
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
     receiver.recv_async().await.unwrap().unwrap();
     output.copy_from_slice(bytemuck::cast_slice(&buffer_slice.get_mapped_range()[..]));
     staging_buffer.unmap();

--- a/examples/features/src/hello_workgroups/mod.rs
+++ b/examples/features/src/hello_workgroups/mod.rs
@@ -171,7 +171,7 @@ async fn get_data<T: bytemuck::Pod>(
     let buffer_slice = staging_buffer.slice(..);
     let (sender, receiver) = flume::bounded(1);
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());
-    device.poll(wgpu::PollType::wait()).unwrap();
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
     receiver.recv_async().await.unwrap().unwrap();
     output.copy_from_slice(bytemuck::cast_slice(&buffer_slice.get_mapped_range()[..]));
     staging_buffer.unmap();

--- a/examples/features/src/mipmap/mod.rs
+++ b/examples/features/src/mipmap/mod.rs
@@ -411,7 +411,7 @@ impl crate::framework::Example for Example {
                 .slice(..)
                 .map_async(wgpu::MapMode::Read, |_| ());
             // Wait for device to be done rendering mipmaps
-            device.poll(wgpu::PollType::wait()).unwrap();
+            device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
             // This is guaranteed to be ready.
             let timestamp_view = query_sets
                 .mapping_buffer

--- a/examples/features/src/ray_shadows/mod.rs
+++ b/examples/features/src/ray_shadows/mod.rs
@@ -360,7 +360,7 @@ impl crate::framework::Example for Example {
             rpass.draw_indexed(0..12, 0, 0..1);
         }
         queue.submit(Some(encoder.finish()));
-        device.poll(wgpu::PollType::Wait).unwrap();
+        device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
     }
 }
 

--- a/examples/features/src/render_to_texture/mod.rs
+++ b/examples/features/src/render_to_texture/mod.rs
@@ -132,7 +132,7 @@ async fn run(_path: Option<String>) {
     let buffer_slice = output_staging_buffer.slice(..);
     let (sender, receiver) = flume::bounded(1);
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());
-    device.poll(wgpu::PollType::wait()).unwrap();
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
     receiver.recv_async().await.unwrap().unwrap();
     log::info!("Output buffer mapped.");
     {

--- a/examples/features/src/repeated_compute/mod.rs
+++ b/examples/features/src/repeated_compute/mod.rs
@@ -105,7 +105,10 @@ async fn compute(local_buffer: &mut [u32], context: &WgpuContext) {
     // One of those can be calling `Device::poll`. This isn't necessary on the web as devices
     // are polled automatically but natively, we need to make sure this happens manually.
     // `PollType::Wait` will cause the thread to wait on native but not on WebGpu.
-    context.device.poll(wgpu::PollType::wait()).unwrap();
+    context
+        .device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
     log::info!("Device polled.");
     // Now we await the receiving and panic if anything went wrong because we're lazy.
     receiver.recv_async().await.unwrap().unwrap();

--- a/examples/features/src/storage_texture/mod.rs
+++ b/examples/features/src/storage_texture/mod.rs
@@ -142,7 +142,7 @@ async fn run(_path: Option<String>) {
     let buffer_slice = output_staging_buffer.slice(..);
     let (sender, receiver) = flume::bounded(1);
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());
-    device.poll(wgpu::PollType::wait()).unwrap();
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
     receiver.recv_async().await.unwrap().unwrap();
     log::info!("Output buffer mapped");
     {

--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -161,7 +161,7 @@ impl Queries {
         self.destination_buffer
             .slice(..)
             .map_async(wgpu::MapMode::Read, |_| ());
-        device.poll(wgpu::PollType::wait()).unwrap();
+        device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
 
         let timestamps = {
             let timestamp_view = self

--- a/examples/standalone/01_hello_compute/src/main.rs
+++ b/examples/standalone/01_hello_compute/src/main.rs
@@ -242,7 +242,7 @@ fn main() {
 
     // Wait for the GPU to finish working on the submitted work. This doesn't work on WebGPU, so we would need
     // to rely on the callback to know when the buffer is mapped.
-    device.poll(wgpu::PollType::Wait).unwrap();
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
 
     // We can now read the data from the buffer.
     let data = buffer_slice.get_mapped_range();

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -134,7 +134,9 @@ fn main() {
         }
 
         unsafe { global.device_stop_graphics_debugger_capture(device) };
-        global.device_poll(device, wgt::PollType::wait()).unwrap();
+        global
+            .device_poll(device, wgt::PollType::wait_indefinitely())
+            .unwrap();
     }
     #[cfg(feature = "winit")]
     {
@@ -227,7 +229,9 @@ fn main() {
                     },
                     Event::LoopExiting => {
                         log::info!("Closing");
-                        global.device_poll(device, wgt::PollType::wait()).unwrap();
+                        global
+                            .device_poll(device, wgt::PollType::wait_indefinitely())
+                            .unwrap();
                     }
                     _ => {}
                 }

--- a/player/tests/player/main.rs
+++ b/player/tests/player/main.rs
@@ -136,7 +136,13 @@ impl Test<'_> {
 
         println!("\t\t\tWaiting...");
         global
-            .device_poll(device_id, wgt::PollType::wait())
+            .device_poll(
+                device_id,
+                wgt::PollType::Wait {
+                    submission_index: None,
+                    timeout: Some(std::time::Duration::from_secs(1)), // Tests really shouldn't need longer than that!
+                },
+            )
             .unwrap();
 
         for expect in self.expectations {

--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -577,7 +577,7 @@ impl ReadbackBuffers {
     ) -> Vec<u8> {
         let buffer_slice = buffer.slice(..);
         buffer_slice.map_async(MapMode::Read, |_| ());
-        ctx.async_poll(PollType::wait()).await.unwrap();
+        ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
         let (block_width, block_height) = self.texture_format.block_dimensions();
         let expected_bytes_per_row = (self.texture_width / block_width)
             * self.texture_format.block_copy_size(aspect).unwrap_or(4);

--- a/tests/tests/wgpu-gpu/bgra8unorm_storage.rs
+++ b/tests/tests/wgpu-gpu/bgra8unorm_storage.rs
@@ -146,7 +146,9 @@ static BGRA8_UNORM_STORAGE: GpuTestConfiguration = GpuTestConfiguration::new()
 
         let buffer_slice = readback_buffer.slice(..);
         buffer_slice.map_async(wgpu::MapMode::Read, Result::unwrap);
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
 
         {
             let texels = buffer_slice.get_mapped_range();

--- a/tests/tests/wgpu-gpu/bind_groups.rs
+++ b/tests/tests/wgpu-gpu/bind_groups.rs
@@ -125,7 +125,7 @@ fn multiple_bindings_with_differing_sizes(ctx: TestingContext) {
     ctx.queue.write_buffer(&buffer, 0, &data);
     ctx.queue.submit(Some(encoder.finish()));
 
-    ctx.device.poll(PollType::Wait).unwrap();
+    ctx.device.poll(PollType::wait_indefinitely()).unwrap();
 }
 
 /// Test `descriptor` against a bind group layout that requires non-filtering sampler.

--- a/tests/tests/wgpu-gpu/binding_array/buffers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/buffers.rs
@@ -265,7 +265,7 @@ async fn binding_array_buffers(
     let slice = readback_buffer.slice(..);
     slice.map_async(MapMode::Read, |_| {});
 
-    ctx.device.poll(PollType::Wait).unwrap();
+    ctx.device.poll(PollType::wait_indefinitely()).unwrap();
 
     let data = slice.get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/binding_array/samplers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/samplers.rs
@@ -251,7 +251,7 @@ async fn binding_array_samplers(ctx: TestingContext, partially_bound: bool) {
     ctx.queue.submit(Some(encoder.finish()));
 
     readback_buffer.slice(..).map_async(MapMode::Read, |_| {});
-    ctx.device.poll(PollType::Wait).unwrap();
+    ctx.device.poll(PollType::wait_indefinitely()).unwrap();
 
     let readback_buffer_slice = readback_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/buffer.rs
+++ b/tests/tests/wgpu-gpu/buffer.rs
@@ -27,7 +27,9 @@ async fn test_empty_buffer_range(ctx: &TestingContext, buffer_size: u64, label: 
         b0.slice(0..0)
             .map_async(wgpu::MapMode::Read, Result::unwrap);
 
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
 
         {
             let view = b0.slice(0..0).get_mapped_range();
@@ -61,7 +63,9 @@ async fn test_empty_buffer_range(ctx: &TestingContext, buffer_size: u64, label: 
             b0.slice(0..0)
                 .map_async(wgpu::MapMode::Write, Result::unwrap);
 
-            ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+            ctx.async_poll(wgpu::PollType::wait_indefinitely())
+                .await
+                .unwrap();
 
             //{
             //    let view = b0.slice(0..0).get_mapped_range_mut();
@@ -90,7 +94,9 @@ async fn test_empty_buffer_range(ctx: &TestingContext, buffer_size: u64, label: 
 
     b1.unmap();
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 }
 
 #[gpu_test]
@@ -135,7 +141,9 @@ static MAP_OFFSET: GpuTestConfiguration = GpuTestConfiguration::new()
                 result.unwrap();
             });
 
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
 
         {
             let slice = write_buf.slice(32..48);
@@ -159,7 +167,9 @@ static MAP_OFFSET: GpuTestConfiguration = GpuTestConfiguration::new()
             .slice(..)
             .map_async(wgpu::MapMode::Read, Result::unwrap);
 
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
 
         let slice = read_buf.slice(..);
         let view = slice.get_mapped_range();

--- a/tests/tests/wgpu-gpu/buffer_usages.rs
+++ b/tests/tests/wgpu-gpu/buffer_usages.rs
@@ -155,7 +155,9 @@ async fn map_test(
         buffer.destroy();
     }
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     if !before_unmap && !before_destroy {
         {

--- a/tests/tests/wgpu-gpu/clip_distances.rs
+++ b/tests/tests/wgpu-gpu/clip_distances.rs
@@ -123,7 +123,9 @@ async fn clip_distances(ctx: TestingContext) {
     ctx.queue.submit([encoder.finish()]);
     let slice = readback_buffer.slice(..);
     slice.map_async(wgpu::MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
     let data: &[u8] = &slice.get_mapped_range();
 
     // We should have filled the upper sector of the texture. Verify that this is the case.

--- a/tests/tests/wgpu-gpu/cloneable_types.rs
+++ b/tests/tests/wgpu-gpu/cloneable_types.rs
@@ -40,7 +40,9 @@ fn cloneable_buffers(ctx: TestingContext) {
         assert_eq!(&*data, &cloned_buffer_contents);
     });
 
-    ctx.device.poll(wgpu::PollType::Wait).unwrap();
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
 
     let data = buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/compute_pass_ownership.rs
+++ b/tests/tests/wgpu-gpu/compute_pass_ownership.rs
@@ -63,7 +63,9 @@ async fn compute_pass_resource_ownership(ctx: TestingContext) {
         drop(pipeline);
         drop(bind_group);
         drop(indirect_buffer);
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
     }
 
     assert_compute_pass_executed_normally(encoder, gpu_buffer, cpu_buffer, buffer_size, ctx).await;
@@ -111,7 +113,9 @@ async fn compute_pass_query_set_ownership_pipeline_statistics(ctx: TestingContex
 
         // Drop the query set. Then do a device poll to make sure it's not dropped too early, no matter what.
         drop(query_set);
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
     }
 
     assert_compute_pass_executed_normally(encoder, gpu_buffer, cpu_buffer, buffer_size, ctx).await;
@@ -167,7 +171,9 @@ async fn compute_pass_query_set_ownership_timestamps(ctx: TestingContext) {
         // Drop the query sets. Then do a device poll to make sure they're not dropped too early, no matter what.
         drop(query_set_timestamp_writes);
         drop(query_set_write_timestamp);
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
     }
 
     assert_compute_pass_executed_normally(encoder, gpu_buffer, cpu_buffer, buffer_size, ctx).await;
@@ -206,7 +212,9 @@ async fn compute_pass_keep_encoder_alive(ctx: TestingContext) {
     let mut cpass = cpass.forget_lifetime();
     drop(encoder);
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     // Record some draw commands.
     cpass.set_pipeline(&pipeline);
@@ -230,7 +238,9 @@ async fn assert_compute_pass_executed_normally(
     encoder.copy_buffer_to_buffer(&gpu_buffer, 0, &cpu_buffer, 0, buffer_size);
     ctx.queue.submit([encoder.finish()]);
     cpu_buffer.slice(..).map_async(wgpu::MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let data = cpu_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -504,7 +504,7 @@ static DEVICE_DESTROY_THEN_LOST: GpuTestConfiguration = GpuTestConfiguration::ne
         // Make sure the device queues are empty, which ensures that the closure
         // has been called.
         assert!(ctx
-            .async_poll(wgpu::PollType::wait())
+            .async_poll(wgpu::PollType::wait_indefinitely())
             .await
             .unwrap()
             .is_queue_empty());

--- a/tests/tests/wgpu-gpu/dispatch_workgroups_indirect.rs
+++ b/tests/tests/wgpu-gpu/dispatch_workgroups_indirect.rs
@@ -312,7 +312,9 @@ async fn run_test(ctx: &TestingContext, num_workgroups: &[u32; 3]) -> [u32; 3] {
             .slice(..)
             .map_async(wgpu::MapMode::Read, |_| {});
 
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
 
         let view = test_resources.readback_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/draw_indirect.rs
+++ b/tests/tests/wgpu-gpu/draw_indirect.rs
@@ -322,7 +322,9 @@ async fn run_test(ctx: TestingContext, test_data: TestData, expect_noop: bool) {
     let slice = readback_buffer.slice(..);
     slice.map_async(wgpu::MapMode::Read, |_| ());
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let data = slice.get_mapped_range();
     let succeeded = if expect_noop {
@@ -782,7 +784,9 @@ async fn indirect_buffer_offsets(ctx: TestingContext) {
     let slice = readback_buffer.slice(..);
     slice.map_async(wgpu::MapMode::Read, |_| ());
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let data = slice.get_mapped_range();
     let half = data.len() / 2;

--- a/tests/tests/wgpu-gpu/external_image_copy.rs
+++ b/tests/tests/wgpu-gpu/external_image_copy.rs
@@ -328,7 +328,9 @@ static IMAGE_BITMAP_IMPORT: GpuTestConfiguration =
                 readback_buffer
                     .slice(..)
                     .map_async(wgpu::MapMode::Read, |_| ());
-                ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+                ctx.async_poll(wgpu::PollType::wait_indefinitely())
+                    .await
+                    .unwrap();
 
                 let buffer = readback_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/external_texture/mod.rs
+++ b/tests/tests/wgpu-gpu/external_texture/mod.rs
@@ -223,7 +223,9 @@ fn get_dimensions(ctx: &TestingContext, texture_resource: wgpu::BindingResource)
     ctx.queue.submit(Some(encoder.finish()));
     let buffer_slice = download_buffer.slice(..);
     buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
-    ctx.device.poll(wgpu::PollType::Wait).unwrap();
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
 
     let data = buffer_slice.get_mapped_range();
     let size: &[u32] = bytemuck::cast_slice(&data);
@@ -306,7 +308,9 @@ fn get_loads(
     ctx.queue.submit(Some(encoder.finish()));
     let buffer_slice = download_buffer.slice(..);
     buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
-    ctx.device.poll(wgpu::PollType::Wait).unwrap();
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
 
     let data = buffer_slice.get_mapped_range();
     let values: &[[f32; 4]] = bytemuck::cast_slice(&data);
@@ -397,7 +401,9 @@ fn get_samples(
     ctx.queue.submit(Some(encoder.finish()));
     let buffer_slice = download_buffer.slice(..);
     buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
-    ctx.device.poll(wgpu::PollType::Wait).unwrap();
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
 
     let data = buffer_slice.get_mapped_range();
     let values: &[[f32; 4]] = bytemuck::cast_slice(&data);

--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -25,7 +25,9 @@ static BUFFER_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
 
         buffer.destroy();
 
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
 
         fail(
             &ctx.device,
@@ -39,7 +41,9 @@ static BUFFER_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
 
         buffer.destroy();
 
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
 
         buffer.destroy();
 
@@ -61,7 +65,9 @@ static BUFFER_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
         }
         let buffer = ctx.device.create_buffer(&descriptor);
         buffer.destroy();
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
         let buffer = ctx.device.create_buffer(&descriptor);
         buffer.destroy();
         {
@@ -70,12 +76,16 @@ static BUFFER_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
             let buffer = ctx.device.create_buffer(&descriptor);
             buffer.destroy();
             let buffer = ctx.device.create_buffer(&descriptor);
-            ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+            ctx.async_poll(wgpu::PollType::wait_indefinitely())
+                .await
+                .unwrap();
             buffer.destroy();
         }
         let buffer = ctx.device.create_buffer(&descriptor);
         buffer.destroy();
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
     });
 
 #[gpu_test]
@@ -101,11 +111,15 @@ static TEXTURE_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
 
         texture.destroy();
 
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
 
         texture.destroy();
 
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
 
         texture.destroy();
 

--- a/tests/tests/wgpu-gpu/mem_leaks.rs
+++ b/tests/tests/wgpu-gpu/mem_leaks.rs
@@ -267,9 +267,12 @@ async fn draw_test_with_reports(
     let report = global_report.hub_report();
     assert_eq!(report.command_buffers.num_allocated, 0);
 
-    ctx.async_poll(wgpu::PollType::wait_for(submit_index))
-        .await
-        .unwrap();
+    ctx.async_poll(wgpu::PollType::Wait {
+        submission_index: Some(submit_index),
+        timeout: None,
+    })
+    .await
+    .unwrap();
 
     let global_report = ctx.instance.generate_report().unwrap();
     let report = global_report.hub_report();

--- a/tests/tests/wgpu-gpu/mesh_shader/mod.rs
+++ b/tests/tests/wgpu-gpu/mesh_shader/mod.rs
@@ -223,7 +223,9 @@ fn mesh_pipeline_build(ctx: &TestingContext, info: MeshPipelineTestInfo) {
             pass.draw_mesh_tasks(1, 1, 1);
         }
         ctx.queue.submit(Some(encoder.finish()));
-        ctx.device.poll(wgpu::PollType::Wait).unwrap();
+        ctx.device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .unwrap();
     }
 }
 
@@ -333,7 +335,9 @@ fn mesh_draw(ctx: &TestingContext, draw_type: DrawType) {
         pass.draw_mesh_tasks_indirect(buffer.as_ref().unwrap(), 0);
     }
     ctx.queue.submit(Some(encoder.finish()));
-    ctx.device.poll(wgpu::PollType::Wait).unwrap();
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
 }
 
 fn default_gpu_test_config(draw_type: DrawType) -> GpuTestConfiguration {

--- a/tests/tests/wgpu-gpu/occlusion_query/mod.rs
+++ b/tests/tests/wgpu-gpu/occlusion_query/mod.rs
@@ -125,7 +125,9 @@ static OCCLUSION_QUERY: GpuTestConfiguration = GpuTestConfiguration::new()
         mapping_buffer
             .slice(..)
             .map_async(wgpu::MapMode::Read, |_| ());
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
         let query_buffer_view = mapping_buffer.slice(..).get_mapped_range();
         let query_data: &[u64; 3] = bytemuck::from_bytes(&query_buffer_view);
 

--- a/tests/tests/wgpu-gpu/oob_indexing.rs
+++ b/tests/tests/wgpu-gpu/oob_indexing.rs
@@ -48,7 +48,9 @@ static RESTRICT_WORKGROUP_PRIVATE_FUNCTION_LET: GpuTestConfiguration = GpuTestCo
             .slice(..)
             .map_async(wgpu::MapMode::Read, |_| {});
 
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
 
         let view = test_resources.readback_buffer.slice(..).get_mapped_range();
 
@@ -449,7 +451,9 @@ async fn d3d12_restrict_dynamic_buffers(ctx: TestingContext) {
         .slice(..)
         .map_async(wgpu::MapMode::Read, |_| {});
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let view = readback_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/pipeline_cache.rs
+++ b/tests/tests/wgpu-gpu/pipeline_cache.rs
@@ -179,7 +179,9 @@ async fn validate_pipeline(
     encoder.copy_buffer_to_buffer(gpu_buffer, 0, cpu_buffer, 0, ARRAY_SIZE * 4);
     ctx.queue.submit([encoder.finish()]);
     cpu_buffer.slice(..).map_async(wgpu::MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let data = cpu_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/poll.rs
+++ b/tests/tests/wgpu-gpu/poll.rs
@@ -14,9 +14,11 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
         WAIT,
         WAIT_WITH_TIMEOUT,
+        WAIT_WITH_TIMEOUT_MAX,
         DOUBLE_WAIT,
         WAIT_ON_SUBMISSION,
         WAIT_ON_SUBMISSION_WITH_TIMEOUT,
+        WAIT_ON_SUBMISSION_WITH_TIMEOUT_MAX,
         DOUBLE_WAIT_ON_SUBMISSION,
         WAIT_OUT_OF_ORDER,
         WAIT_AFTER_BAD_SUBMISSION,
@@ -74,7 +76,12 @@ static WAIT: GpuTestConfiguration = GpuTestConfiguration::new()
         let cmd_buf = generate_dummy_work(&ctx);
 
         ctx.queue.submit(Some(cmd_buf));
-        ctx.async_poll(PollType::wait()).await.unwrap();
+        ctx.async_poll(PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        })
+        .await
+        .unwrap();
     });
 
 #[gpu_test]
@@ -84,9 +91,27 @@ static WAIT_WITH_TIMEOUT: GpuTestConfiguration = GpuTestConfiguration::new()
         let cmd_buf = generate_dummy_work(&ctx);
 
         ctx.queue.submit(Some(cmd_buf));
-        ctx.async_poll(PollType::WaitWithTimeout(Duration::from_secs(1)))
-            .await
-            .unwrap();
+        ctx.async_poll(PollType::Wait {
+            submission_index: None,
+            timeout: Some(Duration::from_secs(1)),
+        })
+        .await
+        .unwrap();
+    });
+
+#[gpu_test]
+static WAIT_WITH_TIMEOUT_MAX: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
+        let cmd_buf = generate_dummy_work(&ctx);
+
+        ctx.queue.submit(Some(cmd_buf));
+        ctx.async_poll(PollType::Wait {
+            submission_index: None,
+            timeout: Some(Duration::MAX),
+        })
+        .await
+        .unwrap();
     });
 
 #[gpu_test]
@@ -96,8 +121,18 @@ static DOUBLE_WAIT: GpuTestConfiguration = GpuTestConfiguration::new()
         let cmd_buf = generate_dummy_work(&ctx);
 
         ctx.queue.submit(Some(cmd_buf));
-        ctx.async_poll(PollType::wait()).await.unwrap();
-        ctx.async_poll(PollType::wait()).await.unwrap();
+        ctx.async_poll(PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        })
+        .await
+        .unwrap();
+        ctx.async_poll(PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        })
+        .await
+        .unwrap();
     });
 
 #[gpu_test]
@@ -107,7 +142,12 @@ static WAIT_ON_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::new()
         let cmd_buf = generate_dummy_work(&ctx);
 
         let index = ctx.queue.submit(Some(cmd_buf));
-        ctx.async_poll(PollType::wait_for(index)).await.unwrap();
+        ctx.async_poll(PollType::Wait {
+            submission_index: Some(index),
+            timeout: None,
+        })
+        .await
+        .unwrap();
     });
 
 #[gpu_test]
@@ -117,9 +157,24 @@ static WAIT_ON_SUBMISSION_WITH_TIMEOUT: GpuTestConfiguration = GpuTestConfigurat
         let cmd_buf = generate_dummy_work(&ctx);
 
         let index = ctx.queue.submit(Some(cmd_buf));
-        ctx.async_poll(PollType::WaitForSubmissionIndexWithTimeout {
-            submission_index: index,
-            timeout: Duration::from_secs(1),
+        ctx.async_poll(PollType::Wait {
+            submission_index: Some(index),
+            timeout: Some(Duration::from_secs(1)),
+        })
+        .await
+        .unwrap();
+    });
+
+#[gpu_test]
+static WAIT_ON_SUBMISSION_WITH_TIMEOUT_MAX: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
+        let cmd_buf = generate_dummy_work(&ctx);
+
+        let index = ctx.queue.submit(Some(cmd_buf));
+        ctx.async_poll(PollType::Wait {
+            submission_index: Some(index),
+            timeout: Some(Duration::MAX),
         })
         .await
         .unwrap();
@@ -132,10 +187,18 @@ static DOUBLE_WAIT_ON_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::n
         let cmd_buf = generate_dummy_work(&ctx);
 
         let index = ctx.queue.submit(Some(cmd_buf));
-        ctx.async_poll(PollType::wait_for(index.clone()))
-            .await
-            .unwrap();
-        ctx.async_poll(PollType::wait_for(index)).await.unwrap();
+        ctx.async_poll(PollType::Wait {
+            submission_index: Some(index.clone()),
+            timeout: None,
+        })
+        .await
+        .unwrap();
+        ctx.async_poll(PollType::Wait {
+            submission_index: Some(index),
+            timeout: None,
+        })
+        .await
+        .unwrap();
     });
 
 #[gpu_test]
@@ -147,8 +210,18 @@ static WAIT_OUT_OF_ORDER: GpuTestConfiguration = GpuTestConfiguration::new()
 
         let index1 = ctx.queue.submit(Some(cmd_buf1));
         let index2 = ctx.queue.submit(Some(cmd_buf2));
-        ctx.async_poll(PollType::wait_for(index2)).await.unwrap();
-        ctx.async_poll(PollType::wait_for(index1)).await.unwrap();
+        ctx.async_poll(PollType::Wait {
+            submission_index: Some(index2),
+            timeout: None,
+        })
+        .await
+        .unwrap();
+        ctx.async_poll(PollType::Wait {
+            submission_index: Some(index1),
+            timeout: None,
+        })
+        .await
+        .unwrap();
     });
 
 /// Submit a command buffer to the wrong device. A wait poll shouldn't hang.
@@ -186,5 +259,5 @@ async fn wait_after_bad_submission(ctx: TestingContext) {
     // Specifically, the failed submission should not cause a new fence value to
     // be allocated that will not be signalled until further work is
     // successfully submitted, causing a greater fence value to be signalled.
-    device2.poll(wgpu::PollType::Wait).unwrap();
+    device2.poll(wgpu::PollType::wait_indefinitely()).unwrap();
 }

--- a/tests/tests/wgpu-gpu/push_constants.rs
+++ b/tests/tests/wgpu-gpu/push_constants.rs
@@ -150,7 +150,9 @@ async fn partial_update_test(ctx: TestingContext) {
     encoder.copy_buffer_to_buffer(&gpu_buffer, 0, &cpu_buffer, 0, 32);
     ctx.queue.submit([encoder.finish()]);
     cpu_buffer.slice(..).map_async(wgpu::MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let data = cpu_buffer.slice(..).get_mapped_range();
 
@@ -368,7 +370,9 @@ async fn render_pass_test(ctx: &TestingContext, use_render_bundle: bool) {
     let command_buffer = command_encoder.finish();
     ctx.queue.submit([command_buffer]);
     cpu_buffer.slice(..).map_async(MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
     let mapped_data = cpu_buffer.slice(..).get_mapped_range();
     let result = bytemuck::cast_slice::<u8, i32>(&mapped_data).to_vec();
     drop(mapped_data);

--- a/tests/tests/wgpu-gpu/queue_transfer.rs
+++ b/tests/tests/wgpu-gpu/queue_transfer.rs
@@ -58,7 +58,7 @@ static QUEUE_WRITE_TEXTURE_THEN_DESTROY: GpuTestConfiguration = GpuTestConfigura
         texture.destroy();
 
         ctx.queue.submit([]);
-        ctx.device.poll(PollType::wait()).unwrap();
+        ctx.device.poll(PollType::wait_indefinitely()).unwrap();
     });
 
 #[gpu_test]

--- a/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
@@ -186,7 +186,7 @@ fn blas_compaction(ctx: TestingContext) {
     });
 
     // On native this will trigger the callback.
-    ctx.device.poll(PollType::Wait).unwrap();
+    ctx.device.poll(PollType::wait_indefinitely()).unwrap();
     // Check that the callback actually gets called (this test will timeout if it doesn't).
     recv.recv().unwrap();
     // This should return true because the callback has been called, and we haven't rebuilt the BLAS

--- a/tests/tests/wgpu-gpu/ray_tracing/as_use_after_free.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_use_after_free.rs
@@ -91,7 +91,7 @@ fn acceleration_structure_use_after_free(ctx: TestingContext) {
 
     // Drop the blas and ensure that if it was going to die, it is dead.
     drop(blas);
-    ctx.device.poll(PollType::Wait).unwrap();
+    ctx.device.poll(PollType::wait_indefinitely()).unwrap();
 
     // build the tlas package to ensure the blas is dropped
     let mut encoder = ctx
@@ -126,7 +126,7 @@ fn acceleration_structure_use_after_free(ctx: TestingContext) {
 
     // Drop the TLAS package and ensure that if it was going to die, it is dead.
     drop(tlas);
-    ctx.device.poll(PollType::Wait).unwrap();
+    ctx.device.poll(PollType::wait_indefinitely()).unwrap();
 
     // Run the pass with the bind group that references the TLAS package.
     let mut encoder = ctx

--- a/tests/tests/wgpu-gpu/ray_tracing/scene/mod.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/scene/mod.rs
@@ -101,7 +101,9 @@ fn acceleration_structure_build(ctx: &TestingContext, use_index_buffer: bool) {
 
     ctx.queue.submit(Some(encoder.finish()));
 
-    ctx.device.poll(wgpu::PollType::Wait).unwrap();
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
 }
 
 #[gpu_test]

--- a/tests/tests/wgpu-gpu/regression/issue_3457.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_3457.rs
@@ -172,7 +172,7 @@ static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration = GpuTestConfiguration::ne
         drop(vertex_buffer2);
 
         // Make sure the buffers are actually deleted.
-        ctx.async_poll(PollType::wait()).await.unwrap();
+        ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
 
         let mut encoder2 = ctx
             .device

--- a/tests/tests/wgpu-gpu/regression/issue_4024.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4024.rs
@@ -41,7 +41,7 @@ static QUEUE_SUBMITTED_CALLBACK_ORDERING: GpuTestConfiguration = GpuTestConfigur
         // Submit the work.
         ctx.queue.submit(Some(encoder.finish()));
         // Ensure the work is finished.
-        ctx.async_poll(PollType::wait()).await.unwrap();
+        ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
 
         #[derive(Debug)]
         struct OrderingContext {

--- a/tests/tests/wgpu-gpu/regression/issue_4122.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_4122.rs
@@ -38,7 +38,9 @@ async fn fill_test(ctx: &TestingContext, range: Range<u64>, size: u64) -> bool {
 
     ctx.queue.submit(Some(encoder.finish()));
     cpu_buffer.slice(..).map_async(wgpu::MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let buffer_slice = cpu_buffer.slice(..);
     let buffer_data = buffer_slice.get_mapped_range();

--- a/tests/tests/wgpu-gpu/regression/issue_6827.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_6827.rs
@@ -79,7 +79,7 @@ async fn run_test(ctx: TestingContext, use_many_writes: bool) {
             let result_cell = result_cell.clone();
             move |result| result_cell.set(result).unwrap()
         });
-        device.poll(wgpu::PollType::Wait).unwrap();
+        device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
         result_cell
             .get()
             .as_ref()

--- a/tests/tests/wgpu-gpu/render_pass_ownership.rs
+++ b/tests/tests/wgpu-gpu/render_pass_ownership.rs
@@ -113,7 +113,9 @@ async fn render_pass_resource_ownership(ctx: TestingContext) {
         drop(vertex_buffer);
         drop(index_buffer);
         drop(occlusion_query_set);
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
     }
 
     assert_render_pass_executed_normally(encoder, gpu_buffer, cpu_buffer, buffer_size, ctx).await;
@@ -183,7 +185,9 @@ async fn render_pass_query_set_ownership_pipeline_statistics(ctx: TestingContext
 
         // Drop the query set. Then do a device poll to make sure it's not dropped too early, no matter what.
         drop(query_set);
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
     }
 
     assert_render_pass_executed_normally(encoder, gpu_buffer, cpu_buffer, buffer_size, ctx).await;
@@ -260,7 +264,9 @@ async fn render_pass_query_set_ownership_timestamps(ctx: TestingContext) {
         // Drop the query sets. Then do a device poll to make sure they're not dropped too early, no matter what.
         drop(query_set_timestamp_writes);
         drop(query_set_write_timestamp);
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
     }
 
     assert_render_pass_executed_normally(encoder, gpu_buffer, cpu_buffer, buffer_size, ctx).await;
@@ -312,7 +318,9 @@ async fn render_pass_keep_encoder_alive(ctx: TestingContext) {
     let mut rpass = rpass.forget_lifetime();
     drop(encoder);
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     // Record some a draw command.
     rpass.set_pipeline(&pipeline);
@@ -338,7 +346,9 @@ async fn assert_render_pass_executed_normally(
     encoder.copy_buffer_to_buffer(&gpu_buffer, 0, &cpu_buffer, 0, buffer_size);
     ctx.queue.submit([encoder.finish()]);
     cpu_buffer.slice(..).map_async(wgpu::MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let data = cpu_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/render_target.rs
+++ b/tests/tests/wgpu-gpu/render_target.rs
@@ -239,7 +239,9 @@ async fn run_test(
     let slice = readback_buffer.slice(..);
     slice.map_async(wgpu::MapMode::Read, |_| ());
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let data = slice.get_mapped_range();
     let succeeded = data.iter().all(|b| *b == u8::MAX);
@@ -420,7 +422,9 @@ async fn run_test_3d(ctx: TestingContext) {
     let slice = readback_buffer.slice(..);
     slice.map_async(wgpu::MapMode::Read, |_| ());
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let data = slice.get_mapped_range();
     let succeeded = data.iter().all(|b| *b == u8::MAX);

--- a/tests/tests/wgpu-gpu/samplers.rs
+++ b/tests/tests/wgpu-gpu/samplers.rs
@@ -124,7 +124,9 @@ fn sampler_creation_failure(ctx: TestingContext) {
     let failed_count = sampler_storage.len();
 
     sampler_storage.clear();
-    ctx.device.poll(wgpu::PollType::Wait).unwrap();
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
 
     for i in 0..failed_count {
         valid(&ctx.device, || {
@@ -539,7 +541,9 @@ fn sampler_bind_group(ctx: TestingContext, group_type: GroupType) {
     let buffer_slice = transfer_buffer.slice(..);
     buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
 
-    ctx.device.poll(wgpu::PollType::Wait).unwrap();
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
 
     let buffer_data = buffer_slice.get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/shader/array_size_overrides.rs
+++ b/tests/tests/wgpu-gpu/shader/array_size_overrides.rs
@@ -144,7 +144,7 @@ async fn array_size_overrides(
     ctx.queue.submit(Some(encoder.finish()));
 
     mapping_buffer.slice(..).map_async(MapMode::Read, |_| ());
-    ctx.async_poll(PollType::wait()).await.unwrap();
+    ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
 
     let mapped = mapping_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/shader/mod.rs
+++ b/tests/tests/wgpu-gpu/shader/mod.rs
@@ -377,7 +377,7 @@ async fn shader_input_output_test(
         ctx.queue.submit(Some(encoder.finish()));
 
         mapping_buffer.slice(..).map_async(MapMode::Read, |_| ());
-        ctx.async_poll(PollType::wait()).await.unwrap();
+        ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
 
         let mapped = mapping_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/shader/workgroup_size_overrides.rs
+++ b/tests/tests/wgpu-gpu/shader/workgroup_size_overrides.rs
@@ -111,7 +111,7 @@ async fn workgroup_size_overrides(
     ctx.queue.submit(Some(encoder.finish()));
 
     mapping_buffer.slice(..).map_async(MapMode::Read, |_| ());
-    ctx.async_poll(PollType::wait()).await.unwrap();
+    ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
 
     let mapped = mapping_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
@@ -135,7 +135,7 @@ static ZERO_INIT_WORKGROUP_MEMORY: GpuTestConfiguration = GpuTestConfiguration::
         ctx.queue.submit(Some(encoder.finish()));
 
         mapping_buffer.slice(..).map_async(MapMode::Read, |_| ());
-        ctx.async_poll(PollType::wait()).await.unwrap();
+        ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
 
         let mapped = mapping_buffer.slice(..).get_mapped_range();
 

--- a/tests/tests/wgpu-gpu/shader_view_format/mod.rs
+++ b/tests/tests/wgpu-gpu/shader_view_format/mod.rs
@@ -189,7 +189,9 @@ async fn reinterpret(
 
     let slice = read_buffer.slice(..);
     slice.map_async(wgpu::MapMode::Read, |_| ());
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let data: Vec<u8> = slice.get_mapped_range().to_vec();
     let tolerance_data: [[u8; 4]; 4] = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [1, 1, 1, 0]];

--- a/tests/tests/wgpu-gpu/texture_binding/mod.rs
+++ b/tests/tests/wgpu-gpu/texture_binding/mod.rs
@@ -181,7 +181,7 @@ fn single_scalar_load(ctx: TestingContext) {
         send.send(()).expect("Thread should wait for receive");
     });
     // Poll to run map.
-    ctx.device.poll(PollType::Wait).unwrap();
+    ctx.device.poll(PollType::wait_indefinitely()).unwrap();
     recv.recv_timeout(Duration::from_secs(10))
         .expect("mapping should not take this long");
     let val = *bytemuck::from_bytes::<[f32; 4]>(&buffer.slice(..).get_mapped_range());

--- a/tests/tests/wgpu-gpu/timestamp_normalization/utils.rs
+++ b/tests/tests/wgpu-gpu/timestamp_normalization/utils.rs
@@ -280,7 +280,9 @@ fn process_shader(ctx: TestingContext, inputs: &[u8], entry_point_src: &str) -> 
     ctx.queue.submit([encoder.finish()]);
     pulldown_buffer.map_async(wgpu::MapMode::Read, .., |_| {});
 
-    ctx.device.poll(wgpu::PollType::Wait).unwrap();
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
 
     pulldown_buffer.get_mapped_range(..).to_vec()
 }

--- a/tests/tests/wgpu-gpu/timestamp_query.rs
+++ b/tests/tests/wgpu-gpu/timestamp_query.rs
@@ -121,7 +121,9 @@ fn timestamp_query(ctx: TestingContext) {
     mapping_buffer
         .slice(..)
         .map_async(wgpu::MapMode::Read, |_| ());
-    ctx.device.poll(wgpu::PollType::wait()).unwrap();
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
     let query_buffer_view = mapping_buffer.slice(..).get_mapped_range();
     let query_data: &[u64] = bytemuck::cast_slice(&query_buffer_view);
 

--- a/tests/tests/wgpu-gpu/vertex_formats/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_formats/mod.rs
@@ -381,11 +381,15 @@ async fn vertex_formats_common(ctx: TestingContext, tests: &[Test<'_>]) {
         // See https://github.com/gfx-rs/wgpu/issues/4732 for why this is split between two submissions
         // with a hard wait in between.
         ctx.queue.submit([encoder1.finish()]);
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
         ctx.queue.submit([encoder2.finish()]);
         let slice = cpu_buffer.slice(..);
         slice.map_async(wgpu::MapMode::Read, |_| ());
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
         let data: Vec<f32> = bytemuck::cast_slice(&slice.get_mapped_range()).to_vec();
 
         let case_name = format!("Case {:?}", test.case);

--- a/tests/tests/wgpu-gpu/vertex_indices/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_indices/mod.rs
@@ -440,11 +440,15 @@ async fn vertex_index_common(ctx: TestingContext) {
         // See https://github.com/gfx-rs/wgpu/issues/4732 for why this is split between two submissions
         // with a hard wait in between.
         ctx.queue.submit([encoder1.finish()]);
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
         ctx.queue.submit([encoder2.finish()]);
         let slice = cpu_buffer.slice(..);
         slice.map_async(wgpu::MapMode::Read, |_| ());
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
         let data: Vec<u32> = bytemuck::cast_slice(&slice.get_mapped_range()).to_vec();
 
         let case_name = format!(

--- a/tests/tests/wgpu-gpu/vertex_state.rs
+++ b/tests/tests/wgpu-gpu/vertex_state.rs
@@ -185,7 +185,9 @@ async fn set_array_stride_to_0(ctx: TestingContext) {
     let slice = readback_buffer.slice(..);
     slice.map_async(wgpu::MapMode::Read, |_| ());
 
-    ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
 
     let data = slice.get_mapped_range();
     let succeeded = data.iter().all(|b| *b == u8::MAX);

--- a/tests/tests/wgpu-gpu/write_texture.rs
+++ b/tests/tests/wgpu-gpu/write_texture.rs
@@ -94,7 +94,9 @@ static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
 
         let slice = read_buffer.slice(..);
         slice.map_async(wgpu::MapMode::Read, |_| ());
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
         let data: Vec<u8> = slice.get_mapped_range().to_vec();
 
         for byte in &data[..(size as usize * 2)] {
@@ -187,7 +189,9 @@ static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
 
         let slice = read_buffer.slice(..);
         slice.map_async(wgpu::MapMode::Read, |_| ());
-        ctx.async_poll(wgpu::PollType::wait()).await.unwrap();
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
         let data: Vec<u8> = slice.get_mapped_range().to_vec();
 
         for byte in &data[..((size * size) as usize * 2)] {
@@ -333,7 +337,7 @@ static WRITE_TEXTURE_VIA_STAGING_BUFFER: GpuTestConfiguration = GpuTestConfigura
 
         let slice = read_buffer.slice(..);
         slice.map_async(MapMode::Read, |_| ());
-        ctx.async_poll(PollType::wait()).await.unwrap();
+        ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
         let read_data: Vec<u8> = slice.get_mapped_range().to_vec();
 
         for x in 0..write_width {

--- a/tests/tests/wgpu-validation/api/buffer_mapping.rs
+++ b/tests/tests/wgpu-validation/api/buffer_mapping.rs
@@ -17,7 +17,7 @@ fn full_immutable_binding() {
     });
 
     buffer.map_async(wgpu::MapMode::Read, .., |_| {});
-    device.poll(wgpu::PollType::Wait).unwrap();
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
 
     let mapping = buffer.slice(..).get_mapped_range();
 
@@ -62,7 +62,7 @@ fn split_immutable_binding() {
     });
 
     buffer.map_async(wgpu::MapMode::Read, .., |_| {});
-    device.poll(wgpu::PollType::Wait).unwrap();
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
 
     let mapping0 = buffer.slice(0..512).get_mapped_range();
     let mapping1 = buffer.slice(512..1024).get_mapped_range();
@@ -167,7 +167,7 @@ fn partially_mapped() {
     });
 
     buffer.map_async(wgpu::MapMode::Write, 0..512, |_| {});
-    device.poll(wgpu::PollType::Wait).unwrap();
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
 
     let _mapping0 = buffer.slice(0..512).get_mapped_range_mut();
     let _mapping1 = buffer.slice(512..1024).get_mapped_range_mut();

--- a/tests/tests/wgpu-validation/api/command_buffer_actions.rs
+++ b/tests/tests/wgpu-validation/api/command_buffer_actions.rs
@@ -37,7 +37,7 @@ fn encoder_map_buffer_on_submit_defers_until_submit() {
 
     // Submit and wait; callback should fire.
     queue.submit([encoder.finish()]);
-    _ = device.poll(wgpu::PollType::Wait);
+    _ = device.poll(wgpu::PollType::wait_indefinitely());
     assert!(fired.load(SeqCst));
 }
 
@@ -115,7 +115,7 @@ fn encoder_on_submitted_work_done_defers_until_submit() {
     assert!(!fired.load(SeqCst));
 
     queue.submit([encoder.finish()]);
-    _ = device.poll(wgpu::PollType::Wait);
+    _ = device.poll(wgpu::PollType::wait_indefinitely());
     assert!(fired.load(SeqCst));
 }
 
@@ -141,7 +141,7 @@ fn encoder_both_callbacks_fire_after_submit() {
     encoder.clear_buffer(&buffer, 0, None);
 
     queue.submit([encoder.finish()]);
-    _ = device.poll(wgpu::PollType::Wait);
+    _ = device.poll(wgpu::PollType::wait_indefinitely());
 
     assert!(map_fired.load(SeqCst));
     assert!(queue_fired.load(SeqCst));
@@ -169,7 +169,7 @@ fn encoder_multiple_map_buffer_on_submit_callbacks_fire() {
     encoder.clear_buffer(&buffer1, 0, None);
 
     queue.submit([encoder.finish()]);
-    _ = device.poll(wgpu::PollType::Wait);
+    _ = device.poll(wgpu::PollType::wait_indefinitely());
 
     assert_eq!(counter.load(SeqCst), 2);
 }
@@ -227,7 +227,7 @@ fn encoder_deferred_map_runs_before_on_submitted_work_done() {
     encoder.clear_buffer(&buffer, 0, None);
 
     queue.submit([encoder.finish()]);
-    _ = device.poll(wgpu::PollType::Wait);
+    _ = device.poll(wgpu::PollType::wait_indefinitely());
 
     assert_eq!(order.counter.load(SeqCst), 2);
     assert_eq!(order.map_order.load(SeqCst), 0);
@@ -255,7 +255,7 @@ fn encoder_multiple_on_submitted_callbacks_fire() {
     encoder.clear_buffer(&buffer, 0, None);
 
     queue.submit([encoder.finish()]);
-    _ = device.poll(wgpu::PollType::Wait);
+    _ = device.poll(wgpu::PollType::wait_indefinitely());
 
     assert_eq!(counter.load(SeqCst), 2);
 }

--- a/tests/tests/wgpu-validation/noop.rs
+++ b/tests/tests/wgpu-validation/noop.rs
@@ -53,6 +53,6 @@ fn device_and_buffers() {
         assert_eq!(*result.unwrap(), [1, 2, 3, 4, 5, 6, 7, 8],);
         done.store(true, Relaxed);
     });
-    device.poll(wgpu::PollType::Wait).unwrap();
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
     assert!(done2.load(Relaxed));
 }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2121,7 +2121,7 @@ impl Global {
 
             for (_id, device) in device_guard.iter() {
                 let poll_type = if force_wait {
-                    // TODO: Should expose timeout to poll_all.
+                    // TODO(#8286): Should expose timeout to poll_all.
                     wgt::PollType::wait_indefinitely()
                 } else {
                     wgt::PollType::Poll

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1995,7 +1995,7 @@ impl Global {
 
                 let maintain_result;
                 (user_callbacks, maintain_result) =
-                    device.maintain(fence, wgt::PollType::Wait, snatch_guard);
+                    device.maintain(fence, wgt::PollType::wait_indefinitely(), snatch_guard);
 
                 match maintain_result {
                     // We're happy
@@ -2121,7 +2121,8 @@ impl Global {
 
             for (_id, device) in device_guard.iter() {
                 let poll_type = if force_wait {
-                    wgt::PollType::Wait
+                    // TODO: Should expose timeout to poll_all.
+                    wgt::PollType::wait_indefinitely()
                 } else {
                     wgt::PollType::Poll
                 };

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -711,9 +711,9 @@ impl Device {
 
         // If a wait was requested, determine which submission index to wait for.
         let wait_submission_index = match poll_type {
-            wgt::PollType::WaitForSubmissionIndex(submission_index)
-            | wgt::PollType::WaitForSubmissionIndexWithTimeout {
-                submission_index, ..
+            wgt::PollType::Wait {
+                submission_index: Some(submission_index),
+                ..
             } => {
                 let last_successful_submission_index = self
                     .last_successful_submission_index
@@ -730,7 +730,10 @@ impl Device {
 
                 Some(submission_index)
             }
-            wgt::PollType::Wait | wgt::PollType::WaitWithTimeout { .. } => Some(
+            wgt::PollType::Wait {
+                submission_index: None,
+                ..
+            } => Some(
                 self.last_successful_submission_index
                     .load(Ordering::Acquire),
             ),
@@ -741,9 +744,16 @@ impl Device {
         if let Some(target_submission_index) = wait_submission_index {
             log::trace!("Device::maintain: waiting for submission index {target_submission_index}");
 
+            let wait_timeout = match poll_type {
+                wgt::PollType::Wait { timeout, .. } => timeout,
+                wgt::PollType::Poll => unreachable!(
+                    "`wait_submission_index` index for poll type `Poll` should be None"
+                ),
+            };
+
             let wait_result = unsafe {
                 self.raw()
-                    .wait(fence.as_ref(), target_submission_index, poll_type.timeout())
+                    .wait(fence.as_ref(), target_submission_index, wait_timeout)
             };
 
             // This error match is only about `DeviceErrors`. At this stage we do not care if

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4507,12 +4507,12 @@ pub enum PollType<T> {
         /// Submission index to wait for.
         ///
         /// If not specified, will wait for the most recent submission at the time of the poll.
-        /// (by the time the method returns, more submissions may have taken place)
+        /// By the time the method returns, more submissions may have taken place.
         submission_index: Option<T>,
 
         /// Max time to wait for the submission to complete.
         ///
-        /// It not specified, will indefinitely (or until an error is detected).
+        /// If not specified, will wait indefinitely (or until an error is detected).
         /// If waiting for the GPU device takes this long or longer, the poll will return [`PollError::Timeout`].
         timeout: Option<Duration>,
     },
@@ -4525,7 +4525,7 @@ impl<T> PollType<T> {
     /// Wait indefinitely until for the most recent submission to complete.
     ///
     /// This is a convenience function that creates a [`Self::Wait`] variant with
-    /// no timeout (== wait indefinitely) and no submission index.
+    /// no timeout and no submission index.
     #[must_use]
     pub fn wait_indefinitely() -> Self {
         Self::Wait {

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4527,7 +4527,7 @@ impl<T> PollType<T> {
     /// This is a convenience function that creates a [`Self::Wait`] variant with
     /// no timeout and no submission index.
     #[must_use]
-    pub fn wait_indefinitely() -> Self {
+    pub const fn wait_indefinitely() -> Self {
         Self::Wait {
             submission_index: None,
             timeout: None,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -4503,58 +4503,42 @@ pub enum PollType<T> {
     ///
     /// On WebGPU, this has no effect. Callbacks are invoked from the
     /// window event loop.
-    WaitForSubmissionIndex(T),
-
-    /// Same as [`Self::WaitForSubmissionIndex`] but with a timeout.
-    WaitForSubmissionIndexWithTimeout {
+    Wait {
         /// Submission index to wait for.
-        submission_index: T,
+        ///
+        /// If not specified, will wait for the most recent submission at the time of the poll.
+        /// (by the time the method returns, more submissions may have taken place)
+        submission_index: Option<T>,
 
         /// Max time to wait for the submission to complete.
         ///
+        /// It not specified, will indefinitely (or until an error is detected).
         /// If waiting for the GPU device takes this long or longer, the poll will return [`PollError::Timeout`].
-        timeout: Duration,
+        timeout: Option<Duration>,
     },
-
-    /// Same as [`Self::WaitForSubmissionIndex`] but waits for the most recent submission.
-    Wait,
-
-    /// Same as [`Self::Wait`], but with a timeout.
-    ///
-    /// If waiting for the GPU device takes this long or longer, the poll will return [`PollError::Timeout`].
-    WaitWithTimeout(Duration),
 
     /// Check the device for a single time without blocking.
     Poll,
 }
 
 impl<T> PollType<T> {
-    /// Construct a [`Self::Wait`] variant
+    /// Wait indefinitely until for the most recent submission to complete.
+    ///
+    /// This is a convenience function that creates a [`Self::Wait`] variant with
+    /// no timeout (== wait indefinitely) and no submission index.
     #[must_use]
-    pub fn wait() -> Self {
-        // This function seems a little silly, but it is useful to allow
-        // <https://github.com/gfx-rs/wgpu/pull/5012> to be split up, as
-        // it has meaning in that PR.
-        Self::Wait
-    }
-
-    /// Construct a [`Self::WaitForSubmissionIndex`] variant
-    #[must_use]
-    pub fn wait_for(submission_index: T) -> Self {
-        // This function seems a little silly, but it is useful to allow
-        // <https://github.com/gfx-rs/wgpu/pull/5012> to be split up, as
-        // it has meaning in that PR.
-        Self::WaitForSubmissionIndex(submission_index)
+    pub fn wait_indefinitely() -> Self {
+        Self::Wait {
+            submission_index: None,
+            timeout: None,
+        }
     }
 
     /// This `PollType` represents a wait of some kind.
     #[must_use]
     pub fn is_wait(&self) -> bool {
         match *self {
-            Self::WaitForSubmissionIndex(..)
-            | Self::Wait
-            | Self::WaitForSubmissionIndexWithTimeout { .. }
-            | Self::WaitWithTimeout { .. } => true,
+            Self::Wait { .. } => true,
             Self::Poll => false,
         }
     }
@@ -4566,27 +4550,14 @@ impl<T> PollType<T> {
         F: FnOnce(T) -> U,
     {
         match self {
-            Self::WaitForSubmissionIndex(i) => PollType::WaitForSubmissionIndex(func(i)),
-            Self::Wait => PollType::Wait,
-            Self::WaitForSubmissionIndexWithTimeout {
+            Self::Wait {
                 submission_index,
                 timeout,
-            } => PollType::WaitForSubmissionIndexWithTimeout {
-                submission_index: func(submission_index),
+            } => PollType::Wait {
+                submission_index: submission_index.map(func),
                 timeout,
             },
-            Self::WaitWithTimeout(timeout) => PollType::WaitWithTimeout(timeout),
             Self::Poll => PollType::Poll,
-        }
-    }
-
-    /// Returns the timeout in milliseconds if the poll type has a timeout.
-    #[must_use]
-    pub fn timeout(&self) -> Option<Duration> {
-        match self {
-            Self::WaitForSubmissionIndexWithTimeout { timeout, .. }
-            | Self::WaitWithTimeout(timeout) => Some(*timeout),
-            _ => None,
         }
     }
 }

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -265,12 +265,11 @@ impl Blas {
     /// ### Interaction with other functions
     /// On native, `queue.submit(..)` and polling devices (that is calling `instance.poll_all` or
     /// `device.poll`) with [`PollType::Poll`] may call the callback. On native, polling devices with
-    /// [`PollType::Wait`] (or [`PollType::WaitForSubmissionIndex`] with a submission index greater
+    /// [`PollType::Wait`] (optionally with a submission index greater
     /// than the last submit the BLAS was used in) will guarantee callback is called.
     ///
     /// [`PollType::Poll`]: wgpu_types::PollType::Poll
     /// [`PollType::Wait`]: wgpu_types::PollType::Wait
-    /// [`PollType::WaitForSubmissionIndex`]: wgpu_types::PollType::WaitForSubmissionIndex
     pub fn prepare_compaction_async(
         &self,
         callback: impl FnOnce(Result<(), BlasAsyncError>) + WasmNotSend + 'static,


### PR DESCRIPTION
**Connections**

* Follow-up to https://github.com/gfx-rs/wgpu/pull/8282
* Discussed at weekly maintainer call today

**Description**
Induces a breaking change into `wgpu::PollType` in order to:
* not silently change behavior subtly
* have less variants on `wgpu::PollType`

**Testing**
Existing test + (kind of unrelated) new tests with max timeout.

**Squash or Rebase?**
squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
