### PR TITLE
Add basic NetBSD support

### DIFF
--- a/deno_webgpu/byow.rs
+++ b/deno_webgpu/byow.rs
@@ -6,6 +6,7 @@ use std::ffi::c_void;
   target_os = "linux",
   target_os = "macos",
   target_os = "freebsd",
+  target_os = "netbsd",
   target_os = "openbsd"
 ))]
 use std::ptr::NonNull;
@@ -29,6 +30,7 @@ pub enum ByowError {
     target_os = "windows",
     target_os = "linux",
     target_os = "freebsd",
+    target_os = "netbsd",
     target_os = "openbsd",
   )))]
   #[class(type)]
@@ -56,6 +58,7 @@ pub enum ByowError {
   #[cfg(any(
     target_os = "linux",
     target_os = "freebsd",
+    target_os = "netbsd",
     target_os = "openbsd"
   ))]
   #[class(type)]
@@ -65,6 +68,7 @@ pub enum ByowError {
     target_os = "windows",
     target_os = "linux",
     target_os = "freebsd",
+    target_os = "netbsd",
     target_os = "openbsd"
   ))]
   #[class(type)]
@@ -73,6 +77,7 @@ pub enum ByowError {
   #[cfg(any(
     target_os = "linux",
     target_os = "freebsd",
+    target_os = "netbsd",
     target_os = "openbsd"
   ))]
   #[class(type)]
@@ -322,7 +327,7 @@ fn raw_window(
   Ok((win_handle, display_handle))
 }
 
-#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 fn raw_window(
   system: UnsafeWindowSurfaceSystem,
   window: *const c_void,
@@ -364,6 +369,7 @@ fn raw_window(
   target_os = "windows",
   target_os = "linux",
   target_os = "freebsd",
+  target_os = "netbsd",
   target_os = "openbsd",
 )))]
 fn raw_window(

--- a/deno_webgpu/byow.rs
+++ b/deno_webgpu/byow.rs
@@ -327,7 +327,12 @@ fn raw_window(
   Ok((win_handle, display_handle))
 }
 
-#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(any(
+  target_os = "linux",
+  target_os = "freebsd",
+  target_os = "netbsd",
+  target_os = "openbsd"
+))]
 fn raw_window(
   system: UnsafeWindowSurfaceSystem,
   window: *const c_void,


### PR DESCRIPTION
closes https://github.com/gfx-rs/wgpu/issues/8541

Tests:
     Summary [ 149.522s] 469 tests run: 463 passed, 6 failed, 0 skipped
        FAIL [   0.095s] naga::naga snapshots::convert_snapshots_spv
        FAIL [   0.387s] wgpu-benchmark::bench/wgpu-benchmark Computepass Encoding
        FAIL [   0.386s] wgpu-benchmark::bench/wgpu-benchmark Device::create_bind_group
        FAIL [   0.378s] wgpu-benchmark::bench/wgpu-benchmark Device::create_buffer
        FAIL [   0.389s] wgpu-benchmark::bench/wgpu-benchmark Renderpass Encoding
        FAIL [   0.075s] wgpu-test::wgpu-validation api::instance::multi_instance::multi_instance

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

_When one pull request builds on another, please put "Depends on
#NNNN" towards the top of its description. This helps maintainers
notice that they shouldn't merge it until its ancestor has been
approved. Don't use draft PR status to indicate this._

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._

**Squash or Rebase?**

_If your pull request contains multiple commits, please indicate whether
they need to be squashed into a single commit before they're merged,
or if they're ready to rebase onto `trunk` as they stand. In the
latter case, please ensure that each commit passes all CI tests, so
that we can continue to bisect along `trunk` to isolate bugs._

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
