### PR TITLE
feat(core): add `Global::create_bind_group_layout_error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ By @cwfitzgerald in [#8609](https://github.com/gfx-rs/wgpu/pull/8609).
 - Added support for binding arrays of storage textures on Metal. By @msvbg in [#8464](https://github.com/gfx-rs/wgpu/pull/8464)
 - Added support for multisampled texture arrays on Vulkan through adapter feature `MULTISAMPLE_ARRAY`. By @LaylBongers in [#8571](https://github.com/gfx-rs/wgpu/pull/8571).
 - Added `get_configuration` to `wgpu::Surface`, that returns the current configuration of `wgpu::Surface`. By @sagudev in [#8664](https://github.com/gfx-rs/wgpu/pull/8664).
+- Add `wgpu_core::Global::create_bind_group_layout_error`. By @ErichDonGubler in [#8650](https://github.com/gfx-rs/wgpu/pull/8650).
 
 ### Changes
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -215,6 +215,23 @@ impl Global {
         fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
     }
 
+    /// Assign `id_in` an error with the given `label`.
+    ///
+    /// In JavaScript environments, it is possible to call `GPUDevice.createBindGroupLayout` with
+    /// entries that are invalid. Because our Rust's types for bind group layouts prevent even
+    /// calling [`Self::device_create_bind_group`], we let standards-compliant environments
+    /// register an invalid bind group layout so this crate's API can still be consistently used.
+    ///
+    /// See [`Self::create_buffer_error`] for additional context and explanation.
+    pub fn create_bind_group_layout_error(
+        &self,
+        id_in: Option<id::BindGroupLayoutId>,
+        label: Option<Cow<'_, str>>,
+    ) {
+        let fid = self.hub.bind_group_layouts.prepare(id_in);
+        fid.assign(Fallible::Invalid(Arc::new(label.to_string())));
+    }
+
     pub fn buffer_destroy(&self, buffer_id: id::BufferId) {
         profiling::scope!("Buffer::destroy");
         api_log!("Buffer::destroy {buffer_id:?}");


### PR DESCRIPTION
**Description**

Some JS runtimes (like Firefox) want to control ID assignment for resources, unconditionally assigning them even when validation rules that has to happen in layers above `wgpu-core` determine that resources are invalid before even talking to `wgpu-core`. For these cases, we make `wgpu_core::Global::create_*_error` APIs, keeping `wgpu-core` the source of truth for the presence and validity of objects. 

The motivation for this PR is that we are missing this for bind group layouts, specifically because of their entries. In WebGPU's WebIDL representation, such entries must have one and only one optional discriminant member specified, indicating which resource type is being used ([link](https://www.w3.org/TR/webgpu/#dictdef-gpubindgrouplayoutentry)). In Rust, we use an `enum`, and make invalid states unrepresentable. However, for JS, we must (and currently do not) afford `wgpu-core` users the ability to register invalid bind group layouts for this case, like we do for other APIs (see also the validation listed for [`GPUDevice.createBindGroupLayout`](https://www.w3.org/TR/webgpu/#dom-gpudevice-createbindgrouplayout)).

Add `wgpu_core::Global::create_bind_group_layout_error`, which fixes this flaw.

**Testing**

I don't see other `create_*_error` APIs tested, and this is consistent with that. This is probably because this sort of API is not something that anything in-tree needs. I've been testing it in Firefox builds, and I believe it works well enough.

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
