### PR TITLE
[wgsl-in] Avoid looking up newly introduced parameter names while parsing function parameters and its return type.

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -374,6 +374,7 @@ webgpu:shader,validation,extension,dual_source_blending:blend_src_stage_input_ou
 webgpu:shader,validation,extension,dual_source_blending:blend_src_syntax_validation:*
 webgpu:shader,validation,extension,dual_source_blending:use_blend_src_requires_extension_enabled:*
 webgpu:shader,validation,extension,pointer_composite_access:*
+webgpu:shader,validation,functions,restrictions:param_type_can_be_alias:*
 webgpu:shader,validation,parse,blankspace:blankspace:*
 webgpu:shader,validation,parse,blankspace:bom:*
 webgpu:shader,validation,parse,blankspace:null_characters:contains_null=false;*
@@ -383,6 +384,7 @@ webgpu:shader,validation,parse,enable:*
 webgpu:shader,validation,parse,identifiers:*
 webgpu:shader,validation,parse,requires:*
 webgpu:shader,validation,parse,semicolon:*
+webgpu:shader,validation,parse,shadow_builtins:function_param:*
 webgpu:shader,validation,parse,source:*
 webgpu:shader,validation,shader_io,entry_point:*
 webgpu:shader,validation,shader_io,invariant:*

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -1712,6 +1712,9 @@ impl Parser {
 
         // start a scope that contains arguments as well as the function body
         ctx.local_table.push_scope();
+        // Reduce lookup scope to parse the parameter list and return type
+        // avoiding identifier lookup to match newly declared param names.
+        ctx.local_table.reduce_lookup_scope();
 
         // read parameter list
         let mut arguments = Vec::new();
@@ -1758,6 +1761,8 @@ impl Parser {
         } else {
             None
         };
+
+        ctx.local_table.reset_lookup_scope();
 
         // do not use `self.block` here, since we must not push a new scope
         lexer.expect(Token::Paren('{'))?;


### PR DESCRIPTION
**Connections**
Fixes a regression from https://github.com/gfx-rs/wgpu/pull/8386 brought up by @andyleiserson in https://phabricator.services.mozilla.com/D281092#9737681.

**Description**
Avoids looking up newly introduced parameter names while parsing function parameters and its return type.

**Testing**
Enabled new CTS tests.

**Squash or Rebase?**
n/a