### PR TITLE
Remove `gpu-descriptor` dependency by inlining the crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,26 +1764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "gzip-header"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4944,7 +4924,6 @@ dependencies = [
  "glutin-winit",
  "glutin_wgl_sys 0.6.1",
  "gpu-allocator",
- "gpu-descriptor",
  "hashbrown 0.16.1",
  "js-sys",
  "khronos-egl",

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -95,7 +95,6 @@ vulkan = [
     "dep:arrayvec",
     "dep:ash",
     "dep:bytemuck",
-    "dep:gpu-descriptor",
     "dep:hashbrown",
     "dep:libc",
     "dep:libloading",
@@ -233,7 +232,6 @@ glow = { workspace = true, optional = true }
 gpu-allocator = { workspace = true, optional = true }
 # Backend: Vulkan
 ash = { workspace = true, optional = true }
-gpu-descriptor = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true, features = ["union"] }
 # Backend: GLES
 khronos-egl = { workspace = true, features = ["dynamic"], optional = true }

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -2570,7 +2570,7 @@ impl super::Adapter {
                 allocation_sizes,
             })?;
 
-        let desc_allocator = gpu_descriptor::DescriptorAllocator::new(
+        let desc_allocator = super::descriptor::DescriptorAllocator::new(
             if let Some(di) = self.phd_capabilities.descriptor_indexing {
                 di.max_update_after_bind_descriptors_in_all_pools
             } else {

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -103,14 +103,6 @@ pub trait DescriptorDevice {
         flags: DescriptorPoolCreateFlags,
     ) -> Result<vk::DescriptorPool, CreatePoolError>;
 
-    /// Destroys descriptor pool.
-    ///
-    /// # Safety
-    ///
-    /// Pool must be created from this device.
-    /// All descriptor sets allocated from this pool become invalid.
-    unsafe fn destroy_descriptor_pool(&self, pool: vk::DescriptorPool);
-
     /// Allocates descriptor sets.
     ///
     /// # Safety
@@ -396,7 +388,7 @@ impl DescriptorBucket {
             match result {
                 Ok(()) => {}
                 Err(err) => {
-                    unsafe { device.destroy_descriptor_pool(raw) };
+                    unsafe { device.raw.destroy_descriptor_pool(raw, None) };
                     match err {
                         DeviceAllocationError::OutOfDeviceMemory => {
                             return Err(AllocationError::OutOfDeviceMemory)
@@ -429,7 +421,7 @@ impl DescriptorBucket {
     unsafe fn free(
         &mut self,
         device: &super::DeviceShared,
-        raw_sets: impl IntoIterator<Item = vk::DescriptorSet>,
+        raw_sets: impl ExactSizeIterator<Item = vk::DescriptorSet>,
         pool_id: u64,
     ) {
         let pool = usize::try_from(pool_id - self.offset)
@@ -437,16 +429,8 @@ impl DescriptorBucket {
             .and_then(|index| self.pools.get_mut(index))
             .expect("Invalid pool id");
 
-        let mut raw_sets = raw_sets.into_iter();
-        let mut count = 0;
-        unsafe {
-            device.dealloc_descriptor_sets(&mut pool.raw, raw_sets.by_ref().inspect(|_| count += 1))
-        };
-
-        debug_assert!(
-            raw_sets.next().is_none(),
-            "Device must deallocated all sets from iterator"
-        );
+        let count = raw_sets.len() as u32;
+        unsafe { device.dealloc_descriptor_sets(&mut pool.raw, raw_sets) };
 
         pool.available += count;
         pool.allocated -= count;
@@ -462,7 +446,7 @@ impl DescriptorBucket {
 
             log::trace!("Destroying old descriptor pool");
 
-            unsafe { device.destroy_descriptor_pool(pool.raw) };
+            unsafe { device.raw.destroy_descriptor_pool(pool.raw, None) };
             self.offset += 1;
         }
     }
@@ -476,7 +460,7 @@ impl DescriptorBucket {
 
             log::trace!("Destroying old descriptor pool");
 
-            unsafe { device.destroy_descriptor_pool(pool.raw) };
+            unsafe { device.raw.destroy_descriptor_pool(pool.raw, None) };
             self.offset += 1;
         }
     }
@@ -496,7 +480,7 @@ pub struct DescriptorAllocator {
 
 impl Drop for DescriptorAllocator {
     fn drop(&mut self) {
-        if self.buckets.drain().any(|(_, bucket)| bucket.total != 0) {
+        if self.buckets.values().any(|bucket| bucket.total != 0) {
             log::error!(
                 "`DescriptorAllocator` is dropped while some descriptor sets were not deallocated"
             );

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -4,6 +4,7 @@
 // which is licenced under MIT/APACHE
 
 use alloc::{collections::VecDeque, vec::Vec};
+use ash::vk;
 use core::{
     convert::TryFrom as _,
     fmt::{self, Debug, Display},
@@ -91,14 +92,16 @@ pub enum DeviceAllocationError {
 }
 
 /// Abstract device that can create pools of type `P` and allocate sets `S` with layout `L`.
-pub trait DescriptorDevice<L, P, S> {
+pub trait DescriptorDevice {
+    //vk::DescriptorSetLayout, vk::DescriptorPool, vk::DescriptorSet
+
     /// Creates a new descriptor pool.
     fn create_descriptor_pool(
         &self,
         descriptor_count: &DescriptorTotalCount,
         max_sets: u32,
         flags: DescriptorPoolCreateFlags,
-    ) -> Result<P, CreatePoolError>;
+    ) -> Result<vk::DescriptorPool, CreatePoolError>;
 
     /// Destroys descriptor pool.
     ///
@@ -106,7 +109,7 @@ pub trait DescriptorDevice<L, P, S> {
     ///
     /// Pool must be created from this device.
     /// All descriptor sets allocated from this pool become invalid.
-    unsafe fn destroy_descriptor_pool(&self, pool: P);
+    unsafe fn destroy_descriptor_pool(&self, pool: vk::DescriptorPool);
 
     /// Allocates descriptor sets.
     ///
@@ -115,19 +118,21 @@ pub trait DescriptorDevice<L, P, S> {
     /// Pool must be created from this device.
     unsafe fn alloc_descriptor_sets<'a>(
         &self,
-        pool: &mut P,
-        layouts: impl ExactSizeIterator<Item = &'a L>,
-        sets: &mut impl Extend<S>,
-    ) -> Result<(), DeviceAllocationError>
-    where
-        L: 'a;
+        pool: &mut vk::DescriptorPool,
+        layouts: impl ExactSizeIterator<Item = &'a vk::DescriptorSetLayout>,
+        sets: &mut impl Extend<vk::DescriptorSet>,
+    ) -> Result<(), DeviceAllocationError>;
 
     /// Deallocates descriptor sets.
     ///
     /// # Safety
     ///
     /// Sets must be allocated from specified pool and not deallocated before.
-    unsafe fn dealloc_descriptor_sets(&self, pool: &mut P, sets: impl Iterator<Item = S>);
+    unsafe fn dealloc_descriptor_sets(
+        &self,
+        pool: &mut vk::DescriptorPool,
+        sets: impl Iterator<Item = vk::DescriptorSet>,
+    );
 }
 
 bitflags::bitflags! {
@@ -145,16 +150,16 @@ bitflags::bitflags! {
 
 /// Descriptor set from allocator.
 #[derive(Debug)]
-pub struct DescriptorSet<S> {
-    raw: S,
+pub struct DescriptorSet {
+    raw: vk::DescriptorSet,
     pool_id: u64,
     size: DescriptorTotalCount,
     update_after_bind: bool,
 }
 
-impl<S> DescriptorSet<S> {
+impl DescriptorSet {
     /// Returns reference to raw descriptor set.
-    pub fn raw(&self) -> &S {
+    pub fn raw(&self) -> &vk::DescriptorSet {
         &self.raw
     }
 }
@@ -203,8 +208,8 @@ const MIN_SETS: u32 = 64;
 const MAX_SETS: u32 = 512;
 
 #[derive(Debug)]
-struct DescriptorPool<P> {
-    raw: P,
+struct DescriptorPool {
+    raw: vk::DescriptorPool,
 
     /// Number of sets allocated from pool.
     allocated: u32,
@@ -214,15 +219,15 @@ struct DescriptorPool<P> {
 }
 
 #[derive(Debug)]
-struct DescriptorBucket<P> {
+struct DescriptorBucket {
     offset: u64,
-    pools: VecDeque<DescriptorPool<P>>,
+    pools: VecDeque<DescriptorPool>,
     total: u32,
     update_after_bind: bool,
     size: DescriptorTotalCount,
 }
 
-impl<P> Drop for DescriptorBucket<P> {
+impl Drop for DescriptorBucket {
     fn drop(&mut self) {
         if std::thread::panicking() {
             return;
@@ -233,7 +238,7 @@ impl<P> Drop for DescriptorBucket<P> {
     }
 }
 
-impl<P> DescriptorBucket<P> {
+impl DescriptorBucket {
     fn new(update_after_bind: bool, size: DescriptorTotalCount) -> Self {
         DescriptorBucket {
             offset: 0,
@@ -290,12 +295,12 @@ impl<P> DescriptorBucket<P> {
         (pool_size, max_sets)
     }
 
-    unsafe fn allocate<L, S>(
+    unsafe fn allocate(
         &mut self,
-        device: &impl DescriptorDevice<L, P, S>,
-        layout: &L,
+        device: &super::DeviceShared,
+        layout: &vk::DescriptorSetLayout,
         mut count: u32,
-        allocated_sets: &mut Vec<DescriptorSet<S>>,
+        allocated_sets: &mut Vec<DescriptorSet>,
     ) -> Result<(), AllocationError> {
         debug_assert!(usize::try_from(count).is_ok(), "Must be ensured by caller");
 
@@ -421,10 +426,10 @@ impl<P> DescriptorBucket<P> {
         Ok(())
     }
 
-    unsafe fn free<L, S>(
+    unsafe fn free(
         &mut self,
-        device: &impl DescriptorDevice<L, P, S>,
-        raw_sets: impl IntoIterator<Item = S>,
+        device: &super::DeviceShared,
+        raw_sets: impl IntoIterator<Item = vk::DescriptorSet>,
         pool_id: u64,
     ) {
         let pool = usize::try_from(pool_id - self.offset)
@@ -462,7 +467,7 @@ impl<P> DescriptorBucket<P> {
         }
     }
 
-    unsafe fn cleanup<L, S>(&mut self, device: &impl DescriptorDevice<L, P, S>) {
+    unsafe fn cleanup(&mut self, device: &super::DeviceShared) {
         while let Some(pool) = self.pools.pop_front() {
             if pool.allocated != 0 {
                 self.pools.push_front(pool);
@@ -480,16 +485,16 @@ impl<P> DescriptorBucket<P> {
 /// Descriptor allocator.
 /// Can be used to allocate descriptor sets for any layout.
 #[derive(Debug)]
-pub struct DescriptorAllocator<P, S> {
-    buckets: HashMap<(DescriptorTotalCount, bool), DescriptorBucket<P>>,
-    sets_cache: Vec<DescriptorSet<S>>,
-    raw_sets_cache: Vec<S>,
+pub struct DescriptorAllocator {
+    buckets: HashMap<(DescriptorTotalCount, bool), DescriptorBucket>,
+    sets_cache: Vec<DescriptorSet>,
+    raw_sets_cache: Vec<vk::DescriptorSet>,
     max_update_after_bind_descriptors_in_all_pools: u32,
     current_update_after_bind_descriptors_in_all_pools: u32,
     total: u32,
 }
 
-impl<P, S> Drop for DescriptorAllocator<P, S> {
+impl Drop for DescriptorAllocator {
     fn drop(&mut self) {
         if self.buckets.drain().any(|(_, bucket)| bucket.total != 0) {
             log::error!(
@@ -499,7 +504,7 @@ impl<P, S> Drop for DescriptorAllocator<P, S> {
     }
 }
 
-impl<P, S> DescriptorAllocator<P, S> {
+impl DescriptorAllocator {
     /// Create new allocator instance.
     pub fn new(max_update_after_bind_descriptors_in_all_pools: u32) -> Self {
         DescriptorAllocator {
@@ -520,19 +525,14 @@ impl<P, S> DescriptorAllocator<P, S> {
     ///   one `DescriptorAllocator` instance.
     /// * `flags` must match flags that were used to create the layout.
     /// * `layout_descriptor_count` must match descriptor numbers in the layout.
-    pub unsafe fn allocate<L, D>(
+    pub unsafe fn allocate(
         &mut self,
-        device: &D,
-        layout: &L,
+        device: &super::DeviceShared,
+        layout: &vk::DescriptorSetLayout,
         flags: DescriptorSetLayoutCreateFlags,
         layout_descriptor_count: &DescriptorTotalCount,
         count: u32,
-    ) -> Result<Vec<DescriptorSet<S>>, AllocationError>
-    where
-        S: Debug,
-        L: Debug,
-        D: DescriptorDevice<L, P, S>,
-    {
+    ) -> Result<Vec<DescriptorSet>, AllocationError> {
         if count == 0 {
             return Ok(Vec::new());
         }
@@ -604,10 +604,9 @@ impl<P, S> DescriptorAllocator<P, S> {
     /// * None of descriptor sets can be referenced in any pending command buffers.
     /// * All command buffers where at least one of descriptor sets referenced
     ///   move to invalid state.
-    pub unsafe fn free<L, D, I>(&mut self, device: &D, sets: I)
+    pub unsafe fn free<I>(&mut self, device: &super::DeviceShared, sets: I)
     where
-        D: DescriptorDevice<L, P, S>,
-        I: IntoIterator<Item = DescriptorSet<S>>,
+        I: IntoIterator<Item = DescriptorSet>,
     {
         debug_assert!(self.raw_sets_cache.is_empty());
 
@@ -640,15 +639,13 @@ impl<P, S> DescriptorAllocator<P, S> {
     }
 
     /// Frees the cached descriptor sets which must be allocated from the same bucket and pool.
-    unsafe fn free_raw_sets_cache<L, D>(
+    unsafe fn free_raw_sets_cache(
         &mut self,
-        device: &D,
+        device: &super::DeviceShared,
         bucket_key: &(DescriptorTotalCount, bool),
         pool_id: u64,
         descriptor_count: u32,
-    ) where
-        D: DescriptorDevice<L, P, S>,
-    {
+    ) {
         let bucket = self
             .buckets
             .get_mut(bucket_key)
@@ -672,7 +669,7 @@ impl<P, S> DescriptorAllocator<P, S> {
     ///
     /// * Same `device` instance must be passed to all method calls of
     ///   one `DescriptorAllocator` instance.
-    pub unsafe fn cleanup<L>(&mut self, device: &impl DescriptorDevice<L, P, S>) {
+    pub unsafe fn cleanup(&mut self, device: &super::DeviceShared) {
         for bucket in self.buckets.values_mut() {
             unsafe { bucket.cleanup(device) }
         }
@@ -698,15 +695,15 @@ const EMPTY_COUNT: DescriptorTotalCount = DescriptorTotalCount {
     inline_uniform_block_bindings: 0,
 };
 
-struct Allocation<'a, S> {
+struct Allocation<'a> {
     update_after_bind: bool,
     size: DescriptorTotalCount,
     pool_id: u64,
-    sets: &'a mut Vec<DescriptorSet<S>>,
+    sets: &'a mut Vec<DescriptorSet>,
 }
 
-impl<S> Extend<S> for Allocation<'_, S> {
-    fn extend<T: IntoIterator<Item = S>>(&mut self, iter: T) {
+impl Extend<vk::DescriptorSet> for Allocation<'_> {
+    fn extend<T: IntoIterator<Item = vk::DescriptorSet>>(&mut self, iter: T) {
         let update_after_bind = self.update_after_bind;
         let size = self.size;
         let pool_id = self.pool_id;

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -6,10 +6,7 @@
 use alloc::{collections::VecDeque, vec::Vec};
 use arrayvec::ArrayVec;
 use ash::vk;
-use core::{
-    convert::TryFrom as _,
-    fmt::{self, Debug, Display},
-};
+use core::convert::TryFrom as _;
 use hashbrown::HashMap;
 
 bitflags::bitflags! {
@@ -66,36 +63,6 @@ impl DescriptorTotalCount {
     }
 }
 
-/// Memory exhausted error.
-#[derive(Debug)]
-pub enum CreatePoolError {
-    /// Device memory exhausted.
-    OutOfDeviceMemory,
-
-    /// Host memory exhausted.
-    OutOfHostMemory,
-
-    /// A descriptor pool creation has failed due to fragmentation.
-    Fragmentation,
-
-    Unexpected,
-}
-
-/// Memory exhausted error.
-#[derive(Debug)]
-pub enum DeviceAllocationError {
-    /// Device memory exhausted.
-    OutOfDeviceMemory,
-
-    /// Host memory exhausted.
-    OutOfHostMemory,
-
-    /// Pool allocation failed due to fragmentation of pool's memory.
-    FragmentedPool,
-
-    Unexpected,
-}
-
 impl super::DeviceShared {
     /// Creates a new descriptor pool.
     fn create_descriptor_pool(
@@ -103,7 +70,7 @@ impl super::DeviceShared {
         descriptor_count: &DescriptorTotalCount,
         max_sets: u32,
         flags: DescriptorPoolCreateFlags,
-    ) -> Result<vk::DescriptorPool, CreatePoolError> {
+    ) -> Result<vk::DescriptorPool, crate::DeviceError> {
         //Note: ignoring other types, since they can't appear here
         let unfiltered_counts = [
             (vk::DescriptorType::SAMPLER, descriptor_count.sampler),
@@ -160,16 +127,8 @@ impl super::DeviceShared {
             .flags(vk_flags)
             .pool_sizes(&filtered_counts);
 
-        match unsafe { self.raw.create_descriptor_pool(&vk_info, None) } {
-            Ok(pool) => Ok(pool),
-            Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY) => Err(CreatePoolError::OutOfHostMemory),
-            Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY) => Err(CreatePoolError::OutOfDeviceMemory),
-            Err(vk::Result::ERROR_FRAGMENTATION) => Err(CreatePoolError::Fragmentation),
-            Err(err) => {
-                log::error!("Unexpected Vulkan error: `{err}`");
-                Err(CreatePoolError::Unexpected)
-            }
-        }
+        unsafe { self.raw.create_descriptor_pool(&vk_info, None) }
+            .map_err(super::map_host_device_oom_err)
     }
 
     /// Allocates descriptor sets.
@@ -181,8 +140,8 @@ impl super::DeviceShared {
         &self,
         pool: &mut vk::DescriptorPool,
         layouts: impl ExactSizeIterator<Item = &'a vk::DescriptorSetLayout>,
-    ) -> Result<Vec<vk::DescriptorSet>, DeviceAllocationError> {
-        let result = unsafe {
+    ) -> Result<Vec<vk::DescriptorSet>, crate::DeviceError> {
+        unsafe {
             self.raw.allocate_descriptor_sets(
                 &vk::DescriptorSetAllocateInfo::default()
                     .descriptor_pool(*pool)
@@ -192,23 +151,8 @@ impl super::DeviceShared {
                         ),
                     ),
             )
-        };
-
-        match result {
-            Ok(vk_sets) => Ok(vk_sets),
-            Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY)
-            | Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY) => {
-                Err(DeviceAllocationError::OutOfHostMemory)
-            }
-            Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY) => {
-                Err(DeviceAllocationError::OutOfDeviceMemory)
-            }
-            Err(vk::Result::ERROR_FRAGMENTED_POOL) => Err(DeviceAllocationError::FragmentedPool),
-            Err(err) => {
-                log::error!("Unexpected Vulkan error: `{err}`");
-                Err(DeviceAllocationError::Unexpected)
-            }
         }
+        .map_err(super::map_host_device_oom_err)
     }
 
     /// Deallocates descriptor sets.
@@ -260,50 +204,6 @@ impl DescriptorSet {
     /// Returns reference to raw descriptor set.
     pub fn raw(&self) -> &vk::DescriptorSet {
         &self.raw
-    }
-}
-
-/// AllocationError that may occur during descriptor sets allocation.
-#[derive(Debug)]
-pub enum AllocationError {
-    /// Backend reported that device memory has been exhausted.\
-    /// Deallocating device memory or other resources may increase chance
-    /// that another allocation would succeed.
-    OutOfDeviceMemory,
-
-    /// Backend reported that host memory has been exhausted.\
-    /// Deallocating host memory may increase chance that another allocation would succeed.
-    OutOfHostMemory,
-
-    /// The total number of descriptors across all pools created\
-    /// with flag `CREATE_UPDATE_AFTER_BIND_BIT` set exceeds `max_update_after_bind_descriptors_in_all_pools`
-    /// Or fragmentation of the underlying hardware resources occurs.
-    Fragmentation,
-
-    Unexpected,
-}
-
-impl Display for AllocationError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            AllocationError::OutOfDeviceMemory => fmt.write_str("Device memory exhausted"),
-            AllocationError::OutOfHostMemory => fmt.write_str("Host memory exhausted"),
-            AllocationError::Fragmentation => fmt.write_str("Fragmentation"),
-            AllocationError::Unexpected => fmt.write_str("Unexpected error"),
-        }
-    }
-}
-
-impl core::error::Error for AllocationError {}
-
-impl From<CreatePoolError> for AllocationError {
-    fn from(err: CreatePoolError) -> Self {
-        match err {
-            CreatePoolError::OutOfDeviceMemory => AllocationError::OutOfDeviceMemory,
-            CreatePoolError::OutOfHostMemory => AllocationError::OutOfHostMemory,
-            CreatePoolError::Fragmentation => AllocationError::Fragmentation,
-            CreatePoolError::Unexpected => AllocationError::Unexpected,
-        }
     }
 }
 
@@ -404,7 +304,7 @@ impl DescriptorBucket {
         layout: &vk::DescriptorSetLayout,
         mut count: u32,
         allocated_sets: &mut Vec<DescriptorSet>,
-    ) -> Result<(), AllocationError> {
+    ) -> Result<(), crate::DeviceError> {
         debug_assert!(usize::try_from(count).is_ok(), "Must be ensured by caller");
 
         if count == 0 {
@@ -420,34 +320,15 @@ impl DescriptorBucket {
 
             log::trace!("Allocate `{}` sets from existing pool", allocate);
 
-            let result = unsafe {
+            let vk_sets = unsafe {
                 device.alloc_descriptor_sets(&mut pool.raw, (0..allocate).map(|_| layout))
-            };
-
-            match result {
-                Ok(vk_sets) => {
-                    allocated_sets.extend(vk_sets.into_iter().map(|raw| DescriptorSet {
-                        raw,
-                        pool_id: index as u64 + self.offset,
-                        update_after_bind: self.update_after_bind,
-                        size: self.size,
-                    }))
-                }
-                Err(DeviceAllocationError::OutOfDeviceMemory) => {
-                    return Err(AllocationError::OutOfDeviceMemory)
-                }
-                Err(DeviceAllocationError::OutOfHostMemory) => {
-                    return Err(AllocationError::OutOfHostMemory)
-                }
-                Err(DeviceAllocationError::Unexpected) => return Err(AllocationError::Unexpected),
-                Err(DeviceAllocationError::FragmentedPool) => {
-                    // Should not happen, but better this than panicing.
-
-                    log::error!("Unexpectedly failed to allocated descriptor sets due to pool fragmentation");
-                    pool.available = 0;
-                    continue;
-                }
-            }
+            }?;
+            allocated_sets.extend(vk_sets.into_iter().map(|raw| DescriptorSet {
+                raw,
+                pool_id: index as u64 + self.offset,
+                update_after_bind: self.update_after_bind,
+                size: self.size,
+            }));
 
             count -= allocate;
             pool.available -= allocate;
@@ -496,23 +377,7 @@ impl DescriptorBucket {
                 }
                 Err(err) => {
                     unsafe { device.raw.destroy_descriptor_pool(raw, None) };
-                    match err {
-                        DeviceAllocationError::OutOfDeviceMemory => {
-                            return Err(AllocationError::OutOfDeviceMemory)
-                        }
-                        DeviceAllocationError::OutOfHostMemory => {
-                            return Err(AllocationError::OutOfHostMemory)
-                        }
-                        DeviceAllocationError::Unexpected => {
-                            return Err(AllocationError::Unexpected)
-                        }
-                        DeviceAllocationError::FragmentedPool => {
-                            // Should not happen, but better this than panicking.
-
-                            log::error!("Unexpectedly failed to allocated descriptor sets due to pool fragmentation");
-                        }
-                    }
-                    panic!("Failed to allocate descriptor sets from fresh pool");
+                    return Err(err);
                 }
             }
 
@@ -626,7 +491,7 @@ impl DescriptorAllocator {
         flags: DescriptorSetLayoutCreateFlags,
         layout_descriptor_count: &DescriptorTotalCount,
         count: u32,
-    ) -> Result<Vec<DescriptorSet>, AllocationError> {
+    ) -> Result<Vec<DescriptorSet>, crate::DeviceError> {
         if count == 0 {
             return Ok(Vec::new());
         }
@@ -640,7 +505,7 @@ impl DescriptorAllocator {
                 - self.current_update_after_bind_descriptors_in_all_pools
                 < descriptor_count
         {
-            return Err(AllocationError::Fragmentation);
+            return Err(crate::DeviceError::OutOfMemory);
         }
 
         log::trace!(
@@ -704,7 +569,7 @@ impl DescriptorAllocator {
     {
         debug_assert!(self.raw_sets_cache.is_empty());
 
-        let mut last_key = (EMPTY_COUNT, false);
+        let mut last_key = (Default::default(), false);
         let mut last_pool_id = None;
 
         let mut descriptor_count = 0;
@@ -770,21 +635,3 @@ impl DescriptorAllocator {
         self.buckets.retain(|_, bucket| !bucket.pools.is_empty());
     }
 }
-
-/// Empty descriptor per_type.
-const EMPTY_COUNT: DescriptorTotalCount = DescriptorTotalCount {
-    sampler: 0,
-    combined_image_sampler: 0,
-    sampled_image: 0,
-    storage_image: 0,
-    uniform_texel_buffer: 0,
-    storage_texel_buffer: 0,
-    uniform_buffer: 0,
-    storage_buffer: 0,
-    uniform_buffer_dynamic: 0,
-    storage_buffer_dynamic: 0,
-    input_attachment: 0,
-    acceleration_structure: 0,
-    inline_uniform_block_bytes: 0,
-    inline_uniform_block_bindings: 0,
-};

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -320,28 +320,28 @@ impl DescriptorBucket {
 
         log::trace!("Freed {} from descriptor bucket", count);
 
-        while let Some(pool) = self.pools.pop_front() {
-            if self.pools.is_empty() || pool.allocated != 0 {
-                self.pools.push_front(pool);
+        while self.pools.len() > 1 {
+            if self.pools.front().unwrap().allocated != 0 {
                 break;
             }
 
             log::trace!("Destroying old descriptor pool");
 
+            let pool = self.pools.pop_front().unwrap();
             unsafe { device.raw.destroy_descriptor_pool(pool.raw, None) };
             self.offset += 1;
         }
     }
 
     unsafe fn cleanup(&mut self, device: &super::DeviceShared) {
-        while let Some(pool) = self.pools.pop_front() {
+        while let Some(pool) = self.pools.front() {
             if pool.allocated != 0 {
-                self.pools.push_front(pool);
                 break;
             }
 
             log::trace!("Destroying old descriptor pool");
 
+            let pool = self.pools.pop_front().unwrap();
             unsafe { device.raw.destroy_descriptor_pool(pool.raw, None) };
             self.offset += 1;
         }

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -554,71 +554,34 @@ impl DescriptorAllocator {
         }
     }
 
-    /// Free descriptor sets.
+    /// Free a descriptor set.
     ///
     /// # Safety
     ///
     /// * Same `device` instance must be passed to all method calls of
     ///   one `DescriptorAllocator` instance.
-    /// * None of descriptor sets can be referenced in any pending command buffers.
-    /// * All command buffers where at least one of descriptor sets referenced
+    /// * The descriptor set cannot be referenced in any pending command buffers.
+    /// * All command buffers where the descriptor set is referenced
     ///   move to invalid state.
-    pub unsafe fn free<I>(&mut self, device: &super::DeviceShared, sets: I)
-    where
-        I: IntoIterator<Item = DescriptorSet>,
-    {
+    pub unsafe fn free(&mut self, device: &super::DeviceShared, set: DescriptorSet) {
         debug_assert!(self.raw_sets_cache.is_empty());
 
-        let mut last_key = (Default::default(), false);
-        let mut last_pool_id = None;
+        self.raw_sets_cache.push(set.raw);
 
-        let mut descriptor_count = 0;
-
-        // Batch freeing of adjacent descriptor sets that belong to the same bucket and pool.
-        for set in sets {
-            descriptor_count += set.size.total();
-
-            if last_key != (set.size, set.update_after_bind) || last_pool_id != Some(set.pool_id) {
-                if let Some(pool_id) = last_pool_id {
-                    unsafe {
-                        self.free_raw_sets_cache(device, &last_key, pool_id, descriptor_count)
-                    };
-                    descriptor_count = 0;
-                }
-
-                last_key = (set.size, set.update_after_bind);
-                last_pool_id = Some(set.pool_id);
-            }
-            self.raw_sets_cache.push(set.raw);
-        }
-
-        if let Some(pool_id) = last_pool_id {
-            unsafe { self.free_raw_sets_cache(device, &last_key, pool_id, descriptor_count) };
-        }
-    }
-
-    /// Frees the cached descriptor sets which must be allocated from the same bucket and pool.
-    unsafe fn free_raw_sets_cache(
-        &mut self,
-        device: &super::DeviceShared,
-        bucket_key: &(DescriptorTotalCount, bool),
-        pool_id: u64,
-        descriptor_count: u32,
-    ) {
         let bucket = self
             .buckets
-            .get_mut(bucket_key)
+            .get_mut(&(set.size, set.update_after_bind))
             .expect("Set must be allocated from this allocator");
 
         debug_assert!(u32::try_from(self.raw_sets_cache.len())
             .ok()
             .is_some_and(|count| count <= bucket.total));
 
-        unsafe { bucket.free(device, self.raw_sets_cache.drain(..), pool_id) };
+        unsafe { bucket.free(device, self.raw_sets_cache.drain(..), set.pool_id) };
 
-        self.total -= descriptor_count;
+        self.total -= set.size.total();
         if bucket.update_after_bind {
-            self.current_update_after_bind_descriptors_in_all_pools -= descriptor_count;
+            self.current_update_after_bind_descriptors_in_all_pools -= set.size.total();
         }
     }
 

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -4,6 +4,7 @@
 // which is licenced under MIT/APACHE
 
 use alloc::{collections::VecDeque, vec::Vec};
+use arrayvec::ArrayVec;
 use ash::vk;
 use core::{
     convert::TryFrom as _,
@@ -76,6 +77,8 @@ pub enum CreatePoolError {
 
     /// A descriptor pool creation has failed due to fragmentation.
     Fragmentation,
+
+    Unexpected,
 }
 
 /// Memory exhausted error.
@@ -89,19 +92,85 @@ pub enum DeviceAllocationError {
 
     /// Pool allocation failed due to fragmentation of pool's memory.
     FragmentedPool,
+
+    Unexpected,
 }
 
-/// Abstract device that can create pools of type `P` and allocate sets `S` with layout `L`.
-pub trait DescriptorDevice {
-    //vk::DescriptorSetLayout, vk::DescriptorPool, vk::DescriptorSet
-
+impl super::DeviceShared {
     /// Creates a new descriptor pool.
     fn create_descriptor_pool(
         &self,
         descriptor_count: &DescriptorTotalCount,
         max_sets: u32,
         flags: DescriptorPoolCreateFlags,
-    ) -> Result<vk::DescriptorPool, CreatePoolError>;
+    ) -> Result<vk::DescriptorPool, CreatePoolError> {
+        //Note: ignoring other types, since they can't appear here
+        let unfiltered_counts = [
+            (vk::DescriptorType::SAMPLER, descriptor_count.sampler),
+            (
+                vk::DescriptorType::SAMPLED_IMAGE,
+                descriptor_count.sampled_image,
+            ),
+            (
+                vk::DescriptorType::STORAGE_IMAGE,
+                descriptor_count.storage_image,
+            ),
+            (
+                vk::DescriptorType::UNIFORM_BUFFER,
+                descriptor_count.uniform_buffer,
+            ),
+            (
+                vk::DescriptorType::UNIFORM_BUFFER_DYNAMIC,
+                descriptor_count.uniform_buffer_dynamic,
+            ),
+            (
+                vk::DescriptorType::STORAGE_BUFFER,
+                descriptor_count.storage_buffer,
+            ),
+            (
+                vk::DescriptorType::STORAGE_BUFFER_DYNAMIC,
+                descriptor_count.storage_buffer_dynamic,
+            ),
+            (
+                vk::DescriptorType::ACCELERATION_STRUCTURE_KHR,
+                descriptor_count.acceleration_structure,
+            ),
+        ];
+
+        let filtered_counts = unfiltered_counts
+            .iter()
+            .cloned()
+            .filter(|&(_, count)| count != 0)
+            .map(|(ty, count)| vk::DescriptorPoolSize {
+                ty,
+                descriptor_count: count,
+            })
+            .collect::<ArrayVec<_, 8>>();
+
+        let mut vk_flags = if flags.contains(DescriptorPoolCreateFlags::UPDATE_AFTER_BIND) {
+            vk::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
+        } else {
+            vk::DescriptorPoolCreateFlags::empty()
+        };
+        if flags.contains(DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET) {
+            vk_flags |= vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET;
+        }
+        let vk_info = vk::DescriptorPoolCreateInfo::default()
+            .max_sets(max_sets)
+            .flags(vk_flags)
+            .pool_sizes(&filtered_counts);
+
+        match unsafe { self.raw.create_descriptor_pool(&vk_info, None) } {
+            Ok(pool) => Ok(pool),
+            Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY) => Err(CreatePoolError::OutOfHostMemory),
+            Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY) => Err(CreatePoolError::OutOfDeviceMemory),
+            Err(vk::Result::ERROR_FRAGMENTATION) => Err(CreatePoolError::Fragmentation),
+            Err(err) => {
+                log::error!("Unexpected Vulkan error: `{err}`");
+                Err(CreatePoolError::Unexpected)
+            }
+        }
+    }
 
     /// Allocates descriptor sets.
     ///
@@ -113,7 +182,38 @@ pub trait DescriptorDevice {
         pool: &mut vk::DescriptorPool,
         layouts: impl ExactSizeIterator<Item = &'a vk::DescriptorSetLayout>,
         sets: &mut impl Extend<vk::DescriptorSet>,
-    ) -> Result<(), DeviceAllocationError>;
+    ) -> Result<(), DeviceAllocationError> {
+        let result = unsafe {
+            self.raw.allocate_descriptor_sets(
+                &vk::DescriptorSetAllocateInfo::default()
+                    .descriptor_pool(*pool)
+                    .set_layouts(
+                        &smallvec::SmallVec::<[vk::DescriptorSetLayout; 32]>::from_iter(
+                            layouts.cloned(),
+                        ),
+                    ),
+            )
+        };
+
+        match result {
+            Ok(vk_sets) => {
+                sets.extend(vk_sets);
+                Ok(())
+            }
+            Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY)
+            | Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY) => {
+                Err(DeviceAllocationError::OutOfHostMemory)
+            }
+            Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY) => {
+                Err(DeviceAllocationError::OutOfDeviceMemory)
+            }
+            Err(vk::Result::ERROR_FRAGMENTED_POOL) => Err(DeviceAllocationError::FragmentedPool),
+            Err(err) => {
+                log::error!("Unexpected Vulkan error: `{err}`");
+                Err(DeviceAllocationError::Unexpected)
+            }
+        }
+    }
 
     /// Deallocates descriptor sets.
     ///
@@ -124,7 +224,18 @@ pub trait DescriptorDevice {
         &self,
         pool: &mut vk::DescriptorPool,
         sets: impl Iterator<Item = vk::DescriptorSet>,
-    );
+    ) {
+        let result = unsafe {
+            self.raw.free_descriptor_sets(
+                *pool,
+                &smallvec::SmallVec::<[vk::DescriptorSet; 32]>::from_iter(sets),
+            )
+        };
+        match result {
+            Ok(()) => {}
+            Err(err) => super::device::handle_unexpected(err),
+        }
+    }
 }
 
 bitflags::bitflags! {
@@ -172,6 +283,8 @@ pub enum AllocationError {
     /// with flag `CREATE_UPDATE_AFTER_BIND_BIT` set exceeds `max_update_after_bind_descriptors_in_all_pools`
     /// Or fragmentation of the underlying hardware resources occurs.
     Fragmentation,
+
+    Unexpected,
 }
 
 impl Display for AllocationError {
@@ -180,6 +293,7 @@ impl Display for AllocationError {
             AllocationError::OutOfDeviceMemory => fmt.write_str("Device memory exhausted"),
             AllocationError::OutOfHostMemory => fmt.write_str("Host memory exhausted"),
             AllocationError::Fragmentation => fmt.write_str("Fragmentation"),
+            AllocationError::Unexpected => fmt.write_str("Unexpected error"),
         }
     }
 }
@@ -192,6 +306,7 @@ impl From<CreatePoolError> for AllocationError {
             CreatePoolError::OutOfDeviceMemory => AllocationError::OutOfDeviceMemory,
             CreatePoolError::OutOfHostMemory => AllocationError::OutOfHostMemory,
             CreatePoolError::Fragmentation => AllocationError::Fragmentation,
+            CreatePoolError::Unexpected => AllocationError::Unexpected,
         }
     }
 }
@@ -330,6 +445,7 @@ impl DescriptorBucket {
                 Err(DeviceAllocationError::OutOfHostMemory) => {
                     return Err(AllocationError::OutOfHostMemory)
                 }
+                Err(DeviceAllocationError::Unexpected) => return Err(AllocationError::Unexpected),
                 Err(DeviceAllocationError::FragmentedPool) => {
                     // Should not happen, but better this than panicing.
 
@@ -395,6 +511,9 @@ impl DescriptorBucket {
                         }
                         DeviceAllocationError::OutOfHostMemory => {
                             return Err(AllocationError::OutOfHostMemory)
+                        }
+                        DeviceAllocationError::Unexpected => {
+                            return Err(AllocationError::Unexpected)
                         }
                         DeviceAllocationError::FragmentedPool => {
                             // Should not happen, but better this than panicking.

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -1,0 +1,720 @@
+// Copyright 2020 The gpu-descriptor Project Developers
+//
+// Copied and modified from https://github.com/zakarumych/gpu-descriptor
+// which is licenced under MIT/APACHE
+
+use alloc::{collections::VecDeque, vec::Vec};
+use core::{
+    convert::TryFrom as _,
+    fmt::{self, Debug, Display},
+};
+use hashbrown::HashMap;
+
+bitflags::bitflags! {
+    /// Flags to augment descriptor pool creation.
+    ///
+    /// Match corresponding bits in Vulkan.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+    pub struct DescriptorPoolCreateFlags: u32 {
+        /// Allows freeing individual sets.
+        const FREE_DESCRIPTOR_SET = 0x1;
+
+        /// Allows allocating sets with layout created with matching backend-specific flag.
+        const UPDATE_AFTER_BIND = 0x2;
+    }
+}
+
+/// Number of descriptors of each type.
+///
+/// For `InlineUniformBlock` this value is number of bytes instead.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct DescriptorTotalCount {
+    pub sampler: u32,
+    pub combined_image_sampler: u32,
+    pub sampled_image: u32,
+    pub storage_image: u32,
+    pub uniform_texel_buffer: u32,
+    pub storage_texel_buffer: u32,
+    pub uniform_buffer: u32,
+    pub storage_buffer: u32,
+    pub uniform_buffer_dynamic: u32,
+    pub storage_buffer_dynamic: u32,
+    pub input_attachment: u32,
+    pub acceleration_structure: u32,
+    pub inline_uniform_block_bytes: u32,
+    pub inline_uniform_block_bindings: u32,
+}
+
+impl DescriptorTotalCount {
+    pub fn total(&self) -> u32 {
+        self.sampler
+            + self.combined_image_sampler
+            + self.sampled_image
+            + self.storage_image
+            + self.uniform_texel_buffer
+            + self.storage_texel_buffer
+            + self.uniform_buffer
+            + self.storage_buffer
+            + self.uniform_buffer_dynamic
+            + self.storage_buffer_dynamic
+            + self.input_attachment
+            + self.acceleration_structure
+            + self.inline_uniform_block_bytes
+            + self.inline_uniform_block_bindings
+    }
+}
+
+/// Memory exhausted error.
+#[derive(Debug)]
+pub enum CreatePoolError {
+    /// Device memory exhausted.
+    OutOfDeviceMemory,
+
+    /// Host memory exhausted.
+    OutOfHostMemory,
+
+    /// A descriptor pool creation has failed due to fragmentation.
+    Fragmentation,
+}
+
+/// Memory exhausted error.
+#[derive(Debug)]
+pub enum DeviceAllocationError {
+    /// Device memory exhausted.
+    OutOfDeviceMemory,
+
+    /// Host memory exhausted.
+    OutOfHostMemory,
+
+    /// Pool allocation failed due to fragmentation of pool's memory.
+    FragmentedPool,
+}
+
+/// Abstract device that can create pools of type `P` and allocate sets `S` with layout `L`.
+pub trait DescriptorDevice<L, P, S> {
+    /// Creates a new descriptor pool.
+    fn create_descriptor_pool(
+        &self,
+        descriptor_count: &DescriptorTotalCount,
+        max_sets: u32,
+        flags: DescriptorPoolCreateFlags,
+    ) -> Result<P, CreatePoolError>;
+
+    /// Destroys descriptor pool.
+    ///
+    /// # Safety
+    ///
+    /// Pool must be created from this device.
+    /// All descriptor sets allocated from this pool become invalid.
+    unsafe fn destroy_descriptor_pool(&self, pool: P);
+
+    /// Allocates descriptor sets.
+    ///
+    /// # Safety
+    ///
+    /// Pool must be created from this device.
+    unsafe fn alloc_descriptor_sets<'a>(
+        &self,
+        pool: &mut P,
+        layouts: impl ExactSizeIterator<Item = &'a L>,
+        sets: &mut impl Extend<S>,
+    ) -> Result<(), DeviceAllocationError>
+    where
+        L: 'a;
+
+    /// Deallocates descriptor sets.
+    ///
+    /// # Safety
+    ///
+    /// Sets must be allocated from specified pool and not deallocated before.
+    unsafe fn dealloc_descriptor_sets(&self, pool: &mut P, sets: impl Iterator<Item = S>);
+}
+
+bitflags::bitflags! {
+    /// Flags to augment descriptor set allocation.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+    pub struct DescriptorSetLayoutCreateFlags: u32 {
+        /// Specified that descriptor set must be allocated from\
+        /// pool with `DescriptorPoolCreateFlags::UPDATE_AFTER_BIND`.
+        ///
+        /// This flag must be specified when and only when layout was created with matching backend-specific flag,
+        /// that allows layout to have UpdateAfterBind bindings.
+        const UPDATE_AFTER_BIND = 0x2;
+    }
+}
+
+/// Descriptor set from allocator.
+#[derive(Debug)]
+pub struct DescriptorSet<S> {
+    raw: S,
+    pool_id: u64,
+    size: DescriptorTotalCount,
+    update_after_bind: bool,
+}
+
+impl<S> DescriptorSet<S> {
+    /// Returns reference to raw descriptor set.
+    pub fn raw(&self) -> &S {
+        &self.raw
+    }
+}
+
+/// AllocationError that may occur during descriptor sets allocation.
+#[derive(Debug)]
+pub enum AllocationError {
+    /// Backend reported that device memory has been exhausted.\
+    /// Deallocating device memory or other resources may increase chance
+    /// that another allocation would succeed.
+    OutOfDeviceMemory,
+
+    /// Backend reported that host memory has been exhausted.\
+    /// Deallocating host memory may increase chance that another allocation would succeed.
+    OutOfHostMemory,
+
+    /// The total number of descriptors across all pools created\
+    /// with flag `CREATE_UPDATE_AFTER_BIND_BIT` set exceeds `max_update_after_bind_descriptors_in_all_pools`
+    /// Or fragmentation of the underlying hardware resources occurs.
+    Fragmentation,
+}
+
+impl Display for AllocationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AllocationError::OutOfDeviceMemory => fmt.write_str("Device memory exhausted"),
+            AllocationError::OutOfHostMemory => fmt.write_str("Host memory exhausted"),
+            AllocationError::Fragmentation => fmt.write_str("Fragmentation"),
+        }
+    }
+}
+
+impl core::error::Error for AllocationError {}
+
+impl From<CreatePoolError> for AllocationError {
+    fn from(err: CreatePoolError) -> Self {
+        match err {
+            CreatePoolError::OutOfDeviceMemory => AllocationError::OutOfDeviceMemory,
+            CreatePoolError::OutOfHostMemory => AllocationError::OutOfHostMemory,
+            CreatePoolError::Fragmentation => AllocationError::Fragmentation,
+        }
+    }
+}
+
+const MIN_SETS: u32 = 64;
+const MAX_SETS: u32 = 512;
+
+#[derive(Debug)]
+struct DescriptorPool<P> {
+    raw: P,
+
+    /// Number of sets allocated from pool.
+    allocated: u32,
+
+    /// Expected number of sets available.
+    available: u32,
+}
+
+#[derive(Debug)]
+struct DescriptorBucket<P> {
+    offset: u64,
+    pools: VecDeque<DescriptorPool<P>>,
+    total: u32,
+    update_after_bind: bool,
+    size: DescriptorTotalCount,
+}
+
+impl<P> Drop for DescriptorBucket<P> {
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            return;
+        }
+        if self.total > 0 {
+            log::error!("Descriptor sets were not deallocated")
+        }
+    }
+}
+
+impl<P> DescriptorBucket<P> {
+    fn new(update_after_bind: bool, size: DescriptorTotalCount) -> Self {
+        DescriptorBucket {
+            offset: 0,
+            pools: VecDeque::new(),
+            total: 0,
+            update_after_bind,
+            size,
+        }
+    }
+
+    fn new_pool_size(&self, minimal_set_count: u32) -> (DescriptorTotalCount, u32) {
+        let mut max_sets = MIN_SETS // at least MIN_SETS
+            .max(minimal_set_count) // at least enough for allocation
+            .max(self.total.min(MAX_SETS)) // at least as much as was allocated so far capped to MAX_SETS
+            .checked_next_power_of_two() // rounded up to nearest 2^N
+            .unwrap_or(i32::MAX as u32);
+
+        max_sets = (u32::MAX / self.size.sampler.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.combined_image_sampler.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.sampled_image.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.storage_image.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.uniform_texel_buffer.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.storage_texel_buffer.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.uniform_buffer.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.storage_buffer.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.uniform_buffer_dynamic.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.storage_buffer_dynamic.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.input_attachment.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.acceleration_structure.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.inline_uniform_block_bytes.max(1)).min(max_sets);
+        max_sets = (u32::MAX / self.size.inline_uniform_block_bindings.max(1)).min(max_sets);
+
+        let mut pool_size = DescriptorTotalCount {
+            sampler: self.size.sampler * max_sets,
+            combined_image_sampler: self.size.combined_image_sampler * max_sets,
+            sampled_image: self.size.sampled_image * max_sets,
+            storage_image: self.size.storage_image * max_sets,
+            uniform_texel_buffer: self.size.uniform_texel_buffer * max_sets,
+            storage_texel_buffer: self.size.storage_texel_buffer * max_sets,
+            uniform_buffer: self.size.uniform_buffer * max_sets,
+            storage_buffer: self.size.storage_buffer * max_sets,
+            uniform_buffer_dynamic: self.size.uniform_buffer_dynamic * max_sets,
+            storage_buffer_dynamic: self.size.storage_buffer_dynamic * max_sets,
+            input_attachment: self.size.input_attachment * max_sets,
+            acceleration_structure: self.size.acceleration_structure * max_sets,
+            inline_uniform_block_bytes: self.size.inline_uniform_block_bytes * max_sets,
+            inline_uniform_block_bindings: self.size.inline_uniform_block_bindings * max_sets,
+        };
+
+        if pool_size == Default::default() {
+            pool_size.sampler = 1;
+        }
+
+        (pool_size, max_sets)
+    }
+
+    unsafe fn allocate<L, S>(
+        &mut self,
+        device: &impl DescriptorDevice<L, P, S>,
+        layout: &L,
+        mut count: u32,
+        allocated_sets: &mut Vec<DescriptorSet<S>>,
+    ) -> Result<(), AllocationError> {
+        debug_assert!(usize::try_from(count).is_ok(), "Must be ensured by caller");
+
+        if count == 0 {
+            return Ok(());
+        }
+
+        for (index, pool) in self.pools.iter_mut().enumerate().rev() {
+            if pool.available == 0 {
+                continue;
+            }
+
+            let allocate = pool.available.min(count);
+
+            log::trace!("Allocate `{}` sets from existing pool", allocate);
+
+            let result = unsafe {
+                device.alloc_descriptor_sets(
+                    &mut pool.raw,
+                    (0..allocate).map(|_| layout),
+                    &mut Allocation {
+                        size: self.size,
+                        update_after_bind: self.update_after_bind,
+                        pool_id: index as u64 + self.offset,
+                        sets: allocated_sets,
+                    },
+                )
+            };
+
+            match result {
+                Ok(()) => {}
+                Err(DeviceAllocationError::OutOfDeviceMemory) => {
+                    return Err(AllocationError::OutOfDeviceMemory)
+                }
+                Err(DeviceAllocationError::OutOfHostMemory) => {
+                    return Err(AllocationError::OutOfHostMemory)
+                }
+                Err(DeviceAllocationError::FragmentedPool) => {
+                    // Should not happen, but better this than panicing.
+
+                    log::error!("Unexpectedly failed to allocated descriptor sets due to pool fragmentation");
+                    pool.available = 0;
+                    continue;
+                }
+            }
+
+            count -= allocate;
+            pool.available -= allocate;
+            pool.allocated += allocate;
+            self.total += allocate;
+
+            if count == 0 {
+                return Ok(());
+            }
+        }
+
+        while count > 0 {
+            let (pool_size, max_sets) = self.new_pool_size(count);
+
+            log::trace!(
+                "Create new pool with {} sets and {:?} descriptors",
+                max_sets,
+                pool_size,
+            );
+
+            let mut raw = device.create_descriptor_pool(
+                &pool_size,
+                max_sets,
+                if self.update_after_bind {
+                    DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET
+                        | DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
+                } else {
+                    DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET
+                },
+            )?;
+
+            let pool_id = self.pools.len() as u64 + self.offset;
+
+            let allocate = max_sets.min(count);
+            let result = unsafe {
+                device.alloc_descriptor_sets(
+                    &mut raw,
+                    (0..allocate).map(|_| layout),
+                    &mut Allocation {
+                        pool_id,
+                        size: self.size,
+                        update_after_bind: self.update_after_bind,
+                        sets: allocated_sets,
+                    },
+                )
+            };
+
+            match result {
+                Ok(()) => {}
+                Err(err) => {
+                    unsafe { device.destroy_descriptor_pool(raw) };
+                    match err {
+                        DeviceAllocationError::OutOfDeviceMemory => {
+                            return Err(AllocationError::OutOfDeviceMemory)
+                        }
+                        DeviceAllocationError::OutOfHostMemory => {
+                            return Err(AllocationError::OutOfHostMemory)
+                        }
+                        DeviceAllocationError::FragmentedPool => {
+                            // Should not happen, but better this than panicking.
+
+                            log::error!("Unexpectedly failed to allocated descriptor sets due to pool fragmentation");
+                        }
+                    }
+                    panic!("Failed to allocate descriptor sets from fresh pool");
+                }
+            }
+
+            count -= allocate;
+            self.pools.push_back(DescriptorPool {
+                raw,
+                allocated: allocate,
+                available: max_sets - allocate,
+            });
+            self.total += allocate;
+        }
+
+        Ok(())
+    }
+
+    unsafe fn free<L, S>(
+        &mut self,
+        device: &impl DescriptorDevice<L, P, S>,
+        raw_sets: impl IntoIterator<Item = S>,
+        pool_id: u64,
+    ) {
+        let pool = usize::try_from(pool_id - self.offset)
+            .ok()
+            .and_then(|index| self.pools.get_mut(index))
+            .expect("Invalid pool id");
+
+        let mut raw_sets = raw_sets.into_iter();
+        let mut count = 0;
+        unsafe {
+            device.dealloc_descriptor_sets(&mut pool.raw, raw_sets.by_ref().inspect(|_| count += 1))
+        };
+
+        debug_assert!(
+            raw_sets.next().is_none(),
+            "Device must deallocated all sets from iterator"
+        );
+
+        pool.available += count;
+        pool.allocated -= count;
+        self.total -= count;
+
+        log::trace!("Freed {} from descriptor bucket", count);
+
+        while let Some(pool) = self.pools.pop_front() {
+            if self.pools.is_empty() || pool.allocated != 0 {
+                self.pools.push_front(pool);
+                break;
+            }
+
+            log::trace!("Destroying old descriptor pool");
+
+            unsafe { device.destroy_descriptor_pool(pool.raw) };
+            self.offset += 1;
+        }
+    }
+
+    unsafe fn cleanup<L, S>(&mut self, device: &impl DescriptorDevice<L, P, S>) {
+        while let Some(pool) = self.pools.pop_front() {
+            if pool.allocated != 0 {
+                self.pools.push_front(pool);
+                break;
+            }
+
+            log::trace!("Destroying old descriptor pool");
+
+            unsafe { device.destroy_descriptor_pool(pool.raw) };
+            self.offset += 1;
+        }
+    }
+}
+
+/// Descriptor allocator.
+/// Can be used to allocate descriptor sets for any layout.
+#[derive(Debug)]
+pub struct DescriptorAllocator<P, S> {
+    buckets: HashMap<(DescriptorTotalCount, bool), DescriptorBucket<P>>,
+    sets_cache: Vec<DescriptorSet<S>>,
+    raw_sets_cache: Vec<S>,
+    max_update_after_bind_descriptors_in_all_pools: u32,
+    current_update_after_bind_descriptors_in_all_pools: u32,
+    total: u32,
+}
+
+impl<P, S> Drop for DescriptorAllocator<P, S> {
+    fn drop(&mut self) {
+        if self.buckets.drain().any(|(_, bucket)| bucket.total != 0) {
+            log::error!(
+                "`DescriptorAllocator` is dropped while some descriptor sets were not deallocated"
+            );
+        }
+    }
+}
+
+impl<P, S> DescriptorAllocator<P, S> {
+    /// Create new allocator instance.
+    pub fn new(max_update_after_bind_descriptors_in_all_pools: u32) -> Self {
+        DescriptorAllocator {
+            buckets: HashMap::default(),
+            total: 0,
+            sets_cache: Vec::new(),
+            raw_sets_cache: Vec::new(),
+            max_update_after_bind_descriptors_in_all_pools,
+            current_update_after_bind_descriptors_in_all_pools: 0,
+        }
+    }
+
+    /// Allocate descriptor set with specified layout.
+    ///
+    /// # Safety
+    ///
+    /// * Same `device` instance must be passed to all method calls of
+    ///   one `DescriptorAllocator` instance.
+    /// * `flags` must match flags that were used to create the layout.
+    /// * `layout_descriptor_count` must match descriptor numbers in the layout.
+    pub unsafe fn allocate<L, D>(
+        &mut self,
+        device: &D,
+        layout: &L,
+        flags: DescriptorSetLayoutCreateFlags,
+        layout_descriptor_count: &DescriptorTotalCount,
+        count: u32,
+    ) -> Result<Vec<DescriptorSet<S>>, AllocationError>
+    where
+        S: Debug,
+        L: Debug,
+        D: DescriptorDevice<L, P, S>,
+    {
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let descriptor_count = count * layout_descriptor_count.total();
+
+        let update_after_bind = flags.contains(DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND);
+
+        if update_after_bind
+            && self.max_update_after_bind_descriptors_in_all_pools
+                - self.current_update_after_bind_descriptors_in_all_pools
+                < descriptor_count
+        {
+            return Err(AllocationError::Fragmentation);
+        }
+
+        log::trace!(
+            "Allocating {} sets with layout {:?} @ {:?}",
+            count,
+            layout,
+            layout_descriptor_count
+        );
+
+        let bucket = self
+            .buckets
+            .entry((*layout_descriptor_count, update_after_bind))
+            .or_insert_with(|| DescriptorBucket::new(update_after_bind, *layout_descriptor_count));
+        match unsafe { bucket.allocate(device, layout, count, &mut self.sets_cache) } {
+            Ok(()) => {
+                self.total += descriptor_count;
+                if update_after_bind {
+                    self.current_update_after_bind_descriptors_in_all_pools += descriptor_count;
+                }
+
+                Ok(core::mem::take(&mut self.sets_cache))
+            }
+            Err(err) => {
+                debug_assert!(self.raw_sets_cache.is_empty());
+
+                // Free sets allocated so far.
+                let mut last = None;
+
+                for set in self.sets_cache.drain(..) {
+                    if Some(set.pool_id) != last {
+                        if let Some(last_id) = last {
+                            // Free contiguous range of sets from one pool in one go.
+                            unsafe { bucket.free(device, self.raw_sets_cache.drain(..), last_id) };
+                        }
+                    }
+                    last = Some(set.pool_id);
+                    self.raw_sets_cache.push(set.raw);
+                }
+
+                if let Some(last_id) = last {
+                    unsafe { bucket.free(device, self.raw_sets_cache.drain(..), last_id) };
+                }
+
+                Err(err)
+            }
+        }
+    }
+
+    /// Free descriptor sets.
+    ///
+    /// # Safety
+    ///
+    /// * Same `device` instance must be passed to all method calls of
+    ///   one `DescriptorAllocator` instance.
+    /// * None of descriptor sets can be referenced in any pending command buffers.
+    /// * All command buffers where at least one of descriptor sets referenced
+    ///   move to invalid state.
+    pub unsafe fn free<L, D, I>(&mut self, device: &D, sets: I)
+    where
+        D: DescriptorDevice<L, P, S>,
+        I: IntoIterator<Item = DescriptorSet<S>>,
+    {
+        debug_assert!(self.raw_sets_cache.is_empty());
+
+        let mut last_key = (EMPTY_COUNT, false);
+        let mut last_pool_id = None;
+
+        let mut descriptor_count = 0;
+
+        // Batch freeing of adjacent descriptor sets that belong to the same bucket and pool.
+        for set in sets {
+            descriptor_count += set.size.total();
+
+            if last_key != (set.size, set.update_after_bind) || last_pool_id != Some(set.pool_id) {
+                if let Some(pool_id) = last_pool_id {
+                    unsafe {
+                        self.free_raw_sets_cache(device, &last_key, pool_id, descriptor_count)
+                    };
+                    descriptor_count = 0;
+                }
+
+                last_key = (set.size, set.update_after_bind);
+                last_pool_id = Some(set.pool_id);
+            }
+            self.raw_sets_cache.push(set.raw);
+        }
+
+        if let Some(pool_id) = last_pool_id {
+            unsafe { self.free_raw_sets_cache(device, &last_key, pool_id, descriptor_count) };
+        }
+    }
+
+    /// Frees the cached descriptor sets which must be allocated from the same bucket and pool.
+    unsafe fn free_raw_sets_cache<L, D>(
+        &mut self,
+        device: &D,
+        bucket_key: &(DescriptorTotalCount, bool),
+        pool_id: u64,
+        descriptor_count: u32,
+    ) where
+        D: DescriptorDevice<L, P, S>,
+    {
+        let bucket = self
+            .buckets
+            .get_mut(bucket_key)
+            .expect("Set must be allocated from this allocator");
+
+        debug_assert!(u32::try_from(self.raw_sets_cache.len())
+            .ok()
+            .is_some_and(|count| count <= bucket.total));
+
+        unsafe { bucket.free(device, self.raw_sets_cache.drain(..), pool_id) };
+
+        self.total -= descriptor_count;
+        if bucket.update_after_bind {
+            self.current_update_after_bind_descriptors_in_all_pools -= descriptor_count;
+        }
+    }
+
+    /// Perform cleanup to allow resources reuse.
+    ///
+    /// # Safety
+    ///
+    /// * Same `device` instance must be passed to all method calls of
+    ///   one `DescriptorAllocator` instance.
+    pub unsafe fn cleanup<L>(&mut self, device: &impl DescriptorDevice<L, P, S>) {
+        for bucket in self.buckets.values_mut() {
+            unsafe { bucket.cleanup(device) }
+        }
+        self.buckets.retain(|_, bucket| !bucket.pools.is_empty());
+    }
+}
+
+/// Empty descriptor per_type.
+const EMPTY_COUNT: DescriptorTotalCount = DescriptorTotalCount {
+    sampler: 0,
+    combined_image_sampler: 0,
+    sampled_image: 0,
+    storage_image: 0,
+    uniform_texel_buffer: 0,
+    storage_texel_buffer: 0,
+    uniform_buffer: 0,
+    storage_buffer: 0,
+    uniform_buffer_dynamic: 0,
+    storage_buffer_dynamic: 0,
+    input_attachment: 0,
+    acceleration_structure: 0,
+    inline_uniform_block_bytes: 0,
+    inline_uniform_block_bindings: 0,
+};
+
+struct Allocation<'a, S> {
+    update_after_bind: bool,
+    size: DescriptorTotalCount,
+    pool_id: u64,
+    sets: &'a mut Vec<DescriptorSet<S>>,
+}
+
+impl<S> Extend<S> for Allocation<'_, S> {
+    fn extend<T: IntoIterator<Item = S>>(&mut self, iter: T) {
+        let update_after_bind = self.update_after_bind;
+        let size = self.size;
+        let pool_id = self.pool_id;
+        self.sets.extend(iter.into_iter().map(|raw| DescriptorSet {
+            raw,
+            pool_id,
+            update_after_bind,
+            size,
+        }))
+    }
+}

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -181,8 +181,7 @@ impl super::DeviceShared {
         &self,
         pool: &mut vk::DescriptorPool,
         layouts: impl ExactSizeIterator<Item = &'a vk::DescriptorSetLayout>,
-        sets: &mut impl Extend<vk::DescriptorSet>,
-    ) -> Result<(), DeviceAllocationError> {
+    ) -> Result<Vec<vk::DescriptorSet>, DeviceAllocationError> {
         let result = unsafe {
             self.raw.allocate_descriptor_sets(
                 &vk::DescriptorSetAllocateInfo::default()
@@ -196,10 +195,7 @@ impl super::DeviceShared {
         };
 
         match result {
-            Ok(vk_sets) => {
-                sets.extend(vk_sets);
-                Ok(())
-            }
+            Ok(vk_sets) => Ok(vk_sets),
             Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY)
             | Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY) => {
                 Err(DeviceAllocationError::OutOfHostMemory)
@@ -425,20 +421,18 @@ impl DescriptorBucket {
             log::trace!("Allocate `{}` sets from existing pool", allocate);
 
             let result = unsafe {
-                device.alloc_descriptor_sets(
-                    &mut pool.raw,
-                    (0..allocate).map(|_| layout),
-                    &mut Allocation {
-                        size: self.size,
-                        update_after_bind: self.update_after_bind,
-                        pool_id: index as u64 + self.offset,
-                        sets: allocated_sets,
-                    },
-                )
+                device.alloc_descriptor_sets(&mut pool.raw, (0..allocate).map(|_| layout))
             };
 
             match result {
-                Ok(()) => {}
+                Ok(vk_sets) => {
+                    allocated_sets.extend(vk_sets.into_iter().map(|raw| DescriptorSet {
+                        raw,
+                        pool_id: index as u64 + self.offset,
+                        update_after_bind: self.update_after_bind,
+                        size: self.size,
+                    }))
+                }
                 Err(DeviceAllocationError::OutOfDeviceMemory) => {
                     return Err(AllocationError::OutOfDeviceMemory)
                 }
@@ -488,21 +482,18 @@ impl DescriptorBucket {
             let pool_id = self.pools.len() as u64 + self.offset;
 
             let allocate = max_sets.min(count);
-            let result = unsafe {
-                device.alloc_descriptor_sets(
-                    &mut raw,
-                    (0..allocate).map(|_| layout),
-                    &mut Allocation {
+            let result =
+                unsafe { device.alloc_descriptor_sets(&mut raw, (0..allocate).map(|_| layout)) };
+
+            match result {
+                Ok(vk_sets) => {
+                    allocated_sets.extend(vk_sets.into_iter().map(|raw| DescriptorSet {
+                        raw,
                         pool_id,
                         size: self.size,
                         update_after_bind: self.update_after_bind,
-                        sets: allocated_sets,
-                    },
-                )
-            };
-
-            match result {
-                Ok(()) => {}
+                    }))
+                }
                 Err(err) => {
                     unsafe { device.raw.destroy_descriptor_pool(raw, None) };
                     match err {
@@ -797,24 +788,3 @@ const EMPTY_COUNT: DescriptorTotalCount = DescriptorTotalCount {
     inline_uniform_block_bytes: 0,
     inline_uniform_block_bindings: 0,
 };
-
-struct Allocation<'a> {
-    update_after_bind: bool,
-    size: DescriptorTotalCount,
-    pool_id: u64,
-    sets: &'a mut Vec<DescriptorSet>,
-}
-
-impl Extend<vk::DescriptorSet> for Allocation<'_> {
-    fn extend<T: IntoIterator<Item = vk::DescriptorSet>>(&mut self, iter: T) {
-        let update_after_bind = self.update_after_bind;
-        let size = self.size;
-        let pool_id = self.pool_id;
-        self.sets.extend(iter.into_iter().map(|raw| DescriptorSet {
-            raw,
-            pool_id,
-            update_after_bind,
-            size,
-        }))
-    }
-}

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -136,20 +136,16 @@ impl super::DeviceShared {
     /// # Safety
     ///
     /// Pool must be created from this device.
-    unsafe fn alloc_descriptor_sets<'a>(
+    unsafe fn alloc_descriptor_sets(
         &self,
         pool: &mut vk::DescriptorPool,
-        layouts: impl ExactSizeIterator<Item = &'a vk::DescriptorSetLayout>,
+        layout: &vk::DescriptorSetLayout,
     ) -> Result<Vec<vk::DescriptorSet>, crate::DeviceError> {
         unsafe {
             self.raw.allocate_descriptor_sets(
                 &vk::DescriptorSetAllocateInfo::default()
                     .descriptor_pool(*pool)
-                    .set_layouts(
-                        &smallvec::SmallVec::<[vk::DescriptorSetLayout; 32]>::from_iter(
-                            layouts.cloned(),
-                        ),
-                    ),
+                    .set_layouts(core::slice::from_ref(layout)),
             )
         }
         .map_err(super::map_host_device_oom_err)
@@ -252,12 +248,8 @@ impl DescriptorBucket {
         }
     }
 
-    fn new_pool_size(&self, minimal_set_count: u32) -> (DescriptorTotalCount, u32) {
-        let mut max_sets = MIN_SETS // at least MIN_SETS
-            .max(minimal_set_count) // at least enough for allocation
-            .max(self.total.min(MAX_SETS)) // at least as much as was allocated so far capped to MAX_SETS
-            .checked_next_power_of_two() // rounded up to nearest 2^N
-            .unwrap_or(i32::MAX as u32);
+    fn new_pool_size(&self) -> (DescriptorTotalCount, u32) {
+        let mut max_sets = self.total.clamp(MIN_SETS, MAX_SETS).next_power_of_two();
 
         max_sets = (u32::MAX / self.size.sampler.max(1)).min(max_sets);
         max_sets = (u32::MAX / self.size.combined_image_sampler.max(1)).min(max_sets);
@@ -302,27 +294,16 @@ impl DescriptorBucket {
         &mut self,
         device: &super::DeviceShared,
         layout: &vk::DescriptorSetLayout,
-        mut count: u32,
         allocated_sets: &mut Vec<DescriptorSet>,
     ) -> Result<(), crate::DeviceError> {
-        debug_assert!(usize::try_from(count).is_ok(), "Must be ensured by caller");
-
-        if count == 0 {
-            return Ok(());
-        }
-
         for (index, pool) in self.pools.iter_mut().enumerate().rev() {
             if pool.available == 0 {
                 continue;
             }
 
-            let allocate = pool.available.min(count);
+            log::trace!("Allocate a set from existing pool");
 
-            log::trace!("Allocate `{}` sets from existing pool", allocate);
-
-            let vk_sets = unsafe {
-                device.alloc_descriptor_sets(&mut pool.raw, (0..allocate).map(|_| layout))
-            }?;
+            let vk_sets = unsafe { device.alloc_descriptor_sets(&mut pool.raw, layout) }?;
             allocated_sets.extend(vk_sets.into_iter().map(|raw| DescriptorSet {
                 raw,
                 pool_id: index as u64 + self.offset,
@@ -330,65 +311,51 @@ impl DescriptorBucket {
                 size: self.size,
             }));
 
-            count -= allocate;
-            pool.available -= allocate;
-            pool.allocated += allocate;
-            self.total += allocate;
+            pool.available -= 1;
+            pool.allocated += 1;
+            self.total += 1;
 
-            if count == 0 {
-                return Ok(());
-            }
+            return Ok(());
         }
 
-        while count > 0 {
-            let (pool_size, max_sets) = self.new_pool_size(count);
+        let (pool_size, max_sets) = self.new_pool_size();
 
-            log::trace!(
-                "Create new pool with {} sets and {:?} descriptors",
-                max_sets,
-                pool_size,
-            );
+        log::trace!("Create new pool with {max_sets} sets and {pool_size:?} descriptors");
 
-            let mut raw = device.create_descriptor_pool(
-                &pool_size,
-                max_sets,
-                if self.update_after_bind {
-                    DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET
-                        | DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
-                } else {
-                    DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET
-                },
-            )?;
+        let mut raw = device.create_descriptor_pool(
+            &pool_size,
+            max_sets,
+            if self.update_after_bind {
+                DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET
+                    | DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
+            } else {
+                DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET
+            },
+        )?;
 
-            let pool_id = self.pools.len() as u64 + self.offset;
+        let pool_id = self.pools.len() as u64 + self.offset;
 
-            let allocate = max_sets.min(count);
-            let result =
-                unsafe { device.alloc_descriptor_sets(&mut raw, (0..allocate).map(|_| layout)) };
+        let result = unsafe { device.alloc_descriptor_sets(&mut raw, layout) };
 
-            match result {
-                Ok(vk_sets) => {
-                    allocated_sets.extend(vk_sets.into_iter().map(|raw| DescriptorSet {
-                        raw,
-                        pool_id,
-                        size: self.size,
-                        update_after_bind: self.update_after_bind,
-                    }))
-                }
-                Err(err) => {
-                    unsafe { device.raw.destroy_descriptor_pool(raw, None) };
-                    return Err(err);
-                }
-            }
-
-            count -= allocate;
-            self.pools.push_back(DescriptorPool {
+        match result {
+            Ok(vk_sets) => allocated_sets.extend(vk_sets.into_iter().map(|raw| DescriptorSet {
                 raw,
-                allocated: allocate,
-                available: max_sets - allocate,
-            });
-            self.total += allocate;
+                pool_id,
+                size: self.size,
+                update_after_bind: self.update_after_bind,
+            })),
+            Err(err) => {
+                unsafe { device.raw.destroy_descriptor_pool(raw, None) };
+                return Err(err);
+            }
         }
+
+        self.pools.push_back(DescriptorPool {
+            raw,
+            allocated: 1,
+            available: max_sets - 1,
+        });
+        self.total += 1;
 
         Ok(())
     }
@@ -490,13 +457,8 @@ impl DescriptorAllocator {
         layout: &vk::DescriptorSetLayout,
         flags: DescriptorSetLayoutCreateFlags,
         layout_descriptor_count: &DescriptorTotalCount,
-        count: u32,
     ) -> Result<Vec<DescriptorSet>, crate::DeviceError> {
-        if count == 0 {
-            return Ok(Vec::new());
-        }
-
-        let descriptor_count = count * layout_descriptor_count.total();
+        let descriptor_count = layout_descriptor_count.total();
 
         let update_after_bind = flags.contains(DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND);
 
@@ -509,8 +471,7 @@ impl DescriptorAllocator {
         }
 
         log::trace!(
-            "Allocating {} sets with layout {:?} @ {:?}",
-            count,
+            "Allocating a set with layout {:?} @ {:?}",
             layout,
             layout_descriptor_count
         );
@@ -519,7 +480,7 @@ impl DescriptorAllocator {
             .buckets
             .entry((*layout_descriptor_count, update_after_bind))
             .or_insert_with(|| DescriptorBucket::new(update_after_bind, *layout_descriptor_count));
-        match unsafe { bucket.allocate(device, layout, count, &mut self.sets_cache) } {
+        match unsafe { bucket.allocate(device, layout, &mut self.sets_cache) } {
             Ok(()) => {
                 self.total += descriptor_count;
                 if update_after_bind {

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -9,20 +9,6 @@ use ash::vk;
 use core::convert::TryFrom as _;
 use hashbrown::HashMap;
 
-bitflags::bitflags! {
-    /// Flags to augment descriptor pool creation.
-    ///
-    /// Match corresponding bits in Vulkan.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-    pub struct DescriptorPoolCreateFlags: u32 {
-        /// Allows freeing individual sets.
-        const FREE_DESCRIPTOR_SET = 0x1;
-
-        /// Allows allocating sets with layout created with matching backend-specific flag.
-        const UPDATE_AFTER_BIND = 0x2;
-    }
-}
-
 /// Number of descriptors of each type.
 ///
 /// For `InlineUniformBlock` this value is number of bytes instead.
@@ -69,7 +55,7 @@ impl super::DeviceShared {
         &self,
         descriptor_count: &DescriptorTotalCount,
         max_sets: u32,
-        flags: DescriptorPoolCreateFlags,
+        flags: vk::DescriptorPoolCreateFlags,
     ) -> Result<vk::DescriptorPool, crate::DeviceError> {
         //Note: ignoring other types, since they can't appear here
         let unfiltered_counts = [
@@ -114,17 +100,9 @@ impl super::DeviceShared {
             })
             .collect::<ArrayVec<_, 8>>();
 
-        let mut vk_flags = if flags.contains(DescriptorPoolCreateFlags::UPDATE_AFTER_BIND) {
-            vk::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
-        } else {
-            vk::DescriptorPoolCreateFlags::empty()
-        };
-        if flags.contains(DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET) {
-            vk_flags |= vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET;
-        }
         let vk_info = vk::DescriptorPoolCreateInfo::default()
             .max_sets(max_sets)
-            .flags(vk_flags)
+            .flags(flags)
             .pool_sizes(&filtered_counts);
 
         unsafe { self.raw.create_descriptor_pool(&vk_info, None) }
@@ -171,19 +149,6 @@ impl super::DeviceShared {
             Ok(()) => {}
             Err(err) => super::device::handle_unexpected(err),
         }
-    }
-}
-
-bitflags::bitflags! {
-    /// Flags to augment descriptor set allocation.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-    pub struct DescriptorSetLayoutCreateFlags: u32 {
-        /// Specified that descriptor set must be allocated from\
-        /// pool with `DescriptorPoolCreateFlags::UPDATE_AFTER_BIND`.
-        ///
-        /// This flag must be specified when and only when layout was created with matching backend-specific flag,
-        /// that allows layout to have UpdateAfterBind bindings.
-        const UPDATE_AFTER_BIND = 0x2;
     }
 }
 
@@ -326,10 +291,10 @@ impl DescriptorBucket {
             &pool_size,
             max_sets,
             if self.update_after_bind {
-                DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET
-                    | DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
+                vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET
+                    | vk::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
             } else {
-                DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET
+                vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET
             },
         )?;
 
@@ -454,15 +419,11 @@ impl DescriptorAllocator {
     pub unsafe fn allocate(
         &mut self,
         device: &super::DeviceShared,
-        layout: &vk::DescriptorSetLayout,
-        flags: DescriptorSetLayoutCreateFlags,
-        layout_descriptor_count: &DescriptorTotalCount,
+        layout: &super::BindGroupLayout,
     ) -> Result<Vec<DescriptorSet>, crate::DeviceError> {
-        let descriptor_count = layout_descriptor_count.total();
+        let descriptor_count = layout.desc_count.total();
 
-        let update_after_bind = flags.contains(DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND);
-
-        if update_after_bind
+        if layout.contains_binding_arrays
             && self.max_update_after_bind_descriptors_in_all_pools
                 - self.current_update_after_bind_descriptors_in_all_pools
                 < descriptor_count
@@ -472,18 +433,20 @@ impl DescriptorAllocator {
 
         log::trace!(
             "Allocating a set with layout {:?} @ {:?}",
-            layout,
-            layout_descriptor_count
+            layout.raw,
+            descriptor_count
         );
 
         let bucket = self
             .buckets
-            .entry((*layout_descriptor_count, update_after_bind))
-            .or_insert_with(|| DescriptorBucket::new(update_after_bind, *layout_descriptor_count));
-        match unsafe { bucket.allocate(device, layout, &mut self.sets_cache) } {
+            .entry((layout.desc_count, layout.contains_binding_arrays))
+            .or_insert_with(|| {
+                DescriptorBucket::new(layout.contains_binding_arrays, layout.desc_count)
+            });
+        match unsafe { bucket.allocate(device, &layout.raw, &mut self.sets_cache) } {
             Ok(()) => {
                 self.total += descriptor_count;
-                if update_after_bind {
+                if layout.contains_binding_arrays {
                     self.current_update_after_bind_descriptors_in_all_pools += descriptor_count;
                 }
 

--- a/wgpu-hal/src/vulkan/descriptor.rs
+++ b/wgpu-hal/src/vulkan/descriptor.rs
@@ -15,37 +15,25 @@ use hashbrown::HashMap;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct DescriptorTotalCount {
     pub sampler: u32,
-    pub combined_image_sampler: u32,
     pub sampled_image: u32,
     pub storage_image: u32,
-    pub uniform_texel_buffer: u32,
-    pub storage_texel_buffer: u32,
     pub uniform_buffer: u32,
     pub storage_buffer: u32,
     pub uniform_buffer_dynamic: u32,
     pub storage_buffer_dynamic: u32,
-    pub input_attachment: u32,
     pub acceleration_structure: u32,
-    pub inline_uniform_block_bytes: u32,
-    pub inline_uniform_block_bindings: u32,
 }
 
 impl DescriptorTotalCount {
     pub fn total(&self) -> u32 {
         self.sampler
-            + self.combined_image_sampler
             + self.sampled_image
             + self.storage_image
-            + self.uniform_texel_buffer
-            + self.storage_texel_buffer
             + self.uniform_buffer
             + self.storage_buffer
             + self.uniform_buffer_dynamic
             + self.storage_buffer_dynamic
-            + self.input_attachment
             + self.acceleration_structure
-            + self.inline_uniform_block_bytes
-            + self.inline_uniform_block_bindings
     }
 }
 
@@ -57,7 +45,6 @@ impl super::DeviceShared {
         max_sets: u32,
         flags: vk::DescriptorPoolCreateFlags,
     ) -> Result<vk::DescriptorPool, crate::DeviceError> {
-        //Note: ignoring other types, since they can't appear here
         let unfiltered_counts = [
             (vk::DescriptorType::SAMPLER, descriptor_count.sampler),
             (
@@ -217,35 +204,23 @@ impl DescriptorBucket {
         let mut max_sets = self.total.clamp(MIN_SETS, MAX_SETS).next_power_of_two();
 
         max_sets = (u32::MAX / self.size.sampler.max(1)).min(max_sets);
-        max_sets = (u32::MAX / self.size.combined_image_sampler.max(1)).min(max_sets);
         max_sets = (u32::MAX / self.size.sampled_image.max(1)).min(max_sets);
         max_sets = (u32::MAX / self.size.storage_image.max(1)).min(max_sets);
-        max_sets = (u32::MAX / self.size.uniform_texel_buffer.max(1)).min(max_sets);
-        max_sets = (u32::MAX / self.size.storage_texel_buffer.max(1)).min(max_sets);
         max_sets = (u32::MAX / self.size.uniform_buffer.max(1)).min(max_sets);
         max_sets = (u32::MAX / self.size.storage_buffer.max(1)).min(max_sets);
         max_sets = (u32::MAX / self.size.uniform_buffer_dynamic.max(1)).min(max_sets);
         max_sets = (u32::MAX / self.size.storage_buffer_dynamic.max(1)).min(max_sets);
-        max_sets = (u32::MAX / self.size.input_attachment.max(1)).min(max_sets);
         max_sets = (u32::MAX / self.size.acceleration_structure.max(1)).min(max_sets);
-        max_sets = (u32::MAX / self.size.inline_uniform_block_bytes.max(1)).min(max_sets);
-        max_sets = (u32::MAX / self.size.inline_uniform_block_bindings.max(1)).min(max_sets);
 
         let mut pool_size = DescriptorTotalCount {
             sampler: self.size.sampler * max_sets,
-            combined_image_sampler: self.size.combined_image_sampler * max_sets,
             sampled_image: self.size.sampled_image * max_sets,
             storage_image: self.size.storage_image * max_sets,
-            uniform_texel_buffer: self.size.uniform_texel_buffer * max_sets,
-            storage_texel_buffer: self.size.storage_texel_buffer * max_sets,
             uniform_buffer: self.size.uniform_buffer * max_sets,
             storage_buffer: self.size.storage_buffer * max_sets,
             uniform_buffer_dynamic: self.size.uniform_buffer_dynamic * max_sets,
             storage_buffer_dynamic: self.size.storage_buffer_dynamic * max_sets,
-            input_attachment: self.size.input_attachment * max_sets,
             acceleration_structure: self.size.acceleration_structure * max_sets,
-            inline_uniform_block_bytes: self.size.inline_uniform_block_bytes * max_sets,
-            inline_uniform_block_bindings: self.size.inline_uniform_block_bindings * max_sets,
         };
 
         if pool_size == Default::default() {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -2640,16 +2640,6 @@ impl super::DeviceShared {
     }
 }
 
-impl From<descriptor::AllocationError> for crate::DeviceError {
-    fn from(error: descriptor::AllocationError) -> Self {
-        use descriptor::AllocationError as Ae;
-        match error {
-            Ae::OutOfDeviceMemory | Ae::OutOfHostMemory | Ae::Fragmentation => Self::OutOfMemory,
-            Ae::Unexpected => Self::Unexpected,
-        }
-    }
-}
-
 /// We usually map unexpected vulkan errors to the [`crate::DeviceError::Unexpected`]
 /// variant to be more robust even in cases where the driver is not
 /// complying with the spec.

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -246,9 +246,7 @@ impl super::DeviceShared {
     }
 }
 
-impl descriptor::DescriptorDevice<vk::DescriptorSetLayout, vk::DescriptorPool, vk::DescriptorSet>
-    for super::DeviceShared
-{
+impl descriptor::DescriptorDevice for super::DeviceShared {
     fn create_descriptor_pool(
         &self,
         descriptor_count: &descriptor::DescriptorTotalCount,
@@ -1496,7 +1494,7 @@ impl crate::Device for super::Device {
 
         let mut vk_sets = unsafe {
             self.desc_allocator.lock().allocate(
-                &*self.shared,
+                &self.shared,
                 &desc.layout.raw,
                 desc_set_layout_flags,
                 &desc.layout.desc_count,
@@ -1694,11 +1692,7 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn destroy_bind_group(&self, group: super::BindGroup) {
-        unsafe {
-            self.desc_allocator
-                .lock()
-                .free(&*self.shared, Some(group.set))
-        };
+        unsafe { self.desc_allocator.lock().free(&self.shared, [group.set]) };
 
         self.counters.bind_groups.sub(1);
     }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1350,19 +1350,10 @@ impl crate::Device for super::Device {
             super::AccelerationStructure,
         >,
     ) -> Result<super::BindGroup, crate::DeviceError> {
-        let desc_set_layout_flags = if desc.layout.contains_binding_arrays {
-            descriptor::DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND
-        } else {
-            descriptor::DescriptorSetLayoutCreateFlags::empty()
-        };
-
         let mut vk_sets = unsafe {
-            self.desc_allocator.lock().allocate(
-                &self.shared,
-                &desc.layout.raw,
-                desc_set_layout_flags,
-                &desc.layout.desc_count,
-            )?
+            self.desc_allocator
+                .lock()
+                .allocate(&self.shared, desc.layout)?
         };
 
         let set = vk_sets.pop().unwrap();

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -323,10 +323,6 @@ impl descriptor::DescriptorDevice for super::DeviceShared {
         }
     }
 
-    unsafe fn destroy_descriptor_pool(&self, pool: vk::DescriptorPool) {
-        unsafe { self.raw.destroy_descriptor_pool(pool, None) }
-    }
-
     unsafe fn alloc_descriptor_sets<'a>(
         &self,
         pool: &mut vk::DescriptorPool,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -12,7 +12,7 @@ use ash::{ext, vk};
 use hashbrown::hash_map::Entry;
 use parking_lot::Mutex;
 
-use super::{conv, RawTlasInstance};
+use super::{conv, descriptor, RawTlasInstance};
 use crate::TlasInstance;
 
 impl super::DeviceShared {
@@ -246,16 +246,15 @@ impl super::DeviceShared {
     }
 }
 
-impl
-    gpu_descriptor::DescriptorDevice<vk::DescriptorSetLayout, vk::DescriptorPool, vk::DescriptorSet>
+impl descriptor::DescriptorDevice<vk::DescriptorSetLayout, vk::DescriptorPool, vk::DescriptorSet>
     for super::DeviceShared
 {
-    unsafe fn create_descriptor_pool(
+    fn create_descriptor_pool(
         &self,
-        descriptor_count: &gpu_descriptor::DescriptorTotalCount,
+        descriptor_count: &descriptor::DescriptorTotalCount,
         max_sets: u32,
-        flags: gpu_descriptor::DescriptorPoolCreateFlags,
-    ) -> Result<vk::DescriptorPool, gpu_descriptor::CreatePoolError> {
+        flags: descriptor::DescriptorPoolCreateFlags,
+    ) -> Result<vk::DescriptorPool, descriptor::CreatePoolError> {
         //Note: ignoring other types, since they can't appear here
         let unfiltered_counts = [
             (vk::DescriptorType::SAMPLER, descriptor_count.sampler),
@@ -300,12 +299,12 @@ impl
             .collect::<ArrayVec<_, 8>>();
 
         let mut vk_flags =
-            if flags.contains(gpu_descriptor::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND) {
+            if flags.contains(descriptor::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND) {
                 vk::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
             } else {
                 vk::DescriptorPoolCreateFlags::empty()
             };
-        if flags.contains(gpu_descriptor::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET) {
+        if flags.contains(descriptor::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET) {
             vk_flags |= vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET;
         }
         let vk_info = vk::DescriptorPoolCreateInfo::default()
@@ -316,14 +315,12 @@ impl
         match unsafe { self.raw.create_descriptor_pool(&vk_info, None) } {
             Ok(pool) => Ok(pool),
             Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY) => {
-                Err(gpu_descriptor::CreatePoolError::OutOfHostMemory)
+                Err(descriptor::CreatePoolError::OutOfHostMemory)
             }
             Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY) => {
-                Err(gpu_descriptor::CreatePoolError::OutOfDeviceMemory)
+                Err(descriptor::CreatePoolError::OutOfDeviceMemory)
             }
-            Err(vk::Result::ERROR_FRAGMENTATION) => {
-                Err(gpu_descriptor::CreatePoolError::Fragmentation)
-            }
+            Err(vk::Result::ERROR_FRAGMENTATION) => Err(descriptor::CreatePoolError::Fragmentation),
             Err(err) => handle_unexpected(err),
         }
     }
@@ -337,7 +334,7 @@ impl
         pool: &mut vk::DescriptorPool,
         layouts: impl ExactSizeIterator<Item = &'a vk::DescriptorSetLayout>,
         sets: &mut impl Extend<vk::DescriptorSet>,
-    ) -> Result<(), gpu_descriptor::DeviceAllocationError> {
+    ) -> Result<(), descriptor::DeviceAllocationError> {
         let result = unsafe {
             self.raw.allocate_descriptor_sets(
                 &vk::DescriptorSetAllocateInfo::default()
@@ -357,13 +354,13 @@ impl
             }
             Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY)
             | Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY) => {
-                Err(gpu_descriptor::DeviceAllocationError::OutOfHostMemory)
+                Err(descriptor::DeviceAllocationError::OutOfHostMemory)
             }
             Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY) => {
-                Err(gpu_descriptor::DeviceAllocationError::OutOfDeviceMemory)
+                Err(descriptor::DeviceAllocationError::OutOfDeviceMemory)
             }
             Err(vk::Result::ERROR_FRAGMENTED_POOL) => {
-                Err(gpu_descriptor::DeviceAllocationError::FragmentedPool)
+                Err(descriptor::DeviceAllocationError::FragmentedPool)
             }
             Err(err) => handle_unexpected(err),
         }
@@ -1290,7 +1287,7 @@ impl crate::Device for super::Device {
         let mut binding_map = Vec::new();
         let mut next_binding = 0;
         let mut contains_binding_arrays = false;
-        let mut desc_count = gpu_descriptor::DescriptorTotalCount::default();
+        let mut desc_count = descriptor::DescriptorTotalCount::default();
         for entry in desc.entries {
             if entry.count.is_some() {
                 contains_binding_arrays = true;
@@ -1492,9 +1489,9 @@ impl crate::Device for super::Device {
         >,
     ) -> Result<super::BindGroup, crate::DeviceError> {
         let desc_set_layout_flags = if desc.layout.contains_binding_arrays {
-            gpu_descriptor::DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND
+            descriptor::DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND
         } else {
-            gpu_descriptor::DescriptorSetLayoutCreateFlags::empty()
+            descriptor::DescriptorSetLayoutCreateFlags::empty()
         };
 
         let mut vk_sets = unsafe {
@@ -2785,9 +2782,9 @@ impl super::DeviceShared {
     }
 }
 
-impl From<gpu_descriptor::AllocationError> for crate::DeviceError {
-    fn from(error: gpu_descriptor::AllocationError) -> Self {
-        use gpu_descriptor::AllocationError as Ae;
+impl From<descriptor::AllocationError> for crate::DeviceError {
+    fn from(error: descriptor::AllocationError) -> Self {
+        use descriptor::AllocationError as Ae;
         match error {
             Ae::OutOfDeviceMemory | Ae::OutOfHostMemory | Ae::Fragmentation => Self::OutOfMemory,
         }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1556,7 +1556,7 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn destroy_bind_group(&self, group: super::BindGroup) {
-        unsafe { self.desc_allocator.lock().free(&self.shared, [group.set]) };
+        unsafe { self.desc_allocator.lock().free(&self.shared, group.set) };
 
         self.counters.bind_groups.sub(1);
     }

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1362,7 +1362,6 @@ impl crate::Device for super::Device {
                 &desc.layout.raw,
                 desc_set_layout_flags,
                 &desc.layout.desc_count,
-                1,
             )?
         };
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -246,138 +246,6 @@ impl super::DeviceShared {
     }
 }
 
-impl descriptor::DescriptorDevice for super::DeviceShared {
-    fn create_descriptor_pool(
-        &self,
-        descriptor_count: &descriptor::DescriptorTotalCount,
-        max_sets: u32,
-        flags: descriptor::DescriptorPoolCreateFlags,
-    ) -> Result<vk::DescriptorPool, descriptor::CreatePoolError> {
-        //Note: ignoring other types, since they can't appear here
-        let unfiltered_counts = [
-            (vk::DescriptorType::SAMPLER, descriptor_count.sampler),
-            (
-                vk::DescriptorType::SAMPLED_IMAGE,
-                descriptor_count.sampled_image,
-            ),
-            (
-                vk::DescriptorType::STORAGE_IMAGE,
-                descriptor_count.storage_image,
-            ),
-            (
-                vk::DescriptorType::UNIFORM_BUFFER,
-                descriptor_count.uniform_buffer,
-            ),
-            (
-                vk::DescriptorType::UNIFORM_BUFFER_DYNAMIC,
-                descriptor_count.uniform_buffer_dynamic,
-            ),
-            (
-                vk::DescriptorType::STORAGE_BUFFER,
-                descriptor_count.storage_buffer,
-            ),
-            (
-                vk::DescriptorType::STORAGE_BUFFER_DYNAMIC,
-                descriptor_count.storage_buffer_dynamic,
-            ),
-            (
-                vk::DescriptorType::ACCELERATION_STRUCTURE_KHR,
-                descriptor_count.acceleration_structure,
-            ),
-        ];
-
-        let filtered_counts = unfiltered_counts
-            .iter()
-            .cloned()
-            .filter(|&(_, count)| count != 0)
-            .map(|(ty, count)| vk::DescriptorPoolSize {
-                ty,
-                descriptor_count: count,
-            })
-            .collect::<ArrayVec<_, 8>>();
-
-        let mut vk_flags =
-            if flags.contains(descriptor::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND) {
-                vk::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
-            } else {
-                vk::DescriptorPoolCreateFlags::empty()
-            };
-        if flags.contains(descriptor::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET) {
-            vk_flags |= vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET;
-        }
-        let vk_info = vk::DescriptorPoolCreateInfo::default()
-            .max_sets(max_sets)
-            .flags(vk_flags)
-            .pool_sizes(&filtered_counts);
-
-        match unsafe { self.raw.create_descriptor_pool(&vk_info, None) } {
-            Ok(pool) => Ok(pool),
-            Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY) => {
-                Err(descriptor::CreatePoolError::OutOfHostMemory)
-            }
-            Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY) => {
-                Err(descriptor::CreatePoolError::OutOfDeviceMemory)
-            }
-            Err(vk::Result::ERROR_FRAGMENTATION) => Err(descriptor::CreatePoolError::Fragmentation),
-            Err(err) => handle_unexpected(err),
-        }
-    }
-
-    unsafe fn alloc_descriptor_sets<'a>(
-        &self,
-        pool: &mut vk::DescriptorPool,
-        layouts: impl ExactSizeIterator<Item = &'a vk::DescriptorSetLayout>,
-        sets: &mut impl Extend<vk::DescriptorSet>,
-    ) -> Result<(), descriptor::DeviceAllocationError> {
-        let result = unsafe {
-            self.raw.allocate_descriptor_sets(
-                &vk::DescriptorSetAllocateInfo::default()
-                    .descriptor_pool(*pool)
-                    .set_layouts(
-                        &smallvec::SmallVec::<[vk::DescriptorSetLayout; 32]>::from_iter(
-                            layouts.cloned(),
-                        ),
-                    ),
-            )
-        };
-
-        match result {
-            Ok(vk_sets) => {
-                sets.extend(vk_sets);
-                Ok(())
-            }
-            Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY)
-            | Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY) => {
-                Err(descriptor::DeviceAllocationError::OutOfHostMemory)
-            }
-            Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY) => {
-                Err(descriptor::DeviceAllocationError::OutOfDeviceMemory)
-            }
-            Err(vk::Result::ERROR_FRAGMENTED_POOL) => {
-                Err(descriptor::DeviceAllocationError::FragmentedPool)
-            }
-            Err(err) => handle_unexpected(err),
-        }
-    }
-
-    unsafe fn dealloc_descriptor_sets<'a>(
-        &self,
-        pool: &mut vk::DescriptorPool,
-        sets: impl Iterator<Item = vk::DescriptorSet>,
-    ) {
-        let result = unsafe {
-            self.raw.free_descriptor_sets(
-                *pool,
-                &smallvec::SmallVec::<[vk::DescriptorSet; 32]>::from_iter(sets),
-            )
-        };
-        match result {
-            Ok(()) => {}
-            Err(err) => handle_unexpected(err),
-        }
-    }
-}
-
 struct CompiledStage {
     create_info: vk::PipelineShaderStageCreateInfo<'static>,
     _entry_point: CString,
@@ -2777,6 +2645,7 @@ impl From<descriptor::AllocationError> for crate::DeviceError {
         use descriptor::AllocationError as Ae;
         match error {
             Ae::OutOfDeviceMemory | Ae::OutOfHostMemory | Ae::Fragmentation => Self::OutOfMemory,
+            Ae::Unexpected => Self::Unexpected,
         }
     }
 }
@@ -2787,7 +2656,7 @@ impl From<descriptor::AllocationError> for crate::DeviceError {
 ///
 /// However, we implement a few Trait methods that don't have an equivalent
 /// error variant. In those cases we use this function.
-fn handle_unexpected(err: vk::Result) -> ! {
+pub(super) fn handle_unexpected(err: vk::Result) -> ! {
     panic!("Unexpected Vulkan error: `{err}`")
 }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -514,7 +514,7 @@ impl Drop for DeviceShared {
 
 pub struct Device {
     mem_allocator: Mutex<gpu_allocator::vulkan::Allocator>,
-    desc_allocator: Mutex<descriptor::DescriptorAllocator<vk::DescriptorPool, vk::DescriptorSet>>,
+    desc_allocator: Mutex<descriptor::DescriptorAllocator>,
     valid_ash_memory_types: u32,
     naga_options: naga::back::spv::Options<'static>,
     #[cfg(feature = "renderdoc")]
@@ -527,7 +527,7 @@ pub struct Device {
 
 impl Drop for Device {
     fn drop(&mut self) {
-        unsafe { self.desc_allocator.lock().cleanup(&*self.shared) };
+        unsafe { self.desc_allocator.lock().cleanup(&self.shared) };
     }
 }
 
@@ -820,7 +820,7 @@ impl crate::DynPipelineLayout for PipelineLayout {}
 
 #[derive(Debug)]
 pub struct BindGroup {
-    set: descriptor::DescriptorSet<vk::DescriptorSet>,
+    set: descriptor::DescriptorSet,
 }
 
 impl crate::DynBindGroup for BindGroup {}

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -27,6 +27,7 @@ Otherwise, we manage a pool of `VkFence` objects behind each `hal::Fence`.
 mod adapter;
 mod command;
 pub mod conv;
+mod descriptor;
 mod device;
 mod drm;
 mod instance;
@@ -513,8 +514,7 @@ impl Drop for DeviceShared {
 
 pub struct Device {
     mem_allocator: Mutex<gpu_allocator::vulkan::Allocator>,
-    desc_allocator:
-        Mutex<gpu_descriptor::DescriptorAllocator<vk::DescriptorPool, vk::DescriptorSet>>,
+    desc_allocator: Mutex<descriptor::DescriptorAllocator<vk::DescriptorPool, vk::DescriptorSet>>,
     valid_ash_memory_types: u32,
     naga_options: naga::back::spv::Options<'static>,
     #[cfg(feature = "renderdoc")]
@@ -799,7 +799,7 @@ struct BindingInfo {
 #[derive(Debug)]
 pub struct BindGroupLayout {
     raw: vk::DescriptorSetLayout,
-    desc_count: gpu_descriptor::DescriptorTotalCount,
+    desc_count: descriptor::DescriptorTotalCount,
     /// Sorted list of entries.
     entries: Box<[wgt::BindGroupLayoutEntry]>,
     /// Map of original binding index to remapped binding index and optional
@@ -820,7 +820,7 @@ impl crate::DynPipelineLayout for PipelineLayout {}
 
 #[derive(Debug)]
 pub struct BindGroup {
-    set: gpu_descriptor::DescriptorSet<vk::DescriptorSet>,
+    set: descriptor::DescriptorSet<vk::DescriptorSet>,
 }
 
 impl crate::DynBindGroup for BindGroup {}


### PR DESCRIPTION
**Description**

Stop depending on `gpu-descriptor` and inline the part of their code that we need directly. 

`gpu-descriptor` is very passively maintained and has outdated dependencies. Inlining the crate into `wgpu-hal` prevents this and simplifies our code at a small cost (~300 LoC). Additionally, this should reduce compile times a bit.

Each commit can be reviewed independently. The first commit bring parts of `gpu-descriptor` and `gpu-descriptor-types` in `wgpu-hal/src/vulkan/descriptor.rs` and does minor import changes to accommodate for this. Other are refactoring that take advantage of the inlining.

**Testing**
Ran tests

**Squash or Rebase?**

Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
