### PR TITLE
fix(naga): some cases of f16 construction from constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ Bottom level categories:
 - BREAKING: Migrated from the `maxInterStageShaderComponents` limit to `maxInterStageShaderVariables`, which changes validation in a way that should not affect most programs. This follows the latest changes of the WebGPU spec. By @ErichDonGubler in [#8652](https://github.com/gfx-rs/wgpu/pull/8652), [#8792](https://github.com/gfx-rs/wgpu/pull/8792).
 - Fixed validation of the texture format in GPUDepthStencilState when neither depth nor stencil is actually enabled. By @andyleiserson in [#8766](https://github.com/gfx-rs/wgpu/pull/8766).
 
+#### naga
+
+- Fix some cases where f16 constants were not working. By @andyleiserson in [#8816](https://github.com/gfx-rs/wgpu/pull/8816).
+
 #### GLES
 
 - `DisplayHandle` should now be passed to `InstanceDescriptor` for correct EGL initialization on Wayland. By @MarijnS95 in [#8012](https://github.com/gfx-rs/wgpu/pull/8012)

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -242,6 +242,13 @@ webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:scalar_vector:op="%26%26";lhs="bool";rhs="bool"
 webgpu:shader,validation,expression,call,builtin,all:arguments:test="ptr_deref"
 webgpu:shader,validation,expression,call,builtin,max:values:*
+// FAIL: others in `value_constructor` due to #8815, #8442, #4720, possibly more
+webgpu:shader,validation,expression,call,builtin,value_constructor:array_value:*
+webgpu:shader,validation,expression,call,builtin,value_constructor:matrix_zero_value:*
+webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_zero_value:*
+webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_value:*
+webgpu:shader,validation,expression,call,builtin,value_constructor:struct_value:*
+webgpu:shader,validation,expression,call,builtin,value_constructor:vector_zero_value:*
 // NOTE: This is supposed to be an exhaustive listing underneath
 // `webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:*`, so exceptions can be
 // worked around.

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -121,6 +121,9 @@ impl crate::Literal {
         match (value, scalar.kind, scalar.width) {
             (value, crate::ScalarKind::Float, 8) => Some(Self::F64(value as _)),
             (value, crate::ScalarKind::Float, 4) => Some(Self::F32(value as _)),
+            (value, crate::ScalarKind::Float, 2) => {
+                Some(Self::F16(half::f16::from_f32_const(value as _)))
+            }
             (value, crate::ScalarKind::Uint, 4) => Some(Self::U32(value as _)),
             (value, crate::ScalarKind::Sint, 4) => Some(Self::I32(value as _)),
             (value, crate::ScalarKind::Uint, 8) => Some(Self::U64(value as _)),


### PR DESCRIPTION
Fixes a match statement that was missing `f16`, causing some CTS tests to fail constructing f16 constants.

**Testing**
Enables relevant CTS tests.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
