### PR TITLE
feat: support blendable f32 textures on vulkan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Bottom level categories:
 - Added support for no-perspective barycentric coordinates. By @atlv24 in [#8852](https://github.com/gfx-rs/wgpu/issues/8852).
 - Added support for obtaining `AdapterInfo` from `Device`. By @sagudev in [#8807](https://github.com/gfx-rs/wgpu/pull/8807).
 - Added `Limits::or_worse_values_from`. By @atlv24 in [#8870](https://github.com/gfx-rs/wgpu/pull/8870).
+- Added `Features::FLOAT32_BLENDABLE`. By @timokoesters in [#8963](https://github.com/gfx-rs/wgpu/pull/8963).
 - Made the following available in `const` contexts:
     - `naga`
         - `Arena::len`

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -33,6 +33,7 @@ webgpu:api,operation,compute,basic:memcpy:*
 webgpu:api,operation,device,lost:*
 webgpu:api,operation,render_pass,storeOp:*
 webgpu:api,operation,render_pipeline,overrides:*
+webgpu:api,operation,render_pipeline,pipeline_output_targets:color,component_count,blend:*
 webgpu:api,operation,rendering,3d_texture_slices:*
 webgpu:api,operation,rendering,basic:clear:*
 webgpu:api,operation,rendering,basic:fullscreen_quad:*
@@ -163,6 +164,7 @@ webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,*
 webgpu:api,validation,render_pass,resolve:resolve_attachment:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:format:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:stencil_write:*
+webgpu:api,validation,render_pipeline,float32_blendable:*
 webgpu:api,validation,render_pipeline,inter_stage:location,*
 webgpu:api,validation,render_pipeline,inter_stage:max_shader_variable_location:*
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,*
@@ -255,3 +257,4 @@ webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="l
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="loop8"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="switch1"
 //FAIL: 9 invalid_statements subtests due to https://github.com/gfx-rs/wgpu/issues/7733
+webgpu:util,texture,texture_ok:*

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -928,6 +928,11 @@ impl PhysicalDeviceFeatures {
             is_float32_filterable_supported(instance, phd),
         );
 
+        features.set(
+            F::FLOAT32_BLENDABLE,
+            is_float32_blendable_supported(instance, phd),
+        );
+
         if let Some(ref _sampler_ycbcr_conversion) = self.sampler_ycbcr_conversion {
             features.set(
                 F::TEXTURE_FORMAT_NV12,
@@ -2822,6 +2827,21 @@ fn is_format_16bit_norm_supported(instance: &ash::Instance, phd: vk::PhysicalDev
 fn is_float32_filterable_supported(instance: &ash::Instance, phd: vk::PhysicalDevice) -> bool {
     let tiling = vk::ImageTiling::OPTIMAL;
     let features = vk::FormatFeatureFlags::SAMPLED_IMAGE_FILTER_LINEAR;
+    let r_float = supports_format(instance, phd, vk::Format::R32_SFLOAT, tiling, features);
+    let rg_float = supports_format(instance, phd, vk::Format::R32G32_SFLOAT, tiling, features);
+    let rgba_float = supports_format(
+        instance,
+        phd,
+        vk::Format::R32G32B32A32_SFLOAT,
+        tiling,
+        features,
+    );
+    r_float && rg_float && rgba_float
+}
+
+fn is_float32_blendable_supported(instance: &ash::Instance, phd: vk::PhysicalDevice) -> bool {
+    let tiling = vk::ImageTiling::OPTIMAL;
+    let features = vk::FormatFeatureFlags::COLOR_ATTACHMENT_BLEND;
     let r_float = supports_format(instance, phd, vk::Format::R32_SFLOAT, tiling, features);
     let rg_float = supports_format(instance, phd, vk::Format::R32G32_SFLOAT, tiling, features);
     let rgba_float = supports_format(

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -58,16 +58,16 @@ mod webgpu_impl {
     pub const WEBGPU_FEATURE_FLOAT32_FILTERABLE: u64 = 1 << 12;
 
     #[doc(hidden)]
-    pub const WEBGPU_FEATURE_DUAL_SOURCE_BLENDING: u64 = 1 << 13;
+    pub const WEBGPU_FEATURE_FLOAT32_BLENDABLE: u64 = 1 << 13;
 
     #[doc(hidden)]
-    pub const WEBGPU_FEATURE_CLIP_DISTANCES: u64 = 1 << 14;
+    pub const WEBGPU_FEATURE_DUAL_SOURCE_BLENDING: u64 = 1 << 14;
 
     #[doc(hidden)]
-    pub const WEBGPU_FEATURE_IMMEDIATES: u64 = 1 << 15;
+    pub const WEBGPU_FEATURE_CLIP_DISTANCES: u64 = 1 << 15;
 
     #[doc(hidden)]
-    pub const WEBGPU_FEATURE_FLOAT32_BLENDABLE: u64 = 1 << 16;
+    pub const WEBGPU_FEATURE_IMMEDIATES: u64 = 1 << 16;
 }
 
 macro_rules! bitflags_array_impl {

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -65,6 +65,9 @@ mod webgpu_impl {
 
     #[doc(hidden)]
     pub const WEBGPU_FEATURE_IMMEDIATES: u64 = 1 << 15;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_FLOAT32_BLENDABLE: u64 = 1 << 16;
 }
 
 macro_rules! bitflags_array_impl {
@@ -574,7 +577,6 @@ bitflags_array! {
         // ? const RW_STORAGE_TEXTURE_TIER_1 = 1 << ??; (https://github.com/gpuweb/gpuweb/issues/3838)
         // ? const NORM16_FILTERABLE = 1 << ??; (https://github.com/gpuweb/gpuweb/issues/3839)
         // ? const NORM16_RESOLVE = 1 << ??; (https://github.com/gpuweb/gpuweb/issues/3839)
-        // ? const FLOAT32_BLENDABLE = 1 << ??; (https://github.com/gpuweb/gpuweb/issues/3556)
         // ? const 32BIT_FORMAT_MULTISAMPLE = 1 << ??; (https://github.com/gpuweb/gpuweb/issues/3844)
         // ? const 32BIT_FORMAT_RESOLVE = 1 << ??; (https://github.com/gpuweb/gpuweb/issues/3844)
         // ? const TEXTURE_COMPRESSION_ASTC_HDR = 1 << ??; (https://github.com/gpuweb/gpuweb/issues/3856)
@@ -1508,6 +1510,12 @@ bitflags_array! {
         ///
         /// This is a web and native feature.
         const FLOAT32_FILTERABLE = WEBGPU_FEATURE_FLOAT32_FILTERABLE;
+
+        /// Allows textures with formats "r32float", "rg32float", and "rgba32float" to be blendable.
+        ///
+        /// Supported Platforms:
+        /// - Vulkan
+        const FLOAT32_BLENDABLE = WEBGPU_FEATURE_FLOAT32_BLENDABLE;
 
         /// Allows two outputs from a shader to be used for blending.
         /// Note that dual-source blending doesn't support multiple render targets.

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -920,7 +920,11 @@ impl TextureFormat {
 
         // Features that enable filtering don't affect blendability
         let sample_type2 = self.sample_type(None, None);
-        let is_blendable = sample_type2 == Some(TextureSampleType::Float { filterable: true });
+        let is_blendable = matches!(
+            sample_type2,
+            Some(TextureSampleType::Float { filterable: true })
+        ) || device_features.contains(Features::FLOAT32_BLENDABLE)
+            && matches!(self, Self::R32Float | Self::Rg32Float | Self::Rgba32Float);
 
         flags.set(TextureFormatFeatureFlags::FILTERABLE, is_filterable);
         flags.set(TextureFormatFeatureFlags::BLENDABLE, is_blendable);

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -920,11 +920,9 @@ impl TextureFormat {
 
         // Features that enable filtering don't affect blendability
         let sample_type2 = self.sample_type(None, None);
-        let is_blendable = matches!(
-            sample_type2,
-            Some(TextureSampleType::Float { filterable: true })
-        ) || device_features.contains(Features::FLOAT32_BLENDABLE)
-            && matches!(self, Self::R32Float | Self::Rg32Float | Self::Rgba32Float);
+        let is_blendable = sample_type2 == Some(TextureSampleType::Float { filterable: true })
+            || device_features.contains(Features::FLOAT32_BLENDABLE)
+                && matches!(self, Self::R32Float | Self::Rg32Float | Self::Rgba32Float);
 
         flags.set(TextureFormatFeatureFlags::FILTERABLE, is_filterable);
         flags.set(TextureFormatFeatureFlags::BLENDABLE, is_blendable);


### PR DESCRIPTION
**Connections**
Issue: https://github.com/gpuweb/gpuweb/issues/3556
PR: https://github.com/gpuweb/gpuweb/pull/4896

**Description**
This PR will allow using float32 textures with blending as render targets.

**Testing**
I manually tested this on Windows, but did not write automated tests yet.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
