### PR TITLE
Move `Features::PRIMITIVE_INDEX` into the WebGPU group 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 - Added `Dx12Compiler::Auto` to automatically use static or dynamic DXC if available, before falling back to FXC. By @inner-daemons in [#8882](https://github.com/gfx-rs/wgpu/pull/8882).
 - Added support for `insert_debug_marker`, `push_debug_group` and `pop_debug_group` on WebGPU. By @evilpie in [#9017](https://github.com/gfx-rs/wgpu/pull/9017).
 - Added support for `@builtin(draw_index)` to the vulkan backend. By @inner-daemons in #8883.
-- Added support for `enable primitive_index` and `@builtin(primitive_index)` with support on all platforms. By @inner-daemons in #8879.
+- BREAKING: WGSL shaders using `@builtin(primitive_index)` must now request it with `enable primitive_index;`. The `SHADER_PRIMITIVE_INDEX` feature has been renamed to `PRIMITIVE_INDEX` and moved from `FeaturesWGPU` to `FeaturesWebGPU`. By @inner-daemons in #8879 and @andyleiserson in [#9101](https://github.com/gfx-rs/wgpu/pull/9101).
 - Added `TextureFormat::channels` method to get some information about which color channels are covered by the texture format. By @TornaxO7 in [#9167](https://github.com/gfx-rs/wgpu/pull/9167)
 - BREAKING: Add `V6_8` variant to `DxcShaderModel` and `naga::back::hlsl::ShaderModel`. By @inner-daemons in [#8882](https://github.com/gfx-rs/wgpu/pull/8882) and @ErichDonGubler in [#9083](https://github.com/gfx-rs/wgpu/pull/9083).
 - BREAKING: Add `V6_9` variant to `DxcShaderModel` and `naga::back::hlsl::ShaderModel`. By @ErichDonGubler in [#????](https://github.com/gfx-rs/wgpu/pull/????).

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -333,6 +333,15 @@ webgpu:shader,execution,flow_control,return:*
 // Many other vertex_buffer_access subtests also passing, but there are too many to enumerate.
 // Fails on Metal in CI only, not when running locally.
 fails-if(metal) webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true
+webgpu:shader,execution,shader_io,fragment_builtins:inputs,front_facing:*
+webgpu:shader,execution,shader_io,fragment_builtins:inputs,interStage,centroid:*
+fails-if(vulkan) webgpu:shader,execution,shader_io,fragment_builtins:inputs,interStage:*
+fails-if(dx12,vulkan) webgpu:shader,execution,shader_io,fragment_builtins:inputs,position:*
+webgpu:shader,execution,shader_io,fragment_builtins:inputs,sample_index:*
+fails-if(dx12,vulkan) webgpu:shader,execution,shader_io,fragment_builtins:inputs,sample_mask:*
+webgpu:shader,execution,shader_io,fragment_builtins:primitive_index,*
+webgpu:shader,execution,shader_io,fragment_builtins:subgroup_invocation_id:*
+webgpu:shader,execution,shader_io,fragment_builtins:subgroup_size:*
 webgpu:shader,execution,statement,compound:*
 
 webgpu:shader,validation,const_assert,const_assert:*

--- a/cts_runner/tests/integration.rs
+++ b/cts_runner/tests/integration.rs
@@ -31,38 +31,73 @@ fn exec_cts_runner(script_file: impl AsRef<OsStr>) -> Output {
         .unwrap()
 }
 
-fn exec_js_file(script_file: impl AsRef<OsStr>) {
+// The idea here is that if the test outputs something on stderr, we want to
+// print it verbatim, not as a quoted string with escape sequences.
+struct Error(String);
+
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+fn exec_js_file(script_file: impl AsRef<OsStr>) -> Result<(), Error> {
     let output = exec_cts_runner(script_file);
     println!("{}", str::from_utf8(&output.stdout).unwrap());
     eprintln!("{}", str::from_utf8(&output.stderr).unwrap());
-    assert!(output.status.success());
+    if !output.status.success() {
+        return Err(Error(format!(
+            "process exited unsuccessfully: {}",
+            output.status
+        )));
+    }
+    Ok(())
 }
 
-fn check_js_stderr(script: &str, expected: &str) {
+fn check_js_stderr(script: &str, expected: &str) -> Result<(), Error> {
     let mut tempfile = NamedTempFile::new().unwrap();
     tempfile.write_all(script.as_bytes()).unwrap();
     tempfile.flush().unwrap();
     let output = exec_cts_runner(tempfile.path());
-    assert!(
-        output.stdout.is_empty(),
-        "unexpected output on stdout: {}",
-        str::from_utf8(&output.stdout).unwrap(),
-    );
-    assert_eq!(str::from_utf8(&output.stderr).unwrap(), expected);
-    assert!(output.status.success());
+    if !output.stdout.is_empty() {
+        return Err(Error(format!(
+            "unexpected output on stdout: {}",
+            str::from_utf8(&output.stdout).unwrap(),
+        )));
+    }
+    let stderr_str = str::from_utf8(&output.stderr).unwrap();
+    if expected.is_empty() && !stderr_str.is_empty() {
+        return Err(Error(format!(
+            "unexpected output on stderr: {}",
+            stderr_str,
+        )));
+    } else if stderr_str != expected {
+        return Err(Error(format!(
+            "expected the following output on stderr:\n{}\n\nbut observed:\n{}",
+            expected, stderr_str,
+        )));
+    }
+    if !output.status.success() {
+        return Err(Error(format!(
+            "process exited unsuccessfully: {}",
+            output.status
+        )));
+    }
+    Ok(())
 }
 
-fn exec_js(script: &str) {
-    check_js_stderr(script, "");
+fn exec_js(script: &str) -> Result<(), Error> {
+    check_js_stderr(script, "")
 }
 
 #[test]
-fn hello_compute_example() {
-    exec_js_file("examples/hello-compute.js");
+fn hello_compute_example() -> Result<(), Error> {
+    exec_js_file("examples/hello-compute.js")
 }
 
 #[test]
-fn features() {
+fn features() -> Result<(), Error> {
+    // Check that we don't expose native-only features.
     exec_js(
         r#"
         const adapter = await navigator.gpu.requestAdapter();
@@ -71,11 +106,31 @@ fn features() {
             throw new TypeError("Adapter should not report support for wgpu native-only features");
         }
     "#,
-    );
+    )?;
+
+    // Check for features tested by the CTS. Because these are optional
+    // features, the applicable CTS tests will pass (silently, without
+    // exercising the functionality) when support is not reported. This test
+    // serves to bridge the gap between the coverage provided by the CTS
+    // ("feature must work if available") and our desired coverage ("feature
+    // must be implemented and work"), in case we inadvertently stop reporting
+    // support for a feature. (There ought to also be relevant wgpu tests of the
+    // feature that would catch this, but better to be safe.)
+    exec_js(
+        r#"
+        const adapter = await navigator.gpu.requestAdapter();
+
+        if (!adapter.features.has("primitive-index")) {
+            throw new TypeError("Adapter should report support for primitive-index feature");
+        }
+    "#,
+    )?;
+
+    Ok(())
 }
 
 #[test]
-fn uncaptured_error() {
+fn uncaptured_error() -> Result<(), Error> {
     check_js_stderr(
         r#"
             const code = `const val: u32 = 1.1;`;
@@ -90,7 +145,7 @@ Shader '' parsing error: the type of `val` is expected to be `u32`, but got `{Ab
   │
 1 │ const val: u32 = 1.1;
   │       ^^^ definition of `val`\n\n\n",
-    );
+    )
 }
 
 #[test]

--- a/deno_webgpu/webidl.rs
+++ b/deno_webgpu/webidl.rs
@@ -400,6 +400,8 @@ pub enum GPUFeatureName {
   DualSourceBlending,
   #[webidl(rename = "subgroups")]
   Subgroups,
+  #[webidl(rename = "primitive-index")]
+  PrimitiveIndex,
 
   // standard feature, but not default yet in wgpu due to incomplete support
   // (and even if enabled in wgpu, doing so may not be appropriate in Deno)
@@ -461,8 +463,6 @@ pub enum GPUFeatureName {
   ShaderF64,
   #[webidl(rename = "shader-i16")]
   ShaderI16,
-  #[webidl(rename = "shader-primitive-index")]
-  ShaderPrimitiveIndex,
   #[webidl(rename = "shader-early-depth-test")]
   ShaderEarlyDepthTest,
   #[webidl(rename = "passthrough-shaders")]
@@ -521,7 +521,7 @@ pub fn feature_names_to_features(
       GPUFeatureName::VertexAttribute64Bit => Features::VERTEX_ATTRIBUTE_64BIT,
       GPUFeatureName::ShaderF64 => Features::SHADER_F64,
       GPUFeatureName::ShaderI16 => Features::SHADER_I16,
-      GPUFeatureName::ShaderPrimitiveIndex => Features::SHADER_PRIMITIVE_INDEX,
+      GPUFeatureName::PrimitiveIndex => Features::PRIMITIVE_INDEX,
       GPUFeatureName::ShaderEarlyDepthTest => Features::SHADER_EARLY_DEPTH_TEST,
       GPUFeatureName::PassthroughShaders => Features::PASSTHROUGH_SHADERS,
     };
@@ -680,8 +680,8 @@ pub fn features_to_feature_names(
   if features.contains(wgpu_types::Features::SHADER_I16) {
     return_features.insert(ShaderI16);
   }
-  if features.contains(wgpu_types::Features::SHADER_PRIMITIVE_INDEX) {
-    return_features.insert(ShaderPrimitiveIndex);
+  if features.contains(wgpu_types::Features::PRIMITIVE_INDEX) {
+    return_features.insert(PrimitiveIndex);
   }
   if features.contains(wgpu_types::Features::SHADER_EARLY_DEPTH_TEST) {
     return_features.insert(ShaderEarlyDepthTest);

--- a/tests/tests/wgpu-gpu/primitive_index.rs
+++ b/tests/tests/wgpu-gpu/primitive_index.rs
@@ -60,7 +60,7 @@ fn fragment(@builtin(primitive_index) index: u32) -> @location(0) vec4<f32> {
 
 #[gpu_test]
 static PRIMITIVE_INDEX: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(Features::SHADER_PRIMITIVE_INDEX))
+    .parameters(TestParameters::default().features(Features::PRIMITIVE_INDEX))
     .run_async(primitive_index);
 
 async fn mesh_primitive_index(
@@ -148,7 +148,7 @@ fn fragment(FRAGMENT_PRIMITIVE_INDEX) -> @location(0) vec4<f32> {
 fn mesh_params() -> TestParameters {
     // TODO: when naga support for MSL/HLSL mesh shaders lands enable Metal and DX12
     TestParameters::default()
-        .features(Features::SHADER_PRIMITIVE_INDEX | Features::EXPERIMENTAL_MESH_SHADER)
+        .features(Features::PRIMITIVE_INDEX | Features::EXPERIMENTAL_MESH_SHADER)
         .limits(Limits::defaults().using_recommended_minimum_mesh_shader_values())
         .skip(FailureCase::backend(
             wgpu::Backends::METAL | wgpu::Backends::DX12,

--- a/tests/tests/wgpu-gpu/shader_primitive_index/mod.rs
+++ b/tests/tests/wgpu-gpu/shader_primitive_index/mod.rs
@@ -45,7 +45,7 @@ static DRAW: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::SHADER_PRIMITIVE_INDEX),
+            .features(wgpu::Features::PRIMITIVE_INDEX),
     )
     .run_async(|ctx| async move {
         //
@@ -69,7 +69,7 @@ static DRAW_INDEXED: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::SHADER_PRIMITIVE_INDEX),
+            .features(wgpu::Features::PRIMITIVE_INDEX),
     )
     .run_async(|ctx| async move {
         //

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -470,7 +470,7 @@ impl super::Adapter {
             | wgt::Features::CLEAR_TEXTURE
             | wgt::Features::TEXTURE_FORMAT_16BIT_NORM
             | wgt::Features::IMMEDIATES
-            | wgt::Features::SHADER_PRIMITIVE_INDEX
+            | wgt::Features::PRIMITIVE_INDEX
             | wgt::Features::RG11B10UFLOAT_RENDERABLE
             | wgt::Features::DUAL_SOURCE_BLENDING
             | wgt::Features::TEXTURE_FORMAT_NV12

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -480,7 +480,7 @@ impl super::Adapter {
             full_ver.is_some() || extensions.contains("GL_EXT_clip_cull_distance"),
         );
         features.set(
-            wgt::Features::SHADER_PRIMITIVE_INDEX,
+            wgt::Features::PRIMITIVE_INDEX,
             supported((3, 2), (3, 2))
                 || extensions.contains("OES_geometry_shader")
                 || extensions.contains("GL_ARB_geometry_shader4"),

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1088,10 +1088,7 @@ impl super::CapabilitiesQuery {
         features.set(F::TEXTURE_COMPRESSION_ETC2, self.format_eac_etc);
 
         features.set(F::DEPTH_CLIP_CONTROL, self.supports_depth_clip_control);
-        features.set(
-            F::SHADER_PRIMITIVE_INDEX,
-            self.supports_shader_primitive_index,
-        );
+        features.set(F::PRIMITIVE_INDEX, self.supports_shader_primitive_index);
 
         features.set(
             F::TEXTURE_BINDING_ARRAY

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -355,7 +355,7 @@ impl PhysicalDeviceFeatures {
                 .shader_int64(requested_features.contains(wgt::Features::SHADER_INT64))
                 .shader_int16(requested_features.contains(wgt::Features::SHADER_I16))
                 //.shader_resource_residency(requested_features.contains(wgt::Features::SHADER_RESOURCE_RESIDENCY))
-                .geometry_shader(requested_features.contains(wgt::Features::SHADER_PRIMITIVE_INDEX))
+                .geometry_shader(requested_features.contains(wgt::Features::PRIMITIVE_INDEX))
                 .depth_clamp(requested_features.contains(wgt::Features::DEPTH_CLIP_CONTROL))
                 .dual_src_blend(requested_features.contains(wgt::Features::DUAL_SOURCE_BLENDING)),
             descriptor_indexing: if requested_features.intersects(INDEXING_FEATURES) {
@@ -738,7 +738,7 @@ impl PhysicalDeviceFeatures {
         features.set(F::SHADER_INT64, self.core.shader_int64 != 0);
         features.set(F::SHADER_I16, self.core.shader_int16 != 0);
 
-        features.set(F::SHADER_PRIMITIVE_INDEX, self.core.geometry_shader != 0);
+        features.set(F::PRIMITIVE_INDEX, self.core.geometry_shader != 0);
 
         if let Some(ref shader_atomic_int64) = self.shader_atomic_int64 {
             features.set(
@@ -2527,7 +2527,7 @@ impl super::Adapter {
                 capabilities.push(spv::Capability::MultiView);
             }
 
-            if features.contains(wgt::Features::SHADER_PRIMITIVE_INDEX) {
+            if features.contains(wgt::Features::PRIMITIVE_INDEX) {
                 capabilities.push(spv::Capability::Geometry);
             }
 

--- a/wgpu-naga-bridge/src/lib.rs
+++ b/wgpu-naga-bridge/src/lib.rs
@@ -26,7 +26,7 @@ pub fn features_to_naga_capabilities(
     );
     caps.set(
         Caps::PRIMITIVE_INDEX,
-        features.contains(wgt::Features::SHADER_PRIMITIVE_INDEX),
+        features.contains(wgt::Features::PRIMITIVE_INDEX),
     );
     caps.set(
         Caps::TEXTURE_AND_SAMPLER_BINDING_ARRAY,

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -68,6 +68,9 @@ mod webgpu_impl {
 
     #[doc(hidden)]
     pub const WEBGPU_FEATURE_IMMEDIATES: u64 = 1 << 16;
+
+    #[doc(hidden)]
+    pub const WEBGPU_FEATURE_PRIMITIVE_INDEX: u64 = 1 << 17;
 }
 
 macro_rules! bitflags_array_impl {
@@ -988,20 +991,9 @@ bitflags_array! {
         ///
         /// This is a native only feature.
         const SHADER_I16 = 1 << 34;
-        /// Enables `builtin(primitive_index)` in fragment shaders.
-        ///
-        /// Note: enables geometry processing for pipelines using the builtin.
-        /// This may come with a significant performance impact on some hardware.
-        /// Other pipelines are not affected.
-        ///
-        /// Supported platforms:
-        /// - Vulkan
-        /// - DX12
-        /// - Metal (some)
-        /// - OpenGL (some)
-        ///
-        /// This is a native only feature.
-        const SHADER_PRIMITIVE_INDEX = 1 << 35;
+
+        // Bit 35 (formerly SHADER_PRIMITIVE_INDEX) is available.
+
         /// Allows shaders to use the `early_depth_test` attribute.
         ///
         /// The attribute is applied to the fragment shader entry point. It can be used in two
@@ -1339,6 +1331,8 @@ bitflags_array! {
         ///
         /// This is a native only feature.
         const MEMORY_DECORATION_VOLATILE = 1 << 62;
+
+        // Adding a new feature? Bit 35 (formerly SHADER_PRIMITIVE_INDEX) is available.
     }
 
     /// Features that are not guaranteed to be supported.
@@ -1644,6 +1638,21 @@ bitflags_array! {
         #[doc = link_to_wgpu_docs!(["`RenderPass::set_immediates`"]: "struct.RenderPass.html#method.set_immediates")]
         /// [`Limits::max_immediate_size`]: super::Limits
         const IMMEDIATES = WEBGPU_FEATURE_IMMEDIATES;
+
+        /// Enables `builtin(primitive_index)` in fragment shaders.
+        ///
+        /// Note: enables geometry processing for pipelines using the builtin.
+        /// This may come with a significant performance impact on some hardware.
+        /// Other pipelines are not affected.
+        ///
+        /// Supported platforms:
+        /// - Vulkan (with geometryShader)
+        /// - DX12
+        /// - Metal (some)
+        /// - OpenGL (some)
+        ///
+        /// This is a web and native feature.
+        const PRIMITIVE_INDEX = WEBGPU_FEATURE_PRIMITIVE_INDEX;
     }
 }
 


### PR DESCRIPTION
Will conflict with #9119 and #9163.

Renames `Features::SHADER_PRIMITIVE_INDEX` to `Features::PRIMITIVE_INDEX` (for consistency with the spec, which uses `shader_f16` but not `shader_primitive_index`), and moves it to the WebGPU feature set.

Putting it in the WebGPU feature set results in it being exposed by Deno and available in CTS runs, so, enable the CTS tests for `primitive_index`. I've also added a `cts_runner` integration test that checks the feature is exposed, because the CTS silently skips the relevant tests if it is not.

I've also reworded the changelog entry related to `enable primitive_index`, but the actual functional change was in #8879. 

CC @inner-daemons 

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
