### PR TITLE
Disallow mixing command encoding APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ SamplerDescriptor {
 #### General
 
 - Texture now has `from_custom`. By @R-Cramer4 in [#8315](https://github.com/gfx-rs/wgpu/pull/8315).
+- Using both the wgpu command encoding APIs and `CommandEncoder::as_hal_mut` on the same encoder will now result in a panic.
 
 ### Bug Fixes
 

--- a/tests/tests/wgpu-validation/api/encoding.rs
+++ b/tests/tests/wgpu-validation/api/encoding.rs
@@ -1,0 +1,50 @@
+//! Tests of [`wgpu::CommandEncoder`] and related.
+
+#[test]
+fn as_hal() {
+    // Sanity-test that the raw encoding API isn't completely broken.
+
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    unsafe {
+        encoder.as_hal_mut::<wgpu_hal::api::Noop, _, ()>(|_| ());
+    }
+    encoder.finish();
+}
+
+#[test]
+#[should_panic = "Mixing the wgpu encoding API with the raw encoding API is not permitted"]
+fn mix_apis_wgpu_then_hal() {
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 256,
+        usage: wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    encoder.clear_buffer(&buffer, 0, None);
+    unsafe {
+        encoder.as_hal_mut::<wgpu_hal::api::Noop, _, ()>(|_| ());
+    }
+}
+
+#[test]
+#[should_panic = "Mixing the wgpu encoding API with the raw encoding API is not permitted"]
+fn mix_apis_hal_then_wgpu() {
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 256,
+        usage: wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    unsafe {
+        encoder.as_hal_mut::<wgpu_hal::api::Noop, _, ()>(|_| ());
+    }
+    encoder.clear_buffer(&buffer, 0, None);
+}

--- a/tests/tests/wgpu-validation/api/mod.rs
+++ b/tests/tests/wgpu-validation/api/mod.rs
@@ -4,6 +4,7 @@ mod buffer_mapping;
 mod buffer_slice;
 mod command_buffer_actions;
 mod device;
+mod encoding;
 mod experimental;
 mod external_texture;
 mod instance;

--- a/wgpu-core/src/as_hal.rs
+++ b/wgpu-core/src/as_hal.rs
@@ -330,6 +330,12 @@ impl Global {
         })
     }
 
+    /// Encode commands using the raw HAL command encoder.
+    ///
+    /// # Panics
+    ///
+    /// If the command encoder has already been used with the wgpu encoding API.
+    ///
     /// # Safety
     ///
     /// - The raw command encoder handle must not be manually destroyed

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -87,6 +87,7 @@ impl Global {
 
         let mut cmd_buf_data = cmd_enc.data.lock();
         cmd_buf_data.with_buffer(
+            crate::command::EncodingApi::Raw,
             |cmd_buf_data| -> Result<(), BuildAccelerationStructureError> {
                 let device = &cmd_enc.device;
                 device.check_is_valid()?;

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -406,6 +406,7 @@ impl PendingWrites {
                     list: vec![cmd_buf],
                     device: device.clone(),
                     is_open: false,
+                    api: crate::command::EncodingApi::InternalUse,
                     label: "(wgpu internal) PendingWrites command encoder".into(),
                 },
                 trackers: Tracker::new(),

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -310,8 +310,16 @@ impl CommandEncoder {
 
 /// [`Features::EXPERIMENTAL_RAY_QUERY`] must be enabled on the device in order to call these functions.
 impl CommandEncoder {
-    /// Mark acceleration structures as being built. ***Should only*** be used with wgpu-hal
-    /// functions, all wgpu functions already mark acceleration structures as built.
+    /// When encoding the acceleration structure build with the raw Hal encoder
+    /// (obtained from [`CommandEncoder::as_hal_mut`]), this function marks the
+    /// acceleration structures as having been built.
+    ///
+    /// This function must only be used with the raw encoder API. When using the
+    /// wgpu encoding API, acceleration structure build is tracked automatically.
+    ///
+    /// # Panics
+    ///
+    /// - If the encoder is being used with the wgpu encoding API.
     ///
     /// # Safety
     ///


### PR DESCRIPTION
Follow-up to #8220. @Vecvec pointed out that the behavior when mixing calls to the two APIs was changed by that PR. Since we don't have any tests for behavior when mixing the APIs, and don't know of use cases, it seems simplest to disallow it entirely.

**Testing**
Adds `wgpu-validation` tests.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] Adds a `CHANGELOG.md` entry.
