### PR TITLE
Use LazyLock for std environments and OnceBox for no_std

### DIFF
--- a/naga/src/racy_lock.rs
+++ b/naga/src/racy_lock.rs
@@ -1,15 +1,34 @@
+#[cfg(no_std)]
 use alloc::boxed::Box;
+#[cfg(no_std)]
 use once_cell::race::OnceBox;
+#[cfg(std)]
+use std::sync::LazyLock;
 
-/// An alternative to [`LazyLock`] based on [`OnceBox`].
+#[cfg(std)]
+type Inner<T> = LazyLock<T, fn() -> T>;
+#[cfg(no_std)]
+type Inner<T> = OnceBox<T>;
+
+/// Lazy static helper that uses [`LazyLock`] with `std` and [`OnceBox`] otherwise.
 ///
 /// [`LazyLock`]: https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html
 pub struct RacyLock<T: 'static> {
-    inner: OnceBox<T>,
+    inner: Inner<T>,
+    #[cfg(no_std)]
     init: fn() -> T,
 }
 
 impl<T: 'static> RacyLock<T> {
+    #[cfg(std)]
+    /// Creates a new [`RacyLock`], which will initialize using the provided `init` function.
+    pub const fn new(init: fn() -> T) -> Self {
+        Self {
+            inner: LazyLock::new(init),
+        }
+    }
+
+    #[cfg(no_std)]
     /// Creates a new [`RacyLock`], which will initialize using the provided `init` function.
     pub const fn new(init: fn() -> T) -> Self {
         Self {
@@ -19,6 +38,17 @@ impl<T: 'static> RacyLock<T> {
     }
 }
 
+#[cfg(std)]
+impl<T: 'static> core::ops::Deref for RacyLock<T> {
+    type Target = T;
+
+    /// Loads the internal value, initializing it if required.
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[cfg(no_std)]
 impl<T: 'static> core::ops::Deref for RacyLock<T> {
     type Target = T;
 

--- a/naga/src/racy_lock.rs
+++ b/naga/src/racy_lock.rs
@@ -13,6 +13,7 @@ type Inner<T> = OnceBox<T>;
 /// Lazy static helper that uses [`LazyLock`] with `std` and [`OnceBox`] otherwise.
 ///
 /// [`LazyLock`]: https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html
+/// [`OnceBox`]: https://docs.rs/once_cell/latest/once_cell/race/struct.OnceBox.html
 pub struct RacyLock<T: 'static> {
     inner: Inner<T>,
     #[cfg(no_std)]


### PR DESCRIPTION
**Description**
Right now, we always use `once_cell` in `naga`, even when `std` with `LazyLock` is available.

**Testing**
I ran `cargo xtask test` locally.

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
