### PR TITLE
Enable CTS suite `api,validation,encoding,cmds,compute_pass`

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -38,8 +38,7 @@ webgpu:api,validation,createBindGroup:buffer,effective_buffer_binding_size:*
 webgpu:api,validation,encoding,beginComputePass:*
 webgpu:api,validation,encoding,beginRenderPass:*
 webgpu:api,validation,encoding,cmds,clearBuffer:*
-webgpu:api,validation,encoding,cmds,compute_pass:set_pipeline:*
-webgpu:api,validation,encoding,cmds,compute_pass:dispatch_sizes:*
+webgpu:api,validation,encoding,cmds,compute_pass:*
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_with_invalid_or_destroyed_texture:*
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture,device_mismatch:*
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:mipmap_level:*

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -894,7 +894,6 @@ fn dispatch_indirect(
         .require_downlevel_flags(wgt::DownlevelFlags::INDIRECT_EXECUTION)?;
 
     buffer.check_usage(wgt::BufferUsages::INDIRECT)?;
-    buffer.check_destroyed(state.pass.base.snatch_guard)?;
 
     if offset % 4 != 0 {
         return Err(ComputePassErrorInner::UnalignedIndirectBufferOffset(offset));
@@ -908,6 +907,8 @@ fn dispatch_indirect(
             buffer_size: buffer.size,
         });
     }
+
+    buffer.check_destroyed(state.pass.base.snatch_guard)?;
 
     let stride = 3 * 4; // 3 integers, x/y/z group size
     state.pass.base.buffer_memory_init_actions.extend(


### PR DESCRIPTION
There was one failure in this suite, which occurred because the error for a destroyed indirect buffer (which really shouldn't be raised until submit) was getting raised before an error for an unaligned offset.

Rearranges the order of checks to make that test happy, and enables the suite.

**Squash or Rebase?** Squash