### PR TITLE
Adjust the expected failure conditions for subgroup_operations

### DIFF
--- a/tests/tests/wgpu-gpu/subgroup_operations/mod.rs
+++ b/tests/tests/wgpu-gpu/subgroup_operations/mod.rs
@@ -21,16 +21,20 @@ static SUBGROUP_OPERATIONS: GpuTestConfiguration = GpuTestConfiguration::new()
             // are not matched against.
             .expect_fail(
                 wgpu_test::FailureCase::molten_vk()
-                    // 14.3 doesn't fail test 29
+                    // 26.0 fails only test 28, and not on thread 0
+                    .panic("thread 1 failed tests: 28,\n")
+                    // 14.3 fails 27 and 28
                     .panic("thread 0 failed tests: 27,\nthread 1 failed tests: 27, 28,\n")
-                    // Prior versions do.
+                    // Prior versions fail 27, 28, and 29
                     .panic("thread 0 failed tests: 27, 29,\nthread 1 failed tests: 27, 28, 29,\n"),
             )
             .expect_fail(
                 wgpu_test::FailureCase::backend(wgpu::Backends::METAL)
-                    // 14.3 doesn't fail test 29
+                    // 26.0 fails only test 28, and not on thread 0
+                    .panic("thread 1 failed tests: 28,\n")
+                    // 14.3 fails 27 and 28
                     .panic("thread 0 failed tests: 27,\nthread 1 failed tests: 27, 28,\n")
-                    // Prior versions do.
+                    // Prior versions fail 27, 28, and 29
                     .panic("thread 0 failed tests: 27, 29,\nthread 1 failed tests: 27, 28, 29,\n"),
             ),
     )


### PR DESCRIPTION
It seems that one more of these tests has started passing on recent MacOS, and the output no longer matches the old failure patterns.

**Testing**
Tested locally.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
