### PR TITLE
fix: Hold snatch lock during present/discard to prevent race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -468,7 +468,6 @@ By @cwfitzgerald in [#8609](https://github.com/gfx-rs/wgpu/pull/8609).
 - The texture subresources used by the color attachments of a render pass are no longer allowed to overlap when accessed via different texture views. By @andyleiserson in [#8402](https://github.com/gfx-rs/wgpu/pull/8402).
 - The `STORAGE_READ_ONLY` texture usage is now permitted to coexist with other read-only usages. By @andyleiserson in [#8490](https://github.com/gfx-rs/wgpu/pull/8490).
 - Validate that buffers are unmapped in `write_buffer` calls. By @ErichDonGubler in [#8454](https://github.com/gfx-rs/wgpu/pull/8454).
-- Shorten critical section inside present such that the snatch write lock is no longer held during present, preventing other work happening on other threads. By @cwfitzgerald in [#8608](https://github.com/gfx-rs/wgpu/pull/8608).
 
 #### naga
 

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -293,11 +293,7 @@ impl Surface {
             .take()
             .ok_or(SurfaceError::AlreadyAcquired)?;
 
-        let mut exclusive_snatch_guard = device.snatchable_lock.write();
-        let inner = texture.inner.snatch(&mut exclusive_snatch_guard);
-        drop(exclusive_snatch_guard);
-
-        let result = match inner {
+        let result = match texture.inner.snatch(&mut device.snatchable_lock.write()) {
             None => return Err(SurfaceError::TextureDestroyed),
             Some(resource::TextureInner::Surface { raw }) => {
                 let raw_surface = self.raw(device.backend()).unwrap();
@@ -341,11 +337,7 @@ impl Surface {
             .take()
             .ok_or(SurfaceError::AlreadyAcquired)?;
 
-        let mut exclusive_snatch_guard = device.snatchable_lock.write();
-        let inner = texture.inner.snatch(&mut exclusive_snatch_guard);
-        drop(exclusive_snatch_guard);
-
-        match inner {
+        match texture.inner.snatch(&mut device.snatchable_lock.write()) {
             None => return Err(SurfaceError::TextureDestroyed),
             Some(resource::TextureInner::Surface { raw }) => {
                 let raw_surface = self.raw(device.backend()).unwrap();


### PR DESCRIPTION
**Connections**
Fixes #9003

_When one pull request builds on another, please put "Depends on
#NNNN" towards the top of its description. This helps maintainers
notice that they shouldn't merge it until its ancestor has been
approved. Don't use draft PR status to indicate this._

**Description**
Reverts the early drop of the snatch lock guard introduced in d85408a. The guard must be held through the entire present/discard operation to ensure the VkQueue is not accessed concurrently from multiple threads.

Releasing the lock early allowed a race condition where background threads calling queue.submit() could access the VkQueue simultaneously with the presentation thread, causing validation errors, semaphore corruption, and crashes on some drivers (notably NVIDIA).

**Testing**
By rerunning the example from #9003

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
