### PR TITLE
Invalidate instead of flushing the mapped range when reading back BLAS compacted size.

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2327,7 +2327,7 @@ impl Blas {
                             // Clippy complains about this because it might not be intended, but
                             // this is intentional.
                             #[expect(clippy::single_range_in_vec_init)]
-                            self.device.raw().flush_mapped_ranges(
+                            self.device.raw().invalidate_mapped_ranges(
                                 compaction_buffer,
                                 &[0..size_of::<wgpu_types::BufferAddress>() as wgt::BufferAddress],
                             );


### PR DESCRIPTION
**Connections**
Noticed while looking for the cause of #8825 , but this is not a fix for it.

**Description**
Previously, if the buffer mapping for a given BLAS's compact readback buffer was non-coherent (I want to say incoherent but I think that's wrong) it would call `device.flush_mapped_ranges`. `flush_mapped_ranges` is meant for CPU -> GPU writes, but this is a readback buffer, so it does a GPU -> CPU read and so needs `invalidate_mapped_ranges` instead. 

**Testing**
I don't think my computers return non-coherent mappings, so probably none.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
