### PR TITLE
Forbid unsafe code in naga

### DIFF
--- a/naga/src/arena/handle.rs
+++ b/naga/src/arena/handle.rs
@@ -109,11 +109,6 @@ impl<T> Handle<T> {
         Handle::new(handle_index)
     }
 
-    /// Convert a `usize` index into a `Handle<T>`, without range checks.
-    pub(super) const unsafe fn from_usize_unchecked(index: usize) -> Self {
-        Handle::new(Index::new_unchecked(index as u32))
-    }
-
     /// Write this handle's index to `formatter`, preceded by `prefix`.
     pub fn write_prefixed(
         &self,

--- a/naga/src/arena/mod.rs
+++ b/naga/src/arena/mod.rs
@@ -98,7 +98,7 @@ impl<T> Arena<T> {
         self.data
             .iter()
             .enumerate()
-            .map(|(i, v)| unsafe { (Handle::from_usize_unchecked(i), v) })
+            .map(|(i, v)| (Handle::from_usize(i), v))
     }
 
     /// Returns an iterator over the items stored in this arena, returning both
@@ -110,7 +110,7 @@ impl<T> Arena<T> {
             .iter_mut()
             .zip(self.span_info.iter())
             .enumerate()
-            .map(|(i, (v, span))| unsafe { (Handle::from_usize_unchecked(i), v, span) })
+            .map(|(i, (v, span))| (Handle::from_usize(i), v, span))
     }
 
     /// Drains the arena, returning an iterator over the items stored.
@@ -121,7 +121,7 @@ impl<T> Arena<T> {
             .into_iter()
             .zip(arena.span_info)
             .enumerate()
-            .map(|(i, (v, span))| unsafe { (Handle::from_usize_unchecked(i), v, span) })
+            .map(|(i, (v, span))| (Handle::from_usize(i), v, span))
     }
 
     /// Returns a iterator over the items stored in this arena,
@@ -130,7 +130,7 @@ impl<T> Arena<T> {
         self.data
             .iter_mut()
             .enumerate()
-            .map(|(i, v)| unsafe { (Handle::from_usize_unchecked(i), v) })
+            .map(|(i, v)| (Handle::from_usize(i), v))
     }
 
     /// Adds a new value to the arena, returning a typed handle.
@@ -146,7 +146,7 @@ impl<T> Arena<T> {
         self.data
             .iter()
             .position(fun)
-            .map(|index| unsafe { Handle::from_usize_unchecked(index) })
+            .map(|index| Handle::from_usize(index))
     }
 
     /// Adds a value with a custom check for uniqueness:
@@ -160,7 +160,7 @@ impl<T> Arena<T> {
         fun: F,
     ) -> Handle<T> {
         if let Some(index) = self.data.iter().position(|d| fun(d, &value)) {
-            unsafe { Handle::from_usize_unchecked(index) }
+            Handle::from_usize(index)
         } else {
             self.append(value, span)
         }

--- a/naga/src/arena/unique_arena.rs
+++ b/naga/src/arena/unique_arena.rs
@@ -108,7 +108,7 @@ impl<T: Eq + hash::Hash> UniqueArena<T> {
     /// the item's handle and a reference to it.
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = (Handle<T>, &T)> + ExactSizeIterator {
         self.set.iter().enumerate().map(|(i, v)| {
-            let index = unsafe { Index::new_unchecked(i as u32) };
+            let index = Index::new(i as u32).unwrap();
             (Handle::new(index), v)
         })
     }
@@ -160,7 +160,7 @@ impl<T: Eq + hash::Hash> UniqueArena<T> {
     pub fn get(&self, value: &T) -> Option<Handle<T>> {
         self.set
             .get_index_of(value)
-            .map(|index| unsafe { Handle::from_usize_unchecked(index) })
+            .map(|index| Handle::from_usize(index))
     }
 
     /// Return this arena's value at `handle`, if that is a valid handle.

--- a/naga/src/back/spv/helpers.rs
+++ b/naga/src/back/spv/helpers.rs
@@ -189,8 +189,7 @@ impl StrUnstable for str {
                 .iter()
                 .rposition(|b| b.is_utf8_char_boundary_polyfill());
 
-            // SAFETY: we know that the character boundary will be within four bytes
-            unsafe { lower_bound + new_index.unwrap_unchecked() }
+            lower_bound + new_index.unwrap()
         }
     }
 }

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -99,6 +99,7 @@ void main() {
     )
 )]
 #![no_std]
+#![forbid(unsafe_code)]
 
 #[cfg(std)]
 extern crate std;

--- a/naga/src/non_max_u32.rs
+++ b/naga/src/non_max_u32.rs
@@ -70,24 +70,6 @@ impl NonMaxU32 {
         self.0.get() - 1
     }
 
-    /// Construct a [`NonMaxU32`] whose value is `n`.
-    ///
-    /// # Safety
-    ///
-    /// The value of `n` must not be [`u32::MAX`].
-    pub const unsafe fn new_unchecked(n: u32) -> NonMaxU32 {
-        NonMaxU32(unsafe { NonZeroU32::new_unchecked(n + 1) })
-    }
-
-    /// Construct a [`NonMaxU32`] whose value is `index`.
-    ///
-    /// # Safety
-    ///
-    /// - The value of `index` must be strictly less than [`u32::MAX`].
-    pub const unsafe fn from_usize_unchecked(index: usize) -> Self {
-        NonMaxU32(unsafe { NonZeroU32::new_unchecked(index as u32 + 1) })
-    }
-
     pub fn checked_add(self, n: u32) -> Option<Self> {
         // Adding `n` to `self` produces `u32::MAX` if and only if
         // adding `n` to `self.0` produces `0`. So we can simply

--- a/naga/src/proc/layouter.rs
+++ b/naga/src/proc/layouter.rs
@@ -22,8 +22,7 @@ impl Alignment {
 
     pub const fn new(n: u32) -> Option<Self> {
         if n.is_power_of_two() {
-            // SAFETY: value can't be 0 since we just checked if it's a power of 2
-            Some(Self(unsafe { NonZeroU32::new_unchecked(n) }))
+            Some(Self(NonZeroU32::new(n).unwrap()))
         } else {
             None
         }
@@ -71,8 +70,7 @@ impl ops::Mul for Alignment {
     type Output = Alignment;
 
     fn mul(self, rhs: Alignment) -> Self::Output {
-        // SAFETY: both lhs and rhs are powers of 2, the result will be a power of 2
-        Self(unsafe { NonZeroU32::new_unchecked(self.0.get() * rhs.0.get()) })
+        Self(NonZeroU32::new(self.0.get() * rhs.0.get()).unwrap())
     }
 }
 
@@ -88,7 +86,7 @@ impl From<crate::VectorSize> for Alignment {
 
 impl From<crate::CooperativeSize> for Alignment {
     fn from(size: crate::CooperativeSize) -> Self {
-        Self(unsafe { NonZeroU32::new_unchecked(size as u32) })
+        Self(NonZeroU32::new(size as u32).unwrap())
     }
 }
 


### PR DESCRIPTION
**Connections**
Closes #9066 either way

**Description**
This forbids unsafe code in naga and removes all existing instances. The existing unsafe code is few and far between, but if there is no performance impact, it would be nice to have it completely removed.

**Testing**
I will be uploading benchmark results.

**Squash or Rebase?**
Squash pls

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
