### PR TITLE
[core] Implement WebGPUError for WaitIdleError.

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -2,6 +2,7 @@ use alloc::{sync::Arc, vec::Vec};
 
 use smallvec::SmallVec;
 use thiserror::Error;
+use wgt::error::{ErrorType, WebGpuError};
 
 use crate::{
     device::{
@@ -142,6 +143,17 @@ impl WaitIdleError {
                 Some(wgt::PollError::WrongSubmissionIndex(a, b))
             }
             _ => None,
+        }
+    }
+}
+
+impl WebGpuError for WaitIdleError {
+    fn webgpu_error_type(&self) -> ErrorType {
+        match self {
+            WaitIdleError::Device(device_error) => device_error.webgpu_error_type(),
+            WaitIdleError::WrongSubmissionIndex(_, _) | WaitIdleError::Timeout => {
+                ErrorType::Internal
+            }
         }
     }
 }


### PR DESCRIPTION
Implement the `wgpu_types::error::WebGpuError` categorization trait for `wgpu_core::device::life::WaitIdleError`, so that the latter can be properly reported to users of the WebGPU API.
