### PR TITLE
fix(d12): fix startup crash for shader models 6.8 and 6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ By @cwfitzgerald in [#8999](https://github.com/gfx-rs/wgpu/pull/8999).
 - Added support for `insert_debug_marker`, `push_debug_group` and `pop_debug_group` on WebGPU. By @evilpie in [#9017](https://github.com/gfx-rs/wgpu/pull/9017).
 - Added support for `@builtin(draw_index)` to the vulkan backend. By @inner-daemons in #8883.
 - Added support for `enable primitive_index` and `@builtin(primitive_index)` with support on all platforms. By @inner-daemons in #8879.
+- BREAKING: Add `V6_8` variant to `DxcShaderModel` and `naga::back::hlsl::ShaderModel`. By @inner-daemons in [#8882](https://github.com/gfx-rs/wgpu/pull/8882) and @ErichDonGubler in [#9083](https://github.com/gfx-rs/wgpu/pull/9083).
+- BREAKING: Add `V6_9` variant to `DxcShaderModel` and `naga::back::hlsl::ShaderModel`. By @ErichDonGubler in [#????](https://github.com/gfx-rs/wgpu/pull/????).
 
 #### naga
 

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -256,6 +256,8 @@ pub enum ShaderModel {
     V6_5,
     V6_6,
     V6_7,
+    V6_8,
+    V6_9,
 }
 
 impl ShaderModel {
@@ -271,6 +273,8 @@ impl ShaderModel {
             Self::V6_5 => "6_5",
             Self::V6_6 => "6_6",
             Self::V6_7 => "6_7",
+            Self::V6_8 => "6_8",
+            Self::V6_9 => "6_9",
         }
     }
 }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -380,6 +380,7 @@ impl super::Adapter {
                 wgt::DxcShaderModel::V6_6 => ShaderModel::_6_6,
                 wgt::DxcShaderModel::V6_7 => ShaderModel::_6_7,
                 wgt::DxcShaderModel::V6_8 => ShaderModel::_6_8,
+                wgt::DxcShaderModel::V6_9 => ShaderModel::_6_9,
             };
 
             let shader_model = max_device_shader_model.min(max_dxc_shader_model);
@@ -404,7 +405,8 @@ impl super::Adapter {
                 ShaderModel::_6_5 => naga::back::hlsl::ShaderModel::V6_5,
                 ShaderModel::_6_6 => naga::back::hlsl::ShaderModel::V6_6,
                 ShaderModel::_6_7 => naga::back::hlsl::ShaderModel::V6_7,
-                _ => unreachable!(),
+                ShaderModel::_6_8 => naga::back::hlsl::ShaderModel::V6_8,
+                ShaderModel::_6_9 => naga::back::hlsl::ShaderModel::V6_9,
             }
         } else {
             naga::back::hlsl::ShaderModel::V5_1

--- a/wgpu-types/src/backend.rs
+++ b/wgpu-types/src/backend.rs
@@ -546,6 +546,7 @@ pub enum DxcShaderModel {
     V6_6,
     V6_7,
     V6_8,
+    V6_9,
 }
 
 impl DxcShaderModel {
@@ -553,9 +554,9 @@ impl DxcShaderModel {
     pub fn from_dxc_version(major: u32, minor: u32) -> Self {
         // DXC version roughly has corresponded to shader model so far, where DXC 1.x supports SM 6.x.
         // See discussion in https://discord.com/channels/590611987420020747/996417435374714920/1471234702206701650.
-        // Presumably DXC 2.0 and up will still support shader model 6.8.
+        // Presumably DXC 2.0 and up will still support shader model 6.9.
         if major > 1 {
-            Self::V6_8
+            Self::V6_9
         } else {
             Self::from_parts(6, minor)
         }
@@ -564,7 +565,7 @@ impl DxcShaderModel {
     /// Parse a DxcShaderModel from its version components.
     pub fn from_parts(major: u32, minor: u32) -> Self {
         if major > 6 || minor > 8 {
-            Self::V6_8
+            Self::V6_9
         } else {
             match minor {
                 0 => DxcShaderModel::V6_0,
@@ -575,8 +576,10 @@ impl DxcShaderModel {
                 5 => DxcShaderModel::V6_5,
                 6 => DxcShaderModel::V6_6,
                 7 => DxcShaderModel::V6_7,
-                // >= 6.8
-                _ => DxcShaderModel::V6_8,
+                8 => DxcShaderModel::V6_8,
+                9 => DxcShaderModel::V6_9,
+                // > 6.9
+                _ => DxcShaderModel::V6_9,
             }
         }
     }


### PR DESCRIPTION
**Connections**

- Discovered while working on [Firefox's bug 2017645](https://bugzilla.mozilla.org/show_bug.cgi?id=2017645).
- Regressed by #8882 (CC @inner-daemons).

**Description**

Support was partially added for shader model 6.8, but the `CHANGELOG` and logic for actually initializing DX12 with were incomplete. This incompleteness caused _crashes_ (😬 ack!). Finish the work of initializing DX12 devices that have this shader model, and add a `CHANGELOG` entry.

**Testing**

Builds are fixed in Firefox. I'm not sure how to prevent this going forward (and I think we need to figure this out so this doesn't bite us again; thoughts, @inner-daemons?), but I want to land this ASAP so Firefox isn't blocked from consuming new versions of wgpu.

**Squash or Rebase?**

Squash please!

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
