### PR TITLE
[metal] fix `destroy_query_set` counter tracking

### DIFF
--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1695,7 +1695,7 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn destroy_query_set(&self, _set: super::QuerySet) {
-        self.counters.query_sets.add(1);
+        self.counters.query_sets.sub(1);
     }
 
     unsafe fn create_fence(&self) -> DeviceResult<super::Fence> {


### PR DESCRIPTION
**Description**
Fix query set counter tracking.

**Testing**
None.

**Checklist**

- [x] Run `cargo fmt`.
- [x] ~~Run `taplo format`.~~
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] ~~`--target wasm32-unknown-unknown`~~
- [x] Run `cargo xtask test` to run tests.
- [x] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ <!-- See instructions at the top of `CHANGELOG.md`. -->
