### PR TITLE
Alphabetize test.lst; add fail.lst and skip.lst

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -8,13 +8,16 @@
 // Many populated by Claude and may be wrong.
 //
 // Linked issues may not cover all failures in the suite.
+//
+// The `cts_runner` integration test `lst_files_are_sorted` verifies that test selectors
+// appear in this file in order -- including ones in comments.
 webgpu:api,validation,buffer,mapping:*, // crash
 webgpu:api,validation,capability_checks,features,* // 21%
 webgpu:api,validation,capability_checks,limits,* // 60%
 webgpu:api,validation,compute_pipeline:limits,workgroup_storage_size:* // 0%
 webgpu:api,validation,compute_pipeline:overrides,identifier:* // 46%
-webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:* // 0%
 webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits,workgroup_storage_size:* // 0%
+webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:* // 0%
 webgpu:api,validation,compute_pipeline:resource_compatibility:* // 84%
 webgpu:api,validation,compute_pipeline:storage_texture,format:* // 8%
 webgpu:api,validation,createBindGroup:buffer,resource_binding_size:* // 33%
@@ -23,9 +26,9 @@ webgpu:api,validation,createBindGroup:external_texture,* // 0%
 webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:* // 0%
 webgpu:api,validation,createBindGroupLayout:storage_texture,formats:* // 12%
-webgpu:api,validation,createBindGroupLayout:visibility:* // 25%
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_buffer_type:* // 25%
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_storage_texture_access:* // 25%
+webgpu:api,validation,createBindGroupLayout:visibility:* // 25%
 webgpu:api,validation,createPipelineLayout:* // 33%, https://github.com/gfx-rs/wgpu/issues/4738, and at least 1 more issue
 webgpu:api,validation,createView:texture_state:* // 0%
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:* // ***, https://github.com/gfx-rs/wgpu/issues/8118
@@ -59,12 +62,12 @@ webgpu:api,validation,queue,writeBuffer:ranges:* // 0%
 webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,depth_clear_value:* // 94%
 webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadOnly:* // 33%
 webgpu:api,validation,render_pass,render_pass_descriptor:occlusionQuerySet,query_set_type:* // 50%
-webgpu:api,validation,render_pipeline,depth_stencil_state:depthCompare_optional:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:depth_write,frag_depth:* // 86%
+webgpu:api,validation,render_pipeline,depth_stencil_state:depthCompare_optional:*
 webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,color_target_count:* // weird assert in test?
 webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,use_blend_src:* // 62%
-webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets:* // 3%
 webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets,blend:* // 95%
+webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets:* // 3%
 webgpu:api,validation,render_pipeline,fragment_state:targets_blend:* // 0%
 webgpu:api,validation,render_pipeline,fragment_state:targets_write_mask:* // 50%
 webgpu:api,validation,render_pipeline,inter_stage:* // 63%
@@ -191,8 +194,8 @@ webgpu:shader,validation,parse,shadow_builtins:* // 60%
 webgpu:shader,validation,shader_io,align:* // 98%
 webgpu:shader,validation,shader_io,binding:* // 95%
 webgpu:shader,validation,shader_io,builtins:* // 50%
-webgpu:shader,validation,shader_io,group:* // 95%
 webgpu:shader,validation,shader_io,group_and_binding:* // 87%
