### PR TITLE
Add missing `maxColorAttachmentBytesPerSample` validation for render passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,7 @@ By @cwfitzgerald in [#8609](https://github.com/gfx-rs/wgpu/pull/8609).
 - Corrected documentation of the minimum alignment of the _end_ of a mapped range of a buffer (it is 4, not 8). By @kpreid in [#8450](https://github.com/gfx-rs/wgpu/pull/8450).
 - `util::StagingBelt` now takes a `Device` when it is created instead of when it is used. By @kpreid in [#8462](https://github.com/gfx-rs/wgpu/pull/8462).
 - `wgpu_hal::vulkan::Texture` API changes to handle externally-created textures and memory more flexibly. By @s-ol in [#8512](https://github.com/gfx-rs/wgpu/pull/8512), [#8521](https://github.com/gfx-rs/wgpu/pull/8521).
+- Render passes are now validated against the `maxColorAttachmentBytesPerSample` limit. By @andyleiserson in [#8697](https://github.com/gfx-rs/wgpu/pull/8697).
 
 #### Metal
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -130,6 +130,7 @@ webgpu:api,validation,queue,buffer_mapped:map_command_recording_order:*
 webgpu:api,validation,queue,submit:command_buffer,*
 webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,depthSlice,*
+webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,limits,*
 webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,*
 webgpu:api,validation,render_pass,resolve:resolve_attachment:*
 webgpu:api,validation,resource_usages,buffer,in_pass_encoder:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -129,8 +129,7 @@ webgpu:api,validation,queue,buffer_mapped:copyTextureToBuffer:*
 webgpu:api,validation,queue,buffer_mapped:map_command_recording_order:*
 webgpu:api,validation,queue,submit:command_buffer,*
 webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*
-webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,depthSlice,*
-webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,limits,*
+webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,*
 webgpu:api,validation,render_pass,resolve:resolve_attachment:*
 webgpu:api,validation,resource_usages,buffer,in_pass_encoder:*

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1277,6 +1277,13 @@ impl RenderPassInfo {
                 ));
             }
 
+            validation::validate_color_attachment_bytes_per_sample(
+                color_attachments,
+                |at| at.view.desc.format,
+                device.limits.max_color_attachment_bytes_per_sample,
+            )
+            .map_err(RenderPassErrorInner::ColorAttachment)?;
+
             fn check_attachment_overlap(
                 attachment_set: &mut crate::FastHashSet<(crate::track::TrackerIndex, u32, u32)>,
                 view: &TextureView,
@@ -1680,13 +1687,6 @@ impl Global {
                     arc_desc.color_attachments.push(None);
                 }
             }
-
-            validation::validate_color_attachment_bytes_per_sample(
-                &arc_desc.color_attachments,
-                |at| at.view.desc.format,
-                device.limits.max_color_attachment_bytes_per_sample,
-            )
-            .map_err(RenderPassErrorInner::ColorAttachment)?;
 
             arc_desc.depth_stencil_attachment =
             // https://gpuweb.github.io/gpuweb/#abstract-opdef-gpurenderpassdepthstencilattachment-gpurenderpassdepthstencilattachment-valid-usage

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1278,8 +1278,10 @@ impl RenderPassInfo {
             }
 
             validation::validate_color_attachment_bytes_per_sample(
-                color_attachments,
-                |at| at.view.desc.format,
+                color_attachments
+                    .iter()
+                    .flatten()
+                    .map(|at| at.view.desc.format),
                 device.limits.max_color_attachment_bytes_per_sample,
             )
             .map_err(RenderPassErrorInner::ColorAttachment)?;

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -44,7 +44,7 @@ use crate::{
         ParentDevice, QuerySet, Texture, TextureView, TextureViewNotRenderableReason,
     },
     track::{ResourceUsageCompatibilityError, Tracker, UsageScope},
-    Label,
+    validation, Label,
 };
 
 #[cfg(feature = "serde")]
@@ -1680,6 +1680,13 @@ impl Global {
                     arc_desc.color_attachments.push(None);
                 }
             }
+
+            validation::validate_color_attachment_bytes_per_sample(
+                &arc_desc.color_attachments,
+                |at| at.view.desc.format,
+                device.limits.max_color_attachment_bytes_per_sample,
+            )
+            .map_err(RenderPassErrorInner::ColorAttachment)?;
 
             arc_desc.depth_stencil_attachment =
             // https://gpuweb.github.io/gpuweb/#abstract-opdef-gpurenderpassdepthstencilattachment-gpurenderpassdepthstencilattachment-valid-usage

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -52,7 +52,7 @@ use crate::{
     snatch::{SnatchGuard, SnatchLock, Snatchable},
     timestamp_normalization::TIMESTAMP_NORMALIZATION_BUFFER_USES,
     track::{BindGroupStates, DeviceTracker, TrackerIndexAllocators, UsageScope, UsageScopePool},
-    validation::{self, validate_color_attachment_bytes_per_sample},
+    validation,
     weak_vec::WeakVec,
     FastHashMap, LabelHelpers, OnceCellOrLock,
 };
@@ -4134,15 +4134,12 @@ impl Device {
             }
         }
 
