### PR TITLE
fix(gles): Only use sampler2DShadow if comparison samplers are used

### DIFF
--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -960,7 +960,10 @@ impl<'a, W: Write> Writer<'a, W> {
                     write!(self.out, "uniform ")?;
 
                     if self.needs_depth_fix(ep_info, handle, &mut class) {
-                        class = crate::ImageClass::Sampled { kind: crate::ScalarKind::Float, multi: false };
+                        class = crate::ImageClass::Sampled {
+                            kind: crate::ScalarKind::Float,
+                            multi: false,
+                        };
                     }
 
                     // write the type
@@ -1038,7 +1041,12 @@ impl<'a, W: Write> Writer<'a, W> {
         self.collect_reflection_info()
     }
 
-    fn needs_depth_fix(&mut self, ep_info: &valid::FunctionInfo, handle: Handle<crate::GlobalVariable>, class: &crate::ImageClass) -> bool {
+    fn needs_depth_fix(
+        &mut self,
+        ep_info: &valid::FunctionInfo,
+        handle: Handle<crate::GlobalVariable>,
+        class: &crate::ImageClass,
+    ) -> bool {
         if let crate::ImageClass::Depth { multi: false } = class {
             // if any sampler uses the comparison sampler, a fix is not needed. Otherwise, we need to actually sample a regular texture as far as glsl is concerned
             !ep_info.sampling_set.iter().all(|key| {
@@ -1047,10 +1055,12 @@ impl<'a, W: Write> Writer<'a, W> {
                     return false;
                 }
 
-                matches!(self.module.types[data.ty].inner, TypeInner::Sampler { comparison: true })
+                matches!(
+                    self.module.types[data.ty].inner,
+                    TypeInner::Sampler { comparison: true }
+                )
             })
-        }
-        else {
+        } else {
             false
         }
     }
@@ -3183,13 +3193,13 @@ impl<'a, W: Write> Writer<'a, W> {
                     self.write_expr(expr, ctx)?;
                 }
 
-                let needs_depth_fix = if let Expression::GlobalVariable(global_handle) = ctx.expressions[image] {
-                    let ep_info = self.info.get_entry_point(self.entry_point_idx as usize);
-                    self.needs_depth_fix(ep_info, global_handle, &class)
-                }
-                else {
-                    false
-                };
+                let needs_depth_fix =
+                    if let Expression::GlobalVariable(global_handle) = ctx.expressions[image] {
+                        let ep_info = self.info.get_entry_point(self.entry_point_idx as usize);
+                        self.needs_depth_fix(ep_info, global_handle, &class)
+                    } else {
+                        false
+                    };
 
                 match level {
                     // Auto needs no more arguments
@@ -3270,9 +3280,6 @@ impl<'a, W: Write> Writer<'a, W> {
                     // parser thinks it will yield f32, but in reality it yields vec4f
                     write!(self.out, ".x")?;
                 }
-
-
-                // TODO: if depth texture but not comparison sampler, add ".x"
             }
             Expression::ImageLoad {
                 image,

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -911,7 +911,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 TypeInner::Image {
                     mut dim,
                     arrayed,
-                    class,
+                    mut class,
                 } => {
                     // Gather the storage format if needed
                     let storage_format_access = match self.module.types[global.ty].inner {
@@ -958,6 +958,10 @@ impl<'a, W: Write> Writer<'a, W> {
                     // All images in glsl are `uniform`
                     // The trailing space is important
                     write!(self.out, "uniform ")?;
+
+                    if self.needs_depth_fix(ep_info, handle, &mut class) {
+                        class = crate::ImageClass::Sampled { kind: crate::ScalarKind::Float, multi: false };
+                    }
 
                     // write the type
                     //
@@ -1032,6 +1036,27 @@ impl<'a, W: Write> Writer<'a, W> {
 
         // Collect all reflection info and return it to the user
         self.collect_reflection_info()
+    }
+
+    fn needs_depth_fix(&mut self, ep_info: &valid::FunctionInfo, handle: Handle<crate::GlobalVariable>, class: &crate::ImageClass) -> bool {
+        if let crate::ImageClass::Depth { multi: false } = class {
+            let has_shadow_sampler = ep_info.sampling_set.iter().all(|key| {
+                let data = &self.module.global_variables[key.sampler];
+                if key.image != handle {
+                    return false;
+                }
+                return if let TypeInner::Sampler { comparison: true } = &self.module.types[data.ty].inner {
+                    true
+                } else {
+                    false
+                }
+            });
+
+            !has_shadow_sampler
+        }
+        else {
+            false
+        }
     }
 
     fn write_array_size(
@@ -3162,6 +3187,14 @@ impl<'a, W: Write> Writer<'a, W> {
                     self.write_expr(expr, ctx)?;
                 }
 
+                let needs_depth_fix = if let Expression::GlobalVariable(global_handle) = ctx.expressions[image] {
+                    let ep_info = self.info.get_entry_point(self.entry_point_idx as usize);
+                    self.needs_depth_fix(ep_info, global_handle, &class)
+                }
+                else {
+                    false
+                };
+
                 match level {
                     // Auto needs no more arguments
                     crate::SampleLevel::Auto => (),
@@ -3180,7 +3213,16 @@ impl<'a, W: Write> Writer<'a, W> {
                     // Exact and bias require another argument
                     crate::SampleLevel::Exact(expr) => {
                         write!(self.out, ", ")?;
+
+                        if needs_depth_fix {
+                            write!(self.out, "float(")?;
+                        }
+
                         self.write_expr(expr, ctx)?;
+
+                        if needs_depth_fix {
+                            write!(self.out, ")")?;
+                        }
                     }
                     crate::SampleLevel::Bias(_) => {
                         // This needs to be done after the offset writing
@@ -3226,7 +3268,15 @@ impl<'a, W: Write> Writer<'a, W> {
                 }
 
                 // End the function
-                write!(self.out, ")")?
+                write!(self.out, ")")?;
+
+                if needs_depth_fix {
+                    // parser thinks it will yield f32, but in reality it yields vec4f
+                    write!(self.out, ".x")?;
+                }
+
+
+                // TODO: if depth texture but not comparison sampler, add ".x"
             }
             Expression::ImageLoad {
                 image,

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -959,7 +959,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     // The trailing space is important
                     write!(self.out, "uniform ")?;
 
-                    if self.needs_depth_fix(ep_info, handle, &mut class) {
+                    if self.needs_depth_fix(ep_info, handle, &class) {
                         class = crate::ImageClass::Sampled {
                             kind: crate::ScalarKind::Float,
                             multi: false,
@@ -1047,7 +1047,7 @@ impl<'a, W: Write> Writer<'a, W> {
         handle: Handle<crate::GlobalVariable>,
         class: &crate::ImageClass,
     ) -> bool {
-        if let crate::ImageClass::Depth { multi: false } = class {
+        if let crate::ImageClass::Depth { multi: false } = *class {
             // if any sampler uses the comparison sampler, a fix is not needed. Otherwise, we need to actually sample a regular texture as far as glsl is concerned
             !ep_info.sampling_set.iter().all(|key| {
                 let data = &self.module.global_variables[key.sampler];

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -959,7 +959,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     // The trailing space is important
                     write!(self.out, "uniform ")?;
 
-                    if self.needs_depth_fix(ep_info, handle, &class) {
+                    if self.needs_depth_comparison_fix(ep_info, handle, &class) {
                         class = crate::ImageClass::Sampled {
                             kind: crate::ScalarKind::Float,
                             multi: false,
@@ -1041,7 +1041,7 @@ impl<'a, W: Write> Writer<'a, W> {
         self.collect_reflection_info()
     }
 
-    fn needs_depth_fix(
+    fn needs_depth_comparison_fix(
         &mut self,
         ep_info: &valid::FunctionInfo,
         handle: Handle<crate::GlobalVariable>,
@@ -1049,20 +1049,24 @@ impl<'a, W: Write> Writer<'a, W> {
     ) -> bool {
         if let crate::ImageClass::Depth { multi: false } = *class {
             // if any sampler uses the comparison sampler, a fix is not needed. Otherwise, we need to actually sample a regular texture as far as glsl is concerned
-            !ep_info.sampling_set.iter().all(|key| {
-                let data = &self.module.global_variables[key.sampler];
+            for key in &ep_info.sampling_set {
                 if key.image != handle {
-                    return false;
+                    // skip samplers that don't use this image
+                    continue;
                 }
 
-                matches!(
+                let data = &self.module.global_variables[key.sampler];
+
+                if matches!(
                     self.module.types[data.ty].inner,
                     TypeInner::Sampler { comparison: true }
-                )
-            })
-        } else {
-            false
+                ) {
+                    return true;
+                }
+            }
         }
+
+        false
     }
 
     fn write_array_size(
@@ -3196,7 +3200,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 let needs_depth_fix =
                     if let Expression::GlobalVariable(global_handle) = ctx.expressions[image] {
                         let ep_info = self.info.get_entry_point(self.entry_point_idx as usize);
-                        self.needs_depth_fix(ep_info, global_handle, &class)
+                        self.needs_depth_comparison_fix(ep_info, global_handle, &class)
                     } else {
                         false
                     };

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -1040,19 +1040,15 @@ impl<'a, W: Write> Writer<'a, W> {
 
     fn needs_depth_fix(&mut self, ep_info: &valid::FunctionInfo, handle: Handle<crate::GlobalVariable>, class: &crate::ImageClass) -> bool {
         if let crate::ImageClass::Depth { multi: false } = class {
-            let has_shadow_sampler = ep_info.sampling_set.iter().all(|key| {
+            // if any sampler uses the comparison sampler, a fix is not needed. Otherwise, we need to actually sample a regular texture as far as glsl is concerned
+            !ep_info.sampling_set.iter().all(|key| {
                 let data = &self.module.global_variables[key.sampler];
                 if key.image != handle {
                     return false;
                 }
-                return if let TypeInner::Sampler { comparison: true } = &self.module.types[data.ty].inner {
-                    true
-                } else {
-                    false
-                }
-            });
 
-            !has_shadow_sampler
+                matches!(self.module.types[data.ty].inner, TypeInner::Sampler { comparison: true })
+            })
         }
         else {
             false


### PR DESCRIPTION
**Description**
When declaring a `texture_depth_2d` in a shader, naga always outputs the texture uniform as type sampler2DShadow. When only interested in depth values and not comparisons, this breaks. This PR only uses `sampler2DShadow` when a comparison sampler is used for it. This is the only fix that I could come up with that only impacts the gles part.