+webgpu:shader,validation,shader_io,group:* // 95%
 webgpu:shader,validation,shader_io,id:* // 94%
 webgpu:shader,validation,shader_io,interpolate:* // 91%
 webgpu:shader,validation,shader_io,layout_constraints:* // 99%

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -1,0 +1,211 @@
+// CTS test selectors that are not expected to pass.
+//
+// At present this only includes tests in the `api,validation` and
+// `shader,validation` hierarchies.
+//
+// Percentages in comments are the portion of tests that are passing. Some
+// failures that are intermittent or platform-dependent are marked with `***`.
+// Many populated by Claude and may be wrong.
+//
+// Linked issues may not cover all failures in the suite.
+webgpu:api,validation,buffer,mapping:*, // crash
+webgpu:api,validation,capability_checks,features,* // 21%
+webgpu:api,validation,capability_checks,limits,* // 60%
+webgpu:api,validation,compute_pipeline:limits,workgroup_storage_size:* // 0%
+webgpu:api,validation,compute_pipeline:overrides,identifier:* // 46%
+webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:* // 0%
+webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits,workgroup_storage_size:* // 0%
+webgpu:api,validation,compute_pipeline:resource_compatibility:* // 84%
+webgpu:api,validation,compute_pipeline:storage_texture,format:* // 8%
+webgpu:api,validation,createBindGroup:buffer,resource_binding_size:* // 33%
+webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%
+webgpu:api,validation,createBindGroup:external_texture,* // 0%
+webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https://github.com/gfx-rs/wgpu/issues/7881
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:* // 0%
+webgpu:api,validation,createBindGroupLayout:storage_texture,formats:* // 12%
+webgpu:api,validation,createBindGroupLayout:visibility:* // 25%
+webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_buffer_type:* // 25%
+webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_storage_texture_access:* // 25%
+webgpu:api,validation,createPipelineLayout:* // 33%, https://github.com/gfx-rs/wgpu/issues/4738, and at least 1 more issue
+webgpu:api,validation,createView:texture_state:* // 0%
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:* // ***, https://github.com/gfx-rs/wgpu/issues/8118
+webgpu:api,validation,encoding,cmds,debug:* // 92%, https://github.com/gfx-rs/wgpu/issues/8039
+webgpu:api,validation,encoding,cmds,render,* // https://github.com/gfx-rs/wgpu/issues/7912
+webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="compute%20pass";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
+webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20bundle";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
+webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20pass";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
+webgpu:api,validation,encoding,createRenderBundleEncoder:* // 26%
+webgpu:api,validation,encoding,encoder_open_state:* // https://github.com/gfx-rs/wgpu/issues/7857
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_binding_mismatch:* // 60%
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_resource_type_mismatch:* // 60%
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_visibility_mismatch:* // 60%
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bind_groups_and_pipeline_layout_mismatch:* // 60%
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:default_bind_group_layouts_never_match,compute_pass:* // 75%
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:default_bind_group_layouts_never_match,render_pass:* // 75%
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:* // 17%
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:* // 17%
+webgpu:api,validation,encoding,queries,resolveQuerySet:* // 93%
+webgpu:api,validation,encoding,render_bundle:* // 81%
+webgpu:api,validation,error_scope:*
+webgpu:api,validation,getBindGroupLayout:* // 29%
+webgpu:api,validation,image_copy,buffer_texture_copies:* // https://github.com/gfx-rs/wgpu/issues/7946
+webgpu:api,validation,image_copy,layout_related:offset_alignment:* // fails on DX12 in CI
+webgpu:api,validation,layout_shader_compat:pipeline_layout_shader_exact_match:* // 99%
+webgpu:api,validation,non_filterable_texture:non_filterable_texture_with_filtering_sampler:* // 80%
+webgpu:api,validation,query_set,create:count:* // 0%
+webgpu:api,validation,queue,buffer_mapped:* // ***, vulkan
+webgpu:api,validation,queue,destroyed,* // 71%
+webgpu:api,validation,queue,writeBuffer:ranges:* // 0%
+webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,depth_clear_value:* // 94%
+webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadOnly:* // 33%
+webgpu:api,validation,render_pass,render_pass_descriptor:occlusionQuerySet,query_set_type:* // 50%
+webgpu:api,validation,render_pipeline,depth_stencil_state:depthCompare_optional:*
+webgpu:api,validation,render_pipeline,depth_stencil_state:depth_write,frag_depth:* // 86%
+webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,color_target_count:* // weird assert in test?
+webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,use_blend_src:* // 62%
+webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets:* // 3%
+webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets,blend:* // 95%
+webgpu:api,validation,render_pipeline,fragment_state:targets_blend:* // 0%
+webgpu:api,validation,render_pipeline,fragment_state:targets_write_mask:* // 50%
+webgpu:api,validation,render_pipeline,inter_stage:* // 63%
+webgpu:api,validation,render_pipeline,misc:external_texture:* // 0%
+webgpu:api,validation,render_pipeline,misc:storage_texture,format:* // 8%
+webgpu:api,validation,render_pipeline,multisample_state:* // 60%, https://github.com/gfx-rs/wgpu/issues/8779
+webgpu:api,validation,render_pipeline,overrides:* // 83%
+webgpu:api,validation,render_pipeline,resource_compatibility:* // 90%
+webgpu:api,validation,render_pipeline,vertex_state:max_vertex_attribute_limit:* // 0%
+webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_limit:* // 0%
+webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_color:* // 92%, https://github.com/gfx-rs/wgpu/issues/3126
+webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_attachment_and_bind_group:* // 69%, https://github.com/gfx-rs/wgpu/issues/8705
+webgpu:api,validation,state,device_lost,destroy:* // crash
+webgpu:api,validation,texture,destroy:submit_a_destroyed_texture_as_attachment:* // 44%, https://github.com/gfx-rs/wgpu/issues/8714
+
+webgpu:shader,validation,const_assert,const_assert:constant_expression_logical_and_no_assert:* // 50%
+webgpu:shader,validation,const_assert,const_assert:constant_expression_logical_or_no_assert:* // 50%
+webgpu:shader,validation,decl,context_dependent_resolution:* // 92%
+webgpu:shader,validation,decl,override:* // 93%
+webgpu:shader,validation,decl,var:* // 97%
+webgpu:shader,validation,expression,access,array:* // 92%
+webgpu:shader,validation,expression,access,matrix:* // 90%
+webgpu:shader,validation,expression,access,vector:* // 52%
+webgpu:shader,validation,expression,binary,add_sub_mul:* // 95%
+webgpu:shader,validation,expression,binary,and_or_xor:* // 96%
+webgpu:shader,validation,expression,binary,bitwise_shift:* // 97%
+webgpu:shader,validation,expression,binary,comparison:* // 74%
+webgpu:shader,validation,expression,binary,div_rem:* // 86%
+webgpu:shader,validation,expression,binary,short_circuiting_and_or:* // 92%, https://github.com/gfx-rs/wgpu/issues/8440
+webgpu:shader,validation,expression,call,builtin,abs:* // 98%
+webgpu:shader,validation,expression,call,builtin,acos:* // 71%
+webgpu:shader,validation,expression,call,builtin,acosh:* // 56%
+webgpu:shader,validation,expression,call,builtin,asin:* // 71%
+webgpu:shader,validation,expression,call,builtin,asinh:* // 85%
+webgpu:shader,validation,expression,call,builtin,atanh:* // 72%
+webgpu:shader,validation,expression,call,builtin,atomics:* // 86%
+webgpu:shader,validation,expression,call,builtin,bitcast:* // 57%
+webgpu:shader,validation,expression,call,builtin,clamp:* // 71%
+webgpu:shader,validation,expression,call,builtin,cosh:* // 61%
+webgpu:shader,validation,expression,call,builtin,countLeadingZeros:* // 98%
+webgpu:shader,validation,expression,call,builtin,countOneBits:* // 98%
+webgpu:shader,validation,expression,call,builtin,countTrailingZeros:* // 98%
+webgpu:shader,validation,expression,call,builtin,cross:* // 86%
+webgpu:shader,validation,expression,call,builtin,degrees:* // 73%
+webgpu:shader,validation,expression,call,builtin,derivatives:* // 83%
+webgpu:shader,validation,expression,call,builtin,determinant:* // 71%
+webgpu:shader,validation,expression,call,builtin,distance:* // 66%
+webgpu:shader,validation,expression,call,builtin,dot:* // 79%
+webgpu:shader,validation,expression,call,builtin,dot4I8Packed:* // 0%
+webgpu:shader,validation,expression,call,builtin,dot4U8Packed:* // 0%
+webgpu:shader,validation,expression,call,builtin,exp:* // 61%
+webgpu:shader,validation,expression,call,builtin,exp2:* // 80%
+webgpu:shader,validation,expression,call,builtin,extractBits:* // 55%
+webgpu:shader,validation,expression,call,builtin,faceForward:* // 68%
+webgpu:shader,validation,expression,call,builtin,firstLeadingBit:* // 98%
+webgpu:shader,validation,expression,call,builtin,firstTrailingBit:* // 98%
+webgpu:shader,validation,expression,call,builtin,fma:* // 85%
+webgpu:shader,validation,expression,call,builtin,frexp:* // 39%
+webgpu:shader,validation,expression,call,builtin,insertBits:* // 73%
+webgpu:shader,validation,expression,call,builtin,inverseSqrt:* // 61%
+webgpu:shader,validation,expression,call,builtin,ldexp:* // 43%
+webgpu:shader,validation,expression,call,builtin,length:* // 74%
+webgpu:shader,validation,expression,call,builtin,log:* // 64%
+webgpu:shader,validation,expression,call,builtin,log2:* // 64%
+webgpu:shader,validation,expression,call,builtin,mix:* // 66%
+webgpu:shader,validation,expression,call,builtin,modf:* // 52%
+webgpu:shader,validation,expression,call,builtin,normalize:* // 63%
+webgpu:shader,validation,expression,call,builtin,pack2x16float:* // 80%
+webgpu:shader,validation,expression,call,builtin,pack2x16snorm:* // 88%
+webgpu:shader,validation,expression,call,builtin,pack2x16unorm:* // 88%
+webgpu:shader,validation,expression,call,builtin,pack4x8snorm:* // 88%
+webgpu:shader,validation,expression,call,builtin,pack4x8unorm:* // 88%
+webgpu:shader,validation,expression,call,builtin,pack4xI8:* // 21%
+webgpu:shader,validation,expression,call,builtin,pack4xI8Clamp:* // 21%
+webgpu:shader,validation,expression,call,builtin,pack4xU8:* // 21%
+webgpu:shader,validation,expression,call,builtin,pack4xU8Clamp:* // 21%
+webgpu:shader,validation,expression,call,builtin,pow:* // 63%
+webgpu:shader,validation,expression,call,builtin,quantizeToF16:* // 61%
+webgpu:shader,validation,expression,call,builtin,reflect:* // 39%
+webgpu:shader,validation,expression,call,builtin,refract:* // 73%
+webgpu:shader,validation,expression,call,builtin,reverseBits:* // 98%
+webgpu:shader,validation,expression,call,builtin,select:* // 75%, https://github.com/gfx-rs/wgpu/issues/4507, https://github.com/gfx-rs/wgpu/issues/5262
+webgpu:shader,validation,expression,call,builtin,sinh:* // 61%
+webgpu:shader,validation,expression,call,builtin,smoothstep:* // 51%
+webgpu:shader,validation,expression,call,builtin,sqrt:* // 64%
+webgpu:shader,validation,expression,call,builtin,textureDimensions:* // 100%
+webgpu:shader,validation,expression,call,builtin,textureGather:* // 99%
+webgpu:shader,validation,expression,call,builtin,textureGatherCompare:* // 99%
+webgpu:shader,validation,expression,call,builtin,textureLoad:* // 85%
+webgpu:shader,validation,expression,call,builtin,textureSample:* // 99%
+webgpu:shader,validation,expression,call,builtin,textureSampleBaseClampToEdge:* // 96%
+webgpu:shader,validation,expression,call,builtin,textureSampleBias:* // 99%
+webgpu:shader,validation,expression,call,builtin,textureSampleCompare:* // 99%
+webgpu:shader,validation,expression,call,builtin,textureSampleCompareLevel:* // 99%
+webgpu:shader,validation,expression,call,builtin,textureSampleGrad:* // 99%
+webgpu:shader,validation,expression,call,builtin,textureSampleLevel:* // 99%
+webgpu:shader,validation,expression,call,builtin,transpose:* // 86%
+webgpu:shader,validation,expression,call,builtin,unpack2x16float:* // 81%
+webgpu:shader,validation,expression,call,builtin,unpack2x16snorm:* // 81%
+webgpu:shader,validation,expression,call,builtin,unpack2x16unorm:* // 81%
+webgpu:shader,validation,expression,call,builtin,unpack4x8snorm:* // 81%
+webgpu:shader,validation,expression,call,builtin,unpack4x8unorm:* // 81%
+webgpu:shader,validation,expression,call,builtin,unpack4xI8:* // 75%
+webgpu:shader,validation,expression,call,builtin,unpack4xU8:* // 75%
+webgpu:shader,validation,expression,call,builtin,value_constructor:* // 92%
+webgpu:shader,validation,expression,early_evaluation:* // 67%
+webgpu:shader,validation,expression,matrix,* // 83%
+webgpu:shader,validation,expression,precedence:* // 76%, https://github.com/gfx-rs/wgpu/issues/4536
+webgpu:shader,validation,expression,unary,* // 74%
+webgpu:shader,validation,extension,dual_source_blending:blend_src_usage:* // 61%
+webgpu:shader,validation,extension,pointer_composite_access:* // 50%
+webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:* // 0%
+webgpu:shader,validation,functions,alias_analysis:* // 2%
+webgpu:shader,validation,functions,restrictions:* // 81%
+webgpu:shader,validation,parse,attribute:* // 93%
+webgpu:shader,validation,parse,blankspace:* // 95%
+webgpu:shader,validation,parse,comments:* // 93%
+webgpu:shader,validation,parse,diagnostic:* // 50%
+webgpu:shader,validation,parse,identifiers:* // 81%
+webgpu:shader,validation,parse,literal:* // 96%
+webgpu:shader,validation,parse,must_use:* // 97%
+webgpu:shader,validation,parse,requires:* // 14%
+webgpu:shader,validation,parse,shadow_builtins:* // 60%
+webgpu:shader,validation,shader_io,align:* // 98%
+webgpu:shader,validation,shader_io,binding:* // 95%
+webgpu:shader,validation,shader_io,builtins:* // 50%
+webgpu:shader,validation,shader_io,group:* // 95%
+webgpu:shader,validation,shader_io,group_and_binding:* // 87%
+webgpu:shader,validation,shader_io,id:* // 94%
+webgpu:shader,validation,shader_io,interpolate:* // 91%
+webgpu:shader,validation,shader_io,layout_constraints:* // 99%
+webgpu:shader,validation,shader_io,locations:* // 98%
+webgpu:shader,validation,shader_io,pipeline_stage:* // 92%
+webgpu:shader,validation,shader_io,size:* // 92%
+webgpu:shader,validation,shader_io,workgroup_size:* // 83%
+webgpu:shader,validation,statement,continue:* // 90%
+webgpu:shader,validation,statement,for:* // 93%
+webgpu:shader,validation,statement,increment_decrement:* // 97%
+webgpu:shader,validation,statement,loop:* // 92%
+webgpu:shader,validation,statement,phony:* // 90%
+webgpu:shader,validation,statement,statement_behavior:* // https://github.com/gfx-rs/wgpu/issues/7733
+webgpu:shader,validation,statement,switch:* // 99%
+webgpu:shader,validation,types,* // 86%
+webgpu:shader,validation,uniformity,* // 21%

