### PR TITLE
chore(deno): Implement `is_fallback_adapter` and validate feature level strings

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -10,6 +10,7 @@
 
 unittests:*
 
+webgpu:api,operation,adapter,requestAdapter:*
 webgpu:api,operation,buffers,createBindGroup:buffer_binding_resource:*
 webgpu:api,operation,command_buffer,basic:*
 webgpu:api,operation,command_buffer,copyBufferToBuffer:*

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -23,6 +23,8 @@ use crate::Instance;
 #[derive(WebIDL)]
 #[webidl(dictionary)]
 pub(crate) struct GPURequestAdapterOptions {
+  #[webidl(default = "core".into())]
+  pub feature_level: String,
   pub power_preference: Option<GPUPowerPreference>,
   #[webidl(default = false)]
   pub force_fallback_adapter: bool,
@@ -498,7 +500,7 @@ impl GPUAdapterInfo {
   #[getter]
   #[string]
   fn architecture(&self) -> &'static str {
-    "" // TODO: wgpu#2170
+    "" // TODO(https://github.com/gfx-rs/wgpu/issues/8649): implement when wgpu has architecture detection
   }
 
   #[getter]
@@ -525,7 +527,6 @@ impl GPUAdapterInfo {
 
   #[getter]
   fn is_fallback_adapter(&self) -> bool {
-    // TODO(lucacasonato): report correctly from wgpu
-    false
+    self.info.device_type == wgpu_types::DeviceType::Cpu
   }
 }

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -11,6 +11,8 @@ use deno_core::op2;
 use deno_core::v8;
 use deno_core::GarbageCollected;
 use deno_core::OpState;
+use serde::de::IntoDeserializer;
+use serde::Deserialize as _;
 pub use wgpu_core;
 pub use wgpu_types;
 use wgpu_types::PowerPreference;
@@ -199,6 +201,16 @@ impl GPU {
       )));
       state.borrow::<Instance>()
     };
+
+    // Check that the feature level string is valid.
+    // `wgpu` does not support compatibility-level adapters. As permitted
+    // by the spec, we always return a core-level adapter.
+    wgpu_types::FeatureLevel::deserialize(IntoDeserializer::<
+      serde::de::value::Error,
+    >::into_deserializer(
+      options.feature_level.as_str()
+    ))
+    .ok()?;
 
     let descriptor = wgpu_core::instance::RequestAdapterOptions {
       power_preference: options

--- a/wgpu-types/src/adapter.rs
+++ b/wgpu-types/src/adapter.rs
@@ -9,6 +9,23 @@ use serde::{Deserialize, Serialize};
 #[cfg(doc)]
 use crate::{Features, TextureUsages};
 
+/// A set of requested capabilities when choosing a physical adapter.
+///
+/// Corresponds to the defined values of [WebGPU feature level string](
+/// https://gpuweb.github.io/gpuweb/#feature-level-string).
+///
+/// `wgpu` does not support compatibility-level adapters per se.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+pub enum FeatureLevel {
+    #[default]
+    /// The `core` capability set
+    Core,
+    /// The `compatibility` capability set
+    Compatibility,
+}
+
 /// Options for requesting adapter.
 ///
 /// Corresponds to [WebGPU `GPURequestAdapterOptions`](


### PR DESCRIPTION
Drive-by TODO fix with a little bit of creep.

**Testing**
CTS

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
