### PR TITLE
test(cts): Update lists with triage results

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -11,202 +11,197 @@
 //
 // The `cts_runner` integration test `lst_files_are_sorted` verifies that test selectors
 // appear in this file in order -- including ones in comments.
-webgpu:api,validation,buffer,mapping:*, // crash
-webgpu:api,validation,capability_checks,features,* // 21%
-webgpu:api,validation,capability_checks,limits,* // 60%
+webgpu:api,validation,buffer,mapping:* // crash
+webgpu:api,validation,capability_checks,features,* // 21%, TypeError not thrown for missing features (needs deno_webgpu fix)
+webgpu:api,validation,capability_checks,limits,* // 60%, wgslLanguageFeatures missing (#8884); workgroup storage size validation unimplemented; interstage vars counting; bind group timing on dx12
 webgpu:api,validation,compute_pipeline:limits,workgroup_storage_size:* // 0%
 webgpu:api,validation,compute_pipeline:overrides,identifier:* // 46%
-webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits,workgroup_storage_size:* // 0%
+webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits,workgroup_storage_size:* // 0%, missing workgroup storage size validation
 webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:* // 0%
-webgpu:api,validation,compute_pipeline:storage_texture,format:* // 8%
-webgpu:api,validation,createBindGroup:buffer,resource_binding_size:* // 33%
-webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%
-webgpu:api,validation,createBindGroup:external_texture,* // 0%
+webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
+webgpu:api,validation,createBindGroup:external_texture,* // 0%, no external external texture in deno
 webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https://github.com/gfx-rs/wgpu/issues/7881
-webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:* // 0%
-webgpu:api,validation,createBindGroupLayout:storage_texture,formats:* // 12%
-webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_buffer_type:* // 25%
-webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_storage_texture_access:* // 25%
-webgpu:api,validation,createBindGroupLayout:visibility:* // 25%
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:* // 0%, using max() instead of +=
+webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_buffer_type:* // 25%, writable storage buffers not allowed in VERTEX
+webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_storage_texture_access:* // 25%, write-access storage textures not allowed in VERTEX
+webgpu:api,validation,createBindGroupLayout:visibility:* // 25%, missing per-stage storage limits
 webgpu:api,validation,createPipelineLayout:* // 33%, https://github.com/gfx-rs/wgpu/issues/4738, and at least 1 more issue
-webgpu:api,validation,createView:texture_state:* // 0%
+webgpu:api,validation,createView:texture_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:* // ***, https://github.com/gfx-rs/wgpu/issues/8118
 webgpu:api,validation,encoding,cmds,debug:* // 92%, https://github.com/gfx-rs/wgpu/issues/8039
 webgpu:api,validation,encoding,cmds,render,* // https://github.com/gfx-rs/wgpu/issues/7912
+webgpu:api,validation,encoding,cmds,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:* // deno unwrap
+webgpu:api,validation,encoding,cmds,setBindGroup:u32array_start_and_length:* // deno unwrap
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="compute%20pass";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20bundle";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20pass";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
-webgpu:api,validation,encoding,createRenderBundleEncoder:* // 26%
+webgpu:api,validation,encoding,cmds,setImmediates:* // 0%, feature not implemented
+webgpu:api,validation,encoding,createRenderBundleEncoder:* // 26%, empty attachments, format compatibility
 webgpu:api,validation,encoding,encoder_open_state:* // https://github.com/gfx-rs/wgpu/issues/7857
-webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_binding_mismatch:* // 60%
-webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_resource_type_mismatch:* // 60%
-webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_visibility_mismatch:* // 60%
-webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bind_groups_and_pipeline_layout_mismatch:* // 60%
-webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:default_bind_group_layouts_never_match,compute_pass:* // 75%
-webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:default_bind_group_layouts_never_match,render_pass:* // 75%
-webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:* // 17%
-webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:* // 17%
-webgpu:api,validation,encoding,queries,resolveQuerySet:* // 93%
-webgpu:api,validation,encoding,render_bundle:* // 81%
-webgpu:api,validation,error_scope:*
-webgpu:api,validation,getBindGroupLayout:* // 29%
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:default_bind_group_layouts_never_match,compute_pass:* // 75%, empty bind group layouts compatibility
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:default_bind_group_layouts_never_match,render_pass:* // 75%, empty bind group layouts compatibility
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:* // 17%, null bind groups, https://github.com/gfx-rs/wgpu/issues/4738
+webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:* // 17%, null bind groups, https://github.com/gfx-rs/wgpu/issues/4738
+webgpu:api,validation,encoding,queries,resolveQuerySet:* // 93%, https://github.com/gfx-rs/wgpu/issues/7881
+webgpu:api,validation,encoding,render_bundle:* // 81%, readonly flag normalization mismatch
+webgpu:api,validation,getBindGroupLayout:* // 29%, rejects valid indices beyond defined layouts
 webgpu:api,validation,image_copy,buffer_texture_copies:* // https://github.com/gfx-rs/wgpu/issues/7946
 webgpu:api,validation,image_copy,layout_related:offset_alignment:* // fails on DX12 in CI
-webgpu:api,validation,layout_shader_compat:pipeline_layout_shader_exact_match:* // 99%
-webgpu:api,validation,non_filterable_texture:non_filterable_texture_with_filtering_sampler:* // 80%
-webgpu:api,validation,query_set,create:count:* // 0%
+webgpu:api,validation,layout_shader_compat:pipeline_layout_shader_exact_match:* // 99%, storage texture read-write bindings not compatible with write-only shaders
+webgpu:api,validation,non_filterable_texture:non_filterable_texture_with_filtering_sampler:* // 80%, depth textures with filtering samplers
+webgpu:api,validation,query_set,create:count:* // 0%, wgpu incorrectly rejects zero-count query sets
 webgpu:api,validation,queue,buffer_mapped:* // ***, vulkan
-webgpu:api,validation,queue,destroyed,* // 71%
-webgpu:api,validation,queue,writeBuffer:ranges:* // 0%
-webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,depth_clear_value:* // 94%
-webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadOnly:* // 33%
-webgpu:api,validation,render_pass,render_pass_descriptor:occlusionQuerySet,query_set_type:* // 50%
-webgpu:api,validation,render_pipeline,depth_stencil_state:depth_write,frag_depth:* // 86%
-webgpu:api,validation,render_pipeline,depth_stencil_state:depthCompare_optional:*
-webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,color_target_count:* // weird assert in test?
-webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,use_blend_src:* // 62%
-webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets,blend:* // 95%
-webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets:* // 3%
-webgpu:api,validation,render_pipeline,fragment_state:targets_blend:* // 0%
-webgpu:api,validation,render_pipeline,fragment_state:targets_write_mask:* // 50%
-webgpu:api,validation,render_pipeline,inter_stage:* // 63%
-webgpu:api,validation,render_pipeline,misc:external_texture:* // 0%
-webgpu:api,validation,render_pipeline,misc:storage_texture,format:* // 8%
+webgpu:api,validation,queue,destroyed,* // 71%, writeBuffer/writeTexture return value, destroyed query set
+webgpu:api,validation,queue,writeBuffer:ranges:* // 0%, missing OperationError for invalid ranges
+webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,depth_clear_value:* // 94%, TypeError instead of validation error
+webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadOnly:* // 33%, missing validation: depth/stencil load/store ops provided for missing texture format aspects
+webgpu:api,validation,render_pass,render_pass_descriptor:occlusionQuerySet,query_set_type:* // 50%, occlusionQuerySet type validation
+webgpu:api,validation,render_pipeline,depth_stencil_state:depth_bias:* // open PR
+webgpu:api,validation,render_pipeline,depth_stencil_state:depth_write,frag_depth:* // 86%, https://github.com/gfx-rs/wgpu/pull/8856
+webgpu:api,validation,render_pipeline,depth_stencil_state:depthCompare_optional:* // https://github.com/gfx-rs/wgpu/issues/8830
+webgpu:api,validation,render_pipeline,depth_stencil_state:depthWriteEnabled_optional:*
+webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,color_target_count:* // https://github.com/gfx-rs/wgpu/pull/8856
+webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,use_blend_src:* // 62%, https://github.com/gfx-rs/wgpu/pull/8856
+webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets,blend:* // 95%, blend factors reading source alpha require vec4
+webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets:* // 3%, color target without shader output requires writeMask=0
+webgpu:api,validation,render_pipeline,fragment_state:targets_blend:* // 0%, missing min/max blend factor validation
+webgpu:api,validation,render_pipeline,fragment_state:targets_write_mask:* // 50%, TypeError instead of validation error
+webgpu:api,validation,render_pipeline,inter_stage:* // 15%, inter-stage type validation gaps and interpolation default handling
+webgpu:api,validation,render_pipeline,misc:external_texture:* // 0%, no external texture in deno
+webgpu:api,validation,render_pipeline,misc:storage_texture,format:* // 8%, similar to compute pipeline issue
 webgpu:api,validation,render_pipeline,multisample_state:* // 60%, https://github.com/gfx-rs/wgpu/issues/8779
-webgpu:api,validation,render_pipeline,overrides:* // 83%
-webgpu:api,validation,render_pipeline,vertex_state:max_vertex_attribute_limit:* // 0%
-webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_limit:* // 0%
+webgpu:api,validation,render_pipeline,overrides:* // 17%, missing validation: invalid pipeline constant identifiers silently ignored
+webgpu:api,validation,render_pipeline,vertex_state:max_vertex_attribute_limit:* // 0%, empty vertex buffers not counted, GPUInternalError no message
+webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_limit:* // 0%, empty vertex buffers not counted toward limit
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_color:* // 92%, https://github.com/gfx-rs/wgpu/issues/3126
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_attachment_and_bind_group:* // 69%, https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,validation,state,device_lost,destroy:* // crash
 webgpu:api,validation,texture,destroy:submit_a_destroyed_texture_as_attachment:* // 44%, https://github.com/gfx-rs/wgpu/issues/8714
 
-webgpu:shader,validation,const_assert,const_assert:constant_expression_logical_and_no_assert:* // 50%
-webgpu:shader,validation,const_assert,const_assert:constant_expression_logical_or_no_assert:* // 50%
-webgpu:shader,validation,decl,context_dependent_resolution:* // 92%
-webgpu:shader,validation,decl,override:* // 93%
-webgpu:shader,validation,decl,var:* // 97%
-webgpu:shader,validation,expression,access,array:* // 92%
-webgpu:shader,validation,expression,access,matrix:* // 90%
-webgpu:shader,validation,expression,access,vector:* // 52%
-webgpu:shader,validation,expression,binary,add_sub_mul:* // 95%
-webgpu:shader,validation,expression,binary,and_or_xor:* // 96%
-webgpu:shader,validation,expression,binary,bitwise_shift:* // 97%
-webgpu:shader,validation,expression,binary,comparison:* // 74%
-webgpu:shader,validation,expression,binary,div_rem:* // 86%
+webgpu:shader,validation,decl,context_dependent_resolution:* // 92%, f16 as reserved keyword when enabled
+webgpu:shader,validation,decl,let:* // texture/sampler let
+webgpu:shader,validation,decl,override:* // 93%, unrestricted_pointer_parameters not implemented, https://github.com/gfx-rs/wgpu/issues/5158
+webgpu:shader,validation,decl,var:* // 97%, https://github.com/gfx-rs/wgpu/issues/8892, atomics in read-only storage, storage textures in vertex shaders
+webgpu:shader,validation,expression,access,array:* // 97%, runtime indexing with compile-time-known values, https://github.com/gfx-rs/wgpu/issues/4390
+webgpu:shader,validation,expression,access,matrix:* // 93%, runtime OOB matrix access with literal indices incorrectly rejected
+webgpu:shader,validation,expression,access,vector:* // 52%, https://github.com/gfx-rs/wgpu/issues/4390, and missing swizzle validation
+webgpu:shader,validation,expression,binary,add_sub_mul:* // 95%, u32 const-eval overflow incorrectly rejected, f16 const-eval overflow not rejected, atomics #5474
+webgpu:shader,validation,expression,binary,and_or_xor:* // 96%, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,binary,bitwise_shift:* // 97%, atomics https://github.com/gfx-rs/wgpu/issues/5474, partial eval errors
+webgpu:shader,validation,expression,binary,comparison:* // 74%, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,binary,div_rem:* // 86%, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:* // 92%, https://github.com/gfx-rs/wgpu/issues/8440
-webgpu:shader,validation,expression,call,builtin,abs:* // 98%
-webgpu:shader,validation,expression,call,builtin,acos:* // 71%
-webgpu:shader,validation,expression,call,builtin,acosh:* // 56%
-webgpu:shader,validation,expression,call,builtin,asin:* // 71%
-webgpu:shader,validation,expression,call,builtin,asinh:* // 85%
-webgpu:shader,validation,expression,call,builtin,atanh:* // 72%
-webgpu:shader,validation,expression,call,builtin,atomics:* // 86%
-webgpu:shader,validation,expression,call,builtin,bitcast:* // 57%
-webgpu:shader,validation,expression,call,builtin,clamp:* // 71%
-webgpu:shader,validation,expression,call,builtin,cosh:* // 61%
-webgpu:shader,validation,expression,call,builtin,countLeadingZeros:* // 98%
-webgpu:shader,validation,expression,call,builtin,countOneBits:* // 98%
-webgpu:shader,validation,expression,call,builtin,countTrailingZeros:* // 98%
-webgpu:shader,validation,expression,call,builtin,cross:* // 86%
-webgpu:shader,validation,expression,call,builtin,degrees:* // 73%
-webgpu:shader,validation,expression,call,builtin,derivatives:* // 83%
-webgpu:shader,validation,expression,call,builtin,determinant:* // 71%
-webgpu:shader,validation,expression,call,builtin,distance:* // 66%
-webgpu:shader,validation,expression,call,builtin,dot:* // 79%
-webgpu:shader,validation,expression,call,builtin,dot4I8Packed:* // 0%
-webgpu:shader,validation,expression,call,builtin,dot4U8Packed:* // 0%
-webgpu:shader,validation,expression,call,builtin,exp:* // 61%
-webgpu:shader,validation,expression,call,builtin,exp2:* // 80%
-webgpu:shader,validation,expression,call,builtin,extractBits:* // 55%
-webgpu:shader,validation,expression,call,builtin,faceForward:* // 68%
-webgpu:shader,validation,expression,call,builtin,firstLeadingBit:* // 98%
-webgpu:shader,validation,expression,call,builtin,firstTrailingBit:* // 98%
-webgpu:shader,validation,expression,call,builtin,fma:* // 85%
-webgpu:shader,validation,expression,call,builtin,frexp:* // 39%
-webgpu:shader,validation,expression,call,builtin,insertBits:* // 73%
-webgpu:shader,validation,expression,call,builtin,inverseSqrt:* // 61%
-webgpu:shader,validation,expression,call,builtin,ldexp:* // 43%
-webgpu:shader,validation,expression,call,builtin,length:* // 74%
-webgpu:shader,validation,expression,call,builtin,log:* // 64%
-webgpu:shader,validation,expression,call,builtin,log2:* // 64%
-webgpu:shader,validation,expression,call,builtin,mix:* // 66%
-webgpu:shader,validation,expression,call,builtin,modf:* // 52%
-webgpu:shader,validation,expression,call,builtin,normalize:* // 63%
-webgpu:shader,validation,expression,call,builtin,pack2x16float:* // 80%
-webgpu:shader,validation,expression,call,builtin,pack2x16snorm:* // 88%
-webgpu:shader,validation,expression,call,builtin,pack2x16unorm:* // 88%
-webgpu:shader,validation,expression,call,builtin,pack4x8snorm:* // 88%
-webgpu:shader,validation,expression,call,builtin,pack4x8unorm:* // 88%
-webgpu:shader,validation,expression,call,builtin,pack4xI8:* // 21%
-webgpu:shader,validation,expression,call,builtin,pack4xI8Clamp:* // 21%
-webgpu:shader,validation,expression,call,builtin,pack4xU8:* // 21%
-webgpu:shader,validation,expression,call,builtin,pack4xU8Clamp:* // 21%
-webgpu:shader,validation,expression,call,builtin,pow:* // 63%
-webgpu:shader,validation,expression,call,builtin,quantizeToF16:* // 61%
-webgpu:shader,validation,expression,call,builtin,reflect:* // 39%
-webgpu:shader,validation,expression,call,builtin,refract:* // 73%
-webgpu:shader,validation,expression,call,builtin,reverseBits:* // 98%
-webgpu:shader,validation,expression,call,builtin,select:* // 75%, https://github.com/gfx-rs/wgpu/issues/4507, https://github.com/gfx-rs/wgpu/issues/5262
-webgpu:shader,validation,expression,call,builtin,sinh:* // 61%
-webgpu:shader,validation,expression,call,builtin,smoothstep:* // 51%
-webgpu:shader,validation,expression,call,builtin,sqrt:* // 64%
-webgpu:shader,validation,expression,call,builtin,textureDimensions:* // 100%
-webgpu:shader,validation,expression,call,builtin,textureGather:* // 99%
-webgpu:shader,validation,expression,call,builtin,textureGatherCompare:* // 99%
-webgpu:shader,validation,expression,call,builtin,textureLoad:* // 85%
-webgpu:shader,validation,expression,call,builtin,textureSample:* // 99%
-webgpu:shader,validation,expression,call,builtin,textureSampleBaseClampToEdge:* // 96%
-webgpu:shader,validation,expression,call,builtin,textureSampleBias:* // 99%
-webgpu:shader,validation,expression,call,builtin,textureSampleCompare:* // 99%
-webgpu:shader,validation,expression,call,builtin,textureSampleCompareLevel:* // 99%
-webgpu:shader,validation,expression,call,builtin,textureSampleGrad:* // 99%
-webgpu:shader,validation,expression,call,builtin,textureSampleLevel:* // 99%
-webgpu:shader,validation,expression,call,builtin,transpose:* // 86%
-webgpu:shader,validation,expression,call,builtin,unpack2x16float:* // 81%
-webgpu:shader,validation,expression,call,builtin,unpack2x16snorm:* // 81%
-webgpu:shader,validation,expression,call,builtin,unpack2x16unorm:* // 81%
-webgpu:shader,validation,expression,call,builtin,unpack4x8snorm:* // 81%
-webgpu:shader,validation,expression,call,builtin,unpack4x8unorm:* // 81%
-webgpu:shader,validation,expression,call,builtin,unpack4xI8:* // 75%
-webgpu:shader,validation,expression,call,builtin,unpack4xU8:* // 75%
-webgpu:shader,validation,expression,call,builtin,value_constructor:* // 92%
-webgpu:shader,validation,expression,early_evaluation:* // 67%
-webgpu:shader,validation,expression,matrix,* // 83%
+webgpu:shader,validation,expression,call,builtin,abs:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,call,builtin,acos:* // 71%, missing domain validation [-1,1] in const eval
+webgpu:shader,validation,expression,call,builtin,acosh:* // 56%, missing domain validation [1,∞) in const eval
+webgpu:shader,validation,expression,call,builtin,asin:* // 71%, missing NaN/Infinity validation for AbstractFloat and F16
+webgpu:shader,validation,expression,call,builtin,asinh:* // 85%, asinh(large f32) produces infinity
+webgpu:shader,validation,expression,call,builtin,atanh:* // 72%, atanh domain (-1,1) not validated in const eval
+webgpu:shader,validation,expression,call,builtin,atomics:* // 86%, atomics in vertex shaders, invalid address spaces/access modes
+webgpu:shader,validation,expression,call,builtin,bitcast:* // 57%, bitcast const-eval unimplemented; size validation missing; f16 vector validation incorrect
+webgpu:shader,validation,expression,call,builtin,clamp:* // 71%, clamp low<=high constraint not checked for const/override parameters
+webgpu:shader,validation,expression,call,builtin,cosh:* // 61%, overflow detection missing for abstract-int, abstract-float, f16
+webgpu:shader,validation,expression,call,builtin,countLeadingZeros:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,call,builtin,countOneBits:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,call,builtin,countTrailingZeros:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,call,builtin,cross:* // 86%, abstract int/float overflow issues in const eval
+webgpu:shader,validation,expression,call,builtin,degrees:* // 73%, const eval overflow detection missing for abstract/f16
+webgpu:shader,validation,expression,call,builtin,derivatives:* // 83%, f16 support not properly validated
+webgpu:shader,validation,expression,call,builtin,determinant:* // 71%, abstract int/float const eval issues
+webgpu:shader,validation,expression,call,builtin,distance:* // 66%, scalar distance uses wrong formula (sqrt instead of abs)
+webgpu:shader,validation,expression,call,builtin,dot:* // 79%, const eval overflow issues for abstract/f16
+webgpu:shader,validation,expression,call,builtin,dot4I8Packed:* // 0%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,dot4U8Packed:* // 0%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,exp:* // 61%, const eval overflow detection missing for abstract/f16
+webgpu:shader,validation,expression,call,builtin,exp2:* // 80%, f16 overflow detection missing
+webgpu:shader,validation,expression,call,builtin,extractBits:* // 55%, const eval issues
+webgpu:shader,validation,expression,call,builtin,faceForward:* // 68%, const eval overflow for abstract/f16
+webgpu:shader,validation,expression,call,builtin,firstLeadingBit:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,call,builtin,firstTrailingBit:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,call,builtin,fma:* // 85%, const eval issues
+webgpu:shader,validation,expression,call,builtin,frexp:* // 39%, const/override eval not supported
+webgpu:shader,validation,expression,call,builtin,insertBits:* // 73%, missing const eval support
+webgpu:shader,validation,expression,call,builtin,inverseSqrt:* // 61%, const eval overflow for abstract/f16
+webgpu:shader,validation,expression,call,builtin,ldexp:* // 43%, const eval not implemented
+webgpu:shader,validation,expression,call,builtin,length:* // 74%, const eval overflow for abstract/f16
+webgpu:shader,validation,expression,call,builtin,log:* // 64%, domain validation (x > 0) missing for abstract/f16
+webgpu:shader,validation,expression,call,builtin,log2:* // 64%, domain validation (x > 0) missing for abstract/f16
+webgpu:shader,validation,expression,call,builtin,mix:* // 66%, const eval issues
+webgpu:shader,validation,expression,call,builtin,modf:* // 52%, const eval not fully implemented
+webgpu:shader,validation,expression,call,builtin,normalize:* // 63%, missing const/override eval overflow validation (intermediate values overflow to infinity)
+webgpu:shader,validation,expression,call,builtin,pack2x16float:* // 80%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,pack2x16snorm:* // 88%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,pack2x16unorm:* // 88%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,pack4x8snorm:* // 88%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,pack4x8unorm:* // 88%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,pack4xI8:* // 21%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,pack4xI8Clamp:* // 21%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,pack4xU8:* // 21%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,pack4xU8Clamp:* // 21%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,pow:* // 63%, missing const/override eval validation (negative base, zero^non-positive, overflow), http://github.com/gpuweb/issues/4527
+webgpu:shader,validation,expression,call,builtin,quantizeToF16:* // 77%, overflow validation issues
+webgpu:shader,validation,expression,call,builtin,reflect:* // 39%, const eval not implemented
+webgpu:shader,validation,expression,call,builtin,refract:* // 44%, const eval not implemented
+webgpu:shader,validation,expression,call,builtin,reverseBits:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,call,builtin,select:* // >99%, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,call,builtin,sinh:* // 61%, const eval overflow for abstract/f16
+webgpu:shader,validation,expression,call,builtin,smoothstep:* // 69%, const eval issues
+webgpu:shader,validation,expression,call,builtin,sqrt:* // 64%, domain validation (x >= 0) missing for abstract/f16
+webgpu:shader,validation,expression,call,builtin,textureDimensions:* // >99%, no external texture in deno
+webgpu:shader,validation,expression,call,builtin,textureGather:* // 99%, https://github.com/gfx-rs/wgpu/issues/8876
+webgpu:shader,validation,expression,call,builtin,textureGatherCompare:* // 99%, edge case in offset or external texture validation
+webgpu:shader,validation,expression,call,builtin,textureLoad:* // 99%, texture_external not implemented
+webgpu:shader,validation,expression,call,builtin,textureSample:* // 99%, texture_external
+webgpu:shader,validation,expression,call,builtin,textureSampleBaseClampToEdge:* // 96%, texture_external
+webgpu:shader,validation,expression,call,builtin,textureSampleBias:* // 99%, missing offset validation (range & cube texture)
+webgpu:shader,validation,expression,call,builtin,textureSampleCompare:* // 99%, missing offset range validation (-8 to +7)
+webgpu:shader,validation,expression,call,builtin,textureSampleCompareLevel:* // 99%, missing offset range validation (-8 to +7)
+webgpu:shader,validation,expression,call,builtin,textureSampleGrad:* // 99%, missing offset range validation + depth textures incorrectly accepted
+webgpu:shader,validation,expression,call,builtin,textureSampleLevel:* // 99%, missing offset validation (cube texture & value range)
+webgpu:shader,validation,expression,call,builtin,transpose:* // 86%, missing const eval
+webgpu:shader,validation,expression,call,builtin,unpack2x16float:* // 81%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,unpack2x16snorm:* // 81%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,unpack2x16unorm:* // 81%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,unpack4x8snorm:* // 81%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,unpack4x8unorm:* // 81%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,unpack4xI8:* // 75%, wgslLanguageFeatures not implemented, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,unpack4xU8:* // 75%, wgslLanguageFeatures not implemented, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,value_constructor:* // 92%, value constructors lack must-use validation + abstract-float matrix validation issues
+webgpu:shader,validation,expression,early_evaluation:* // 67%, mixed override/runtime composite evaluation
+webgpu:shader,validation,expression,matrix,* // 83%, #5474, #8790, #8868
 webgpu:shader,validation,expression,precedence:* // 76%, https://github.com/gfx-rs/wgpu/issues/4536
