### PR TITLE
chore(deno_webgpu): Removed unnecessary vec

### DIFF
--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -732,7 +732,7 @@ impl GPUDevice {
       .scopes
       .lock()
       .unwrap()
-      .push((filter, vec![]));
+      .push((filter, None));
   }
 
   #[async_method(fake)]
@@ -746,7 +746,7 @@ impl GPUDevice {
       return Ok(v8::Global::new(scope, val));
     }
 
-    let Some((_, errors)) = self.error_handler.scopes.lock().unwrap().pop()
+    let Some((_, error)) = self.error_handler.scopes.lock().unwrap().pop()
     else {
       return Err(JsErrorBox::new(
         "DOMExceptionOperationError",
@@ -754,7 +754,7 @@ impl GPUDevice {
       ));
     };
 
-    let val = if let Some(err) = errors.into_iter().next() {
+    let val = if let Some(err) = error {
       deno_core::error::to_v8_error(scope, &err)
     } else {
       v8::null(scope).into()

--- a/deno_webgpu/error.rs
+++ b/deno_webgpu/error.rs
@@ -45,7 +45,7 @@ pub type ErrorHandler = std::rc::Rc<DeviceErrorHandler>;
 
 pub struct DeviceErrorHandler {
   pub is_lost: OnceLock<()>,
-  pub scopes: Mutex<Vec<(GPUErrorFilter, Vec<GPUError>)>>,
+  pub scopes: Mutex<Vec<(GPUErrorFilter, Option<GPUError>)>>,
   lost_resolver: Mutex<Option<v8::Global<v8::PromiseResolver>>>,
   spawner: V8TaskSpawner,
 
@@ -111,7 +111,10 @@ impl DeviceErrorHandler {
       .rfind(|(filter, _)| filter == &error_filter);
 
     if let Some(scope) = scope {
-      scope.1.push(err);
+      // Only saving the first error in the scope as it's likely the culprit.
+      if scope.1.is_none() {
+        scope.1 = Some(err);
+      }
     } else {
       let device = self
         .device


### PR DESCRIPTION
**Description**
Replaced vec with option as only the first item is ever used.

**Testing**
Just the tests mentioned in the checklist section.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->

Running `cargo xtask test` gave me some failures even without my commit, so I suspect that those failures are not because of this change.