### PR TITLE
[egl] bump the lock timeout from 1 to 6s

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -7,7 +7,7 @@ use hashbrown::HashMap;
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard, RwLock};
 
 /// The amount of time to wait while trying to obtain a lock to the adapter context
-const CONTEXT_LOCK_TIMEOUT_SECS: u64 = 1;
+const CONTEXT_LOCK_TIMEOUT_SECS: u64 = 6;
 
 const EGL_CONTEXT_FLAGS_KHR: i32 = 0x30FC;
 const EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR: i32 = 0x0001;


### PR DESCRIPTION
**Description**
Raise the EGL lock acquiring timeout from 1 to 6s.
Some very low-end Android devices are just too slow for the 1s timeout. Some lock acquiring can take up to 5s (hence the 6s, 5+1 for security) in legitimate use-cases and panicking after just 1s was a bit aggressive.

**Testing**
Manually on Android.

**Checklist**

- [x] Run `cargo fmt`.
- [x] ~~Run `taplo format`.~~
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] ~~`--target wasm32-unknown-unknown`~~
- [x] Run `cargo xtask test` to run tests.
- [x] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ <!-- See instructions at the top of `CHANGELOG.md`. -->
