### PR TITLE
test(cts): silence `advice.detachedHead` for shallow CTS clone

### DIFF
--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -197,6 +197,8 @@ pub fn run_cts(
             cmd = cmd.args([
                 "-c",
                 "remote.origin.fetch=+refs/heads/gh-pages:refs/remotes/origin/gh-pages",
+                "-c",
+                "advice.detachedHead=false",
             ]);
         } else {
             log::info!("Cloning full checkout of CTS with revision {cts_revision}");


### PR DESCRIPTION
Expressed roughly as a diff, shorten the output of this case like so:

```diff
 $ cargo xtask cts

 <snip>

 [WARN  wgpu_xtask::cts] fails-if conditions are only evaluated if a backend is specified with --backend
 [INFO  wgpu_xtask::cts] Reading default test list from cts_runner/test.lst
 [INFO  wgpu_xtask::cts] Cloning CTS shallowly with revision e98e602fe2cf38f73565c6529350453fdb616df6
 Cloning into 'cts'...
 remote: Enumerating objects: 8416, done.
 remote: Counting objects: 100% (8416/8416), done.
 remote: Compressing objects: 100% (4836/4836), done.
 remote: Total 8416 (delta 5890), reused 5391 (delta 3505), pack-reused 0 (from 0)
 Receiving objects: 100% (8416/8416), 11.84 MiB | 13.25 MiB/s, done.
 Resolving deltas: 100% (5890/5890), done.
-Note: switching to '7442e594a7bd99b1f2984d679051be41a5230b7a'.
-
-You are in 'detached HEAD' state. You can look around, make experimental
-changes and commit them, and you can discard any commits you make in this
-state without impacting any branches by switching back to a branch.
-
-If you want to create a new branch to retain commits you create, you may
-do so (now or later) by using -c with the switch command. Example:
-
-  git switch -c <new-branch-name>
-
-Or undo this operation with:
-
-  git switch -
-
-Turn off this advice by setting config variable advice.detachedHead to false
-
 Updating files: 100% (7404/7404), done.
 [INFO  wgpu_xtask::cts] Checking out CTS
 [INFO  wgpu_xtask::cts] Running CTS
 
 <snip>
```