### PR TITLE
fix(naga): Calculate 1D distance using `abs`

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -251,6 +251,8 @@ webgpu:shader,validation,expression,binary,short_circuiting_and_or:array_overrid
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:scalar_vector:op="%26%26";lhs="bool";rhs="bool"
 webgpu:shader,validation,expression,call,builtin,all:arguments:test="ptr_deref"
+webgpu:shader,validation,expression,call,builtin,distance:values:stage="constant";type="f32"
+webgpu:shader,validation,expression,call,builtin,length:scalar:stage="constant";type="f32"
 webgpu:shader,validation,expression,call,builtin,max:values:*
 // FAIL: others in `value_constructor` due to https://github.com/gfx-rs/wgpu/issues/4720, possibly more
 webgpu:shader,validation,expression,call,builtin,value_constructor:array_value:*

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1791,7 +1791,12 @@ impl<'a> ConstantEvaluator<'a> {
                     F: core::ops::Mul<F>,
                     F: num_traits::Float + iter::Sum,
                 {
-                    e.iter().map(|&ei| ei * ei).sum::<F>().sqrt()
+                    if e.len() == 1 {
+                        // Avoids possible overflow in squaring
+                        e[0].abs()
+                    } else {
+                        e.iter().map(|&ei| ei * ei).sum::<F>().sqrt()
+                    }
                 }
 
                 let result = match_literal_vector!(match e1 => Literal {
@@ -1812,12 +1817,17 @@ impl<'a> ConstantEvaluator<'a> {
                     F: core::ops::Mul<F>,
                     F: num_traits::Float + iter::Sum + core::ops::Sub,
                 {
-                    a.iter()
-                        .zip(b.iter())
-                        .map(|(&aa, &bb)| aa - bb)
-                        .map(|ei| ei * ei)
-                        .sum::<F>()
-                        .sqrt()
+                    if a.len() == 1 {
+                        // Avoids possible overflow in squaring
+                        (a[0] - b[0]).abs()
+                    } else {
+                        a.iter()
+                            .zip(b.iter())
+                            .map(|(&aa, &bb)| aa - bb)
+                            .map(|ei| ei * ei)
+                            .sum::<F>()
+                            .sqrt()
+                    }
                 }
                 let result = match_literal_vector!(match (e1, e2) => Literal {
                     Float => |e1, e2| { float_distance(e1, e2) },


### PR DESCRIPTION
Trivial fix for a CTS failure. (Although I am not sure the CTS is correct to be expecting this, see https://github.com/gpuweb/cts/issues/4571. But even if the CTS is changed, this seems like a reasonable optimization. If the CTS is changed, then we may want our own tests for this.)

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