--- a/cts_runner/skip.lst
+++ b/cts_runner/skip.lst
@@ -1,0 +1,17 @@
+// CTS test selectors that are entirely or nearly entirely skipped.
+webgpu:api,validation,encoding,queries,begin_end:nesting:*
+webgpu:api,validation,gpu_external_texture_expiration:*
+webgpu:api,validation,queue,copyToTexture,CopyExternalImageToTexture:*
+
+webgpu:shader,validation,expression,call,builtin,quadBroadcast:* // https://github.com/gfx-rs/wgpu/issues/8722
+webgpu:shader,validation,expression,call,builtin,quadSwap:* // ibid.
+webgpu:shader,validation,expression,call,builtin,subgroupAdd:* // ibid.
+webgpu:shader,validation,expression,call,builtin,subgroupAnyAll:* // ibid.
+webgpu:shader,validation,expression,call,builtin,subgroupBallot:* // ibid.
+webgpu:shader,validation,expression,call,builtin,subgroupBitwise:* // ibid.
+webgpu:shader,validation,expression,call,builtin,subgroupBroadcast:* // ibid.
+webgpu:shader,validation,expression,call,builtin,subgroupBroadcastFirst:* // ibid.
+webgpu:shader,validation,expression,call,builtin,subgroupElect:* // ibid.
+webgpu:shader,validation,expression,call,builtin,subgroupMinMax:* // ibid.
+webgpu:shader,validation,expression,call,builtin,subgroupMul:* // ibid.
+webgpu:shader,validation,expression,call,builtin,subgroupShuffle:* // ibid.

