### PR TITLE
Improve bindgroup layout entry docs to document PARTIALLY_BOUND_BINDING_ARRAY

### DIFF
--- a/wgpu-types/src/binding.rs
+++ b/wgpu-types/src/binding.rs
@@ -327,7 +327,7 @@ pub struct BindGroupLayoutEntry {
     /// If the binding is an array of multiple resources. Corresponds to `binding_array<T>` in the shader.
     ///
     /// When this is `Some` the following validation applies:
-    /// - Size must be of value 1 or greater.
+    /// - Count must be of value 1 or greater, this corresponds to the length of the array of resources that will be bound.
     /// - When `ty == BindingType::Texture`, [`Features::TEXTURE_BINDING_ARRAY`] must be supported.
     /// - When `ty == BindingType::Sampler`, [`Features::TEXTURE_BINDING_ARRAY`] must be supported.
     /// - When `ty == BindingType::Buffer`, [`Features::BUFFER_BINDING_ARRAY`] must be supported.
@@ -335,6 +335,7 @@ pub struct BindGroupLayoutEntry {
     /// - When `ty == BindingType::StorageTexture`, [`Features::STORAGE_RESOURCE_BINDING_ARRAY`] must be supported.
     /// - When any binding in the group is an array, no `BindingType::Buffer` in the group may have `has_dynamic_offset == true`
     /// - When any binding in the group is an array, no `BindingType::Buffer` in the group may have `ty.ty == BufferBindingType::Uniform`.
+    /// - If [`Features::PARTIALLY_BOUND_BINDING_ARRAY`] is enabled, the specified count becomes the upper bound instead.
     ///
     #[cfg_attr(feature = "serde", serde(default))]
     pub count: Option<NonZeroU32>,


### PR DESCRIPTION
**Connections**
None.

**Description**
This improves the documentation for the [count](https://docs.rs/wgpu/latest/wgpu/struct.BindGroupLayoutEntry.html#structfield.count) field of the `BindGroupLayoutEntry` to document the behaviour of the `count` field when the `PARTIALLY_BOUND_BINDING_ARRAY` feature is enabled. I expect this was just an accidental omission when that feature was introduced.

Second commit removes the `/` from `target/` in the gitignore. If `target/` is used, this does not match symlinks but only directories. Using `target` applies to both symlinks and directories as far as I know. I usually symlink to `/tmp/target` to keep the volatile assets in tmpfs and off my actual disk, so when I made the first commit I almost comitted my target symlink. Other projects in this namespace, like [wgpu-native](https://github.com/gfx-rs/wgpu-native/blob/ba4deb5d935652f40c7e051b15cbb5d097219941/.gitignore#L1) and [rspirv](https://github.com/gfx-rs/rspirv/blob/3e8814d838a49a98084ada2d1a8677e3281c6d33/.gitignore#L6) also lack the trailing `/`.

**Testing**
I determined the existing validation rules by assigning texture arrays of varying sizes with and without `PARTIALLY_BOUND_BINDING_ARRAY` active. Then I modified the documentation, built the documentation and verified that the link to the feature works.

**Squash or Rebase?**

I would recommend a rebase, given that the two commits are completely independent.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`. -> don't have this installed, but I didn't touch any toml files.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`  N/A
- [ ] Run `cargo xtask test` to run tests. -> Don't have this installed, first thing passed.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry.  -> No changes the user needs to be aware of.
