### PR TITLE
Adjust the placement of the zero size check for some texture copies

### DIFF
--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -189,6 +189,8 @@ pub(super) fn clear_buffer(
         });
     }
 
+    // This must happen after parameter validation (so that errors are reported
+    // as required by the spec), but before any side effects.
     if offset == end_offset {
         log::trace!("Ignoring fill_buffer of size 0");
         return Ok(());

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -1037,6 +1037,8 @@ pub(super) fn copy_buffer_to_buffer(
         .into());
     }
 
+    // This must happen after parameter validation (so that errors are reported
+    // as required by the spec), but before any side effects.
     if size == 0 {
         log::trace!("Ignoring copy_buffer_to_buffer of size 0");
         return Ok(());
@@ -1255,6 +1257,8 @@ pub(super) fn copy_texture_to_buffer(
         .check_usage(BufferUsages::COPY_DST)
         .map_err(TransferError::MissingBufferUsage)?;
 
+    // This must happen after parameter validation (so that errors are reported
+    // as required by the spec), but before any side effects.
     if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
         log::trace!("Ignoring copy_texture_to_buffer of size 0");
         return Ok(());
@@ -1376,12 +1380,6 @@ pub(super) fn copy_texture_to_texture(
         .into());
     }
 
-    // Handle texture init *before* dealing with barrier transitions so we
-    // have an easier time inserting "immediate-inits" that may be required
-    // by prior discards in rare cases.
-    handle_src_texture_init(state, source, copy_size, src_texture)?;
-    handle_dst_texture_init(state, destination, copy_size, dst_texture)?;
-
     let src_raw = src_texture.try_raw(state.snatch_guard)?;
     src_texture
         .check_usage(TextureUsages::COPY_SRC)
@@ -1391,10 +1389,18 @@ pub(super) fn copy_texture_to_texture(
         .check_usage(TextureUsages::COPY_DST)
         .map_err(TransferError::MissingTextureUsage)?;
 
+    // This must happen after parameter validation (so that errors are reported
+    // as required by the spec), but before any side effects.
     if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
         log::trace!("Ignoring copy_texture_to_texture of size 0");
         return Ok(());
     }
+
+    // Handle texture init *before* dealing with barrier transitions so we
+    // have an easier time inserting "immediate-inits" that may be required
+    // by prior discards in rare cases.
+    handle_src_texture_init(state, source, copy_size, src_texture)?;
+    handle_dst_texture_init(state, destination, copy_size, dst_texture)?;
 
     let src_pending =
         state


### PR DESCRIPTION
It is important that we not call `handle_*_init` if we are not actually going to perform a transfer.

The order of operations is changed for `copy_texture_to_texture` and `copy_external_image_to_texture`. The rest are just adding the comment.

**Testing**
Tested manually in Firefox.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
