### PR TITLE
fix(naga): Coerce matrix initializers to concrete floats

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -245,6 +245,7 @@ webgpu:shader,validation,expression,call,builtin,trunc:*
 // FAIL: others in `value_constructor` due to https://github.com/gfx-rs/wgpu/issues/4720, possibly more
 webgpu:shader,validation,expression,call,builtin,value_constructor:array_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:matrix_zero_value:*
+webgpu:shader,validation,expression,call,builtin,value_constructor:must_use:ctor="mat4x4";use=true
 webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_zero_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:struct_value:*

--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -345,11 +345,11 @@ impl<'source> Lowerer<'source, '_> {
                 },
                 Constructor::PartialVector { size },
             ) => {
-                let consensus_scalar =
-                    ctx.automatic_conversion_consensus(&components)
-                        .map_err(|index| {
-                            Error::InvalidConstructorComponentType(spans[index], index as i32)
-                        })?;
+                let consensus_scalar = ctx
+                    .automatic_conversion_consensus(None, &components)
+                    .map_err(|index| {
+                        Error::InvalidConstructorComponentType(spans[index], index as i32)
+                    })?;
                 ctx.convert_slice_to_common_leaf_scalar(&mut components, consensus_scalar)?;
                 let inner = consensus_scalar.to_inner_vector(size);
                 let ty = ctx.ensure_type_exists(inner);
@@ -373,15 +373,14 @@ impl<'source> Lowerer<'source, '_> {
                 },
                 Constructor::PartialMatrix { columns, rows },
             ) if components.len() == columns as usize * rows as usize => {
-                let consensus_scalar =
-                    ctx.automatic_conversion_consensus(&components)
-                        .map_err(|index| {
-                            Error::InvalidConstructorComponentType(spans[index], index as i32)
-                        })?;
-                // We actually only accept floating-point elements.
-                let consensus_scalar = consensus_scalar
-                    .automatic_conversion_combine(crate::Scalar::ABSTRACT_FLOAT)
-                    .unwrap_or(consensus_scalar);
+                let consensus_scalar = ctx
+                    .automatic_conversion_consensus(
+                        Some(crate::Scalar::ABSTRACT_FLOAT),
+                        &components,
+                    )
+                    .map_err(|index| {
+                        Error::InvalidConstructorComponentType(spans[index], index as i32)
+                    })?;
                 ctx.convert_slice_to_common_leaf_scalar(&mut components, consensus_scalar)?;
                 let vec_ty = ctx.ensure_type_exists(consensus_scalar.to_inner_vector(rows));
 
@@ -451,11 +450,14 @@ impl<'source> Lowerer<'source, '_> {
                 },
                 Constructor::PartialMatrix { columns, rows },
             ) => {
-                let consensus_scalar =
-                    ctx.automatic_conversion_consensus(&components)
-                        .map_err(|index| {
-                            Error::InvalidConstructorComponentType(spans[index], index as i32)
-                        })?;
+                let consensus_scalar = ctx
+                    .automatic_conversion_consensus(
+                        Some(crate::Scalar::ABSTRACT_FLOAT),
+                        &components,
+                    )
+                    .map_err(|index| {
+                        Error::InvalidConstructorComponentType(spans[index], index as i32)
+                    })?;
                 ctx.convert_slice_to_common_leaf_scalar(&mut components, consensus_scalar)?;
                 let ty = ctx.ensure_type_exists(crate::TypeInner::Matrix {
                     columns,
@@ -489,7 +491,8 @@ impl<'source> Lowerer<'source, '_> {
             // Array constructor - infer type
             (components, Constructor::PartialArray) => {
                 let mut components = components.into_components_vec();
-                if let Ok(consensus_scalar) = ctx.automatic_conversion_consensus(&components) {
+                if let Ok(consensus_scalar) = ctx.automatic_conversion_consensus(None, &components)
+                {
                     // Note that this will *not* necessarily convert all the
                     // components to the same type! The `automatic_conversion_consensus`
                     // method only considers the parameters' leaf scalar

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -1987,7 +1987,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     .collect::<Result<(Vec<_>, Vec<_>)>>()?;
 
                 let mut consensus =
-                    ectx.automatic_conversion_consensus(&exprs)
+                    ectx.automatic_conversion_consensus(None, &exprs)
                         .map_err(|span_idx| Error::SwitchCaseTypeMismatch {
                             span: spans[span_idx],
                         })?;
@@ -2928,7 +2928,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     ctx.grow_types(left)?;
                     ctx.grow_types(right)?;
                     if let Ok(consensus_scalar) =
-                        ctx.automatic_conversion_consensus([left, right].iter())
+                        ctx.automatic_conversion_consensus(None, [left, right].iter())
                     {
                         ctx.convert_to_leaf_scalar(&mut left, consensus_scalar)?;
                         ctx.convert_to_leaf_scalar(&mut right, consensus_scalar)?;
@@ -3123,7 +3123,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         }
                     }
                     let mut consensus_scalar = ctx
-                        .automatic_conversion_consensus(&values)
+                        .automatic_conversion_consensus(None, &values)
                         .map_err(|_idx| {
                             let [reject, accept] = values;
                             let [(reject_span, reject_type), (accept_span, accept_type)] =


### PR DESCRIPTION
We had logic to force a floating point type as the concensus scalar for only one out of two cases of matrix constructors (by elements vs. by columns). This tweaks the code slightly to avoid redundancy and corrects the omission.

**Testing**
Enables a relevant CTS test. (There are more, but would need to be listed individually due to failures elsewhere in the suite, and I think one is sufficient coverage.)

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
