### PR TITLE
Add DownlevelFlags::TEXTURE_FORMAT_BGRA for WebGL

### DIFF
--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -607,7 +607,7 @@ static DIFFERENT_BGL_ORDER_BW_SHADER_AND_API: GpuTestConfiguration = GpuTestConf
                     entry_point: Some("fs_main"),
                     compilation_options: Default::default(),
                     targets: &[Some(wgpu::ColorTargetState {
-                        format: wgpu::TextureFormat::Bgra8Unorm,
+                        format: wgpu::TextureFormat::Rgba8Unorm,
                         blend: None,
                         write_mask: wgpu::ColorWrites::ALL,
                     })],

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -282,6 +282,25 @@ pub(crate) enum DeferredDestroy {
     BindGroups(WeakVec<BindGroup>),
 }
 
+#[derive(Clone, Debug)]
+enum FormatFeaturesError {
+    MissingFeatures(TextureFormat, MissingFeatures),
+    MissingDownlevelFlags(MissingDownlevelFlags),
+}
+
+impl From<FormatFeaturesError> for resource::CreateTextureError {
+    fn from(error: FormatFeaturesError) -> Self {
+        match error {
+            FormatFeaturesError::MissingFeatures(format, missing) => {
+                resource::CreateTextureError::MissingFeatures(format, missing)
+            }
+            FormatFeaturesError::MissingDownlevelFlags(missing) => {
+                resource::CreateTextureError::MissingDownlevelFlags(missing)
+            }
+        }
+    }
+}
+
 impl fmt::Debug for Device {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Device")
@@ -1199,9 +1218,7 @@ impl Device {
         hal_texture: Box<dyn hal::DynTexture>,
         desc: &resource::TextureDescriptor,
     ) -> Result<Arc<Texture>, resource::CreateTextureError> {
-        let format_features = self
-            .describe_format_features(desc.format)
-            .map_err(|error| resource::CreateTextureError::MissingFeatures(desc.format, error))?;
+        let format_features = self.describe_format_features(desc.format)?;
 
         unsafe { self.raw().add_raw_texture(&*hal_texture) };
 
@@ -1472,9 +1489,7 @@ impl Device {
             }
         }
 
-        let format_features = self
-            .describe_format_features(desc.format)
-            .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
+        let format_features = self.describe_format_features(desc.format)?;
 
         if desc.sample_count > 1 {
             // <https://www.w3.org/TR/2025/CRD-webgpu-20251120/#:~:text=If%20descriptor%2EsampleCount%20%3E%201>
@@ -1541,10 +1556,7 @@ impl Device {
                 for plane in 0..planes {
                     let aspect = wgt::TextureAspect::from_plane(plane).unwrap();
                     let format = desc.format.aspect_specific_format(aspect).unwrap();
-                    let format_features = self
-                        .describe_format_features(format)
-                        .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
-
+                    let format_features = self.describe_format_features(format)?;
                     planes_usages &= format_features.allowed_usages;
                 }
 
@@ -1749,7 +1761,16 @@ impl Device {
             }
         };
 
-        let format_features = self.describe_format_features(resolved_format)?;
+        let format_features = self
+            .describe_format_features(resolved_format)
+            .map_err(|error| match error {
+                FormatFeaturesError::MissingFeatures(_, missing) => {
+                    resource::CreateTextureViewError::MissingFeatures(missing)
+                }
+                FormatFeaturesError::MissingDownlevelFlags(missing) => {
+                    resource::CreateTextureViewError::MissingDownlevelFlags(missing)
+                }
+            })?;
         let allowed_format_usages = format_features.allowed_usages;
         if resolved_usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT)
             && !allowed_format_usages.contains(wgt::TextureUsages::RENDER_ATTACHMENT)
@@ -2657,7 +2678,14 @@ impl Device {
                         self.describe_format_features(format).map_err(|error| {
                             binding_model::CreateBindGroupLayoutError::Entry {
                                 binding: entry.binding,
-                                error: BindGroupLayoutEntryError::MissingFeatures(error),
+                                error: match error {
+                                    FormatFeaturesError::MissingFeatures(_, missing) => {
+                                        BindGroupLayoutEntryError::MissingFeatures(missing)
+                                    }
+                                    FormatFeaturesError::MissingDownlevelFlags(missing) => {
+                                        BindGroupLayoutEntryError::MissingDownlevelFlags(missing)
+                                    }
+                                },
                             }
                         })?;
 
@@ -4127,7 +4155,18 @@ impl Device {
                         ));
                     }
 
-                    let format_features = self.describe_format_features(cs.format)?;
+                    let format_features =
+                        self.describe_format_features(cs.format)
+                            .map_err(|error| match error {
+                                FormatFeaturesError::MissingFeatures(_, missing) => {
+                                    pipeline::CreateRenderPipelineError::MissingFeatures(missing)
+                                }
+                                FormatFeaturesError::MissingDownlevelFlags(missing) => {
+                                    pipeline::CreateRenderPipelineError::MissingDownlevelFlags(
+                                        missing,
+                                    )
+                                }
+                            })?;
                     if !format_features
                         .allowed_usages
                         .contains(wgt::TextureUsages::RENDER_ATTACHMENT)
