### PR TITLE
[hal] Remove spurious Cargo features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ SamplerDescriptor {
 - Reject fragment shader output `location`s > `max_color_attachments` limit. By @ErichDonGubler in [#8316](https://github.com/gfx-rs/wgpu/pull/8316).
 - WebGPU device requests now support the required limits `maxColorAttachments` and `maxColorAttachmentBytesPerSample`. By @evilpie in [#8328](https://github.com/gfx-rs/wgpu/pull/8328)
 - Reject binding indices that exceed `wgpu_types::Limits::max_bindings_per_bind_group` when deriving a bind group layout for a pipeline. By @jimblandy in [#8325](https://github.com/gfx-rs/wgpu/pull/8325).
+- Removed three features from `wgpu-hal` which did nothing useful: `"cargo-clippy"`, `"gpu-allocator"`, and `"rustc-hash"`. By @kpreid in [#8357](https://github.com/gfx-rs/wgpu/pull/8357).
 
 #### DX12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4981,7 +4981,6 @@ dependencies = [
  "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
  "renderdoc-sys",
- "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.17",
  "wasm-bindgen",

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -141,7 +141,7 @@ dx12 = [
     "dep:profiling",
     "dep:range-alloc",
     "dep:windows-core",
-    "gpu-allocator/d3d12",
+    "dep:gpu-allocator",
     "windows/Win32_Graphics_Direct3D_Fxc",
     "windows/Win32_Graphics_Direct3D_Dxc",
     "windows/Win32_Graphics_Direct3D",
@@ -258,7 +258,7 @@ windows-core = { workspace = true, optional = true }
 # Backend: Dx12
 bit-set = { workspace = true, optional = true }
 range-alloc = { workspace = true, optional = true }
-gpu-allocator = { workspace = true, optional = true }
+gpu-allocator = { workspace = true, optional = true, features = ["d3d12"] }
 once_cell = { workspace = true, optional = true }
 # backend: GLES
 glutin_wgl_sys = { workspace = true, optional = true }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -219,7 +219,6 @@ hashbrown = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 ordered-float = { workspace = true, optional = true }
 profiling = { workspace = true, optional = true, default-features = false }
-rustc-hash = { workspace = true, optional = true }
 
 # Backend: GLES
 glow = { workspace = true, optional = true }

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -36,7 +36,8 @@ ignored = ["cfg_aliases"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(web_sys_unstable_apis)', # web-sys uses this
+    'cfg(feature, values("cargo-clippy"))', # objc's `msg_send` macro injects this in our code https://github.com/SSheldon/rust-objc/issues/125
+    'cfg(web_sys_unstable_apis)',           # web-sys uses this
 ] }
 
 [lib]
@@ -181,14 +182,6 @@ device_lost_panic = []
 internal_error_panic = []
 # Tracks validation errors in a `VALIDATION_CANARY` static.
 validation_canary = ["dep:parking_lot"]
-
-###################
-### Workarounds ###
-###################
-
-# objc's `msg_send` macro injects this in our code https://github.com/SSheldon/rust-objc/issues/125
-# You shouldn't ever enable this feature.
-cargo-clippy = []
 
 [[example]]
 name = "halmark"


### PR DESCRIPTION
**Description**
Removes 3 features that do nothing, and 1 dependency:

* `cargo-clippy` — Is a workaround that can be replaced with private lint configuration.
* `gpu-allocator` — Probably accidental implicit feature; has no effect other than unnecessarily compiling `gpu-allocator`.
* `rustc-hash` — Has no effect other than unnecessarily compiling `rustc-hash`.

This PR was inspired by looking at my own project’s platform-specific dependencies via wgpu, and prepared by reviewing the feature list at <https://docs.rs/crate/wgpu-hal/27.0.2/features>.

**Testing**
`xtask test`, `cargo clippy --all-features --all-targets`

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [x] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [X] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