-webgpu:shader,validation,expression,unary,* // 74%
-webgpu:shader,validation,extension,dual_source_blending:blend_src_usage:* // 61%
-webgpu:shader,validation,extension,pointer_composite_access:* // 50%
-webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:* // 0%
-webgpu:shader,validation,functions,alias_analysis:* // 2%
-webgpu:shader,validation,functions,restrictions:* // 81%
-webgpu:shader,validation,parse,attribute:* // 93%
-webgpu:shader,validation,parse,blankspace:* // 95%
-webgpu:shader,validation,parse,comments:* // 93%
-webgpu:shader,validation,parse,diagnostic:* // 50%
-webgpu:shader,validation,parse,identifiers:* // 81%
-webgpu:shader,validation,parse,literal:* // 96%
-webgpu:shader,validation,parse,must_use:* // 97%
-webgpu:shader,validation,parse,requires:* // 14%
-webgpu:shader,validation,parse,shadow_builtins:* // 60%
-webgpu:shader,validation,shader_io,align:* // 98%
-webgpu:shader,validation,shader_io,binding:* // 95%
-webgpu:shader,validation,shader_io,builtins:* // 50%
-webgpu:shader,validation,shader_io,group_and_binding:* // 87%
-webgpu:shader,validation,shader_io,group:* // 95%
-webgpu:shader,validation,shader_io,id:* // 94%
-webgpu:shader,validation,shader_io,interpolate:* // 91%
-webgpu:shader,validation,shader_io,layout_constraints:* // 99%
-webgpu:shader,validation,shader_io,locations:* // 98%
-webgpu:shader,validation,shader_io,pipeline_stage:* // 92%
-webgpu:shader,validation,shader_io,size:* // 92%
-webgpu:shader,validation,shader_io,workgroup_size:* // 83%
-webgpu:shader,validation,statement,continue:* // 90%
-webgpu:shader,validation,statement,for:* // 93%
-webgpu:shader,validation,statement,increment_decrement:* // 97%
-webgpu:shader,validation,statement,loop:* // 92%
-webgpu:shader,validation,statement,phony:* // 90%
-webgpu:shader,validation,statement,statement_behavior:* // https://github.com/gfx-rs/wgpu/issues/7733
-webgpu:shader,validation,statement,switch:* // 99%
-webgpu:shader,validation,types,* // 86%
-webgpu:shader,validation,uniformity,* // 21%
+webgpu:shader,validation,expression,unary,* // 74%, pointer_composite_access not advertised, https://github.com/gfx-rs/wgpu/issues/8884, #5474
+webgpu:shader,validation,extension,dual_source_blending:blend_src_usage:* // 61%, @blend_src validation gaps
+webgpu:shader,validation,extension,pointer_composite_access:* // 50%, wgslLanguageFeatures not exposed, https://github.com/gfx-rs/wgpu/issues/8884
+webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:* // 0%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,functions,alias_analysis:* // 2%, https://github.com/gfx-rs/wgpu/issues/7650
+webgpu:shader,validation,functions,restrictions:* // 81%, texture_external
+webgpu:shader,validation,parse,attribute:* // 93%, group index validation at shader module creation
+webgpu:shader,validation,parse,blankspace:* // 95%, null in comments, https://github.com/gfx-rs/wgpu/issues/8877
+webgpu:shader,validation,parse,comments:* // 93%, unterminated block comments, https://github.com/gfx-rs/wgpu/issues/8877
+webgpu:shader,validation,parse,diagnostic:* // 50%, https://github.com/gfx-rs/wgpu/issues/6458
+webgpu:shader,validation,parse,literal:* // 96%, https://github.com/gfx-rs/wgpu/issues/7046
+webgpu:shader,validation,parse,must_use:* // 97%, https://github.com/gfx-rs/wgpu/issues/8876
+webgpu:shader,validation,parse,requires:* // 14%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,parse,shadow_builtins:* // 83%, function param shadowing parser issue; determinant const-eval; texture_external capability missing
+webgpu:shader,validation,shader_io,align:* // 98%, https://github.com/gfx-rs/wgpu/issues/8892
+webgpu:shader,validation,shader_io,binding:* // 95%, https://github.com/gfx-rs/wgpu/issues/8892
+webgpu:shader,validation,shader_io,builtins:* // 50%, trailing comma not accepted
+webgpu:shader,validation,shader_io,group_and_binding:* // 87%, texture_external
+webgpu:shader,validation,shader_io,group:* // 95%, https://github.com/gfx-rs/wgpu/issues/8892
+webgpu:shader,validation,shader_io,id:* // 94%, https://github.com/gfx-rs/wgpu/issues/8892, @id on const
+webgpu:shader,validation,shader_io,interpolate:* // 91%, https://github.com/gfx-rs/wgpu/issues/8892
+webgpu:shader,validation,shader_io,layout_constraints:* // 99%, struct alignment not inferred from @align on members
+webgpu:shader,validation,shader_io,locations:* // 98%, https://github.com/gfx-rs/wgpu/issues/8892
+webgpu:shader,validation,shader_io,pipeline_stage:* // 92%, stage attributes incorrectly accepted on var<private> and var<storage>
+webgpu:shader,validation,shader_io,size:* // 92%, https://github.com/gfx-rs/wgpu/issues/8892, large size validation, runtime-sized array
+webgpu:shader,validation,shader_io,workgroup_size:* // 83%, https://github.com/gfx-rs/wgpu/issues/8892, type mixing, attribute placement
+webgpu:shader,validation,statement,continue:* // 90%, continue bypassing declaration used in continuing block, https://github.com/gfx-rs/wgpu/issues/7650
+webgpu:shader,validation,statement,for:* // 93%, phony/increment in for-loop init/cont, empty loop behavior
+webgpu:shader,validation,statement,increment_decrement:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,statement,loop:* // 92%, https://github.com/gfx-rs/wgpu/issues/7650
+webgpu:shader,validation,statement,phony:* // 90%, phony assignment in for-loops with semicolons
+webgpu:shader,validation,statement,statement_behavior:* // https://github.com/gfx-rs/wgpu/issues/7650
+webgpu:shader,validation,statement,switch:* // https://github.com/gfx-rs/wgpu/issues/7650
+webgpu:shader,validation,types,* // 86%, trailing commas in template args (~100 tests), keyword shadowing (10 tests), f16 constructors without enable (9 tests)
+webgpu:shader,validation,uniformity,* // 21%, https://github.com/gfx-rs/wgpu/issues/4369

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -13,7 +13,7 @@
 // appear in this file in order -- including ones in comments.
 webgpu:api,validation,buffer,mapping:* // crash
 webgpu:api,validation,capability_checks,features,* // 21%, TypeError not thrown for missing features (needs deno_webgpu fix)
-webgpu:api,validation,capability_checks,limits,* // 60%, wgslLanguageFeatures missing (#8884); workgroup storage size validation unimplemented; interstage vars counting; bind group timing on dx12
+webgpu:api,validation,capability_checks,limits,* // 60%, workgroup storage size validation unimplemented; interstage vars counting; bind group timing on dx12
 webgpu:api,validation,compute_pipeline:limits,workgroup_storage_size:* // 0%
 webgpu:api,validation,compute_pipeline:overrides,identifier:* // 46%
 webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits,workgroup_storage_size:* // 0%, missing workgroup storage size validation
@@ -21,6 +21,8 @@ webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:* // 0%
 webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,createBindGroup:external_texture,* // 0%, no external external texture in deno
 webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https://github.com/gfx-rs/wgpu/issues/7881
+webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:* // fails on vulkan
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_bind_group_layout:*
 webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:* // 0%, using max() instead of +=
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_buffer_type:* // 25%, writable storage buffers not allowed in VERTEX
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_storage_texture_access:* // 25%, write-access storage textures not allowed in VERTEX
@@ -31,10 +33,10 @@ webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:* // ***, h
 webgpu:api,validation,encoding,cmds,debug:* // 92%, https://github.com/gfx-rs/wgpu/issues/8039
 webgpu:api,validation,encoding,cmds,render,* // https://github.com/gfx-rs/wgpu/issues/7912
 webgpu:api,validation,encoding,cmds,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:* // deno unwrap
-webgpu:api,validation,encoding,cmds,setBindGroup:u32array_start_and_length:* // deno unwrap
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="compute%20pass";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20bundle";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20pass";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
+webgpu:api,validation,encoding,cmds,setBindGroup:u32array_start_and_length:* // deno unwrap
 webgpu:api,validation,encoding,cmds,setImmediates:* // 0%, feature not implemented
 webgpu:api,validation,encoding,createRenderBundleEncoder:* // 26%, empty attachments, format compatibility
 webgpu:api,validation,encoding,encoder_open_state:* // https://github.com/gfx-rs/wgpu/issues/7857
@@ -46,13 +48,13 @@ webgpu:api,validation,encoding,queries,resolveQuerySet:* // 93%, https://github.
 webgpu:api,validation,encoding,render_bundle:* // 81%, readonly flag normalization mismatch
 webgpu:api,validation,getBindGroupLayout:* // 29%, rejects valid indices beyond defined layouts
 webgpu:api,validation,image_copy,buffer_texture_copies:* // https://github.com/gfx-rs/wgpu/issues/7946
-webgpu:api,validation,image_copy,layout_related:offset_alignment:* // fails on DX12 in CI
 webgpu:api,validation,layout_shader_compat:pipeline_layout_shader_exact_match:* // 99%, storage texture read-write bindings not compatible with write-only shaders
 webgpu:api,validation,non_filterable_texture:non_filterable_texture_with_filtering_sampler:* // 80%, depth textures with filtering samplers
 webgpu:api,validation,query_set,create:count:* // 0%, wgpu incorrectly rejects zero-count query sets
 webgpu:api,validation,queue,buffer_mapped:* // ***, vulkan
 webgpu:api,validation,queue,destroyed,* // 71%, writeBuffer/writeTexture return value, destroyed query set
 webgpu:api,validation,queue,writeBuffer:ranges:* // 0%, missing OperationError for invalid ranges
+webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_stencil_read_only_write_state:* // fails on dx12
 webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,depth_clear_value:* // 94%, TypeError instead of validation error
 webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadOnly:* // 33%, missing validation: depth/stencil load/store ops provided for missing texture format aspects
 webgpu:api,validation,render_pass,render_pass_descriptor:occlusionQuerySet,query_set_type:* // 50%, occlusionQuerySet type validation
@@ -73,6 +75,7 @@ webgpu:api,validation,render_pipeline,multisample_state:* // 60%, https://github
 webgpu:api,validation,render_pipeline,overrides:* // 17%, missing validation: invalid pipeline constant identifiers silently ignored
 webgpu:api,validation,render_pipeline,vertex_state:max_vertex_attribute_limit:* // 0%, empty vertex buffers not counted, GPUInternalError no message
 webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_limit:* // 0%, empty vertex buffers not counted toward limit
+webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:* // fails on metal https://github.com/gfx-rs/wgpu/issues/8312
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_color:* // 92%, https://github.com/gfx-rs/wgpu/issues/3126
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_attachment_and_bind_group:* // 69%, https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,validation,state,device_lost,destroy:* // crash
@@ -110,8 +113,8 @@ webgpu:shader,validation,expression,call,builtin,derivatives:* // 83%, f16 suppo
 webgpu:shader,validation,expression,call,builtin,determinant:* // 71%, abstract int/float const eval issues
 webgpu:shader,validation,expression,call,builtin,distance:* // 66%, scalar distance uses wrong formula (sqrt instead of abs)
 webgpu:shader,validation,expression,call,builtin,dot:* // 79%, const eval overflow issues for abstract/f16
-webgpu:shader,validation,expression,call,builtin,dot4I8Packed:* // 0%, https://github.com/gfx-rs/wgpu/pull/8884
-webgpu:shader,validation,expression,call,builtin,dot4U8Packed:* // 0%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,dot4I8Packed:* // 91%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,dot4U8Packed:* // 91%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,exp:* // 61%, const eval overflow detection missing for abstract/f16
 webgpu:shader,validation,expression,call,builtin,exp2:* // 80%, f16 overflow detection missing
 webgpu:shader,validation,expression,call,builtin,extractBits:* // 55%, const eval issues
@@ -134,10 +137,10 @@ webgpu:shader,validation,expression,call,builtin,pack2x16snorm:* // 88%, missing
 webgpu:shader,validation,expression,call,builtin,pack2x16unorm:* // 88%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,pack4x8snorm:* // 88%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,pack4x8unorm:* // 88%, missing const eval (#4507)
-webgpu:shader,validation,expression,call,builtin,pack4xI8:* // 21%, https://github.com/gfx-rs/wgpu/pull/8884
-webgpu:shader,validation,expression,call,builtin,pack4xI8Clamp:* // 21%, https://github.com/gfx-rs/wgpu/pull/8884
-webgpu:shader,validation,expression,call,builtin,pack4xU8:* // 21%, https://github.com/gfx-rs/wgpu/pull/8884
-webgpu:shader,validation,expression,call,builtin,pack4xU8Clamp:* // 21%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,pack4xI8:* // 74%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,pack4xI8Clamp:* // 74%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,pack4xU8:* // 74%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,pack4xU8Clamp:* // 74%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,pow:* // 63%, missing const/override eval validation (negative base, zero^non-positive, overflow), http://github.com/gpuweb/issues/4527
 webgpu:shader,validation,expression,call,builtin,quantizeToF16:* // 77%, overflow validation issues
 webgpu:shader,validation,expression,call,builtin,reflect:* // 39%, const eval not implemented
@@ -164,16 +167,15 @@ webgpu:shader,validation,expression,call,builtin,unpack2x16snorm:* // 81%, missi
 webgpu:shader,validation,expression,call,builtin,unpack2x16unorm:* // 81%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,unpack4x8snorm:* // 81%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,unpack4x8unorm:* // 81%, missing const eval (#4507)
-webgpu:shader,validation,expression,call,builtin,unpack4xI8:* // 75%, wgslLanguageFeatures not implemented, https://github.com/gfx-rs/wgpu/pull/8884
-webgpu:shader,validation,expression,call,builtin,unpack4xU8:* // 75%, wgslLanguageFeatures not implemented, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,expression,call,builtin,unpack4xI8:* // 75%, missing const eval (#4507)
+webgpu:shader,validation,expression,call,builtin,unpack4xU8:* // 75%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,value_constructor:* // 92%, value constructors lack must-use validation + abstract-float matrix validation issues
 webgpu:shader,validation,expression,early_evaluation:* // 67%, mixed override/runtime composite evaluation
 webgpu:shader,validation,expression,matrix,* // 83%, #5474, #8790, #8868
 webgpu:shader,validation,expression,precedence:* // 76%, https://github.com/gfx-rs/wgpu/issues/4536
-webgpu:shader,validation,expression,unary,* // 74%, pointer_composite_access not advertised, https://github.com/gfx-rs/wgpu/issues/8884, #5474
+webgpu:shader,validation,expression,unary,* // 99%, matrix negation accepted, #5474
 webgpu:shader,validation,extension,dual_source_blending:blend_src_usage:* // 61%, @blend_src validation gaps
-webgpu:shader,validation,extension,pointer_composite_access:* // 50%, wgslLanguageFeatures not exposed, https://github.com/gfx-rs/wgpu/issues/8884
-webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:* // 0%, https://github.com/gfx-rs/wgpu/pull/8884
+webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:* // 0%, CTS bug https://github.com/gpuweb/cts/pull/4567
 webgpu:shader,validation,functions,alias_analysis:* // 2%, https://github.com/gfx-rs/wgpu/issues/7650
 webgpu:shader,validation,functions,restrictions:* // 81%, texture_external
 webgpu:shader,validation,parse,attribute:* // 93%, group index validation at shader module creation
@@ -182,7 +184,6 @@ webgpu:shader,validation,parse,comments:* // 93%, unterminated block comments, h
 webgpu:shader,validation,parse,diagnostic:* // 50%, https://github.com/gfx-rs/wgpu/issues/6458
 webgpu:shader,validation,parse,literal:* // 96%, https://github.com/gfx-rs/wgpu/issues/7046
 webgpu:shader,validation,parse,must_use:* // 97%, https://github.com/gfx-rs/wgpu/issues/8876
