### PR TITLE
Don't generate a `BufferTextureCopy::rows_per_image` if `None` was specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,7 @@ By @cwfitzgerald in [#8609](https://github.com/gfx-rs/wgpu/pull/8609).
 
 - Fix race when downloading texture from compute shader pass. By @SpeedCrash100 in [#8527](https://github.com/gfx-rs/wgpu/pull/8527)
 - Fix double window class registration when dynamic libraries are used. By @Azorlogh in [#8548](https://github.com/gfx-rs/wgpu/pull/8548)
+- Fix Firefox error in WebGL when using Queue::write_texture with a 2D texture. By @tgecho in [#8668](https://github.com/gfx-rs/wgpu/pull/8673)
 
 #### hal
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -905,6 +905,13 @@ impl Queue {
 
         let staging_buffer = staging_buffer.flush();
 
+        let copy_rows_per_image =
+            if array_layer_count > 1 || dst.desc.dimension == wgt::TextureDimension::D3 {
+                Some(rows_per_image)
+            } else {
+                None
+            };
+
         let regions = (0..array_layer_count)
             .map(|array_layer_offset| {
                 let mut texture_base = dst_base.clone();
@@ -915,7 +922,7 @@ impl Queue {
                             * rows_per_image as u64
                             * stage_bytes_per_row as u64,
                         bytes_per_row: Some(stage_bytes_per_row),
-                        rows_per_image: Some(rows_per_image),
+                        rows_per_image: copy_rows_per_image,
                     },
                     texture_base,
                     size: hal_copy_size,


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/8668

**Description**
When we generate a fallback value, it causes the gles backend to set `UNPACK_IMAGE_HEIGHT` to a non-zero value, which causes Firefox to log a warning and not write... sometimes. But None does seem to be the correct value for 1D/2D textures.

**Testing**
I've tested it manually in context of the app I'm building, but I haven't managed to come up with a self contained test case. There's clearly some other state or something in Firefox that leads to this actually triggering a malfunction.

I'm not quite sure how to add an automated test. Is it practical to write a test where we read back the `UNPACK_IMAGE_HEIGHT`?

If we're nervous about side effects, I could scope this down to be done just within the gles backend by checking for `dst_target == glow::TEXTURE_2D` and forcing the `UNPACK_IMAGE_HEIGHT` value to 0 in https://github.com/gfx-rs/wgpu/blob/trunk/wgpu-hal/src/gles/queue.rs#L754

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
