### PR TITLE
refactor: removed unused TextureViewDestroyError

### DIFF
--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -84,7 +84,7 @@ impl GPUTexture {
 impl Drop for GPUTexture {
   fn drop(&mut self) {
     if let Some(id) = self.default_view_id.take() {
-      self.instance.texture_view_drop(id).unwrap();
+      self.instance.texture_view_drop(id);
     }
     self.instance.texture_drop(self.id);
   }
@@ -273,7 +273,7 @@ pub struct GPUTextureView {
 
 impl Drop for GPUTextureView {
   fn drop(&mut self) {
-    let _ = self.instance.texture_view_drop(self.id);
+    self.instance.texture_view_drop(self.id);
   }
 }
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -481,10 +481,7 @@ impl Global {
         (id, Some(error))
     }
 
-    pub fn texture_view_drop(
-        &self,
-        texture_view_id: id::TextureViewId,
-    ) -> Result<(), resource::TextureViewDestroyError> {
+    pub fn texture_view_drop(&self, texture_view_id: id::TextureViewId) {
         profiling::scope!("TextureView::drop");
         api_log!("TextureView::drop {texture_view_id:?}");
 
@@ -498,7 +495,6 @@ impl Global {
                 t.add(trace::Action::DestroyTextureView(view.to_trace()));
             }
         }
-        Ok(())
     }
 
     pub fn device_create_external_texture(

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1913,10 +1913,6 @@ impl WebGpuError for CreateTextureViewError {
     }
 }
 
-#[derive(Clone, Debug, Error)]
-#[non_exhaustive]
-pub enum TextureViewDestroyError {}
-
 crate::impl_resource_type!(TextureView);
 crate::impl_labeled!(TextureView);
 crate::impl_parent_device!(TextureView);

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2156,8 +2156,7 @@ impl dispatch::TextureViewInterface for CoreTextureView {}
 
 impl Drop for CoreTextureView {
     fn drop(&mut self) {
-        // TODO: We don't use this error at all?
-        let _ = self.context.0.texture_view_drop(self.id);
+        self.context.0.texture_view_drop(self.id);
     }
 }
 


### PR DESCRIPTION
**Description**
Removes unused type `TextureViewDestroyError`

This type was never constructed, was name 'destroy error' but was returned from drop, and didn't match other destroy methods that don't return anything. There was even a comment in the wgpu_core backend expressing surprise that this error exists at all.

**Testing**
 Just the tests mentioned in the checklist section.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->

Running cargo xtask test gave me some failures even without my commit, so I think that those failures are not because of this change.

I didn't add this change to the CHANGELOG as it seems to mostly list wgpu specific changes, and not wgpu-core changes.