### PR TITLE
Use test to generate .gpuinfo file to reduce recompilations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ env:
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
   WASM_BINDGEN_TEST_TIMEOUT: 300 # 5 minutes
-  CACHE_SUFFIX: d # cache busting
+  CACHE_SUFFIX: e # cache busting
   WGPU_CI: true
 
 # Every time a PR is pushed to, cancel any previous jobs. This
@@ -588,16 +588,6 @@ jobs:
           # Delete snapshots so we can ensure there aren't any excess output files.
           rm -r naga/tests/out
 
-      - name: Run `wgpu-info`
-        shell: bash
-        run: |
-          echo "$PATH"
-
-          export RUST_LOG=trace
-
-          # This needs to match the command in xtask/tests.rs
-          cargo --locked llvm-cov --no-cfg-coverage --no-report run --bin wgpu-info -- -vv
-
       - name: Run tests
         shell: bash
         run: |
@@ -610,12 +600,22 @@ jobs:
         run: git add . && git diff --exit-code HEAD naga/tests/out
 
       - uses: actions/upload-artifact@v5
+        name: Upload comparison images
         if: always() # We want artifacts even if the tests fail.
         with:
           name: comparison-images-${{ matrix.os }}
           path: |
             **/*-actual.png
             **/*-difference.png
+
+      # Print GPU configuration so we can see what features were available during the test.
+      - name: Print GPU configurations
+        if: always() # We want this information even if the tests fail.
+        shell: bash
+        run: |
+          set -e
+
+          cat .gpuconfig
 
       - name: Generate coverage report
         id: coverage

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -1,16 +1,11 @@
-#[cfg(not(target_arch = "wasm32"))]
+#![cfg_attr(target_arch = "wasm32", no_main)]
+#![cfg(not(target_arch = "wasm32"))]
+
 mod cli;
-#[cfg(not(target_arch = "wasm32"))]
 mod human;
-#[cfg(not(target_arch = "wasm32"))]
 mod report;
-#[cfg(not(target_arch = "wasm32"))]
 mod texture;
 
 fn main() -> anyhow::Result<()> {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        cli::main()?;
-    }
-    Ok(())
+    cli::main()
 }

--- a/wgpu-info/src/main.rs
+++ b/wgpu-info/src/main.rs
@@ -4,6 +4,8 @@
 mod cli;
 mod human;
 mod report;
