### PR TITLE
Fix mesh task workgroup limit on nvidia

### DIFF
--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -645,7 +645,7 @@ impl Limits {
             // This is a DirectX limitation
             max_task_mesh_workgroups_per_dimension: 256,
             // Copied from compute limits, this is low enough that it should be sensible.
-            max_task_invocations_per_workgroup: 256,
+            max_task_invocations_per_workgroup: 128,
             max_task_invocations_per_dimension: 64,
 
             // DX12 limitation, revisit for vulkan

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -644,7 +644,7 @@ impl Limits {
             max_task_mesh_workgroup_total_count: 1024,
             // This is a DirectX limitation
             max_task_mesh_workgroups_per_dimension: 256,
-            // Copied from compute limits, this is low enough that it should be sensible.
+            // Nvidia limit on vulkan
             max_task_invocations_per_workgroup: 128,
             max_task_invocations_per_dimension: 64,
 


### PR DESCRIPTION
**Connections**
#7197 

**Description**
Default limit was 256 which was higher than nvidia's limit of 128.

**Testing**
On my system

**Squash or Rebase?**
Dumb commit name so squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
