### PR TITLE
[hal/vulkan] Wait for fence signalled in vkAcquireNextImage

### DIFF
--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -578,6 +578,13 @@ impl super::Device {
         let images =
             unsafe { functor.get_swapchain_images(raw) }.map_err(super::map_host_device_oom_err)?;
 
+        let fence = unsafe {
+            self.shared
+                .raw
+                .create_fence(&vk::FenceCreateInfo::default(), None)
+                .map_err(super::map_host_device_oom_err)?
+        };
+
         // NOTE: It's important that we define the same number of acquire/present semaphores
         // as we will need to index into them with the image index.
         let acquire_semaphores = (0..=images.len())
@@ -597,6 +604,7 @@ impl super::Device {
             functor,
             device: Arc::clone(&self.shared),
             images,
+            fence,
             config: config.clone(),
             acquire_semaphores,
             next_acquire_index: 0,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -390,6 +390,8 @@ struct Swapchain {
     functor: khr::swapchain::Device,
     device: Arc<DeviceShared>,
     images: Vec<vk::Image>,
+    /// Fence used to wait on the acquired image.
+    fence: vk::Fence,
     config: crate::SurfaceConfiguration,
 
     /// Semaphores used between image acquisition and the first submission


### PR DESCRIPTION
**Connections**

Closes #8310 
Backport to v27 #8419 
Backport to v26 #8414 

**Description**

This prevents frame pacing issues on vulkan/windows. See upstream issue for more information.

**Testing**

Manually tested

**Squash or Rebase?**

Izzacommit.

**Checklist**

Changelogs will be handled in backports.