### PR TITLE
fix(naga): Validate presence of pipeline constants

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -15,7 +15,6 @@ webgpu:api,validation,buffer,mapping:* // crash
 webgpu:api,validation,capability_checks,features,* // 21%, TypeError not thrown for missing features (needs deno_webgpu fix)
 webgpu:api,validation,capability_checks,limits,* // 60%, workgroup storage size validation unimplemented; interstage vars counting; bind group timing on dx12
 webgpu:api,validation,compute_pipeline:limits,workgroup_storage_size:* // 0%
-webgpu:api,validation,compute_pipeline:overrides,identifier:* // 46%
 webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits,workgroup_storage_size:* // 0%, missing workgroup storage size validation
 webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:* // 0%
 webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -66,6 +66,7 @@ webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:crea
 webgpu:api,validation,compute_pipeline:basic:*
 webgpu:api,validation,compute_pipeline:limits,invocations_per_workgroup,each_component:*
 webgpu:api,validation,compute_pipeline:limits,invocations_per_workgroup:*
+webgpu:api,validation,compute_pipeline:overrides,identifier:*
 webgpu:api,validation,compute_pipeline:overrides,entry_point,validation_error:*
 webgpu:api,validation,compute_pipeline:overrides,uninitialized:*
 webgpu:api,validation,compute_pipeline:overrides,value,type_error:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -66,8 +66,8 @@ webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:crea
 webgpu:api,validation,compute_pipeline:basic:*
 webgpu:api,validation,compute_pipeline:limits,invocations_per_workgroup,each_component:*
 webgpu:api,validation,compute_pipeline:limits,invocations_per_workgroup:*
-webgpu:api,validation,compute_pipeline:overrides,identifier:*
 webgpu:api,validation,compute_pipeline:overrides,entry_point,validation_error:*
+webgpu:api,validation,compute_pipeline:overrides,identifier:*
 webgpu:api,validation,compute_pipeline:overrides,uninitialized:*
 webgpu:api,validation,compute_pipeline:overrides,value,type_error:*
 webgpu:api,validation,compute_pipeline:overrides,value,validation_error,f16:*

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -1,6 +1,7 @@
 use alloc::{
     borrow::Cow,
     string::{String, ToString},
+    vec::Vec,
 };
 use core::mem;
 
@@ -27,6 +28,8 @@ use num_traits::float::FloatCore as _;
 pub enum PipelineConstantError {
     #[error("Missing value for pipeline-overridable constant with identifier string: '{0}'")]
     MissingValue(String),
+    #[error("pipeline-overridable constant '{0}' not found in the shader")]
+    NotFound(String),
     #[error(
         "Source f64 value needs to be finite ({}) for number destinations",
         "NaNs and Inifinites are not allowed"
@@ -66,6 +69,27 @@ pub fn process_overrides<'a>(
     entry_point: Option<(ir::ShaderStage, &str)>,
     pipeline_constants: &PipelineConstants,
 ) -> Result<(Cow<'a, Module>, Cow<'a, ModuleInfo>), PipelineConstantError> {
+    let mut handles = module
+        .overrides
+        .iter()
+        .map(|(handle, _)| handle)
+        .collect::<Vec<_>>();
+    for c in pipeline_constants.keys() {
+        let c_id = c.parse().ok();
+        if let Some((i, _)) = handles.iter().enumerate().find(|&(_, handle)| {
+            let o = &module.overrides[*handle];
+            if o.id.is_some() {
+                o.id == c_id
+            } else {
+                o.name.as_deref() == Some(c.as_str())
+            }
+        }) {
+            handles.swap_remove(i);
+        } else {
+            return Err(PipelineConstantError::NotFound(c.clone()));
+        }
+    }
+
     if (entry_point.is_none() || module.entry_points.len() <= 1) && module.overrides.is_empty() {
         // We skip compacting the module here mostly to reduce the risk of
         // hitting corner cases like https://github.com/gfx-rs/wgpu/issues/7793.


### PR DESCRIPTION
**Connections**
Fixes #8906

**Description**
Cause an error if a pipeline constant identifier doesn't exist in the shader

**Testing**
* Existing tests (cargo xtask test)
  passed
* CTS pass ratio
  webgpu:api,validation,compute_pipeline:overrides,identifier:* : 12/26 (46.15%) -> 26/26 (100%)

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
