### PR TITLE
Fix typo in document of `VertexFormat::Sint16`

### DIFF
--- a/wgpu-types/src/vertex.rs
+++ b/wgpu-types/src/vertex.rs
@@ -141,7 +141,7 @@ pub enum VertexFormat {
     Uint16x2 = 13,
     /// Four unsigned shorts (u16). `vec4<u32>` in shaders.
     Uint16x4 = 14,
-    /// One signed short (u16). `i32` in shaders.
+    /// One signed short (i16). `i32` in shaders.
     Sint16 = 15,
     /// Two signed shorts (i16). `vec2<i32>` in shaders.
     Sint16x2 = 16,


### PR DESCRIPTION
**Connections**
None

**Description**
Document `VertexFormat::Sint16` is `i16` instead of `u16`.

**Testing**
None

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
