### PR TITLE
fix(deno): Remove early validation of depthClearValue

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -55,7 +55,6 @@ webgpu:api,validation,queue,buffer_mapped:* // ***, vulkan
 webgpu:api,validation,queue,destroyed,* // 71%, writeBuffer/writeTexture return value, destroyed query set
 webgpu:api,validation,queue,writeBuffer:ranges:* // 0%, missing OperationError for invalid ranges
 webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_stencil_read_only_write_state:* // fails on dx12
-webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,depth_clear_value:* // 94%, TypeError instead of validation error
 webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadOnly:* // 33%, missing validation: depth/stencil load/store ops provided for missing texture format aspects
 webgpu:api,validation,render_pass,render_pass_descriptor:occlusionQuerySet,query_set_type:* // 50%, occlusionQuerySet type validation
 webgpu:api,validation,render_pipeline,depth_stencil_state:depth_bias:* // open PR

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -225,6 +225,7 @@ fails-if(dx12) webgpu:api,validation,render_pass,attachment_compatibility:render
 webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,sample_count:*
 webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,*
+webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,depth_clear_value:*
 webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,sample_counts_mismatch:*
 webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,*
 webgpu:api,validation,render_pass,render_pass_descriptor:timestampWrite,query_index:*

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -21,7 +21,6 @@ use crate::command_buffer::GPUCommandBuffer;
 use crate::compute_pass::GPUComputePassEncoder;
 use crate::error::GPUGenericError;
 use crate::queue::GPUTexelCopyTextureInfo;
-use crate::render_pass::GPULoadOp;
 use crate::render_pass::GPURenderPassEncoder;
 use crate::webidl::GPUExtent3D;
 use crate::Instance;
@@ -98,39 +97,26 @@ impl GPUCommandEncoder {
         .collect::<Vec<_>>(),
     );
 
-    let depth_stencil_attachment = descriptor
-            .depth_stencil_attachment
-            .map(|attachment| {
-                if attachment
-                    .depth_load_op
-                    .as_ref()
-                    .is_some_and(|op| matches!(op, GPULoadOp::Clear))
-                    && attachment.depth_clear_value.is_none()
-                {
-                    return Err(JsErrorBox::type_error(
-                        r#"'depthClearValue' must be specified when 'depthLoadOp' is "clear""#,
-                    ));
-                }
-
-                Ok(wgpu_core::command::RenderPassDepthStencilAttachment {
-                    view: attachment.view.to_view_id(),
-                    depth: PassChannel {
-                        load_op: attachment
-                            .depth_load_op
-                            .map(|load_op| load_op.with_value(attachment.depth_clear_value)),
-                        store_op: attachment.depth_store_op.map(Into::into),
-                        read_only: attachment.depth_read_only,
-                    },
-                    stencil: PassChannel {
-                        load_op: attachment.stencil_load_op.map(|load_op| {
-                            load_op.with_value(Some(attachment.stencil_clear_value))
-                        }),
-                        store_op: attachment.stencil_store_op.map(Into::into),
-                        read_only: attachment.stencil_read_only,
-                    },
-                })
-            })
-            .transpose()?;
+    let depth_stencil_attachment =
+      descriptor.depth_stencil_attachment.map(|attachment| {
+        wgpu_core::command::RenderPassDepthStencilAttachment {
+          view: attachment.view.to_view_id(),
+          depth: PassChannel {
+            load_op: attachment
+              .depth_load_op
+              .map(|load_op| load_op.with_value(attachment.depth_clear_value)),
+            store_op: attachment.depth_store_op.map(Into::into),
+            read_only: attachment.depth_read_only,
+          },
+          stencil: PassChannel {
+            load_op: attachment.stencil_load_op.map(|load_op| {
+              load_op.with_value(Some(attachment.stencil_clear_value))
+            }),
+            store_op: attachment.stencil_store_op.map(Into::into),
+            read_only: attachment.stencil_read_only,
+          },
+        }
+      });
 
     let timestamp_writes =
       descriptor.timestamp_writes.map(|timestamp_writes| {


### PR DESCRIPTION
Another CTS pick-up. This only affects Deno, the test is already passing in Firefox.

This validation needs to (and does) happen on the device timeline.

**Squash or Rebase?** Squash