### PR TITLE
[naga] Add GLSL constant_id layout qualifier support and WGSL backend override output

### DIFF
--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -135,12 +135,6 @@ impl<W: Write> Writer<W> {
     }
 
     pub fn write(&mut self, module: &Module, info: &valid::ModuleInfo) -> BackendResult {
-        if !module.overrides.is_empty() {
-            return Err(Error::Unimplemented(
-                "Pipeline constants are not yet supported for this back-end".to_string(),
-            ));
-        }
-
         self.reset(module);
 
         // Write all `enable` declarations
@@ -168,6 +162,16 @@ impl<W: Write> Writer<W> {
             self.write_global_constant(module, handle)?;
             // Add extra newline for readability on last iteration
             if constants.peek().is_none() {
+                writeln!(self.out)?;
+            }
+        }
+
+        // Write all overrides
+        let mut overrides = module.overrides.iter().peekable();
+        while let Some((handle, _)) = overrides.next() {
+            self.write_override(module, handle)?;
+            // Add extra newline for readability on last iteration
+            if overrides.peek().is_none() {
                 writeln!(self.out)?;
             }
         }
@@ -1205,6 +1209,9 @@ impl<W: Write> Writer<W> {
                 write_expression(self, value)?;
                 write!(self.out, ")")?;
             }
+            Expression::Override(handle) => {
+                write!(self.out, "{}", self.names[&NameKey::Override(handle)])?;
+            }
             _ => unreachable!(),
         }
 
@@ -1255,7 +1262,9 @@ impl<W: Write> Writer<W> {
                     |writer, expr| writer.write_expr(module, expr, func_ctx),
                 )?;
             }
