### PR TITLE
Use all ray tracing pipeline builtins in snapshots.

### DIFF
--- a/naga/tests/in/wgsl/ray-tracing-pipeline.wgsl
+++ b/naga/tests/in/wgsl/ray-tracing-pipeline.wgsl
@@ -11,24 +11,26 @@ var<ray_payload> hit_num: HitCounters;
 var acc_struct: acceleration_structure;
 
 @ray_generation
-fn ray_gen_main() {
+fn ray_gen_main(@builtin(ray_invocation_id) id: vec3<u32>, @builtin(num_ray_invocations) num_invocations: vec3<u32>) {
     hit_num = HitCounters();
-    traceRay(acc_struct, RayDesc(RAY_FLAG_NONE, 0xff, 0.01, 100.0, vec3(0.0), vec3(0.0, 1.0, 0.0)), &hit_num);
+    let shift = vec3<f32>(id) / vec3<f32>(num_invocations);
+    let ray_shift = (vec3(shift.x, 0.0, shift.y) * 2.0) - 1.0;
+    traceRay(acc_struct, RayDesc(RAY_FLAG_NONE, 0xff, 0.01, 100.0, vec3(0.0), vec3(0.0, 1.0, 0.0) + ray_shift), &hit_num);
 }
 
 var<incoming_ray_payload> incoming_hit_num: HitCounters;
 
 @miss
 @incoming_payload(incoming_hit_num)
-fn miss() {}
+fn miss(@builtin(world_ray_origin) origin: vec3<f32>, @builtin(world_ray_direction) dir: vec3<f32>, @builtin(ray_t_min) t_min: f32) {}
 
 @any_hit
 @incoming_payload(incoming_hit_num)
-fn any_hit_main() {
+fn any_hit_main(@builtin(instance_custom_data) data: u32, @builtin(geometry_index) geo_idx: u32, @builtin(ray_t_current_max) max: f32, @builtin(hit_kind) kind: u32) {
     incoming_hit_num.hit_num++;
-    incoming_hit_num.selected_hit = incoming_hit_num.hit_num;
+    incoming_hit_num.selected_hit = data;
 }
 
 @closest_hit
 @incoming_payload(incoming_hit_num)
-fn closest_hit_main() {}
+fn closest_hit_main(@builtin(object_ray_origin) origin: vec3<f32>, @builtin(object_ray_direction) dir: vec3<f32>, @builtin(object_to_world) obj_to_world: mat4x3<f32>, @builtin(world_to_object) world_to_obj: mat4x3<f32>) {}

--- a/naga/tests/out/wgsl/wgsl-ray-tracing-pipeline.wgsl
+++ b/naga/tests/out/wgsl/wgsl-ray-tracing-pipeline.wgsl
@@ -20,27 +20,28 @@ var acc_struct: acceleration_structure;
 var<incoming_ray_payload> incoming_hit_num: HitCounters;
 
 @ray_generation 
-fn ray_gen_main() {
+fn ray_gen_main(@builtin(ray_invocation_id) id: vec3<u32>, @builtin(num_ray_invocations) num_invocations: vec3<u32>) {
     hit_num = HitCounters();
-    traceRay(acc_struct, RayDesc(0u, 255u, 0.01f, 100f, vec3(0f), vec3<f32>(0f, 1f, 0f)), (&hit_num));
+    let shift = (vec3<f32>(id) / vec3<f32>(num_invocations));
+    let ray_shift = ((vec3<f32>(shift.x, 0f, shift.y) * 2f) - vec3(1f));
+    traceRay(acc_struct, RayDesc(0u, 255u, 0.01f, 100f, vec3(0f), (vec3<f32>(0f, 1f, 0f) + ray_shift)), (&hit_num));
     return;
 }
 
 @miss @incoming_payload(incoming_hit_num) 
-fn miss() {
+fn miss(@builtin(world_ray_origin) origin: vec3<f32>, @builtin(world_ray_direction) dir: vec3<f32>, @builtin(ray_t_min) t_min: f32) {
     return;
 }
 
 @any_hit @incoming_payload(incoming_hit_num) 
-fn any_hit_main() {
-    let _e3 = incoming_hit_num.hit_num;
-    incoming_hit_num.hit_num = (_e3 + 1u);
-    let _e9 = incoming_hit_num.hit_num;
-    incoming_hit_num.selected_hit = _e9;
+fn any_hit_main(@builtin(instance_custom_data) data: u32, @builtin(geometry_index) geo_idx: u32, @builtin(ray_t_current_max) max_: f32, @builtin(hit_kind) kind: u32) {
+    let _e7 = incoming_hit_num.hit_num;
+    incoming_hit_num.hit_num = (_e7 + 1u);
+    incoming_hit_num.selected_hit = data;
     return;
 }
 
 @closest_hit @incoming_payload(incoming_hit_num) 
-fn closest_hit_main() {
+fn closest_hit_main(@builtin(object_ray_origin) origin_1: vec3<f32>, @builtin(object_ray_direction) dir_1: vec3<f32>, @builtin(object_to_world) obj_to_world: mat4x3<f32>, @builtin(world_to_object) world_to_obj: mat4x3<f32>) {
     return;
 }


### PR DESCRIPTION
**Connections**
Discussed in the maintainers meeting.

**Description**
Although the ray tracing pipeline builtins are tested in naga errors, this only works for the front-ends. By including these in the snapshots too, the backend outputs (when added) are also tested. I have included one of every supported builtin, but haven't included them in all their supported stages.

**Testing**
Is testing.

**Squash or Rebase?**
Should just be one commit.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo xtask test` to run tests.
- [ ] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~ N/A
