### PR TITLE
Validation fixes for dual-source blending, depth bias, and `frag_depth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Bottom level categories:
 - Fixed validation of the texture format in GPUDepthStencilState when neither depth nor stencil is actually enabled. By @andyleiserson in [#8766](https://github.com/gfx-rs/wgpu/pull/8766).
 - Tracing support has been restored. By @andyleiserson in [#8429](https://github.com/gfx-rs/wgpu/pull/8429).
 - Pipelines using passthrough shaders now correctly require explicit pipeline layout. By @inner-daemons in #8881.
+- Allow using a shader that defines I/O for dual-source blending in a pipeline that does not make use of it. By @andyleiserson in [#8856](https://github.com/gfx-rs/wgpu/pull/8856).
 
 #### naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Bottom level categories:
 
 - General
 - naga
+- Validation
 - DX12
 - Vulkan
 - Metal
@@ -80,7 +81,6 @@ Bottom level categories:
 #### General
 
 - BREAKING: Migrated from the `maxInterStageShaderComponents` limit to `maxInterStageShaderVariables`, which changes validation in a way that should not affect most programs. This follows the latest changes of the WebGPU spec. By @ErichDonGubler in [#8652](https://github.com/gfx-rs/wgpu/pull/8652), [#8792](https://github.com/gfx-rs/wgpu/pull/8792).
-- Fixed validation of the texture format in GPUDepthStencilState when neither depth nor stencil is actually enabled. By @andyleiserson in [#8766](https://github.com/gfx-rs/wgpu/pull/8766).
 - Tracing support has been restored. By @andyleiserson in [#8429](https://github.com/gfx-rs/wgpu/pull/8429).
 - Pipelines using passthrough shaders now correctly require explicit pipeline layout. By @inner-daemons in #8881.
 - Allow using a shader that defines I/O for dual-source blending in a pipeline that does not make use of it. By @andyleiserson in [#8856](https://github.com/gfx-rs/wgpu/pull/8856).
@@ -96,6 +96,12 @@ Bottom level categories:
 - Reject splat vector construction if the argument type does not match the type of the vector's scalar. Previously it would succeed. By @mooori in [#8829](https://github.com/gfx-rs/wgpu/pull/8829).
 - Fixed `workgroupUniformLoad` incorrectly returning an atomic when called on an atomic, it now returns the inner `T` as per the spec. By @cryvosh in [#8791](https://github.com/gfx-rs/wgpu/pull/8791).
 - Fixed constant evaluation for `sign()` builtin to return zero when the argument is zero. By @mandryskowski in [#8942](https://github.com/gfx-rs/wgpu/pull/8942).
+
+#### Validation
+
+- Fixed validation of the texture format in GPUDepthStencilState when neither depth nor stencil is actually enabled. By @andyleiserson in [#8766](https://github.com/gfx-rs/wgpu/pull/8766).
+- Check that depth bias is not used with non-triangle topologies. By @andyleiserson in [#8856](https://github.com/gfx-rs/wgpu/pull/8856).
+- Check that if the shader outputs `frag_depth`, then the pipeline must have a depth attachment. By @andyleiserson in [#8856](https://github.com/gfx-rs/wgpu/pull/8856).
 
 #### GLES
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -165,6 +165,7 @@ webgpu:api,validation,render_pass,resolve:resolve_attachment:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:format:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:stencil_write:*
 webgpu:api,validation,render_pipeline,float32_blendable:*
+webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,use_blend_src:*
 webgpu:api,validation,render_pipeline,inter_stage:location,*
 webgpu:api,validation,render_pipeline,inter_stage:max_shader_variable_location:*
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -162,6 +162,8 @@ webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,*
 webgpu:api,validation,render_pass,resolve:resolve_attachment:*
+webgpu:api,validation,render_pipeline,depth_stencil_state:depth_bias:*
+webgpu:api,validation,render_pipeline,depth_stencil_state:depth_write,frag_depth:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:format:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:stencil_write:*
 webgpu:api,validation,render_pipeline,float32_blendable:*

--- a/tests/tests/wgpu-gpu/dual_source_blending.rs
+++ b/tests/tests/wgpu-gpu/dual_source_blending.rs
@@ -182,30 +182,26 @@ async fn dual_source_blending_enabled(ctx: TestingContext) {
             ..render_pipeline_descriptor_template.clone()
         });
 
-    // Failure mode:
+    // Happy path:
     // blend operator dual source: no
     // shader handling dual source: yes
-    fail(
-        &ctx.device,
-        || {
-            let _ = ctx
-                .device
-                .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                    fragment: Some(wgpu::FragmentState {
-                        module: &fragment_shader_with_dual_source_blending,
-                        entry_point: None,
-                        targets: &[Some(wgpu::ColorTargetState {
-                            format: wgpu::TextureFormat::Rgba8Unorm,
-                            blend: None,
-                            write_mask: wgpu::ColorWrites::all(),
-                        })],
-                        compilation_options: Default::default(),
-                    }),
-                    ..render_pipeline_descriptor_template.clone()
-                });
-        },
-        Some("Shader entry point expects the pipeline to make use of dual-source blending."),
-    );
+    // (It is okay for the shader to define dual-source I/O that the pipeline
+    // does not use.)
+    let _ = ctx
+        .device
+        .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            fragment: Some(wgpu::FragmentState {
+                module: &fragment_shader_with_dual_source_blending,
+                entry_point: None,
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: wgpu::TextureFormat::Rgba8Unorm,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::all(),
+                })],
+                compilation_options: Default::default(),
+            }),
+            ..render_pipeline_descriptor_template.clone()
+        });
 
     // Failure mode:
     // blend operator dual source: yes
@@ -229,6 +225,6 @@ async fn dual_source_blending_enabled(ctx: TestingContext) {
                     ..render_pipeline_descriptor_template.clone()
                 });
         },
-        Some("Pipeline expects the shader entry point to make use of dual-source blending."),
+        Some("Pipeline uses dual-source blending, but the shader does not support it"),
     );
 }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3899,14 +3899,11 @@ impl Device {
         let mut vertex_steps;
         let mut vertex_buffers;
         let mut total_attributes;
-        let mut shader_expects_dual_source_blending = false;
-        let mut pipeline_expects_dual_source_blending = false;
+        let mut dual_source_blending = false;
         if let pipeline::RenderPipelineVertexProcessor::Vertex(ref vertex) = desc.vertex {
             vertex_steps = Vec::with_capacity(vertex.buffers.len());
             vertex_buffers = Vec::with_capacity(vertex.buffers.len());
             total_attributes = 0;
-            shader_expects_dual_source_blending = false;
-            pipeline_expects_dual_source_blending = false;
             for (i, vb_state) in vertex.buffers.iter().enumerate() {
                 // https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-gpuvertexbufferlayout
 
@@ -4126,7 +4123,7 @@ impl Device {
                             if factor.ref_second_blend_source() {
                                 self.require_features(wgt::Features::DUAL_SOURCE_BLENDING)?;
                                 if i == 0 {
-                                    pipeline_expects_dual_source_blending = true;
+                                    dual_source_blending = true;
                                     break;
                                 } else {
                                     return Err(pipeline::CreateRenderPipelineError
@@ -4381,7 +4378,9 @@ impl Device {
         let fragment_entry_point_name;
         let fragment_stage = match desc.fragment {
             Some(ref fragment_state) => {
-                let stage = validation::ShaderStageForValidation::Fragment;
+                let stage = validation::ShaderStageForValidation::Fragment {
+                    dual_source_blending,
+                };
                 let stage_bit = stage.to_wgt_bit();
 
                 let shader_module = &fragment_state.stage.module;
@@ -4416,15 +4415,6 @@ impl Device {
                     validated_stages |= stage_bit;
                 }
 
-                if let Some(ref interface) = shader_module.interface {
-                    shader_expects_dual_source_blending = interface
-                        .fragment_uses_dual_source_blending(&fragment_entry_point_name)
-                        .map_err(|error| pipeline::CreateRenderPipelineError::Stage {
-                            stage: stage_bit,
-                            error,
-                        })?;
-                }
-
                 Some(hal::ProgrammableStage {
                     module: shader_module.raw(),
                     entry_point: &fragment_entry_point_name,
@@ -4436,17 +4426,6 @@ impl Device {
             }
             None => None,
         };
-
-        if !pipeline_expects_dual_source_blending && shader_expects_dual_source_blending {
-            return Err(
-                pipeline::CreateRenderPipelineError::ShaderExpectsPipelineToUseDualSourceBlending,
-            );
-        }
-        if pipeline_expects_dual_source_blending && !shader_expects_dual_source_blending {
-            return Err(
-                pipeline::CreateRenderPipelineError::PipelineExpectsShaderToUseDualSourceBlending,
-            );
-        }
 
         if validated_stages.contains(wgt::ShaderStages::FRAGMENT) {
             for (i, output) in io.varyings.iter() {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3900,6 +3900,7 @@ impl Device {
         let mut vertex_buffers;
         let mut total_attributes;
         let mut dual_source_blending = false;
+        let mut has_depth_attachment = false;
         if let pipeline::RenderPipelineVertexProcessor::Vertex(ref vertex) = desc.vertex {
             vertex_steps = Vec::with_capacity(vertex.buffers.len());
             vertex_buffers = Vec::with_capacity(vertex.buffers.len());
@@ -4169,7 +4170,9 @@ impl Device {
                 }
 
                 let aspect = hal::FormatAspects::from(ds.format);
-                if ds.is_depth_enabled() && !aspect.contains(hal::FormatAspects::DEPTH) {
+                if aspect.contains(hal::FormatAspects::DEPTH) {
+                    has_depth_attachment = true;
+                } else if ds.is_depth_enabled() {
                     break 'error Some(pipeline::DepthStencilStateError::FormatNotDepth(ds.format));
                 }
                 if ds.stencil.is_enabled() && !aspect.contains(hal::FormatAspects::STENCIL) {
@@ -4204,6 +4207,16 @@ impl Device {
 
             if ds.bias.clamp != 0.0 {
                 self.require_downlevel_flags(wgt::DownlevelFlags::DEPTH_BIAS_CLAMP)?;
+            }
+
+            if (ds.bias.is_enabled() || ds.bias.clamp != 0.0)
+                && !desc.primitive.topology.is_triangles()
+            {
+                return Err(pipeline::CreateRenderPipelineError::DepthStencilState(
+                    pipeline::DepthStencilStateError::DepthBiasWithIncompatibleTopology(
+                        desc.primitive.topology,
+                    ),
+                ));
             }
         }
 
@@ -4380,6 +4393,7 @@ impl Device {
             Some(ref fragment_state) => {
                 let stage = validation::ShaderStageForValidation::Fragment {
                     dual_source_blending,
+                    has_depth_attachment,
                 };
                 let stage_bit = stage.to_wgt_bit();
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -642,6 +642,8 @@ pub enum DepthStencilStateError {
     FormatNotStencil(wgt::TextureFormat),
     #[error("Sample count {0} is not supported by format {1:?} on this device. The WebGPU spec guarantees {2:?} samples are supported by this format. With the TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES feature your device supports {3:?}.")]
     InvalidSampleCount(u32, wgt::TextureFormat, Vec<u32>, Vec<u32>),
+    #[error("Depth bias is not compatible with non-triangle topology {0:?}")]
+    DepthBiasWithIncompatibleTopology(wgt::PrimitiveTopology),
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -719,10 +719,6 @@ pub enum CreateRenderPipelineError {
         factor: wgt::BlendFactor,
         target: u32,
     },
-    #[error("Pipeline expects the shader entry point to make use of dual-source blending.")]
-    PipelineExpectsShaderToUseDualSourceBlending,
-    #[error("Shader entry point expects the pipeline to make use of dual-source blending.")]
-    ShaderExpectsPipelineToUseDualSourceBlending,
     #[error("{}", concat!(
         "At least one color attachment or depth-stencil attachment was expected, ",
         "but no render target for the pipeline was specified."
@@ -759,8 +755,6 @@ impl WebGpuError for CreateRenderPipelineError {
             | Self::Stage { .. }
             | Self::UnalignedShader { .. }
             | Self::BlendFactorOnUnsupportedTarget { .. }
-            | Self::PipelineExpectsShaderToUseDualSourceBlending
-            | Self::ShaderExpectsPipelineToUseDualSourceBlending
             | Self::NoTargetSpecified
             | Self::PipelineConstants { .. }
             | Self::VertexAttributeStrideTooLarge { .. } => return ErrorType::Validation,

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -396,6 +396,10 @@ pub enum StageError {
     MissingPrimitiveIndex,
     #[error("DrawId cannot be used in the same pipeline as a task shader")]
     DrawIdError,
+    #[error("Pipeline expects the shader entry point to make use of dual-source blending.")]
+    PipelineExpectsShaderToUseDualSourceBlending,
+    #[error("Shader entry point expects the pipeline to make use of dual-source blending.")]
+    ShaderExpectsPipelineToUseDualSourceBlending,
 }
 
 impl WebGpuError for StageError {
@@ -428,7 +432,9 @@ impl WebGpuError for StageError {
             | Self::TaskPayloadMustMatch { .. }
             | Self::InvalidPrimitiveIndex
             | Self::MissingPrimitiveIndex
-            | Self::DrawIdError => return ErrorType::Validation,
+            | Self::DrawIdError
+            | Self::PipelineExpectsShaderToUseDualSourceBlending
+            | Self::ShaderExpectsPipelineToUseDualSourceBlending => return ErrorType::Validation,
         };
         e.webgpu_error_type()
     }
@@ -1569,7 +1575,9 @@ impl Interface {
                     });
                 }
             }
-            ShaderStageForValidation::Fragment => {
+            ShaderStageForValidation::Fragment {
+                dual_source_blending,
+            } => {
                 let mut max_fragment_shader_input_variables =
                     self.limits.max_inter_stage_shader_variables;
 
@@ -1636,6 +1644,17 @@ impl Interface {
                             limit: self.limits.max_color_attachments,
                         });
                     }
+                }
+
+                if !dual_source_blending && entry_point.dual_source_blending {
+                    return Err(
+                        StageError::ShaderExpectsPipelineToUseDualSourceBlending,
+                    );
+                }
+                if dual_source_blending && !entry_point.dual_source_blending {
+                    return Err(
+                        StageError::PipelineExpectsShaderToUseDualSourceBlending,
+                    );
                 }
             }
             _ => (),
@@ -1759,7 +1778,9 @@ pub enum ShaderStageForValidation {
         compare_function: Option<wgt::CompareFunction>,
     },
     Mesh,
-    Fragment,
+    Fragment {
+        dual_source_blending: bool,
+    },
     Compute,
     Task,
 }
@@ -1769,7 +1790,7 @@ impl ShaderStageForValidation {
         match self {
             Self::Vertex { .. } => naga::ShaderStage::Vertex,
             Self::Mesh => naga::ShaderStage::Mesh,
-            Self::Fragment => naga::ShaderStage::Fragment,
+            Self::Fragment { .. } => naga::ShaderStage::Fragment,
             Self::Compute => naga::ShaderStage::Compute,
             Self::Task => naga::ShaderStage::Task,
         }
@@ -1778,7 +1799,7 @@ impl ShaderStageForValidation {
     pub fn to_wgt_bit(&self) -> wgt::ShaderStages {
         match self {
             Self::Vertex { .. } => wgt::ShaderStages::VERTEX,
-            Self::Mesh { .. } => wgt::ShaderStages::MESH,
+            Self::Mesh => wgt::ShaderStages::MESH,
             Self::Fragment { .. } => wgt::ShaderStages::FRAGMENT,
             Self::Compute => wgt::ShaderStages::COMPUTE,
             Self::Task => wgt::ShaderStages::TASK,

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -85,7 +85,7 @@ struct Resource {
     class: naga::AddressSpace,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum NumericDimension {
     Scalar,
     Vector(naga::VectorSize),
@@ -102,7 +102,7 @@ impl fmt::Display for NumericDimension {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NumericType {
     dim: NumericDimension,
     scalar: naga::Scalar,
@@ -120,7 +120,7 @@ impl fmt::Display for NumericType {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InterfaceVar {
     pub ty: NumericType,
     interpolation: Option<naga::Interpolation>,
@@ -149,7 +149,7 @@ impl fmt::Display for InterfaceVar {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 enum Varying {
     Local { location: u32, iv: InterfaceVar },
     BuiltIn(naga::BuiltIn),
@@ -398,6 +398,8 @@ pub enum StageError {
     DrawIdError,
     #[error("Pipeline uses dual-source blending, but the shader does not support it")]
     InvalidDualSourceBlending,
+    #[error("Fragment shader writes depth, but pipeline does not have a depth attachment")]
+    MissingFragDepthAttachment,
 }
 
 impl WebGpuError for StageError {
@@ -431,7 +433,8 @@ impl WebGpuError for StageError {
             | Self::InvalidPrimitiveIndex
             | Self::MissingPrimitiveIndex
             | Self::DrawIdError
-            | Self::InvalidDualSourceBlending => return ErrorType::Validation,
+            | Self::InvalidDualSourceBlending
+            | Self::MissingFragDepthAttachment => return ErrorType::Validation,
         };
         e.webgpu_error_type()
     }
@@ -1574,6 +1577,7 @@ impl Interface {
             }
             ShaderStageForValidation::Fragment {
                 dual_source_blending,
+                has_depth_attachment,
             } => {
                 let mut max_fragment_shader_input_variables =
                     self.limits.max_inter_stage_shader_variables;
@@ -1649,6 +1653,14 @@ impl Interface {
                 // uses one blend source.
                 if dual_source_blending && !entry_point.dual_source_blending {
                     return Err(StageError::InvalidDualSourceBlending);
+                }
+
+                if entry_point
+                    .outputs
+                    .contains(&Varying::BuiltIn(naga::BuiltIn::FragDepth))
+                    && !has_depth_attachment
+                {
+                    return Err(StageError::MissingFragDepthAttachment);
                 }
             }
             _ => (),
@@ -1774,6 +1786,7 @@ pub enum ShaderStageForValidation {
     Mesh,
     Fragment {
         dual_source_blending: bool,
+        has_depth_attachment: bool,
     },
     Compute,
     Task,

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -396,10 +396,8 @@ pub enum StageError {
     MissingPrimitiveIndex,
     #[error("DrawId cannot be used in the same pipeline as a task shader")]
     DrawIdError,
-    #[error("Pipeline expects the shader entry point to make use of dual-source blending.")]
-    PipelineExpectsShaderToUseDualSourceBlending,
-    #[error("Shader entry point expects the pipeline to make use of dual-source blending.")]
-    ShaderExpectsPipelineToUseDualSourceBlending,
+    #[error("Pipeline uses dual-source blending, but the shader does not support it")]
+    InvalidDualSourceBlending,
 }
 
 impl WebGpuError for StageError {
@@ -433,8 +431,7 @@ impl WebGpuError for StageError {
             | Self::InvalidPrimitiveIndex
             | Self::MissingPrimitiveIndex
             | Self::DrawIdError
-            | Self::PipelineExpectsShaderToUseDualSourceBlending
-            | Self::ShaderExpectsPipelineToUseDualSourceBlending => return ErrorType::Validation,
+            | Self::InvalidDualSourceBlending => return ErrorType::Validation,
         };
         e.webgpu_error_type()
     }
@@ -1646,15 +1643,12 @@ impl Interface {
                     }
                 }
 
-                if !dual_source_blending && entry_point.dual_source_blending {
-                    return Err(
-                        StageError::ShaderExpectsPipelineToUseDualSourceBlending,
-                    );
-                }
+                // If the pipeline uses dual-source blending, then the shader
+                // must configure appropriate I/O, but it is not an error to
+                // use a shader that defines the I/O in a pipeline that only
+                // uses one blend source.
                 if dual_source_blending && !entry_point.dual_source_blending {
-                    return Err(
-                        StageError::PipelineExpectsShaderToUseDualSourceBlending,
-                    );
+                    return Err(StageError::InvalidDualSourceBlending);
                 }
             }
             _ => (),

--- a/wgpu-types/src/render.rs
+++ b/wgpu-types/src/render.rs
@@ -298,6 +298,15 @@ impl PrimitiveTopology {
             Self::LineStrip | Self::TriangleStrip => true,
         }
     }
+
+    /// Returns true for triangle topologies.
+    #[must_use]
+    pub fn is_triangles(&self) -> bool {
+        match *self {
+            Self::TriangleList | Self::TriangleStrip => true,
+            Self::PointList | Self::LineList | Self::LineStrip => false,
+        }
+    }
 }
 
 /// Vertex winding order which classifies the "front" face of a triangle.


### PR DESCRIPTION
Several validation fixes. The only reason the dual-source blending fix is related is that both it and the `frag_depth` fix add fields to `ShaderStageForValidation::Fragment` that @ErichDonGubler added recently.

* If the pipeline uses dual-source blending, then the shader must configure appropriate I/O, but it is not an error to use a shader that defines the I/O in a pipeline that only uses one blend source. Fixes #8592.
* Depth bias is only supported with triangle topologies. Fixes #6071.
* If the shader outputs `frag_depth`, then the pipeline must have a depth attachment. (No bug.)

This change will conflict with #8840, which needs more discussion, so I expect #8840 will be rebased on this one. Whichever lands second should enable the entire `depth_stencil_state` suite.

**Testing**
Enables relevant CTS tests.

**Squash or Rebase?** Rebase

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] Add `CHANGELOG.md` entries.