### PR TITLE
fix(OpenGL): enable using `VertexFormat::Unorm10_10_10_2` on `gl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,7 @@ By @cwfitzgerald in [#8609](https://github.com/gfx-rs/wgpu/pull/8609).
 - Fix race when downloading texture from compute shader pass. By @SpeedCrash100 in [#8527](https://github.com/gfx-rs/wgpu/pull/8527)
 - Fix double window class registration when dynamic libraries are used. By @Azorlogh in [#8548](https://github.com/gfx-rs/wgpu/pull/8548)
 - Fix context loss on device initialization on GL3.3-4.1 contexts. By @cwfitzgerald in [#8674](https://github.com/gfx-rs/wgpu/pull/8674).
+- `VertexFormat::Unorm10_10_10_2` can now be used on `gl` backends. By @mooori in [#8717](https://github.com/gfx-rs/wgpu/pull/8717).
 
 #### hal
 

--- a/tests/tests/wgpu-gpu/vertex_formats/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_formats/mod.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU64;
 
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 
-use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration, TestParameters, TestingContext};
+use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
 pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
     vec.extend([VERTEX_FORMATS_ALL, VERTEX_FORMATS_10_10_10_2]);
@@ -428,7 +428,6 @@ static VERTEX_FORMATS_ALL: GpuTestConfiguration = GpuTestConfiguration::new()
 static VERTEX_FORMATS_10_10_10_2: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .expect_fail(FailureCase::backend(wgpu::Backends::GL))
             .test_features_limits()
             .features(wgpu::Features::VERTEX_WRITABLE_STORAGE),
     )

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -223,7 +223,7 @@ pub(super) fn describe_vertex_format(vertex_format: wgt::VertexFormat) -> super:
         Vf::Uint32x4 => (4, glow::UNSIGNED_INT, Vak::Integer),
         Vf::Sint32x4 => (4, glow::INT, Vak::Integer),
         Vf::Float32x4 => (4, glow::FLOAT, Vak::Float),
-        Vf::Unorm10_10_10_2 => (4, glow::UNSIGNED_INT_10_10_10_2, Vak::Float),
+        Vf::Unorm10_10_10_2 => (4, glow::UNSIGNED_INT_2_10_10_10_REV, Vak::Float),
         Vf::Unorm8x4Bgra => (glow::BGRA as i32, glow::UNSIGNED_BYTE, Vak::Float),
         Vf::Float64 | Vf::Float64x2 | Vf::Float64x3 | Vf::Float64x4 => unimplemented!(),
     };


### PR DESCRIPTION
**Connections**

Fixes #7306

**Description**
`Unorm10_10_10_2` works on Vulkan and there the format is `A2B10G10R10_UNORM_PACK32`:

https://github.com/gfx-rs/wgpu/blob/0ac2da4b6baea94c1e9d9bb03bdcf69122da857a/wgpu-hal/src/vulkan/conv.rs#L422

The corresponding OpenGL format is `UNSIGNED_INT_2_10_10_10_REV`, see specs: [vulkan](https://docs.vulkan.org/refpages/latest/refpages/source/VkFormat.html), [gl](https://wikis.khronos.org/opengl/Vertex_Specification#Component_type).

**Testing**

Test `vertex_formats_10_10_10_2` no longer fails on `gl`. Also see comment below.

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry.

`cargo xtask test`: On my machine the same set of 9 tests fails on both `trunk` and on this branch.