### PR TITLE
Bump MSRV to 1.92 for real

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ env:
   #
 
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
-  REPO_MSRV: "1.88"
+  REPO_MSRV: "1.92"
 
   #
   # Environment variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   #
 
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
-  REPO_MSRV: "1.88"
+  REPO_MSRV: "1.92"
   # This is the MSRV used by the `wgpu-core`, `wgpu-hal`, and `wgpu-types` crates,
   # to ensure that they can be used with firefox.
   CORE_MSRV: "1.82.0"

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -17,7 +17,7 @@ env:
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
-  MSRV: "1.88"
+  MSRV: "1.92"
 
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
-  REPO_MSRV: "1.88"
+  REPO_MSRV: "1.92"
 
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -19,7 +19,7 @@ env:
   #
 
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.
-  REPO_MSRV: "1.88"
+  REPO_MSRV: "1.92"
   RUSTFLAGS: -D warnings
 
 # Every time a PR is pushed to, cancel any previous jobs. This

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ ref_as_ptr = "warn"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.92"
 keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 homepage = "https://wgpu.rs/"

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For an overview of all the components in the gfx-rs ecosystem, see [the big pict
 
 ## MSRV policy
 
-TL;DR: If you're using `wgpu`, our MSRV is **1.88**.
+TL;DR: If you're using `wgpu`, our MSRV is **1.92**.
 
 <details>
 <summary> Specific Details </summary>
@@ -104,7 +104,7 @@ TL;DR: If you're using `wgpu`, our MSRV is **1.88**.
 Due to complex dependants, we have two MSRV policies:
 
 - `naga`, `wgpu-core`, `wgpu-hal`, and `wgpu-types`'s MSRV is **1.82**.
-- The rest of the workspace has an MSRV of **1.88**.
+- The rest of the workspace has an MSRV of **1.92**.
 
 It is enforced on CI (in "/.github/workflows/ci.yml") with the `CORE_MSRV` and `REPO_MSRV` variables.
 This version can only be upgraded in breaking releases, though we release a breaking version every three months.

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -154,7 +154,9 @@ impl GPUDevice {
     // error, not a validation error. (WebGPU specifies this check on the
     // content timeline.)
     if descriptor.mapped_at_creation
-      && descriptor.size % wgpu_types::COPY_BUFFER_ALIGNMENT != 0
+      && !descriptor
+        .size
+        .is_multiple_of(wgpu_types::COPY_BUFFER_ALIGNMENT)
     {
       return Err(JsErrorBox::range_error(
         format!(

--- a/examples/standalone/01_hello_compute/Cargo.toml
+++ b/examples/standalone/01_hello_compute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wgpu-example-01-hello-compute"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.92"
 publish = false
 
 [dependencies]

--- a/examples/standalone/02_hello_window/Cargo.toml
+++ b/examples/standalone/02_hello_window/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wgpu-example-02-hello-window"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.92"
 publish = false
 
 [dependencies]

--- a/examples/standalone/custom_backend/Cargo.toml
+++ b/examples/standalone/custom_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wgpu-example-custom-backend"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.92"
 publish = false
 
 [features]

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -745,7 +745,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
     /// Resolve the types of all expressions up through `handle`.
     ///
     /// Ensure that [`self.typifier`] has a [`TypeResolution`] for
-    /// every expression in [`self.function.expressions`].
+    /// every expression in `self.function.expressions`.
     ///
     /// This does not add types to any arena. The [`Typifier`]
     /// documentation explains the steps we take to avoid filling

--- a/naga/src/proc/layouter.rs
+++ b/naga/src/proc/layouter.rs
@@ -161,10 +161,11 @@ impl Layouter {
         self.layouts.clear();
     }
 
+    #[expect(rustdoc::private_intra_doc_links)]
     /// Extend this `Layouter` with layouts for any new entries in `gctx.types`.
     ///
     /// Ensure that every type in `gctx.types` has a corresponding [TypeLayout]
-    /// in [`self.layouts`].
+    /// in [`Self::layouts`].
     ///
     /// Some front ends need to be able to compute layouts for existing types
     /// while module construction is still in progress and new types are still

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88"
+channel = "1.92"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/wgpu-core/src/command/encoder_command.rs
+++ b/wgpu-core/src/command/encoder_command.rs
@@ -35,7 +35,7 @@ pub struct IdReferences;
 /// This is used for trace recording and playback. Recording stores the pointer
 /// value of `Arc` references in the trace. Playback uses the integer values
 /// as keys to a `HashMap`.
-#[cfg(feature = "serde")]
+#[cfg(any(feature = "trace", feature = "replay"))]
 #[doc(hidden)]
 #[derive(Clone, Debug)]
 pub struct PointerReferences;
@@ -59,7 +59,7 @@ impl ReferenceType for IdReferences {
     type Tlas = id::TlasId;
 }
 
-#[cfg(feature = "serde")]
+#[cfg(any(feature = "trace", feature = "replay"))]
 impl ReferenceType for PointerReferences {
     type Buffer = id::PointerId<id::markers::Buffer>;
     type Surface = id::PointerId<id::markers::Surface>;

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -74,13 +74,10 @@ where
         + From<DestroyedResourceError>
         + From<BindError>,
 {
-    if bind_group.is_none() {
-        api_log!("Pass::set_bind_group {index} None");
+    if let Some(ref bind_group) = bind_group {
+        api_log!("Pass::set_bind_group {index} {}", bind_group.error_ident());
     } else {
-        api_log!(
-            "Pass::set_bind_group {index} {}",
-            bind_group.as_ref().unwrap().error_ident()
-        );
+        api_log!("Pass::set_bind_group {index} None");
     }
 
     let max_bind_groups = state.base.device.limits.max_bind_groups;

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -875,7 +875,6 @@ impl Buffer {
                 range,
                 host,
             } => {
-                #[cfg_attr(not(feature = "trace"), expect(clippy::collapsible_if))]
                 if host == HostMap::Write {
                     #[cfg(feature = "trace")]
                     if let Some(ref mut trace) = *device.trace.lock() {

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1333,7 +1333,14 @@ impl crate::Device for super::Device {
                 ShaderVisibility: Direct3D12::D3D12_SHADER_VISIBILITY_ALL, // really needed for VS and CS only,
             });
             let binding = bind_cbv;
-            bind_cbv.register += 1;
+            // This is the last time we use this, but lets increment
+            // it so if we add more later, the value behaves correctly.
+
+            // This is an allow as it doesn't trigger on 1.82, hal's MSRV.
+            #[allow(unused_assignments)]
+            {
+                bind_cbv.register += 1;
+            }
             (Some(parameter_index as u32), Some(binding))
         } else {
             (None, None)

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -54,7 +54,7 @@ the limit is merely 2048 unique samplers in existence, which is much more reason
 
 ## Resource binding
 
-See ['Device::create_pipeline_layout`] documentation for the structure
+See [`crate::Device::create_pipeline_layout`] documentation for the structure
 of the root signature corresponding to WebGPU pipeline layout.
 
 Binding groups is mostly straightforward, with one big caveat:

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -998,7 +998,7 @@ struct CommandState {
     ///   checks and the WGSL `arrayLength` function.
     ///
     /// For each stage `S` in `stage_infos`, we consult this to find the sizes
-    /// of the buffers listed in [`stage_infos.S.sized_bindings`], which we must
+    /// of the buffers listed in `stage_infos.S.sized_bindings`, which we must
     /// pass to the entry point.
     ///
     /// See `device::CompiledShader::sized_bindings` for more details.

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -28,7 +28,7 @@
 //! | --------------------- | ---------------------- |
 //! | ![render_coordinates] | ![texture_coordinates] |
 //!
-//! `wgpu`'s MSRV is **1.88**.
+//! `wgpu`'s MSRV is **1.92**.
 //!
 //! [Learn Wgpu]: https://sotrh.github.io/learn-wgpu/
 //! [WebGPU Fundamentals]: https://webgpufundamentals.org/


### PR DESCRIPTION
Soooooooooooo somehow I managed to revert the actual change to the toolchain in #8678? No idea how I did that.

While we're at it, lets actually go all the way up to 1.92 as that just came out.