-        let limit = self.limits.max_color_attachment_bytes_per_sample;
-        let formats = color_targets
-            .iter()
-            .map(|cs| cs.as_ref().map(|cs| cs.format));
-        if let Err(total) = validate_color_attachment_bytes_per_sample(formats, limit) {
-            return Err(pipeline::CreateRenderPipelineError::ColorAttachment(
-                command::ColorAttachmentError::TooManyBytesPerSample { total, limit },
-            ));
-        }
+        validation::validate_color_attachment_bytes_per_sample(
+            color_targets,
+            |cs| cs.format,
+            self.limits.max_color_attachment_bytes_per_sample,
+        )
+        .map_err(pipeline::CreateRenderPipelineError::ColorAttachment)?;
 
         if let Some(ds) = depth_stencil_state {
             target_specified = true;

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4135,8 +4135,7 @@ impl Device {
         }
 
         validation::validate_color_attachment_bytes_per_sample(
-            color_targets,
-            |cs| cs.format,
+            color_targets.iter().flatten().map(|cs| cs.format),
             self.limits.max_color_attachment_bytes_per_sample,
         )
         .map_err(pipeline::CreateRenderPipelineError::ColorAttachment)?;

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1417,14 +1417,12 @@ impl Interface {
 /// descriptor. A closure is used to access the attachment format.
 ///
 /// Implements <https://gpuweb.github.io/gpuweb/#abstract-opdef-calculating-color-attachment-bytes-per-sample>.
-pub fn validate_color_attachment_bytes_per_sample<'a, T: 'a>(
-    attachments: impl IntoIterator<Item = &'a Option<T>>,
-    format_fn: impl Fn(&T) -> wgt::TextureFormat,
+pub fn validate_color_attachment_bytes_per_sample(
+    attachment_formats: impl IntoIterator<Item = wgt::TextureFormat>,
     limit: u32,
 ) -> Result<(), crate::command::ColorAttachmentError> {
     let mut total_bytes_per_sample: u32 = 0;
-    for attachment in attachments.into_iter().filter_map(Option::as_ref) {
-        let format = format_fn(attachment);
+    for format in attachment_formats {
         let byte_cost = format.target_pixel_byte_cost().unwrap();
         let alignment = format.target_component_alignment().unwrap();
 

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1411,17 +1411,20 @@ impl Interface {
     }
 }
 
-// https://gpuweb.github.io/gpuweb/#abstract-opdef-calculating-color-attachment-bytes-per-sample
-pub fn validate_color_attachment_bytes_per_sample(
-    attachment_formats: impl Iterator<Item = Option<wgt::TextureFormat>>,
+/// Validate a list of color attachments against `maxColorAttachmentBytesPerSample`.
+///
+/// The color attachments can be from a render pass descriptor or a pipeline
+/// descriptor. A closure is used to access the attachment format.
+///
+/// Implements <https://gpuweb.github.io/gpuweb/#abstract-opdef-calculating-color-attachment-bytes-per-sample>.
+pub fn validate_color_attachment_bytes_per_sample<'a, T: 'a>(
+    attachments: impl IntoIterator<Item = &'a Option<T>>,
+    format_fn: impl Fn(&T) -> wgt::TextureFormat,
     limit: u32,
-) -> Result<(), u32> {
+) -> Result<(), crate::command::ColorAttachmentError> {
     let mut total_bytes_per_sample: u32 = 0;
-    for format in attachment_formats {
-        let Some(format) = format else {
-            continue;
-        };
-
+    for attachment in attachments.into_iter().filter_map(Option::as_ref) {
+        let format = format_fn(attachment);
         let byte_cost = format.target_pixel_byte_cost().unwrap();
         let alignment = format.target_component_alignment().unwrap();
 
@@ -1430,7 +1433,12 @@ pub fn validate_color_attachment_bytes_per_sample(
     }
 
     if total_bytes_per_sample > limit {
-        return Err(total_bytes_per_sample);
+        return Err(
+            crate::command::ColorAttachmentError::TooManyBytesPerSample {
+                total: total_bytes_per_sample,
+                limit,
+            },
+        );
     }
 
     Ok(())

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1411,10 +1411,9 @@ impl Interface {
     }
 }
 
-/// Validate a list of color attachments against `maxColorAttachmentBytesPerSample`.
+/// Validate a list of color attachment formats against `maxColorAttachmentBytesPerSample`.
 ///
-/// The color attachments can be from a render pass descriptor or a pipeline
-/// descriptor. A closure is used to access the attachment format.
+/// The color attachments can be from a render pass descriptor or a pipeline descriptor.
 ///
 /// Implements <https://gpuweb.github.io/gpuweb/#abstract-opdef-calculating-color-attachment-bytes-per-sample>.
 pub fn validate_color_attachment_bytes_per_sample(


### PR DESCRIPTION
Fix a small bit of missing validation and enable the associated CTS tests.

**Squash or Rebase?** Squash

**Checklist**

- [x] Need to update the CHANGELOG entry with the PR link.