### PR TITLE
staging belt: allow creation with custom buffer usages

### DIFF
--- a/tests/tests/wgpu-validation/util.rs
+++ b/tests/tests/wgpu-validation/util.rs
@@ -1,6 +1,7 @@
 //! Tests of [`wgpu::util`].
 
 use nanorand::Rng;
+use wgpu::BufferUsages;
 
 /// Generate (deterministic) random staging belt operations to exercise its logic.
 #[test]
@@ -38,4 +39,42 @@ fn staging_belt_random_test() {
         queue.submit([encoder.finish()]);
         belt.recall();
     }
+}
+
+#[test]
+#[should_panic]
+fn staging_belt_panics_with_invalid_buffer_usages() {
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+
+    for usage in BufferUsages::all()
+        .difference(BufferUsages::COPY_SRC | BufferUsages::MAP_WRITE)
+        .iter()
+    {
+        let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(device.clone(), 512, usage);
+        let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(
+            device.clone(),
+            512,
+            usage | BufferUsages::MAP_WRITE,
+        );
+    }
+}
+
+#[test]
+fn staging_belt_works_with_non_exclusive_buffer_usages() {
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(
+        device.clone(),
+        512,
+        BufferUsages::COPY_SRC,
+    );
+    let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(
+        device.clone(),
+        512,
+        BufferUsages::COPY_SRC | BufferUsages::MAP_WRITE,
+    );
+    let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(
+        device.clone(),
+        512,
+        BufferUsages::MAP_WRITE,
+    );
 }

--- a/tests/tests/wgpu-validation/util.rs
+++ b/tests/tests/wgpu-validation/util.rs
@@ -127,7 +127,7 @@ fn staging_belt_works_with_exclusive_buffer_usages_with_mappable_primary_buffers
         // Check that the constructor doesn't panic without explicit `MAP_WRITE`
         let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(device.clone(), 512, usage);
 
