### PR TITLE
Support for storing failed commands in traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Bottom level categories:
 
 - BREAKING: Migrated from the `maxInterStageShaderComponents` limit to `maxInterStageShaderVariables`, which changes validation in a way that should not affect most programs. This follows the latest changes of the WebGPU spec. By @ErichDonGubler in [#8652](https://github.com/gfx-rs/wgpu/pull/8652), [#8792](https://github.com/gfx-rs/wgpu/pull/8792).
 - Fixed validation of the texture format in GPUDepthStencilState when neither depth nor stencil is actually enabled. By @andyleiserson in [#8766](https://github.com/gfx-rs/wgpu/pull/8766).
+- Tracing support has been restored. By @andyleiserson in [#8429](https://github.com/gfx-rs/wgpu/pull/8429).
 
 #### GLES
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4942,8 +4942,10 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
  "wgpu",
+ "wgpu-core",
  "wgpu-hal",
  "wgpu-macros",
+ "wgpu-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4816,6 +4816,7 @@ dependencies = [
  "obj",
  "png",
  "pollster",
+ "tempfile",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -4823,7 +4824,6 @@ dependencies = [
  "web-time 1.1.0",
  "wgpu",
  "wgpu-test",
- "wgpu-types",
  "winit 0.29.15",
 ]
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,6 +40,7 @@ This is a table of contents, in the form of the repository's directory structure
    - [compile](#wgpu-compile-tests)
    - [dependency](#wgpu-dependency-tests)
    - [gpu](#wgpu-gpu-tests)
+   - [trace](#wgpu-trace-tests)
    - [validation](#wgpu-validation-tests)
 
 And where applicable [unit-tests](#unit-tests)
@@ -102,7 +103,7 @@ There are inputs in `wgsl`, `spirv`, and `glsl`. There are outputs for
 `hlsl`, `spirv`, `wgsl`, `msl`, `glsl`, and naga's internal IR. The tests
 can be configured by a sidecar toml file of the same name as the input file.
 
-This is the goto tool for testing all kinds of codegen and parsing features. 
+This is the goto tool for testing all kinds of codegen and parsing features.
 
 To avoid clutter we generally use the following pattern:
 
@@ -143,7 +144,7 @@ the [wgsl errors](#naga-wgsl-error-tests) tests.
 
 These are tests for the error messages that the `wgsl` frontend
 produces. Additionally you can check that a given validation error
-is produced by the validator from a given `wgsl` snippet. 
+is produced by the validator from a given `wgsl` snippet.
 
 ## `player` Tests
 
@@ -208,6 +209,15 @@ Normal `#[test]`s will not be found in this test crate, as we use a custom harne
 
 See also the [example tests](#example-tests) for additional GPU tests.
 
+## `wgpu` Trace Tests
+
+- Located in: `tests/tests/wgpu_trace.rs`
+- Run with `cargo nextest run --test wgpu_trace`
+- Use the standard `#[test]` harness.
+
+These tests are focused on testing the tracing functionality in `wgpu`.  They
+use the a special `noop` backend which does not connect to a real GPU.
+
 ## `wgpu` Validation Tests
 
 - Located in: `tests/tests/wgpu-validation`
@@ -215,7 +225,7 @@ See also the [example tests](#example-tests) for additional GPU tests.
 - Use the standard `#[test]` harness.
 - `wgpu` integration tests, with access to `wgpu_test` helpers.
 
-These tests are focused on testing the validation inside of `wgpu-core`. 
+These tests are focused on testing the validation inside of `wgpu-core`.
 They are written against the `wgpu` API, but are targeting a special `noop`
 backend which does not connect to a real GPU.
 

--- a/examples/features/Cargo.toml
+++ b/examples/features/Cargo.toml
@@ -45,11 +45,8 @@ noise.workspace = true
 obj.workspace = true
 png.workspace = true
 pollster.workspace = true
+tempfile.workspace = true
 web-time.workspace = true
-wgpu-types = { workspace = true, features = [
-    "std",
-    "trace", # TODO(#5974): this should be a dep on wgpu/trace and not wgpu-types at all
-] }
 winit.workspace = true
 
 [dev-dependencies]
@@ -57,7 +54,7 @@ wgpu-test.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger.workspace = true
-wgpu.workspace = true
+wgpu = { workspace = true, features = ["trace"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook.workspace = true
@@ -65,9 +62,10 @@ console_log.workspace = true
 fern.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
-wgpu = { path = "../../wgpu", default-features = false, features = [
+wgpu = { workspace = true, default-features = false, features = [
     "wgsl",
     "std",
+    "trace",
 ] }
 # We need these features in the framework examples and tests
 web-sys = { workspace = true, features = [

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -1,4 +1,5 @@
 use std::{borrow::Cow, sync::Arc};
+use tempfile::tempdir;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -28,6 +29,8 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         .await
         .expect("Failed to find an appropriate adapter");
 
+    let trace_dir = tempdir().expect("Failed to create temporary directory for trace");
+
     // Create the logical device and command queue
     let (device, queue) = adapter
         .request_device(&wgpu::DeviceDescriptor {
@@ -38,7 +41,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                 .using_resolution(adapter.limits()),
             experimental_features: wgpu::ExperimentalFeatures::disabled(),
             memory_hints: wgpu::MemoryHints::MemoryUsage,
-            trace: wgpu::Trace::Off,
+            trace: wgpu::Trace::Directory(trace_dir.path().to_path_buf()),
         })
         .await
         .expect("Failed to create device");

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -95,9 +95,8 @@ pub(crate) const FREXP_FUNCTION: &str = "naga_frexp";
 // Must match code in glsl_built_in
 pub const FIRST_INSTANCE_BINDING: &str = "naga_vs_first_instance";
 
-#[cfg(any(feature = "serialize", feature = "deserialize"))]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg(feature = "deserialize")]
+#[derive(serde::Deserialize)]
 struct BindingMapSerialization {
     resource_binding: crate::ResourceBinding,
     bind_target: u8,

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -216,9 +216,8 @@ pub struct OffsetsBindTarget {
     pub size: u32,
 }
 
-#[cfg(any(feature = "serialize", feature = "deserialize"))]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg(feature = "deserialize")]
+#[derive(serde::Deserialize)]
 struct BindingMapSerialization {
     resource_binding: crate::ResourceBinding,
     bind_target: BindTarget,
@@ -337,9 +336,8 @@ impl Default for SamplerHeapBindTargets {
     }
 }
 
-#[cfg(any(feature = "serialize", feature = "deserialize"))]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg(feature = "deserialize")]
+#[derive(serde::Deserialize)]
 struct SamplerIndexBufferBindingSerialization {
     group: u32,
     bind_target: BindTarget,
@@ -369,9 +367,8 @@ where
 pub type SamplerIndexBufferBindingMap =
     alloc::collections::BTreeMap<SamplerIndexBufferKey, BindTarget>;
 
-#[cfg(any(feature = "serialize", feature = "deserialize"))]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg(feature = "deserialize")]
+#[derive(serde::Deserialize)]
 struct DynamicStorageBufferOffsetTargetSerialization {
     index: u32,
     bind_target: OffsetsBindTarget,
@@ -425,9 +422,8 @@ pub struct ExternalTextureBindTarget {
     pub params: BindTarget,
 }
 
-#[cfg(any(feature = "serialize", feature = "deserialize"))]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg(feature = "deserialize")]
+#[derive(serde::Deserialize)]
 struct ExternalTextureBindingMapSerialization {
     resource_binding: crate::ResourceBinding,
     bind_target: ExternalTextureBindTarget,

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -86,6 +86,8 @@ fn main() {
         )
     }
     .unwrap();
+    #[cfg(feature = "winit")]
+    let mut configured_surface_id = None;
 
     let (backends, device_desc) =
         match actions.pop_if(|action| matches!(action, trace::Action::Init { .. })) {
@@ -149,9 +151,9 @@ fn main() {
 
                 match event {
                     Event::WindowEvent { event, .. } => match event {
-                        WindowEvent::RedrawRequested if resize_config.is_none() => {
+                        WindowEvent::RedrawRequested if resize_config.is_none() => loop {
                             match actions.pop() {
-                                Some(trace::Action::ConfigureSurface(_device_id, config)) => {
+                                Some(trace::Action::ConfigureSurface(surface_id, config)) => {
                                     log::info!("Configuring the surface");
                                     let current_size: (u32, u32) = window.inner_size().into();
                                     let size = (config.width, config.height);
@@ -163,24 +165,33 @@ fn main() {
                                             ),
                                         );
                                         resize_config = Some(config);
-                                        target.exit();
+                                        break;
                                     } else {
                                         let error = device.configure_surface(&surface, &config);
+                                        configured_surface_id = Some(surface_id);
                                         if let Some(e) = error {
                                             panic!("{e:?}");
                                         }
                                     }
                                 }
+                                Some(trace::Action::GetSurfaceTexture { id, parent }) => {
+                                    log::debug!("Get surface texture for frame {frame_count}");
+                                    assert!(
+                                        configured_surface_id == Some(parent),
+                                        "rendering to an unexpected surface"
+                                    );
+                                    player.get_surface_texture(id, &surface);
+                                }
                                 Some(trace::Action::Present(_id)) => {
                                     frame_count += 1;
                                     log::debug!("Presenting frame {frame_count}");
                                     surface.present().unwrap();
-                                    target.exit();
+                                    break;
                                 }
                                 Some(trace::Action::DiscardSurfaceTexture(_id)) => {
                                     log::debug!("Discarding frame {frame_count}");
                                     surface.discard().unwrap();
-                                    target.exit();
+                                    break;
                                 }
                                 Some(action) => {
                                     player.process(
@@ -195,10 +206,10 @@ fn main() {
                                         println!("Finished the end at frame {frame_count}");
                                         done = true;
                                     }
-                                    target.exit();
+                                    break;
                                 }
                             }
-                        }
+                        },
                         WindowEvent::Resized(_) => {
                             if let Some(config) = resize_config.take() {
                                 let error = device.configure_surface(&surface, &config);

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -127,7 +127,7 @@ fn main() {
         unsafe { device.start_graphics_debugger_capture() };
 
         while let Some(action) = actions.pop() {
-            player.process(&device, &queue, action, &dir);
+            player.process(&device, &queue, action, trace::DiskTraceLoader::new(&dir));
         }
 
         unsafe { device.stop_graphics_debugger_capture() };
@@ -183,7 +183,12 @@ fn main() {
                                     target.exit();
                                 }
                                 Some(action) => {
-                                    player.process(&device, &queue, action, &dir);
+                                    player.process(
+                                        &device,
+                                        &queue,
+                                        action,
+                                        trace::DiskTraceLoader::new(&dir),
+                                    );
                                 }
                                 None => {
                                     if !done {

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -6,14 +6,14 @@
 extern crate wgpu_core as wgc;
 extern crate wgpu_types as wgt;
 
-use std::{borrow::Cow, convert::Infallible, fs, path::Path, sync::Arc};
+use std::{borrow::Cow, convert::Infallible, sync::Arc};
 
 use hashbrown::HashMap;
 
 use wgc::{
     binding_model::BindingResource,
     command::{ArcCommand, ArcReferences, BasePass, Command, PointerReferences},
-    device::trace,
+    device::trace::{self, DataKind, DataLoader},
     id::PointerId,
 };
 
@@ -94,7 +94,7 @@ impl Player {
         device: &Arc<wgc::device::Device>,
         queue: &Arc<wgc::device::queue::Queue>,
         action: trace::Action<PointerReferences>,
-        dir: &Path,
+        loader: impl DataLoader,
     ) {
         use wgc::device::trace::Action;
         log::debug!("action {action:?}");
@@ -226,15 +226,17 @@ impl Player {
                 let _bind_group = self.bind_groups.remove(&id).expect("invalid bind group");
             }
             Action::CreateShaderModule { id, desc, data } => {
-                log::debug!("Creating shader from {data}");
-                let code = fs::read_to_string(dir.join(&data)).unwrap();
-                let source = if data.ends_with(".wgsl") {
-                    wgc::pipeline::ShaderModuleSource::Wgsl(Cow::Owned(code.clone()))
-                } else if data.ends_with(".ron") {
+                let code = loader.load_utf8(&data);
+                let source = if data.kind() == DataKind::Wgsl {
+                    wgc::pipeline::ShaderModuleSource::Wgsl(code.clone())
+                } else if data.kind() == DataKind::Ron {
                     let module = ron::de::from_str(&code).unwrap();
                     wgc::pipeline::ShaderModuleSource::Naga(module)
                 } else {
-                    panic!("Unknown shader {data}");
+                    panic!(
+                        "Unknown data kind for CreateShaderModule: {:?}",
+                        data.kind()
+                    );
                 };
                 match device.create_shader_module(&desc, source) {
                     Ok(module) => self.shader_modules.insert(id, module),
@@ -250,8 +252,8 @@ impl Player {
                 runtime_checks,
             } => {
                 let spirv = data.iter().find_map(|a| {
-                    if a.ends_with(".spv") {
-                        let data = fs::read(dir.join(a)).unwrap();
+                    if a.kind() == DataKind::Spv {
+                        let data = loader.load(a);
                         assert!(data.len().is_multiple_of(4));
 
                         Some(Cow::Owned(bytemuck::pod_collect_to_vec(&data)))
@@ -259,46 +261,21 @@ impl Player {
                         None
                     }
                 });
-                let dxil = data.iter().find_map(|a| {
-                    if a.ends_with(".dxil") {
-                        let vec = std::fs::read(dir.join(a)).unwrap();
-                        Some(Cow::Owned(vec))
-                    } else {
-                        None
-                    }
-                });
-                let hlsl = data.iter().find_map(|a| {
-                    if a.ends_with(".hlsl") {
-                        let code = fs::read_to_string(dir.join(a)).unwrap();
-                        Some(Cow::Owned(code))
-                    } else {
-                        None
-                    }
-                });
-                let msl = data.iter().find_map(|a| {
-                    if a.ends_with(".msl") {
-                        let code = fs::read_to_string(dir.join(a)).unwrap();
-                        Some(Cow::Owned(code))
-                    } else {
-                        None
-                    }
-                });
-                let glsl = data.iter().find_map(|a| {
-                    if a.ends_with(".glsl") {
-                        let code = fs::read_to_string(dir.join(a)).unwrap();
-                        Some(Cow::Owned(code))
-                    } else {
-                        None
-                    }
-                });
-                let wgsl = data.iter().find_map(|a| {
-                    if a.ends_with(".wgsl") {
-                        let code = fs::read_to_string(dir.join(a)).unwrap();
-                        Some(Cow::Owned(code))
-                    } else {
-                        None
-                    }
-                });
+                let dxil = data
+                    .iter()
+                    .find_map(|a| (a.kind() == DataKind::Dxil).then(|| loader.load(a)));
+                let hlsl = data
+                    .iter()
+                    .find_map(|a| (a.kind() == DataKind::Hlsl).then(|| loader.load_utf8(a)));
+                let msl = data
+                    .iter()
+                    .find_map(|a| (a.kind() == DataKind::Msl).then(|| loader.load_utf8(a)));
+                let glsl = data
+                    .iter()
+                    .find_map(|a| (a.kind() == DataKind::Glsl).then(|| loader.load_utf8(a)));
+                let wgsl = data
+                    .iter()
+                    .find_map(|a| (a.kind() == DataKind::Wgsl).then(|| loader.load_utf8(a)));
                 let desc = wgt::CreateShaderModuleDescriptorPassthrough {
                     entry_point,
                     label,
@@ -382,7 +359,7 @@ impl Player {
                 queued,
             } => {
                 let buffer = self.resolve_buffer_id(id);
-                let bin = std::fs::read(dir.join(data)).unwrap();
+                let bin = loader.load(&data);
                 let size = (range.end - range.start) as usize;
                 if queued {
                     queue
@@ -401,7 +378,7 @@ impl Player {
                 size,
             } => {
                 let to = self.resolve_texel_copy_texture_info(to);
-                let bin = std::fs::read(dir.join(data)).unwrap();
+                let bin = loader.load(&data);
                 queue
                     .write_texture(to, &bin, &layout, &size)
                     .expect("Queue::write_texture error");

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -417,6 +417,23 @@ impl Player {
                 let buffer = wgc::command::CommandBuffer::from_trace(device, resolved_commands);
                 queue.submit(&[buffer]).unwrap();
             }
+            Action::FailedCommands {
+                commands,
+                failed_at_submit,
+                error,
+            } => {
+                let action = if failed_at_submit.is_some() {
+                    "submitting"
+                } else {
+                    "encoding"
+                };
+                if let Some(commands) = commands {
+                    log::trace!(
+                        "Trace recorded an error {action} the following commands: {commands:#?}"
+                    );
+                }
+                panic!("Error recorded in trace: {error}");
+            }
             Action::CreateBlas { id, desc, sizes } => {
                 let blas = device.create_blas(&desc, sizes).expect("create_blas error");
                 self.blas_s.insert(id, blas);

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -428,6 +428,21 @@ impl Player {
         }
     }
 
+    // This one is a little strange because the surface is held by the
+    // `player` application but we want to insert the texture into our
+    // map so we can find it for rendering.
+    pub fn get_surface_texture(
+        &mut self,
+        id: wgc::id::PointerId<wgc::id::markers::Texture>,
+        surface: &wgc::instance::Surface,
+    ) {
+        let frame = surface
+            .get_current_texture()
+            .expect("get_current_texture error");
+        let texture = frame.texture.expect("did not obtain a surface texture");
+        self.textures.insert(id, texture);
+    }
+
     pub fn resolve_buffer_id(
         &self,
         id: wgc::id::PointerId<wgc::id::markers::Buffer>,

--- a/player/tests/player/data/bind-group.ron
+++ b/player/tests/player/data/bind-group.ron
@@ -47,7 +47,7 @@
                 label: None,
                 flags: (bits: 3),
             ),
-            data: "empty.wgsl",
+            data: File("empty.wgsl"),
         ),
         CreateComputePipeline(
             id: PointerId(0x10),

--- a/player/tests/player/data/buffer-copy.ron
+++ b/player/tests/player/data/buffer-copy.ron
@@ -20,7 +20,7 @@
         ),
         WriteBuffer(
             id: PointerId(0x10),
-            data: "data1.bin",
+            data: File("data1.bin"),
             range: (
                 start: 0,
                 end: 16,

--- a/player/tests/player/data/clear-buffer-texture.ron
+++ b/player/tests/player/data/clear-buffer-texture.ron
@@ -40,7 +40,7 @@
                 mip_level: 0,
                 array_layer: 0,
             ),
-            data: "quad.bin",
+            data: File("quad.bin"),
             layout: (
                 offset: 0,
                 bytes_per_row: Some(256),
@@ -73,7 +73,7 @@
         // Make sure there is something in the buffer, otherwise it might be just zero init!
         WriteBuffer(
             id: PointerId(0x110),
-            data: "data1.bin",
+            data: File("data1.bin"),
             range: (
                 start: 0,
                 end: 16,

--- a/player/tests/player/data/pipeline-statistics-query.ron
+++ b/player/tests/player/data/pipeline-statistics-query.ron
@@ -20,7 +20,7 @@
                 label: None,
                 flags: (bits: 3),
             ),
-            data: "empty.wgsl",
+            data: File("empty.wgsl"),
         ),
         CreateComputePipeline(
             id: PointerId(0x10),

--- a/player/tests/player/data/quad.ron
+++ b/player/tests/player/data/quad.ron
@@ -15,7 +15,7 @@
                 label: None,
                 flags: (bits: 3),
             ),
-            data: "quad.wgsl",
+            data: File("quad.wgsl"),
         ),
         CreateTexture(PointerId(0x10), (
             label: Some("Output Texture"),

--- a/player/tests/player/data/zero-init-buffer.ron
+++ b/player/tests/player/data/zero-init-buffer.ron
@@ -67,7 +67,7 @@
         ),
         WriteBuffer(
             id: PointerId(0x120),
-            data: "data1.bin",
+            data: File("data1.bin"),
             range: (
                 start: 4,
                 end: 20,
@@ -80,7 +80,7 @@
                 label: None,
                 flags: (bits: 3),
             ),
-            data: "zero-init-buffer-for-binding.wgsl",
+            data: File("zero-init-buffer-for-binding.wgsl"),
         ),
         CreateBuffer(PointerId(0x130), (
             label: Some("used in binding"),

--- a/player/tests/player/data/zero-init-texture-binding.ron
+++ b/player/tests/player/data/zero-init-texture-binding.ron
@@ -125,7 +125,7 @@
                 label: None,
                 flags: (bits: 3),
             ),
-            data: "zero-init-texture-binding.wgsl",
+            data: File("zero-init-texture-binding.wgsl"),
         ),
         CreateComputePipeline(
             id: PointerId(0x10),

--- a/player/tests/player/main.rs
+++ b/player/tests/player/main.rs
@@ -21,7 +21,7 @@ use std::{
     slice,
     sync::Arc,
 };
-use wgc::command::PointerReferences;
+use wgc::{command::PointerReferences, device::trace::DiskTraceLoader};
 
 #[derive(serde::Deserialize)]
 enum ExpectedData {
@@ -98,7 +98,7 @@ impl Test<'_> {
 
         println!("\t\t\tRunning...");
         for action in self.actions {
-            player.process(&device, &queue, action, dir);
+            player.process(&device, &queue, action, DiskTraceLoader::new(dir));
         }
         println!("\t\t\tMapping...");
         for expect in &self.expectations {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -24,6 +24,10 @@ name = "wgpu-gpu"
 harness = false
 
 [[test]]
+name = "wgpu_trace"
+harness = true
+
+[[test]]
 name = "wgpu-validation"
 harness = true
 
@@ -39,8 +43,10 @@ test-build-with-profiling = ["profiling/type-check"]
 # `cargo clippy -- -Wunused-crate-dependencies` give fewer false positives.
 [dependencies]
 wgpu = { workspace = true, features = ["noop"] }
+wgpu-core = { workspace = true, features = ["trace"] }
 wgpu-hal = { workspace = true, features = ["validation_canary"] }
 wgpu-macros.workspace = true
+wgpu-types.workspace = true
 
 anyhow.workspace = true
 arrayvec.workspace = true

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -1,0 +1,189 @@
+//! Tests of [`wgpu::Buffer`] and related.
+
+use std::any::Any;
+
+use wgpu_core as wgc;
+use wgpu_types as wgt;
+
+use wgc::{command::Command, device::trace::Action};
+
+#[derive(Eq, PartialEq)]
+enum TestType {
+    Normal,
+    FailedCommands,
+    FailedSubmit,
+}
+
+fn trace_test(test_type: TestType) {
+    let global = wgc::global::Global::new(
+        "test",
+        wgt::instance::InstanceDescriptor {
+            backends: wgt::Backends::NOOP,
+            backend_options: wgt::BackendOptions {
+                noop: wgt::NoopBackendOptions { enable: true },
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        None,
+    );
+    let adapter_id = global
+        .request_adapter(
+            &wgt::RequestAdapterOptions::default(),
+            wgt::Backends::NOOP,
+            None,
+        )
+        .unwrap();
+    let (device_id, queue_id) = global
+        .adapter_request_device(
+            adapter_id,
+            &wgt::DeviceDescriptor {
+                trace: wgt::Trace::Memory,
+                ..Default::default()
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    let (buffer_id, error) = global.device_create_buffer(
+        device_id,
+        &wgt::BufferDescriptor {
+            label: None,
+            size: 1024,
+            usage: wgt::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        },
+        None,
+    );
+    assert!(error.is_none());
+
+    let (encoder_id, error) = global.device_create_command_encoder(
+        device_id,
+        &wgt::CommandEncoderDescriptor::default(),
+        None,
+    );
+    assert!(error.is_none());
+
+    match test_type {
+        TestType::Normal => {
+            global
+                .command_encoder_clear_buffer(encoder_id, buffer_id, 0, None)
+                .unwrap();
+            let (cmdbuf_id, error) = global.command_encoder_finish(
+                encoder_id,
+                &wgt::CommandBufferDescriptor::default(),
+                None,
+            );
+            assert!(error.is_none());
+            global.queue_submit(queue_id, &[cmdbuf_id]).unwrap();
+        }
+        TestType::FailedCommands => {
+            // Try to clear past the end of the buffer.
+            global
+                .command_encoder_clear_buffer(encoder_id, buffer_id, 0, Some(2048))
+                .unwrap();
+            let (_cmdbuf_id, error) = global.command_encoder_finish(
+                encoder_id,
+                &wgt::CommandBufferDescriptor::default(),
+                None,
+            );
+            assert!(error.is_some());
+        }
+        TestType::FailedSubmit => {
+            // Destroy the buffer after encoding the clear command, before submitting it.
+            global
+                .command_encoder_clear_buffer(encoder_id, buffer_id, 0, None)
+                .unwrap();
+            let (cmdbuf_id, error) = global.command_encoder_finish(
+                encoder_id,
+                &wgt::CommandBufferDescriptor::default(),
+                None,
+            );
+            assert!(error.is_none());
+            global.buffer_destroy(buffer_id);
+            global.queue_submit(queue_id, &[cmdbuf_id]).unwrap_err();
+        }
+    }
+
+    let trace = global.device_take_trace(device_id).unwrap();
+    let trace = (trace.as_ref() as &dyn Any)
+        .downcast_ref::<wgc::device::trace::MemoryTrace>()
+        .unwrap();
+    let actions = trace.actions();
+
+    match test_type {
+        TestType::Normal => {
+            let Some(Action::Submit(_, commands)) = actions.last() else {
+                panic!("expected last action to be Submit");
+            };
+            assert_eq!(commands.len(), 1);
+            assert!(matches!(
+                commands[0],
+                Command::ClearBuffer {
+                    dst: _,
+                    offset: 0,
+                    size: None,
+                },
+            ));
+        }
+        TestType::FailedCommands => {
+            let Some(Action::FailedCommands {
+                commands: Some(commands),
+                failed_at_submit: None,
+                error,
+            }) = actions.last()
+            else {
+                panic!("expected last action to be FailedCommands");
+            };
+            assert_eq!(
+                error,
+                "Clear of 0..2048 would end up overrunning the bounds of the buffer of size 1024"
+            );
+            assert_eq!(commands.len(), 1);
+            assert!(matches!(
+                commands[0],
+                Command::ClearBuffer {
+                    dst: _,
+                    offset: 0,
+                    size: Some(2048),
+                },
+            ));
+        }
+        TestType::FailedSubmit => {
+            let Some(Action::FailedCommands {
+                commands: Some(commands),
+                failed_at_submit: Some(_),
+                error,
+            }) = actions.last()
+            else {
+                panic!("expected last action to be FailedCommands");
+            };
+            assert_eq!(error, "Buffer with '' label has been destroyed");
+            assert_eq!(commands.len(), 1);
+            assert!(matches!(
+                commands[0],
+                Command::ClearBuffer {
+                    dst: _,
+                    offset: 0,
+                    size: None,
+                },
+            ));
+        }
+    }
+}
+
+#[test]
+fn trace_clear_buffer() {
+    trace_test(TestType::Normal);
+}
+
+#[test]
+fn trace_failed_commands() {
+    trace_test(TestType::FailedCommands);
+}
+
+#[test]
+fn trace_failed_submit() {
+    trace_test(TestType::FailedSubmit);
+}

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -98,6 +98,31 @@ pub type CopyExternalImageDestInfo = ffi::CopyExternalImageDestInfo;
 
 const IMMEDIATES_CLEAR_ARRAY: &[u32] = &[0_u32; 64];
 
+pub(crate) struct EncoderErrorState {
+    error: CommandEncoderError,
+
+    #[cfg(feature = "trace")]
+    trace_commands: Option<Vec<Command<PointerReferences>>>,
+}
+
+/// Construct an `EncoderErrorState` with only a `CommandEncoderError` (without
+/// any traced commands).
+///
+/// This is used in cases where pass begin/end were mismatched, if the same
+/// encoder was finished multiple times, or in the status of a command buffer
+/// (in which case the commands were already saved to the trace). In some of
+/// these cases there may be commands that could be saved to the trace, but if
+/// the application is that confused about using encoders, it's not clear
+/// whether it's worth the effort to try and preserve the commands.
+fn make_error_state<E: Into<CommandEncoderError>>(error: E) -> CommandEncoderStatus {
+    CommandEncoderStatus::Error(EncoderErrorState {
+        error: error.into(),
+
+        #[cfg(feature = "trace")]
+        trace_commands: None,
+    })
+}
+
 /// The current state of a command or pass encoder.
 ///
 /// In the WebGPU spec, the state of an encoder (open, locked, or ended) is
@@ -145,7 +170,7 @@ pub(crate) enum CommandEncoderStatus {
     ///
     /// The error that caused the invalidation is stored here, and will
     /// be raised by `CommandEncoder.finish()`.
-    Error(CommandEncoderError),
+    Error(EncoderErrorState),
 
     /// Temporary state used internally by methods on `CommandEncoderStatus`.
     /// Encoder should never be left in this state.
@@ -333,7 +358,7 @@ impl CommandEncoderStatus {
                 Err(EncoderStateError::Ended)
             }
             Self::Recording(_) => {
-                *self = Self::Error(EncoderStateError::Unlocked.into());
+                *self = make_error_state(EncoderStateError::Unlocked);
                 Err(EncoderStateError::Unlocked)
             }
             st @ Self::Consumed => {
@@ -362,22 +387,39 @@ impl CommandEncoderStatus {
                 }
                 Self::Finished(inner)
             }
-            Self::Consumed | Self::Finished(_) => Self::Error(EncoderStateError::Ended.into()),
-            Self::Locked(_) => Self::Error(EncoderStateError::Locked.into()),
+            Self::Consumed | Self::Finished(_) => make_error_state(EncoderStateError::Ended),
+            Self::Locked(_) => make_error_state(EncoderStateError::Locked),
             st @ Self::Error(_) => st,
             Self::Transitioning => unreachable!(),
         }
     }
 
-    // Invalidate the command encoder and store the error `err` causing the
-    // invalidation for diagnostic purposes.
-    //
-    // Since we do not track the state of an invalid encoder, it is not
-    // necessary to unlock an encoder that has been invalidated.
+    /// Invalidate the command encoder due to an error.
+    ///
+    /// The error `err` is stored so that it can be reported when the encoder is
+    /// finished. If tracing is enabled, the traced commands are also stored.
+    ///
+    /// Since we do not track the state of an invalid encoder, it is not
+    /// necessary to unlock an encoder that has been invalidated.
     fn invalidate<E: Clone + Into<CommandEncoderError>>(&mut self, err: E) -> E {
+        #[cfg(feature = "trace")]
+        let trace_commands = match self {
+            Self::Recording(cmd_buf_data) => Some(
+                mem::take(&mut cmd_buf_data.commands)
+                    .into_iter()
+                    .map(crate::device::trace::IntoTrace::into_trace)
+                    .collect(),
+            ),
+            _ => None,
+        };
+
         let enc_err = err.clone().into();
         api_log!("Invalidating command encoder: {enc_err:?}");
-        *self = Self::Error(enc_err);
+        *self = Self::Error(EncoderErrorState {
+            error: enc_err,
+            #[cfg(feature = "trace")]
+            trace_commands,
+        });
         err
     }
 }
@@ -861,7 +903,7 @@ impl CommandEncoder {
         CommandEncoder {
             device: device.clone(),
             label: label.to_string(),
-            data: Mutex::new(rank::COMMAND_BUFFER_DATA, CommandEncoderStatus::Error(err)),
+            data: Mutex::new(rank::COMMAND_BUFFER_DATA, make_error_state(err)),
         }
     }
 
@@ -941,6 +983,220 @@ impl CommandEncoder {
         }
     }
 
+    fn encode_commands(
+        device: &Arc<Device>,
+        cmd_buf_data: &mut CommandBufferMutable,
+    ) -> Result<(), CommandEncoderError> {
+        device.check_is_valid()?;
+        let snatch_guard = device.snatchable_lock.read();
+        let mut debug_scope_depth = 0;
+
+        if cmd_buf_data.encoder.api == EncodingApi::Raw {
+            // Should have panicked on the first call that switched APIs,
+            // but lets be sure.
+            assert!(cmd_buf_data.commands.is_empty());
+        }
+
+        let commands = mem::take(&mut cmd_buf_data.commands);
+
+        #[cfg(feature = "trace")]
+        if device.trace.lock().is_some() {
+            cmd_buf_data.trace_commands = Some(
+                commands
+                    .iter()
+                    .map(crate::device::trace::IntoTrace::to_trace)
+                    .collect(),
+            );
+        }
+
+        for command in commands {
+            if matches!(
+                command,
+                ArcCommand::RunRenderPass { .. } | ArcCommand::RunComputePass { .. }
+            ) {
+                // Compute passes and render passes can accept either an
+                // open or closed encoder. This state object holds an
+                // `InnerCommandEncoder`. See the documentation of
+                // [`EncodingState`].
+                let mut state = EncodingState {
+                    device,
+                    raw_encoder: &mut cmd_buf_data.encoder,
+                    tracker: &mut cmd_buf_data.trackers,
+                    buffer_memory_init_actions: &mut cmd_buf_data.buffer_memory_init_actions,
+                    texture_memory_actions: &mut cmd_buf_data.texture_memory_actions,
+                    as_actions: &mut cmd_buf_data.as_actions,
+                    temp_resources: &mut cmd_buf_data.temp_resources,
+                    indirect_draw_validation_resources: &mut cmd_buf_data
+                        .indirect_draw_validation_resources,
+                    snatch_guard: &snatch_guard,
+                    debug_scope_depth: &mut debug_scope_depth,
+                };
+
+                match command {
+                    ArcCommand::RunRenderPass {
+                        pass,
+                        color_attachments,
+                        depth_stencil_attachment,
+                        timestamp_writes,
+                        occlusion_query_set,
+                        multiview_mask,
+                    } => {
+                        api_log!(
+                            "Begin encoding render pass with '{}' label",
+                            pass.label.as_deref().unwrap_or("")
+                        );
+                        let res = encode_render_pass(
+                            &mut state,
+                            pass,
+                            color_attachments,
+                            depth_stencil_attachment,
+                            timestamp_writes,
+                            occlusion_query_set,
+                            multiview_mask,
+                        );
+                        match res.as_ref() {
+                            Err(err) => {
+                                api_log!("Finished encoding render pass ({err:?})")
+                            }
+                            Ok(_) => {
+                                api_log!("Finished encoding render pass (success)")
+                            }
+                        }
+                        res?;
+                    }
+                    ArcCommand::RunComputePass {
+                        pass,
+                        timestamp_writes,
+                    } => {
+                        api_log!(
+                            "Begin encoding compute pass with '{}' label",
+                            pass.label.as_deref().unwrap_or("")
+                        );
+                        let res = encode_compute_pass(&mut state, pass, timestamp_writes);
+                        match res.as_ref() {
+                            Err(err) => {
+                                api_log!("Finished encoding compute pass ({err:?})")
+                            }
+                            Ok(_) => {
+                                api_log!("Finished encoding compute pass (success)")
+                            }
+                        }
+                        res?;
+                    }
+                    _ => unreachable!(),
+                }
+            } else {
+                // All the other non-pass encoding routines assume the
+                // encoder is open, so open it if necessary. This state
+                // object holds an `&mut dyn hal::DynCommandEncoder`. By
+                // convention, a bare HAL encoder reference in
+                // [`EncodingState`] must always be an open encoder.
+                let raw_encoder = cmd_buf_data.encoder.open_if_closed()?;
+                let mut state = EncodingState {
+                    device,
+                    raw_encoder,
+                    tracker: &mut cmd_buf_data.trackers,
+                    buffer_memory_init_actions: &mut cmd_buf_data.buffer_memory_init_actions,
+                    texture_memory_actions: &mut cmd_buf_data.texture_memory_actions,
+                    as_actions: &mut cmd_buf_data.as_actions,
+                    temp_resources: &mut cmd_buf_data.temp_resources,
+                    indirect_draw_validation_resources: &mut cmd_buf_data
+                        .indirect_draw_validation_resources,
+                    snatch_guard: &snatch_guard,
+                    debug_scope_depth: &mut debug_scope_depth,
+                };
+                match command {
+                    ArcCommand::CopyBufferToBuffer {
+                        src,
+                        src_offset,
+                        dst,
+                        dst_offset,
+                        size,
+                    } => {
+                        copy_buffer_to_buffer(
+                            &mut state, &src, src_offset, &dst, dst_offset, size,
+                        )?;
+                    }
+                    ArcCommand::CopyBufferToTexture { src, dst, size } => {
+                        copy_buffer_to_texture(&mut state, &src, &dst, &size)?;
+                    }
+                    ArcCommand::CopyTextureToBuffer { src, dst, size } => {
+                        copy_texture_to_buffer(&mut state, &src, &dst, &size)?;
+                    }
+                    ArcCommand::CopyTextureToTexture { src, dst, size } => {
+                        copy_texture_to_texture(&mut state, &src, &dst, &size)?;
+                    }
+                    ArcCommand::ClearBuffer { dst, offset, size } => {
+                        clear_buffer(&mut state, dst, offset, size)?;
+                    }
+                    ArcCommand::ClearTexture {
+                        dst,
+                        subresource_range,
+                    } => {
+                        clear_texture_cmd(&mut state, dst, &subresource_range)?;
+                    }
+                    ArcCommand::WriteTimestamp {
+                        query_set,
+                        query_index,
+                    } => {
+                        write_timestamp(&mut state, query_set, query_index)?;
+                    }
+                    ArcCommand::ResolveQuerySet {
+                        query_set,
+                        start_query,
+                        query_count,
+                        destination,
+                        destination_offset,
+                    } => {
+                        resolve_query_set(
+                            &mut state,
+                            query_set,
+                            start_query,
+                            query_count,
+                            destination,
+                            destination_offset,
+                        )?;
+                    }
+                    ArcCommand::PushDebugGroup(label) => {
+                        push_debug_group(&mut state, &label)?;
+                    }
+                    ArcCommand::PopDebugGroup => {
+                        pop_debug_group(&mut state)?;
+                    }
+                    ArcCommand::InsertDebugMarker(label) => {
+                        insert_debug_marker(&mut state, &label)?;
+                    }
+                    ArcCommand::BuildAccelerationStructures { blas, tlas } => {
+                        build_acceleration_structures(&mut state, blas, tlas)?;
+                    }
+                    ArcCommand::TransitionResources {
+                        buffer_transitions,
+                        texture_transitions,
+                    } => {
+                        transition_resources(&mut state, buffer_transitions, texture_transitions)?;
+                    }
+                    ArcCommand::RunComputePass { .. } | ArcCommand::RunRenderPass { .. } => {
+                        unreachable!()
+                    }
+                }
+            }
+        }
+
+        if debug_scope_depth > 0 {
+            Err(CommandEncoderError::DebugGroupError(
+                DebugGroupError::MissingPop,
+            ))?;
+        }
+
+        // Close the encoder, unless it was closed already by a render or compute pass.
+        cmd_buf_data.encoder.close_if_open()?;
+
+        // Note: if we want to stop tracking the swapchain texture view,
+        // this is the place to do it.
+
+        Ok(())
+    }
+
     fn finish(
         self: &Arc<Self>,
         desc: &wgt::CommandBufferDescriptor<Label>,
@@ -948,239 +1204,46 @@ impl CommandEncoder {
         let mut cmd_enc_status = self.data.lock();
 
         let res = match cmd_enc_status.finish() {
-            CommandEncoderStatus::Finished(cmd_buf_data) => Ok(cmd_buf_data),
-            CommandEncoderStatus::Error(err) => Err(err),
+            CommandEncoderStatus::Finished(mut cmd_buf_data) => {
+                match Self::encode_commands(&self.device, &mut cmd_buf_data) {
+                    Ok(()) => Ok(cmd_buf_data),
+                    Err(error) => Err(EncoderErrorState {
+                        error,
+                        #[cfg(feature = "trace")]
+                        trace_commands: mem::take(&mut cmd_buf_data.trace_commands),
+                    }),
+                }
+            }
+            CommandEncoderStatus::Error(error_state) => Err(error_state),
             _ => unreachable!(),
         };
 
-        let res = res.and_then(|mut cmd_buf_data| {
-            self.device.check_is_valid()?;
-            let snatch_guard = self.device.snatchable_lock.read();
-            let mut debug_scope_depth = 0;
-
-            if cmd_buf_data.encoder.api == EncodingApi::Raw {
-                // Should have panicked on the first call that switched APIs,
-                // but lets be sure.
-                assert!(cmd_buf_data.commands.is_empty());
-            }
-
-            let mut commands = mem::take(&mut cmd_buf_data.commands);
-            #[cfg(not(feature = "trace"))]
-            let command_iter = commands.drain(..);
-            #[cfg(feature = "trace")]
-            let mut trace_commands = None;
-
-            #[cfg(feature = "trace")]
-            let command_iter = {
-                if self.device.trace.lock().is_some() {
-                    trace_commands = Some(
-                        cmd_buf_data
-                            .trace_commands
-                            .insert(Vec::with_capacity(commands.len())),
-                    );
-                }
-
-                commands.drain(..).inspect(|cmd| {
-                    use crate::device::trace::IntoTrace;
-
-                    if let Some(ref mut trace) = trace_commands {
-                        trace.push(cmd.clone().to_trace());
-                    }
-                })
-            };
-
-            for command in command_iter {
-                if matches!(
-                    command,
-                    ArcCommand::RunRenderPass { .. } | ArcCommand::RunComputePass { .. }
-                ) {
-                    // Compute passes and render passes can accept either an
-                    // open or closed encoder. This state object holds an
-                    // `InnerCommandEncoder`. See the documentation of
-                    // [`EncodingState`].
-                    let mut state = EncodingState {
-                        device: &self.device,
-                        raw_encoder: &mut cmd_buf_data.encoder,
-                        tracker: &mut cmd_buf_data.trackers,
-                        buffer_memory_init_actions: &mut cmd_buf_data.buffer_memory_init_actions,
-                        texture_memory_actions: &mut cmd_buf_data.texture_memory_actions,
-                        as_actions: &mut cmd_buf_data.as_actions,
-                        temp_resources: &mut cmd_buf_data.temp_resources,
-                        indirect_draw_validation_resources: &mut cmd_buf_data
-                            .indirect_draw_validation_resources,
-                        snatch_guard: &snatch_guard,
-                        debug_scope_depth: &mut debug_scope_depth,
-                    };
-
-                    match command {
-                        ArcCommand::RunRenderPass {
-                            pass,
-                            color_attachments,
-                            depth_stencil_attachment,
-                            timestamp_writes,
-                            occlusion_query_set,
-                            multiview_mask,
-                        } => {
-                            api_log!(
-                                "Begin encoding render pass with '{}' label",
-                                pass.label.as_deref().unwrap_or("")
-                            );
-                            let res = encode_render_pass(
-                                &mut state,
-                                pass,
-                                color_attachments,
-                                depth_stencil_attachment,
-                                timestamp_writes,
-                                occlusion_query_set,
-                                multiview_mask,
-                            );
-                            match res.as_ref() {
-                                Err(err) => api_log!("Finished encoding render pass ({err:?})"),
-                                Ok(_) => api_log!("Finished encoding render pass (success)"),
-                            }
-                            res?;
-                        }
-                        ArcCommand::RunComputePass {
-                            pass,
-                            timestamp_writes,
-                        } => {
-                            api_log!(
-                                "Begin encoding compute pass with '{}' label",
-                                pass.label.as_deref().unwrap_or("")
-                            );
-                            let res = encode_compute_pass(&mut state, pass, timestamp_writes);
-                            match res.as_ref() {
-                                Err(err) => api_log!("Finished encoding compute pass ({err:?})"),
-                                Ok(_) => api_log!("Finished encoding compute pass (success)"),
-                            }
-                            res?;
-                        }
-                        _ => unreachable!(),
-                    }
-                } else {
-                    // All the other non-pass encoding routines assume the
-                    // encoder is open, so open it if necessary. This state
-                    // object holds an `&mut dyn hal::DynCommandEncoder`. By
-                    // convention, a bare HAL encoder reference in
-                    // [`EncodingState`] must always be an open encoder.
-                    let raw_encoder = cmd_buf_data.encoder.open_if_closed()?;
-                    let mut state = EncodingState {
-                        device: &self.device,
-                        raw_encoder,
-                        tracker: &mut cmd_buf_data.trackers,
-                        buffer_memory_init_actions: &mut cmd_buf_data.buffer_memory_init_actions,
-                        texture_memory_actions: &mut cmd_buf_data.texture_memory_actions,
-                        as_actions: &mut cmd_buf_data.as_actions,
-                        temp_resources: &mut cmd_buf_data.temp_resources,
-                        indirect_draw_validation_resources: &mut cmd_buf_data
-                            .indirect_draw_validation_resources,
-                        snatch_guard: &snatch_guard,
-                        debug_scope_depth: &mut debug_scope_depth,
-                    };
-                    match command {
-                        ArcCommand::CopyBufferToBuffer {
-                            src,
-                            src_offset,
-                            dst,
-                            dst_offset,
-                            size,
-                        } => {
-                            copy_buffer_to_buffer(
-                                &mut state, &src, src_offset, &dst, dst_offset, size,
-                            )?;
-                        }
-                        ArcCommand::CopyBufferToTexture { src, dst, size } => {
-                            copy_buffer_to_texture(&mut state, &src, &dst, &size)?;
-                        }
-                        ArcCommand::CopyTextureToBuffer { src, dst, size } => {
-                            copy_texture_to_buffer(&mut state, &src, &dst, &size)?;
-                        }
-                        ArcCommand::CopyTextureToTexture { src, dst, size } => {
-                            copy_texture_to_texture(&mut state, &src, &dst, &size)?;
-                        }
-                        ArcCommand::ClearBuffer { dst, offset, size } => {
-                            clear_buffer(&mut state, dst, offset, size)?;
-                        }
-                        ArcCommand::ClearTexture {
-                            dst,
-                            subresource_range,
-                        } => {
-                            clear_texture_cmd(&mut state, dst, &subresource_range)?;
-                        }
-                        ArcCommand::WriteTimestamp {
-                            query_set,
-                            query_index,
-                        } => {
-                            write_timestamp(&mut state, query_set, query_index)?;
-                        }
-                        ArcCommand::ResolveQuerySet {
-                            query_set,
-                            start_query,
-                            query_count,
-                            destination,
-                            destination_offset,
-                        } => {
-                            resolve_query_set(
-                                &mut state,
-                                query_set,
-                                start_query,
-                                query_count,
-                                destination,
-                                destination_offset,
-                            )?;
-                        }
-                        ArcCommand::PushDebugGroup(label) => {
-                            push_debug_group(&mut state, &label)?;
-                        }
-                        ArcCommand::PopDebugGroup => {
-                            pop_debug_group(&mut state)?;
-                        }
-                        ArcCommand::InsertDebugMarker(label) => {
-                            insert_debug_marker(&mut state, &label)?;
-                        }
-                        ArcCommand::BuildAccelerationStructures { blas, tlas } => {
-                            build_acceleration_structures(&mut state, blas, tlas)?;
-                        }
-                        ArcCommand::TransitionResources {
-                            buffer_transitions,
-                            texture_transitions,
-                        } => {
-                            transition_resources(
-                                &mut state,
-                                buffer_transitions,
-                                texture_transitions,
-                            )?;
-                        }
-                        ArcCommand::RunComputePass { .. } | ArcCommand::RunRenderPass { .. } => {
-                            unreachable!()
-                        }
-                    }
-                }
-            }
-
-            if debug_scope_depth > 0 {
-                Err(CommandEncoderError::DebugGroupError(
-                    DebugGroupError::MissingPop,
-                ))?;
-            }
-
-            // Close the encoder, unless it was closed already by a render or compute pass.
-            cmd_buf_data.encoder.close_if_open()?;
-
-            // Note: if we want to stop tracking the swapchain texture view,
-            // this is the place to do it.
-
-            Ok(cmd_buf_data)
-        });
-
         let (data, error) = match res {
-            Err(e) => {
-                if e.is_destroyed_error() {
+            Err(EncoderErrorState {
+                error,
+                #[cfg(feature = "trace")]
+                trace_commands,
+            }) => {
+                // Normally, commands are added to the trace when submitted, but
+                // since this command buffer won't be submitted, add it to the
+                // trace now.
+                #[cfg(feature = "trace")]
+                if let Some(trace) = self.device.trace.lock().as_mut() {
+                    use alloc::string::ToString;
+
+                    trace.add(crate::device::trace::Action::FailedCommands {
+                        commands: trace_commands,
+                        failed_at_submit: None,
+                        error: error.to_string(),
+                    });
+                }
+
+                if error.is_destroyed_error() {
                     // Errors related to destroyed resources are not reported until the
                     // command buffer is submitted.
-                    (CommandEncoderStatus::Error(e.clone()), None)
+                    (make_error_state(error), None)
                 } else {
-                    (CommandEncoderStatus::Error(e.clone()), Some(e))
+                    (make_error_state(error.clone()), Some(error))
                 }
             }
 
@@ -1222,10 +1285,14 @@ impl CommandBuffer {
         use CommandEncoderStatus as St;
         match mem::replace(
             &mut *self.data.lock(),
-            CommandEncoderStatus::Error(EncoderStateError::Submitted.into()),
+            make_error_state(EncoderStateError::Submitted),
         ) {
             St::Finished(command_buffer_mutable) => Ok(command_buffer_mutable),
-            St::Error(err) => Err(err),
+            St::Error(EncoderErrorState {
+                #[cfg(feature = "trace")]
+                    trace_commands: _,
+                error,
+            }) => Err(error),
             St::Recording(_) | St::Locked(_) | St::Consumed | St::Transitioning => unreachable!(),
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -997,27 +997,31 @@ impl Global {
             let device = self.hub.devices.get(device_id);
 
             #[cfg(feature = "trace")]
-            let data = device.trace.lock().as_mut().map(|trace| match source {
-                #[cfg(feature = "wgsl")]
-                pipeline::ShaderModuleSource::Wgsl(ref code) => {
-                    trace.make_binary("wgsl", code.as_bytes())
-                }
-                #[cfg(feature = "glsl")]
-                pipeline::ShaderModuleSource::Glsl(ref code, _) => {
-                    trace.make_binary("glsl", code.as_bytes())
-                }
-                #[cfg(feature = "spirv")]
-                pipeline::ShaderModuleSource::SpirV(ref code, _) => {
-                    trace.make_binary("spirv", bytemuck::cast_slice::<u32, u8>(code))
-                }
-                pipeline::ShaderModuleSource::Naga(ref module) => {
-                    let string =
-                        ron::ser::to_string_pretty(module, ron::ser::PrettyConfig::default())
-                            .unwrap();
-                    trace.make_binary("ron", string.as_bytes())
-                }
-                pipeline::ShaderModuleSource::Dummy(_) => {
-                    panic!("found `ShaderModuleSource::Dummy`")
+            let data = device.trace.lock().as_mut().map(|trace| {
+                use crate::device::trace::DataKind;
+
+                match source {
+                    #[cfg(feature = "wgsl")]
+                    pipeline::ShaderModuleSource::Wgsl(ref code) => {
+                        trace.make_binary(DataKind::Wgsl, code.as_bytes())
+                    }
+                    #[cfg(feature = "glsl")]
+                    pipeline::ShaderModuleSource::Glsl(ref code, _) => {
+                        trace.make_binary(DataKind::Glsl, code.as_bytes())
+                    }
+                    #[cfg(feature = "spirv")]
+                    pipeline::ShaderModuleSource::SpirV(ref code, _) => {
+                        trace.make_binary(DataKind::Spv, bytemuck::cast_slice::<u32, u8>(code))
+                    }
+                    pipeline::ShaderModuleSource::Naga(ref module) => {
+                        let string =
+                            ron::ser::to_string_pretty(module, ron::ser::PrettyConfig::default())
+                                .unwrap();
+                        trace.make_binary(DataKind::Ron, string.as_bytes())
+                    }
+                    pipeline::ShaderModuleSource::Dummy(_) => {
+                        panic!("found `ShaderModuleSource::Dummy`")
+                    }
                 }
             });
 
@@ -1081,17 +1085,22 @@ impl Global {
 
             #[cfg(feature = "trace")]
             if let Some(ref mut trace) = *device.trace.lock() {
+                use crate::device::trace::DataKind;
+
                 let mut file_names = Vec::new();
-                for (data, ext) in [
-                    (desc.spirv.as_ref().map(|a| bytemuck::cast_slice(a)), "spv"),
-                    (desc.dxil.as_deref(), "dxil"),
-                    (desc.hlsl.as_ref().map(|a| a.as_bytes()), "hlsl"),
-                    (desc.msl.as_ref().map(|a| a.as_bytes()), "msl"),
-                    (desc.glsl.as_ref().map(|a| a.as_bytes()), "glsl"),
-                    (desc.wgsl.as_ref().map(|a| a.as_bytes()), "wgsl"),
+                for (data, kind) in [
+                    (
+                        desc.spirv.as_ref().map(|a| bytemuck::cast_slice(a)),
+                        DataKind::Spv,
+                    ),
+                    (desc.dxil.as_deref(), DataKind::Dxil),
+                    (desc.hlsl.as_ref().map(|a| a.as_bytes()), DataKind::Hlsl),
+                    (desc.msl.as_ref().map(|a| a.as_bytes()), DataKind::Msl),
+                    (desc.glsl.as_ref().map(|a| a.as_bytes()), DataKind::Glsl),
+                    (desc.wgsl.as_ref().map(|a| a.as_bytes()), DataKind::Wgsl),
                 ] {
                     if let Some(data) = data {
-                        file_names.push(trace.make_binary(ext, data));
+                        file_names.push(trace.make_binary(kind, data));
                     }
                 }
                 trace.add(trace::Action::CreateShaderModulePassthrough {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1993,6 +1993,15 @@ impl Global {
         device.generate_allocator_report()
     }
 
+    #[cfg(feature = "trace")]
+    pub fn device_take_trace(
+        &self,
+        device_id: DeviceId,
+    ) -> Option<Box<dyn trace::Trace + Send + Sync + 'static>> {
+        let device = self.hub.devices.get(device_id);
+        device.take_trace()
+    }
+
     pub fn queue_drop(&self, queue_id: QueueId) {
         profiling::scope!("Queue::drop");
         api_log!("Queue::drop {queue_id:?}");

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1611,11 +1611,13 @@ impl Global {
 
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *queue.device.trace.lock() {
-            let data_path = trace.make_binary("bin", data);
+            use crate::device::trace::DataKind;
+            let range = buffer_offset..buffer_offset + data.len() as u64;
+            let data = trace.make_binary(DataKind::Bin, data);
             trace.add(Action::WriteBuffer {
                 id: buffer.to_trace(),
-                data: data_path,
-                range: buffer_offset..buffer_offset + data.len() as u64,
+                data,
+                range,
                 queued: true,
             });
         }
@@ -1682,10 +1684,11 @@ impl Global {
 
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *queue.device.trace.lock() {
-            let data_path = trace.make_binary("bin", data);
+            use crate::device::trace::DataKind;
+            let data = trace.make_binary(DataKind::Bin, data);
             trace.add(Action::WriteTexture {
                 to: destination.to_trace(),
-                data: data_path,
+                data,
                 layout: *data_layout,
                 size: *size,
             });

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1155,6 +1155,33 @@ impl Queue {
         Ok(())
     }
 
+    #[cfg(feature = "trace")]
+    fn trace_submission(
+        &self,
+        submit_index: SubmissionIndex,
+        commands: Vec<crate::command::Command<crate::command::PointerReferences>>,
+    ) {
+        if let Some(ref mut trace) = *self.device.trace.lock() {
+            trace.add(Action::Submit(submit_index, commands));
+        }
+    }
+
+    #[cfg(feature = "trace")]
+    fn trace_failed_submission(
+        &self,
+        submit_index: SubmissionIndex,
+        commands: Option<Vec<crate::command::Command<crate::command::PointerReferences>>>,
+        error: alloc::string::String,
+    ) {
+        if let Some(ref mut trace) = *self.device.trace.lock() {
+            trace.add(Action::FailedCommands {
+                commands,
+                failed_at_submit: Some(submit_index),
+                error,
+            });
+        }
+    }
+
     pub fn submit(
         &self,
         command_buffers: &[Arc<CommandBuffer>],
@@ -1209,19 +1236,15 @@ impl Queue {
                         #[allow(unused_mut)]
                         let mut cmd_buf_data = command_buffer.take_finished();
 
-                        #[cfg(feature = "trace")]
-                        if let Some(ref mut trace) = *self.device.trace.lock() {
-                            if let Ok(ref mut cmd_buf_data) = cmd_buf_data {
-                                trace.add(Action::Submit(
-                                    submit_index,
-                                    cmd_buf_data.trace_commands.take().unwrap(),
-                                ));
-                            }
-                        }
-
                         if first_error.is_some() {
                             continue;
                         }
+
+                        #[cfg(feature = "trace")]
+                        let trace_commands = cmd_buf_data
+                            .as_mut()
+                            .ok()
+                            .and_then(|data| mem::take(&mut data.trace_commands));
 
                         let mut baked = match cmd_buf_data {
                             Ok(cmd_buf_data) => {
@@ -1235,12 +1258,30 @@ impl Queue {
                                     &mut command_index_guard,
                                 );
                                 if let Err(err) = res {
+                                    #[cfg(feature = "trace")]
+                                    self.trace_failed_submission(
+                                        submit_index,
+                                        trace_commands,
+                                        err.to_string(),
+                                    );
                                     first_error.get_or_insert(err);
                                     continue;
                                 }
+
+                                #[cfg(feature = "trace")]
+                                if let Some(commands) = trace_commands {
+                                    self.trace_submission(submit_index, commands);
+                                }
+
                                 cmd_buf_data.into_baked_commands()
                             }
                             Err(err) => {
+                                #[cfg(feature = "trace")]
+                                self.trace_failed_submission(
+                                    submit_index,
+                                    trace_commands,
+                                    err.to_string(),
+                                );
                                 first_error.get_or_insert(err.into());
                                 continue;
                             }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -642,6 +642,14 @@ impl Device {
         }
     }
 
+    /// Stop tracing and return the trace object.
+    ///
+    /// This is mostly useful for in-memory traces.
+    #[cfg(feature = "trace")]
+    pub fn take_trace(&self) -> Option<Box<dyn trace::Trace + Send + Sync + 'static>> {
+        self.trace.lock().take()
+    }
+
     /// Checks that we are operating within the memory budget reported by the native APIs.
     ///
     /// If we are not, the device gets invalidated.

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -272,7 +272,7 @@ pub struct Device {
     pub(crate) default_external_texture_params_buffer: ManuallyDrop<Box<dyn hal::DynBuffer>>,
     // needs to be dropped last
     #[cfg(feature = "trace")]
-    pub(crate) trace: Mutex<Option<trace::Trace>>,
+    pub(crate) trace: Mutex<Option<Box<dyn trace::Trace + Send + Sync + 'static>>>,
 }
 
 pub(crate) enum DeferredDestroy {
@@ -385,9 +385,41 @@ impl Device {
             }
         };
         #[cfg(feature = "trace")]
-        let trace_dir_name: Option<&std::path::PathBuf> = match &desc.trace {
+        let trace: Option<Box<dyn trace::Trace + Send + Sync + 'static>> = match &desc.trace {
             wgt::Trace::Off => None,
-            wgt::Trace::Directory(d) => Some(d),
+            wgt::Trace::Directory(dir) => match trace::DiskTrace::new(dir.clone()) {
+                Ok(mut trace) => {
+                    trace::Trace::add(
+                        &mut trace,
+                        trace::Action::Init {
+                            desc: wgt::DeviceDescriptor {
+                                trace: wgt::Trace::Off,
+                                ..desc.clone()
+                            },
+                            backend: adapter.backend(),
+                        },
+                    );
+                    Some(Box::new(trace))
+                }
+                Err(e) => {
+                    log::error!("Unable to start a trace in '{dir:?}': {e}");
+                    None
+                }
+            },
+            wgt::Trace::Memory => {
+                let mut trace = trace::MemoryTrace::new();
+                trace::Trace::add(
+                    &mut trace,
+                    trace::Action::Init {
+                        desc: wgt::DeviceDescriptor {
+                            trace: wgt::Trace::Off,
+                            ..desc.clone()
+                        },
+                        backend: adapter.backend(),
+                    },
+                );
+                Some(Box::new(trace))
+            }
             // The enum is non_exhaustive, so we must have a fallback arm (that should be
             // unreachable in practice).
             t => {
@@ -483,25 +515,7 @@ impl Device {
             tracker_indices: TrackerIndexAllocators::new(),
             bgl_pool: ResourcePool::new(),
             #[cfg(feature = "trace")]
-            trace: Mutex::new(
-                rank::DEVICE_TRACE,
-                trace_dir_name.and_then(|path| match trace::Trace::new(path.clone()) {
-                    Ok(mut trace) => {
-                        trace.add(trace::Action::Init {
-                            desc: wgt::DeviceDescriptor {
-                                trace: wgt::Trace::Off,
-                                ..desc.clone()
-                            },
-                            backend: adapter.backend(),
-                        });
-                        Some(trace)
-                    }
-                    Err(e) => {
-                        log::error!("Unable to start a trace in '{path:?}': {e}");
-                        None
-                    }
-                }),
-            ),
+            trace: Mutex::new(rank::DEVICE_TRACE, trace),
             alignments,
             limits: desc.required_limits.clone(),
             features: desc.required_features,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -130,6 +130,14 @@ pub enum Action<'a, R: ReferenceType> {
         size: wgt::Extent3d,
     },
     Submit(crate::SubmissionIndex, Vec<Command<R>>),
+    FailedCommands {
+        commands: Option<Vec<Command<R>>>,
+        /// If `None`, then encoding failed due to a validation error (returned
+        /// from `CommandEncoder::finish`). If `Some`, submission failed due to
+        /// a resource having been destroyed.
+        failed_at_submit: Option<crate::SubmissionIndex>,
+        error: String,
+    },
     CreateBlas {
         id: R::Blas,
         desc: crate::resource::BlasDescriptor<'a>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "trace")]
 mod record;
+#[cfg(feature = "replay")]
+mod replay;
 
 use core::{convert::Infallible, ops::Range};
 
@@ -14,10 +16,97 @@ use crate::{
 
 #[cfg(feature = "trace")]
 pub use record::*;
+#[cfg(feature = "replay")]
+pub use replay::*;
 
 type FileName = String;
 
 pub const FILE_NAME: &str = "trace.ron";
+
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Data {
+    File(FileName),
+    String(DataKind, String),
+    Binary(DataKind, Vec<u8>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "lowercase")
+)]
+pub enum DataKind {
+    Bin,
+    Wgsl,
+
+    /// IR of Naga module, serialized in RON format
+    Ron,
+    Spv,
+    Dxil,
+    Hlsl,
+    Msl,
+    Glsl,
+}
+
+impl core::fmt::Display for DataKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let s = match self {
+            DataKind::Bin => "bin",
+            DataKind::Wgsl => "wgsl",
+            DataKind::Ron => "ron",
+            DataKind::Spv => "spv",
+            DataKind::Dxil => "dxil",
+            DataKind::Hlsl => "hlsl",
+            DataKind::Msl => "msl",
+            DataKind::Glsl => "glsl",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl DataKind {
+    #[cfg(feature = "replay")]
+    fn is_string(&self) -> bool {
+        match *self {
+            DataKind::Wgsl | DataKind::Ron | DataKind::Hlsl | DataKind::Msl | DataKind::Glsl => {
+                true
+            }
+            DataKind::Bin | DataKind::Spv | DataKind::Dxil => false,
+        }
+    }
+}
+
+impl Data {
+    pub fn kind(&self) -> DataKind {
+        match self {
+            Data::File(file) => {
+                if file.ends_with(".bin") {
+                    DataKind::Bin
+                } else if file.ends_with(".wgsl") {
+                    DataKind::Wgsl
+                } else if file.ends_with(".ron") {
+                    DataKind::Ron
+                } else if file.ends_with(".spv") {
+                    DataKind::Spv
+                } else if file.ends_with(".dxil") {
+                    DataKind::Dxil
+                } else if file.ends_with(".hlsl") {
+                    DataKind::Hlsl
+                } else if file.ends_with(".msl") {
+                    DataKind::Msl
+                } else if file.ends_with(".glsl") {
+                    DataKind::Glsl
+                } else {
+                    panic!("unknown data file extension: {file}");
+                }
+            }
+            Data::String(kind, _) => *kind,
+            Data::Binary(kind, _) => *kind,
+        }
+    }
+}
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
@@ -79,11 +168,11 @@ pub enum Action<'a, R: ReferenceType> {
     CreateShaderModule {
         id: PointerId<markers::ShaderModule>,
         desc: crate::pipeline::ShaderModuleDescriptor<'a>,
-        data: FileName,
+        data: Data,
     },
     CreateShaderModulePassthrough {
         id: PointerId<markers::ShaderModule>,
-        data: Vec<FileName>,
+        data: Vec<Data>,
 
         entry_point: String,
         label: crate::Label<'a>,
@@ -119,13 +208,13 @@ pub enum Action<'a, R: ReferenceType> {
     DestroyQuerySet(PointerId<markers::QuerySet>),
     WriteBuffer {
         id: R::Buffer,
-        data: FileName,
+        data: Data,
         range: Range<wgt::BufferAddress>,
         queued: bool,
     },
     WriteTexture {
         to: wgt::TexelCopyTextureInfo<R::Texture>,
-        data: FileName,
+        data: Data,
         layout: wgt::TexelCopyBufferLayout,
         size: wgt::Extent3d,
     },

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -1,5 +1,5 @@
 use alloc::{borrow::Cow, string::ToString, sync::Arc, vec::Vec};
-use core::convert::Infallible;
+use core::{any::Any, convert::Infallible};
 use std::io::Write as _;
 
 use crate::{
@@ -39,7 +39,7 @@ pub(crate) fn new_render_bundle_encoder_descriptor(
     }
 }
 
-pub trait Trace: Send + Sync {
+pub trait Trace: Any + Send + Sync {
     fn make_binary(&mut self, kind: DataKind, data: &[u8]) -> Data;
 
     fn make_string(&mut self, kind: DataKind, data: &str) -> Data;
@@ -831,6 +831,17 @@ impl<T: IntoTrace> IntoTrace for Option<T> {
 fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, PointerReferences> {
     use Action as A;
     match action {
+        A::Init { desc, backend } => A::Init {
+            desc: wgt::DeviceDescriptor {
+                label: desc.label.map(|l| Cow::Owned(l.into_owned())),
+                required_features: desc.required_features,
+                required_limits: desc.required_limits,
+                experimental_features: desc.experimental_features,
+                memory_hints: desc.memory_hints,
+                trace: desc.trace,
+            },
+            backend,
+        },
         A::ConfigureSurface(surface, config) => A::ConfigureSurface(surface, config),
         A::CreateBuffer(buffer, desc) => A::CreateBuffer(
             buffer,
@@ -896,8 +907,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DestroyBlas(blas) => A::DestroyBlas(blas),
         A::DestroyTlas(tlas) => A::DestroyTlas(tlas),
 
-        A::Init { .. }
-        | A::CreateTexture(..)
+        A::CreateTexture(..)
         | A::CreateTextureView { .. }
         | A::CreateExternalTexture { .. }
         | A::CreateSampler(..)

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -1,9 +1,4 @@
-use alloc::{
-    borrow::Cow,
-    string::{String, ToString},
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::{borrow::Cow, string::ToString, sync::Arc, vec::Vec};
 use core::convert::Infallible;
 use std::io::Write as _;
 
@@ -13,6 +8,7 @@ use crate::{
         BasePass, ColorAttachments, Command, ComputeCommand, PointerReferences, RenderCommand,
         RenderPassColorAttachment, ResolvedRenderPassDepthStencilAttachment,
     },
+    device::trace::{Data, DataKind},
     id::{markers, PointerId},
     storage::StorageItem,
 };
@@ -43,15 +39,25 @@ pub(crate) fn new_render_bundle_encoder_descriptor(
     }
 }
 
+pub trait Trace: Send + Sync {
+    fn make_binary(&mut self, kind: DataKind, data: &[u8]) -> Data;
+
+    fn make_string(&mut self, kind: DataKind, data: &str) -> Data;
+
+    fn add(&mut self, action: Action<'_, PointerReferences>)
+    where
+        for<'a> Action<'a, PointerReferences>: serde::Serialize;
+}
+
 #[derive(Debug)]
-pub struct Trace {
+pub struct DiskTrace {
     path: std::path::PathBuf,
     file: std::fs::File,
     config: ron::ser::PrettyConfig,
-    binary_id: usize,
+    data_id: usize,
 }
 
-impl Trace {
+impl DiskTrace {
     pub fn new(path: std::path::PathBuf) -> Result<Self, std::io::Error> {
         log::debug!("Tracing into '{path:?}'");
         let mut file = std::fs::File::create(path.join(FILE_NAME))?;
@@ -60,18 +66,32 @@ impl Trace {
             path,
             file,
             config: ron::ser::PrettyConfig::default(),
-            binary_id: 0,
+            data_id: 0,
         })
     }
+}
 
-    pub fn make_binary(&mut self, kind: &str, data: &[u8]) -> String {
-        self.binary_id += 1;
-        let name = std::format!("data{}.{}", self.binary_id, kind);
+impl Trace for DiskTrace {
+    /// Store `[u8]` data in the trace.
+    ///
+    /// Using a string `kind` is probably a bug, but should work as long as the
+    /// data is UTF-8.
+    fn make_binary(&mut self, kind: DataKind, data: &[u8]) -> Data {
+        self.data_id += 1;
+        let name = std::format!("data{}.{}", self.data_id, kind);
         let _ = std::fs::write(self.path.join(&name), data);
-        name
+        Data::File(name)
     }
 
-    pub(crate) fn add(&mut self, action: Action<'_, PointerReferences>)
+    /// Store `str` data in the trace.
+    ///
+    /// Using a binary `kind` is fine, but it's not clear why not use
+    /// `make_binary` instead.
+    fn make_string(&mut self, kind: DataKind, data: &str) -> Data {
+        self.make_binary(kind, data.as_bytes())
+    }
+
+    fn add(&mut self, action: Action<'_, PointerReferences>)
     where
         for<'a> Action<'a, PointerReferences>: serde::Serialize,
     {
@@ -86,9 +106,49 @@ impl Trace {
     }
 }
 
-impl Drop for Trace {
+impl Drop for DiskTrace {
     fn drop(&mut self) {
         let _ = self.file.write_all(b"]");
+    }
+}
+
+#[derive(Default)]
+pub struct MemoryTrace {
+    actions: Vec<Action<'static, PointerReferences>>,
+}
+
+impl MemoryTrace {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn actions(&self) -> &[Action<'static, PointerReferences>] {
+        &self.actions
+    }
+}
+
+impl Trace for MemoryTrace {
+    /// Store `[u8]` data in the trace.
+    ///
+    /// Using a string `kind` is probably a bug, but should work as long as the
+    /// data is UTF-8.
+    fn make_binary(&mut self, kind: DataKind, data: &[u8]) -> Data {
+        Data::Binary(kind, data.to_vec())
+    }
+
+    /// Store `str` data in the trace.
+    ///
+    /// Using a binary `kind` is fine, but it's not clear why not use
+    /// `make_binary` instead.
+    fn make_string(&mut self, kind: DataKind, data: &str) -> Data {
+        Data::String(kind, data.to_string())
+    }
+
+    fn add(&mut self, action: Action<'_, PointerReferences>)
+    where
+        for<'a> Action<'a, PointerReferences>: serde::Serialize,
+    {
+        self.actions.push(action_to_owned(action))
     }
 }
 
@@ -565,9 +625,11 @@ impl IntoTrace for ArcRenderCommand {
     }
 }
 
-impl<'a> IntoTrace for crate::binding_model::ResolvedPipelineLayoutDescriptor<'a> {
-    type Output =
-        crate::binding_model::PipelineLayoutDescriptor<'a, PointerId<markers::BindGroupLayout>>;
+impl IntoTrace for crate::binding_model::ResolvedPipelineLayoutDescriptor<'_> {
+    type Output = crate::binding_model::PipelineLayoutDescriptor<
+        'static,
+        PointerId<markers::BindGroupLayout>,
+    >;
     fn into_trace(self) -> Self::Output {
         crate::binding_model::PipelineLayoutDescriptor {
             label: self.label.map(|l| Cow::Owned(l.into_owned())),
@@ -754,5 +816,102 @@ impl<T: IntoTrace> IntoTrace for Option<T> {
     type Output = Option<T::Output>;
     fn into_trace(self) -> Self::Output {
         self.map(|v| v.into_trace())
+    }
+}
+
+/// For selected `Action`s (mostly actions containing only owned data), return a
+/// copy with `'static` lifetime.
+///
+/// This is used for in-memory tracing.
+///
+/// # Panics
+///
+/// If `action` is not supported for in-memory tracing (likely because it
+/// contains borrowed data).
+fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, PointerReferences> {
+    use Action as A;
+    match action {
+        A::ConfigureSurface(surface, config) => A::ConfigureSurface(surface, config),
+        A::CreateBuffer(buffer, desc) => A::CreateBuffer(
+            buffer,
+            wgt::BufferDescriptor {
+                label: desc.label.map(|l| Cow::Owned(l.into_owned())),
+                size: desc.size,
+                usage: desc.usage,
+                mapped_at_creation: desc.mapped_at_creation,
+            },
+        ),
+        A::FreeBuffer(buffer) => A::FreeBuffer(buffer),
+        A::DestroyBuffer(buffer) => A::DestroyBuffer(buffer),
+        A::FreeTexture(texture) => A::FreeTexture(texture),
+        A::DestroyTexture(texture) => A::DestroyTexture(texture),
+        A::DestroyTextureView(texture_view) => A::DestroyTextureView(texture_view),
+        A::FreeExternalTexture(external_texture) => A::FreeExternalTexture(external_texture),
+        A::DestroyExternalTexture(external_texture) => A::DestroyExternalTexture(external_texture),
+        A::DestroySampler(sampler) => A::DestroySampler(sampler),
+        A::GetSurfaceTexture { id, parent } => A::GetSurfaceTexture { id, parent },
+        A::Present(surface) => A::Present(surface),
+        A::DiscardSurfaceTexture(surface) => A::DiscardSurfaceTexture(surface),
+        A::DestroyBindGroupLayout(layout) => A::DestroyBindGroupLayout(layout),
+        A::DestroyPipelineLayout(layout) => A::DestroyPipelineLayout(layout),
+        A::DestroyBindGroup(bind_group) => A::DestroyBindGroup(bind_group),
+        A::DestroyShaderModule(shader_module) => A::DestroyShaderModule(shader_module),
+        A::DestroyComputePipeline(pipeline) => A::DestroyComputePipeline(pipeline),
+        A::DestroyRenderPipeline(pipeline) => A::DestroyRenderPipeline(pipeline),
+        A::DestroyPipelineCache(cache) => A::DestroyPipelineCache(cache),
+        A::DestroyRenderBundle(render_bundle) => A::DestroyRenderBundle(render_bundle),
+        A::DestroyQuerySet(query_set) => A::DestroyQuerySet(query_set),
+        A::WriteBuffer {
+            id,
+            data,
+            range,
+            queued,
+        } => A::WriteBuffer {
+            id,
+            data,
+            range,
+            queued,
+        },
+        A::WriteTexture {
+            to,
+            data,
+            layout,
+            size,
+        } => A::WriteTexture {
+            to,
+            data,
+            layout,
+            size,
+        },
+        A::Submit(index, commands) => A::Submit(index, commands),
+        A::FailedCommands {
+            commands,
+            failed_at_submit,
+            error,
+        } => A::FailedCommands {
+            commands,
+            failed_at_submit,
+            error,
+        },
+        A::DestroyBlas(blas) => A::DestroyBlas(blas),
+        A::DestroyTlas(tlas) => A::DestroyTlas(tlas),
+
+        A::Init { .. }
+        | A::CreateTexture(..)
+        | A::CreateTextureView { .. }
+        | A::CreateExternalTexture { .. }
+        | A::CreateSampler(..)
+        | A::CreateBindGroupLayout(..)
+        | A::CreatePipelineLayout(..)
+        | A::CreateBindGroup(..)
+        | A::CreateShaderModule { .. }
+        | A::CreateShaderModulePassthrough { .. }
+        | A::CreateComputePipeline { .. }
+        | A::CreateGeneralRenderPipeline { .. }
+        | A::CreatePipelineCache { .. }
+        | A::CreateRenderBundle { .. }
+        | A::CreateQuerySet { .. }
+        | A::CreateBlas { .. }
+        | A::CreateTlas { .. } => panic!("Unsupported action for tracing: {action:?}"),
     }
 }

--- a/wgpu-core/src/device/trace/replay.rs
+++ b/wgpu-core/src/device/trace/replay.rs
@@ -1,0 +1,51 @@
+use alloc::borrow::Cow;
+
+use super::Data;
+
+pub trait DataLoader {
+    fn load<'loader, 'data>(&'loader self, data: &'data Data) -> Cow<'data, [u8]>;
+    fn load_utf8<'loader, 'data>(&'loader self, data: &'data Data) -> Cow<'data, str>;
+}
+
+#[cfg(feature = "std")]
+pub struct DiskTraceLoader<'a>(&'a std::path::Path);
+
+#[cfg(feature = "std")]
+impl<'a> DiskTraceLoader<'a> {
+    pub fn new(path: &'a std::path::Path) -> DiskTraceLoader<'a> {
+        DiskTraceLoader(path)
+    }
+}
+
+impl DataLoader for DiskTraceLoader<'_> {
+    fn load<'loader, 'data>(&'loader self, data: &'data Data) -> Cow<'data, [u8]> {
+        match data {
+            Data::File(file) => {
+                Cow::from(std::fs::read(self.0.join(file)).expect("Failed to read data file"))
+            }
+            Data::String(_, s) => Cow::from(s.as_bytes()),
+            Data::Binary(_, b) => Cow::from(b),
+        }
+    }
+
+    /// Load UTF-8 string data
+    ///
+    /// # Panics
+    ///
+    /// If the data kind is not a string format or the data is not valid UTF-8
+    fn load_utf8<'loader, 'data>(&'loader self, data: &'data Data) -> Cow<'data, str> {
+        match data {
+            Data::File(file) => Cow::from(
+                std::fs::read_to_string(self.0.join(file)).expect("Failed to read data file"),
+            ),
+            Data::String(kind, s) => {
+                assert!(kind.is_string(), "{kind:?} cannot be loaded as a string");
+                Cow::from(s)
+            }
+            Data::Binary(kind, b) => {
+                assert!(kind.is_string(), "{kind:?} cannot be loaded as a string");
+                Cow::from(core::str::from_utf8(b).unwrap())
+            }
+        }
+    }
+}

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -128,7 +128,7 @@ impl TryFrom<SerialId> for RawId {
 
 /// Identify an object by the pointer returned by `Arc::as_ptr`.
 ///
-/// This is used for tracing.
+/// This is used for tracing. See [IDs and tracing](crate::hub#ids-and-tracing).
 #[allow(dead_code)]
 #[cfg(feature = "serde")]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -368,6 +368,8 @@ impl Global {
 
         let fid = self.hub.textures.prepare(texture_id_in);
 
+        let output = surface.get_current_texture()?;
+
         #[cfg(feature = "trace")]
         if let Some(present) = surface.presentation.lock().as_ref() {
             if let Some(ref mut trace) = *present.device.trace.lock() {
@@ -379,8 +381,6 @@ impl Global {
                 }
             }
         }
-
-        let output = surface.get_current_texture()?;
 
         let status = output.status;
         let texture_id = output

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -815,9 +815,9 @@ impl Buffer {
             BufferMapState::Init { staging_buffer } => {
                 #[cfg(feature = "trace")]
                 if let Some(ref mut trace) = *device.trace.lock() {
-                    use crate::device::trace::IntoTrace;
+                    use crate::device::trace::{DataKind, IntoTrace};
 
-                    let data = trace.make_binary("bin", staging_buffer.get_data());
+                    let data = trace.make_binary(DataKind::Bin, staging_buffer.get_data());
                     trace.add(trace::Action::WriteBuffer {
                         id: self.to_trace(),
                         data,
@@ -878,10 +878,10 @@ impl Buffer {
                 if host == HostMap::Write {
                     #[cfg(feature = "trace")]
                     if let Some(ref mut trace) = *device.trace.lock() {
-                        use crate::device::trace::IntoTrace;
+                        use crate::device::trace::{DataKind, IntoTrace};
 
                         let size = range.end - range.start;
-                        let data = trace.make_binary("bin", unsafe {
+                        let data = trace.make_binary(DataKind::Bin, unsafe {
                             core::slice::from_raw_parts(mapping.ptr.as_ptr(), size as usize)
                         });
                         trace.add(trace::Action::WriteBuffer {

--- a/wgpu-types/src/device.rs
+++ b/wgpu-types/src/device.rs
@@ -95,9 +95,13 @@ pub enum Trace {
     #[default]
     Off,
 
-    /// Tracing enabled.
+    /// Write trace to disk.
     #[cfg(feature = "trace")]
     // This must be owned rather than `&'a Path`, because if it were that, then the lifetime
     // parameter would be unused when the "trace" feature is disabled, which is prohibited.
     Directory(std::path::PathBuf),
+
+    /// Store trace in memory.
+    #[cfg(feature = "trace")]
+    Memory,
 }

--- a/wgpu-types/src/device.rs
+++ b/wgpu-types/src/device.rs
@@ -83,9 +83,6 @@ pub enum MemoryHints {
 }
 
 /// Controls API call tracing and specifies where the trace is written.
-///
-/// **Note:** Tracing is currently unavailable.
-/// See [issue 5974](https://github.com/gfx-rs/wgpu/issues/5974) for updates.
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 // This enum must be non-exhaustive so that enabling the "trace" feature is not a semver break.

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -120,9 +120,8 @@ strict_asserts = ["wgpu-core?/strict_asserts", "wgpu-types/strict_asserts"]
 ## Enables serialization via `serde` on common wgpu types.
 serde = ["wgpu-core?/serde", "wgpu-types/serde"]
 
-# Uncomment once we get to https://github.com/gfx-rs/wgpu/issues/5974
 # ## Allow writing of trace capture files. See [`Adapter::request_device`].
-# trace = ["serde", "wgpu-core/trace"]
+trace = ["serde", "wgpu-core?/trace"]
 
 #! ### External libraries
 # --------------------------------------------------------------------

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -110,15 +110,6 @@ impl ContextWgpuCore {
         hal_device: hal::OpenDevice<A>,
         desc: &crate::DeviceDescriptor<'_>,
     ) -> Result<(CoreDevice, CoreQueue), crate::RequestDeviceError> {
-        if !matches!(desc.trace, wgt::Trace::Off) {
-            log::error!(
-                "
-                Feature 'trace' has been removed temporarily; \
-                see https://github.com/gfx-rs/wgpu/issues/5974. \
-                The `trace` parameter will have no effect."
-            );
-        }
-
         let (device_id, queue_id) = unsafe {
             self.0.create_device_from_hal(
                 adapter.id,
@@ -930,15 +921,6 @@ impl dispatch::AdapterInterface for CoreAdapter {
         &self,
         desc: &crate::DeviceDescriptor<'_>,
     ) -> Pin<Box<dyn dispatch::RequestDeviceFuture>> {
-        if !matches!(desc.trace, wgt::Trace::Off) {
-            log::error!(
-                "
-                Feature 'trace' has been removed temporarily; \
-                see https://github.com/gfx-rs/wgpu/issues/5974. \
-                The `trace` parameter will have no effect."
-            );
-        }
-
         let res = self.context.0.adapter_request_device(
             self.id,
             &desc.map_label(|l| l.map(Borrowed)),


### PR DESCRIPTION
This adds support for storing commands that resulted in an error (either during encoding, or on submission) in a trace. It also adds a simple test for tracing and for the new error tracing functionality, restores the tracing controls in the `wgpu` API, and fixes some bugs playing back traces in a window.

The loop/break changes in `play.rs` are reverting changes made in https://github.com/gfx-rs/wgpu/pull/4202.

**Squash or Rebase?** Rebase

**Testing**
Adds some tests for the tracing functionality in wgpu-core. Also enables tracing to a temporary directory in the hello_triangle example, to get some coverage of activating tracing from `wgpu`.

I did verify manually that I can play back the hello_triangle trace (which required some fixes), but there isn't an automated test for that.

**Checklist**

- [x] Added a `CHANGELOG.md` entry for restoring tracing in `wgpu`.