### PR TITLE
[xtask] Attempt to handle CTS revision moving backwards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5091,6 +5091,7 @@ dependencies = [
  "log",
  "pico-args",
  "regex-lite",
+ "serde_json",
  "xshell",
 ]
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,4 +18,5 @@ env_logger.workspace = true
 regex-lite.workspace = true
 log.workspace = true
 pico-args.workspace = true
+serde_json.workspace = true
 xshell.workspace = true

--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -36,16 +36,19 @@ use regex_lite::{Regex, RegexBuilder};
 use std::{ffi::OsString, sync::LazyLock};
 use xshell::Shell;
 
-use crate::util::git_version_at_least;
+use crate::util::{git_version_at_least, looks_like_git_sha};
 
 /// Path within the repository where the CTS will be checked out.
 const CTS_CHECKOUT_PATH: &str = "cts";
+
+/// Path to git's `shallow` file.
+const GIT_SHALLOW_PATH: &str = ".git/shallow";
 
 /// Path within the repository to a file containing the git revision of the CTS to check out.
 const CTS_REVISION_PATH: &str = "cts_runner/revision.txt";
 
 /// URL of the CTS git repository.
-const CTS_GIT_URL: &str = "https://github.com/gpuweb/cts.git";
+const CTS_GITHUB_PATH: &str = "gpuweb/cts";
 
 /// Path to default CTS test list.
 const CTS_DEFAULT_TEST_LIST: &str = "cts_runner/test.lst";
