### PR TITLE
Expose vulkan buffer usages

### DIFF
--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -26,7 +26,7 @@ Otherwise, we manage a pool of `VkFence` objects behind each `hal::Fence`.
 
 mod adapter;
 mod command;
-mod conv;
+pub mod conv;
 mod device;
 mod drm;
 mod instance;


### PR DESCRIPTION
**Connections**

**Description**
One line change to expose functions in `wgpu_hal::vulkan::conv`, e.g. `map_texture_usage` and `map_buffer_usage`

**Testing**
Not tested
Squash. Also its only one commit with bad naming so don't do it from phone or whatever mistake happened last time

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
