### PR TITLE
docs(CHANGELOG): nest unreleased `Changes` > `General` section properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@ Bottom level categories:
 
 ### Changes
 
-### General
+#### General
 
 - Tracing now uses the `.metal` extension for metal source files, instead of `.msl`. By @inner-daemons in #8880.
 


### PR DESCRIPTION
I missed this when reviewing #8880. 😅