### PR TITLE
test(naga): Tests for mesh shader extension validation

### DIFF
--- a/naga/src/compact/mod.rs
+++ b/naga/src/compact/mod.rs
@@ -157,19 +157,15 @@ pub fn compact(module: &mut crate::Module, keep_unused: KeepUnused) {
                 }
             }
             if e.stage == crate::ShaderStage::Task || e.stage == crate::ShaderStage::Mesh {
-                // u32 should always be there if the module is valid, as it is e.g. the type of some expressions
-                let u32_type = module
-                    .types
-                    .iter()
-                    .find_map(|tuple| {
-                        if tuple.1.inner == crate::TypeInner::Scalar(crate::Scalar::U32) {
-                            Some(tuple.0)
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap();
-                module_tracer.types_used.insert(u32_type);
+                // Mesh shaders always need a u32 type, as it is e.g. the type of some
+                // expressions. We tolerate its absence here because compaction is
+                // infallible, but the module will fail validation.
+                if let Some(u32_type) = module.types.iter().find_map(|tuple| {
+                    (tuple.1.inner == crate::TypeInner::Scalar(crate::Scalar::U32))
+                        .then_some(tuple.0)
+                }) {
+                    module_tracer.types_used.insert(u32_type);
+                }
             }
 
             let mut used = module_tracer.as_function(&e.function);

--- a/naga/tests/naga/validation.rs
+++ b/naga/tests/naga/validation.rs
@@ -8,10 +8,62 @@
 )]
 
 use naga::{
-    ir,
-    valid::{self, ModuleInfo},
-    Expression, Function, Module, Scalar,
+    ir::{self, Expression, Function, Module, Scalar},
+    valid::{self, Capabilities, ModuleInfo, ValidationFlags},
 };
+
+fn test_span_generator() -> impl FnMut() -> naga::Span {
+    let mut index = 0;
+    move || {
+        let span = naga::Span::new(index, index + 1);
+        index += 1;
+        span
+    }
+}
+
+#[track_caller]
+fn expect_validation_error_impl<I: IntoIterator<Item = naga::Span>>(
+    module: &Module,
+    validation_flags: valid::ValidationFlags,
+    capabilities: valid::Capabilities,
+    spans: Option<I>,
+) -> naga::valid::ValidationError {
+    let err = valid::Validator::new(validation_flags, capabilities)
+        .validate(module)
+        .expect_err("module should be invalid");
+
+    if let Some(expected_spans_iter) = spans {
+        let actual_spans = err.spans().map(|sctx| sctx.0).collect::<Vec<_>>();
+        let expected_spans = expected_spans_iter.into_iter().collect::<Vec<_>>();
+        assert_eq!(
+            actual_spans, expected_spans,
+            "expected error spans to be {expected_spans:?}, got {actual_spans:?}",
+        );
+    }
+
+    err.into_inner()
+}
+
+/// Validate `module` with the given `validation_flags` and `capabilities`.
+///
+/// Panics if validation succeeds or fails with an error not associated with
+/// `span`. Otherwise, returns the validation error.
+///
+/// Note that only the span is checked, not the associated context string.
+#[track_caller]
+fn expect_validation_error_with_span(
+    module: &Module,
+    validation_flags: valid::ValidationFlags,
+    capabilities: valid::Capabilities,
+    span: naga::Span,
+) -> naga::valid::ValidationError {
+    expect_validation_error_impl(
+        module,
+        validation_flags,
+        capabilities,
+        Some(core::iter::once(span)),
+    )
+}
 
 /// Validation should fail if `AtomicResult` expressions are not
 /// populated by `Atomic` statements.
@@ -1183,4 +1235,57 @@ fn main() {
 
 "#,
     );
+}
+
+#[test]
+fn unexpected_task_payload() {
+    let mut make_test_span = test_span_generator();
+    let mut module = Module::default();
+
+    let ty_payload = module.types.insert(
+        ir::Type {
+            name: Some("u32".into()),
+            inner: ir::TypeInner::Scalar(naga::Scalar::U32),
+        },
+        make_test_span(),
+    );
+
+    let err_span = make_test_span();
+    let payload_handle = module.global_variables.append(
+        ir::GlobalVariable {
+            name: Some("task_payload".into()),
+            space: ir::AddressSpace::TaskPayload,
+            binding: None,
+            ty: ty_payload,
+            init: None,
+        },
+        err_span,
+    );
+
+    let entry_point = ir::EntryPoint {
+        name: "main".into(),
+        stage: ir::ShaderStage::Compute,
+        early_depth_test: None,
+        workgroup_size: [1, 1, 1],
+        workgroup_size_overrides: None,
+        function: ir::Function::default(),
+        mesh_info: None,
+        task_payload: Some(payload_handle), // invalid for compute stage
+    };
+    module.entry_points.push(entry_point);
+
+    let err = expect_validation_error_with_span(
+        &module,
+        ValidationFlags::default(),
+        Capabilities::MESH_SHADER,
+        err_span,
+    );
+
+    assert!(matches!(
+        err,
+        valid::ValidationError::EntryPoint {
+            source: valid::EntryPointError::UnexpectedTaskPayload,
+            ..
+        }
+    ));
 }

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -4594,3 +4594,133 @@ fn cooperative_matrix_enable_extension() {
         );
     }
 }
