### PR TITLE
wgpu: Relese map_context lock before map_async closure call

### DIFF
--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -572,6 +572,7 @@ impl<'a> BufferSlice<'a> {
         assert_eq!(mc.mapped_range, 0..0, "Buffer is already mapped");
         let end = self.offset + self.size.get();
         mc.mapped_range = self.offset..end;
+        drop(mc); // release the lock of map_context as callback can call lock it again
 
         self.buffer
             .inner


### PR DESCRIPTION
**Connections**
Fixes #8958

**Description**
Release lock early so we do not deadlock in calling the closure.

**Testing**
None

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
