### PR TITLE
wgpu: Add `get_configuration` to `Surface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ By @cwfitzgerald in [#8609](https://github.com/gfx-rs/wgpu/pull/8609).
 - Implement shader triangle barycentric coordinate builtins. By @atlv24 in [#8320](https://github.com/gfx-rs/wgpu/pull/8320).
 - Added support for binding arrays of storage textures on Metal. By @msvbg in [#8464](https://github.com/gfx-rs/wgpu/pull/8464)
 - Added support for multisampled texture arrays on Vulkan through adapter feature `MULTISAMPLE_ARRAY`. By @LaylBongers in [#8571](https://github.com/gfx-rs/wgpu/pull/8571).
+- Added `get_configuration` to `wgpu::Surface`, that returns the current configuration of `wgpu::Surface`. By @sagudev in [#8664](https://github.com/gfx-rs/wgpu/pull/8664).
 
 ### Changes
 

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -99,6 +99,13 @@ impl Surface<'_> {
         *conf = Some(config.clone());
     }
 
+    /// Returns the current configuration of [`Surface`], if configured.
+    ///
+    /// This is similar to [WebGPU `GPUcCanvasContext::getConfiguration`](https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getconfiguration).
+    pub fn get_configuration(&self) -> Option<SurfaceConfiguration> {
+        self.config.lock().clone()
+    }
+
     /// Returns the next texture to be presented by the swapchain for drawing.
     ///
     /// In order to present the [`SurfaceTexture`] returned by this method,


### PR DESCRIPTION
**Description**
In WebGPU one can use [`getConfiguration`](https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getconfiguration) to get configuration of context (surface). So let's expose obtaining configuration from `wgpu::Surface`, to better match WebGPUs API.

**Testing**
None.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
