### PR TITLE
chore(deps): Update `bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calloop"


### PR DESCRIPTION
Resolves a `cargo-deny` security advisory warning.

`bytes` is used only as a transitive dependency of deno, so the advisory does not apply to wgpu.

**Squash or Rebase?** Squash