### PR TITLE
fix validation of dual source blending structs

### DIFF
--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -645,18 +645,28 @@ impl VaryingContext<'_> {
 
                 if !self.blend_src_mask.is_empty() {
                     let span_context = self.types.get_span_context(ty);
+                    let location_members = members
+                        .as_slice()
+                        .iter()
+                        .filter(|m| {
+                            m.binding
+                                .as_ref()
+                                .is_some_and(|b| matches!(b, crate::Binding::Location { .. }))
+                        })
+                        .collect::<Vec<_>>();
 
-                    // If there's any blend_src usage, it must apply to all members of which there must be exactly 2.
-                    if members.len() != 2 || self.blend_src_mask.len() != 2 {
+                    // If there's any blend_src usage, it must apply to all members with a `location` attribute, of which there must be exactly 2.
+                    if location_members.len() != 2 || self.blend_src_mask.len() != 2 {
                         return Err(
                             VaryingError::IncompleteBlendSrcUsage.with_span_context(span_context)
                         );
                     }
-                    // Also, all members must have the same type.
-                    if members[0].ty != members[1].ty {
+
+                    // Also, all of them must have the same type.
+                    if location_members[0].ty != location_members[1].ty {
                         return Err(VaryingError::BlendSrcOutputTypeMismatch {
-                            blend_src_0_type: members[0].ty,
-                            blend_src_1_type: members[1].ty,
+                            blend_src_0_type: location_members[0].ty,
+                            blend_src_1_type: location_members[1].ty,
                         }
                         .with_span_context(span_context));
                     }


### PR DESCRIPTION
**Description**
validation for structs that contain a `blend_src` attribute in one of their members is wrong. the WebGPU spec says: 

> For each structure type S defined in a WGSL module (not just those used in shader stage inputs or outputs), let _members_ be the set of members of S that have [location](https://www.w3.org/TR/WGSL/#attribute-location) attributes.
>
>    If any entry in _members_ specifies a [blend_src](https://www.w3.org/TR/WGSL/#attribute-blend_src) attribute, _members_ must use dual source blending, which means:
>
>    - _members_ [must](https://www.w3.org/TR/WGSL/#shader-creation-error) contain exactly 2 entries, one with `@location(0) @blend_src(0)` and one with `@location(0) @blend_src(1)`.
>    - All the _members_ [must](https://www.w3.org/TR/WGSL/#shader-creation-error) have same data type.
>
>    Otherwise, _members_ [must not](https://www.w3.org/TR/WGSL/#shader-creation-error) contain two entries with the same [location](https://www.w3.org/TR/WGSL/#attribute-location) value.

([source](https://www.w3.org/TR/WGSL/#input-output-locations))

the part where `naga` is wrong is this one:
> let _members_ be the set of members of S that have [location](https://www.w3.org/TR/WGSL/#attribute-location) attributes

currently, `naga` uses _all_ the members of S during validation, instead of just the members with `location` attributes. this means you can't use any members with `builtin` attributes (such as `frag_depth`).

this PR fixes this by only checking members with `location` attributes.

related PR: #8856