### PR TITLE
Limit ray_cube_normal test failure to AMD prop

### DIFF
--- a/examples/features/src/ray_cube_normals/mod.rs
+++ b/examples/features/src/ray_cube_normals/mod.rs
@@ -480,8 +480,14 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     height: 768,
     optional_features: wgpu::Features::default(),
     base_test_parameters: wgpu_test::TestParameters::default().expect_fail(
-        wgpu_test::FailureCase::backend_adapter(wgpu::Backends::VULKAN, "AMD")
-            .panic("Image data mismatch"),
+        // RADV does this fine.
+        wgpu_test::FailureCase {
+            backends: Some(wgpu::Backends::VULKAN),
+            adapter: Some("AMD"),
+            driver: Some("AMD proprietary driver"),
+            ..wgpu_test::FailureCase::default()
+        }
+        .panic("Image data mismatch"),
     ),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,


### PR DESCRIPTION
**Connections**

Closes #8615

**Description**

RADV handles this fine, so we should only match this on AMD proprietary.

**Testing**

Manual testing. @DGriffin91 could you test this via `cargo xtask test "ray_cube_normals"`