### PR TITLE
fix(core): set is_open only after begin_encoding succeeds

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -677,10 +677,10 @@ impl InnerCommandEncoder {
     /// In both cases, returns a reference to the raw encoder.
     fn open_if_closed(&mut self) -> Result<&mut dyn hal::DynCommandEncoder, DeviceError> {
         if !self.is_open {
-            self.is_open = true;
             let hal_label = hal_label(Some(self.label.as_str()), self.device.instance_flags);
             unsafe { self.raw.begin_encoding(hal_label) }
                 .map_err(|e| self.device.handle_hal_error(e))?;
+            self.is_open = true;
         }
 
         Ok(self.raw.as_mut())
@@ -691,10 +691,10 @@ impl InnerCommandEncoder {
     /// The underlying hal encoder is put in the "recording" state.
     pub(crate) fn open(&mut self) -> Result<&mut dyn hal::DynCommandEncoder, DeviceError> {
         if !self.is_open {
-            self.is_open = true;
             let hal_label = hal_label(Some(self.label.as_str()), self.device.instance_flags);
             unsafe { self.raw.begin_encoding(hal_label) }
                 .map_err(|e| self.device.handle_hal_error(e))?;
+            self.is_open = true;
         }
 
         Ok(self.raw.as_mut())
@@ -713,11 +713,11 @@ impl InnerCommandEncoder {
         label: Option<&str>,
     ) -> Result<&mut dyn hal::DynCommandEncoder, DeviceError> {
         assert!(!self.is_open);
-        self.is_open = true;
 
         let hal_label = hal_label(label, self.device.instance_flags);
         unsafe { self.raw.begin_encoding(hal_label) }
             .map_err(|e| self.device.handle_hal_error(e))?;
+        self.is_open = true;
 
         Ok(self.raw.as_mut())
     }


### PR DESCRIPTION
**Connections**
I believe this should fix #7897 

**Description**
I believe what is happening is roughly this:

1. end_encoding sets self.active = null
2. One of the open functions runs : is_open = true, then begin_encoding is called and fails (e.g., OOM)
3. self.active is still null on Vulkan from step 1 (never got updated) 
4. Drop impl sees is_open = true → calls discard_encoding()
5. Panic: assert_ne!(self.active, vk::CommandBuffer::null()) https://github.com/gfx-rs/wgpu/blob/b9324e9da95657ddd9eecef43d05bf234e39ef9b/wgpu-hal/src/vulkan/command.rs#L165-L173

With my fix, is_open will be set to false when begin_encoding returns an error, thus preventing the Drop impl calling discard_encoding and preventing the panic.

**Testing**
This is hard to test because replicating the begin_encoding error is not trivial. But I believe the current code to be logically incorrect.

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown` (not applicable)
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. (not applicable) -->