--- a/cts_runner/skip.lst
+++ b/cts_runner/skip.lst
@@ -1,4 +1,7 @@
 // CTS test selectors that are entirely or nearly entirely skipped.
+//
+// The `cts_runner` integration test `lst_files_are_sorted` verifies that test selectors
+// appear in this file in order -- including ones in comments.
 webgpu:api,validation,encoding,queries,begin_end:nesting:*
 webgpu:api,validation,gpu_external_texture_expiration:*
 webgpu:api,validation,queue,copyToTexture,CopyExternalImageToTexture:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -2,14 +2,18 @@
 // ```
 // cargo xtask cts -- --list <selector>
 // ```
+//
+// The `cts_runner` integration test `lst_files_are_sorted` verifies that test selectors
+// appear in this file in order -- including ones in comments.
+
 unittests:*
 
 webgpu:api,operation,buffers,createBindGroup:buffer_binding_resource:*
 webgpu:api,operation,command_buffer,basic:*
 webgpu:api,operation,command_buffer,copyBufferToBuffer:*
+fails-if(vulkan) webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="depth16unorm"
 fails-if(vulkan) webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="depth24plus"
 fails-if(vulkan) webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="depth24plus-stencil8"
-fails-if(vulkan) webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="depth16unorm"
 fails-if(vulkan) webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="depth32float"
 fails-if(vulkan) webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="depth32float-stencil8"
 webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="stencil8"
@@ -51,39 +55,36 @@ webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribu
 webgpu:api,validation,buffer,create:*
 webgpu:api,validation,buffer,destroy:*
 fails-if(dx12) webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
-// NOTE: Only test some of these `maxInterStageShaderVariables` cases, because of a CTS bug (see
-// below). CTS (incorrectly) only deducts once for any set of them being enabled, but it should
-// deduct for _each_ built-in.
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
+// NOTE: Only test some of these `maxInterStageShaderVariables` cases, because of
+// https://github.com/gpuweb/cts/issues/4538. The CTS (incorrectly) only deducts once for
+// any set of them being enabled, but it should deduct for _each_ built-in.
 //FAIL: webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:*
-// https://github.com/gpuweb/cts/issues/4538
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 webgpu:api,validation,createBindGroup:binding_must_contain_resource_defined_in_layout:*
 webgpu:api,validation,createBindGroup:buffer_offset_and_size_for_bind_groups_match:*
 webgpu:api,validation,createBindGroup:buffer,effective_buffer_binding_size:*
 webgpu:api,validation,createBindGroup:buffer,resource_binding_size:*
 webgpu:api,validation,createBindGroup:storage_texture,*
 webgpu:api,validation,createBindGroupLayout:storage_texture,formats:*