-        // Check that the constructor doesn't panic with explicity `MAP_WRITE`
+        // Check that the constructor doesn't panic with explicitly `MAP_WRITE`
         let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(
             device.clone(),
             512,

--- a/tests/tests/wgpu-validation/util.rs
+++ b/tests/tests/wgpu-validation/util.rs
@@ -44,10 +44,12 @@ fn staging_belt_random_test() {
 fn staging_belt_panics_with_invalid_buffer_usages() {
     #[track_caller]
     fn test_if_panics(usage: wgpu::BufferUsages) {
-        if let Err(panic) = std::panic::catch_unwind(|| {
+        let result = std::panic::catch_unwind(|| {
             let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
             let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(device.clone(), 512, usage);
-        }) {
+        });
+
+        if let Err(panic) = result {
             // according to [1] the panic payload is either a `&str` or `String`
             // [1]: https://doc.rust-lang.org/std/macro.panic.html
 
@@ -72,12 +74,17 @@ fn staging_belt_panics_with_invalid_buffer_usages() {
         }
     }
 
+    // This tests that `StagingBelt::new_with_buffer_usages` panics for any buffer usages that contain anything else than `COPY_SRC | MAP_WRITE`.
+    //
+    // First we iterate over all possible buffer usages except `COPY_SRC | MAP_WRITE` (anything invalid).
     for mut usage in wgpu::BufferUsages::all()
         .difference(wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_WRITE)
         .iter()
     {
+        // check if the constructor panics with the selected buffer usage
         test_if_panics(usage);
 
+        // add MAP_WRITE to the selected buffer usage and check that the constructor still panics
         usage.insert(wgpu::BufferUsages::MAP_WRITE);
         test_if_panics(usage);
     }
@@ -101,4 +108,30 @@ fn staging_belt_works_with_non_exclusive_buffer_usages() {
         512,
         wgpu::BufferUsages::MAP_WRITE,
     );
+}
+
+#[test]
+fn staging_belt_works_with_exclusive_buffer_usages_with_mappable_primary_buffers() {
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor {
+        required_features: wgpu::Features::MAPPABLE_PRIMARY_BUFFERS,
+        ..Default::default()
+    });
+
+    // This tests that `StagingBelt::new_with_buffer_usages` works for any buffer usages that contain anything else than `COPY_SRC | MAP_WRITE`.
+    //
+    // First we iterate over all possible buffer usages except `COPY_SRC | MAP_WRITE` (anything that would be invalid without mappable primary buffers).
+    for usage in wgpu::BufferUsages::all()
+        .difference(wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_WRITE)
+        .iter()
+    {
+        // Check that the constructor doesn't panic without explicit `MAP_WRITE`
+        let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(device.clone(), 512, usage);
+
+        // Check that the constructor doesn't panic with explicity `MAP_WRITE`
+        let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(
+            device.clone(),
+            512,
+            wgpu::BufferUsages::MAP_WRITE,
+        );
+    }
 }

--- a/tests/tests/wgpu-validation/util.rs
+++ b/tests/tests/wgpu-validation/util.rs
@@ -1,7 +1,6 @@
 //! Tests of [`wgpu::util`].
 
 use nanorand::Rng;
-use wgpu::BufferUsages;
 
 /// Generate (deterministic) random staging belt operations to exercise its logic.
 #[test]
@@ -43,22 +42,44 @@ fn staging_belt_random_test() {
 
 #[test]
 fn staging_belt_panics_with_invalid_buffer_usages() {
-    fn test_if_panics(usage: BufferUsages) -> bool {
-        std::panic::catch_unwind(|| {
+    #[track_caller]
+    fn test_if_panics(usage: wgpu::BufferUsages) {
+        if let Err(panic) = std::panic::catch_unwind(|| {
             let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
             let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(device.clone(), 512, usage);
-        })
-        .is_err()
+        }) {
+            // according to [1] the panic payload is either a `&str` or `String`
+            // [1]: https://doc.rust-lang.org/std/macro.panic.html
+
+            let message = if let Some(message) = panic.downcast_ref::<&str>() {
+                *message
+            } else if let Some(message) = panic.downcast_ref::<String>() {
+                message.as_str()
+            } else {
+                // don't know what this panic is, but it's not ours
+                std::panic::resume_unwind(panic);
+            };
+
+            let expected_message = format!("Only BufferUsages::COPY_SRC may be used when Features::MAPPABLE_PRIMARY_BUFFERS is not enabled. Specified buffer usages: {usage:?}");
+            if expected_message == message {
+                // panicked with the correct message
+            } else {
+                // This is not our panic (or the panic message was changed)
+                std::panic::resume_unwind(panic);
+            }
+        } else {
+            panic!("StagingBelt::new_with_buffer_usages should panic without MAPPABLE_PRIMARY_BUFFERS with usage={usage:?}");
+        }
     }
 
-    for mut usage in BufferUsages::all()
-        .difference(BufferUsages::COPY_SRC | BufferUsages::MAP_WRITE)
+    for mut usage in wgpu::BufferUsages::all()
+        .difference(wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_WRITE)
         .iter()
     {
-        assert!(test_if_panics(usage), "StagingBelt::new_with_buffer_usages should panic without MAPPABLE_PRIMARY_BUFFERS with usage={usage:?}");
+        test_if_panics(usage);
 
-        usage.insert(BufferUsages::MAP_WRITE);
-        assert!(test_if_panics(usage), "StagingBelt::new_with_buffer_usages should panic without MAPPABLE_PRIMARY_BUFFERS with usage={usage:?}");
+        usage.insert(wgpu::BufferUsages::MAP_WRITE);
+        test_if_panics(usage);
     }
 }
 
@@ -68,16 +89,16 @@ fn staging_belt_works_with_non_exclusive_buffer_usages() {
     let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(
         device.clone(),
         512,
-        BufferUsages::COPY_SRC,
+        wgpu::BufferUsages::COPY_SRC,
     );
     let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(
         device.clone(),
         512,
-        BufferUsages::COPY_SRC | BufferUsages::MAP_WRITE,
+        wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_WRITE,
     );
     let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(
         device.clone(),
         512,
-        BufferUsages::MAP_WRITE,
+        wgpu::BufferUsages::MAP_WRITE,
     );
 }

--- a/tests/tests/wgpu-validation/util.rs
+++ b/tests/tests/wgpu-validation/util.rs
@@ -42,20 +42,23 @@ fn staging_belt_random_test() {
 }
 
 #[test]
-#[should_panic]
 fn staging_belt_panics_with_invalid_buffer_usages() {
-    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    fn test_if_panics(usage: BufferUsages) -> bool {
+        std::panic::catch_unwind(|| {
+            let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+            let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(device.clone(), 512, usage);
+        })
+        .is_err()
+    }
 
-    for usage in BufferUsages::all()
+    for mut usage in BufferUsages::all()
         .difference(BufferUsages::COPY_SRC | BufferUsages::MAP_WRITE)
         .iter()
     {
-        let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(device.clone(), 512, usage);
-        let _belt = wgpu::util::StagingBelt::new_with_buffer_usages(
-            device.clone(),
-            512,
-            usage | BufferUsages::MAP_WRITE,
-        );
+        assert!(test_if_panics(usage), "StagingBelt::new_with_buffer_usages should panic without MAPPABLE_PRIMARY_BUFFERS with usage={usage:?}");
+
+        usage.insert(BufferUsages::MAP_WRITE);
+        assert!(test_if_panics(usage), "StagingBelt::new_with_buffer_usages should panic without MAPPABLE_PRIMARY_BUFFERS with usage={usage:?}");
     }
 }
 

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -27,7 +27,7 @@ use crate::COPY_BUFFER_ALIGNMENT;
 pub struct StagingBelt {
     device: Device,
     chunk_size: BufferAddress,
-    /// User-specified [`BufferUsages`] with which the chunk buffers are created.
+    /// User-specified [`BufferUsages`] used to create the chunk buffers are created.
     ///
     /// [`new`](Self::new) guarantees that this always contains
     /// [`MAP_WRITE`](BufferUsages::MAP_WRITE).
@@ -58,8 +58,8 @@ impl StagingBelt {
     ///   (per [`StagingBelt::finish()`]); and
     /// * bigger is better, within these bounds.
     ///
-    /// The buffers returned by this staging belt will have the buffer usages
-    /// [`MAP_READ | MAP_WRITE`](BufferUsages).
+    /// The buffers returned by this [`StagingBelt`] will be have the buffer usages
+    /// [`COPY_SRC | MAP_WRITE`](wgpu::BufferUsages)
     pub fn new(device: Device, chunk_size: BufferAddress) -> Self {
         Self::new_with_buffer_usages(device, chunk_size, BufferUsages::COPY_SRC)
     }
@@ -75,12 +75,13 @@ impl StagingBelt {
     ///   (per [`StagingBelt::finish()`]); and
     /// * bigger is better, within these bounds.
     ///
-    /// `buffer_usages` specifies with which [`BufferUsages`] the staging buffers
-    /// will be created. [`MAP_WRITE`](BufferUsages::MAP_WRITE) will be added
+    /// `buffer_usages` specifies the [`BufferUsages`] the staging buffers
+    /// will be created with. [`MAP_WRITE`](BufferUsages::MAP_WRITE) will be added
     /// automatically. The method will panic if the combination of usages is not
-    /// supported. Because [`MAP_WRITE`](BufferUsages::MAP_WRITE) is implied, only
-    /// [`COPY_SRC`](BufferUsages::COPY_SRC) can be used, except if
-    /// [`Features::MAPPABLE_PRIMARY_BUFFERS`] is enabled.
+    /// supported. Because [`MAP_WRITE`](BufferUsages::MAP_WRITE) is implied, the allowed usages
+    /// depends on if [`Features::MAPPABLE_PRIMARY_BUFFERS`] is enabled.
+    /// - If enabled: any usage is valid.
+    /// - If disabled: only [`COPY_SRC`](BufferUsages::COPY_SRC) can be used.
     #[track_caller]
     pub fn new_with_buffer_usages(
         device: Device,

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -5,6 +5,7 @@ use crate::{
 use alloc::vec::Vec;
 use core::fmt;
 use std::sync::mpsc;
+use wgt::Features;
 
 use crate::COPY_BUFFER_ALIGNMENT;
 
@@ -26,6 +27,11 @@ use crate::COPY_BUFFER_ALIGNMENT;
 pub struct StagingBelt {
     device: Device,
     chunk_size: BufferAddress,
+    /// User-specified [`BufferUsages`] with which the chunk buffers are created.
+    ///
+    /// [`new`](Self::new) guarantees that this always constains
+    /// [`MAP_WRITE`](BufferUsages::MAP_WRITE).
+    buffer_usages: BufferUsages,
     /// Chunks into which we are accumulating data to be transferred.
     active_chunks: Vec<Chunk>,
     /// Chunks that have scheduled transfers already; they are unmapped and some
@@ -51,11 +57,54 @@ impl StagingBelt {
     /// * 1-4 times less than the total amount of data uploaded per submission
     ///   (per [`StagingBelt::finish()`]); and
     /// * bigger is better, within these bounds.
+    ///
+    /// The buffers returned by this staging belt will have the buffer usages
+    /// [`MAP_READ | MAP_WRITE`](BufferUsages).
     pub fn new(device: Device, chunk_size: BufferAddress) -> Self {
+        Self::new_with_buffer_usages(device, chunk_size, BufferUsages::COPY_SRC)
+    }
+
+    /// Create a new staging belt.
+    ///
+    /// The `chunk_size` is the unit of internal buffer allocation; writes will be
+    /// sub-allocated within each chunk. Therefore, for optimal use of memory, the
+    /// chunk size should be:
+    ///
+    /// * larger than the largest single [`StagingBelt::write_buffer()`] operation;
+    /// * 1-4 times less than the total amount of data uploaded per submission
+    ///   (per [`StagingBelt::finish()`]); and
+    /// * bigger is better, within these bounds.
+    ///
+    /// `buffer_usages` specifies with which [`BufferUsages`] the staging buffers
+    /// will be created. [`MAP_WRITE`](BufferUsages::MAP_WRITE) will be added
+    /// automatically. The method will panic if the combination of usages is not
+    /// supported. Because [`MAP_WRITE`](BufferUsages::MAP_WRITE) is implied, only
+    /// [`COPY_SRC`](BufferUsages::COPY_SRC) can be used, except if
+    /// [`Features::MAPPABLE_PRIMARY_BUFFERS`] is enabled.
+    pub fn new_with_buffer_usages(
+        device: Device,
+        chunk_size: BufferAddress,
+        mut buffer_usages: BufferUsages,
+    ) -> Self {
         let (sender, receiver) = mpsc::channel();
+
+        // make sure anything other than MAP_WRITE | COPY_SRC is only allowed with MAPPABLE_PRIMARY_BUFFERS.
+        let extra_usages =
+            buffer_usages.difference(BufferUsages::MAP_WRITE | BufferUsages::COPY_SRC);
+        if !extra_usages.is_empty()
+            && !device
+                .features()
+                .contains(Features::MAPPABLE_PRIMARY_BUFFERS)
+        {
+            panic!("Only BufferUsages::COPY_SRC may be used when Features::MAPPABLE_PRIMARY_BUFFERS is not enabled. Specified buffer usages: {buffer_usages:?}");
+        }
+        // always set MAP_WRITE
+        buffer_usages.insert(BufferUsages::MAP_WRITE);
+
         StagingBelt {
             device,
             chunk_size,
+            buffer_usages,
             active_chunks: Vec::new(),
             closed_chunks: Vec::new(),
             free_chunks: Vec::new(),
@@ -117,7 +166,7 @@ impl StagingBelt {
     /// (The view must be dropped before [`StagingBelt::finish()`] is called.)
     ///
     /// You can then record your own GPU commands to perform with the slice,
-    /// such as copying it to a texture or executing a compute shader that reads it (whereas
+    /// such as copying it to a texture (whereas
     /// [`StagingBelt::write_buffer()`] can only write to other buffers).
     /// All commands involving this slice must be submitted after
     /// [`StagingBelt::finish()`] is called and before [`StagingBelt::recall()`] is called.
@@ -162,7 +211,7 @@ impl StagingBelt {
                     buffer: self.device.create_buffer(&BufferDescriptor {
                         label: Some("(wgpu internal) StagingBelt staging buffer"),
                         size: self.chunk_size.max(size.get()),
-                        usage: BufferUsages::MAP_WRITE | BufferUsages::COPY_SRC,
+                        usage: self.buffer_usages,
                         mapped_at_creation: true,
                     }),
                     offset: 0,
@@ -230,6 +279,7 @@ impl fmt::Debug for StagingBelt {
         let Self {
             device,
             chunk_size,
+            buffer_usages,
             active_chunks,
             closed_chunks,
             free_chunks,
@@ -239,6 +289,7 @@ impl fmt::Debug for StagingBelt {
         f.debug_struct("StagingBelt")
             .field("device", device)
             .field("chunk_size", chunk_size)
+            .field("buffer_usages", buffer_usages)
             .field("active_chunks", &active_chunks.len())
             .field("closed_chunks", &closed_chunks.len())
             .field("free_chunks", &free_chunks.len())

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -29,7 +29,7 @@ pub struct StagingBelt {
     chunk_size: BufferAddress,
     /// User-specified [`BufferUsages`] with which the chunk buffers are created.
     ///
-    /// [`new`](Self::new) guarantees that this always constains
+    /// [`new`](Self::new) guarantees that this always contains
     /// [`MAP_WRITE`](BufferUsages::MAP_WRITE).
     buffer_usages: BufferUsages,
     /// Chunks into which we are accumulating data to be transferred.

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -81,6 +81,7 @@ impl StagingBelt {
     /// supported. Because [`MAP_WRITE`](BufferUsages::MAP_WRITE) is implied, only
     /// [`COPY_SRC`](BufferUsages::COPY_SRC) can be used, except if
     /// [`Features::MAPPABLE_PRIMARY_BUFFERS`] is enabled.
+    #[track_caller]
     pub fn new_with_buffer_usages(
         device: Device,
         chunk_size: BufferAddress,

--- a/wgpu/src/util/belt.rs
+++ b/wgpu/src/util/belt.rs
@@ -59,7 +59,7 @@ impl StagingBelt {
     /// * bigger is better, within these bounds.
     ///
     /// The buffers returned by this [`StagingBelt`] will be have the buffer usages
-    /// [`COPY_SRC | MAP_WRITE`](wgpu::BufferUsages)
+    /// [`COPY_SRC | MAP_WRITE`](crate::BufferUsages)
     pub fn new(device: Device, chunk_size: BufferAddress) -> Self {
         Self::new_with_buffer_usages(device, chunk_size, BufferUsages::COPY_SRC)
     }


### PR DESCRIPTION
**Connections**

This addresses #8575. `allocate` was introduced in #6900 

**Description**

`StagingBelt` can give you the buffer slice for more advanced usecases. The documentation incorrectly states that you could e.g. use it in a compute pass. Because the buffers are created with `MAP_WRITE | COPY_SRC` this is incorrect.

Creating buffers with custom buffer usages is possible, although `MAPPABLE_PRIMARY_BUFFERS` must be enabled.

This PR adds a `new_with_buffer_usages` method with a third argument for the intended buffer usages. We could also just extend the current `new` method, if API breakage is possible. The new method verifies that the combination of `BufferUsage`s is possible depending on the `MAPPABLE_PRIMARY_BUFFERS` feature.

The `MAP_WRITE` usage is always added to the supplied buffer usages.

I've also stripped the mention of using this with a compute pass from the documentation of `allocate`. In my opinion using the staging belt with mappable primary buffers is really a niece case. 

**Testing**

I've added 2 test:

1. `staging_belt_panics_with_invalid_buffer_usages` goes through all buffer usages except `COPY_SRC` and `MAP_WRITE` and checks that the constructor panics.
2. `staging_belt_works_with_non_exclusive_buffer_usages` that the new constructor works with `COPY_SRC`, `COPY_SRC | MAP_WRITE` and `MAP_WRITE`.

Furthermore `staging_belt_random_test` verifies that any previous functionality isn't lost.

**Merge or Squash**

This should be squashed.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
