### PR TITLE
naga: Accept `var<function>` syntax for local variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,7 @@ By @cwfitzgerald in [#8609](https://github.com/gfx-rs/wgpu/pull/8609).
 
 - Prevent UB with invalid ray query calls on spirv. By @Vecvec in [#8390](https://github.com/gfx-rs/wgpu/pull/8390).
 - Update the set of binding_array capabilities. In most cases, they are set automatically from `wgpu` features, and this change should not be user-visible. By @andyleiserson in [#8671](https://github.com/gfx-rs/wgpu/pull/8671).
+- Naga now accepts the `var<function>` syntax for declaring local variables. By @andyleiserson in [#8710](https://github.com/gfx-rs/wgpu/pull/8710).
 
 ### Bug Fixes
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -170,6 +170,7 @@ webgpu:shader,execution,flow_control,return:*
 // Many other vertex_buffer_access subtests also passing, but there are too many to enumerate.
 // Fails on Metal in CI only, not when running locally.
 fails-if(metal) webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true
+webgpu:shader,validation,expression,call,builtin,all:arguments:test="ptr_deref"
 webgpu:shader,validation,expression,call,builtin,max:values:*
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break_if"

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -199,6 +199,7 @@ pub(crate) enum Error<'a> {
     InvalidIdentifierUnderscore(Span),
     ReservedIdentifierPrefix(Span),
     UnknownAddressSpace(Span),
+    InvalidLocalVariableAddressSpace(Span),
     RepeatedAttribute(Span),
     UnknownAttribute(Span),
     UnknownBuiltin(Span),
@@ -658,6 +659,11 @@ impl<'a> Error<'a> {
             Error::UnknownAddressSpace(bad_span) => ParseError {
                 message: format!("unknown address space: `{}`", &source[bad_span]),
                 labels: vec![(bad_span, "unknown address space".into())],
+                notes: vec![],
+            },
+            Error::InvalidLocalVariableAddressSpace(bad_span) => ParseError {
+                message: format!("invalid address space for local variable: `{}`", &source[bad_span]),
+                labels: vec![(bad_span, "local variables can only use 'function' address space".into())],
                 notes: vec![],
             },
             Error::RepeatedAttribute(bad_span) => ParseError {

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -2273,6 +2273,16 @@ impl Parser {
                         "var" => {
                             let _ = lexer.next();
 
+                            if lexer.skip(Token::Paren('<')) {
+                                let (class_str, span) = lexer.next_ident_with_span()?;
+                                if class_str != "function" {
+                                    return Err(Box::new(Error::InvalidLocalVariableAddressSpace(
+                                        span,
+                                    )));
+                                }
+                                lexer.expect(Token::Paren('>'))?;
+                            }
+
                             let name = lexer.next_ident()?;
                             let ty = if lexer.skip(Token::Separator(':')) {
                                 let ty = this.type_decl(lexer, ctx)?;

--- a/naga/src/front/wgsl/tests.rs
+++ b/naga/src/front/wgsl/tests.rs
@@ -457,6 +457,41 @@ fn parse_assignment_statements() {
 }
 
 #[test]
+fn parse_local_var_address_space() {
+    parse_str(
+        "
+        fn foo() {
+            var<function> a = true;
+            var<function> b: i32 = 5;
+            var c = 10;
+        }",
+    )
+    .unwrap();
+
+    let error = parse_str(
+        "fn foo() {
+            var<private> x: i32 = 5;
+        }",
+    )
+    .unwrap_err();
+    assert_eq!(
+        error.message(),
+        "invalid address space for local variable: `private`",
+    );
+
+    let error = parse_str(
+        "fn foo() {
+            var<storage> x: i32 = 5;
+        }",
+    )
+    .unwrap_err();
+    assert_eq!(
+        error.message(),
+        "invalid address space for local variable: `storage`",
+    );
+}
+
+#[test]
 fn binary_expression_mixed_scalar_and_vector_operands() {
     for (operand, expect_splat) in [
         ('<', false),


### PR DESCRIPTION
It's superfluous to specify, but WGSL allows `var<function>` to declare local variables. This changes Naga to accept it.

**Testing**
By the CTS.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] Need to update PR link in CHANGELOG.md