### PR TITLE
Add `no_std` support for the `naga/wgsl-in` feature

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -77,7 +77,6 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "CC0-1.0",
     "ISC",
     "MPL-2.0",
     "MIT",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,8 +1773,10 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+source = "git+https://github.com/lifthrasiir/hexf?rev=0e69bc4f63895feb51e9b738a8a2d4ec9398957b#0e69bc4f63895feb51e9b738a8a2d4ec9398957b"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "hlsl-snapshots"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,14 +1771,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hexf-parse"
-version = "0.2.1"
-source = "git+https://github.com/lifthrasiir/hexf?rev=0e69bc4f63895feb51e9b738a8a2d4ec9398957b#0e69bc4f63895feb51e9b738a8a2d4ec9398957b"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "hlsl-snapshots"
 version = "28.0.0"
 dependencies = [
@@ -2316,7 +2308,6 @@ dependencies = [
  "env_logger",
  "half",
  "hashbrown 0.16.1",
- "hexf-parse",
  "hlsl-snapshots",
  "indexmap",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ hashbrown = { version = "0.16", default-features = false, features = [
     "inline-more",
 ] }
 heck = "0.5"
-hexf-parse = "0.2"
+hexf-parse = { version = "0.2.1", git = "https://github.com/lifthrasiir/hexf", rev = "0e69bc4f63895feb51e9b738a8a2d4ec9398957b", default-features = false }
 image = { version = "0.25", default-features = false, features = ["png"] }
 indexmap = { version = "2.11.4", default-features = false }
 indicatif = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,6 @@ hashbrown = { version = "0.16", default-features = false, features = [
     "inline-more",
 ] }
 heck = "0.5"
-hexf-parse = { version = "0.2.1", git = "https://github.com/lifthrasiir/hexf", rev = "0e69bc4f63895feb51e9b738a8a2d4ec9398957b", default-features = false }
 image = { version = "0.25", default-features = false, features = ["png"] }
 indexmap = { version = "2.11.4", default-features = false }
 indicatif = "0.18"

--- a/naga-cli/src/bin/naga.rs
+++ b/naga-cli/src/bin/naga.rs
@@ -769,7 +769,7 @@ fn parse_input(input_path: &Path, input: Vec<u8>, params: &Parameters) -> anyhow
                 Err(ref e) => {
                     let message = anyhow!(
                         "Could not parse WGSL:\n{}",
-                        e.emit_to_string_with_path(&input, input_path)
+                        e.emit_to_string_with_path(&input, &input_path.display().to_string())
                     );
                     return Err(message);
                 }

--- a/naga-test/Cargo.toml
+++ b/naga-test/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 
 [dependencies]
 naga = { workspace = true, features = [
+    "fs",
     "serialize",
     "deserialize",
     "glsl-in",

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -58,7 +58,7 @@ arbitrary = [
 ]
 spv-in = ["dep:petgraph", "petgraph/graphmap", "dep:spirv"]
 spv-out = ["dep:spirv"]
-wgsl-in = ["dep:hexf-parse", "dep:unicode-ident"]
+wgsl-in = ["dep:unicode-ident"]
 wgsl-out = []
 
 ## Enables outputting to HLSL (Microsoft's High-Level Shader Language).
@@ -101,7 +101,6 @@ thiserror.workspace = true
 serde = { workspace = true, features = ["alloc", "derive"], optional = true }
 petgraph = { workspace = true, optional = true }
 pp-rs = { workspace = true, optional = true }
-hexf-parse = { workspace = true, optional = true }
 unicode-ident = { workspace = true, optional = true }
 
 [build-dependencies]

--- a/naga/build.rs
+++ b/naga/build.rs
@@ -6,7 +6,7 @@ fn main() {
         msl_out: { any(feature = "msl-out", all(target_vendor = "apple", feature = "msl-out-if-target-apple")) },
         spv_out: { feature = "spv-out" },
         wgsl_out: { feature = "wgsl-out" },
-        std: { any(test, feature = "wgsl-in", feature = "stderr", feature = "fs") },
+        std: { any(test, feature = "stderr", feature = "fs") },
         no_std: { not(std) },
     }
 }

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -102,6 +102,7 @@ impl ParseError {
     }
 
     /// Emits a summary of the error to a string.
+    #[cfg(feature = "fs")]
     pub fn emit_to_string_with_path<P>(&self, source: &str, path: P) -> String
     where
         P: AsRef<std::path::Path>,
@@ -113,6 +114,18 @@ impl ParseError {
         let mut writer = crate::error::DiagnosticBuffer::new();
         writer
             .emit_to_self(&config, &files, &self.diagnostic())
+            .expect("cannot write error");
+        writer.into_string()
+    }
+
+    /// Emits a summary of the error to a string.
+    #[cfg(not(feature = "fs"))]
+    pub fn emit_to_string_with_path(&self, source: &str, path: &str) -> String {
+        let files = SimpleFile::new(path, replace_control_chars(source));
+        let config = term::Config::default();
+
+        let mut writer = crate::error::DiagnosticBuffer::new();
+        term::emit(writer.inner_mut(), &config, &files, &self.diagnostic())
             .expect("cannot write error");
         writer.into_string()
     }

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -102,30 +102,16 @@ impl ParseError {
     }
 
     /// Emits a summary of the error to a string.
-    #[cfg(feature = "fs")]
-    pub fn emit_to_string_with_path<P>(&self, source: &str, path: P) -> String
-    where
-        P: AsRef<std::path::Path>,
-    {
-        let path = path.as_ref().display().to_string();
+    ///
+    /// `path` gives the filename to attribute the error to in the
+    /// output; this function does not try to access the file.
+    pub fn emit_to_string_with_path(&self, source: &str, path: &str) -> String {
         let files = SimpleFile::new(path, replace_control_chars(source));
         let config = term::Config::default();
 
         let mut writer = crate::error::DiagnosticBuffer::new();
         writer
             .emit_to_self(&config, &files, &self.diagnostic())
-            .expect("cannot write error");
-        writer.into_string()
-    }
-
-    /// Emits a summary of the error to a string.
-    #[cfg(not(feature = "fs"))]
-    pub fn emit_to_string_with_path(&self, source: &str, path: &str) -> String {
-        let files = SimpleFile::new(path, replace_control_chars(source));
-        let config = term::Config::default();
-
-        let mut writer = crate::error::DiagnosticBuffer::new();
-        term::emit(writer.inner_mut(), &config, &files, &self.diagnostic())
             .expect("cannot write error");
         writer.into_string()
     }

--- a/naga/src/front/wgsl/parse/number.rs
+++ b/naga/src/front/wgsl/parse/number.rs
@@ -369,7 +369,6 @@ fn parse_dec(
 //   on overflow and inexact for hexadecimal floating point literals
 // (underflow is not mentioned)
 
-// hexf_parse errors on overflow, underflow, inexact
 // rust std lib float from str handles overflow, underflow, inexact transparently (rounds and will not error)
 
 // Therefore we only check for overflow manually for decimal floating point literals
@@ -377,23 +376,248 @@ fn parse_dec(
 // input format: 0[xX] ( [0-9a-fA-F]+\.[0-9a-fA-F]* | [0-9a-fA-F]*\.[0-9a-fA-F]+ ) [pP][+-]?[0-9]+
 fn parse_hex_float(input: &str, kind: Option<FloatKind>) -> Result<Number, NumberError> {
     match kind {
-        None => match hexf_parse::parse_hexf64(input, false) {
-            Ok(num) => Ok(Number::AbstractFloat(num)),
-            // can only be ParseHexfErrorKind::Inexact but we can't check since it's private
-            _ => Err(NumberError::NotRepresentable),
-        },
-        // TODO: f16 is not supported by hexf_parse
+        None => {
+            let (neg, mant, exp) = parse_hex_float_parts(input.as_bytes())?;
+            let bits = convert_hex_float(neg, mant, exp, F64)?;
+            let num = f64::from_bits(bits);
+
+            Ok(Number::AbstractFloat(num))
+        }
+        // TODO: f16 is not supported
         Some(FloatKind::F16) => Err(NumberError::NotRepresentable),
-        Some(FloatKind::F32) => match hexf_parse::parse_hexf32(input, false) {
-            Ok(num) => Ok(Number::F32(num)),
-            // can only be ParseHexfErrorKind::Inexact but we can't check since it's private
-            _ => Err(NumberError::NotRepresentable),
-        },
-        Some(FloatKind::F64) => match hexf_parse::parse_hexf64(input, false) {
-            Ok(num) => Ok(Number::F64(num)),
-            // can only be ParseHexfErrorKind::Inexact but we can't check since it's private
-            _ => Err(NumberError::NotRepresentable),
-        },
+        Some(FloatKind::F32) => {
+            let (neg, mant, exp) = parse_hex_float_parts(input.as_bytes())?;
+            let bits = convert_hex_float(neg, mant, exp, F32)?;
+            let num = f32::from_bits(bits as u32);
+
+            Ok(Number::F32(num))
+        }
+        Some(FloatKind::F64) => {
+            let (neg, mant, exp) = parse_hex_float_parts(input.as_bytes())?;
+            let bits = convert_hex_float(neg, mant, exp, F64)?;
+            let num = f64::from_bits(bits);
+
+            Ok(Number::F64(num))
+        }
+    }
+}
+
+// a config for representing a hexadecimal floating-point
+struct HexFloatFormat {
+    mant_bits: usize,  // number of bits in the mantissa (excluding implicit leading 1)
+    precision: usize,  // total precision in bits including implicit bit
+    bias: i32,         // exponent bias
+    max_exp: i32,      // max exponent before overflow
+    exp_bits: usize,   // number of bits in exponent
+    min_norm_exp: i32, // smallest exponent for normalized numbers
+}
+
+const F32: HexFloatFormat = HexFloatFormat {
+    mant_bits: 23,
+    precision: 24,
+    bias: 127,
+    max_exp: 127,
+    exp_bits: 8,
+    min_norm_exp: -126,
+};
+
+const F64: HexFloatFormat = HexFloatFormat {
+    mant_bits: 52,
+    precision: 53,
+    bias: 1023,
+    max_exp: 1023,
+    exp_bits: 11,
+    min_norm_exp: -1022,
+};
+
+// parses a hexadecimal floating-point string into its sign, mantissa, and exponent
+// input format: 0[xX] ( [0-9a-fA-F]+\.[0-9a-fA-F]* | [0-9a-fA-F]*\.[0-9a-fA-F]+ ) [pP][+-]?[0-9]+
+fn parse_hex_float_parts(s: &[u8]) -> Result<(bool, u64, i32), NumberError> {
+    let (s, negative) = match s.split_first() {
+        Some((&b'+', s)) => (s, false),
+        Some((&b'-', s)) => (s, true),
+        Some(_) => (s, false),
+        // empty
+        None => return Err(NumberError::Invalid),
+    };
+
+    if !(s.starts_with(b"0x") || s.starts_with(b"0X")) {
+        return Err(NumberError::Invalid);
+    }
+
+    let mut s = &s[2..];
+    let mut acc: u128 = 0;
+    let mut digit_seen = false;
+
+    // integer part: [0-9a-fA-F]+
+    loop {
+        let (rest, digit) = match s.split_first() {
+            Some((&c @ b'0'..=b'9', s)) => (s, c - b'0'),
+            Some((&c @ b'a'..=b'f', s)) => (s, c - b'a' + 10),
+            Some((&c @ b'A'..=b'F', s)) => (s, c - b'A' + 10),
+            _ => break,
+        };
+        s = rest;
+        digit_seen = true;
+        acc = acc.checked_shl(4).ok_or(NumberError::NotRepresentable)? | digit as u128;
+    }
+
+    // fractional part: \.[0-9a-fA-F]+
+    let mut nfracs: i32 = 0;
+    let mut frac_digit_seen = false;
+    if s.starts_with(b".") {
+        s = &s[1..];
+        loop {
+            let (rest, digit) = match s.split_first() {
+                Some((&c @ b'0'..=b'9', s)) => (s, c - b'0'),
+                Some((&c @ b'a'..=b'f', s)) => (s, c - b'a' + 10),
+                Some((&c @ b'A'..=b'F', s)) => (s, c - b'A' + 10),
+                _ => break,
+            };
+            s = rest;
+            frac_digit_seen = true;
+            acc = acc.checked_shl(4).ok_or(NumberError::NotRepresentable)? | digit as u128;
+            nfracs = nfracs.checked_add(1).ok_or(NumberError::NotRepresentable)?;
+        }
+    }
+
+    if !(digit_seen || frac_digit_seen) {
+        return Err(NumberError::Invalid);
+    }
+
+    // exponent marker 'p' or 'P'
+    let s = match s.split_first() {
+        Some((&b'P', s)) | Some((&b'p', s)) => s,
+        _ => return Err(NumberError::Invalid),
+    };
+
+    // exponent sign
+    let (mut s, negative_exponent) = match s.split_first() {
+        Some((&b'+', s)) => (s, false),
+        Some((&b'-', s)) => (s, true),
+        Some(_) => (s, false),
+        None => return Err(NumberError::Invalid),
+    };
+
+    // exponent digits: [0-9]+
+    let mut digit_seen = false;
+    let mut exponent: i32 = 0;
+    loop {
+        let (rest, digit) = match s.split_first() {
+            Some((&c @ b'0'..=b'9', s)) => (s, c - b'0'),
+            None if digit_seen => break,
+            _ => return Err(NumberError::Invalid),
+        };
+        s = rest;
+        digit_seen = true;
+
+        // only update exponent if non‑zero mantissa
+        if acc != 0 {
+            exponent = exponent
+                .checked_mul(10)
+                .and_then(|v| v.checked_add(digit as i32))
+                .ok_or(NumberError::NotRepresentable)?;
+        }
+    }
+
+    if negative_exponent {
+        exponent = -exponent;
+    }
+
+    if acc == 0 {
+        return Ok((negative, 0, 0));
+    }
+
+    // adjust exponent by 4 per fractional digit
+    let exp_adj = nfracs.checked_mul(4).ok_or(NumberError::NotRepresentable)?;
+    let exponent = exponent
+        .checked_sub(exp_adj)
+        .ok_or(NumberError::NotRepresentable)?;
+
+    // remove trailing hex zeros
+    let mut mant = acc;
+    let mut extra_shift = 0i32;
+    while mant > 0 && (mant & 0xF) == 0 {
+        mant >>= 4;
+        extra_shift = extra_shift
+            .checked_add(4)
+            .ok_or(NumberError::NotRepresentable)?;
+    }
+
+    // final mantissa must fit in 64 bits
+    if mant > u64::MAX as u128 {
+        return Err(NumberError::NotRepresentable);
+    }
+
+    let exponent = exponent
+        .checked_add(extra_shift)
+        .ok_or(NumberError::NotRepresentable)?;
+
+    Ok((negative, mant as u64, exponent))
+}
+
+fn convert_hex_float(
+    negative: bool,
+    mant: u64,
+    exp: i32,
+    fmt: HexFloatFormat,
+) -> Result<u64, NumberError> {
+    let sign_shift = fmt.mant_bits + fmt.exp_bits;
+    let sign = (negative as u64) << sign_shift;
+
+    if mant == 0 {
+        return Ok(sign);
+    }
+
+    let k = 63usize - mant.leading_zeros() as usize;
+    let normalexp = exp
+        .checked_add(k as i32)
+        .ok_or(NumberError::NotRepresentable)?;
+
+    if normalexp > fmt.max_exp {
+        return Err(NumberError::NotRepresentable);
+    }
+
+    // shift to align mantissa
+    let shift = k as i32 - ((fmt.precision as i32) - 1);
+    let mut mant_field: u64;
+
+    if normalexp >= fmt.min_norm_exp {
+        // normalized
+        if shift > 0 {
+            if shift >= 64 || (mant & ((1u64 << shift) - 1)) != 0 {
+                return Err(NumberError::NotRepresentable);
+            }
+            mant_field = mant >> shift;
+        } else {
+            mant_field = mant << -shift;
+        }
+
+        mant_field &= (1u64 << fmt.mant_bits) - 1;
+        let expo_field = (normalexp + fmt.bias) as u64;
+
+        Ok(sign | (expo_field << fmt.mant_bits) | mant_field)
+    } else {
+        // subnormal
+        let shift_sub = exp - (fmt.min_norm_exp - ((fmt.precision as i32) - 1));
+        if shift_sub < 0 {
+            let rs = (-shift_sub) as usize;
+            if rs >= 64 || (mant & ((1u64 << rs) - 1)) != 0 {
+                return Err(NumberError::NotRepresentable);
+            }
+            mant_field = mant >> rs;
+        } else {
+            mant_field = mant << shift_sub as u32;
+            if (mant_field >> fmt.mant_bits) != 0 {
+                return Err(NumberError::NotRepresentable);
+            }
+        }
+
+        if mant_field == 0 {
+            return Err(NumberError::NotRepresentable);
+        }
+
+        Ok(sign | (mant_field & ((1u64 << fmt.mant_bits) - 1)))
     }
 }
 

--- a/naga/src/front/wgsl/parse/number.rs
+++ b/naga/src/front/wgsl/parse/number.rs
@@ -430,6 +430,7 @@ const F64: HexFloatFormat = HexFloatFormat {
     min_norm_exp: -1022,
 };
 
+// derived from hexf-parse module: https://github.com/lifthrasiir/hexf (0BSD)
 // parses a hexadecimal floating-point string into its sign, mantissa, and exponent
 // input format: 0[xX] ( [0-9a-fA-F]+\.[0-9a-fA-F]* | [0-9a-fA-F]*\.[0-9a-fA-F]+ ) [pP][+-]?[0-9]+
 fn parse_hex_float_parts(s: &[u8]) -> Result<(bool, u64, i32), NumberError> {

--- a/naga/tests/naga/snapshots.rs
+++ b/naga/tests/naga/snapshots.rs
@@ -424,7 +424,13 @@ fn convert_snapshots_wgsl() {
         let mut frontend = naga::front::wgsl::Frontend::new_with_options((&params.wgsl_in).into());
         match frontend.parse(&source) {
             Ok(mut module) => check_targets(&input, &mut module, Some(&source)),
-            Err(e) => panic!("{}", e.emit_to_string_with_path(&source, DIR_IN)),
+            Err(e) => panic!(
+                "{}",
+                e.emit_to_string_with_path(
+                    &source,
+                    &input.input_path(DIR_IN).display().to_string()
+                )
+            ),
         }
     }
 }

--- a/naga/tests/naga/snapshots.rs
+++ b/naga/tests/naga/snapshots.rs
@@ -424,10 +424,7 @@ fn convert_snapshots_wgsl() {
         let mut frontend = naga::front::wgsl::Frontend::new_with_options((&params.wgsl_in).into());
         match frontend.parse(&source) {
             Ok(mut module) => check_targets(&input, &mut module, Some(&source)),
-            Err(e) => panic!(
-                "{}",
-                e.emit_to_string_with_path(&source, input.input_path(DIR_IN))
-            ),
+            Err(e) => panic!("{}", e.emit_to_string_with_path(&source, DIR_IN)),
         }
     }
 }


### PR DESCRIPTION
**Description**
The feature `wgsl-in` in the `naga` crate can be built with `no_std`. However, two issues prevent it from compiling, which this PR fixes:

1. `naga::front::wgsl::error::ParseError::emit_to_string_with_path`  accepts the `path` parameter as `AsRef<std::path::Path>`, which pulls in `std`. Solution: explicitly pass `path` as `&str`.
2. The `hexf-parse` crate released on crates.io does not support `no_std`. However, it is a lightweight crate, and it could be inlined into the project. Solution: inline the `hexf-parse` crate and remove `hexf-parse` from dependencies.

Note: the inlined version of `hexf-parse` is licensed under 0BSD (GitHub source code: https://github.com/lifthrasiir/hexf), which permits copying and modifying the source. This PR removes CC0-1.0 from `.deny.toml`, since `naga` no longer depends on `hexf-parse`, which previously included that license.

**Testing**
`no_std` support: compiled locally using `cargo build -p naga --target wasm32-unknown-unknown --no-default-features --features "wgsl-in wgsl-out"` and built a project with `#![no_std]` and `naga` with the only features `wgsl-in` and `wgsl-out` enabled.
Hexadecimal floating point numbers: used the same tests as `hexf-parse`: https://github.com/lifthrasiir/hexf/blob/master/parse/src/lib.rs

**Squash or Rebase?**
Squash.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
