### PR TITLE
In GitHub CI, check that docs build for private items in `wgpu`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,11 +336,11 @@ jobs:
         run: |
           set -e
 
-          # wgpu_core package
           cargo --locked doc --target ${{ matrix.target }} ${{ matrix.extra-flags }} \
                 --package wgpu-core \
                 --package wgpu-hal \
                 --package naga \
+                --package wgpu \
                 --all-features --no-deps --document-private-items
 
   # We run minimal checks on the MSRV of the core crates, ensuring that


### PR DESCRIPTION
Include the `wgpu` crate in the list of crates that `.github/workflows/ci.yml` checks that `cargo doc --private-items` works without warnings.
