### PR TITLE
Split the CTS into multiple jobs

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -31,26 +31,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        suite: ["API Operation", "API Validation", "Other"]
+        platform: ["Windows x86_64", "Mac aarch64", "Linux x86_64"]
         include:
+          # When an `include` item matches existing matrix entries, the additional items are
+          # added only to the matching entries. The two lines above define the matrix, and
+          # the items below attach the rest of the configuration values that apply to suites
+          # and platforms.
+          - suite: API Operation
+            filter: "^webgpu:api,operation,"
+          - suite: API Validation
+            filter: "^webgpu:api,validation,"
+          - suite: Other
+            filter: "!^webgpu:api,operation,|^webgpu:api,validation,"
+
           # Windows
-          - name: Windows x86_64
+          - platform: Windows x86_64
             os: windows-2022
             target: x86_64-pc-windows-msvc
             backend: dx12
 
           # Mac
-          - name: Mac aarch64
+          - platform: Mac aarch64
             os: macos-14
             target: x86_64-apple-darwin
             backend: metal
 
           # Linux
-          - name: Linux x86_64
+          - platform: Linux x86_64
             os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             backend: vulkan
 
-    name: CTS ${{ matrix.name }}
+    name: ${{ matrix.suite }} ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -103,12 +116,13 @@ jobs:
       # Explicitly set the backend to avoid EGL messages in output,
       # because these tests check stdout.
       - name: Test cts_runner
+        if: matrix.suite == 'other'
         shell: bash
         run: DENO_WEBGPU_BACKEND=${{ matrix.backend }} cargo --locked test -p cts_runner
 
       - name: Run CTS
         shell: bash
-        run: cargo --locked xtask cts --llvm-cov --backend ${{ matrix.backend }}
+        run: cargo --locked xtask cts --llvm-cov --backend ${{ matrix.backend }} --filter '${{matrix.filter }}'
 
       - name: Generate coverage report
         id: coverage

--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -65,6 +65,25 @@ pub fn run_cts(
     let llvm_cov = args.contains("--llvm-cov");
     let release = args.contains("--release");
     let running_on_backend = args.opt_value_from_str::<_, String>("--backend")?;
+    let mut filter_pattern = args.opt_value_from_str::<_, String>("--filter")?;
+    let mut filter_invert = false;
+
+    if let Some(filter) = filter_pattern.as_deref() {
+        if let Some(filter) = filter.strip_prefix('!') {
+            filter_pattern = Some(filter.to_owned());
+            filter_invert = true;
+        }
+    }
+
+    // Compile filter regex early to fail fast on invalid patterns
+    let filter = if let Some(pattern) = filter_pattern {
+        Some(
+            Regex::new(&pattern)
+                .context(format!("Invalid regex pattern '{pattern}' for --filter"))?,
+        )
+    } else {
+        None
+    };
 
     if running_on_backend.is_none() {
         log::warn!(
@@ -123,6 +142,33 @@ pub fn run_cts(
                     .unwrap_or_default(),
             })
         }))
+    }
+
+    // Apply filter if specified
+    if let Some(ref filter) = filter {
+        let original_count = tests.len();
+        tests.retain(|test| {
+            let selector_str = test.selector.to_string_lossy();
+            let matched = filter.is_match(&selector_str);
+            if filter_invert {
+                !matched
+            } else {
+                matched
+            }
+        });
+        let filtered_count = tests.len();
+        if filtered_count == original_count {
+            log::warn!("Filter did not exclude any tests");
+        } else if filtered_count != 0 {
+            log::info!(
+                "Filter selected {filtered_count} of {original_count} test{}",
+                if original_count == 1 { "" } else { "s" },
+            );
+        } else if filtered_count == 0 {
+            bail!("Filter did not select any tests");
+        } else {
+            bail!("Filtering introduced additional tests??");
+        }
     }
 
     let wgpu_cargo_toml = std::path::absolute(shell.current_dir().join("Cargo.toml"))

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -28,6 +28,8 @@ Commands:
     --llvm-cov              Run with LLVM code coverage
     --backend <backend>     Specify the backend (metal, dx12, or vulkan). Used
                             to evaluate `fails-if` conditions in the test list.
+    --filter <regex>        Filter tests by selector using a regex pattern.
+                            Applied after all tests are collected.
 
   run-wasm
     Build and run web examples


### PR DESCRIPTION
The CTS jobs has gotten longer as we've added more tests. Split it into three jobs so it won't be the long pole in CI.

**Testing**
By CI.

**Squash or Rebase?** Rebase (after squashing any fixups)

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
