### PR TITLE
Fix constant evaluation of indexing by an i32 override

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -209,6 +209,7 @@ webgpu:shader,execution,flow_control,return:*
 // Fails on Metal in CI only, not when running locally.
 fails-if(metal) webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true
 webgpu:shader,validation,const_assert,const_assert:*
+webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_in_bounds"
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:array_override:op="%26%26";a_val=1;b_val=1
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:scalar_vector:op="%26%26";lhs="bool";rhs="bool"

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -280,7 +280,7 @@ fn process_workgroup_size_override(
                         Some(h) => {
                             ep.workgroup_size[i] = module
                                 .to_ctx()
-                                .eval_expr_to_u32(adjusted_global_expressions[h])
+                                .get_const_val(adjusted_global_expressions[h])
                                 .map(|n| {
                                     if n == 0 {
                                         Err(PipelineConstantError::NegativeWorkgroupSize)
@@ -309,13 +309,13 @@ fn process_mesh_shader_overrides(
         if let Some(r#override) = mesh_info.max_vertices_override {
             mesh_info.max_vertices = module
                 .to_ctx()
-                .eval_expr_to_u32(adjusted_global_expressions[r#override])
+                .get_const_val(adjusted_global_expressions[r#override])
                 .map_err(|_| PipelineConstantError::NegativeMeshOutputMax)?;
         }
         if let Some(r#override) = mesh_info.max_primitives_override {
             mesh_info.max_primitives = module
                 .to_ctx()
-                .eval_expr_to_u32(adjusted_global_expressions[r#override])
+                .get_const_val(adjusted_global_expressions[r#override])
                 .map_err(|_| PipelineConstantError::NegativeMeshOutputMax)?;
         }
     }

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -561,7 +561,7 @@ impl<'a> Context<'a> {
                     _ => self
                         .module
                         .to_ctx()
-                        .eval_expr_to_u32_from(index, &self.expressions)
+                        .get_const_val_from(index, &self.expressions)
                         .ok(),
                 };
 

--- a/naga/src/front/glsl/parser.rs
+++ b/naga/src/front/glsl/parser.rs
@@ -14,7 +14,7 @@ use super::{
     variables::{GlobalOrConstant, VarDeclaration},
     Frontend, Result,
 };
-use crate::{arena::Handle, proc::U32EvalError, Expression, Module, Span, Type};
+use crate::{arena::Handle, proc::ConstValueError, Expression, Module, Span, Type};
 
 mod declarations;
 mod expressions;
@@ -215,11 +215,11 @@ impl<'source> ParsingContext<'source> {
 
         let int = match res {
             Ok(value) => Ok(value),
-            Err(U32EvalError::Negative) => Err(Error {
+            Err(ConstValueError::Negative) => Err(Error {
                 kind: ErrorKind::SemanticError("int constant overflows".into()),
                 meta,
             }),
-            Err(U32EvalError::NonConst) => Err(Error {
+            Err(ConstValueError::NonConst) => Err(Error {
                 kind: ErrorKind::SemanticError("Expected a uint constant".into()),
                 meta,
             }),

--- a/naga/src/front/glsl/parser.rs
+++ b/naga/src/front/glsl/parser.rs
@@ -211,7 +211,7 @@ impl<'source> ParsingContext<'source> {
             ctx.global_expression_kind_tracker,
         )?;
 
-        let res = ctx.module.to_ctx().eval_expr_to_u32(const_expr);
+        let res = ctx.module.to_ctx().get_const_val(const_expr);
 
         let int = match res {
             Ok(value) => Ok(value),
@@ -219,7 +219,7 @@ impl<'source> ParsingContext<'source> {
                 kind: ErrorKind::SemanticError("int constant overflows".into()),
                 meta,
             }),
-            Err(ConstValueError::NonConst) => Err(Error {
+            Err(ConstValueError::NonConst | ConstValueError::InvalidType) => Err(Error {
                 kind: ErrorKind::SemanticError("Expected a uint constant".into()),
                 meta,
             }),

--- a/naga/src/front/spv/next_block.rs
+++ b/naga/src/front/spv/next_block.rs
@@ -277,7 +277,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                         let index_maybe = match *index_expr_data {
                             crate::Expression::Constant(const_handle) => Some(
                                 ctx.gctx()
-                                    .eval_expr_to_u32(ctx.module.constants[const_handle].init)
+                                    .get_const_val(ctx.module.constants[const_handle].init)
                                     .map_err(|_| {
                                         Error::InvalidAccess(crate::Expression::Constant(
                                             const_handle,

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -535,10 +535,10 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
             .map_err(|e| Box::new(Error::ConstantEvaluatorError(e.into(), span)))
     }
 
-    fn const_eval_expr_to_u32(
+    fn get_const_val<T: TryFrom<crate::Literal, Error = proc::ConstValueError>>(
         &self,
         handle: Handle<ir::Expression>,
-    ) -> core::result::Result<u32, proc::ConstValueError> {
+    ) -> core::result::Result<T, proc::ConstValueError> {
         match self.expr_type {
             ExpressionContextType::Runtime(ref ctx) => {
                 if !ctx.local_expression_kind_tracker.is_const(handle) {
@@ -547,38 +547,16 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
 
                 self.module
                     .to_ctx()
-                    .eval_expr_to_u32_from(handle, &ctx.function.expressions)
+                    .get_const_val_from(handle, &ctx.function.expressions)
             }
             ExpressionContextType::Constant(Some(ref ctx)) => {
                 assert!(ctx.local_expression_kind_tracker.is_const(handle));
                 self.module
                     .to_ctx()
-                    .eval_expr_to_u32_from(handle, &ctx.function.expressions)
+                    .get_const_val_from(handle, &ctx.function.expressions)
             }
-            ExpressionContextType::Constant(None) => self.module.to_ctx().eval_expr_to_u32(handle),
+            ExpressionContextType::Constant(None) => self.module.to_ctx().get_const_val(handle),
             ExpressionContextType::Override => Err(proc::ConstValueError::NonConst),
-        }
-    }
-
-    fn const_eval_expr_to_bool(&self, handle: Handle<ir::Expression>) -> Option<bool> {
-        match self.expr_type {
-            ExpressionContextType::Runtime(ref ctx) => {
-                if !ctx.local_expression_kind_tracker.is_const(handle) {
-                    return None;
-                }
-
-                self.module
-                    .to_ctx()
-                    .eval_expr_to_bool_from(handle, &ctx.function.expressions)
-            }
-            ExpressionContextType::Constant(Some(ref ctx)) => {
-                assert!(ctx.local_expression_kind_tracker.is_const(handle));
-                self.module
-                    .to_ctx()
-                    .eval_expr_to_bool_from(handle, &ctx.function.expressions)
-            }
-            ExpressionContextType::Constant(None) => self.module.to_ctx().eval_expr_to_bool(handle),
-            ExpressionContextType::Override => None,
         }
     }
 
@@ -716,9 +694,9 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
                 let index = self
                     .module
                     .to_ctx()
-                    .eval_expr_to_u32_from(expr, &rctx.function.expressions)
+                    .get_const_val_from::<u32, _>(expr, &rctx.function.expressions)
                     .map_err(|err| match err {
-                        proc::ConstValueError::NonConst => {
+                        proc::ConstValueError::NonConst | proc::ConstValueError::InvalidType => {
                             Error::ExpectedConstExprConcreteIntegerScalar(component_span)
                         }
                         proc::ConstValueError::Negative => {
@@ -1419,11 +1397,14 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     match ctx
                         .module
                         .to_ctx()
-                        .eval_expr_to_bool_from(condition, &ctx.module.global_expressions)
+                        .get_const_val_from(condition, &ctx.module.global_expressions)
                     {
-                        Some(true) => Ok(()),
-                        Some(false) => Err(Error::ConstAssertFailed(span)),
-                        _ => Err(Error::NotBool(span)),
+                        Ok(true) => Ok(()),
+                        Ok(false) => Err(Error::ConstAssertFailed(span)),
+                        Err(proc::ConstValueError::NonConst | proc::ConstValueError::Negative) => {
+                            unreachable!()
+                        }
+                        Err(proc::ConstValueError::InvalidType) => Err(Error::NotBool(span)),
                     }?;
                 }
             }
@@ -1942,14 +1923,10 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                     match ctx
                                         .module
                                         .to_ctx()
-                                        .eval_expr_to_literal_from(expr, &ctx.function.expressions)
+                                        .get_const_val_from(expr, &ctx.function.expressions)
                                     {
-                                        Some(ir::Literal::I32(value)) => {
-                                            ir::SwitchValue::I32(value)
-                                        }
-                                        Some(ir::Literal::U32(value)) => {
-                                            ir::SwitchValue::U32(value)
-                                        }
+                                        Ok(ir::Literal::I32(value)) => ir::SwitchValue::I32(value),
+                                        Ok(ir::Literal::U32(value)) => ir::SwitchValue::U32(value),
                                         _ => {
                                             return Err(Box::new(Error::InvalidSwitchCase {
                                                 span,
@@ -2170,11 +2147,14 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 match ctx
                     .module
                     .to_ctx()
-                    .eval_expr_to_bool_from(condition, &ctx.function.expressions)
+                    .get_const_val_from(condition, &ctx.function.expressions)
                 {
-                    Some(true) => Ok(()),
-                    Some(false) => Err(Error::ConstAssertFailed(span)),
-                    _ => Err(Error::NotBool(span)),
+                    Ok(true) => Ok(()),
+                    Ok(false) => Err(Error::ConstAssertFailed(span)),
+                    Err(proc::ConstValueError::NonConst | proc::ConstValueError::Negative) => {
+                        unreachable!()
+                    }
+                    Err(proc::ConstValueError::InvalidType) => Err(Error::NotBool(span)),
                 }?;
 
                 block.extend(emitter.finish(&ctx.function.expressions));
@@ -2372,7 +2352,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     }
                 }
 
-                lowered_base.try_map(|base| match ctx.const_eval_expr_to_u32(index).ok() {
+                lowered_base.try_map(|base| match ctx.get_const_val(index).ok() {
                     Some(index) => Ok::<_, Box<Error>>(ir::Expression::AccessIndex { base, index }),
                     None => {
                         // When an abstract array value e is indexed by an expression
@@ -2567,7 +2547,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 result_var,
             )))
         } else {
-            let left_val = ctx.const_eval_expr_to_bool(left);
+            let left_val: Option<bool> = ctx.get_const_val(left).ok();
 
             if left_val.is_some_and(|left_val| {
                 op == crate::BinaryOperator::LogicalAnd && !left_val
@@ -4203,9 +4183,11 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
         let value = ctx
             .module
             .to_ctx()
-            .eval_expr_to_u32(expr)
+            .get_const_val(expr)
             .map_err(|err| match err {
-                proc::ConstValueError::NonConst => Error::ExpectedConstExprConcreteIntegerScalar(span),
+                proc::ConstValueError::NonConst | proc::ConstValueError::InvalidType => {
+                    Error::ExpectedConstExprConcreteIntegerScalar(span)
+                }
                 proc::ConstValueError::Negative => Error::ExpectedNonNegative(span),
             })?;
         Ok((value, span))
@@ -4222,9 +4204,10 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 let const_expr = self.expression(expr, &mut ctx.as_const());
                 match const_expr {
                     Ok(value) => {
-                        let len = ctx.const_eval_expr_to_u32(value).map_err(|err| {
+                        let len = ctx.get_const_val(value).map_err(|err| {
                             Box::new(match err {
-                                proc::ConstValueError::NonConst => {
+                                proc::ConstValueError::NonConst
+                                | proc::ConstValueError::InvalidType => {
                                     Error::ExpectedConstExprConcreteIntegerScalar(span)
                                 }
                                 proc::ConstValueError::Negative => {

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -538,11 +538,11 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
     fn const_eval_expr_to_u32(
         &self,
         handle: Handle<ir::Expression>,
-    ) -> core::result::Result<u32, proc::U32EvalError> {
+    ) -> core::result::Result<u32, proc::ConstValueError> {
         match self.expr_type {
             ExpressionContextType::Runtime(ref ctx) => {
                 if !ctx.local_expression_kind_tracker.is_const(handle) {
-                    return Err(proc::U32EvalError::NonConst);
+                    return Err(proc::ConstValueError::NonConst);
                 }
 
                 self.module
@@ -556,7 +556,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
                     .eval_expr_to_u32_from(handle, &ctx.function.expressions)
             }
             ExpressionContextType::Constant(None) => self.module.to_ctx().eval_expr_to_u32(handle),
-            ExpressionContextType::Override => Err(proc::U32EvalError::NonConst),
+            ExpressionContextType::Override => Err(proc::ConstValueError::NonConst),
         }
     }
 
@@ -718,10 +718,12 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
                     .to_ctx()
                     .eval_expr_to_u32_from(expr, &rctx.function.expressions)
                     .map_err(|err| match err {
-                        proc::U32EvalError::NonConst => {
+                        proc::ConstValueError::NonConst => {
                             Error::ExpectedConstExprConcreteIntegerScalar(component_span)
                         }
-                        proc::U32EvalError::Negative => Error::ExpectedNonNegative(component_span),
+                        proc::ConstValueError::Negative => {
+                            Error::ExpectedNonNegative(component_span)
+                        }
                     })?;
                 ir::SwizzleComponent::XYZW
                     .get(index as usize)
@@ -4203,8 +4205,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             .to_ctx()
             .eval_expr_to_u32(expr)
             .map_err(|err| match err {
-                proc::U32EvalError::NonConst => Error::ExpectedConstExprConcreteIntegerScalar(span),
-                proc::U32EvalError::Negative => Error::ExpectedNonNegative(span),
+                proc::ConstValueError::NonConst => Error::ExpectedConstExprConcreteIntegerScalar(span),
+                proc::ConstValueError::Negative => Error::ExpectedNonNegative(span),
             })?;
         Ok((value, span))
     }
@@ -4222,10 +4224,10 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     Ok(value) => {
                         let len = ctx.const_eval_expr_to_u32(value).map_err(|err| {
                             Box::new(match err {
-                                proc::U32EvalError::NonConst => {
+                                proc::ConstValueError::NonConst => {
                                     Error::ExpectedConstExprConcreteIntegerScalar(span)
                                 }
-                                proc::U32EvalError::Negative => {
+                                proc::ConstValueError::Negative => {
                                     Error::ExpectedPositiveArrayLength(span)
                                 }
                             })

--- a/naga/src/proc/index.rs
+++ b/naga/src/proc/index.rs
@@ -483,7 +483,7 @@ impl GuardedIndex {
         expressions: &crate::Arena<crate::Expression>,
         module: &crate::Module,
     ) -> Self {
-        match module.to_ctx().eval_expr_to_u32_from(expr, expressions) {
+        match module.to_ctx().get_const_val_from(expr, expressions) {
             Ok(value) => Self::Known(value),
             Err(_) => Self::Expression(expr),
         }

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -172,6 +172,29 @@ impl crate::Literal {
     }
 }
 
+impl TryFrom<crate::Literal> for u32 {
+    type Error = ConstValueError;
+
+    fn try_from(value: crate::Literal) -> Result<Self, Self::Error> {
+        match value {
+            crate::Literal::U32(value) => Ok(value),
+            crate::Literal::I32(value) => value.try_into().map_err(|_| ConstValueError::Negative),
+            _ => Err(ConstValueError::InvalidType),
+        }
+    }
+}
+
+impl TryFrom<crate::Literal> for bool {
+    type Error = ConstValueError;
+
+    fn try_from(value: crate::Literal) -> Result<Self, Self::Error> {
+        match value {
+            crate::Literal::Bool(value) => Ok(value),
+            _ => Err(ConstValueError::InvalidType),
+        }
+    }
+}
+
 impl super::AddressSpace {
     pub fn access(self) -> crate::StorageAccess {
         use crate::StorageAccess as Sa;
@@ -425,9 +448,16 @@ impl crate::Module {
 }
 
 #[derive(Debug)]
-pub(super) enum ConstValueError {
+pub enum ConstValueError {
     NonConst,
     Negative,
+    InvalidType,
+}
+
+impl From<core::convert::Infallible> for ConstValueError {
+    fn from(_: core::convert::Infallible) -> Self {
+        unreachable!()
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -452,63 +482,26 @@ impl GlobalCtx<'_> {
         )),
         allow(dead_code)
     )]
-    pub(super) fn eval_expr_to_u32(
+    pub(super) fn get_const_val<T, E>(
         &self,
         handle: crate::Handle<crate::Expression>,
-    ) -> Result<u32, ConstValueError> {
-        self.eval_expr_to_u32_from(handle, self.global_expressions)
+    ) -> Result<T, ConstValueError>
+    where
+        T: TryFrom<crate::Literal, Error = E>,
+        E: Into<ConstValueError>,
+    {
+        self.get_const_val_from(handle, self.global_expressions)
     }
 
-    /// Try to evaluate the expression in the `arena` using its `handle` and return it as a `u32`.
-    pub(super) fn eval_expr_to_u32_from(
+    pub(super) fn get_const_val_from<T, E>(
         &self,
         handle: crate::Handle<crate::Expression>,
         arena: &crate::Arena<crate::Expression>,
-    ) -> Result<u32, ConstValueError> {
-        match self.eval_expr_to_literal_from(handle, arena) {
-            Some(crate::Literal::U32(value)) => Ok(value),
-            Some(crate::Literal::I32(value)) => {
-                value.try_into().map_err(|_| ConstValueError::Negative)
-            }
-            _ => Err(ConstValueError::NonConst),
-        }
-    }
-
-    /// Try to evaluate the expression in `self.global_expressions` using its `handle` and return it as a `bool`.
-    #[cfg_attr(not(feature = "wgsl-in"), allow(dead_code))]
-    pub(super) fn eval_expr_to_bool(
-        &self,
-        handle: crate::Handle<crate::Expression>,
-    ) -> Option<bool> {
-        self.eval_expr_to_bool_from(handle, self.global_expressions)
-    }
-
-    /// Try to evaluate the expression in the `arena` using its `handle` and return it as a `bool`.
-    #[cfg_attr(not(feature = "wgsl-in"), allow(dead_code))]
-    pub(super) fn eval_expr_to_bool_from(
-        &self,
-        handle: crate::Handle<crate::Expression>,
-        arena: &crate::Arena<crate::Expression>,
-    ) -> Option<bool> {
-        match self.eval_expr_to_literal_from(handle, arena) {
-            Some(crate::Literal::Bool(value)) => Some(value),
-            _ => None,
-        }
-    }
-
-    #[expect(dead_code)]
-    pub(crate) fn eval_expr_to_literal(
-        &self,
-        handle: crate::Handle<crate::Expression>,
-    ) -> Option<crate::Literal> {
-        self.eval_expr_to_literal_from(handle, self.global_expressions)
-    }
-
-    pub(super) fn eval_expr_to_literal_from(
-        &self,
-        handle: crate::Handle<crate::Expression>,
-        arena: &crate::Arena<crate::Expression>,
-    ) -> Option<crate::Literal> {
+    ) -> Result<T, ConstValueError>
+    where
+        T: TryFrom<crate::Literal, Error = E>,
+        E: Into<ConstValueError>,
+    {
         fn get(
             gctx: GlobalCtx,
             handle: crate::Handle<crate::Expression>,
@@ -523,11 +516,15 @@ impl GlobalCtx<'_> {
                 _ => None,
             }
         }
-        match arena[handle] {
+        let value = match arena[handle] {
             crate::Expression::Constant(c) => {
                 get(*self, self.constants[c].init, self.global_expressions)
             }
             _ => get(*self, handle, arena),
+        };
+        match value {
+            Some(v) => v.try_into().map_err(Into::into),
+            None => Err(ConstValueError::NonConst),
         }
     }
 
@@ -561,9 +558,11 @@ impl crate::ArraySize {
                 let Some(expr) = gctx.overrides[handle].init else {
                     return Err(ResolveArraySizeError::NonConstArrayLength);
                 };
-                let length = gctx.eval_expr_to_u32(expr).map_err(|err| match err {
+                let length = gctx.get_const_val(expr).map_err(|err| match err {
                     ConstValueError::NonConst => ResolveArraySizeError::NonConstArrayLength,
-                    ConstValueError::Negative => ResolveArraySizeError::ExpectedPositiveArrayLength,
+                    ConstValueError::Negative | ConstValueError::InvalidType => {
+                        ResolveArraySizeError::ExpectedPositiveArrayLength
+                    }
                 })?;
 
                 if length == 0 {

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -425,7 +425,7 @@ impl crate::Module {
 }
 
 #[derive(Debug)]
-pub(super) enum U32EvalError {
+pub(super) enum ConstValueError {
     NonConst,
     Negative,
 }
@@ -455,7 +455,7 @@ impl GlobalCtx<'_> {
     pub(super) fn eval_expr_to_u32(
         &self,
         handle: crate::Handle<crate::Expression>,
-    ) -> Result<u32, U32EvalError> {
+    ) -> Result<u32, ConstValueError> {
         self.eval_expr_to_u32_from(handle, self.global_expressions)
     }
 
@@ -464,13 +464,13 @@ impl GlobalCtx<'_> {
         &self,
         handle: crate::Handle<crate::Expression>,
         arena: &crate::Arena<crate::Expression>,
-    ) -> Result<u32, U32EvalError> {
+    ) -> Result<u32, ConstValueError> {
         match self.eval_expr_to_literal_from(handle, arena) {
             Some(crate::Literal::U32(value)) => Ok(value),
             Some(crate::Literal::I32(value)) => {
-                value.try_into().map_err(|_| U32EvalError::Negative)
+                value.try_into().map_err(|_| ConstValueError::Negative)
             }
-            _ => Err(U32EvalError::NonConst),
+            _ => Err(ConstValueError::NonConst),
         }
     }
 
@@ -562,8 +562,8 @@ impl crate::ArraySize {
                     return Err(ResolveArraySizeError::NonConstArrayLength);
                 };
                 let length = gctx.eval_expr_to_u32(expr).map_err(|err| match err {
-                    U32EvalError::NonConst => ResolveArraySizeError::NonConstArrayLength,
-                    U32EvalError::Negative => ResolveArraySizeError::ExpectedPositiveArrayLength,
+                    ConstValueError::NonConst => ResolveArraySizeError::NonConstArrayLength,
+                    ConstValueError::Negative => ResolveArraySizeError::ExpectedPositiveArrayLength,
                 })?;
 
                 if length == 0 {

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -287,7 +287,7 @@ impl super::Validator {
                 // If index is const we can do check for non-negative index
                 match module
                     .to_ctx()
-                    .eval_expr_to_u32_from(index, &function.expressions)
+                    .get_const_val_from(index, &function.expressions)
                 {
                     Ok(value) => {
                         let length = if self.overrides_resolved {
@@ -307,6 +307,9 @@ impl super::Validator {
                         return Err(ExpressionError::NegativeIndex(base))
                     }
                     Err(crate::proc::ConstValueError::NonConst) => {}
+                    Err(crate::proc::ConstValueError::InvalidType) => {
+                        return Err(ExpressionError::InvalidIndexType(index))
+                    }
                 }
 
                 ShaderStages::all()

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -303,10 +303,10 @@ impl super::Validator {
                             }
                         }
                     }
-                    Err(crate::proc::U32EvalError::Negative) => {
+                    Err(crate::proc::ConstValueError::Negative) => {
                         return Err(ExpressionError::NegativeIndex(base))
                     }
-                    Err(crate::proc::U32EvalError::NonConst) => {}
+                    Err(crate::proc::ConstValueError::NonConst) => {}
                 }
 
                 ShaderStages::all()


### PR DESCRIPTION
Fixes a random CTS failure that I noticed while looking for CTS tests relevant to #7806.

The first two commits do some refactoring of the "constant evaluation" helpers that I resisted doing in #8721. 

The last commit removes the dedicated helper `constant_index` (which failed to allow for i32 index type) and uses the newly refactored helpers.

**Testing**
Enables the relevant CTS test.

**Squash or Rebase?** Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
