### PR TITLE
make some error types constructible

### DIFF
--- a/wgpu-types/src/adapter.rs
+++ b/wgpu-types/src/adapter.rs
@@ -192,6 +192,10 @@ pub enum RequestAdapterError {
     /// Attempted to obtain adapter specified by environment variable, but the environment variable
     /// was not set.
     EnvNotSet,
+
+    /// Custom error message for custom interfaces
+    //#[cfg(custom)]
+    Custom(String),
 }
 
 impl core::error::Error for RequestAdapterError {}
@@ -239,6 +243,7 @@ impl fmt::Display for RequestAdapterError {
                 }
             }
             RequestAdapterError::EnvNotSet => f.write_str("WGPU_ADAPTER_NAME not set")?,
+            RequestAdapterError::Custom(e) => f.write_str(e)?,
         }
         Ok(())
     }

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -707,6 +707,10 @@ pub(crate) enum RequestDeviceErrorKind {
     /// (This is currently never used by the webgl backend, but it could be.)
     #[cfg(webgpu)]
     WebGpu(String),
+
+    /// Custom error message for custom interfaces
+    #[cfg(custom)]
+    Custom(String),
 }
 
 static_assertions::assert_impl_all!(RequestDeviceError: Send, Sync);
@@ -718,6 +722,10 @@ impl fmt::Display for RequestDeviceError {
             RequestDeviceErrorKind::Core(error) => error.fmt(_f),
             #[cfg(webgpu)]
             RequestDeviceErrorKind::WebGpu(error) => {
+                write!(_f, "{error}")
+            }
+            #[cfg(custom)]
+            RequestDeviceErrorKind::Custom(error) => {
                 write!(_f, "{error}")
             }
             #[cfg(not(any(webgpu, wgpu_core)))]
@@ -733,6 +741,8 @@ impl error::Error for RequestDeviceError {
             RequestDeviceErrorKind::Core(error) => error.source(),
             #[cfg(webgpu)]
             RequestDeviceErrorKind::WebGpu(_) => None,
+            #[cfg(custom)]
+            RequestDeviceErrorKind::Custom(_) => None,
             #[cfg(not(any(webgpu, wgpu_core)))]
             _ => unimplemented!("unknown `RequestDeviceErrorKind`"),
         }
@@ -744,6 +754,16 @@ impl From<wgc::instance::RequestDeviceError> for RequestDeviceError {
     fn from(error: wgc::instance::RequestDeviceError) -> Self {
         Self {
             inner: RequestDeviceErrorKind::Core(error),
+        }
+    }
+}
+
+#[cfg(custom)]
+impl RequestDeviceError {
+    /// Creates a custom device request error from a message.
+    pub fn custom(message: String) -> Self {
+        Self {
+            inner: RequestDeviceErrorKind::Custom(message),
         }
     }
 }

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -423,6 +423,9 @@ pub(crate) enum CreateSurfaceErrorKind {
     /// [rdh]: raw_window_handle::RawDisplayHandle
     /// [rwh]: raw_window_handle::RawWindowHandle
     RawHandle(raw_window_handle::HandleError),
+
+    #[cfg(custom)]
+    Custom(String),
 }
 static_assertions::assert_impl_all!(CreateSurfaceError: Send, Sync);
 
@@ -433,6 +436,8 @@ impl fmt::Display for CreateSurfaceError {
             CreateSurfaceErrorKind::Hal(e) => e.fmt(f),
             CreateSurfaceErrorKind::Web(e) => e.fmt(f),
             CreateSurfaceErrorKind::RawHandle(e) => e.fmt(f),
+            #[cfg(custom)]
+            CreateSurfaceErrorKind::Custom(e) => e.fmt(f),
         }
     }
 }
@@ -447,6 +452,8 @@ impl error::Error for CreateSurfaceError {
             CreateSurfaceErrorKind::RawHandle(e) => e.source(),
             #[cfg(not(feature = "std"))]
             CreateSurfaceErrorKind::RawHandle(_) => None,
+            #[cfg(custom)]
+            CreateSurfaceErrorKind::Custom(_) => None,
         }
     }
 }
@@ -456,6 +463,16 @@ impl From<wgc::instance::CreateSurfaceError> for CreateSurfaceError {
     fn from(e: wgc::instance::CreateSurfaceError) -> Self {
         Self {
             inner: CreateSurfaceErrorKind::Hal(e),
+        }
+    }
+}
+
+#[cfg(custom)]
+impl CreateSurfaceError {
+    /// Creates a custom surface creation error from a message.
+    pub fn custom(message: String) -> Self {
+        Self {
+            inner: CreateSurfaceErrorKind::Custom(message),
         }
     }
 }


### PR DESCRIPTION
As mentioned in #8826 I ran into a few issues while implementing a custom backend. Specifically I needed to add functions to construct error types that some interfaces return.

This is a draft because I think there might be better ways to fix this. These are just the changes to make it work quickly.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry.
