### PR TITLE
Make internal-use hidden macros crate-private instead.

### DIFF
--- a/wgpu/src/api/adapter.rs
+++ b/wgpu/src/api/adapter.rs
@@ -108,10 +108,10 @@ impl Adapter {
     ///
     /// The returned type depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("Adapter")]
-    #[doc = crate::hal_type_metal!("Adapter")]
-    #[doc = crate::hal_type_dx12!("Adapter")]
-    #[doc = crate::hal_type_gles!("Adapter")]
+    #[doc = crate::macros::hal_type_vulkan!("Adapter")]
+    #[doc = crate::macros::hal_type_metal!("Adapter")]
+    #[doc = crate::macros::hal_type_dx12!("Adapter")]
+    #[doc = crate::macros::hal_type_gles!("Adapter")]
     ///
     /// # Errors
     ///

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -166,10 +166,10 @@ impl Blas {
     ///
     /// The returned type depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("AccelerationStructure")]
-    #[doc = crate::hal_type_metal!("AccelerationStructure")]
-    #[doc = crate::hal_type_dx12!("AccelerationStructure")]
-    #[doc = crate::hal_type_gles!("AccelerationStructure")]
+    #[doc = crate::macros::hal_type_vulkan!("AccelerationStructure")]
+    #[doc = crate::macros::hal_type_metal!("AccelerationStructure")]
+    #[doc = crate::macros::hal_type_dx12!("AccelerationStructure")]
+    #[doc = crate::macros::hal_type_gles!("AccelerationStructure")]
     ///
     /// # Deadlocks
     ///

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -257,10 +257,10 @@ impl Buffer {
     ///
     /// The returned type depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("Buffer")]
-    #[doc = crate::hal_type_metal!("Buffer")]
-    #[doc = crate::hal_type_dx12!("Buffer")]
-    #[doc = crate::hal_type_gles!("Buffer")]
+    #[doc = crate::macros::hal_type_vulkan!("Buffer")]
+    #[doc = crate::macros::hal_type_metal!("Buffer")]
+    #[doc = crate::macros::hal_type_dx12!("Buffer")]
+    #[doc = crate::macros::hal_type_gles!("Buffer")]
     ///
     /// # Deadlocks
     ///

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -262,10 +262,10 @@ impl CommandEncoder {
     ///
     /// The callback argument depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("CommandEncoder")]
-    #[doc = crate::hal_type_metal!("CommandEncoder")]
-    #[doc = crate::hal_type_dx12!("CommandEncoder")]
-    #[doc = crate::hal_type_gles!("CommandEncoder")]
+    #[doc = crate::macros::hal_type_vulkan!("CommandEncoder")]
+    #[doc = crate::macros::hal_type_metal!("CommandEncoder")]
+    #[doc = crate::macros::hal_type_dx12!("CommandEncoder")]
+    #[doc = crate::macros::hal_type_gles!("CommandEncoder")]
     ///
     /// # Safety
     ///

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -310,10 +310,10 @@ impl Device {
     ///
     /// The type of `A::Texture` depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("Texture")]
-    #[doc = crate::hal_type_metal!("Texture")]
-    #[doc = crate::hal_type_dx12!("Texture")]
-    #[doc = crate::hal_type_gles!("Texture")]
+    #[doc = crate::macros::hal_type_vulkan!("Texture")]
+    #[doc = crate::macros::hal_type_metal!("Texture")]
+    #[doc = crate::macros::hal_type_dx12!("Texture")]
+    #[doc = crate::macros::hal_type_gles!("Texture")]
     ///
     /// # Safety
     ///
@@ -363,10 +363,10 @@ impl Device {
     ///
     /// The type of `A::Buffer` depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("Buffer")]
-    #[doc = crate::hal_type_metal!("Buffer")]
-    #[doc = crate::hal_type_dx12!("Buffer")]
-    #[doc = crate::hal_type_gles!("Buffer")]
+    #[doc = crate::macros::hal_type_vulkan!("Buffer")]
+    #[doc = crate::macros::hal_type_metal!("Buffer")]
+    #[doc = crate::macros::hal_type_dx12!("Buffer")]
+    #[doc = crate::macros::hal_type_gles!("Buffer")]
     ///
     /// # Safety
     ///
@@ -555,10 +555,10 @@ impl Device {
     ///
     /// The returned type depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("Device")]
-    #[doc = crate::hal_type_metal!("Device")]
-    #[doc = crate::hal_type_dx12!("Device")]
-    #[doc = crate::hal_type_gles!("Device")]
+    #[doc = crate::macros::hal_type_vulkan!("Device")]
+    #[doc = crate::macros::hal_type_metal!("Device")]
+    #[doc = crate::macros::hal_type_dx12!("Device")]
+    #[doc = crate::macros::hal_type_gles!("Device")]
     ///
     /// # Errors
     ///

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -309,10 +309,10 @@ impl Instance {
     ///
     /// The type of `A::Instance` depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("Instance")]
-    #[doc = crate::hal_type_metal!("Instance")]
-    #[doc = crate::hal_type_dx12!("Instance")]
-    #[doc = crate::hal_type_gles!("Instance")]
+    #[doc = crate::macros::hal_type_vulkan!("Instance")]
+    #[doc = crate::macros::hal_type_metal!("Instance")]
+    #[doc = crate::macros::hal_type_dx12!("Instance")]
+    #[doc = crate::macros::hal_type_gles!("Instance")]
     ///
     /// # Safety
     ///
@@ -337,10 +337,10 @@ impl Instance {
     ///
     /// # Types
     ///
-    #[doc = crate::hal_type_vulkan!("Instance")]
-    #[doc = crate::hal_type_metal!("Instance")]
-    #[doc = crate::hal_type_dx12!("Instance")]
-    #[doc = crate::hal_type_gles!("Instance")]
+    #[doc = crate::macros::hal_type_vulkan!("Instance")]
+    #[doc = crate::macros::hal_type_metal!("Instance")]
+    #[doc = crate::macros::hal_type_dx12!("Instance")]
+    #[doc = crate::macros::hal_type_gles!("Instance")]
     ///
     /// # Errors
     ///
@@ -368,10 +368,10 @@ impl Instance {
     ///
     /// The type of `hal_adapter.adapter` depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("Adapter")]
-    #[doc = crate::hal_type_metal!("Adapter")]
-    #[doc = crate::hal_type_dx12!("Adapter")]
-    #[doc = crate::hal_type_gles!("Adapter")]
+    #[doc = crate::macros::hal_type_vulkan!("Adapter")]
+    #[doc = crate::macros::hal_type_metal!("Adapter")]
+    #[doc = crate::macros::hal_type_dx12!("Adapter")]
+    #[doc = crate::macros::hal_type_gles!("Adapter")]
     ///
     /// # Safety
     ///

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -305,10 +305,10 @@ impl Queue {
     ///
     /// The returned type depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("Queue")]
-    #[doc = crate::hal_type_metal!("Queue")]
-    #[doc = crate::hal_type_dx12!("Queue")]
-    #[doc = crate::hal_type_gles!("Queue")]
+    #[doc = crate::macros::hal_type_vulkan!("Queue")]
+    #[doc = crate::macros::hal_type_metal!("Queue")]
+    #[doc = crate::macros::hal_type_dx12!("Queue")]
+    #[doc = crate::macros::hal_type_gles!("Queue")]
     ///
     /// # Errors
     ///

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -171,10 +171,10 @@ impl Surface<'_> {
     ///
     /// The returned type depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("Surface")]
-    #[doc = crate::hal_type_metal!("Surface")]
-    #[doc = crate::hal_type_dx12!("Surface")]
-    #[doc = crate::hal_type_gles!("Surface")]
+    #[doc = crate::macros::hal_type_vulkan!("Surface")]
+    #[doc = crate::macros::hal_type_metal!("Surface")]
+    #[doc = crate::macros::hal_type_dx12!("Surface")]
+    #[doc = crate::macros::hal_type_gles!("Surface")]
     ///
     /// # Errors
     ///

--- a/wgpu/src/api/texture.rs
+++ b/wgpu/src/api/texture.rs
@@ -31,10 +31,10 @@ impl Texture {
     ///
     /// The returned type depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("Texture")]
-    #[doc = crate::hal_type_metal!("Texture")]
-    #[doc = crate::hal_type_dx12!("Texture")]
-    #[doc = crate::hal_type_gles!("Texture")]
+    #[doc = crate::macros::hal_type_vulkan!("Texture")]
+    #[doc = crate::macros::hal_type_metal!("Texture")]
+    #[doc = crate::macros::hal_type_dx12!("Texture")]
+    #[doc = crate::macros::hal_type_gles!("Texture")]
     ///
     /// # Deadlocks
     ///

--- a/wgpu/src/api/texture_view.rs
+++ b/wgpu/src/api/texture_view.rs
@@ -43,10 +43,10 @@ impl TextureView {
     ///
     /// The returned type depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("TextureView")]
-    #[doc = crate::hal_type_metal!("TextureView")]
-    #[doc = crate::hal_type_dx12!("TextureView")]
-    #[doc = crate::hal_type_gles!("TextureView")]
+    #[doc = crate::macros::hal_type_vulkan!("TextureView")]
+    #[doc = crate::macros::hal_type_metal!("TextureView")]
+    #[doc = crate::macros::hal_type_dx12!("TextureView")]
+    #[doc = crate::macros::hal_type_gles!("TextureView")]
     ///
     /// # Deadlocks
     ///

--- a/wgpu/src/api/tlas.rs
+++ b/wgpu/src/api/tlas.rs
@@ -42,10 +42,10 @@ impl Tlas {
     ///
     /// The returned type depends on the backend:
     ///
-    #[doc = crate::hal_type_vulkan!("AccelerationStructure")]
-    #[doc = crate::hal_type_metal!("AccelerationStructure")]
-    #[doc = crate::hal_type_dx12!("AccelerationStructure")]
-    #[doc = crate::hal_type_gles!("AccelerationStructure")]
+    #[doc = crate::macros::hal_type_vulkan!("AccelerationStructure")]
+    #[doc = crate::macros::hal_type_metal!("AccelerationStructure")]
+    #[doc = crate::macros::hal_type_dx12!("AccelerationStructure")]
+    #[doc = crate::macros::hal_type_gles!("AccelerationStructure")]
     ///
     /// # Deadlocks
     ///

--- a/wgpu/src/macros/mod.rs
+++ b/wgpu/src/macros/mod.rs
@@ -82,7 +82,6 @@ fn test_vertex_attr_array() {
 macro_rules! include_spirv_source {
     ($($token:tt)*) => {
         {
-            // FIXME(MSRV): when bumping to 1.89, use [u8; _] here
             const SPIRV_SOURCE: [
                 u8;
                 $crate::__macro_helpers::include_bytes!($($token)*).len()
@@ -190,8 +189,6 @@ macro_rules! include_wgsl {
 // so cannot have more than one line, so cannot use internal cfgs.
 
 /// Helper macro to generate the documentation for dx12 hal methods, referencing the hal type.
-#[macro_export]
-#[doc(hidden)]
 #[cfg(dx12)]
 macro_rules! hal_type_dx12 {
     ($ty: literal) => {
@@ -199,18 +196,15 @@ macro_rules! hal_type_dx12 {
     };
 }
 /// Helper macro to generate the documentation for dx12 hal methods, referencing the hal type.
-#[macro_export]
-#[doc(hidden)]
 #[cfg(not(dx12))]
 macro_rules! hal_type_dx12 {
     ($ty: literal) => {
         concat!("- `hal::api::Dx12` uses `hal::dx12::", $ty, "`")
     };
 }
+pub(crate) use hal_type_dx12;
 
 /// Helper macro to generate the documentation for metal hal methods, referencing the hal type.
-#[macro_export]
-#[doc(hidden)]
 #[cfg(metal)]
 macro_rules! hal_type_metal {
     ($ty: literal) => {
@@ -218,18 +212,15 @@ macro_rules! hal_type_metal {
     };
 }
 /// Helper macro to generate the documentation for metal hal methods, referencing the hal type.
-#[macro_export]
-#[doc(hidden)]
 #[cfg(not(metal))]
 macro_rules! hal_type_metal {
     ($ty: literal) => {
         concat!("- `hal::api::Metal` uses `hal::metal::", $ty, "`")
     };
 }
+pub(crate) use hal_type_metal;
 
 /// Helper macro to generate the documentation for vulkan hal methods, referencing the hal type.
-#[macro_export]
-#[doc(hidden)]
 #[cfg(vulkan)]
 macro_rules! hal_type_vulkan {
     ($ty: literal) => {
@@ -237,18 +228,15 @@ macro_rules! hal_type_vulkan {
     };
 }
 /// Helper macro to generate the documentation for vulkan hal methods, referencing the hal type.
-#[macro_export]
-#[doc(hidden)]
 #[cfg(not(vulkan))]
 macro_rules! hal_type_vulkan {
     ($ty: literal) => {
         concat!("- `hal::api::Vulkan` uses `hal::vulkan::", $ty, "`")
     };
 }
+pub(crate) use hal_type_vulkan;
 
 /// Helper macro to generate the documentation for gles hal methods, referencing the hal type.
-#[macro_export]
-#[doc(hidden)]
 #[cfg(gles)]
 macro_rules! hal_type_gles {
     ($ty: literal) => {
@@ -256,14 +244,13 @@ macro_rules! hal_type_gles {
     };
 }
 /// Helper macro to generate the documentation for gles hal methods, referencing the hal type.
-#[macro_export]
-#[doc(hidden)]
 #[cfg(not(gles))]
 macro_rules! hal_type_gles {
     ($ty: literal) => {
         concat!("- `hal::api::Gles` uses `hal::gles::", $ty, "`")
     };
 }
+pub(crate) use hal_type_gles;
 
 #[doc(hidden)]
 pub mod helpers {


### PR DESCRIPTION
**Description**
There is no need for these macros to be public but hidden. Keep them `pub(crate)` instead.

For those not familiar with what’s going on here, `macro_rules!` macros can be used via 3 different scoping rules:

1. Default: pure lexical scope. Must be defined textually above the usage.
2. `#[macro_export]`: makes the macro usable in other modules and also exported from the crate root for use in other crates.
3. `use <macro>`: adds the macro to the current module (can only be used within the crate unless you *also* `#[macro_export`] as well as making the `use` public).

This PR moves from type 2 to type 3.

**Testing**
Viewed affected documentation.

**Squash or Rebase?**
Whatever

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
