### PR TITLE
Tweak some limit reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
         - Split the `OutOfBoundsOverrun` variant into new `OutOfBoundsStartOffsetOverrun` and `OutOfBoundsEndOffsetOverrun` variants. 
         - Removed the `NegativeRange` variant in favor of new `MapStartOffsetUnderrun` and `MapStartOffsetOverrun` variants.
     - Split the `TransferError::BufferOverrun` variant into new `BufferStartOffsetOverrun` and `BufferEndOffsetOverrun` variants.
-- The various "max resources per stage" limits are now capped at 999 (one less than `wgt::Limits::default().max_bindings_per_bind_group`). By @andyleiserson in [#9118](https://github.com/gfx-rs/wgpu/pull/9118).
+- The various "max resources per stage" limits are now capped at 100, so that their total remains below `max_bindings_per_bind_group`, as required by WebGPU. By @andyleiserson in [#9118](https://github.com/gfx-rs/wgpu/pull/9118).
 
 #### Metal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
         - Split the `OutOfBoundsOverrun` variant into new `OutOfBoundsStartOffsetOverrun` and `OutOfBoundsEndOffsetOverrun` variants. 
         - Removed the `NegativeRange` variant in favor of new `MapStartOffsetUnderrun` and `MapStartOffsetOverrun` variants.
     - Split the `TransferError::BufferOverrun` variant into new `BufferStartOffsetOverrun` and `BufferEndOffsetOverrun` variants.
+- The various "max resources per stage" limits are now capped at 999 (one less than `wgt::Limits::default().max_bindings_per_bind_group`). By @andyleiserson in [#9118](https://github.com/gfx-rs/wgpu/pull/9118).
 
 #### Metal
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -21,13 +21,10 @@ webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:* // 0%
 webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,createBindGroup:external_texture,* // 0%, no external external texture in deno
 webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https://github.com/gfx-rs/wgpu/issues/7881
-webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:* // fails on vulkan
-webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_bind_group_layout:* // https://github.com/gfx-rs/wgpu/issues/8748
 webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:* // metal, https://github.com/gfx-rs/wgpu/issues/8173
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_buffer_type:* // 25%, writable storage buffers not allowed in VERTEX
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_storage_texture_access:* // 25%, write-access storage textures not allowed in VERTEX
 webgpu:api,validation,createBindGroupLayout:visibility:* // 25%, missing per-stage storage limits
-webgpu:api,validation,createPipelineLayout:number_of_dynamic_buffers_exceeds_the_maximum_value:* // limits issue
 webgpu:api,validation,createView:texture_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:* // ***, https://github.com/gfx-rs/wgpu/issues/8118
 webgpu:api,validation,encoding,cmds,debug:* // 92%, https://github.com/gfx-rs/wgpu/issues/8039

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -94,24 +94,14 @@ webgpu:api,validation,createBindGroup:texture_binding_must_have_correct_usage:*
 webgpu:api,validation,createBindGroup:texture_must_have_correct_component_type:*
 webgpu:api,validation,createBindGroup:texture_must_have_correct_dimension:*
 webgpu:api,validation,createBindGroupLayout:duplicate_bindings:*
-fails-if(vulkan) webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:*
-fails-if(vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"sampler":{"type":"comparison"}}
-fails-if(vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"sampler":{"type":"filtering"}}
-fails-if(vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"sampler":{"type":"non-filtering"}}
-fails-if(dx12,vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"storageTexture":{"access":"read-only","format":"r32float"}}
-fails-if(dx12,vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"storageTexture":{"access":"read-write","format":"r32float"}}
-fails-if(dx12,vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"storageTexture":{"access":"write-only","format":"r32float"}}
-fails-if(dx12,vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"texture":{"multisampled":false,"sampleType":"unfilterable-float"}}
-fails-if(dx12,vulkan) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:maxedEntry={"texture":{"multisampled":true,"sampleType":"unfilterable-float"}}
+webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:*
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_bind_group_layout:*
+fails-if(metal) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:*
 webgpu:api,validation,createBindGroupLayout:maximum_binding_limit:*
 webgpu:api,validation,createBindGroupLayout:multisampled_validation:*
 webgpu:api,validation,createBindGroupLayout:storage_texture,formats:*
 webgpu:api,validation,createBindGroupLayout:storage_texture,layout_dimension:*
-webgpu:api,validation,createPipelineLayout:bind_group_layouts,create_pipeline_with_null_bind_group_layouts:*
-webgpu:api,validation,createPipelineLayout:bind_group_layouts,device_mismatch:*
-webgpu:api,validation,createPipelineLayout:bind_group_layouts,null_bind_group_layouts:*
-webgpu:api,validation,createPipelineLayout:bind_group_layouts,set_pipeline_with_null_bind_group_layouts:*
-webgpu:api,validation,createPipelineLayout:number_of_bind_group_layouts_exceeds_the_maximum_value:*
+webgpu:api,validation,createPipelineLayout:*
 webgpu:api,validation,createSampler:*
 webgpu:api,validation,createTexture:*
 webgpu:api,validation,createView:array_layers:*

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -337,7 +337,35 @@ impl GPUSupportedLimits {
   }
 
   #[getter]
+  fn maxStorageBuffersInVertexStage(&self) -> u32 {
+    // TODO(https://github.com/gfx-rs/wgpu/issues/8748): InVertexStage limit
+    // not implemented; return the PerShaderStage limit.
+    self.0.max_storage_buffers_per_shader_stage
+  }
+
+  #[getter]
+  fn maxStorageBuffersInFragmentStage(&self) -> u32 {
+    // TODO(https://github.com/gfx-rs/wgpu/issues/8748): InFragmentStage limit
+    // not implemented; return the PerShaderStage limit.
+    self.0.max_storage_buffers_per_shader_stage
+  }
+
+  #[getter]
   fn maxStorageTexturesPerShaderStage(&self) -> u32 {
+    self.0.max_storage_textures_per_shader_stage
+  }
+
+  #[getter]
+  fn maxStorageTexturesInVertexStage(&self) -> u32 {
+    // TODO(https://github.com/gfx-rs/wgpu/issues/8748): InVertexStage limit
+    // not implemented; return the PerShaderStage limit.
+    self.0.max_storage_textures_per_shader_stage
+  }
+
+  #[getter]
+  fn maxStorageTexturesInFragmentStage(&self) -> u32 {
+    // TODO(https://github.com/gfx-rs/wgpu/issues/8748): InFragmentStage limit
+    // not implemented; return the PerShaderStage limit.
     self.0.max_storage_textures_per_shader_stage
   }
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -78,7 +78,6 @@ metal = [
     "dep:bytemuck",
     "dep:hashbrown",
     "dep:libc",
-    "dep:log",
     "dep:objc2",
     "dep:objc2-core-foundation",
     "dep:objc2-foundation",
@@ -99,7 +98,6 @@ vulkan = [
     "dep:hashbrown",
     "dep:libc",
     "dep:libloading",
-    "dep:log",
     "dep:ordered-float",
     "dep:parking_lot",
     "dep:profiling",
@@ -120,7 +118,6 @@ gles = [
     "dep:khronos-egl",
     "dep:wayland-sys",
     "dep:libloading",
-    "dep:log",
     "dep:ndk-sys",
     "dep:objc2",
     "dep:parking_lot",
@@ -141,7 +138,6 @@ dx12 = [
     "dep:bytemuck",
     "dep:hashbrown",
     "dep:libloading",
-    "dep:log",
     "dep:ordered-float",
     "dep:once_cell",
     "dep:parking_lot",
@@ -170,7 +166,7 @@ dx12 = [
 ###########################
 
 static-dxc = ["dep:mach-dxcompiler-rs"]
-renderdoc = ["dep:libloading", "dep:renderdoc-sys", "dep:log"]
+renderdoc = ["dep:libloading", "dep:renderdoc-sys"]
 fragile-send-sync-non-atomic-wasm = [
     "wgpu-types/fragile-send-sync-non-atomic-wasm",
 ]
@@ -209,15 +205,15 @@ wgpu-types = { workspace = true, default-features = false }
 # Dependencies in the lib and empty backend
 bitflags.workspace = true
 cfg-if.workspace = true
-raw-window-handle.workspace = true
+log = { workspace = true }
 parking_lot = { workspace = true, optional = true }
+raw-window-handle.workspace = true
 thiserror.workspace = true
 
 # Target agnostic dependencies used only in backends.
 arrayvec = { workspace = true, optional = true }
 bytemuck = { workspace = true, optional = true, features = ["derive"] }
 hashbrown = { workspace = true, optional = true }
-log = { workspace = true, optional = true }
 ordered-float = { workspace = true, optional = true }
 profiling = { workspace = true, optional = true, default-features = false }
 
@@ -345,7 +341,6 @@ cfg_aliases.workspace = true
 [dev-dependencies]
 env_logger.workspace = true
 glam.workspace = true                                            # for ray-traced-triangle example
-log.workspace = true
 naga = { workspace = true, features = ["wgsl-in", "termcolor"] }
 winit.workspace = true                                           # for "halmark" example
 

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -183,7 +183,7 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
     {
         // This is the "adjusted limits that are in a range where an application might reach
         // them" case. (In reality, even something quite a bit less than the default
-        // `max_bindings_per_bind_group` of 1000 ought to be sufficent.)
+        // `max_bindings_per_bind_group` of 1000 ought to be sufficient.)
         log::warn!(
             "Unexpected adjustment of per-stage resource limits to fit within max_bindings_per_bind_group."
         );

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -1,5 +1,3 @@
-use core::cmp::min;
-
 #[cfg(dx12)]
 pub(super) mod dxgi;
 
@@ -154,13 +152,25 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
         .min(crate::MAX_COLOR_ATTACHMENTS as u32);
 
     // Vulkan and DX12 sometimes report large values for the "max resources per stage"
-    // limits. We clamp them at one less than `max_bindings_per_bind_group` (i.e., 999), for
-    // some CTS tests that ignore `max_bindings_per_bind_group` when calculating how to test
-    // the per-stage limits. Note that because we are clamping to the large, fixed default
-    // limit, this won't result in adjusting the per-stage limits when they are actually in
-    // the range that an application might reach them.
-    let max_bindings = wgt::Limits::default().max_bindings_per_bind_group - 1;
-    let clamp = |limit: &mut u32| *limit = min(*limit, max_bindings);
+    // limits. WebGPU requires that consuming the maximum number of resources of every type
+    // in every stage cannot exceed `max_bindings_per_bind_group`. To ensure this, we clamp
+    // per-stage limit at an equal division of `max_bindings_per_bind_group`.
+    //
+    // It is not expected that this clamping adjusts limits that are in a range where an
+    // application might reach them. (The main dilemma here being how WebGPU will eventually
+    // apply these or other limits to bindless. wgpu has separate `binding_array` limits for
+    // its native-only extension; those are not touched here.)
+    //
+    // See <https://gpuweb.github.io/gpuweb/#adapter-capability-guarantees>.
+    const BINDING_TYPE_AND_STAGE_COUNT: u32 = 10;
+    let max_bindings = limits.max_bindings_per_bind_group / BINDING_TYPE_AND_STAGE_COUNT;
+    let mut did_clamp = false;
+    let mut clamp = |limit: &mut u32| {
+        if *limit > max_bindings {
+            *limit = max_bindings;
+            did_clamp = true;
+        }
+    };
     clamp(&mut limits.max_dynamic_uniform_buffers_per_pipeline_layout);
     clamp(&mut limits.max_dynamic_storage_buffers_per_pipeline_layout);
     clamp(&mut limits.max_sampled_textures_per_shader_stage);
@@ -168,6 +178,16 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
     clamp(&mut limits.max_storage_buffers_per_shader_stage);
     clamp(&mut limits.max_storage_textures_per_shader_stage);
     clamp(&mut limits.max_uniform_buffers_per_shader_stage);
+    if did_clamp
+        && limits.max_bindings_per_bind_group < wgt::Limits::defaults().max_bindings_per_bind_group
+    {
+        // This is the "adjusted limits that are in a range where an application might reach
+        // them" case. (In reality, even something quite a bit less than the default
+        // `max_bindings_per_bind_group` of 1000 ought to be sufficent.)
+        log::warn!(
+            "Unexpected adjustment of per-stage resource limits to fit within max_bindings_per_bind_group."
+        );
+    }
 
     // Round some limits down to the WebGPU alignment requirement, to avoid
     // suggesting values that won't work. (In particular, the CTS queries limits

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -1,3 +1,5 @@
+use core::cmp::min;
+
 #[cfg(dx12)]
 pub(super) mod dxgi;
 
@@ -150,6 +152,22 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
     limits.max_color_attachments = limits
         .max_color_attachments
         .min(crate::MAX_COLOR_ATTACHMENTS as u32);
+
+    // Vulkan and DX12 sometimes report large values for the "max resources per stage"
+    // limits. We clamp them at one less than `max_bindings_per_bind_group` (i.e., 999), for
+    // some CTS tests that ignore `max_bindings_per_bind_group` when calculating how to test
+    // the per-stage limits. Note that because we are clamping to the large, fixed default
+    // limit, this won't result in adjusting the per-stage limits when they are actually in
+    // the range that an application might reach them.
+    let max_bindings = wgt::Limits::default().max_bindings_per_bind_group - 1;
+    let clamp = |limit: &mut u32| *limit = min(*limit, max_bindings);
+    clamp(&mut limits.max_dynamic_uniform_buffers_per_pipeline_layout);
+    clamp(&mut limits.max_dynamic_storage_buffers_per_pipeline_layout);
+    clamp(&mut limits.max_sampled_textures_per_shader_stage);
+    clamp(&mut limits.max_samplers_per_shader_stage);
+    clamp(&mut limits.max_storage_buffers_per_shader_stage);
+    clamp(&mut limits.max_storage_textures_per_shader_stage);
+    clamp(&mut limits.max_uniform_buffers_per_shader_stage);
 
     // Round some limits down to the WebGPU alignment requirement, to avoid
     // suggesting values that won't work. (In particular, the CTS queries limits


### PR DESCRIPTION
This does two things to keep CTS limit tests happy:

1. Reports the value of the corresponding "max resources per stage" limit for the not-yet-implemented "max resources in fragment/vertex stage" limits. (Implementation of the new limits is tracked in #8748.)
2. Clamps all of the per-stage limits at an equal division of max_bindings_per_bind_group. WebGPU requires that consuming the maximum number of resources of every type in every stage does not exceed `max_bindings_per_bind_group`.

**Testing**
Enables some CTS tests.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
