### PR TITLE
[wgpu] Fix warnings in `cargo doc --document-private-items`.

### DIFF
--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -165,10 +165,9 @@ impl Device {
     /// thus it's the caller responsibility to pass a shader which doesn't perform any of this
     /// operations.
     ///
-    /// See the documentation for [`ShaderRuntimeChecks`][src] for more information about specific checks.
+    /// See the documentation for [`ShaderRuntimeChecks`] for more information about specific checks.
     ///
     /// [csm]: Self::create_shader_module
-    /// [src]: crate::ShaderRuntimeChecks
     #[must_use]
     pub unsafe fn create_shader_module_trusted(
         &self,

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -26,7 +26,9 @@ static_assertions::assert_impl_all!(SurfaceConfiguration: Send, Sync);
 /// [`GPUCanvasContext`](https://gpuweb.github.io/gpuweb/#canvas-context)
 /// serves a similar role.
 pub struct Surface<'window> {
-    /// Additional surface data returned by [`DynContext::instance_create_surface`].
+    /// Additional surface data returned by [`InstanceInterface::create_surface`][cs].
+    ///
+    /// [cs]: crate::dispatch::InstanceInterface::create_surface
     pub(crate) inner: dispatch::DispatchSurface,
 
     // Stores the latest `SurfaceConfiguration` that was set using `Surface::configure`.
@@ -408,8 +410,11 @@ pub(crate) enum CreateSurfaceErrorKind {
     #[cfg_attr(not(webgpu), expect(dead_code))]
     Web(String),
 
-    /// Error when trying to get a [`DisplayHandle`] or a [`WindowHandle`] from
-    /// `raw_window_handle`.
+    /// Error when trying to get a [`RawDisplayHandle`][rdh] or a
+    /// [`RawWindowHandle`][rwh] from a [`SurfaceTarget`].
+    ///
+    /// [rdh]: raw_window_handle::RawDisplayHandle
+    /// [rwh]: raw_window_handle::RawWindowHandle
     RawHandle(raw_window_handle::HandleError),
 }
 static_assertions::assert_impl_all!(CreateSurfaceError: Send, Sync);


### PR DESCRIPTION
Fix some broken and outdated links in documentation for private items. CI only checks `wgpu`'s public interface.
