### PR TITLE
Fix: Race condition when compute shader writes to texture. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,10 @@ By @SupaMaggie70Incorporated in [#8206](https://github.com/gfx-rs/wgpu/pull/8206
 
 - Fixed a bug where the texture aspect was not passed through when calling `copy_texture_to_buffer` in WebGPU, causing the copy to fail for depth/stencil textures. By @Tim-Evans-Seequent in [#8445](https://github.com/gfx-rs/wgpu/pull/8445).
 
+#### GLES
+
+- Fix race when downloading texture from compute shader pass. By @SpeedCrash100 in [#8527](https://github.com/gfx-rs/wgpu/pull/8527)
+
 #### hal
 
 - `DropCallback`s are now called after dropping all other fields of their parent structs. By @jerzywilczek in [#8353](https://github.com/gfx-rs/wgpu/pull/8353)

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -312,11 +312,9 @@ impl crate::CommandEncoder for super::CommandEncoder {
         for bar in barriers {
             // GLES only synchronizes storage -> anything explicitly
             // if shader writes to a texture then barriers should be placed
-            if !bar
-                .usage
-                .from
-                .intersects(wgt::TextureUses::STORAGE_READ_WRITE | wgt::TextureUses::STORAGE_WRITE_ONLY)
-            {
+            if !bar.usage.from.intersects(
+                wgt::TextureUses::STORAGE_READ_WRITE | wgt::TextureUses::STORAGE_WRITE_ONLY,
+            ) {
                 continue;
             }
             // unlike buffers, there is no need for a concrete texture

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -311,10 +311,11 @@ impl crate::CommandEncoder for super::CommandEncoder {
         let mut combined_usage = wgt::TextureUses::empty();
         for bar in barriers {
             // GLES only synchronizes storage -> anything explicitly
+            // if shader writes to a texture then barriers should be placed
             if !bar
                 .usage
                 .from
-                .contains(wgt::TextureUses::STORAGE_READ_WRITE)
+                .intersects(wgt::TextureUses::STORAGE_READ_WRITE | wgt::TextureUses::STORAGE_WRITE_ONLY)
             {
                 continue;
             }


### PR DESCRIPTION
**Connections**
fixes #8473 

**Description**
This fix for race where compute pass writes to texture which then copy to buffer. The race can be seen only on Mesa radeonsi drivers.


**Testing**
It tested on this gist https://gist.github.com/SpeedCrash100/6c60d121a32ef5bd6077c1822da19a38 with AMD RX 9070 XT.
The test switches white and black images and find inconsistency. For example when parts of white images found when the black one image were passed to input. The gist will print error:
```log
!!! ERROR !!!. Iteration 150, 5997060 errors
!!! ERROR !!!. Iteration 151, 5735112 errors
!!! ERROR !!!. Iteration 152, 6104640 errors
!!! ERROR !!!. Iteration 153, 5704908 errors
!!! ERROR !!!. Iteration 154, 5863704 errors
```

Before the changes if run with `WGPU_BACKEND=gl` env (to force use radeonsi) the errors were detected by the gist. The error no longer printing by the test program.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Test run results**

```
     Summary [  24.578s] 1039 tests run: 1033 passed, 6 failed, 12 skipped
        FAIL [   0.698s] wgpu-test::wgpu-gpu [Executed Failure: BACKEND] [Gl/AMD Radeon RX 9070 XT (radeonsi, gfx1201, LLVM 21.1.5, DRM 3.64, 6.17.7-5-cachyos)/1] wgpu_gpu::clear_texture::clear_texture_uncompressed
        FAIL [   3.233s] wgpu-examples [Executed Failure: BACKEND] [Vulkan/AMD Radeon RX 9070 XT (RADV GFX1201)/0] water
        FAIL [   3.270s] wgpu-examples [Executed Failure: BACKEND & ADAPTER] [Vulkan/AMD Radeon RX 9070 XT (RADV GFX1201)/0] ray_cube_normals
        FAIL [   0.198s] wgpu-test::wgpu-gpu [Executed Failure: BACKEND] [Vulkan/AMD Radeon RX 9070 XT (RADV GFX1201)/0] wgpu_gpu::shader::struct_layout::uniform_input
        FAIL [   0.098s] wgpu-test::wgpu-gpu [Executed] [Vulkan/AMD Radeon RX 9070 XT (RADV GFX1201)/0] wgpu_gpu::push_constants::render_pass_test
     SIGSEGV [   0.757s] wgpu-test::wgpu-gpu [Executed] [Vulkan/AMD Radeon RX 9070 XT (RADV GFX1201)/0] wgpu_gpu::ray_tracing::shader::prevent_invalid_ray_query_calls
```

