### PR TITLE
[naga][metal] Annotate dot product functions as wrapped functions

### DIFF
--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -19,7 +19,7 @@ use crate::{
     back::{self, get_entry_points, Baked},
     common,
     proc::{
-        self,
+        self, concrete_int_scalars,
         index::{self, BoundsCheck},
         ExternalTextureNameKey, NameKey, TypeResolution,
     },
@@ -55,6 +55,7 @@ pub(crate) const MODF_FUNCTION: &str = "naga_modf";
 pub(crate) const FREXP_FUNCTION: &str = "naga_frexp";
 pub(crate) const ABS_FUNCTION: &str = "naga_abs";
 pub(crate) const DIV_FUNCTION: &str = "naga_div";
+pub(crate) const DOT_FUNCTION_PREFIX: &str = "naga_dot";
 pub(crate) const MOD_FUNCTION: &str = "naga_mod";
 pub(crate) const NEG_FUNCTION: &str = "naga_neg";
 pub(crate) const F2I32_FUNCTION: &str = "naga_f2i32";
@@ -488,7 +489,7 @@ pub struct Writer<W> {
 }
 
 impl crate::Scalar {
-    fn to_msl_name(self) -> &'static str {
+    pub(super) fn to_msl_name(self) -> &'static str {
         use crate::ScalarKind as Sk;
         match self {
             Self {
@@ -2334,26 +2335,28 @@ impl<W: Write> Writer<W> {
                         crate::TypeInner::Vector {
                             scalar:
                                 crate::Scalar {
+                                    // Resolve float values to MSL's builtin dot function.
                                     kind: crate::ScalarKind::Float,
                                     ..
                                 },
                             ..
                         } => "dot",
-                        crate::TypeInner::Vector { size, .. } => {
-                            return self.put_dot_product(
-                                arg,
-                                arg1.unwrap(),
-                                size as usize,
-                                |writer, arg, index| {
-                                    // Write the vector expression; this expression is marked to be
-                                    // cached so unless it can't be cached (for example, it's a Constant)
-                                    // it shouldn't produce large expressions.
-                                    writer.put_expression(arg, context, true)?;
-                                    // Access the current component on the vector.
-                                    write!(writer.out, ".{}", back::COMPONENTS[index])?;
-                                    Ok(())
+                        crate::TypeInner::Vector {
+                            size,
+                            scalar:
+                                scalar @ crate::Scalar {
+                                    kind: crate::ScalarKind::Sint | crate::ScalarKind::Uint,
+                                    ..
                                 },
-                            );
+                        } => {
+                            // Integer vector dot: call our mangled helper `dot_{type}{N}(a, b)`.
+                            let fun_name = self.get_dot_wrapper_function_helper_name(scalar, size);
+                            write!(self.out, "{fun_name}(")?;
+                            self.put_expression(arg, context, true)?;
+                            write!(self.out, ", ")?;
+                            self.put_expression(arg1.unwrap(), context, true)?;
+                            write!(self.out, ")")?;
+                            return Ok(());
                         }
                         _ => unreachable!(
                             "Correct TypeInner for dot product should be already validated"
@@ -3370,26 +3373,15 @@ impl<W: Write> Writer<W> {
             } = *expr
             {
                 match fun {
-                    crate::MathFunction::Dot => {
-                        // WGSL's `dot` function works on any `vecN` type, but Metal's only
-                        // works on floating-point vectors, so we emit inline code for
-                        // integer vector `dot` calls. But that code uses each argument `N`
-                        // times, once for each component (see `put_dot_product`), so to
-                        // avoid duplicated evaluation, we must bake integer operands.
-
-                        // check what kind of product this is depending
-                        // on the resolve type of the Dot function itself
-                        let inner = context.resolve_type(expr_handle);
-                        if let crate::TypeInner::Scalar(scalar) = *inner {
-                            match scalar.kind {
-                                crate::ScalarKind::Sint | crate::ScalarKind::Uint => {
-                                    self.need_bake_expressions.insert(arg);
-                                    self.need_bake_expressions.insert(arg1.unwrap());
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
+                    // WGSL's `dot` function works on any `vecN` type, but Metal's only
+                    // works on floating-point vectors, so we emit inline code for
+                    // integer vector `dot` calls. But that code uses each argument `N`
+                    // times, once for each component (see `put_dot_product`), so to
+                    // avoid duplicated evaluation, we must bake integer operands.
+                    // This applies both when using the polyfill (because of the duplicate
+                    // evaluation issue) and when we don't use the polyfill (because we
+                    // need them to be emitted before casting to packed chars -- see the
+                    // comment at the call to `put_casting_to_packed_chars`).
                     crate::MathFunction::Dot4U8Packed | crate::MathFunction::Dot4I8Packed => {
                         self.need_bake_expressions.insert(arg);
                         self.need_bake_expressions.insert(arg1.unwrap());
@@ -5806,6 +5798,24 @@ template <typename A>
         Ok(())
     }
 
+    /// Build the mangled helper name for integer vector dot products.
+    ///
+    /// `scalar` must be a concrete integer scalar type.
+    ///
+    /// Result format: `{DOT_FUNCTION_PREFIX}_{type}{N}` (e.g., `naga_dot_int3`).
+    fn get_dot_wrapper_function_helper_name(
+        &self,
+        scalar: crate::Scalar,
+        size: crate::VectorSize,
+    ) -> String {
+        // Check for consistency with [`super::keywords::RESERVED_SET`]
+        debug_assert!(concrete_int_scalars().any(|s| s == scalar));
+
+        let type_name = scalar.to_msl_name();
+        let size_suffix = common::vector_size_str(size);
+        format!("{DOT_FUNCTION_PREFIX}_{type_name}{size_suffix}")
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn write_wrapped_math_function(
         &mut self,
@@ -5861,6 +5871,45 @@ template <typename A>
                 writeln!(self.out, "}}")?;
                 writeln!(self.out)?;
             }
+
+            crate::MathFunction::Dot => match *arg_ty {
+                crate::TypeInner::Vector { size, scalar }
+                    if matches!(
+                        scalar.kind,
+                        crate::ScalarKind::Sint | crate::ScalarKind::Uint
+                    ) =>
+                {
+                    // De-duplicate per (fun, arg type) like other wrapped math functions
+                    let wrapped = WrappedFunction::Math {
+                        fun,
+                        arg_ty: (Some(size), scalar),
+                    };
+                    if !self.wrapped_functions.insert(wrapped) {
+                        return Ok(());
+                    }
+
+                    let mut vec_ty = String::new();
+                    put_numeric_type(&mut vec_ty, scalar, &[size])?;
+                    let mut ret_ty = String::new();
+                    put_numeric_type(&mut ret_ty, scalar, &[])?;
+
+                    let fun_name = self.get_dot_wrapper_function_helper_name(scalar, size);
+
+                    // Emit function signature and body using put_dot_product for the expression
+                    writeln!(self.out, "{ret_ty} {fun_name}({vec_ty} a, {vec_ty} b) {{")?;
+                    let level = back::Level(1);
+                    write!(self.out, "{level}return ")?;
+                    self.put_dot_product("a", "b", size as usize, |writer, name, index| {
+                        write!(writer.out, "{name}.{}", back::COMPONENTS[index])?;
+                        Ok(())
+                    })?;
+                    writeln!(self.out, ";")?;
+                    writeln!(self.out, "}}")?;
+                    writeln!(self.out)?;
+                }
+                _ => {}
+            },
+
             _ => {}
         }
         Ok(())

--- a/naga/src/common/mod.rs
+++ b/naga/src/common/mod.rs
@@ -8,11 +8,5 @@ pub mod wgsl;
 pub use diagnostic_debug::{DiagnosticDebug, ForDebug, ForDebugWithTypes};
 pub use diagnostic_display::DiagnosticDisplay;
 
-/// Helper function that returns the string corresponding to the [`VectorSize`](crate::VectorSize)
-pub const fn vector_size_str(size: crate::VectorSize) -> &'static str {
-    match size {
-        crate::VectorSize::Bi => "2",
-        crate::VectorSize::Tri => "3",
-        crate::VectorSize::Quad => "4",
-    }
-}
+// Re-exported here for backwards compatibility
+pub use super::proc::vector_size_str;

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -24,7 +24,9 @@ pub use namer::{EntryPointIndex, ExternalTextureNameKey, NameKey, Namer};
 pub use overloads::{Conclusion, MissingSpecialType, OverloadSet, Rule};
 pub use terminator::ensure_block_returns;
 use thiserror::Error;
-pub use type_methods::min_max_float_representable_by;
+pub use type_methods::{
+    concrete_int_scalars, min_max_float_representable_by, vector_size_str, vector_sizes,
+};
 pub use typifier::{compare_types, ResolveContext, ResolveError, TypeResolution};
 
 use crate::non_max_u32::NonMaxU32;

--- a/naga/src/proc/overloads/mathfunction.rs
+++ b/naga/src/proc/overloads/mathfunction.rs
@@ -4,10 +4,10 @@ use crate::proc::overloads::any_overload_set::AnyOverloadSet;
 use crate::proc::overloads::list::List;
 use crate::proc::overloads::regular::regular;
 use crate::proc::overloads::utils::{
-    concrete_int_scalars, float_scalars, float_scalars_unimplemented_abstract, list, pairs, rule,
-    scalar_or_vecn, triples, vector_sizes,
+    float_scalars, float_scalars_unimplemented_abstract, list, pairs, rule, scalar_or_vecn, triples,
 };
 use crate::proc::overloads::OverloadSet;
+use crate::proc::type_methods::{concrete_int_scalars, vector_sizes};
 
 use crate::ir;
 

--- a/naga/src/proc/overloads/utils.rs
+++ b/naga/src/proc/overloads/utils.rs
@@ -9,17 +9,6 @@ use crate::proc::TypeResolution;
 
 use alloc::vec::Vec;
 
-/// Produce all vector sizes.
-pub fn vector_sizes() -> impl Iterator<Item = ir::VectorSize> + Clone {
-    static SIZES: [ir::VectorSize; 3] = [
-        ir::VectorSize::Bi,
-        ir::VectorSize::Tri,
-        ir::VectorSize::Quad,
-    ];
-
-    SIZES.iter().cloned()
-}
-
 /// Produce all the floating-point [`ir::Scalar`]s.
 ///
 /// Note that `F32` must appear before other sizes; this is how we
@@ -38,20 +27,6 @@ pub fn float_scalars() -> impl Iterator<Item = ir::Scalar> + Clone {
 /// abstract types, for #7405.
 pub fn float_scalars_unimplemented_abstract() -> impl Iterator<Item = ir::Scalar> + Clone {
     [ir::Scalar::F32, ir::Scalar::F16, ir::Scalar::F64].into_iter()
-}
-
-/// Produce all concrete integer [`ir::Scalar`]s.
-///
-/// Note that `I32` and `U32` must come first; this is how we
-/// represent conversion rank.
-pub fn concrete_int_scalars() -> impl Iterator<Item = ir::Scalar> {
-    [
-        ir::Scalar::I32,
-        ir::Scalar::U32,
-        ir::Scalar::I64,
-        ir::Scalar::U64,
-    ]
-    .into_iter()
 }
 
 /// Produce the scalar and vector [`ir::TypeInner`]s that have `s` as

--- a/naga/src/proc/type_methods.rs
+++ b/naga/src/proc/type_methods.rs
@@ -1,8 +1,9 @@
-//! Methods on [`TypeInner`], [`Scalar`], and [`ScalarKind`].
+//! Methods on or related to [`TypeInner`], [`Scalar`], [`ScalarKind`], and [`VectorSize`].
 //!
 //! [`TypeInner`]: crate::TypeInner
 //! [`Scalar`]: crate::Scalar
 //! [`ScalarKind`]: crate::ScalarKind
+//! [`VectorSize`]: crate::VectorSize
 
 use crate::{ir, valid::MAX_TYPE_SIZE};
 
@@ -95,6 +96,31 @@ impl crate::Scalar {
     pub const fn to_inner_atomic(self) -> crate::TypeInner {
         crate::TypeInner::Atomic(self)
     }
+}
+
+/// Produce all concrete integer [`ir::Scalar`]s.
+///
+/// Note that `I32` and `U32` must come first; this represents conversion rank
+/// in overload resolution.
+pub fn concrete_int_scalars() -> impl Iterator<Item = ir::Scalar> {
+    [
+        ir::Scalar::I32,
+        ir::Scalar::U32,
+        ir::Scalar::I64,
+        ir::Scalar::U64,
+    ]
+    .into_iter()
+}
+
+/// Produce all vector sizes.
+pub fn vector_sizes() -> impl Iterator<Item = ir::VectorSize> + Clone {
+    static SIZES: [ir::VectorSize; 3] = [
+        ir::VectorSize::Bi,
+        ir::VectorSize::Tri,
+        ir::VectorSize::Quad,
+    ];
+
+    SIZES.iter().cloned()
 }
 
 const POINTER_SPAN: u32 = 4;
@@ -610,5 +636,14 @@ pub fn min_max_float_representable_by(
             crate::Literal::F64(u64::max_float()),
         ),
         _ => unreachable!(),
+    }
+}
+
+/// Helper function that returns the string corresponding to the [`VectorSize`](crate::VectorSize)
+pub const fn vector_size_str(size: crate::VectorSize) -> &'static str {
+    match size {
+        crate::VectorSize::Bi => "2",
+        crate::VectorSize::Tri => "3",
+        crate::VectorSize::Quad => "4",
     }
 }

--- a/naga/tests/out/msl/wgsl-functions.msl
+++ b/naga/tests/out/msl/wgsl-functions.msl
@@ -13,14 +13,22 @@ metal::float2 test_fma(
     return metal::fma(a, b, c);
 }
 
+int naga_dot_int2(metal::int2 a, metal::int2 b) {
+    return ( + a.x * b.x + a.y * b.y);
+}
+
+uint naga_dot_uint3(metal::uint3 a, metal::uint3 b) {
+    return ( + a.x * b.x + a.y * b.y + a.z * b.z);
+}
+
 int test_integer_dot_product(
 ) {
     metal::int2 a_2_ = metal::int2(1);
     metal::int2 b_2_ = metal::int2(1);
-    int c_2_ = ( + a_2_.x * b_2_.x + a_2_.y * b_2_.y);
+    int c_2_ = naga_dot_int2(a_2_, b_2_);
     metal::uint3 a_3_ = metal::uint3(1u);
     metal::uint3 b_3_ = metal::uint3(1u);
-    uint c_3_ = ( + a_3_.x * b_3_.x + a_3_.y * b_3_.y + a_3_.z * b_3_.z);
+    uint c_3_ = naga_dot_uint3(a_3_, b_3_);
     return 32;
 }
 

--- a/naga/tests/out/msl/wgsl-int64.msl
+++ b/naga/tests/out/msl/wgsl-int64.msl
@@ -43,6 +43,10 @@ long naga_abs(long val) {
     return metal::select(as_type<long>(-as_type<ulong>(val)), val, val >= 0);
 }
 
+long naga_dot_long2(metal::long2 a, metal::long2 b) {
+    return ( + a.x * b.x + a.y * b.y);
+}
+
 long int64_function(
     long x,
     thread long& private_variable,
@@ -111,11 +115,9 @@ long int64_function(
     long _e130 = val;
     val = as_type<long>(as_type<ulong>(_e130) + as_type<ulong>(metal::clamp(_e126, _e127, _e128)));
     long _e132 = val;
-    metal::long2 _e133 = metal::long2(_e132);
     long _e134 = val;
-    metal::long2 _e135 = metal::long2(_e134);
     long _e137 = val;
-    val = as_type<long>(as_type<ulong>(_e137) + as_type<ulong>(( + _e133.x * _e135.x + _e133.y * _e135.y)));
+    val = as_type<long>(as_type<ulong>(_e137) + as_type<ulong>(naga_dot_long2(metal::long2(_e132), metal::long2(_e134))));
     long _e139 = val;
     long _e140 = val;
     long _e142 = val;
@@ -133,6 +135,10 @@ long int64_function(
 
 ulong naga_f2u64(float value) {
     return static_cast<ulong>(metal::clamp(value, 0.0, 18446743000000000000.0));
+}
+
+ulong naga_dot_ulong2(metal::ulong2 a, metal::ulong2 b) {
+    return ( + a.x * b.x + a.y * b.y);
 }
 
 ulong uint64_function(
@@ -199,11 +205,9 @@ ulong uint64_function(
     ulong _e125 = val_1;
     val_1 = _e125 + metal::clamp(_e121, _e122, _e123);
     ulong _e127 = val_1;
-    metal::ulong2 _e128 = metal::ulong2(_e127);
     ulong _e129 = val_1;
-    metal::ulong2 _e130 = metal::ulong2(_e129);
     ulong _e132 = val_1;
-    val_1 = _e132 + ( + _e128.x * _e130.x + _e128.y * _e130.y);
+    val_1 = _e132 + naga_dot_ulong2(metal::ulong2(_e127), metal::ulong2(_e129));
     ulong _e134 = val_1;
     ulong _e135 = val_1;
     ulong _e137 = val_1;


### PR DESCRIPTION
**Connections**
related — #7105 

**Description**
Similar to other wrapped math functions in #7012 I've followed the same structure/procedure with functions calculating dot product on integers. Some key changes:

- Introduce a mangled helper for integer vector dot: `naga_dot_{int|uint}{N}(a, b)` -> returns the scalar dot result.
- Emitted once per concrete type/width, re-used on call sites.
- Modify integer-vector dot emission to call the helper directly.
- Leave float vector dot mapping to MSL’s builtin dot unchanged (Added a brief comment to make this clear).
- Name mangling logic centralized (e.g., `naga_dot_int3`, `naga_dot_uint4`) and shared between call expr site and wrapper generation.

**Testing**
I required minimal testing — output metal files seem to have generated correctly with the proper helper. I'm still trying to figure out how testing works, but the emitted files seem to make sense.

**Squash or Rebase?** Rebase, after squashing everything except https://github.com/gfx-rs/wgpu/pull/8432/commits/4c6e527f9ff4232fea53f4c83a5f024ff273ad8a.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
