### PR TITLE
docs(CHANGELOG): polish `enumerate_adapters`-is-`async` section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,14 @@ BREAKING CHANGE: `enumerate_adapters` is now `async`:
 + pub fn enumerate_adapters(&self, backends: Backends) -> impl Future<Output = Vec<Adapter>> {
 ```
 
-This yields two benefits:
+This yields ([kek]) two benefits:
 
 - This method is now implemented on non-native using the standard `Adapter::request_adapter(…)`, making `enumerate_adapters` a portable surface. This was previous a nontrivial pain point when an application wanted to do some of its own filtering of adapters.
 - This method can now be implemented in custom backends.
 
 By @R-Cramer4 in [#8230](https://github.com/gfx-rs/wgpu/pull/8230)
+
+[kek]: https://web.archive.org/web/20250923122958/https://knowyourmeme.com/memes/kek
 
 #### `MipmapFilterMode` is split from `FilterMode`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,17 +40,21 @@ Bottom level categories:
 
 ## Unreleased
 
+### Major changes
+
 #### 'wgpu::Instance::enumerate_adapters` is now `async` & available on WebGPU
 
-Making `enumerate_adapters` async allows custom backends to use it along with eliminating some native/non-native distinctions
-
-This is a breaking change
+BREAKING CHANGE: `enumerate_adapters` is now `async`:
 
 ```diff
 - pub fn enumerate_adapters(&self, backends: Backends) -> Vec<Adapter> {
 + pub fn enumerate_adapters(&self, backends: Backends) -> impl Future<Output = Vec<Adapter>> {
-
 ```
+
+This yields two benefits:
+
+- This method is now implemented on non-native using the standard `Adapter::request_adapter(…)`, making `enumerate_adapters` a portable surface. This was previous a nontrivial pain point when an application wanted to do some of its own filtering of adapters.
+- This method can now be implemented in custom backends.
 
 By @R-Cramer4 in [#8230](https://github.com/gfx-rs/wgpu/pull/8230)
 


### PR DESCRIPTION
Based on #8317 (ETA: now merged). CC @Wumpf, @R-Cramer4.