### PR TITLE
Fix typo in docs regarding memory init tracker

### DIFF
--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -26,7 +26,7 @@ system there are two kind of writes:
   Shader. The system is not able to determine if a resource is fully
   initialized afterwards but is no longer allowed to perform any
   clears, therefore this leads to a
-  `MemoryInitKind.ImplicitlyInitialized` action, exactly like a read
+  `MemoryInitKind.NeedsInitializedMemory` action, exactly like a read
   would.
 
  */


### PR DESCRIPTION
**Connections**
N/A

**Description**
If I understand correctly, wgpu will initialize buffers and textures if they are used in binding regardless read/write. The init kind should be NeedsInitializedMemory.

**Testing**
N/A

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
