### PR TITLE
fix(naga): Support dual-source blending for SPIR-V shaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,14 @@ Bottom level categories:
 
 ### New Features
 
+#### General
+
 - Added support for cooperative load/store operations in shaders. Currently only WGSL on the input and SPIR-V, METAL, and WGSL on the output are supported. By @kvark in [#8251](https://github.com/gfx-rs/wgpu/issues/8251).
 - Added support for obtaining `AdapterInfo` from `Device`. By @sagudev in [#8807](https://github.com/gfx-rs/wgpu/pull/8807).
+
+#### naga
+
+- Added support for dual-source blending in SPIR-V shaders. By @andyleiserson in [#8865](https://github.com/gfx-rs/wgpu/pull/8865).
 
 ### Bug Fixes
 

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -215,6 +215,7 @@ struct Decoration {
     name: Option<String>,
     built_in: Option<spirv::Word>,
     location: Option<spirv::Word>,
+    index: Option<spirv::Word>,
     desc_set: Option<spirv::Word>,
     desc_index: Option<spirv::Word>,
     specialization_constant_id: Option<spirv::Word>,
@@ -256,6 +257,18 @@ impl Decoration {
                 invariant,
                 ..
             } => Ok(crate::Binding::BuiltIn(map_builtin(built_in, invariant)?)),
+            Decoration {
+                built_in: None,
+                location: Some(location),
+                index: Some(index),
+                ..
+            } => Ok(crate::Binding::Location {
+                location,
+                interpolation: None,
+                sampling: None,
+                blend_src: Some(index),
+                per_primitive: false,
+            }),
             Decoration {
                 built_in: None,
                 location: Some(location),
@@ -745,6 +758,10 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
             spirv::Decoration::Location => {
                 inst.expect(base_words + 2)?;
                 dec.location = Some(self.next()?);
+            }
+            spirv::Decoration::Index => {
+                inst.expect(base_words + 2)?;
+                dec.index = Some(self.next()?);
             }
             spirv::Decoration::DescriptorSet => {
                 inst.expect(base_words + 2)?;

--- a/naga/tests/in/spv/dual-source-blending.spvasm
+++ b/naga/tests/in/spv/dual-source-blending.spvasm
@@ -1,0 +1,35 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 22
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %output0 %output1
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %output0 "output0"
+               OpName %output1 "output1"
+               OpDecorate %output0 Location 0
+               OpDecorate %output0 Index 0
+               OpDecorate %output1 Location 0
+               OpDecorate %output1 Index 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+    %output0 = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+    %float_0 = OpConstant %float 0
+         %13 = OpConstantComposite %v4float %float_1 %float_0 %float_1 %float_0
+    %output1 = OpVariable %_ptr_Output_v4float Output
+         %15 = OpConstantComposite %v4float %float_0 %float_1 %float_0 %float_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpStore %output0 %13
+               OpStore %output1 %15
+               OpReturn
+               OpFunctionEnd

--- a/naga/tests/in/spv/dual-source-blending.toml
+++ b/naga/tests/in/spv/dual-source-blending.toml
@@ -1,0 +1,1 @@
+capabilities = "DUAL_SOURCE_BLENDING"

--- a/naga/tests/out/wgsl/spv-dual-source-blending.wgsl
+++ b/naga/tests/out/wgsl/spv-dual-source-blending.wgsl
@@ -1,0 +1,23 @@
+enable dual_source_blending;
+
+struct FragmentOutput {
+    @location(0) @blend_src(0) member: vec4<f32>,
+    @location(0) @blend_src(1) member_1: vec4<f32>,
+}
+
+var<private> output0_: vec4<f32>;
+var<private> output1_: vec4<f32>;
+
+fn main_1() {
+    output0_ = vec4<f32>(1f, 0f, 1f, 0f);
+    output1_ = vec4<f32>(0f, 1f, 0f, 1f);
+    return;
+}
+
+@fragment 
+fn main() -> FragmentOutput {
+    main_1();
+    let _e2 = output0_;
+    let _e3 = output1_;
+    return FragmentOutput(_e2, _e3);
+}


### PR DESCRIPTION
Parse `index` decorations into the `blend_src` binding property. I modeled this after what the GLSL front-end does. @Wumpf tagging you because it looks like you added that support in GLSL. I'm a bit out of my element here.

Fixes #8864

**Testing**
Tested in `kas` with https://github.com/kas-gui/kas/pull/635. Also adds a snapshot test.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
