### PR TITLE
Make passthrough shaders non-experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ By @cwfitzgerald in [#8999](https://github.com/gfx-rs/wgpu/pull/8999).
 - Pipelines using passthrough shaders now correctly require explicit pipeline layout. By @inner-daemons in #8881.
 - Allow using a shader that defines I/O for dual-source blending in a pipeline that does not make use of it. By @andyleiserson in [#8856](https://github.com/gfx-rs/wgpu/pull/8856).
 - Validate `strip_index_format` isn't None and equals index buffer format for indexed drawing with strip topology. By @beicause in [#8850](https://github.com/gfx-rs/wgpu/pull/8850).
+- Renamed `EXPERIMENTAL_PASSTHROUGH_SHADERS` to `PASSTHROUGH_SHADERS` and made this no longer an experimental feature. by @inner-daemons in [#9054](https://github.com/gfx-rs/wgpu/pull/9054).
 
 #### naga
 

--- a/deno_webgpu/webidl.rs
+++ b/deno_webgpu/webidl.rs
@@ -520,7 +520,7 @@ pub fn feature_names_to_features(
       GPUFeatureName::ShaderI16 => Features::SHADER_I16,
       GPUFeatureName::ShaderPrimitiveIndex => Features::SHADER_PRIMITIVE_INDEX,
       GPUFeatureName::ShaderEarlyDepthTest => Features::SHADER_EARLY_DEPTH_TEST,
-      GPUFeatureName::PassthroughShaders => Features::EXPERIMENTAL_PASSTHROUGH_SHADERS,
+      GPUFeatureName::PassthroughShaders => Features::PASSTHROUGH_SHADERS,
     };
     features.set(feature, true);
   }
@@ -680,7 +680,7 @@ pub fn features_to_feature_names(
   if features.contains(wgpu_types::Features::SHADER_EARLY_DEPTH_TEST) {
     return_features.insert(ShaderEarlyDepthTest);
   }
-  if features.contains(wgpu_types::Features::EXPERIMENTAL_PASSTHROUGH_SHADERS) {
+  if features.contains(wgpu_types::Features::PASSTHROUGH_SHADERS) {
     return_features.insert(PassthroughShaders);
   }
 

--- a/examples/features/src/mesh_shader/mod.rs
+++ b/examples/features/src/mesh_shader/mod.rs
@@ -65,7 +65,7 @@ struct Shaders {
 
 fn get_shaders(device: &wgpu::Device, backend: wgpu::Backend) -> Shaders {
     // In the case that the platform does support mesh shaders, the dummy
-    // shader is used to avoid requiring EXPERIMENTAL_PASSTHROUGH_SHADERS.
+    // shader is used to avoid requiring PASSTHROUGH_SHADERS.
     match backend {
         wgpu::Backend::Vulkan => {
             let compiled = compile_wgsl(device);
@@ -191,7 +191,7 @@ impl crate::framework::Example for Example {
         Default::default()
     }
     fn required_features() -> wgpu::Features {
-        wgpu::Features::EXPERIMENTAL_MESH_SHADER | wgpu::Features::EXPERIMENTAL_PASSTHROUGH_SHADERS
+        wgpu::Features::EXPERIMENTAL_MESH_SHADER | wgpu::Features::PASSTHROUGH_SHADERS
     }
     fn required_limits() -> wgpu::Limits {
         wgpu::Limits::defaults().using_recommended_minimum_mesh_shader_values()
@@ -222,10 +222,7 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     height: 768,
     optional_features: wgpu::Features::default(),
     base_test_parameters: wgpu_test::TestParameters::default()
-        .features(
-            wgpu::Features::EXPERIMENTAL_MESH_SHADER
-                | wgpu::Features::EXPERIMENTAL_PASSTHROUGH_SHADERS,
-        )
+        .features(wgpu::Features::EXPERIMENTAL_MESH_SHADER | wgpu::Features::PASSTHROUGH_SHADERS)
         .instance_flags(wgpu::InstanceFlags::advanced_debugging())
         .limits(wgpu::Limits::defaults().using_recommended_minimum_mesh_shader_values())
         .skip(wgpu_test::FailureCase {

--- a/tests/tests/wgpu-gpu/mesh_shader/mod.rs
+++ b/tests/tests/wgpu-gpu/mesh_shader/mod.rs
@@ -99,7 +99,7 @@ fn get_shaders(
         unreachable!();
     }
     // In the case that the platform does support mesh shaders, the dummy
-    // shader is used to avoid requiring EXPERIMENTAL_PASSTHROUGH_SHADERS.
+    // shader is used to avoid requiring PASSTHROUGH_SHADERS.
     match backend {
         wgpu::Backend::Vulkan => {
             let compiled = compile_wgsl(device);
@@ -395,7 +395,7 @@ fn default_gpu_test_config(draw_type: DrawType) -> GpuTestConfiguration {
             .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
             .features(
                 wgpu::Features::EXPERIMENTAL_MESH_SHADER
-                    | wgpu::Features::EXPERIMENTAL_PASSTHROUGH_SHADERS
+                    | wgpu::Features::PASSTHROUGH_SHADERS
                     | match draw_type {
                         DrawType::Standard | DrawType::Indirect | DrawType::MultiIndirect => {
                             wgpu::Features::empty()

--- a/tests/tests/wgpu-gpu/passthrough/mod.rs
+++ b/tests/tests/wgpu-gpu/passthrough/mod.rs
@@ -90,7 +90,7 @@ fn metal_test(ctx: TestingContext) {
 static METAL_PASSTHROUGH_SHADER: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::EXPERIMENTAL_PASSTHROUGH_SHADERS)
+            .features(Features::PASSTHROUGH_SHADERS)
             .skip(FailureCase::backend(!Backends::METAL)),
     )
     .run_sync(metal_test);
@@ -175,7 +175,7 @@ fn metallib_test(ctx: TestingContext) {
 static METALLIB_PASSTHROUGH_SHADER: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::EXPERIMENTAL_PASSTHROUGH_SHADERS)
+            .features(Features::PASSTHROUGH_SHADERS)
             .skip(FailureCase::backend(!Backends::METAL)),
     )
     .run_sync(metallib_test);
@@ -199,7 +199,7 @@ fn hlsl_test(ctx: TestingContext) {
 static HLSL_PASSTHROUGH_SHADER: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::EXPERIMENTAL_PASSTHROUGH_SHADERS)
+            .features(Features::PASSTHROUGH_SHADERS)
             .skip(FailureCase::backend(!Backends::DX12)),
     )
     .run_sync(hlsl_test);
@@ -279,7 +279,7 @@ fn dxil_test(ctx: TestingContext) {
 static DXIL_PASSTHROUGH_SHADER: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::EXPERIMENTAL_PASSTHROUGH_SHADERS)
+            .features(Features::PASSTHROUGH_SHADERS)
             .skip(FailureCase::backend(!Backends::DX12)),
     )
     .run_sync(dxil_test);
@@ -334,7 +334,7 @@ fn spirv_test(ctx: TestingContext) {
 static SPIRV_PASSTHROUGH_SHADER: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::EXPERIMENTAL_PASSTHROUGH_SHADERS)
+            .features(Features::PASSTHROUGH_SHADERS)
             .skip(FailureCase::backend(!Backends::VULKAN)),
     )
     .run_sync(spirv_test);
@@ -369,7 +369,7 @@ fn glsl_test(ctx: TestingContext) {
 static GLSL_PASSTHROUGH_SHADER: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::EXPERIMENTAL_PASSTHROUGH_SHADERS)
+            .features(Features::PASSTHROUGH_SHADERS)
             .skip(FailureCase::backend(!Backends::GL)),
     )
     .run_sync(glsl_test);
@@ -393,7 +393,7 @@ fn wgsl_test(ctx: TestingContext) {
 static WGSL_PASSTHROUGH_SHADER: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::EXPERIMENTAL_PASSTHROUGH_SHADERS)
+            .features(Features::PASSTHROUGH_SHADERS)
             .skip(FailureCase::backend(!Backends::BROWSER_WEBGPU)),
     )
     .run_sync(wgsl_test);
@@ -433,7 +433,7 @@ fn all_passthrough_shaders_binary(ctx: TestingContext) {
 
 #[gpu_test]
 static ALL_PASSTHROUGH_SHADERS_BINARY: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(Features::EXPERIMENTAL_PASSTHROUGH_SHADERS))
+    .parameters(TestParameters::default().features(Features::PASSTHROUGH_SHADERS))
     .run_sync(all_passthrough_shaders_binary);
 
 fn all_passthrough_shader_source(ctx: TestingContext) {
@@ -471,7 +471,7 @@ fn all_passthrough_shader_source(ctx: TestingContext) {
 
 #[gpu_test]
 static ALL_PASSTHROUGH_SHADERS_SOURCE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(Features::EXPERIMENTAL_PASSTHROUGH_SHADERS))
+    .parameters(TestParameters::default().features(Features::PASSTHROUGH_SHADERS))
     .run_sync(all_passthrough_shader_source);
 
 fn explicit_layout_validation(ctx: TestingContext) {
@@ -539,7 +539,7 @@ static PASSTHROUGH_SHADERS_EXPLICIT_LAYOUT_VALIDATION: GpuTestConfiguration =
     GpuTestConfiguration::new()
         .parameters(
             TestParameters::default()
-                .features(Features::EXPERIMENTAL_PASSTHROUGH_SHADERS)
+                .features(Features::PASSTHROUGH_SHADERS)
                 .expect_fail(FailureCase::always()),
         )
         .run_sync(explicit_layout_validation);

--- a/tests/tests/wgpu-validation/api/experimental.rs
+++ b/tests/tests/wgpu-validation/api/experimental.rs
@@ -61,7 +61,7 @@ fn request_multiple_experimental_features_when_not_enabled() {
     let dq = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
         // Experimental
         required_features: wgpu::Features::EXPERIMENTAL_MESH_SHADER
-            | wgpu::Features::EXPERIMENTAL_PASSTHROUGH_SHADERS,
+            | wgpu::Features::EXPERIMENTAL_COOPERATIVE_MATRIX,
         experimental_features: wgpu::ExperimentalFeatures::disabled(),
         ..Default::default()
     }));

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2355,7 +2355,7 @@ impl Device {
         descriptor: &pipeline::ShaderModuleDescriptorPassthrough<'a>,
     ) -> Result<Arc<pipeline::ShaderModule>, pipeline::CreateShaderModuleError> {
         self.check_is_valid()?;
-        self.require_features(wgt::Features::EXPERIMENTAL_PASSTHROUGH_SHADERS)?;
+        self.require_features(wgt::Features::PASSTHROUGH_SHADERS)?;
 
         let hal_shader = match self.backend() {
             wgt::Backend::Vulkan => hal::ShaderInput::SpirV(

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -487,7 +487,7 @@ impl super::Adapter {
             | wgt::Features::TEXTURE_FORMAT_NV12
             | wgt::Features::FLOAT32_FILTERABLE
             | wgt::Features::TEXTURE_ATOMIC
-            | wgt::Features::EXPERIMENTAL_PASSTHROUGH_SHADERS
+            | wgt::Features::PASSTHROUGH_SHADERS
             | wgt::Features::EXTERNAL_TEXTURE;
 
         //TODO: in order to expose this, we need to run a compute shader

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1004,7 +1004,7 @@ impl super::PrivateCapabilities {
             | F::SHADER_F16
             | F::DEPTH32FLOAT_STENCIL8
             | F::BGRA8UNORM_STORAGE
-            | F::EXPERIMENTAL_PASSTHROUGH_SHADERS
+            | F::PASSTHROUGH_SHADERS
             | F::EXTERNAL_TEXTURE;
 
         features.set(F::FLOAT32_FILTERABLE, self.supports_float_filtering);

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -648,7 +648,7 @@ impl PhysicalDeviceFeatures {
             | F::PIPELINE_CACHE
             | F::SHADER_EARLY_DEPTH_TEST
             | F::TEXTURE_ATOMIC
-            | F::EXPERIMENTAL_PASSTHROUGH_SHADERS;
+            | F::PASSTHROUGH_SHADERS;
 
         let mut dl_flags = Df::COMPUTE_SHADERS
             | Df::BASE_VERTEX

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -1223,7 +1223,7 @@ bitflags_array! {
         /// [this comment](https://github.com/gfx-rs/wgpu/issues/3103#issuecomment-2833058367).
         ///
         #[doc = link_to_wgpu_docs!(["`Device::create_shader_module_passthrough`"]: "struct.Device.html#method.create_shader_module_passthrough")]
-        const EXPERIMENTAL_PASSTHROUGH_SHADERS = 1 << 52;
+        const PASSTHROUGH_SHADERS = 1 << 52;
 
         /// Enables shader barycentric coordinates.
         ///
@@ -1621,7 +1621,6 @@ impl Features {
                 | FeaturesWGPU::EXPERIMENTAL_MESH_SHADER_POINTS.bits()
                 | FeaturesWGPU::EXPERIMENTAL_RAY_QUERY.bits()
                 | FeaturesWGPU::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN.bits()
-                | FeaturesWGPU::EXPERIMENTAL_PASSTHROUGH_SHADERS.bits()
                 | FeaturesWGPU::EXPERIMENTAL_COOPERATIVE_MATRIX.bits(),
             FeaturesWebGPU::empty().bits(),
         ]))

--- a/wgpu/src/macros/mod.rs
+++ b/wgpu/src/macros/mod.rs
@@ -129,11 +129,11 @@ macro_rules! include_spirv {
 #[expect(dead_code)]
 static SPIRV: crate::ShaderModuleDescriptor<'_> = include_spirv!("le-aligned.spv");
 
-/// Macro to load raw SPIR-V data statically, for use with [`Features::EXPERIMENTAL_PASSTHROUGH_SHADERS`].
+/// Macro to load raw SPIR-V data statically, for use with [`Features::PASSTHROUGH_SHADERS`].
 ///
 /// It ensures the word alignment as well as the magic number.
 ///
-/// [`Features::EXPERIMENTAL_PASSTHROUGH_SHADERS`]: crate::Features::EXPERIMENTAL_PASSTHROUGH_SHADERS
+/// [`Features::PASSTHROUGH_SHADERS`]: crate::Features::PASSTHROUGH_SHADERS
 #[macro_export]
 macro_rules! include_spirv_raw {
     ($($token:tt)*) => {


### PR DESCRIPTION
**Connections**
Closes #9008

**Description**
Makes passthrough shaders non-experimental.

**Testing**


**Squash or Rebase?**
Squash pls

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
