### PR TITLE
boids: use div_ceil to calculate work group count

### DIFF
--- a/examples/features/src/boids/mod.rs
+++ b/examples/features/src/boids/mod.rs
@@ -226,8 +226,7 @@ impl crate::framework::Example for Example {
         }
 
         // calculates number of work groups from PARTICLES_PER_GROUP constant
-        let work_group_count =
-            ((NUM_PARTICLES as f32) / (PARTICLES_PER_GROUP as f32)).ceil() as u32;
+        let work_group_count = NUM_PARTICLES.div_ceil(PARTICLES_PER_GROUP);
 
         // returns Example struct and No encoder commands
 


### PR DESCRIPTION
**Description**
In the boids example, use the `div_ceil` function to get the work group count. This is simpler and easier to understand than casting.

**Testing**
Boids runs as expected, with the same work group count.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
