### PR TITLE
Fix lazy jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,17 @@
 name: Docs
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/docs.yml"
   push:
-    branches:
-      - trunk
+    branches-ignore: [
+        # Renovate branches are always PRs, so they will be covered
+        # by the pull_request event.
+        "renovate/**",
+        # Branches with the `gh-readonly-queue` prefix are used by the
+        # merge queue, so they are already covered by the `merge_group` event.
+        "gh-readonly-queue/**",
+      ]
+  pull_request:
+  merge_group:
 
 env:
   # This is the MSRV used by `wgpu` itself and all surrounding infrastructure.

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -103,12 +103,8 @@ jobs:
         run: |
           cargo build --release -p naga-cli
 
-      - name: Install `spirv-tools`
-        run: |
-          cd naga
-          wget -q https://storage.googleapis.com/spirv-tools/artifacts/prod/graphics_shader_compiler/spirv-tools/linux-clang-release/continuous/1489/20210629-121459/install.tgz
-          tar zxf install.tgz
-          ./install/bin/spirv-as --version
+      - name: Install Vulkan SDK
+        uses: ./.github/actions/install-vulkan-sdk
 
       - name: Compile `spv` from `spvasm`
         run: |
@@ -118,7 +114,7 @@ jobs:
           find "./spvasm" -name '*.spvasm' | while read fname;
           do
               echo "Convert to spv with spirv-as: $fname"
-              ../install/bin/spirv-as --target-env spv1.3 $(realpath ${fname}) -o ./spv/$(basename ${fname}).spv
+              spirv-as --target-env spv1.3 $(realpath ${fname}) -o ./spv/$(basename ${fname}).spv
           done;
 
       - name: Validate `spv` and generate `wgsl`

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -1,11 +1,18 @@
-# Lazy jobs running on trunk post merges.
+# Non-critical jobs
 name: Lazy
+
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/lazy.yml"
   push:
-    branches: [trunk]
+    branches-ignore: [
+        # Renovate branches are always PRs, so they will be covered
+        # by the pull_request event.
+        "renovate/**",
+        # Branches with the `gh-readonly-queue` prefix are used by the
+        # merge queue, so they are already covered by the `merge_group` event.
+        "gh-readonly-queue/**",
+      ]
+  pull_request:
+  merge_group:
 
 env:
   CARGO_INCREMENTAL: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,17 @@
 name: Publish
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/publish.yml"
   push:
-    branches:
-      - trunk
+    branches-ignore: [
+        # Renovate branches are always PRs, so they will be covered
+        # by the pull_request event.
+        "renovate/**",
+        # Branches with the `gh-readonly-queue` prefix are used by the
+        # merge queue, so they are already covered by the `merge_group` event.
+        "gh-readonly-queue/**",
+      ]
+  pull_request:
+  merge_group:
 
 env:
   CARGO_INCREMENTAL: false

--- a/wgpu/src/api/adapter.rs
+++ b/wgpu/src/api/adapter.rs
@@ -216,7 +216,6 @@ impl Adapter {
     /// Returns an empty vector if cooperative matrices are not supported.
     ///
     /// Requires [`Features::EXPERIMENTAL_COOPERATIVE_MATRIX`] to be meaningful.
-    #[cfg(wgpu_core)]
     pub fn cooperative_matrix_properties(&self) -> Vec<CooperativeMatrixProperties> {
         self.inner.cooperative_matrix_properties()
     }

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -125,7 +125,6 @@ pub trait AdapterInterface: CommonTraits {
 
     fn get_presentation_timestamp(&self) -> crate::PresentationTimestamp;
 
-    #[cfg(wgpu_core)]
     fn cooperative_matrix_properties(&self) -> Vec<crate::wgt::CooperativeMatrixProperties>;
 }
 


### PR DESCRIPTION
This fixes three issues with lazy jobs:
- Build issues with the publishing job
- A very old way of getting the vulkan sdk on the spirv samples job.
- This switches them to always run on every PR, but be optional (and only actually publish on trunk).

Publishing can only actually happen if secrets are available, and secrets are not accessible to PRs.