### PR TITLE
[ci] Key CTS job caches to the CTS version

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -71,7 +71,8 @@ jobs:
       - name: caching
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v2-rust # Increment version for cache busting
+          # The version number can be incremented for cache busting.
+          prefix-key: v2-rust-${{ hashFiles('cts_runner/revision.txt') }}
           cache-directories: cts
 
       # We enable line numbers for panics, but that's it


### PR DESCRIPTION
Fixes #8313 in a much simpler way than #8319.

**Squash or Rebase?** Squash
