### PR TITLE
fix(gles): Check EXT_sRGB_write_control before setting glEnable(glow::FRAMEBUFFER_SRGB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,8 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 
 - Added `GlDebugFns` option in `GlBackendOptions` to control OpenGL debug functions (`glPushDebugGroup`, `glPopDebugGroup`, `glObjectLabel`, etc.). Automatically disables them on Mali GPUs to work around a driver crash. By @Xavientois in [#8931](https://github.com/gfx-rs/wgpu/pull/8931).
 
+- Check EXT_sRGB_write_control before setting glEnable/glDisable(glow::FRAMEBUFFER_SRGB). By @richerfu in [#9120](https://github.com/gfx-rs/wgpu/pull/9120).
+
 #### WebGPU
 - Added support for `insert_debug_marker`, `push_debug_group` and `pop_debug_group`. By @evilpie in [#9017](https://github.com/gfx-rs/wgpu/pull/9017).
 - Added support for `begin_occlusion_query` and `end_occlusion_query`. By @evilpie in [#9039](https://github.com/gfx-rs/wgpu/pull/9039).

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1,6 +1,6 @@
 use alloc::{string::String, sync::Arc, vec::Vec};
 use core::{ffi, mem::ManuallyDrop, ptr, time::Duration};
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 use glow::HasContext;
 use hashbrown::HashMap;
@@ -86,6 +86,21 @@ enum SrgbFrameBufferKind {
     Core,
     /// Using EGL_KHR_gl_colorspace
     Khr,
+}
+
+fn supports_framebuffer_srgb_toggle(gl: &glow::Context, srgb_kind: SrgbFrameBufferKind) -> bool {
+    if matches!(srgb_kind, SrgbFrameBufferKind::None) {
+        return false;
+    }
+
+    if gl.version().is_embedded {
+        let extensions = gl.supported_extensions();
+        // In OpenGL ES, GL_FRAMEBUFFER_SRGB is only a valid toggle when this extension exists.
+        extensions.contains("GL_EXT_sRGB_write_control")
+    } else {
+        // EGL OpenGL contexts created here are expected to support this control.
+        true
+    }
 }
 
 /// Choose GLES framebuffer configuration.
@@ -952,6 +967,7 @@ impl crate::Instance for Instance {
             raw_window_handle: window_handle,
             swapchain: RwLock::new(None),
             srgb_kind: inner.srgb_kind,
+            framebuffer_srgb_toggle_supported: OnceLock::new(),
         })
     }
 
@@ -974,7 +990,7 @@ impl crate::Instance for Instance {
 
         // In contrast to OpenGL ES, OpenGL requires explicitly enabling sRGB conversions,
         // as otherwise the user has to do the sRGB conversion.
-        if !matches!(inner.srgb_kind, SrgbFrameBufferKind::None) {
+        if supports_framebuffer_srgb_toggle(&gl, inner.srgb_kind) {
             unsafe { gl.enable(glow::FRAMEBUFFER_SRGB) };
         }
 
@@ -1072,6 +1088,7 @@ pub struct Surface {
     raw_window_handle: raw_window_handle::RawWindowHandle,
     swapchain: RwLock<Option<Swapchain>>,
     srgb_kind: SrgbFrameBufferKind,
+    framebuffer_srgb_toggle_supported: OnceLock<bool>,
 }
 
 unsafe impl Send for Surface {}
@@ -1108,7 +1125,11 @@ impl Surface {
         unsafe { gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, None) };
         unsafe { gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(sc.framebuffer)) };
 
-        if !matches!(self.srgb_kind, SrgbFrameBufferKind::None) {
+        let framebuffer_srgb_toggle_supported = *self
+            .framebuffer_srgb_toggle_supported
+            .get_or_init(|| supports_framebuffer_srgb_toggle(&gl, self.srgb_kind));
+
+        if framebuffer_srgb_toggle_supported {
             // Disable sRGB conversions for `glBlitFramebuffer` as behavior does diverge between
             // drivers and formats otherwise and we want to ensure no sRGB conversions happen.
             unsafe { gl.disable(glow::FRAMEBUFFER_SRGB) };
@@ -1132,7 +1153,7 @@ impl Surface {
             )
         };
 
-        if !matches!(self.srgb_kind, SrgbFrameBufferKind::None) {
+        if framebuffer_srgb_toggle_supported {
             unsafe { gl.enable(glow::FRAMEBUFFER_SRGB) };
         }
 


### PR DESCRIPTION
…low::FRAMEBUFFER_SRGB)

**Connections**

Before setting `gl.disable(glow::FRAMEBUFFER_SRGB)` or `gl.enable(glow::FRAMEBUFFER_SRGB)` , we need to check `EXT_sRGB_write_control ` exists . `FRAMEBUFFER_SRGB` will depend on `EXT_sRGB_write_control` in OpenGLES. If ext don't exist and we try to set it and will get the error 
```txt
<cap> is not one of the accepted values
```

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._

Test locally in OpenHarmony device.

**Squash or Rebase?**

_If your pull request contains multiple commits, please indicate whether
they need to be squashed into a single commit before they're merged,
or if they're ready to rebase onto `trunk` as they stand. In the
latter case, please ensure that each commit passes all CI tests, so
that we can continue to bisect along `trunk` to isolate bugs._

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
