### PR TITLE
Remove layer from superlayer in `Drop` if needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,7 +258,7 @@ objc2-quartz-core = { version = "0.3.2", default-features = false, features = [
     "CAMetalLayer",
     "objc2-metal",
 ] }
-raw-window-metal = "1.0"
+raw-window-metal = "1.2"
 
 # Vulkan dependencies
 android_system_properties = "0.1.1"

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -167,13 +167,15 @@ impl crate::Instance for Instance {
             }
         };
 
+        let should_remove_from_super = !layer.pre_existing();
+
         // SAFETY: The layer is an initialized instance of `CAMetalLayer`, and
         // we transfer the retain count to `Retained` using `into_raw`.
         let layer = unsafe {
             Retained::from_raw(layer.into_raw().cast::<CAMetalLayer>().as_ptr()).unwrap()
         };
 
-        Ok(Surface::new(layer))
+        Ok(Surface::new(layer, should_remove_from_super))
     }
 
     unsafe fn enumerate_adapters(
@@ -437,12 +439,26 @@ pub struct Device {
 
 pub struct Surface {
     render_layer: Mutex<Retained<CAMetalLayer>>,
+    /// If the provided `CALayer` was not `CAMetalLayer`, we create and insert
+    /// a new child layer.
+    ///
+    /// To avoid keeping these layers around indefinitely, we need to remove
+    /// them from the parent layer again once we're done with them.
+    should_remove_from_super: bool,
     swapchain_format: RwLock<Option<wgt::TextureFormat>>,
     extent: RwLock<wgt::Extent3d>,
 }
 
 unsafe impl Send for Surface {}
 unsafe impl Sync for Surface {}
+
+impl Drop for Surface {
+    fn drop(&mut self) {
+        if self.should_remove_from_super {
+            self.render_layer.get_mut().removeFromSuperlayer();
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct SurfaceTexture {

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -15,9 +15,10 @@ use parking_lot::{Mutex, RwLock};
 use super::OsFeatures;
 
 impl super::Surface {
-    pub fn new(layer: Retained<CAMetalLayer>) -> Self {
+    pub fn new(layer: Retained<CAMetalLayer>, should_remove_from_super: bool) -> Self {
         Self {
             render_layer: Mutex::new(layer),
+            should_remove_from_super,
             swapchain_format: RwLock::new(None),
             extent: RwLock::new(wgt::Extent3d::default()),
         }
@@ -25,7 +26,7 @@ impl super::Surface {
 
     pub fn from_layer(layer: &CAMetalLayer) -> Self {
         assert!(layer.isKindOfClass(CAMetalLayer::class()));
-        Self::new(layer.retain())
+        Self::new(layer.retain(), false)
     }
 
     pub fn render_layer(&self) -> &Mutex<Retained<CAMetalLayer>> {

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -539,7 +539,16 @@ impl super::Instance {
             unsafe { metal_loader.create_metal_surface(&vk_info, None).unwrap() }
         };
 
-        Ok(self.create_surface_from_vk_surface_khr(surface))
+        let native_surface = crate::vulkan::swapchain::NativeSurface::from_vk_surface_khr(
+            self,
+            surface,
+            Some(layer),
+        );
+
+        Ok(super::Surface {
+            inner: ManuallyDrop::new(Box::new(native_surface)),
+            swapchain: RwLock::new(None),
+        })
     }
 
     pub(super) fn create_surface_from_vk_surface_khr(
@@ -547,7 +556,7 @@ impl super::Instance {
         surface: vk::SurfaceKHR,
     ) -> super::Surface {
         let native_surface =
-            crate::vulkan::swapchain::NativeSurface::from_vk_surface_khr(self, surface);
+            crate::vulkan::swapchain::NativeSurface::from_vk_surface_khr(self, surface, None);
 
         super::Surface {
             inner: ManuallyDrop::new(Box::new(native_surface)),

--- a/wgpu-hal/src/vulkan/swapchain/native.rs
+++ b/wgpu-hal/src/vulkan/swapchain/native.rs
@@ -17,15 +17,29 @@ pub(crate) struct NativeSurface {
     raw: vk::SurfaceKHR,
     functor: khr::surface::Instance,
     instance: Arc<InstanceShared>,
+    /// On Apple platforms, if the provided `CALayer` was not `CAMetalLayer`,
+    /// we create and insert a new child layer.
+    ///
+    /// To avoid keeping these layers around indefinitely, we need to remove
+    /// them from the parent layer again once we're done with them.
+    #[cfg(target_vendor = "apple")]
+    layer_to_remove_from_super: Option<raw_window_metal::Layer>,
 }
 
 impl NativeSurface {
-    pub fn from_vk_surface_khr(instance: &crate::vulkan::Instance, raw: vk::SurfaceKHR) -> Self {
+    pub fn from_vk_surface_khr(
+        instance: &crate::vulkan::Instance,
+        raw: vk::SurfaceKHR,
+        #[cfg(target_vendor = "apple")] layer_to_remove_from_super: Option<raw_window_metal::Layer>,
+        #[cfg(not(target_vendor = "apple"))] _layer_to_remove_from_super: Option<()>,
+    ) -> Self {
         let functor = khr::surface::Instance::new(&instance.shared.entry, &instance.shared.raw);
         Self {
             raw,
             functor,
             instance: Arc::clone(&instance.shared),
+            #[cfg(target_vendor = "apple")]
+            layer_to_remove_from_super,
         }
     }
 
@@ -36,6 +50,11 @@ impl NativeSurface {
 
 impl Surface for NativeSurface {
     unsafe fn delete_surface(self: Box<Self>) {
+        #[cfg(target_vendor = "apple")]
+        if let Some(layer_to_remove_from_super) = &self.layer_to_remove_from_super {
+            layer_to_remove_from_super.remove_from_superlayer_if_necessary();
+        }
+
         unsafe {
             self.functor.destroy_surface(self.raw, None);
         }


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/9021.

**Description**
`CALayer` holds a strong reference to its sublayers, which means that the layer that `raw-window-metal` inserts for us is never deallocated.

This PR fixes that by explicitly removing the layer from the superlayer when `Surface` is dropped.

**Testing**
TODO: Not yet tested.

**Checklist**
- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [ ] Run `cargo clippy --tests`.
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