-// Fails because we coerce a size of 0 in `GPUDevice.createBindGroup(…)` to `buffer.size - offset`.
-// FAIL webgpu:api,validation,createBindGroup:buffer_offset_and_size_for_bind_groups_match:*
 webgpu:api,validation,encoding,beginComputePass:*
 webgpu:api,validation,encoding,beginRenderPass:*
 webgpu:api,validation,encoding,cmds,clearBuffer:*
@@ -138,45 +139,45 @@ webgpu:api,validation,encoding,queries,begin_end:occlusion_query,*
 webgpu:api,validation,encoding,queries,general:occlusion_query,query_index:*
 webgpu:api,validation,encoding,queries,general:occlusion_query,query_type:*
 webgpu:api,validation,image_copy,buffer_related:*
-webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
-webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 // image_copy depth/stencil failures on dx12: https://github.com/gfx-rs/wgpu/issues/8133
-fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyB2T"
-fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyT2B"
-fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth32float";aspect="depth-only";copyType="CopyT2B"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyB2T"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyT2B"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth32float";aspect="depth-only";copyType="CopyT2B"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyB2T"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyT2B"
 //mix of PASS and FAIL: other subtests of copy_buffer_offset. Related bugs:
 // https://github.com/gfx-rs/wgpu/issues/7946
+webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
+webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 webgpu:api,validation,image_copy,buffer_texture_copies:device_mismatch:*
-webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*
-webgpu:api,validation,image_copy,buffer_texture_copies:texture_buffer_usages:*
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="2d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="3d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="2d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="3d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="bgra8unorm";copyType="CopyB2T";dimension="2d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="bgra8unorm";copyType="CopyT2B";dimension="2d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="r8uint";copyType="CopyB2T";dimension="1d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="r8uint";copyType="CopyT2B";dimension="1d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba32float";copyType="CopyB2T";dimension="1d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba32float";copyType="CopyT2B";dimension="1d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="2d"
-fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="2d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="3d"
+fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="2d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="3d"
-fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="bgra8unorm";copyType="CopyB2T";dimension="2d"
-fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="bgra8unorm";copyType="CopyT2B";dimension="2d"
-fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="2d"
-fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="2d"
-fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyT2B";dimension="3d"
-fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="astc-4x4-unorm";copyType="CopyB2T";dimension="3d"
 //mix of PASS and FAIL: other subtests of offset_and_bytesPerRow. Related bugs:
 // https://github.com/gfx-rs/wgpu/issues/7946
+webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*
+webgpu:api,validation,image_copy,buffer_texture_copies:texture_buffer_usages:*
 webgpu:api,validation,image_copy,layout_related:copy_end_overflows_u64:*
 // Fails with OOM in CI.
 fails-if(dx12) webgpu:api,validation,image_copy,layout_related:offset_alignment:*
 webgpu:api,validation,image_copy,texture_related:*
-// `vulkan` failure: https://github.com/gfx-rs/wgpu/issues/????
-fails-if(vulkan) webgpu:api,validation,queue,buffer_mapped:writeBuffer:*
 webgpu:api,validation,queue,buffer_mapped:copyBufferToBuffer:*
 webgpu:api,validation,queue,buffer_mapped:copyBufferToTexture:*
 webgpu:api,validation,queue,buffer_mapped:copyTextureToBuffer:*
 webgpu:api,validation,queue,buffer_mapped:map_command_recording_order:*
+// `vulkan` failure: https://github.com/gfx-rs/wgpu/issues/????
+fails-if(vulkan) webgpu:api,validation,queue,buffer_mapped:writeBuffer:*
 webgpu:api,validation,queue,submit:command_buffer,*
 webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,*
@@ -187,16 +188,16 @@ webgpu:api,validation,render_pipeline,depth_stencil_state:stencil_write:*
 webgpu:api,validation,render_pipeline,inter_stage:max_shader_variable_location:isAsync=false;*
 //FAIL: webgpu:api,validation,render_pipeline,inter_stage:max_shader_variable_location:isAsync=true;*
 // https://github.com/gfx-rs/wgpu/pull/8712
+//FAIL: webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=false;numVariablesDelta=-1;useExtraBuiltinInputs=true
+// https://github.com/gpuweb/cts/pull/4546
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=false;numVariablesDelta=0;useExtraBuiltinInputs=false
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=false;numVariablesDelta=0;useExtraBuiltinInputs=true
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=false;numVariablesDelta=1;useExtraBuiltinInputs=false
-//FAIL: webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=false;numVariablesDelta=-1;useExtraBuiltinInputs=true
+//FAIL: webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=true;numVariablesDelta=-1;useExtraBuiltinInputs=true
 // https://github.com/gpuweb/cts/pull/4546
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=true;numVariablesDelta=0;useExtraBuiltinInputs=false
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=true;numVariablesDelta=0;useExtraBuiltinInputs=true
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=true;numVariablesDelta=1;useExtraBuiltinInputs=false
-//FAIL: webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=true;numVariablesDelta=-1;useExtraBuiltinInputs=true
-// https://github.com/gpuweb/cts/pull/4546
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,output:*
 webgpu:api,validation,render_pipeline,vertex_state:many_attributes_overlapping:*
 webgpu:api,validation,resource_usages,buffer,in_pass_encoder:*
@@ -224,27 +225,27 @@ webgpu:shader,execution,expression,call,builtin,textureSampleBaseClampToEdge:2d_
 // NOTE: This is supposed to be an exhaustive listing underneath
 // `webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:*`, so exceptions can be
 // worked around.
-webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="atomic%3Cu32%3E";*
+webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="array%3Cu32,%204%3E";*
 webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="atomic%3Ci32%3E";*
+webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="atomic%3Cu32%3E";*
 webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="AtomicInStruct";*
 webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="bool";*
-webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="u32";*
-webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="vec4u";*
-webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="mat3x2f";*
-webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="array%3Cu32,%204%3E";*
-webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="SimpleStruct";*
 //FAIL: https://github.com/gfx-rs/wgpu/issues/8812
 // webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="ComplexStruct";*
+webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="mat3x2f";*
+webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="SimpleStruct";*
+webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="u32";*
+webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="vec4u";*
 webgpu:shader,execution,flow_control,return:*
 // Many other vertex_buffer_access subtests also passing, but there are too many to enumerate.
 // Fails on Metal in CI only, not when running locally.
 fails-if(metal) webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true
 
 webgpu:shader,validation,const_assert,const_assert:*
-webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_zero_unsigned"
-webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_zero_signed"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_neg"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_one"
+webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_zero_signed"
+webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_zero_unsigned"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_in_bounds"
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:array_override:op="%26%26";a_val=1;b_val=1
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types:*
@@ -254,20 +255,20 @@ webgpu:shader,validation,expression,call,builtin,max:values:*
 // FAIL: others in `value_constructor` due to https://github.com/gfx-rs/wgpu/issues/4720, possibly more
 webgpu:shader,validation,expression,call,builtin,value_constructor:array_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:matrix_zero_value:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_zero_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_value:*
+webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_zero_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:struct_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:vector_splat:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:vector_zero_value:*
 // NOTE: This is supposed to be an exhaustive listing underneath
 // `webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:*`, so exceptions can be
 // worked around.
-webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:only_in_compute:*
-webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:no_atomics:*
-webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:param_constructible_only:*
-webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:must_use:use=true
 //FAIL: https://github.com/gfx-rs/wgpu/pull/8713
 // webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:must_use:use=false
+webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:must_use:use=true
+webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:no_atomics:*
+webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:only_in_compute:*
+webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:param_constructible_only:*
 webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break_if"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break"

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -3,6 +3,7 @@
 // cargo xtask cts -- --list <selector>
 // ```
 unittests:*
+
 webgpu:api,operation,buffers,createBindGroup:buffer_binding_resource:*
 webgpu:api,operation,command_buffer,basic:*
 webgpu:api,operation,command_buffer,copyBufferToBuffer:*
@@ -14,22 +15,39 @@ fails-if(vulkan) webgpu:api,operation,command_buffer,copyTextureToTexture:copy_d
 webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="stencil8"
 // Fails with OOM in CI.
 fails-if(dx12) webgpu:api,operation,command_buffer,image_copy:offsets_and_sizes:*
+webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="CopyB2T";checkMethod="FullCopyT2B";dimension="1d"
+webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="CopyB2T";checkMethod="FullCopyT2B";dimension="2d"
+fails-if(dx12,vulkan,metal) webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="CopyB2T";checkMethod="FullCopyT2B";dimension="3d"
 webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="WriteTexture";checkMethod="FullCopyT2B";dimension="1d"
 webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="WriteTexture";checkMethod="FullCopyT2B";dimension="2d"
 webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="WriteTexture";checkMethod="FullCopyT2B";dimension="3d"
 webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="WriteTexture";checkMethod="PartialCopyT2B";dimension="1d"
 fails-if(dx12) webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="WriteTexture";checkMethod="PartialCopyT2B";dimension="2d"
 webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="WriteTexture";checkMethod="PartialCopyT2B";dimension="3d"
-webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="CopyB2T";checkMethod="FullCopyT2B";dimension="1d"
-webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="CopyB2T";checkMethod="FullCopyT2B";dimension="2d"
-fails-if(dx12,vulkan,metal) webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="CopyB2T";checkMethod="FullCopyT2B";dimension="3d"
-webgpu:api,operation,compute,basic:memcpy:*
-//FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute_pipeline,overrides:*
+//FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
+webgpu:api,operation,compute,basic:memcpy:*
 webgpu:api,operation,device,lost:*
 webgpu:api,operation,render_pass,storeOp:*
+webgpu:api,operation,render_pipeline,overrides:*
+webgpu:api,operation,rendering,3d_texture_slices:*
+webgpu:api,operation,rendering,basic:clear:*
+webgpu:api,operation,rendering,basic:fullscreen_quad:*
+//FAIL: webgpu:api,operation,rendering,basic:large_draw:*
+webgpu:api,operation,rendering,color_target_state:blend_constant,setting:*
+webgpu:api,operation,rendering,color_target_state:blending,formats:*
+webgpu:api,operation,rendering,color_target_state:blending,GPUBlendComponent:*
+webgpu:api,operation,rendering,depth:*
+webgpu:api,operation,rendering,draw:*
+webgpu:api,operation,shader_module,compilation_info:*
+// Likely due to https://github.com/gfx-rs/wgpu/issues/7357.
+fails-if(metal) webgpu:api,operation,uncapturederror:iff_uncaptured:*
+//FAIL: webgpu:api,operation,uncapturederror:onuncapturederror_order_wrt_addEventListener
+// There are also two unimplemented SKIPs in uncapturederror not enumerated here.
 fails-if(vulkan) webgpu:api,operation,vertex_state,correctness:array_stride_zero:*
+webgpu:api,operation,vertex_state,correctness:non_zero_array_stride_and_attribute_offset:*
 webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribute_offset:*
+
 webgpu:api,validation,buffer,create:*
 webgpu:api,validation,buffer,destroy:*
 fails-if(dx12) webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
@@ -71,24 +89,24 @@ webgpu:api,validation,encoding,beginRenderPass:*
 webgpu:api,validation,encoding,cmds,clearBuffer:*
 webgpu:api,validation,encoding,cmds,compute_pass:*
 webgpu:api,validation,encoding,cmds,copyBufferToBuffer:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_with_invalid_or_destroyed_texture:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture,device_mismatch:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:mipmap_level:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_usage:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:sample_count:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:multisampled_copy_restrictions:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_format_compatibility:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:depth_stencil_copy_restrictions:*
