### PR TITLE
Fix big_compute_buffer examples

### DIFF
--- a/examples/features/src/big_compute_buffers/mod.rs
+++ b/examples/features/src/big_compute_buffers/mod.rs
@@ -4,7 +4,7 @@
 //! A lot of things aren't explained here via comments. See hello-compute and
 //! repeated-compute for code that is more thoroughly commented.
 
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 use wgpu::{util::DeviceExt, Features};
 
 // These are set by the minimum required defaults for webgpu.
@@ -144,37 +144,36 @@ fn setup_binds(
     storage_buffers: &[wgpu::Buffer],
     device: &wgpu::Device,
 ) -> (wgpu::BindGroupLayout, wgpu::BindGroup) {
-    let bind_group_entries: Vec<wgpu::BindGroupEntry> = storage_buffers
+    let buffers: Vec<_> = storage_buffers
         .iter()
-        .enumerate()
-        .map(|(bind_idx, buffer)| wgpu::BindGroupEntry {
-            binding: bind_idx as u32,
-            resource: buffer.as_entire_binding(),
-        })
+        .map(|b| b.as_entire_buffer_binding())
         .collect();
 
-    let bind_group_layout_entries: Vec<wgpu::BindGroupLayoutEntry> = (0..storage_buffers.len())
-        .map(|bind_idx| wgpu::BindGroupLayoutEntry {
-            binding: bind_idx as u32,
-            visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Buffer {
-                ty: wgpu::BufferBindingType::Storage { read_only: false },
-                has_dynamic_offset: false,
-                min_binding_size: None,
-            },
-            count: Some(NonZeroU32::new(1).unwrap()),
-        })
-        .collect();
+    let entry = wgpu::BindGroupEntry {
+        binding: 0,
+        resource: wgpu::BindingResource::BufferArray(&buffers),
+    };
+
+    let bgl_entry = wgpu::BindGroupLayoutEntry {
+        binding: 0,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only: false },
+            has_dynamic_offset: false,
+            min_binding_size: Some(NonZeroU64::new(4).unwrap()),
+        },
+        count: Some(NonZeroU32::new(buffers.len() as u32).unwrap()),
+    };
 
     let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: Some("Custom Storage Bind Group Layout"),
-        entries: &bind_group_layout_entries,
+        entries: &[bgl_entry],
     });
 
     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some("Combined Storage Bind Group"),
         layout: &bind_group_layout,
-        entries: &bind_group_entries,
+        entries: &[entry],
     });
 
     (bind_group_layout, bind_group)

--- a/examples/features/src/big_compute_buffers/tests.rs
+++ b/examples/features/src/big_compute_buffers/tests.rs
@@ -10,6 +10,7 @@ pub static TWO_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
                     | Features::STORAGE_RESOURCE_BINDING_ARRAY
                     | Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
             )
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits {
                 max_buffer_size: MAX_BUFFER_SIZE,

--- a/examples/features/src/texture_arrays/mod.rs
+++ b/examples/features/src/texture_arrays/mod.rs
@@ -438,7 +438,8 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     width: 1024,
     height: 768,
     optional_features: wgpu::Features::empty(),
-    base_test_parameters: wgpu_test::TestParameters::default(),
+    base_test_parameters: wgpu_test::TestParameters::default()
+        .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.0)],
     _phantom: std::marker::PhantomData::<Example>,
 };
@@ -452,7 +453,8 @@ pub static TEST_UNIFORM: crate::framework::ExampleTestParams =
         width: 1024,
         height: 768,
         optional_features: wgpu::Features::empty(),
-        base_test_parameters: wgpu_test::TestParameters::default(),
+        base_test_parameters: wgpu_test::TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.0)],
         _phantom: std::marker::PhantomData::<Example>,
     };
@@ -467,7 +469,8 @@ pub static TEST_NON_UNIFORM: crate::framework::ExampleTestParams =
         height: 768,
         optional_features:
             wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
-        base_test_parameters: wgpu_test::TestParameters::default(),
+        base_test_parameters: wgpu_test::TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.0)],
         _phantom: std::marker::PhantomData::<Example>,
     };

