### PR TITLE
Make `HasDisplayHandle` optional in `WindowHandle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 - Added `TextureFormat::channels` method to get some information about which color channels are covered by the texture format. By @TornaxO7 in [#9167](https://github.com/gfx-rs/wgpu/pull/9167)
 - BREAKING: Add `V6_8` variant to `DxcShaderModel` and `naga::back::hlsl::ShaderModel`. By @inner-daemons in [#8882](https://github.com/gfx-rs/wgpu/pull/8882) and @ErichDonGubler in [#9083](https://github.com/gfx-rs/wgpu/pull/9083).
 - BREAKING: Add `V6_9` variant to `DxcShaderModel` and `naga::back::hlsl::ShaderModel`. By @ErichDonGubler in [#????](https://github.com/gfx-rs/wgpu/pull/????).
+- `DisplayHandle` is now optional in surface creation if it was passed to `InstanceDescriptor::display`. By @MarijnS95 in [#8782](https://github.com/gfx-rs/wgpu/pull/8782)
 
 #### naga
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5029,6 +5029,7 @@ dependencies = [
  "png",
  "pollster",
  "profiling",
+ "raw-window-handle 0.6.2",
  "serde",
  "serde_json",
  "strum",

--- a/benches/benches/wgpu-benchmark/main.rs
+++ b/benches/benches/wgpu-benchmark/main.rs
@@ -29,7 +29,7 @@ impl DeviceState {
 
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::from_env().unwrap_or(base_backend),
-            ..wgpu::InstanceDescriptor::from_env_or_default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle_from_env()
         });
 
         let adapter = block_on(wgpu::util::initialize_adapter_from_env_or_default(

--- a/deno_webgpu/byow.rs
+++ b/deno_webgpu/byow.rs
@@ -276,7 +276,7 @@ impl<'a> FromV8<'a> for UnsafeWindowSurfaceOptions {
 
 type RawHandles = (
   raw_window_handle::RawWindowHandle,
-  raw_window_handle::RawDisplayHandle,
+  Option<raw_window_handle::RawDisplayHandle>,
 );
 
 #[cfg(target_os = "macos")]
@@ -298,7 +298,7 @@ fn raw_window(
   let display_handle = raw_window_handle::RawDisplayHandle::AppKit(
     raw_window_handle::AppKitDisplayHandle::new(),
   );
-  Ok((win_handle, display_handle))
+  Ok((win_handle, Some(display_handle)))
 }
 
 #[cfg(target_os = "windows")]
@@ -324,7 +324,7 @@ fn raw_window(
 
   let display_handle =
     raw_window_handle::RawDisplayHandle::Windows(WindowsDisplayHandle::new());
-  Ok((win_handle, display_handle))
+  Ok((win_handle, Some(display_handle)))
 }
 
 #[cfg(any(
@@ -366,7 +366,7 @@ fn raw_window(
     return Err(ByowError::InvalidSystem);
   }
 
-  Ok((win_handle, display_handle))
+  Ok((win_handle, Some(display_handle)))
 }
 
 #[cfg(not(any(

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -260,8 +260,8 @@ impl ExampleContext {
     async fn init_async<E: Example>(surface: &mut SurfaceWrapper, window: Arc<Window>) -> Self {
         log::info!("Initializing wgpu...");
 
-        let instance_descriptor = wgpu::InstanceDescriptor::from_env_or_default()
-            .with_display_handle(Box::new(
+        let instance_descriptor =
+            wgpu::InstanceDescriptor::new_with_display_handle_from_env(Box::new(
                 // TODO: Use event_loop.owned_display_handle() with winit 0.30
                 window.clone(),
             ));

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -12,11 +12,10 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
     size.width = size.width.max(1);
     size.height = size.height.max(1);
 
-    let instance = wgpu::Instance::new(
-        wgpu::InstanceDescriptor::from_env_or_default()
-            // TODO: Use event_loop.owned_display_handle() with winit 0.30
-            .with_display_handle(Box::new(window.clone())),
-    );
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_with_display_handle_from_env(
+        // TODO: Use event_loop.owned_display_handle() with winit 0.30
+        Box::new(window.clone()),
+    ));
 
     let surface = instance.create_surface(&window).unwrap();
     let adapter = instance

--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -193,7 +193,8 @@ impl Queries {
 
 async fn run() {
     // Instantiates instance of wgpu
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::from_env_or_default());
+    let instance =
+        wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
 
     // `request_adapter` instantiates the general connection to the GPU
     let adapter = instance

--- a/examples/standalone/01_hello_compute/src/main.rs
+++ b/examples/standalone/01_hello_compute/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
     // We first initialize an wgpu `Instance`, which contains any "global" state wgpu needs.
     //
     // This is what loads the vulkan/dx12/metal/opengl libraries.
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
 
     // We then create an `Adapter` which represents a physical gpu in the system. It allows
     // us to query information about it and create a `Device` from it.

--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -18,9 +18,9 @@ struct State {
 
 impl State {
     async fn new(display: OwnedDisplayHandle, window: Arc<Window>) -> State {
-        let instance = wgpu::Instance::new(
-            wgpu::InstanceDescriptor::default().with_display_handle(Box::new(display)),
-        );
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_with_display_handle(
+            Box::new(display),
+        ));
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions::default())
             .await

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -17,7 +17,7 @@ fn main() {
     };
 
     #[cfg(feature = "winit")]
-    use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+    use raw_window_handle::HasWindowHandle;
     #[cfg(feature = "winit")]
     use winit::{
         event::KeyEvent,
@@ -79,13 +79,8 @@ fn main() {
     let instance = wgc::instance::Instance::new("player", instance_desc, None);
 
     #[cfg(feature = "winit")]
-    let surface = unsafe {
-        instance.create_surface(
-            window.display_handle().unwrap().into(),
-            window.window_handle().unwrap().into(),
-        )
-    }
-    .unwrap();
+    let surface =
+        unsafe { instance.create_surface(None, window.window_handle().unwrap().into()) }.unwrap();
     #[cfg(feature = "winit")]
     let mut configured_surface_id = None;
 

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -71,7 +71,7 @@ fn main() {
             .unwrap(),
     );
 
-    let instance_desc = wgt::InstanceDescriptor::from_env_or_default();
+    let instance_desc = wgt::InstanceDescriptor::new_without_display_handle_from_env();
     #[cfg(feature = "winit")]
     // TODO: Use event_loop.owned_display_handle() with winit 0.30
     let instance_desc = instance_desc.with_display_handle(Box::new(window.clone()));

--- a/player/tests/player/main.rs
+++ b/player/tests/player/main.rs
@@ -181,7 +181,7 @@ impl Corpus {
             for test_path in &corpus.tests {
                 println!("\t\tTest '{test_path:?}'");
 
-                let instance_desc = wgt::InstanceDescriptor::from_env_or_default();
+                let instance_desc = wgt::InstanceDescriptor::new_without_display_handle_from_env();
                 let instance_flags = instance_desc.flags;
                 let instance = wgc::instance::Instance::new("test", instance_desc, None);
                 let adapter = match instance.request_adapter(

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -67,6 +67,7 @@ log.workspace = true
 png.workspace = true
 pollster.workspace = true
 profiling.workspace = true
+raw-window-handle.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -76,7 +76,18 @@ pub fn initialize_instance(backends: wgpu::Backends, params: &TestParameters) ->
                 enable: !cfg!(target_arch = "wasm32"),
             },
         },
+        #[cfg(not(all(
+            target_arch = "wasm32",
+            any(target_os = "emscripten", feature = "webgl")
+        )))]
         display: None,
+        // Wasm requires a canvas surface below, and create_surface() requires
+        // the `display` to be set even if it's "empty" on Web:
+        #[cfg(all(
+            target_arch = "wasm32",
+            any(target_os = "emscripten", feature = "webgl")
+        ))]
+        display: Some(Box::new(WebDisplayHandle)),
     })
 }
 
@@ -212,5 +223,26 @@ impl SurfaceGuard {
             .unwrap()
             .get_error()
             != web_sys::WebGl2RenderingContext::NO_ERROR
+    }
+}
+
+/// [`raw_window_handle::HasDisplayHandle`] implementation for Web that's [`Send`]+[`Sync`]
+/// because it doesn't own any pointers
+#[cfg(all(
+    target_arch = "wasm32",
+    any(target_os = "emscripten", feature = "webgl")
+))]
+#[derive(Debug)]
+struct WebDisplayHandle;
+
+#[cfg(all(
+    target_arch = "wasm32",
+    any(target_os = "emscripten", feature = "webgl")
+))]
+impl raw_window_handle::HasDisplayHandle for WebDisplayHandle {
+    fn display_handle(
+        &self,
+    ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
+        Ok(raw_window_handle::DisplayHandle::web())
     }
 }

--- a/tests/tests/wgpu-validation/api/experimental.rs
+++ b/tests/tests/wgpu-validation/api/experimental.rs
@@ -5,7 +5,7 @@ fn noop_adapter() -> wgpu::Adapter {
             noop: wgpu::NoopBackendOptions { enable: true },
             ..Default::default()
         },
-        ..Default::default()
+        ..wgpu::InstanceDescriptor::new_without_display_handle()
     });
 
     pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))

--- a/tests/tests/wgpu-validation/api/instance.rs
+++ b/tests/tests/wgpu-validation/api/instance.rs
@@ -5,7 +5,7 @@ mod multi_instance {
         let adapter = {
             let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
                 backends: wgpu::Backends::from_env().unwrap_or_default(),
-                ..Default::default()
+                ..wgpu::InstanceDescriptor::new_without_display_handle()
             });
             instance
                 .request_adapter(&wgpu::RequestAdapterOptions::default())

--- a/tests/tests/wgpu-validation/noop.rs
+++ b/tests/tests/wgpu-validation/noop.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 fn device_is_not_available_by_default() {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::NOOP,
-        ..Default::default()
+        ..wgpu::InstanceDescriptor::new_without_display_handle()
     });
 
     pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))
@@ -22,7 +22,7 @@ fn device_is_available_when_requested() {
             noop: wgpu::NoopBackendOptions { enable: true },
             ..Default::default()
         },
-        ..Default::default()
+        ..wgpu::InstanceDescriptor::new_without_display_handle()
     });
 
     pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -23,7 +23,7 @@ fn trace_test(test_type: TestType) {
                 noop: wgt::NoopBackendOptions { enable: true },
                 ..Default::default()
             },
-            ..Default::default()
+            ..wgt::instance::InstanceDescriptor::new_without_display_handle()
         },
         None,
     );

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -227,26 +227,33 @@ impl Instance {
     ///
     /// # Safety
     ///
-    /// - `display_handle` must be a valid object to create a surface upon.
+    /// - `display_handle` must be a valid object to create a surface upon,
+    ///   falls back to the instance display handle otherwise.
     /// - `window_handle` must remain valid as long as the returned
     ///   [`SurfaceId`] is being used.
     pub unsafe fn create_surface(
         &self,
-        display_handle: raw_window_handle::RawDisplayHandle,
+        display_handle: Option<raw_window_handle::RawDisplayHandle>,
         window_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<Surface, CreateSurfaceError> {
         profiling::scope!("Instance::create_surface");
 
-        if let Some(instance_display_handle) = &self.display {
-            if instance_display_handle
-                .display_handle()
+        let instance_display_handle = self.display.as_ref().map(|d| {
+            d.display_handle()
                 .expect("Implementation did not provide a DisplayHandle")
                 .as_raw()
-                != display_handle
-            {
-                return Err(CreateSurfaceError::MismatchingDisplayHandle);
+        });
+        let display_handle = match (instance_display_handle, display_handle) {
+            (Some(a), Some(b)) => {
+                if a != b {
+                    return Err(CreateSurfaceError::MismatchingDisplayHandle);
+                }
+                a
             }
-        }
+            (Some(hnd), None) => hnd,
+            (None, Some(hnd)) => hnd,
+            (None, None) => return Err(CreateSurfaceError::MissingDisplayHandle),
+        };
 
         let mut errors = HashMap::default();
         let mut surface_per_backend = HashMap::default();
@@ -936,6 +943,13 @@ pub enum CreateSurfaceError {
     FailedToCreateSurfaceForAnyBackend(HashMap<Backend, hal::InstanceError>),
     #[error("The display handle used to create this Instance does not match the one used to create a surface on it")]
     MismatchingDisplayHandle,
+    #[error(
+        "No `DisplayHandle` is available to create this surface with.  When creating a surface with `create_surface()` \
+        you must specify a display handle in `InstanceDescriptor::display`.  \
+        Rarely, if you need to create surfaces from different `DisplayHandle`s (ex. different Wayland or X11 connections), \
+        you must use `create_surface_unsafe()`."
+    )]
+    MissingDisplayHandle,
 }
 
 impl Global {
@@ -953,12 +967,13 @@ impl Global {
     ///
     /// # Safety
     ///
-    /// - `display_handle` must be a valid object to create a surface upon.
+    /// - `display_handle` must be a valid object to create a surface upon,
+    ///   falls back to the instance display handle otherwise.
     /// - `window_handle` must remain valid as long as the returned
     ///   [`SurfaceId`] is being used.
     pub unsafe fn instance_create_surface(
         &self,
-        display_handle: raw_window_handle::RawDisplayHandle,
+        display_handle: Option<raw_window_handle::RawDisplayHandle>,
         window_handle: raw_window_handle::RawWindowHandle,
         id_in: Option<SurfaceId>,
     ) -> Result<SurfaceId, CreateSurfaceError> {

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -147,9 +147,13 @@ impl crate::Instance for super::Instance {
 
     unsafe fn create_surface(
         &self,
-        _display_handle: raw_window_handle::RawDisplayHandle,
+        display_handle: raw_window_handle::RawDisplayHandle,
         window_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<super::Surface, crate::InstanceError> {
+        assert!(matches!(
+            display_handle,
+            raw_window_handle::RawDisplayHandle::Windows(_)
+        ));
         match window_handle {
             raw_window_handle::RawWindowHandle::Win32(handle) => {
                 // https://github.com/rust-windowing/raw-window-handle/issues/171

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -563,12 +563,12 @@ impl crate::Instance for Instance {
         })
     }
 
-    #[cfg_attr(target_os = "macos", allow(unused, unused_mut, unreachable_code))]
     unsafe fn create_surface(
         &self,
-        _display_handle: RawDisplayHandle,
+        display_handle: RawDisplayHandle,
         window_handle: RawWindowHandle,
     ) -> Result<Surface, crate::InstanceError> {
+        assert!(matches!(display_handle, RawDisplayHandle::Windows(_)));
         let window = if let RawWindowHandle::Win32(handle) = window_handle {
             handle
         } else {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -151,16 +151,18 @@ impl crate::Instance for Instance {
 
     unsafe fn create_surface(
         &self,
-        _display_handle: raw_window_handle::RawDisplayHandle,
+        display_handle: raw_window_handle::RawDisplayHandle,
         window_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<Surface, crate::InstanceError> {
-        let layer = match window_handle {
-            raw_window_handle::RawWindowHandle::AppKit(handle) => unsafe {
-                raw_window_metal::Layer::from_ns_view(handle.ns_view)
-            },
-            raw_window_handle::RawWindowHandle::UiKit(handle) => unsafe {
-                raw_window_metal::Layer::from_ui_view(handle.ui_view)
-            },
+        let layer = match (display_handle, window_handle) {
+            (
+                raw_window_handle::RawDisplayHandle::AppKit(_),
+                raw_window_handle::RawWindowHandle::AppKit(handle),
+            ) => unsafe { raw_window_metal::Layer::from_ns_view(handle.ns_view) },
+            (
+                raw_window_handle::RawDisplayHandle::UiKit(_),
+                raw_window_handle::RawWindowHandle::UiKit(handle),
+            ) => unsafe { raw_window_metal::Layer::from_ui_view(handle.ui_view) },
             _ => {
                 return Err(crate::InstanceError::new(format!(
                     "window handle {window_handle:?} is not a Metal-compatible handle"

--- a/wgpu-info/src/report.rs
+++ b/wgpu-info/src/report.rs
@@ -20,7 +20,7 @@ pub struct GpuReport {
 impl GpuReport {
     pub fn generate() -> Self {
         let instance = wgpu::Instance::new({
-            let mut desc = wgpu::InstanceDescriptor::default();
+            let mut desc = wgpu::InstanceDescriptor::new_without_display_handle();
             desc.backend_options.dx12.shader_compiler = Dx12Compiler::StaticDxc;
             desc.flags = wgpu::InstanceFlags::debugging();
             desc.with_env()

--- a/wgpu-types/src/instance.rs
+++ b/wgpu-types/src/instance.rs
@@ -58,9 +58,6 @@ pub struct InstanceDescriptor {
     /// the `EventLoop`) here.
     ///
     /// [`OwnedDisplayHandle`]: https://docs.rs/winit/latest/winit/event_loop/struct.OwnedDisplayHandle.html
-    // FUTURE: The RawDisplayHandle trait can/should be removed entirely from create_display()? At
-    // least `trait WindowHandle: HasWindowHandle + HasDisplayHandle` should really be removed as
-    // it's impractical and not implementable everywhere.
     pub display: Option<alloc::boxed::Box<dyn WgpuHasDisplayHandle>>,
 }
 

--- a/wgpu-types/src/instance.rs
+++ b/wgpu-types/src/instance.rs
@@ -19,11 +19,11 @@ impl<T: raw_window_handle::HasDisplayHandle + core::fmt::Debug + Send + Sync + '
 
 /// Options for creating an instance.
 ///
-/// If you want to allow control of instance settings via environment variables, call either
-/// [`InstanceDescriptor::from_env_or_default()`] or [`InstanceDescriptor::with_env()`]. Each type
-/// within this descriptor has its own equivalent methods, so you can select which options you want
-/// to expose to influence from the environment.
-#[derive(Debug, Default)]
+/// If you want to allow control of instance settings via environment variables, call any of the
+/// `*from_env()` functions or [`InstanceDescriptor::with_env()`]. Each type within this descriptor
+/// has its own equivalent methods, so you can select which options you want to expose to influence
+/// from the environment.
+#[derive(Debug)]
 pub struct InstanceDescriptor {
     /// Which [`Backends`] to enable.
     ///
@@ -62,12 +62,41 @@ pub struct InstanceDescriptor {
 }
 
 impl InstanceDescriptor {
+    /// The default instance options, without display handle.
+    #[must_use]
+    pub fn new_without_display_handle() -> Self {
+        Self {
+            backends: Default::default(),
+            flags: Default::default(),
+            memory_budget_thresholds: Default::default(),
+            backend_options: Default::default(),
+            display: None,
+        }
+    }
+
+    /// The default instance options, with display handle.
+    #[must_use]
+    pub fn new_with_display_handle(display: alloc::boxed::Box<dyn WgpuHasDisplayHandle>) -> Self {
+        Self::new_without_display_handle().with_display_handle(display)
+    }
+
     /// Choose instance options entirely from environment variables.
     ///
     /// This is equivalent to calling `from_env` on every field.
     #[must_use]
-    pub fn from_env_or_default() -> Self {
-        Self::default().with_env()
+    pub fn new_without_display_handle_from_env() -> Self {
+        Self::new_without_display_handle().with_env()
+    }
+
+    /// Choose instance options entirely from environment variables, while including a display handle.
+    ///
+    /// This is equivalent to calling `from_env` on every field.
+    #[must_use]
+    pub fn new_with_display_handle_from_env(
+        display: alloc::boxed::Box<dyn WgpuHasDisplayHandle>,
+    ) -> Self {
+        // Self::new_without_display_handle_from_env().with_display_handle(display)
+        Self::new_with_display_handle(display).with_env()
     }
 
     /// Takes the given options, modifies them based on the environment variables, and returns the result.
@@ -83,7 +112,7 @@ impl InstanceDescriptor {
             flags,
             memory_budget_thresholds: MemoryBudgetThresholds::default(),
             backend_options,
-            display: None,
+            display: self.display,
         }
     }
 

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -66,7 +66,7 @@ impl Device {
                 noop: NoopBackendOptions { enable: true },
                 ..Default::default()
             },
-            ..Default::default()
+            ..InstanceDescriptor::new_without_display_handle()
         });
 
         // Both of these futures are trivial and should complete instantaneously,

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -176,7 +176,7 @@ impl Instance {
     /// Internally, this creates surfaces for all backends that are enabled for this instance.
     ///
     /// See [`SurfaceTarget`] for what targets are supported.
-    /// See [`Instance::create_surface_unsafe`] for surface creation with unsafe target variants.
+    /// See [`Instance::create_surface_unsafe()`] for surface creation with unsafe target variants.
     ///
     /// Most commonly used are window handles (or provider of windows handles)
     /// which can be passed directly as they're automatically converted to [`SurfaceTarget`].
@@ -199,7 +199,20 @@ impl Instance {
 
                 surface
             }?,
+            SurfaceTarget::DisplayAndWindow(display_and_window_handle) => unsafe {
+                let surface = self.create_surface_unsafe(
+                    SurfaceTargetUnsafe::from_display_and_window(
+                        &display_and_window_handle,
+                        &display_and_window_handle,
+                    )
+                    .map_err(|e| CreateSurfaceError {
+                        inner: CreateSurfaceErrorKind::RawHandle(e),
+                    })?,
+                );
+                handle_source = Some(display_and_window_handle);
 
+                surface
+            }?,
             #[cfg(web)]
             SurfaceTarget::Canvas(canvas) => {
                 handle_source = None;
@@ -207,18 +220,16 @@ impl Instance {
                 let value: &wasm_bindgen::JsValue = &canvas;
                 let obj = core::ptr::NonNull::from(value).cast();
                 let raw_window_handle = raw_window_handle::WebCanvasWindowHandle::new(obj).into();
-                let raw_display_handle = raw_window_handle::WebDisplayHandle::new().into();
 
                 // Note that we need to call this while we still have `value` around.
                 // This is safe without storing canvas to `handle_origin` since the surface will create a copy internally.
                 unsafe {
                     self.create_surface_unsafe(SurfaceTargetUnsafe::RawHandle {
-                        raw_display_handle,
+                        raw_display_handle: None,
                         raw_window_handle,
                     })
                 }?
             }
-
             #[cfg(web)]
             SurfaceTarget::OffscreenCanvas(canvas) => {
                 handle_source = None;
@@ -227,13 +238,12 @@ impl Instance {
                 let obj = core::ptr::NonNull::from(value).cast();
                 let raw_window_handle =
                     raw_window_handle::WebOffscreenCanvasWindowHandle::new(obj).into();
-                let raw_display_handle = raw_window_handle::WebDisplayHandle::new().into();
 
                 // Note that we need to call this while we still have `value` around.
                 // This is safe without storing canvas to `handle_origin` since the surface will create a copy internally.
                 unsafe {
                     self.create_surface_unsafe(SurfaceTargetUnsafe::RawHandle {
-                        raw_display_handle,
+                        raw_display_handle: None,
                         raw_window_handle,
                     })
                 }?

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -47,7 +47,8 @@ impl Default for Instance {
     /// If no backend feature for the active target platform is enabled,
     /// this method will panic, see [`Instance::enabled_backend_features()`].
     fn default() -> Self {
-        Self::new(InstanceDescriptor::default())
+        // TODO: Differentiate constructors here too?
+        Self::new(InstanceDescriptor::new_without_display_handle())
     }
 }
 

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -235,10 +235,15 @@ static_assertions::assert_impl_all!(Surface<'_>: Send, Sync);
 
 crate::cmp::impl_eq_ord_hash_proxy!(Surface<'_> => .inner);
 
-/// Super trait for window handles as used in [`SurfaceTarget`].
-pub trait WindowHandle: HasWindowHandle + HasDisplayHandle + WasmNotSendSync {}
+/// [`Send`]/[`Sync`] blanket trait for [`HasWindowHandle`] used in [`SurfaceTarget`].
+pub trait WindowHandle: HasWindowHandle + WasmNotSendSync {}
 
-impl<T> WindowHandle for T where T: HasWindowHandle + HasDisplayHandle + WasmNotSendSync {}
+impl<T: HasWindowHandle + WasmNotSendSync> WindowHandle for T {}
+
+/// Super trait for a pair of display and window handles as used in [`SurfaceTarget`].
+pub trait DisplayAndWindowHandle: WindowHandle + HasDisplayHandle {}
+
+impl<T> DisplayAndWindowHandle for T where T: WindowHandle + HasDisplayHandle {}
 
 /// The window/canvas/surface/swap-chain/etc. a surface is attached to, for use with safe surface creation.
 ///
@@ -249,7 +254,7 @@ impl<T> WindowHandle for T where T: HasWindowHandle + HasDisplayHandle + WasmNot
 /// See also [`SurfaceTargetUnsafe`] for unsafe variants.
 #[non_exhaustive]
 pub enum SurfaceTarget<'window> {
-    /// Window handle producer.
+    /// Window and display handle producer.
     ///
     /// If the specified display and window handle are not supported by any of the backends, then the surface
     /// will not be supported by any adapters.
@@ -262,8 +267,18 @@ pub enum SurfaceTarget<'window> {
     /// # Panics
     ///
     /// - On macOS/Metal: will panic if not called on the main thread.
-    /// - On web: will panic if the `raw_window_handle` does not properly refer to a
+    /// - On web: will panic if the [`HasWindowHandle`] does not properly refer to a
     ///   canvas element.
+    /// - On all platforms: If [`crate::InstanceDescriptor::display`] was not [`None`]
+    ///   but its value is not identical to that returned by [`HasDisplayHandle::display_handle()`].
+    DisplayAndWindow(Box<dyn DisplayAndWindowHandle + 'window>),
+
+    /// Window handle producer.
+    ///
+    /// [`HasWindowHandle`]-only version of [`SurfaceTarget::DisplayAndWindow`].
+    ///
+    /// This requires that the display handle was already passed through
+    /// [`crate::InstanceDescriptor::display`].
     Window(Box<dyn WindowHandle + 'window>),
 
     /// Surface from a `web_sys::HtmlCanvasElement`.
@@ -291,12 +306,19 @@ pub enum SurfaceTarget<'window> {
     OffscreenCanvas(web_sys::OffscreenCanvas),
 }
 
+impl<'a> SurfaceTarget<'a> {
+    /// Constructor for [`Self::Window`] without consuming a display handle
+    pub fn from_window_without_display(window: impl WindowHandle + 'a) -> Self {
+        Self::Window(Box::new(window))
+    }
+}
+
 impl<'a, T> From<T> for SurfaceTarget<'a>
 where
-    T: WindowHandle + 'a,
+    T: DisplayAndWindowHandle + 'a,
 {
     fn from(window: T) -> Self {
-        Self::Window(Box::new(window))
+        Self::DisplayAndWindow(Box::new(window))
     }
 }
 
@@ -314,6 +336,9 @@ pub enum SurfaceTargetUnsafe {
     /// If the specified display and window handle are not supported by any of the backends, then the surface
     /// will not be supported by any adapters.
     ///
+    /// If the `raw_display_handle` is not [`None`] here and was not [`None`] in
+    /// [`crate::InstanceDescriptor::display`], their values _must_ be identical.
+    ///
     /// # Safety
     ///
     /// - `raw_window_handle` & `raw_display_handle` must be valid objects to create a surface upon.
@@ -321,9 +346,9 @@ pub enum SurfaceTargetUnsafe {
     ///   [`Surface`] is  dropped.
     RawHandle {
         /// Raw display handle, underlying display must outlive the surface created from this.
-        raw_display_handle: raw_window_handle::RawDisplayHandle,
+        raw_display_handle: Option<raw_window_handle::RawDisplayHandle>,
 
-        /// Raw display handle, underlying window must outlive the surface created from this.
+        /// Raw window handle, underlying window must outlive the surface created from this.
         raw_window_handle: raw_window_handle::RawWindowHandle,
     },
 
@@ -389,18 +414,38 @@ pub enum SurfaceTargetUnsafe {
 }
 
 impl SurfaceTargetUnsafe {
+    /// Creates a [`SurfaceTargetUnsafe::RawHandle`] from a display and window.
+    ///
+    /// The `display` is optional and may be omitted if it was also passed to
+    /// [`crate::InstanceDescriptor::display`].  If passed to both it must (currently) be identical.
+    ///
+    /// # Safety
+    ///
+    /// - `display` must outlive the resulting surface target
+    ///   (and subsequently the surface created for this target).
+    /// - `window` must outlive the resulting surface target
+    ///   (and subsequently the surface created for this target).
+    pub unsafe fn from_display_and_window(
+        display: &impl HasDisplayHandle,
+        window: &impl HasWindowHandle,
+    ) -> Result<Self, raw_window_handle::HandleError> {
+        Ok(Self::RawHandle {
+            raw_display_handle: Some(display.display_handle()?.as_raw()),
+            raw_window_handle: window.window_handle()?.as_raw(),
+        })
+    }
+
     /// Creates a [`SurfaceTargetUnsafe::RawHandle`] from a window.
     ///
     /// # Safety
     ///
     /// - `window` must outlive the resulting surface target
     ///   (and subsequently the surface created for this target).
-    pub unsafe fn from_window<T>(window: &T) -> Result<Self, raw_window_handle::HandleError>
-    where
-        T: HasDisplayHandle + HasWindowHandle,
-    {
+    pub unsafe fn from_window(
+        window: &impl HasWindowHandle,
+    ) -> Result<Self, raw_window_handle::HandleError> {
         Ok(Self::RawHandle {
-            raw_display_handle: window.display_handle()?.as_raw(),
+            raw_display_handle: None,
             raw_window_handle: window.window_handle()?.as_raw(),
         })
     }


### PR DESCRIPTION
**Connections**
Followup to https://github.com/gfx-rs/wgpu/pull/8012#issuecomment-3618408387 and https://github.com/rust-windowing/softbuffer/issues/298#issuecomment-3617254907 (CC @cwfitzgerald @dhardy)

**Description**
While true for some window objects like `winit`'s `Window` object, not everyone is or should be required to return their display handle in the same place as the window handle, by means of implementing both `RawDisplayHandle` and `RawWindowHandle` on the same object.

Additionally some APIs, specifically most/all GL(ES) context creation APIs require the `RawDisplayHandle` up-front to create a context that is compatible with that "compositor connection".

For this reason callers should no longer be required to pass a single object that implements both `HasDisplayHandle` and `HasWindowHandle`, allowing the former to become `Option`al in favour of taking the one stored (and kept alive!) in the `Instance`.

`HasDisplayHandle` can still be passed in this position however, because APIs like Vulkan have completely pushed out compositor integration via surfaces to the edge of the API and can technically let one instance or device render into multiple different `RawDisplayHandle` "compositor connections" concurrently.

**Testing**

```console
$ WGPU_BACKEND=gl cargo r -p wgpu-example-02-hello-window
$ WGPU_BACKEND=gl cargo r -p wgpu-examples -- hello_triangle
$ WGPU_BACKEND=gl RUST_LOG=wgpu_hal=debug cargo r -p player # Changed code but don't have a file to play and test it yet
```


**Squash or Rebase?**

Doesn't matter.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry.