### PR TITLE
Include cts_runner tests in CTS jobs

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -99,7 +99,11 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         uses: ./.github/actions/install-mesa
 
-      - name: run CTS
+      - name: Test cts_runner
+        shell: bash
+        run: cargo --locked xtask test --llvm-cov -p cts_runner
+
+      - name: Run CTS
         shell: bash
         run: cargo --locked xtask cts --llvm-cov --backend ${{ matrix.backend }}
 

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -99,9 +99,12 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         uses: ./.github/actions/install-mesa
 
+      # Mixing --llvm-cov with deno (rusty_v8) has linking problems.
+      # Explicitly set the backend to avoid EGL messages in output,
+      # because these tests check stdout.
       - name: Test cts_runner
         shell: bash
-        run: cargo --locked xtask test --llvm-cov -p cts_runner
+        run: DENO_WEBGPU_BACKEND=${{ matrix.backend }} cargo --locked test -p cts_runner
 
       - name: Run CTS
         shell: bash


### PR DESCRIPTION
Stumbling on #3164 this morning reminded me that these tests weren't being run in CI.

**Testing**
Adds already passing tests to CI so they don't regress.

**Squash or Rebase?** Squash