### PR TITLE
Remove `!encoder.is_open` assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,17 @@ Bottom level categories:
 
 ### Bug Fixes
 
+#### General
+
+- Remove an assertion that causes problems if `CommandEncoder::as_hal_mut` is used. By @andyleiserson in [#8387](https://github.com/gfx-rs/wgpu/pull/8387).
+
 #### DX12
 
 - Align copies b/w textures and buffers via a single intermediate buffer per copy when `D3D12_FEATURE_DATA_D3D12_OPTIONS13.UnrestrictedBufferTextureCopyPitchSupported` is `false`. By @ErichDonGubler in [#7721](https://github.com/gfx-rs/wgpu/pull/7721).
+
+#### Naga
+
+- Fix a bug that resulted in the Metal error `program scope variable must reside in constant address space` in some cases. Backport of [#8311](https://github.com/gfx-rs/wgpu/pull/8311) by @teoxoy.
 
 ## v27.0.2 (2025-10-03)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
 name = "cts_runner"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "deno_console",
  "deno_core",
@@ -1920,7 +1920,7 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hlsl-snapshots"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "anyhow",
  "nanoserde",
@@ -2328,7 +2328,7 @@ checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock-analyzer"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "anyhow",
  "ron",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "naga-cli"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "anyhow",
  "argh",
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "naga-fuzz"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "arbitrary",
  "cfg_aliases 0.2.1",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "naga-test"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "bitflags 2.9.4",
  "env_logger",
@@ -3172,7 +3172,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "player"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "bytemuck",
  "env_logger",
@@ -4784,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.4",
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-benchmark"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "bincode 2.0.1",
  "bytemuck",
@@ -4829,7 +4829,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -4862,28 +4862,28 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "wgpu-hal",
 ]
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-examples"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-info"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-macros"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "heck",
  "quote",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-test"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.1"
+version = "27.0.2"
 dependencies = [
  "bitflags 2.9.4",
  "bytemuck",

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -357,11 +357,7 @@ impl CommandEncoderStatus {
         // Replace our state with `Consumed`, and return either the inner
         // state or an error, to be transferred to the command buffer.
         match mem::replace(self, Self::Consumed) {
-            Self::Recording(inner) => {
-                // Nothing should have opened the encoder yet.
-                assert!(!inner.encoder.is_open);
-                Self::Finished(inner)
-            }
+            Self::Recording(inner) => Self::Finished(inner),
             Self::Consumed | Self::Finished(_) => Self::Error(EncoderStateError::Ended.into()),
             Self::Locked(_) => Self::Error(EncoderStateError::Locked.into()),
             st @ Self::Error(_) => st,


### PR DESCRIPTION
Note: target is `v27` branch. This backports a variation of a change in #8373.

As discussed in #8373, the assertion that `!encoder.is_open` is falsified when `CommandEncoder::as_hal_mut` has been called, so remove it.

Also adds a changelog entry for https://github.com/gfx-rs/wgpu/commit/98caa62267ff2b723b23ea44d1488fd4a7a690f8 and a commit that updates Cargo.lock for the v27.0.2 release.

**Testing**
Untested here, but there are some related tests added on trunk in #8373.

**Squash or Rebase?** Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
