### PR TITLE
[naga] Fix issues with const evaluation of bitwise shifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Bottom level categories:
 - Fixed `workgroupUniformLoad` incorrectly returning an atomic when called on an atomic, it now returns the inner `T` as per the spec. By @cryvosh in [#8791](https://github.com/gfx-rs/wgpu/pull/8791).
 - Fixed constant evaluation for `sign()` builtin to return zero when the argument is zero. By @mandryskowski in [#8942](https://github.com/gfx-rs/wgpu/pull/8942).
 - Allow array generation to compile with the macOS 10.12 Metal compiler. By @madsmtm in [#8953](https://github.com/gfx-rs/wgpu/pull/8953)
+- Naga now detects bitwise shifts by a constant exceeding the operand bit width at compile time, and disallows scalar-by-vector and vector-by-scalar shifts in constant evaluation. By @andyleiserson in [#8907](https://github.com/gfx-rs/wgpu/pull/8907).
 
 #### Validation
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -91,7 +91,7 @@ webgpu:shader,validation,expression,access,matrix:* // 93%, runtime OOB matrix a
 webgpu:shader,validation,expression,access,vector:* // 52%, https://github.com/gfx-rs/wgpu/issues/4390, and missing swizzle validation
 webgpu:shader,validation,expression,binary,add_sub_mul:* // 95%, u32 const-eval overflow incorrectly rejected, f16 const-eval overflow not rejected, atomics #5474
 webgpu:shader,validation,expression,binary,and_or_xor:* // 96%, https://github.com/gfx-rs/wgpu/issues/5474
-webgpu:shader,validation,expression,binary,bitwise_shift:* // 97%, atomics https://github.com/gfx-rs/wgpu/issues/5474, partial eval errors
+webgpu:shader,validation,expression,binary,bitwise_shift:invalid_types:* // 93%, atomics #5474
 webgpu:shader,validation,expression,binary,comparison:* // 74%, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,expression,binary,div_rem:* // 86%, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:* // 92%, https://github.com/gfx-rs/wgpu/issues/8440

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -326,7 +326,12 @@ webgpu:shader,validation,expression,access,array:early_eval_errors:case="overrid
 webgpu:shader,validation,expression,access,structure:*
 webgpu:shader,validation,expression,binary,add_sub_mul:scalar_vector_out_of_range:lhs="i32";*
 webgpu:shader,validation,expression,binary,add_sub_mul:scalar_vector_out_of_range:lhs="u32";*
+webgpu:shader,validation,expression,binary,bitwise_shift:partial_eval_errors:*
 webgpu:shader,validation,expression,binary,bitwise_shift:scalar_vector:*
+webgpu:shader,validation,expression,binary,bitwise_shift:shift_left_abstract:*
+webgpu:shader,validation,expression,binary,bitwise_shift:shift_left_concrete:*
+webgpu:shader,validation,expression,binary,bitwise_shift:shift_right_abstract:*
+webgpu:shader,validation,expression,binary,bitwise_shift:shift_right_concrete:*
 webgpu:shader,validation,expression,binary,parse:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:array_override:op="%26%26";a_val=1;b_val=1
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -326,6 +326,7 @@ webgpu:shader,validation,expression,access,array:early_eval_errors:case="overrid
 webgpu:shader,validation,expression,access,structure:*
 webgpu:shader,validation,expression,binary,add_sub_mul:scalar_vector_out_of_range:lhs="i32";*
 webgpu:shader,validation,expression,binary,add_sub_mul:scalar_vector_out_of_range:lhs="u32";*
+webgpu:shader,validation,expression,binary,bitwise_shift:scalar_vector:*
 webgpu:shader,validation,expression,binary,parse:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:array_override:op="%26%26";a_val=1;b_val=1
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types:*

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -3040,6 +3040,10 @@ impl<'a> ConstantEvaluator<'a> {
         h
     }
 
+    /// Resolve the type of `expr` if it is a constant expression.
+    ///
+    /// If `expr` was evaluated to a constant, returns its type.
+    /// Otherwise, returns an error.
     fn resolve_type(
         &self,
         expr: Handle<Expression>,

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -2753,26 +2753,36 @@ impl<'a> ConstantEvaluator<'a> {
                     ty,
                 },
                 &Expression::Literal(_),
-            ) => {
-                let mut components = src_components.clone();
-                for component in &mut components {
-                    *component = self.binary_op(op, *component, right, span)?;
+            ) => match op {
+                BinaryOperator::ShiftLeft | BinaryOperator::ShiftRight => {
+                    return Err(ConstantEvaluatorError::InvalidBinaryOpArgs);
                 }
-                Expression::Compose { ty, components }
-            }
+                _ => {
+                    let mut components = src_components.clone();
+                    for component in &mut components {
+                        *component = self.binary_op(op, *component, right, span)?;
+                    }
+                    Expression::Compose { ty, components }
+                }
+            },
             (
                 &Expression::Literal(_),
                 &Expression::Compose {
                     components: ref src_components,
                     ty,
                 },
-            ) => {
-                let mut components = src_components.clone();
-                for component in &mut components {
-                    *component = self.binary_op(op, left, *component, span)?;
+            ) => match op {
+                BinaryOperator::ShiftLeft | BinaryOperator::ShiftRight => {
+                    return Err(ConstantEvaluatorError::InvalidBinaryOpArgs);
                 }
-                Expression::Compose { ty, components }
-            }
+                _ => {
+                    let mut components = src_components.clone();
+                    for component in &mut components {
+                        *component = self.binary_op(op, left, *component, span)?;
+                    }
+                    Expression::Compose { ty, components }
+                }
+            },
             (
                 &Expression::Compose {
                     components: ref left_components,

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -475,7 +475,12 @@ pub struct GlobalCtx<'a> {
 }
 
 impl GlobalCtx<'_> {
-    /// Try to evaluate the expression in `self.global_expressions` using its `handle` and return it as a `u32`.
+    /// Try to evaluate the expression in `self.global_expressions` using its `handle`
+    /// and return it as a `T: TryFrom<ir::Literal>`.
+    ///
+    /// This currently only evaluates scalar expressions. If adding support for vectors,
+    /// consider changing `valid::expression::validate_constant_shift_amounts` to use that
+    /// support.
     #[cfg_attr(
         not(any(
             feature = "glsl-in",

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -273,7 +273,7 @@ impl super::Validator {
                     | Ti::ValuePointer { size: Some(_), .. }
                     | Ti::BindingArray { .. } => {}
                     ref other => {
-                        log::error!("Indexing of {other:?}");
+                        log::debug!("Indexing of {other:?}");
                         return Err(ExpressionError::InvalidBaseType(base));
                     }
                 };
@@ -284,7 +284,7 @@ impl super::Validator {
                         ..
                     }) => {}
                     ref other => {
-                        log::error!("Indexing by {other:?}");
+                        log::debug!("Indexing by {other:?}");
                         return Err(ExpressionError::InvalidIndexType(index));
                     }
                 }
@@ -342,7 +342,7 @@ impl super::Validator {
                         }
                         Ti::Struct { ref members, .. } => members.len() as u32,
                         ref other => {
-                            log::error!("Indexing of {other:?}");
+                            log::debug!("Indexing of {other:?}");
                             return Err(ExpressionError::InvalidBaseType(top));
                         }
                     };
@@ -358,7 +358,7 @@ impl super::Validator {
             E::Splat { size: _, value } => match resolver[value] {
                 Ti::Scalar { .. } => ShaderStages::all(),
                 ref other => {
-                    log::error!("Splat scalar type {other:?}");
+                    log::debug!("Splat scalar type {other:?}");
                     return Err(ExpressionError::InvalidSplatType(value));
                 }
             },
@@ -370,7 +370,7 @@ impl super::Validator {
                 let vec_size = match resolver[vector] {
                     Ti::Vector { size: vec_size, .. } => vec_size,
                     ref other => {
-                        log::error!("Swizzle vector type {other:?}");
+                        log::debug!("Swizzle vector type {other:?}");
                         return Err(ExpressionError::InvalidVectorType(vector));
                     }
                 };
@@ -414,7 +414,7 @@ impl super::Validator {
                             .contains(TypeFlags::SIZED | TypeFlags::DATA) => {}
                     Ti::ValuePointer { .. } => {}
                     ref other => {
-                        log::error!("Loading {other:?}");
+                        log::debug!("Loading {other:?}");
                         return Err(ExpressionError::InvalidPointerType(pointer));
                     }
                 }
@@ -786,7 +786,7 @@ impl super::Validator {
                     | (Uo::LogicalNot, Some(Sk::Bool))
                     | (Uo::BitwiseNot, Some(Sk::Sint | Sk::Uint)) => {}
                     other => {
-                        log::error!("Op {op:?} kind {other:?}");
+                        log::debug!("Op {op:?} kind {other:?}");
                         return Err(ExpressionError::InvalidUnaryOperandType(op, expr));
                     }
                 }
@@ -903,7 +903,7 @@ impl super::Validator {
                                 Sk::Bool | Sk::AbstractInt | Sk::AbstractFloat => false,
                             },
                             ref other => {
-                                log::error!("Op {op:?} left type {other:?}");
+                                log::debug!("Op {op:?} left type {other:?}");
                                 false
                             }
                         }
@@ -915,7 +915,7 @@ impl super::Validator {
                             ..
                         } => left_inner == right_inner,
                         ref other => {
-                            log::error!("Op {op:?} left type {other:?}");
+                            log::debug!("Op {op:?} left type {other:?}");
                             false
                         }
                     },
@@ -925,7 +925,7 @@ impl super::Validator {
                             Sk::Float | Sk::AbstractInt | Sk::AbstractFloat => false,
                         },
                         ref other => {
-                            log::error!("Op {op:?} left type {other:?}");
+                            log::debug!("Op {op:?} left type {other:?}");
                             false
                         }
                     },
@@ -935,7 +935,7 @@ impl super::Validator {
                             Sk::Bool | Sk::Float | Sk::AbstractInt | Sk::AbstractFloat => false,
                         },
                         ref other => {
-                            log::error!("Op {op:?} left type {other:?}");
+                            log::debug!("Op {op:?} left type {other:?}");
                             false
                         }
                     },
@@ -944,7 +944,7 @@ impl super::Validator {
                             Ti::Scalar(scalar) => (Ok(None), scalar),
                             Ti::Vector { size, scalar } => (Ok(Some(size)), scalar),
                             ref other => {
-                                log::error!("Op {op:?} base type {other:?}");
+                                log::debug!("Op {op:?} base type {other:?}");
                                 (Err(()), Sc::BOOL)
                             }
                         };
@@ -955,7 +955,7 @@ impl super::Validator {
                                 scalar: Sc { kind: Sk::Uint, .. },
                             } => Ok(Some(size)),
                             ref other => {
-                                log::error!("Op {op:?} shift type {other:?}");
+                                log::debug!("Op {op:?} shift type {other:?}");
                                 Err(())
                             }
                         };
@@ -966,12 +966,12 @@ impl super::Validator {
                     }
                 };
                 if !good {
-                    log::error!(
+                    log::debug!(
                         "Left: {:?} of type {:?}",
                         function.expressions[left],
                         left_inner
                     );
-                    log::error!(
+                    log::debug!(
                         "Right: {:?} of type {:?}",
                         function.expressions[right],
                         right_inner
@@ -1060,7 +1060,7 @@ impl super::Validator {
                             ..
                         } => {}
                         ref other => {
-                            log::error!("All/Any of type {other:?}");
+                            log::debug!("All/Any of type {other:?}");
                             return Err(ExpressionError::InvalidBooleanVector(argument));
                         }
                     },
@@ -1068,7 +1068,7 @@ impl super::Validator {
                         Ti::Scalar(scalar) | Ti::Vector { scalar, .. }
                             if scalar.kind == Sk::Float => {}
                         ref other => {
-                            log::error!("Float test of type {other:?}");
+                            log::debug!("Float test of type {other:?}");
                             return Err(ExpressionError::InvalidFloatArgument(argument));
                         }
                     },
@@ -1206,7 +1206,7 @@ impl super::Validator {
                     }
                 }
                 ref other => {
-                    log::error!("Array length of {other:?}");
+                    log::debug!("Array length of {other:?}");
                     return Err(ExpressionError::InvalidArrayType(expr));
                 }
             },
@@ -1221,12 +1221,12 @@ impl super::Validator {
                 } => match resolver.types[base].inner {
                     Ti::RayQuery { .. } => ShaderStages::all(),
                     ref other => {
-                        log::error!("Intersection result of a pointer to {other:?}");
+                        log::debug!("Intersection result of a pointer to {other:?}");
                         return Err(ExpressionError::InvalidRayQueryType(query));
                     }
                 },
                 ref other => {
-                    log::error!("Intersection result of {other:?}");
+                    log::debug!("Intersection result of {other:?}");
                     return Err(ExpressionError::InvalidRayQueryType(query));
                 }
             },
