### PR TITLE
Defer some bind group processing until draw/dispatch

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -125,7 +125,13 @@ webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,depth
 // FAIL: webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,depthSlice,overlaps,diff_miplevel:*
 webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,*
 webgpu:api,validation,render_pass,resolve:resolve_attachment:*
+webgpu:api,validation,resource_usages,buffer,in_pass_encoder:*
+// FAIL: 8 other cases in resource_usages,texture,in_pass_encoder. https://github.com/gfx-rs/wgpu/issues/3126
+webgpu:api,validation,resource_usages,texture,in_pass_encoder:scope,*
+webgpu:api,validation,resource_usages,texture,in_pass_encoder:shader_stages_and_visibility,*
+webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_aspect:*
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_color:compute=false;type0="render-target";type1="render-target"
+webgpu:api,validation,resource_usages,texture,in_pass_encoder:unused_bindings_in_pipeline:*
 webgpu:api,validation,texture,rg11b10ufloat_renderable:*
 webgpu:api,operation,render_pipeline,overrides:*
 webgpu:api,operation,rendering,basic:clear:*

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -293,21 +293,14 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
         }
 
         for bind_group in self.pass.binder.list_active() {
-            unsafe {
-                self.intermediate_trackers
-                    .set_and_remove_from_usage_scope_sparse(&mut self.pass.scope, &bind_group.used)
-            }
+            self.intermediate_trackers
+                .set_from_bind_group(&mut self.pass.scope, &bind_group.used);
         }
 
         // Add the state of the indirect buffer if it hasn't been hit before.
