### PR TITLE
feat(webgpu): map `FLOAT32_BLENDABLE` feature name to `GPUFeatureName::Float32Blendable`

### DIFF
--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -711,7 +711,7 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
     }
 }
 
-const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 15] = [
+const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 16] = [
     (
         wgt::Features::DEPTH_CLIP_CONTROL,
         webgpu_sys::GpuFeatureName::DepthClipControl,
@@ -763,6 +763,10 @@ const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 15] = [
     (
         wgt::Features::FLOAT32_FILTERABLE,
         webgpu_sys::GpuFeatureName::Float32Filterable,
+    ),
+    (
+        wgt::Features::FLOAT32_BLENDABLE,
+        webgpu_sys::GpuFeatureName::Float32Blendable,
     ),
     (
         wgt::Features::DUAL_SOURCE_BLENDING,


### PR DESCRIPTION
Resolves #9102.