-// Intermittently fails on dx12, https://github.com/gfx-rs/wgpu/issues/8118
-fails-if(dx12) webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_within_same_texture:*
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_aspects:*
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges_with_compressed_texture_formats:*
-webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="non-pass"
+// Intermittently fails on dx12, https://github.com/gfx-rs/wgpu/issues/8118
+fails-if(dx12) webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_with_invalid_or_destroyed_texture:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_within_same_texture:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:depth_stencil_copy_restrictions:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:mipmap_level:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:multisampled_copy_restrictions:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:sample_count:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_format_compatibility:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_usage:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture,device_mismatch:*
 webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="compute%20pass"
-webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="render%20pass"
+webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="non-pass"
 //FAIL: webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="render%20bundle"
 // https://github.com/gfx-rs/wgpu/issues/8039
+webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="render%20pass"
 webgpu:api,validation,encoding,cmds,debug:debug_group:*
 webgpu:api,validation,encoding,cmds,debug:debug_marker:*
 webgpu:api,validation,encoding,cmds,index_access:*
@@ -97,30 +115,31 @@ webgpu:api,validation,encoding,cmds,index_access:*
 webgpu:api,validation,encoding,cmds,render,draw:index_buffer_OOB:*
 webgpu:api,validation,encoding,cmds,render,draw:unused_buffer_bound:*
 webgpu:api,validation,encoding,cmds,render,dynamic_state:*
-webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_buffer,device_mismatch:*
 webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_buffer_usage:*
+webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_buffer,device_mismatch:*
 webgpu:api,validation,encoding,cmds,render,setIndexBuffer:*
 webgpu:api,validation,encoding,cmds,render,setPipeline:*
 webgpu:api,validation,encoding,cmds,render,setVertexBuffer:*
 webgpu:api,validation,encoding,cmds,render,state_tracking:vertex_buffers_do_not_inherit_between_render_passes:*
 webgpu:api,validation,encoding,cmds,render,state_tracking:vertex_buffers_inherit_from_previous_pipeline:*
-webgpu:api,validation,encoding,encoder_state:*
+webgpu:api,validation,encoding,encoder_open_state:compute_pass_commands:*
 webgpu:api,validation,encoding,encoder_open_state:non_pass_commands:*
-webgpu:api,validation,encoding,encoder_open_state:render_pass_commands:*
 //FAIL: webgpu:api,validation,encoding,encoder_open_state:render_bundle_commands:*
 // https://github.com/gfx-rs/wgpu/issues/7857
-webgpu:api,validation,encoding,encoder_open_state:compute_pass_commands:*
+webgpu:api,validation,encoding,encoder_open_state:render_pass_commands:*
+webgpu:api,validation,encoding,encoder_state:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_binding_mismatch:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_resource_type_mismatch:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_visibility_mismatch:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bind_groups_and_pipeline_layout_mismatch:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:buffer_binding,render_pipeline:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:sampler_binding,render_pipeline:*
+webgpu:api,validation,encoding,queries,begin_end:occlusion_query,*
 webgpu:api,validation,encoding,queries,general:occlusion_query,query_index:*
-webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
+webgpu:api,validation,encoding,queries,general:occlusion_query,query_type:*
 webgpu:api,validation,image_copy,buffer_related:*
-webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
+webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 // image_copy depth/stencil failures on dx12: https://github.com/gfx-rs/wgpu/issues/8133
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyB2T"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyT2B"
@@ -129,9 +148,9 @@ fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_sten
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyT2B"
 //mix of PASS and FAIL: other subtests of copy_buffer_offset. Related bugs:
 // https://github.com/gfx-rs/wgpu/issues/7946
+webgpu:api,validation,image_copy,buffer_texture_copies:device_mismatch:*
 webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*
 webgpu:api,validation,image_copy,buffer_texture_copies:texture_buffer_usages:*
-webgpu:api,validation,image_copy,buffer_texture_copies:device_mismatch:*
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="r8uint";copyType="CopyB2T";dimension="1d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="r8uint";copyType="CopyT2B";dimension="1d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba32float";copyType="CopyB2T";dimension="1d"
@@ -179,6 +198,7 @@ webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAs
 //FAIL: webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,input:isAsync=true;numVariablesDelta=-1;useExtraBuiltinInputs=true
 // https://github.com/gpuweb/cts/pull/4546
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,output:*
+webgpu:api,validation,render_pipeline,vertex_state:many_attributes_overlapping:*
 webgpu:api,validation,resource_usages,buffer,in_pass_encoder:*
 // FAIL: 2 other cases in resource_usages,texture,in_pass_encoder. https://github.com/gfx-rs/wgpu/issues/3126
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:scope,*
@@ -186,35 +206,19 @@ webgpu:api,validation,resource_usages,texture,in_pass_encoder:shader_stages_and_
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_aspect:*
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_color:compute=false;type0="render-target";type1="render-target"
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:unused_bindings_in_pipeline:*
-webgpu:api,validation,resource_usages,texture,in_render_common:subresources,color_attachments:*
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,color_attachment_and_bind_group:*
+webgpu:api,validation,resource_usages,texture,in_render_common:subresources,color_attachments:*
 // FAIL: webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_attachment_and_bind_group:*
 // https://github.com/gfx-rs/wgpu/issues/8705
-webgpu:api,validation,resource_usages,texture,in_render_common:subresources,multiple_bind_groups:*
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_texture_in_bind_groups:*
+webgpu:api,validation,resource_usages,texture,in_render_common:subresources,multiple_bind_groups:*
 webgpu:api,validation,texture,rg11b10ufloat_renderable:*
