### PR TITLE
Validate that buffers are unmapped in `write_buffer` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ By @SupaMaggie70Incorporated in [#8206](https://github.com/gfx-rs/wgpu/pull/8206
 - `wgpu_types::PollError` now always implements the `Error` trait. By @kpreid in [#8384](https://github.com/gfx-rs/wgpu/pull/8384).
 - The texture subresources used by the color attachments of a render pass are no longer allowed to overlap when accessed via different texture views. By @andyleiserson in [#8402](https://github.com/gfx-rs/wgpu/pull/8402).
 - Fixed a bug where the texture aspect was not passed through when calling `copy_texture_to_buffer` in WebGPU, causing the copy to fail for depth/stencil textures. By @Tim-Evans-Seequent in [#8445](https://github.com/gfx-rs/wgpu/pull/8445).
+- Validate that buffers are unmapped in `write_buffer` calls. By @ErichDonGubler in [#8454](https://github.com/gfx-rs/wgpu/pull/8454).
 
 #### DX12
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -87,7 +87,8 @@ webgpu:api,validation,encoding,queries,general:occlusion_query,query_index:*
 webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
-fails-if(dx12,vulkan,metal) webgpu:api,validation,queue,buffer_mapped:writeBuffer:*
+// `vulkan` failure: https://github.com/gfx-rs/wgpu/issues/????
+fails-if(vulkan) webgpu:api,validation,queue,buffer_mapped:writeBuffer:*
 webgpu:api,validation,queue,buffer_mapped:copyBufferToBuffer:*
 webgpu:api,validation,queue,buffer_mapped:copyBufferToTexture:*
 webgpu:api,validation,queue,buffer_mapped:copyTextureToBuffer:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -87,6 +87,11 @@ webgpu:api,validation,encoding,queries,general:occlusion_query,query_index:*
 webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
+fails-if(dx12,vulkan,metal) webgpu:api,validation,queue,buffer_mapped:writeBuffer:*
+webgpu:api,validation,queue,buffer_mapped:copyBufferToBuffer:*
+webgpu:api,validation,queue,buffer_mapped:copyBufferToTexture:*
+webgpu:api,validation,queue,buffer_mapped:copyTextureToBuffer:*
+webgpu:api,validation,queue,buffer_mapped:map_command_recording_order:*
 // image_copy depth/stencil failures on dx12: https://github.com/gfx-rs/wgpu/issues/8133
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyB2T"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyT2B"

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -170,6 +170,8 @@ pub enum TransferError {
     },
     #[error("Requested mip level {requested} does not exist (count: {count})")]
     InvalidMipLevel { requested: u32, count: u32 },
+    #[error("Buffer is expected to be unmapped, but was not")]
+    BufferNotAvailable,
 }
 
 impl WebGpuError for TransferError {
@@ -211,7 +213,8 @@ impl WebGpuError for TransferError {
             | Self::InvalidSampleCount { .. }
             | Self::SampleCountNotEqual { .. }
             | Self::InvalidMipLevel { .. }
-            | Self::SameSourceDestinationBuffer => return ErrorType::Validation,
+            | Self::SameSourceDestinationBuffer
+            | Self::BufferNotAvailable => return ErrorType::Validation,
         };
         e.webgpu_error_type()
     }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -648,6 +648,9 @@ impl Queue {
         buffer_offset: u64,
         buffer_size: wgt::BufferSize,
     ) -> Result<(), TransferError> {
+        if !matches!(&*buffer.map_state.lock(), BufferMapState::Idle) {
+            return Err(TransferError::BufferNotAvailable);
+        }
         buffer.check_usage(wgt::BufferUsages::COPY_DST)?;
         if buffer_size.get() % wgt::COPY_BUFFER_ALIGNMENT != 0 {
             return Err(TransferError::UnalignedCopySize(buffer_size.get()));


### PR DESCRIPTION
This is a standard validation we should be doing, and we're not. Oops!

**Testing**

I've added `webgpu:api,validation,queue,buffer_mapped:writeBuffer:*`. We were already passing its siblings, so I added these as the first commit in the stack.

**Squash or Rebase?**

rebaseplz

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
