### PR TITLE
feat(deno): implement WGSLLanguageFeatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Top level categories:
 - Performance
 - Documentation
 - Dependency Updates
-- deno-webgpu
+- deno_webgpu
 - Examples
 - Testing/Internal
 
@@ -92,6 +92,10 @@ Bottom level categories:
 #### Naga
 
 - Prevent UB from incorrectly using ray queries on HLSL. By @Vecvec in [#8763](https://github.com/gfx-rs/wgpu/pull/8763).
+
+### deno\_webgpu
+
+- Expose the `GPU.wgslLanguageFeatures` property. By @andyleiserson in [#8884](https://github.com/gfx-rs/wgpu/pull/8884).
 
 ## v28.0.0 (2025-12-17)
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -240,6 +240,8 @@ webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:no_atomics
 webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:only_in_compute:*
 webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:param_constructible_only:*
 webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
+webgpu:shader,validation,extension,pointer_composite_access:*
+webgpu:shader,validation,parse,requires:*
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break_if"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="continue"

--- a/deno_webgpu/01_webgpu.js
+++ b/deno_webgpu/01_webgpu.js
@@ -36,6 +36,7 @@ import {
   GPUTexture,
   GPUTextureView,
   GPUExternalTexture,
+  WGSLLanguageFeatures,
   op_create_gpu,
   op_webgpu_device_start_capture,
   op_webgpu_device_stop_capture,
@@ -229,6 +230,21 @@ ObjectDefineProperty(GPUSupportedFeaturesPrototype, privateCustomInspect, {
   __proto__: null,
   value(inspect, inspectOptions) {
     if (ObjectPrototypeIsPrototypeOf(GPUSupportedFeaturesPrototype, this)) {
+      return `${this.constructor.name} ${
+        // deno-lint-ignore prefer-primordials
+        inspect([...this], inspectOptions)}`;
+    } else {
+      return `${this.constructor.name} ${inspect({}, inspectOptions)}`;
+    }
+  },
+});
+
+const WGSLLanguageFeaturesPrototype = WGSLLanguageFeatures.prototype;
+webidl.setlikeObjectWrap(WGSLLanguageFeaturesPrototype, true);
+ObjectDefineProperty(WGSLLanguageFeaturesPrototype, privateCustomInspect, {
+  __proto__: null,
+  value(inspect, inspectOptions) {
+    if (ObjectPrototypeIsPrototypeOf(WGSLLanguageFeaturesPrototype, this)) {
       return `${this.constructor.name} ${
         // deno-lint-ignore prefer-primordials
         inspect([...this], inspectOptions)}`;
@@ -938,5 +954,6 @@ export {
   GPUExternalTexture,
   GPUUncapturedErrorEvent,
   GPUValidationError,
+  WGSLLanguageFeatures,
   initGPU,
 };

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -73,6 +73,7 @@ deno_core::extension!(
   ],
   objects = [
     GPU,
+    WGSLLanguageFeatures,
     adapter::GPUAdapter,
     adapter::GPUAdapterInfo,
     bind_group::GPUBindGroup,
@@ -129,7 +130,9 @@ pub fn op_create_gpu(
     scope,
     pipeline_error_class,
   )));
-  GPU
+  GPU {
+    wgsl_language_features: SameObject::new(),
+  }
 }
 
 struct EventTargetSetup {
@@ -139,7 +142,9 @@ struct EventTargetSetup {
 struct ErrorEventClass(v8::Global<v8::Value>);
 struct PipelineErrorClass(v8::Global<v8::Value>);
 
-pub struct GPU;
+pub struct GPU {
+  pub wgsl_language_features: SameObject<WGSLLanguageFeatures>,
+}
 
 impl GarbageCollected for GPU {
   fn get_name(&self) -> &'static std::ffi::CStr {
@@ -227,6 +232,53 @@ impl GPU {
     } else {
       texture::GPUTextureFormat::Bgra8unorm.as_str()
     }
+  }
+
+  #[getter]
+  #[global]
+  fn wgslLanguageFeatures(
+    &self,
+    scope: &mut v8::HandleScope,
+  ) -> v8::Global<v8::Object> {
+    self
+      .wgsl_language_features
+      .get(scope, WGSLLanguageFeatures::new)
+  }
+}
+
+pub struct WGSLLanguageFeatures(v8::Global<v8::Value>);
+
+impl GarbageCollected for WGSLLanguageFeatures {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"WGSLLanguageFeatures"
+  }
+}
+
+impl WGSLLanguageFeatures {
+  pub fn new(scope: &mut v8::HandleScope) -> Self {
+    use wgpu_core::naga::front::wgsl::ImplementedLanguageExtension;
+
+    let set = v8::Set::new(scope);
+    for ext in ImplementedLanguageExtension::all() {
+      let key = v8::String::new(scope, ext.to_ident()).unwrap();
+      set.add(scope, key.into());
+    }
+    Self(v8::Global::new(scope, <v8::Local<v8::Value>>::from(set)))
+  }
+}
+
+#[op2]
+impl WGSLLanguageFeatures {
+  #[constructor]
+  #[cppgc]
+  fn constructor(_: bool) -> Result<WGSLLanguageFeatures, GPUGenericError> {
+    Err(GPUGenericError::InvalidConstructor)
+  }
+
+  #[global]
+  #[symbol("setlike_set")]
+  fn set(&self) -> v8::Global<v8::Value> {
+    self.0.clone()
   }
 }
 


### PR DESCRIPTION
Implements `WGSLLanguageFeatures` in the deno bindings. The code is mostly mirroring what was already there for `GPUSupportedFeatures`.

**Testing**
Enables CTS tests. The `webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:*` tests also passed with the change in https://github.com/gpuweb/cts/pull/4567.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
