### PR TITLE
Prune unused dependencies.

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -13,6 +13,7 @@ skip = [
     { name = "nanorand", version = "0.7.0" },
 
     # Deno uses an old version
+    { name = "bincode", version = "1.3.3" },
     { name = "which", version = "6.0.3" },
 
     # Winit uses an old version
@@ -25,11 +26,6 @@ skip = [
     { name = "windows-interface", version = "0.59.1" },
     { name = "windows-result", version = "0.3.4" },
     { name = "windows-strings", version = "0.4.2" },
-
-    # bindgen (used by deno) uses old version
-    { name = "itertools", version = "0.13.0" },
-    # Deno uses an old version
-    { name = "bincode", version = "1.3.3" },
 ]
 wildcards = "deny"
 allow-wildcard-paths = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,15 +2520,12 @@ name = "naga-test"
 version = "27.0.0"
 dependencies = [
  "bitflags 2.9.4",
- "env_logger",
  "naga",
  "ron",
- "rspirv",
  "serde",
  "serde_json",
  "spirv",
  "toml",
- "walkdir",
 ]
 
 [[package]]
@@ -4781,7 +4778,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "document-features",
- "hashbrown 0.16.0",
  "js-sys",
  "log",
  "naga",

--- a/naga-test/Cargo.toml
+++ b/naga-test/Cargo.toml
@@ -29,11 +29,8 @@ naga = { workspace = true, features = [
     "hlsl-out",
 ] }
 spirv = { workspace = true, features = ["deserialize"] }
-rspirv.workspace = true
 ron.workspace = true
 toml.workspace = true
 bitflags.workspace = true
 serde_json.workspace = true
 serde.workspace = true
-walkdir.workspace = true
-env_logger.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -33,6 +33,10 @@ webgl = ["wgpu/webgl"]
 # allows us to force the build to have profiling code enabled so we can test that configuration.
 test-build-with-profiling = ["profiling/type-check"]
 
+# Note that even though this is a package of tests and a library of tests, there is a split of
+# [depenencies] and [dev-dependencies]. This is because keeping as many deps as possible as
+# dev-dependencies will make the dependency graph just a bit shallower, and makes
+# `cargo clippy -- -Wunused-crate-dependencies` give fewer false positives.
 [dependencies]
 wgpu = { workspace = true, features = ["noop"] }
 wgpu-hal = { workspace = true, features = ["validation_canary"] }
@@ -40,25 +44,27 @@ wgpu-macros.workspace = true
 
 anyhow.workspace = true
 arrayvec.workspace = true
-approx.workspace = true
 bitflags.workspace = true
 bytemuck.workspace = true
 cfg-if.workspace = true
 ctor.workspace = true
 futures-lite.workspace = true
+libtest-mimic.workspace = true
+log.workspace = true
+png.workspace = true
+pollster.workspace = true
+profiling.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+approx.workspace = true
 glam.workspace = true
 half = { workspace = true, features = ["bytemuck", "std"] }
 itertools.workspace = true
 image.workspace = true
-libtest-mimic.workspace = true
-log.workspace = true
 nanorand.workspace = true
 parking_lot.workspace = true
-png.workspace = true
-pollster.workspace = true
-profiling.workspace = true
-serde_json.workspace = true
-serde.workspace = true
 strum = { workspace = true, features = ["derive"] }
 trybuild.workspace = true
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -192,7 +192,6 @@ arrayvec.workspace = true
 bitflags.workspace = true
 cfg-if.workspace = true
 document-features.workspace = true
-hashbrown.workspace = true
 log.workspace = true
 parking_lot = { workspace = true, optional = true }
 profiling.workspace = true


### PR DESCRIPTION
**Description**

* Removed unnecessary dependency in `wgpu` on `hashbrown`.
* Removed unused dependencies in `naga-test`.
* Moved some dependencies in `wgpu-test` to `[dev-dependencies]` (see comment for why this is worth doing).

Candidates were discovered by `cargo clippy -- -Wunused-crate-dependencies`. This command reports whether each dependency is unused in each *crate*, so it has false positives when a dependency is used by only some crates in a package, but it is still useful as a short-list.

**Testing**
`xtask test`

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [x] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
