### PR TITLE
fix(naga): Validate swizzles in lowering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Bottom level categories:
 - Fixed validation of the texture format in GPUDepthStencilState when neither depth nor stencil is actually enabled. By @andyleiserson in [#8766](https://github.com/gfx-rs/wgpu/pull/8766).
 - Check that depth bias is not used with non-triangle topologies. By @andyleiserson in [#8856](https://github.com/gfx-rs/wgpu/pull/8856).
 - Check that if the shader outputs `frag_depth`, then the pipeline must have a depth attachment. By @andyleiserson in [#8856](https://github.com/gfx-rs/wgpu/pull/8856).
+- Fix incorrect acceptance of some swizzle selectors that are not valid for their operand, e.g. `const v = vec2<i32>(); let r = v.xyz`. By @andyleiserson in [#8949](https://github.com/gfx-rs/wgpu/pull/8949).
 
 #### GLES
 

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -46,6 +46,10 @@ pub enum PipelineConstantError {
 
 /// Compact `module` and replace all overrides with constants.
 ///
+/// `module` must be valid. Both compaction and constant evaluation may produce
+/// invalid results (e.g. replace an invalid expression with a constant) for
+/// invalid modules.
+///
 /// If no changes are needed, this just returns `Cow::Borrowed` references to
 /// `module` and `module_info`. Otherwise, it clones `module`, retains only the
 /// selected entry point, compacts the module, edits its [`global_expressions`]

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2490,9 +2490,14 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
                         lowered_base.map(|base| ir::Expression::AccessIndex { base, index })
                     }
-                    ir::TypeInner::Vector { .. } => {
+                    ir::TypeInner::Vector { size: vec_size, .. } => {
                         match Components::new(field.name, field.span)? {
                             Components::Swizzle { size, pattern } => {
+                                for &component in pattern[..size as usize].iter() {
+                                    if component as u8 >= vec_size as u8 {
+                                        return Err(Box::new(Error::BadAccessor(field.span)));
+                                    }
+                                }
                                 Typed::Plain(ir::Expression::Swizzle {
                                     size,
                                     vector: ctx.apply_load_rule(lowered_base)?,
@@ -2500,6 +2505,9 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                 })
                             }
                             Components::Single(index) => {
+                                if index >= vec_size as u32 {
+                                    return Err(Box::new(Error::BadAccessor(field.span)));
+                                }
                                 lowered_base.map(|base| ir::Expression::AccessIndex { base, index })
                             }
                         }

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -3500,6 +3500,45 @@ fn only_one_swizzle_type() {
 }
 
 #[test]
+fn swizzle_oob() {
+    // 3-component swizzle from const vec2
+    check(
+        "
+        @compute @workgroup_size(1)
+        fn main() {
+            const v = vec2<i32>();
+            let r : vec3<i32> = v.xyz;
+        }
+        ",
+        r###"error: invalid field accessor `xyz`
+  ┌─ wgsl:5:35
+  │
+5 │             let r : vec3<i32> = v.xyz;
+  │                                   ^^^ invalid accessor
+
+"###,
+    );
+
+    // 4-component swizzle from non-const vec3
+    check(
+        "
+        @compute @workgroup_size(1)
+        fn main() {
+            var v = vec3<i32>();
+            let r : vec4<i32> = v.xyzw;
+        }
+        ",
+        r###"error: invalid field accessor `xyzw`
+  ┌─ wgsl:5:35
+  │
+5 │             let r : vec4<i32> = v.xyzw;
+  │                                   ^^^^ invalid accessor
+
+"###,
+    );
+}
+
+#[test]
 fn const_assert_must_be_const() {
     check(
         "


### PR DESCRIPTION
The validator checks swizzle expressions, but the constant evaluator does not (*), so we need to check them in lowering to avoid producing incorrect results.

(*) In the general case it does, but if the operand of the swizzle is a `ZeroValue` or a `Splat`, it resolves the swizzle using the scalar without checking that the selector is valid for the operand.

I went back and forth whether to fix this in lowering, in the constant evaluator, or both. I went with lowering because (1) detecting non-const invalid swizzles in the front-end is also useful, to produce better error messages, (2) the change to constant evaluation was annoyingly verbose and we anticipate changes to constant evaluation (for #8440 and similar issues).

I also add a note on `process_overrides` that the module must be valid. Since `process_overrides` now uses both compaction and constant evaluation, it would acquire a valid-module restriction from compaction even if not needed for constant evaluation. But I feel like this may not be the only place where constant evaluation is relying on checks elsewhere in the frontend to catch illegal input. Related: #7464.

**Testing**
Adds `wgsl_errors` tests. This is also covered by CTS tests under `webgpu:shader,validation,expression,access,vector:*`, but those remain failing due to #4390.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
