### PR TITLE
Add frontend checks for wgpu_cooperative_matrix extension

### DIFF
--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -279,6 +279,7 @@ impl<W: Write> Writer<W> {
         let mut needs_dual_source_blending = false;
         let mut needs_clip_distances = false;
         let mut needs_mesh_shaders = false;
+        let mut needs_cooperative_matrix = false;
 
         // Determine which `enable` declarations are needed
         for (_, ty) in module.types.iter() {
@@ -322,6 +323,9 @@ impl<W: Write> Writer<W> {
                         }
                     }
                 }
+                TypeInner::CooperativeMatrix { .. } => {
+                    needs_cooperative_matrix = true;
+                }
                 _ => {}
             }
         }
@@ -358,6 +362,10 @@ impl<W: Write> Writer<W> {
         }
         if needs_mesh_shaders {
             writeln!(self.out, "enable wgpu_mesh_shader;")?;
+            any_written = true;
+        }
+        if needs_cooperative_matrix {
+            writeln!(self.out, "enable wgpu_cooperative_matrix;")?;
             any_written = true;
         }
         if any_written {

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -223,15 +223,10 @@ impl<'a> BindingParser<'a> {
                 self.invariant.set(true, name_span)?;
             }
             "blend_src" => {
-                if !lexer
-                    .enable_extensions
-                    .contains(ImplementedEnableExtension::DualSourceBlending)
-                {
-                    return Err(Box::new(Error::EnableExtensionNotEnabled {
-                        span: name_span,
-                        kind: ImplementedEnableExtension::DualSourceBlending.into(),
-                    }));
-                }
+                lexer.require_enable_extension(
+                    ImplementedEnableExtension::DualSourceBlending,
+                    name_span,
+                )?;
 
                 lexer.expect(Token::Paren('('))?;
                 self.blend_src
@@ -240,15 +235,10 @@ impl<'a> BindingParser<'a> {
                 lexer.expect(Token::Paren(')'))?;
             }
             "per_primitive" => {
-                if !lexer
-                    .enable_extensions
-                    .contains(ImplementedEnableExtension::WgpuMeshShader)
-                {
-                    return Err(Box::new(Error::EnableExtensionNotEnabled {
-                        span: name_span,
-                        kind: ImplementedEnableExtension::WgpuMeshShader.into(),
-                    }));
-                }
+                lexer.require_enable_extension(
+                    ImplementedEnableExtension::WgpuMeshShader,
+                    name_span,
+                )?;
                 self.per_primitive.set((), name_span)?;
             }
             _ => return Err(Box::new(Error::UnknownAttribute(name_span))),
@@ -899,12 +889,7 @@ impl Parser {
                 let num = res.map_err(|err| Error::BadNumber(span, err))?;
 
                 if let Some(enable_extension) = num.requires_enable_extension() {
-                    if !lexer.enable_extensions.contains(enable_extension) {
-                        return Err(Box::new(Error::EnableExtensionNotEnabled {
-                            kind: enable_extension.into(),
-                            span,
-                        }));
-                    }
+                    lexer.require_enable_extension(enable_extension, span)?;
                 }
 
                 ast::Expression::Literal(ast::Literal::Number(num))
@@ -2002,85 +1987,33 @@ impl Parser {
                 }
             }
             "acceleration_structure" => {
-                if !lexer
-                    .enable_extensions
-                    .contains(ImplementedEnableExtension::WgpuRayQuery)
-                {
-                    return Err(Box::new(Error::EnableExtensionNotEnabled {
-                        kind: EnableExtension::Implemented(
-                            ImplementedEnableExtension::WgpuRayQuery,
-                        ),
-                        span,
-                    }));
-                }
+                lexer.require_enable_extension(ImplementedEnableExtension::WgpuRayQuery, span)?;
                 let vertex_return = lexer.next_acceleration_structure_flags()?;
-                if !lexer
-                    .enable_extensions
-                    .contains(ImplementedEnableExtension::WgpuRayQueryVertexReturn)
-                    && vertex_return
-                {
-                    return Err(Box::new(Error::EnableExtensionNotEnabled {
-                        kind: EnableExtension::Implemented(
-                            ImplementedEnableExtension::WgpuRayQueryVertexReturn,
-                        ),
+                if vertex_return {
+                    lexer.require_enable_extension(
+                        ImplementedEnableExtension::WgpuRayQueryVertexReturn,
                         span,
-                    }));
+                    )?;
                 }
                 ast::Type::AccelerationStructure { vertex_return }
             }
             "ray_query" => {
-                if !lexer
-                    .enable_extensions
-                    .contains(ImplementedEnableExtension::WgpuRayQuery)
-                {
-                    return Err(Box::new(Error::EnableExtensionNotEnabled {
-                        kind: EnableExtension::Implemented(
-                            ImplementedEnableExtension::WgpuRayQuery,
-                        ),
-                        span,
-                    }));
-                }
+                lexer.require_enable_extension(ImplementedEnableExtension::WgpuRayQuery, span)?;
                 let vertex_return = lexer.next_acceleration_structure_flags()?;
-                if !lexer
-                    .enable_extensions
-                    .contains(ImplementedEnableExtension::WgpuRayQueryVertexReturn)
-                    && vertex_return
-                {
-                    return Err(Box::new(Error::EnableExtensionNotEnabled {
-                        kind: EnableExtension::Implemented(
-                            ImplementedEnableExtension::WgpuRayQueryVertexReturn,
-                        ),
+                if vertex_return {
+                    lexer.require_enable_extension(
+                        ImplementedEnableExtension::WgpuRayQueryVertexReturn,
                         span,
-                    }));
+                    )?;
                 }
                 ast::Type::RayQuery { vertex_return }
             }
             "RayDesc" => {
-                if !lexer
-                    .enable_extensions
-                    .contains(ImplementedEnableExtension::WgpuRayQuery)
-                {
-                    return Err(Box::new(Error::EnableExtensionNotEnabled {
-                        kind: EnableExtension::Implemented(
-                            ImplementedEnableExtension::WgpuRayQuery,
-                        ),
-                        span,
-                    }));
-                }
+                lexer.require_enable_extension(ImplementedEnableExtension::WgpuRayQuery, span)?;
                 ast::Type::RayDesc
             }
             "RayIntersection" => {
-                if !lexer
-                    .enable_extensions
-                    .contains(ImplementedEnableExtension::WgpuRayQuery)
-                {
-                    return Err(Box::new(Error::EnableExtensionNotEnabled {
-                        kind: EnableExtension::Implemented(
-                            ImplementedEnableExtension::WgpuRayQuery,
-                        ),
-                        span,
-                    }));
-                }
+                lexer.require_enable_extension(ImplementedEnableExtension::WgpuRayQuery, span)?;
                 ast::Type::RayIntersection
             }
             _ => return Ok(None),
@@ -3028,28 +2961,18 @@ impl Parser {
                     compute_like_span = name_span;
                 }
                 "task" => {
-                    if !lexer
-                        .enable_extensions
-                        .contains(ImplementedEnableExtension::WgpuMeshShader)
-                    {
-                        return Err(Box::new(Error::EnableExtensionNotEnabled {
-                            span: name_span,
-                            kind: ImplementedEnableExtension::WgpuMeshShader.into(),
-                        }));
-                    }
+                    lexer.require_enable_extension(
+                        ImplementedEnableExtension::WgpuMeshShader,
+                        name_span,
+                    )?;
                     stage.set(ShaderStage::Task, name_span)?;
                     compute_like_span = name_span;
                 }
                 "mesh" => {
-                    if !lexer
-                        .enable_extensions
-                        .contains(ImplementedEnableExtension::WgpuMeshShader)
-                    {
-                        return Err(Box::new(Error::EnableExtensionNotEnabled {
-                            span: name_span,
-                            kind: ImplementedEnableExtension::WgpuMeshShader.into(),
-                        }));
-                    }
+                    lexer.require_enable_extension(
+                        ImplementedEnableExtension::WgpuMeshShader,
+                        name_span,
+                    )?;
                     stage.set(ShaderStage::Mesh, name_span)?;
                     compute_like_span = name_span;
 
@@ -3058,15 +2981,10 @@ impl Parser {
                     lexer.expect(Token::Paren(')'))?;
                 }
                 "payload" => {
-                    if !lexer
-                        .enable_extensions
-                        .contains(ImplementedEnableExtension::WgpuMeshShader)
-                    {
-                        return Err(Box::new(Error::EnableExtensionNotEnabled {
-                            span: name_span,
-                            kind: ImplementedEnableExtension::WgpuMeshShader.into(),
-                        }));
-                    }
+                    lexer.require_enable_extension(
+                        ImplementedEnableExtension::WgpuMeshShader,
+                        name_span,
+                    )?;
                     lexer.expect(Token::Paren('('))?;
                     payload.set(lexer.next_ident_with_span()?, name_span)?;
                     lexer.expect(Token::Paren(')'))?;

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -663,14 +663,26 @@ impl Parser {
                     ty_span: Span::UNDEFINED,
                 }))
             }
-            "coop_mat8x8" => ast::ConstructorType::PartialCooperativeMatrix {
-                columns: crate::CooperativeSize::Eight,
-                rows: crate::CooperativeSize::Eight,
-            },
-            "coop_mat16x16" => ast::ConstructorType::PartialCooperativeMatrix {
-                columns: crate::CooperativeSize::Sixteen,
-                rows: crate::CooperativeSize::Sixteen,
-            },
+            "coop_mat8x8" => {
+                lexer.require_enable_extension(
+                    ImplementedEnableExtension::WgpuCooperativeMatrix,
+                    span,
+                )?;
+                ast::ConstructorType::PartialCooperativeMatrix {
+                    columns: crate::CooperativeSize::Eight,
+                    rows: crate::CooperativeSize::Eight,
+                }
+            }
+            "coop_mat16x16" => {
+                lexer.require_enable_extension(
+                    ImplementedEnableExtension::WgpuCooperativeMatrix,
+                    span,
+                )?;
+                ast::ConstructorType::PartialCooperativeMatrix {
+                    columns: crate::CooperativeSize::Sixteen,
+                    rows: crate::CooperativeSize::Sixteen,
+                }
+            }
             "array" => ast::ConstructorType::PartialArray,
             "atomic"
             | "binding_array"
@@ -1744,18 +1756,30 @@ impl Parser {
                 ty: ctx.new_scalar(Scalar::F16),
                 ty_span: Span::UNDEFINED,
             },
-            "coop_mat8x8" => self.cooperative_matrix_with_type(
-                lexer,
-                ctx,
-                crate::CooperativeSize::Eight,
-                crate::CooperativeSize::Eight,
-            )?,
-            "coop_mat16x16" => self.cooperative_matrix_with_type(
-                lexer,
-                ctx,
-                crate::CooperativeSize::Sixteen,
-                crate::CooperativeSize::Sixteen,
-            )?,
+            "coop_mat8x8" => {
+                lexer.require_enable_extension(
+                    ImplementedEnableExtension::WgpuCooperativeMatrix,
+                    span,
+                )?;
+                self.cooperative_matrix_with_type(
+                    lexer,
+                    ctx,
+                    crate::CooperativeSize::Eight,
+                    crate::CooperativeSize::Eight,
+                )?
+            }
+            "coop_mat16x16" => {
+                lexer.require_enable_extension(
+                    ImplementedEnableExtension::WgpuCooperativeMatrix,
+                    span,
+                )?;
+                self.cooperative_matrix_with_type(
+                    lexer,
+                    ctx,
+                    crate::CooperativeSize::Sixteen,
+                    crate::CooperativeSize::Sixteen,
+                )?
+            }
             "atomic" => {
                 let scalar = lexer.next_scalar_generic()?;
                 ast::Type::Atomic(scalar)

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -222,6 +222,7 @@ impl Capabilities {
             Self::MESH_SHADER => Some(Ext::WgpuMeshShader),
             Self::RAY_QUERY => Some(Ext::WgpuRayQuery),
             Self::RAY_HIT_VERTEX_POSITION => Some(Ext::WgpuRayQueryVertexReturn),
+            Self::COOPERATIVE_MATRIX => Some(Ext::WgpuCooperativeMatrix),
             _ => None,
         }
     }

--- a/naga/tests/in/wgsl/cooperative-matrix.wgsl
+++ b/naga/tests/in/wgsl/cooperative-matrix.wgsl
@@ -1,3 +1,5 @@
+enable wgpu_cooperative_matrix;
+
 // type declarations with different roles
 var<private> a: coop_mat8x8<f32, A>;
 var<private> b: coop_mat8x8<f32, B>;

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -4510,3 +4510,62 @@ fn binding_array_requires_capability() {
         Capabilities::all()
     }
 }
+
+#[test]
+fn cooperative_matrix_enable_extension() {
+    for ty in ["coop_mat8x8", "coop_mat16x16"] {
+        let carets = "^".repeat(ty.len());
+
+        check_extension_validation!(
+            // Used in type declaration
+            Capabilities::COOPERATIVE_MATRIX,
+            &format!(
+                r#"fn foo() {{
+    var a: {ty}<f32, A>;
+}}
+"#
+            ),
+            &format!(
+                r#"error: the `wgpu_cooperative_matrix` enable extension is not enabled
+  ┌─ wgsl:2:12
+  │
+2 │     var a: {ty}<f32, A>;
+  │            {carets} the `wgpu_cooperative_matrix` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_cooperative_matrix;` at the top of the shader, before any other items.
+
+"#,
+            ),
+            Err(naga::valid::ValidationError::Type {
+                source: naga::valid::TypeError::MissingCapability(Capabilities::COOPERATIVE_MATRIX),
+                ..
+            })
+        );
+
+        // Used as constructor
+        check_extension_validation!(
+            Capabilities::COOPERATIVE_MATRIX,
+            &format!(
+                r#"fn foo() {{
+    let a = {ty}<f32, A>();
+}}
+"#,
+            ),
+            &format!(
+                r#"error: the `wgpu_cooperative_matrix` enable extension is not enabled
+  ┌─ wgsl:2:13
+  │
+2 │     let a = {ty}<f32, A>();
+  │             {carets} the `wgpu_cooperative_matrix` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_cooperative_matrix;` at the top of the shader, before any other items.
+
+"#,
+            ),
+            Err(naga::valid::ValidationError::Type {
+                source: naga::valid::TypeError::MissingCapability(Capabilities::COOPERATIVE_MATRIX),
+                ..
+            })
+        );
+    }
+}

--- a/naga/tests/out/wgsl/wgsl-cooperative-matrix.wgsl
+++ b/naga/tests/out/wgsl/wgsl-cooperative-matrix.wgsl
@@ -1,3 +1,5 @@
+enable wgpu_cooperative_matrix;
+
 var<private> a: coop_mat8x8<f32,A>;
 var<private> b: coop_mat8x8<f32,B>;
 @group(0) @binding(0) 


### PR DESCRIPTION
Adds checks for the `wgpu_cooperative_matrix` enable extension when encountering the `coop_matNxN` types in the WGSL front-end.

Also has (as a separate commit) a small refactor to reduce the verbosity of these checks.

Related to #8866, but I expect one more PR.

**Testing**
Adds wgsl_errors tests.

**Squash or Rebase?** Rebase

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] CHANGELOG entry not needed because cooperative matrix is new in current version.