### PR TITLE
metal: Use `objc2::available!` macro 

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -9,7 +9,7 @@ use wgt::{AstcBlock, AstcChannel};
 
 use alloc::{string::ToString as _, sync::Arc, vec::Vec};
 
-use super::TimestampQuerySupport;
+use super::{OsFeatures, TimestampQuerySupport};
 
 /// Maximum number of command buffers for `MTLCommandQueue`s that we create.
 ///
@@ -375,19 +375,24 @@ impl crate::Adapter for super::Adapter {
             formats.push(wgt::TextureFormat::Rgb10a2Unorm);
         }
 
-        let pc = &self.shared.private_caps;
         Some(crate::SurfaceCapabilities {
             formats,
             // We use this here to govern the maximum number of drawables + 1.
-            // See https://developer.apple.com/documentation/quartzcore/cametallayer/2938720-maximumdrawablecount
-            maximum_frame_latency: if pc.can_set_maximum_drawables_count {
+            // See https://developer.apple.com/documentation/quartzcore/cametallayer/maximumdrawablecount
+            maximum_frame_latency: if available!(
+                macos = 10.13.2,
+                ios = 11.2,
+                tvos = 11.2,
+                visionos = 1.0
+            ) {
                 1..=2
             } else {
                 // 3 is the default value for maximum drawables in `CAMetalLayer` documentation
                 // iOS 10.3 was tested to use 3 on iphone5s
                 2..=2
             },
-            present_modes: if pc.can_set_display_sync {
+            // We enable Immediate mode using `-[CAMetalLayer setDisplaySyncEnabled: false]`.
+            present_modes: if OsFeatures::display_sync() {
                 vec![wgt::PresentMode::Fifo, wgt::PresentMode::Immediate]
             } else {
                 vec![wgt::PresentMode::Fifo]
@@ -883,29 +888,6 @@ impl super::PrivateCapabilities {
                 && (metal3
                     || device.supportsFamily(MTLGPUFamily::Apple3)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
-            // https://developer.apple.com/documentation/metal/mtlcapturemanager
-            supports_capture_manager: available!(
-                macos = 10.13,
-                ios = 11.0,
-                tvos = 11.0,
-                visionos = 1.0
-            ),
-            // https://developer.apple.com/documentation/quartzcore/cametallayer/maximumdrawablecount
-            can_set_maximum_drawables_count: available!(
-                macos = 10.14,
-                ios = 11.2,
-                tvos = 11.2,
-                visionos = 1.0
-            ),
-            // https://developer.apple.com/documentation/quartzcore/cametallayer/displaysyncenabled
-            can_set_display_sync: available!(macos = 10.13) || cfg!(target_env = "macabi"),
-            // https://developer.apple.com/documentation/quartzcore/cametallayer/allowsnextdrawabletimeout
-            can_set_next_drawable_timeout: available!(
-                macos = 10.13,
-                ios = 11.0,
-                tvos = 11.0,
-                visionos = 1.0
-            ),
             // This is just trusted blindly since docs referencing supports_any have been removed
             // but we don't want to remove feature support.
             supports_arrays_of_textures: Self::supports_any(
@@ -921,18 +903,9 @@ impl super::PrivateCapabilities {
                 && (metal3
                     || device.supportsFamily(MTLGPUFamily::Apple6)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
-            // https://developer.apple.com/documentation/metal/mtlpipelinebufferdescriptor/mutability
-            supports_mutability: available!(macos = 10.13, ios = 11.0, tvos = 11.0, visionos = 1.0),
             // Depth clipping is supported on all macOS GPU families and iOS family 4 and later
             supports_depth_clip_control: os_type == super::OsType::Macos
                 || device.supportsFeatureSet(MTLFeatureSet::iOS_GPUFamily4_v1),
-            // https://developer.apple.com/documentation/metal/mtlcompileoptions/preserveinvariance
-            supports_preserve_invariance: available!(
-                macos = 11.0,
-                ios = 13.0,
-                tvos = 14.0,
-                visionos = 1.0
-            ),
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=4
             supports_shader_primitive_index: family_check
                 && (metal3
@@ -966,13 +939,6 @@ impl super::PrivateCapabilities {
                 && (metal3
                     || device.supportsFamily(MTLGPUFamily::Apple7)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
-            // https://developer.apple.com/documentation/metal/mtlsharedevent
-            supports_shared_event: available!(
-                macos = 10.14,
-                ios = 12.0,
-                tvos = 12.0,
-                visionos = 1.0
-            ),
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=5 (footnote)
             // Supported on some Metal4, Apple7, Mac2, and some other platforms can be queried with device.supportsShaderBarycentricCoordinates().
             shader_barycentrics: metal4

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1,4 +1,4 @@
-use objc2::runtime::ProtocolObject;
+use objc2::{available, runtime::ProtocolObject};
 use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};
 use objc2_metal::{
     MTLArgumentBuffersTier, MTLCounterSamplingPoint, MTLDevice, MTLFeatureSet, MTLGPUFamily,
@@ -519,8 +519,6 @@ const DEPTH_CLIP_MODE: &[MTLFeatureSet] = &[
     MTLFeatureSet::macOS_GPUFamily1_v1,
 ];
 
-const OS_NOT_SUPPORT: (isize, isize) = (10000, 0);
-
 impl super::PrivateCapabilities {
     fn supports_any(raw: &ProtocolObject<dyn MTLDevice>, features_sets: &[MTLFeatureSet]) -> bool {
         features_sets
@@ -529,11 +527,35 @@ impl super::PrivateCapabilities {
             .any(|x| raw.supportsFeatureSet(x))
     }
 
+    /// Query the capabilities of the device.
     pub fn new(device: &ProtocolObject<dyn MTLDevice>) -> Self {
-        let version = NSProcessInfo::processInfo().operatingSystemVersion();
+        // There are four different OSes we can target: macOS, iOS, tvOS and
+        // visionOS. This can be detected using `cfg!(target_os = "ios")`, or
+        // more conveniently using the `available!(...)` macro, which also
+        // checks that the OS version that the binary is currently running on
+        // is higher than or equal to the specified version.
+        //
+        // Along with the different OSes, there is also two other modes that
+        // applications can run in: the Simulator, and Mac Catalyst. This can
+        // be detected using `cfg!(target_env = "sim")` or
+        // `cfg!(target_env = "macabi")`.
+        //
+        // Finally, iOS applications can be run on macOS and visionOS directly
+        // using the "Designed for iPad" mode. This cannot be detected at
+        // compile-time.
+        //
+        // All of this means that it only makes sense to use `cfg!(...)` and
+        // `available!(...)` in here to check which Metal APIs are available;
+        // we cannot rely on it for knowing properties of the device. For
+        // that, we'll want to use `supportsFeatureSet` or `supportsFamily`.
+        //
+        // See the following link for further details:
+        // https://developer.apple.com/documentation/metal/developing-metal-apps-that-run-in-simulator
 
+        let version = NSProcessInfo::processInfo().operatingSystemVersion();
         let os_type = super::OsType::new(version, device);
-        let family_check = version.at_least((10, 15), (13, 0), (13, 0), (1, 0), os_type);
+
+        let family_check = available!(macos = 10.15, ios = 13.0, tvos = 13.0, visionos = 1.0);
         let metal3 = family_check && device.supportsFamily(MTLGPUFamily::Metal3);
         let metal4 = family_check && device.supportsFamily(MTLGPUFamily::Metal4);
         let mut sample_count_mask = crate::TextureFormatCapabilities::MULTISAMPLE_X4; // 1 and 4 samples are supported on all devices
@@ -547,15 +569,10 @@ impl super::PrivateCapabilities {
             sample_count_mask |= crate::TextureFormatCapabilities::MULTISAMPLE_X16;
         }
 
-        let rw_texture_tier = if version.at_least((10, 13), (11, 0), (11, 0), (1, 0), os_type) {
+        let rw_texture_tier = if available!(macos = 10.13, ios = 11.0, tvos = 11.0, visionos = 1.0)
+        {
             device.readWriteTextureSupport()
-        } else if version.at_least(
-            (10, 12),
-            OS_NOT_SUPPORT,
-            OS_NOT_SUPPORT,
-            OS_NOT_SUPPORT,
-            os_type,
-        ) {
+        } else if available!(macos = 10.12) {
             if Self::supports_any(device, &[MTLFeatureSet::macOS_ReadWriteTextureTier2]) {
                 MTLReadWriteTextureTier::Tier2
             } else {
@@ -566,7 +583,7 @@ impl super::PrivateCapabilities {
         };
 
         let mut timestamp_query_support = TimestampQuerySupport::empty();
-        if version.at_least((11, 0), (14, 0), (14, 0), (1, 0), os_type)
+        if available!(macos = 11.0, ios = 14.0, tvos = 14.0, visionos = 1.0)
             && device.supportsCounterSampling(MTLCounterSamplingPoint::AtStageBoundary)
         {
             // If we don't support at stage boundary, don't support anything else.
@@ -584,8 +601,7 @@ impl super::PrivateCapabilities {
             // `TimestampQuerySupport::INSIDE_WGPU_PASSES` emerges from the other flags.
         }
 
-        let argument_buffers = version
-            .at_least((10, 13), (11, 0), (11, 0), (1, 0), os_type)
+        let argument_buffers = available!(macos = 10.13, ios = 11.0, tvos = 11.0, visionos = 1.0)
             .then(|| device.argumentBuffersSupport());
 
         let is_virtual = device.name().to_string().to_lowercase().contains("virtual");
@@ -597,23 +613,23 @@ impl super::PrivateCapabilities {
                     // Mesh shaders don't work on virtual devices even if they should be supported. CI thing
                 && !is_virtual;
 
-        let msl_version = if version.at_least((14, 0), (17, 0), (17, 0), (1, 0), os_type) {
+        let msl_version = if available!(macos = 14.0, ios = 17.0, tvos = 17.0, visionos = 1.0) {
             MTLLanguageVersion::Version3_1
-        } else if version.at_least((13, 0), (16, 0), (16, 0), (1, 0), os_type) {
+        } else if available!(macos = 13.0, ios = 16.0, tvos = 16.0, visionos = 1.0) {
             MTLLanguageVersion::Version3_0
-        } else if version.at_least((12, 0), (15, 0), (15, 0), (1, 0), os_type) {
+        } else if available!(macos = 12.0, ios = 15.0, tvos = 15.0, visionos = 1.0) {
             MTLLanguageVersion::Version2_4
-        } else if version.at_least((11, 0), (14, 0), (14, 0), (1, 0), os_type) {
+        } else if available!(macos = 11.0, ios = 14.0, tvos = 14.0, visionos = 1.0) {
             MTLLanguageVersion::Version2_3
-        } else if version.at_least((10, 15), (13, 0), (13, 0), (1, 0), os_type) {
+        } else if available!(macos = 10.15, ios = 13.0, tvos = 13.0, visionos = 1.0) {
             MTLLanguageVersion::Version2_2
-        } else if version.at_least((10, 14), (12, 0), (12, 0), (1, 0), os_type) {
+        } else if available!(macos = 10.14, ios = 12.0, tvos = 12.0, visionos = 1.0) {
             MTLLanguageVersion::Version2_1
-        } else if version.at_least((10, 13), (11, 0), (11, 0), (1, 0), os_type) {
+        } else if available!(macos = 10.13, ios = 11.0, tvos = 11.0, visionos = 1.0) {
             MTLLanguageVersion::Version2_0
-        } else if version.at_least((10, 12), (10, 0), (10, 0), (1, 0), os_type) {
+        } else if available!(macos = 10.12, ios = 10.0, tvos = 10.0, visionos = 1.0) {
             MTLLanguageVersion::Version1_2
-        } else if version.at_least((10, 11), (9, 0), (9, 0), (1, 0), os_type) {
+        } else if available!(macos = 10.11, ios = 9.0, tvos = 9.0, visionos = 1.0) {
             MTLLanguageVersion::Version1_1
         } else {
             MTLLanguageVersion::Version1_0
@@ -627,7 +643,7 @@ impl super::PrivateCapabilities {
         Self {
             msl_version,
             // macOS 10.11 doesn't support read-write resources
-            fragment_rw_storage: version.at_least((10, 12), (8, 0), (8, 0), (1, 0), os_type),
+            fragment_rw_storage: available!(macos = 10.12, ios = 8.0, tvos = 8.0, visionos = 1.0),
             read_write_texture_tier: rw_texture_tier,
             msaa_desktop: os_type == super::OsType::Macos,
             msaa_apple3: (family_check && device.supportsFamily(MTLGPUFamily::Apple3))
@@ -653,7 +669,7 @@ impl super::PrivateCapabilities {
             depth_clip_mode: Self::supports_any(device, DEPTH_CLIP_MODE),
             texture_cube_array: Self::supports_any(device, TEXTURE_CUBE_ARRAY_SUPPORT),
             supports_float_filtering: os_type == super::OsType::Macos
-                || (version.at_least((11, 0), (14, 0), (16, 0), (1, 0), os_type)
+                || (available!(macos = 11.0, ios = 14.0, tvos = 16.0, visionos = 1.0)
                     && device.supports32BitFloatFiltering()),
             format_depth24_stencil8: os_type == super::OsType::Macos
                 && device.isDepth24Stencil8PixelFormatSupported(),
@@ -718,7 +734,7 @@ impl super::PrivateCapabilities {
             // Only macOS support rgba32float's all capabilities
             format_rgba32float_all: os_type == super::OsType::Macos,
             // https://developer.apple.com/documentation/metal/mtlpixelformat/depth16unorm
-            format_depth16unorm: version.at_least((10, 12), (13, 0), (13, 0), (1, 0), os_type),
+            format_depth16unorm: available!(macos = 10.12, ios = 13.0, tvos = 13.0, visionos = 1.0),
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=12
             format_depth16unorm_filter: family_check
                 && (metal3
@@ -767,7 +783,7 @@ impl super::PrivateCapabilities {
             } else {
                 64
             },
-            max_buffer_size: if version.at_least((10, 14), (12, 0), (12, 0), (1, 0), os_type) {
+            max_buffer_size: if available!(macos = 10.14, ios = 12.0, tvos = 12.0, visionos = 1.0) {
                 device.maxBufferLength() as u64
             } else if os_type == super::OsType::Macos {
                 1 << 30 // 1GB on macOS 10.11 and up
@@ -868,30 +884,27 @@ impl super::PrivateCapabilities {
                     || device.supportsFamily(MTLGPUFamily::Apple3)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
             // https://developer.apple.com/documentation/metal/mtlcapturemanager
-            supports_capture_manager: version.at_least((10, 13), (11, 0), (11, 0), (1, 0), os_type),
+            supports_capture_manager: available!(
+                macos = 10.13,
+                ios = 11.0,
+                tvos = 11.0,
+                visionos = 1.0
+            ),
             // https://developer.apple.com/documentation/quartzcore/cametallayer/maximumdrawablecount
-            can_set_maximum_drawables_count: version.at_least(
-                (10, 14),
-                (11, 2),
-                (11, 2),
-                (1, 0),
-                os_type,
+            can_set_maximum_drawables_count: available!(
+                macos = 10.14,
+                ios = 11.2,
+                tvos = 11.2,
+                visionos = 1.0
             ),
             // https://developer.apple.com/documentation/quartzcore/cametallayer/displaysyncenabled
-            can_set_display_sync: version.at_least(
-                (10, 13),
-                OS_NOT_SUPPORT,
-                OS_NOT_SUPPORT,
-                OS_NOT_SUPPORT,
-                os_type,
-            ),
+            can_set_display_sync: available!(macos = 10.13) || cfg!(target_env = "macabi"),
             // https://developer.apple.com/documentation/quartzcore/cametallayer/allowsnextdrawabletimeout
-            can_set_next_drawable_timeout: version.at_least(
-                (10, 13),
-                (11, 0),
-                (11, 0),
-                (1, 0),
-                os_type,
+            can_set_next_drawable_timeout: available!(
+                macos = 10.13,
+                ios = 11.0,
+                tvos = 11.0,
+                visionos = 1.0
             ),
             // This is just trusted blindly since docs referencing supports_any have been removed
             // but we don't want to remove feature support.
@@ -909,17 +922,16 @@ impl super::PrivateCapabilities {
                     || device.supportsFamily(MTLGPUFamily::Apple6)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
             // https://developer.apple.com/documentation/metal/mtlpipelinebufferdescriptor/mutability
-            supports_mutability: version.at_least((10, 13), (11, 0), (11, 0), (1, 0), os_type),
+            supports_mutability: available!(macos = 10.13, ios = 11.0, tvos = 11.0, visionos = 1.0),
             // Depth clipping is supported on all macOS GPU families and iOS family 4 and later
             supports_depth_clip_control: os_type == super::OsType::Macos
                 || device.supportsFeatureSet(MTLFeatureSet::iOS_GPUFamily4_v1),
             // https://developer.apple.com/documentation/metal/mtlcompileoptions/preserveinvariance
-            supports_preserve_invariance: version.at_least(
-                (11, 0),
-                (14, 0),
-                (14, 0),
-                (1, 0),
-                os_type,
+            supports_preserve_invariance: available!(
+                macos = 11.0,
+                ios = 13.0,
+                tvos = 14.0,
+                visionos = 1.0
             ),
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=4
             supports_shader_primitive_index: family_check
@@ -927,7 +939,8 @@ impl super::PrivateCapabilities {
                     || device.supportsFamily(MTLGPUFamily::Apple7)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
             // https://developer.apple.com/documentation/metal/mtldevice/hasunifiedmemory
-            has_unified_memory: if version.at_least((10, 15), (13, 0), (13, 0), (1, 0), os_type) {
+            has_unified_memory: if available!(macos = 15.0, ios = 13.0, tvos = 13.0, visionos = 1.0)
+            {
                 Some(device.hasUnifiedMemory())
             } else {
                 None
@@ -954,14 +967,19 @@ impl super::PrivateCapabilities {
                     || device.supportsFamily(MTLGPUFamily::Apple7)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
             // https://developer.apple.com/documentation/metal/mtlsharedevent
-            supports_shared_event: version.at_least((10, 14), (12, 0), (12, 0), (1, 0), os_type),
+            supports_shared_event: available!(
+                macos = 10.14,
+                ios = 12.0,
+                tvos = 12.0,
+                visionos = 1.0
+            ),
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=5 (footnote)
             // Supported on some Metal4, Apple7, Mac2, and some other platforms can be queried with device.supportsShaderBarycentricCoordinates().
             shader_barycentrics: metal4
                 || (family_check
                     && (device.supportsFamily(MTLGPUFamily::Apple7)
                         || device.supportsFamily(MTLGPUFamily::Mac2)))
-                || (version.at_least((10, 15), (14, 0), (16, 0), (1, 0), os_type)
+                || (available!(macos = 10.15, ios = 14.0, tvos = 16.0, visionos = 1.0)
                     && device.supportsShaderBarycentricCoordinates()),
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=3
             // See https://github.com/gfx-rs/wgpu/pull/8725 for more details
@@ -973,26 +991,18 @@ impl super::PrivateCapabilities {
                     // macOS: Always rely on family check
                     // iOS/tvOS: API added in 10.0
                     // visionOS: Always rely on family check
-                    version.at_least(OS_NOT_SUPPORT, (10, 0), (10, 0), OS_NOT_SUPPORT, os_type)
+                    available!(ios = 10.0, tvos = 10.0)
                 },
             supported_vertex_amplification_factor: {
                 let mut factor = 1;
-                // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=8
-                // The table specifies either none, 2, 8, or unsupported, implying it is a relatively small power of 2
-                // The bitmask only uses 32 bits, so it can't be higher even if the device for some reason claims to support that.
-                while factor < 32
-                    // See https://developer.apple.com/documentation/metal/mtldevice/supportsvertexamplificationcount(_:)
-                    && version.at_least(
-                        // "10.15.4" so we're taking the conservative route.
-                        (10, 16),
-                        (13, 0),
-                        (16, 0),
-                        (1, 0),
-                        os_type,
-                    )
-                    && device.supportsVertexAmplificationCount(factor * 2)
-                {
-                    factor *= 2
+                // https://developer.apple.com/documentation/metal/mtldevice/supportsvertexamplificationcount(_:)
+                if available!(macos = 10.15.4, ios = 13.0, tvos = 16.0, visionos = 1.0) {
+                    // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=8
+                    // The table specifies either none, 2, 8, or unsupported, implying it is a relatively small power of 2
+                    // The bitmask only uses 32 bits, so it can't be higher even if the device for some reason claims to support that.
+                    while factor < 32 && device.supportsVertexAmplificationCount(factor * 2) {
+                        factor *= 2
+                    }
                 }
                 factor as u32
             },
@@ -1509,35 +1519,5 @@ impl super::OsType {
         } else {
             Self::Ios
         }
-    }
-}
-
-trait AtLeast {
-    fn at_least(
-        &self,
-        mac_version: (isize, isize),
-        ios_version: (isize, isize),
-        tvos_version: (isize, isize),
-        visionos_version: (isize, isize),
-        os_type: super::OsType,
-    ) -> bool;
-}
-
-impl AtLeast for NSOperatingSystemVersion {
-    fn at_least(
-        &self,
-        mac_version: (isize, isize),
-        ios_version: (isize, isize),
-        tvos_version: (isize, isize),
-        visionos_version: (isize, isize),
-        os_type: super::OsType,
-    ) -> bool {
-        let required = match os_type {
-            super::OsType::Macos => mac_version,
-            super::OsType::Ios => ios_version,
-            super::OsType::Tvos => tvos_version,
-            super::OsType::VisionOs => visionos_version,
-        };
-        (self.majorVersion, self.minorVersion) >= required
     }
 }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -3,7 +3,7 @@ use core::{ptr::NonNull, sync::atomic};
 use std::{thread, time};
 
 use objc2::{
-    msg_send,
+    available, msg_send,
     rc::{autoreleasepool, Retained},
     runtime::ProtocolObject,
 };
@@ -221,7 +221,8 @@ impl super::Device {
                 let options = MTLCompileOptions::new();
                 options.setLanguageVersion(self.shared.private_caps.msl_version);
 
-                if self.shared.private_caps.supports_preserve_invariance {
+                // https://developer.apple.com/documentation/metal/mtlcompileoptions/preserveinvariance
+                if available!(macos = 11.0, ios = 13.0, tvos = 14.0, visionos = 1.0) {
                     options.setPreserveInvariance(true);
                 }
 
@@ -1183,6 +1184,10 @@ impl crate::Device for super::Device {
                 }
             }
 
+            // https://developer.apple.com/documentation/metal/mtlpipelinebufferdescriptor/mutability
+            let supports_mutability =
+                available!(macos = 10.13, ios = 11.0, tvos = 11.0, visionos = 1.0);
+
             let (primitive_class, raw_primitive_type) =
                 conv::map_primitive_topology(desc.primitive.topology);
 
@@ -1253,7 +1258,8 @@ impl crate::Device for super::Device {
                         )?;
 
                         descriptor.setVertexFunction(Some(&vs.function));
-                        if self.shared.private_caps.supports_mutability {
+
+                        if supports_mutability {
                             Self::set_buffers_mutability(
                                 &descriptor.vertexBuffers(),
                                 vs.immutable_buffer_mask,
@@ -1357,7 +1363,7 @@ impl crate::Device for super::Device {
                             naga::ShaderStage::Task,
                         )?;
                         unsafe { descriptor.setObjectFunction(Some(&ts.function)) };
-                        if self.shared.private_caps.supports_mutability {
+                        if supports_mutability {
                             Self::set_buffers_mutability(
                                 &descriptor.meshBuffers(),
                                 ts.immutable_buffer_mask,
@@ -1386,7 +1392,7 @@ impl crate::Device for super::Device {
                             naga::ShaderStage::Mesh,
                         )?;
                         unsafe { descriptor.setMeshFunction(Some(&ms.function)) };
-                        if self.shared.private_caps.supports_mutability {
+                        if supports_mutability {
                             Self::set_buffers_mutability(
                                 &descriptor.meshBuffers(),
                                 ms.immutable_buffer_mask,
@@ -1428,7 +1434,7 @@ impl crate::Device for super::Device {
                     )?;
 
                     unsafe { descriptor.setFragmentFunction(Some(&fs.function)) };
-                    if self.shared.private_caps.supports_mutability {
+                    if supports_mutability {
                         Self::set_buffers_mutability(
                             &descriptor.fragmentBuffers(),
                             fs.immutable_buffer_mask,
@@ -1628,7 +1634,8 @@ impl crate::Device for super::Device {
 
             descriptor.setComputeFunction(Some(&cs.function));
 
-            if self.shared.private_caps.supports_mutability {
+            // https://developer.apple.com/documentation/metal/mtlpipelinebufferdescriptor/mutability
+            if available!(macos = 10.13, ios = 11.0, tvos = 11.0, visionos = 1.0) {
                 Self::set_buffers_mutability(&descriptor.buffers(), cs.immutable_buffer_mask);
             }
 
@@ -1761,7 +1768,8 @@ impl crate::Device for super::Device {
 
     unsafe fn create_fence(&self) -> DeviceResult<super::Fence> {
         self.counters.fences.add(1);
-        let shared_event = if self.shared.private_caps.supports_shared_event {
+        // https://developer.apple.com/documentation/metal/mtlsharedevent
+        let shared_event = if available!(macos = 10.14, ios = 12.0, tvos = 12.0, visionos = 1.0) {
             Some(self.shared.device.newSharedEvent().unwrap())
         } else {
             None
@@ -1823,7 +1831,8 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn start_graphics_debugger_capture(&self) -> bool {
-        if !self.shared.private_caps.supports_capture_manager {
+        // https://developer.apple.com/documentation/metal/mtlcapturemanager
+        if !available!(macos = 10.13, ios = 11.0, tvos = 11.0, visionos = 1.0) {
             return false;
         }
         let device = &self.shared.device;

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -37,6 +37,7 @@ use bitflags::bitflags;
 use hashbrown::HashMap;
 use naga::FastHashMap;
 use objc2::{
+    available,
     rc::{autoreleasepool, Retained},
     runtime::ProtocolObject,
 };
@@ -113,6 +114,21 @@ crate::impl_dyn_resource!(
     Texture,
     TextureView
 );
+
+/// Provides availability information about Mac APIs.
+///
+/// This may include Metal features that depend only on software support.
+/// Features with varying hardware support are in [`PrivateCapabilities`]
+///
+/// When feature detection is only needed once, it may also be done inline.
+struct OsFeatures;
+
+impl OsFeatures {
+    fn display_sync() -> bool {
+        // https://developer.apple.com/documentation/quartzcore/cametallayer/displaysyncenabled
+        available!(macos = 10.13) || cfg!(target_abi = "macabi")
+    }
+}
 
 pub struct Instance {}
 
@@ -317,15 +333,9 @@ struct PrivateCapabilities {
     sample_count_mask: crate::TextureFormatCapabilities,
     supports_debug_markers: bool,
     supports_binary_archives: bool,
-    supports_capture_manager: bool,
-    can_set_maximum_drawables_count: bool,
-    can_set_display_sync: bool,
-    can_set_next_drawable_timeout: bool,
     supports_arrays_of_textures: bool,
     supports_arrays_of_textures_write: bool,
-    supports_mutability: bool,
     supports_depth_clip_control: bool,
-    supports_preserve_invariance: bool,
     supports_shader_primitive_index: bool,
     has_unified_memory: Option<bool>,
     timestamp_query_support: TimestampQuerySupport,
@@ -335,7 +345,6 @@ struct PrivateCapabilities {
     int64_atomics_min_max: bool,
     int64_atomics: bool,
     float_atomics: bool,
-    supports_shared_event: bool,
     mesh_shaders: bool,
     max_mesh_task_workgroup_count: u32,
     max_task_payload_size: u32,

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,6 +1,7 @@
 use alloc::borrow::ToOwned as _;
 
 use objc2::{
+    available,
     rc::{autoreleasepool, Retained},
     runtime::ProtocolObject,
     ClassType, Message,
@@ -10,6 +11,8 @@ use objc2_foundation::NSObjectProtocol;
 use objc2_metal::MTLTextureType;
 use objc2_quartz_core::{CAMetalDrawable, CAMetalLayer};
 use parking_lot::{Mutex, RwLock};
+
+use super::OsFeatures;
 
 impl super::Surface {
     pub fn new(layer: Retained<CAMetalLayer>) -> Self {
@@ -95,10 +98,11 @@ impl crate::Surface for super::Surface {
         // this gets ignored on iOS for certain OS/device combinations (iphone5s iOS 10.3)
         render_layer.setMaximumDrawableCount(config.maximum_frame_latency as usize + 1);
         render_layer.setDrawableSize(drawable_size);
-        if caps.can_set_next_drawable_timeout {
+        // https://developer.apple.com/documentation/quartzcore/cametallayer/allowsnextdrawabletimeout
+        if available!(macos = 10.13, ios = 11.0, tvos = 11.0, visionos = 1.0) {
             render_layer.setAllowsNextDrawableTimeout(false);
         }
-        if caps.can_set_display_sync {
+        if OsFeatures::display_sync() {
             render_layer.setDisplaySyncEnabled(display_sync);
         }
 


### PR DESCRIPTION
**Connections**
Part of https://github.com/gfx-rs/wgpu/issues/7057 (though https://github.com/gfx-rs/wgpu/pull/8439 already fixed most of this).

**Description**
Using the [`objc2::available!`](https://docs.rs/objc2/0.6.3/objc2/macro.available.html) macro:
- It's a bit clearer than the check against `NSOperatingSystemVersion` IMO.
- The macro allows being compiled away if the deployment target is specified to be high enough (use when compiling for macOS Aarch64, the minimum deployment target there is `11.0`, so `available!(macos = 10.13)` would compile down to to `true` at compile-time).
- The `available!` macro also allows checking against patch versions.

Since OS version checks no longer require state, this PR also moves them out of `PrivateCapabilities` and directly into the usage site. This is nice because there is a fundamental separation between these checks: `available!` is for checking the OS version and using newer Metal APIs when we can, while `PrivateCapabilities` is mostly about the GPU capabilities.

**Testing**
I put a `dbg!` around `PrivateCapabilities`, and ran a simple example on the following configurations before and after the first commit, and verified that they matched:
- Host macOS M2, target macOS.
- Host macOS M2, target Mac Catalyst.
- Host macOS M2, target iOS Simulator.
- Host macOS M2, target tvOS Simulator.
- Host macOS M2, target visionOS Simulator.
- Host macOS M2, target Mac (Designed for iPad).
- Host macOS M2, target Vision Pro Simulator (Designed for iPad).
- Host macOS 10.12 Intel, target macOS.

This isn't really exhaustive, but it was the best I could do at a moment's notice (my only real iOS device is an iPad running iOS 9.3, which is a hazzle to test, since it's no longer supported by the standard library).

**Squash or Rebase?**

Can be rebased.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`.
- [x] Run `cargo xtask test` to run tests.
- [x] ~If this contains user-facing changes, add a `CHANGELOG.md` entry.~ Probably no entry needed.
