### PR TITLE
GLES: Fix copying depth to texture and cubemap to buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,8 @@ By @cwfitzgerald in [#8999](https://github.com/gfx-rs/wgpu/pull/8999).
 - `DisplayHandle` should now be passed to `InstanceDescriptor` for correct EGL initialization on Wayland. By @MarijnS95 in [#8012](https://github.com/gfx-rs/wgpu/pull/8012)
   Note that the existing workaround to create surfaces before the adapter is no longer valid.
 - Changing shader constants now correctly recompiles the shader. By @DerSchmale in [#8291](https://github.com/gfx-rs/wgpu/pull/8291).
+- Fix copying depth texture to texture and copying cubemap to buffer, by @beicause in [#9082
+](https://github.com/gfx-rs/wgpu/pull/9082)
 
 ### Documentation
 

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -401,6 +401,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
             self.cmd_buffer.commands.push(C::CopyTextureToTexture {
                 src: src_raw,
                 src_target,
+                src_format: src.format,
                 dst: dst_raw,
                 dst_target,
                 copy,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -880,6 +880,7 @@ enum Command {
     CopyTextureToTexture {
         src: glow::Texture,
         src_target: BindTarget,
+        src_format: wgt::TextureFormat,
         dst: glow::Texture,
         dst_target: BindTarget,
         copy: crate::TextureCopy,

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -671,61 +671,128 @@ impl super::Queue {
             C::CopyTextureToTexture {
                 src,
                 src_target,
+                src_format,
                 dst,
                 dst_target,
                 ref copy,
             } => {
-                //TODO: handle 3D copies
-                unsafe { gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(self.copy_fbo)) };
-                if is_layered_target(src_target) {
-                    //TODO: handle GLES without framebuffer_texture_3d
-                    unsafe {
-                        gl.framebuffer_texture_layer(
-                            glow::READ_FRAMEBUFFER,
-                            glow::COLOR_ATTACHMENT0,
-                            Some(src),
-                            copy.src_base.mip_level as i32,
-                            copy.src_base.array_layer as i32,
-                        )
-                    };
-                } else {
-                    unsafe {
-                        gl.framebuffer_texture_2d(
-                            glow::READ_FRAMEBUFFER,
-                            glow::COLOR_ATTACHMENT0,
-                            src_target,
-                            Some(src),
-                            copy.src_base.mip_level as i32,
-                        )
-                    };
+                if src_format.is_compressed() {
+                    log::error!("Copying compressed texture to texture is disallowed");
+                    return;
                 }
 
-                unsafe { gl.bind_texture(dst_target, Some(dst)) };
-                if is_layered_target(dst_target) {
+                let (src_depth_or_layer, dst_depth_or_layer, depth_or_layers) =
+                    if dst_target == glow::TEXTURE_3D {
+                        (
+                            copy.src_base.origin.z,
+                            copy.dst_base.origin.z,
+                            copy.size.depth,
+                        )
+                    } else {
+                        (copy.src_base.array_layer, copy.dst_base.array_layer, 1)
+                    };
+
+                let version = gl.version();
+                let is_min_es_3_2 = version.is_embedded && (version.major, version.minor) >= (3, 2);
+                let is_min_4_3 = !version.is_embedded && (version.major, version.minor) >= (4, 3);
+                if is_min_es_3_2 || is_min_4_3 {
                     unsafe {
-                        gl.copy_tex_sub_image_3d(
+                        gl.copy_image_sub_data(
+                            src,
+                            src_target,
+                            copy.src_base.mip_level as i32,
+                            copy.src_base.origin.x as i32,
+                            copy.src_base.origin.y as i32,
+                            src_depth_or_layer as i32,
+                            dst,
                             dst_target,
                             copy.dst_base.mip_level as i32,
                             copy.dst_base.origin.x as i32,
                             copy.dst_base.origin.y as i32,
-                            get_z_offset(dst_target, &copy.dst_base) as i32,
-                            copy.src_base.origin.x as i32,
-                            copy.src_base.origin.y as i32,
+                            dst_depth_or_layer as i32,
                             copy.size.width as i32,
                             copy.size.height as i32,
-                        )
+                            copy.size.depth as i32,
+                        );
                     };
-                } else {
+                    return;
+                }
+
+                let (attachment, blit_mask) = match copy.src_base.aspect {
+                    crate::FormatAspects::COLOR => {
+                        (glow::COLOR_ATTACHMENT0, glow::COLOR_BUFFER_BIT)
+                    }
+                    crate::FormatAspects::DEPTH => (glow::DEPTH_ATTACHMENT, glow::DEPTH_BUFFER_BIT),
+                    crate::FormatAspects::STENCIL => {
+                        (glow::STENCIL_ATTACHMENT, glow::STENCIL_BUFFER_BIT)
+                    }
+                    crate::FormatAspects::DEPTH_STENCIL => (
+                        glow::DEPTH_STENCIL_ATTACHMENT,
+                        glow::DEPTH_BUFFER_BIT | glow::STENCIL_BUFFER_BIT,
+                    ),
+                    _ => unimplemented!(),
+                };
+
+                unsafe { gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(self.copy_fbo)) };
+                unsafe { gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, Some(self.draw_fbo)) };
+
+                for z in 0..depth_or_layers {
+                    let src_layer = src_depth_or_layer + z;
+                    let dst_layer = dst_depth_or_layer + z;
+                    if is_layered_target(src_target) {
+                        unsafe {
+                            gl.framebuffer_texture_layer(
+                                glow::READ_FRAMEBUFFER,
+                                attachment,
+                                Some(src),
+                                copy.src_base.mip_level as i32,
+                                src_layer as i32,
+                            )
+                        };
+                    } else {
+                        unsafe {
+                            gl.framebuffer_texture_2d(
+                                glow::READ_FRAMEBUFFER,
+                                attachment,
+                                get_2d_target(src_target, src_layer),
+                                Some(src),
+                                copy.src_base.mip_level as i32,
+                            )
+                        };
+                    }
+                    if is_layered_target(dst_target) {
+                        unsafe {
+                            gl.framebuffer_texture_layer(
+                                glow::DRAW_FRAMEBUFFER,
+                                attachment,
+                                Some(dst),
+                                copy.dst_base.mip_level as i32,
+                                dst_layer as i32,
+                            )
+                        };
+                    } else {
+                        unsafe {
+                            gl.framebuffer_texture_2d(
+                                glow::DRAW_FRAMEBUFFER,
+                                attachment,
+                                get_2d_target(dst_target, dst_layer),
+                                Some(dst),
+                                copy.dst_base.mip_level as i32,
+                            )
+                        };
+                    }
                     unsafe {
-                        gl.copy_tex_sub_image_2d(
-                            get_2d_target(dst_target, copy.dst_base.array_layer),
-                            copy.dst_base.mip_level as i32,
+                        gl.blit_framebuffer(
+                            copy.src_base.origin.x as i32,
+                            copy.src_base.origin.y as i32,
+                            (copy.src_base.origin.x + copy.size.width) as i32,
+                            (copy.src_base.origin.y + copy.size.height) as i32,
                             copy.dst_base.origin.x as i32,
                             copy.dst_base.origin.y as i32,
-                            copy.src_base.origin.x as i32,
-                            copy.src_base.origin.y as i32,
-                            copy.size.width as i32,
-                            copy.size.height as i32,
+                            (copy.dst_base.origin.x + copy.size.width) as i32,
+                            (copy.dst_base.origin.y + copy.size.height) as i32,
+                            blit_mask,
+                            glow::NEAREST,
                         )
                     };
                 }
@@ -876,17 +943,11 @@ impl super::Queue {
                 dst_target: _,
                 ref copy,
             } => {
-                let block_size = src_format.block_copy_size(None).unwrap();
                 if src_format.is_compressed() {
-                    log::error!("Not implemented yet: compressed texture copy to buffer");
+                    log::error!("Copying compressed texture to buffer is disallowed");
                     return;
                 }
-                if src_target == glow::TEXTURE_CUBE_MAP
-                    || src_target == glow::TEXTURE_CUBE_MAP_ARRAY
-                {
-                    log::error!("Not implemented yet: cubemap texture copy to buffer");
-                    return;
-                }
+                let block_size = src_format.block_copy_size(None).unwrap();
                 let format_desc = self.shared.describe_texture_format(src_format);
                 let row_texels = copy
                     .buffer_layout
@@ -939,7 +1000,19 @@ impl super::Queue {
                         };
                         read_pixels(copy.buffer_layout.offset);
                     }
-                    glow::TEXTURE_2D_ARRAY => {
+                    glow::TEXTURE_CUBE_MAP => {
+                        unsafe {
+                            gl.framebuffer_texture_2d(
+                                glow::READ_FRAMEBUFFER,
+                                glow::COLOR_ATTACHMENT0,
+                                get_2d_target(src_target, copy.texture_base.array_layer),
+                                Some(src),
+                                copy.texture_base.mip_level as i32,
+                            )
+                        };
+                        read_pixels(copy.buffer_layout.offset);
+                    }
+                    glow::TEXTURE_2D_ARRAY | glow::TEXTURE_CUBE_MAP_ARRAY => {
                         unsafe {
                             gl.framebuffer_texture_layer(
                                 glow::READ_FRAMEBUFFER,
@@ -967,7 +1040,6 @@ impl super::Queue {
                             read_pixels(offset);
                         }
                     }
-                    glow::TEXTURE_CUBE_MAP | glow::TEXTURE_CUBE_MAP_ARRAY => unimplemented!(),
                     _ => unreachable!(),
                 }
             }


### PR DESCRIPTION
**Connections**
Current `copy_texture_to_texture` fails to copy depth textures and layered textures. And `copy_texture_to_buffer` doesn't implement copying cubemap/cubemap array to buffer.

Fixes https://github.com/gfx-rs/wgpu/issues/8995
Related https://github.com/gpuweb/gpuweb/issues/5570

**Description**
1. `copy_texture_to_texture`: Change to use `glCopyImageSubData` or `glBlitFramebuffer` which supports depth texture, and handle 3d texture copy.
2. Reject copying compressed texture to texture, neither `glCopyTexSubImage2D` nor `glBlitFramebuffer` supports it on WebGL2. [WebGPU compatibility mode](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#3-disallow-commandencodercopytexturetobuffer-and-commandencodercopytexturetotexture-for-compressed-texture-formats) disallows it, too.
3. `copy_texture_to_buffer`: Implement copying cubemap/cubemap array to buffer.

**Testing**
Apply this patch and run `shadow` example to test copying depth, run `skybox` example to test copying cubemap (3d texture and cubemap array are untested):
<details>
<summary>git diff</summary>

```diff
diff --git a/examples/features/src/shadow/mod.rs b/examples/features/src/shadow/mod.rs
index 7a4fb9ea9..19fa9974e 100644
--- a/examples/features/src/shadow/mod.rs
+++ b/examples/features/src/shadow/mod.rs
@@ -1,7 +1,10 @@
 use std::{f32::consts, iter, ops::Range};
 
 use bytemuck::{Pod, Zeroable};
-use wgpu::util::{align_to, DeviceExt};
+use wgpu::{
+    util::{align_to, DeviceExt, TextureBlitter, TextureBlitterBuilder},
+    Origin3d,
+};
 
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -152,7 +155,10 @@ struct Example {
     lights_are_dirty: bool,
     shadow_pass: Pass,
     forward_pass: Pass,
-    forward_depth: wgpu::TextureView,
+    forward_depth: (wgpu::Texture, wgpu::TextureView),
+    depth_copyable: wgpu::Texture,
+    depth_buffer: wgpu::Buffer,
+    blitter: TextureBlitter,
     entity_bind_group: wgpu::BindGroup,
     light_storage_buf: wgpu::Buffer,
     entity_uniform_buf: wgpu::Buffer,
@@ -181,7 +187,7 @@ impl Example {
     fn create_depth_texture(
         config: &wgpu::SurfaceConfiguration,
         device: &wgpu::Device,
-    ) -> wgpu::TextureView {
+    ) -> (wgpu::Texture, wgpu::TextureView) {
         let depth_texture = device.create_texture(&wgpu::TextureDescriptor {
             size: wgpu::Extent3d {
                 width: config.width,
@@ -192,12 +198,12 @@ impl Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: Self::DEPTH_FORMAT,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TRANSIENT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
             label: None,
             view_formats: &[],
         });
-
-        depth_texture.create_view(&wgpu::TextureViewDescriptor::default())
+        let view = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (depth_texture, view)
     }
 }
 
@@ -665,6 +671,31 @@ impl crate::framework::Example for Example {
         };
 
         let forward_depth = Self::create_depth_texture(config, device);
+        let depth_copyable = device.create_texture(&wgpu::TextureDescriptor {
+            size: wgpu::Extent3d {
+                width: config.width,
+                height: config.height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: Self::DEPTH_FORMAT,
+            usage: wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            label: None,
+            view_formats: &[],
+        });
+        let depth_buffer = device.create_buffer(&wgpu::wgt::BufferDescriptor {
+            label: None,
+            size: wgpu::wgt::math::align_to(config.width, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
+                as u64
+                * config.height as u64
+                * 4,
+            usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
 
         Example {
             entities,
@@ -673,6 +704,9 @@ impl crate::framework::Example for Example {
             shadow_pass,
             forward_pass,
             forward_depth,
+            depth_buffer,
+            depth_copyable,
+            blitter: TextureBlitterBuilder::new(device, config.view_formats[0]).build(),
             light_storage_buf,
             entity_uniform_buf,
             entity_bind_group,
@@ -699,6 +733,31 @@ impl crate::framework::Example for Example {
         );
 
         self.forward_depth = Self::create_depth_texture(config, device);
+        self.depth_copyable = device.create_texture(&wgpu::TextureDescriptor {
+            size: wgpu::Extent3d {
+                width: config.width,
+                height: config.height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: Self::DEPTH_FORMAT,
+            usage: wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            label: None,
+            view_formats: &[],
+        });
+        self.depth_buffer = device.create_buffer(&wgpu::wgt::BufferDescriptor {
+            label: None,
+            size: wgpu::wgt::math::align_to(config.width, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
+                as u64
+                * config.height as u64
+                * 4,
+            usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
     }
 
     fn render(&mut self, view: &wgpu::TextureView, device: &wgpu::Device, queue: &wgpu::Queue) {
@@ -808,10 +867,10 @@ impl crate::framework::Example for Example {
                     },
                 })],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                    view: &self.forward_depth,
+                    view: &self.forward_depth.1,
                     depth_ops: Some(wgpu::Operations {
                         load: wgpu::LoadOp::Clear(1.0),
-                        store: wgpu::StoreOp::Discard,
+                        store: wgpu::StoreOp::Store,
                     }),
                     stencil_ops: None,
                 }),
@@ -831,6 +890,41 @@ impl crate::framework::Example for Example {
         }
         encoder.pop_debug_group();
 
+        encoder.push_debug_group("test copying depth");
+        {
+            encoder.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &self.forward_depth.0,
+                    mip_level: 0,
+                    origin: Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::TexelCopyTextureInfo {
+                    texture: &self.depth_copyable,
+                    mip_level: 0,
+                    origin: Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::Extent3d {
+                    width: self.depth_copyable.width(),
+                    height: self.depth_copyable.height(),
+                    depth_or_array_layers: 1,
+                },
+            );
+            self.blitter.copy(
+                device,
+                &mut encoder,
+                &self
+                    .depth_copyable
+                    .create_view(&wgpu::wgt::TextureViewDescriptor {
+                        label: Some("blit to screen"),
+                        ..Default::default()
+                    }),
+                view,
+            );
+        }
+        encoder.pop_debug_group();
+
         queue.submit(iter::once(encoder.finish()));
     }
 }
diff --git a/examples/features/src/skybox/mod.rs b/examples/features/src/skybox/mod.rs
index e5c5df7ff..2a5fcc6e8 100644
--- a/examples/features/src/skybox/mod.rs
+++ b/examples/features/src/skybox/mod.rs
@@ -56,6 +56,10 @@ pub struct Example {
     camera: Camera,
     sky_pipeline: wgpu::RenderPipeline,
     entity_pipeline: wgpu::RenderPipeline,
+    cubemap_format: wgpu::TextureFormat,
+    cubemap_texture: wgpu::Texture,
+    cubemap_texture_copied: wgpu::Texture,
+    cubemap_buffer: wgpu::Buffer,
     bind_group: wgpu::BindGroup,
     uniform_buf: wgpu::Buffer,
     entities: Vec<Entity>,
@@ -268,23 +272,25 @@ impl crate::framework::Example for Example {
         });
 
         let device_features = device.features();
-
-        let skybox_format = if device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_ASTC) {
-            log::info!("Using astc");
-            wgpu::TextureFormat::Astc {
-                block: AstcBlock::B4x4,
-                channel: AstcChannel::UnormSrgb,
-            }
-        } else if device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_ETC2) {
-            log::info!("Using etc2");
-            wgpu::TextureFormat::Etc2Rgb8A1UnormSrgb
-        } else if device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_BC) {
-            log::info!("Using bc7");
-            wgpu::TextureFormat::Bc7RgbaUnormSrgb
-        } else {
-            log::info!("Using rgba8");
-            wgpu::TextureFormat::Rgba8UnormSrgb
-        };
+        // For testing texture copy, it can't be compressed format.
+        let is_gl = _adapter.get_info().backend == wgpu::Backend::Gl;
+        let skybox_format =
+            if !is_gl && device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_ASTC) {
+                log::info!("Using astc");
+                wgpu::TextureFormat::Astc {
+                    block: AstcBlock::B4x4,
+                    channel: AstcChannel::UnormSrgb,
+                }
+            } else if !is_gl && device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_ETC2) {
+                log::info!("Using etc2");
+                wgpu::TextureFormat::Etc2Rgb8A1UnormSrgb
+            } else if !is_gl && device_features.contains(wgpu::Features::TEXTURE_COMPRESSION_BC) {
+                log::info!("Using bc7");
+                wgpu::TextureFormat::Bc7RgbaUnormSrgb
+            } else {
+                log::info!("Using rgba8");
+                wgpu::TextureFormat::Rgba8UnormSrgb
+            };
 
         let size = wgpu::Extent3d {
             width: IMAGE_SIZE,
@@ -321,7 +327,7 @@ impl crate::framework::Example for Example {
             image.extend_from_slice(level.data);
         }
 
-        let texture = device.create_texture_with_data(
+        let cubemap_texture = device.create_texture_with_data(
             queue,
             &wgpu::TextureDescriptor {
                 size,
@@ -329,7 +335,9 @@ impl crate::framework::Example for Example {
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: skybox_format,
-                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::COPY_DST
+                    | wgpu::TextureUsages::COPY_SRC,
                 label: None,
                 view_formats: &[],
             },
@@ -337,8 +345,34 @@ impl crate::framework::Example for Example {
             wgpu::util::TextureDataOrder::MipMajor,
             &image,
         );
+        let cubemap_texture_copied = device.create_texture(&wgpu::TextureDescriptor {
+            size,
+            mip_level_count: header.level_count,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: skybox_format,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC,
+            label: None,
+            view_formats: &[],
+        });
+        let (block_width, block_height) = skybox_format.block_dimensions();
+        let block_size = skybox_format
+            .block_copy_size(Some(wgpu::TextureAspect::All))
+            .unwrap();
+        let bytes_per_row = wgpu::wgt::math::align_to(
+            (size.width / block_width) * block_size,
+            wgpu::COPY_BYTES_PER_ROW_ALIGNMENT,
+        );
+        let cubemap_buffer = device.create_buffer(&wgpu::wgt::BufferDescriptor {
+            label: None,
+            size: (bytes_per_row * size.height / block_height * size.depth_or_array_layers) as u64,
+            usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
 
-        let texture_view = texture.create_view(&wgpu::TextureViewDescriptor {
+        let texture_view = cubemap_texture_copied.create_view(&wgpu::TextureViewDescriptor {
             label: None,
             dimension: Some(wgpu::TextureViewDimension::Cube),
             ..wgpu::TextureViewDescriptor::default()
@@ -368,6 +402,10 @@ impl crate::framework::Example for Example {
             camera,
             sky_pipeline,
             entity_pipeline,
+            cubemap_format: skybox_format,
+            cubemap_texture,
+            cubemap_texture_copied,
+            cubemap_buffer,
             bind_group,
             uniform_buf,
             entities,
@@ -402,6 +440,59 @@ impl crate::framework::Example for Example {
     fn render(&mut self, view: &wgpu::TextureView, device: &wgpu::Device, queue: &wgpu::Queue) {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        encoder.copy_texture_to_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.cubemap_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.cubemap_texture_copied,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::Extent3d {
+                width: self.cubemap_texture.width(),
+                height: self.cubemap_texture.height(),
+                depth_or_array_layers: self.cubemap_texture.depth_or_array_layers(),
+            },
+        );
+        if device.adapter_info().backend != wgpu::Backend::Gl
+            || !self.cubemap_format.is_compressed()
+        {
+            let (block_width, block_height) = self.cubemap_format.block_dimensions();
+            let block_size = self
+                .cubemap_format
+                .block_copy_size(Some(wgpu::TextureAspect::All))
+                .unwrap();
+            let bytes_per_row = wgpu::wgt::math::align_to(
+                (self.cubemap_texture.width() / block_width) * block_size,
+                wgpu::COPY_BYTES_PER_ROW_ALIGNMENT,
+            );
+            encoder.copy_texture_to_buffer(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &self.cubemap_texture_copied,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::TexelCopyBufferInfo {
+                    buffer: &self.cubemap_buffer,
+                    layout: wgpu::TexelCopyBufferLayout {
+                        offset: 0,
+                        bytes_per_row: Some(bytes_per_row),
+                        rows_per_image: Some(self.cubemap_texture.height() / block_height),
+                    },
+                },
+                wgpu::Extent3d {
+                    width: self.cubemap_texture.width(),
+                    height: self.cubemap_texture.height(),
+                    depth_or_array_layers: self.cubemap_texture.depth_or_array_layers(),
+                },
+            );
+        }
 
         // update rotation
         let raw_uniforms = self.camera.to_uniform_data();

```

</details>


**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
