### PR TITLE
naga: Enforce `@must_use` for built-in functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Bottom level categories:
 - Fix some cases where f16 constants were not working. By @andyleiserson in [#8816](https://github.com/gfx-rs/wgpu/pull/8816).
 - Use wrapping arithmetic when evaluating constant expressions involving `u32`. By @andyleiserson in [#8912](https://github.com/gfx-rs/wgpu/pull/8912).
 - Fix missing side effects from sequence expressions in GLSL. By @Vipitis in [#8787](https://github.com/gfx-rs/wgpu/pull/8787).
+- Naga now enforces the `@must_use` attribute on WGSL built-in functions, when applicable. You can waive the error with a phony assignment, e.g., `_ = subgroupElect()`. By @andyleiserson in [#8713](https://github.com/gfx-rs/wgpu/pull/8713).
 - Reject zero-value construction of a runtime-sized array with a validation error. Previously it would crash in the HLSL backend. By @mooori in [#8741](https://github.com/gfx-rs/wgpu/pull/8741).
 - Reject splat vector construction if the argument type does not match the type of the vector's scalar. Previously it would succeed. By @mooori in [#8829](https://github.com/gfx-rs/wgpu/pull/8829).
 - Fixed `workgroupUniformLoad` incorrectly returning an atomic when called on an atomic, it now returns the inner `T` as per the spec. By @cryvosh in [#8791](https://github.com/gfx-rs/wgpu/pull/8791).

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -220,9 +220,26 @@ webgpu:shader,validation,expression,binary,short_circuiting_and_or:array_overrid
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:scalar_vector:op="%26%26";lhs="bool";rhs="bool"
 webgpu:shader,validation,expression,call,builtin,all:arguments:test="ptr_deref"
+webgpu:shader,validation,expression,call,builtin,arrayLength:*
+webgpu:shader,validation,expression,call,builtin,barriers:*
+webgpu:shader,validation,expression,call,builtin,cos:*
 webgpu:shader,validation,expression,call,builtin,distance:values:stage="constant";type="f32"
+webgpu:shader,validation,expression,call,builtin,floor:*
+webgpu:shader,validation,expression,call,builtin,fract:*
 webgpu:shader,validation,expression,call,builtin,length:scalar:stage="constant";type="f32"
-webgpu:shader,validation,expression,call,builtin,max:values:*
+webgpu:shader,validation,expression,call,builtin,max:*
+webgpu:shader,validation,expression,call,builtin,min:*
+webgpu:shader,validation,expression,call,builtin,radians:*
+webgpu:shader,validation,expression,call,builtin,sign:*
+webgpu:shader,validation,expression,call,builtin,sin:*
+webgpu:shader,validation,expression,call,builtin,step:*
+webgpu:shader,validation,expression,call,builtin,tan:*
+webgpu:shader,validation,expression,call,builtin,tanh:*
+webgpu:shader,validation,expression,call,builtin,textureNumLayers:*
+webgpu:shader,validation,expression,call,builtin,textureNumLevels:*
+webgpu:shader,validation,expression,call,builtin,textureNumSamples:*
+webgpu:shader,validation,expression,call,builtin,textureStore:*
+webgpu:shader,validation,expression,call,builtin,trunc:*
 // FAIL: others in `value_constructor` due to https://github.com/gfx-rs/wgpu/issues/4720, possibly more
 webgpu:shader,validation,expression,call,builtin,value_constructor:array_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:matrix_zero_value:*
@@ -231,15 +248,7 @@ webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_zero_v
 webgpu:shader,validation,expression,call,builtin,value_constructor:struct_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:vector_splat:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:vector_zero_value:*
-// NOTE: This is supposed to be an exhaustive listing underneath
-// `webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:*`, so exceptions can be
-// worked around.
-//FAIL: https://github.com/gfx-rs/wgpu/pull/8713
-// webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:must_use:use=false
-webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:must_use:use=true
-webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:no_atomics:*
-webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:only_in_compute:*
-webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:param_constructible_only:*
+webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:*
 webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
 webgpu:shader,validation,extension,pointer_composite_access:*
 webgpu:shader,validation,parse,requires:*

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1237,6 +1237,23 @@ enum AbstractRule {
     Allow,
 }
 
+/// Whether `@must_use` applies to a call expression.
+#[derive(Debug, Copy, Clone)]
+enum MustUse {
+    Yes,
+    No,
+}
+
+impl From<bool> for MustUse {
+    fn from(value: bool) -> Self {
+        if value {
+            MustUse::Yes
+        } else {
+            MustUse::No
+        }
+    }
+}
+
 pub struct Lowerer<'source, 'temp> {
     index: &'temp Index<'source>,
 }
@@ -2918,8 +2935,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
         call_span: Span,
         ctx: &mut ExpressionContext<'source, '_, '_>,
         is_statement: bool,
-    ) -> Result<'source, Option<Handle<ir::Expression>>> {
-        let expr = if let Some(fun) = conv::map_relational_fun(function_name) {
+    ) -> Result<'source, Option<(Handle<ir::Expression>, MustUse)>> {
+        let (expr, must_use) = if let Some(fun) = conv::map_relational_fun(function_name) {
             let mut args = ctx.prepare_args(arguments, 1, function_span);
             let argument = self.expression(args.next()?, ctx)?;
             args.finish()?;
@@ -2939,37 +2956,43 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             };
 
             if argument_unmodified {
-                return Ok(Some(argument));
+                return Ok(Some((argument, MustUse::No)));
             } else {
-                ir::Expression::Relational { fun, argument }
+                (ir::Expression::Relational { fun, argument }, MustUse::No)
             }
         } else if let Some((axis, ctrl)) = conv::map_derivative(function_name) {
             let mut args = ctx.prepare_args(arguments, 1, function_span);
             let expr = self.expression(args.next()?, ctx)?;
             args.finish()?;
 
-            ir::Expression::Derivative { axis, ctrl, expr }
+            (
+                ir::Expression::Derivative { axis, ctrl, expr },
+                MustUse::Yes,
+            )
         } else if let Some(fun) = conv::map_standard_fun(function_name) {
-            self.math_function_helper(function_span, fun, arguments, ctx)?
+            (
+                self.math_function_helper(function_span, fun, arguments, ctx)?,
+                MustUse::Yes,
+            )
         } else if let Some(fun) = Texture::map(function_name) {
-            self.texture_sample_helper(fun, arguments, function_span, ctx)?
+            (
+                self.texture_sample_helper(fun, arguments, function_span, ctx)?,
+                MustUse::Yes,
+            )
         } else if let Some((op, cop)) = conv::map_subgroup_operation(function_name) {
-            return Ok(Some(self.subgroup_operation_helper(
-                function_span,
-                op,
-                cop,
-                arguments,
-                ctx,
-            )?));
+            return Ok(Some((
+                self.subgroup_operation_helper(function_span, op, cop, arguments, ctx)?,
+                MustUse::Yes,
+            )));
         } else if let Some(mode) = SubgroupGather::map(function_name) {
-            return Ok(Some(self.subgroup_gather_helper(
-                function_span,
-                mode,
-                arguments,
-                ctx,
-            )?));
+            return Ok(Some((
+                self.subgroup_gather_helper(function_span, mode, arguments, ctx)?,
+                MustUse::Yes,
+            )));
         } else if let Some(fun) = ir::AtomicFunction::map(function_name) {
-            return self.atomic_helper(function_span, fun, arguments, is_statement, ctx);
+            return Ok(self
+                .atomic_helper(function_span, fun, arguments, is_statement, ctx)?
+                .map(|result| (result, MustUse::No)));
         } else {
             match function_name {
                 "bitcast" => {
@@ -2992,11 +3015,14 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         }
                     };
 
-                    ir::Expression::As {
-                        expr,
-                        kind: element_scalar.kind,
-                        convert: None,
-                    }
+                    (
+                        ir::Expression::As {
+                            expr,
+                            kind: element_scalar.kind,
+                            convert: None,
+                        },
+                        MustUse::Yes,
+                    )
                 }
                 "coopLoad" | "coopLoadT" => {
                     let row_major = function_name.ends_with("T");
@@ -3029,16 +3055,19 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     };
                     args.finish()?;
 
-                    crate::Expression::CooperativeLoad {
-                        columns,
-                        rows,
-                        role,
-                        data: crate::CooperativeData {
-                            pointer,
-                            stride,
-                            row_major,
+                    (
+                        crate::Expression::CooperativeLoad {
+                            columns,
+                            rows,
+                            role,
+                            data: crate::CooperativeData {
+                                pointer,
+                                stride,
+                                row_major,
+                            },
                         },
-                    }
+                        MustUse::Yes,
+                    )
                 }
                 "select" => {
                     let mut args = ctx.prepare_args(arguments, 3, function_span);
@@ -3103,25 +3132,28 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
                     let [reject, accept] = values;
 
-                    ir::Expression::Select {
-                        reject,
-                        accept,
-                        condition,
-                    }
+                    (
+                        ir::Expression::Select {
+                            reject,
+                            accept,
+                            condition,
+                        },
+                        MustUse::Yes,
+                    )
                 }
                 "arrayLength" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
                     let expr = self.expression(args.next()?, ctx)?;
                     args.finish()?;
 
-                    ir::Expression::ArrayLength(expr)
+                    (ir::Expression::ArrayLength(expr), MustUse::Yes)
                 }
                 "atomicLoad" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
                     let (pointer, _scalar) = self.atomic_pointer(args.next()?, ctx)?;
                     args.finish()?;
 
-                    ir::Expression::Load { pointer }
+                    (ir::Expression::Load { pointer }, MustUse::No)
                 }
                 "atomicStore" => {
                     let mut args = ctx.prepare_args(arguments, 2, function_span);
@@ -3173,7 +3205,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         },
                         function_span,
                     );
-                    return Ok(Some(result));
+                    return Ok(Some((result, MustUse::No)));
                 }
                 "textureAtomicMin" | "textureAtomicMax" | "textureAtomicAdd"
                 | "textureAtomicAnd" | "textureAtomicOr" | "textureAtomicXor" => {
@@ -3310,7 +3342,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         function_span,
                     );
 
