### PR TITLE
naga build exclusion PoC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,7 +320,7 @@ wgpu = { path = "./wgpu" }
 generator = { git = "https://github.com/Xudong-Huang/generator-rs", rev = "70b89fdabcc0e82fe84ca17f65cc52ff25e8e6de" }
 
 [profile.release]
-lto = "thin"
+lto = "fat"
 debug = true
 
 # Speed up image comparison even in debug builds

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -907,6 +907,10 @@ fn dispatch_indirect(
     );
 
     if let Some(ref indirect_validation) = state.pass.base.device.indirect_validation {
+        if !wgt::shader_compilation_enabled() {
+            unreachable!("indirect validation is on, but shader compilation is disabled");
+        }
+
         let params = indirect_validation.dispatch.params(
             &state.pass.base.device.limits,
             offset,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2308,6 +2308,9 @@ pub(super) fn encode_render_pass(
         );
 
         if let Some(ref indirect_validation) = device.indirect_validation {
+            if !wgt::shader_compilation_enabled() {
+                unreachable!("indirect validation is on, but shader compilation is disabled");
+            }
             indirect_validation
                 .draw
                 .inject_validation_pass(
@@ -2833,6 +2836,9 @@ fn multi_draw_indirect(
     }
 
     if state.pass.base.device.indirect_validation.is_some() {
+        if !wgt::shader_compilation_enabled() {
+            unreachable!("indirect validation is on, but shader compilation is disabled");
+        }
         state
             .pass
             .scope

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -332,6 +332,12 @@ pub enum DeviceError {
     OutOfMemory,
     #[error(transparent)]
     DeviceMismatch(#[from] Box<DeviceMismatch>),
+    #[error(
+        "{0:?} {verb} not supported when shader compilation is disabled",
+        verb = if .0.bits().count_ones() > 1 { "are" } else { "is" },
+    )]
+    #[cfg_attr(feature = "serde", serde(skip))]
+    UnsupportedInstanceFlags(wgt::InstanceFlags),
 }
 
 impl WebGpuError for DeviceError {
@@ -340,6 +346,7 @@ impl WebGpuError for DeviceError {
             Self::DeviceMismatch(e) => e.webgpu_error_type(),
             Self::Lost => ErrorType::DeviceLost,
             Self::OutOfMemory => ErrorType::OutOfMemory,
+            Self::UnsupportedInstanceFlags(_) => ErrorType::Validation,
         }
     }
 }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -382,6 +382,15 @@ impl Device {
         desc: &DeviceDescriptor,
         instance_flags: wgt::InstanceFlags,
     ) -> Result<Self, DeviceError> {
+        if !wgt::shader_compilation_enabled() {
+            let unsupported = instance_flags
+                & (wgt::InstanceFlags::VALIDATION_INDIRECT_CALL
+                    | wgt::InstanceFlags::AUTOMATIC_TIMESTAMP_NORMALIZATION);
+            if !unsupported.is_empty() {
+                return Err(DeviceError::UnsupportedInstanceFlags(unsupported));
+            }
+        }
+
         #[cfg(not(feature = "trace"))]
         match &desc.trace {
             wgt::Trace::Off => {}
@@ -492,6 +501,9 @@ impl Device {
             && limits.max_storage_buffers_per_shader_stage >= 2;
 
         let indirect_validation = if enable_indirect_validation {
+            if !wgt::shader_compilation_enabled() {
+                unreachable!("indirect validation is on, but shader compilation is disabled");
+            }
             Some(crate::indirect_validation::IndirectValidation::new(
                 raw_device.as_ref(),
                 &desc.required_limits,
@@ -2234,6 +2246,10 @@ impl Device {
         desc: &pipeline::ShaderModuleDescriptor<'a>,
         source: pipeline::ShaderModuleSource<'a>,
     ) -> Result<Arc<pipeline::ShaderModule>, pipeline::CreateShaderModuleError> {
+        if !wgt::shader_compilation_enabled() {
+            return Err(pipeline::CreateShaderModuleError::ShaderCompilationDisabled);
+        }
+
         self.check_is_valid()?;
 
         let (module, source) = match source {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -135,6 +135,8 @@ pub enum CreateShaderModuleError {
     },
     #[error("Generic shader passthrough does not contain any code compatible with this backend.")]
     NotCompiledForBackend,
+    #[error("create_shader_module is not available when shader compilation is disabled")]
+    ShaderCompilationDisabled,
 }
 
 impl WebGpuError for CreateShaderModuleError {
@@ -152,7 +154,9 @@ impl WebGpuError for CreateShaderModuleError {
             Self::ParsingGlsl(..) => return ErrorType::Validation,
             #[cfg(feature = "spirv")]
             Self::ParsingSpirV(..) => return ErrorType::Validation,
-            Self::NotCompiledForBackend => return ErrorType::Validation,
+            Self::NotCompiledForBackend | Self::ShaderCompilationDisabled => {
+                return ErrorType::Validation
+            }
         };
         e.webgpu_error_type()
     }

--- a/wgpu-core/src/timestamp_normalization/mod.rs
+++ b/wgpu-core/src/timestamp_normalization/mod.rs
@@ -109,6 +109,10 @@ impl TimestampNormalizer {
                 return Ok(Self { state: None });
             }
 
+            if !wgt::shader_compilation_enabled() {
+                unreachable!("timestamp validation is on, but shader compilation is disabled");
+            }
+
             let temporary_bind_group_layout = device
                 .raw()
                 .create_bind_group_layout(&hal::BindGroupLayoutDescriptor {

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -314,6 +314,9 @@ impl super::Device {
 
         let key = match &stage.module.source {
             super::ShaderModuleSource::Naga(naga_shader) => {
+                if !wgt::shader_compilation_enabled() {
+                    unreachable!("shader compilation not enabled");
+                }
                 use naga::back::hlsl;
 
                 let frag_ep = match fragment_stage {

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -224,6 +224,9 @@ impl super::Device {
         context: CompilationContext,
         program: glow::Program,
     ) -> Result<glow::Shader, crate::PipelineError> {
+        if !wgt::shader_compilation_enabled() {
+            unreachable!("shader compilation not enabled");
+        }
         use naga::back::glsl;
         let pipeline_options = glsl::PipelineOptions {
             shader_stage: naga_stage,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -145,6 +145,9 @@ impl super::Device {
     ) -> Result<CompiledShader, crate::PipelineError> {
         match stage.module.source {
             ShaderModuleSource::Naga(ref naga_shader) => {
+                if !wgt::shader_compilation_enabled() {
+                    unreachable!("shader compilation not enabled");
+                }
                 let stage_bit = map_naga_stage(naga_stage);
                 let (module, module_info) = naga::back::pipeline_constants::process_overrides(
                     &naga_shader.module,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -644,6 +644,9 @@ impl super::Device {
                 ref naga_shader,
                 runtime_checks,
             } => {
+                if !wgt::shader_compilation_enabled() {
+                    unreachable!("shader compilation not enabled");
+                }
                 let pipeline_options = naga::back::spv::PipelineOptions {
                     entry_point: stage.entry_point.to_owned(),
                     shader_stage: naga_stage,
@@ -1735,12 +1738,18 @@ impl crate::Device for super::Device {
                     .contains(super::Workarounds::SEPARATE_ENTRY_POINTS)
                     || !naga_shader.module.overrides.is_empty() =>
             {
+                if !wgt::shader_compilation_enabled() {
+                    unreachable!("shader compilation not enabled");
+                }
                 super::ShaderModule::Intermediate {
                     naga_shader,
                     runtime_checks: desc.runtime_checks,
                 }
             }
             crate::ShaderInput::Naga(naga_shader) => {
+                if !wgt::shader_compilation_enabled() {
+                    unreachable!("shader compilation not enabled");
+                }
                 let mut naga_options = self.naga_options.clone();
                 naga_options.debug_info =
                     naga_shader

--- a/wgpu-types/src/tokens.rs
+++ b/wgpu-types/src/tokens.rs
@@ -1,4 +1,17 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use crate::link_to_wgpu_item;
+
+static SHADER_COMPILATION_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Returns whether shader compilation has been enabled via
+/// [`ExperimentalFeatures::enabled()`].
+///
+/// When fat LTO is enabled and `ExperimentalFeatures::enabled()` is never called, LLVM can
+/// see that naga is unused and eliminate nearly all the naga code from the binary.
+pub fn shader_compilation_enabled() -> bool {
+    SHADER_COMPILATION_ENABLED.load(Ordering::Relaxed)
+}
 
 /// Token of the user agreeing to access experimental features.
 #[derive(Debug, Default, Copy, Clone)]
@@ -34,7 +47,8 @@ impl ExperimentalFeatures {
     ///
     #[doc = link_to_wgpu_item!(struct Features)]
     /// [`api-specs`]: https://github.com/gfx-rs/wgpu/tree/trunk/docs/api-specs
-    pub const unsafe fn enabled() -> Self {
+    pub unsafe fn enabled() -> Self {
+        SHADER_COMPILATION_ENABLED.store(true, Ordering::Relaxed);
         Self { enabled: true }
     }
 


### PR DESCRIPTION
PoC of a global flag (`AtomicBool`, not a const) for whether shader compilation is enabled. If fat LTO is used and the flag is never set, most of naga is removed from the resulting binary.

(Here I've overloaded setting the flag on `ExperimentalFeatures::enabled`, because it was easy and convenient, obviously that is not how it would really be controlled.)