### PR TITLE
Fixed texture array multisampling validation

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1431,11 +1431,9 @@ impl Device {
                 });
             }
 
-            if desc.size.depth_or_array_layers != 1 {
+            if desc.dimension != wgt::TextureDimension::D2 {
                 return Err(CreateTextureError::InvalidDimension(
-                    TextureDimensionError::MultisampledDepthOrArrayLayer(
-                        desc.size.depth_or_array_layers,
-                    ),
+                    TextureDimensionError::MultisampledDepthOrArrayLayer(desc.sample_count),
                 ));
             }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1432,8 +1432,11 @@ impl Device {
             }
 
             if desc.dimension != wgt::TextureDimension::D2 {
-                return Err(CreateTextureError::Non2DMultisampledTexture(
-                    desc.sample_count,
+                return Err(CreateTextureError::InvalidDimension(
+                    TextureDimensionError::InvalidMultisampledDimension(
+                        desc.dimension,
+                        desc.sample_count,
+                    ),
                 ));
             }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1432,11 +1432,9 @@ impl Device {
             }
 
             if desc.dimension != wgt::TextureDimension::D2 {
-                return Err(CreateTextureError::InvalidDimension(
-                    TextureDimensionError::InvalidMultisampledDimension(
-                        desc.dimension,
-                        desc.sample_count,
-                    ),
+                return Err(CreateTextureError::InvalidMultisampledDimension(
+                    desc.dimension,
+                    desc.sample_count,
                 ));
             }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1432,8 +1432,8 @@ impl Device {
             }
 
             if desc.dimension != wgt::TextureDimension::D2 {
-                return Err(CreateTextureError::InvalidDimension(
-                    TextureDimensionError::MultisampledDepthOrArrayLayer(desc.sample_count),
+                return Err(CreateTextureError::Non2DMultisampledTexture(
+                    desc.sample_count,
                 ));
             }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1551,8 +1551,6 @@ pub enum TextureDimensionError {
         multiple: u32,
         format: wgt::TextureFormat,
     },
-    #[error("3D texture multisample count must be 1, got {0}")]
-    MultisampledDepthOrArrayLayer(u32),
 }
 
 impl WebGpuError for TextureDimensionError {
@@ -1597,6 +1595,8 @@ pub enum CreateTextureError {
     InvalidMultisampledFormat(wgt::TextureFormat),
     #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarantees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
     InvalidSampleCount(u32, wgt::TextureFormat, Vec<u32>, Vec<u32>),
+    #[error("1D/3D texture multisample count must be 1, got {0}")]
+    Non2DMultisampledTexture(u32),
     #[error("Multisampled textures must have RENDER_ATTACHMENT usage")]
     MultisampledNotRenderAttachment,
     #[error("Texture format {0:?} can't be used due to missing features")]
@@ -1637,7 +1637,8 @@ impl WebGpuError for CreateTextureError {
             | Self::InvalidMultisampledStorageBinding
             | Self::InvalidMultisampledFormat(_)
             | Self::InvalidSampleCount(..)
-            | Self::MultisampledNotRenderAttachment => return ErrorType::Validation,
+            | Self::MultisampledNotRenderAttachment
+            | Self::Non2DMultisampledTexture(_) => return ErrorType::Validation,
         };
         e.webgpu_error_type()
     }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1551,10 +1551,6 @@ pub enum TextureDimensionError {
         multiple: u32,
         format: wgt::TextureFormat,
     },
-    #[error(
-        "Textures of dimension {0:?} cannot be multisampled, but the multisample count is {1}"
-    )]
-    InvalidMultisampledDimension(wgt::TextureDimension, u32),
 }
 
 impl WebGpuError for TextureDimensionError {
@@ -1599,6 +1595,10 @@ pub enum CreateTextureError {
     InvalidMultisampledFormat(wgt::TextureFormat),
     #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarantees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
     InvalidSampleCount(u32, wgt::TextureFormat, Vec<u32>, Vec<u32>),
+    #[error(
+        "Textures of dimension {0:?} cannot be multisampled, but the multisample count is {1}"
+    )]
+    InvalidMultisampledDimension(wgt::TextureDimension, u32),
     #[error("Multisampled textures must have RENDER_ATTACHMENT usage")]
     MultisampledNotRenderAttachment,
     #[error("Texture format {0:?} can't be used due to missing features")]
@@ -1639,7 +1639,8 @@ impl WebGpuError for CreateTextureError {
             | Self::InvalidMultisampledStorageBinding
             | Self::InvalidMultisampledFormat(_)
             | Self::InvalidSampleCount(..)
-            | Self::MultisampledNotRenderAttachment => return ErrorType::Validation,
+            | Self::MultisampledNotRenderAttachment
+            | Self::InvalidMultisampledDimension(..) => return ErrorType::Validation,
         };
         e.webgpu_error_type()
     }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1551,6 +1551,10 @@ pub enum TextureDimensionError {
         multiple: u32,
         format: wgt::TextureFormat,
     },
+    #[error(
+        "Textures of dimension {0:?} cannot be multisampled, but the multisample count is {1}"
+    )]
+    InvalidMultisampledDimension(wgt::TextureDimension, u32),
 }
 
 impl WebGpuError for TextureDimensionError {
@@ -1595,8 +1599,6 @@ pub enum CreateTextureError {
     InvalidMultisampledFormat(wgt::TextureFormat),
     #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarantees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
     InvalidSampleCount(u32, wgt::TextureFormat, Vec<u32>, Vec<u32>),
-    #[error("1D/3D texture multisample count must be 1, got {0}")]
-    Non2DMultisampledTexture(u32),
     #[error("Multisampled textures must have RENDER_ATTACHMENT usage")]
     MultisampledNotRenderAttachment,
     #[error("Texture format {0:?} can't be used due to missing features")]
@@ -1637,8 +1639,7 @@ impl WebGpuError for CreateTextureError {
             | Self::InvalidMultisampledStorageBinding
             | Self::InvalidMultisampledFormat(_)
             | Self::InvalidSampleCount(..)
-            | Self::MultisampledNotRenderAttachment
-            | Self::Non2DMultisampledTexture(_) => return ErrorType::Validation,
+            | Self::MultisampledNotRenderAttachment => return ErrorType::Validation,
         };
         e.webgpu_error_type()
     }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1551,7 +1551,7 @@ pub enum TextureDimensionError {
         multiple: u32,
         format: wgt::TextureFormat,
     },
-    #[error("Multisampled texture depth or array layers must be 1, got {0}")]
+    #[error("3D texture multisample count must be 1, got {0}")]
     MultisampledDepthOrArrayLayer(u32),
 }
 


