### PR TITLE
Get presents_with_transaction from render_layer

### DIFF
--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -397,9 +397,6 @@ pub struct Surface {
     render_layer: Mutex<metal::MetalLayer>,
     swapchain_format: RwLock<Option<wgt::TextureFormat>>,
     extent: RwLock<wgt::Extent3d>,
-    // Useful for UI-intensive applications that are sensitive to
-    // window resizing.
-    pub present_with_transaction: bool,
 }
 
 unsafe impl Send for Surface {}
@@ -409,6 +406,8 @@ unsafe impl Sync for Surface {}
 pub struct SurfaceTexture {
     texture: Texture,
     drawable: metal::MetalDrawable,
+    // Useful for UI-intensive applications that are sensitive to
+    // window resizing.
     present_with_transaction: bool,
 }
 

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -28,7 +28,6 @@ impl super::Surface {
             render_layer: Mutex::new(layer),
             swapchain_format: RwLock::new(None),
             extent: RwLock::new(wgt::Extent3d::default()),
-            present_with_transaction: false,
         }
     }
 
@@ -168,7 +167,6 @@ impl crate::Surface for super::Surface {
         render_layer.set_device(&device_raw);
         render_layer.set_pixel_format(caps.map_format(config.format));
         render_layer.set_framebuffer_only(framebuffer_only);
-        render_layer.set_presents_with_transaction(self.present_with_transaction);
         // opt-in to Metal EDR
         // EDR potentially more power used in display and more bandwidth, memory footprint.
         let wants_edr = config.format == wgt::TextureFormat::Rgba16Float;
@@ -224,7 +222,7 @@ impl crate::Surface for super::Surface {
                 },
             },
             drawable,
-            present_with_transaction: self.present_with_transaction,
+            present_with_transaction: render_layer.presents_with_transaction(),
         };
 
         Ok(Some(crate::AcquiredSurfaceTexture {


### PR DESCRIPTION
**Description**
We cannot modify  `present_with_transaction` without a mutable reference to the Surface(#6500). But now we have exposed `render_layer`(#8707), user can directly modify `present_with_transaction` with `render_layer`, so we read it from `render_layer`.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
