### PR TITLE
[d3d12] fix panics in adapter creation

### DIFF
--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2814,6 +2814,7 @@ pub struct TlasInstance {
 #[cfg(dx12)]
 pub enum D3D12ExposeAdapterResult {
     CreateDeviceError(dx12::CreateDeviceError),
+    UnknownFeatureLevel(i32),
     ResourceBindingTier2Requirement,
     ShaderModel6Requirement,
     Success(dx12::FeatureLevel, dx12::ShaderModel),
@@ -2825,7 +2826,7 @@ pub struct Telemetry {
     #[cfg(dx12)]
     pub d3d12_expose_adapter: fn(
         desc: &windows::Win32::Graphics::Dxgi::DXGI_ADAPTER_DESC2,
-        driver_version: [u16; 4],
+        driver_version: Result<[u16; 4], windows_core::HRESULT>,
         result: D3D12ExposeAdapterResult,
     ),
 }


### PR DESCRIPTION
**Connections**
Fixes #8803 & [Bug 2007754](https://bugzilla.mozilla.org/show_bug.cgi?id=2007754).
Closes #8806.

**Description**
Allows driver version query to fail and handles unknown feature levels.

**Testing**
Hard to test but it should stop the crashes we've been seeing in Firefox's crash stats.

**Squash or Rebase?**
n/a