+
+/// Tests for mesh shader extension validation via WGSL parsing.
+///
+/// Some mesh shader features can only be tested at parse-level in WGSL due to
+/// parse-order limitations (e.g., mesh builtins in structs fail before mesh-specific
+/// attributes are checked). For IR-level validation tests that directly test the
+/// validator capability checks, see `validation::mesh_shader_capability`.
+#[test]
+fn mesh_shader_enable_extension() {
+    // @task stage attribute
+    check_extension_validation!(
+        Capabilities::MESH_SHADER,
+        r#"@task @workgroup_size(1)
+        fn main() -> @builtin(mesh_task_size) vec3<u32> {
+            return vec3(1u, 1u, 1u);
+        }
+        "#,
+        r#"error: the `wgpu_mesh_shader` enable extension is not enabled
+  ┌─ wgsl:1:2
+  │
+1 │ @task @workgroup_size(1)
+  │  ^^^^ the `wgpu_mesh_shader` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_mesh_shader;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::EntryPoint {
+            source: naga::valid::EntryPointError::UnsupportedCapability(Capabilities::MESH_SHADER),
+            ..
+        })
+    );
+
+    // @mesh stage attribute
+    check_extension_validation!(
+        Capabilities::MESH_SHADER,
+        r#"struct MeshOutput { dummy: u32 }
+        var<workgroup> mesh_output: MeshOutput;
+        @mesh(mesh_output) @workgroup_size(1)
+        fn main() {}
+        "#,
+        r#"error: the `wgpu_mesh_shader` enable extension is not enabled
+  ┌─ wgsl:3:10
+  │
+3 │         @mesh(mesh_output) @workgroup_size(1)
+  │          ^^^^ the `wgpu_mesh_shader` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_mesh_shader;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::EntryPoint {
+            source: naga::valid::EntryPointError::UnsupportedCapability(Capabilities::MESH_SHADER),
+            ..
+        })
+    );
+
+    // @per_primitive attribute
+    check_extension_validation!(
+        Capabilities::MESH_SHADER,
+        r#"struct FragInput {
+            @location(0) @per_primitive value: f32,
+        }
+        @fragment
+        fn main(input: FragInput) {}
+        "#,
+        r#"error: the `wgpu_mesh_shader` enable extension is not enabled
+  ┌─ wgsl:2:27
+  │
+2 │             @location(0) @per_primitive value: f32,
+  │                           ^^^^^^^^^^^^^ the `wgpu_mesh_shader` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_mesh_shader;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::EntryPoint {
+            source: naga::valid::EntryPointError::Argument(
+                _,
+                naga::valid::VaryingError::UnsupportedCapability(Capabilities::MESH_SHADER)
+            ),
+            ..
+        })
+    );
+
+    // `@payload`` attribute. It is not possible for this attribute to reach the validator
+    // without the extension enabled, because the attribute is only allowed on mesh and task
+    // stages, and those stages are rejected (with or without the `@payload` attribute) when
+    // the mesh shader extension is not enabled.
+    //
+    // There is a direct-to-validator test case for `@payload` in `validation.rs`.
+    check(
+        r#"@compute @workgroup_size(1) @payload(foo)
+        fn main() {}
+        "#,
+        r#"error: the `wgpu_mesh_shader` enable extension is not enabled
+  ┌─ wgsl:1:30
+  │
+1 │ @compute @workgroup_size(1) @payload(foo)
+  │                              ^^^^^^^ the `wgpu_mesh_shader` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_mesh_shader;` at the top of the shader, before any other items.
+
+"#,
+    );
+
+    // `task_payload` address space
+    check_extension_validation!(
+        Capabilities::MESH_SHADER,
+        r#"struct Payload { dummy: u32 }
+        var<task_payload> taskPayload: Payload;
+        @compute @workgroup_size(1)
+        fn main() {
+            taskPayload.dummy = 1u;
+        }
+        "#,
+        r#"error: the `wgpu_mesh_shader` enable extension is not enabled
+  ┌─ wgsl:2:13
+  │
+2 │         var<task_payload> taskPayload: Payload;
+  │             ^^^^^^^^^^^^ the `wgpu_mesh_shader` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_mesh_shader;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::GlobalVariable {
+            source: naga::valid::GlobalVariableError::UnsupportedCapability(
+                Capabilities::MESH_SHADER
+            ),
+            ..
+        })
+    );
+}


### PR DESCRIPTION
Adds some tests for the checks that the mesh shader extension is present when necessary. Related to #8866, although there wasn't actually anything missing related to mesh shaders.

Also includes a small change to the compactor to not panic on certain invalid modules. This showed up with an intermediate version of the tests, but is actually not exercised by the final version here.

**Squash or Rebase?** Squash