### PR TITLE
Fix weird comma

### DIFF
--- a/wgpu-types/src/surface.rs
+++ b/wgpu-types/src/surface.rs
@@ -105,7 +105,7 @@ pub enum PresentMode {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum CompositeAlphaMode {
-    /// Chooses either `Opaque` or `Inherit` automatically，depending on the
+    /// Chooses either `Opaque` or `Inherit` automatically, depending on the
     /// `alpha_mode` that the current surface can support.
     #[default]
     Auto = 0,


### PR DESCRIPTION
**Description**
My IDE didn't display the docs for `CompositeAlphaMode::Auto` correctly and I got curious. Turns out it's using "U+FF0C FULLWIDTH COMMA" instead of the more common "U+002C COMMA" followed by a regular old "U+0020 SPACE"

**Testing**
N/A

**Squash or Rebase?**

Squash

**Checklist**

Didn't bother because this is just an extremely trivial docs change :D
