### PR TITLE
Correct documentation of alignment/size requirements for buffer mapping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ SamplerDescriptor {
 - Using both the wgpu command encoding APIs and `CommandEncoder::as_hal_mut` on the same encoder will now result in a panic.
 - Allow `include_spirv!` and `include_spirv_raw!` macros to be used in constants and statics. By @clarfonthey in [#8250](https://github.com/gfx-rs/wgpu/pull/8250).
 - Added support for rendering onto multi-planar textures. By @noituri in [#8307](https://github.com/gfx-rs/wgpu/pull/8307).
+- Corrected documentation of the minimum alignment of the *end* of a mapped range of a buffer (it is 4, not 8). By @kpreid in [#8450](https://github.com/gfx-rs/wgpu/pull/8450).
 
 ### Added/New Features
 

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -377,8 +377,8 @@ impl Buffer {
     /// - If the buffer is already mapped.
     /// - If the buffer’s [`BufferUsages`] do not allow the requested [`MapMode`].
     /// - If `bounds` is outside of the bounds of `self`.
-    /// - If `bounds` has a length less than 1.
-    /// - If the start and end of `bounds` are not be aligned to [`MAP_ALIGNMENT`].
+    /// - If `bounds` does not start at a multiple of [`MAP_ALIGNMENT`].
+    /// - If `bounds` has a length that is not a multiple of 4 greater than 0.
     ///
     /// [CEmbos]: CommandEncoder::map_buffer_on_submit
     /// [CBmbos]: CommandBuffer::map_buffer_on_submit
@@ -409,8 +409,8 @@ impl Buffer {
     /// # Panics
     ///
     /// - If `bounds` is outside of the bounds of `self`.
-    /// - If `bounds` has a length less than 1.
-    /// - If the start and end of `bounds` are not aligned to [`MAP_ALIGNMENT`].
+    /// - If `bounds` does not start at a multiple of [`MAP_ALIGNMENT`].
+    /// - If `bounds` has a length that is not a multiple of 4 greater than 0.
     /// - If the buffer to which `self` refers is not currently [mapped].
     /// - If you try to create a view which overlaps an existing [`BufferViewMut`].
     ///
@@ -433,8 +433,8 @@ impl Buffer {
     /// # Panics
     ///
     /// - If `bounds` is outside of the bounds of `self`.
-    /// - If `bounds` has a length less than 1.
-    /// - If the start and end of `bounds` are not aligned to [`MAP_ALIGNMENT`].
+    /// - If `bounds` does not start at a multiple of [`MAP_ALIGNMENT`].
+    /// - If `bounds` has a length that is not a multiple of 4 greater than 0.
     /// - If the buffer to which `self` refers is not currently [mapped].
     /// - If you try to create a view which overlaps an existing [`BufferView`] or [`BufferViewMut`].
     ///
@@ -553,7 +553,8 @@ impl<'a> BufferSlice<'a> {
     ///
     /// - If the buffer is already mapped.
     /// - If the buffer’s [`BufferUsages`] do not allow the requested [`MapMode`].
-    /// - If the endpoints of this slice are not aligned to [`MAP_ALIGNMENT`] within the buffer.
+    /// - If the beginning of this slice is not aligned to [`MAP_ALIGNMENT`] within the buffer.
+    /// - If the length of this slice is not a multiple of 4.
     ///
     /// [CEmbos]: CommandEncoder::map_buffer_on_submit
     /// [CBmbos]: CommandBuffer::map_buffer_on_submit
@@ -589,7 +590,8 @@ impl<'a> BufferSlice<'a> {
     ///
     /// # Panics
     ///
-    /// - If the endpoints of this slice are not aligned to [`MAP_ALIGNMENT`] within the buffer.
+    /// - If the beginning of this slice is not aligned to [`MAP_ALIGNMENT`] within the buffer.
+    /// - If the length of this slice is not a multiple of 4.
     /// - If the buffer to which `self` refers is not currently [mapped].
     /// - If you try to create a view which overlaps an existing [`BufferViewMut`].
     ///
@@ -622,7 +624,8 @@ impl<'a> BufferSlice<'a> {
     ///
     /// # Panics
     ///
-    /// - If the endpoints of this slice are not aligned to [`MAP_ALIGNMENT`].
+    /// - If the beginning of this slice is not aligned to [`MAP_ALIGNMENT`] within the buffer.
+    /// - If the length of this slice is not a multiple of 4.
     /// - If the buffer to which `self` refers is not currently [mapped].
     /// - If you try to create a view which overlaps an existing [`BufferView`] or [`BufferViewMut`].
     ///

--- a/wgpu/src/api/command_buffer_actions.rs
+++ b/wgpu/src/api/command_buffer_actions.rs
@@ -91,7 +91,9 @@ macro_rules! impl_deferred_command_buffer_actions {
         ///
         /// - If the buffer is already mapped.
         /// - If the buffer’s [`BufferUsages`] do not allow the requested [`MapMode`].
-        /// - If the endpoints of this slice are not aligned to [`MAP_ALIGNMENT`] within the buffer.
+        /// - If `bounds` is outside of the bounds of `buffer`.
+        /// - If `bounds` does not start at a multiple of [`MAP_ALIGNMENT`].
+        /// - If `bounds` has a length that is not a multiple of 4 greater than 0.
         ///
         /// [q::s]: Queue::submit
         /// [i::p_a]: Instance::poll_all


### PR DESCRIPTION
**Connections**
Fixes #8448.

**Description**
The documentation previously claimed that the end point must be aligned to `MAP_ALIGNMENT` = 8, but in fact it only needs to be aligned to 4.

Also fixed `map_buffer_on_submit()` referring to “this slice” instead of “`bounds`”.

**Testing**
Docs only. Reviewed `cargo doc` output.

**Squash or Rebase?**
Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
