### PR TITLE
docs: clarify bytes_per_row requirement

### DIFF
--- a/wgpu-types/src/texture.rs
+++ b/wgpu-types/src/texture.rs
@@ -809,7 +809,8 @@ pub struct TexelCopyBufferLayout {
     ///
     /// Must be a multiple of 256 for [`CommandEncoder::copy_buffer_to_texture`][CEcbtt]
     /// and [`CommandEncoder::copy_texture_to_buffer`][CEcttb]. You must manually pad the
-    /// image such that this is a multiple of 256. It will not affect the image data.
+    /// buffer as if the image width is a multiple of 256. An image of size (500, 500) can be
+    /// written to a buffer of size (512, 500) with `bytes_per_row` of 512,
     ///
     /// [`Queue::write_texture`][Qwt] does not have this requirement.
     ///


### PR DESCRIPTION
Following the discussion with @cwfitzgerald in the wgpu chat, I clarified how buffers should be created for copy_texture_to_buffer

https://matrix.to/#/!FZyQrssSlHEZqrYcOb:matrix.org/$3FN1_YUMMNvSz1MckrkJUCLySqCqHhbxD3pMRoHG5xA?via=matrix.org&via=mozilla.org&via=nitro.chat

Please comment if you have more ideas for better wording.