### PR TITLE
hal/vulkan: Fix multi draw indirect emulating and respect `maxDrawIndirectCount`

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1883,6 +1883,7 @@ impl super::Instance {
                 depth_stencil_required_flags(),
             ),
             multi_draw_indirect: phd_features.core.multi_draw_indirect != 0,
+            max_draw_indirect_count: phd_capabilities.properties.limits.max_draw_indirect_count,
             non_coherent_map_mask: phd_capabilities.properties.limits.non_coherent_atom_size - 1,
             can_present: true,
             //TODO: make configurable

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -1128,15 +1128,34 @@ impl crate::CommandEncoder for super::CommandEncoder {
         offset: wgt::BufferAddress,
         draw_count: u32,
     ) {
-        unsafe {
-            self.device.raw.cmd_draw_indirect(
-                self.active,
-                buffer.raw,
-                offset,
-                draw_count,
-                size_of::<wgt::DrawIndirectArgs>() as u32,
-            )
-        };
+        if draw_count >= 1
+            && self.device.private_caps.multi_draw_indirect
+            && draw_count <= self.device.private_caps.max_draw_indirect_count
+        {
+            unsafe {
+                self.device.raw.cmd_draw_indirect(
+                    self.active,
+                    buffer.raw,
+                    offset,
+                    draw_count,
+                    size_of::<wgt::DrawIndirectArgs>() as u32,
+                )
+            };
+        } else {
+            for i in 0..draw_count {
+                unsafe {
+                    self.device.raw.cmd_draw_indirect(
+                        self.active,
+                        buffer.raw,
+                        offset
+                            + i as wgt::BufferAddress
+                                * size_of::<wgt::DrawIndirectArgs>() as wgt::BufferAddress,
+                        1,
+                        size_of::<wgt::DrawIndirectArgs>() as u32,
+                    )
+                };
+            }
+        }
     }
     unsafe fn draw_indexed_indirect(
         &mut self,
@@ -1144,7 +1163,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
         offset: wgt::BufferAddress,
         draw_count: u32,
     ) {
-        if draw_count >= 1 && self.device.private_caps.multi_draw_indirect {
+        if draw_count >= 1
+            && self.device.private_caps.multi_draw_indirect
+            && draw_count <= self.device.private_caps.max_draw_indirect_count
+        {
             unsafe {
                 self.device.raw.cmd_draw_indexed_indirect(
                     self.active,
@@ -1155,12 +1177,14 @@ impl crate::CommandEncoder for super::CommandEncoder {
                 )
             };
         } else {
-            for _ in 0..draw_count {
+            for i in 0..draw_count {
                 unsafe {
                     self.device.raw.cmd_draw_indexed_indirect(
                         self.active,
                         buffer.raw,
-                        offset,
+                        offset
+                            + i as wgt::BufferAddress
+                                * size_of::<wgt::DrawIndexedIndirectArgs>() as wgt::BufferAddress,
                         1,
                         size_of::<wgt::DrawIndexedIndirectArgs>() as u32,
                     )

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -1143,13 +1143,14 @@ impl crate::CommandEncoder for super::CommandEncoder {
             };
         } else {
             for i in 0..draw_count {
+                let indirect_offset = offset
+                    + i as wgt::BufferAddress
+                        * size_of::<wgt::DrawIndirectArgs>() as wgt::BufferAddress;
                 unsafe {
                     self.device.raw.cmd_draw_indirect(
                         self.active,
                         buffer.raw,
-                        offset
-                            + i as wgt::BufferAddress
-                                * size_of::<wgt::DrawIndirectArgs>() as wgt::BufferAddress,
+                        indirect_offset,
                         1,
                         size_of::<wgt::DrawIndirectArgs>() as u32,
                     )
@@ -1178,13 +1179,14 @@ impl crate::CommandEncoder for super::CommandEncoder {
             };
         } else {
             for i in 0..draw_count {
+                let indirect_offset = offset
+                    + i as wgt::BufferAddress
+                        * size_of::<wgt::DrawIndexedIndirectArgs>() as wgt::BufferAddress;
                 unsafe {
                     self.device.raw.cmd_draw_indexed_indirect(
                         self.active,
                         buffer.raw,
-                        offset
-                            + i as wgt::BufferAddress
-                                * size_of::<wgt::DrawIndexedIndirectArgs>() as wgt::BufferAddress,
+                        indirect_offset,
                         1,
                         size_of::<wgt::DrawIndexedIndirectArgs>() as u32,
                     )

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -319,6 +319,7 @@ struct PrivateCapabilities {
     can_present: bool,
     non_coherent_map_mask: wgt::BufferAddress,
     multi_draw_indirect: bool,
+    max_draw_indirect_count: u32,
 
     /// True if this adapter advertises the [`robustBufferAccess`][vrba] feature.
     ///


### PR DESCRIPTION
**Description**
Noted this when I was checking #8162

The offset argument of `draw_indexed_indirect` in hal/vulkan seems incorrect. It should `+ i * stride`.
Also multi draw indirect should respect [limits.maxDrawIndirectCount](https://docs.vulkan.org/spec/latest/chapters/limits.html#limits-maxDrawIndirectCount).

Actually, `vkCmdDrawIndirectCount` `vkCmdDrawIndexedIndirectCount` `vkCmdDrawMeshTasksIndirectCountEXT` also require that the count in the countBuffer must be <= [maxDrawIndirectCount](https://docs.vulkan.org/spec/latest/chapters/drawing.html#VUID-vkCmdDrawIndirectCount-countBuffer-02717), altough on many devices it's `u32::MAX`([vulkan gpuinfo](https://vulkan.gpuinfo.org/displaydevicelimit.php?platform=all&name=maxDrawIndirectCount))

**Testing**
I assume the code is correct, I don't have a device to test this.

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
