### PR TITLE
fix(naga): Fix builtin metal imports

### DIFF
--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -4374,8 +4374,7 @@ impl<W: Write> Writer<W> {
         writeln!(self.out, "#include <metal_stdlib>")?;
         writeln!(self.out, "#include <simd/simd.h>")?;
         writeln!(self.out)?;
-        // Work around Metal bug where `uint` is not available by default
-        writeln!(self.out, "using {NAMESPACE}::uint;")?;
+        writeln!(self.out, "using namespace {NAMESPACE};")?;
 
         let mut uses_ray_query = false;
         for (_, ty) in module.types.iter() {

--- a/naga/tests/out/msl/wgsl-6438-conflicting-idents.metal
+++ b/naga/tests/out/msl/wgsl-6438-conflicting-idents.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct OurVertexShaderOutput {
     metal::float4 position;

--- a/naga/tests/out/msl/wgsl-6772-unpack-expr-accesses.metal
+++ b/naga/tests/out/msl/wgsl-6772-unpack-expr-accesses.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 kernel void main_(

--- a/naga/tests/out/msl/wgsl-7995-unicode-idents.metal
+++ b/naga/tests/out/msl/wgsl-7995-unicode-idents.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 float compute(

--- a/naga/tests/out/msl/wgsl-abstract-types-builtins.metal
+++ b/naga/tests/out/msl/wgsl-abstract-types-builtins.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 kernel void f(

--- a/naga/tests/out/msl/wgsl-abstract-types-const.metal
+++ b/naga/tests/out/msl/wgsl-abstract-types-const.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_7 {
     float inner[2];

--- a/naga/tests/out/msl/wgsl-abstract-types-function-calls.metal
+++ b/naga/tests/out/msl/wgsl-abstract-types-function-calls.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_7 {
     float inner[2];

--- a/naga/tests/out/msl/wgsl-abstract-types-let.metal
+++ b/naga/tests/out/msl/wgsl-abstract-types-let.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_7 {
     float inner[2];

--- a/naga/tests/out/msl/wgsl-abstract-types-operators.metal
+++ b/naga/tests/out/msl/wgsl-abstract-types-operators.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_3 {
     uint inner[64];

--- a/naga/tests/out/msl/wgsl-abstract-types-return.metal
+++ b/naga/tests/out/msl/wgsl-abstract-types-return.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_4 {
     float inner[4];

--- a/naga/tests/out/msl/wgsl-abstract-types-texture.metal
+++ b/naga/tests/out/msl/wgsl-abstract-types-texture.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 void color(

--- a/naga/tests/out/msl/wgsl-abstract-types-var.metal
+++ b/naga/tests/out/msl/wgsl-abstract-types-var.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_7 {
     float inner[2];

--- a/naga/tests/out/msl/wgsl-access.metal
+++ b/naga/tests/out/msl/wgsl-access.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint size1;

--- a/naga/tests/out/msl/wgsl-aliased-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-aliased-ray-query.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct _RayQuery {
     metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector;
     metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data>::result_type intersection;

--- a/naga/tests/out/msl/wgsl-array-in-ctor.metal
+++ b/naga/tests/out/msl/wgsl-array-in-ctor.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_1 {
     float inner[2];

--- a/naga/tests/out/msl/wgsl-array-in-function-return-type.metal
+++ b/naga/tests/out/msl/wgsl-array-in-function-return-type.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_1 {
     float inner[2];

--- a/naga/tests/out/msl/wgsl-atomicCompareExchange.metal
+++ b/naga/tests/out/msl/wgsl-atomicCompareExchange.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_2 {
     metal::atomic_int inner[128];

--- a/naga/tests/out/msl/wgsl-atomicOps-float32.metal
+++ b/naga/tests/out/msl/wgsl-atomicOps-float32.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_1 {
     metal::atomic_float inner[2];

--- a/naga/tests/out/msl/wgsl-atomicOps-int64-min-max.metal
+++ b/naga/tests/out/msl/wgsl-atomicOps-int64-min-max.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_1 {
     metal::atomic_ulong inner[2];

--- a/naga/tests/out/msl/wgsl-atomicOps.metal
+++ b/naga/tests/out/msl/wgsl-atomicOps.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_2 {
     metal::atomic_int inner[2];

--- a/naga/tests/out/msl/wgsl-atomicTexture-int64.metal
+++ b/naga/tests/out/msl/wgsl-atomicTexture-int64.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 struct cs_mainInput {

--- a/naga/tests/out/msl/wgsl-atomicTexture.metal
+++ b/naga/tests/out/msl/wgsl-atomicTexture.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 struct cs_mainInput {

--- a/naga/tests/out/msl/wgsl-barycentrics.metal
+++ b/naga/tests/out/msl/wgsl-barycentrics.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 struct fs_mainInput {

--- a/naga/tests/out/msl/wgsl-binding-arrays.metal
+++ b/naga/tests/out/msl/wgsl-binding-arrays.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct DefaultConstructible {
     template<typename T>
     operator T() && {

--- a/naga/tests/out/msl/wgsl-bitcast.metal
+++ b/naga/tests/out/msl/wgsl-bitcast.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 kernel void main_(

--- a/naga/tests/out/msl/wgsl-bits-optimized-msl.metal
+++ b/naga/tests/out/msl/wgsl-bits-optimized-msl.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 kernel void main_(

--- a/naga/tests/out/msl/wgsl-bits.metal
+++ b/naga/tests/out/msl/wgsl-bits.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 kernel void main_(

--- a/naga/tests/out/msl/wgsl-boids.metal
+++ b/naga/tests/out/msl/wgsl-boids.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint size1;

--- a/naga/tests/out/msl/wgsl-bounds-check-image-restrict-depth.metal
+++ b/naga/tests/out/msl/wgsl-bounds-check-image-restrict-depth.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 float test_textureLoad_depth_2d(

--- a/naga/tests/out/msl/wgsl-bounds-check-image-restrict.metal
+++ b/naga/tests/out/msl/wgsl-bounds-check-image-restrict.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 metal::float4 test_textureLoad_1d(

--- a/naga/tests/out/msl/wgsl-bounds-check-image-rzsw-depth.metal
+++ b/naga/tests/out/msl/wgsl-bounds-check-image-rzsw-depth.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct DefaultConstructible {
     template<typename T>
     operator T() && {

--- a/naga/tests/out/msl/wgsl-bounds-check-image-rzsw.metal
+++ b/naga/tests/out/msl/wgsl-bounds-check-image-rzsw.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct DefaultConstructible {
     template<typename T>
     operator T() && {

--- a/naga/tests/out/msl/wgsl-bounds-check-restrict.metal
+++ b/naga/tests/out/msl/wgsl-bounds-check-restrict.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint size0;

--- a/naga/tests/out/msl/wgsl-bounds-check-zero-atomic.metal
+++ b/naga/tests/out/msl/wgsl-bounds-check-zero-atomic.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct DefaultConstructible {
     template<typename T>
     operator T() && {

--- a/naga/tests/out/msl/wgsl-bounds-check-zero.metal
+++ b/naga/tests/out/msl/wgsl-bounds-check-zero.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct DefaultConstructible {
     template<typename T>
     operator T() && {

--- a/naga/tests/out/msl/wgsl-break-if.metal
+++ b/naga/tests/out/msl/wgsl-break-if.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 void breakIfEmpty(

--- a/naga/tests/out/msl/wgsl-collatz.metal
+++ b/naga/tests/out/msl/wgsl-collatz.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint size0;

--- a/naga/tests/out/msl/wgsl-const-exprs.metal
+++ b/naga/tests/out/msl/wgsl-const-exprs.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_6 {
     float inner[2];

--- a/naga/tests/out/msl/wgsl-constructors.metal
+++ b/naga/tests/out/msl/wgsl-constructors.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct Foo {
     metal::float4 a;

--- a/naga/tests/out/msl/wgsl-control-flow.metal
+++ b/naga/tests/out/msl/wgsl-control-flow.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 void control_flow(

--- a/naga/tests/out/msl/wgsl-conversion-float-to-int-no-f64.metal
+++ b/naga/tests/out/msl/wgsl-conversion-float-to-int-no-f64.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 constant half MIN_F16_ = -65504.0h;
 constant half MAX_F16_ = 65504.0h;

--- a/naga/tests/out/msl/wgsl-conversions.metal
+++ b/naga/tests/out/msl/wgsl-conversions.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 constant metal::float2 ic0_ = metal::float2(2.0, 2.0);
 

--- a/naga/tests/out/msl/wgsl-cooperative-matrix.metal
+++ b/naga/tests/out/msl/wgsl-cooperative-matrix.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint size2;

--- a/naga/tests/out/msl/wgsl-cross.metal
+++ b/naga/tests/out/msl/wgsl-cross.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 kernel void main_(

--- a/naga/tests/out/msl/wgsl-dualsource.metal
+++ b/naga/tests/out/msl/wgsl-dualsource.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct FragmentOutput {
     metal::float4 output0_;

--- a/naga/tests/out/msl/wgsl-empty-if.metal
+++ b/naga/tests/out/msl/wgsl-empty-if.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 struct compInput {

--- a/naga/tests/out/msl/wgsl-empty.metal
+++ b/naga/tests/out/msl/wgsl-empty.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 kernel void main_(

--- a/naga/tests/out/msl/wgsl-extra.metal
+++ b/naga/tests/out/msl/wgsl-extra.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct ImmediateData {
     uint index;

--- a/naga/tests/out/msl/wgsl-f16.metal
+++ b/naga/tests/out/msl/wgsl-f16.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct UniformCompatible {
     uint val_u32_;

--- a/naga/tests/out/msl/wgsl-fragment-output.metal
+++ b/naga/tests/out/msl/wgsl-fragment-output.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct FragmentOutputVec4Vec3_ {
     metal::float4 vec4f;

--- a/naga/tests/out/msl/wgsl-functions-optimized-by-version.metal
+++ b/naga/tests/out/msl/wgsl-functions-optimized-by-version.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 uint test_packed_integer_dot_product(

--- a/naga/tests/out/msl/wgsl-functions-unoptimized.metal
+++ b/naga/tests/out/msl/wgsl-functions-unoptimized.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 uint test_packed_integer_dot_product(

--- a/naga/tests/out/msl/wgsl-functions.metal
+++ b/naga/tests/out/msl/wgsl-functions.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 metal::float2 test_fma(

--- a/naga/tests/out/msl/wgsl-globals.metal
+++ b/naga/tests/out/msl/wgsl-globals.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint size3;

--- a/naga/tests/out/msl/wgsl-image.metal
+++ b/naga/tests/out/msl/wgsl-image.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 metal::int2 naga_mod(metal::int2 lhs, metal::int2 rhs) {
     metal::int2 divisor = metal::select(rhs, 1, (lhs == (-2147483647 - 1) & rhs == -1) | (rhs == 0));

--- a/naga/tests/out/msl/wgsl-int64.metal
+++ b/naga/tests/out/msl/wgsl-int64.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct UniformCompatible {
     uint val_u32_;

--- a/naga/tests/out/msl/wgsl-interface.metal
+++ b/naga/tests/out/msl/wgsl-interface.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct VertexOutput {
     metal::float4 position;

--- a/naga/tests/out/msl/wgsl-interpolate.metal
+++ b/naga/tests/out/msl/wgsl-interpolate.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct FragmentInput {
     metal::float4 position;

--- a/naga/tests/out/msl/wgsl-interpolate_compat.metal
+++ b/naga/tests/out/msl/wgsl-interpolate_compat.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct FragmentInput {
     metal::float4 position;

--- a/naga/tests/out/msl/wgsl-math-functions.metal
+++ b/naga/tests/out/msl/wgsl-math-functions.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _modf_result_f32_ {
     float fract;

--- a/naga/tests/out/msl/wgsl-msl-varyings.metal
+++ b/naga/tests/out/msl/wgsl-msl-varyings.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct Vertex {
     metal::float2 position;

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x1.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x1.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint buffer_size1;

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x2.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x2.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint buffer_size1;

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x3.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x3.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint buffer_size1;

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x4.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x4.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint buffer_size1;

--- a/naga/tests/out/msl/wgsl-msl-vpt.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint buffer_size1;

--- a/naga/tests/out/msl/wgsl-multiview.metal
+++ b/naga/tests/out/msl/wgsl-multiview.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 struct main_Input {

--- a/naga/tests/out/msl/wgsl-operators.metal
+++ b/naga/tests/out/msl/wgsl-operators.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 constant metal::float4 v_f32_one = metal::float4(1.0, 1.0, 1.0, 1.0);
 constant metal::float4 v_f32_zero = metal::float4(0.0, 0.0, 0.0, 0.0);

--- a/naga/tests/out/msl/wgsl-overrides-atomicCompareExchangeWeak.metal
+++ b/naga/tests/out/msl/wgsl-overrides-atomicCompareExchangeWeak.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _atomic_compare_exchange_result_Uint_4_ {
     uint old_value;

--- a/naga/tests/out/msl/wgsl-overrides-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-overrides-ray-query.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct _RayQuery {
     metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector;
     metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data>::result_type intersection;

--- a/naga/tests/out/msl/wgsl-overrides.metal
+++ b/naga/tests/out/msl/wgsl-overrides.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 constant bool has_point_light = false;
 constant float specular_param = 2.3;

--- a/naga/tests/out/msl/wgsl-padding.metal
+++ b/naga/tests/out/msl/wgsl-padding.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct S {
     metal::float3 a;

--- a/naga/tests/out/msl/wgsl-phony_assignment.metal
+++ b/naga/tests/out/msl/wgsl-phony_assignment.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 int five(

--- a/naga/tests/out/msl/wgsl-pointer-function-arg-restrict.metal
+++ b/naga/tests/out/msl/wgsl-pointer-function-arg-restrict.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_2 {
     int inner[4];

--- a/naga/tests/out/msl/wgsl-pointer-function-arg-rzsw.metal
+++ b/naga/tests/out/msl/wgsl-pointer-function-arg-rzsw.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct DefaultConstructible {
     template<typename T>
     operator T() && {

--- a/naga/tests/out/msl/wgsl-pointer-function-arg.metal
+++ b/naga/tests/out/msl/wgsl-pointer-function-arg.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_2 {
     int inner[4];

--- a/naga/tests/out/msl/wgsl-policy-mix.metal
+++ b/naga/tests/out/msl/wgsl-policy-mix.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct DefaultConstructible {
     template<typename T>
     operator T() && {

--- a/naga/tests/out/msl/wgsl-quad.metal
+++ b/naga/tests/out/msl/wgsl-quad.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct VertexOutput {
     metal::float2 uv;

--- a/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
+++ b/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct _RayQuery {
     metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector;
     metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data>::result_type intersection;

--- a/naga/tests/out/msl/wgsl-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-ray-query.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct _RayQuery {
     metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector;
     metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data>::result_type intersection;

--- a/naga/tests/out/msl/wgsl-resource-binding-map.metal
+++ b/naga/tests/out/msl/wgsl-resource-binding-map.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 struct DefaultConstructible {
     template<typename T>
     operator T() && {

--- a/naga/tests/out/msl/wgsl-select.metal
+++ b/naga/tests/out/msl/wgsl-select.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 kernel void main_(

--- a/naga/tests/out/msl/wgsl-shadow.metal
+++ b/naga/tests/out/msl/wgsl-shadow.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct _mslBufferSizes {
     uint size2;

--- a/naga/tests/out/msl/wgsl-skybox.metal
+++ b/naga/tests/out/msl/wgsl-skybox.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct VertexOutput {
     metal::float4 position;

--- a/naga/tests/out/msl/wgsl-standard.metal
+++ b/naga/tests/out/msl/wgsl-standard.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 bool test_any_and_all_for_bool(

--- a/naga/tests/out/msl/wgsl-storage-textures.metal
+++ b/naga/tests/out/msl/wgsl-storage-textures.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 kernel void csLoad(

--- a/naga/tests/out/msl/wgsl-struct-layout.metal
+++ b/naga/tests/out/msl/wgsl-struct-layout.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct NoPadding {
     metal::packed_float3 v3_;

--- a/naga/tests/out/msl/wgsl-subgroup-operations.metal
+++ b/naga/tests/out/msl/wgsl-subgroup-operations.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct Structure {
     uint num_subgroups;

--- a/naga/tests/out/msl/wgsl-texture-arg.metal
+++ b/naga/tests/out/msl/wgsl-texture-arg.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 
 metal::float4 test(

--- a/naga/tests/out/msl/wgsl-texture-external.metal
+++ b/naga/tests/out/msl/wgsl-texture-external.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct NagaExternalTextureTransferFn {
     float a;

--- a/naga/tests/out/msl/wgsl-type-inference.metal
+++ b/naga/tests/out/msl/wgsl-type-inference.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 constant uint g1_ = 1u;
 constant float g3_ = 1.0;

--- a/naga/tests/out/msl/wgsl-workgroup-uniform-load-atomic.metal
+++ b/naga/tests/out/msl/wgsl-workgroup-uniform-load-atomic.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_2 {
     metal::atomic_int inner[2];

--- a/naga/tests/out/msl/wgsl-workgroup-uniform-load.metal
+++ b/naga/tests/out/msl/wgsl-workgroup-uniform-load.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_2 {
     int inner[128];

--- a/naga/tests/out/msl/wgsl-workgroup-var-init.metal
+++ b/naga/tests/out/msl/wgsl-workgroup-var-init.metal
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-using metal::uint;
+using namespace metal;
 
 struct type_1 {
     uint inner[512];


### PR DESCRIPTION
**Connections**
Might help with https://github.com/gfx-rs/wgpu/issues/5827.
Part of https://github.com/gfx-rs/wgpu/issues/4632.
See also related past issue https://github.com/gfx-rs/naga/issues/1625.

**Description**
In https://github.com/gfx-rs/naga/pull/289 / https://github.com/gfx-rs/naga/issues/239, `using namespace metal;` was removed, probably to help with avoiding name clashes. This causes issues on older platforms such as macOS 10.12 though, since a lot of types there doesn't seem to be builtin, and are only exposed as typedefs in the `metal` namespace. Naga already contains a partial workaround for this (the `using metal::uint;`).

TODO: Solution?

**Testing**
`cargo xtask test` on a macOS 10.12 machine with https://github.com/gfx-rs/wgpu/pull/8953 applied gets us down to 11 failed tests.

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`.
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
