### PR TITLE
Additional `api_log`ging for passes

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -7,7 +7,7 @@ use wgt::{
 use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use core::{convert::Infallible, fmt, str};
 
-use crate::{binding_model::BindError, resource::RawResourceAccess};
+use crate::{api_log, binding_model::BindError, resource::RawResourceAccess};
 use crate::{
     binding_model::{LateMinBufferBindingSizeMismatch, PushConstantUploadError},
     command::{
@@ -853,6 +853,8 @@ fn set_pipeline(
 }
 
 fn dispatch(state: &mut State, groups: [u32; 3]) -> Result<(), ComputePassErrorInner> {
+    api_log!("ComputePass::dispatch {groups:?}");
+
     state.is_ready()?;
 
     state.flush_states(None)?;
@@ -888,6 +890,8 @@ fn dispatch_indirect(
     buffer: Arc<Buffer>,
     offset: u64,
 ) -> Result<(), ComputePassErrorInner> {
+    api_log!("ComputePass::dispatch_indirect");
+
     buffer.same_device(device)?;
 
     state.is_ready()?;

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -948,20 +948,38 @@ impl CommandEncoder {
                             timestamp_writes,
                             occlusion_query_set,
                         } => {
-                            encode_render_pass(
+                            api_log!(
+                                "Begin encoding render pass with '{}' label",
+                                pass.label.as_deref().unwrap_or("")
+                            );
+                            let res = encode_render_pass(
                                 &mut state,
                                 pass,
                                 color_attachments,
                                 depth_stencil_attachment,
                                 timestamp_writes,
                                 occlusion_query_set,
-                            )?;
+                            );
+                            match res.as_ref() {
+                                Err(err) => api_log!("Finished encoding render pass ({err:?})"),
+                                Ok(_) => api_log!("Finished encoding render pass (success)"),
+                            }
+                            res?;
                         }
                         ArcCommand::RunComputePass {
                             pass,
                             timestamp_writes,
                         } => {
-                            encode_compute_pass(&mut state, pass, timestamp_writes)?;
+                            api_log!(
+                                "Begin encoding compute pass with '{}' label",
+                                pass.label.as_deref().unwrap_or("")
+                            );
+                            let res = encode_compute_pass(&mut state, pass, timestamp_writes);
+                            match res.as_ref() {
+                                Err(err) => api_log!("Finished encoding compute pass ({err:?})"),
+                                Ok(_) => api_log!("Finished encoding compute pass (success)"),
+                            }
+                            res?;
                         }
                         _ => unreachable!(),
                     }


### PR DESCRIPTION
Add some `api_log` invocations that were useful for me and seem consistent with what generally gets logged.

**Testing**
Tested manually

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