-                    return Ok(Some(result));
+                    return Ok(Some((result, MustUse::Yes)));
                 }
                 "textureStore" => {
                     let mut args = ctx.prepare_args(arguments, 3, function_span);
@@ -3383,13 +3415,16 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
                     args.finish()?;
 
-                    ir::Expression::ImageLoad {
-                        image,
-                        coordinate,
-                        array_index,
-                        level,
-                        sample,
-                    }
+                    (
+                        ir::Expression::ImageLoad {
+                            image,
+                            coordinate,
+                            array_index,
+                            level,
+                            sample,
+                        },
+                        MustUse::Yes,
+                    )
                 }
                 "textureDimensions" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
@@ -3401,40 +3436,52 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         .transpose()?;
                     args.finish()?;
 
-                    ir::Expression::ImageQuery {
-                        image,
-                        query: ir::ImageQuery::Size { level },
-                    }
+                    (
+                        ir::Expression::ImageQuery {
+                            image,
+                            query: ir::ImageQuery::Size { level },
+                        },
+                        MustUse::Yes,
+                    )
                 }
                 "textureNumLevels" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
                     let image = self.expression(args.next()?, ctx)?;
                     args.finish()?;
 
-                    ir::Expression::ImageQuery {
-                        image,
-                        query: ir::ImageQuery::NumLevels,
-                    }
+                    (
+                        ir::Expression::ImageQuery {
+                            image,
+                            query: ir::ImageQuery::NumLevels,
+                        },
+                        MustUse::Yes,
+                    )
                 }
                 "textureNumLayers" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
                     let image = self.expression(args.next()?, ctx)?;
                     args.finish()?;
 
