### PR TITLE
Fix metallib tests

### DIFF
--- a/tests/tests/wgpu-gpu/passthrough/mod.rs
+++ b/tests/tests/wgpu-gpu/passthrough/mod.rs
@@ -96,6 +96,14 @@ static METAL_PASSTHROUGH_SHADER: GpuTestConfiguration = GpuTestConfiguration::ne
     .run_sync(metal_test);
 
 fn metallib_source(test_hash: u64) -> Cow<'static, [u8]> {
+    struct FileDropGuard<'a> {
+        file_name: &'a str,
+    }
+    impl Drop for FileDropGuard<'_> {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(self.file_name);
+        }
+    }
     if cfg!(not(target_vendor = "apple")) {
         return Cow::Borrowed(&[]);
     }
@@ -140,6 +148,9 @@ fn metallib_source(test_hash: u64) -> Cow<'static, [u8]> {
             );
         }
     }
+    let _air_drop_guard = FileDropGuard {
+        file_name: &air_name,
+    };
     {
         let output = std::process::Command::new("xcrun")
             .args(["metallib", &air_name, "-o", &output_name])
@@ -152,6 +163,9 @@ fn metallib_source(test_hash: u64) -> Cow<'static, [u8]> {
             );
         }
     }
+    let _metallib_drop_guard = FileDropGuard {
+        file_name: &output_name,
+    };
     let source = std::fs::read(&output_name).unwrap();
     Cow::Owned(source)
 }

--- a/tests/tests/wgpu-gpu/passthrough/mod.rs
+++ b/tests/tests/wgpu-gpu/passthrough/mod.rs
@@ -127,6 +127,10 @@ fn metallib_source(test_hash: u64) -> Cow<'static, [u8]> {
         env!("CARGO_MANIFEST_DIR")
     );
 
+    let _air_drop_guard = FileDropGuard {
+        file_name: &air_name,
+    };
+
     {
         let output = std::process::Command::new("xcrun")
             .args([
@@ -148,9 +152,11 @@ fn metallib_source(test_hash: u64) -> Cow<'static, [u8]> {
             );
         }
     }
-    let _air_drop_guard = FileDropGuard {
-        file_name: &air_name,
+
+    let _metallib_drop_guard = FileDropGuard {
+        file_name: &output_name,
     };
+
     {
         let output = std::process::Command::new("xcrun")
             .args(["metallib", &air_name, "-o", &output_name])
@@ -163,9 +169,6 @@ fn metallib_source(test_hash: u64) -> Cow<'static, [u8]> {
             );
         }
     }
-    let _metallib_drop_guard = FileDropGuard {
-        file_name: &output_name,
-    };
     let source = std::fs::read(&output_name).unwrap();
     Cow::Owned(source)
 }


### PR DESCRIPTION
**Connections**
Taken from #9048 where this fix didn't belong.

**Description**
Currently the metallib tests generate files in the tree and don't delete them. This change makes sure these files get deleted.

**Testing**
Works on my machine

**Squash or Rebase?**
Squash pls

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