+#[cfg(test)]
+mod tests;
 mod texture;
 
 fn main() -> anyhow::Result<()> {

--- a/wgpu-info/src/tests.rs
+++ b/wgpu-info/src/tests.rs
@@ -1,0 +1,25 @@
+use std::{fs::File, io::BufWriter};
+
+const ENV_VAR_SAVE: &str = "WGPU_INFO_SAVE_GPUCONFIG_REPORT";
+
+// We use a test to generate the .gpuconfig file instead of using the cli directly
+// as `cargo run --bin wgpu-info` would build a different set of dependencies, causing
+// incremental changes to need to rebuild the wgpu stack twice, one for the tests
+// and once for the cli binary.
+//
+// Needs to be kept in sync with the test in xtask/src/test.rs
+#[test]
+fn generate_gpuconfig_report() {
+    let report = crate::report::GpuReport::generate();
+
+    // If we don't get the env var, just test that we can generate the report, but don't save it
+    // to avoid a race condition when other tests are reading the file.
+    if std::env::var(ENV_VAR_SAVE).is_err() {
+        println!("Set {ENV_VAR_SAVE} to generate a .gpuconfig report using this test");
+        return;
+    }
+
+    let file = File::create(concat!(env!("CARGO_MANIFEST_DIR"), "/../.gpuconfig")).unwrap();
+    let buf = BufWriter::new(file);
+    report.into_json(buf).unwrap();
+}

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -31,10 +31,17 @@ pub fn run_tests(
     let mut cargo_args = flatten_args(args, passthrough_args);
 
     // Re-add profile flags that were consumed during argument parsing
-    if is_release {
-        cargo_args.insert(0, OsString::from("--release"));
+    #[expect(clippy::manual_map)] // This is much clearer than using map()
+    let profile_arg = if is_release {
+        Some(OsString::from("--release"))
     } else if let Some(ref p) = custom_profile {
-        cargo_args.insert(0, OsString::from(format!("--cargo-profile={p}")));
+        Some(OsString::from(format!("--cargo-profile={p}")))
+    } else {
+        None
+    };
+
+    if let Some(ref profile_arg) = profile_arg {
+        cargo_args.insert(0, profile_arg.clone());
     }
 
     // Retries handled by cargo nextest natively
@@ -50,37 +57,36 @@ pub fn run_tests(
         install_warp::install_warp(&shell, &target_dir)?;
     }
 
-    // These needs to match the command in "run wgpu-info" in `.github/workflows/ci.yml`
-    let llvm_cov_flags: &[_] = if llvm_cov {
-        &["llvm-cov", "--no-cfg-coverage", "--no-report"]
-    } else {
-        &[]
-    };
-    let llvm_cov_nextest_flags: &[_] = if llvm_cov {
+    let test_suite_run_flags: &[_] = if llvm_cov {
         &["llvm-cov", "--no-cfg-coverage", "--no-report", "nextest"]
-    } else if list {
-        &["nextest", "list"]
     } else {
         &["nextest", "run"]
     };
 
     log::info!("Generating .gpuconfig file based on gpus on the system");
 
+    // We use a test to generate the .gpuconfig file instead of using the cli directly
+    // as `cargo run --bin wgpu-info` would build a different set of dependencies, causing
+    // incremental changes to need to rebuild the wgpu stack twice, one for the tests
+    // and once for the cli binary.
+    //
+    // Needs to be kept in sync with the test in wgpu-info/src/tests.rs
     shell
         .cmd("cargo")
-        .args(llvm_cov_flags)
-        .args([
-            "run",
-            "--bin",
-            "wgpu-info",
-            "--",
-            "--json",
-            "-o",
-            ".gpuconfig",
-        ])
+        .args(test_suite_run_flags)
+        // Use the same build configuration as the main tests, so that we only build once.
+        .args(["--benches", "--tests", "--all-features"])
+        // Use the same cargo profile as the main tests.
+        .args(profile_arg)
+        // We need to tell nextest to filter by binary too, so it doesn't try to enumerate
+        // tests on any of the gpu enabled test binaries, as that will fail due to
+        // old or missing .gpuconfig files.
+        .args(["-E", "binary(wgpu-info)", "generate_gpuconfig_report"])
+        // Turn on the env var for saving the .gpuconfig files
+        .env("WGPU_INFO_SAVE_GPUCONFIG_REPORT", "1")
         .quiet()
         .run()
-        .context("Failed to run wgpu-info to generate .gpuconfig")?;
+        .context("Failed to run tests to generate .gpuconfig")?;
 
     let gpu_count = shell
         .read_file(".gpuconfig")
@@ -99,7 +105,7 @@ pub fn run_tests(
         log::info!("Listing tests");
         shell
             .cmd("cargo")
-            .args(llvm_cov_nextest_flags)
+            .args(["nextest", "list"])
             .args(["-v", "--benches", "--tests", "--all-features"])
             .args(cargo_args)
             .run()
@@ -110,7 +116,7 @@ pub fn run_tests(
 
     shell
         .cmd("cargo")
-        .args(llvm_cov_nextest_flags)
+        .args(test_suite_run_flags)
         .args(["--benches", "--tests", "--all-features"])
         .args(cargo_args)
         .quiet()


### PR DESCRIPTION
**Connections**

Closes #8659 

**Description**

To avoid recompilations, we use a test in the test suite to generate the needed .gpuinfo file. See inline comments for more discussion.

I also updated the cfgs in wgpu-info to be the newer no_main style.

A whitespace change in wgpu-types now takes 43s vs 60s and a clean build from 156s (11.6GB) to 99s (9.8GB)

**Testing**

It is.

**Squash or Rebase?**

Rebase