### PR TITLE
[deno] Resolve CTS OOMs in CI

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -17,7 +17,6 @@ fails-if(vulkan) webgpu:api,operation,command_buffer,copyTextureToTexture:copy_d
 fails-if(vulkan) webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="depth32float"
 fails-if(vulkan) webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="depth32float-stencil8"
 webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:format="stencil8"
-// Fails with OOM in CI.
 fails-if(dx12) webgpu:api,operation,command_buffer,image_copy:offsets_and_sizes:*
 webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="CopyB2T";checkMethod="FullCopyT2B";dimension="1d"
 webgpu:api,operation,command_buffer,image_copy:undefined_params:initMethod="CopyB2T";checkMethod="FullCopyT2B";dimension="2d"
@@ -54,12 +53,12 @@ webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribu
 
 webgpu:api,validation,buffer,create:*
 webgpu:api,validation,buffer,destroy:*
-// Limit tests fail with OOM in CI.
-fails-if(dx12) webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
+webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
 //FAIL: other `maxInterStageShaderVariables` cases w/ limitTest ∈ [underDefault, overMaximum]
-fails-if(dx12) webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";*
-fails-if(dx12) webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atMaximum";*
-fails-if(dx12) webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";*
+// https://github.com/gfx-rs/wgpu/issues/8945
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";*
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atMaximum";*
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";*
 webgpu:api,validation,createBindGroup:binding_must_contain_resource_defined_in_layout:*
 webgpu:api,validation,createBindGroup:buffer_offset_and_size_for_bind_groups_match:*
 webgpu:api,validation,createBindGroup:buffer,effective_buffer_binding_size:*
@@ -150,8 +149,7 @@ fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and
 webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*
 webgpu:api,validation,image_copy,buffer_texture_copies:texture_buffer_usages:*
 webgpu:api,validation,image_copy,layout_related:copy_end_overflows_u64:*
-// Fails with OOM in CI.
-fails-if(dx12) webgpu:api,validation,image_copy,layout_related:offset_alignment:*
+webgpu:api,validation,image_copy,layout_related:offset_alignment:*
 webgpu:api,validation,image_copy,texture_related:*
 webgpu:api,validation,queue,buffer_mapped:copyBufferToBuffer:*
 webgpu:api,validation,queue,buffer_mapped:copyBufferToTexture:*

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -13,6 +13,7 @@ use deno_core::V8TaskSpawner;
 use deno_core::WebIDL;
 
 use super::device::GPUDevice;
+use super::device::DEVICE_EXTERNAL_MEMORY_SIZE;
 use super::queue::GPUQueue;
 use crate::error::GPUGenericError;
 use crate::webidl::features_to_feature_names;
@@ -161,6 +162,11 @@ impl GPUAdapter {
       None,
     )?;
 
+    // Associate external memory with the device to encourage V8 to garbage
+    // collect devices promptly.
+    scope
+      .adjust_amount_of_external_allocated_memory(DEVICE_EXTERNAL_MEMORY_SIZE);
+
     let spawner = state.borrow::<V8TaskSpawner>().clone();
     let lost_resolver = v8::PromiseResolver::new(scope).unwrap();
     let lost_promise = lost_resolver.get_promise(scope);
@@ -195,6 +201,7 @@ impl GPUAdapter {
       lost_promise: v8::Global::new(scope, lost_promise),
       limits: SameObject::new(),
       features: SameObject::new(),
+      weak: std::sync::OnceLock::new(),
     };
     let device = deno_core::cppgc::make_cppgc_object(scope, device);
     let weak_device = v8::Weak::new(scope, device);
@@ -207,13 +214,24 @@ impl GPUAdapter {
     let null = v8::null(scope);
     set_event_target_data.call(scope, null.into(), &[device.into()]);
 
+    let finalizer = v8::Weak::with_finalizer(
+      scope,
+      device,
+      Box::new(move |isolate| {
+        isolate.adjust_amount_of_external_allocated_memory(
+          -DEVICE_EXTERNAL_MEMORY_SIZE,
+        );
+      }),
+    );
+
     // Now that the device is fully constructed, give the error handler a
-    // weak reference to it.
+    // weak reference to it, and store the finalizer weak reference.
     let device = device.cast::<v8::Value>();
-    deno_core::cppgc::try_unwrap_cppgc_object::<GPUDevice>(scope, device)
-      .unwrap()
-      .error_handler
-      .set_device(weak_device);
+    let device_ref =
+      deno_core::cppgc::try_unwrap_cppgc_object::<GPUDevice>(scope, device)
+        .unwrap();
+    device_ref.error_handler.set_device(weak_device);
+    device_ref.weak.set(finalizer).unwrap();
 
     Ok(v8::Global::new(scope, device))
   }

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -13,6 +13,7 @@ use deno_core::V8TaskSpawner;
 use deno_core::WebIDL;
 
 use super::device::GPUDevice;
+use super::queue::GPUQueue;
 use crate::error::GPUGenericError;
 use crate::webidl::features_to_feature_names;
 use crate::webidl::GPUFeatureName;