--- a/tests/tests/wgpu-gpu/binding_array/buffers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/buffers.rs
@@ -18,6 +18,7 @@ pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
 static BINDING_ARRAY_UNIFORM_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(Features::BUFFER_BINDING_ARRAY | Features::UNIFORM_BUFFER_BINDING_ARRAYS)
             .limits(Limits {
                 max_binding_array_elements_per_shader_stage: 16,
@@ -36,6 +37,7 @@ static BINDING_ARRAY_UNIFORM_BUFFERS: GpuTestConfiguration = GpuTestConfiguratio
 static PARTIAL_BINDING_ARRAY_UNIFORM_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(
                 Features::BUFFER_BINDING_ARRAY
                     | Features::PARTIALLY_BOUND_BINDING_ARRAY
@@ -58,6 +60,7 @@ static PARTIAL_BINDING_ARRAY_UNIFORM_BUFFERS: GpuTestConfiguration = GpuTestConf
 static BINDING_ARRAY_STORAGE_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(
                 Features::BUFFER_BINDING_ARRAY
                     | Features::STORAGE_RESOURCE_BINDING_ARRAY
@@ -76,6 +79,7 @@ static BINDING_ARRAY_STORAGE_BUFFERS: GpuTestConfiguration = GpuTestConfiguratio
 static PARTIAL_BINDING_ARRAY_STORAGE_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(
                 Features::BUFFER_BINDING_ARRAY
                     | Features::PARTIALLY_BOUND_BINDING_ARRAY

--- a/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
@@ -17,6 +17,7 @@ pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
 static BINDING_ARRAY_SAMPLED_TEXTURES: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(
                 Features::TEXTURE_BINDING_ARRAY
                     | Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
@@ -32,6 +33,7 @@ static BINDING_ARRAY_SAMPLED_TEXTURES: GpuTestConfiguration = GpuTestConfigurati
 static PARTIAL_BINDING_ARRAY_SAMPLED_TEXTURES: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(
                 Features::TEXTURE_BINDING_ARRAY
                     | Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING

--- a/tests/tests/wgpu-gpu/binding_array/samplers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/samplers.rs
@@ -13,6 +13,7 @@ pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
 static BINDING_ARRAY_SAMPLERS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(
                 Features::TEXTURE_BINDING_ARRAY
                     | Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
@@ -29,6 +30,7 @@ static BINDING_ARRAY_SAMPLERS: GpuTestConfiguration = GpuTestConfiguration::new(
 static PARTIAL_BINDING_ARRAY_SAMPLERS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(
                 Features::TEXTURE_BINDING_ARRAY
                     | Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING

--- a/tests/tests/wgpu-gpu/binding_array/storage_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/storage_textures.rs
@@ -17,6 +17,7 @@ pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
 static BINDING_ARRAY_STORAGE_TEXTURES: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(
                 Features::TEXTURE_BINDING_ARRAY
                     | Features::STORAGE_RESOURCE_BINDING_ARRAY
@@ -34,6 +35,7 @@ static BINDING_ARRAY_STORAGE_TEXTURES: GpuTestConfiguration = GpuTestConfigurati
 static PARTIAL_BINDING_ARRAY_STORAGE_TEXTURES: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(
                 Features::TEXTURE_BINDING_ARRAY
                     | Features::PARTIALLY_BOUND_BINDING_ARRAY

--- a/tests/tests/wgpu-gpu/mesh_shader/mod.rs
+++ b/tests/tests/wgpu-gpu/mesh_shader/mod.rs
@@ -393,6 +393,7 @@ fn mesh_draw(ctx: &TestingContext, draw_type: DrawType) {
 fn default_gpu_test_config(draw_type: DrawType) -> GpuTestConfiguration {
     GpuTestConfiguration::new().parameters(
         TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .test_features_limits()
             .features(
                 wgpu::Features::EXPERIMENTAL_MESH_SHADER


### PR DESCRIPTION
**Connections**

Closes #8618 

**Description**

This example was improperly making a buffer binding array.

I've also added GPU assisted validation for a few examples that use binding arrays or mesh shaders. I think we should automatically turn this on based on features, but that can follow.

**Testing**

CI

**Squash or Rebase?**

Rebase