### PR TITLE
Enable `FLOAT32_BLENDABLE` on Metal, in Deno, and separate from filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ By @cwfitzgerald in [#8999](https://github.com/gfx-rs/wgpu/pull/8999).
 - Added support for no-perspective barycentric coordinates. By @atlv24 in [#8852](https://github.com/gfx-rs/wgpu/issues/8852).
 - Added support for obtaining `AdapterInfo` from `Device`. By @sagudev in [#8807](https://github.com/gfx-rs/wgpu/pull/8807).
 - Added `Limits::or_worse_values_from`. By @atlv24 in [#8870](https://github.com/gfx-rs/wgpu/pull/8870).
-- Added `Features::FLOAT32_BLENDABLE`. By @timokoesters in [#8963](https://github.com/gfx-rs/wgpu/pull/8963).
+- Added `Features::FLOAT32_BLENDABLE` on Vulkan and Metal. By @timokoesters in [#8963](https://github.com/gfx-rs/wgpu/pull/8963) and @andyleiserson in [#9032](https://github.com/gfx-rs/wgpu/pull/9032).
 - Made the following available in `const` contexts:
     - `naga`
         - `Arena::len`

--- a/deno_webgpu/webidl.rs
+++ b/deno_webgpu/webidl.rs
@@ -392,10 +392,10 @@ pub enum GPUFeatureName {
   Rg11b10ufloatRenderable,
   #[webidl(rename = "bgra8unorm-storage")]
   Bgra8unormStorage,
-  #[webidl(rename = "float32-blendable")]
-  Float32Blendable,
   #[webidl(rename = "float32-filterable")]
   Float32Filterable,
+  #[webidl(rename = "float32-blendable")]
+  Float32Blendable,
   #[webidl(rename = "dual-source-blending")]
   DualSourceBlending,
   #[webidl(rename = "subgroups")]
@@ -490,8 +490,8 @@ pub fn feature_names_to_features(
       GPUFeatureName::TextureCompressionAstcSliced3d => Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D,
       GPUFeatureName::Rg11b10ufloatRenderable => Features::RG11B10UFLOAT_RENDERABLE,
       GPUFeatureName::Bgra8unormStorage => Features::BGRA8UNORM_STORAGE,
-      GPUFeatureName::Float32Blendable => Features::FLOAT32_BLENDABLE,
       GPUFeatureName::Float32Filterable => Features::FLOAT32_FILTERABLE,
+      GPUFeatureName::Float32Blendable => Features::FLOAT32_BLENDABLE,
       GPUFeatureName::DualSourceBlending => Features::DUAL_SOURCE_BLENDING,
       GPUFeatureName::Subgroups => Features::SUBGROUP,
       GPUFeatureName::ExternalTexture => Features::EXTERNAL_TEXTURE,
@@ -578,11 +578,11 @@ pub fn features_to_feature_names(
   if features.contains(wgpu_types::Features::BGRA8UNORM_STORAGE) {
     return_features.insert(Bgra8unormStorage);
   }
-  if features.contains(wgpu_types::Features::FLOAT32_BLENDABLE) {
-    return_features.insert(Float32Blendable);
-  }
   if features.contains(wgpu_types::Features::FLOAT32_FILTERABLE) {
     return_features.insert(Float32Filterable);
+  }
+  if features.contains(wgpu_types::Features::FLOAT32_BLENDABLE) {
+    return_features.insert(Float32Blendable);
   }
   if features.contains(wgpu_types::Features::DUAL_SOURCE_BLENDING) {
     return_features.insert(DualSourceBlending);

--- a/deno_webgpu/webidl.rs
+++ b/deno_webgpu/webidl.rs
@@ -392,6 +392,8 @@ pub enum GPUFeatureName {
   Rg11b10ufloatRenderable,
   #[webidl(rename = "bgra8unorm-storage")]
   Bgra8unormStorage,
+  #[webidl(rename = "float32-blendable")]
+  Float32Blendable,
   #[webidl(rename = "float32-filterable")]
   Float32Filterable,
   #[webidl(rename = "dual-source-blending")]
@@ -488,6 +490,7 @@ pub fn feature_names_to_features(
       GPUFeatureName::TextureCompressionAstcSliced3d => Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D,
       GPUFeatureName::Rg11b10ufloatRenderable => Features::RG11B10UFLOAT_RENDERABLE,
       GPUFeatureName::Bgra8unormStorage => Features::BGRA8UNORM_STORAGE,
+      GPUFeatureName::Float32Blendable => Features::FLOAT32_BLENDABLE,
       GPUFeatureName::Float32Filterable => Features::FLOAT32_FILTERABLE,
       GPUFeatureName::DualSourceBlending => Features::DUAL_SOURCE_BLENDING,
       GPUFeatureName::Subgroups => Features::SUBGROUP,
@@ -574,6 +577,9 @@ pub fn features_to_feature_names(
   }
   if features.contains(wgpu_types::Features::BGRA8UNORM_STORAGE) {
     return_features.insert(Bgra8unormStorage);
+  }
+  if features.contains(wgpu_types::Features::FLOAT32_BLENDABLE) {
+    return_features.insert(Float32Blendable);
   }
   if features.contains(wgpu_types::Features::FLOAT32_FILTERABLE) {
     return_features.insert(Float32Filterable);

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4087,16 +4087,7 @@ impl Device {
                             cs.format,
                         ));
                     }
-                    let blendable = format_features.flags.contains(Tfff::BLENDABLE);
-                    let filterable = format_features.flags.contains(Tfff::FILTERABLE);
-                    let adapter_specific = self
-                        .features
-                        .contains(wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES);
-                    // according to WebGPU specifications the texture needs to be
-                    // [`TextureFormatFeatureFlags::FILTERABLE`] if blending is set - use
-                    // [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] to elude
-                    // this limitation
-                    if cs.blend.is_some() && (!blendable || (!filterable && !adapter_specific)) {
+                    if cs.blend.is_some() && !format_features.flags.contains(Tfff::BLENDABLE) {
                         break 'error Some(pipeline::ColorStateError::FormatNotBlendable(
                             cs.format,
                         ));

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1008,6 +1008,7 @@ impl super::PrivateCapabilities {
             | F::EXTERNAL_TEXTURE;
 
         features.set(F::FLOAT32_FILTERABLE, self.supports_float_filtering);
+        features.set(F::FLOAT32_BLENDABLE, true);
         features.set(F::INDIRECT_FIRST_INSTANCE, self.indirect_draw_dispatch);
         features.set(
             F::TIMESTAMP_QUERY | F::TIMESTAMP_QUERY_INSIDE_ENCODERS,


### PR DESCRIPTION
According to the Metal feature tables, this is always available.

I've also added it to the Deno bindings, and removed a check that conflated blendability with filterability, which I believe reflected a spec error that was fixed some time ago in https://github.com/gpuweb/gpuweb/pull/3920.

**Testing**
The CTS test `webgpu:api,validation,render_pipeline,float32_blendable:*` is already enabled. Since this is an optional feature, the CTS test will pass whether or not it is available. But with this change, subcases change from SKIP to PASS. 

**Squash or Rebase?** Squash

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
