### PR TITLE
Added some validation of a downlevel flag

### DIFF
--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -172,6 +172,8 @@ pub enum TransferError {
     InvalidMipLevel { requested: u32, count: u32 },
     #[error("Buffer is expected to be unmapped, but was not")]
     BufferNotAvailable,
+    #[error("Copying between depth stencil textures requires `DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES`")]
+    DepthStencilCopyRequiresDownlevel,
 }
 
 impl WebGpuError for TransferError {
@@ -214,7 +216,8 @@ impl WebGpuError for TransferError {
             | Self::SampleCountNotEqual { .. }
             | Self::InvalidMipLevel { .. }
             | Self::SameSourceDestinationBuffer
-            | Self::BufferNotAvailable => return ErrorType::Validation,
+            | Self::BufferNotAvailable
+            | Self::DepthStencilCopyRequiresDownlevel => return ErrorType::Validation,
         };
         e.webgpu_error_type()
     }
@@ -1372,6 +1375,15 @@ pub(super) fn copy_texture_to_texture(
     }
     if dst_tex_base.aspect != dst_texture_aspects {
         return Err(TransferError::CopyDstMissingAspects.into());
+    }
+    if (src_texture_aspects | dst_texture_aspects).intersects(hal::FormatAspects::DEPTH_STENCIL)
+        && !state
+            .device
+            .downlevel
+            .flags
+            .contains(wgt::DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES)
+    {
+        return Err(TransferError::DepthStencilCopyRequiresDownlevel.into());
     }
 
     if src_texture.desc.sample_count != dst_texture.desc.sample_count {


### PR DESCRIPTION
**Connections**
Closes #8995

**Description**
Adds validation for depth texture copies which are unsupported on WebGL/GLES.

**Testing**
Not tested

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
