### PR TITLE
fix(gles): Only use sampler2DShadow if comparison samplers are used

### DIFF
--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -330,7 +330,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 TypeInner::Image {
                     mut dim,
                     arrayed,
-                    class,
+                    mut class,
                 } => {
                     // Gather the storage format if needed
                     let storage_format_access = match self.module.types[global.ty].inner {
@@ -377,6 +377,10 @@ impl<'a, W: Write> Writer<'a, W> {
                     // All images in glsl are `uniform`
                     // The trailing space is important
                     write!(self.out, "uniform ")?;
+
+                    if self.needs_depth_fix(ep_info, handle, &mut class) {
+                        class = crate::ImageClass::Sampled { kind: crate::ScalarKind::Float, multi: false };
+                    }
 
                     // write the type
                     //
@@ -451,6 +455,27 @@ impl<'a, W: Write> Writer<'a, W> {
 
         // Collect all reflection info and return it to the user
         self.collect_reflection_info()
+    }
+
+    fn needs_depth_fix(&mut self, ep_info: &valid::FunctionInfo, handle: Handle<crate::GlobalVariable>, class: &crate::ImageClass) -> bool {
+        if let crate::ImageClass::Depth { multi: false } = class {
+            let has_shadow_sampler = ep_info.sampling_set.iter().all(|key| {
+                let data = &self.module.global_variables[key.sampler];
+                if key.image != handle {
+                    return false;
+                }
+                return if let TypeInner::Sampler { comparison: true } = &self.module.types[data.ty].inner {
+                    true
+                } else {
+                    false
+                }
+            });
+
+            !has_shadow_sampler
+        }
+        else {
+            false
+        }
     }
 
     fn write_array_size(
@@ -2586,6 +2611,14 @@ impl<'a, W: Write> Writer<'a, W> {
                     self.write_expr(expr, ctx)?;
                 }
 
+                let needs_depth_fix = if let Expression::GlobalVariable(global_handle) = ctx.expressions[image] {
+                    let ep_info = self.info.get_entry_point(self.entry_point_idx as usize);
+                    self.needs_depth_fix(ep_info, global_handle, &class)
+                }
+                else {
+                    false
+                };
+
                 match level {
                     // Auto needs no more arguments
                     crate::SampleLevel::Auto => (),
@@ -2604,7 +2637,16 @@ impl<'a, W: Write> Writer<'a, W> {
                     // Exact and bias require another argument
                     crate::SampleLevel::Exact(expr) => {
                         write!(self.out, ", ")?;
+
+                        if needs_depth_fix {
+                            write!(self.out, "float(")?;
+                        }
+
                         self.write_expr(expr, ctx)?;
+
+                        if needs_depth_fix {
+                            write!(self.out, ")")?;
+                        }
                     }
                     crate::SampleLevel::Bias(_) => {
                         // This needs to be done after the offset writing
@@ -2651,6 +2693,11 @@ impl<'a, W: Write> Writer<'a, W> {
 
                 // End the function
                 write!(self.out, ")")?
+
+                if needs_depth_fix {
+                    // parser thinks it will yield f32, but in reality it yields vec4f
+                    write!(self.out, ".x")?;
+                }
             }
             Expression::ImageLoad {
                 image,

--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -379,7 +379,10 @@ impl<'a, W: Write> Writer<'a, W> {
                     write!(self.out, "uniform ")?;
 
                     if self.needs_depth_fix(ep_info, handle, &mut class) {
-                        class = crate::ImageClass::Sampled { kind: crate::ScalarKind::Float, multi: false };
+                        class = crate::ImageClass::Sampled {
+                            kind: crate::ScalarKind::Float,
+                            multi: false,
+                        };
                     }
 
                     // write the type
@@ -457,23 +460,29 @@ impl<'a, W: Write> Writer<'a, W> {
         self.collect_reflection_info()
     }
 
-    fn needs_depth_fix(&mut self, ep_info: &valid::FunctionInfo, handle: Handle<crate::GlobalVariable>, class: &crate::ImageClass) -> bool {
+    fn needs_depth_fix(
+        &mut self,
+        ep_info: &valid::FunctionInfo,
+        handle: Handle<crate::GlobalVariable>,
+        class: &crate::ImageClass,
+    ) -> bool {
         if let crate::ImageClass::Depth { multi: false } = class {
             let has_shadow_sampler = ep_info.sampling_set.iter().all(|key| {
                 let data = &self.module.global_variables[key.sampler];
                 if key.image != handle {
                     return false;
                 }
-                return if let TypeInner::Sampler { comparison: true } = &self.module.types[data.ty].inner {
+                return if let TypeInner::Sampler { comparison: true } =
+                    &self.module.types[data.ty].inner
+                {
                     true
                 } else {
                     false
-                }
+                };
             });
 
             !has_shadow_sampler
-        }
-        else {
+        } else {
             false
         }
     }
@@ -2611,13 +2620,13 @@ impl<'a, W: Write> Writer<'a, W> {
                     self.write_expr(expr, ctx)?;
                 }
 
-                let needs_depth_fix = if let Expression::GlobalVariable(global_handle) = ctx.expressions[image] {
-                    let ep_info = self.info.get_entry_point(self.entry_point_idx as usize);
-                    self.needs_depth_fix(ep_info, global_handle, &class)
-                }
-                else {
-                    false
-                };
+                let needs_depth_fix =
+                    if let Expression::GlobalVariable(global_handle) = ctx.expressions[image] {
+                        let ep_info = self.info.get_entry_point(self.entry_point_idx as usize);
+                        self.needs_depth_fix(ep_info, global_handle, &class)
+                    } else {
+                        false
+                    };
 
                 match level {
                     // Auto needs no more arguments

--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -378,7 +378,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     // The trailing space is important
                     write!(self.out, "uniform ")?;
 
-                    if self.needs_depth_fix(ep_info, handle, &mut class) {
+                    if self.needs_depth_fix(ep_info, handle, class) {
                         class = crate::ImageClass::Sampled {
                             kind: crate::ScalarKind::Float,
                             multi: false,
@@ -464,21 +464,23 @@ impl<'a, W: Write> Writer<'a, W> {
         &mut self,
         ep_info: &valid::FunctionInfo,
         handle: Handle<crate::GlobalVariable>,
-        class: &crate::ImageClass,
+        class: crate::ImageClass,
     ) -> bool {
         if let crate::ImageClass::Depth { multi: false } = class {
             let has_shadow_sampler = ep_info.sampling_set.iter().all(|key| {
                 let data = &self.module.global_variables[key.sampler];
+
                 if key.image != handle {
                     return false;
                 }
-                return if let TypeInner::Sampler { comparison: true } =
-                    &self.module.types[data.ty].inner
+
+                if let TypeInner::Sampler { comparison: true } =
+                    self.module.types[data.ty].inner
                 {
                     true
                 } else {
                     false
-                };
+                }
             });
 
             !has_shadow_sampler
@@ -2623,7 +2625,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 let needs_depth_fix =
                     if let Expression::GlobalVariable(global_handle) = ctx.expressions[image] {
                         let ep_info = self.info.get_entry_point(self.entry_point_idx as usize);
-                        self.needs_depth_fix(ep_info, global_handle, &class)
+                        self.needs_depth_fix(ep_info, global_handle, class)
                     } else {
                         false
                     };

--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -467,7 +467,7 @@ impl<'a, W: Write> Writer<'a, W> {
         class: crate::ImageClass,
     ) -> bool {
         if let crate::ImageClass::Depth { multi: false } = class {
-            let has_shadow_sampler = ep_info.sampling_set.iter().all(|key| {
+            let has_shadow_sampler = ep_info.sampling_set.iter().any(|key| {
                 let data = &self.module.global_variables[key.sampler];
 
                 if key.image != handle {

--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -474,9 +474,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     return false;
                 }
 
-                if let TypeInner::Sampler { comparison: true } =
-                    self.module.types[data.ty].inner
-                {
+                if let TypeInner::Sampler { comparison: true } = self.module.types[data.ty].inner {
                     true
                 } else {
                     false

--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -2692,7 +2692,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 }
 
                 // End the function
-                write!(self.out, ")")?
+                write!(self.out, ")")?;
 
                 if needs_depth_fix {
                     // parser thinks it will yield f32, but in reality it yields vec4f

--- a/wgpu.iml
+++ b/wgpu.iml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RUST_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/benches/benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/cts_runner/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/cts_runner/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/cts_runner/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/examples/features/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/examples/standalone/01_hello_compute/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/examples/standalone/02_hello_window/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/examples/standalone/custom_backend/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/lock-analyzer/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/naga-cli/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/naga-test/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/naga/hlsl-snapshots/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/naga/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/naga/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/naga/xtask/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/player/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/player/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/tests/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu-core/platform-deps/apple/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu-core/platform-deps/emscripten/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu-core/platform-deps/wasm/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu-core/platform-deps/windows-linux-android/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu-core/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu-hal/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu-hal/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu-info/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu-macros/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu-types/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/wgpu/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/xtask/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/benches/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
Description
When declaring a texture_depth_2d in a shader, naga always outputs the texture uniform as type sampler2DShadow. When only interested in depth values and not comparisons, this breaks. This PR only uses sampler2DShadow when a comparison sampler is used for it. This is the only fix that I could come up with that only impacts the gles part.

This is a redo of closed PR https://github.com/gfx-rs/wgpu/pull/8301 , with fixed tests.