### PR TITLE
[core] Don't skip binding index checks for derived layouts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ SamplerDescriptor {
 
 - Reject fragment shader output `location`s > `max_color_attachments` limit. By @ErichDonGubler in [#8316](https://github.com/gfx-rs/wgpu/pull/8316).
 - WebGPU device requests now support the required limits `maxColorAttachments` and `maxColorAttachmentBytesPerSample`. By @evilpie in [#8328](https://github.com/gfx-rs/wgpu/pull/8328)
+- Reject binding indices that exceed `wgpu_types::Limits::max_bindings_per_bind_group` when deriving a bind group layout for a pipeline. By @jimblandy in [#8325](https://github.com/gfx-rs/wgpu/pull/8325).
 
 ## v27.0.2 (2025-10-03)
 

--- a/wgpu-core/src/device/bgl.rs
+++ b/wgpu-core/src/device/bgl.rs
@@ -63,19 +63,10 @@ impl EntryMap {
     /// Errors if there are duplicate bindings or if any binding index is greater than
     /// the device's limits.
     pub fn from_entries(
-        device_limits: &wgt::Limits,
         entries: &[wgt::BindGroupLayoutEntry],
     ) -> Result<Self, binding_model::CreateBindGroupLayoutError> {
         let mut inner = FastIndexMap::with_capacity_and_hasher(entries.len(), Default::default());
         for entry in entries {
-            if entry.binding >= device_limits.max_bindings_per_bind_group {
-                return Err(
-                    binding_model::CreateBindGroupLayoutError::InvalidBindingIndex {
-                        binding: entry.binding,
-                        maximum: device_limits.max_bindings_per_bind_group,
-                    },
-                );
-            }
             if inner.insert(entry.binding, *entry).is_some() {
                 return Err(binding_model::CreateBindGroupLayoutError::ConflictBinding(
                     entry.binding,

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -693,7 +693,7 @@ impl Global {
                 break 'error e.into();
             }
 
-            let entry_map = match bgl::EntryMap::from_entries(&device.limits, &desc.entries) {
+            let entry_map = match bgl::EntryMap::from_entries(&desc.entries) {
                 Ok(map) => map,
                 Err(e) => break 'error e,
             };

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2292,6 +2292,15 @@ impl Device {
         }
 
         for entry in entry_map.values() {
+            if entry.binding >= self.limits.max_bindings_per_bind_group {
+                return Err(
+                    binding_model::CreateBindGroupLayoutError::InvalidBindingIndex {
+                        binding: entry.binding,
+                        maximum: self.limits.max_bindings_per_bind_group,
+                    },
+                );
+            }
+
             use wgt::BindingType as Bt;
 
             let mut required_features = wgt::Features::empty();


### PR DESCRIPTION
When deriving a bind group layout for a pipeline, bother to enforce `wgpu_types::Limits::max_bindings_per_bind_group`. Move the check:

- from `wgpu_core::device::bgl::EntryMap::from_entries`, which is only used for explicit bind group creation

- into `wgpu_core::device::Device::create_bind_group_layout`, which is used for all bind group layout creation.
