### PR TITLE
Fix typo in documentation comment

### DIFF
--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -199,7 +199,7 @@ impl Queue {
         })
     }
 
-    /// Copies the bytes of `data` into into a texture.
+    /// Copies the bytes of `data` into a texture.
     ///
     /// * `data` contains the texels to be written, which must be in
     ///   [the same format as the texture](TextureFormat).


### PR DESCRIPTION
Documentation for `Queue.write_texture(...)` had the typo "Copies the bytes of `data` into ~~into~~ a texture", I simply removed the extra "into".