### PR TITLE
Fix workgroupUniformLoad returning atomic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Bottom level categories:
 
 - Reject zero-value construction of a runtime-sized array with a validation error. Previously it would crash in the HLSL backend. By @mooori in [#8741](https://github.com/gfx-rs/wgpu/pull/8741).
 - Reject splat vector construction if the argument type does not match the type of the vector's scalar. Previously it would succeed. By @mooori in [#8829](https://github.com/gfx-rs/wgpu/pull/8829).
+- Fixed `workgroupUniformLoad` incorrectly returning an atomic when called on an atomic, it now returns the inner `T` as per the spec. By @cryvosh in [#8791](https://github.com/gfx-rs/wgpu/pull/8791).
 
 ### Documentation
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -220,6 +220,9 @@ webgpu:shader,execution,expression,call,builtin,textureSampleBaseClampToEdge:2d_
 // NOTE: This is supposed to be an exhaustive listing underneath
 // `webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:*`, so exceptions can be
 // worked around.
+webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="atomic%3Cu32%3E";*
+webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="atomic%3Ci32%3E";*
+webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="AtomicInStruct";*
 webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="bool";*
 webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="u32";*
 webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="vec4u";*
@@ -228,10 +231,6 @@ webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type=
 webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="SimpleStruct";*
 //FAIL: https://github.com/gfx-rs/wgpu/issues/8812
 // webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="ComplexStruct";*
-//FAIL: https://github.com/gfx-rs/wgpu/pull/8791
-// webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="atomic%3Cu32%3E";*
-// webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="atomic%3Ci32%3E";*
-// webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="AtomicInStruct";*
 webgpu:shader,execution,flow_control,return:*
 // Many other vertex_buffer_access subtests also passing, but there are too many to enumerate.
 // Fails on Metal in CI only, not when running locally.

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -4122,43 +4122,15 @@ impl BlockContext<'_> {
                     self.writer
                         .write_control_barrier(crate::Barrier::WORK_GROUP, &mut block.body);
                     let result_type_id = self.get_expression_type_id(&self.fun_info[result].ty);
-                    // Embed the body of
-                    match self.write_access_chain(
+                    // Match `Expression::Load` behavior, including `OpAtomicLoad` when
+                    // loading from a pointer to `atomic<T>`.
+                    let id = self.write_checked_load(
                         pointer,
                         &mut block,
                         AccessTypeAdjustment::None,
-                    )? {
-                        ExpressionPointer::Ready { pointer_id } => {
-                            let id = self.gen_id();
-                            block.body.push(Instruction::load(
-                                result_type_id,
-                                id,
-                                pointer_id,
-                                None,
-                            ));
-                            self.cached[result] = id;
-                        }
-                        ExpressionPointer::Conditional { condition, access } => {
-                            self.cached[result] = self.write_conditional_indexed_load(
-                                result_type_id,
-                                condition,
-                                &mut block,
-                                move |id_gen, block| {
-                                    // The in-bounds path. Perform the access and the load.
-                                    let pointer_id = access.result_id.unwrap();
-                                    let value_id = id_gen.next();
-                                    block.body.push(access);
-                                    block.body.push(Instruction::load(
-                                        result_type_id,
-                                        value_id,
-                                        pointer_id,
-                                        None,
-                                    ));
-                                    value_id
-                                },
-                            )
-                        }
-                    }
+                        result_type_id,
+                    )?;
+                    self.cached[result] = id;
                     self.writer
                         .write_control_barrier(crate::Barrier::WORK_GROUP, &mut block.body);
                 }

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -3041,7 +3041,32 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                 ir::TypeInner::Pointer {
                                     base,
                                     space: ir::AddressSpace::WorkGroup,
-                                } => base,
+                                } => match ctx.module.types[base].inner {
+                                    // Match `Expression::Load` semantics:
+                                    // loading through a pointer to `atomic<T>` produces a `T`.
+                                    ir::TypeInner::Atomic(scalar) => ctx.module.types.insert(
+                                        ir::Type {
+                                            name: None,
+                                            inner: ir::TypeInner::Scalar(scalar),
+                                        },
+                                        span,
+                                    ),
+                                    _ => base,
+                                },
+                                ir::TypeInner::ValuePointer {
+                                    size,
+                                    scalar,
+                                    space: ir::AddressSpace::WorkGroup,
+                                } => ctx.module.types.insert(
+                                    ir::Type {
+                                        name: None,
+                                        inner: match size {
+                                            Some(size) => ir::TypeInner::Vector { size, scalar },
+                                            None => ir::TypeInner::Scalar(scalar),
+                                        },
+                                    },
+                                    span,
+                                ),
                                 ref other => {
                                     log::error!("Type {other:?} passed to workgroupUniformLoad");
                                     let span = ctx.ast_expressions.get_span(expr);

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -3067,7 +3067,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                     },
                                     span,
                                 ),
-                                ref other => {
+                                _ => {
                                     let span = ctx.ast_expressions.get_span(expr);
                                     return Err(Box::new(Error::InvalidWorkGroupUniformLoad(span)));
                                 }

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -3068,7 +3068,6 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                     span,
                                 ),
                                 ref other => {
-                                    log::error!("Type {other:?} passed to workgroupUniformLoad");
                                     let span = ctx.ast_expressions.get_span(expr);
                                     return Err(Box::new(Error::InvalidWorkGroupUniformLoad(span)));
                                 }

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -1479,6 +1479,8 @@ impl super::Validator {
                         base: ty,
                         space: AddressSpace::WorkGroup,
                     };