@@ -54,6 +57,100 @@ const CTS_DEFAULT_TEST_LIST: &str = "cts_runner/test.lst";
 struct TestLine {
     pub selector: OsString,
     pub fails_if: Vec<String>,
+}
+
+fn have_git_sha(shell: &Shell, sha: &str) -> bool {
+    shell
+        .cmd("git")
+        .args(["cat-file", "commit", sha])
+        .quiet()
+        .ignore_stdout()
+        .ignore_stderr()
+        .run()
+        .is_ok()
+}
+
+fn maybe_deepen_git_repo(shell: &Shell, desired: &str) -> anyhow::Result<()> {
+    if shell
+        .cmd("curl")
+        .args([
+            "-f",
+            "-L",
+            "-I",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "-H",
+            "X-GitHub-Api-Version: 2022-11-28",
+        ])
+        .arg(format!(
+            "https://api.github.com/repos/{CTS_GITHUB_PATH}/commits/{desired}"
+        ))
+        .quiet()
+        .ignore_stdout()
+        .ignore_stderr()
+        .run()
+        .is_err()
+    {
+        log::warn!("Not deepening repo because the desired CTS SHA was not found on GitHub.");
+        return Ok(());
+    }
+
+    if !shell.path_exists(GIT_SHALLOW_PATH) {
+        log::warn!("Not deepening repo because it is not a shallow clone.");
+        return Ok(());
+    }
+
+    let shallow = shell
+        .read_file(GIT_SHALLOW_PATH)
+        .context(format!(
+            "Failed to read git shallow SHA from {GIT_SHALLOW_PATH}"
+        ))?
+        .trim()
+        .to_string();
+
+    if !looks_like_git_sha(&shallow) {
+        log::warn!(
+            "Automatic deepening of git repo requires a shallow clone with a single graft point"
+        );
+        return Ok(());
+    }
+
+    let output = shell
+        .cmd("curl")
+        .args([
+            "-f",
+            "-L",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "-H",
+            "X-GitHub-Api-Version: 2022-11-28",
+        ])
+        .arg(format!(
+            "https://api.github.com/repos/{CTS_GITHUB_PATH}/compare/{desired}...{shallow}"
+        ))
+        .output()
+        .context("Error calling GitHub API")?;
+
+    let gh_json: serde_json::Map<String, serde_json::Value> =
+        serde_json::from_slice(&output.stdout).context("Failed parsing GitHub API JSON")?;
+
+    let Some(deepen_count) = gh_json
+        .get("total_commits")
+        .and_then(serde_json::Value::as_u64)
+    else {
+        bail!("missing or invalid total_commits");
+    };
+
+    log::info!("Fetching CTS with --deepen {deepen_count}");
+
+    shell
+        .cmd("git")
+        .args(["fetch", "--deepen", &deepen_count.to_string()])
+        .quiet()
+        .run()
+        .context("Failed to deepen git repo")?;
+
+    Ok(())
 }
 
 pub fn run_cts(
@@ -142,7 +239,11 @@ pub fn run_cts(
         }
         let mut cmd = shell
             .cmd("git")
-            .args(["clone", CTS_GIT_URL, CTS_CHECKOUT_PATH])
+            .args([
+                "clone",
+                &format!("https://github.com/{CTS_GITHUB_PATH}.git"),
+                CTS_CHECKOUT_PATH,
+            ])
             .quiet();
 
         if git_version_at_least(&shell, [2, 49, 0])? {
@@ -187,22 +288,24 @@ pub fn run_cts(
         }
 
         // If we don't have the CTS commit we want, try to fetch it.
-        if shell
-            .cmd("git")
-            .args(["cat-file", "commit", &cts_revision])
-            .quiet()
-            .ignore_stdout()
-            .ignore_stderr()
-            .run()
-            .is_err()
-        {
-            log::info!("Fetching CTS");
+        if !have_git_sha(&shell, &cts_revision) {
+            log::info!("Desired SHA not found, fetching CTS");
             shell
                 .cmd("git")
                 .args(["fetch", "--quiet"])
                 .quiet()
                 .run()
                 .context("Failed to fetch CTS")?;
+        }
+
+        // If we still don't have the commit we want, maybe we need more history.
+        if !have_git_sha(&shell, &cts_revision) {
+            log::info!("Desired SHA still not found, checking if missing from shallow clone");
+            maybe_deepen_git_repo(&shell, &cts_revision)?;
+        }
+
+        if !have_git_sha(&shell, &cts_revision) {
+            bail!("Unable to obtain the desired CTS revision {cts_revision}");
         }
     } else {
         shell.change_dir(CTS_CHECKOUT_PATH);


### PR DESCRIPTION
As of #7800, if the git version is new enough that `git clone` supports the `--revision` option, the CTS xtask does the initial clone of the CTS repository shallowly, fetching only the desired commit of the CTS. Subsequent runs of the xtask will fetch the repository if the desired CTS commit is not present locally, which works when the desired commit is a descendant of the commit in the original shallow clone. However, it does not work if the desired commit is an ancestor of the commit in the original shallow clone.

In CI, we use GitHub actions caching feature to reduce repeated network fetches on each run. The CTS checkout is included in the cache.  

Shortly after the [v27 branch](https://github.com/gfx-rs/wgpu/commits/v27) was created, the CTS version was bumped on trunk. This caused CTS jobs run on the v27 branch to fail (e.g. for 98caa622), because the GitHub actions cache contained a shallow clone of the CTS at a commit after the desired commit for the v27 branch. I fixed the immediate problem by changing the cache tag for the CTS jobs on the v27 branch (in 2ea52e0). This gave jobs running on the v27 branch their own git clones at the CTS commit used on the branch but would not do anything to prevent the same problem from occurring in the future. #8313 was filed for a better solution. 

This PR fixes #8313 by adding an additional step to the xtask when cloning the CTS. Previously, the xtask fetched the CTS if it was not able to check out the desired revision. With this PR, it will still do that, but if the desired revision is still not available after fetching, it calls the GitHub API to determine if deepening the CTS clone can obtain the desired revision (and if so, by how many commits it needs to be deepened).

This seems like it will not be exercised very often, and could bit rot before it ever gets used. Feel free to say "just because you can, doesn't mean you should" and decline this PR.

Putting the branch name in all of our GitHub actions cache keys seems like a reasonable thing to do for various reasons, although doing so has some complications like getting PRs to use the cache for their target branch. Doing that would have helped in this case, but is not as general as the fix here, which would also handle developer checkouts switching between branches and cases where the CTS version moves backwards on the same branch (e.g. reverting a CTS version bump).

Other options are to fall back on a full fetch if the desired SHA is not found, or to delete/rename the clone and do a fresh shallow clone. (I find the latter undesirable because it can delete or hide work that a developer has done locally, although realistically, very few wgpu developers will be making changes to the CTS.)

**Testing**
Tested manually.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
