### PR TITLE
[wgpu-hal] Fix `mismatched_lifetime_syntaxes` lint in `gles`.

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -422,7 +422,7 @@ impl AdapterContext {
     ///
     /// > **Note:** Calling this function **will** still lock the [`glow::Context`] which adds an
     /// > extra safe-guard against accidental concurrent access to the context.
-    pub unsafe fn get_without_egl_lock(&self) -> MappedMutexGuard<glow::Context> {
+    pub unsafe fn get_without_egl_lock(&self) -> MappedMutexGuard<'_, glow::Context> {
         let guard = self
             .glow
             .try_lock_for(Duration::from_secs(CONTEXT_LOCK_TIMEOUT_SECS))


### PR DESCRIPTION
Add a placeholder lifetime to `AdapterContext::get_without_egl_lock` to address Clippy's concerns about easy-to-misread function signatures.