-                    ir::Expression::ImageQuery {
-                        image,
-                        query: ir::ImageQuery::NumLayers,
-                    }
+                    (
+                        ir::Expression::ImageQuery {
+                            image,
+                            query: ir::ImageQuery::NumLayers,
+                        },
+                        MustUse::Yes,
+                    )
                 }
                 "textureNumSamples" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
                     let image = self.expression(args.next()?, ctx)?;
                     args.finish()?;
 
-                    ir::Expression::ImageQuery {
-                        image,
-                        query: ir::ImageQuery::NumSamples,
-                    }
+                    (
+                        ir::Expression::ImageQuery {
+                            image,
+                            query: ir::ImageQuery::NumSamples,
+                        },
+                        MustUse::Yes,
+                    )
                 }
                 "rayQueryInitialize" => {
                     let mut args = ctx.prepare_args(arguments, 3, function_span);
@@ -3464,10 +3511,13 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
                     let _ = ctx.module.generate_vertex_return_type();
 
-                    ir::Expression::RayQueryVertexPositions {
-                        query,
-                        committed: true,
-                    }
+                    (
+                        ir::Expression::RayQueryVertexPositions {
+                            query,
+                            committed: true,
+                        },
+                        MustUse::No,
+                    )
                 }
                 "getCandidateHitVertexPositions" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
@@ -3476,10 +3526,13 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
                     let _ = ctx.module.generate_vertex_return_type();
 