-            Expression::Override(_) => unreachable!(),
+            Expression::Override(handle) => {
+                write!(self.out, "{}", self.names[&NameKey::Override(handle)])?;
+            }
             Expression::FunctionArgument(pos) => {
                 let name_key = func_ctx.argument_key(pos);
                 let name = &self.names[&name_key];
@@ -1770,6 +1779,38 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
+    /// Helper method used to write overrides
+    ///
+    /// # Notes
+    /// Ends in a newline
+    fn write_override(
+        &mut self,
+        module: &Module,
+        handle: Handle<crate::Override>,
+    ) -> BackendResult {
+        let override_ = &module.overrides[handle];
+        let name = &self.names[&NameKey::Override(handle)];
+
+        // Write @id attribute if present
+        if let Some(id) = override_.id {
+            write!(self.out, "@id({id}) ")?;
+        }
+
+        // Write override declaration
+        write!(self.out, "override {name}: ")?;
+        self.write_type(module, override_.ty)?;
+
+        // Write initializer if present
+        if let Some(init) = override_.init {
+            write!(self.out, " = ")?;
+            self.write_const_expression(module, init, &module.global_expressions)?;
+        }
+
+        writeln!(self.out, ";")?;
+
+        Ok(())
+    }
+
     // See https://github.com/rust-lang/rust-clippy/issues/4979.
     #[allow(clippy::missing_const_for_fn)]
     pub fn finish(self) -> W {
@@ -1795,8 +1836,12 @@ impl TypeContext for WriterTypeContext<'_> {
         unreachable!("the WGSL back end should always provide type handles");
     }
 
-    fn write_override<W: Write>(&self, _: Handle<crate::Override>, _: &mut W) -> core::fmt::Result {
-        unreachable!("overrides should be validated out");
+    fn write_override<W: Write>(
+        &self,
+        handle: Handle<crate::Override>,
+        out: &mut W,
+    ) -> core::fmt::Result {
+        write!(out, "{}", self.names[&NameKey::Override(handle)])
     }
 
     fn write_non_wgsl_inner<W: Write>(&self, _: &TypeInner, _: &mut W) -> core::fmt::Result {

--- a/naga/src/front/glsl/ast.rs
+++ b/naga/src/front/glsl/ast.rs
@@ -4,13 +4,14 @@ use core::fmt;
 use super::{builtins::MacroCall, Span};
 use crate::{
     AddressSpace, BinaryOperator, Binding, Constant, Expression, Function, GlobalVariable, Handle,
-    Interpolation, Literal, Sampling, StorageAccess, Type, UnaryOperator,
+    Interpolation, Literal, Override, Sampling, StorageAccess, Type, UnaryOperator,
 };
 
 #[derive(Debug, Clone, Copy)]
 pub enum GlobalLookupKind {
     Variable(Handle<GlobalVariable>),
     Constant(Handle<Constant>, Handle<Type>),
+    Override(Handle<Override>, Handle<Type>),
     BlockSelect(Handle<GlobalVariable>, u32),
 }
 

--- a/naga/src/front/glsl/parser.rs
+++ b/naga/src/front/glsl/parser.rs
@@ -436,6 +436,7 @@ impl DeclarationContext<'_, '_, '_> {
                 let expr = match global {
                     GlobalOrConstant::Global(handle) => Expression::GlobalVariable(handle),
                     GlobalOrConstant::Constant(handle) => Expression::Constant(handle),
+                    GlobalOrConstant::Override(handle) => Expression::Override(handle),
                 };
                 Ok(self.ctx.add_expression(expr, meta)?)
             }

--- a/naga/src/front/glsl/parser/declarations.rs
+++ b/naga/src/front/glsl/parser/declarations.rs
@@ -608,6 +608,7 @@ impl ParsingContext<'_> {
                 kind: match global {
                     GlobalOrConstant::Global(handle) => GlobalLookupKind::BlockSelect(handle, i),
                     GlobalOrConstant::Constant(handle) => GlobalLookupKind::Constant(handle, ty),
+                    GlobalOrConstant::Override(handle) => GlobalLookupKind::Override(handle, ty),
                 },
                 entry_arg: None,
                 mutable: true,

--- a/naga/src/front/glsl/variables.rs
+++ b/naga/src/front/glsl/variables.rs
@@ -8,8 +8,8 @@ use super::{
 };
 use crate::{
     AddressSpace, Binding, BuiltIn, Constant, Expression, GlobalVariable, Handle, Interpolation,
-    LocalVariable, ResourceBinding, Scalar, ScalarKind, ShaderStage, SwizzleComponent, Type,
-    TypeInner, VectorSize,
+    LocalVariable, Override, ResourceBinding, Scalar, ScalarKind, ShaderStage, SwizzleComponent,
+    Type, TypeInner, VectorSize,
 };
 
 pub struct VarDeclaration<'a, 'key> {
@@ -35,6 +35,7 @@ struct BuiltInData {
 pub enum GlobalOrConstant {
     Global(Handle<GlobalVariable>),
     Constant(Handle<Constant>),
+    Override(Handle<Override>),
 }
 
 impl Frontend {
@@ -481,25 +482,69 @@ impl Frontend {
                 (GlobalOrConstant::Global(handle), lookup)
             }
             StorageQualifier::Const => {
-                let init = init.ok_or_else(|| Error {
-                    kind: ErrorKind::SemanticError("const values must have an initializer".into()),
-                    meta,
-                })?;
+                // Check if this is a specialization constant with constant_id
+                let constant_id = qualifiers.uint_layout_qualifier("constant_id", &mut self.errors);
 
-                let constant = Constant {
-                    name: name.clone(),
-                    ty,
-                    init,
-                };
-                let handle = ctx.module.constants.append(constant, meta);
+                if let Some(id) = constant_id {
+                    // This is a specialization constant - convert to Override
+                    let id: Option<u16> = match id.try_into() {
+                        Ok(v) => Some(v),
+                        Err(_) => {
+                            self.errors.push(Error {
+                                kind: ErrorKind::SemanticError(
+                                    format!(
+                                        "constant_id value {id} is too high (maximum is {})",
+                                        u16::MAX
+                                    )
+                                    .into(),
+                                ),
+                                meta,
+                            });
+                            None
+                        }
+                    };
 
-                let lookup = GlobalLookup {
-                    kind: GlobalLookupKind::Constant(handle, ty),
-                    entry_arg: None,
-                    mutable: false,
-                };
+                    let override_handle = ctx.module.overrides.append(
+                        Override {
+                            name: name.clone(),
+                            id,
+                            ty,
+                            init,
+                        },
+                        meta,
+                    );
 
-                (GlobalOrConstant::Constant(handle), lookup)
+                    let lookup = GlobalLookup {
+                        kind: GlobalLookupKind::Override(override_handle, ty),
+                        entry_arg: None,
+                        mutable: false,
+                    };
+
+                    (GlobalOrConstant::Override(override_handle), lookup)
+                } else {
+                    // Regular constant
+                    let init = init.ok_or_else(|| Error {
+                        kind: ErrorKind::SemanticError(
+                            "const values must have an initializer".into(),
+                        ),
+                        meta,
+                    })?;
+
+                    let constant = Constant {
+                        name: name.clone(),
+                        ty,
+                        init,
+                    };
+                    let handle = ctx.module.constants.append(constant, meta);
+
+                    let lookup = GlobalLookup {
+                        kind: GlobalLookupKind::Constant(handle, ty),
+                        entry_arg: None,
+                        mutable: false,
+                    };
+
+                    (GlobalOrConstant::Constant(handle), lookup)
+                }
             }
             StorageQualifier::AddressSpace(mut space) => {
                 match space {

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1189,8 +1189,13 @@ impl<'a> ConstantEvaluator<'a> {
                 Behavior::Wgsl(WgslRestrictions::Const(_)) => {
                     Err(ConstantEvaluatorError::OverrideExpr)
                 }
-                Behavior::Glsl(_) => {
-                    unreachable!()
+
+                // GLSL specialization constants (constant_id) become Override expressions
+                Behavior::Glsl(GlslRestrictions::Runtime(_)) => {
+                    Ok(self.append_expr(expr, span, ExpressionKind::Override))
+                }
+                Behavior::Glsl(GlslRestrictions::Const) => {
+                    Err(ConstantEvaluatorError::OverrideExpr)
                 }
             },
             ExpressionKind::Runtime => {

--- a/naga/src/proc/namer.rs
+++ b/naga/src/proc/namer.rs
@@ -51,6 +51,7 @@ impl ExternalTextureNameKey {
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub enum NameKey {
     Constant(Handle<crate::Constant>),
+    Override(Handle<crate::Override>),
     GlobalVariable(Handle<crate::GlobalVariable>),
     Type(Handle<crate::Type>),
     StructMember(Handle<crate::Type>, u32),
@@ -373,6 +374,21 @@ impl Namer {
             };
             let name = self.call(label);
             output.insert(NameKey::Constant(handle), name);
+        }
+
+        for (handle, override_) in module.overrides.iter() {
+            let label = match override_.name {
+                Some(ref name) => name,
+                None => {
+                    use core::fmt::Write;
+                    // Try to be more descriptive about the override values
+                    temp.clear();
+                    write!(temp, "override_{}", output[&NameKey::Type(override_.ty)]).unwrap();
+                    &temp
+                }
+            };
+            let name = self.call(label);
+            output.insert(NameKey::Override(handle), name);
         }
     }
 }

--- a/naga/tests/in/glsl/spec-constant.frag
+++ b/naga/tests/in/glsl/spec-constant.frag
@@ -1,0 +1,24 @@
+#version 450
+
+// Specialization constants with constant_id layout qualifier
+layout(constant_id = 0) const bool SPEC_CONST_BOOL = true;
+layout(constant_id = 1) const int SPEC_CONST_INT = 42;
+layout(constant_id = 2) const uint SPEC_CONST_UINT = 10u;
+layout(constant_id = 3) const float SPEC_CONST_FLOAT = 3.14;
+
+// NOTE: Naga does not yet support GLSL const variables depending on specialization constants (constant_id).
+// const vec3 scVec = vec3(SPEC_CONST_FLOAT, 1, 1); // Would cause error
+
+layout(location = 0) out vec4 o_color;
+
+void main() {
+    float result = 0.0;
+    
+    if (SPEC_CONST_BOOL) {
+        result += float(SPEC_CONST_INT);
+    }
+    
+    result += float(SPEC_CONST_UINT) * SPEC_CONST_FLOAT;
+    
+    o_color = vec4(result, 0.0, 0.0, 1.0);
+}

--- a/naga/tests/in/glsl/spec-constant.toml
+++ b/naga/tests/in/glsl/spec-constant.toml
@@ -1,0 +1,1 @@
+targets = "WGSL"

--- a/naga/tests/out/wgsl/glsl-spec-constant.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-spec-constant.frag.wgsl
@@ -1,0 +1,33 @@
+struct FragmentOutput {
+    @location(0) o_color: vec4<f32>,
+}
+
+@id(0) override SPEC_CONST_BOOL: bool = true;
+@id(1) override SPEC_CONST_INT: i32 = 42i;
+@id(2) override SPEC_CONST_UINT: u32 = 10u;
+@id(3) override SPEC_CONST_FLOAT: f32 = 3.14f;
+
+var<private> o_color: vec4<f32>;
+
+fn main_1() {
+    var result: f32 = 0f;
+
+    if SPEC_CONST_BOOL {
+        {
+            let _e7 = result;
+            result = (_e7 + f32(SPEC_CONST_INT));
+        }
+    }
+    let _e10 = result;
+    result = (_e10 + (f32(SPEC_CONST_UINT) * SPEC_CONST_FLOAT));
+    let _e14 = result;
+    o_color = vec4<f32>(_e14, 0f, 0f, 1f);
+    return;
+}
+
+@fragment 
+fn main() -> FragmentOutput {
+    main_1();
+    let _e1 = o_color;
+    return FragmentOutput(_e1);
+}


### PR DESCRIPTION
**Connections**
No dependencies on other PRs. Please add related issues if any.

**Description**
This PR adds support for GLSL specialization constants (`constant_id` layout qualifier) in the Naga GLSL frontend and enables the WGSL backend to output `override` declarations.

1. GLSL Frontend
- Parse `layout(constant_id = N)` qualifier for `const` declarations
- Convert these to Naga `Override` instead of `Constant`
- Handle `Override` expressions in the constant evaluator

2. WGSL Backend  
- Remove the "pipeline constants not supported" error
- Add `write_override()` method to output `@id(N) override` declarations
- Support `Expression::Override` in expression writers
- Implement `write_override` in `TypeContext`

3. Naming
- Add `NameKey::Override` variant for override naming


**Testing**
- Add `spec-constant.frag` test case with various specialization constant types

**Squash or Rebase?**

This branch contains a single functional commit and can be rebased directly.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
