### PR TITLE
Backport #8371 `ordered-float` fix to v27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ obj = "0.10"
 # NOTE: once_cell/std is *required* for some commonly-used features, selecting this per crate
 once_cell = { version = "1.21", default-features = false }
 # Firefox has 3.4.0 vendored, so we allow that version in our dependencies
-ordered-float = { version = ">=3, <=5.0", default-features = false }
+ordered-float = { version = ">=3, <6.0", default-features = false }
 parking_lot = "0.12.3"
 petgraph = { version = "0.8", default-features = false }
 pico-args = { version = "0.5", features = [


### PR DESCRIPTION
**Connections**
Fixes #8404 by backporting the fix to v27 maintenance branch

**Testing**
`xtask test`

**Squash or Rebase?**
Rebase

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
