### PR TITLE
[types] Replace conditional `derive(thiserror::Error)` with unconditional `impl`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ SamplerDescriptor {
 - WebGPU device requests now support the required limits `maxColorAttachments` and `maxColorAttachmentBytesPerSample`. By @evilpie in [#8328](https://github.com/gfx-rs/wgpu/pull/8328)
 - Reject binding indices that exceed `wgpu_types::Limits::max_bindings_per_bind_group` when deriving a bind group layout for a pipeline. By @jimblandy in [#8325](https://github.com/gfx-rs/wgpu/pull/8325).
 - Removed three features from `wgpu-hal` which did nothing useful: `"cargo-clippy"`, `"gpu-allocator"`, and `"rustc-hash"`. By @kpreid in [#8357](https://github.com/gfx-rs/wgpu/pull/8357).
+- `wgpu_types::PollError` now always implements the `Error` trait. By @kpreid in [#8384](https://github.com/gfx-rs/wgpu/pull/8384).
 
 #### DX12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5062,7 +5062,6 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
  "web-sys",
 ]
 

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -37,7 +37,7 @@ alloc_instead_of_core = "warn"
 
 [features]
 default = ["std"]
-std = ["js-sys?/std", "web-sys?/std", "thiserror/std"]
+std = ["js-sys?/std", "web-sys?/std"]
 strict_asserts = []
 fragile-send-sync-non-atomic-wasm = []
 serde = ["dep:serde", "bitflags/serde"]
@@ -52,7 +52,6 @@ web = ["dep:js-sys", "dep:web-sys"]
 bitflags.workspace = true
 bytemuck = { workspace = true, features = ["derive"] }
 log.workspace = true
-thiserror = { workspace = true, optional = true }
 serde = { workspace = true, default-features = false, features = [
     "alloc",
     "derive",


### PR DESCRIPTION
**Connections**
Fixes #8380.

**Description**
This is two changes in one:

* Make `PollError` always implement `Error` (fixes #8380).
* Remove the dependency on `thiserror`, even though we use it elsewhere, because having shorter chains of dependencies is good for build parallelism.

**Testing**
Reviewed documentation to confirm that the `Error` implementation is present as it should be.

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