+                    // workgroupUniformLoad on atomic<T> returns T, not atomic<T>.
+                    // Verify the pointer's atomic scalar matches the result scalar.
                     let atomic_specialization_ok = match *pointer_inner {
                         Ti::Pointer {
                             base: pointer_base,

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -1479,7 +1479,24 @@ impl super::Validator {
                         base: ty,
                         space: AddressSpace::WorkGroup,
                     };
-                    if !expected_pointer_inner.non_struct_equivalent(pointer_inner, context.types) {
+                    let atomic_specialization_ok = match *pointer_inner {
+                        Ti::Pointer {
+                            base: pointer_base,
+                            space: AddressSpace::WorkGroup,
+                        } => match (
+                            &context.types[pointer_base].inner,
+                            &context.types[ty].inner,
+                        ) {
+                            (&Ti::Atomic(pointer_scalar), &Ti::Scalar(result_scalar)) => {
+                                pointer_scalar == result_scalar
+                            }
+                            _ => false,
+                        },
+                        _ => false,
+                    };
+                    if !expected_pointer_inner.non_struct_equivalent(pointer_inner, context.types)
+                        && !atomic_specialization_ok
+                    {
                         return Err(FunctionError::WorkgroupUniformLoadInvalidPointer(pointer)
                             .with_span_static(span, "WorkGroupUniformLoad"));
                     }

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -1483,10 +1483,7 @@ impl super::Validator {
                         Ti::Pointer {
                             base: pointer_base,
                             space: AddressSpace::WorkGroup,
-                        } => match (
-                            &context.types[pointer_base].inner,
-                            &context.types[ty].inner,
-                        ) {
+                        } => match (&context.types[pointer_base].inner, &context.types[ty].inner) {
                             (&Ti::Atomic(pointer_scalar), &Ti::Scalar(result_scalar)) => {
                                 pointer_scalar == result_scalar
                             }

--- a/naga/tests/in/wgsl/workgroup-uniform-load-atomic.wgsl
+++ b/naga/tests/in/wgsl/workgroup-uniform-load-atomic.wgsl
@@ -1,0 +1,30 @@
+// Test workgroupUniformLoad specialization for atomic<T> -> T
+// Issue: https://github.com/gfx-rs/wgpu/issues/8785
+
+var<workgroup> wg_scalar: atomic<u32>;
+var<workgroup> wg_signed: atomic<i32>;
+
+@compute @workgroup_size(64)
+fn test_atomic_workgroup_uniform_load(
+    @builtin(workgroup_id) workgroup_id: vec3u,
+    @builtin(local_invocation_id) local_id: vec3u
+) {
+    let active_tile_index = workgroup_id.x + workgroup_id.y * 32768;
+    
+    // Each thread may set the atomic
+    atomicOr(&wg_scalar, u32(active_tile_index >= 64));
+    atomicAdd(&wg_signed, 1i);
+    
+    workgroupBarrier();
+    
+    // workgroupUniformLoad on atomic<u32> should return u32
+    let scalar_val: u32 = workgroupUniformLoad(&wg_scalar);
+    
+    // workgroupUniformLoad on atomic<i32> should return i32
+    let signed_val: i32 = workgroupUniformLoad(&wg_signed);
+    
+    // Should be able to use the result in comparisons
+    if scalar_val == 0u && signed_val > 0i {
+        return;
+    }
+}

--- a/naga/tests/in/wgsl/workgroup-uniform-load-atomic.wgsl
+++ b/naga/tests/in/wgsl/workgroup-uniform-load-atomic.wgsl
@@ -1,8 +1,13 @@
 // Test workgroupUniformLoad specialization for atomic<T> -> T
-// Issue: https://github.com/gfx-rs/wgpu/issues/8785
+
+struct AtomicStruct {
+    atomic_scalar: atomic<u32>,
+    atomic_arr: array<atomic<i32>, 2>,
+}
 
 var<workgroup> wg_scalar: atomic<u32>;
 var<workgroup> wg_signed: atomic<i32>;
+var<workgroup> wg_struct: AtomicStruct;
 
 @compute @workgroup_size(64)
 fn test_atomic_workgroup_uniform_load(
@@ -11,9 +16,11 @@ fn test_atomic_workgroup_uniform_load(
 ) {
     let active_tile_index = workgroup_id.x + workgroup_id.y * 32768;
     
-    // Each thread may set the atomic
+    // Each thread may set the atomics
     atomicOr(&wg_scalar, u32(active_tile_index >= 64));
     atomicAdd(&wg_signed, 1i);
+    atomicStore(&wg_struct.atomic_scalar, 1u);
+    atomicAdd(&wg_struct.atomic_arr[0], 1i);
     
     workgroupBarrier();
     
@@ -23,8 +30,14 @@ fn test_atomic_workgroup_uniform_load(
     // workgroupUniformLoad on atomic<i32> should return i32
     let signed_val: i32 = workgroupUniformLoad(&wg_signed);
     
-    // Should be able to use the result in comparisons
-    if scalar_val == 0u && signed_val > 0i {
+    // workgroupUniformLoad on struct.atomic_scalar should return u32
+    let struct_scalar: u32 = workgroupUniformLoad(&wg_struct.atomic_scalar);
+    
+    // workgroupUniformLoad on struct.atomic_arr[i] should return i32
+    let struct_arr_val: i32 = workgroupUniformLoad(&wg_struct.atomic_arr[0]);
+    
+    // Should be able to use all results in comparisons
+    if scalar_val == 0u && signed_val > 0i && struct_scalar > 0u && struct_arr_val > 0i {
         return;
     }
 }

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -48,37 +48,6 @@ fn check_success(input: &str) {
 }
 
 #[test]
-fn workgroup_uniform_load_atomic_returns_scalar() {
-    let input = r#"
-var<workgroup> wg_scratch: atomic<u32>;
-
-@compute @workgroup_size(4, 4, 4)
-fn interval_tile_main(
-    @builtin(workgroup_id) workgroup_id: vec3u,
-    @builtin(local_invocation_id) local_id: vec3u
-) {
-    let active_tile_index = workgroup_id.x + workgroup_id.y * 32768u;
-    atomicOr(&wg_scratch, u32(active_tile_index >= 64u));
-    workgroupBarrier();
-    if workgroupUniformLoad(&wg_scratch) == 0 {
-        return;
-    }
-}
-"#;
-
-    let module = naga::front::wgsl::parse_str(input).unwrap_or_else(|err| {
-        panic!(
-            "expected success, but parsing failed with:\n{}",
-            err.emit_to_string(input)
-        )
-    });
-
-    naga::valid::Validator::new(valid::ValidationFlags::default(), Capabilities::all())
-        .validate(&module)
-        .unwrap();
-}
-
-#[test]
 fn very_negative_integers() {
     // wgpu#4492
     check(

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -48,6 +48,37 @@ fn check_success(input: &str) {
 }
 
 #[test]
+fn workgroup_uniform_load_atomic_returns_scalar() {
+    let input = r#"
+var<workgroup> wg_scratch: atomic<u32>;
+
+@compute @workgroup_size(4, 4, 4)
+fn interval_tile_main(
+    @builtin(workgroup_id) workgroup_id: vec3u,
+    @builtin(local_invocation_id) local_id: vec3u
+) {
+    let active_tile_index = workgroup_id.x + workgroup_id.y * 32768u;
+    atomicOr(&wg_scratch, u32(active_tile_index >= 64u));
+    workgroupBarrier();
+    if workgroupUniformLoad(&wg_scratch) == 0 {
+        return;
+    }
+}
+"#;
+
+    let module = naga::front::wgsl::parse_str(input).unwrap_or_else(|err| {
+        panic!(
+            "expected success, but parsing failed with:\n{}",
+            err.emit_to_string(input)
+        )
+    });
+
+    naga::valid::Validator::new(valid::ValidationFlags::default(), Capabilities::all())
+        .validate(&module)
+        .unwrap();
+}
+
+#[test]
 fn very_negative_integers() {
     // wgpu#4492
     check(

--- a/naga/tests/out/glsl/wgsl-workgroup-uniform-load-atomic.test_atomic_workgroup_uniform_load.Compute.glsl
+++ b/naga/tests/out/glsl/wgsl-workgroup-uniform-load-atomic.test_atomic_workgroup_uniform_load.Compute.glsl
@@ -5,43 +5,76 @@ precision highp int;
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
+struct AtomicStruct {
+    uint atomic_scalar;
+    int atomic_arr[2];
+};
 shared uint wg_scalar;
 
 shared int wg_signed;
+
+shared AtomicStruct wg_struct;
 
 
 void main() {
     if (gl_LocalInvocationID == uvec3(0u)) {
         wg_scalar = 0u;
         wg_signed = 0;
+        wg_struct = AtomicStruct(0u, int[2](0, 0));
     }
     memoryBarrierShared();
     barrier();
     uvec3 workgroup_id = gl_WorkGroupID;
     uvec3 local_id = gl_LocalInvocationID;
     bool local = false;
+    bool local_1 = false;
+    bool local_2 = false;
     uint active_tile_index = (workgroup_id.x + (workgroup_id.y * 32768u));
     uint _e11 = atomicOr(wg_scalar, uint((active_tile_index >= 64u)));
     int _e14 = atomicAdd(wg_signed, 1);
+    wg_struct.atomic_scalar = 1u;
+    int _e22 = atomicAdd(wg_struct.atomic_arr[0], 1);
     memoryBarrierShared();
     barrier();
     memoryBarrierShared();
     barrier();
-    uint _e16 = wg_scalar;
+    uint _e24 = wg_scalar;
     memoryBarrierShared();
     barrier();
     memoryBarrierShared();
     barrier();
-    int _e18 = wg_signed;
+    int _e26 = wg_signed;
     memoryBarrierShared();
     barrier();
-    if ((_e16 == 0u)) {
-        local = (_e18 > 0);
+    memoryBarrierShared();
+    barrier();
+    uint _e29 = wg_struct.atomic_scalar;
+    memoryBarrierShared();
+    barrier();
+    memoryBarrierShared();
+    barrier();
+    int _e33 = wg_struct.atomic_arr[0];
+    memoryBarrierShared();
+    barrier();
+    if ((_e24 == 0u)) {
+        local = (_e26 > 0);
     } else {
         local = false;
     }
-    bool _e26 = local;
-    if (_e26) {
+    bool _e41 = local;
+    if (_e41) {
+        local_1 = (_e29 > 0u);
+    } else {
+        local_1 = false;
+    }
+    bool _e47 = local_1;
+    if (_e47) {
+        local_2 = (_e33 > 0);
+    } else {
+        local_2 = false;
+    }
+    bool _e53 = local_2;
+    if (_e53) {
         return;
     } else {
         return;

--- a/naga/tests/out/glsl/wgsl-workgroup-uniform-load-atomic.test_atomic_workgroup_uniform_load.Compute.glsl
+++ b/naga/tests/out/glsl/wgsl-workgroup-uniform-load-atomic.test_atomic_workgroup_uniform_load.Compute.glsl
@@ -1,0 +1,50 @@
+#version 310 es
+
+precision highp float;
+precision highp int;
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+shared uint wg_scalar;
+
+shared int wg_signed;
+
+
+void main() {
+    if (gl_LocalInvocationID == uvec3(0u)) {
+        wg_scalar = 0u;
+        wg_signed = 0;
+    }
+    memoryBarrierShared();
+    barrier();
+    uvec3 workgroup_id = gl_WorkGroupID;
+    uvec3 local_id = gl_LocalInvocationID;
+    bool local = false;
+    uint active_tile_index = (workgroup_id.x + (workgroup_id.y * 32768u));
+    uint _e11 = atomicOr(wg_scalar, uint((active_tile_index >= 64u)));
+    int _e14 = atomicAdd(wg_signed, 1);
+    memoryBarrierShared();
+    barrier();
+    memoryBarrierShared();
+    barrier();
+    uint _e16 = wg_scalar;
+    memoryBarrierShared();
+    barrier();
+    memoryBarrierShared();
+    barrier();
+    int _e18 = wg_signed;
+    memoryBarrierShared();
+    barrier();
+    if ((_e16 == 0u)) {
+        local = (_e18 > 0);
+    } else {
+        local = false;
+    }
+    bool _e26 = local;
+    if (_e26) {
+        return;
+    } else {
+        return;
+    }
+}
+

--- a/naga/tests/out/hlsl/wgsl-workgroup-uniform-load-atomic.hlsl
+++ b/naga/tests/out/hlsl/wgsl-workgroup-uniform-load-atomic.hlsl
@@ -1,0 +1,35 @@
+groupshared uint wg_scalar;
+groupshared int wg_signed;
+
+[numthreads(64, 1, 1)]
+void test_atomic_workgroup_uniform_load(uint3 workgroup_id : SV_GroupID, uint3 local_id : SV_GroupThreadID, uint3 __local_invocation_id : SV_GroupThreadID)
+{
+    if (all(__local_invocation_id == uint3(0u, 0u, 0u))) {
+        wg_scalar = (uint)0;
+        wg_signed = (int)0;
+    }
+    GroupMemoryBarrierWithGroupSync();
+    bool local = (bool)0;
+
+    uint active_tile_index = (workgroup_id.x + (workgroup_id.y * 32768u));
+    uint _e11; InterlockedOr(wg_scalar, uint((active_tile_index >= 64u)), _e11);
+    int _e14; InterlockedAdd(wg_signed, int(1), _e14);
+    GroupMemoryBarrierWithGroupSync();
+    GroupMemoryBarrierWithGroupSync();
+    uint _e16 = wg_scalar;
+    GroupMemoryBarrierWithGroupSync();
+    GroupMemoryBarrierWithGroupSync();
+    int _e18 = wg_signed;
+    GroupMemoryBarrierWithGroupSync();
+    if ((_e16 == 0u)) {
+        local = (_e18 > int(0));
+    } else {
+        local = false;
+    }
+    bool _e26 = local;
+    if (_e26) {
+        return;
+    } else {
+        return;
+    }
+}

--- a/naga/tests/out/hlsl/wgsl-workgroup-uniform-load-atomic.hlsl
+++ b/naga/tests/out/hlsl/wgsl-workgroup-uniform-load-atomic.hlsl
@@ -1,5 +1,11 @@
+struct AtomicStruct {
+    uint atomic_scalar;
+    int atomic_arr[2];
+};
+
 groupshared uint wg_scalar;
 groupshared int wg_signed;
+groupshared AtomicStruct wg_struct;
 
 [numthreads(64, 1, 1)]
 void test_atomic_workgroup_uniform_load(uint3 workgroup_id : SV_GroupID, uint3 local_id : SV_GroupThreadID, uint3 __local_invocation_id : SV_GroupThreadID)
@@ -7,27 +13,50 @@ void test_atomic_workgroup_uniform_load(uint3 workgroup_id : SV_GroupID, uint3 l
     if (all(__local_invocation_id == uint3(0u, 0u, 0u))) {
         wg_scalar = (uint)0;
         wg_signed = (int)0;
+        wg_struct = (AtomicStruct)0;
     }
     GroupMemoryBarrierWithGroupSync();
     bool local = (bool)0;
+    bool local_1 = (bool)0;
+    bool local_2 = (bool)0;
 
     uint active_tile_index = (workgroup_id.x + (workgroup_id.y * 32768u));
     uint _e11; InterlockedOr(wg_scalar, uint((active_tile_index >= 64u)), _e11);
     int _e14; InterlockedAdd(wg_signed, int(1), _e14);
+    wg_struct.atomic_scalar = 1u;
+    int _e22; InterlockedAdd(wg_struct.atomic_arr[0], int(1), _e22);
     GroupMemoryBarrierWithGroupSync();
     GroupMemoryBarrierWithGroupSync();
-    uint _e16 = wg_scalar;
+    uint _e24 = wg_scalar;
     GroupMemoryBarrierWithGroupSync();
     GroupMemoryBarrierWithGroupSync();
-    int _e18 = wg_signed;
+    int _e26 = wg_signed;
     GroupMemoryBarrierWithGroupSync();
-    if ((_e16 == 0u)) {
-        local = (_e18 > int(0));
+    GroupMemoryBarrierWithGroupSync();
+    uint _e29 = wg_struct.atomic_scalar;
+    GroupMemoryBarrierWithGroupSync();
+    GroupMemoryBarrierWithGroupSync();
+    int _e33 = wg_struct.atomic_arr[0];
+    GroupMemoryBarrierWithGroupSync();
+    if ((_e24 == 0u)) {
+        local = (_e26 > int(0));
     } else {
         local = false;
     }
-    bool _e26 = local;
-    if (_e26) {
+    bool _e41 = local;
+    if (_e41) {
+        local_1 = (_e29 > 0u);
+    } else {
+        local_1 = false;
+    }
+    bool _e47 = local_1;
+    if (_e47) {
+        local_2 = (_e33 > int(0));
+    } else {
+        local_2 = false;
+    }
+    bool _e53 = local_2;
+    if (_e53) {
         return;
     } else {
         return;

--- a/naga/tests/out/hlsl/wgsl-workgroup-uniform-load-atomic.ron
+++ b/naga/tests/out/hlsl/wgsl-workgroup-uniform-load-atomic.ron
@@ -1,0 +1,12 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"test_atomic_workgroup_uniform_load",
+            target_profile:"cs_5_1",
+        ),
+    ],
+)

--- a/naga/tests/out/msl/wgsl-workgroup-uniform-load-atomic.msl
+++ b/naga/tests/out/msl/wgsl-workgroup-uniform-load-atomic.msl
@@ -1,0 +1,43 @@
+// language: metal1.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+
+struct test_atomic_workgroup_uniform_loadInput {
+};
+kernel void test_atomic_workgroup_uniform_load(
+  metal::uint3 workgroup_id [[threadgroup_position_in_grid]]
+, metal::uint3 local_id [[thread_position_in_threadgroup]]
+, threadgroup metal::atomic_uint& wg_scalar
+, threadgroup metal::atomic_int& wg_signed
+) {
+    if (metal::all(local_id == metal::uint3(0u))) {
+        metal::atomic_store_explicit(&wg_scalar, 0, metal::memory_order_relaxed);
+        metal::atomic_store_explicit(&wg_signed, 0, metal::memory_order_relaxed);
+    }
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    bool local = {};
+    uint active_tile_index = workgroup_id.x + (workgroup_id.y * 32768u);
+    uint _e11 = metal::atomic_fetch_or_explicit(&wg_scalar, static_cast<uint>(active_tile_index >= 64u), metal::memory_order_relaxed);
+    int _e14 = metal::atomic_fetch_add_explicit(&wg_signed, 1, metal::memory_order_relaxed);
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    uint unnamed = metal::atomic_load_explicit(&wg_scalar, metal::memory_order_relaxed);
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    int unnamed_1 = metal::atomic_load_explicit(&wg_signed, metal::memory_order_relaxed);
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    if (unnamed == 0u) {
+        local = unnamed_1 > 0;
+    } else {
+        local = false;
+    }
+    bool _e26 = local;
+    if (_e26) {
+        return;
+    } else {
+        return;
+    }
+}

--- a/naga/tests/out/msl/wgsl-workgroup-uniform-load-atomic.msl
+++ b/naga/tests/out/msl/wgsl-workgroup-uniform-load-atomic.msl
@@ -4,6 +4,13 @@
 
 using metal::uint;
 
+struct type_2 {
+    metal::atomic_int inner[2];
+};
+struct AtomicStruct {
+    metal::atomic_uint atomic_scalar;
+    type_2 atomic_arr;
+};
 
 struct test_atomic_workgroup_uniform_loadInput {
 };
@@ -12,16 +19,25 @@ kernel void test_atomic_workgroup_uniform_load(
 , metal::uint3 local_id [[thread_position_in_threadgroup]]
 , threadgroup metal::atomic_uint& wg_scalar
 , threadgroup metal::atomic_int& wg_signed
+, threadgroup AtomicStruct& wg_struct
 ) {
     if (metal::all(local_id == metal::uint3(0u))) {
         metal::atomic_store_explicit(&wg_scalar, 0, metal::memory_order_relaxed);
         metal::atomic_store_explicit(&wg_signed, 0, metal::memory_order_relaxed);
+        metal::atomic_store_explicit(&wg_struct.atomic_scalar, 0, metal::memory_order_relaxed);
+        for (int __i0 = 0; __i0 < 2; __i0++) {
+            metal::atomic_store_explicit(&wg_struct.atomic_arr.inner[__i0], 0, metal::memory_order_relaxed);
+        }
     }
     metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
     bool local = {};
+    bool local_1 = {};
+    bool local_2 = {};
     uint active_tile_index = workgroup_id.x + (workgroup_id.y * 32768u);
     uint _e11 = metal::atomic_fetch_or_explicit(&wg_scalar, static_cast<uint>(active_tile_index >= 64u), metal::memory_order_relaxed);
     int _e14 = metal::atomic_fetch_add_explicit(&wg_signed, 1, metal::memory_order_relaxed);
+    metal::atomic_store_explicit(&wg_struct.atomic_scalar, 1u, metal::memory_order_relaxed);
+    int _e22 = metal::atomic_fetch_add_explicit(&wg_struct.atomic_arr.inner[0], 1, metal::memory_order_relaxed);
     metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
     metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
     uint unnamed = metal::atomic_load_explicit(&wg_scalar, metal::memory_order_relaxed);
@@ -29,13 +45,31 @@ kernel void test_atomic_workgroup_uniform_load(
     metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
     int unnamed_1 = metal::atomic_load_explicit(&wg_signed, metal::memory_order_relaxed);
     metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    uint unnamed_2 = metal::atomic_load_explicit(&wg_struct.atomic_scalar, metal::memory_order_relaxed);
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    int unnamed_3 = metal::atomic_load_explicit(&wg_struct.atomic_arr.inner[0], metal::memory_order_relaxed);
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
     if (unnamed == 0u) {
         local = unnamed_1 > 0;
     } else {
         local = false;
     }
-    bool _e26 = local;
-    if (_e26) {
+    bool _e41 = local;
+    if (_e41) {
+        local_1 = unnamed_2 > 0u;
+    } else {
+        local_1 = false;
+    }
+    bool _e47 = local_1;
+    if (_e47) {
+        local_2 = unnamed_3 > 0;
+    } else {
+        local_2 = false;
+    }
+    bool _e53 = local_2;
+    if (_e53) {
         return;
     } else {
         return;

--- a/naga/tests/out/spv/wgsl-workgroup-uniform-load-atomic.spvasm
+++ b/naga/tests/out/spv/wgsl-workgroup-uniform-load-atomic.spvasm
@@ -1,95 +1,143 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 61
+; Bound: 88
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %17 "test_atomic_workgroup_uniform_load" %12 %15
-OpExecutionMode %17 LocalSize 64 1 1
-OpDecorate %12 BuiltIn WorkgroupId
-OpDecorate %15 BuiltIn LocalInvocationId
+OpEntryPoint GLCompute %22 "test_atomic_workgroup_uniform_load" %17 %20
+OpExecutionMode %22 LocalSize 64 1 1
+OpDecorate %5 ArrayStride 4
+OpMemberDecorate %7 0 Offset 0
+OpMemberDecorate %7 1 Offset 4
+OpDecorate %17 BuiltIn WorkgroupId
+OpDecorate %20 BuiltIn LocalInvocationId
 %2 = OpTypeVoid
 %3 = OpTypeInt 32 0
 %4 = OpTypeInt 32 1
-%5 = OpTypeVector %3 3
-%6 = OpTypeBool
-%8 = OpTypePointer Workgroup %3
-%7 = OpVariable  %8  Workgroup
-%10 = OpTypePointer Workgroup %4
-%9 = OpVariable  %10  Workgroup
-%13 = OpTypePointer Input %5
-%12 = OpVariable  %13  Input
-%15 = OpVariable  %13  Input
-%18 = OpTypeFunction %2
-%19 = OpConstant  %3  32768
-%20 = OpConstant  %3  64
-%21 = OpConstant  %4  1
-%22 = OpConstant  %3  0
-%23 = OpConstantFalse  %6
-%24 = OpConstant  %4  0
-%26 = OpTypePointer Function %6
-%27 = OpConstantNull  %6
-%29 = OpConstantNull  %3
-%30 = OpConstantNull  %4
-%31 = OpConstantNull  %5
-%32 = OpTypeVector %6 3
-%37 = OpConstant  %3  2
-%38 = OpConstant  %3  264
-%45 = OpConstant  %3  1
-%48 = OpConstant  %4  2
-%17 = OpFunction  %2  None %18
-%11 = OpLabel
-%25 = OpVariable  %26  Function %27
-%14 = OpLoad  %5  %12
-%16 = OpLoad  %5  %15
-OpBranch %28
-%28 = OpLabel
-%33 = OpIEqual  %32  %16 %31
-%34 = OpAll  %6  %33
-OpSelectionMerge %35 None
-OpBranchConditional %34 %36 %35
-%36 = OpLabel
-OpStore %7 %29
-OpStore %9 %30
-OpBranch %35
-%35 = OpLabel
-OpControlBarrier %37 %37 %38
-OpBranch %39
-%39 = OpLabel
-%40 = OpCompositeExtract  %3  %14 0
-%41 = OpCompositeExtract  %3  %14 1
-%42 = OpIMul  %3  %41 %19
-%43 = OpIAdd  %3  %40 %42
-%44 = OpUGreaterThanEqual  %6  %43 %20
-%46 = OpSelect  %3  %44 %45 %22
-%47 = OpAtomicOr  %3  %7 %48 %22 %46
-%49 = OpAtomicIAdd  %4  %9 %48 %22 %21
-OpControlBarrier %37 %37 %38
-OpControlBarrier %37 %37 %38
-%50 = OpAtomicLoad  %3  %7 %48 %22
-OpControlBarrier %37 %37 %38
-OpControlBarrier %37 %37 %38
-%51 = OpAtomicLoad  %4  %9 %48 %22
-OpControlBarrier %37 %37 %38
-%52 = OpIEqual  %6  %50 %22
-OpSelectionMerge %53 None
-OpBranchConditional %52 %54 %55
-%54 = OpLabel
-%56 = OpSGreaterThan  %6  %51 %24
-OpStore %25 %56
-OpBranch %53
-%55 = OpLabel
-OpStore %25 %23
-OpBranch %53
-%53 = OpLabel
-%57 = OpLoad  %6  %25
-OpSelectionMerge %58 None
-OpBranchConditional %57 %59 %60
-%59 = OpLabel
+%6 = OpConstant  %3  2
+%5 = OpTypeArray %4 %6
+%7 = OpTypeStruct %3 %5
+%8 = OpTypeVector %3 3
+%9 = OpTypeBool
+%11 = OpTypePointer Workgroup %3
+%10 = OpVariable  %11  Workgroup
+%13 = OpTypePointer Workgroup %4
+%12 = OpVariable  %13  Workgroup
+%15 = OpTypePointer Workgroup %7
+%14 = OpVariable  %15  Workgroup
+%18 = OpTypePointer Input %8
+%17 = OpVariable  %18  Input
+%20 = OpVariable  %18  Input
+%23 = OpTypeFunction %2
+%24 = OpConstant  %3  32768
+%25 = OpConstant  %3  64
+%26 = OpConstant  %4  1
+%27 = OpConstant  %3  1
+%28 = OpConstant  %3  0
+%29 = OpConstantFalse  %9
+%30 = OpConstant  %4  0
+%32 = OpTypePointer Function %9
+%33 = OpConstantNull  %9
+%35 = OpConstantNull  %9
+%37 = OpConstantNull  %9
+%39 = OpConstantNull  %3
+%40 = OpConstantNull  %4
+%41 = OpConstantNull  %7
+%42 = OpConstantNull  %8
+%43 = OpTypeVector %9 3
+%48 = OpConstant  %3  264
+%57 = OpConstant  %4  2
+%60 = OpTypePointer Workgroup %5
+%22 = OpFunction  %2  None %23
+%16 = OpLabel
+%31 = OpVariable  %32  Function %33
+%34 = OpVariable  %32  Function %35
+%36 = OpVariable  %32  Function %37
+%19 = OpLoad  %8  %17
+%21 = OpLoad  %8  %20
+OpBranch %38
+%38 = OpLabel
+%44 = OpIEqual  %43  %21 %42
+%45 = OpAll  %9  %44
+OpSelectionMerge %46 None
+OpBranchConditional %45 %47 %46
+%47 = OpLabel
+OpStore %10 %39
+OpStore %12 %40
+OpStore %14 %41
+OpBranch %46
+%46 = OpLabel
+OpControlBarrier %6 %6 %48
+OpBranch %49
+%49 = OpLabel
+%50 = OpCompositeExtract  %3  %19 0
+%51 = OpCompositeExtract  %3  %19 1
+%52 = OpIMul  %3  %51 %24
+%53 = OpIAdd  %3  %50 %52
+%54 = OpUGreaterThanEqual  %9  %53 %25
+%55 = OpSelect  %3  %54 %27 %28
+%56 = OpAtomicOr  %3  %10 %57 %28 %55
+%58 = OpAtomicIAdd  %4  %12 %57 %28 %26
+%59 = OpAccessChain  %11  %14 %28
+OpAtomicStore %59 %57 %28 %27
+%62 = OpAccessChain  %13  %14 %27 %28
+%61 = OpAtomicIAdd  %4  %62 %57 %28 %26
+OpControlBarrier %6 %6 %48
+OpControlBarrier %6 %6 %48
+%63 = OpAtomicLoad  %3  %10 %57 %28
+OpControlBarrier %6 %6 %48
+OpControlBarrier %6 %6 %48
+%64 = OpAtomicLoad  %4  %12 %57 %28
+OpControlBarrier %6 %6 %48
+OpControlBarrier %6 %6 %48
+%65 = OpAccessChain  %11  %14 %28
+%66 = OpAtomicLoad  %3  %65 %57 %28
+OpControlBarrier %6 %6 %48
+OpControlBarrier %6 %6 %48
+%67 = OpAccessChain  %13  %14 %27 %28
+%68 = OpAtomicLoad  %4  %67 %57 %28
+OpControlBarrier %6 %6 %48
+%69 = OpIEqual  %9  %63 %28
+OpSelectionMerge %70 None
+OpBranchConditional %69 %71 %72
+%71 = OpLabel
+%73 = OpSGreaterThan  %9  %64 %30
+OpStore %31 %73
+OpBranch %70
+%72 = OpLabel
+OpStore %31 %29
+OpBranch %70
+%70 = OpLabel
+%74 = OpLoad  %9  %31
+OpSelectionMerge %75 None
+OpBranchConditional %74 %76 %77
+%76 = OpLabel
+%78 = OpUGreaterThan  %9  %66 %28
+OpStore %34 %78
+OpBranch %75
+%77 = OpLabel
+OpStore %34 %29
+OpBranch %75
+%75 = OpLabel
+%79 = OpLoad  %9  %34
+OpSelectionMerge %80 None
+OpBranchConditional %79 %81 %82
+%81 = OpLabel
+%83 = OpSGreaterThan  %9  %68 %30
+OpStore %36 %83
+OpBranch %80
+%82 = OpLabel
+OpStore %36 %29
+OpBranch %80
+%80 = OpLabel
+%84 = OpLoad  %9  %36
+OpSelectionMerge %85 None
+OpBranchConditional %84 %86 %87
+%86 = OpLabel
 OpReturn
-%60 = OpLabel
+%87 = OpLabel
 OpReturn
-%58 = OpLabel
+%85 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/wgsl-workgroup-uniform-load-atomic.spvasm
+++ b/naga/tests/out/spv/wgsl-workgroup-uniform-load-atomic.spvasm
@@ -1,0 +1,95 @@
+; SPIR-V
+; Version: 1.1
+; Generator: rspirv
+; Bound: 61
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %17 "test_atomic_workgroup_uniform_load" %12 %15
+OpExecutionMode %17 LocalSize 64 1 1
+OpDecorate %12 BuiltIn WorkgroupId
+OpDecorate %15 BuiltIn LocalInvocationId
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%4 = OpTypeInt 32 1
+%5 = OpTypeVector %3 3
+%6 = OpTypeBool
+%8 = OpTypePointer Workgroup %3
+%7 = OpVariable  %8  Workgroup
+%10 = OpTypePointer Workgroup %4
+%9 = OpVariable  %10  Workgroup
+%13 = OpTypePointer Input %5
+%12 = OpVariable  %13  Input
+%15 = OpVariable  %13  Input
+%18 = OpTypeFunction %2
+%19 = OpConstant  %3  32768
+%20 = OpConstant  %3  64
+%21 = OpConstant  %4  1
+%22 = OpConstant  %3  0
+%23 = OpConstantFalse  %6
+%24 = OpConstant  %4  0
+%26 = OpTypePointer Function %6
+%27 = OpConstantNull  %6
+%29 = OpConstantNull  %3
+%30 = OpConstantNull  %4
+%31 = OpConstantNull  %5
+%32 = OpTypeVector %6 3
+%37 = OpConstant  %3  2
+%38 = OpConstant  %3  264
+%45 = OpConstant  %3  1
+%48 = OpConstant  %4  2
+%17 = OpFunction  %2  None %18
+%11 = OpLabel
+%25 = OpVariable  %26  Function %27
+%14 = OpLoad  %5  %12
+%16 = OpLoad  %5  %15
+OpBranch %28
+%28 = OpLabel
+%33 = OpIEqual  %32  %16 %31
+%34 = OpAll  %6  %33
+OpSelectionMerge %35 None
+OpBranchConditional %34 %36 %35
+%36 = OpLabel
+OpStore %7 %29
+OpStore %9 %30
+OpBranch %35
+%35 = OpLabel
+OpControlBarrier %37 %37 %38
+OpBranch %39
+%39 = OpLabel
+%40 = OpCompositeExtract  %3  %14 0
+%41 = OpCompositeExtract  %3  %14 1
+%42 = OpIMul  %3  %41 %19
+%43 = OpIAdd  %3  %40 %42
+%44 = OpUGreaterThanEqual  %6  %43 %20
+%46 = OpSelect  %3  %44 %45 %22
+%47 = OpAtomicOr  %3  %7 %48 %22 %46
+%49 = OpAtomicIAdd  %4  %9 %48 %22 %21
+OpControlBarrier %37 %37 %38
+OpControlBarrier %37 %37 %38
+%50 = OpAtomicLoad  %3  %7 %48 %22
+OpControlBarrier %37 %37 %38
+OpControlBarrier %37 %37 %38
+%51 = OpAtomicLoad  %4  %9 %48 %22
+OpControlBarrier %37 %37 %38
+%52 = OpIEqual  %6  %50 %22
+OpSelectionMerge %53 None
+OpBranchConditional %52 %54 %55
+%54 = OpLabel
+%56 = OpSGreaterThan  %6  %51 %24
+OpStore %25 %56
+OpBranch %53
+%55 = OpLabel
+OpStore %25 %23
+OpBranch %53
+%53 = OpLabel
+%57 = OpLoad  %6  %25
+OpSelectionMerge %58 None
+OpBranchConditional %57 %59 %60
+%59 = OpLabel
+OpReturn
+%60 = OpLabel
+OpReturn
+%58 = OpLabel
+OpReturn
+OpFunctionEnd

--- a/naga/tests/out/wgsl/wgsl-workgroup-uniform-load-atomic.wgsl
+++ b/naga/tests/out/wgsl/wgsl-workgroup-uniform-load-atomic.wgsl
@@ -1,0 +1,25 @@
+var<workgroup> wg_scalar: atomic<u32>;
+var<workgroup> wg_signed: atomic<i32>;
+
+@compute @workgroup_size(64, 1, 1) 
+fn test_atomic_workgroup_uniform_load(@builtin(workgroup_id) workgroup_id: vec3<u32>, @builtin(local_invocation_id) local_id: vec3<u32>) {
+    var local: bool;
+
+    let active_tile_index = (workgroup_id.x + (workgroup_id.y * 32768u));
+    let _e11 = atomicOr((&wg_scalar), u32((active_tile_index >= 64u)));
+    let _e14 = atomicAdd((&wg_signed), 1i);
+    workgroupBarrier();
+    let _e16 = workgroupUniformLoad((&wg_scalar));
+    let _e18 = workgroupUniformLoad((&wg_signed));
+    if (_e16 == 0u) {
+        local = (_e18 > 0i);
+    } else {
+        local = false;
+    }
+    let _e26 = local;
+    if _e26 {
+        return;
+    } else {
+        return;
+    }
+}

--- a/naga/tests/out/wgsl/wgsl-workgroup-uniform-load-atomic.wgsl
+++ b/naga/tests/out/wgsl/wgsl-workgroup-uniform-load-atomic.wgsl
@@ -1,23 +1,47 @@
+struct AtomicStruct {
+    atomic_scalar: atomic<u32>,
+    atomic_arr: array<atomic<i32>, 2>,
+}
+
 var<workgroup> wg_scalar: atomic<u32>;
 var<workgroup> wg_signed: atomic<i32>;
+var<workgroup> wg_struct: AtomicStruct;
 
 @compute @workgroup_size(64, 1, 1) 
 fn test_atomic_workgroup_uniform_load(@builtin(workgroup_id) workgroup_id: vec3<u32>, @builtin(local_invocation_id) local_id: vec3<u32>) {
     var local: bool;
+    var local_1: bool;
+    var local_2: bool;
 
     let active_tile_index = (workgroup_id.x + (workgroup_id.y * 32768u));
     let _e11 = atomicOr((&wg_scalar), u32((active_tile_index >= 64u)));
     let _e14 = atomicAdd((&wg_signed), 1i);
+    atomicStore((&wg_struct.atomic_scalar), 1u);
+    let _e22 = atomicAdd((&wg_struct.atomic_arr[0]), 1i);
     workgroupBarrier();
-    let _e16 = workgroupUniformLoad((&wg_scalar));
-    let _e18 = workgroupUniformLoad((&wg_signed));
-    if (_e16 == 0u) {
-        local = (_e18 > 0i);
+    let _e24 = workgroupUniformLoad((&wg_scalar));
+    let _e26 = workgroupUniformLoad((&wg_signed));
+    let _e29 = workgroupUniformLoad((&wg_struct.atomic_scalar));
+    let _e33 = workgroupUniformLoad((&wg_struct.atomic_arr[0]));
+    if (_e24 == 0u) {
+        local = (_e26 > 0i);
     } else {
         local = false;
     }
-    let _e26 = local;
-    if _e26 {
+    let _e41 = local;
+    if _e41 {
+        local_1 = (_e29 > 0u);
+    } else {
+        local_1 = false;
+    }
+    let _e47 = local_1;
+    if _e47 {
+        local_2 = (_e33 > 0i);
+    } else {
+        local_2 = false;
+    }
+    let _e53 = local_2;
+    if _e53 {
         return;
     } else {
         return;


### PR DESCRIPTION
**Connections**
FIxes https://github.com/gfx-rs/wgpu/issues/8785.

**Description**
`workgroupUniformLoad` now matches the spec and returns the inner type when called on an atomic.

**Testing**
Added a new snapshot test `workgroup-uniform-load-atomic.wgsl`

**Squash or Rebase?**
Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
