### PR TITLE
Refactor `build_acceleration_structures` to require fewer passes

### DIFF
--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -549,13 +549,20 @@ impl CommandBufferMutable {
 }
 
 ///iterates over the blas iterator, and it's geometry, pushing the buffers into a storage vector (and also some validation).
-fn iter_blas(
+fn iter_blas<'snatch_guard:'buffers, 'buffers>(
     blas_iter: impl Iterator<Item = OwnedBlasBuildEntry<ArcReferences>>,
     tracker: &mut Tracker,
     build_command: &mut AsBuild,
     buf_storage: &mut Vec<TriangleBufferStore>,
+    input_barriers: &mut Vec<hal::BufferBarrier<'buffers, dyn hal::DynBuffer>>,
+    scratch_buffer_blas_size: &mut u64,
+    blas_storage: &mut Vec<BlasStore<'buffers>>,
+    state: &mut EncodingState<'snatch_guard, '_>,
 ) -> Result<(), BuildAccelerationStructureError> {
     let mut temp_buffer = Vec::new();
+    
+    let mut triangle_entries =
+        Vec::<hal::AccelerationStructureTriangles<dyn hal::DynBuffer>>::new();
     for entry in blas_iter {
         let blas = &entry.blas;
         tracker.blas_s.insert_single(blas.clone());
@@ -729,6 +736,166 @@ fn iter_blas(
                         },
                         ending_blas: None,
                     });
+
+                    let mesh = &buf.geometry;
+                    let vertex_buffer = {
+                        let vertex_raw = buf.vertex_buffer.as_ref().try_raw(state.snatch_guard)?;
+                        let vertex_buffer = &buf.vertex_buffer;
+                        vertex_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
+                    
+                        if let Some(barrier) = buf
+                            .vertex_transition
+                            .take()
+                            .map(|pending| pending.into_hal(buf.vertex_buffer.as_ref(), state.snatch_guard))
+                        {
+                            input_barriers.push(barrier);
+                        }
+                        if vertex_buffer.size
+                            < (mesh.size.vertex_count + mesh.first_vertex) as u64 * mesh.vertex_stride
+                        {
+                            return Err(BuildAccelerationStructureError::InsufficientBufferSize(
+                                vertex_buffer.error_ident(),
+                                vertex_buffer.size,
+                                (mesh.size.vertex_count + mesh.first_vertex) as u64 * mesh.vertex_stride,
+                            ));
+                        }
+                        let vertex_buffer_offset = mesh.first_vertex as u64 * mesh.vertex_stride;
+                        state.buffer_memory_init_actions.extend(
+                            vertex_buffer.initialization_status.read().create_action(
+                                vertex_buffer,
+                                vertex_buffer_offset
+                                    ..(vertex_buffer_offset
+                                        + mesh.size.vertex_count as u64 * mesh.vertex_stride),
+                                MemoryInitKind::NeedsInitializedMemory,
+                            ),
+                        );
+                        vertex_raw
+                    };
+                    let index_buffer = if let Some((ref mut index_buffer, ref mut index_pending)) =
+                        buf.index_buffer_transition
+                    {
+                        let index_raw = index_buffer.try_raw(state.snatch_guard)?;
+                        index_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
+                    
+                        if let Some(barrier) = index_pending
+                            .take()
+                            .map(|pending| pending.into_hal(index_buffer, state.snatch_guard))
+                        {
+                            input_barriers.push(barrier);
+                        }
+                        let index_stride = mesh.size.index_format.unwrap().byte_size() as u64;
+                        let offset = mesh.first_index.unwrap() as u64 * index_stride;
+                        let index_buffer_size = mesh.size.index_count.unwrap() as u64 * index_stride;
+                    
+                        if mesh.size.index_count.unwrap() % 3 != 0 {
+                            return Err(BuildAccelerationStructureError::InvalidIndexCount(
+                                index_buffer.error_ident(),
+                                mesh.size.index_count.unwrap(),
+                            ));
+                        }
+                        if index_buffer.size < mesh.size.index_count.unwrap() as u64 * index_stride + offset {
+                            return Err(BuildAccelerationStructureError::InsufficientBufferSize(
+                                index_buffer.error_ident(),
+                                index_buffer.size,
+                                mesh.size.index_count.unwrap() as u64 * index_stride + offset,
+                            ));
+                        }
+                    
+                        state.buffer_memory_init_actions.extend(
+                            index_buffer.initialization_status.read().create_action(
+                                index_buffer,
+                                offset..(offset + index_buffer_size),
+                                MemoryInitKind::NeedsInitializedMemory,
+                            ),
+                        );
+                        Some(index_raw)
+                    } else {
+                        None
+                    };
+                    let transform_buffer = if let Some((ref mut transform_buffer, ref mut transform_pending)) =
+                        buf.transform_buffer_transition
+                    {
+                        if mesh.transform_buffer_offset.is_none() {
+                            return Err(BuildAccelerationStructureError::MissingAssociatedData(
+                                transform_buffer.error_ident(),
+                            ));
+                        }
+                        let transform_raw = transform_buffer.try_raw(state.snatch_guard)?;
+                        transform_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
+                    
+                        if let Some(barrier) = transform_pending
+                            .take()
+                            .map(|pending| pending.into_hal(transform_buffer, state.snatch_guard))
+                        {
+                            input_barriers.push(barrier);
+                        }
+                    
+                        let offset = mesh.transform_buffer_offset.unwrap();
+                    
+                        if offset % wgt::TRANSFORM_BUFFER_ALIGNMENT != 0 {
+                            return Err(
+                                BuildAccelerationStructureError::UnalignedTransformBufferOffset(
+                                    transform_buffer.error_ident(),
+                                ),
+                            );
+                        }
+                        if transform_buffer.size < 48 + offset {
+                            return Err(BuildAccelerationStructureError::InsufficientBufferSize(
+                                transform_buffer.error_ident(),
+                                transform_buffer.size,
+                                48 + offset,
+                            ));
+                        }
+                        state.buffer_memory_init_actions.extend(
+                            transform_buffer.initialization_status.read().create_action(
+                                transform_buffer,
+                                offset..(offset + 48),
+                                MemoryInitKind::NeedsInitializedMemory,
+                            ),
+                        );
+                        Some(transform_raw)
+                    } else {
+                        None
+                    };
+                
+                    let triangles = hal::AccelerationStructureTriangles {
+                        vertex_buffer: Some(vertex_buffer),
+                        vertex_format: mesh.size.vertex_format,
+                        first_vertex: mesh.first_vertex,
+                        vertex_count: mesh.size.vertex_count,
+                        vertex_stride: mesh.vertex_stride,
+                        indices: index_buffer.map(|index_buffer| {
+                            let index_stride = mesh.size.index_format.unwrap().byte_size() as u32;
+                            hal::AccelerationStructureTriangleIndices::<dyn hal::DynBuffer> {
+                                format: mesh.size.index_format.unwrap(),
+                                buffer: Some(index_buffer),
+                                offset: mesh.first_index.unwrap() * index_stride,
+                                count: mesh.size.index_count.unwrap(),
+                            }
+                        }),
+                        transform: transform_buffer.map(|transform_buffer| {
+                            hal::AccelerationStructureTriangleTransform {
+                                buffer: transform_buffer,
+                                offset: mesh.transform_buffer_offset.unwrap() as u32,
+                            }
+                        }),
+                        flags: mesh.size.flags,
+                    };
+                    triangle_entries.push(triangles);
+                    if let Some(blas) = buf.ending_blas.take() {
+                        let scratch_buffer_offset = *scratch_buffer_blas_size;
+                        *scratch_buffer_blas_size += align_to(
+                            blas.size_info.build_scratch_size as u32,
+                            state.device.alignments.ray_tracing_scratch_buffer_alignment,
+                        ) as u64;
+                    
+                        blas_storage.push(BlasStore {
+                            blas,
+                            entries: hal::AccelerationStructureEntries::Triangles(triangle_entries),
+                            scratch_buffer_offset,
+                        });
+                        triangle_entries = Vec::new();
+                    }
                 }
 
                 if let Some(last) = temp_buffer.last_mut() {
@@ -736,184 +903,6 @@ fn iter_blas(
                     buf_storage.append(&mut temp_buffer);
                 }
             }
