### PR TITLE
fix: Move `DropGuards` to the end of their parent structs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ SamplerDescriptor {
 
 - Align copies b/w textures and buffers via a single intermediate buffer per copy when `D3D12_FEATURE_DATA_D3D12_OPTIONS13.UnrestrictedBufferTextureCopyPitchSupported` is `false`. By @ErichDonGubler in [#7721](https://github.com/gfx-rs/wgpu/pull/7721).
 
+#### hal
+
+- `DropCallback`s are now called after dropping all other fields of their parent structs. By @jerzywilczek in [#8353](https://github.com/gfx-rs/wgpu/pull/8353)
+
 ## v27.0.2 (2025-10-03)
 
 ### Bug Fixes

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -408,13 +408,13 @@ impl TextureInner {
 #[derive(Debug)]
 pub struct Texture {
     pub inner: TextureInner,
-    pub drop_guard: Option<crate::DropGuard>,
     pub mip_level_count: u32,
     pub array_layer_count: u32,
     pub format: wgt::TextureFormat,
     #[allow(unused)]
     pub format_desc: TextureFormatDesc,
     pub copy_size: CopyExtent,
+    pub drop_guard: Option<crate::DropGuard>,
 }
 
 impl crate::DynTexture for Texture {}

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -414,6 +414,9 @@ pub struct Texture {
     #[allow(unused)]
     pub format_desc: TextureFormatDesc,
     pub copy_size: CopyExtent,
+
+    // The `drop_guard` field must be the last field of this struct so it is dropped last.
+    // Do not add new fields after it.
     pub drop_guard: Option<crate::DropGuard>,
 }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -156,7 +156,6 @@ pub struct DebugUtilsMessengerUserData {
 pub struct InstanceShared {
     raw: ash::Instance,
     extensions: Vec<&'static CStr>,
-    drop_guard: Option<crate::DropGuard>,
     flags: wgt::InstanceFlags,
     memory_budget_thresholds: wgt::MemoryBudgetThresholds,
     debug_utils: Option<DebugUtils>,
@@ -171,6 +170,7 @@ pub struct InstanceShared {
     /// It is associated with a `VkInstance` and its children,
     /// except for a `VkPhysicalDevice` and its children.
     instance_api_version: u32,
+    drop_guard: Option<crate::DropGuard>,
 }
 
 pub struct Instance {
@@ -715,7 +715,6 @@ struct DeviceShared {
     family_index: u32,
     queue_index: u32,
     raw_queue: vk::Queue,
-    drop_guard: Option<crate::DropGuard>,
     instance: Arc<InstanceShared>,
     physical_device: vk::PhysicalDevice,
     enabled_extensions: Vec<&'static CStr>,
@@ -737,6 +736,7 @@ struct DeviceShared {
     texture_identity_factory: ResourceIdentityFactory<vk::Image>,
     /// As above, for texture views.
     texture_view_identity_factory: ResourceIdentityFactory<vk::ImageView>,
+    drop_guard: Option<crate::DropGuard>,
 }
 
 impl Drop for DeviceShared {
@@ -945,12 +945,12 @@ impl crate::DynAccelerationStructure for AccelerationStructure {}
 #[derive(Debug)]
 pub struct Texture {
     raw: vk::Image,
-    drop_guard: Option<crate::DropGuard>,
     external_memory: Option<vk::DeviceMemory>,
     block: Option<gpu_alloc::MemoryBlock<vk::DeviceMemory>>,
     format: wgt::TextureFormat,
     copy_size: crate::CopyExtent,
     identity: ResourceIdentity<vk::Image>,
+    drop_guard: Option<crate::DropGuard>,
 }
 
 impl crate::DynTexture for Texture {}

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -170,6 +170,9 @@ pub struct InstanceShared {
     /// It is associated with a `VkInstance` and its children,
     /// except for a `VkPhysicalDevice` and its children.
     instance_api_version: u32,
+
+    // The `drop_guard` field must be the last field of this struct so it is dropped last.
+    // Do not add new fields after it.
     drop_guard: Option<crate::DropGuard>,
 }
 
@@ -736,6 +739,9 @@ struct DeviceShared {
     texture_identity_factory: ResourceIdentityFactory<vk::Image>,
     /// As above, for texture views.
     texture_view_identity_factory: ResourceIdentityFactory<vk::ImageView>,
+
+    // The `drop_guard` field must be the last field of this struct so it is dropped last.
+    // Do not add new fields after it.
     drop_guard: Option<crate::DropGuard>,
 }
 
@@ -950,6 +956,9 @@ pub struct Texture {
     format: wgt::TextureFormat,
     copy_size: crate::CopyExtent,
     identity: ResourceIdentity<vk::Image>,
+
+    // The `drop_guard` field must be the last field of this struct so it is dropped last.
+    // Do not add new fields after it.
     drop_guard: Option<crate::DropGuard>,
 }
 


### PR DESCRIPTION
**Connections**
None

**Description**
Currently, some structures in vulkan and gles have `DropGuard`s. Those are intended to allow creation of `wgpu_hal` structs, such as `Device`, from their raw counterparts initialized manually by the user. The drop guard signals to the user when the resource is not used by wgpu anymore so that they know it can be cleaned up.

The problem is that `DropGuard`s are not last members of `wgpu_hal` structs. Struct's fields are dropped in declaration order. This can lead to problems, such as the fields defined later in the struct requiring the underlying raw structure to be alive in order to free themselves properly, and the raw structure not being alive because the `DropGuard` was dropped earlier.

This patch moves the drop guards to the end of their parent structs.

**Testing**
Not sure how to test this or if testing is necessary

**Squash or Rebase?**
Squash I guess...

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
  181 failed tests, with and without the changes
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
