### PR TITLE
expose adapter info on device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Bottom level categories:
 ### New Features
 
 - Added support for cooperative load/store operations in shaders. Currently only WGSL on the input and SPIR-V, METAL, and WGSL on the output are supported. By @kvark in [#8251](https://github.com/gfx-rs/wgpu/issues/8251).
+- Added support for obtaining `AdapterInfo` from `Device`. By @sagudev in [#8807](https://github.com/gfx-rs/wgpu/pull/8807).
 
 ### Bug Fixes
 

--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -128,6 +128,10 @@ impl DeviceInterface for CustomDevice {
         unimplemented!()
     }
 
+    fn adapter_info(&self) -> wgpu::AdapterInfo {
+        unimplemented!()
+    }
+
     fn create_shader_module(
         &self,
         desc: wgpu::ShaderModuleDescriptor<'_>,

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -87,6 +87,11 @@ impl Global {
         device.limits.clone()
     }
 
+    pub fn device_adapter_info(&self, device_id: DeviceId) -> wgt::AdapterInfo {
+        let device = self.hub.devices.get(device_id);
+        device.adapter.get_info()
+    }
+
     pub fn device_downlevel_properties(&self, device_id: DeviceId) -> wgt::DownlevelCapabilities {
         let device = self.hub.devices.get(device_id);
         device.downlevel.clone()

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -116,6 +116,11 @@ impl Device {
         self.inner.limits()
     }
 
+    /// Get info about the adapter that this device was created from.
+    pub fn adapter_info(&self) -> AdapterInfo {
+        self.inner.adapter_info()
+    }
+
     /// Creates a shader module.
     ///
     /// <div class="warning">

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -850,6 +850,23 @@ fn map_wgt_limits(limits: webgpu_sys::GpuSupportedLimits) -> wgt::Limits {
     }
 }
 
+fn map_adapter_info(adapter_info: &webgpu_sys::GpuAdapterInfo) -> wgt::AdapterInfo {
+    // TODO: populate more fields if/when possible
+    wgt::AdapterInfo {
+        name: adapter_info.description().to_string(),
+        vendor: 0,
+        device: 0,
+        device_type: wgt::DeviceType::Other,
+        device_pci_bus_id: String::new(),
+        driver: String::new(),
+        driver_info: String::new(),
+        backend: wgt::Backend::BrowserWebGpu,
+        subgroup_min_size: wgt::MINIMUM_SUBGROUP_MIN_SIZE,
+        subgroup_max_size: wgt::MAXIMUM_SUBGROUP_MAX_SIZE,
+        transient_saves_memory: false,
+    }
+}
+
 fn map_js_sys_limits(limits: &wgt::Limits) -> js_sys::Object {
     let object = js_sys::Object::new();
 
@@ -1762,6 +1779,10 @@ impl dispatch::DeviceInterface for WebDevice {
         map_wgt_limits(self.inner.limits())
     }
 
+    fn adapter_info(&self) -> crate::AdapterInfo {
+        map_adapter_info(&self.inner.adapter_info())
+    }
+
     fn create_shader_module(
         &self,
         desc: crate::ShaderModuleDescriptor<'_>,
@@ -2560,6 +2581,7 @@ impl dispatch::DeviceInterface for WebDevice {
         self.inner.destroy();
     }
 }
+
 impl Drop for WebDevice {
     fn drop(&mut self) {
         // no-op

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -851,7 +851,7 @@ fn map_wgt_limits(limits: webgpu_sys::GpuSupportedLimits) -> wgt::Limits {
 }
 
 fn map_adapter_info(adapter_info: &webgpu_sys::GpuAdapterInfo) -> wgt::AdapterInfo {
-    // TODO: populate more fields if/when possible
+    // TODO(https://github.com/gfx-rs/wgpu/issues/8819): populate more fields if/when possible
     wgt::AdapterInfo {
         name: adapter_info.description().to_string(),
         vendor: 0,
@@ -1733,7 +1733,7 @@ impl dispatch::AdapterInterface for WebAdapter {
     }
 
     fn get_info(&self) -> crate::AdapterInfo {
-        // TODO: web-sys has no way of getting information on adapters
+        // TODO(https://github.com/gfx-rs/wgpu/issues/8818): web-sys has no way of getting information on adapters
         wgt::AdapterInfo {
             name: String::new(),
             vendor: 0,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1025,6 +1025,10 @@ impl dispatch::DeviceInterface for CoreDevice {
         self.context.0.device_limits(self.id)
     }
 
+    fn adapter_info(&self) -> crate::AdapterInfo {
+        self.context.0.device_adapter_info(self.id)
+    }
+
     // If we have no way to create a shader module, we can't return one, and so most of the function is unreachable.
     #[cfg_attr(
         not(any(

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -132,6 +132,7 @@ pub trait AdapterInterface: CommonTraits {
 pub trait DeviceInterface: CommonTraits {
     fn features(&self) -> crate::Features;
     fn limits(&self) -> crate::Limits;
+    fn adapter_info(&self) -> crate::AdapterInfo;
 
     fn create_shader_module(
         &self,


### PR DESCRIPTION
**Description**
Spec also allows obtaining adapter_info from device: https://www.w3.org/TR/webgpu/#dom-gpudevice-adapterinfo, so I implemented this. Ironically web-sys only allows obtaining adapter_info from device. We could implemented this without any changes to core (by caching adapter_info from adapter), but I decided against this for consistency (we now have `device_adapter_info` on global).

**Testing**
None.

**Squash or Rebase?**
Squash
<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