@@ -1242,12 +1242,12 @@ impl super::Validator {
                         vertex_return: true,
                     } => ShaderStages::all(),
                     ref other => {
-                        log::error!("Intersection result of a pointer to {other:?}");
+                        log::debug!("Intersection result of a pointer to {other:?}");
                         return Err(ExpressionError::InvalidRayQueryType(query));
                     }
                 },
                 ref other => {
-                    log::error!("Intersection result of {other:?}");
+                    log::debug!("Intersection result of {other:?}");
                     return Err(ExpressionError::InvalidRayQueryType(query));
                 }
             },
@@ -1272,7 +1272,7 @@ impl super::Validator {
                     match resolver[operand] {
                         Ti::CooperativeMatrix { role, .. } if role == expected_role => {}
                         ref other => {
-                            log::error!("{expected_role:?} operand type: {other:?}");
+                            log::debug!("{expected_role:?} operand type: {other:?}");
                             return Err(ExpressionError::InvalidCooperativeOperand(a));
                         }
                     }

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -148,6 +148,11 @@ pub enum ExpressionError {
     UnsupportedWidth(crate::MathFunction, crate::ScalarKind, crate::Bytes),
     #[error("Invalid operand for cooperative op")]
     InvalidCooperativeOperand(Handle<crate::Expression>),
+    #[error("Shift amount exceeds the bit width of {lhs_type:?}")]
+    ShiftAmountTooLarge {
+        lhs_type: crate::TypeInner,
+        rhs_expr: Handle<crate::Expression>,
+    },
 }
 
 #[derive(Clone, Debug, thiserror::Error)]
@@ -241,6 +246,74 @@ impl super::Validator {
         }
 
         Ok(())
+    }
+
+    /// Return an error if a constant shift amount in `right` exceeds the bit
+    /// width of `left_ty`.
+    ///
+    /// This function promises to return an error in cases where (1) the
+    /// expression is well-typed, (2) `left_ty` is a concrete integer, and
+    /// (3) the shift will overflow. It does not return an error in cases where
+    /// the expression is not well-typed (e.g. vector dimension mismatch),
+    /// because those will be rejected elsewhere.
+    fn validate_constant_shift_amounts(
+        left_ty: &crate::TypeInner,
+        right: Handle<crate::Expression>,
+        module: &crate::Module,
+        function: &crate::Function,
+    ) -> Result<(), ExpressionError> {
+        fn is_overflowing_shift(
+            left_ty: &crate::TypeInner,
+            right: Handle<crate::Expression>,
+            module: &crate::Module,
+            function: &crate::Function,
+        ) -> bool {
+            let Some((vec_size, scalar)) = left_ty.vector_size_and_scalar() else {
+                return false;
+            };
+            if !matches!(
+                scalar.kind,
+                crate::ScalarKind::Sint | crate::ScalarKind::Uint
+            ) {
+                return false;
+            }
+            let lhs_bits = u32::from(8 * scalar.width);
+            if vec_size.is_none() {
+                let shift_amount = module
+                    .to_ctx()
+                    .get_const_val_from::<u32, _>(right, &function.expressions);
+                shift_amount.ok().is_some_and(|s| s >= lhs_bits)
+            } else {
+                match function.expressions[right] {
+                    crate::Expression::ZeroValue(_) => false, // zero shift does not overflow
+                    crate::Expression::Splat { value, .. } => module
+                        .to_ctx()
+                        .get_const_val_from::<u32, _>(value, &function.expressions)
+                        .ok()
+                        .is_some_and(|s| s >= lhs_bits),
+                    crate::Expression::Compose {
+                        ty: _,
+                        ref components,
+                    } => components.iter().any(|comp| {
+                        module
+                            .to_ctx()
+                            .get_const_val_from::<u32, _>(*comp, &function.expressions)
+                            .ok()
+                            .is_some_and(|s| s >= lhs_bits)
+                    }),
+                    _ => false,
+                }
+            }
+        }
+
+        if is_overflowing_shift(left_ty, right, module, function) {
+            Err(ExpressionError::ShiftAmountTooLarge {
+                lhs_type: left_ty.clone(),
+                rhs_expr: right,
+            })
+        } else {
+            Ok(())
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -983,6 +1056,10 @@ impl super::Validator {
                         rhs_expr: right,
                         rhs_type: right_inner.clone(),
                     });
+                }
+                // For shift operations, check if the constant shift amount exceeds the bit width
+                if matches!(op, Bo::ShiftLeft | Bo::ShiftRight) {
+                    Self::validate_constant_shift_amounts(left_inner, right, module, function)?;
                 }
                 ShaderStages::all()
             }

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -32,6 +32,18 @@ fn check(input: &str, snapshot: &str) {
 }
 
 #[track_caller]
