### PR TITLE
Fix early out placement for CopyB2T

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -85,14 +85,9 @@ webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:buffer_bi
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:sampler_binding,render_pipeline:*
 webgpu:api,validation,encoding,queries,general:occlusion_query,query_index:*
 webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
+webgpu:api,validation,image_copy,buffer_related:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
-// `vulkan` failure: https://github.com/gfx-rs/wgpu/issues/????
-fails-if(vulkan) webgpu:api,validation,queue,buffer_mapped:writeBuffer:*
-webgpu:api,validation,queue,buffer_mapped:copyBufferToBuffer:*
-webgpu:api,validation,queue,buffer_mapped:copyBufferToTexture:*
-webgpu:api,validation,queue,buffer_mapped:copyTextureToBuffer:*
-webgpu:api,validation,queue,buffer_mapped:map_command_recording_order:*
 // image_copy depth/stencil failures on dx12: https://github.com/gfx-rs/wgpu/issues/8133
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyB2T"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyT2B"
@@ -124,6 +119,12 @@ webgpu:api,validation,image_copy,layout_related:copy_end_overflows_u64:*
 // Fails with OOM in CI.
 fails-if(dx12) webgpu:api,validation,image_copy,layout_related:offset_alignment:*
 webgpu:api,validation,image_copy,texture_related:format:dimension="1d";*
+// `vulkan` failure: https://github.com/gfx-rs/wgpu/issues/????
+fails-if(vulkan) webgpu:api,validation,queue,buffer_mapped:writeBuffer:*
+webgpu:api,validation,queue,buffer_mapped:copyBufferToBuffer:*
+webgpu:api,validation,queue,buffer_mapped:copyBufferToTexture:*
+webgpu:api,validation,queue,buffer_mapped:copyTextureToBuffer:*
+webgpu:api,validation,queue,buffer_mapped:map_command_recording_order:*
 webgpu:api,validation,queue,submit:command_buffer,*
 webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,depthSlice,*

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -1101,39 +1101,14 @@ pub(super) fn copy_buffer_to_texture(
     let (dst_range, dst_base) = extract_texture_selector(destination, copy_size, dst_texture)?;
 
     let src_raw = src_buffer.try_raw(state.snatch_guard)?;
-    let dst_raw = dst_texture.try_raw(state.snatch_guard)?;
-
-    if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
-        log::trace!("Ignoring copy_buffer_to_texture of size 0");
-        return Ok(());
-    }
-
-    // Handle texture init *before* dealing with barrier transitions so we
-    // have an easier time inserting "immediate-inits" that may be required
-    // by prior discards in rare cases.
-    handle_dst_texture_init(state, destination, copy_size, dst_texture)?;
-
-    let src_pending = state
-        .tracker
-        .buffers
-        .set_single(src_buffer, wgt::BufferUses::COPY_SRC);
-
     src_buffer
         .check_usage(BufferUsages::COPY_SRC)
         .map_err(TransferError::MissingBufferUsage)?;
-    let src_barrier = src_pending.map(|pending| pending.into_hal(src_buffer, state.snatch_guard));
 
-    let dst_pending =
-        state
-            .tracker
-            .textures
-            .set_single(dst_texture, dst_range, wgt::TextureUses::COPY_DST);
+    let dst_raw = dst_texture.try_raw(state.snatch_guard)?;
     dst_texture
         .check_usage(TextureUsages::COPY_DST)
         .map_err(TransferError::MissingTextureUsage)?;
-    let dst_barrier = dst_pending
-        .map(|pending| pending.into_hal(dst_raw))
-        .collect::<Vec<_>>();
 
     validate_texture_copy_dst_format(dst_texture.desc.format, destination.aspect)?;
 
@@ -1161,6 +1136,33 @@ pub(super) fn copy_buffer_to_texture(
             .require_downlevel_flags(wgt::DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES)
             .map_err(TransferError::from)?;
     }
+
+    // This must happen after parameter validation (so that errors are reported
+    // as required by the spec), but before any side effects.
+    if copy_size.width == 0 || copy_size.height == 0 || copy_size.depth_or_array_layers == 0 {
+        log::trace!("Ignoring copy_buffer_to_texture of size 0");
+        return Ok(());
+    }
+
+    // Handle texture init *before* dealing with barrier transitions so we
+    // have an easier time inserting "immediate-inits" that may be required
+    // by prior discards in rare cases.
+    handle_dst_texture_init(state, destination, copy_size, dst_texture)?;
+
+    let src_pending = state
+        .tracker
+        .buffers
+        .set_single(src_buffer, wgt::BufferUses::COPY_SRC);
+    let src_barrier = src_pending.map(|pending| pending.into_hal(src_buffer, state.snatch_guard));
+
+    let dst_pending =
+        state
+            .tracker
+            .textures
+            .set_single(dst_texture, dst_range, wgt::TextureUses::COPY_DST);
+    let dst_barrier = dst_pending
+        .map(|pending| pending.into_hal(dst_raw))
+        .collect::<Vec<_>>();
 
     handle_buffer_init(
         state,


### PR DESCRIPTION
I checked a bunch of these recently, but apparently I missed one, and of course the one I missed was wrong.

The key issue is in the comment on lines 1140-1141:

> This must happen after parameter validation (so that errors are reported as required by the spec), but before any side effects.

**Testing**
Enables CTS tests.

**Squash or Rebase?** Squash
