### PR TITLE
Implement tracing for derived BGLs

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -186,6 +186,28 @@ impl Player {
                     .expect("create_bind_group_layout error");
                 self.bind_group_layouts.insert(id, bind_group_layout);
             }
+            Action::GetRenderPipelineBindGroupLayout {
+                id,
+                pipeline,
+                index,
+            } => {
+                let pipeline = self.resolve_render_pipeline_id(pipeline);
+                let bgl = pipeline
+                    .get_bind_group_layout(index)
+                    .expect("invalid render pipeline");
+                self.bind_group_layouts.insert(id, bgl);
+            }
+            Action::GetComputePipelineBindGroupLayout {
+                id,
+                pipeline,
+                index,
+            } => {
+                let pipeline = self.resolve_compute_pipeline_id(pipeline);
+                let bgl = pipeline
+                    .get_bind_group_layout(index)
+                    .expect("invalid compute pipeline");
+                self.bind_group_layouts.insert(id, bgl);
+            }
             Action::DestroyBindGroupLayout(id) => {
                 self.bind_group_layouts
                     .remove(&id)

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -154,6 +154,16 @@ pub enum Action<'a, R: ReferenceType> {
         PointerId<markers::BindGroupLayout>,
         crate::binding_model::BindGroupLayoutDescriptor<'a>,
     ),
+    GetRenderPipelineBindGroupLayout {
+        id: PointerId<markers::BindGroupLayout>,
+        pipeline: PointerId<markers::RenderPipeline>,
+        index: u32,
+    },
+    GetComputePipelineBindGroupLayout {
+        id: PointerId<markers::BindGroupLayout>,
+        pipeline: PointerId<markers::ComputePipeline>,
+        index: u32,
+    },
     DestroyBindGroupLayout(PointerId<markers::BindGroupLayout>),
     CreatePipelineLayout(
         PointerId<markers::PipelineLayout>,

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -864,6 +864,24 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::Present(surface) => A::Present(surface),
         A::DiscardSurfaceTexture(surface) => A::DiscardSurfaceTexture(surface),
         A::DestroyBindGroupLayout(layout) => A::DestroyBindGroupLayout(layout),
+        A::GetRenderPipelineBindGroupLayout {
+            id,
+            pipeline,
+            index,
+        } => A::GetRenderPipelineBindGroupLayout {
+            id,
+            pipeline,
+            index,
+        },
+        A::GetComputePipelineBindGroupLayout {
+            id,
+            pipeline,
+            index,
+        } => A::GetComputePipelineBindGroupLayout {
+            id,
+            pipeline,
+            index,
+        },
         A::DestroyPipelineLayout(layout) => A::DestroyPipelineLayout(layout),
         A::DestroyBindGroup(bind_group) => A::DestroyBindGroup(bind_group),
         A::DestroyShaderModule(shader_module) => A::DestroyShaderModule(shader_module),

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -14,7 +14,10 @@ use wgt::error::{ErrorType, WebGpuError};
 
 pub use crate::pipeline_cache::PipelineCacheValidationError;
 use crate::{
-    binding_model::{CreateBindGroupLayoutError, CreatePipelineLayoutError, PipelineLayout},
+    binding_model::{
+        BindGroupLayout, CreateBindGroupLayoutError, CreatePipelineLayoutError,
+        GetBindGroupLayoutError, PipelineLayout,
+    },
     command::ColorAttachmentError,
     device::{Device, DeviceError, MissingDownlevelFlags, MissingFeatures, RenderPassContext},
     id::{PipelineCacheId, PipelineLayoutId, ShaderModuleId},
@@ -300,6 +303,17 @@ crate::impl_trackable!(ComputePipeline);
 impl ComputePipeline {
     pub(crate) fn raw(&self) -> &dyn hal::DynComputePipeline {
         self.raw.as_ref()
+    }
+
+    pub fn get_bind_group_layout(
+        self: &Arc<Self>,
+        index: u32,
+    ) -> Result<Arc<BindGroupLayout>, GetBindGroupLayoutError> {
+        self.layout
+            .bind_group_layouts
+            .get(index as usize)
+            .cloned()
+            .ok_or(GetBindGroupLayoutError::InvalidGroupIndex(index))
     }
 }
 
@@ -824,5 +838,16 @@ crate::impl_trackable!(RenderPipeline);
 impl RenderPipeline {
     pub(crate) fn raw(&self) -> &dyn hal::DynRenderPipeline {
         self.raw.as_ref()
+    }
+
+    pub fn get_bind_group_layout(
+        self: &Arc<Self>,
+        index: u32,
+    ) -> Result<Arc<BindGroupLayout>, GetBindGroupLayoutError> {
+        self.layout
+            .bind_group_layouts
+            .get(index as usize)
+            .cloned()
+            .ok_or(GetBindGroupLayoutError::InvalidGroupIndex(index))
     }
 }


### PR DESCRIPTION
Identified this small piece of missing functionality while testing #8289 in Firefox. When an application calls `getBindGroupLayout` to retrieve a derived BGL, we need to record that in the trace so that subsequent calls can reference the layout ID.

**Testing**
Tested manually when I wrote it several months ago, but no automated testing.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
