### PR TITLE
Upgrade wasm-bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,11 +289,11 @@ windows = { version = "0.62", default-features = false }
 # wasm32 dependencies
 console_error_panic_hook = "0.1.5"
 console_log = "1"
-js-sys = { version = "0.3.85", default-features = false }
-wasm-bindgen = { version = "0.2.108", default-features = false }
-wasm-bindgen-futures = { version = "0.4.58", default-features = false }
+js-sys = { version = "0.3.91", default-features = false }
+wasm-bindgen = { version = "0.2.114", default-features = false }
+wasm-bindgen-futures = { version = "0.4.64", default-features = false }
 wasm-bindgen-test = "0.3"
-web-sys = { version = "0.3.85", default-features = false }
+web-sys = { version = "0.3.91", default-features = false }
 web-time = "1.1.0"
 
 # deno dependencies


### PR DESCRIPTION
**Connections**

**Description**

It seems like just upgrading wasm-bindgen/js-sys/web-sys breaks the WGPU examples: 

> Uncaught (in promise) RuntimeError: unreachable executed
    __wbg_finalize_init http://127.0.0.1:8000/webgl2.js:2039
    __wbg_init http://127.0.0.1:8000/webgl2.js:2121
webgl2_bg.wasm:12106005:1

The question is if that is a problem with wasm-bindgen and should be reported upstream, or caused by the vendoring of  WebGPU.

**Testing**


**Squash or Rebase?**


**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