### PR DESCRIPTION
**Connections**
Closes #8565 

**Description**
[Here](https://www.w3.org/TR/webgpu/#abstract-opdef-validating-gputexturedescriptor) the spec discusses validation of multisample state for textures. It says the following:

```
["1d"](https://www.w3.org/TR/webgpu/#dom-gputexturedimension-1d)

        descriptor.[size](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-size).[width](https://www.w3.org/TR/webgpu/#gpuextent3d-width) must be ≤ limits.[maxTextureDimension1D](https://www.w3.org/TR/webgpu/#dom-supported-limits-maxtexturedimension1d).

        descriptor.[size](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-size).[height](https://www.w3.org/TR/webgpu/#gpuextent3d-height) must be 1.

        descriptor.[size](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-size).[depthOrArrayLayers](https://www.w3.org/TR/webgpu/#gpuextent3d-depthorarraylayers) must be 1.

        descriptor.[sampleCount](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-samplecount) must be 1.

        descriptor.[format](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-format) must not be a [compressed format](https://www.w3.org/TR/webgpu/#compressed-format) or [depth-or-stencil format](https://www.w3.org/TR/webgpu/#depth-or-stencil-format).

["2d"](https://www.w3.org/TR/webgpu/#dom-gputexturedimension-2d)

        descriptor.[size](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-size).[width](https://www.w3.org/TR/webgpu/#gpuextent3d-width) must be ≤ limits.[maxTextureDimension2D](https://www.w3.org/TR/webgpu/#dom-supported-limits-maxtexturedimension2d).

        descriptor.[size](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-size).[height](https://www.w3.org/TR/webgpu/#gpuextent3d-height) must be ≤ limits.[maxTextureDimension2D](https://www.w3.org/TR/webgpu/#dom-supported-limits-maxtexturedimension2d).

        descriptor.[size](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-size).[depthOrArrayLayers](https://www.w3.org/TR/webgpu/#gpuextent3d-depthorarraylayers) must be ≤ limits.[maxTextureArrayLayers](https://www.w3.org/TR/webgpu/#dom-supported-limits-maxtexturearraylayers).

["3d"](https://www.w3.org/TR/webgpu/#dom-gputexturedimension-3d)

        descriptor.[size](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-size).[width](https://www.w3.org/TR/webgpu/#gpuextent3d-width) must be ≤ limits.[maxTextureDimension3D](https://www.w3.org/TR/webgpu/#dom-supported-limits-maxtexturedimension3d).

        descriptor.[size](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-size).[height](https://www.w3.org/TR/webgpu/#gpuextent3d-height) must be ≤ limits.[maxTextureDimension3D](https://www.w3.org/TR/webgpu/#dom-supported-limits-maxtexturedimension3d).

        descriptor.[size](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-size).[depthOrArrayLayers](https://www.w3.org/TR/webgpu/#gpuextent3d-depthorarraylayers) must be ≤ limits.[maxTextureDimension3D](https://www.w3.org/TR/webgpu/#dom-supported-limits-maxtexturedimension3d).

        descriptor.[sampleCount](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-samplecount) must be 1.

        descriptor.[format](https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-format) must support ["3d"](https://www.w3.org/TR/webgpu/#dom-gputexturedimension-3d) textures according to [§ 26.1 Texture Format Capabilities](https://www.w3.org/TR/webgpu/#texture-format-caps).
```

Clearly, this disallows multisampling for 1D and 3D textures but allows it for 2D textures and 2D texture arrays. The existing validation only checked that an image with multisampling >1 had an array length or depth of 1. This incorrectly allowed 1D textures and 3D textures with depth 1 to have multisampling, and incorrectly blocked 2D texture arrays.

**Testing**
Nothing new

**Squash or Rebase?**
Squash


**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
