### PR TITLE
Avoid excessive ArrayVec monomorphization

### DIFF
--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1,3 +1,8 @@
+// Code in this file intentionally uses `for` loops and `.push()` rather than
+// `ArrayVec::from_iter`, because the latter is monomorphized by all three of
+// the item type, the capacity, and the iterator type, which can easily bloat
+// the compiled executable (by ~260 KiB, when it was removed).
+
 use alloc::{
     format,
     string::{String, ToString},
@@ -74,15 +79,14 @@ macro_rules! gen_component_wise_extractor {
         /// `handler`'s output is registered as a new expression. If `exprs` are vectors of the
         /// same length, a new vector expression is registered, composed of each component emitted
         /// by `handler`.
-        fn $ident<const N: usize, const M: usize, F>(
+        fn $ident<const N: usize, const M: usize>(
             eval: &mut ConstantEvaluator<'_>,
             span: Span,
             exprs: [Handle<Expression>; N],
-            mut handler: F,
+            handler: fn($target<N>) -> Result<$target<M>, ConstantEvaluatorError>,
         ) -> Result<Handle<Expression>, ConstantEvaluatorError>
         where
             $target<M>: Into<Expression>,
-            F: FnMut($target<N>) -> Result<$target<M>, ConstantEvaluatorError> + Clone,
         {
             assert!(N > 0);
             let err = ConstantEvaluatorError::InvalidMathArg;
@@ -95,19 +99,20 @@ macro_rules! gen_component_wise_extractor {
                 };
             }
 
-            let new_expr = match sanitize!(exprs.next().unwrap())? {
+            let new_expr: Result<Expression, ConstantEvaluatorError> = match sanitize!(exprs.next().unwrap())? {
                 $(
-                    &Expression::Literal(Literal::$literal(x)) => iter::once(Ok(x))
-                        .chain(exprs.map(|expr| {
-                            sanitize!(expr).and_then(|expr| match expr {
-                                &Expression::Literal(Literal::$literal(x)) => Ok(x),
-                                _ => Err(err.clone()),
-                            })
-                        }))
-                        .collect::<Result<ArrayVec<_, N>, _>>()
-                        .map(|a| a.into_inner().unwrap())
-                        .map($target::$mapping)
-                        .and_then(|comps| Ok(handler(comps)?.into())),
+                    &Expression::Literal(Literal::$literal(x)) => {
+                        let mut arr = ArrayVec::<_, N>::new();
+                        arr.push(x);
+                        for expr in exprs {
+                            match sanitize!(expr)? {
+                                &Expression::Literal(Literal::$literal(val)) => arr.push(val),
+                                _ => return Err(err),
+                            }
+                        }
+                        let comps = $target::$mapping(arr.into_inner().unwrap());
+                        Ok(handler(comps)?.into())
+                    },
                 )+
                 &Expression::Compose { ty, ref components } => match &eval.types[ty].inner {
                     &TypeInner::Vector { size, scalar } => match scalar.kind {
@@ -115,48 +120,54 @@ macro_rules! gen_component_wise_extractor {
                             let first_ty = ty;
                             let mut component_groups =
                                 ArrayVec::<ArrayVec<_, { crate::VectorSize::MAX }>, N>::new();
-                            component_groups.push(crate::proc::flatten_compose(
-                                first_ty,
-                                components,
-                                eval.expressions,
-                                eval.types,
-                            ).collect());
-                            component_groups.extend(
-                                exprs
-                                    .map(|expr| {
-                                        sanitize!(expr).and_then(|expr| match expr {
-                                            &Expression::Compose { ty, ref components }
-                                                if &eval.types[ty].inner
-                                                    == &eval.types[first_ty].inner =>
-                                            {
-                                                Ok(crate::proc::flatten_compose(
-                                                    ty,
-                                                    components,
-                                                    eval.expressions,
-                                                    eval.types,
-                                                ).collect())
-                                            }
-                                            _ => Err(err.clone()),
-                                        })
-                                    })
-                                    .collect::<Result<ArrayVec<_, { crate::VectorSize::MAX }>, _>>(
-                                    )?,
-                            );
+                            {
+                                let mut inner = ArrayVec::new();
+                                for item in crate::proc::flatten_compose(
+                                    first_ty,
+                                    components,
+                                    eval.expressions,
+                                    eval.types,
+                                ) {
+                                    inner.push(item);
+                                }
+                                component_groups.push(inner);
+                            }
+                            for expr in exprs {
+                                match sanitize!(expr)? {
+                                    &Expression::Compose { ty, ref components }
+                                        if &eval.types[ty].inner
+                                            == &eval.types[first_ty].inner =>
+                                    {
+                                        let mut inner = ArrayVec::new();
+                                        for item in crate::proc::flatten_compose(
+                                            ty,
+                                            components,
+                                            eval.expressions,
+                                            eval.types,
+                                        ) {
+                                            inner.push(item);
+                                        }
+                                        component_groups.push(inner);
+                                    }
+                                    _ => return Err(err),
+                                }
+                            }
                             let component_groups = component_groups.into_inner().unwrap();
                             let mut new_components =
                                 ArrayVec::<_, { crate::VectorSize::MAX }>::new();
                             for idx in 0..(size as u8).into() {
-                                let group = component_groups
-                                    .iter()
-                                    .map(|cs| cs.get(idx).cloned().ok_or(err.clone()))
-                                    .collect::<Result<ArrayVec<_, N>, _>>()?
-                                    .into_inner()
-                                    .unwrap();
+                                let mut group_arr = ArrayVec::<_, N>::new();
+                                for cs in component_groups.iter() {
+                                    group_arr.push(
+                                        cs.get(idx).cloned().ok_or_else(|| err.clone())?,
+                                    );
+                                }
+                                let group = group_arr.into_inner().unwrap();
                                 new_components.push($ident(
                                     eval,
                                     span,
                                     group,
-                                    handler.clone(),
+                                    handler,
                                 )?);
                             }
                             Ok(Expression::Compose {
@@ -169,8 +180,8 @@ macro_rules! gen_component_wise_extractor {
                     _ => return Err(err),
                 },
                 _ => return Err(err),
-            }?;
-            eval.register_evaluated_expr(new_expr, span)
+            };
+            eval.register_evaluated_expr(new_expr?, span)
         }
 
         with_dollar_sign! {
@@ -302,17 +313,22 @@ impl LiteralVector {
 
     /// Creates [`LiteralVector`] of size 1 from single [`Literal`]
     fn from_literal(literal: Literal) -> Self {
+        fn arrayvec_of<T, const N: usize>(val: T) -> ArrayVec<T, N> {
+            let mut v = ArrayVec::new();
+            v.push(val);
+            v
+        }
         match literal {
-            Literal::F64(e) => Self::F64(ArrayVec::from_iter(iter::once(e))),
-            Literal::F32(e) => Self::F32(ArrayVec::from_iter(iter::once(e))),
-            Literal::U32(e) => Self::U32(ArrayVec::from_iter(iter::once(e))),
-            Literal::I32(e) => Self::I32(ArrayVec::from_iter(iter::once(e))),
-            Literal::U64(e) => Self::U64(ArrayVec::from_iter(iter::once(e))),
-            Literal::I64(e) => Self::I64(ArrayVec::from_iter(iter::once(e))),
-            Literal::Bool(e) => Self::Bool(ArrayVec::from_iter(iter::once(e))),
-            Literal::AbstractInt(e) => Self::AbstractInt(ArrayVec::from_iter(iter::once(e))),
-            Literal::AbstractFloat(e) => Self::AbstractFloat(ArrayVec::from_iter(iter::once(e))),
-            Literal::F16(e) => Self::F16(ArrayVec::from_iter(iter::once(e))),
+            Literal::F64(e) => Self::F64(arrayvec_of(e)),
+            Literal::F32(e) => Self::F32(arrayvec_of(e)),
+            Literal::U32(e) => Self::U32(arrayvec_of(e)),
+            Literal::I32(e) => Self::I32(arrayvec_of(e)),
+            Literal::U64(e) => Self::U64(arrayvec_of(e)),
+            Literal::I64(e) => Self::I64(arrayvec_of(e)),
+            Literal::Bool(e) => Self::Bool(arrayvec_of(e)),
+            Literal::AbstractInt(e) => Self::AbstractInt(arrayvec_of(e)),
+            Literal::AbstractFloat(e) => Self::AbstractFloat(arrayvec_of(e)),
+            Literal::F16(e) => Self::F16(arrayvec_of(e)),
         }
     }
 
@@ -324,119 +340,58 @@ impl LiteralVector {
         components: ArrayVec<Literal, { crate::VectorSize::MAX }>,
     ) -> Result<Self, ConstantEvaluatorError> {
         assert!(!components.is_empty());
+        // TODO: should a vector of i32 be constructible from abstract int?
+        macro_rules! compose_literals {
+            ($components:expr, $variant:ident, $self_variant:ident) => {{
+                let mut out = ArrayVec::new();
+                for l in &$components {
+                    match l {
+                        &Literal::$variant(v) => out.push(v),
+                        _ => return Err(ConstantEvaluatorError::InvalidMathArg),
+                    }
+                }
+                Self::$self_variant(out)
+            }};
+        }
         Ok(match components[0] {
-            Literal::I32(_) => Self::I32(
-                components
-                    .iter()
-                    .map(|l| match l {
-                        &Literal::I32(v) => Ok(v),
-                        // TODO: should we handle abstract int here?
-                        _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                    })
-                    .collect::<Result<_, _>>()?,
-            ),
-            Literal::U32(_) => Self::U32(
-                components
-                    .iter()
-                    .map(|l| match l {
-                        &Literal::U32(v) => Ok(v),
-                        _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                    })
-                    .collect::<Result<_, _>>()?,
-            ),
-            Literal::I64(_) => Self::I64(
-                components
-                    .iter()
-                    .map(|l| match l {
-                        &Literal::I64(v) => Ok(v),
-                        _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                    })
-                    .collect::<Result<_, _>>()?,
-            ),
-            Literal::U64(_) => Self::U64(
-                components
-                    .iter()
-                    .map(|l| match l {
-                        &Literal::U64(v) => Ok(v),
-                        _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                    })
-                    .collect::<Result<_, _>>()?,
-            ),
-            Literal::F32(_) => Self::F32(
-                components
-                    .iter()
-                    .map(|l| match l {
-                        &Literal::F32(v) => Ok(v),
-                        _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                    })
-                    .collect::<Result<_, _>>()?,
-            ),
-            Literal::F64(_) => Self::F64(
-                components
-                    .iter()
-                    .map(|l| match l {
-                        &Literal::F64(v) => Ok(v),
-                        _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                    })
-                    .collect::<Result<_, _>>()?,
-            ),
-            Literal::Bool(_) => Self::Bool(
-                components
-                    .iter()
-                    .map(|l| match l {
-                        &Literal::Bool(v) => Ok(v),
-                        _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                    })
-                    .collect::<Result<_, _>>()?,
-            ),
-            Literal::AbstractInt(_) => Self::AbstractInt(
-                components
-                    .iter()
-                    .map(|l| match l {
-                        &Literal::AbstractInt(v) => Ok(v),
-                        _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                    })
-                    .collect::<Result<_, _>>()?,
-            ),
-            Literal::AbstractFloat(_) => Self::AbstractFloat(
-                components
-                    .iter()
-                    .map(|l| match l {
-                        &Literal::AbstractFloat(v) => Ok(v),
-                        _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                    })
-                    .collect::<Result<_, _>>()?,
-            ),
-            Literal::F16(_) => Self::F16(
-                components
-                    .iter()
-                    .map(|l| match l {
-                        &Literal::F16(v) => Ok(v),
-                        _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                    })
-                    .collect::<Result<_, _>>()?,
-            ),
+            Literal::I32(_) => compose_literals!(components, I32, I32),
+            Literal::U32(_) => compose_literals!(components, U32, U32),
+            Literal::I64(_) => compose_literals!(components, I64, I64),
+            Literal::U64(_) => compose_literals!(components, U64, U64),
+            Literal::F32(_) => compose_literals!(components, F32, F32),
+            Literal::F64(_) => compose_literals!(components, F64, F64),
+            Literal::Bool(_) => compose_literals!(components, Bool, Bool),
+            Literal::AbstractInt(_) => compose_literals!(components, AbstractInt, AbstractInt),
+            Literal::AbstractFloat(_) => {
+                compose_literals!(components, AbstractFloat, AbstractFloat)
+            }
+            Literal::F16(_) => compose_literals!(components, F16, F16),
         })
     }
 
     #[allow(dead_code)]
     /// Returns [`ArrayVec`] of [`Literal`]s
     fn to_literal_vec(&self) -> ArrayVec<Literal, { crate::VectorSize::MAX }> {
+        macro_rules! decompose_literals {
+            ($v:expr, $variant:ident) => {{
+                let mut out = ArrayVec::new();
+                for e in $v {
+                    out.push(Literal::$variant(*e));
+                }
+                out
+            }};
+        }
         match *self {
-            LiteralVector::F64(ref v) => v.iter().map(|e| Literal::F64(*e)).collect(),
-            LiteralVector::F32(ref v) => v.iter().map(|e| Literal::F32(*e)).collect(),
-            LiteralVector::F16(ref v) => v.iter().map(|e| Literal::F16(*e)).collect(),
-            LiteralVector::U32(ref v) => v.iter().map(|e| Literal::U32(*e)).collect(),
-            LiteralVector::I32(ref v) => v.iter().map(|e| Literal::I32(*e)).collect(),
-            LiteralVector::U64(ref v) => v.iter().map(|e| Literal::U64(*e)).collect(),
-            LiteralVector::I64(ref v) => v.iter().map(|e| Literal::I64(*e)).collect(),
-            LiteralVector::Bool(ref v) => v.iter().map(|e| Literal::Bool(*e)).collect(),
-            LiteralVector::AbstractInt(ref v) => {
-                v.iter().map(|e| Literal::AbstractInt(*e)).collect()
-            }
-            LiteralVector::AbstractFloat(ref v) => {
-                v.iter().map(|e| Literal::AbstractFloat(*e)).collect()
-            }
+            LiteralVector::F64(ref v) => decompose_literals!(v, F64),
+            LiteralVector::F32(ref v) => decompose_literals!(v, F32),
+            LiteralVector::F16(ref v) => decompose_literals!(v, F16),
+            LiteralVector::U32(ref v) => decompose_literals!(v, U32),
+            LiteralVector::I32(ref v) => decompose_literals!(v, I32),
+            LiteralVector::U64(ref v) => decompose_literals!(v, U64),
+            LiteralVector::I64(ref v) => decompose_literals!(v, I64),
+            LiteralVector::Bool(ref v) => decompose_literals!(v, Bool),
+            LiteralVector::AbstractInt(ref v) => decompose_literals!(v, AbstractInt),
+            LiteralVector::AbstractFloat(ref v) => decompose_literals!(v, AbstractFloat),
         }
     }
 
@@ -1850,7 +1805,11 @@ impl<'a> ConstantEvaluator<'a> {
                     F: num_traits::Float + iter::Sum,
                 {
                     let len = e.iter().map(|&ei| ei * ei).sum::<F>().sqrt();
-                    e.iter().map(|&ei| ei / len).collect()
+                    let mut out = ArrayVec::new();
+                    for &ei in e {
+                        out.push(ei / len);
+                    }
+                    out
                 }
 
                 let result = match_literal_vector!(match e1 => LiteralVector {
@@ -2051,14 +2010,16 @@ impl<'a> ConstantEvaluator<'a> {
                 Ok(LiteralVector::from_literal(literal))
             }
             Expression::Compose { ty, ref components } => {
-                let components: ArrayVec<Literal, { crate::VectorSize::MAX }> =
+                let mut components_out = ArrayVec::<Literal, { crate::VectorSize::MAX }>::new();
+                for expr in
                     crate::proc::flatten_compose(ty, components, self.expressions, self.types)
-                        .map(|expr| match self.expressions[expr] {
-                            Expression::Literal(l) => Ok(l),
-                            _ => Err(ConstantEvaluatorError::InvalidMathArg),
-                        })
-                        .collect::<Result<_, ConstantEvaluatorError>>()?;
-                LiteralVector::from_literal_vec(components)
+                {
+                    match self.expressions[expr] {
+                        Expression::Literal(l) => components_out.push(l),
+                        _ => return Err(ConstantEvaluatorError::InvalidMathArg),
+                    }
+                }
+                LiteralVector::from_literal_vec(components_out)
             }
             _ => Err(ConstantEvaluatorError::InvalidMathArg),
         }
@@ -2900,13 +2861,20 @@ impl<'a> ConstantEvaluator<'a> {
                 Expression::Compose { ty, ref components }
                     if matches!(self.types[ty].inner, TypeInner::Vector { .. }) =>
                 {
-                    let components =
+                    let mut bool_components = ArrayVec::<bool, { crate::VectorSize::MAX }>::new();
+                    for component in
                         crate::proc::flatten_compose(ty, components, self.expressions, self.types)
-                            .map(|component| match self.expressions[component] {
-                                Expression::Literal(Literal::Bool(val)) => Ok(val),
-                                _ => Err(ConstantEvaluatorError::InvalidRelationalArg(fun)),
-                            })
-                            .collect::<Result<ArrayVec<bool, { crate::VectorSize::MAX }>, _>>()?;
+                    {
+                        match self.expressions[component] {
+                            Expression::Literal(Literal::Bool(val)) => {
+                                bool_components.push(val);
+                            }
+                            _ => {
+                                return Err(ConstantEvaluatorError::InvalidRelationalArg(fun));
+                            }
+                        }
+                    }
+                    let components = bool_components;
                     let result = match fun {
                         RelationalFunction::All => components.iter().all(|c| *c),
                         RelationalFunction::Any => components.iter().any(|c| *c),


### PR DESCRIPTION
Avoids using `ArrayVec::from_iter` in the constant evaluator. It is monomorphized by all three of the item type, the capacity, and the iterator type, which results in a shocking amount of bloat (take a guess, then you can see the actual number I measured in a comment in the diff).

Inspired by #9075, but not directly responsive to the suggestion in that issue.

**Testing**
Compiles and passes existing tests.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
