### PR TITLE
[glsl-in] fix missing side effects from sequence expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ Bottom level categories:
 - BREAKING: Migrated from the `maxInterStageShaderComponents` limit to `maxInterStageShaderVariables`, which changes validation in a way that should not affect most programs. This follows the latest changes of the WebGPU spec. By @ErichDonGubler in [#8652](https://github.com/gfx-rs/wgpu/pull/8652).
 - Fixed validation of the texture format in GPUDepthStencilState when neither depth nor stencil is actually enabled. By @andyleiserson in [#8766](https://github.com/gfx-rs/wgpu/pull/8766).
 
+#### Naga
+
+- Fix missing side effects from sequence expressions in GLSL. By @Vipitis in [#8787](https://github.com/gfx-rs/wgpu/pull/8787).
+
 #### GLES
 
 - `DisplayHandle` should now be passed to `InstanceDescriptor` for correct EGL initialization on Wayland. By @MarijnS95 in [#8012](https://github.com/gfx-rs/wgpu/pull/8012)

--- a/naga/src/front/glsl/ast.rs
+++ b/naga/src/front/glsl/ast.rs
@@ -117,7 +117,7 @@ pub struct HirExpr {
 #[derive(Debug, Clone)]
 pub enum HirExprKind {
     /// helper to represent a sequence of expressions where side effects matter, the last one is return to the caller
-    Sequence{
+    Sequence {
         exprs: Vec<Handle<HirExpr>>,
     },
     Access {

--- a/naga/src/front/glsl/ast.rs
+++ b/naga/src/front/glsl/ast.rs
@@ -116,6 +116,10 @@ pub struct HirExpr {
 
 #[derive(Debug, Clone)]
 pub enum HirExprKind {
+    /// helper to represent a sequence of expressions where side effects matter, the last one is return to the caller
+    Sequence{
+        exprs: Vec<Handle<HirExpr>>,
+    },
     Access {
         base: Handle<HirExpr>,
         index: Handle<HirExpr>,

--- a/naga/src/front/glsl/ast.rs
+++ b/naga/src/front/glsl/ast.rs
@@ -116,7 +116,7 @@ pub struct HirExpr {
 
 #[derive(Debug, Clone)]
 pub enum HirExprKind {
-    /// helper to represent a sequence of expressions where side effects matter, the last one is return to the caller
+    /// helper to represent a sequence of expressions where side effects matter, the last one is returned to the caller
     Sequence {
         exprs: Vec<Handle<HirExpr>>,
     },

--- a/naga/src/front/glsl/ast.rs
+++ b/naga/src/front/glsl/ast.rs
@@ -116,7 +116,7 @@ pub struct HirExpr {
 
 #[derive(Debug, Clone)]
 pub enum HirExprKind {
-    /// helper to represent a sequence of expressions where side effects matter, the last one is returned to the caller
+    /// Represents a sequence of expressions. It returns the type and value of the last (i.e. right-most) expression.
     Sequence {
         exprs: Vec<Handle<HirExpr>>,
     },

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -1333,7 +1333,7 @@ impl<'a> Context<'a> {
                             }
                         }
                     }
-                
+
                     _ => {
                         return Err(Error {
                             kind: ErrorKind::SemanticError(
@@ -1355,9 +1355,7 @@ impl<'a> Context<'a> {
                     Some(handle) => handle,
                     None => {
                         return Err(Error {
-                            kind: ErrorKind::SemanticError(
-                                "Empty expression sequence".into(),
-                            ),
+                            kind: ErrorKind::SemanticError("Empty expression sequence".into()),
                             meta,
                         })
                     }

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -1353,12 +1353,7 @@ impl<'a> Context<'a> {
                 }
                 match last_handle {
                     Some(handle) => handle,
-                    None => {
-                        return Err(Error {
-                            kind: ErrorKind::SemanticError("Empty expression sequence".into()),
-                            meta,
-                        })
-                    }
+                    None => unreachable!(),
                 }
             }
             _ => {

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -1333,6 +1333,7 @@ impl<'a> Context<'a> {
                             }
                         }
                     }
+                
                     _ => {
                         return Err(Error {
                             kind: ErrorKind::SemanticError(
@@ -1340,6 +1341,25 @@ impl<'a> Context<'a> {
                             ),
                             meta,
                         });
+                    }
+                }
+            }
+            HirExprKind::Sequence { ref exprs } if pos != ExprPos::Lhs => {
+                let mut last_handle = None;
+                for expr in exprs.iter() {
+                    let (handle, _) =
+                        self.lower_expect_inner(stmt, frontend, *expr, ExprPos::Rhs)?;
+                    last_handle = Some(handle);
+                }
+                match last_handle {
+                    Some(handle) => handle,
+                    None => {
+                        return Err(Error {
+                            kind: ErrorKind::SemanticError(
+                                "Empty expression sequence".into(),
+                            ),
+                            meta,
+                        })
                     }
                 }
             }

--- a/naga/src/front/glsl/parser/expressions.rs
+++ b/naga/src/front/glsl/parser/expressions.rs
@@ -511,6 +511,10 @@ impl ParsingContext<'_> {
         })
     }
 
+    // shader grammar :-
+    // expression :
+    // assignment_expression
+    // expression COMMA assignment_expression
     pub fn parse_expression(
         &mut self,
         frontend: &mut Frontend,

--- a/naga/src/front/glsl/parser/expressions.rs
+++ b/naga/src/front/glsl/parser/expressions.rs
@@ -545,8 +545,8 @@ impl ParsingContext<'_> {
                 },
                 Default::default(),
             );
-        
-        Ok(expr)
+
+            Ok(expr)
         }
     }
 }

--- a/naga/src/front/glsl/parser/expressions.rs
+++ b/naga/src/front/glsl/parser/expressions.rs
@@ -521,14 +521,33 @@ impl ParsingContext<'_> {
         ctx: &mut Context,
         stmt: &mut StmtContext,
     ) -> Result<Handle<HirExpr>> {
+        let mut exprs = Vec::new();
         let mut expr = self.parse_assignment(frontend, ctx, stmt)?;
+        exprs.push(expr);
 
         while let TokenValue::Comma = self.expect_peek(frontend)?.value {
             self.bump(frontend)?;
             expr = self.parse_assignment(frontend, ctx, stmt)?;
+            exprs.push(expr);
         }
 
+        if exprs.len() == 1 {
+            Ok(expr)
+        } else {
+            let mut meta = stmt.hir_exprs[exprs[0]].meta;
+            for &e in &exprs[1..] {
+                meta.subsume(stmt.hir_exprs[e].meta);
+            }
+            expr = stmt.hir_exprs.append(
+                HirExpr {
+                    kind: HirExprKind::Sequence { exprs },
+                    meta,
+                },
+                Default::default(),
+            );
+        
         Ok(expr)
+        }
     }
 }
 

--- a/naga/src/front/glsl/parser/expressions.rs
+++ b/naga/src/front/glsl/parser/expressions.rs
@@ -511,10 +511,6 @@ impl ParsingContext<'_> {
         })
     }
 
-    // shader grammar :-
-    // expression :
-    // assignment_expression
-    // expression COMMA assignment_expression
     pub fn parse_expression(
         &mut self,
         frontend: &mut Frontend,

--- a/naga/src/front/glsl/parser/functions.rs
+++ b/naga/src/front/glsl/parser/functions.rs
@@ -436,7 +436,8 @@ impl ParsingContext<'_> {
             // shader grammar :-
             // iteration_statement : (third option only)
             // FOR LEFT_PAREN for_init_statement for_rest_statement RIGHT_PAREN statement_no_new_scope
-            TokenValue::For => { //FOR
+            TokenValue::For => {
+                //FOR
                 let mut meta = self.bump(frontend)?.meta;
                 ctx.symbol_table.push_scope();
                 self.expect(frontend, TokenValue::LeftParen)?; // LEFT_PAREN
@@ -447,9 +448,9 @@ impl ParsingContext<'_> {
                 // declariation_statement
                 if self.bump_if(frontend, TokenValue::Semicolon).is_none() {
                     if self.peek_type_name(frontend) || self.peek_type_qualifier(frontend) {
-                        self.parse_declaration(frontend, ctx, false, is_inside_loop)?; // declariation_statement (besically the same as `declaration`)
+                        self.parse_declaration(frontend, ctx, false, is_inside_loop)?;
+                    // declariation_statement (besically the same as `declaration`)
                     } else {
-
                         // shader grammar :-
                         // expression_statement :
                         // SEMICOLON
@@ -523,7 +524,6 @@ impl ParsingContext<'_> {
                     }
                     Ok(())
                 })?;
-
 
                 // shader grammar just has a single expression here, which can be multiple expressions separated by commas...
                 let continuing = ctx.new_body(|ctx| {

--- a/naga/src/front/glsl/parser/functions.rs
+++ b/naga/src/front/glsl/parser/functions.rs
@@ -432,16 +432,28 @@ impl ParsingContext<'_> {
 
                 meta
             }
-            TokenValue::For => {
+
+            // shader grammar :-
+            // iteration_statement : (third option only)
+            // FOR LEFT_PAREN for_init_statement for_rest_statement RIGHT_PAREN statement_no_new_scope
+            TokenValue::For => { //FOR
                 let mut meta = self.bump(frontend)?.meta;
-
                 ctx.symbol_table.push_scope();
-                self.expect(frontend, TokenValue::LeftParen)?;
+                self.expect(frontend, TokenValue::LeftParen)?; // LEFT_PAREN
 
+                // shader grammar :-
+                // for_init_statement :
+                // expression_statement
+                // declariation_statement
                 if self.bump_if(frontend, TokenValue::Semicolon).is_none() {
                     if self.peek_type_name(frontend) || self.peek_type_qualifier(frontend) {
-                        self.parse_declaration(frontend, ctx, false, is_inside_loop)?;
+                        self.parse_declaration(frontend, ctx, false, is_inside_loop)?; // declariation_statement (besically the same as `declaration`)
                     } else {
+
+                        // shader grammar :-
+                        // expression_statement :
+                        // SEMICOLON
+                        // expression SEMICOLON
                         let mut stmt = ctx.stmt_ctx();
                         let expr = self.parse_expression(frontend, ctx, &mut stmt)?;
                         ctx.lower(stmt, frontend, expr, ExprPos::Rhs)?;
@@ -449,6 +461,10 @@ impl ParsingContext<'_> {
                     }
                 }
 
+                // shader grammar :-
+                // for_rest_statement :
+                // conditionopt SEMICOLON
+                // conditionopt SEMICOLON expression
                 let loop_body = ctx.new_body(|ctx| {
                     if self.bump_if(frontend, TokenValue::Semicolon).is_none() {
                         let (expr, expr_meta) = if self.peek_type_name(frontend)
@@ -508,6 +524,8 @@ impl ParsingContext<'_> {
                     Ok(())
                 })?;
 
+
+                // shader grammar just has a single expression here, which can be multiple expressions separated by commas...
                 let continuing = ctx.new_body(|ctx| {
                     match self.expect_peek(frontend)?.value {
                         TokenValue::RightParen => {}

--- a/naga/src/front/glsl/parser/functions.rs
+++ b/naga/src/front/glsl/parser/functions.rs
@@ -445,11 +445,11 @@ impl ParsingContext<'_> {
                 // shader grammar :-
                 // for_init_statement :
                 // expression_statement
-                // declariation_statement
+                // declaration_statement
                 if self.bump_if(frontend, TokenValue::Semicolon).is_none() {
                     if self.peek_type_name(frontend) || self.peek_type_qualifier(frontend) {
                         self.parse_declaration(frontend, ctx, false, is_inside_loop)?;
-                    // declariation_statement (besically the same as `declaration`)
+                    // declaration_statement (basically the same as `declaration`)
                     } else {
                         // shader grammar :-
                         // expression_statement :

--- a/naga/src/front/glsl/parser/functions.rs
+++ b/naga/src/front/glsl/parser/functions.rs
@@ -432,9 +432,9 @@ impl ParsingContext<'_> {
 
                 meta
             }
-
             TokenValue::For => {
                 let mut meta = self.bump(frontend)?.meta;
+
                 ctx.symbol_table.push_scope();
                 self.expect(frontend, TokenValue::LeftParen)?;
 

--- a/naga/src/front/glsl/parser/functions.rs
+++ b/naga/src/front/glsl/parser/functions.rs
@@ -433,28 +433,15 @@ impl ParsingContext<'_> {
                 meta
             }
 
-            // shader grammar :-
-            // iteration_statement : (third option only)
-            // FOR LEFT_PAREN for_init_statement for_rest_statement RIGHT_PAREN statement_no_new_scope
             TokenValue::For => {
-                //FOR
                 let mut meta = self.bump(frontend)?.meta;
                 ctx.symbol_table.push_scope();
-                self.expect(frontend, TokenValue::LeftParen)?; // LEFT_PAREN
+                self.expect(frontend, TokenValue::LeftParen)?;
 
-                // shader grammar :-
-                // for_init_statement :
-                // expression_statement
-                // declaration_statement
                 if self.bump_if(frontend, TokenValue::Semicolon).is_none() {
                     if self.peek_type_name(frontend) || self.peek_type_qualifier(frontend) {
                         self.parse_declaration(frontend, ctx, false, is_inside_loop)?;
-                    // declaration_statement (basically the same as `declaration`)
                     } else {
-                        // shader grammar :-
-                        // expression_statement :
-                        // SEMICOLON
-                        // expression SEMICOLON
                         let mut stmt = ctx.stmt_ctx();
                         let expr = self.parse_expression(frontend, ctx, &mut stmt)?;
                         ctx.lower(stmt, frontend, expr, ExprPos::Rhs)?;
@@ -462,10 +449,6 @@ impl ParsingContext<'_> {
                     }
                 }
 
-                // shader grammar :-
-                // for_rest_statement :
-                // conditionopt SEMICOLON
-                // conditionopt SEMICOLON expression
                 let loop_body = ctx.new_body(|ctx| {
                     if self.bump_if(frontend, TokenValue::Semicolon).is_none() {
                         let (expr, expr_meta) = if self.peek_type_name(frontend)
@@ -525,7 +508,6 @@ impl ParsingContext<'_> {
                     Ok(())
                 })?;
 
-                // shader grammar just has a single expression here, which can be multiple expressions separated by commas...
                 let continuing = ctx.new_body(|ctx| {
                     match self.expect_peek(frontend)?.value {
                         TokenValue::RightParen => {}

--- a/naga/tests/in/glsl/multipart-for-loop.frag
+++ b/naga/tests/in/glsl/multipart-for-loop.frag
@@ -4,11 +4,16 @@
 void main() {
     float a = 1.0;
     float b = 0.25;
+    float c = 1.5;
+    int i = 20;
 
-    // tests for multiple expressions in the third part!
-    for (int i = 0; i < 25; i++, b+=0.01) {
+    // tests for multiple expressions in first part (if it's a expression, not declaration)!
+    // also the third part!
+    for (i = 0, c-=1.0; i < 25; i++, b+=0.01) {
         a -= 0.02;
     }
 
-    // a and b should be both ~0.5!
+    // a, b and c should be all ~0.5!
+    // right now it only ever takes the last expression in the block... 
+    // leading to infinite loops, lost devices and incorrect results.
 }

--- a/naga/tests/in/glsl/multipart-for-loop.frag
+++ b/naga/tests/in/glsl/multipart-for-loop.frag
@@ -1,4 +1,4 @@
-// issue #6258 https://github.com/gfx-rs/wgpu/issues/6208
+// issue #6208 https://github.com/gfx-rs/wgpu/issues/6208
 # version 460
 
 void main() {

--- a/naga/tests/in/glsl/multipart-for-loop.frag
+++ b/naga/tests/in/glsl/multipart-for-loop.frag
@@ -1,0 +1,14 @@
+// issue #6258 https://github.com/gfx-rs/wgpu/issues/6208
+# version 460
+
+void main() {
+    float a = 1.0;
+    float b = 0.25;
+
+    // tests for multiple expressions in the third part!
+    for (int i = 0; i < 25; i++, b+=0.01) {
+        a -= 0.02;
+    }
+
+    // a and b should be both ~0.5!
+}

--- a/naga/tests/in/glsl/multipart-for-loop.frag
+++ b/naga/tests/in/glsl/multipart-for-loop.frag
@@ -14,6 +14,4 @@ void main() {
     }
 
     // a, b and c should be all ~0.5!
-    // right now it only ever takes the last expression in the block... 
-    // leading to infinite loops, lost devices and incorrect results.
 }

--- a/naga/tests/out/wgsl/glsl-multipart-for-loop.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-multipart-for-loop.frag.wgsl
@@ -1,0 +1,27 @@
+fn main_1() {
+    var a: f32 = 1f;
+    var b: f32 = 0.25f;
+    var i: i32 = 0i;
+
+    loop {
+        let _e6 = i;
+        if !((_e6 < 25i)) {
+            break;
+        }
+        {
+            let _e13 = a;
+            a = (_e13 - 0.02f);
+        }
+        continuing {
+            let _e10 = b;
+            b = (_e10 + 0.01f);
+        }
+    }
+    return;
+}
+
+@fragment 
+fn main() {
+    main_1();
+    return;
+}

--- a/naga/tests/out/wgsl/glsl-multipart-for-loop.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-multipart-for-loop.frag.wgsl
@@ -5,22 +5,22 @@ fn main_1() {
     var i: i32 = 20i;
 
     i = 0i;
-    let _e8 = c;
-    c = (_e8 - 1f);
+    let _e9 = c;
+    c = (_e9 - 1f);
     loop {
-        let _e11 = i;
-        if !((_e11 < 25i)) {
+        let _e12 = i;
+        if !((_e12 < 25i)) {
             break;
         }
         {
-            let _e18 = a;
-            a = (_e18 - 0.02f);
+            let _e22 = a;
+            a = (_e22 - 0.02f);
         }
         continuing {
-            let _e15 = i;
-            i = (_e15 + 1i);
-            let _e16 = b;
-            b = (_e16 + 0.01f);
+            let _e16 = i;
+            i = (_e16 + 1i);
+            let _e19 = b;
+            b = (_e19 + 0.01f);
         }
     }
     return;

--- a/naga/tests/out/wgsl/glsl-multipart-for-loop.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-multipart-for-loop.frag.wgsl
@@ -1,20 +1,23 @@
 fn main_1() {
     var a: f32 = 1f;
     var b: f32 = 0.25f;
-    var i: i32 = 0i;
+    var c: f32 = 1.5f;
+    var i: i32 = 20i;
 
+    let _e8 = c;
+    c = (_e8 - 1f);
     loop {
-        let _e6 = i;
-        if !((_e6 < 25i)) {
+        let _e11 = i;
+        if !((_e11 < 25i)) {
             break;
         }
         {
-            let _e13 = a;
-            a = (_e13 - 0.02f);
+            let _e18 = a;
+            a = (_e18 - 0.02f);
         }
         continuing {
-            let _e10 = b;
-            b = (_e10 + 0.01f);
+            let _e15 = b;
+            b = (_e15 + 0.01f);
         }
     }
     return;

--- a/naga/tests/out/wgsl/glsl-multipart-for-loop.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-multipart-for-loop.frag.wgsl
@@ -4,6 +4,7 @@ fn main_1() {
     var c: f32 = 1.5f;
     var i: i32 = 20i;
 
+    i = 0i;
     let _e8 = c;
     c = (_e8 - 1f);
     loop {
@@ -16,8 +17,10 @@ fn main_1() {
             a = (_e18 - 0.02f);
         }
         continuing {
-            let _e15 = b;
-            b = (_e15 + 0.01f);
+            let _e15 = i;
+            i = (_e15 + 1i);
+            let _e16 = b;
+            b = (_e16 + 0.01f);
         }
     }
     return;


### PR DESCRIPTION
**Connections**
fixes #6208

**Description**
Adds a `Sequence` expression kind so side effect of comma separated expressions aren't lost.

Comments welcome this is my first time trying to fix rust code.

**Testing**
Adds naga glsl test case, sanity checked against shadertoy, now both are visually grey. 

**Squash or Rebase?**
squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
