### PR TITLE
Fix constant evaluation of sign(0.0f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Bottom level categories:
 - Reject zero-value construction of a runtime-sized array with a validation error. Previously it would crash in the HLSL backend. By @mooori in [#8741](https://github.com/gfx-rs/wgpu/pull/8741).
 - Reject splat vector construction if the argument type does not match the type of the vector's scalar. Previously it would succeed. By @mooori in [#8829](https://github.com/gfx-rs/wgpu/pull/8829).
 - Fixed `workgroupUniformLoad` incorrectly returning an atomic when called on an atomic, it now returns the inner `T` as per the spec. By @cryvosh in [#8791](https://github.com/gfx-rs/wgpu/pull/8791).
+- Fixed constant evaluation for `sign()` builtin to return zero when the argument is zero. By @mandryskowski in [#8942](https://github.com/gfx-rs/wgpu/pull/8942).
 
 #### GLES
 

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1670,7 +1670,11 @@ impl<'a> ConstantEvaluator<'a> {
             // computational
             crate::MathFunction::Sign => {
                 component_wise_signed!(self, span, [arg], |e| {
-                    Ok([if e.is_zero() { Zero::zero() } else { e.signum() }])
+                    Ok([if e.is_zero() {
+                        Zero::zero()
+                    } else {
+                        e.signum()
+                    }])
                 })
             }
             crate::MathFunction::Fma => {

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1669,7 +1669,9 @@ impl<'a> ConstantEvaluator<'a> {
 
             // computational
             crate::MathFunction::Sign => {
-                component_wise_signed!(self, span, [arg], |e| { Ok([e.signum()]) })
+                component_wise_signed!(self, span, [arg], |e| {
+                    Ok([if e.is_zero() { Zero::zero() } else { e.signum() }])
+                })
             }
             crate::MathFunction::Fma => {
                 component_wise_float!(

--- a/naga/tests/in/wgsl/math-functions.wgsl
+++ b/naga/tests/in/wgsl/math-functions.wgsl
@@ -12,6 +12,7 @@ fn main() {
     let sign_b = sign(vec4(-1));
     let sign_c = sign(-1.0);
     let sign_d = sign(vec4(-1.0));
+    let sign_e = sign(vec4(0.0));
     let const_dot = dot(vec2<i32>(), vec2<i32>());
     let first_leading_bit_abs = firstLeadingBit(abs(0u));
     let flb_a = firstLeadingBit(-1);

--- a/naga/tests/out/glsl/wgsl-math-functions.main.Fragment.glsl
+++ b/naga/tests/out/glsl/wgsl-math-functions.main.Fragment.glsl
@@ -64,6 +64,7 @@ void main() {
     vec4 g = refract(v, v, 1.0);
     ivec4 sign_b = ivec4(-1, -1, -1, -1);
     vec4 sign_d = vec4(-1.0, -1.0, -1.0, -1.0);
+    vec4 sign_e = vec4(0.0, 0.0, 0.0, 0.0);
     ivec2 flb_b = ivec2(-1, -1);
     uvec2 flb_c = uvec2(0u, 0u);
     ivec2 ftb_c = ivec2(0, 0);
@@ -87,12 +88,12 @@ void main() {
     int frexp_c = naga_frexp(1.5).exp_;
     int frexp_d = naga_frexp(vec4(1.5, 1.5, 1.5, 1.5)).exp_.x;
     float quantizeToF16_a = unpackHalf2x16(packHalf2x16(vec2(1.0))).x;
-    vec2 _e118 = vec2(1.0, 1.0);
-    vec2 quantizeToF16_b = unpackHalf2x16(packHalf2x16(_e118));
-    vec3 _e123 = vec3(1.0, 1.0, 1.0);
-    vec3 quantizeToF16_c = vec3(unpackHalf2x16(packHalf2x16(_e123.xy)), unpackHalf2x16(packHalf2x16(_e123.zz)).x);
-    vec4 _e129 = vec4(1.0, 1.0, 1.0, 1.0);
-    vec4 quantizeToF16_d = vec4(unpackHalf2x16(packHalf2x16(_e129.xy)), unpackHalf2x16(packHalf2x16(_e129.zw)));
+    vec2 _e123 = vec2(1.0, 1.0);
+    vec2 quantizeToF16_b = unpackHalf2x16(packHalf2x16(_e123));
+    vec3 _e128 = vec3(1.0, 1.0, 1.0);
+    vec3 quantizeToF16_c = vec3(unpackHalf2x16(packHalf2x16(_e128.xy)), unpackHalf2x16(packHalf2x16(_e128.zz)).x);
+    vec4 _e134 = vec4(1.0, 1.0, 1.0, 1.0);
+    vec4 quantizeToF16_d = vec4(unpackHalf2x16(packHalf2x16(_e134.xy)), unpackHalf2x16(packHalf2x16(_e134.zw)));
     return;
 }
 

--- a/naga/tests/out/hlsl/wgsl-math-functions.hlsl
+++ b/naga/tests/out/hlsl/wgsl-math-functions.hlsl
@@ -74,6 +74,7 @@ void main()
     float4 g = refract(v, v, 1.0);
     int4 sign_b = int4(int(-1), int(-1), int(-1), int(-1));
     float4 sign_d = float4(-1.0, -1.0, -1.0, -1.0);
+    float4 sign_e = float4(0.0, 0.0, 0.0, 0.0);
     int2 flb_b = int2(int(-1), int(-1));
     uint2 flb_c = uint2(0u, 0u);
     int2 ftb_c = int2(int(0), int(0));

--- a/naga/tests/out/msl/wgsl-math-functions.metal
+++ b/naga/tests/out/msl/wgsl-math-functions.metal
@@ -66,6 +66,7 @@ fragment void main_(
     metal::float4 g = metal::refract(v, v, 1.0);
     metal::int4 sign_b = metal::int4(-1, -1, -1, -1);
     metal::float4 sign_d = metal::float4(-1.0, -1.0, -1.0, -1.0);
+    metal::float4 sign_e = metal::float4(0.0, 0.0, 0.0, 0.0);
     metal::int2 flb_b = metal::int2(-1, -1);
     metal::uint2 flb_c = metal::uint2(0u, 0u);
     metal::int2 ftb_c = metal::int2(0, 0);

--- a/naga/tests/out/spv/wgsl-math-functions.spvasm
+++ b/naga/tests/out/spv/wgsl-math-functions.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 85
+; Bound: 86
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
@@ -40,66 +40,67 @@ OpMemberDecorate %15 1 Offset 16
 %24 = OpConstantComposite  %6  %23 %23 %23 %23
 %25 = OpConstant  %3  -1
 %26 = OpConstantComposite  %4  %25 %25 %25 %25
-%27 = OpConstant  %5  0
-%28 = OpConstant  %9  4294967295
-%29 = OpConstantComposite  %7  %23 %23
-%30 = OpConstant  %9  0
-%31 = OpConstantComposite  %8  %30 %30
-%32 = OpConstantComposite  %7  %27 %27
-%33 = OpConstant  %9  32
-%34 = OpConstant  %5  32
-%35 = OpConstantComposite  %8  %33 %33
-%36 = OpConstantComposite  %7  %34 %34
-%37 = OpConstant  %9  31
-%38 = OpConstantComposite  %8  %37 %37
-%39 = OpConstant  %5  2
-%40 = OpConstant  %3  2
-%41 = OpConstantComposite  %10  %20 %40
-%42 = OpConstant  %5  3
-%43 = OpConstant  %5  4
-%44 = OpConstantComposite  %7  %42 %43
-%45 = OpConstant  %3  1.5
-%46 = OpConstantComposite  %10  %45 %45
-%47 = OpConstantComposite  %4  %45 %45 %45 %45
-%48 = OpConstantComposite  %10  %20 %20
-%49 = OpConstantComposite  %16  %20 %20 %20
-%50 = OpConstantComposite  %4  %20 %20 %20 %20
-%57 = OpConstantComposite  %4  %20 %20 %20 %20
+%27 = OpConstantComposite  %4  %21 %21 %21 %21
+%28 = OpConstant  %5  0
+%29 = OpConstant  %9  4294967295
+%30 = OpConstantComposite  %7  %23 %23
+%31 = OpConstant  %9  0
+%32 = OpConstantComposite  %8  %31 %31
+%33 = OpConstantComposite  %7  %28 %28
+%34 = OpConstant  %9  32
+%35 = OpConstant  %5  32
+%36 = OpConstantComposite  %8  %34 %34
+%37 = OpConstantComposite  %7  %35 %35
+%38 = OpConstant  %9  31
+%39 = OpConstantComposite  %8  %38 %38
+%40 = OpConstant  %5  2
+%41 = OpConstant  %3  2
+%42 = OpConstantComposite  %10  %20 %41
+%43 = OpConstant  %5  3
+%44 = OpConstant  %5  4
+%45 = OpConstantComposite  %7  %43 %44
+%46 = OpConstant  %3  1.5
+%47 = OpConstantComposite  %10  %46 %46
+%48 = OpConstantComposite  %4  %46 %46 %46 %46
+%49 = OpConstantComposite  %10  %20 %20
+%50 = OpConstantComposite  %16  %20 %20 %20
+%51 = OpConstantComposite  %4  %20 %20 %20 %20
+%58 = OpConstantComposite  %4  %20 %20 %20 %20
 %18 = OpFunction  %2  None %19
 %17 = OpLabel
-OpBranch %51
-%51 = OpLabel
-%52 = OpExtInst  %3  %1 Degrees %20
-%53 = OpExtInst  %3  %1 Radians %20
-%54 = OpExtInst  %4  %1 Degrees %22
-%55 = OpExtInst  %4  %1 Radians %22
-%56 = OpExtInst  %4  %1 FClamp %22 %22 %57
-%58 = OpExtInst  %4  %1 Refract %22 %22 %20
-%59 = OpExtInst  %3  %1 Ldexp %20 %39
-%60 = OpExtInst  %10  %1 Ldexp %41 %44
-%61 = OpExtInst  %11  %1 ModfStruct %45
-%62 = OpExtInst  %11  %1 ModfStruct %45
-%63 = OpCompositeExtract  %3  %62 0
-%64 = OpExtInst  %11  %1 ModfStruct %45
-%65 = OpCompositeExtract  %3  %64 1
-%66 = OpExtInst  %12  %1 ModfStruct %46
-%67 = OpExtInst  %13  %1 ModfStruct %47
-%68 = OpCompositeExtract  %4  %67 1
-%69 = OpCompositeExtract  %3  %68 0
-%70 = OpExtInst  %12  %1 ModfStruct %46
-%71 = OpCompositeExtract  %10  %70 0
-%72 = OpCompositeExtract  %3  %71 1
-%73 = OpExtInst  %14  %1 FrexpStruct %45
-%74 = OpExtInst  %14  %1 FrexpStruct %45
-%75 = OpCompositeExtract  %3  %74 0
-%76 = OpExtInst  %14  %1 FrexpStruct %45
-%77 = OpCompositeExtract  %5  %76 1
-%78 = OpExtInst  %15  %1 FrexpStruct %47
-%79 = OpCompositeExtract  %6  %78 1
-%80 = OpCompositeExtract  %5  %79 0
-%81 = OpQuantizeToF16  %3  %20
-%82 = OpQuantizeToF16  %10  %48
-%83 = OpQuantizeToF16  %16  %49
-%84 = OpQuantizeToF16  %4  %50
+OpBranch %52
+%52 = OpLabel
+%53 = OpExtInst  %3  %1 Degrees %20
+%54 = OpExtInst  %3  %1 Radians %20
+%55 = OpExtInst  %4  %1 Degrees %22
+%56 = OpExtInst  %4  %1 Radians %22
+%57 = OpExtInst  %4  %1 FClamp %22 %22 %58
+%59 = OpExtInst  %4  %1 Refract %22 %22 %20
+%60 = OpExtInst  %3  %1 Ldexp %20 %40
+%61 = OpExtInst  %10  %1 Ldexp %42 %45
+%62 = OpExtInst  %11  %1 ModfStruct %46
+%63 = OpExtInst  %11  %1 ModfStruct %46
+%64 = OpCompositeExtract  %3  %63 0
+%65 = OpExtInst  %11  %1 ModfStruct %46
+%66 = OpCompositeExtract  %3  %65 1
+%67 = OpExtInst  %12  %1 ModfStruct %47
+%68 = OpExtInst  %13  %1 ModfStruct %48
+%69 = OpCompositeExtract  %4  %68 1
+%70 = OpCompositeExtract  %3  %69 0
+%71 = OpExtInst  %12  %1 ModfStruct %47
+%72 = OpCompositeExtract  %10  %71 0
+%73 = OpCompositeExtract  %3  %72 1
+%74 = OpExtInst  %14  %1 FrexpStruct %46
+%75 = OpExtInst  %14  %1 FrexpStruct %46
+%76 = OpCompositeExtract  %3  %75 0
+%77 = OpExtInst  %14  %1 FrexpStruct %46
+%78 = OpCompositeExtract  %5  %77 1
+%79 = OpExtInst  %15  %1 FrexpStruct %48
+%80 = OpCompositeExtract  %6  %79 1
+%81 = OpCompositeExtract  %5  %80 0
+%82 = OpQuantizeToF16  %3  %20
+%83 = OpQuantizeToF16  %10  %49
+%84 = OpQuantizeToF16  %16  %50
+%85 = OpQuantizeToF16  %4  %51
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/wgsl-math-functions.wgsl
+++ b/naga/tests/out/wgsl/wgsl-math-functions.wgsl
@@ -9,6 +9,7 @@ fn main() {
     let g = refract(v, v, 1f);
     let sign_b = vec4<i32>(-1i, -1i, -1i, -1i);
     let sign_d = vec4<f32>(-1f, -1f, -1f, -1f);
+    let sign_e = vec4<f32>(0f, 0f, 0f, 0f);
     let flb_b = vec2<i32>(-1i, -1i);
     let flb_c = vec2<u32>(0u, 0u);
     let ftb_c = vec2<i32>(0i, 0i);


### PR DESCRIPTION
**Description**
According to WGSL spec, sign(0) = 0
In `constant_evaluator.rs` the `signum` method is used to evaluate sign(e).
However, `0_f32.signum()` and `f16::ZERO.signum()` output 1.0f, not 0.0f.
https://doc.rust-lang.org/std/primitive.f32.html#method.signum
https://docs.rs/half/latest/half/struct.f16.html#method.signum

Because of this, the following shader outputs 1.0f:
```wgsl
struct StorageBuffer {
    a: f32,
}

@group(0)
@binding(0)
var<storage, read_write> s_output: StorageBuffer;

@compute
@workgroup_size(1)
fn main() {
    s_output = StorageBuffer(sign(0.0));
}
```
<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