-webgpu:api,operation,render_pipeline,overrides:*
-webgpu:api,operation,rendering,3d_texture_slices:*
-webgpu:api,operation,rendering,basic:clear:*
-webgpu:api,operation,rendering,basic:fullscreen_quad:*
-//FAIL: webgpu:api,operation,rendering,basic:large_draw:*
-webgpu:api,operation,rendering,color_target_state:blending,GPUBlendComponent:*
-webgpu:api,operation,rendering,color_target_state:blending,formats:*
-webgpu:api,operation,rendering,color_target_state:blend_constant,setting:*
-webgpu:api,operation,rendering,depth:*
-webgpu:api,operation,rendering,draw:*
-webgpu:api,operation,shader_module,compilation_info:*
-webgpu:api,operation,vertex_state,correctness:non_zero_array_stride_and_attribute_offset:*
-// Likely due to https://github.com/gfx-rs/wgpu/issues/7357.
-fails-if(metal) webgpu:api,operation,uncapturederror:iff_uncaptured:*
+
+webgpu:shader,execution,expression,call,builtin,atan2:f16:*
+webgpu:shader,execution,expression,call,builtin,atan2:f32:*
 //FAIL: webgpu:shader,execution,expression,call,builtin,select:*
 // - Fails with `const`/abstract int cases on all platforms because of <https://github.com/gfx-rs/wgpu/issues/4507>.
 // - Fails with `vec3` & `f16` cases on macOS because of <https://github.com/gfx-rs/wgpu/issues/5262>.
-//FAIL: webgpu:api,operation,uncapturederror:onuncapturederror_order_wrt_addEventListener
-// There are also two unimplemented SKIPs in uncapturederror not enumerated here.
-webgpu:api,validation,encoding,queries,general:occlusion_query,query_type:*
-webgpu:shader,execution,expression,call,builtin,atan2:f16:*
-webgpu:shader,execution,expression,call,builtin,atan2:f32:*
 webgpu:shader,execution,expression,call,builtin,textureSample:sampled_1d_coords:*
 webgpu:shader,execution,expression,call,builtin,textureSampleBaseClampToEdge:2d_coords:stage="c";textureType="texture_2d<f32>";*
 // NOTE: This is supposed to be an exhaustive listing underneath
@@ -235,6 +239,7 @@ webgpu:shader,execution,flow_control,return:*
 // Many other vertex_buffer_access subtests also passing, but there are too many to enumerate.
 // Fails on Metal in CI only, not when running locally.
 fails-if(metal) webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true
+
 webgpu:shader,validation,const_assert,const_assert:*
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_zero_unsigned"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_zero_signed"
@@ -263,8 +268,9 @@ webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:param_cons
 webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:must_use:use=true
 //FAIL: https://github.com/gfx-rs/wgpu/pull/8713
 // webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:must_use:use=false
-webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break"
+webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break_if"
+webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="continue"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="for3"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="for4"
@@ -275,5 +281,3 @@ webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="l
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="loop8"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="switch1"
 //FAIL: 9 invalid_statements subtests due to https://github.com/gfx-rs/wgpu/issues/7733
-webgpu:api,validation,render_pipeline,vertex_state:many_attributes_overlapping:*
-webgpu:api,validation,encoding,queries,begin_end:occlusion_query,*

--- a/cts_runner/tests/integration.rs
+++ b/cts_runner/tests/integration.rs
@@ -4,6 +4,7 @@
 
 use std::{
     ffi::OsStr,
+    fs,
     io::Write,
     path::PathBuf,
     process::{Command, Output},
@@ -94,4 +95,66 @@ Shader '' parsing error: the type of `val` is expected to be `u32`, but got `{Ab
 1 │ const val: u32 = 1.1;
   │       ^^^ definition of `val`\n\n",
     );
+}
+
+#[test]
+fn lst_files_are_sorted() {
+    let workspace_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let files = ["test.lst", "fail.lst", "skip.lst"];
+
+    for file in &files {
+        let file_path = workspace_dir.join("cts_runner").join(file);
+        let contents = fs::read_to_string(&file_path).unwrap();
+        let selectors = contents
+            .lines()
+            .enumerate()
+            .filter_map(|(idx, line)| {
+                // Extract selectors (including in comments, removing fails-if annotations)
+                let trimmed = line.trim();
+                trimmed
+                    .find("webgpu:")
+                    .or_else(|| trimmed.find("unittests:"))
+                    .map(|pos| (idx, &trimmed[pos..]))
+            })
+            .map(|(idx, line)| {
+                // Crude en_US sort. '_' < ',' < ':' < digits < letters
+                let sort_key = line
+                    .chars()
+                    .map(|c| {
+                        if c.is_ascii_uppercase() {
+                            c.to_ascii_lowercase()
+                        } else if c == '_' {
+                            ' '
+                        } else if c == ':' {
+                            '-'
+                        } else {
+                            c
+                        }
+                    })
+                    .collect::<String>();
+                (idx, line, sort_key)
+            })
+            .collect::<Vec<_>>();
+
+        let mut sorted = selectors.clone();
+        sorted.sort_by_key(|(_, _, sort_key)| sort_key.clone());
+
+        if selectors != sorted {
+            let (found, expected) = selectors
+                .iter()
+                .zip(sorted.iter())
+                .find(|(a, b)| a != b)
+                .unwrap();
+            panic!(
+                "{} is not sorted. First mismatch on line {}:\nFound: {}\nShould be: {}",
+                file,
+                found.0 + 1,
+                found.1,
+                expected.1,
+            );
+        }
+    }
 }

--- a/cts_runner/tests/integration.rs
+++ b/cts_runner/tests/integration.rs
@@ -1,7 +1,3 @@
-// Tests for cts_runner
-//
-// As of June 2025, these tests are not run in CI.
-
 use std::{
     ffi::OsStr,
     fs,


### PR DESCRIPTION
Artifacts from some CTS triage I did.

Pass ∪ Fail ∪ Skip will not cover all of the validation tests, because the fail list is a snapshot from the tip of a WIP branch that has additional passes. But it should be pretty close.

**Testing**
Adds a test requiring that the list files stay in sorted order.

**Squash or Rebase?** Squash