### PR TITLE
Fix stray comma in function signatures in Metal

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -157,3 +157,4 @@ webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="l
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="loop8"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="switch1"
 //FAIL: 9 invalid_statements subtests due to https://github.com/gfx-rs/wgpu/issues/7733
+webgpu:api,validation,render_pipeline,vertex_state:many_attributes_overlapping:*


### PR DESCRIPTION
**Connections**
Fixes [Bug 1992500](https://bugzilla.mozilla.org/show_bug.cgi?id=1992500)

**Description**
Fixes a regression introduced by https://github.com/gfx-rs/wgpu/pull/8265 where we were mistakenly writing a comma before the first buffer argument (if no other arguments were printed before it).

**Testing**
Enabled more CTS tests.

**Squash or Rebase?**
Rebase.