### PR TITLE
fix(core): Calculate total number of bindings correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ By @cwfitzgerald in [#8999](https://github.com/gfx-rs/wgpu/pull/8999).
 - Check that depth bias is not used with non-triangle topologies. By @andyleiserson in [#8856](https://github.com/gfx-rs/wgpu/pull/8856).
 - Check that if the shader outputs `frag_depth`, then the pipeline must have a depth attachment. By @andyleiserson in [#8856](https://github.com/gfx-rs/wgpu/pull/8856).
 - Fix incorrect acceptance of some swizzle selectors that are not valid for their operand, e.g. `const v = vec2<i32>(); let r = v.xyz`. By @andyleiserson in [#8949](https://github.com/gfx-rs/wgpu/pull/8949).
+- Fixed calculation of the total number of bindings in a pipeline layout when validating against device limits. By @andyleiserson in [#8997](https://github.com/gfx-rs/wgpu/pull/8997).
 
 #### GLES
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -22,8 +22,8 @@ webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%, https://git
 webgpu:api,validation,createBindGroup:external_texture,* // 0%, no external external texture in deno
 webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:* // fails on vulkan
-webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_bind_group_layout:*
-webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:* // 0%, using max() instead of +=
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_bind_group_layout:* // https://github.com/gfx-rs/wgpu/issues/8748
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:* // metal, https://github.com/gfx-rs/wgpu/issues/8173
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_buffer_type:* // 25%, writable storage buffers not allowed in VERTEX
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_storage_texture_access:* // 25%, write-access storage textures not allowed in VERTEX
 webgpu:api,validation,createBindGroupLayout:visibility:* // 25%, missing per-stage storage limits

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -94,6 +94,14 @@ webgpu:api,validation,createBindGroup:texture_must_have_correct_component_type:*
 webgpu:api,validation,createBindGroup:texture_must_have_correct_dimension:*
 webgpu:api,validation,createBindGroupLayout:duplicate_bindings:*
 fails-if(vulkan) webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:*
+fails-if(vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"sampler":{"type":"comparison"}}
+fails-if(vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"sampler":{"type":"filtering"}}
+fails-if(vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"sampler":{"type":"non-filtering"}}
+fails-if(dx12,vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"storageTexture":{"access":"read-only","format":"r32float"}}
+fails-if(dx12,vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"storageTexture":{"access":"read-write","format":"r32float"}}
+fails-if(dx12,vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"storageTexture":{"access":"write-only","format":"r32float"}}
+fails-if(dx12,vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"texture":{"multisampled":false,"sampleType":"unfilterable-float"}}
+fails-if(dx12,vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"texture":{"multisampled":true,"sampleType":"unfilterable-float"}}
 webgpu:api,validation,createBindGroupLayout:maximum_binding_limit:*
 webgpu:api,validation,createBindGroupLayout:multisampled_validation:*
 webgpu:api,validation,createBindGroupLayout:storage_texture,formats:*

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -398,9 +398,9 @@ impl PerStageBindingTypeCounter {
     }
 
     pub(crate) fn merge(&mut self, other: &Self) {
-        self.vertex = self.vertex.max(other.vertex);
-        self.fragment = self.fragment.max(other.fragment);
-        self.compute = self.compute.max(other.compute);
+        self.vertex += other.vertex;
+        self.fragment += other.fragment;
+        self.compute += other.compute;
     }
 
     pub(crate) fn validate(


### PR DESCRIPTION
`PerStageBindingTypeCounter::merge` used `max` rather than `+` to combine the binding counts from different layouts. This seems pretty clearly wrong in some cases, but I don't know if there are others where it is desired behavior (because the new layout is superseding the prior layout, rather than augmenting it).

So, I only have moderate confidence that this change is correct, but it's simple enough, so I'm putting it up for review to see if anybody else has opinions.

Fixes #8993.

**Testing**
Enables some CTS tests (there are still multiple other problems in the suite -- in particular #8748 and #8173)  

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
