### PR TITLE
wgpu: Require Drop on *PassInterface and remove end from it

### DIFF
--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -3424,14 +3424,10 @@ impl dispatch::ComputePassInterface for WebComputePassEncoder {
         self.inner
             .dispatch_workgroups_indirect_with_f64(&indirect_buffer.inner, indirect_offset as f64);
     }
-
-    fn end(&mut self) {
-        self.inner.end();
-    }
 }
 impl Drop for WebComputePassEncoder {
     fn drop(&mut self) {
-        dispatch::ComputePassInterface::end(self);
+        self.inner.end();
     }
 }
 
@@ -3724,14 +3720,10 @@ impl dispatch::RenderPassInterface for WebRenderPassEncoder {
             .collect::<js_sys::Array>();
         self.inner.execute_bundles(&mapped);
     }
-
-    fn end(&mut self) {
-        self.inner.end();
-    }
 }
 impl Drop for WebRenderPassEncoder {
     fn drop(&mut self) {
-        dispatch::RenderPassInterface::end(self);
+        self.inner.end();
     }
 }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -3068,8 +3068,10 @@ impl dispatch::ComputePassInterface for CoreComputePass {
             );
         }
     }
+}
 
-    fn end(&mut self) {
+impl Drop for CoreComputePass {
+    fn drop(&mut self) {
         if let Err(cause) = self.context.0.compute_pass_end(&mut self.pass) {
             self.context.handle_error(
                 &self.error_sink,
@@ -3078,12 +3080,6 @@ impl dispatch::ComputePassInterface for CoreComputePass {
                 "ComputePass::end",
             );
         }
-    }
-}
-
-impl Drop for CoreComputePass {
-    fn drop(&mut self) {
-        dispatch::ComputePassInterface::end(self);
     }
 }
 
@@ -3683,8 +3679,10 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
             );
         }
     }
+}
 
-    fn end(&mut self) {
+impl Drop for CoreRenderPass {
+    fn drop(&mut self) {
         if let Err(cause) = self.context.0.render_pass_end(&mut self.pass) {
             self.context.handle_error(
                 &self.error_sink,
@@ -3693,12 +3691,6 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
                 "RenderPass::end",
             );
         }
-    }
-}
-
-impl Drop for CoreRenderPass {
-    fn drop(&mut self) {
-        dispatch::RenderPassInterface::end(self);
     }
 }
 

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -372,7 +372,7 @@ pub trait CommandEncoderInterface: CommonTraits {
         texture_transitions: &mut dyn Iterator<Item = wgt::TextureTransition<&'a DispatchTexture>>,
     );
 }
-pub trait ComputePassInterface: CommonTraits {
+pub trait ComputePassInterface: CommonTraits + Drop {
     fn set_pipeline(&mut self, pipeline: &DispatchComputePipeline);
     fn set_bind_group(
         &mut self,
@@ -396,9 +396,8 @@ pub trait ComputePassInterface: CommonTraits {
         indirect_buffer: &DispatchBuffer,
         indirect_offset: crate::BufferAddress,
     );
-    fn end(&mut self);
 }
-pub trait RenderPassInterface: CommonTraits {
+pub trait RenderPassInterface: CommonTraits + Drop {
     fn set_pipeline(&mut self, pipeline: &DispatchRenderPipeline);
     fn set_bind_group(
         &mut self,
@@ -507,8 +506,6 @@ pub trait RenderPassInterface: CommonTraits {
     fn end_pipeline_statistics_query(&mut self);
 
     fn execute_bundles(&mut self, render_bundles: &mut dyn Iterator<Item = &DispatchRenderBundle>);
-
-    fn end(&mut self);
 }
 
 pub trait RenderBundleEncoderInterface: CommonTraits {


### PR DESCRIPTION
**Description**
As noted in https://github.com/gfx-rs/wgpu/issues/8826 `*PassInterface::end` is never called outside of Drop impl (wgpu expects that `Dispatch*Pass` will end pass on drop), so this PR inlines end into drop and removes end from *PassInterface. *PassInterface are now also required to impl Drop (as it was already expected for pass end).

**Testing**
It compiles

**Squash or Rebase?**
Squash

<!--
Thanks for filing! The codeowners file will automatically request reviews from the appropriate teams.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
