### PR TITLE
Fix bug where mapped range in WebBuffer is not cloned correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ SamplerDescriptor {
 
 ### Bug Fixes
 
+- Fixed bug where mapping sub-ranges of a buffer on web would fail with `OperationError: GPUBuffer.getMappedRange: GetMappedRange range extends beyond buffer's mapped range`. By @ryankaplan in [#8349](https://github.com/gfx-rs/wgpu/pull/8349)
+
 #### General
 
 - Reject fragment shader output `location`s > `max_color_attachments` limit. By @ErichDonGubler in [#8316](https://github.com/gfx-rs/wgpu/pull/8316).

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -688,6 +688,10 @@ fn range_overlaps(a: &Range<BufferAddress>, b: &Range<BufferAddress>) -> bool {
     a.start < b.end && b.start < a.end
 }
 
+fn range_contains(a: &Range<BufferAddress>, b: &Range<BufferAddress>) -> bool {
+    a.start <= b.start && a.end >= b.end
+}
+
 #[derive(Debug, Copy, Clone)]
 enum RangeMappingKind {
     Mutable,
@@ -786,7 +790,7 @@ impl MapContext {
         if self.mapped_range.is_empty() {
             panic!("tried to call get_mapped_range(_mut) on an unmapped buffer");
         }
-        if !range_overlaps(&self.mapped_range, &new_sub.index) {
+        if !range_contains(&self.mapped_range, &new_sub.index) {
             panic!(
                 "tried to call get_mapped_range(_mut) on a range that is not entirely mapped. \
                  Attempted to get range {}, but the mapped range is {}..{}",

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1221,7 +1221,7 @@ pub struct WebBuffer {
     /// The associated GPU buffer.
     inner: webgpu_sys::GpuBuffer,
     /// The mapped array buffer and mapped range.
-    mapping: RefCell<WebBufferMapState>,
+    mapping: Rc<RefCell<WebBufferMapState>>,
     /// Unique identifier for this Buffer.
     ident: crate::cmp::Identifier,
 }
@@ -1231,10 +1231,10 @@ impl WebBuffer {
     fn new(inner: webgpu_sys::GpuBuffer, desc: &crate::BufferDescriptor<'_>) -> Self {
         Self {
             inner,
-            mapping: RefCell::new(WebBufferMapState {
+            mapping: Rc::new(RefCell::new(WebBufferMapState {
                 mapped_buffer: None,
                 range: 0..desc.size,
-            }),
+            })),
             ident: crate::cmp::Identifier::create(),
         }
     }


### PR DESCRIPTION
**Connections**

N/A

**Description**

Mapping sub-ranges of buffers on web is currently broken and fails with `OperationError: GPUBuffer.getMappedRange: GetMappedRange range extends beyond buffer's mapped range`. I have code like the code below in my app that reliably fails on `27.0.1` but not on `26.0.1`. It works again after this PR.

```rust
let for_closure = my_buffer.clone();

my_buffer.slice(..amount_to_read_back).map_async(wgpu::MapMode::Read, move |res| {
  if res.is_err() {
    panic!("Failed to map buffer");
  }

  // This fails with the above error
  let data = for_closure.slice(..amount_to_read_back).get_mapped_range();
});
```

When you call `create_buffer(..)` on web, we create a `WebBuffer` under the hood. This contains a reference to the underlying GPUBuffer and a `WebBufferMapState` which is stores the _last range passed_ to `map_async(..)`.

The bug: this range is stored in a `RefCell<..>` and *not* in an `Rc<RefCell<..>>`. So if you clone the buffer and call `map_async(..)` on one of the clones, the others will have an out-of-date mapped range.

On web, this potentially stale range is used any time someone calls `get_mapped_range(..)`. That because on web when you call `buffer.get_mapped_range(sub_range)` we do not map `sub_range`! We map the range used for `map_async(..)` and then use `sub_range` to get a slice of the appropriate size.

This is a pretty common case because the typical way to call `get_mapped_range(..)` is inside a callback passed to `.map_async(..)`, which requires cloning the buffer.

So this PR wraps WebBufferMapState in an Rc<>, and fixes a validation check that seemed off.

**Testing**

I didn't add new tests, but my app no longer fails with `OperationError: GPUBuffer.getMappedRange: GetMappedRange range extends beyond buffer's mapped range`.

**Squash or Rebase?**

Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests <-- can't find a way to get this to run locally
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry.
