### PR TITLE
[vulkan] Correct alignment if a buffer is an acceleration structure scratch buffer.

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1892,6 +1892,14 @@ impl super::Instance {
             );
         }
 
+        let has_robust_buffer_access2 = phd_features
+            .robustness2
+            .as_ref()
+            .map(|r| r.robust_buffer_access2 == 1)
+            .unwrap_or_default();
+
+        let alignments = phd_capabilities.to_hal_alignments(has_robust_buffer_access2);
+
         let private_caps = super::PrivateCapabilities {
             image_view_usage: phd_capabilities.device_api_version >= vk::API_VERSION_1_1
                 || phd_capabilities.supports_extension(khr::maintenance2::NAME),
@@ -1934,11 +1942,7 @@ impl super::Instance {
                     .image_robustness
                     .is_some_and(|ext| ext.robust_image_access != 0),
             },
-            robust_buffer_access2: phd_features
-                .robustness2
-                .as_ref()
-                .map(|r| r.robust_buffer_access2 == 1)
-                .unwrap_or_default(),
+            robust_buffer_access2: has_robust_buffer_access2,
             robust_image_access2: phd_features
                 .robustness2
                 .as_ref()
@@ -1963,10 +1967,11 @@ impl super::Instance {
                 .multiview
                 .map(|a| a.max_multiview_instance_index)
                 .unwrap_or(0),
+            scratch_buffer_alignment: alignments.ray_tracing_scratch_buffer_alignment,
         };
         let capabilities = crate::Capabilities {
             limits: phd_capabilities.to_wgpu_limits(),
-            alignments: phd_capabilities.to_hal_alignments(private_caps.robust_buffer_access2),
+            alignments,
             downlevel: wgt::DownlevelCapabilities {
                 flags: downlevel_flags,
                 limits: wgt::DownlevelLimits {},

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -879,7 +879,7 @@ impl crate::Device for super::Device {
                 .map_err(super::map_host_device_oom_and_ioca_err)?
         };
 
-        let requirements = unsafe { self.shared.raw.get_buffer_memory_requirements(raw) };
+        let mut requirements = unsafe { self.shared.raw.get_buffer_memory_requirements(raw) };
 
         let is_cpu_read = desc.usage.contains(wgt::BufferUses::MAP_READ);
         let is_cpu_write = desc.usage.contains(wgt::BufferUses::MAP_WRITE);
@@ -899,6 +899,16 @@ impl crate::Device for super::Device {
             })?;
 
         let name = desc.label.unwrap_or("Unlabeled buffer");
+
+        if desc
+            .usage
+            .contains(wgt::BufferUses::ACCELERATION_STRUCTURE_SCRATCH)
+        {
+            // There is no way to specify this usage to Vulkan so we must make sure the alignment requirement is large enough.
+            requirements.alignment = requirements
+                .alignment
+                .max(self.shared.private_caps.scratch_buffer_alignment as u64);
+        }
 
         let allocation = self
             .mem_allocator

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -388,6 +388,12 @@ struct PrivateCapabilities {
     /// if you are drawing more than 128 million instances. We still want to avoid
     /// undefined behavior in this situation, so we panic if the limit is violated.
     multiview_instance_index_limit: u32,
+
+    /// BufferUsages::ACCELERATION_STRUCTURE_SCRATCH allows usage as a scratch buffer.
+    /// Vulkan has no way to specify this as a usage, and it maps to other usages, but
+    /// these usages do not have as high of an alignment requirement using the buffer as
+    ///  a scratch buffer when building acceleration structures.
+    scratch_buffer_alignment: u32,
 }
 
 bitflags::bitflags!(


### PR DESCRIPTION
**Connections**
fixes #8743 

**Description**
Because vulkan has no way to specify a given buffer is going to be a scratch buffer, we must check for the usage and make sure the alignment requirements are high enough.

**Testing**
ray_cube_compute no longer has validation errors when I run it.

**Squash or Rebase?**
squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`.
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. --> N/A, regression between v27 and now
