### PR TITLE
Fix multi-planar texture copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ By @cwfitzgerald in [#8999](https://github.com/gfx-rs/wgpu/pull/8999).
 - BREAKING: End offsets in trace and `player` commands are now represented using `offset` + `size` instead. By @ErichDonGubler in [9073](https://github.com/gfx-rs/wgpu/pull/9073).
 - Validate some uncaught cases where buffer transfer operations could overflow when computing an end offset. By @ErichDonGubler in [9073](https://github.com/gfx-rs/wgpu/pull/9073).
 - Added internal labels to validation GPU objects and timestamp normalization code to improve clarity in graphics debuggers. By @szostid in [9094](https://github.com/gfx-rs/wgpu/pull/9094)
+- Fix multi-planar texture copying. By @noituri [#9069](https://github.com/gfx-rs/wgpu/pull/9069)
 
 #### naga
 

--- a/tests/tests/wgpu-gpu/planar_texture/mod.rs
+++ b/tests/tests/wgpu-gpu/planar_texture/mod.rs
@@ -9,6 +9,8 @@ pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
         NV12_TEXTURE_CREATION_SAMPLING,
         P010_TEXTURE_CREATION_SAMPLING,
         NV12_TEXTURE_RENDERING,
+        NV12_TEXTURE_COPYING,
+        P010_TEXTURE_COPYING,
     ]);
 }
 
@@ -337,4 +339,98 @@ static NV12_TEXTURE_RENDERING: GpuTestConfiguration = GpuTestConfiguration::new(
             (&y_view, wgpu::TextureFormat::R8Unorm),
             (&uv_view, wgpu::TextureFormat::Rg8Unorm),
         );
+    });
+
+/// Ensures that copying NV12 texture to NV12 texture works as expected
+#[gpu_test]
+static NV12_TEXTURE_COPYING: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::TEXTURE_FORMAT_NV12)
+            .enable_noop(),
+    )
+    .run_sync(|ctx| {
+        let size = wgpu::Extent3d {
+            width: 256,
+            height: 256,
+            depth_or_array_layers: 1,
+        };
+        let input_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size,
+            format: wgpu::TextureFormat::NV12,
+            usage: wgpu::TextureUsages::COPY_SRC,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[],
+        });
+        let output_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size,
+            format: wgpu::TextureFormat::NV12,
+            usage: wgpu::TextureUsages::COPY_DST,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[],
+        });
+
+        let mut command_encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        command_encoder.copy_texture_to_texture(
+            input_texture.as_image_copy(),
+            output_texture.as_image_copy(),
+            size,
+        );
+        ctx.queue.submit([command_encoder.finish()]);
+    });
+
+/// Ensures that copying P010 texture to P010 texture works as expected
+#[gpu_test]
+static P010_TEXTURE_COPYING: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(
+                wgpu::Features::TEXTURE_FORMAT_P010 | wgpu::Features::TEXTURE_FORMAT_16BIT_NORM,
+            )
+            .enable_noop(),
+    )
+    .run_sync(|ctx| {
+        let size = wgpu::Extent3d {
+            width: 256,
+            height: 256,
+            depth_or_array_layers: 1,
+        };
+        let input_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size,
+            format: wgpu::TextureFormat::P010,
+            usage: wgpu::TextureUsages::COPY_SRC,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[],
+        });
+        let output_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            dimension: wgpu::TextureDimension::D2,
+            size,
+            format: wgpu::TextureFormat::P010,
+            usage: wgpu::TextureUsages::COPY_DST,
+            mip_level_count: 1,
+            sample_count: 1,
+            view_formats: &[],
+        });
+
+        let mut command_encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        command_encoder.copy_texture_to_texture(
+            input_texture.as_image_copy(),
+            output_texture.as_image_copy(),
+            size,
+        );
+        ctx.queue.submit([command_encoder.finish()]);
     });

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -1468,6 +1468,8 @@ pub(super) fn copy_texture_to_texture(
         depth: src_copy_size.depth.min(dst_copy_size.depth),
     };
 
+    let dst_format = dst_texture.desc.format;
+
     let regions = (0..array_layer_count).map(|rel_array_layer| {
         let mut src_base = src_tex_base.clone();
         let mut dst_base = dst_tex_base.clone();
@@ -1489,6 +1491,33 @@ pub(super) fn copy_texture_to_texture(
                 stencil.src_base.aspect = hal::FormatAspects::STENCIL;
                 stencil.dst_base.aspect = hal::FormatAspects::STENCIL;
                 [depth, stencil]
+            })
+            .collect::<Vec<_>>()
+    } else if let Some(plane_count) = dst_format.planes() {
+        regions
+            .into_iter()
+            .flat_map(|region| {
+                (0..plane_count).map(move |plane| {
+                    let mut plane_region = region.clone();
+
+                    let plane_aspect = wgt::TextureAspect::from_plane(plane)
+                        .expect("expected texture aspect to exist for the plane");
+                    let plane_aspect = hal::FormatAspects::new(dst_format, plane_aspect);
+                    plane_region.src_base.aspect = plane_aspect;
+                    plane_region.dst_base.aspect = plane_aspect;
+
+                    let (w_subsampling, h_subsampling) =
+                        dst_format.subsampling_factors(Some(plane));
+                    plane_region.src_base.origin.x /= w_subsampling;
+                    plane_region.src_base.origin.y /= h_subsampling;
+                    plane_region.dst_base.origin.x /= w_subsampling;
+                    plane_region.dst_base.origin.y /= h_subsampling;
+
+                    plane_region.size.width /= w_subsampling;
+                    plane_region.size.height /= h_subsampling;
+
+                    plane_region
+                })
             })
             .collect::<Vec<_>>()
     } else {

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -970,6 +970,7 @@ impl Texture {
             | crate::FormatAspects::DEPTH
             | crate::FormatAspects::PLANE_0 => 0,
             crate::FormatAspects::STENCIL | crate::FormatAspects::PLANE_1 => 1,
+            crate::FormatAspects::PLANE_2 => 2,
             _ => unreachable!(),
         };
         self.calc_subresource(base.mip_level, base.array_layer, plane)

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -966,8 +966,10 @@ impl Texture {
 
     fn calc_subresource_for_copy(&self, base: &crate::TextureCopyBase) -> u32 {
         let plane = match base.aspect {
-            crate::FormatAspects::COLOR | crate::FormatAspects::DEPTH => 0,
-            crate::FormatAspects::STENCIL => 1,
+            crate::FormatAspects::COLOR
+            | crate::FormatAspects::DEPTH
+            | crate::FormatAspects::PLANE_0 => 0,
+            crate::FormatAspects::STENCIL | crate::FormatAspects::PLANE_1 => 1,
             _ => unreachable!(),
         };
         self.calc_subresource(base.mip_level, base.array_layer, plane)


### PR DESCRIPTION
**Connections**
None

**Description**
Texture to texture copy didn't account for multi-planar textures which resulted in artifacts on linux-vulkan (windows-vulkan seems unaffected for some reason) and panic on DX12.

**Testing**
I made a simple app which renders a moving triangle onto NV12 texture and displays it (run on windows (dx12/vulkan) and linux (vulkan)). 
I can also add tests to `wgpu-gpu` if you want me to. 

**Squash or Rebase?**
squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
