### PR TITLE
Limit tiering support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Bottom level categories:
 
 ### Added/New Features
 
+#### General
+
+- Added "limit bucketing" functionality which can adjust adapter limits and features to match one of several pre-defined buckets. This is controlled by the new `apply_limit_buckets` member in `RequestAdapterOptions`, which is `false` by default. By @andyleiserson in [#9119](https://github.com/gfx-rs/wgpu/pull/9119).
+
 #### Metal
 
 - Unconditionally enable `Features::CLIP_DISTANCES`. By @ErichDonGubler in [#9270](https://github.com/gfx-rs/wgpu/pull/9270).

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -230,6 +230,7 @@ impl GPU {
         .unwrap_or_default(),
       force_fallback_adapter: options.force_fallback_adapter,
       compatible_surface: None, // windowless
+      apply_limit_buckets: false,
     };
     let id = instance.request_adapter(&descriptor, backends, None).ok()?;
 

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -110,9 +110,9 @@ impl ApplicationHandler<TriangleAction> for App {
             let adapter = instance
                 .request_adapter(&wgpu::RequestAdapterOptions {
                     power_preference: wgpu::PowerPreference::default(),
-                    force_fallback_adapter: false,
                     // Request an adapter which can render to our surface
                     compatible_surface: Some(&surface),
+                    ..Default::default()
                 })
                 .await
                 .expect("Failed to find an appropriate adapter");

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -123,7 +123,7 @@ impl WgpuContext {
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
                 compatible_surface: Some(&surface),
-                force_fallback_adapter: false,
+                ..Default::default()
             })
             .await
             .unwrap();

--- a/player/tests/player/main.rs
+++ b/player/tests/player/main.rs
@@ -185,11 +185,7 @@ impl Corpus {
                 let instance_flags = instance_desc.flags;
                 let instance = wgc::instance::Instance::new("test", instance_desc, None);
                 let adapter = match instance.request_adapter(
-                    &wgt::RequestAdapterOptions {
-                        power_preference: wgt::PowerPreference::None,
-                        force_fallback_adapter: false,
-                        compatible_surface: None,
-                    },
+                    &wgt::RequestAdapterOptions::default(),
                     wgt::Backends::from(backend),
                 ) {
                     Ok(adapter) => Arc::new(adapter),

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -73,6 +73,7 @@ pub fn initialize_instance(backends: wgpu::Backends, params: &TestParameters) ->
             // will chose the noop on wasm32 for some reason.
             noop: wgpu::NoopBackendOptions {
                 enable: !cfg!(target_arch = "wasm32"),
+                ..Default::default()
             },
         }
         .with_env(),

--- a/tests/tests/wgpu-validation/api/experimental.rs
+++ b/tests/tests/wgpu-validation/api/experimental.rs
@@ -2,7 +2,7 @@ fn noop_adapter() -> wgpu::Adapter {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::NOOP,
         backend_options: wgpu::BackendOptions {
-            noop: wgpu::NoopBackendOptions { enable: true },
+            noop: wgpu::NoopBackendOptions::enabled(),
             ..Default::default()
         },
         ..wgpu::InstanceDescriptor::new_without_display_handle()

--- a/tests/tests/wgpu-validation/api/instance.rs
+++ b/tests/tests/wgpu-validation/api/instance.rs
@@ -47,13 +47,9 @@ mod request_adapter_error {
 
     fn adapter_error(desc: wgpu::InstanceDescriptor) -> String {
         let instance = wgpu::Instance::new(desc);
-        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::default(),
-            force_fallback_adapter: false,
-            compatible_surface: None,
-        }))
-        .unwrap_err()
-        .to_string()
+        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))
+            .unwrap_err()
+            .to_string()
     }
 
     #[test]