@@ -4222,7 +4261,16 @@ impl Device {
                     ));
                 }
 
-                let format_features = self.describe_format_features(ds.format)?;
+                let format_features =
+                    self.describe_format_features(ds.format)
+                        .map_err(|error| match error {
+                            FormatFeaturesError::MissingFeatures(_, missing) => {
+                                pipeline::CreateRenderPipelineError::MissingFeatures(missing)
+                            }
+                            FormatFeaturesError::MissingDownlevelFlags(missing) => {
+                                pipeline::CreateRenderPipelineError::MissingDownlevelFlags(missing)
+                            }
+                        })?;
                 if !format_features
                     .allowed_usages
                     .contains(wgt::TextureUsages::RENDER_ATTACHMENT)
@@ -4795,8 +4843,17 @@ impl Device {
     fn describe_format_features(
         &self,
         format: TextureFormat,
-    ) -> Result<wgt::TextureFormatFeatures, MissingFeatures> {
-        self.require_features(format.required_features())?;
+    ) -> Result<wgt::TextureFormatFeatures, FormatFeaturesError> {
+        self.require_features(format.required_features())
+            .map_err(|missing| FormatFeaturesError::MissingFeatures(format, missing))?;
+
+        if matches!(
+            format,
+            TextureFormat::Bgra8Unorm | TextureFormat::Bgra8UnormSrgb
+        ) {
+            self.require_downlevel_flags(wgt::DownlevelFlags::TEXTURE_FORMAT_BGRA)
+                .map_err(FormatFeaturesError::MissingDownlevelFlags)?;
+        }
 
         let using_device_features = self
             .features

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -301,6 +301,45 @@ impl From<FormatFeaturesError> for resource::CreateTextureError {
     }
 }
 
+impl From<FormatFeaturesError> for pipeline::CreateRenderPipelineError {
+    fn from(error: FormatFeaturesError) -> Self {
+        match error {
+            FormatFeaturesError::MissingFeatures(_, missing) => {
+                pipeline::CreateRenderPipelineError::MissingFeatures(missing)
+            }
+            FormatFeaturesError::MissingDownlevelFlags(missing) => {
+                pipeline::CreateRenderPipelineError::MissingDownlevelFlags(missing)
+            }
+        }
+    }
+}
+
+impl From<FormatFeaturesError> for resource::CreateTextureViewError {
+    fn from(error: FormatFeaturesError) -> Self {
+        match error {
+            FormatFeaturesError::MissingFeatures(_, missing) => {
+                resource::CreateTextureViewError::MissingFeatures(missing)
+            }
+            FormatFeaturesError::MissingDownlevelFlags(missing) => {
+                resource::CreateTextureViewError::MissingDownlevelFlags(missing)
+            }
+        }
+    }
+}
+
+impl From<FormatFeaturesError> for BindGroupLayoutEntryError {
+    fn from(error: FormatFeaturesError) -> Self {
+        match error {
+            FormatFeaturesError::MissingFeatures(_, missing) => {
+                BindGroupLayoutEntryError::MissingFeatures(missing)
+            }
+            FormatFeaturesError::MissingDownlevelFlags(missing) => {
+                BindGroupLayoutEntryError::MissingDownlevelFlags(missing)
+            }
+        }
+    }
+}
+
 impl fmt::Debug for Device {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Device")
@@ -1761,16 +1800,7 @@ impl Device {
             }
         };
 
-        let format_features = self
-            .describe_format_features(resolved_format)
-            .map_err(|error| match error {
-                FormatFeaturesError::MissingFeatures(_, missing) => {
-                    resource::CreateTextureViewError::MissingFeatures(missing)
-                }
-                FormatFeaturesError::MissingDownlevelFlags(missing) => {
-                    resource::CreateTextureViewError::MissingDownlevelFlags(missing)
-                }
-            })?;
+        let format_features = self.describe_format_features(resolved_format)?;
         let allowed_format_usages = format_features.allowed_usages;
         if resolved_usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT)
             && !allowed_format_usages.contains(wgt::TextureUsages::RENDER_ATTACHMENT)
@@ -2678,14 +2708,7 @@ impl Device {
                         self.describe_format_features(format).map_err(|error| {
                             binding_model::CreateBindGroupLayoutError::Entry {
                                 binding: entry.binding,
-                                error: match error {
-                                    FormatFeaturesError::MissingFeatures(_, missing) => {
-                                        BindGroupLayoutEntryError::MissingFeatures(missing)
-                                    }
-                                    FormatFeaturesError::MissingDownlevelFlags(missing) => {
-                                        BindGroupLayoutEntryError::MissingDownlevelFlags(missing)
-                                    }
-                                },
+                                error: error.into(),
                             }
                         })?;
 
@@ -4155,18 +4178,7 @@ impl Device {
                         ));
                     }
 