-                    ir::Expression::RayQueryVertexPositions {
-                        query,
-                        committed: false,
-                    }
+                    (
+                        ir::Expression::RayQueryVertexPositions {
+                            query,
+                            committed: false,
+                        },
+                        MustUse::No,
+                    )
                 }
                 "rayQueryProceed" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
@@ -3492,7 +3545,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     let rctx = ctx.runtime_expression_ctx(function_span)?;
                     rctx.block
                         .push(ir::Statement::RayQuery { query, fun }, function_span);
-                    return Ok(Some(result));
+                    return Ok(Some((result, MustUse::No)));
                 }
                 "rayQueryGenerateIntersection" => {
                     let mut args = ctx.prepare_args(arguments, 2, function_span);
@@ -3534,10 +3587,13 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     args.finish()?;
 
                     let _ = ctx.module.generate_ray_intersection_type();
-                    ir::Expression::RayQueryGetIntersection {
-                        query,
-                        committed: true,
-                    }
+                    (
+                        ir::Expression::RayQueryGetIntersection {
+                            query,
+                            committed: true,
+                        },
+                        MustUse::No,
+                    )
                 }
                 "rayQueryGetCandidateIntersection" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
@@ -3545,10 +3601,13 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     args.finish()?;
 
                     let _ = ctx.module.generate_ray_intersection_type();
-                    ir::Expression::RayQueryGetIntersection {
-                        query,
-                        committed: false,
-                    }
+                    (
+                        ir::Expression::RayQueryGetIntersection {
+                            query,
+                            committed: false,
+                        },
+                        MustUse::No,
+                    )
                 }
                 "subgroupBallot" => {
                     let mut args = ctx.prepare_args(arguments, 0, function_span);
@@ -3566,7 +3625,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         ir::Statement::SubgroupBallot { result, predicate },
                         function_span,
                     );
-                    return Ok(Some(result));
+                    return Ok(Some((result, MustUse::Yes)));
                 }
                 "quadSwapX" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
@@ -3589,7 +3648,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         },
                         function_span,
                     );
-                    return Ok(Some(result));
+                    return Ok(Some((result, MustUse::Yes)));
                 }
                 "quadSwapY" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
@@ -3612,7 +3671,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         },
                         function_span,
                     );
-                    return Ok(Some(result));
+                    return Ok(Some((result, MustUse::Yes)));
                 }
                 "quadSwapDiagonal" => {
                     let mut args = ctx.prepare_args(arguments, 1, function_span);
@@ -3635,7 +3694,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         },
                         function_span,
                     );
-                    return Ok(Some(result));
+                    return Ok(Some((result, MustUse::Yes)));
                 }
                 "coopStore" | "coopStoreT" => {
                     let row_major = function_name.ends_with("T");
@@ -3685,14 +3744,17 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     let c = self.expression(args.next()?, ctx)?;
                     args.finish()?;
 
-                    ir::Expression::CooperativeMultiplyAdd { a, b, c }
+                    (
+                        ir::Expression::CooperativeMultiplyAdd { a, b, c },
+                        MustUse::Yes,
+                    )
                 }
                 _ => return Err(Box::new(Error::UnknownIdent(function_span, function_name))),
             }
         };
 
         let expr = ctx.append_expression(expr, function_span)?;
-        Ok(Some(expr))
+        Ok(Some((expr, must_use)))
     }
 
     /// Generate Naga IR for call expressions and statements, and type
@@ -3734,25 +3796,27 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
         let mut tl = TemplateListIter::new(function_span, &call_phrase.function.template_list);
 
