### PR TITLE
hal/vulkan: fix invalid request of VK_EXT_physical_device_drm as an instance extension

### DIFF
--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -271,8 +271,7 @@ impl super::Instance {
             extensions.push(ext::acquire_drm_display::NAME);
             extensions.push(ext::direct_mode_display::NAME);
             extensions.push(khr::display::NAME);
-            //  VK_EXT_physical_device_drm -> VK_KHR_get_physical_device_properties2
-            extensions.push(ext::physical_device_drm::NAME);
+            extensions.push(khr::get_physical_device_properties2::NAME);
             extensions.push(khr::get_display_properties2::NAME);
         }
 


### PR DESCRIPTION
**Description**
It's a device extension [1], so this fails 100% of the time.

The comment above mentions `VK_KHR_get_physical_device_properties2`, which _is_ an instance extension [2], so let's check for that instead.

[1]: https://docs.vulkan.org/refpages/latest/refpages/source/VK_EXT_physical_device_drm.html
[2]: https://docs.vulkan.org/refpages/latest/refpages/source/VK_KHR_get_physical_device_properties2.html

**Testing**
It compiles 😅

The previous code was clearly invalid so deleting it is definitely correct; replacing it as described above seems sensible, but I haven't checked what `VK_KHR_get_physical_device_properties2` is needed for, so maybe it's not needed either, in which case I'm also happy to just delete it :)

**Squash or Rebase?**

N/A

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
