### PR TITLE
fix(naga): avoid vector splat construction from invalid scalar type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Bottom level categories:
 #### naga
 
 - Reject zero-value construction of a runtime-sized array with a validation error. Previously it would crash in the HLSL backend. By @mooori in [#8741](https://github.com/gfx-rs/wgpu/pull/8741).
+- Reject splat vector construction if the argument type does not match the type of the vector's scalar. Previously it would succeed. By @mooori in [#8829](https://github.com/gfx-rs/wgpu/pull/8829).
 
 ### Documentation
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -247,12 +247,13 @@ webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:scalar_vector:op="%26%26";lhs="bool";rhs="bool"
 webgpu:shader,validation,expression,call,builtin,all:arguments:test="ptr_deref"
 webgpu:shader,validation,expression,call,builtin,max:values:*
-// FAIL: others in `value_constructor` due to #8815, #8442, #4720, possibly more
+// FAIL: others in `value_constructor` due to https://github.com/gfx-rs/wgpu/issues/4720, possibly more
 webgpu:shader,validation,expression,call,builtin,value_constructor:array_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:matrix_zero_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_zero_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_value:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:struct_value:*
+webgpu:shader,validation,expression,call,builtin,value_constructor:vector_splat:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:vector_zero_value:*
 // NOTE: This is supposed to be an exhaustive listing underneath
 // `webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:*`, so exceptions can be

--- a/naga/tests/in/wgsl/msl-vpt-formats-x1.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x1.wgsl
@@ -58,5 +58,5 @@ fn render_vertex(
   v_in: VertexInput,
 ) -> VertexOutput
 {
-  return VertexOutput(vec4f(v_in.v_uint8));
+  return VertexOutput(vec4f(v_in.v_float32));
 }

--- a/naga/tests/in/wgsl/msl-vpt-formats-x2.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x2.wgsl
@@ -58,5 +58,5 @@ fn render_vertex(
   v_in: VertexInput,
 ) -> VertexOutput
 {
-  return VertexOutput(vec4f(v_in.v_uint8.x));
+  return VertexOutput(vec4f(v_in.v_float32.x));
 }

--- a/naga/tests/in/wgsl/msl-vpt-formats-x3.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x3.wgsl
@@ -58,5 +58,5 @@ fn render_vertex(
   v_in: VertexInput,
 ) -> VertexOutput
 {
-  return VertexOutput(vec4f(v_in.v_uint8.x));
+  return VertexOutput(vec4f(v_in.v_float32.x));
 }

--- a/naga/tests/in/wgsl/msl-vpt-formats-x4.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x4.wgsl
@@ -58,5 +58,5 @@ fn render_vertex(
   v_in: VertexInput,
 ) -> VertexOutput
 {
-  return VertexOutput(vec4f(v_in.v_uint8.x));
+  return VertexOutput(vec4f(v_in.v_float32.x));
 }

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -367,6 +367,27 @@ fn vector_constructor_incorrect_component_count() {
 }
 
 #[test]
+fn vector_constructor_type_mismatch() {
+    check(
+        r#"
+            fn x(a: u32) -> vec2f {
+                return vec2f(a);
+            }
+        "#,
+        r#"error: wrong type passed as argument #1 to `vec2<f32>`
+  ┌─ wgsl:3:24
+  │
+3 │                 return vec2f(a);
+  │                        ^^^^^ ^ argument #1 has type `u32`
+  │
+  = note: `vec2<f32>` accepts the following types for argument #1:
+  = note: allowed type: f32
+
+"#,
+    );
+}
+
+#[test]
 fn bad_texture_sample_type() {
     check(
         r#"

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x1.msl
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x1.msl
@@ -302,6 +302,6 @@ vertex render_vertexOutput render_vertex(
         v_unorm8x4_bgra = unpackUnorm8x4Bgra(vb_1_elem.data[640], vb_1_elem.data[641], vb_1_elem.data[642], vb_1_elem.data[643]).x;
     }
     const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra };
-    const auto _tmp = VertexOutput {metal::float4(static_cast<float>(v_in.v_uint8_))};
+    const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_)};
     return render_vertexOutput { _tmp.position };
 }

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x2.msl
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x2.msl
@@ -302,6 +302,6 @@ vertex render_vertexOutput render_vertex(
         v_unorm8x4_bgra = unpackUnorm8x4Bgra(vb_1_elem.data[640], vb_1_elem.data[641], vb_1_elem.data[642], vb_1_elem.data[643]).xy;
     }
     const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra };
-    const auto _tmp = VertexOutput {metal::float4(static_cast<float>(v_in.v_uint8_.x))};
+    const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_.x)};
     return render_vertexOutput { _tmp.position };
 }

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x3.msl
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x3.msl
@@ -311,6 +311,6 @@ vertex render_vertexOutput render_vertex(
         v_unorm8x4_bgra = unpackUnorm8x4Bgra(vb_1_elem.data[640], vb_1_elem.data[641], vb_1_elem.data[642], vb_1_elem.data[643]).xyz;
     }
     const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra };
-    const auto _tmp = VertexOutput {metal::float4(static_cast<float>(v_in.v_uint8_.x))};
+    const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_.x)};
     return render_vertexOutput { _tmp.position };
 }

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x4.msl
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x4.msl
@@ -300,6 +300,6 @@ vertex render_vertexOutput render_vertex(
         v_unorm8x4_bgra = unpackUnorm8x4Bgra(vb_1_elem.data[640], vb_1_elem.data[641], vb_1_elem.data[642], vb_1_elem.data[643]);
     }
     const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra };
-    const auto _tmp = VertexOutput {metal::float4(static_cast<float>(v_in.v_uint8_.x))};
+    const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_.x)};
     return render_vertexOutput { _tmp.position };
 }


### PR DESCRIPTION
**Connections**

- Fixes #8767
- Also #8815 is related. I'm not yet familiar with running CTS, so right now I can't tell if it would be resolved too.


**Description**

Expressions like `vec2f<1u>` are parsed as `ast::Expression::Construct` and then converted to `naga::ir::Expression::Splat`. Currently the splat then happily converts the `u32` to `f32`, but my understanding is that splat must not auto convert concrete types. This PR adds a check to avoid this and error out instead.

The Chrome/Tint error mentions a missing overload. In Naga overload resolution is not triggered, as far as I can tell.

With these changes, wgsl like the following does not compile anymore:

```wgsl
fn foo(x: u32) -> vec2f {
    return vec2f(x);
}
```

Instead naga errors out with:

```
Could not parse WGSL:
error: wrong type passed as argument #1 to `vec2<f32>`
  ┌─ foo.wgsl:2:12
  │
2 │     return vec2f(x);
  │            ^^^^^ ^ argument #1 has type `u32`
  │
  = note: `vec2<f32>` accepts the following types for argument #1:
  = note: allowed type: f32
```

**Testing**

Adds test `vector_constructor_type_mismatch`.

**Squash or Rebase?**

Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry.