### PR TITLE
clippy: Adjust `large-error-threshold` and remove waivers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,8 @@ default-members = [
 
 [workspace.lints.clippy]
 ref_as_ptr = "warn"
-# NOTE: disallowed-types is configured in other file: clippy.toml
+# NOTE: clippy configuration values (disallowed-types and
+# large-error-threshold) are in other file: clippy.toml
 
 [workspace.package]
 edition = "2021"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,6 +1,10 @@
-# NOTE: Other global Clippy config is in top-level Cargo.toml.
+# NOTE: Other global Clippy config (severity overrides) is in top-level Cargo.toml.
 
 disallowed-types = [
     { path = "std::collections::HashMap", reason = "use hashbrown::HashMap instead" },
     { path = "std::collections::HashSet", reason = "use hashbrown::HashSet instead" },
 ]
+
+# The default large-error-threshold is 128. We have a bunch of complex error
+# types that are slightly larger than that.
+large-error-threshold = 192

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -75,8 +75,7 @@ void main() {
     clippy::derive_partial_eq_without_eq,
     clippy::needless_borrowed_reference,
     clippy::single_match,
-    clippy::enum_variant_names,
-    clippy::result_large_err
+    clippy::enum_variant_names
 )]
 #![warn(
     trivial_casts,

--- a/naga/tests/naga/validation.rs
+++ b/naga/tests/naga/validation.rs
@@ -2,11 +2,6 @@
 //!
 //! There are also some validation tests in [`wgsl_errors`](super::wgsl_errors).
 
-#![allow(
-    // We need to investigate these.
-    clippy::result_large_err
-)]
-
 use naga::{
     ir::{self, Expression, Function, Module, Scalar},
     valid::{self, Capabilities, ModuleInfo, ValidationFlags},

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -6,10 +6,6 @@
 //! for the validator tests to be in the `validation` test suite.
 
 #![cfg(feature = "wgsl-in")]
-#![allow(
-    // We need to investigate these.
-    clippy::result_large_err
-)]
 
 use naga::{
     compact::KeepUnused,

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -37,8 +37,6 @@
     clippy::pattern_type_mismatch,
     // `wgpu-core` isn't entirely user-facing, so it's useful to document internal items.
     rustdoc::private_intra_doc_links,
-    // We should investigate these.
-    clippy::result_large_err
 )]
 #![warn(
     clippy::alloc_instead_of_core,


### PR DESCRIPTION
Increases the value of the clippy `large-error-threshold` setting from the default of 128 to 192, and removes waivers for the associated lint (which get applied at module scope, because otherwise they need to be applied to each function that uses the big error type, and would allow any error in that module to be arbitrarily large).

Errors that are between 128 and 192 bytes:

* `back::pipeline_constants::PipelineConstantError`
* `ValidationError`
* `RenderBundleError`, `RenderPassError`, `CommandEncoderError`
* `(SubmissionIndex, QueueSubmitError)`

**Testing**
Clippy is still happy.

**Squash or Rebase?** Squash (bonus points if you correct `large_error_threshold` to `large-error-threshold` in the commit message)

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
