### PR TITLE
[d3d12] fix possible crash on GPUs that only support SM5.1

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -345,6 +345,7 @@ impl super::Adapter {
                 .is_ok()
                 {
                     break match sm.HighestShaderModel {
+                        Direct3D12::D3D_SHADER_MODEL_5_1 => ShaderModel::_5_1,
                         Direct3D12::D3D_SHADER_MODEL_6_0 => ShaderModel::_6_0,
                         Direct3D12::D3D_SHADER_MODEL_6_1 => ShaderModel::_6_1,
                         Direct3D12::D3D_SHADER_MODEL_6_2 => ShaderModel::_6_2,


### PR DESCRIPTION
**Connections**
Fixes [Bug 2011999](https://bugzilla.mozilla.org/show_bug.cgi?id=2011999).
Regression from https://github.com/gfx-rs/wgpu/pull/8576.

**Description**
Adapt code to expect SM5.1.

**Testing**
\-

**Squash or Rebase?**
n/a