--- a/tests/tests/wgpu-validation/limit_buckets.rs
+++ b/tests/tests/wgpu-validation/limit_buckets.rs
@@ -1,0 +1,345 @@
+//! Limit bucketing tests
+//!
+//! See [`wgpu_core::limits`].
+
+use wgpu_core as wgc;
+use wgpu_types as wgt;
+
+const UPLEVEL_FEATURES: wgt::Features = {
+    use wgt::Features;
+
+    Features::DEPTH_CLIP_CONTROL
+        .union(Features::DEPTH32FLOAT_STENCIL8)
+        .union(Features::TEXTURE_COMPRESSION_BC)
+        .union(Features::TEXTURE_COMPRESSION_BC_SLICED_3D)
+        .union(Features::TIMESTAMP_QUERY)
+        .union(Features::INDIRECT_FIRST_INSTANCE)
+        .union(Features::RG11B10UFLOAT_RENDERABLE)
+        .union(Features::BGRA8UNORM_STORAGE)
+        .union(Features::FLOAT32_FILTERABLE)
+        .union(Features::DUAL_SOURCE_BLENDING)
+        .union(Features::PRIMITIVE_INDEX)
+        .union(Features::SUBGROUP)
+        .union(Features::IMMEDIATES)
+};
+
+fn create_noop_global(options: wgt::NoopBackendOptions) -> wgc::global::Global {
+    wgc::global::Global::new(
+        "test",
+        wgt::instance::InstanceDescriptor {
+            backends: wgt::Backends::NOOP,
+            backend_options: wgt::BackendOptions {
+                noop: options,
+                ..Default::default()
+            },
+            ..wgt::instance::InstanceDescriptor::new_without_display_handle()
+        },
+        None,
+    )
+}
+
+#[test]
+fn enabled() {
+    let global = create_noop_global(wgt::NoopBackendOptions {
+        enable: true,
+        device_type: Some(wgt::DeviceType::DiscreteGpu),
+        features: Some(wgt::Features::empty()),
+        subgroup_min_size: Some(4),
+        subgroup_max_size: Some(128),
+        ..Default::default() // noop defaults to max limits
+    });
+
+    let adapter_id = global
+        .request_adapter(
+            &wgt::RequestAdapterOptions {
+                apply_limit_buckets: true,
+                ..Default::default()
+            },
+            wgt::Backends::NOOP,
+            None,
+        )
+        .unwrap();
+
+    let limits = global.adapter_limits(adapter_id);
+    let features = global.adapter_features(adapter_id);
+    let info = global.adapter_get_info(adapter_id);
+
+    // Max limits should be replaced with "default"
+    assert_eq!(limits, wgt::Limits::defaults());
+    assert_eq!(features, wgt::Features::empty());
+    assert_eq!(info.subgroup_min_size, 4);
+    assert_eq!(info.subgroup_max_size, 128);
+}
+
+#[test]
+fn exempt_features() {
+    const EXEMPT_FEATURES: wgt::Features = wgt::Features::EXTERNAL_TEXTURE
+        .union(wgt::Features::TEXTURE_FORMAT_NV12)
+        .union(wgt::Features::TEXTURE_FORMAT_P010)
+        .union(wgt::Features::TEXTURE_FORMAT_16BIT_NORM);
+
+    let global = create_noop_global(wgt::NoopBackendOptions {
+        enable: true,
+        device_type: Some(wgt::DeviceType::DiscreteGpu),
+        features: Some(EXEMPT_FEATURES.union(wgt::Features::SUBGROUP)),
+        subgroup_min_size: Some(4),
+        subgroup_max_size: Some(128),
+        ..Default::default() // noop defaults to max limits
+    });
+
+    let adapter_id = global
+        .request_adapter(
+            &wgt::RequestAdapterOptions {
+                apply_limit_buckets: true,
+                ..Default::default()
+            },
+            wgt::Backends::NOOP,
+            None,
+        )
+        .unwrap();
+
+    let limits = global.adapter_limits(adapter_id);
+    let features = global.adapter_features(adapter_id);
+    let info = global.adapter_get_info(adapter_id);
+
+    // Max limits should be replaced with "default" bucket
+    assert_eq!(limits, wgt::Limits::defaults());
+    assert_eq!(features, EXEMPT_FEATURES);
+    assert_eq!(info.subgroup_min_size, 4);
+    assert_eq!(info.subgroup_max_size, 128);
+}
+
+#[test]
+fn limits_below_minimums_returns_no_adapter() {
+    let global = create_noop_global(wgt::NoopBackendOptions {
+        enable: true,
+        limits: Some(wgt::Limits {
+            max_texture_dimension_2d: 1024,
+            ..wgt::Limits::default()
+        }),
+        device_type: Some(wgt::DeviceType::DiscreteGpu),
+        features: Some(wgt::Features::empty()),
+        ..Default::default()
+    });
+
+    let result = global.request_adapter(
+        &wgt::RequestAdapterOptions {
+            apply_limit_buckets: true,
+            ..Default::default()
+        },
+        wgt::Backends::NOOP,
+        None,
+    );
+
+    // Device is below WebGPU minimums, so no bucket matches
+    assert!(result.is_err());
+}
+
+#[test]
+fn device_creation_exceeding_bucket_fails() {
+    let global = create_noop_global(wgt::NoopBackendOptions {
+        enable: true,
+        device_type: Some(wgt::DeviceType::DiscreteGpu),
+        features: Some(wgt::Features::empty()),
+        ..Default::default()
+    });
+
+    let adapter_id = global
+        .request_adapter(
+            &wgt::RequestAdapterOptions {
+                apply_limit_buckets: true,
+                ..Default::default()
+            },
+            wgt::Backends::NOOP,
+            None,
+        )
+        .unwrap();
+
+    // The "default" bucket has max_bind_groups = 4
+    let result = global.adapter_request_device(
+        adapter_id,
+        &wgt::DeviceDescriptor {
+            required_limits: wgt::Limits {
+                max_bind_groups: 8,
+                ..wgt::Limits::default()
+            },
+            ..Default::default()
+        },
+        None,
+        None,
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn subgroup_sizes_fixed_when_unsupported() {
+    let global = create_noop_global(wgt::NoopBackendOptions {
+        enable: true,
+        device_type: Some(wgt::DeviceType::DiscreteGpu),
+        features: Some(wgt::Features::empty()),
+        subgroup_min_size: Some(64),
+        subgroup_max_size: Some(64),
+        ..Default::default()
+    });
+
+    let adapter_id = global
+        .request_adapter(
+            &wgt::RequestAdapterOptions {
+                apply_limit_buckets: true,
+                ..Default::default()
+            },
+            wgt::Backends::NOOP,
+            None,
+        )
+        .unwrap();
+
+    let info = global.adapter_get_info(adapter_id);
+    let features = global.adapter_features(adapter_id);
+
+    // Since the "default" bucket doesn't have the `subgroups` feature:
+    //  - bucket match should succeed despite subgroup size range being narrower than bucket,
+    //  - subgroup sizes should be replaced with WebGPU's fixed defaults.
+    assert!(!features.contains(wgt::Features::SUBGROUP));
+    assert_eq!(info.subgroup_min_size, 4);
+    assert_eq!(info.subgroup_max_size, 128);
+}
+
+#[test]
+fn fallback_adapter() {
+    // DeviceType::Cpu with empty features should match "fallback" bucket
+    let global = create_noop_global(wgt::NoopBackendOptions {
+        enable: true,
+        device_type: Some(wgt::DeviceType::Cpu),
+        features: Some(wgt::Features::empty()),
+        ..Default::default()
+    });
+
+    let adapter_id = global
+        .request_adapter(
+            &wgt::RequestAdapterOptions {
+                apply_limit_buckets: true,
+                ..Default::default()
+            },
+            wgt::Backends::NOOP,
+            None,
+        )
+        .unwrap();
+
+    let info = global.adapter_get_info(adapter_id);
+
+    // Should match fallback bucket which is a CPU/fallback adapter
+    assert_eq!(info.device_type, wgt::DeviceType::Cpu);
+}
+
+// Subgroup limits are not treated like regular limits (where a device qualifies
+// if its max limits meet or exceed the bucket). A device qualifies if its max
+// subgroup size is the same or less than the bucket's max, and conversely for
+// min. i.e. the device's subgroup size range must be a subset of the bucket's
+// subgroup size range.
+
+#[test]
+fn subgroup_max_above_bucket() {
+    // Construct a device with UPLEVEL_FEATURES and a subgroup max size of 65.
+    // This device is disqualified from all tiers besides NO_F16 due to not
+    // having f16 support, and disqualified from NO_F16 due to the subgroup max
+    // size.
+    let global = create_noop_global(wgt::NoopBackendOptions {
+        enable: true,
+        device_type: Some(wgt::DeviceType::DiscreteGpu),
+        subgroup_min_size: Some(32),
+        subgroup_max_size: Some(65),
+        features: Some(UPLEVEL_FEATURES),
+        ..Default::default()
+    });
+
+    let adapter_id = global
+        .request_adapter(
+            &wgt::RequestAdapterOptions {
+                apply_limit_buckets: true,
+                ..Default::default()
+            },
+            wgt::Backends::NOOP,
+            None,
+        )
+        .unwrap();
+
+    let features = global.adapter_features(adapter_id);
+
+    assert!(!features.contains(wgt::Features::SUBGROUP));
+}
+
+#[test]
+fn subgroup_min_below_bucket() {
+    // The uplevel buckets with smallest subgroup_min_size are M1 (4) and I1/I2 (8). We
+    // construct a device that has subgroup_min_size = 7 and max_vertex_attributes = 29, so
+    // that it will not qualify for any UPLEVEL bucket (which means it won't get subgroups).
+    let global = create_noop_global(wgt::NoopBackendOptions {
+        enable: true,
+        device_type: Some(wgt::DeviceType::DiscreteGpu),
+        subgroup_min_size: Some(7),
+        subgroup_max_size: Some(32),
+        limits: Some(wgt::Limits {
+            max_vertex_attributes: 29, // Disqualify from M1 bucket
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let adapter_id = global
+        .request_adapter(
+            &wgt::RequestAdapterOptions {
+                apply_limit_buckets: true,
+                ..Default::default()
+            },
+            wgt::Backends::NOOP,
+            None,
+        )
+        .unwrap();
+
+    let features = global.adapter_features(adapter_id);
+
+    assert!(!features.contains(wgt::Features::SUBGROUP));
+}
+
+#[test]
+fn enumerate_adapters_bucketing_enabled() {
+    let global = create_noop_global(wgt::NoopBackendOptions {
+        enable: true,
+        device_type: Some(wgt::DeviceType::DiscreteGpu),
+        features: Some(wgt::Features::SUBGROUP),
+        ..Default::default()
+    });
+
+    let adapters = global.enumerate_adapters(wgt::Backends::NOOP, true);
+    assert_eq!(adapters.len(), 1);
+
+    let adapter_id = adapters[0];
+    let limits = global.adapter_limits(adapter_id);
+
+    // With bucketing, should have bucketed limits
+    assert_eq!(limits, wgt::Limits::defaults());
+}
+
+#[test]
+fn enumerate_adapters_bucketing_disabled() {
+    let custom_limits = wgt::Limits {
+        max_bind_groups: 99,
+        ..wgt::Limits::default()
+    };
+
+    let global = create_noop_global(wgt::NoopBackendOptions {
+        enable: true,
+        limits: Some(custom_limits),
+        ..Default::default()
+    });
+
+    let adapters = global.enumerate_adapters(wgt::Backends::NOOP, false);
+    assert_eq!(adapters.len(), 1);
+
+    let adapter_id = adapters[0];
+    let limits = global.adapter_limits(adapter_id);
+
+    // Without bucketing, should have raw limits
+    assert_eq!(limits.max_bind_groups, 99);
+}

--- a/tests/tests/wgpu-validation/main.rs
+++ b/tests/tests/wgpu-validation/main.rs
@@ -1,5 +1,6 @@
 //! Tests of the [`wgpu`] library API that are not run against a particular GPU.
 
 mod api;
+mod limit_buckets;
 mod noop;
 mod util;

--- a/tests/tests/wgpu-validation/noop.rs
+++ b/tests/tests/wgpu-validation/noop.rs
@@ -19,7 +19,7 @@ fn device_is_available_when_requested() {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::NOOP,
         backend_options: wgpu::BackendOptions {
-            noop: wgpu::NoopBackendOptions { enable: true },
+            noop: wgpu::NoopBackendOptions::enabled(),
             ..Default::default()
         },
         ..wgpu::InstanceDescriptor::new_without_display_handle()

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -20,7 +20,7 @@ fn trace_test(test_type: TestType) {
         wgt::instance::InstanceDescriptor {
             backends: wgt::Backends::NOOP,
             backend_options: wgt::BackendOptions {
-                noop: wgt::NoopBackendOptions { enable: true },
+                noop: wgt::NoopBackendOptions::enabled(),
                 ..Default::default()
             },
             ..wgt::instance::InstanceDescriptor::new_without_display_handle()

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1,21 +1,14 @@
-use alloc::{
-    borrow::{Cow, ToOwned as _},
-    boxed::Box,
-    string::String,
-    sync::Arc,
-    vec,
-    vec::Vec,
-};
+use alloc::{borrow::ToOwned as _, boxed::Box, string::String, sync::Arc, vec, vec::Vec};
 
 use hashbrown::HashMap;
 use thiserror::Error;
-use wgt::error::{ErrorType, WebGpuError};
 
 use crate::{
     api_log, api_log_debug,
     device::{queue::Queue, resource::Device, DeviceDescriptor, DeviceError},
     global::Global,
     id::{markers, AdapterId, DeviceId, QueueId, SurfaceId},
+    limits::{self, check_limits, FailedLimit},
     lock::{rank, Mutex},
     present::Presentation,
     resource::ResourceType,
@@ -27,35 +20,6 @@ use crate::{
 use wgt::{Backend, Backends, PowerPreference};
 
 pub type RequestAdapterOptions = wgt::RequestAdapterOptions<SurfaceId>;
-
-#[derive(Clone, Debug, Error)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[error("Limit '{name}' value {requested} is better than allowed {allowed}")]
-pub struct FailedLimit {
-    name: Cow<'static, str>,
-    requested: u64,
-    allowed: u64,
-}
-
-impl WebGpuError for FailedLimit {
-    fn webgpu_error_type(&self) -> ErrorType {
-        ErrorType::Validation
-    }
-}
-
-fn check_limits(requested: &wgt::Limits, allowed: &wgt::Limits) -> Vec<FailedLimit> {
-    let mut failed = Vec::new();
-
-    requested.check_limits_with_fail_fn(allowed, false, |name, requested, allowed| {
-        failed.push(FailedLimit {
-            name: Cow::Borrowed(name),
-            requested,
-            allowed,
-        })
-    });
-
-    failed
-}
 
 #[test]
 fn downlevel_default_limits_less_than_default_limits() {
@@ -454,7 +418,11 @@ impl Instance {
         })
     }
 
-    pub fn enumerate_adapters(&self, backends: Backends) -> Vec<Adapter> {
+    pub fn enumerate_adapters(
+        &self,
+        backends: Backends,
+        apply_limit_buckets: bool,
+    ) -> Vec<Adapter> {
         profiling::scope!("Instance::enumerate_adapters");
         api_log!("Instance::enumerate_adapters");
 
@@ -469,11 +437,23 @@ impl Instance {
             profiling::scope!("enumerating", &*alloc::format!("{_backend:?}"));
 
             let hal_adapters = unsafe { instance.enumerate_adapters(None) };
-            for raw in hal_adapters {
-                let adapter = Adapter::new(raw);
-                api_log_debug!("Adapter {:?}", adapter.raw.info);
-                adapters.push(adapter);
-            }
+
+            adapters.extend(
+                hal_adapters
+                    .into_iter()
+                    .filter_map(|raw| {
+                        if apply_limit_buckets {
+                            limits::apply_limit_buckets(raw)
+                        } else {
+                            Some(raw)
+                        }
+                    })
+                    .map(|raw| {
+                        let adapter = Adapter::new(raw);
+                        api_log_debug!("Adapter {:?}", adapter.raw.info);
+                        adapter
+                    }),
+            );
         }
         adapters
     }
@@ -545,7 +525,16 @@ impl Instance {
                     continue;
                 }
             }
-            adapters.extend(backend_adapters);
+
+            if desc.apply_limit_buckets {
+                adapters.extend(
+                    backend_adapters
+                        .into_iter()
+                        .filter_map(limits::apply_limit_buckets),
+                );
+            } else {
+                adapters.append(&mut backend_adapters);
+            }
         }
 
         match desc.power_preference {
@@ -678,19 +667,7 @@ pub struct Adapter {
 }
 
 impl Adapter {
-    pub fn new(mut raw: hal::DynExposedAdapter) -> Self {
-        // WebGPU requires this offset alignment as lower bound on all adapters.
-        const MIN_BUFFER_OFFSET_ALIGNMENT_LOWER_BOUND: u32 = 32;
-
-        let limits = &mut raw.capabilities.limits;
-
-        limits.min_uniform_buffer_offset_alignment = limits
-            .min_uniform_buffer_offset_alignment
-            .max(MIN_BUFFER_OFFSET_ALIGNMENT_LOWER_BOUND);
-        limits.min_storage_buffer_offset_alignment = limits
-            .min_storage_buffer_offset_alignment
-            .max(MIN_BUFFER_OFFSET_ALIGNMENT_LOWER_BOUND);
-
+    pub fn new(raw: hal::DynExposedAdapter) -> Self {
         Self { raw }
     }
 
@@ -1092,8 +1069,14 @@ impl Global {
         self.surfaces.remove(id);
     }
 
-    pub fn enumerate_adapters(&self, backends: Backends) -> Vec<AdapterId> {
-        let adapters = self.instance.enumerate_adapters(backends);
+    pub fn enumerate_adapters(
+        &self,
+        backends: Backends,
+        apply_limit_buckets: bool,
+    ) -> Vec<AdapterId> {
+        let adapters = self
+            .instance
+            .enumerate_adapters(backends, apply_limit_buckets);
         adapters
             .into_iter()
             .map(|adapter| self.hub.adapters.prepare(None).assign(Arc::new(adapter)))
@@ -1111,15 +1094,26 @@ impl Global {
             power_preference: desc.power_preference,
             force_fallback_adapter: desc.force_fallback_adapter,
             compatible_surface: compatible_surface.as_deref(),
+            apply_limit_buckets: desc.apply_limit_buckets,
         };
         let adapter = self.instance.request_adapter(&desc, backends)?;
         let id = self.hub.adapters.prepare(id_in).assign(Arc::new(adapter));
         Ok(id)
     }
 
+    /// Create an adapter from a HAL adapter.
+    ///
+    /// The HAL adapter may be obtained e.g. by calling `enumerate_adapters` on
+    /// the HAL directly.
+    ///
+    /// If [limit bucketing][lt] is desired, [`crate::limits::apply_limit_buckets`]
+    /// should be called with the HAL adapter before calling this function.
+    ///
     /// # Safety
     ///
     /// `hal_adapter` must be created from this global internal instance handle.
+    ///
+    /// [lt]: crate::limits#Limit-bucketing
     pub unsafe fn create_adapter_from_hal(
         &self,
         hal_adapter: hal::DynExposedAdapter,

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -79,6 +79,7 @@ pub mod identity;
 mod indirect_validation;
 mod init_tracker;
 pub mod instance;
+pub mod limits;
 mod lock;
 pub mod pipeline;
 mod pipeline_cache;

--- a/wgpu-core/src/limits.rs
+++ b/wgpu-core/src/limits.rs
@@ -1,0 +1,603 @@
+//! Functionality related to device and adapter limits.
+//!
+//! # Limit Bucketing
+//!
+//! Web browsers make various information about their operating environment
+//! available to content to provide a better experience. For example, content is
+//! able to detect whether the device has a touch-screen, in order to provide an
+//! appropriate user interface.
+//!
+//! [Browser fingerprinting][bfp] employs this information for the purpose of
+//! constructing a unique "fingerprint" value that is unique to a single browser
+//! or shared among a relatively small number of browsers. Fingerprinting can be
+//! used for various purposes, including to identify and track users across
+//! different websites.
+//!
+//! Limit bucketing can reduce the ability to fingerprint users based on GPU
+//! hardware characteristics when using `wgpu` in applications like a web
+//! browser.
+//!
+//! When limit bucketing is enabled, the adapter limits offered by `wgpu` do not
+//! necessarily reflect the exact capabilities of the hardware. Instead, the
+//! hardware capabilities are rounded down to one of several pre-defined buckets.
+//! The goal of doing this is for there to be enough devices assigned to each
+//! bucket that knowledge of which bucket applies is minimally useful for
+//! fingerprinting.
+//!
+//! Limit bucketing may be requested by setting `apply_limit_buckets` in
+//! [`wgt::RequestAdapterOptions`] or by setting `apply_limit_buckets` to
+//! true when calling [`enumerate_adapters`].
+//!
+//! If your application does not expose `wgpu` to untrusted content, limit
+//! bucketing is not necessary.
+//!
+//! [bfp]: https://support.mozilla.org/en-US/kb/firefox-protection-against-fingerprinting
+//! [`enumerate_adapters`]: `crate::instance::Instance::enumerate_adapters`
+
+use core::mem;
+
+use alloc::{borrow::Cow, vec::Vec};
+use thiserror::Error;
+use wgt::error::{ErrorType, WebGpuError};
+use wgt::{AdapterInfo, AdapterLimitBucketInfo, DeviceType, Features, Limits};
+
+use crate::api_log;
+
+#[derive(Clone, Debug, Error)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[error("Limit '{name}' value {requested} is better than allowed {allowed}")]
+pub struct FailedLimit {
+    name: Cow<'static, str>,
+    requested: u64,
+    allowed: u64,
+}
+
+impl WebGpuError for FailedLimit {
+    fn webgpu_error_type(&self) -> ErrorType {
+        ErrorType::Validation
+    }
+}
+
+pub(crate) fn check_limits(requested: &Limits, allowed: &Limits) -> Vec<FailedLimit> {
+    let mut failed = Vec::new();
+
+    requested.check_limits_with_fail_fn(allowed, false, |name, requested, allowed| {
+        failed.push(FailedLimit {
+            name: Cow::Borrowed(name),
+            requested,
+            allowed,
+        })
+    });
+
+    failed
+}
+
+/// Fields in [`wgt::AdapterInfo`] relevant to limit bucketing.
+pub(crate) struct BucketedAdapterInfo {
+    // Equivalent to `adapter.info.device_type == wgt::DeviceType::Cpu`
+    is_fallback_adapter: bool,
+
+    subgroup_min_size: u32,
+    subgroup_max_size: u32,
+}
+
+impl BucketedAdapterInfo {
+    const fn defaults() -> Self {
+        Self {
+            is_fallback_adapter: false,
+            subgroup_min_size: 4,
+            subgroup_max_size: 128,
+        }
+    }
+}
+
+impl Default for BucketedAdapterInfo {
+    fn default() -> Self {
+        Self::defaults()
+    }
+}
+
+pub(crate) struct Bucket {
+    name: &'static str,
+    limits: Limits,
+    info: BucketedAdapterInfo,
+    features: Features,
+}
+
+impl Bucket {
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns `true` if the device having `limits`, `info`, and `features` satisfies
+    /// the bucket definition in `self`.
+    pub fn is_compatible(&self, limits: &Limits, info: &AdapterInfo, features: Features) -> bool {
+        // In the context of limit checks, "allowed" or "available" means
+        // what the device supports. If an application requests an
+        // unsupported value, the error message might say "limit of {} exceeds
+        // allowed value {}". For purposes of bucket compatibility, the bucket values
+        // take the place of application-requested values. If the bucket value
+        // is beyond what the device supports, then the device does not qualify
+        // for that bucket.
+        let candidate_is_fallback_adapter = info.device_type == DeviceType::Cpu;
+
+        let failing_limits = check_limits(&self.limits, limits);
+        let limits_ok = failing_limits.is_empty();
+
+        if !limits_ok {
+            log::debug!("Failing limits: {:#?}", failing_limits);
+        }
+
+        let bucket_has_subgroups = self.features.contains(Features::SUBGROUP);
+        let subgroups_ok = !bucket_has_subgroups
+            || info.subgroup_min_size >= self.info.subgroup_min_size
+                && info.subgroup_max_size <= self.info.subgroup_max_size;
+        if !subgroups_ok {
+            log::debug!(
+                "Subgroup min/max {}/{} is not compatible with allowed {}/{}",
+                self.info.subgroup_min_size,
+                self.info.subgroup_max_size,
+                info.subgroup_min_size,
+                info.subgroup_max_size,
+            );
+        }
+
+        let features_ok = features.contains(self.features);
+        if !features_ok {
+            log::debug!("{:?} are not available", self.features - features);
+        }
+
+        limits_ok
+            && candidate_is_fallback_adapter == self.info.is_fallback_adapter
+            && subgroups_ok
+            && features_ok
+    }
+
+    pub fn try_apply_to(&self, adapter: &mut hal::DynExposedAdapter) -> bool {
+        if !self.is_compatible(
+            &adapter.capabilities.limits,
+            &adapter.info,
+            adapter.features,
+        ) {
+            log::debug!("bucket `{}` is not compatible", self.name);
+            return false;
+        }
+
+        let raw_limits = mem::replace(&mut adapter.capabilities.limits, self.limits.clone());
+
+        // Features in EXEMPT_FEATURES are not affected by limit bucketing.
+        let exposed_features = adapter
+            .features
+            .intersection(EXEMPT_FEATURES)
+            .union(self.features);
+        let raw_features = mem::replace(&mut adapter.features, exposed_features);
+
+        let (bucket_subgroup_min_size, bucket_subgroup_max_size) =
+            if self.features.contains(Features::SUBGROUP) {
+                (self.info.subgroup_min_size, self.info.subgroup_max_size)
+            } else {
+                // WebGPU requires that we report these values when subgroups are
+                // not supported
+                (
+                    wgt::MINIMUM_SUBGROUP_MIN_SIZE,
+                    wgt::MAXIMUM_SUBGROUP_MAX_SIZE,
+                )
+            };
+        let raw_subgroup_min_size = mem::replace(
+            &mut adapter.info.subgroup_min_size,
+            bucket_subgroup_min_size,
+        );
+        let raw_subgroup_max_size = mem::replace(
+            &mut adapter.info.subgroup_max_size,
+            bucket_subgroup_max_size,
+        );
+
+        adapter.info.limit_bucket = Some(AdapterLimitBucketInfo {
+            name: Cow::Borrowed(self.name),
+            raw_limits,
+            raw_features,
+            raw_subgroup_min_size,
+            raw_subgroup_max_size,
+        });
+
+        true
+    }
+}
+
+/// Apply [limit bucketing][lt] to the adapter limits and features in `raw`.
+///
+/// Finds a supported bucket and replaces the capabilities with the set defined by
+/// the bucket. If no suitable bucket is found, returns `None`, but this should only
+/// happen with downlevel devices, and attempting to use limit bucketing with
+/// downlevel devices is not recommended.
+///
+/// [lt]: self#Limit-bucketing
+pub fn apply_limit_buckets(mut raw: hal::DynExposedAdapter) -> Option<hal::DynExposedAdapter> {
+    for bucket in buckets() {
+        if bucket.try_apply_to(&mut raw) {
+            let name = bucket.name();
+            api_log!("Applied limit bucket `{name}`");
+            return Some(raw);
+        }
+    }
+    log::warn!(
+        "No suitable limit bucket found for device with {:?}, {:?}, {:?}",
+        raw.capabilities.limits,
+        raw.info,
+        raw.features,
+    );
+    None
+}
+
+/// These features are left alone by limit bucketing. They will be exposed to higher layers
+/// whenever the device supports them, and they are not considered when determining bucket
+/// compatibility.
+///
+/// All four features in the list are related to external textures. (The texture format
+/// features are used internally by Firefox to support external textures.)
+///
+/// Handling them this way is a bit of a kludge, but is expected to be a short-term
+/// situation only until external texture support is universally available.
+///
+/// Note that while NV12 and P010 can be hidden from content by excluding them from WebIDL,
+/// TEXTURE_FORMATS_16BIT_NORM will eventually be replaced with TEXTURE_FORMATS_TIER1, and
+/// at that point neither excluding the tier1 formats from WebIDL entirely nor allowing
+/// content to use them on a device that doesn't have the feature enabled will be
+/// acceptable. See <https://github.com/gfx-rs/wgpu/issues/8122>.
+const EXEMPT_FEATURES: Features = Features::EXTERNAL_TEXTURE
+    .union(Features::TEXTURE_FORMAT_NV12)
+    .union(Features::TEXTURE_FORMAT_P010)
+    .union(Features::TEXTURE_FORMAT_16BIT_NORM);
+
+/// Return the defined adapter feature/limit buckets
+///
+/// Buckets are not always subsets of preceding buckets, but [`enumerate_adapters`]
+/// considers them in the order they are listed here and uses the first bucket satisfied
+/// by the device.
+///
+/// [`enumerate_adapters`]: `crate::instance::Instance::enumerate_adapters`
+pub(crate) fn buckets() -> impl Iterator<Item = &'static Bucket> {
+    [
+        &BUCKET_M1,
+        &BUCKET_A2,
+        &BUCKET_I1,
+        &BUCKET_N1,
+        &BUCKET_A1,
+        &BUCKET_NO_F16,
+        &BUCKET_LLVMPIPE,
+        &BUCKET_WARP,
+        &BUCKET_DEFAULT,
+        &BUCKET_FALLBACK,
+    ]
+    .iter()
+    .copied()
+}
+
+// The following limits could be higher for some hardware, but are capped where they
+// are to avoid introducing platform or backend dependencies.
+//
+// **`max_vertex_attributes`:** While there is broad support for 32, Intel hardware with
+// Vulkan only supports 29.
+// See <https://gitlab.freedesktop.org/mesa/mesa/-/blob/465c186fc5f72c51bda943ac0e19f6512f8e6262/src/intel/vulkan/anv_private.h#L188>.
+//
+// **`max_dynamic_{storage,uniform}_buffers_per_pipeline_layout`:** These are limited to
+// 4 and 8 by DX12.
+
+// UPLEVEL is not a bucket that is actually applied to devices. It serves as a baseline from
+// which most of the rest of the buckets are derived. (It could be a real bucket if desired,
+// but since UPLEVEL is an intersection across many devices, there is usually a better match
+// for any particular device.)
+const UPLEVEL: Bucket = Bucket {
+    name: "uplevel-defaults",
+    limits: Limits {
+        max_bind_groups: 8,
+        // wgpu does not implement max_bind_groups_plus_vertex_buffers
+        // use default max_bindings_per_bind_group
+        max_buffer_size: 1 << 30, // 1 GB
+        max_color_attachment_bytes_per_sample: 64,
+        // use default max_color_attachments
+        max_compute_invocations_per_workgroup: 1024,
+        max_compute_workgroup_size_x: 1024,
+        max_compute_workgroup_size_y: 1024,
+        // use default max_compute_workgroup_size_z
+        max_compute_workgroup_storage_size: 32 << 10, // 32 kB
+        // use default max_compute_workgroups_per_dimension
+        // use default max_dynamic_storage_buffers_per_pipeline_layout
+        // use default max_dynamic_uniform_buffers_per_pipeline_layout
+        max_inter_stage_shader_variables: 28,
+        // use default max_sampled_textures_per_shader_stage
+        // use default max_samplers_per_shader_stage
+        // use default max_storage_buffer_binding_size
+        // wgpu does not implement max_storage_buffers_in_fragment_stage: 8,
+        // wgpu does not implement max_storage_buffers_in_vertex_stage: 8,
+        // use default max_storage_buffers_per_shader_stage
+        // wgpu does not implement max_storage_textures_in_fragment_stage: 8,
+        // wgpu does not implement max_storage_textures_in_vertex_stage: 8,
+        max_storage_textures_per_shader_stage: 8,
+        max_texture_array_layers: 2048,
+        max_texture_dimension_1d: 16384,
+        max_texture_dimension_2d: 16384,
+        // use default max_texture_dimension_3d
+        // use default max_uniform_buffer_binding_size
+        // use default max_uniform_buffers_per_shader_stage
+        max_vertex_attributes: 29,
+        // use default max_vertex_buffer_array_stride
+        // use default max_vertex_buffers
+        // use default min_storage_buffer_offset_alignment
+        // use default min_uniform_buffer_offset_alignment
+        ..Limits::defaults()
+    },
+    info: BucketedAdapterInfo {
+        is_fallback_adapter: false,
+        subgroup_min_size: 4,
+        subgroup_max_size: 128,
+    },
+    features: Features::DEPTH_CLIP_CONTROL
+        .union(Features::DEPTH32FLOAT_STENCIL8)
+        // omit TEXTURE_COMPRESSION_ASTC
+        // omit TEXTURE_COMPRESSION_ASTC_SLICED_3D
+        .union(Features::TEXTURE_COMPRESSION_BC)
+        .union(Features::TEXTURE_COMPRESSION_BC_SLICED_3D)
+        // omit TEXTURE_COMPRESSION_ETC2
+        .union(Features::TIMESTAMP_QUERY)
+        .union(Features::INDIRECT_FIRST_INSTANCE)
+        // omit SHADER_F16
+        .union(Features::RG11B10UFLOAT_RENDERABLE)
+        .union(Features::BGRA8UNORM_STORAGE)
+        .union(Features::FLOAT32_FILTERABLE)
+        // FLOAT32_BLENDABLE not implemented in wgpu dx12 backend; https://github.com/gfx-rs/wgpu/issues/6555
+        // CLIP_DISTANCES not implemented in wgpu dx12 backend; https://github.com/gfx-rs/wgpu/issues/6236
+        .union(Features::DUAL_SOURCE_BLENDING)
+        // TIER1/TIER2 not implemented in wgpu; https://github.com/gfx-rs/wgpu/issues/8122
+        .union(Features::PRIMITIVE_INDEX)
+        // TEXTURE_COMPONENT_SWIZZLE not implemented in wgpu; https://github.com/gfx-rs/wgpu/issues/1028
+        .union(Features::SUBGROUP)
+        .union(Features::IMMEDIATES),
+};
+
+// e.g. Apple M Series
+const BUCKET_M1: Bucket = Bucket {
+    name: "m1",
+    limits: Limits {
+        max_dynamic_uniform_buffers_per_pipeline_layout: 12,
+        max_sampled_textures_per_shader_stage: 48,
+        max_storage_buffer_binding_size: 1 << 30, // 1 GB,
+        max_vertex_attributes: 31,
+        ..UPLEVEL.limits
+    },
+    info: BucketedAdapterInfo {
+        subgroup_min_size: 4,
+        subgroup_max_size: 64,
+        ..UPLEVEL.info
+    },
+    features: UPLEVEL
+        .features
+        .union(Features::TEXTURE_COMPRESSION_ASTC)
+        .union(Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D)
+        .union(Features::TEXTURE_COMPRESSION_ETC2)
+        .union(Features::SHADER_F16)
+        .union(Features::FLOAT32_BLENDABLE)
+        .union(Features::CLIP_DISTANCES),
+};
+
+// e.g. Radeon Vega
+const BUCKET_A2: Bucket = Bucket {
+    name: "a2",
+    limits: Limits {
+        max_color_attachment_bytes_per_sample: 128,
+        max_compute_workgroup_storage_size: 64 << 10, // 64 kB,
+        max_sampled_textures_per_shader_stage: 48,
+        max_storage_buffer_binding_size: 1 << 30, // 1 GB,
+        max_storage_buffers_per_shader_stage: 16,
+        max_vertex_attributes: 32,
+        ..UPLEVEL.limits
+    },
+    info: BucketedAdapterInfo {
+        subgroup_min_size: 64,
+        subgroup_max_size: 64,
+        ..UPLEVEL.info
+    },
+    features: UPLEVEL.features.union(Features::SHADER_F16),
+};
+
+// e.g. Intel Arc, UHD 600 Series, Iris Xe
+const BUCKET_I1: Bucket = Bucket {
+    name: "i1",
+    limits: Limits {
+        max_color_attachment_bytes_per_sample: 128,
+        max_sampled_textures_per_shader_stage: 48,
+        max_storage_buffer_binding_size: 1 << 29, // 512 MB,
+        max_storage_buffers_per_shader_stage: 16,
+        ..UPLEVEL.limits
+    },
+    info: BucketedAdapterInfo {
+        subgroup_min_size: 8,
+        subgroup_max_size: 32,
+        ..UPLEVEL.info
+    },
+    features: UPLEVEL.features.union(Features::SHADER_F16),
+};
+
+// e.g. GeForce GTX 1650, GeForce RTX 20, 30, 40, 50 Series
+const BUCKET_N1: Bucket = Bucket {
+    name: "n1",
+    limits: Limits {
+        max_color_attachment_bytes_per_sample: 128,
+        max_compute_workgroup_storage_size: 48 << 10, // 48 kB,
+        max_sampled_textures_per_shader_stage: 48,
+        max_storage_buffer_binding_size: 1 << 30, // 1 GB,
+        max_storage_buffers_per_shader_stage: 16,
+        max_vertex_attributes: 32,
+        ..UPLEVEL.limits
+    },
+    info: BucketedAdapterInfo {
+        subgroup_min_size: 32,
+        subgroup_max_size: 32,
+        ..UPLEVEL.info
+    },
+    features: UPLEVEL.features.union(Features::SHADER_F16),
+};
+
+// e.g. Radeon RX 6000, 7000, 9000 Series
+const BUCKET_A1: Bucket = Bucket {
+    name: "a1",
+    limits: Limits {
+        max_color_attachment_bytes_per_sample: 128,
+        max_sampled_textures_per_shader_stage: 48,
+        max_storage_buffer_binding_size: 1 << 30, // 1 GB,
+        max_storage_buffers_per_shader_stage: 16,
+        max_vertex_attributes: 32,
+        ..UPLEVEL.limits
+    },
+    info: BucketedAdapterInfo {
+        subgroup_min_size: 32,
+        subgroup_max_size: 64,
+        ..UPLEVEL.info
+    },
+    features: UPLEVEL.features.union(Features::SHADER_F16),
+};
+
+// e.g. GeForce GTX 1050, Radeon WX 5100
+const BUCKET_NO_F16: Bucket = Bucket {
+    name: "no-f16",
+    limits: Limits {
+        max_color_attachment_bytes_per_sample: 128,
+        max_compute_workgroup_storage_size: 48 << 10, // 48 kB
+        max_sampled_textures_per_shader_stage: 48,
+        max_storage_buffer_binding_size: 1 << 30, // 1 GB
+        max_storage_buffers_per_shader_stage: 16,
+        max_vertex_attributes: 32,
+        ..UPLEVEL.limits
+    },
+    info: BucketedAdapterInfo {
+        subgroup_min_size: 32,
+        subgroup_max_size: 64,
+        ..UPLEVEL.info
+    },
+    features: UPLEVEL.features,
+};
+
+const BUCKET_LLVMPIPE: Bucket = Bucket {
+    name: "llvmpipe",
+    limits: Limits {
+        max_color_attachment_bytes_per_sample: 128,
+        max_sampled_textures_per_shader_stage: 48,
+        max_storage_buffers_per_shader_stage: 16,
+        max_vertex_attributes: 32,
+        ..UPLEVEL.limits
+    },
+    info: BucketedAdapterInfo {
+        is_fallback_adapter: true,
+        subgroup_min_size: 8,
+        subgroup_max_size: 8,
+    },
+    features: UPLEVEL
+        .features
+        .union(Features::SHADER_F16)
+        .union(Features::CLIP_DISTANCES),
+};
+
+// a.k.a. Microsoft Basic Render Driver
+const BUCKET_WARP: Bucket = Bucket {
+    name: "warp",
+    limits: Limits {
+        max_color_attachment_bytes_per_sample: 128,
+        max_sampled_textures_per_shader_stage: 48,
+        max_storage_buffers_per_shader_stage: 16,
+        max_vertex_attributes: 32,
+        ..UPLEVEL.limits
+    },
+    info: BucketedAdapterInfo {
+        is_fallback_adapter: true,
+        subgroup_min_size: 4,
+        subgroup_max_size: 128,
+    },
+    features: UPLEVEL.features.union(Features::SHADER_F16),
+};
+
+// WebGPU default limits, not a fallback adapter
+const BUCKET_DEFAULT: Bucket = Bucket {
+    name: "default",
+    limits: Limits::defaults(),
+    info: BucketedAdapterInfo::defaults(),
+    features: Features::empty(),
+};
+
+// WebGPU default limits, is a fallback adapter
+const BUCKET_FALLBACK: Bucket = Bucket {
+    name: "fallback",
+    limits: Limits::defaults(),
+    info: BucketedAdapterInfo {
+        is_fallback_adapter: true,
+        ..BucketedAdapterInfo::defaults()
+    },
+    features: Features::empty(),
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wgt::Features;
+
+    #[test]
+    fn enumerate_webgpu_features() {
+        let difference = Features::all_webgpu_mask().difference(
+            Features::DEPTH_CLIP_CONTROL
+                .union(Features::DEPTH32FLOAT_STENCIL8)
+                .union(Features::TEXTURE_COMPRESSION_ASTC)
+                .union(Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D)
+                .union(Features::TEXTURE_COMPRESSION_BC)
+                .union(Features::TEXTURE_COMPRESSION_BC_SLICED_3D)
+                .union(Features::TEXTURE_COMPRESSION_ETC2)
+                .union(Features::TIMESTAMP_QUERY)
+                .union(Features::INDIRECT_FIRST_INSTANCE)
+                .union(Features::SHADER_F16)
+                .union(Features::RG11B10UFLOAT_RENDERABLE)
+                .union(Features::BGRA8UNORM_STORAGE)
+                .union(Features::FLOAT32_FILTERABLE)
+                .union(Features::FLOAT32_BLENDABLE)
+                .union(Features::CLIP_DISTANCES)
+                .union(Features::DUAL_SOURCE_BLENDING)
+                .union(Features::SUBGROUP)
+                //.union(Features::TEXTURE_FORMATS_TIER1) not implemented
+                //.union(Features::TEXTURE_FORMATS_TIER2) not implemented
+                .union(Features::PRIMITIVE_INDEX)
+                //.union(Features::TEXTURE_COMPONENT_SWIZZLE) not implemented
+                // Standard-track features not in official spec
+                .union(Features::IMMEDIATES),
+        );
+        assert!(
+            difference.is_empty(),
+            "New WebGPU features should be assigned to appropriate limit buckets; missing {difference:?}"
+        );
+    }
+
+    #[test]
+    fn relationships() {
+        // Check that each bucket is a superset of UPLEVEL, ignoring the `is_fallback_adapter` flag.
+        for bucket in [
+            &BUCKET_M1,
+            &BUCKET_A2,
+            &BUCKET_I1,
+            &BUCKET_N1,
+            &BUCKET_A1,
+            &BUCKET_NO_F16,
+            &BUCKET_WARP,
+            &BUCKET_LLVMPIPE,
+        ] {
+            let info = AdapterInfo {
+                subgroup_min_size: bucket.info.subgroup_min_size,
+                subgroup_max_size: bucket.info.subgroup_max_size,
+                ..AdapterInfo::new(
+                    DeviceType::DiscreteGpu, // not a fallback adapter
+                    wgt::Backend::Noop,
+                )
+            };
+            assert!(
+                UPLEVEL.is_compatible(&bucket.limits, &info, bucket.features),
+                "Bucket `{}` should be a superset of UPLEVEL",
+                bucket.name(),
+            );
+        }
+    }
+}

--- a/wgpu-core/src/pipeline_cache.rs
+++ b/wgpu-core/src/pipeline_cache.rs
@@ -326,6 +326,7 @@ mod tests {
         subgroup_min_size: 32,
         subgroup_max_size: 32,
         transient_saves_memory: true,
+        limit_bucket: None,
     };
 
     // IMPORTANT: If these tests fail, then you MUST increment HEADER_VERSION

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -208,6 +208,7 @@ impl super::Adapter {
             subgroup_min_size: features1.WaveLaneCountMin,
             subgroup_max_size: features1.WaveLaneCountMax,
             transient_saves_memory: false,
+            limit_bucket: None,
         };
 
         let mut options = Direct3D12::D3D12_FEATURE_DATA_D3D12_OPTIONS::default();

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -184,15 +184,8 @@ impl super::Adapter {
         wgt::AdapterInfo {
             name: renderer_orig,
             vendor: vendor_id,
-            device: 0,
-            device_type: inferred_device_type,
-            driver: "".to_owned(),
-            device_pci_bus_id: String::new(),
             driver_info: version,
-            backend: wgt::Backend::Gl,
-            subgroup_min_size: wgt::MINIMUM_SUBGROUP_MIN_SIZE,
-            subgroup_max_size: wgt::MAXIMUM_SUBGROUP_MAX_SIZE,
-            transient_saves_memory: false,
+            ..wgt::AdapterInfo::new(inferred_device_type, wgt::Backend::Gl)
         }
     }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -26,11 +26,7 @@ mod library_from_metallib;
 mod surface;
 mod time;
 
-use alloc::{
-    string::{String, ToString as _},
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::{string::ToString as _, sync::Arc, vec::Vec};
 use core::{fmt, iter, ops, ptr::NonNull, sync::atomic};
 
 use bitflags::bitflags;
@@ -419,13 +415,6 @@ impl AdapterShared {
         crate::ExposedAdapter {
             info: wgt::AdapterInfo {
                 name,
-                vendor: 0,
-                device: 0,
-                device_type: shared.private_caps.device_type(),
-                device_pci_bus_id: String::new(),
-                driver: String::new(),
-                driver_info: String::new(),
-                backend: wgt::Backend::Metal,
                 // These are hardcoded based on typical values for Metal devices
                 //
                 // See <https://github.com/gpuweb/gpuweb/blob/main/proposals/subgroups.md#adapter-info>
@@ -433,6 +422,7 @@ impl AdapterShared {
                 subgroup_min_size: 4,
                 subgroup_max_size: 64,
                 transient_saves_memory: shared.private_caps.supports_memoryless_storage,
+                ..wgt::AdapterInfo::new(shared.private_caps.device_type(), wgt::Backend::Metal)
             },
             features,
             capabilities,

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
 
-use alloc::{string::String, vec, vec::Vec};
+use alloc::{string::String, sync::Arc, vec, vec::Vec};
 use core::{ptr, sync::atomic::Ordering, time::Duration};
 
 #[cfg(supports_64bit_atomics)]
@@ -17,7 +17,10 @@ pub use command::CommandBuffer;
 
 #[derive(Clone, Debug)]
 pub struct Api;
-pub struct Context;
+
+pub struct Context {
+    options: Arc<wgt::NoopBackendOptions>,
+}
 #[derive(Debug)]
 pub struct Encoder;
 #[derive(Debug)]
@@ -89,20 +92,9 @@ impl crate::Instance for Context {
     type A = Api;
 
     unsafe fn init(desc: &crate::InstanceDescriptor<'_>) -> Result<Self, crate::InstanceError> {
-        let crate::InstanceDescriptor {
-            backend_options:
-                wgt::BackendOptions {
-                    noop: wgt::NoopBackendOptions { enable },
-                    ..
-                },
-            name: _,
-            flags: _,
-            memory_budget_thresholds: _,
-            telemetry: _,
-            display: _,
-        } = *desc;
-        if enable {
-            Ok(Context)
+        let options = Arc::new(desc.backend_options.noop.clone());
+        if options.enable {
+            Ok(Context { options })
         } else {
             Err(crate::InstanceError::new(String::from(
                 "noop backend disabled because NoopBackendOptions::enable is false",
@@ -114,17 +106,48 @@ impl crate::Instance for Context {
         _display_handle: raw_window_handle::RawDisplayHandle,
         _window_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<Context, crate::InstanceError> {
-        Ok(Context)
+        Ok(Context {
+            options: Arc::clone(&self.options),
+        })
     }
     unsafe fn enumerate_adapters(
         &self,
         _surface_hint: Option<&Context>,
     ) -> Vec<crate::ExposedAdapter<Api>> {
+        let device_type = self.options.device_type.unwrap_or(wgt::DeviceType::Other);
+        let subgroup_min_size = self
+            .options
+            .subgroup_min_size
+            .unwrap_or(wgt::MINIMUM_SUBGROUP_MIN_SIZE);
+        let subgroup_max_size = self
+            .options
+            .subgroup_max_size
+            .unwrap_or(wgt::MAXIMUM_SUBGROUP_MAX_SIZE);
+        let features = self.options.features.unwrap_or(wgt::Features::all());
+        let limits = self
+            .options
+            .limits
+            .clone()
+            .unwrap_or(CAPABILITIES.limits.clone());
+
+        let info = wgt::AdapterInfo {
+            subgroup_min_size,
+            subgroup_max_size,
+            ..adapter_info()
+        };
+
+        let capabilities = crate::Capabilities {
+            limits,
+            ..CAPABILITIES
+        };
+
         vec![crate::ExposedAdapter {
-            adapter: Context,
-            info: adapter_info(),
-            features: wgt::Features::all(),
-            capabilities: CAPABILITIES,
+            adapter: Context {
+                options: Arc::clone(&self.options),
+            },
+            info,
+            features,
+            capabilities,
         }]
     }
 }
@@ -261,8 +284,12 @@ impl crate::Adapter for Context {
         _memory_hints: &wgt::MemoryHints,
     ) -> DeviceResult<crate::OpenDevice<Api>> {
         Ok(crate::OpenDevice {
-            device: Context,
-            queue: Context,
+            device: Context {
+                options: Arc::clone(&self.options),
+            },
+            queue: Context {
+                options: Arc::clone(&self.options),
+            },
         })
     }
     unsafe fn texture_format_capabilities(

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -136,16 +136,8 @@ impl crate::Instance for Context {
 pub fn adapter_info() -> wgt::AdapterInfo {
     wgt::AdapterInfo {
         name: String::from("noop wgpu backend"),
-        vendor: 0,
-        device: 0,
-        device_type: wgt::DeviceType::Cpu,
-        device_pci_bus_id: String::new(),
         driver: String::from("wgpu"),
-        driver_info: String::new(),
-        backend: wgt::Backend::Noop,
-        subgroup_min_size: wgt::MINIMUM_SUBGROUP_MIN_SIZE,
-        subgroup_max_size: wgt::MAXIMUM_SUBGROUP_MAX_SIZE,
-        transient_saves_memory: false,
+        ..wgt::AdapterInfo::new(wgt::DeviceType::Cpu, wgt::Backend::Noop)
     }
 }
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -2090,6 +2090,14 @@ impl super::Instance {
                 .contains(vk::MemoryPropertyFlags::LAZILY_ALLOCATED)
         });
 
+        let device_type = match phd_capabilities.properties.device_type {
+            vk::PhysicalDeviceType::OTHER => wgt::DeviceType::Other,
+            vk::PhysicalDeviceType::INTEGRATED_GPU => wgt::DeviceType::IntegratedGpu,
+            vk::PhysicalDeviceType::DISCRETE_GPU => wgt::DeviceType::DiscreteGpu,
+            vk::PhysicalDeviceType::VIRTUAL_GPU => wgt::DeviceType::VirtualGpu,
+            vk::PhysicalDeviceType::CPU => wgt::DeviceType::Cpu,
+            _ => wgt::DeviceType::Other,
+        };
         let info = wgt::AdapterInfo {
             name: {
                 phd_capabilities
@@ -2102,14 +2110,6 @@ impl super::Instance {
             },
             vendor: phd_capabilities.properties.vendor_id,
             device: phd_capabilities.properties.device_id,
-            device_type: match phd_capabilities.properties.device_type {
-                vk::PhysicalDeviceType::OTHER => wgt::DeviceType::Other,
-                vk::PhysicalDeviceType::INTEGRATED_GPU => wgt::DeviceType::IntegratedGpu,
-                vk::PhysicalDeviceType::DISCRETE_GPU => wgt::DeviceType::DiscreteGpu,
-                vk::PhysicalDeviceType::VIRTUAL_GPU => wgt::DeviceType::VirtualGpu,
-                vk::PhysicalDeviceType::CPU => wgt::DeviceType::Cpu,
-                _ => wgt::DeviceType::Other,
-            },
             device_pci_bus_id: phd_capabilities
                 .pci_bus_info
                 .filter(|info| info.pci_bus != 0 || info.pci_device != 0)
@@ -2138,7 +2138,6 @@ impl super::Instance {
                     .unwrap_or("?")
                     .to_owned()
             },
-            backend: wgt::Backend::Vulkan,
             subgroup_min_size: phd_capabilities
                 .subgroup_size_control
                 .map(|subgroup_size| subgroup_size.min_subgroup_size)
@@ -2148,6 +2147,7 @@ impl super::Instance {
                 .map(|subgroup_size| subgroup_size.max_subgroup_size)
                 .unwrap_or(wgt::MAXIMUM_SUBGROUP_MAX_SIZE),
             transient_saves_memory: supports_lazily_allocated,
+            ..wgt::AdapterInfo::new(device_type, wgt::Backend::Vulkan)
         };
         let mut workarounds = super::Workarounds::empty();
         {

--- a/wgpu-info/src/human.rs
+++ b/wgpu-info/src/human.rs
@@ -102,6 +102,7 @@ fn print_adapter(output: &mut impl io::Write, report: &AdapterReport, idx: usize
         subgroup_min_size,
         subgroup_max_size,
         transient_saves_memory,
+        limit_bucket,
     } = info;
 
     if matches!(verbosity, PrintingVerbosity::NameOnly) {
@@ -121,6 +122,7 @@ fn print_adapter(output: &mut impl io::Write, report: &AdapterReport, idx: usize
     writeln!(output, "\t     Subgroup Min Size: {subgroup_min_size}")?;
     writeln!(output, "\t     Subgroup Max Size: {subgroup_max_size}")?;
     writeln!(output, "\tTransient Saves Memory: {transient_saves_memory}")?;
+    writeln!(output, "\t          Limit Bucket: {}", limit_bucket.as_ref().map_or("<disabled>", |b| &b.name))?;
     writeln!(output, "\t      WebGPU Compliant: {:?}", downlevel.is_webgpu_compliant())?;
 
     if matches!(verbosity, PrintingVerbosity::Information) {

--- a/wgpu-types/src/adapter.rs
+++ b/wgpu-types/src/adapter.rs
@@ -1,7 +1,7 @@
-use alloc::string::String;
+use alloc::{borrow::Cow, string::String};
 use core::{fmt, mem};
 
-use crate::{link_to_wgpu_docs, Backend, Backends};
+use crate::{link_to_wgc_docs, link_to_wgpu_docs, Backend, Backends};
 
 #[cfg(any(feature = "serde", test))]
 use serde::{Deserialize, Serialize};
@@ -29,7 +29,8 @@ pub enum FeatureLevel {
 /// Options for requesting adapter.
 ///
 /// Corresponds to [WebGPU `GPURequestAdapterOptions`](
-/// https://gpuweb.github.io/gpuweb/#dictdef-gpurequestadapteroptions).
+/// https://gpuweb.github.io/gpuweb/#dictdef-gpurequestadapteroptions),
+/// with some wgpu extensions.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -43,6 +44,16 @@ pub struct RequestAdapterOptions<S> {
     /// create the surface, only guarantees that the adapter can present to said surface.
     /// For WebGL, this is strictly required, as an adapter can not be created without a surface.
     pub compatible_surface: Option<S>,
+    /// Requests that the returned adapter's limits are mapped to one of several pre-defined
+    /// buckets, as described in [limit bucketing]. If your application exposes `wgpu` to untrusted
+    /// content (e.g. a web browser), this can reduce the potential for fingerprinting via adapter
+    /// characteristics.
+    ///
+    /// To be effective, control of this option must not be available to the untrusted content.
+    /// Instead, set this option unconditionally in trusted code.
+    ///
+    #[doc = link_to_wgc_docs!(["limit bucketing"]: "limits/index.html#Limit-bucketing")]
+    pub apply_limit_buckets: bool,
 }
 
 impl<S> Default for RequestAdapterOptions<S> {
@@ -51,6 +62,7 @@ impl<S> Default for RequestAdapterOptions<S> {
             power_preference: PowerPreference::default(),
             force_fallback_adapter: false,
             compatible_surface: None,
+            apply_limit_buckets: false,
         }
     }
 }
@@ -101,6 +113,28 @@ pub enum DeviceType {
     VirtualGpu,
     /// Cpu / Software Rendering.
     Cpu,
+}
+
+/// Information about the applied limit bucket, present in the `limit_bucket` field
+/// of [`AdapterInfo`] when limit bucketing is requested.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AdapterLimitBucketInfo {
+    /// The name of the assigned bucket.
+    ///
+    /// No guarantee is made about the format or stability of the bucket names.
+    /// This should only be used for diagnostic purposes.
+    pub name: Cow<'static, str>,
+
+    /// The adapter's original limits, before bucketing was applied.
+    pub raw_limits: crate::Limits,
+    /// The adapter's original features, before bucketing was applied.
+    pub raw_features: crate::Features,
+
+    /// The adapter's original subgroup_min_size, before bucketing was applied.
+    pub raw_subgroup_min_size: u32,
+    /// The adapter's original subgroup_max_size, before bucketing was applied.
+    pub raw_subgroup_max_size: u32,
 }
 
 //TODO: convert `vendor` and `device` to `u32`
@@ -177,6 +211,32 @@ pub struct AdapterInfo {
     pub subgroup_max_size: u32,
     /// If true, adding [`TextureUsages::TRANSIENT`] to a texture will decrease memory usage.
     pub transient_saves_memory: bool,
+
+    /// If limit bucketing was requested, contains the name of the applied
+    /// bucket and the original capabilities of the adapter.
+    pub limit_bucket: Option<AdapterLimitBucketInfo>,
+}
+
+impl AdapterInfo {
+    /// Create a new `AdapterInfo` with the given device type and backend.
+    ///
+    /// All other info fields are not populated.
+    pub const fn new(device_type: DeviceType, backend: Backend) -> Self {
+        Self {
+            name: String::new(),
+            vendor: 0,
+            device: 0,
+            device_type,
+            device_pci_bus_id: String::new(),
+            driver: String::new(),
+            driver_info: String::new(),
+            backend,
+            subgroup_min_size: crate::MINIMUM_SUBGROUP_MIN_SIZE,
+            subgroup_max_size: crate::MAXIMUM_SUBGROUP_MAX_SIZE,
+            transient_saves_memory: false,
+            limit_bucket: None,
+        }
+    }
 }
 
 /// Error when [`Instance::request_adapter()`] fails.

--- a/wgpu-types/src/backend.rs
+++ b/wgpu-types/src/backend.rs
@@ -610,12 +610,30 @@ pub struct NoopBackendOptions {
     /// it must not be used when not expected. Therefore, it will not be used unless explicitly
     /// enabled.
     pub enable: bool,
+
+    /// Specify the reported limits values. If `None`, reports maximally permissive limits.
+    pub limits: Option<crate::Limits>,
+
+    /// Specify the reported feature support. If `None`, reports support for all features.
+    pub features: Option<crate::Features>,
+
+    /// Specify the reported device type. If `None`, uses [`crate::DeviceType::Other`].
+    pub device_type: Option<crate::DeviceType>,
+
+    /// Specify the reported minimum subgroup size.
+    pub subgroup_min_size: Option<u32>,
+
+    /// Specify the reported maximum subgroup size.
+    pub subgroup_max_size: Option<u32>,
 }
 
 impl NoopBackendOptions {
     /// Enable the noop backend.
     pub fn enabled() -> Self {
-        Self { enable: true }
+        Self {
+            enable: true,
+            ..Default::default()
+        }
     }
 
     /// Choose whether the noop backend is enabled from the environment.
@@ -626,6 +644,7 @@ impl NoopBackendOptions {
     pub fn from_env_or_default() -> Self {
         Self {
             enable: Self::enable_from_env().unwrap_or(false),
+            ..Default::default()
         }
     }
 
@@ -637,6 +656,7 @@ impl NoopBackendOptions {
     pub fn with_env(self) -> Self {
         Self {
             enable: Self::enable_from_env().unwrap_or(self.enable),
+            ..self
         }
     }
 

--- a/wgpu-types/src/backend.rs
+++ b/wgpu-types/src/backend.rs
@@ -613,6 +613,11 @@ pub struct NoopBackendOptions {
 }
 
 impl NoopBackendOptions {
+    /// Enable the noop backend.
+    pub fn enabled() -> Self {
+        Self { enable: true }
+    }
+
     /// Choose whether the noop backend is enabled from the environment.
     ///
     /// It will be enabled if the environment variable `WGPU_NOOP_BACKEND` has the value `1`

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -130,7 +130,45 @@ macro_rules! link_to_wgpu_item {
     };
 }
 
-pub(crate) use {link_to_wgpu_docs, link_to_wgpu_item};
+/// Create a Markdown link definition referring to the `wgpu_core` crate.
+///
+/// This macro should be used inside a `#[doc = ...]` attribute.
+/// See [`link_to_wgpu_docs`] for more details.
+#[cfg(not(docsrs))]
+macro_rules! link_to_wgc_docs {
+    ([$reference:expr]: $url_path:expr) => {
+        concat!("[", $reference, "]: ../wgpu_core/", $url_path)
+    };
+
+    (../ [$reference:expr]: $url_path:expr) => {
+        concat!("[", $reference, "]: ../../wgpu_core/", $url_path)
+    };
+}
+#[cfg(docsrs)]
+macro_rules! link_to_wgc_docs {
+    ($(../)? [$reference:expr]: $url_path:expr) => {
+        concat!(
+            "[",
+            $reference,
+            // URL path will have a base URL of https://docs.rs/
+            "]: /wgpu_core/",
+            // The version of wgpu-types is not necessarily the same as the version of wgpu_core
+            // if a patch release of either has been published, so we cannot use the full version
+            // number. docs.rs will interpret this single number as a Cargo-style version
+            // requirement and redirect to the latest compatible version.
+            //
+            // This technique would break if `wgpu_core` and `wgpu-types` ever switch to having
+            // distinct major version numbering. An alternative would be to hardcode the
+            // corresponding `wgpu_core` version, but that would give us another thing to forget
+            // to update.
+            env!("CARGO_PKG_VERSION_MAJOR"),
+            "/wgpu_core/",
+            $url_path
+        )
+    };
+}
+
+pub(crate) use {link_to_wgc_docs, link_to_wgpu_docs, link_to_wgpu_item};
 
 /// Integral type used for [`Buffer`] offsets and sizes.
 ///

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -63,7 +63,7 @@ impl Device {
         let instance = Instance::new(InstanceDescriptor {
             backends: Backends::NOOP,
             backend_options: BackendOptions {
-                noop: NoopBackendOptions { enable: true },
+                noop: NoopBackendOptions::enabled(),
                 ..Default::default()
             },
             ..InstanceDescriptor::new_without_display_handle()

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -871,6 +871,7 @@ fn map_adapter_info(adapter_info: &webgpu_sys::GpuAdapterInfo) -> wgt::AdapterIn
         subgroup_min_size: wgt::MINIMUM_SUBGROUP_MIN_SIZE,
         subgroup_max_size: wgt::MAXIMUM_SUBGROUP_MAX_SIZE,
         transient_saves_memory: false,
+        limit_bucket: None,
     }
 }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -80,7 +80,8 @@ impl ContextWgpuCore {
 
     #[cfg(wgpu_core)]
     pub fn enumerate_adapters(&self, backends: wgt::Backends) -> Vec<wgc::id::AdapterId> {
-        self.0.enumerate_adapters(backends)
+        self.0
+            .enumerate_adapters(backends, false /* no limit bucketing */)
     }
 
     pub unsafe fn create_adapter_from_hal<A: hal::Api>(
@@ -864,6 +865,7 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
                 compatible_surface: options
                     .compatible_surface
                     .map(|surface| surface.inner.as_core().id),
+                apply_limit_buckets: false,
             },
             wgt::Backends::all(),
             None,

--- a/wgpu/src/util/init.rs
+++ b/wgpu/src/util/init.rs
@@ -64,8 +64,8 @@ pub async fn initialize_adapter_from_env_or_default(
             instance
                 .request_adapter(&RequestAdapterOptions {
                     power_preference: crate::PowerPreference::from_env().unwrap_or_default(),
-                    force_fallback_adapter: false,
                     compatible_surface,
+                    ..Default::default()
                 })
                 .await
         }


### PR DESCRIPTION
Related Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1979753

To make it harder to use WebGPU for fingerprinting, we want to report limit values that are quantized to a set of pre-defined buckets, rather than raw limit values that are likely to have more entropy that is useful for fingerprinting.

This change implements tiered limit support. Tiered limits are requested by a new `apply_limit_tiers` flag in `RequestAdapterOptions`. By default that flag is `false` and limits are not modified by the tiering logic.

There is a module comment in the new `wgpu_core::limits` module that explains limit tiering in more depth.

I determined the tiers by crunching a bunch of data from gpuinfo and collected at https://webgpu-limits.netlify.app/. I am not sure how best to capture/preserve the analysis tooling for future use, I'm open to suggestions. For more detail of the tiers, see the `tiers.html` attachment on the linked bug. 

**Testing**
Adds a directed test suite.

**Squash or Rebase?** Rebase

**Checklist**

- [x] Need to change `log::info!` to `debug!`.
- [x] Needs a `CHANGELOG.md` entry.