### PR TITLE
windows/gl: Fix double window class registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ By @SupaMaggie70Incorporated in [#8206](https://github.com/gfx-rs/wgpu/pull/8206
 #### GLES
 
 - Fix race when downloading texture from compute shader pass. By @SpeedCrash100 in [#8527](https://github.com/gfx-rs/wgpu/pull/8527)
+- Fix double window class registration when dynamic libraries are used. By @Azorlogh in [#8548](https://github.com/gfx-rs/wgpu/pull/8548)
 
 #### hal
 


### PR DESCRIPTION
**Description**

On windows + gl backend:
- When a process loads a dynamic library containing wgpu, the gles backend will create a window class.
- It then leaks the window class (never unregisters it)
- If the library is unloaded and loaded again by that same process, wgpu will try to initialize the window class again, with the same name, and fail with: `wgpu_core::instance: Instance::new: failed to create Gl backend: InstanceError { message: "unable to register window class", source: Some(Error { code: HRESULT(0x80070582), message: "Class already exists." }) }`

This adds an additional check to skip initialization if the window class already exists.

**Testing**

I ran my wgpu-based VST plugin against this PR and it now works properly.
Without this change, it only managed to initialize once, then subsequent initializations fail to get the adapter.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - ~~[ ] `--target wasm32-unknown-unknown`~~
- [ ] Run `cargo xtask test` to run tests. <- I don't have a windows machine to run tests on... The aforementioned VST ran on wine
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry.