-        match ctx.globals.get(function_name) {
+        let result = match ctx.globals.get(function_name) {
             Some(&LoweredGlobalDecl::Type(ty)) => {
                 // user-declared types can't make use of template lists
                 tl.finish(ctx)?;
 
                 let handle =
                     self.construct(span, Constructor::Type(ty), function_span, arguments, ctx)?;
-                Ok(Some(handle))
+                Some((handle, MustUse::Yes))
             }
             Some(
                 &LoweredGlobalDecl::Const(_)
                 | &LoweredGlobalDecl::Override(_)
                 | &LoweredGlobalDecl::Var(_),
-            ) => Err(Box::new(Error::Unexpected(
-                function_span,
-                ExpectedToken::Function,
-            ))),
+            ) => {
+                return Err(Box::new(Error::Unexpected(
+                    function_span,
+                    ExpectedToken::Function,
+                )))
+            }
             Some(&LoweredGlobalDecl::EntryPoint(_)) => {
-                Err(Box::new(Error::CalledEntryPoint(function_span)))
+                return Err(Box::new(Error::CalledEntryPoint(function_span)));
             }
             Some(&LoweredGlobalDecl::Function {
                 handle: function,
@@ -3786,10 +3850,6 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
                 let has_result = ctx.module.functions[function].result.is_some();
 
-                if must_use && is_statement {
-                    return Err(Box::new(Error::FunctionMustUseUnused(function_span)));
-                }
-
                 let rctx = ctx.runtime_expression_ctx(span)?;
                 // we need to always do this before a fn call since all arguments need to be emitted before the fn call
                 rctx.block
@@ -3801,19 +3861,19 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         .append(ir::Expression::CallResult(function), span);
                     rctx.local_expression_kind_tracker
                         .insert(result, proc::ExpressionKind::Runtime);
-                    result
+                    (result, must_use.into())
                 });
                 rctx.emitter.start(&rctx.function.expressions);
                 rctx.block.push(
                     ir::Statement::Call {
                         function,
                         arguments,
-                        result,
+                        result: result.map(|(expr, _)| expr),
                     },
                     span,
                 );
 
-                Ok(result)
+                result
             }
             None => {
                 // If the name refers to a predeclared type, this is a construction expression.
@@ -3847,25 +3907,29 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     tl.finish(ctx)?;
                     let handle =
                         self.construct(span, constructor_ty, function_span, arguments, ctx)?;
-                    return Ok(Some(handle));
-                };
-
-                // Otherwise, it must be a call to a builtin function.
-                let expr = self.call_builtin(
-                    function_name,
-                    function_span,
-                    arguments,
-                    &mut tl,
-                    span,
-                    ctx,
-                    is_statement,
-                )?;
-
-                tl.finish(ctx)?;
-
-                Ok(expr)
+                    Some((handle, MustUse::Yes))
+                } else {
+                    // Otherwise, it must be a call to a builtin function.
+                    let result = self.call_builtin(
+                        function_name,
+                        function_span,
+                        arguments,
+                        &mut tl,
+                        span,
+                        ctx,
+                        is_statement,
+                    )?;
+                    tl.finish(ctx)?;
+                    result
+                }
             }
+        };
+
+        let result_used = !is_statement;
+        if matches!(result, Some((_, MustUse::Yes))) && !result_used {
+            return Err(Box::new(Error::FunctionMustUseUnused(function_span)));
         }