-        }
-    }
-    Ok(())
-}
-
-/// Iterates over the buffers generated in [iter_blas], convert the barriers into hal barriers, and the triangles into [hal::AccelerationStructureEntries] (and also some validation).
-///
-/// `'buffers` is the lifetime of `&dyn hal::DynBuffer` in our working data,
-/// i.e., needs to span until `build_acceleration_structures` finishes encoding.
-/// `'snatch_guard` is the lifetime of the snatch lock acquisition.
-fn iter_buffers<'snatch_guard: 'buffers, 'buffers>(
-    state: &mut EncodingState<'snatch_guard, '_>,
-    buf_storage: &'buffers mut Vec<TriangleBufferStore>,
-    input_barriers: &mut Vec<hal::BufferBarrier<'buffers, dyn hal::DynBuffer>>,
-    scratch_buffer_blas_size: &mut u64,
-    blas_storage: &mut Vec<BlasStore<'buffers>>,
-) -> Result<(), BuildAccelerationStructureError> {
-    let mut triangle_entries =
-        Vec::<hal::AccelerationStructureTriangles<dyn hal::DynBuffer>>::new();
-    for buf in buf_storage {
-        let mesh = &buf.geometry;
-        let vertex_buffer = {
-            let vertex_raw = buf.vertex_buffer.as_ref().try_raw(state.snatch_guard)?;
-            let vertex_buffer = &buf.vertex_buffer;
-            vertex_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
-
-            if let Some(barrier) = buf
-                .vertex_transition
-                .take()
-                .map(|pending| pending.into_hal(buf.vertex_buffer.as_ref(), state.snatch_guard))
-            {
-                input_barriers.push(barrier);
-            }
-            if vertex_buffer.size
-                < (mesh.size.vertex_count + mesh.first_vertex) as u64 * mesh.vertex_stride
-            {
-                return Err(BuildAccelerationStructureError::InsufficientBufferSize(
-                    vertex_buffer.error_ident(),
-                    vertex_buffer.size,
-                    (mesh.size.vertex_count + mesh.first_vertex) as u64 * mesh.vertex_stride,
-                ));
-            }
-            let vertex_buffer_offset = mesh.first_vertex as u64 * mesh.vertex_stride;
-            state.buffer_memory_init_actions.extend(
-                vertex_buffer.initialization_status.read().create_action(
-                    vertex_buffer,
-                    vertex_buffer_offset
-                        ..(vertex_buffer_offset
-                            + mesh.size.vertex_count as u64 * mesh.vertex_stride),
-                    MemoryInitKind::NeedsInitializedMemory,
-                ),
-            );
-            vertex_raw
-        };
-        let index_buffer = if let Some((ref mut index_buffer, ref mut index_pending)) =
-            buf.index_buffer_transition
-        {
-            let index_raw = index_buffer.try_raw(state.snatch_guard)?;
-            index_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
-
-            if let Some(barrier) = index_pending
-                .take()
-                .map(|pending| pending.into_hal(index_buffer, state.snatch_guard))
-            {
-                input_barriers.push(barrier);
-            }
-            let index_stride = mesh.size.index_format.unwrap().byte_size() as u64;
-            let offset = mesh.first_index.unwrap() as u64 * index_stride;
-            let index_buffer_size = mesh.size.index_count.unwrap() as u64 * index_stride;
-
-            if mesh.size.index_count.unwrap() % 3 != 0 {
-                return Err(BuildAccelerationStructureError::InvalidIndexCount(
-                    index_buffer.error_ident(),
-                    mesh.size.index_count.unwrap(),
-                ));
-            }
-            if index_buffer.size < mesh.size.index_count.unwrap() as u64 * index_stride + offset {
-                return Err(BuildAccelerationStructureError::InsufficientBufferSize(
-                    index_buffer.error_ident(),
-                    index_buffer.size,
-                    mesh.size.index_count.unwrap() as u64 * index_stride + offset,
-                ));
-            }
-
-            state.buffer_memory_init_actions.extend(
-                index_buffer.initialization_status.read().create_action(
-                    index_buffer,
-                    offset..(offset + index_buffer_size),
-                    MemoryInitKind::NeedsInitializedMemory,
-                ),
-            );
-            Some(index_raw)
-        } else {
-            None
-        };
-        let transform_buffer = if let Some((ref mut transform_buffer, ref mut transform_pending)) =
-            buf.transform_buffer_transition
-        {
-            if mesh.transform_buffer_offset.is_none() {
-                return Err(BuildAccelerationStructureError::MissingAssociatedData(
-                    transform_buffer.error_ident(),
-                ));
-            }
-            let transform_raw = transform_buffer.try_raw(state.snatch_guard)?;
-            transform_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
-
-            if let Some(barrier) = transform_pending
-                .take()
-                .map(|pending| pending.into_hal(transform_buffer, state.snatch_guard))
-            {
-                input_barriers.push(barrier);
-            }
-
-            let offset = mesh.transform_buffer_offset.unwrap();
-
-            if offset % wgt::TRANSFORM_BUFFER_ALIGNMENT != 0 {
-                return Err(
-                    BuildAccelerationStructureError::UnalignedTransformBufferOffset(
-                        transform_buffer.error_ident(),
-                    ),
-                );
-            }
-            if transform_buffer.size < 48 + offset {
-                return Err(BuildAccelerationStructureError::InsufficientBufferSize(
-                    transform_buffer.error_ident(),
-                    transform_buffer.size,
-                    48 + offset,
-                ));
-            }
-            state.buffer_memory_init_actions.extend(
-                transform_buffer.initialization_status.read().create_action(
-                    transform_buffer,
-                    offset..(offset + 48),
-                    MemoryInitKind::NeedsInitializedMemory,
-                ),
-            );
-            Some(transform_raw)
-        } else {
-            None
-        };
-
-        let triangles = hal::AccelerationStructureTriangles {
-            vertex_buffer: Some(vertex_buffer),
-            vertex_format: mesh.size.vertex_format,
-            first_vertex: mesh.first_vertex,
-            vertex_count: mesh.size.vertex_count,
-            vertex_stride: mesh.vertex_stride,
-            indices: index_buffer.map(|index_buffer| {
-                let index_stride = mesh.size.index_format.unwrap().byte_size() as u32;
-                hal::AccelerationStructureTriangleIndices::<dyn hal::DynBuffer> {
-                    format: mesh.size.index_format.unwrap(),
-                    buffer: Some(index_buffer),
-                    offset: mesh.first_index.unwrap() * index_stride,
-                    count: mesh.size.index_count.unwrap(),
-                }
-            }),
-            transform: transform_buffer.map(|transform_buffer| {
-                hal::AccelerationStructureTriangleTransform {
-                    buffer: transform_buffer,
-                    offset: mesh.transform_buffer_offset.unwrap() as u32,
-                }
-            }),
-            flags: mesh.size.flags,
-        };
-        triangle_entries.push(triangles);
-        if let Some(blas) = buf.ending_blas.take() {
-            let scratch_buffer_offset = *scratch_buffer_blas_size;
-            *scratch_buffer_blas_size += align_to(
-                blas.size_info.build_scratch_size as u32,
-                state.device.alignments.ray_tracing_scratch_buffer_alignment,
-            ) as u64;
-
-            blas_storage.push(BlasStore {
-                blas,
-                entries: hal::AccelerationStructureEntries::Triangles(triangle_entries),
-                scratch_buffer_offset,
-            });
-            triangle_entries = Vec::new();
         }
     }
     Ok(())

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -197,14 +197,14 @@ pub(crate) fn build_acceleration_structures(
         &mut input_barriers,
         &mut scratch_buffer_blas_size,
         &mut blas_storage,
-        state
+        state,
     )?;
 
     let mut scratch_buffer_tlas_size = 0;
     let mut tlas_storage = Vec::<TlasStore>::with_capacity(tlas.len());
     let mut instance_buffer_staging_source = Vec::<u8>::new();
 
-    for package  in tlas.iter() {
+    for package in tlas.iter() {
         let tlas = &package.tlas;
         state.tracker.tlas_s.insert_single(tlas.clone());
 
@@ -525,7 +525,7 @@ impl CommandBufferMutable {
 }
 
 ///iterates over the blas iterator, and it's geometry, pushing the buffers into a storage vector (and also some validation).
-fn iter_blas<'snatch_guard:'buffers, 'buffers>(
+fn iter_blas<'snatch_guard: 'buffers, 'buffers>(
     blas_iter: impl Iterator<Item = &'buffers OwnedBlasBuildEntry<ArcReferences>>,
     build_command: &mut AsBuild,
     input_barriers: &mut Vec<hal::BufferBarrier<'buffers, dyn hal::DynBuffer>>,
@@ -651,19 +651,21 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         let vertex_raw = mesh.vertex_buffer.as_ref().try_raw(state.snatch_guard)?;
                         let vertex_buffer = &mesh.vertex_buffer;
                         vertex_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
-                    
-                        if let Some(barrier) = vertex_pending
-                            .map(|pending| pending.into_hal(vertex_buffer.as_ref(), state.snatch_guard))
-                        {
+
+                        if let Some(barrier) = vertex_pending.map(|pending| {
+                            pending.into_hal(vertex_buffer.as_ref(), state.snatch_guard)
+                        }) {
                             input_barriers.push(barrier);
                         }
                         if vertex_buffer.size
-                            < (mesh.size.vertex_count + mesh.first_vertex) as u64 * mesh.vertex_stride
+                            < (mesh.size.vertex_count + mesh.first_vertex) as u64
+                                * mesh.vertex_stride
                         {
                             return Err(BuildAccelerationStructureError::InsufficientBufferSize(
                                 vertex_buffer.error_ident(),
                                 vertex_buffer.size,
-                                (mesh.size.vertex_count + mesh.first_vertex) as u64 * mesh.vertex_stride,
+                                (mesh.size.vertex_count + mesh.first_vertex) as u64
+                                    * mesh.vertex_stride,
                             ));
                         }
                         let vertex_buffer_offset = mesh.first_vertex as u64 * mesh.vertex_stride;
@@ -693,30 +695,33 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         );
                         let index_raw = index_buffer.try_raw(state.snatch_guard)?;
                         index_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
-                    
-                        if let Some(barrier) = index_pending
-                            .map(|pending| pending.into_hal(index_buffer.as_ref(), state.snatch_guard))
-                        {
+
+                        if let Some(barrier) = index_pending.map(|pending| {
+                            pending.into_hal(index_buffer.as_ref(), state.snatch_guard)
+                        }) {
                             input_barriers.push(barrier);
                         }
                         let index_stride = mesh.size.index_format.unwrap().byte_size() as u64;
                         let offset = mesh.first_index.unwrap() as u64 * index_stride;
-                        let index_buffer_size = mesh.size.index_count.unwrap() as u64 * index_stride;
-                    
+                        let index_buffer_size =
+                            mesh.size.index_count.unwrap() as u64 * index_stride;
+
                         if mesh.size.index_count.unwrap() % 3 != 0 {
                             return Err(BuildAccelerationStructureError::InvalidIndexCount(
                                 index_buffer.error_ident(),
                                 mesh.size.index_count.unwrap(),
                             ));
                         }
-                        if index_buffer.size < mesh.size.index_count.unwrap() as u64 * index_stride + offset {
+                        if index_buffer.size
+                            < mesh.size.index_count.unwrap() as u64 * index_stride + offset
+                        {
                             return Err(BuildAccelerationStructureError::InsufficientBufferSize(
                                 index_buffer.error_ident(),
                                 index_buffer.size,
                                 mesh.size.index_count.unwrap() as u64 * index_stride + offset,
                             ));
                         }
-                    
+
                         state.buffer_memory_init_actions.extend(
                             index_buffer.initialization_status.read().create_action(
                                 &index_buffer,
@@ -728,7 +733,8 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                     } else {
                         None
                     };
-                    let transform_buffer = if let Some(ref transform_buffer) = mesh.transform_buffer {
+                    let transform_buffer = if let Some(ref transform_buffer) = mesh.transform_buffer
+                    {
                         if !blas
                             .flags
                             .contains(wgt::AccelerationStructureFlags::USE_TRANSFORM)
@@ -753,15 +759,15 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         }
                         let transform_raw = transform_buffer.try_raw(state.snatch_guard)?;
                         transform_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
-                    
-                        if let Some(barrier) = transform_pending
-                            .map(|pending| pending.into_hal(transform_buffer.as_ref(), state.snatch_guard))
-                        {
+
+                        if let Some(barrier) = transform_pending.map(|pending| {
+                            pending.into_hal(transform_buffer.as_ref(), state.snatch_guard)
+                        }) {
                             input_barriers.push(barrier);
                         }
-                    
+
                         let offset = mesh.transform_buffer_offset.unwrap();
-                    
+
                         if offset % wgt::TRANSFORM_BUFFER_ALIGNMENT != 0 {
                             return Err(
                                 BuildAccelerationStructureError::UnalignedTransformBufferOffset(
@@ -795,7 +801,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         }
                         None
                     };
-                
+
                     let triangles = hal::AccelerationStructureTriangles {
                         vertex_buffer: Some(vertex_buffer),
                         vertex_format: mesh.size.vertex_format,
@@ -823,18 +829,18 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                 }
 
                 {
-                        let scratch_buffer_offset = *scratch_buffer_blas_size;
-                        *scratch_buffer_blas_size += align_to(
-                            blas.size_info.build_scratch_size as u32,
-                            state.device.alignments.ray_tracing_scratch_buffer_alignment,
-                        ) as u64;
-                    
-                        blas_storage.push(BlasStore {
-                            blas: blas.clone(),
-                            entries: hal::AccelerationStructureEntries::Triangles(triangle_entries),
-                            scratch_buffer_offset,
-                        });
-                        triangle_entries = Vec::new();
+                    let scratch_buffer_offset = *scratch_buffer_blas_size;
+                    *scratch_buffer_blas_size += align_to(
+                        blas.size_info.build_scratch_size as u32,
+                        state.device.alignments.ray_tracing_scratch_buffer_alignment,
+                    ) as u64;
+
+                    blas_storage.push(BlasStore {
+                        blas: blas.clone(),
+                        entries: hal::AccelerationStructureEntries::Triangles(triangle_entries),
+                        scratch_buffer_offset,
+                    });
+                    triangle_entries = Vec::new();
                 }
             }
         }

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -204,7 +204,7 @@ pub(crate) fn build_acceleration_structures(
     let mut scratch_buffer_blas_size = 0;
     let mut blas_storage = Vec::new();
     iter_blas(
-        blas.into_iter(),
+        blas.iter(),
         &mut build_command,
         &mut buf_storage,
         &mut input_barriers,
@@ -546,7 +546,7 @@ impl CommandBufferMutable {
 
 ///iterates over the blas iterator, and it's geometry, pushing the buffers into a storage vector (and also some validation).
 fn iter_blas<'snatch_guard:'buffers, 'buffers>(
-    blas_iter: impl Iterator<Item = OwnedBlasBuildEntry<ArcReferences>>,
+    blas_iter: impl Iterator<Item = &'buffers OwnedBlasBuildEntry<ArcReferences>>,
     build_command: &mut AsBuild,
     buf_storage: &mut Vec<TriangleBufferStore>,
     input_barriers: &mut Vec<hal::BufferBarrier<'buffers, dyn hal::DynBuffer>>,
@@ -562,7 +562,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
 
         build_command.blas_s_built.push(blas.clone());
 
-        match entry.geometries {
+        match &entry.geometries {
             ArcBlasGeometries::TriangleGeometries(triangle_geometries) => {
                 for (i, mesh) in triangle_geometries.into_iter().enumerate() {
                     let size_desc = match &blas.sizes {
@@ -699,7 +699,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         );
                         vertex_raw
                     };
-                    let index_buffer = if let Some(index_buffer) = mesh.index_buffer {
+                    let index_buffer = if let Some(ref index_buffer) = mesh.index_buffer {
                         if mesh.first_index.is_none()
                             || mesh.size.index_count.is_none()
                             || mesh.size.index_count.is_none()
@@ -749,7 +749,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                     } else {
                         None
                     };
-                    let transform_buffer = if let Some(transform_buffer) = mesh.transform_buffer {
+                    let transform_buffer = if let Some(ref transform_buffer) = mesh.transform_buffer {
                         if !blas
                             .flags
                             .contains(wgt::AccelerationStructureFlags::USE_TRANSFORM)

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -554,8 +554,6 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
     blas_storage: &mut Vec<BlasStore<'buffers>>,
     state: &mut EncodingState<'snatch_guard, '_>,
 ) -> Result<(), BuildAccelerationStructureError> {
-    let mut temp_buffer = Vec::new();
-    
     let mut triangle_entries =
         Vec::<hal::AccelerationStructureTriangles<dyn hal::DynBuffer>>::new();
     for entry in blas_iter {
@@ -676,7 +674,6 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         vertex_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
                     
                         if let Some(barrier) = vertex_pending
-                            .take()
                             .map(|pending| pending.into_hal(vertex_buffer.as_ref(), state.snatch_guard))
                         {
                             input_barriers.push(barrier);
@@ -719,7 +716,6 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         index_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
                     
                         if let Some(barrier) = index_pending
-                            .take()
                             .map(|pending| pending.into_hal(index_buffer.as_ref(), state.snatch_guard))
                         {
                             input_barriers.push(barrier);
@@ -780,7 +776,6 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         transform_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
                     
                         if let Some(barrier) = transform_pending
-                            .take()
                             .map(|pending| pending.into_hal(transform_buffer.as_ref(), state.snatch_guard))
                         {
                             input_barriers.push(barrier);

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -190,7 +190,7 @@ pub(crate) fn build_acceleration_structures(
     let mut build_command = AsBuild::default();
     let mut input_barriers = Vec::<hal::BufferBarrier<dyn hal::DynBuffer>>::new();
     let mut scratch_buffer_blas_size = 0;
-    let mut blas_storage = Vec::new();
+    let mut blas_storage = Vec::with_capacity(blas.len());
     iter_blas(
         blas.iter(),
         &mut build_command,
@@ -201,7 +201,7 @@ pub(crate) fn build_acceleration_structures(
     )?;
 
     let mut scratch_buffer_tlas_size = 0;
-    let mut tlas_storage = Vec::<TlasStore>::new();
+    let mut tlas_storage = Vec::<TlasStore>::with_capacity(tlas.len());
     let mut instance_buffer_staging_source = Vec::<u8>::new();
 
     for package  in tlas.iter() {
@@ -335,7 +335,7 @@ pub(crate) fn build_acceleration_structures(
     let raw_encoder = &mut state.raw_encoder;
 
     let mut blas_s_compactable = Vec::new();
-    let mut descriptors = Vec::new();
+    let mut descriptors = Vec::with_capacity(blas.len());
 
     for storage in &blas_storage {
         descriptors.push(map_blas(

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -821,20 +821,6 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         }
                         None
                     };
-                    temp_buffer.push(TriangleBufferStore {
-                        vertex_buffer,
-                        vertex_transition: vertex_pending,
-                        index_buffer_transition: index_data,
-                        transform_buffer_transition: transform_data,
-                        geometry: BlasTriangleGeometryInfo {
-                            size: mesh.size,
-                            first_vertex: mesh.first_vertex,
-                            vertex_stride: mesh.vertex_stride,
-                            first_index: mesh.first_index,
-                            transform_buffer_offset: mesh.transform_buffer_offset,
-                        },
-                        ending_blas: None,
-                    });
                 
                     let triangles = hal::AccelerationStructureTriangles {
                         vertex_buffer: Some(vertex_buffer),
@@ -860,7 +846,9 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         flags: mesh.size.flags,
                     };
                     triangle_entries.push(triangles);
-                    if let Some(blas) = buf.ending_blas.take() {
+                }
+
+                {
                         let scratch_buffer_offset = *scratch_buffer_blas_size;
                         *scratch_buffer_blas_size += align_to(
                             blas.size_info.build_scratch_size as u32,
@@ -868,17 +856,11 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         ) as u64;
                     
                         blas_storage.push(BlasStore {
-                            blas,
+                            blas: blas.clone(),
                             entries: hal::AccelerationStructureEntries::Triangles(triangle_entries),
                             scratch_buffer_offset,
                         });
                         triangle_entries = Vec::new();
-                    }
-                }
-
-                if let Some(last) = temp_buffer.last_mut() {
-                    last.ending_blas = Some(blas.clone());
-                    buf_storage.append(&mut temp_buffer);
                 }
             }
         }

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -671,14 +671,13 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                     );
                     let vertex_buffer = {
-                        let vertex_raw = buf.vertex_buffer.as_ref().try_raw(state.snatch_guard)?;
-                        let vertex_buffer = &buf.vertex_buffer;
+                        let vertex_raw = mesh.vertex_buffer.as_ref().try_raw(state.snatch_guard)?;
+                        let vertex_buffer = &mesh.vertex_buffer;
                         vertex_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
                     
-                        if let Some(barrier) = buf
-                            .vertex_transition
+                        if let Some(barrier) = vertex_pending
                             .take()
-                            .map(|pending| pending.into_hal(buf.vertex_buffer.as_ref(), state.snatch_guard))
+                            .map(|pending| pending.into_hal(vertex_buffer.as_ref(), state.snatch_guard))
                         {
                             input_barriers.push(barrier);
                         }
@@ -703,7 +702,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         );
                         vertex_raw
                     };
-                    let index_data = if let Some(index_buffer) = mesh.index_buffer {
+                    let index_buffer = if let Some(index_buffer) = mesh.index_buffer {
                         if mesh.first_index.is_none()
                             || mesh.size.index_count.is_none()
                             || mesh.size.index_count.is_none()
@@ -712,17 +711,16 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                                 index_buffer.error_ident(),
                             ));
                         }
-                        let data = state.tracker.buffers.set_single(
+                        let index_pending = state.tracker.buffers.set_single(
                             &index_buffer,
                             BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                         );
-                        Some((index_buffer, data))
                         let index_raw = index_buffer.try_raw(state.snatch_guard)?;
                         index_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
                     
                         if let Some(barrier) = index_pending
                             .take()
-                            .map(|pending| pending.into_hal(index_buffer, state.snatch_guard))
+                            .map(|pending| pending.into_hal(index_buffer.as_ref(), state.snatch_guard))
                         {
                             input_barriers.push(barrier);
                         }
@@ -746,7 +744,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                     
                         state.buffer_memory_init_actions.extend(
                             index_buffer.initialization_status.read().create_action(
-                                index_buffer,
+                                &index_buffer,
                                 offset..(offset + index_buffer_size),
                                 MemoryInitKind::NeedsInitializedMemory,
                             ),
@@ -755,7 +753,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                     } else {
                         None
                     };
-                    let transform_data = if let Some(transform_buffer) = mesh.transform_buffer {
+                    let transform_buffer = if let Some(transform_buffer) = mesh.transform_buffer {
                         if !blas
                             .flags
                             .contains(wgt::AccelerationStructureFlags::USE_TRANSFORM)
@@ -769,11 +767,10 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                                 transform_buffer.error_ident(),
                             ));
                         }
-                        let data = state.tracker.buffers.set_single(
+                        let transform_pending = state.tracker.buffers.set_single(
                             &transform_buffer,
                             BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                         );
-                        Some((transform_buffer, data))
                         if mesh.transform_buffer_offset.is_none() {
                             return Err(BuildAccelerationStructureError::MissingAssociatedData(
                                 transform_buffer.error_ident(),
@@ -784,7 +781,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                     
                         if let Some(barrier) = transform_pending
                             .take()
-                            .map(|pending| pending.into_hal(transform_buffer, state.snatch_guard))
+                            .map(|pending| pending.into_hal(transform_buffer.as_ref(), state.snatch_guard))
                         {
                             input_barriers.push(barrier);
                         }
@@ -807,7 +804,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         }
                         state.buffer_memory_init_actions.extend(
                             transform_buffer.initialization_status.read().create_action(
-                                transform_buffer,
+                                &transform_buffer,
                                 offset..(offset + 48),
                                 MemoryInitKind::NeedsInitializedMemory,
                             ),

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -533,8 +533,6 @@ fn iter_blas<'snatch_guard: 'buffers, 'buffers>(
     blas_storage: &mut Vec<BlasStore<'buffers>>,
     state: &mut EncodingState<'snatch_guard, '_>,
 ) -> Result<(), BuildAccelerationStructureError> {
-    let mut triangle_entries =
-        Vec::<hal::AccelerationStructureTriangles<dyn hal::DynBuffer>>::new();
     for entry in blas_iter {
         let blas = &entry.blas;
         state.tracker.blas_s.insert_single(blas.clone());
@@ -543,6 +541,9 @@ fn iter_blas<'snatch_guard: 'buffers, 'buffers>(
 
         match &entry.geometries {
             ArcBlasGeometries::TriangleGeometries(triangle_geometries) => {
+                let mut triangle_entries =
+                    Vec::<hal::AccelerationStructureTriangles<dyn hal::DynBuffer>>::new();
+
                 for (i, mesh) in triangle_geometries.iter().enumerate() {
                     let size_desc = match &blas.sizes {
                         wgt::BlasGeometrySizeDescriptors::Triangles { descriptors } => descriptors,
@@ -840,7 +841,6 @@ fn iter_blas<'snatch_guard: 'buffers, 'buffers>(
                         entries: hal::AccelerationStructureEntries::Triangles(triangle_entries),
                         scratch_buffer_offset,
                     });
-                    triangle_entries = Vec::new();
                 }
             }
         }

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -9,9 +9,8 @@ use wgt::{math::align_to, BufferUsages, BufferUses, Features};
 
 use crate::{
     command::encoder::EncodingState,
-    ray_tracing::{AsAction, AsBuild, BlasTriangleGeometryInfo, TlasBuild, ValidateAsActionsError},
+    ray_tracing::{AsAction, AsBuild, TlasBuild, ValidateAsActionsError},
     resource::InvalidResourceError,
-    track::Tracker,
 };
 use crate::{command::EncoderStateError, device::resource::CommandIndices};
 use crate::{
@@ -25,23 +24,13 @@ use crate::{
         ArcTlasPackage, BlasBuildEntry, BlasGeometries, BuildAccelerationStructureError,
         OwnedBlasBuildEntry, OwnedTlasPackage, TlasPackage,
     },
-    resource::{Blas, BlasCompactState, Buffer, Labeled, StagingBuffer, Tlas},
+    resource::{Blas, BlasCompactState, Labeled, StagingBuffer, Tlas},
     scratch::ScratchBuffer,
     snatch::SnatchGuard,
-    track::PendingTransition,
 };
 use crate::{lock::RwLockWriteGuard, resource::RawResourceAccess};
 
 use crate::id::{BlasId, TlasId};
-
-struct TriangleBufferStore {
-    vertex_buffer: Arc<Buffer>,
-    vertex_transition: Option<PendingTransition<BufferUses>>,
-    index_buffer_transition: Option<(Arc<Buffer>, Option<PendingTransition<BufferUses>>)>,
-    transform_buffer_transition: Option<(Arc<Buffer>, Option<PendingTransition<BufferUses>>)>,
-    geometry: BlasTriangleGeometryInfo,
-    ending_blas: Option<Arc<Blas>>,
-}
 
 struct BlasStore<'a> {
     blas: Arc<Blas>,
@@ -199,14 +188,12 @@ pub(crate) fn build_acceleration_structures(
         .require_features(Features::EXPERIMENTAL_RAY_QUERY)?;
 
     let mut build_command = AsBuild::default();
-    let mut buf_storage = Vec::new();
     let mut input_barriers = Vec::<hal::BufferBarrier<dyn hal::DynBuffer>>::new();
     let mut scratch_buffer_blas_size = 0;
     let mut blas_storage = Vec::new();
     iter_blas(
         blas.iter(),
         &mut build_command,
-        &mut buf_storage,
         &mut input_barriers,
         &mut scratch_buffer_blas_size,
         &mut blas_storage,
@@ -548,7 +535,6 @@ impl CommandBufferMutable {
 fn iter_blas<'snatch_guard:'buffers, 'buffers>(
     blas_iter: impl Iterator<Item = &'buffers OwnedBlasBuildEntry<ArcReferences>>,
     build_command: &mut AsBuild,
-    buf_storage: &mut Vec<TriangleBufferStore>,
     input_barriers: &mut Vec<hal::BufferBarrier<'buffers, dyn hal::DynBuffer>>,
     scratch_buffer_blas_size: &mut u64,
     blas_storage: &mut Vec<BlasStore<'buffers>>,

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -675,69 +675,6 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         &vertex_buffer,
                         BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                     );
-                    let index_data = if let Some(index_buffer) = mesh.index_buffer {
-                        if mesh.first_index.is_none()
-                            || mesh.size.index_count.is_none()
-                            || mesh.size.index_count.is_none()
-                        {
-                            return Err(BuildAccelerationStructureError::MissingAssociatedData(
-                                index_buffer.error_ident(),
-                            ));
-                        }
-                        let data = tracker.buffers.set_single(
-                            &index_buffer,
-                            BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
-                        );
-                        Some((index_buffer, data))
-                    } else {
-                        None
-                    };
-                    let transform_data = if let Some(transform_buffer) = mesh.transform_buffer {
-                        if !blas
-                            .flags
-                            .contains(wgt::AccelerationStructureFlags::USE_TRANSFORM)
-                        {
-                            return Err(BuildAccelerationStructureError::UseTransformMissing(
-                                blas.error_ident(),
-                            ));
-                        }
-                        if mesh.transform_buffer_offset.is_none() {
-                            return Err(BuildAccelerationStructureError::MissingAssociatedData(
-                                transform_buffer.error_ident(),
-                            ));
-                        }
-                        let data = tracker.buffers.set_single(
-                            &transform_buffer,
-                            BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
-                        );
-                        Some((transform_buffer, data))
-                    } else {
-                        if blas
-                            .flags
-                            .contains(wgt::AccelerationStructureFlags::USE_TRANSFORM)
-                        {
-                            return Err(BuildAccelerationStructureError::TransformMissing(
-                                blas.error_ident(),
-                            ));
-                        }
-                        None
-                    };
-                    temp_buffer.push(TriangleBufferStore {
-                        vertex_buffer,
-                        vertex_transition: vertex_pending,
-                        index_buffer_transition: index_data,
-                        transform_buffer_transition: transform_data,
-                        geometry: BlasTriangleGeometryInfo {
-                            size: mesh.size,
-                            first_vertex: mesh.first_vertex,
-                            vertex_stride: mesh.vertex_stride,
-                            first_index: mesh.first_index,
-                            transform_buffer_offset: mesh.transform_buffer_offset,
-                        },
-                        ending_blas: None,
-                    });
-
-                    let mesh = &buf.geometry;
                     let vertex_buffer = {
                         let vertex_raw = buf.vertex_buffer.as_ref().try_raw(state.snatch_guard)?;
                         let vertex_buffer = &buf.vertex_buffer;
@@ -771,9 +708,20 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         );
                         vertex_raw
                     };
-                    let index_buffer = if let Some((ref mut index_buffer, ref mut index_pending)) =
-                        buf.index_buffer_transition
-                    {
+                    let index_data = if let Some(index_buffer) = mesh.index_buffer {
+                        if mesh.first_index.is_none()
+                            || mesh.size.index_count.is_none()
+                            || mesh.size.index_count.is_none()
+                        {
+                            return Err(BuildAccelerationStructureError::MissingAssociatedData(
+                                index_buffer.error_ident(),
+                            ));
+                        }
+                        let data = tracker.buffers.set_single(
+                            &index_buffer,
+                            BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
+                        );
+                        Some((index_buffer, data))
                         let index_raw = index_buffer.try_raw(state.snatch_guard)?;
                         index_buffer.check_usage(BufferUsages::BLAS_INPUT)?;
                     
@@ -812,9 +760,25 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                     } else {
                         None
                     };
-                    let transform_buffer = if let Some((ref mut transform_buffer, ref mut transform_pending)) =
-                        buf.transform_buffer_transition
-                    {
+                    let transform_data = if let Some(transform_buffer) = mesh.transform_buffer {
+                        if !blas
+                            .flags
+                            .contains(wgt::AccelerationStructureFlags::USE_TRANSFORM)
+                        {
+                            return Err(BuildAccelerationStructureError::UseTransformMissing(
+                                blas.error_ident(),
+                            ));
+                        }
+                        if mesh.transform_buffer_offset.is_none() {
+                            return Err(BuildAccelerationStructureError::MissingAssociatedData(
+                                transform_buffer.error_ident(),
+                            ));
+                        }
+                        let data = tracker.buffers.set_single(
+                            &transform_buffer,
+                            BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
+                        );
+                        Some((transform_buffer, data))
                         if mesh.transform_buffer_offset.is_none() {
                             return Err(BuildAccelerationStructureError::MissingAssociatedData(
                                 transform_buffer.error_ident(),
@@ -855,8 +819,30 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         );
                         Some(transform_raw)
                     } else {
+                        if blas
+                            .flags
+                            .contains(wgt::AccelerationStructureFlags::USE_TRANSFORM)
+                        {
+                            return Err(BuildAccelerationStructureError::TransformMissing(
+                                blas.error_ident(),
+                            ));
+                        }
                         None
                     };
+                    temp_buffer.push(TriangleBufferStore {
+                        vertex_buffer,
+                        vertex_transition: vertex_pending,
+                        index_buffer_transition: index_data,
+                        transform_buffer_transition: transform_data,
+                        geometry: BlasTriangleGeometryInfo {
+                            size: mesh.size,
+                            first_vertex: mesh.first_vertex,
+                            vertex_stride: mesh.vertex_stride,
+                            first_index: mesh.first_index,
+                            transform_buffer_offset: mesh.transform_buffer_offset,
+                        },
+                        ending_blas: None,
+                    });
                 
                     let triangles = hal::AccelerationStructureTriangles {
                         vertex_buffer: Some(vertex_buffer),

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -200,20 +200,13 @@ pub(crate) fn build_acceleration_structures(
         state
     )?;
 
-    let mut tlas_lock_store = Vec::<(Option<OwnedTlasPackage<ArcReferences>>, Arc<Tlas>)>::new();
-
-    for package in tlas.into_iter() {
-        let tlas = package.tlas.clone();
-        state.tracker.tlas_s.insert_single(tlas.clone());
-        tlas_lock_store.push((Some(package), tlas))
-    }
-
     let mut scratch_buffer_tlas_size = 0;
     let mut tlas_storage = Vec::<TlasStore>::new();
     let mut instance_buffer_staging_source = Vec::<u8>::new();
 
-    for (package, tlas) in &mut tlas_lock_store {
-        let package = package.take().unwrap();
+    for package  in tlas.iter() {
+        let tlas = &package.tlas;
+        state.tracker.tlas_s.insert_single(tlas.clone());
 
         let scratch_buffer_offset = scratch_buffer_tlas_size;
         scratch_buffer_tlas_size += align_to(
@@ -226,7 +219,7 @@ pub(crate) fn build_acceleration_structures(
         let mut dependencies = Vec::new();
 
         let mut instance_count = 0;
-        for instance in package.instances.into_iter().flatten() {
+        for instance in package.instances.iter().flatten() {
             if instance.custom_data >= (1u32 << 24u32) {
                 return Err(BuildAccelerationStructureError::TlasInvalidCustomIndex(
                     tlas.error_ident(),

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -543,7 +543,7 @@ fn iter_blas<'snatch_guard: 'buffers, 'buffers>(
 
         match &entry.geometries {
             ArcBlasGeometries::TriangleGeometries(triangle_geometries) => {
-                for (i, mesh) in triangle_geometries.into_iter().enumerate() {
+                for (i, mesh) in triangle_geometries.iter().enumerate() {
                     let size_desc = match &blas.sizes {
                         wgt::BlasGeometrySizeDescriptors::Triangles { descriptors } => descriptors,
                     };
@@ -690,7 +690,7 @@ fn iter_blas<'snatch_guard: 'buffers, 'buffers>(
                             ));
                         }
                         let index_pending = state.tracker.buffers.set_single(
-                            &index_buffer,
+                            index_buffer,
                             BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                         );
                         let index_raw = index_buffer.try_raw(state.snatch_guard)?;
@@ -724,7 +724,7 @@ fn iter_blas<'snatch_guard: 'buffers, 'buffers>(
 
                         state.buffer_memory_init_actions.extend(
                             index_buffer.initialization_status.read().create_action(
-                                &index_buffer,
+                                index_buffer,
                                 offset..(offset + index_buffer_size),
                                 MemoryInitKind::NeedsInitializedMemory,
                             ),
@@ -749,7 +749,7 @@ fn iter_blas<'snatch_guard: 'buffers, 'buffers>(
                             ));
                         }
                         let transform_pending = state.tracker.buffers.set_single(
-                            &transform_buffer,
+                            transform_buffer,
                             BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                         );
                         if mesh.transform_buffer_offset.is_none() {
@@ -784,7 +784,7 @@ fn iter_blas<'snatch_guard: 'buffers, 'buffers>(
                         }
                         state.buffer_memory_init_actions.extend(
                             transform_buffer.initialization_status.read().create_action(
-                                &transform_buffer,
+                                transform_buffer,
                                 offset..(offset + 48),
                                 MemoryInitKind::NeedsInitializedMemory,
                             ),

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -200,23 +200,19 @@ pub(crate) fn build_acceleration_structures(
 
     let mut build_command = AsBuild::default();
     let mut buf_storage = Vec::new();
-    iter_blas(
-        blas.into_iter(),
-        state.tracker,
-        &mut build_command,
-        &mut buf_storage,
-    )?;
-
     let mut input_barriers = Vec::<hal::BufferBarrier<dyn hal::DynBuffer>>::new();
     let mut scratch_buffer_blas_size = 0;
     let mut blas_storage = Vec::new();
-    iter_buffers(
-        state,
+    iter_blas(
+        blas.into_iter(),
+        &mut build_command,
         &mut buf_storage,
         &mut input_barriers,
         &mut scratch_buffer_blas_size,
         &mut blas_storage,
+        state
     )?;
+
     let mut tlas_lock_store = Vec::<(Option<OwnedTlasPackage<ArcReferences>>, Arc<Tlas>)>::new();
 
     for package in tlas.into_iter() {
@@ -551,7 +547,6 @@ impl CommandBufferMutable {
 ///iterates over the blas iterator, and it's geometry, pushing the buffers into a storage vector (and also some validation).
 fn iter_blas<'snatch_guard:'buffers, 'buffers>(
     blas_iter: impl Iterator<Item = OwnedBlasBuildEntry<ArcReferences>>,
-    tracker: &mut Tracker,
     build_command: &mut AsBuild,
     buf_storage: &mut Vec<TriangleBufferStore>,
     input_barriers: &mut Vec<hal::BufferBarrier<'buffers, dyn hal::DynBuffer>>,
@@ -565,7 +560,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
         Vec::<hal::AccelerationStructureTriangles<dyn hal::DynBuffer>>::new();
     for entry in blas_iter {
         let blas = &entry.blas;
-        tracker.blas_s.insert_single(blas.clone());
+        state.tracker.blas_s.insert_single(blas.clone());
 
         build_command.blas_s_built.push(blas.clone());
 
@@ -671,7 +666,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                         ));
                     }
                     let vertex_buffer = mesh.vertex_buffer.clone();
-                    let vertex_pending = tracker.buffers.set_single(
+                    let vertex_pending = state.tracker.buffers.set_single(
                         &vertex_buffer,
                         BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                     );
@@ -717,7 +712,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                                 index_buffer.error_ident(),
                             ));
                         }
-                        let data = tracker.buffers.set_single(
+                        let data = state.tracker.buffers.set_single(
                             &index_buffer,
                             BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                         );
@@ -774,7 +769,7 @@ fn iter_blas<'snatch_guard:'buffers, 'buffers>(
                                 transform_buffer.error_ident(),
                             ));
                         }
-                        let data = tracker.buffers.set_single(
+                        let data = state.tracker.buffers.set_single(
                             &transform_buffer,
                             BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                         );

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -78,7 +78,7 @@ impl Global {
                 device.check_is_valid()?;
                 device.require_features(Features::EXPERIMENTAL_RAY_QUERY)?;
 
-                let mut build_command = AsBuild::default();
+                let mut build_command = AsBuild::with_capacity(blas_ids.len(), tlas_ids.len());
 
                 for blas in blas_ids {
                     let blas = hub.blas_s.get(*blas).get()?;
@@ -187,7 +187,7 @@ pub(crate) fn build_acceleration_structures(
         .device
         .require_features(Features::EXPERIMENTAL_RAY_QUERY)?;
 
-    let mut build_command = AsBuild::default();
+    let mut build_command = AsBuild::with_capacity(blas.len(), tlas.len());
     let mut input_barriers = Vec::<hal::BufferBarrier<dyn hal::DynBuffer>>::new();
     let mut scratch_buffer_blas_size = 0;
     let mut blas_storage = Vec::with_capacity(blas.len());

--- a/wgpu-core/src/ray_tracing.rs
+++ b/wgpu-core/src/ray_tracing.rs
@@ -302,6 +302,15 @@ pub(crate) struct AsBuild {
     pub tlas_s_built: Vec<TlasBuild>,
 }
 
+impl AsBuild {
+    pub(crate) fn with_capacity(blas: usize, tlas: usize) -> Self {
+        Self {
+            blas_s_built: Vec::with_capacity(blas),
+            tlas_s_built: Vec::with_capacity(tlas),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum AsAction {
     Build(AsBuild),


### PR DESCRIPTION
**Connections**

**Description**
This PR take advantage of changes from encode on finish to reduce the number of temporary vectors and do BLAS processing in one less pass. Also swapped some `Vec::new`s to `Vec::with_capacity` because the capacity is now known.

A notable benefit of this is that implementing custom geometry (AABBs) should be easier because previously the intermediate vector storage assumed that all geometries were triangle geometries. 

Note: first commit & most of the second commit are refactors without changing names to try and make things easier to compare - I recommend reviewing the first one w/o whitespace diffs to check no validation has been removed. (These first few commits also don't compile) The next few commits are for changing the references.

**Testing**
Uses existing tests

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`.
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. No user facing changes.