+fn check_error_matches(input: &str, expected_substring: &str) {
+    let result = naga::front::wgsl::parse_str(input);
+    let Err(ref err) = result else {
+        panic!("expected ParseError, got {result:#?}");
+    };
+    let message = err.message();
+    if !message.contains(expected_substring) {
+        panic!("expected error containing '{expected_substring}', got '{message}'",);
+    }
+}
+
+#[track_caller]
 fn check_success(input: &str) {
     match naga::front::wgsl::parse_str(input) {
         Ok(_) => {}
@@ -3777,18 +3789,10 @@ fn inconsistent_type() {
 fn more_inconsistent_type() {
     #[track_caller]
     fn variant(call: &str) {
-        let input = format!(
-            r#"
-            fn f() {{ var x = {call}; }}
-        "#
+        check_error_matches(
+            &format!("fn f() {{ var x = {call}; }}"),
+            "inconsistent type",
         );
-        let result = naga::front::wgsl::parse_str(&input);
-        let Err(ref err) = result else {
-            panic!("expected ParseError, got {result:#?}");
-        };
-        if !err.message().contains("inconsistent type") {
-            panic!("expected 'inconsistent type' error, got {result:#?}");
-        }
     }
 
     variant("min(1.0, 1i)");
@@ -4945,5 +4949,73 @@ fn enable_without_capability() {
             ),
             !extension.capability(),
         );
+    }
+}
+
+#[test]
+fn bitwise_shift_errors() {
+    // 32-bit const by const >= bitwidth
+    check_error_matches(
+        "const N: u32 = 1u >> 32;",
+        "RHS of shift operation is greater than or equal to 32",
+    );
+    check_error_matches(
+        "const N: i32 = 1i >> 32;",
+        "RHS of shift operation is greater than or equal to 32",
+    );
+
+    // 32-bit const by const overflow
+    check_error_matches("const N: u32 = 0xFFFFFFFFu << 1;", "overflowed");
+    check_error_matches("const N: i32 = 1i << 31;", "overflowed");
+
+    // 32-bit const by const negative shift
+    check_error_matches("const N: u32 = 1u << -1;", "cannot represent");
+    check_error_matches("const N: i32 = 1i << -1;", "cannot represent");
+
+    // 32-bit runtime by const < bitwidth
+    check_success("fn foo() { var x: u32; var n = x << 31; }");
+    check_success("fn foo() { var x: i32; var n = x << 31; }");
+    check_success("fn foo() { var x: u32; var n = x >> 31; }");
+    check_success("fn foo() { var x: i32; var n = x >> 31; }");
+
+    // 32-bit runtime by const >= bitwidth
+    check_validation! {
+        "fn foo() { var x: u32; var n = x >> 32; }",
+        "fn foo() { var x: i32; var n = x >> 32; }",
+        "fn foo() { var x: u32; var n = x << 32; }",
+        "fn foo() { var x: i32; var n = x << 32; }":
+        Err(naga::valid::ValidationError::Function {
+            source: naga::valid::FunctionError::Expression {
+                source: naga::valid::ExpressionError::ShiftAmountTooLarge { .. },
+                ..
+            },
+            ..
+        })
+    }
+
+    // (CTS has more 32-bit test cases)
+
+    // Const evaluation of `i64` and `u64` is not implemented, https://github.com/gfx-rs/wgpu/issues/8972
+
+    // 64-bit runtime by const < bitwidth
+    check_success("fn foo() { var x: u64; var n = x << 63; }");
+    check_success("fn foo() { var x: i64; var n = x << 63; }");
+    check_success("fn foo() { var x: u64; var n = x >> 63; }");
+    check_success("fn foo() { var x: i64; var n = x >> 63; }");
+
+    // 64-bit runtime by const >= bitwidth
+    check_validation! {
+        "fn foo() { var x: u64; var n = x << 64; }",
+        "fn foo() { var x: i64; var n = x << 64; }",
+        "fn foo() { var x: u64; var n = x >> 64; }",
+        "fn foo() { var x: i64; var n = x >> 64; }":
+        Err(naga::valid::ValidationError::Function {
+            source: naga::valid::FunctionError::Expression {
+                source: naga::valid::ExpressionError::ShiftAmountTooLarge { .. },
+                ..
+            },
+            ..
+        }),
+        naga::valid::Capabilities::SHADER_INT64
     }
 }


### PR DESCRIPTION
Fixes two issues with const evaluation of bitwise shifts:

* Disallows mixed scalar/vector shifts (scalar << vector or vector << scalar), which should not be allowed.
* Detects overflowing runtime << constant shifts at constant evaluation time.

Also includes, as a separate commit, cleanup of some noisy log messages in the naga expression validator. 

**Testing**
Enables CTS tests.

**Squash or Rebase?** Rebase

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