+        Ok(result.map(|(expr, _)| expr))
     }
 
     /// Generate a Naga IR [`Math`] expression.

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2956,9 +2956,9 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             };
 
             if argument_unmodified {
-                return Ok(Some((argument, MustUse::No)));
+                return Ok(Some((argument, MustUse::Yes)));
             } else {
-                (ir::Expression::Relational { fun, argument }, MustUse::No)
+                (ir::Expression::Relational { fun, argument }, MustUse::Yes)
             }
         } else if let Some((axis, ctrl)) = conv::map_derivative(function_name) {
             let mut args = ctx.prepare_args(arguments, 1, function_span);

--- a/naga/tests/in/wgsl/subgroup-operations.wgsl
+++ b/naga/tests/in/wgsl/subgroup-operations.wgsl
@@ -11,32 +11,32 @@ fn main(
 ) {
     subgroupBarrier();
 
-    subgroupBallot((subgroup_invocation_id & 1u) == 1u);
-    subgroupBallot();
+    _ = subgroupBallot((subgroup_invocation_id & 1u) == 1u);
+    _ = subgroupBallot();
 
-    subgroupAll(subgroup_invocation_id != 0u);
-    subgroupAny(subgroup_invocation_id == 0u);
-    subgroupAdd(subgroup_invocation_id);
-    subgroupMul(subgroup_invocation_id);
-    subgroupMin(subgroup_invocation_id);
-    subgroupMax(subgroup_invocation_id);
-    subgroupAnd(subgroup_invocation_id);
-    subgroupOr(subgroup_invocation_id);
-    subgroupXor(subgroup_invocation_id);
-    subgroupExclusiveAdd(subgroup_invocation_id);
-    subgroupExclusiveMul(subgroup_invocation_id);
-    subgroupInclusiveAdd(subgroup_invocation_id);
-    subgroupInclusiveMul(subgroup_invocation_id);
+    _ = subgroupAll(subgroup_invocation_id != 0u);
+    _ = subgroupAny(subgroup_invocation_id == 0u);
+    _ = subgroupAdd(subgroup_invocation_id);
+    _ = subgroupMul(subgroup_invocation_id);
+    _ = subgroupMin(subgroup_invocation_id);
+    _ = subgroupMax(subgroup_invocation_id);
+    _ = subgroupAnd(subgroup_invocation_id);
+    _ = subgroupOr(subgroup_invocation_id);
+    _ = subgroupXor(subgroup_invocation_id);
+    _ = subgroupExclusiveAdd(subgroup_invocation_id);
+    _ = subgroupExclusiveMul(subgroup_invocation_id);
+    _ = subgroupInclusiveAdd(subgroup_invocation_id);
+    _ = subgroupInclusiveMul(subgroup_invocation_id);
 
-    subgroupBroadcastFirst(subgroup_invocation_id);
-    subgroupBroadcast(subgroup_invocation_id, 4u);
-    subgroupShuffle(subgroup_invocation_id, sizes.subgroup_size - 1u - subgroup_invocation_id);
-    subgroupShuffleDown(subgroup_invocation_id, 1u);
-    subgroupShuffleUp(subgroup_invocation_id, 1u);
-    subgroupShuffleXor(subgroup_invocation_id, sizes.subgroup_size - 1u);
+    _ = subgroupBroadcastFirst(subgroup_invocation_id);
+    _ = subgroupBroadcast(subgroup_invocation_id, 4u);
+    _ = subgroupShuffle(subgroup_invocation_id, sizes.subgroup_size - 1u - subgroup_invocation_id);
+    _ = subgroupShuffleDown(subgroup_invocation_id, 1u);
+    _ = subgroupShuffleUp(subgroup_invocation_id, 1u);
+    _ = subgroupShuffleXor(subgroup_invocation_id, sizes.subgroup_size - 1u);
 
-    quadBroadcast(subgroup_invocation_id, 4u);
-    quadSwapX(subgroup_invocation_id);
-    quadSwapY(subgroup_invocation_id);
-    quadSwapDiagonal(subgroup_invocation_id);
+    _ = quadBroadcast(subgroup_invocation_id, 4u);
+    _ = quadSwapX(subgroup_invocation_id);
+    _ = quadSwapY(subgroup_invocation_id);
+    _ = quadSwapDiagonal(subgroup_invocation_id);
 }

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -3923,7 +3923,7 @@ fn subgroup_capability() {
             &format!("
                 {stage_attr}
                 fn main() {{
-                    subgroupBallot();
+                    _ = subgroupBallot();
                 }}
             "),
             Err(naga::valid::ValidationError::EntryPoint {
@@ -3948,7 +3948,7 @@ fn subgroup_capability() {
                 "
                 {stage_attr}
                 fn main() {{
-                    subgroupBallot();
+                    _ = subgroupBallot();
                 }}
             "
             ),
@@ -3965,7 +3965,7 @@ fn subgroup_capability() {
             "
                 @vertex
                 fn main() -> @builtin(position) vec4<f32> {{
-                    subgroupBallot();
+                    _ = subgroupBallot();
                     return vec4();
                 }}
             ":
@@ -3977,7 +3977,7 @@ fn subgroup_capability() {
         "
             @vertex
             fn main() -> @builtin(position) vec4<f32> {{
-                subgroupBallot();
+                _ = subgroupBallot();
                 return vec4();
             }}
         ",
@@ -4074,7 +4074,7 @@ fn subgroup_invalid_broadcast() {
     check_validation! {
         r#"
             fn main(id: u32) {
-                subgroupBroadcast(123, id);
+                _ = subgroupBroadcast(123, id);
             }
         "#:
         Err(naga::valid::ValidationError::Function {
@@ -4088,7 +4088,7 @@ fn subgroup_invalid_broadcast() {
     check_validation! {
         r#"
             fn main(id: u32) {
-                quadBroadcast(123, id);
+                _ = quadBroadcast(123, id);
             }
         "#:
         Err(naga::valid::ValidationError::Function {


### PR DESCRIPTION
The spec defines many built-ins to have the `@must_use` attribute. This PR applies "must use" enforcement on calls to applicable built-ins.

This is a breaking change for shaders that call these functions without using the result, which is unfortunate, but we don't have infrastructure for deprecation warnings.

**Testing**
Tested by the CTS

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Need to update PR link in changelog.