### PR TITLE
Fix mesh shader validation

### DIFF
--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -1165,7 +1165,7 @@ impl super::Validator {
                     // WorkGroupUniformLoad
                     .contains(TypeFlags::SIZED | TypeFlags::CONSTRUCTIBLE)
                 {
-                    ShaderStages::COMPUTE
+                    ShaderStages::COMPUTE_LIKE
                 } else {
                     return Err(ExpressionError::InvalidWorkGroupUniformLoadResultType(ty));
                 }

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -1014,7 +1014,7 @@ impl super::Validator {
                     stages &= super::ShaderStages::FRAGMENT;
                 }
                 S::ControlBarrier(barrier) | S::MemoryBarrier(barrier) => {
-                    stages &= super::ShaderStages::COMPUTE;
+                    stages &= super::ShaderStages::COMPUTE_LIKE;
                     if barrier.contains(crate::Barrier::SUB_GROUP) {
                         if !self.capabilities.contains(
                             super::Capabilities::SUBGROUP | super::Capabilities::SUBGROUP_BARRIER,
@@ -1443,7 +1443,7 @@ impl super::Validator {
                     }
                 }
                 S::WorkGroupUniformLoad { pointer, result } => {
-                    stages &= super::ShaderStages::COMPUTE;
+                    stages &= super::ShaderStages::COMPUTE_LIKE;
                     let pointer_inner =
                         context.resolve_type_inner(pointer, &self.valid_expression_set)?;
                     match *pointer_inner {

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -297,7 +297,7 @@ bitflags::bitflags! {
         const COMPUTE = 0x4;
         const MESH = 0x8;
         const TASK = 0x10;
-        const COMPUTE_LIKE = 0x4 | 0x8 | 0x10;
+        const COMPUTE_LIKE = Self::COMPUTE.bits() | Self::TASK.bits() | Self::MESH.bits();
     }
 }
 

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -297,6 +297,7 @@ bitflags::bitflags! {
         const COMPUTE = 0x4;
         const MESH = 0x8;
         const TASK = 0x10;
+        const COMPUTE_LIKE = Self::COMPUTE | Self::TASK | Self::MESH;
     }
 }
 
@@ -548,7 +549,7 @@ impl Validator {
                 stages |= ShaderStages::VERTEX;
             }
             if capabilities.contains(Capabilities::SUBGROUP) {
-                stages |= ShaderStages::FRAGMENT | ShaderStages::COMPUTE;
+                stages |= ShaderStages::FRAGMENT | ShaderStages::COMPUTE_LIKE;
             }
             stages
         };

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -297,7 +297,7 @@ bitflags::bitflags! {
         const COMPUTE = 0x4;
         const MESH = 0x8;
         const TASK = 0x10;
-        const COMPUTE_LIKE = Self::COMPUTE | Self::TASK | Self::MESH;
+        const COMPUTE_LIKE = 0x4 | 0x8 | 0x10;
     }
 }
 


### PR DESCRIPTION
**Connections**
#7197 

**Description**
Fixes some validation that only allowed some compute-like functionality in compute shaders, even though it should be allowed in mesh/task shaders.

**Testing**
Nothing

**Squash or Rebase?**
Squash since only commit name is dumb

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
