### PR TITLE
fix(core): s/COPY_SRC/COPY_DST/ for first transition in external texture init.

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -567,7 +567,7 @@ impl Device {
                     buffer: params_buffer,
                     usage: hal::StateTransition {
                         from: wgt::BufferUses::MAP_WRITE,
-                        to: wgt::BufferUses::COPY_SRC,
+                        to: wgt::BufferUses::COPY_DST,
                     },
                 }]);
             pending_writes.command_encoder.copy_buffer_to_buffer(


### PR DESCRIPTION
**Description**

External texture init.'s transitions were only supposed to move from `MAP_WRITE` to `COPY_DST`. Using `COPY_SRC` is wrong, since the buffer isn't copied from during this part of the init. process, but copied _to_.

**Testing**

This wasn't covered before, and it's not covered now. However, I did validate that this solves an `ERROR` emitted by the D3D12 debug layer in <https://github.com/Visionary-Laboratory/visionary/issues/1>.

**Squash or Rebase?**

sqoosh