-webgpu:shader,validation,parse,requires:* // 14%, https://github.com/gfx-rs/wgpu/pull/8884
 webgpu:shader,validation,parse,shadow_builtins:* // 83%, function param shadowing parser issue; determinant const-eval; texture_external capability missing
 webgpu:shader,validation,shader_io,align:* // 98%, https://github.com/gfx-rs/wgpu/issues/8892
 webgpu:shader,validation,shader_io,binding:* // 95%, https://github.com/gfx-rs/wgpu/issues/8892
@@ -203,5 +204,5 @@ webgpu:shader,validation,statement,loop:* // 92%, https://github.com/gfx-rs/wgpu
 webgpu:shader,validation,statement,phony:* // 90%, phony assignment in for-loops with semicolons
 webgpu:shader,validation,statement,statement_behavior:* // https://github.com/gfx-rs/wgpu/issues/7650
 webgpu:shader,validation,statement,switch:* // https://github.com/gfx-rs/wgpu/issues/7650
-webgpu:shader,validation,types,* // 86%, trailing commas in template args (~100 tests), keyword shadowing (10 tests), f16 constructors without enable (9 tests)
+webgpu:shader,validation,types,* // 95%, texture_external not supported (2 tests), atomic validation gaps (8 tests), pointer validation gaps (5 tests), 16-bit normalized storage texture formats (36 tests)
 webgpu:shader,validation,uniformity,* // 21%, https://github.com/gfx-rs/wgpu/issues/4369

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -75,7 +75,8 @@ webgpu:api,validation,render_pipeline,multisample_state:* // 60%, https://github
 webgpu:api,validation,render_pipeline,overrides:* // 17%, missing validation: invalid pipeline constant identifiers silently ignored
 webgpu:api,validation,render_pipeline,vertex_state:max_vertex_attribute_limit:* // 0%, empty vertex buffers not counted, GPUInternalError no message
 webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_limit:* // 0%, empty vertex buffers not counted toward limit
-webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:* // fails on metal https://github.com/gfx-rs/wgpu/issues/8312
+webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:* // fails on metal in CI https://github.com/gfx-rs/wgpu/issues/8312
+webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_offset_alignment:* // fails on metal in CI
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_color:* // 92%, https://github.com/gfx-rs/wgpu/issues/3126
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_attachment_and_bind_group:* // 69%, https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,validation,state,device_lost,destroy:* // crash
@@ -84,7 +85,7 @@ webgpu:api,validation,texture,destroy:submit_a_destroyed_texture_as_attachment:*
 webgpu:shader,validation,decl,context_dependent_resolution:* // 92%, f16 as reserved keyword when enabled
 webgpu:shader,validation,decl,let:* // texture/sampler let
 webgpu:shader,validation,decl,override:* // 93%, unrestricted_pointer_parameters not implemented, https://github.com/gfx-rs/wgpu/issues/5158
-webgpu:shader,validation,decl,var:* // 97%, https://github.com/gfx-rs/wgpu/issues/8892, atomics in read-only storage, storage textures in vertex shaders
+webgpu:shader,validation,decl,var:* // 99%, https://github.com/gfx-rs/wgpu/issues/8925 (trailing comma), atomics in read-only storage, shader stage restrictions
 webgpu:shader,validation,expression,access,array:* // 97%, runtime indexing with compile-time-known values, https://github.com/gfx-rs/wgpu/issues/4390
 webgpu:shader,validation,expression,access,matrix:* // 93%, runtime OOB matrix access with literal indices incorrectly rejected
 webgpu:shader,validation,expression,access,vector:* // 52%, https://github.com/gfx-rs/wgpu/issues/4390, and missing swizzle validation

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -92,8 +92,7 @@ webgpu:api,validation,createBindGroup:texture_binding_must_have_correct_usage:*
 webgpu:api,validation,createBindGroup:texture_must_have_correct_component_type:*
 webgpu:api,validation,createBindGroup:texture_must_have_correct_dimension:*
 webgpu:api,validation,createBindGroupLayout:duplicate_bindings:*
-webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:*
-webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_bind_group_layout:*
+fails-if(vulkan) webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:*
 webgpu:api,validation,createBindGroupLayout:maximum_binding_limit:*
 webgpu:api,validation,createBindGroupLayout:multisampled_validation:*
 webgpu:api,validation,createBindGroupLayout:storage_texture,formats:*
@@ -215,7 +214,14 @@ webgpu:api,validation,queue,writeBuffer:buffer_state:*
 webgpu:api,validation,queue,writeBuffer:buffer,device_mismatch:*
 webgpu:api,validation,queue,writeBuffer:usages:*
 webgpu:api,validation,queue,writeTexture:*
-webgpu:api,validation,render_pass,attachment_compatibility:*
+webgpu:api,validation,render_pass,attachment_compatibility:render_pass_and_bundle,color_sparse:*
+webgpu:api,validation,render_pass,attachment_compatibility:render_pass_and_bundle,depth_format:*
+webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,color_count:*
+webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,color_format:*
+webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,color_sparse:*
+webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_format:*
+fails-if(dx12) webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_stencil_read_only_write_state:*
+webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,sample_count:*
 webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,sample_counts_mismatch:*
@@ -249,7 +255,7 @@ webgpu:api,validation,render_pipeline,resource_compatibility:*
 webgpu:api,validation,render_pipeline,shader_module:*
 webgpu:api,validation,render_pipeline,vertex_state:many_attributes_overlapping:*
 webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_array_stride_limit:*
-webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:*
+fails-if(metal) webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:*
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_offset_alignment:*
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_shaderLocation_limit:*
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_shaderLocation_unique:*
@@ -309,6 +315,7 @@ webgpu:shader,execution,flow_control,return:*
 fails-if(metal) webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true
 
 webgpu:shader,validation,const_assert,const_assert:*
+webgpu:shader,validation,decl,assignment_statement:*
 webgpu:shader,validation,decl,compound_statement:*
 webgpu:shader,validation,decl,const:*
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_neg"
@@ -373,6 +380,7 @@ webgpu:shader,validation,parse,blankspace:null_characters:contains_null=false;*
 webgpu:shader,validation,parse,blankspace:null_characters:contains_null=true;placement="delimiter"
 webgpu:shader,validation,parse,blankspace:null_characters:contains_null=true;placement="eol"
 webgpu:shader,validation,parse,enable:*
+webgpu:shader,validation,parse,identifiers:*
 webgpu:shader,validation,parse,requires:*
 webgpu:shader,validation,parse,semicolon:*
 webgpu:shader,validation,parse,source:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -1,3 +1,5 @@
+// CTS test selectors that are expected to pass. These are run in CI.
+//
 // The following may be useful to generate lists of tests for this file:
 // ```
 // cargo xtask cts -- --list <selector>
@@ -59,13 +61,54 @@ webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
 webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";*
 webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atMaximum";*
 webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";*
+webgpu:api,validation,compute_pipeline:basic:*
+webgpu:api,validation,compute_pipeline:limits,invocations_per_workgroup,each_component:*
+webgpu:api,validation,compute_pipeline:limits,invocations_per_workgroup:*
+webgpu:api,validation,compute_pipeline:overrides,entry_point,validation_error:*
+webgpu:api,validation,compute_pipeline:overrides,uninitialized:*
+webgpu:api,validation,compute_pipeline:overrides,value,type_error:*
+webgpu:api,validation,compute_pipeline:overrides,value,validation_error,f16:*
+webgpu:api,validation,compute_pipeline:overrides,value,validation_error:*
+webgpu:api,validation,compute_pipeline:overrides,workgroup_size:*
+webgpu:api,validation,compute_pipeline:pipeline_layout,device_mismatch:*
 webgpu:api,validation,compute_pipeline:resource_compatibility:*
+webgpu:api,validation,compute_pipeline:shader_module,*
+webgpu:api,validation,compute_pipeline:storage_texture,format:*
+webgpu:api,validation,createBindGroup:bind_group_layout,device_mismatch:*
+webgpu:api,validation,createBindGroup:binding_count_mismatch:*
+webgpu:api,validation,createBindGroup:binding_must_be_present_in_layout:*
 webgpu:api,validation,createBindGroup:binding_must_contain_resource_defined_in_layout:*
+webgpu:api,validation,createBindGroup:binding_resources,device_mismatch:*
 webgpu:api,validation,createBindGroup:buffer_offset_and_size_for_bind_groups_match:*
 webgpu:api,validation,createBindGroup:buffer,effective_buffer_binding_size:*
 webgpu:api,validation,createBindGroup:buffer,resource_binding_size:*
