### PR TITLE
Fixed clippy lint in CI

### DIFF
--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -201,7 +201,8 @@ impl super::CommandEncoder {
                 self.state.blit = Some(cmd_buf.blitCommandEncoder().unwrap());
             });
 
-            #[expect(clippy::panicking_unwrap, reason = "false positive")]
+            // Clippy 1.93 hates this (it was patched in 1.93.1)
+            #[allow(clippy::panicking_unwrap, reason = "false positive")]
             let encoder = self.state.blit.as_ref().unwrap();
 
             // UNTESTED:


### PR DESCRIPTION
**Connections**

**Description**
Rust 1.93.1 released today fixing a false positive that we had placed an `#[expect()]` over, causing CI to fail. This changes that to an `#[allow]` and adds a comment explaining why.

**Testing**
None required

**Squash or Rebase?**
skwosh

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
