### PR TITLE
test(naga): assert error for ImageStore type mismatch

### DIFF
--- a/naga/tests/naga/validation.rs
+++ b/naga/tests/naga/validation.rs
@@ -1100,3 +1100,55 @@ fn used() {
         Some("_ = arr2[3];"),
     );
 }
+
+/// Expects parsing `input` to succeed and its validation to fail with error equal to `snapshot`.
+#[track_caller]
+fn check_wgsl_validation_error_message(input: &str, snapshot: &str) {
+    let module = naga::front::wgsl::parse_str(input).unwrap();
+    let err = valid::Validator::new(Default::default(), valid::Capabilities::all())
+        .validate(&module)
+        .expect_err("module should be invalid")
+        .emit_to_string(input);
+    if err != snapshot {
+        for diff in diff::lines(snapshot, &err) {
+            match diff {
+                diff::Result::Left(l) => println!("-{l}"),
+                diff::Result::Both(l, _) => println!(" {l}"),
+                diff::Result::Right(r) => println!("+{r}"),
+            }
+        }
+        panic!("Error does not match the expected snapshot");
+    }
+}
+
+#[test]
+fn image_store_type_mismatch() {
+    check_wgsl_validation_error_message(
+        r#"
+@group(0) @binding(0)
+var input_texture: texture_depth_2d;
+@group(0) @binding(1)
+var input_sampler: sampler;
+@group(0) @binding(2)
+var output_texture: texture_storage_2d<r32float,write>;
+
+@compute @workgroup_size(1, 1)
+fn main() {
+    let d: vec4<f32> = textureGather(input_texture, input_sampler, vec2f(0.0));
+    let min_d = min(min(d[0], d[1]), min(d[2], d[3]));
+    textureStore(output_texture, vec2u(1), min_d);
+}
+"#,
+        r#"error: Entry point main at Compute is invalid
+   ┌─ wgsl:12:17
+   │
+12 │     let min_d = min(min(d[0], d[1]), min(d[2], d[3]));
+   │                 ^^^ this value is of type Scalar(Scalar { kind: Float, width: 4 })
+13 │     textureStore(output_texture, vec2u(1), min_d);
+   │     ^^^^^^^^^^^^ expects a value argument of type Vector { size: Quad, scalar: Scalar { kind: Float, width: 4 } }
+   │
+   = Image store value parameter type mismatch
+
+"#,
+    );
+}


### PR DESCRIPTION
**Connections**

#7023 

**Description**

Adds the test to `tests/naga/validation.rs`, as this seemed to be the simplest way to do it (though I'm new to the codebase). Seems like naga snapshot tests are currently only parsing (not validating) and are not handling (validation) errors ([ref](https://github.com/gfx-rs/wgpu/blob/f14458b06794a4e0837949889364cf80938d92b5/naga/tests/naga/snapshots.rs#L401-L407)).

**Testing**

```
cargo nextest run --test naga validation::image_store_type_mismatch
```

**Squash or Rebase?**

Squash would be easier if more commits follow, but I'm fine with both.

**Checklist**

- [X] Run `cargo fmt`.
- [X] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry.

For `cargo xtask test`, on my machine a few tests fail. I think the failures shouldn't be due to the changes in this PR which only affects items private to `tests/naga/validation.rs`.
