### PR TITLE
Add labels to indirect validation and timestamp normalization code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ By @cwfitzgerald in [#8999](https://github.com/gfx-rs/wgpu/pull/8999).
 - Renamed `EXPERIMENTAL_PASSTHROUGH_SHADERS` to `PASSTHROUGH_SHADERS` and made this no longer an experimental feature. by @inner-daemons in [#9054](https://github.com/gfx-rs/wgpu/pull/9054).
 - BREAKING: End offsets in trace and `player` commands are now represented using `offset` + `size` instead. By @ErichDonGubler in [9073](https://github.com/gfx-rs/wgpu/pull/9073).
 - Validate some uncaught cases where buffer transfer operations could overflow when computing an end offset. By @ErichDonGubler in [9073](https://github.com/gfx-rs/wgpu/pull/9073).
+- Added internal labels to validation GPU objects and timestamp normalization code to improve clarity in graphics debuggers. By @szostid in [9094](https://github.com/gfx-rs/wgpu/pull/9094)
 
 #### naga
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -483,6 +483,7 @@ impl Device {
                 raw_device.as_ref(),
                 &desc.required_limits,
                 &desc.required_features,
+                instance_flags,
                 adapter.backend(),
             )?)
         } else {

--- a/wgpu-core/src/indirect_validation/dispatch.rs
+++ b/wgpu-core/src/indirect_validation/dispatch.rs
@@ -1,6 +1,7 @@
 use super::CreateIndirectValidationPipelineError;
 use crate::{
     device::DeviceError,
+    hal_label,
     pipeline::{CreateComputePipelineError, CreateShaderModuleError},
 };
 use alloc::{boxed::Box, format, string::ToString as _};
@@ -40,6 +41,7 @@ pub struct Params<'a> {
 impl Dispatch {
     pub(super) fn new(
         device: &dyn hal::DynDevice,
+        instance_flags: wgt::InstanceFlags,
         limits: &wgt::Limits,
     ) -> Result<Self, CreateIndirectValidationPipelineError> {
         let max_compute_workgroups_per_dimension = limits.max_compute_workgroups_per_dimension;
@@ -109,7 +111,10 @@ impl Dispatch {
             debug_source: None,
         });
         let hal_desc = hal::ShaderModuleDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect dispatch validation shader module"),
+                instance_flags,
+            ),
             runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
         };
         let module =
@@ -126,7 +131,10 @@ impl Dispatch {
             })?;
 
         let dst_bind_group_layout_desc = hal::BindGroupLayoutDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect dispatch validation destination bind group layout"),
+                instance_flags,
+            ),
             flags: hal::BindGroupLayoutFlags::empty(),
             entries: &[wgt::BindGroupLayoutEntry {
                 binding: 0,
@@ -146,7 +154,10 @@ impl Dispatch {
         };
 
         let src_bind_group_layout_desc = hal::BindGroupLayoutDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect dispatch validation source bind group layout"),
+                instance_flags,
+            ),
             flags: hal::BindGroupLayoutFlags::empty(),
             entries: &[wgt::BindGroupLayoutEntry {
                 binding: 0,
@@ -166,7 +177,10 @@ impl Dispatch {
         };
 
         let pipeline_layout_desc = hal::PipelineLayoutDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect dispatch validation pipeline layout"),
+                instance_flags,
+            ),
             flags: hal::PipelineLayoutFlags::empty(),
             bind_group_layouts: &[
                 dst_bind_group_layout.as_ref(),
@@ -181,7 +195,10 @@ impl Dispatch {
         };
 
         let pipeline_desc = hal::ComputePipelineDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect dispatch validation pipeline"),
+                instance_flags,
+            ),
             layout: pipeline_layout.as_ref(),
             stage: hal::ProgrammableStage {
                 module: module.as_ref(),
@@ -208,7 +225,10 @@ impl Dispatch {
             })?;
 
         let dst_buffer_desc = hal::BufferDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect dispatch validation destination buffer"),
+                instance_flags,
+            ),
             size: DST_BUFFER_SIZE.get(),
             usage: wgt::BufferUses::INDIRECT | wgt::BufferUses::STORAGE_READ_WRITE,
             memory_flags: hal::MemoryFlags::empty(),
@@ -217,7 +237,10 @@ impl Dispatch {
             unsafe { device.create_buffer(&dst_buffer_desc) }.map_err(DeviceError::from_hal)?;
 
         let dst_bind_group_desc = hal::BindGroupDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect dispatch validation destination bind group"),
+                instance_flags,
+            ),
             layout: dst_bind_group_layout.as_ref(),
             entries: &[hal::BindGroupEntry {
                 binding: 0,
@@ -259,13 +282,17 @@ impl Dispatch {
         limits: &wgt::Limits,
         buffer_size: u64,
         buffer: &dyn hal::DynBuffer,
+        instance_flags: wgt::InstanceFlags,
     ) -> Result<Option<Box<dyn hal::DynBindGroup>>, DeviceError> {
         let binding_size = calculate_src_buffer_binding_size(buffer_size, limits);
         let Some(binding_size) = NonZeroU64::new(binding_size) else {
             return Ok(None);
         };
         let hal_desc = hal::BindGroupDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect dispatch validation source bind group"),
+                instance_flags,
+            ),
             layout: self.src_bind_group_layout.as_ref(),
             entries: &[hal::BindGroupEntry {
                 binding: 0,

--- a/wgpu-core/src/indirect_validation/draw.rs
+++ b/wgpu-core/src/indirect_validation/draw.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::{
     command::RenderPassErrorInner,
     device::{queue::TempResource, Device, DeviceError},
+    hal_label,
     lock::{rank, Mutex},
     pipeline::{CreateComputePipelineError, CreateShaderModuleError},
     resource::{RawResourceAccess as _, StagingBuffer, Trackable},
@@ -63,18 +64,47 @@ impl Draw {
     pub(super) fn new(
         device: &dyn hal::DynDevice,
         required_features: &wgt::Features,
+        instance_flags: wgt::InstanceFlags,
         backend: wgt::Backend,
     ) -> Result<Self, CreateIndirectValidationPipelineError> {
-        let module = create_validation_module(device)?;
+        let module = create_validation_module(device, instance_flags)?;
 
-        let metadata_bind_group_layout =
-            create_bind_group_layout(device, true, false, BUFFER_SIZE)?;
-        let src_bind_group_layout =
-            create_bind_group_layout(device, true, true, wgt::BufferSize::new(4 * 4).unwrap())?;
-        let dst_bind_group_layout = create_bind_group_layout(device, false, false, BUFFER_SIZE)?;
+        let metadata_bind_group_layout = create_bind_group_layout(
+            device,
+            true,
+            false,
+            BUFFER_SIZE,
+            hal_label(
+                Some("(wgpu internal) Indirect draw validation metadata bind group layout"),
+                instance_flags,
+            ),
+        )?;
+        let src_bind_group_layout = create_bind_group_layout(
+            device,
+            true,
+            true,
+            wgt::BufferSize::new(4 * 4).unwrap(),
+            hal_label(
+                Some("(wgpu internal) Indirect draw validation source bind group layout"),
+                instance_flags,
+            ),
+        )?;
+        let dst_bind_group_layout = create_bind_group_layout(
+            device,
+            false,
+            false,
+            BUFFER_SIZE,
+            hal_label(
+                Some("(wgpu internal) Indirect draw validation destination bind group layout"),
+                instance_flags,
+            ),
+        )?;
 
         let pipeline_layout_desc = hal::PipelineLayoutDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect draw validation pipeline layout"),
+                instance_flags,
+            ),
             flags: hal::PipelineLayoutFlags::empty(),
             bind_group_layouts: &[
                 metadata_bind_group_layout.as_ref(),
@@ -98,6 +128,7 @@ impl Draw {
             pipeline_layout.as_ref(),
             supports_indirect_first_instance,
             write_d3d12_special_constants,
+            instance_flags,
         )?;
 
         Ok(Self {
@@ -120,13 +151,17 @@ impl Draw {
         limits: &Limits,
         buffer_size: u64,
         buffer: &dyn hal::DynBuffer,
+        instance_flags: wgt::InstanceFlags,
     ) -> Result<Option<Box<dyn hal::DynBindGroup>>, DeviceError> {
         let binding_size = calculate_src_buffer_binding_size(buffer_size, limits);
         let Some(binding_size) = NonZeroU64::new(binding_size) else {
             return Ok(None);
         };
         let hal_desc = hal::BindGroupDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect draw validation source bind group"),
+                instance_flags,
+            ),
             layout: self.src_bind_group_layout.as_ref(),
             entries: &[hal::BindGroupEntry {
                 binding: 0,
@@ -151,13 +186,20 @@ impl Draw {
     fn acquire_dst_entry(
         &self,
         device: &dyn hal::DynDevice,
+        instance_flags: wgt::InstanceFlags,
     ) -> Result<BufferPoolEntry, hal::DeviceError> {
         let mut free_buffers = self.free_indirect_entries.lock();
         match free_buffers.pop() {
             Some(buffer) => Ok(buffer),
             None => {
                 let usage = wgt::BufferUses::INDIRECT | wgt::BufferUses::STORAGE_READ_WRITE;
-                create_buffer_and_bind_group(device, usage, self.dst_bind_group_layout.as_ref())
+                create_buffer_and_bind_group(
+                    device,
+                    usage,
+                    self.dst_bind_group_layout.as_ref(),
+                    hal_label(Some("(wgpu internal) Indirect draw validation destination buffer"), instance_flags),
+                    hal_label(Some("(wgpu internal) Indirect draw validation destination bind group layout"), instance_flags),
+                )
             }
         }
     }
@@ -169,6 +211,7 @@ impl Draw {
     fn acquire_metadata_entry(
         &self,
         device: &dyn hal::DynDevice,
+        instance_flags: wgt::InstanceFlags,
     ) -> Result<BufferPoolEntry, hal::DeviceError> {
         let mut free_buffers = self.free_metadata_entries.lock();
         match free_buffers.pop() {
@@ -179,6 +222,14 @@ impl Draw {
                     device,
                     usage,
                     self.metadata_bind_group_layout.as_ref(),
+                    hal_label(
+                        Some("(wgpu internal) Indirect draw validation metadata buffer"),
+                        instance_flags,
+                    ),
+                    hal_label(
+                        Some("(wgpu internal) Indirect draw validation metadata bind group layout"),
+                        instance_flags,
+                    ),
                 )
             }
         }
@@ -345,7 +396,10 @@ impl Draw {
             .encode(encoder);
 
         let desc = hal::ComputePassDescriptor {
-            label: None,
+            label: hal_label(
+                Some("(wgpu internal) Indirect draw validation pass"),
+                device.instance_flags,
+            ),
             timestamp_writes: None,
         };
         unsafe {
@@ -463,6 +517,7 @@ impl Draw {
 
 fn create_validation_module(
     device: &dyn hal::DynDevice,
+    instance_flags: wgt::InstanceFlags,
 ) -> Result<Box<dyn hal::DynShaderModule>, CreateIndirectValidationPipelineError> {
     let src = include_str!("./validate_draw.wgsl");
 
@@ -497,7 +552,10 @@ fn create_validation_module(
         debug_source: None,
     });
     let hal_desc = hal::ShaderModuleDescriptor {
-        label: None,
+        label: hal_label(
+            Some("(wgpu internal) Indirect draw validation shader module"),
+            instance_flags,
+        ),
         runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
     };
     let module = unsafe { device.create_shader_module(&hal_desc, hal_shader) }.map_err(
@@ -521,9 +579,13 @@ fn create_validation_pipeline(
     pipeline_layout: &dyn hal::DynPipelineLayout,
     supports_indirect_first_instance: bool,
     write_d3d12_special_constants: bool,
+    instance_flags: wgt::InstanceFlags,
 ) -> Result<Box<dyn hal::DynComputePipeline>, CreateIndirectValidationPipelineError> {
     let pipeline_desc = hal::ComputePipelineDescriptor {
-        label: None,
+        label: hal_label(
+            Some("(wgpu internal) Indirect draw validation pipeline"),
+            instance_flags,
+        ),
         layout: pipeline_layout,
         stage: hal::ProgrammableStage {
             module,
@@ -564,9 +626,10 @@ fn create_bind_group_layout(
     read_only: bool,
     has_dynamic_offset: bool,
     min_binding_size: wgt::BufferSize,
+    label: Option<&'static str>,
 ) -> Result<Box<dyn hal::DynBindGroupLayout>, CreateIndirectValidationPipelineError> {
     let bind_group_layout_desc = hal::BindGroupLayoutDescriptor {
-        label: None,
+        label,
         flags: hal::BindGroupLayoutFlags::empty(),
         entries: &[wgt::BindGroupLayoutEntry {
             binding: 0,
@@ -662,16 +725,18 @@ fn create_buffer_and_bind_group(
     device: &dyn hal::DynDevice,
     usage: wgt::BufferUses,
     bind_group_layout: &dyn hal::DynBindGroupLayout,
+    buffer_label: Option<&'static str>,
+    bind_group_label: Option<&'static str>,
 ) -> Result<BufferPoolEntry, hal::DeviceError> {
     let buffer_desc = hal::BufferDescriptor {
-        label: None,
+        label: buffer_label,
         size: BUFFER_SIZE.get(),
         usage,
         memory_flags: hal::MemoryFlags::empty(),
     };
     let buffer = unsafe { device.create_buffer(&buffer_desc) }?;
     let bind_group_desc = hal::BindGroupDescriptor {
-        label: None,
+        label: bind_group_label,
         layout: bind_group_layout,
         entries: &[hal::BindGroupEntry {
             binding: 0,
@@ -753,7 +818,8 @@ impl DrawResources {
         let indirect_draw_validation = &self.device.indirect_validation.as_ref().unwrap().draw;
         let ensure_entry = |index: usize| {
             if self.dst_entries.len() <= index {
-                let entry = indirect_draw_validation.acquire_dst_entry(self.device.raw())?;
+                let entry = indirect_draw_validation
+                    .acquire_dst_entry(self.device.raw(), self.device.instance_flags)?;
                 self.dst_entries.push(entry);
             }
             Ok(())
@@ -770,7 +836,8 @@ impl DrawResources {
         let indirect_draw_validation = &self.device.indirect_validation.as_ref().unwrap().draw;
         let ensure_entry = |index: usize| {
             if self.metadata_entries.len() <= index {
-                let entry = indirect_draw_validation.acquire_metadata_entry(self.device.raw())?;
+                let entry = indirect_draw_validation
+                    .acquire_metadata_entry(self.device.raw(), self.device.instance_flags)?;
                 self.metadata_entries.push(entry);
             }
             Ok(())

--- a/wgpu-core/src/indirect_validation/mod.rs
+++ b/wgpu-core/src/indirect_validation/mod.rs
@@ -33,16 +33,17 @@ impl IndirectValidation {
         device: &dyn hal::DynDevice,
         required_limits: &wgt::Limits,
         required_features: &wgt::Features,
+        instance_flags: wgt::InstanceFlags,
         backend: wgt::Backend,
     ) -> Result<Self, DeviceError> {
-        let dispatch = match Dispatch::new(device, required_limits) {
+        let dispatch = match Dispatch::new(device, instance_flags, required_limits) {
             Ok(dispatch) => dispatch,
             Err(e) => {
                 log::error!("indirect-validation error: {e:?}");
                 return Err(DeviceError::Lost);
             }
         };
-        let draw = match Draw::new(device, required_features, backend) {
+        let draw = match Draw::new(device, required_features, instance_flags, backend) {
             Ok(draw) => draw,
             Err(e) => {
                 log::error!("indirect-draw-validation error: {e:?}");
@@ -79,12 +80,14 @@ impl BindGroups {
             &device.limits,
             buffer_size,
             buffer,
+            device.instance_flags,
         )?;
         let draw = indirect_validation.draw.create_src_bind_group(
             device.raw(),
             &device.adapter.limits(),
             buffer_size,
             buffer,
+            device.instance_flags,
         )?;
 
         match (dispatch, draw) {

--- a/wgpu-core/src/timestamp_normalization/mod.rs
+++ b/wgpu-core/src/timestamp_normalization/mod.rs
@@ -113,7 +113,7 @@ impl TimestampNormalizer {
                 .raw()
                 .create_bind_group_layout(&hal::BindGroupLayoutDescriptor {
                     label: hal_label(
-                        Some("Timestamp Normalization Bind Group Layout"),
+                        Some("(wgpu internal) Timestamp Normalization Bind Group Layout"),
                         device.instance_flags,
                     ),
                     flags: hal::BindGroupLayoutFlags::empty(),
@@ -169,7 +169,10 @@ impl TimestampNormalizer {
                 debug_source: None,
             });
             let hal_desc = hal::ShaderModuleDescriptor {
-                label: None,
+                label: hal_label(
+                    Some("(wgpu internal) Timestamp normalizer shader module"),
+                    device.instance_flags,
+                ),
                 runtime_checks: wgt::ShaderRuntimeChecks::unchecked(),
             };
             let module = device
@@ -188,7 +191,10 @@ impl TimestampNormalizer {
             let pipeline_layout = device
                 .raw()
                 .create_pipeline_layout(&hal::PipelineLayoutDescriptor {
-                    label: None,
+                    label: hal_label(
+                        Some("(wgpu internal) Timestamp normalizer pipeline layout"),
+                        device.instance_flags,
+                    ),
                     bind_group_layouts: &[temporary_bind_group_layout.as_ref()],
                     immediate_size: 8,
                     flags: hal::PipelineLayoutFlags::empty(),
@@ -204,7 +210,10 @@ impl TimestampNormalizer {
             constants.insert(String::from("TIMESTAMP_PERIOD_SHIFT"), shift as f64);
 
             let pipeline_desc = hal::ComputePipelineDescriptor {
-                label: None,
+                label: hal_label(
+                    Some("(wgpu internal) Timestamp normalizer pipeline"),
+                    device.instance_flags,
+                ),
                 layout: pipeline_layout.as_ref(),
                 stage: hal::ProgrammableStage {
                     module: module.as_ref(),
@@ -332,7 +341,7 @@ impl TimestampNormalizer {
             encoder.transition_buffers(barrier.as_slice());
             encoder.begin_compute_pass(&hal::ComputePassDescriptor {
                 label: hal_label(
-                    Some("Timestamp normalization pass"),
+                    Some("(wgpu internal) Timestamp normalization pass"),
                     buffer.device.instance_flags,
                 ),
                 timestamp_writes: None,


### PR DESCRIPTION
**Connections**
None

**Description**
Some of the internally used HAL code did not use labels. Validation pipelines will show up in graphics debuggers without any labels and confuse users. I've added labels to all GPU objects within validation code, and the timestamp normalization code (I've also added the `(wgpu internal)` prefix to some of the timestamp normalization labels which were there but did not use the prefix, which could've been confusing too)

**Testing**
Verified that the labels are showing up correctly in the `xcode` debugger
<img width="778" height="78" alt="image" src="https://github.com/user-attachments/assets/13c6688f-517f-4e22-bedc-66a93be0b682" />


**Checklist**

- [X] Run `cargo fmt`.
- [x] Run `taplo format` (no TOML changes)
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
