### PR TITLE
Disable DX on gnu target.

### DIFF
--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -262,7 +262,7 @@ glutin_wgl_sys = { workspace = true, optional = true }
 # This doesn't support aarch64. See https://github.com/gfx-rs/wgpu/issues/6860.
 #
 # ⚠️ Keep in sync with static_dxc cfg in build.rs and cfg_alias in `wgpu` crate ⚠️
-[target.'cfg(all(windows, not(target_arch = "aarch64")))'.dependencies]
+[target.'cfg(all(windows, not(target_arch = "aarch64"), target_env = "msvc"))'.dependencies]
 mach-dxcompiler-rs = { workspace = true, optional = true }
 
 #######################

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -260,6 +260,7 @@ glutin_wgl_sys = { workspace = true, optional = true }
 
 ### Platform: x86/x86_64 Windows ###
 # This doesn't support aarch64. See https://github.com/gfx-rs/wgpu/issues/6860.
+# This doesn't support x86_64-pc-windows-gnu. See https://github.com/gfx-rs/wgpu/issues/8303
 #
 # ⚠️ Keep in sync with static_dxc cfg in build.rs and cfg_alias in `wgpu` crate ⚠️
 [target.'cfg(all(windows, not(target_arch = "aarch64"), target_env = "msvc"))'.dependencies]

--- a/wgpu-hal/build.rs
+++ b/wgpu-hal/build.rs
@@ -24,7 +24,7 @@ fn main() {
         metal: { all(target_vendor = "apple", feature = "metal") },
         vulkan: { all(not(target_arch = "wasm32"), feature = "vulkan") },
         // ⚠️ Keep in sync with target.cfg() definition in Cargo.toml and cfg_alias in `wgpu` crate ⚠️
-        static_dxc: { all(target_os = "windows", feature = "static-dxc", not(target_arch = "aarch64")) },
+        static_dxc: { all(target_os = "windows", feature = "static-dxc", not(target_arch = "aarch64"), target_env = "msvc") },
         supports_64bit_atomics: { target_has_atomic = "64" },
         supports_ptr_atomics: { target_has_atomic = "ptr" }
     }

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -45,7 +45,7 @@ fn main() {
         // its own re-export of naga, which can be used in other situations
         naga: { any(feature = "naga-ir", feature = "spirv", feature = "glsl") },
         // ⚠️ Keep in sync with target.cfg() definition in wgpu-hal/Cargo.toml and cfg_alias in `wgpu-hal` crate ⚠️
-        static_dxc: { all(target_os = "windows", feature = "static-dxc", not(target_arch = "aarch64")) },
+        static_dxc: { all(target_os = "windows", feature = "static-dxc", not(target_arch = "aarch64"), target_env = "msvc") },
         supports_64bit_atomics: { target_has_atomic = "64" },
         custom: {any(feature = "custom")},
         std: { any(


### PR DESCRIPTION
**Connections**
Fix #8303

**Description**
Don't link against matchdx for the x86_64-pc-windows-gnu target

**Testing**
I could run the cube example

**Squash or Rebase?**


<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