-        unsafe {
-            self.intermediate_trackers
-                .buffers
-                .set_and_remove_from_usage_scope_sparse(
-                    &mut self.pass.scope.buffers,
-                    indirect_buffer,
-                );
-        }
+        self.intermediate_trackers
+            .buffers
+            .set_multiple(&mut self.pass.scope.buffers, indirect_buffer);
 
         CommandEncoder::drain_barriers(
             self.pass.base.raw_encoder,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -7,7 +7,10 @@ use wgt::{
 use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use core::{convert::Infallible, fmt, str};
 
-use crate::{api_log, binding_model::BindError, resource::RawResourceAccess};
+use crate::{
+    api_log, binding_model::BindError, command::pass::flush_bindings_helper,
+    resource::RawResourceAccess,
+};
 use crate::{
     binding_model::{LateMinBufferBindingSizeMismatch, PushConstantUploadError},
     command::{
@@ -280,27 +283,68 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
         }
     }
 
-    // `extra_buffer` is there to represent the indirect buffer that is also
-    // part of the usage scope.
-    fn flush_states(
+    /// Flush binding state in preparation for a dispatch.
+    ///
+    /// # Differences between render and compute passes
+    ///
+    /// There are differences between the `flush_bindings` implementations for
+    /// render and compute passes, because render passes have a single usage
+    /// scope for the entire pass, and compute passes have a separate usage
+    /// scope for each dispatch.
+    ///
+    /// For compute passes, bind groups are merged into a fresh usage scope
+    /// here, not into the pass usage scope within calls to `set_bind_group`. As
+    /// specified by WebGPU, for compute passes, we merge only the bind groups
+    /// that are actually used by the pipeline, unlike render passes, which
+    /// merge every bind group that is ever set, even if it is not ultimately
+    /// used by the pipeline.
+    ///
+    /// For compute passes, we call `drain_barriers` here, because barriers may
+    /// be needed before each dispatch if a previous dispatch had a conflicting
+    /// usage. For render passes, barriers are emitted once at the start of the
+    /// render pass.
+    ///
+    /// # Indirect buffer handling
+    ///
+    /// For indirect dispatches without validation, pass both `indirect_buffer`
+    /// and `indirect_buffer_index_if_not_validating`. The indirect buffer will
+    /// be added to the usage scope and the tracker.
+    ///
+    /// For indirect dispatches with validation, pass only `indirect_buffer`.
+    /// The indirect buffer will be added to the usage scope to detect usage
+    /// conflicts. The indirect buffer does not need to be added to the tracker;
+    /// the indirect validation code handles transitions manually.
+    fn flush_bindings(
         &mut self,
-        indirect_buffer: Option<TrackerIndex>,
-    ) -> Result<(), ResourceUsageCompatibilityError> {
-        for bind_group in self.pass.binder.list_active() {
-            unsafe { self.pass.scope.merge_bind_group(&bind_group.used)? };
-            // Note: stateless trackers are not merged: the lifetime reference
-            // is held to the bind group itself.
-        }
+        indirect_buffer: Option<&Arc<Buffer>>,
+        indirect_buffer_index_if_not_validating: Option<TrackerIndex>,
+    ) -> Result<(), ComputePassErrorInner> {
+        let mut scope = self.pass.base.device.new_usage_scope();
 
         for bind_group in self.pass.binder.list_active() {
-            self.intermediate_trackers
-                .set_from_bind_group(&mut self.pass.scope, &bind_group.used);
+            unsafe { scope.merge_bind_group(&bind_group.used)? };
         }
 
-        // Add the state of the indirect buffer if it hasn't been hit before.
+        // When indirect validation is turned on, our actual use of the buffer
+        // is `STORAGE_READ_ONLY`, but for usage scope validation, we still want
+        // to treat it as indirect so we can detect the conflicts prescribed by
+        // WebGPU. The usage scope we construct here never leaves this function
+        // (and is not used to populate a tracker), so it's fine to do this.
+        if let Some(buffer) = indirect_buffer {
+            scope
+                .buffers
+                .merge_single(buffer, wgt::BufferUses::INDIRECT)?;
+        }
+
+        // Add the state of the indirect buffer, if needed (see above).
         self.intermediate_trackers
             .buffers
-            .set_multiple(&mut self.pass.scope.buffers, indirect_buffer);
+            .set_multiple(&mut scope.buffers, indirect_buffer_index_if_not_validating);
+
+        flush_bindings_helper(&mut self.pass, |bind_group| {
+            self.intermediate_trackers
+                .set_from_bind_group(&mut scope, &bind_group.used)
+        })?;
 
         CommandEncoder::drain_barriers(
             self.pass.base.raw_encoder,
@@ -821,7 +865,7 @@ fn set_pipeline(
     }
 
     // Rebind resources
-    pass::rebind_resources::<ComputePassErrorInner, _>(
+    pass::change_pipeline_layout::<ComputePassErrorInner, _>(
         &mut state.pass,
         &pipeline.layout,
         &pipeline.late_sized_buffer_groups,
@@ -850,7 +894,7 @@ fn dispatch(state: &mut State, groups: [u32; 3]) -> Result<(), ComputePassErrorI
 
     state.is_ready()?;
 
-    state.flush_states(None)?;
+    state.flush_bindings(None, None)?;
 
     let groups_size_limit = state
         .pass
@@ -1051,7 +1095,7 @@ fn dispatch_indirect(
                 }]);
         }
 
-        state.flush_states(None)?;
+        state.flush_bindings(Some(&buffer), None)?;
         unsafe {
             state
                 .pass
@@ -1060,14 +1104,8 @@ fn dispatch_indirect(
                 .dispatch_indirect(params.dst_buffer, 0);
         }
     } else {
-        state
-            .pass
-            .scope
-            .buffers
-            .merge_single(&buffer, wgt::BufferUses::INDIRECT)?;
-
         use crate::resource::Trackable;
-        state.flush_states(Some(buffer.tracker_index()))?;
+        state.flush_bindings(Some(&buffer), Some(buffer.tracker_index()))?;
 
         let buf_raw = buffer.try_raw(state.pass.base.snatch_guard)?;
         unsafe {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -11,7 +11,9 @@ use wgt::{
 };
 
 use crate::command::{
-    encoder::EncodingState, pass, pass_base, pass_try, validate_and_begin_occlusion_query,
+    encoder::EncodingState,
+    pass::{self, flush_bindings_helper},
+    pass_base, pass_try, validate_and_begin_occlusion_query,
     validate_and_begin_pipeline_statistics_query, ArcCommand, DebugGroupError, EncoderStateError,
     InnerCommandEncoder, PassStateError, TimestampWritesError,
 };
@@ -569,6 +571,15 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
         } else {
             Err(DrawError::MissingPipeline(pass::MissingPipeline))
         }
+    }
+
+    /// Flush binding state in preparation for a draw call.
+    ///
+    /// See the compute pass version for an explanation of some ways that
+    /// `flush_bindings` differs between the two types of passes.
+    fn flush_bindings(&mut self) -> Result<(), RenderPassErrorInner> {
+        flush_bindings_helper(&mut self.pass, |_| {})?;
+        Ok(())
     }
 
     /// Reset the `RenderBundle`-related states.
@@ -2376,7 +2387,7 @@ fn set_pipeline(
     }
 
     // Rebind resource
-    pass::rebind_resources::<RenderPassErrorInner, _>(
+    pass::change_pipeline_layout::<RenderPassErrorInner, _>(
         &mut state.pass,
         &pipeline.layout,
         &pipeline.late_sized_buffer_groups,
@@ -2610,10 +2621,11 @@ fn draw(
     instance_count: u32,
     first_vertex: u32,
     first_instance: u32,
-) -> Result<(), DrawError> {
+) -> Result<(), RenderPassErrorInner> {
     api_log!("RenderPass::draw {vertex_count} {instance_count} {first_vertex} {first_instance}");
 
     state.is_ready(DrawCommandFamily::Draw)?;
+    state.flush_bindings()?;
 
     state
         .vertex
@@ -2644,10 +2656,11 @@ fn draw_indexed(
     first_index: u32,
     base_vertex: i32,
     first_instance: u32,
-) -> Result<(), DrawError> {
+) -> Result<(), RenderPassErrorInner> {
     api_log!("RenderPass::draw_indexed {index_count} {instance_count} {first_index} {base_vertex} {first_instance}");
 
     state.is_ready(DrawCommandFamily::DrawIndexed)?;
+    state.flush_bindings()?;
 
     let last_index = first_index as u64 + index_count as u64;
     let index_limit = state.index.limit;
@@ -2655,7 +2668,8 @@ fn draw_indexed(
         return Err(DrawError::IndexBeyondLimit {
             last_index,
             index_limit,
-        });
+        }
+        .into());
     }
     state
         .vertex
@@ -2681,10 +2695,11 @@ fn draw_mesh_tasks(
     group_count_x: u32,
     group_count_y: u32,
     group_count_z: u32,
-) -> Result<(), DrawError> {
+) -> Result<(), RenderPassErrorInner> {
     api_log!("RenderPass::draw_mesh_tasks {group_count_x} {group_count_y} {group_count_z}");
 
     state.is_ready(DrawCommandFamily::DrawMeshTasks)?;
+    state.flush_bindings()?;
 
     let groups_size_limit = state
         .pass
@@ -2702,7 +2717,8 @@ fn draw_mesh_tasks(
             current: [group_count_x, group_count_y, group_count_z],
             limit: groups_size_limit,
             max_total: max_groups,
-        });
+        }
+        .into());
     }
 
     unsafe {
@@ -2732,6 +2748,7 @@ fn multi_draw_indirect(
     );
 
     state.is_ready(family)?;
+    state.flush_bindings()?;
 
     state
         .pass
@@ -2913,6 +2930,7 @@ fn multi_draw_indirect_count(
     );
 
     state.is_ready(family)?;
+    state.flush_bindings()?;
 
     let stride = get_stride_of_indirect_args(family);
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1799,6 +1799,12 @@ fn validate_command_buffer(
                 }
             }
         }
+        {
+            profiling::scope!("bind groups");
+            for bind_group in &cmd_buf_data.trackers.bind_groups {
+                bind_group.try_raw(snatch_guard)?;
+            }
+        }
 
         if let Err(e) =
             cmd_buf_data.validate_acceleration_structure_actions(snatch_guard, command_index_guard)

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -303,7 +303,7 @@ impl BufferTracker {
     }
 
     /// Extend the vectors to let the given index be valid.
-    fn allow_index(&mut self, index: usize) {
+    pub fn allow_index(&mut self, index: usize) {
         if index >= self.start.len() {
             self.set_size(index + 1);
         }
@@ -442,6 +442,11 @@ impl BufferTracker {
     /// over all elements in the usage scope. We use each the
     /// a given iterator of ids as a source of which IDs to look at.
     /// All the IDs must have first been added to the usage scope.
+    ///
+    /// # Panics
+    ///
+    /// If a resource identified by `index_source` is not found in the usage
+    /// scope.
     pub fn set_multiple(
         &mut self,
         scope: &mut BufferUsageScope,
@@ -456,9 +461,8 @@ impl BufferTracker {
             let index = index.as_usize();
 
             scope.tracker_assert_in_bounds(index);
-
-            if unsafe { !scope.metadata.contains_unchecked(index) } {
-                continue;
+            unsafe {
+                assert!(scope.metadata.contains_unchecked(index));
             }
 
             // SAFETY: we checked that the index is in bounds for the scope, and

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -442,12 +442,7 @@ impl BufferTracker {
     /// over all elements in the usage scope. We use each the
     /// a given iterator of ids as a source of which IDs to look at.
     /// All the IDs must have first been added to the usage scope.
-    ///
-    /// # Safety
-    ///
-    /// [`Self::set_size`] must be called with the maximum possible Buffer ID before this
-    /// method is called.
-    pub unsafe fn set_and_remove_from_usage_scope_sparse(
+    pub fn set_multiple(
         &mut self,
         scope: &mut BufferUsageScope,
         index_source: impl IntoIterator<Item = TrackerIndex>,
@@ -465,6 +460,9 @@ impl BufferTracker {
             if unsafe { !scope.metadata.contains_unchecked(index) } {
                 continue;
             }
+
+            // SAFETY: we checked that the index is in bounds for the scope, and
+            // called `set_size` to ensure it is valid for `self`.
             unsafe {
                 self.insert_or_barrier_update(
                     index,
@@ -477,8 +475,6 @@ impl BufferTracker {
                     },
                 )
             };
-
-            unsafe { scope.metadata.remove(index) };
         }
     }
 

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -130,14 +130,6 @@ impl<T: Clone> ResourceMetadata<T> {
         };
         iterate_bitvec_indices(&self.owned)
     }
-
-    /// Remove the resource with the given index from the set.
-    pub(super) unsafe fn remove(&mut self, index: usize) {
-        unsafe {
-            *self.resources.get_unchecked_mut(index) = None;
-        }
-        self.owned.set(index, false);
-    }
 }
 
 /// A source of resource metadata.

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -641,8 +641,7 @@ impl Tracker {
     }
 
     /// Iterates through all resources in the given bind group and adopts
-    /// the state given for those resources in the UsageScope. It also
-    /// removes all touched resources from the usage scope.
+    /// the state given for those resources in the UsageScope.
     ///
     /// If a transition is needed to get the resources into the needed
     /// state, those transitions are stored within the tracker. A
@@ -650,32 +649,17 @@ impl Tracker {
     /// [`TextureTracker::drain_transitions`] is needed to get those transitions.
     ///
     /// This is a really funky method used by Compute Passes to generate
-    /// barriers after a call to dispatch without needing to iterate
-    /// over all elements in the usage scope. We use each the
-    /// bind group as a source of which IDs to look at. The bind groups
-    /// must have first been added to the usage scope.
+    /// barriers for each dispatch. We use the bind group as a source of which
+    /// IDs to look at.
     ///
     /// Only stateful things are merged in here, all other resources are owned
     /// indirectly by the bind group.
-    ///
-    /// # Safety
-    ///
-    /// The maximum ID given by each bind group resource must be less than the
-    /// value given to `set_size`
-    pub unsafe fn set_and_remove_from_usage_scope_sparse(
-        &mut self,
-        scope: &mut UsageScope,
-        bind_group: &BindGroupStates,
-    ) {
-        unsafe {
-            self.buffers.set_and_remove_from_usage_scope_sparse(
-                &mut scope.buffers,
-                bind_group.buffers.used_tracker_indices(),
-            )
-        };
-        unsafe {
-            self.textures
-                .set_and_remove_from_usage_scope_sparse(&mut scope.textures, &bind_group.views)
-        };
+    pub fn set_from_bind_group(&mut self, scope: &mut UsageScope, bind_group: &BindGroupStates) {
+        self.buffers.set_multiple(
+            &mut scope.buffers,
+            bind_group.buffers.used_tracker_indices(),
+        );
+        self.textures
+            .set_multiple(&mut scope.textures, &bind_group.views);
     }
 }

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -612,12 +612,32 @@ impl DeviceTracker {
 
 /// A full double sided tracker used by CommandBuffers.
 pub(crate) struct Tracker {
+    /// Buffers used within this command buffer.
+    ///
+    /// For compute passes, this only includes buffers actually used by the
+    /// pipeline (contrast with the `bind_groups` member).
     pub buffers: BufferTracker,
+
+    /// Textures used within this command buffer.
+    ///
+    /// For compute passes, this only includes textures actually used by the
+    /// pipeline (contrast with the `bind_groups` member).
     pub textures: TextureTracker,
+
     pub blas_s: BlasTracker,
     pub tlas_s: StatelessTracker<resource::Tlas>,
     pub views: StatelessTracker<resource::TextureView>,
+
+    /// Contains all bind groups that were passed in any call to
+    /// `set_bind_group` on the encoder.
+    ///
+    /// WebGPU requires that submission fails if any resource in any of these
+    /// bind groups is destroyed, even if the resource is not actually used by
+    /// the pipeline (e.g. because the pipeline does not use the bound slot, or
+    /// because the bind group was replaced by a subsequent call to
+    /// `set_bind_group`).
     pub bind_groups: StatelessTracker<binding_model::BindGroup>,
+
     pub compute_pipelines: StatelessTracker<pipeline::ComputePipeline>,
     pub render_pipelines: StatelessTracker<pipeline::RenderPipeline>,
     pub bundles: StatelessTracker<command::RenderBundle>,
@@ -654,6 +674,10 @@ impl Tracker {
     ///
     /// Only stateful things are merged in here, all other resources are owned
     /// indirectly by the bind group.
+    ///
+    /// # Panics
+    ///
+    /// If a resource in the `bind_group` is not found in the usage scope.
     pub fn set_from_bind_group(&mut self, scope: &mut UsageScope, bind_group: &BindGroupStates) {
         self.buffers.set_multiple(
             &mut scope.buffers,

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -611,6 +611,10 @@ impl TextureTracker {
     /// over all elements in the usage scope. We use each the
     /// bind group as a source of which IDs to look at. The bind groups
     /// must have first been added to the usage scope.
+    ///
+    /// # Panics
+    ///
+    /// If a resource in `bind_group_state` is not found in the usage scope.
     pub fn set_multiple(
         &mut self,
         scope: &mut TextureUsageScope,
@@ -623,11 +627,12 @@ impl TextureTracker {
 
         for (view, _) in bind_group_state.views.iter() {
             let index = view.parent.tracker_index().as_usize();
-            scope.tracker_assert_in_bounds(index);
 
-            if unsafe { !scope.metadata.contains_unchecked(index) } {
-                continue;
+            scope.tracker_assert_in_bounds(index);
+            unsafe {
+                assert!(scope.metadata.contains_unchecked(index));
             }
+
             let texture_selector = &view.parent.full_range;
             // SAFETY: we checked that the index is in bounds for the scope, and
             // called `set_size` to ensure it is valid for `self`.

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -611,12 +611,7 @@ impl TextureTracker {
     /// over all elements in the usage scope. We use each the
     /// bind group as a source of which IDs to look at. The bind groups
     /// must have first been added to the usage scope.
-    ///
-    /// # Safety
-    ///
-    /// [`Self::set_size`] must be called with the maximum possible Buffer ID before this
-    /// method is called.
-    pub unsafe fn set_and_remove_from_usage_scope_sparse(
+    pub fn set_multiple(
         &mut self,
         scope: &mut TextureUsageScope,
         bind_group_state: &TextureViewBindGroupState,
@@ -634,6 +629,8 @@ impl TextureTracker {
                 continue;
             }
             let texture_selector = &view.parent.full_range;
+            // SAFETY: we checked that the index is in bounds for the scope, and
+            // called `set_size` to ensure it is valid for `self`.
             unsafe {
                 insert_or_barrier_update(
                     texture_selector,
@@ -649,8 +646,6 @@ impl TextureTracker {
                     &mut self.temp,
                 )
             };
-
-            unsafe { scope.metadata.remove(index) };
         }
     }
 }


### PR DESCRIPTION
This allows us to save some work when a bind group is replaced, although WebGPU still requires us to fail a submission if any resource in any bind group that was ever referenced during encoding is destroyed.

Fixes #8399.

**Testing**
Enables some relevant CTS tests.

**Squash or Rebase?** Rebase (after squashing any fixups)

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
