### PR TITLE
[wgpu-core] validate occlusion and pipeline statistics queries end

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -180,3 +180,4 @@ webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="l
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="switch1"
 //FAIL: 9 invalid_statements subtests due to https://github.com/gfx-rs/wgpu/issues/7733
 webgpu:api,validation,render_pipeline,vertex_state:many_attributes_overlapping:*
+webgpu:api,validation,encoding,queries,begin_end:occlusion_query,*

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -150,8 +150,8 @@ pub enum QueryUseError {
         set_type: SimplifiedQueryType,
         query_type: SimplifiedQueryType,
     },
-    #[error("A query was not ended before the encoder was finished")]
-    MissingEnd,
+    #[error("A query of type {query_type:?} was not ended before the encoder was finished")]
+    MissingEnd { query_type: SimplifiedQueryType },
 }
 
 impl WebGpuError for QueryUseError {
@@ -163,7 +163,7 @@ impl WebGpuError for QueryUseError {
             | Self::AlreadyStarted { .. }
             | Self::AlreadyStopped
             | Self::IncompatibleType { .. }
-            | Self::MissingEnd => ErrorType::Validation,
+            | Self::MissingEnd { .. } => ErrorType::Validation,
         }
     }
 }

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -150,6 +150,8 @@ pub enum QueryUseError {
         set_type: SimplifiedQueryType,
         query_type: SimplifiedQueryType,
     },
+    #[error("A query was not ended before the encoder was finished")]
+    MissingEnd,
 }
 
 impl WebGpuError for QueryUseError {
@@ -160,7 +162,8 @@ impl WebGpuError for QueryUseError {
             | Self::UsedTwiceInsideRenderpass { .. }
             | Self::AlreadyStarted { .. }
             | Self::AlreadyStopped
-            | Self::IncompatibleType { .. } => ErrorType::Validation,
+            | Self::IncompatibleType { .. }
+            | Self::MissingEnd => ErrorType::Validation,
         }
     }
 }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2241,6 +2241,12 @@ pub(super) fn encode_render_pass(
                     .map_pass_err(pass_scope),
             )?;
         }
+        if state.active_occlusion_query.is_some() {
+            Err(RenderPassErrorInner::QueryUse(QueryUseError::MissingEnd).map_pass_err(pass_scope))?;
+        }
+        if state.active_pipeline_statistics_query.is_some() {
+            Err(RenderPassErrorInner::QueryUse(QueryUseError::MissingEnd).map_pass_err(pass_scope))?;
+        }
 
         state
             .info

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2242,10 +2242,16 @@ pub(super) fn encode_render_pass(
             )?;
         }
         if state.active_occlusion_query.is_some() {
-            Err(RenderPassErrorInner::QueryUse(QueryUseError::MissingEnd).map_pass_err(pass_scope))?;
+            Err(RenderPassErrorInner::QueryUse(QueryUseError::MissingEnd {
+                query_type: super::SimplifiedQueryType::Occlusion,
+            })
+            .map_pass_err(pass_scope))?;
         }
         if state.active_pipeline_statistics_query.is_some() {
-            Err(RenderPassErrorInner::QueryUse(QueryUseError::MissingEnd).map_pass_err(pass_scope))?;
+            Err(RenderPassErrorInner::QueryUse(QueryUseError::MissingEnd {
+                query_type: super::SimplifiedQueryType::PipelineStatistics,
+            })
+            .map_pass_err(pass_scope))?;
         }
 
         state


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/7869.

**Description**
Validates that occlusion and pipeline statistics queries end.

**Testing**
Added new CTS test to list.

**Squash or Rebase?**
n/a