@@ -163,17 +164,33 @@ impl GPUAdapter {
     let spawner = state.borrow::<V8TaskSpawner>().clone();
     let lost_resolver = v8::PromiseResolver::new(scope).unwrap();
     let lost_promise = lost_resolver.get_promise(scope);
+    let error_handler = Rc::new(super::error::DeviceErrorHandler::new(
+      v8::Global::new(scope, lost_resolver),
+      spawner,
+    ));
+
+    // Create the queue object eagerly so that the wgpu-core queue resource
+    // gets cleaned up when the device is garbage collected, even if JS code
+    // never accesses the queue property.
+    let queue_obj = deno_core::cppgc::make_cppgc_object(
+      scope,
+      GPUQueue {
+        instance: self.instance.clone(),
+        error_handler: error_handler.clone(),
+        label: descriptor.label.clone(),
+        id: queue,
+        device,
+      },
+    );
+    let queue_obj = v8::Global::new(scope, queue_obj);
+
     let device = GPUDevice {
       instance: self.instance.clone(),
       id: device,
-      queue,
       label: descriptor.label,
-      queue_obj: SameObject::new(),
+      queue_obj,
       adapter_info: self.info.clone(),
-      error_handler: Rc::new(super::error::DeviceErrorHandler::new(
-        v8::Global::new(scope, lost_resolver),
-        spawner,
-      )),
+      error_handler,
       adapter: self.id,
       lost_promise: v8::Global::new(scope, lost_promise),
       limits: SameObject::new(),

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -37,6 +37,12 @@ use crate::shader::GPUCompilationInfo;
 use crate::webidl::features_to_feature_names;
 use crate::Instance;
 
+/// External memory associated with device and queue, to encourage V8 to garbage
+/// collect devices promptly. This seems to be particularly important when
+/// running CTS tests under `webgpu:api,validation,capability_checks,limits,*`
+/// on DX12 in wgpu CI, where any smaller power of two results in OOM errors.
+pub(crate) const DEVICE_EXTERNAL_MEMORY_SIZE: i64 = 1 << 24; // 16 MB
+
 pub struct GPUDevice {
   pub instance: Instance,
   pub id: wgpu_core::id::DeviceId,
@@ -52,6 +58,9 @@ pub struct GPUDevice {
 
   pub error_handler: super::error::ErrorHandler,
   pub lost_promise: v8::Global<v8::Promise>,
+
+  // Weak reference to the JS object so we can attach a finalizer.
+  pub(crate) weak: std::sync::OnceLock<v8::Weak<v8::Object>>,
 }
 
 impl Drop for GPUDevice {

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -21,7 +21,6 @@ use super::bind_group_layout::GPUBindGroupLayout;
 use super::buffer::GPUBuffer;
 use super::compute_pipeline::GPUComputePipeline;
 use super::pipeline_layout::GPUPipelineLayout;
-use super::queue::GPUQueue;
 use super::sampler::GPUSampler;
 use super::shader::GPUShaderModule;
 use super::texture::GPUTexture;
@@ -42,7 +41,6 @@ pub struct GPUDevice {
   pub instance: Instance,
   pub id: wgpu_core::id::DeviceId,
   pub adapter: wgpu_core::id::AdapterId,
-  pub queue: wgpu_core::id::QueueId,
 
   pub label: String,
 
@@ -50,7 +48,7 @@ pub struct GPUDevice {
   pub limits: SameObject<GPUSupportedLimits>,
   pub adapter_info: Rc<SameObject<GPUAdapterInfo>>,
 
-  pub queue_obj: SameObject<GPUQueue>,
+  pub queue_obj: v8::Global<v8::Object>,
 
   pub error_handler: super::error::ErrorHandler,
   pub lost_promise: v8::Global<v8::Promise>,
@@ -126,14 +124,8 @@ impl GPUDevice {
 
   #[getter]
   #[global]
-  fn queue(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
-    self.queue_obj.get(scope, |_| GPUQueue {
-      id: self.queue,
-      device: self.id,
-      error_handler: self.error_handler.clone(),
-      instance: self.instance.clone(),
-      label: self.label.clone(),
-    })
+  fn queue(&self) -> v8::Global<v8::Object> {
+    self.queue_obj.clone()
   }
 
   #[fast]


### PR DESCRIPTION
Two changes to enable some CTS suites that would previously OOM in CI:

* Because the `GPUQueue` object was lazily constructed the first time the queue was accessed from JS, if JS never accessed the queue at all, the `GPUQueue` was never created, and thus never dropped, causing queues (and devices, since the queue has a reference to the device) to leak.
* Associate external memory with the devices in v8, to encourage garbage collection. Unlike extra memory for the command buffers, it required a substantial amount of external memory (16 MB for each dx12 device) to resolve the OOMs. 16 MB for each dx12 device seems reasonable, but I don't know if we might want to make this value platform-specific or do the external memory tracking only in `cts_runner`.

**Testing**
Enables CTS tests that weren't working before, although it's not directed coverage for the changes.

**Squash or Rebase?** Rebase

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
