### PR TITLE
Fix up `CreateTextureViewError::TooMany{MipLevels,ArrayLayers}` crashes and style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ Bottom level categories:
 
 - Added guards to avoid calling some feature detection methods that are not implemented on `CaptureMTLDevice`. By @andyleiserson in [#9284](https://github.com/gfx-rs/wgpu/pull/9284).
 
+#### Validation
+
+- Don't crash in the `Display` implementation of `CreateTextureViewError::TooMany{MipLevels,ArrayLayers}` when their base and offset overflow. By @ErichDonGubler in [#8808](https://github.com/gfx-rs/wgpu/pull/8808).
+
 ## v29.0.0 (2026-03-18)
 
 ### Major Changes

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1838,9 +1838,8 @@ pub enum CreateTextureViewError {
     #[error("Array layer count is 0")]
     ZeroArrayLayerCount,
     #[error(
-        "`TextureView` spans mip levels [{base_mip_level}, {end_mip_level}) \
-        (`mipLevelCount` {mip_level_count}) but the texture view only has {total} total mip levels",
-        end_mip_level = base_mip_level + mip_level_count
+        "`TextureView` starts at mip level {base_mip_level} and spans {mip_level_count} mip \
+        levels, but the texture view only has {total} total mip levels"
     )]
     TooManyMipLevels {
         base_mip_level: u32,
@@ -1848,9 +1847,8 @@ pub enum CreateTextureViewError {
         total: u32,
     },
     #[error(
-        "`TextureView` spans array layers [{base_array_layer}, {end_array_layer}) \
-         (`arrayLayerCount` {array_layer_count}) but the texture view only has {total} total layers",
-        end_array_layer = base_array_layer + array_layer_count
+        "`TextureView` starts at array layer {base_array_layer} and spans {array_layer_count}) \
+        array layers, but the texture view only has {total} total layers"
     )]
     TooManyArrayLayers {
         base_array_layer: u32,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1839,7 +1839,7 @@ pub enum CreateTextureViewError {
     ZeroArrayLayerCount,
     #[error(
         "`TextureView` starts at mip level {base_mip_level} and spans {mip_level_count} mip \
-        levels, but the texture view only has {total} total mip levels"
+        levels, but the texture view only has {total} total mip level(s)"
     )]
     TooManyMipLevels {
         base_mip_level: u32,
@@ -1848,7 +1848,7 @@ pub enum CreateTextureViewError {
     },
     #[error(
         "`TextureView` starts at array layer {base_array_layer} and spans {array_layer_count}) \
-        array layers, but the texture view only has {total} total layers"
+        array layers, but the texture view only has {total} total layer(s)"
     )]
     TooManyArrayLayers {
         base_array_layer: u32,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1838,8 +1838,8 @@ pub enum CreateTextureViewError {
     #[error("Array layer count is 0")]
     ZeroArrayLayerCount,
     #[error(
-        "TextureView spans mip levels [{base_mip_level}, {end_mip_level}) \
-        (mipLevelCount {mip_level_count}) but the texture view only has {total} total mip levels",
+        "`TextureView` spans mip levels [{base_mip_level}, {end_mip_level}) \
+        (`mipLevelCount` {mip_level_count}) but the texture view only has {total} total mip levels",
         end_mip_level = base_mip_level + mip_level_count
     )]
     TooManyMipLevels {
@@ -1848,8 +1848,8 @@ pub enum CreateTextureViewError {
         total: u32,
     },
     #[error(
-        "TextureView spans array layers [{base_array_layer}, {end_array_layer}) \
-         (arrayLayerCount {array_layer_count}) but the texture view only has {total} total layers",
+        "`TextureView` spans array layers [{base_array_layer}, {end_array_layer}) \
+         (`arrayLayerCount` {array_layer_count}) but the texture view only has {total} total layers",
         end_array_layer = base_array_layer + array_layer_count
     )]
     TooManyArrayLayers {


### PR DESCRIPTION
**Connections**

Regressed by <https://github.com/gfx-rs/wgpu/pull/8323>, which I reviewed. 😅

**Description**

These error variants use a naive `base + offset` from user-provided input in order to be diagnostically helpful in `Display`. Eek! Add a `BasePlusOffset` structure that can be safely used to show calculations like this, falling back to displaying `<overflow>` if it doesn't work, and use that instead of the naive addition.

Also, fix up some styling stuff that I noticed was wrong and/or not consistent with other parts of code. See individual commits for more details.

**Testing**

TBD. I'd like to see a CTS test for this, since this is prime validation coverage that doesn't appear to be tested. Filed https://github.com/gpuweb/cts/issues/4617 for this.

**Squash or Rebase?**

rebase plz

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry.