+webgpu:api,validation,createBindGroup:buffer,resource_offset:*
+webgpu:api,validation,createBindGroup:buffer,usage:*
+webgpu:api,validation,createBindGroup:minBindingSize:*
+webgpu:api,validation,createBindGroup:multisampled_validation:*
+webgpu:api,validation,createBindGroup:sampler,*
 webgpu:api,validation,createBindGroup:storage_texture,*
+webgpu:api,validation,createBindGroup:texture_binding_must_have_correct_usage:*
+webgpu:api,validation,createBindGroup:texture_must_have_correct_component_type:*
+webgpu:api,validation,createBindGroup:texture_must_have_correct_dimension:*
+webgpu:api,validation,createBindGroupLayout:duplicate_bindings:*
+webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:*
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_bind_group_layout:*
+webgpu:api,validation,createBindGroupLayout:maximum_binding_limit:*
+webgpu:api,validation,createBindGroupLayout:multisampled_validation:*
 webgpu:api,validation,createBindGroupLayout:storage_texture,formats:*
+webgpu:api,validation,createBindGroupLayout:storage_texture,layout_dimension:*
+webgpu:api,validation,createSampler:*
+webgpu:api,validation,createTexture:*
+webgpu:api,validation,createView:array_layers:*
+webgpu:api,validation,createView:aspect:*
+webgpu:api,validation,createView:cube_faces_square:*
+webgpu:api,validation,createView:dimension:*
+webgpu:api,validation,createView:format:*
+webgpu:api,validation,createView:mip_levels:*
+webgpu:api,validation,createView:texture_view_usage_with_view_format:*
+webgpu:api,validation,createView:texture_view_usage:*
+webgpu:api,validation,debugMarker:*
 webgpu:api,validation,encoding,beginComputePass:*
 webgpu:api,validation,encoding,beginRenderPass:*
 webgpu:api,validation,encoding,cmds,clearBuffer:*
@@ -92,8 +135,6 @@ webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="rend
 webgpu:api,validation,encoding,cmds,debug:debug_group:*
 webgpu:api,validation,encoding,cmds,debug:debug_marker:*
 webgpu:api,validation,encoding,cmds,index_access:*
-//FAIL: some others in webgpu:api,validation,encoding,cmds,render,draw:*
-// due to e.g. https://github.com/gfx-rs/wgpu/issues/7912
 webgpu:api,validation,encoding,cmds,render,draw:index_buffer_OOB:*
 webgpu:api,validation,encoding,cmds,render,draw:unused_buffer_bound:*
 webgpu:api,validation,encoding,cmds,render,dynamic_state:*
@@ -104,6 +145,15 @@ webgpu:api,validation,encoding,cmds,render,setPipeline:*
 webgpu:api,validation,encoding,cmds,render,setVertexBuffer:*
 webgpu:api,validation,encoding,cmds,render,state_tracking:vertex_buffers_do_not_inherit_between_render_passes:*
 webgpu:api,validation,encoding,cmds,render,state_tracking:vertex_buffers_inherit_from_previous_pipeline:*
+webgpu:api,validation,encoding,cmds,setBindGroup:bind_group,device_mismatch:*
+webgpu:api,validation,encoding,cmds,setBindGroup:buffer_dynamic_offsets:*
+webgpu:api,validation,encoding,cmds,setBindGroup:dynamic_offsets_passed_but_not_expected:*
+webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="compute%20pass";state="invalid";*
+webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="compute%20pass";state="valid";*
+webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20bundle";state="invalid";*
+webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20bundle";state="valid";*
+webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20pass";state="invalid";*
+webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20pass";state="valid";*
 webgpu:api,validation,encoding,encoder_open_state:compute_pass_commands:*
 webgpu:api,validation,encoding,encoder_open_state:non_pass_commands:*
 //FAIL: webgpu:api,validation,encoding,encoder_open_state:render_bundle_commands:*
@@ -117,8 +167,8 @@ webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bind_grou
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:buffer_binding,render_pipeline:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:sampler_binding,render_pipeline:*
 webgpu:api,validation,encoding,queries,begin_end:occlusion_query,*
-webgpu:api,validation,encoding,queries,general:occlusion_query,query_index:*
-webgpu:api,validation,encoding,queries,general:occlusion_query,query_type:*
+webgpu:api,validation,encoding,queries,general:occlusion_query,*
+webgpu:api,validation,error_scope:*
 webgpu:api,validation,image_copy,buffer_related:*
 // image_copy depth/stencil failures on dx12: https://github.com/gfx-rs/wgpu/issues/8133
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyB2T"
@@ -126,8 +176,6 @@ fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_sten
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="depth32float";aspect="depth-only";copyType="CopyT2B"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyB2T"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_offset:format="stencil8";aspect="stencil-only";copyType="CopyT2B"
-//mix of PASS and FAIL: other subtests of copy_buffer_offset. Related bugs:
-// https://github.com/gfx-rs/wgpu/issues/7946
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_buffer_size:*
 webgpu:api,validation,image_copy,buffer_texture_copies:depth_stencil_format,copy_usage_and_aspect:*
 webgpu:api,validation,image_copy,buffer_texture_copies:device_mismatch:*
@@ -145,13 +193,17 @@ fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyB2T";dimension="3d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="2d"
 fails-if(dx12) webgpu:api,validation,image_copy,buffer_texture_copies:offset_and_bytesPerRow:format="rgba8unorm";copyType="CopyT2B";dimension="3d"
-//mix of PASS and FAIL: other subtests of offset_and_bytesPerRow. Related bugs:
-// https://github.com/gfx-rs/wgpu/issues/7946
 webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*
 webgpu:api,validation,image_copy,buffer_texture_copies:texture_buffer_usages:*
+webgpu:api,validation,image_copy,layout_related:bound_on_bytes_per_row:*
+webgpu:api,validation,image_copy,layout_related:bound_on_offset:*
+webgpu:api,validation,image_copy,layout_related:bound_on_rows_per_image:*
 webgpu:api,validation,image_copy,layout_related:copy_end_overflows_u64:*
 webgpu:api,validation,image_copy,layout_related:offset_alignment:*
+webgpu:api,validation,image_copy,layout_related:required_bytes_in_copy:*
+webgpu:api,validation,image_copy,layout_related:rows_per_image_alignment:*
 webgpu:api,validation,image_copy,texture_related:*
+webgpu:api,validation,query_set,destroy:*
 webgpu:api,validation,queue,buffer_mapped:copyBufferToBuffer:*
 webgpu:api,validation,queue,buffer_mapped:copyBufferToTexture:*
 webgpu:api,validation,queue,buffer_mapped:copyTextureToBuffer:*
@@ -159,23 +211,56 @@ webgpu:api,validation,queue,buffer_mapped:map_command_recording_order:*
 // `vulkan` failure: https://github.com/gfx-rs/wgpu/issues/????
 fails-if(vulkan) webgpu:api,validation,queue,buffer_mapped:writeBuffer:*
 webgpu:api,validation,queue,submit:command_buffer,*
+webgpu:api,validation,queue,writeBuffer:buffer_state:*
+webgpu:api,validation,queue,writeBuffer:buffer,device_mismatch:*
+webgpu:api,validation,queue,writeBuffer:usages:*
+webgpu:api,validation,queue,writeTexture:*
+webgpu:api,validation,render_pass,attachment_compatibility:*
 webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,*
+webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,sample_counts_mismatch:*
 webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,*
+webgpu:api,validation,render_pass,render_pass_descriptor:timestampWrite,query_index:*
+webgpu:api,validation,render_pass,render_pass_descriptor:timestampWrites,query_set_type:*
 webgpu:api,validation,render_pass,resolve:resolve_attachment:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:depth_bias:*
+webgpu:api,validation,render_pipeline,depth_stencil_state:depth_test:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:depth_write,frag_depth:*
+webgpu:api,validation,render_pipeline,depth_stencil_state:depth_write:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:format:*
+webgpu:api,validation,render_pipeline,depth_stencil_state:stencil_test:*
 webgpu:api,validation,render_pipeline,depth_stencil_state:stencil_write:*
 webgpu:api,validation,render_pipeline,float32_blendable:*
+webgpu:api,validation,render_pipeline,fragment_state:color_target_exists:*
 webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,use_blend_src:*
