### PR TITLE
Make `StagingBelt` own the `Device` it uses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ By @SupaMaggie70Incorporated in [#8206](https://github.com/gfx-rs/wgpu/pull/8206
 - Added support for rendering onto multi-planar textures. By @noituri in [#8307](https://github.com/gfx-rs/wgpu/pull/8307).
 - Validation errors from `CommandEncoder::finish()` will report the label of the invalid encoder. By @kpreid in [#8449](https://github.com/gfx-rs/wgpu/pull/8449).
 - Corrected documentation of the minimum alignment of the *end* of a mapped range of a buffer (it is 4, not 8). By @kpreid in [#8450](https://github.com/gfx-rs/wgpu/pull/8450).
+- `util::StagingBelt` now takes a `Device` when it is created instead of when it is used. By @kpreid in [#8462](https://github.com/gfx-rs/wgpu/pull/8462).
 
 ### Bug Fixes
 

--- a/examples/features/src/skybox/mod.rs
+++ b/examples/features/src/skybox/mod.rs
@@ -372,7 +372,7 @@ impl crate::framework::Example for Example {
             uniform_buf,
             entities,
             depth_view,
-            staging_belt: wgpu::util::StagingBelt::new(0x100),
+            staging_belt: wgpu::util::StagingBelt::new(device.clone(), 0x100),
         }
     }
 
@@ -411,7 +411,6 @@ impl crate::framework::Example for Example {
                 &self.uniform_buf,
                 0,
                 wgpu::BufferSize::new((raw_uniforms.len() * 4) as wgpu::BufferAddress).unwrap(),
-                device,
             )
             .copy_from_slice(bytemuck::cast_slice(&raw_uniforms));
 

--- a/tests/tests/wgpu-validation/util.rs
+++ b/tests/tests/wgpu-validation/util.rs
@@ -9,7 +9,7 @@ fn staging_belt_random_test() {
     let mut rng = nanorand::WyRand::new_seed(0xDEAD_BEEF);
     let buffer_size = 1024;
     let align = wgpu::COPY_BUFFER_ALIGNMENT;
-    let mut belt = wgpu::util::StagingBelt::new(buffer_size / 2);
+    let mut belt = wgpu::util::StagingBelt::new(device.clone(), buffer_size / 2);
     let target_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
         size: buffer_size,
@@ -30,7 +30,6 @@ fn staging_belt_random_test() {
                 &target_buffer,
                 offset,
                 wgpu::BufferSize::new(size).unwrap(),
-                &device,
             );
             slice[0] = 1; // token amount of actual writing, just in case it makes a difference
         }

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -24,6 +24,7 @@ use crate::COPY_BUFFER_ALIGNMENT;
 ///
 /// [`Queue::write_buffer_with()`]: crate::Queue::write_buffer_with
 pub struct StagingBelt {
+    device: Device,
     chunk_size: BufferAddress,
     /// Chunks into which we are accumulating data to be transferred.
     active_chunks: Vec<Chunk>,
@@ -50,9 +51,10 @@ impl StagingBelt {
     /// * 1-4 times less than the total amount of data uploaded per submission
     ///   (per [`StagingBelt::finish()`]); and
     /// * bigger is better, within these bounds.
-    pub fn new(chunk_size: BufferAddress) -> Self {
+    pub fn new(device: Device, chunk_size: BufferAddress) -> Self {
         let (sender, receiver) = mpsc::channel();
         StagingBelt {
+            device,
             chunk_size,
             active_chunks: Vec::new(),
             closed_chunks: Vec::new(),
@@ -82,7 +84,6 @@ impl StagingBelt {
         target: &Buffer,
         offset: BufferAddress,
         size: BufferSize,
-        device: &Device,
     ) -> BufferViewMut {
         // Asserting this explicitly gives a usefully more specific, and more prompt, error than
         // leaving it to regular API validation.
@@ -95,7 +96,6 @@ impl StagingBelt {
         let slice_of_belt = self.allocate(
             size,
             const { BufferSize::new(crate::COPY_BUFFER_ALIGNMENT).unwrap() },
-            device,
         );
         encoder.copy_buffer_to_buffer(
             slice_of_belt.buffer(),
@@ -130,12 +130,7 @@ impl StagingBelt {
     /// which may be used to meet alignment requirements for the operation you wish to perform
     /// with the slice. This does not necessarily affect the alignment of the [`BufferViewMut`].
     #[track_caller]
-    pub fn allocate(
-        &mut self,
-        size: BufferSize,
-        alignment: BufferSize,
-        device: &Device,
-    ) -> BufferSlice<'_> {
+    pub fn allocate(&mut self, size: BufferSize, alignment: BufferSize) -> BufferSlice<'_> {
         assert!(
             size.get().is_multiple_of(COPY_BUFFER_ALIGNMENT),
             "StagingBelt allocation size {size} must be a multiple of `COPY_BUFFER_ALIGNMENT`"
@@ -164,7 +159,7 @@ impl StagingBelt {
                 self.free_chunks.swap_remove(index)
             } else {
                 Chunk {
-                    buffer: device.create_buffer(&BufferDescriptor {
+                    buffer: self.device.create_buffer(&BufferDescriptor {
                         label: Some("(wgpu internal) StagingBelt staging buffer"),
                         size: self.chunk_size.max(size.get()),
                         usage: BufferUsages::MAP_WRITE | BufferUsages::COPY_SRC,
@@ -232,11 +227,21 @@ impl StagingBelt {
 
 impl fmt::Debug for StagingBelt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            device,
+            chunk_size,
+            active_chunks,
+            closed_chunks,
+            free_chunks,
+            sender: _,
+            receiver: _,
+        } = self;
         f.debug_struct("StagingBelt")
-            .field("chunk_size", &self.chunk_size)
-            .field("active_chunks", &self.active_chunks.len())
-            .field("closed_chunks", &self.closed_chunks.len())
-            .field("free_chunks", &self.free_chunks.len())
+            .field("device", device)
+            .field("chunk_size", chunk_size)
+            .field("active_chunks", &active_chunks.len())
+            .field("closed_chunks", &closed_chunks.len())
+            .field("free_chunks", &free_chunks.len())
             .finish_non_exhaustive()
     }
 }


### PR DESCRIPTION
**Description**
Make `StagingBelt` own the `Device` it uses instead of having it passed in at each use.

This means that usage of a `StagingBelt` only requires passing along the current `CommandEncoder` instead of both the encoder and the device. It also makes the API reflect the fact that a `StagingBelt` cannot be reused with a fresh device.

As far as I know, the only reason this was not done previously was that `Device` was not clonable, and so doing this would have required an `Arc<Device>` or other specific mechanism.

**Testing**
Ran tests and skybox example, and also tried the new API in my own code.

**Squash or Rebase?**
Rebase

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
