### PR TITLE
chore: update `CORE_MSRV` to 1.82 → 1.90

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
   REPO_MSRV: "1.92"
   # This is the MSRV used by the `wgpu-core`, `wgpu-hal`, and `wgpu-types` crates,
   # to ensure that they can be used with firefox.
-  CORE_MSRV: "1.82.0"
+  CORE_MSRV: "1.90.0"
 
   #
   # Environment variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ Bottom level categories:
 - Added support for no-perspective barycentric coordinates. By @atlv24 in [#8852](https://github.com/gfx-rs/wgpu/issues/8852).
 - Added support for obtaining `AdapterInfo` from `Device`. By @sagudev in [#8807](https://github.com/gfx-rs/wgpu/pull/8807).
 - Added `Limits::or_worse_values_from`. By @atlv24 in [#8870](https://github.com/gfx-rs/wgpu/pull/8870).
+- Made the following available in `const` contexts:
+    - `naga`
+        - `Arena::len`
+        - `Arena::is_empty`
+        - `Range::first_and_last`
+        - `front::wgsl::Frontend::set_options`
+        - `ir::Block::is_empty`
+        - `ir::Block::len`
 
 #### Naga
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ TL;DR: If you're using `wgpu`, our MSRV is **1.92**.
 
 Due to complex dependants, we have two MSRV policies:
 
-- `naga`, `wgpu-core`, `wgpu-hal`, and `wgpu-types`'s MSRV is **1.82**.
+- `naga`, `wgpu-core`, `wgpu-hal`, and `wgpu-types`'s MSRV is **1.90**.
 - The rest of the workspace has an MSRV of **1.92**.
 
 It is enforced on CI (in "/.github/workflows/ci.yml") with the `CORE_MSRV` and `REPO_MSRV` variables.

--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -1,6 +1,4 @@
-#![allow(clippy::manual_strip)]
 use anyhow::{anyhow, Context as _};
-#[allow(unused_imports)]
 use std::fs;
 use std::{error::Error, fmt, io::Read, path::Path, str::FromStr};
 
@@ -260,10 +258,10 @@ impl FromStr for GlslProfileArg {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use naga::back::glsl::Version;
-        Ok(Self(if s.starts_with("core") {
-            Version::Desktop(s[4..].parse().unwrap_or(330))
-        } else if s.starts_with("es") {
-            Version::new_gles(s[2..].parse().unwrap_or(310))
+        Ok(Self(if let Some(s) = s.strip_prefix("core") {
+            Version::Desktop(s.parse().unwrap_or(330))
+        } else if let Some(s) = s.strip_prefix("es") {
+            Version::new_gles(s.parse().unwrap_or(310))
         } else {
             return Err(format!("Unknown profile: {s}"));
         }))

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["bin/**/*", "tests/**/*", "Cargo.lock", "target/**/*"]
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.82.0"
+rust-version = "1.90.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/naga/README.md
+++ b/naga/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/naga.svg?label=naga)](https://crates.io/crates/naga)
 [![Docs.rs](https://docs.rs/naga/badge.svg)](https://docs.rs/naga)
 [![Build Status](https://github.com/gfx-rs/naga/workflows/pipeline/badge.svg)](https://github.com/gfx-rs/naga/actions)
-![MSRV](https://img.shields.io/badge/rustc-1.82-blue.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.90-blue.svg)
 [![codecov.io](https://codecov.io/gh/gfx-rs/naga/branch/master/graph/badge.svg?token=9VOKYO8BM2)](https://codecov.io/gh/gfx-rs/naga)
 
 The shader translation library for the needs of [wgpu](https://github.com/gfx-rs/wgpu).

--- a/naga/src/arena/handlevec.rs
+++ b/naga/src/arena/handlevec.rs
@@ -50,7 +50,7 @@ impl<T, U> HandleVec<T, U> {
         }
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) const fn len(&self) -> usize {
         self.inner.len()
     }
 

--- a/naga/src/arena/mod.rs
+++ b/naga/src/arena/mod.rs
@@ -78,18 +78,17 @@ impl<T> Arena<T> {
     }
 
     /// Extracts the inner vector.
-    #[allow(clippy::missing_const_for_fn)] // ignore due to requirement of #![feature(const_precise_live_drops)]
     pub fn into_inner(self) -> Vec<T> {
         self.data
     }
 
     /// Returns the current number of items stored in this arena.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.data.len()
     }
 
     /// Returns `true` if the arena contains no elements.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
 

--- a/naga/src/arena/range.rs
+++ b/naga/src/arena/range.rs
@@ -106,7 +106,7 @@ impl<T> Range<T> {
     ///
     /// If `self` is an empty range, there are no handles included, so
     /// return `None`.
-    pub fn first_and_last(&self) -> Option<(Handle<T>, Handle<T>)> {
+    pub const fn first_and_last(&self) -> Option<(Handle<T>, Handle<T>)> {
         if self.inner.start < self.inner.end {
             Some((
                 // `Range::new_from_bounds` expects a start- and end-inclusive

--- a/naga/src/back/glsl/features.rs
+++ b/naga/src/back/glsl/features.rs
@@ -78,7 +78,7 @@ impl FeaturesManager {
     }
 
     /// Checks if the list of features [`Features`] contains the specified [`Features`]
-    pub fn contains(&mut self, features: Features) -> bool {
+    pub const fn contains(&mut self, features: Features) -> bool {
         self.0.contains(features)
     }
 

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -454,7 +454,7 @@ struct IdGenerator(u32);
 
 impl IdGenerator {
     /// Generates a number that's guaranteed to be unique for this `IdGenerator`
-    fn generate(&mut self) -> u32 {
+    const fn generate(&mut self) -> u32 {
         // It's just an increasing number but it does the job
         let ret = self.0;
         self.0 += 1;

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -242,7 +242,6 @@ where
 pub type BindingMap = alloc::collections::BTreeMap<crate::ResourceBinding, BindTarget>;
 
 /// A HLSL shader model version.
-#[allow(non_snake_case, non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]

--- a/naga/src/back/msl/sampler.rs
+++ b/naga/src/back/msl/sampler.rs
@@ -132,8 +132,6 @@ pub struct InlineSampler {
 
 impl Eq for InlineSampler {}
 
-#[allow(renamed_and_removed_lints)]
-#[allow(clippy::derive_hash_xor_eq)]
 impl core::hash::Hash for InlineSampler {
     fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) {
         self.coord.hash(hasher);

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -864,7 +864,6 @@ impl<W: Write> Writer<W> {
 
     /// Finishes writing and returns the output.
     // See https://github.com/rust-lang/rust-clippy/issues/4979.
-    #[allow(clippy::missing_const_for_fn)]
     pub fn finish(self) -> W {
         self.out
     }
@@ -3035,7 +3034,6 @@ impl<W: Write> Writer<W> {
     /// [`ReadZeroSkipWrite`]: index::BoundsCheckPolicy::ReadZeroSkipWrite
     /// [`Store`]: crate::Statement::Store
     /// [`Load`]: crate::Expression::Load
-    #[allow(unused_variables)]
     fn put_bounds_checks(
         &mut self,
         chain: Handle<crate::Expression>,

--- a/naga/src/back/spv/helpers.rs
+++ b/naga/src/back/spv/helpers.rs
@@ -20,7 +20,7 @@ pub(super) fn string_to_words(input: &str) -> Vec<Word> {
 
 pub(super) fn str_bytes_to_words(bytes: &[u8]) -> Vec<Word> {
     let mut words = bytes_to_words(bytes);
-    if bytes.len() % 4 == 0 {
+    if bytes.len().is_multiple_of(4) {
         // nul-termination
         words.push(0x0u32);
     }

--- a/naga/src/back/spv/instructions.rs
+++ b/naga/src/back/spv/instructions.rs
@@ -309,7 +309,6 @@ impl super::Instruction {
         instruction
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn type_image(
         id: Word,
         sampled_type_id: Word,

--- a/naga/src/back/spv/layout.rs
+++ b/naga/src/back/spv/layout.rs
@@ -96,14 +96,12 @@ impl Instruction {
         }
     }
 
-    #[allow(clippy::panic)]
     pub(super) fn set_type(&mut self, id: Word) {
         assert!(self.type_id.is_none(), "Type can only be set once");
         self.type_id = Some(id);
         self.wc += 1;
     }
 
-    #[allow(clippy::panic)]
     pub(super) fn set_result(&mut self, id: Word) {
         assert!(self.result_id.is_none(), "Result can only be set once");
         self.result_id = Some(id);

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -183,7 +183,7 @@ pub enum Error {
 struct IdGenerator(Word);
 
 impl IdGenerator {
-    fn next(&mut self) -> Word {
+    const fn next(&mut self) -> Word {
         self.0 += 1;
         self.0
     }
@@ -763,7 +763,7 @@ impl GlobalVariable {
     }
 
     /// Prepare `self` for use within a single function.
-    fn reset_for_function(&mut self) {
+    const fn reset_for_function(&mut self) {
         self.handle_id = 0;
         self.access_id = 0;
     }
@@ -857,7 +857,7 @@ struct RayQueryTrackers {
 }
 
 impl BlockContext<'_> {
-    fn gen_id(&mut self) -> Word {
+    const fn gen_id(&mut self) -> Word {
         self.writer.id_gen.next()
     }
 

--- a/naga/src/back/spv/selection.rs
+++ b/naga/src/back/spv/selection.rs
@@ -102,7 +102,7 @@ impl<'b, M: MergeTuple> Selection<'b, M> {
     /// fresh `Selection`.)
     ///
     /// [`finish`]: Selection::finish
-    pub(super) fn start(block: &'b mut Block, merge_types: M) -> Self {
+    pub(super) const fn start(block: &'b mut Block, merge_types: M) -> Self {
         Selection {
             block,
             merge_label: None,
@@ -111,7 +111,7 @@ impl<'b, M: MergeTuple> Selection<'b, M> {
         }
     }
 
-    pub(super) fn block(&mut self) -> &mut Block {
+    pub(super) const fn block(&mut self) -> &mut Block {
         self.block
     }
 

--- a/naga/src/back/spv/writer.rs
+++ b/naga/src/back/spv/writer.rs
@@ -3488,7 +3488,7 @@ impl Writer {
         }
     }
 
-    fn write_physical_layout(&mut self) {
+    const fn write_physical_layout(&mut self) {
         self.physical_layout.bound = self.id_gen.0 + 1;
     }
 

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -1955,7 +1955,6 @@ impl<W: Write> Writer<W> {
     }
 
     // See https://github.com/rust-lang/rust-clippy/issues/4979.
-    #[allow(clippy::missing_const_for_fn)]
     pub fn finish(self) -> W {
         self.out
     }

--- a/naga/src/compact/functions.rs
+++ b/naga/src/compact/functions.rs
@@ -56,7 +56,7 @@ impl FunctionTracer<'_> {
         self.as_expression().trace_expressions();
     }
 
-    fn as_expression(&mut self) -> super::expressions::ExpressionTracer<'_> {
+    const fn as_expression(&mut self) -> super::expressions::ExpressionTracer<'_> {
         super::expressions::ExpressionTracer {
             constants: self.constants,
             overrides: self.overrides,

--- a/naga/src/compact/mod.rs
+++ b/naga/src/compact/mod.rs
@@ -529,7 +529,7 @@ impl<'module> ModuleTracer<'module> {
         }
     }
 
-    fn as_type(&mut self) -> types::TypeTracer<'_> {
+    const fn as_type(&mut self) -> types::TypeTracer<'_> {
         types::TypeTracer {
             overrides: &self.module.overrides,
             types_used: &mut self.types_used,
@@ -538,7 +538,7 @@ impl<'module> ModuleTracer<'module> {
         }
     }
 
-    fn as_const_expression(&mut self) -> expressions::ExpressionTracer<'_> {
+    const fn as_const_expression(&mut self) -> expressions::ExpressionTracer<'_> {
         expressions::ExpressionTracer {
             constants: &self.module.constants,
             overrides: &self.module.overrides,

--- a/naga/src/error.rs
+++ b/naga/src/error.rs
@@ -109,7 +109,7 @@ impl DiagnosticBuffer {
         Self { inner }
     }
 
-    pub fn inner_mut(&mut self) -> &mut DiagnosticBufferInner {
+    pub const fn inner_mut(&mut self) -> &mut DiagnosticBufferInner {
         &mut self.inner
     }
 

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -409,7 +409,7 @@ impl<'a> Context<'a> {
     /// - If more than one [`StmtContext`] are active at the same time or if the
     ///   previous call didn't use it in lowering.
     #[must_use]
-    pub fn stmt_ctx(&mut self) -> StmtContext {
+    pub const fn stmt_ctx(&mut self) -> StmtContext {
         self.stmt_ctx.take().unwrap()
     }
 

--- a/naga/src/front/glsl/functions.rs
+++ b/naga/src/front/glsl/functions.rs
@@ -355,7 +355,6 @@ impl Frontend {
         ctx.add_expression(Expression::Compose { ty, components }, meta)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn vector_constructor(
         &mut self,
         ctx: &mut Context,
@@ -513,7 +512,6 @@ impl Frontend {
         ctx.add_expression(Expression::Compose { ty, components }, meta)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn function_call(
         &mut self,
         ctx: &mut Context,

--- a/naga/src/front/spv/function.rs
+++ b/naga/src/front/spv/function.rs
@@ -617,7 +617,7 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
 }
 
 impl BlockContext<'_> {
-    pub(super) fn gctx(&self) -> crate::proc::GlobalCtx<'_> {
+    pub(super) const fn gctx(&self) -> crate::proc::GlobalCtx<'_> {
         crate::proc::GlobalCtx {
             types: &self.module.types,
             constants: &self.module.constants,

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -231,7 +231,7 @@ struct Decoration {
 }
 
 impl Decoration {
-    fn debug_name(&self) -> &str {
+    const fn debug_name(&self) -> &str {
         match self.name {
             Some(ref name) => name.as_str(),
             None => "?",
@@ -1493,10 +1493,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
         overrides: &Arena<crate::Override>,
     ) -> Arena<crate::Expression> {
         let mut expressions = Arena::new();
-        #[allow(clippy::panic)]
-        {
-            assert!(self.lookup_expression.is_empty());
-        }
+        assert!(self.lookup_expression.is_empty());
         // register global variables
         for (&id, var) in self.lookup_variable.iter() {
             let span = globals.get_span(var.handle);
@@ -3176,7 +3173,7 @@ fn resolve_constant(gctx: crate::proc::GlobalCtx, constant: &Constant) -> Option
 }
 
 pub fn parse_u8_slice(data: &[u8], options: &Options) -> Result<crate::Module, Error> {
-    if data.len() % 4 != 0 {
+    if !data.len().is_multiple_of(4) {
         return Err(Error::IncompleteData);
     }
 

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -105,7 +105,7 @@ pub struct GlobalContext<'source, 'temp, 'out> {
 }
 
 impl<'source> GlobalContext<'source, '_, '_> {
-    fn as_const(&mut self) -> ExpressionContext<'source, '_, '_> {
+    const fn as_const(&mut self) -> ExpressionContext<'source, '_, '_> {
         ExpressionContext {
             ast_expressions: self.ast_expressions,
             globals: self.globals,
@@ -118,7 +118,7 @@ impl<'source> GlobalContext<'source, '_, '_> {
         }
     }
 
-    fn as_override(&mut self) -> ExpressionContext<'source, '_, '_> {
+    const fn as_override(&mut self) -> ExpressionContext<'source, '_, '_> {
         ExpressionContext {
             ast_expressions: self.ast_expressions,
             globals: self.globals,
@@ -202,7 +202,7 @@ pub struct StatementContext<'source, 'temp, 'out> {
 }
 
 impl<'a, 'temp> StatementContext<'a, 'temp, '_> {
-    fn as_const<'t>(
+    const fn as_const<'t>(
         &'t mut self,
         block: &'t mut ir::Block,
         emitter: &'t mut proc::Emitter,
@@ -229,7 +229,7 @@ impl<'a, 'temp> StatementContext<'a, 'temp, '_> {
         }
     }
 
-    fn as_expression<'t>(
+    const fn as_expression<'t>(
         &'t mut self,
         block: &'t mut ir::Block,
         emitter: &'t mut proc::Emitter,
@@ -257,7 +257,7 @@ impl<'a, 'temp> StatementContext<'a, 'temp, '_> {
     }
 
     #[allow(dead_code)]
-    fn as_global(&mut self) -> GlobalContext<'a, '_, '_> {
+    const fn as_global(&mut self) -> GlobalContext<'a, '_, '_> {
         GlobalContext {
             ast_expressions: self.ast_expressions,
             globals: self.globals,
@@ -434,7 +434,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
     }
 
     #[allow(dead_code)]
-    fn as_const(&mut self) -> ExpressionContext<'source, '_, '_> {
+    const fn as_const(&mut self) -> ExpressionContext<'source, '_, '_> {
         ExpressionContext {
             globals: self.globals,
             types: self.types,
@@ -461,7 +461,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
         }
     }
 
-    fn as_global(&mut self) -> GlobalContext<'source, '_, '_> {
+    const fn as_global(&mut self) -> GlobalContext<'source, '_, '_> {
         GlobalContext {
             ast_expressions: self.ast_expressions,
             globals: self.globals,
@@ -473,7 +473,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
         }
     }
 
-    fn as_const_evaluator(&mut self) -> proc::ConstantEvaluator<'_> {
+    const fn as_const_evaluator(&mut self) -> proc::ConstantEvaluator<'_> {
         match self.expr_type {
             ExpressionContextType::Runtime(ref mut rctx) => {
                 proc::ConstantEvaluator::for_wgsl_function(
@@ -517,7 +517,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
     /// Return a wrapper around `value` that implements
     /// [`core::fmt::Display`] in a form suitable for use in
     /// diagnostic messages.
-    fn as_diagnostic_display<T>(
+    const fn as_diagnostic_display<T>(
         &self,
         value: T,
     ) -> crate::common::DiagnosticDisplay<(T, proc::GlobalCtx<'_>)> {
@@ -585,7 +585,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
         }
     }
 
-    fn typifier(&self) -> &Typifier {
+    const fn typifier(&self) -> &Typifier {
         match self.expr_type {
             ExpressionContextType::Runtime(ref ctx)
             | ExpressionContextType::Constant(Some(ref ctx)) => ctx.typifier,

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -52,7 +52,8 @@ impl Frontend {
             options,
         }
     }
-    pub fn set_options(&mut self, options: Options) {
+
+    pub const fn set_options(&mut self, options: Options) {
         self.options = options;
     }
 

--- a/naga/src/front/wgsl/parse/directive/enable_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/enable_extension.rs
@@ -34,7 +34,7 @@ impl EnableExtensions {
     }
 
     /// Add an enable-extension to the set requested by a module.
-    pub(crate) fn add(&mut self, ext: ImplementedEnableExtension) {
+    pub(crate) const fn add(&mut self, ext: ImplementedEnableExtension) {
         let field = match ext {
             ImplementedEnableExtension::WgpuMeshShader => &mut self.wgpu_mesh_shader,
             ImplementedEnableExtension::WgpuRayQuery => &mut self.wgpu_ray_query,

--- a/naga/src/front/wgsl/parse/directive/language_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/language_extension.rs
@@ -7,7 +7,6 @@
 /// WGSL spec.: <https://www.w3.org/TR/WGSL/#language-extensions-sec>
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum LanguageExtension {
-    #[allow(unused)]
     Implemented(ImplementedLanguageExtension),
     Unimplemented(UnimplementedLanguageExtension),
 }

--- a/naga/src/ir/block.rs
+++ b/naga/src/ir/block.rs
@@ -81,11 +81,11 @@ impl Block {
         self.body.iter_mut().zip(span_iter)
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.body.is_empty()
     }
 
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.body.len()
     }
 }

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -979,7 +979,7 @@ impl<'a> ConstantEvaluator<'a> {
     /// constant expression arena.
     ///
     /// Report errors according to WGSL's rules for constant evaluation.
-    pub fn for_wgsl_module(
+    pub const fn for_wgsl_module(
         module: &'a mut crate::Module,
         global_expression_kind_tracker: &'a mut ExpressionKindTracker,
         layouter: &'a mut crate::proc::Layouter,
@@ -1001,7 +1001,7 @@ impl<'a> ConstantEvaluator<'a> {
     /// constant expression arena.
     ///
     /// Report errors according to GLSL's rules for constant evaluation.
-    pub fn for_glsl_module(
+    pub const fn for_glsl_module(
         module: &'a mut crate::Module,
         global_expression_kind_tracker: &'a mut ExpressionKindTracker,
         layouter: &'a mut crate::proc::Layouter,
@@ -1014,7 +1014,7 @@ impl<'a> ConstantEvaluator<'a> {
         )
     }
 
-    fn for_module(
+    const fn for_module(
         behavior: Behavior<'a>,
         module: &'a mut crate::Module,
         global_expression_kind_tracker: &'a mut ExpressionKindTracker,
@@ -1035,7 +1035,7 @@ impl<'a> ConstantEvaluator<'a> {
     /// expression arena.
     ///
     /// Report errors according to WGSL's rules for constant evaluation.
-    pub fn for_wgsl_function(
+    pub const fn for_wgsl_function(
         module: &'a mut crate::Module,
         expressions: &'a mut Arena<Expression>,
         local_expression_kind_tracker: &'a mut ExpressionKindTracker,
@@ -1068,7 +1068,7 @@ impl<'a> ConstantEvaluator<'a> {
     /// expression arena.
     ///
     /// Report errors according to GLSL's rules for constant evaluation.
-    pub fn for_glsl_function(
+    pub const fn for_glsl_function(
         module: &'a mut crate::Module,
         expressions: &'a mut Arena<Expression>,
         local_expression_kind_tracker: &'a mut ExpressionKindTracker,
@@ -1091,7 +1091,7 @@ impl<'a> ConstantEvaluator<'a> {
         }
     }
 
-    pub fn to_ctx(&self) -> crate::proc::GlobalCtx<'_> {
+    pub const fn to_ctx(&self) -> crate::proc::GlobalCtx<'_> {
         crate::proc::GlobalCtx {
             types: self.types,
             constants: self.constants,

--- a/naga/src/proc/emitter.rs
+++ b/naga/src/proc/emitter.rs
@@ -1,13 +1,11 @@
 use crate::arena::Arena;
 
 /// Helper class to emit expressions
-#[allow(dead_code)]
 #[derive(Default, Debug)]
 pub struct Emitter {
     start_len: Option<usize>,
 }
 
-#[allow(dead_code)]
 impl Emitter {
     pub fn start(&mut self, arena: &Arena<crate::Expression>) {
         if self.start_len.is_some() {
@@ -25,7 +23,6 @@ impl Emitter {
     ) -> Option<(crate::Statement, crate::span::Span)> {
         let start_len = self.start_len.take().unwrap();
         if start_len != arena.len() {
-            #[allow(unused_mut)]
             let mut span = crate::span::Span::default();
             let range = arena.range_from(start_len);
             for handle in range.clone() {

--- a/naga/src/proc/layouter.rs
+++ b/naga/src/proc/layouter.rs
@@ -12,11 +12,11 @@ use crate::{
 pub struct Alignment(NonZeroU32);
 
 impl Alignment {
-    pub const ONE: Self = Self(unsafe { NonZeroU32::new_unchecked(1) });
-    pub const TWO: Self = Self(unsafe { NonZeroU32::new_unchecked(2) });
-    pub const FOUR: Self = Self(unsafe { NonZeroU32::new_unchecked(4) });
-    pub const EIGHT: Self = Self(unsafe { NonZeroU32::new_unchecked(8) });
-    pub const SIXTEEN: Self = Self(unsafe { NonZeroU32::new_unchecked(16) });
+    pub const ONE: Self = Self(NonZeroU32::new(1).unwrap());
+    pub const TWO: Self = Self(NonZeroU32::new(2).unwrap());
+    pub const FOUR: Self = Self(NonZeroU32::new(4).unwrap());
+    pub const EIGHT: Self = Self(NonZeroU32::new(8).unwrap());
+    pub const SIXTEEN: Self = Self(NonZeroU32::new(16).unwrap());
 
     pub const MIN_UNIFORM: Self = Self::SIXTEEN;
 
@@ -31,7 +31,7 @@ impl Alignment {
 
     /// # Panics
     /// If `width` is not a power of 2
-    pub fn from_width(width: u8) -> Self {
+    pub const fn from_width(width: u8) -> Self {
         Self::new(width as u32).unwrap()
     }
 

--- a/naga/src/proc/type_methods.rs
+++ b/naga/src/proc/type_methods.rs
@@ -356,7 +356,7 @@ impl crate::TypeInner {
         }
     }
 
-    pub fn components(&self) -> Option<u32> {
+    pub const fn components(&self) -> Option<u32> {
         Some(match *self {
             Self::Vector { size, .. } => size as u32,
             Self::Matrix { columns, .. } => columns as u32,

--- a/naga/src/span.rs
+++ b/naga/src/span.rs
@@ -178,7 +178,6 @@ impl<E> WithSpan<E> {
     }
 
     /// Reverse of [`Self::new`], discards span information and returns an inner error.
-    #[allow(clippy::missing_const_for_fn)] // ignore due to requirement of #![feature(const_precise_live_drops)]
     pub fn into_inner(self) -> E {
         self.inner
     }

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -239,7 +239,6 @@ struct Sampling {
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct FunctionInfo {
     /// Validation flags.
-    #[allow(dead_code)]
     flags: ValidationFlags,
     /// Set of shader stages where calling this function is valid.
     pub available_stages: ShaderStages,

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -1318,7 +1318,7 @@ impl super::Validator {
     }
 }
 
-pub fn check_literal_value(literal: crate::Literal) -> Result<(), LiteralError> {
+pub const fn check_literal_value(literal: crate::Literal) -> Result<(), LiteralError> {
     let is_nan = match literal {
         crate::Literal::F64(v) => v.is_nan(),
         crate::Literal::F32(v) => v.is_nan(),

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -349,7 +349,6 @@ pub struct Validator {
     location_mask: BitSet,
     blend_src_mask: BitSet,
     ep_resource_bindings: FastHashSet<crate::ResourceBinding>,
-    #[allow(dead_code)]
     switch_values: FastHashSet<crate::SwitchValue>,
     valid_expression_list: Vec<Handle<crate::Expression>>,
     valid_expression_set: HandleSet<crate::Expression>,
@@ -581,13 +580,13 @@ impl Validator {
     }
 
     // TODO(https://github.com/gfx-rs/wgpu/issues/8207): Consider removing this
-    pub fn subgroup_stages(&mut self, stages: ShaderStages) -> &mut Self {
+    pub const fn subgroup_stages(&mut self, stages: ShaderStages) -> &mut Self {
         self.subgroup_stages = stages;
         self
     }
 
     // TODO(https://github.com/gfx-rs/wgpu/issues/8207): Consider removing this
-    pub fn subgroup_operations(&mut self, operations: SubgroupOperationSet) -> &mut Self {
+    pub const fn subgroup_operations(&mut self, operations: SubgroupOperationSet) -> &mut Self {
         self.subgroup_operations = operations;
         self
     }

--- a/naga/tests/naga/snapshots.rs
+++ b/naga/tests/naga/snapshots.rs
@@ -435,7 +435,6 @@ fn convert_snapshots_spv() {
 // While we _can_ run this test under miri, it is extremely slow (>5 minutes),
 // and naga isn't the primary target for miri testing, so we disable it.
 #[cfg_attr(miri, ignore)]
-#[allow(unused_variables)]
 #[test]
 fn convert_snapshots_glsl() {
     let _ = env_logger::try_init();

--- a/naga/tests/naga/validation.rs
+++ b/naga/tests/naga/validation.rs
@@ -545,7 +545,6 @@ fn main(input: VertexOutput) {{
     }
 }
 
-#[allow(dead_code)]
 struct BindingArrayFixture {
     module: Module,
     span: naga::Span,

--- a/tests/src/report.rs
+++ b/tests/src/report.rs
@@ -45,7 +45,6 @@ pub struct AdapterReport {
     pub features: Features,
     pub limits: Limits,
     pub downlevel_caps: DownlevelCapabilities,
-    #[allow(unused)]
     pub texture_format_features: HashMap<TextureFormat, TextureFormatFeatures>,
 }
 

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.82.0"
+rust-version = "1.90.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -733,7 +733,6 @@ pub struct BindGroupLayout {
     /// (derived BGLs) must not be removed.
     pub(crate) origin: bgl::Origin,
     pub(crate) exclusive_pipeline: crate::OnceCellOrLock<ExclusivePipeline>,
-    #[allow(unused)]
     pub(crate) binding_count_validator: BindingTypeMaxCountValidator,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
@@ -902,7 +901,7 @@ impl PipelineLayout {
         // as immediate data ranges are already validated to be within bounds,
         // and we validate that they are within the ranges.
 
-        if offset % wgt::IMMEDIATE_DATA_ALIGNMENT != 0 {
+        if !offset.is_multiple_of(wgt::IMMEDIATE_DATA_ALIGNMENT) {
             return Err(ImmediateUploadError::Unaligned(offset));
         }
 
@@ -1163,7 +1162,7 @@ impl BindGroup {
         {
             let (alignment, limit_name) =
                 buffer_binding_type_alignment(&self.device.limits, info.binding_type);
-            if offset as wgt::BufferAddress % alignment as u64 != 0 {
+            if !(offset as wgt::BufferAddress).is_multiple_of(alignment as u64) {
                 return Err(BindError::UnalignedDynamicBinding {
                     bind_group: self.error_ident(),
                     group: bind_group_index,

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -624,7 +624,7 @@ fn set_index_buffer(
     buffer.same_device(&state.device)?;
     buffer.check_usage(wgt::BufferUsages::INDEX)?;
 
-    if offset % u64::try_from(index_format.byte_size()).unwrap() != 0 {
+    if !offset.is_multiple_of(u64::try_from(index_format.byte_size()).unwrap()) {
         return Err(RenderCommandError::UnalignedIndexBuffer {
             offset,
             alignment: index_format.byte_size(),
@@ -672,7 +672,7 @@ fn set_vertex_buffer(
     buffer.same_device(&state.device)?;
     buffer.check_usage(wgt::BufferUsages::VERTEX)?;
 
-    if offset % wgt::VERTEX_ALIGNMENT != 0 {
+    if !offset.is_multiple_of(wgt::VERTEX_ALIGNMENT) {
         return Err(RenderCommandError::UnalignedVertexBuffer { slot, offset }.into());
     }
     let end = offset + buffer.resolve_binding_size(offset, size)?;

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -166,12 +166,12 @@ pub(super) fn clear_buffer(
     dst_buffer.check_usage(BufferUsages::COPY_DST)?;
 
     // Check if offset & size are valid.
-    if offset % wgt::COPY_BUFFER_ALIGNMENT != 0 {
+    if !offset.is_multiple_of(wgt::COPY_BUFFER_ALIGNMENT) {
         return Err(ClearError::UnalignedBufferOffset(offset));
     }
 
     let size = size.unwrap_or(dst_buffer.size.saturating_sub(offset));
-    if size % wgt::COPY_BUFFER_ALIGNMENT != 0 {
+    if !size.is_multiple_of(wgt::COPY_BUFFER_ALIGNMENT) {
         return Err(ClearError::UnalignedFillSize(size));
     }
     let end_offset =

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -882,7 +882,7 @@ fn dispatch_indirect(
 
     buffer.check_usage(wgt::BufferUsages::INDIRECT)?;
 
-    if offset % 4 != 0 {
+    if !offset.is_multiple_of(4) {
         return Err(ComputePassErrorInner::UnalignedIndirectBufferOffset(offset));
     }
 

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -427,7 +427,7 @@ pub(super) fn resolve_query_set(
     dst_buffer: Arc<Buffer>,
     destination_offset: BufferAddress,
 ) -> Result<(), QueryError> {
-    if destination_offset % wgt::QUERY_RESOLVE_BUFFER_ALIGNMENT != 0 {
+    if !destination_offset.is_multiple_of(wgt::QUERY_RESOLVE_BUFFER_ALIGNMENT) {
         return Err(QueryError::Resolve(ResolveError::BufferOffsetAlignment));
     }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2410,7 +2410,7 @@ fn set_index_buffer(
 
     buffer.check_usage(BufferUsages::INDEX)?;
 
-    if offset % u64::try_from(index_format.byte_size()).unwrap() != 0 {
+    if !offset.is_multiple_of(u64::try_from(index_format.byte_size()).unwrap()) {
         return Err(RenderCommandError::UnalignedIndexBuffer {
             offset,
             alignment: index_format.byte_size(),
@@ -2474,7 +2474,7 @@ fn set_vertex_buffer(
 
     buffer.check_usage(BufferUsages::VERTEX)?;
 
-    if offset % wgt::VERTEX_ALIGNMENT != 0 {
+    if !offset.is_multiple_of(wgt::VERTEX_ALIGNMENT) {
         return Err(RenderCommandError::UnalignedVertexBuffer { slot, offset }.into());
     }
     let (binding, buffer_size) = buffer
@@ -2781,7 +2781,7 @@ fn multi_draw_indirect(
     indirect_buffer.check_usage(BufferUsages::INDIRECT)?;
     indirect_buffer.check_destroyed(state.pass.base.snatch_guard)?;
 
-    if offset % 4 != 0 {
+    if !offset.is_multiple_of(4) {
         return Err(RenderPassErrorInner::UnalignedIndirectBufferOffset(offset));
     }
 
@@ -2991,7 +2991,7 @@ fn multi_draw_indirect_count(
     count_buffer.check_usage(BufferUsages::INDIRECT)?;
     let count_raw = count_buffer.try_raw(state.pass.base.snatch_guard)?;
 
-    if offset % 4 != 0 {
+    if !offset.is_multiple_of(4) {
         return Err(RenderPassErrorInner::UnalignedIndirectBufferOffset(offset));
     }
 

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -460,7 +460,7 @@ pub(crate) fn validate_texture_buffer_copy<T>(
             .expect("non-copyable formats should have been rejected previously")
     };
 
-    if aligned && layout.offset % u64::from(offset_alignment) != 0 {
+    if aligned && !layout.offset.is_multiple_of(u64::from(offset_alignment)) {
         return Err(TransferError::UnalignedBufferOffset(layout.offset));
     }
 
@@ -559,16 +559,16 @@ pub(crate) fn validate_texture_copy_range<T>(
         false, // partial copy always allowed on Z/layer dimension
     )?;
 
-    if texture_copy_view.origin.x % block_width != 0 {
+    if !texture_copy_view.origin.x.is_multiple_of(block_width) {
         return Err(TransferError::UnalignedCopyOriginX);
     }
-    if texture_copy_view.origin.y % block_height != 0 {
+    if !texture_copy_view.origin.y.is_multiple_of(block_height) {
         return Err(TransferError::UnalignedCopyOriginY);
     }
-    if copy_size.width % block_width != 0 {
+    if !copy_size.width.is_multiple_of(block_width) {
         return Err(TransferError::UnalignedCopyWidth);
     }
-    if copy_size.height % block_height != 0 {
+    if !copy_size.height.is_multiple_of(block_height) {
         return Err(TransferError::UnalignedCopyHeight);
     }
 
@@ -989,10 +989,10 @@ pub(super) fn copy_buffer_to_buffer(
     if size % wgt::COPY_BUFFER_ALIGNMENT != 0 {
         return Err(TransferError::UnalignedCopySize(size).into());
     }
-    if source_offset % wgt::COPY_BUFFER_ALIGNMENT != 0 {
+    if !source_offset.is_multiple_of(wgt::COPY_BUFFER_ALIGNMENT) {
         return Err(TransferError::UnalignedBufferOffset(source_offset).into());
     }
-    if destination_offset % wgt::COPY_BUFFER_ALIGNMENT != 0 {
+    if !destination_offset.is_multiple_of(wgt::COPY_BUFFER_ALIGNMENT) {
         return Err(TransferError::UnalignedBufferOffset(destination_offset).into());
     }
     if !state

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1059,7 +1059,6 @@ impl Global {
         (id, Some(error))
     }
 
-    #[allow(unused_unsafe)]
     /// # Safety
     ///
     /// This function passes source code or binary to the backend as-is and can potentially result in a

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -654,10 +654,10 @@ impl Queue {
             return Err(TransferError::BufferNotAvailable);
         }
         buffer.check_usage(wgt::BufferUsages::COPY_DST)?;
-        if buffer_size.get() % wgt::COPY_BUFFER_ALIGNMENT != 0 {
+        if !buffer_size.get().is_multiple_of(wgt::COPY_BUFFER_ALIGNMENT) {
             return Err(TransferError::UnalignedCopySize(buffer_size.get()));
         }
-        if buffer_offset % wgt::COPY_BUFFER_ALIGNMENT != 0 {
+        if !buffer_offset.is_multiple_of(wgt::COPY_BUFFER_ALIGNMENT) {
             return Err(TransferError::UnalignedBufferOffset(buffer_offset));
         }
         if buffer_offset + buffer_size.get() > buffer.size {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1015,7 +1015,7 @@ impl Device {
         }
 
         if desc.mapped_at_creation {
-            if desc.size % wgt::COPY_BUFFER_ALIGNMENT != 0 {
+            if !desc.size.is_multiple_of(wgt::COPY_BUFFER_ALIGNMENT) {
                 return Err(resource::CreateBufferError::UnalignedSize);
             }
             if !desc.usage.contains(wgt::BufferUsages::MAP_WRITE) {
@@ -1362,7 +1362,7 @@ impl Device {
         if desc.format.is_compressed() {
             let (block_width, block_height) = desc.format.block_dimensions();
 
-            if desc.size.width % block_width != 0 {
+            if !desc.size.width.is_multiple_of(block_width) {
                 return Err(CreateTextureError::InvalidDimension(
                     TextureDimensionError::NotMultipleOfBlockWidth {
                         width: desc.size.width,
@@ -1372,7 +1372,7 @@ impl Device {
                 ));
             }
 
-            if desc.size.height % block_height != 0 {
+            if !desc.size.height.is_multiple_of(block_height) {
                 return Err(CreateTextureError::InvalidDimension(
                     TextureDimensionError::NotMultipleOfBlockHeight {
                         height: desc.size.height,
@@ -1419,7 +1419,7 @@ impl Device {
                 height_multiple <<= desc.mip_level_count.saturating_sub(1);
             }
 
-            if desc.size.width % width_multiple != 0 {
+            if !desc.size.width.is_multiple_of(width_multiple) {
                 return Err(CreateTextureError::InvalidDimension(
                     TextureDimensionError::WidthNotMultipleOf {
                         width: desc.size.width,
@@ -1429,7 +1429,7 @@ impl Device {
                 ));
             }
 
-            if desc.size.height % height_multiple != 0 {
+            if !desc.size.height.is_multiple_of(height_multiple) {
                 return Err(CreateTextureError::InvalidDimension(
                     TextureDimensionError::HeightNotMultipleOf {
                         height: desc.size.height,
@@ -1822,7 +1822,7 @@ impl Device {
                 }
             }
             TextureViewDimension::CubeArray => {
-                if resolved_array_layer_count % 6 != 0 {
+                if !resolved_array_layer_count.is_multiple_of(6) {
                     return Err(
                         resource::CreateTextureViewError::InvalidCubemapArrayTextureDepth {
                             depth: resolved_array_layer_count,
@@ -2826,7 +2826,7 @@ impl Device {
 
         let (align, align_limit_name) =
             binding_model::buffer_binding_type_alignment(&self.limits, binding_ty);
-        if bb.offset % align as u64 != 0 {
+        if !bb.offset.is_multiple_of(align as u64) {
             return Err(Error::UnalignedBufferOffset(
                 bb.offset,
                 align_limit_name,
@@ -3610,7 +3610,10 @@ impl Device {
                 max: self.limits.max_immediate_size,
             });
         }
-        if desc.immediate_size % wgt::IMMEDIATE_DATA_ALIGNMENT != 0 {
+        if !desc
+            .immediate_size
+            .is_multiple_of(wgt::IMMEDIATE_DATA_ALIGNMENT)
+        {
             return Err(Error::MisalignedImmediateSize {
                 size: desc.immediate_size,
             });

--- a/wgpu-core/src/indirect_validation/dispatch.rs
+++ b/wgpu-core/src/indirect_validation/dispatch.rs
@@ -73,15 +73,10 @@ impl Dispatch {
         );
 
         // SAFETY: The value we are passing to `new_unchecked` is not zero, so this is safe.
-        const SRC_BUFFER_SIZE: NonZeroU64 =
-            unsafe { NonZeroU64::new_unchecked(size_of::<u32>() as u64 * 3) };
+        const SRC_BUFFER_SIZE: NonZeroU64 = NonZeroU64::new(size_of::<u32>() as u64 * 3).unwrap();
 
         // SAFETY: The value we are passing to `new_unchecked` is not zero, so this is safe.
-        const DST_BUFFER_SIZE: NonZeroU64 = unsafe {
-            NonZeroU64::new_unchecked(
-                SRC_BUFFER_SIZE.get() * 2, // From above: `dst: array<u32, 6>`
-            )
-        };
+        const DST_BUFFER_SIZE: NonZeroU64 = NonZeroU64::new(SRC_BUFFER_SIZE.get() * 2).unwrap();
 
         #[cfg(feature = "wgsl")]
         let module = naga::front::wgsl::parse_str(&src).map_err(|inner| {

--- a/wgpu-core/src/indirect_validation/draw.rs
+++ b/wgpu-core/src/indirect_validation/draw.rs
@@ -33,7 +33,7 @@ use wgt::Limits;
 ///
 /// - 65535 [`wgt::DrawIndirectArgs`] / [`MetadataEntry`]
 /// - 52428 [`wgt::DrawIndexedIndirectArgs`]
-const BUFFER_SIZE: wgt::BufferSize = unsafe { wgt::BufferSize::new_unchecked(1_048_560) };
+const BUFFER_SIZE: wgt::BufferSize = wgt::BufferSize::new(1_048_560).unwrap();
 
 /// Holds all device-level resources that are needed to validate indirect draws.
 ///

--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -248,7 +248,6 @@ where
 
 impl InitTracker<u32> {
     // Makes a single entry uninitialized if not already uninitialized
-    #[allow(dead_code)]
     pub(crate) fn discard(&mut self, pos: u32) {
         // first range where end>=idx
         let r_idx = self.uninitialized_ranges.partition_point(|r| r.end < pos);

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -810,7 +810,6 @@ impl Adapter {
         }
     }
 
-    #[allow(clippy::type_complexity)]
     fn create_device_and_queue_from_hal(
         self: &Arc<Self>,
         hal_device: hal::DynOpenDevice,

--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -360,7 +360,6 @@ struct ObservationLog {
     buffer: String,
 }
 
-#[allow(trivial_casts)]
 impl ObservationLog {
     /// Create an observation log in `dir` for the current pid and thread.
     fn create(dir: impl AsRef<Path>) -> Result<Self, std::io::Error> {

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -133,7 +133,6 @@ define_lock_ranks! {
     rank DEVICE_COMMAND_INDICES "Device::command_indices" followed by {}
     rank DEVICE_DEFERRED_DESTROY "Device::deferred_destroy" followed by {}
     rank DEVICE_FENCE "Device::fence" followed by { }
-    #[allow(dead_code)]
     rank DEVICE_TRACE "Device::trace" followed by { }
     rank DEVICE_TRACKERS "Device::trackers" followed by { }
     rank DEVICE_LOST_CLOSURE "Device::device_lost_closure" followed by { }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -585,7 +585,7 @@ impl Buffer {
             self.size.saturating_sub(offset)
         };
 
-        if offset % wgt::MAP_ALIGNMENT != 0 {
+        if !offset.is_multiple_of(wgt::MAP_ALIGNMENT) {
             return Err((op, BufferAccessError::UnalignedOffset { offset }));
         }
         if range_size % wgt::COPY_BUFFER_ALIGNMENT != 0 {
@@ -693,7 +693,7 @@ impl Buffer {
             self.size.saturating_sub(offset)
         };
 
-        if offset % wgt::MAP_ALIGNMENT != 0 {
+        if !offset.is_multiple_of(wgt::MAP_ALIGNMENT) {
             return Err(BufferAccessError::UnalignedOffset { offset });
         }
         if range_size % wgt::COPY_BUFFER_ALIGNMENT != 0 {

--- a/wgpu-core/src/track/metadata.rs
+++ b/wgpu-core/src/track/metadata.rs
@@ -43,7 +43,6 @@ impl<T: Clone> ResourceMetadata<T> {
     /// sanity checks of the presence of a refcount.
     ///
     /// In release mode this function is completely empty and is removed.
-    #[cfg_attr(not(feature = "strict_asserts"), allow(unused_variables))]
     pub(super) fn tracker_assert_in_bounds(&self, index: usize) {
         strict_assert!(index < self.owned.len());
         strict_assert!(index < self.resources.len());

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.82.0"
+rust-version = "1.90.0"
 
 [package.metadata.docs.rs]
 # Ideally we would enable all the features.

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -951,7 +951,6 @@ impl crate::CommandEncoder for super::CommandEncoder {
         });
 
         let list = self.list.as_ref().unwrap();
-        #[allow(trivial_casts)] // No other clean way to write the coercion inside .map() below?
         unsafe {
             list.OMSetRenderTargets(
                 desc.color_attachments.len() as u32,

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1336,7 +1336,7 @@ impl crate::Device for super::Device {
             // This is the last time we use this, but lets increment
             // it so if we add more later, the value behaves correctly.
 
-            // This is an allow as it doesn't trigger on 1.82, hal's MSRV.
+            // This is an allow as it doesn't trigger on 1.90, hal's MSRV.
             #[allow(unused_assignments)]
             {
                 bind_cbv.register += 1;

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -37,7 +37,6 @@ impl crate::Instance for super::Instance {
                     .flags
                     .intersects(wgt::InstanceFlags::GPU_BASED_VALIDATION)
                 {
-                    #[allow(clippy::collapsible_if)]
                     if let Ok(debug1) = debug_controller.cast::<Direct3D12::ID3D12Debug1>() {
                         unsafe { debug1.SetEnableGPUBasedValidation(true) }
                     } else {

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -227,7 +227,6 @@ impl super::CommandEncoder {
         }
     }
 
-    #[allow(clippy::clone_on_copy)] // False positive when cloning glow::UniformLocation
     fn set_pipeline_inner(&mut self, inner: &super::PipelineInner) {
         self.cmd_buffer.commands.push(C::SetProgram(inner.program));
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -335,7 +335,6 @@ struct Inner {
     /// Note: the context contains a dummy pbuffer (1x1).
     /// Required for `eglMakeCurrent` on platforms that doesn't supports `EGL_KHR_surfaceless_context`.
     egl: EglContext,
-    #[allow(unused)]
     version: (i32, i32),
     supports_native_window: bool,
     config: khronos_egl::Config,
@@ -888,7 +887,6 @@ impl crate::Instance for Instance {
         })
     }
 
-    #[cfg_attr(target_os = "macos", allow(unused, unused_mut, unreachable_code))]
     unsafe fn create_surface(
         &self,
         display_handle: raw_window_handle::RawDisplayHandle,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -407,7 +407,6 @@ pub struct Texture {
     pub mip_level_count: u32,
     pub array_layer_count: u32,
     pub format: wgt::TextureFormat,
-    #[allow(unused)]
     pub format_desc: TextureFormatDesc,
     pub copy_size: CopyExtent,
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2031,7 +2031,7 @@ impl TextureDescriptor<'_> {
 
     pub fn is_cube_compatible(&self) -> bool {
         self.dimension == wgt::TextureDimension::D2
-            && self.size.depth_or_array_layers % 6 == 0
+            && self.size.depth_or_array_layers.is_multiple_of(6)
             && self.sample_count == 1
             && self.size.width == self.size.height
     }
@@ -2336,7 +2336,6 @@ impl fmt::Debug for NagaShader {
 }
 
 /// Shader input.
-#[allow(clippy::large_enum_variant)]
 pub enum ShaderInput<'a> {
     Naga(NagaShader),
     Msl {

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -284,7 +284,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         if self.device.workarounds.contains(
             super::Workarounds::FORCE_FILL_BUFFER_WITH_SIZE_GREATER_4096_ALIGNED_OFFSET_16,
         ) && range_size >= 4096
-            && range.start % 16 != 0
+            && !range.start.is_multiple_of(16)
         {
             let rounded_start = wgt::math::align_to(range.start, 16);
             let prefix_size = rounded_start - range.start;

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -1044,7 +1044,6 @@ pub struct CommandBuffer {
 impl crate::DynCommandBuffer for CommandBuffer {}
 
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum ShaderModule {
     Raw(vk::ShaderModule),
     Intermediate {

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.82.0"
+rust-version = "1.90.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
[Firefox bug 1975583](https://bugzilla.mozilla.org/show_bug.cgi?id=1975583) upgrades the MSRV to 1.90, let's gooo!

See also <https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html#schedule>.