### PR TITLE
Replace noop waker implementation with `Waker::noop()`.

### DIFF
--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -58,7 +58,7 @@ impl Device {
         use core::future::Future as _;
         use core::pin::pin;
         use core::task;
-        let ctx = &mut task::Context::from_waker(waker::noop_waker_ref());
+        let ctx = &mut task::Context::from_waker(task::Waker::noop());
 
         let instance = Instance::new(&InstanceDescriptor {
             backends: Backends::NOOP,
@@ -793,38 +793,5 @@ impl fmt::Display for Error {
             Error::Validation { description, .. } => f.write_str(description),
             Error::Internal { description, .. } => f.write_str(description),
         }
-    }
-}
-
-// Copied from [`futures::task::noop_waker`].
-// Needed until MSRV is 1.85 with `task::Waker::noop()` available
-#[cfg(feature = "noop")]
-mod waker {
-    use core::ptr::null;
-    use core::task::{RawWaker, RawWakerVTable, Waker};
-
-    unsafe fn noop_clone(_data: *const ()) -> RawWaker {
-        noop_raw_waker()
-    }
-
-    unsafe fn noop(_data: *const ()) {}
-
-    const NOOP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
-
-    const fn noop_raw_waker() -> RawWaker {
-        RawWaker::new(null(), &NOOP_WAKER_VTABLE)
-    }
-
-    /// Get a static reference to a [`Waker`] which
-    /// does nothing when `wake()` is called on it.
-    #[inline]
-    pub fn noop_waker_ref() -> &'static Waker {
-        struct SyncRawWaker(RawWaker);
-        unsafe impl Sync for SyncRawWaker {}
-
-        static NOOP_WAKER_INSTANCE: SyncRawWaker = SyncRawWaker(noop_raw_waker());
-
-        // SAFETY: `Waker` is #[repr(transparent)] over its `RawWaker`.
-        unsafe { &*(&NOOP_WAKER_INSTANCE.0 as *const RawWaker as *const Waker) }
     }
 }


### PR DESCRIPTION
**Connections**
Reverts part of #7425 (the motivation appears to be obsolete).

**Description**
Removes unsafe `Waker` implementation code that is no longer needed because it is available in the standard library. The `rust-version` of the `wgpu` package is currently 1.88, so it can use `Waker::noop()`, which was stabilized in 1.85.

**Testing**
`xtask test`

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
