### PR TITLE
Add `set_web_canvas_size` option.

### DIFF
--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -81,6 +81,7 @@ impl GPUCanvasContext {
       format,
       width: *self.width.borrow(),
       height: *self.height.borrow(),
+      set_web_canvas_size: false, // GPUCanvasConfiguration does not contain width,height
       present_mode: configuration
         .present_mode
         .map(Into::into)

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -557,6 +557,7 @@ impl<E: Example + wgpu::WasmNotSendSync> From<ExampleTestParams<E>>
                         format,
                         width: params.width,
                         height: params.height,
+                        set_web_canvas_size: true,
                         desired_maximum_frame_latency: 2,
                         present_mode: wgpu::PresentMode::Fifo,
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,

--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -62,6 +62,7 @@ impl State {
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
             width: self.size.width,
             height: self.size.height,
+            set_web_canvas_size: false,
             desired_maximum_frame_latency: 2,
             present_mode: wgpu::PresentMode::AutoVsync,
         };

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4933,6 +4933,7 @@ impl Device {
                         height: config.height,
                         depth_or_array_layers: 1,
                     },
+                    set_web_canvas_size: config.set_web_canvas_size,
                     usage: conv::map_texture_usage(
                         config.usage,
                         hal::FormatAspects::COLOR,

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -149,6 +149,7 @@ impl<A: hal::Api> Example<A> {
                 height: window_size.1,
                 depth_or_array_layers: 1,
             },
+            set_web_canvas_size: false,
             usage: wgpu_types::TextureUses::COLOR_TARGET,
             view_formats: vec![],
         };

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -304,6 +304,7 @@ impl<A: hal::Api> Example<A> {
                 height: window_size.1,
                 depth_or_array_layers: 1,
             },
+            set_web_canvas_size: false,
             usage: wgpu_types::TextureUses::COLOR_TARGET | wgpu_types::TextureUses::COPY_DST,
             view_formats: vec![surface_format],
         };

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -315,14 +315,16 @@ impl crate::Surface for Surface {
         device: &super::Device,
         config: &crate::SurfaceConfiguration,
     ) -> Result<(), crate::SurfaceError> {
-        match self.canvas {
-            Canvas::Canvas(ref canvas) => {
-                canvas.set_width(config.extent.width);
-                canvas.set_height(config.extent.height);
-            }
-            Canvas::Offscreen(ref canvas) => {
-                canvas.set_width(config.extent.width);
-                canvas.set_height(config.extent.height);
+        if config.set_web_canvas_size {
+            match self.canvas {
+                Canvas::Canvas(ref canvas) => {
+                    canvas.set_width(config.extent.width);
+                    canvas.set_height(config.extent.height);
+                }
+                Canvas::Offscreen(ref canvas) => {
+                    canvas.set_width(config.extent.width);
+                    canvas.set_height(config.extent.height);
+                }
             }
         }
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2380,6 +2380,10 @@ pub struct SurfaceConfiguration {
     /// Requested texture extent. Must be in
     /// `SurfaceCapabilities::extents` range.
     pub extent: wgt::Extent3d,
+    /// Whether, when the [`Surface`] being configured refers to a HTML `<canvas>` element,
+    /// the `width` and `height` of this configuration are used to set the `width` and `height`
+    /// attributes of the canvas element.
+    pub set_web_canvas_size: bool,
     /// Allowed usage of surface textures,
     pub usage: wgt::TextureUses,
     /// Allows views of swapchain texture to have a different format

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -5821,6 +5821,29 @@ pub struct SurfaceConfiguration<V> {
     /// but platform-specific, and may change in the future (currently macOS
     /// scales the surface, other platforms may do something else).
     pub height: u32,
+    /// Whether, when the [`Surface`] being configured refers to a HTML `<canvas>` element,
+    /// the `width` and `height` of this configuration are used to set the `width` and `height`
+    /// attributes of the canvas element.
+    ///
+    /// This option is ignored by all backends except for WebGPU and WebGL 2.
+    ///
+    /// Set this to `true` if you wish this configuration to control the resolution of
+    /// the image rendered to the canvas.
+    /// If you are also using DOM layout information to determine
+    /// the width and height you provide here, then you must ensure that the computed size of the
+    /// canvas element is being controlled by explicit CSS (such as
+    /// `#my-canvas { width: 100%; height: 100%; }`)
+    /// rather than intrinsic size, as otherwise, you will get runaway resizing if
+    /// `window.devicePixelRatio` is not equal to 1.
+    ///
+    /// Set this to `false` if the canvas `width` and `height` are being managed by other code or
+    /// static HTML, if your code does not know whether it is rendering to a canvas or how that
+    /// canvas is being managed, or if you want behavior maximally like the WebGPU API
+    /// (which does not accept a size in `GPUCanvasConfiguration`).
+    ///
+    /// If you are writing code that is not going to be used in a web page, or if you do not
+    /// understand what to put here, `false` is the safe default choice.
+    pub set_web_canvas_size: bool,
     /// Presentation mode of the swap chain. Fifo is the only mode guaranteed to be supported.
     /// `FifoRelaxed`, `Immediate`, and `Mailbox` will crash if unsupported, while `AutoVsync` and
     /// `AutoNoVsync` will gracefully do a designed sets of fallbacks if their primary modes are
@@ -5879,6 +5902,7 @@ impl<V: Clone> SurfaceConfiguration<V> {
             format: self.format,
             width: self.width,
             height: self.height,
+            set_web_canvas_size: self.set_web_canvas_size,
             present_mode: self.present_mode,
             desired_maximum_frame_latency: self.desired_maximum_frame_latency,
             alpha_mode: self.alpha_mode,

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -69,6 +69,7 @@ impl Surface<'_> {
             format: *caps.formats.first()?,
             width,
             height,
+            set_web_canvas_size: false,
             desired_maximum_frame_latency: 2,
             present_mode: *caps.present_modes.first()?,
             alpha_mode: wgt::CompositeAlphaMode::Auto,

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -3852,14 +3852,16 @@ impl dispatch::SurfaceInterface for WebSurface {
     fn configure(&self, device: &dispatch::DispatchDevice, config: &crate::SurfaceConfiguration) {
         let device = device.as_webgpu();
 
-        match self.canvas {
-            Canvas::Canvas(ref canvas) => {
-                canvas.set_width(config.width);
-                canvas.set_height(config.height);
-            }
-            Canvas::Offscreen(ref canvas) => {
-                canvas.set_width(config.width);
-                canvas.set_height(config.height);
+        if config.set_web_canvas_size {
+            match self.canvas {
+                Canvas::Canvas(ref canvas) => {
+                    canvas.set_width(config.width);
+                    canvas.set_height(config.height);
+                }
+                Canvas::Offscreen(ref canvas) => {
+                    canvas.set_width(config.width);
+                    canvas.set_height(config.height);
+                }
             }
         }
 


### PR DESCRIPTION
**Connections**
Implements “option 1” of [#7938.](https://github.com/gfx-rs/wgpu/issues/7938#issuecomment-3079523549)

**Description**
Adds a field `SurfaceConfiguration::set_web_canvas_size` which, on the WebGPU and WebGL backends, disables setting the `<canvas>` size. By setting this to `false` by default, authors of code who do not yet intend to provide any web support, do not understand how to configure the HTML/CSS to get good results, or don’t know what any of this means at all, can get non-disastrous results. They may end up with rendering at a non-ideal resolution, but that is better than a runaway resize followed by a panic.

**Testing**
I have not yet tested how this change actually behaves in practice on both web backends. Do not merge.

**Squash or Rebase?**
Don't merge yet!

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
