### PR TITLE
core: Reject zero-size bindings in createBindGroup

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -33,6 +33,7 @@ webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribu
 webgpu:api,validation,buffer,create:*
 webgpu:api,validation,buffer,destroy:*
 fails-if(dx12) webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
+webgpu:api,validation,createBindGroup:buffer_offset_and_size_for_bind_groups_match:*
 webgpu:api,validation,createBindGroup:buffer,effective_buffer_binding_size:*
 webgpu:api,validation,createBindGroup:buffer,resource_binding_size:*
 // Fails because we coerce a size of 0 in `GPUDevice.createBindGroup(…)` to `buffer.size - offset`.

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -423,14 +423,14 @@ impl GPUDevice {
             BindingResource::Buffer(wgpu_core::binding_model::BufferBinding {
               buffer: buffer.id,
               offset: 0,
-              size: NonZeroU64::new(buffer.size),
+              size: Some(buffer.size),
             })
           }
           GPUBindingResource::BufferBinding(buffer_binding) => {
             BindingResource::Buffer(wgpu_core::binding_model::BufferBinding {
               buffer: buffer_binding.buffer.id,
               offset: buffer_binding.offset,
-              size: buffer_binding.size.and_then(NonZeroU64::new),
+              size: buffer_binding.size,
             })
           }
         },

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -1015,7 +1015,15 @@ crate::impl_storage_item!(PipelineLayout);
 pub struct BufferBinding<B = BufferId> {
     pub buffer: B,
     pub offset: wgt::BufferAddress,
-    pub size: Option<wgt::BufferSize>,
+
+    /// Size of the binding. If `None`, the binding spans from `offset` to the
+    /// end of the buffer.
+    ///
+    /// We use `BufferAddress` to allow a size of zero on this `wgpu_core` type,
+    /// because JavaScript bindings cannot readily express `Option<NonZeroU64>`.
+    /// The `wgpu` API uses `Option<BufferSize>` (i.e. `NonZeroU64`) for this
+    /// field.
+    pub size: Option<wgt::BufferAddress>,
 }
 
 pub type ResolvedBufferBinding = BufferBinding<Arc<Buffer>>;

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2794,7 +2794,19 @@ impl Device {
 
         buffer.check_usage(pub_usage)?;
 
-        let (bb, bind_size) = buffer.binding(bb.offset, bb.size, snatch_guard)?;
+        let req_size = match bb.size.map(wgt::BufferSize::new) {
+            // Requested a non-zero size
+            Some(non_zero @ Some(_)) => non_zero,
+            // Requested size not specified
+            None => None,
+            // Requested zero size
+            Some(None) => {
+                return Err(binding_model::CreateBindGroupError::BindingZeroSize(
+                    buffer.error_ident(),
+                ))
+            }
+        };
+        let (bb, bind_size) = buffer.binding(bb.offset, req_size, snatch_guard)?;
 
         if matches!(binding_ty, wgt::BufferBindingType::Storage { .. })
             && bind_size % u64::from(wgt::STORAGE_BINDING_SIZE_ALIGNMENT) != 0

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1184,7 +1184,7 @@ impl dispatch::DeviceInterface for CoreDevice {
                     arrayed_buffer_bindings.extend(array.iter().map(|binding| bm::BufferBinding {
                         buffer: binding.buffer.inner.as_core().id,
                         offset: binding.offset,
-                        size: binding.size,
+                        size: binding.size.map(wgt::BufferSize::get),
                     }));
                 }
             }
@@ -1204,7 +1204,7 @@ impl dispatch::DeviceInterface for CoreDevice {
                     }) => bm::BindingResource::Buffer(bm::BufferBinding {
                         buffer: buffer.inner.as_core().id,
                         offset,
-                        size,
+                        size: size.map(wgt::BufferSize::get),
                     }),
                     BindingResource::BufferArray(array) => {
                         let slice = &remaining_arrayed_buffer_bindings[..array.len()];


### PR DESCRIPTION
Fixes a CTS failure caused by mapping `Some(0)` to `None` when converting to `Option<NonZeroU64>` for the wgpu-core API. A zero-size binding is illegal. Omitting the size of a binding is valid and means to bind until the end of the buffer. Change the wgpu-core API to allow `Some(0)` and then reject it with an error. wgpu API remains the same.

**Testing**
Enables the relevant CTS test.

**Squash or Rebase?** Squash
