### PR TITLE
Restrict several internal Naga APIs to `pub(crate)`

### DIFF
--- a/naga/src/back/glsl/features.rs
+++ b/naga/src/back/glsl/features.rs
@@ -64,7 +64,7 @@ bitflags::bitflags! {
 /// [`Module`](crate::Module)
 ///
 /// Provides helper methods to check for availability and writing required extensions
-pub struct FeaturesManager(Features);
+pub(crate) struct FeaturesManager(Features);
 
 impl FeaturesManager {
     /// Creates a new [`FeaturesManager`] instance

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -45,7 +45,7 @@ impl ExprPos {
 }
 
 #[derive(Debug)]
-pub struct Context<'a> {
+pub(crate) struct Context<'a> {
     pub expressions: Arena<Expression>,
     pub locals: Arena<LocalVariable>,
 

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -46,6 +46,7 @@ impl Frontend {
             options: Options::new(),
         }
     }
+
     pub const fn new_with_options(options: Options) -> Self {
         Self {
             parser: Parser::new(),

--- a/naga/src/front/wgsl/parse/directive/enable_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/enable_extension.rs
@@ -9,7 +9,7 @@ use alloc::boxed::Box;
 
 /// Tracks the status of every enable-extension known to Naga.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct EnableExtensions {
+pub(crate) struct EnableExtensions {
     wgpu_mesh_shader: bool,
     wgpu_ray_query: bool,
     wgpu_ray_query_vertex_return: bool,


### PR DESCRIPTION
**Testing**

Still compiles = still gud! I checked that none of these symbols were exposed by checking `rustdoc` output locally before making these changes.

**Squash or Rebase?**

rebase plz
