### PR TITLE
[deno] Associate external memory with each command encoder on Metal

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -143,6 +143,7 @@ webgpu:api,validation,resource_usages,texture,in_pass_encoder:unused_bindings_in
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,color_attachments:*
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,color_attachment_and_bind_group:*
 // FAIL: webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_attachment_and_bind_group:*
+// https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,multiple_bind_groups:*
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_texture_in_bind_groups:*
 webgpu:api,validation,texture,rg11b10ufloat_renderable:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -140,7 +140,11 @@ webgpu:api,validation,resource_usages,texture,in_pass_encoder:shader_stages_and_
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_aspect:*
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_color:compute=false;type0="render-target";type1="render-target"
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:unused_bindings_in_pipeline:*
-webgpu:api,validation,resource_usages,texture,in_render_common:subresources,multiple_bind_groups:bg0Levels={"base":0,"count":1};*
+webgpu:api,validation,resource_usages,texture,in_render_common:subresources,color_attachments:*
+webgpu:api,validation,resource_usages,texture,in_render_common:subresources,color_attachment_and_bind_group:*
+// FAIL: webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_attachment_and_bind_group:*
+webgpu:api,validation,resource_usages,texture,in_render_common:subresources,multiple_bind_groups:*
+webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_texture_in_bind_groups:*
 webgpu:api,validation,texture,rg11b10ufloat_renderable:*
 webgpu:api,operation,render_pipeline,overrides:*
 webgpu:api,operation,rendering,3d_texture_slices:*

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -3,6 +3,8 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::num::NonZero;
+#[cfg(target_vendor = "apple")]
+use std::sync::OnceLock;
 
 use deno_core::cppgc::Ptr;
 use deno_core::op2;
@@ -30,6 +32,11 @@ pub struct GPUCommandEncoder {
 
   pub id: wgpu_core::id::CommandEncoderId,
   pub label: String,
+
+  // Weak reference to the JS object so we can attach a finalizer.
+  // See `GPUDevice::create_command_encoder`.
+  #[cfg(target_vendor = "apple")]
+  pub(crate) weak: OnceLock<v8::Weak<v8::Object>>,
 }
 
 impl Drop for GPUCommandEncoder {

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -5,8 +5,7 @@ use std::cell::RefCell;
 use std::num::NonZeroU64;
 use std::rc::Rc;
 
-use deno_core::cppgc::make_cppgc_object;
-use deno_core::cppgc::SameObject;
+use deno_core::cppgc::{make_cppgc_object, SameObject};
 use deno_core::op2;
 use deno_core::v8;
 use deno_core::webidl::WebIdlInterfaceConverter;
@@ -531,17 +530,29 @@ impl GPUDevice {
     self.new_render_pipeline(descriptor)
   }
 
-  #[cppgc]
-  fn create_command_encoder(
+  fn create_command_encoder<'a>(
     &self,
+    scope: &mut v8::HandleScope<'a>,
     #[webidl] descriptor: Option<
       super::command_encoder::GPUCommandEncoderDescriptor,
     >,
-  ) -> GPUCommandEncoder {
+  ) -> v8::Local<'a, v8::Object> {
+    // Metal imposes a limit on the number of outstanding command buffers.
+    // Attempting to create another command buffer after reaching that limit
+    // will block, which can result in a deadlock if GC is required to
+    // recover old command buffers. To encourage V8 to garbage collect
+    // command buffers before that happens, we associate some external
+    // memory with each command buffer.
+    #[cfg(target_vendor = "apple")]
+    const EXTERNAL_MEMORY_AMOUNT: i64 = 1 << 16;
+
     let label = descriptor.map(|d| d.label).unwrap_or_default();
     let wgpu_descriptor = wgpu_types::CommandEncoderDescriptor {
       label: Some(Cow::Owned(label.clone())),
     };
+
+    #[cfg(target_vendor = "apple")]
+    scope.adjust_amount_of_external_allocated_memory(EXTERNAL_MEMORY_AMOUNT);
 
     let (id, err) = self.instance.device_create_command_encoder(
       self.id,
@@ -551,12 +562,39 @@ impl GPUDevice {
 
     self.error_handler.push_error(err);
 
-    GPUCommandEncoder {
+    let encoder = GPUCommandEncoder {
       instance: self.instance.clone(),
       error_handler: self.error_handler.clone(),
       id,
       label,
+      #[cfg(target_vendor = "apple")]
+      weak: std::sync::OnceLock::new(),
+    };
+
+    let obj = make_cppgc_object(scope, encoder);
+
+    #[cfg(target_vendor = "apple")]
+    {
+      let finalizer = v8::Weak::with_finalizer(
+        scope,
+        obj,
+        Box::new(|isolate: &mut v8::Isolate| {
+          isolate.adjust_amount_of_external_allocated_memory(
+            -EXTERNAL_MEMORY_AMOUNT,
+          );
+        }),
+      );
+      deno_core::cppgc::try_unwrap_cppgc_object::<GPUCommandEncoder>(
+        scope,
+        obj.into(),
+      )
+      .unwrap()
+      .weak
+      .set(finalizer)
+      .unwrap();
     }
+
+    obj
   }
 
   #[required(1)]


### PR DESCRIPTION
This encourages doing garbage collection before the command buffer limit is reached.

This change is complementary to #8574. That change will change deadlocks into device loss, in any environment where wgpu runs. This change avoids reaching the limit, only in Deno.

I made the change specific to Metal, and not specific to cts_runner. I don't have strong feelings about either of those things, i.e., I'd also be fine doing it on all platforms, and I'd be fine adding a `cts_runner` feature so that we can do this only in cts_runner and not in other contexts where Deno runs.

**Connections**
Related to #3084.

**Testing**
Tested locally that this resolves some CTS suites that were hanging. However, both suites still have failing tests, so can't be run as a single selector in CI.

I also got a hang in CI on #8699 that I suspect is this issue, I will confirm that #8699 can run the CTS reliably with this fix.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
