### PR TITLE
Document OpenGL support for timestamp queries

### DIFF
--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -647,12 +647,13 @@ bitflags_array! {
         /// Implies [`Features::TIMESTAMP_QUERY`] is supported.
         ///
         /// Additionally allows for timestamp writes on command encoders
-        /// using  [`CommandEncoder::write_timestamp`].
+        /// using [`CommandEncoder::write_timestamp`].
         ///
         /// Supported platforms:
         /// - Vulkan
         /// - DX12
         /// - Metal
+        /// - OpenGL (with GL_ARB_timer_query)
         ///
         /// This is a native only feature.
         ///
@@ -670,6 +671,7 @@ bitflags_array! {
         /// - Vulkan
         /// - DX12
         /// - Metal (AMD & Intel, not Apple GPUs)
+        /// - OpenGL (with GL_ARB_timer_query)
         ///
         /// This is generally not available on tile-based rasterization GPUs.
         ///
@@ -1459,6 +1461,7 @@ bitflags_array! {
         /// - Vulkan
         /// - DX12
         /// - Metal
+        /// - OpenGL (with GL_ARB_timer_query)
         /// - WebGPU
         ///
         /// This is a web and native feature.


### PR DESCRIPTION
**Description**

I saw that opengl wasn't mentioned, but checked and saw that the [backend does support these features](https://github.com/gfx-rs/wgpu/blob/3dfa9af0db208d8435ed132c66d73f28bda970d9/wgpu-hal/src/gles/adapter.rs#L493C33-L493C51) when `GL_ARB_timer_query` is enabled. This updates the documentation to make this easier to discover.

**Testing**
N/A

**Squash or Rebase?**

N/A (single commit for now)

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
