### PR TITLE
An even fancier `CHANGELOG` check in CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,6 +10,8 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
+      - unlabeled
 
 env:
   #
@@ -42,6 +44,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      # NOTE: Keep label name(s) in sync. with `xtask`'s implementation.
       - name: Run `cargo xtask changelog …`
         run: |
-          cargo xtask changelog "origin/${{ github.event.pull_request.base.ref }}"
+          cargo xtask changelog "origin/${{ github.event.pull_request.base.ref }}" ${{ contains(github.event.pull_request.labels.*.name, 'changelog: released entry changed') && '--allow-released-changes' || ''  }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,6 +6,10 @@ on:
       - ".github/workflows/changelog.yml"
       - "CHANGELOG.md"
       - "xtask/**/*"
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 env:
   #

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -6,6 +6,7 @@ use xshell::Shell;
 
 pub(crate) fn check_changelog(shell: Shell, mut args: Arguments) -> anyhow::Result<()> {
     const CHANGELOG_PATH_RELATIVE: &str = "./CHANGELOG.md";
+    let allow_released_changes = args.contains("--allow-released-changes");
 
     let from_branch = args
         .free_from_str()
@@ -72,7 +73,12 @@ pub(crate) fn check_changelog(shell: Shell, mut args: Arguments) -> anyhow::Resu
             "one or more checks against `{}` failed; see above for details",
             CHANGELOG_PATH_RELATIVE,
         );
-        Err(anyhow::Error::msg(msg))
+        if allow_released_changes {
+            log::warn!("{msg}");
+            Ok(())
+        } else {
+            Err(anyhow::Error::msg(msg))
+        }
     } else {
         Ok(())
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -53,6 +53,8 @@ Commands:
 
         `<to_commit>` is the tip of the `git diff` that will be used for checking (1).
 
+    --allow-released-changes  Only reports issues as warnings, rather than reporting errors and forcing a non-zero exit code.
+
   miri
     Run all miri-compatible tests under miri. Requires a nightly toolchain
     with the x86_64-unknown-linux-gnu target and miri component installed.


### PR DESCRIPTION
Builds on <https://github.com/gfx-rs/wgpu/pull/8351> by allowing an escape hatch for the `CHANGELOG` check in CI. If a `changelog: released entry changed` label is applied to the PR, the check is run with the `--warn-only` flag, which emits [`warning`s](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-warning-message) instead of `error`s, and emits error code 0. The check triggers on label changes, so no push is needed to apply this escape hatch.