+webgpu:api,validation,render_pipeline,fragment_state:limits,*
+webgpu:api,validation,render_pipeline,fragment_state:targets_format_filterable:*
+webgpu:api,validation,render_pipeline,fragment_state:targets_format_is_color_format:*
+webgpu:api,validation,render_pipeline,fragment_state:targets_format_renderable:*
 webgpu:api,validation,render_pipeline,inter_stage:location,*
 webgpu:api,validation,render_pipeline,inter_stage:max_shader_variable_location:*
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,*
+webgpu:api,validation,render_pipeline,misc:basic:*
+webgpu:api,validation,render_pipeline,misc:no_attachment:*
+webgpu:api,validation,render_pipeline,misc:pipeline_layout,device_mismatch:*
+webgpu:api,validation,render_pipeline,misc:vertex_state_only:*
+webgpu:api,validation,render_pipeline,primitive_state:*
 webgpu:api,validation,render_pipeline,resource_compatibility:*
+webgpu:api,validation,render_pipeline,shader_module:*
 webgpu:api,validation,render_pipeline,vertex_state:many_attributes_overlapping:*
+webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_array_stride_limit:*
+webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:*
+webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_offset_alignment:*
+webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_shaderLocation_limit:*
+webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_shaderLocation_unique:*
+webgpu:api,validation,render_pipeline,vertex_state:vertex_buffer_array_stride_limit_alignment:*
+webgpu:api,validation,render_pipeline,vertex_state:vertex_shader_input_location_in_vertex_state:*
+webgpu:api,validation,render_pipeline,vertex_state:vertex_shader_input_location_limit:*
+webgpu:api,validation,render_pipeline,vertex_state:vertex_shader_type_matches_attribute_format:*
 webgpu:api,validation,resource_usages,buffer,in_pass_encoder:*
-// FAIL: 2 other cases in resource_usages,texture,in_pass_encoder. https://github.com/gfx-rs/wgpu/issues/3126
+webgpu:api,validation,resource_usages,buffer,in_pass_misc:*
+webgpu:api,validation,resource_usages,texture,in_pass_encoder:bindings_in_bundle:*
+webgpu:api,validation,resource_usages,texture,in_pass_encoder:replaced_binding:*
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:scope,*
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:shader_stages_and_visibility,*
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_aspect:*
@@ -187,6 +272,13 @@ webgpu:api,validation,resource_usages,texture,in_render_common:subresources,colo
 // https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,depth_stencil_texture_in_bind_groups:*
 webgpu:api,validation,resource_usages,texture,in_render_common:subresources,multiple_bind_groups:*
+webgpu:api,validation,resource_usages,texture,in_render_misc:*
+webgpu:api,validation,shader_module,*
+webgpu:api,validation,texture,bgra8unorm_storage:*
+webgpu:api,validation,texture,destroy:base:*
+webgpu:api,validation,texture,destroy:invalid_texture:*
+webgpu:api,validation,texture,destroy:twice:*
+webgpu:api,validation,texture,float32_filterable:create_bind_group:*
 webgpu:api,validation,texture,rg11b10ufloat_renderable:*
 
 webgpu:shader,execution,expression,call,builtin,atan2:f16:*
@@ -210,25 +302,34 @@ webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type=
 webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="SimpleStruct";*
 webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="u32";*
 webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:types:type="vec4u";*
+webgpu:shader,execution,expression,unary,bool_conversion:*
 webgpu:shader,execution,flow_control,return:*
 // Many other vertex_buffer_access subtests also passing, but there are too many to enumerate.
 // Fails on Metal in CI only, not when running locally.
 fails-if(metal) webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true
 
 webgpu:shader,validation,const_assert,const_assert:*
+webgpu:shader,validation,decl,compound_statement:*
+webgpu:shader,validation,decl,const:*
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_neg"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_one"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_zero_signed"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_zero_unsigned"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_in_bounds"
+webgpu:shader,validation,expression,access,structure:*
 webgpu:shader,validation,expression,binary,add_sub_mul:scalar_vector_out_of_range:lhs="i32";*
 webgpu:shader,validation,expression,binary,add_sub_mul:scalar_vector_out_of_range:lhs="u32";*
+webgpu:shader,validation,expression,binary,parse:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:array_override:op="%26%26";a_val=1;b_val=1
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:scalar_vector:op="%26%26";lhs="bool";rhs="bool"
-webgpu:shader,validation,expression,call,builtin,all:arguments:test="ptr_deref"
+webgpu:shader,validation,expression,call,builtin,all:*
+webgpu:shader,validation,expression,call,builtin,any:*
 webgpu:shader,validation,expression,call,builtin,arrayLength:*
+webgpu:shader,validation,expression,call,builtin,atan:*
+webgpu:shader,validation,expression,call,builtin,atan2:*
 webgpu:shader,validation,expression,call,builtin,barriers:*
+webgpu:shader,validation,expression,call,builtin,ceil:*
 webgpu:shader,validation,expression,call,builtin,cos:*
 webgpu:shader,validation,expression,call,builtin,distance:values:stage="constant";type="f32"
 webgpu:shader,validation,expression,call,builtin,floor:*
@@ -237,6 +338,8 @@ webgpu:shader,validation,expression,call,builtin,length:scalar:stage="constant";
 webgpu:shader,validation,expression,call,builtin,max:*
 webgpu:shader,validation,expression,call,builtin,min:*
 webgpu:shader,validation,expression,call,builtin,radians:*
+webgpu:shader,validation,expression,call,builtin,round:*
+webgpu:shader,validation,expression,call,builtin,saturate:*
 webgpu:shader,validation,expression,call,builtin,sign:*
 webgpu:shader,validation,expression,call,builtin,sin:*
 webgpu:shader,validation,expression,call,builtin,step:*
@@ -257,9 +360,32 @@ webgpu:shader,validation,expression,call,builtin,value_constructor:struct_value:
 webgpu:shader,validation,expression,call,builtin,value_constructor:vector_splat:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:vector_zero_value:*
 webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:*
+webgpu:shader,validation,expression,overload_resolution:*
+webgpu:shader,validation,extension,clip_distances:*
+webgpu:shader,validation,extension,dual_source_blending:blend_src_same_type:*
+webgpu:shader,validation,extension,dual_source_blending:blend_src_stage_input_output:*
 webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
+webgpu:shader,validation,extension,dual_source_blending:use_blend_src_requires_extension_enabled:*
 webgpu:shader,validation,extension,pointer_composite_access:*
+webgpu:shader,validation,parse,blankspace:blankspace:*
+webgpu:shader,validation,parse,blankspace:bom:*
+webgpu:shader,validation,parse,blankspace:null_characters:contains_null=false;*
+webgpu:shader,validation,parse,blankspace:null_characters:contains_null=true;placement="delimiter"
+webgpu:shader,validation,parse,blankspace:null_characters:contains_null=true;placement="eol"
+webgpu:shader,validation,parse,enable:*
 webgpu:shader,validation,parse,requires:*
+webgpu:shader,validation,parse,semicolon:*
+webgpu:shader,validation,parse,source:*
+webgpu:shader,validation,shader_io,entry_point:*
+webgpu:shader,validation,shader_io,invariant:*
+webgpu:shader,validation,statement,break_if:*
+webgpu:shader,validation,statement,break:*
+webgpu:shader,validation,statement,compound:*
+webgpu:shader,validation,statement,const_assert:*
+webgpu:shader,validation,statement,continuing:*
+webgpu:shader,validation,statement,discard:*
+webgpu:shader,validation,statement,if:*
+webgpu:shader,validation,statement,return:*
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break_if"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="continue"
@@ -271,5 +397,5 @@ webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="l
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="loop6"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="loop8"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="switch1"
-//FAIL: 9 invalid_statements subtests due to https://github.com/gfx-rs/wgpu/issues/7733
+webgpu:shader,validation,statement,while:*
 webgpu:util,texture,texture_ok:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -256,7 +256,7 @@ webgpu:api,validation,render_pipeline,shader_module:*
 webgpu:api,validation,render_pipeline,vertex_state:many_attributes_overlapping:*
 webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_array_stride_limit:*
 fails-if(metal) webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:*
-webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_offset_alignment:*
+fails-if(metal) webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_offset_alignment:*
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_shaderLocation_limit:*
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_shaderLocation_unique:*
 webgpu:api,validation,render_pipeline,vertex_state:vertex_buffer_array_stride_limit_alignment:*


### PR DESCRIPTION
Adds some passing tests to test.lst. Adds triage notes to fail.lst. Removes some failure comments from test.lst.

It looks like this increases the CTS runtime to about 15 minutes, which means it is back to being the long pole, but maybe that's still in a tolerable range?

**Squash or Rebase?** Squash