-                    let format_features =
-                        self.describe_format_features(cs.format)
-                            .map_err(|error| match error {
-                                FormatFeaturesError::MissingFeatures(_, missing) => {
-                                    pipeline::CreateRenderPipelineError::MissingFeatures(missing)
-                                }
-                                FormatFeaturesError::MissingDownlevelFlags(missing) => {
-                                    pipeline::CreateRenderPipelineError::MissingDownlevelFlags(
-                                        missing,
-                                    )
-                                }
-                            })?;
+                    let format_features = self.describe_format_features(cs.format)?;
                     if !format_features
                         .allowed_usages
                         .contains(wgt::TextureUsages::RENDER_ATTACHMENT)
@@ -4261,16 +4273,7 @@ impl Device {
                     ));
                 }
 
-                let format_features =
-                    self.describe_format_features(ds.format)
-                        .map_err(|error| match error {
-                            FormatFeaturesError::MissingFeatures(_, missing) => {
-                                pipeline::CreateRenderPipelineError::MissingFeatures(missing)
-                            }
-                            FormatFeaturesError::MissingDownlevelFlags(missing) => {
-                                pipeline::CreateRenderPipelineError::MissingDownlevelFlags(missing)
-                            }
-                        })?;
+                let format_features = self.describe_format_features(ds.format)?;
                 if !format_features
                     .allowed_usages
                     .contains(wgt::TextureUsages::RENDER_ATTACHMENT)

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1881,6 +1881,8 @@ pub enum CreateTextureViewError {
     InvalidResource(#[from] InvalidResourceError),
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
+    #[error(transparent)]
+    MissingDownlevelFlags(#[from] MissingDownlevelFlags),
 }
 
 impl WebGpuError for CreateTextureViewError {
@@ -1905,7 +1907,8 @@ impl WebGpuError for CreateTextureViewError {
             | Self::TextureViewFormatNotRenderable(_)
             | Self::TextureViewFormatNotStorage(_)
             | Self::InvalidTextureViewUsage { .. }
-            | Self::MissingFeatures(_) => ErrorType::Validation,
+            | Self::MissingFeatures(_)
+            | Self::MissingDownlevelFlags(_) => ErrorType::Validation,
         }
     }
 }

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -447,6 +447,10 @@ impl super::Adapter {
         if query_buffers {
             downlevel_flags.set(wgt::DownlevelFlags::NONBLOCKING_QUERY_RESOLVE, true);
         }
+        downlevel_flags.set(
+            wgt::DownlevelFlags::TEXTURE_FORMAT_BGRA,
+            !cfg!(any(webgl, Emscripten)),
+        );
 
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -449,7 +449,8 @@ impl super::Adapter {
         }
         downlevel_flags.set(
             wgt::DownlevelFlags::TEXTURE_FORMAT_BGRA,
-            !cfg!(any(webgl, Emscripten)),
+            !cfg!(any(webgl, Emscripten))
+                && (full_ver.is_some() || extensions.contains("GL_EXT_texture_format_BGRA8888")),
         );
 
         let mut features = wgt::Features::empty()

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -664,7 +664,8 @@ impl PhysicalDeviceFeatures {
             | Df::VIEW_FORMATS
             | Df::UNRESTRICTED_EXTERNAL_TEXTURE_COPIES
             | Df::NONBLOCKING_QUERY_RESOLVE
-            | Df::SHADER_F16_IN_F32;
+            | Df::SHADER_F16_IN_F32
+            | Df::TEXTURE_FORMAT_BGRA;
 
         dl_flags.set(
             Df::SURFACE_VIEW_FORMATS,

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -952,6 +952,11 @@ bitflags::bitflags! {
         ///
         /// Not supported by Vulkan on Mesa when [`Features::SHADER_F16`] is absent.
         const SHADER_F16_IN_F32 = 1 << 23;
+
+        /// Support for [`TextureFormat::Bgra8Unorm`] and [`TextureFormat::Bgra8UnormSrgb`].
+        ///
+        /// WebGL doesn't support this. WebGPU does.
+        const TEXTURE_FORMAT_BGRA = 1 << 24;
     }
 }
 

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -955,7 +955,16 @@ bitflags::bitflags! {
 
         /// Support for [`TextureFormat::Bgra8Unorm`] and [`TextureFormat::Bgra8UnormSrgb`].
         ///
-        /// WebGL doesn't support this. WebGPU does.
+        /// Supported by:
+        /// - Vulkan
+        /// - DX12
+        /// - Metal
+        /// - OpenGL
+        /// - GL ES (with GL_EXT_texture_format_BGRA8888)
+        /// - WebGPU
+        ///
+        /// Not Supported by:
+        /// - WebGL
         const TEXTURE_FORMAT_BGRA = 1 << 24;
     }
 }


### PR DESCRIPTION
**Connections**
Fixes #3583

**Description**
WebGL is the only backend that doesn't support BGRA texture formats.

It seems like dx12 and metal will automatically set all DownlevelFlags, but Vulkan doesn't?

**Testing**
Manually tested.

**Squash or Rebase?**
squah

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
