### PR TITLE
macOS: Fix one-second delay when switching a wgpu app to the foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ By @teoxoy in [#9034](https://github.com/gfx-rs/wgpu/pull/9034).
 
 #### MSRV update
 
-`wgpu` now has a new MSRV policy. This release has an MSRV of **1.87**. This is lower than v27's 1.88 and v28's 1.92. Going forward, we will only bump wgpu's MSRV if it has tangible benefits for the code, and we will never bump to an MSRV higher than `stable - 3`. So if stable is at 1.97 and 1.94 brought benefit to our code, we could bump it no higher than 1.94. As before, MSRV bumps will always be breaking changes. 
+`wgpu` now has a new MSRV policy. This release has an MSRV of **1.87**. This is lower than v27's 1.88 and v28's 1.92. Going forward, we will only bump wgpu's MSRV if it has tangible benefits for the code, and we will never bump to an MSRV higher than `stable - 3`. So if stable is at 1.97 and 1.94 brought benefit to our code, we could bump it no higher than 1.94. As before, MSRV bumps will always be breaking changes.
 
 By @cwfitzgerald in [#8999](https://github.com/gfx-rs/wgpu/pull/8999).
 
@@ -143,7 +143,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 
 - Several error APIs were changed by @ErichDonGubler in [#9073](https://github.com/gfx-rs/wgpu/pull/9073):
     - `BufferAccessError`:
-        - Split the `OutOfBoundsOverrun` variant into new `OutOfBoundsStartOffsetOverrun` and `OutOfBoundsEndOffsetOverrun` variants. 
+        - Split the `OutOfBoundsOverrun` variant into new `OutOfBoundsStartOffsetOverrun` and `OutOfBoundsEndOffsetOverrun` variants.
         - Removed the `NegativeRange` variant in favor of new `MapStartOffsetUnderrun` and `MapStartOffsetOverrun` variants.
     - Split the `TransferError::BufferOverrun` variant into new `BufferStartOffsetOverrun` and `BufferEndOffsetOverrun` variants.
 
@@ -201,6 +201,9 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 #### Vulkan
 - Fixed a variety of mesh shader SPIR-V writer issues from the original implementation. By @inner-daemons in [#8756](https://github.com/gfx-rs/wgpu/pull/8756)
 
+#### Metal / macOS
+- Fix one-second delay when switching a wgpu app to the foreground. By [@emilk](https://github.com/emilk) in [#9141](https://github.com/gfx-rs/wgpu/pull/9141)
+
 #### GLES
 
 - `DisplayHandle` should now be passed to `InstanceDescriptor` for correct EGL initialization on Wayland. By @MarijnS95 in [#8012](https://github.com/gfx-rs/wgpu/pull/8012)
@@ -238,7 +241,7 @@ This has been a long time coming. See [the tracking issue](https://github.com/gf
 They are now fully supported on Vulkan, and supported on Metal and DX12 with passthrough shaders. WGSL parsing and rewriting
 is supported, meaning they can be used through WESL or naga_oil.
 
-Mesh shader pipelines replace the standard vertex shader pipelines and allow new ways to render meshes. 
+Mesh shader pipelines replace the standard vertex shader pipelines and allow new ways to render meshes.
 They are ideal for meshlet rendering, a form of rendering where small groups of triangles are handled together,
 for both culling and rendering.
 
@@ -285,7 +288,7 @@ fn ms_main(@builtin(local_invocation_index) index: u32, @builtin(global_invocati
 
     mesh_output.vertices[2].position = positions[2];
     mesh_output.vertices[2].color = colors[2] * taskPayload.colorMask;
-    
+
     // Set the vertex indices for the only primitive
     mesh_output.primitives[0].indices = vec3<u32>(0, 1, 2);
     // Cull it if the data passed by the task shader says to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 )),
 ```
 
+#### Other breaking changes
+- ⚠️ `get_current_texture` can now return `SurfaceError::Occluded` [#9141](https://github.com/gfx-rs/wgpu/pull/9141)
+
 ### New Features
 
 #### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ By @teoxoy in [#9034](https://github.com/gfx-rs/wgpu/pull/9034).
 
 #### MSRV update
 
-`wgpu` now has a new MSRV policy. This release has an MSRV of **1.87**. This is lower than v27's 1.88 and v28's 1.92. Going forward, we will only bump wgpu's MSRV if it has tangible benefits for the code, and we will never bump to an MSRV higher than `stable - 3`. So if stable is at 1.97 and 1.94 brought benefit to our code, we could bump it no higher than 1.94. As before, MSRV bumps will always be breaking changes.
+`wgpu` now has a new MSRV policy. This release has an MSRV of **1.87**. This is lower than v27's 1.88 and v28's 1.92. Going forward, we will only bump wgpu's MSRV if it has tangible benefits for the code, and we will never bump to an MSRV higher than `stable - 3`. So if stable is at 1.97 and 1.94 brought benefit to our code, we could bump it no higher than 1.94. As before, MSRV bumps will always be breaking changes. 
 
 By @cwfitzgerald in [#8999](https://github.com/gfx-rs/wgpu/pull/8999).
 
@@ -143,7 +143,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 
 - Several error APIs were changed by @ErichDonGubler in [#9073](https://github.com/gfx-rs/wgpu/pull/9073):
     - `BufferAccessError`:
-        - Split the `OutOfBoundsOverrun` variant into new `OutOfBoundsStartOffsetOverrun` and `OutOfBoundsEndOffsetOverrun` variants.
+        - Split the `OutOfBoundsOverrun` variant into new `OutOfBoundsStartOffsetOverrun` and `OutOfBoundsEndOffsetOverrun` variants. 
         - Removed the `NegativeRange` variant in favor of new `MapStartOffsetUnderrun` and `MapStartOffsetOverrun` variants.
     - Split the `TransferError::BufferOverrun` variant into new `BufferStartOffsetOverrun` and `BufferEndOffsetOverrun` variants.
 
@@ -241,7 +241,7 @@ This has been a long time coming. See [the tracking issue](https://github.com/gf
 They are now fully supported on Vulkan, and supported on Metal and DX12 with passthrough shaders. WGSL parsing and rewriting
 is supported, meaning they can be used through WESL or naga_oil.
 
-Mesh shader pipelines replace the standard vertex shader pipelines and allow new ways to render meshes.
+Mesh shader pipelines replace the standard vertex shader pipelines and allow new ways to render meshes. 
 They are ideal for meshlet rendering, a form of rendering where small groups of triangles are handled together,
 for both culling and rendering.
 
@@ -288,7 +288,7 @@ fn ms_main(@builtin(local_invocation_index) index: u32, @builtin(global_invocati
 
     mesh_output.vertices[2].position = positions[2];
     mesh_output.vertices[2].color = colors[2] * taskPayload.colorMask;
-
+    
     // Set the vertex indices for the only primitive
     mesh_output.primitives[0].indices = vec3<u32>(0, 1, 2);
     // Cull it if the data passed by the task shader says to

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -205,15 +205,15 @@ impl SurfaceWrapper {
     }
 
     /// Acquire the next surface texture.
-    fn acquire(&mut self, context: &ExampleContext) -> wgpu::SurfaceTexture {
+    ///
+    /// Returns `None` on failure.
+    fn acquire(&mut self, context: &ExampleContext) -> Option<wgpu::SurfaceTexture> {
         let surface = self.surface.as_ref().unwrap();
 
         match surface.get_current_texture() {
-            Ok(frame) => frame,
-            // If we timed out, just try again
-            Err(wgpu::SurfaceError::Timeout) => surface
-                .get_current_texture()
-                .expect("Failed to acquire next surface texture!"),
+            Ok(frame) => Some(frame),
+            // If we timed out or the window is occluded, skip this frame:
+            Err(wgpu::SurfaceError::Timeout | wgpu::SurfaceError::Occluded) => None,
             Err(
                 // If the surface is outdated, or was lost, reconfigure it.
                 wgpu::SurfaceError::Outdated
@@ -223,9 +223,9 @@ impl SurfaceWrapper {
                 | wgpu::SurfaceError::OutOfMemory,
             ) => {
                 surface.configure(&context.device, self.config());
-                surface
+                Some(surface
                     .get_current_texture()
-                    .expect("Failed to acquire next surface texture!")
+                    .expect("Failed to acquire next surface texture!"))
             }
         }
     }
@@ -427,19 +427,21 @@ async fn start<E: Example>(title: &str) {
 
                         frame_counter.update();
 
-                        let frame = surface.acquire(&context);
-                        let view = frame.texture.create_view(&wgpu::TextureViewDescriptor {
-                            format: Some(surface.config().view_formats[0]),
-                            ..wgpu::TextureViewDescriptor::default()
-                        });
+                        if let Some(frame) = surface.acquire(&context) {
+                            let view = frame.texture.create_view(&wgpu::TextureViewDescriptor {
+                                format: Some(surface.config().view_formats[0]),
+                                ..wgpu::TextureViewDescriptor::default()
+                            });
 
-                        example
-                            .as_mut()
-                            .unwrap()
-                            .render(&view, &context.device, &context.queue);
+                            example.as_mut().unwrap().render(
+                                &view,
+                                &context.device,
+                                &context.queue,
+                            );
 
-                        window_loop.window.pre_present_notify();
-                        frame.present();
+                            window_loop.window.pre_present_notify();
+                            frame.present();
+                        }
 
                         window_loop.window.request_redraw();
                     }

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -1,4 +1,5 @@
 use std::{borrow::Cow, sync::Arc};
+use wgpu::SurfaceError;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -107,43 +108,51 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                         // On macos the window needs to be redrawn manually after resizing
                         window.request_redraw();
                     }
-                    WindowEvent::RedrawRequested => {
-                        let frame = surface
-                            .get_current_texture()
-                            .expect("Failed to acquire next swap chain texture");
-                        let view = frame
-                            .texture
-                            .create_view(&wgpu::TextureViewDescriptor::default());
-                        let mut encoder =
-                            device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                                label: None,
-                            });
-                        {
-                            let mut rpass =
-                                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    WindowEvent::RedrawRequested => match surface.get_current_texture() {
+                        Ok(frame) => {
+                            let view = frame
+                                .texture
+                                .create_view(&wgpu::TextureViewDescriptor::default());
+                            let mut encoder =
+                                device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
                                     label: None,
-                                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                        view: &view,
-                                        depth_slice: None,
-                                        resolve_target: None,
-                                        ops: wgpu::Operations {
-                                            load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
-                                            store: wgpu::StoreOp::Store,
-                                        },
-                                    })],
-                                    depth_stencil_attachment: None,
-                                    timestamp_writes: None,
-                                    occlusion_query_set: None,
-                                    multiview_mask: None,
                                 });
-                            rpass.set_pipeline(&render_pipeline);
-                            rpass.draw(0..3, 0..1);
-                        }
+                            {
+                                let mut rpass =
+                                    encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                        label: None,
+                                        color_attachments: &[Some(
+                                            wgpu::RenderPassColorAttachment {
+                                                view: &view,
+                                                depth_slice: None,
+                                                resolve_target: None,
+                                                ops: wgpu::Operations {
+                                                    load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
+                                                    store: wgpu::StoreOp::Store,
+                                                },
+                                            },
+                                        )],
+                                        depth_stencil_attachment: None,
+                                        timestamp_writes: None,
+                                        occlusion_query_set: None,
+                                        multiview_mask: None,
+                                    });
+                                rpass.set_pipeline(&render_pipeline);
+                                rpass.draw(0..3, 0..1);
+                            }
 
-                        queue.submit(Some(encoder.finish()));
-                        window.pre_present_notify();
-                        frame.present();
-                    }
+                            queue.submit(Some(encoder.finish()));
+                            window.pre_present_notify();
+                            frame.present();
+                        }
+                        Err(SurfaceError::Timeout | SurfaceError::Occluded) => {
+                            window.request_redraw(); // Try again  later
+                        }
+                        Err(err) => {
+                            // TODO: reconfigure the surface instead
+                            panic!("get_current_texture: {err}");
+                        }
+                    },
                     WindowEvent::CloseRequested => target.exit(),
                     _ => {}
                 };

--- a/examples/features/src/hello_windows/mod.rs
+++ b/examples/features/src/hello_windows/mod.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(target_arch = "wasm32", allow(dead_code))]
 
 use std::{collections::HashMap, sync::Arc};
+use wgpu::SurfaceError;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -45,11 +46,9 @@ impl Viewport {
         self.config.height = size.height;
         self.desc.surface.configure(device, &self.config);
     }
-    fn get_current_texture(&mut self) -> wgpu::SurfaceTexture {
-        self.desc
-            .surface
-            .get_current_texture()
-            .expect("Failed to acquire next swap chain texture")
+
+    fn get_current_texture(&mut self) -> Result<wgpu::SurfaceTexture, SurfaceError> {
+        self.desc.surface.get_current_texture()
     }
 }
 
@@ -105,41 +104,51 @@ async fn run(event_loop: EventLoop<()>, viewports: Vec<(Arc<Window>, wgpu::Color
                     }
                     WindowEvent::RedrawRequested => {
                         if let Some(viewport) = viewports.get_mut(&window_id) {
-                            let frame = viewport.get_current_texture();
-                            let view = frame
-                                .texture
-                                .create_view(&wgpu::TextureViewDescriptor::default());
-                            let mut encoder =
-                                device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                                    label: None,
-                                });
-                            {
-                                let _rpass =
-                                    encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                        label: None,
-                                        color_attachments: &[Some(
-                                            wgpu::RenderPassColorAttachment {
-                                                view: &view,
-                                                depth_slice: None,
-                                                resolve_target: None,
-                                                ops: wgpu::Operations {
-                                                    load: wgpu::LoadOp::Clear(
-                                                        viewport.desc.background,
-                                                    ),
-                                                    store: wgpu::StoreOp::Store,
-                                                },
+                            match viewport.get_current_texture() {
+                                Ok(frame) => {
+                                    let view = frame
+                                        .texture
+                                        .create_view(&wgpu::TextureViewDescriptor::default());
+                                    let mut encoder = device.create_command_encoder(
+                                        &wgpu::CommandEncoderDescriptor { label: None },
+                                    );
+                                    {
+                                        let _rpass = encoder.begin_render_pass(
+                                            &wgpu::RenderPassDescriptor {
+                                                label: None,
+                                                color_attachments: &[Some(
+                                                    wgpu::RenderPassColorAttachment {
+                                                        view: &view,
+                                                        depth_slice: None,
+                                                        resolve_target: None,
+                                                        ops: wgpu::Operations {
+                                                            load: wgpu::LoadOp::Clear(
+                                                                viewport.desc.background,
+                                                            ),
+                                                            store: wgpu::StoreOp::Store,
+                                                        },
+                                                    },
+                                                )],
+                                                depth_stencil_attachment: None,
+                                                timestamp_writes: None,
+                                                occlusion_query_set: None,
+                                                multiview_mask: None,
                                             },
-                                        )],
-                                        depth_stencil_attachment: None,
-                                        timestamp_writes: None,
-                                        occlusion_query_set: None,
-                                        multiview_mask: None,
-                                    });
-                            }
+                                        );
+                                    }
 
-                            queue.submit(Some(encoder.finish()));
-                            viewport.desc.window.pre_present_notify();
-                            frame.present();
+                                    queue.submit(Some(encoder.finish()));
+                                    viewport.desc.window.pre_present_notify();
+                                    frame.present();
+                                }
+                                Err(SurfaceError::Timeout | SurfaceError::Occluded) => {
+                                    viewport.desc.window.request_redraw(); // Try again later
+                                }
+                                Err(err) => {
+                                    // TODO: reconfigure the surface instead
+                                    panic!("get_current_texture: {err}");
+                                }
+                            }
                         }
                     }
                     WindowEvent::CloseRequested => {

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 // We won't bring StorageBuffer into scope as that might be too easy to confuse
 // with actual GPU-allocated wgpu storage buffers.
 use encase::ShaderType;
+use wgpu::SurfaceError;
 use winit::{
     event::{Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
@@ -284,55 +285,68 @@ async fn run(event_loop: EventLoop<()>, window: Arc<Window>) {
                         WindowEvent::RedrawRequested => {
                             let wgpu_context_ref = wgpu_context.as_ref().unwrap();
                             let state_ref = state.as_ref().unwrap();
-                            let frame = wgpu_context_ref.surface.get_current_texture().unwrap();
-                            let view = frame
-                                .texture
-                                .create_view(&wgpu::TextureViewDescriptor::default());
+                            match wgpu_context_ref.surface.get_current_texture() {
+                                Ok(frame) => {
+                                    let view = frame
+                                        .texture
+                                        .create_view(&wgpu::TextureViewDescriptor::default());
 
-                            // (8)
-                            wgpu_context_ref.queue.write_buffer(
-                                &wgpu_context_ref.uniform_buffer,
-                                0,
-                                &state_ref.as_wgsl_bytes().expect(
-                                    "Error in encase translating AppState \
-                    struct to WGSL bytes.",
-                                ),
-                            );
-                            let mut encoder = wgpu_context_ref.device.create_command_encoder(
-                                &wgpu::CommandEncoderDescriptor { label: None },
-                            );
-                            {
-                                let mut render_pass =
-                                    encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                        label: None,
-                                        color_attachments: &[Some(
-                                            wgpu::RenderPassColorAttachment {
-                                                view: &view,
-                                                depth_slice: None,
-                                                resolve_target: None,
-                                                ops: wgpu::Operations {
-                                                    load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
-                                                    store: wgpu::StoreOp::Store,
-                                                },
+                                    // (8)
+                                    wgpu_context_ref.queue.write_buffer(
+                                        &wgpu_context_ref.uniform_buffer,
+                                        0,
+                                        &state_ref.as_wgsl_bytes().expect(
+                                            "Error in encase translating AppState struct to WGSL bytes."
+                                        ),
+                                    );
+                                    let mut encoder =
+                                        wgpu_context_ref.device.create_command_encoder(
+                                            &wgpu::CommandEncoderDescriptor { label: None },
+                                        );
+                                    {
+                                        let mut render_pass = encoder.begin_render_pass(
+                                            &wgpu::RenderPassDescriptor {
+                                                label: None,
+                                                color_attachments: &[Some(
+                                                    wgpu::RenderPassColorAttachment {
+                                                        view: &view,
+                                                        depth_slice: None,
+                                                        resolve_target: None,
+                                                        ops: wgpu::Operations {
+                                                            load: wgpu::LoadOp::Clear(
+                                                                wgpu::Color::GREEN,
+                                                            ),
+                                                            store: wgpu::StoreOp::Store,
+                                                        },
+                                                    },
+                                                )],
+                                                depth_stencil_attachment: None,
+                                                occlusion_query_set: None,
+                                                timestamp_writes: None,
+                                                multiview_mask: None,
                                             },
-                                        )],
-                                        depth_stencil_attachment: None,
-                                        occlusion_query_set: None,
-                                        timestamp_writes: None,
-                                        multiview_mask: None,
-                                    });
-                                render_pass.set_pipeline(&wgpu_context_ref.pipeline);
-                                // (9)
-                                render_pass.set_bind_group(
-                                    0,
-                                    Some(&wgpu_context_ref.bind_group),
-                                    &[],
-                                );
-                                render_pass.draw(0..3, 0..1);
+                                        );
+                                        render_pass.set_pipeline(&wgpu_context_ref.pipeline);
+                                        // (9)
+                                        render_pass.set_bind_group(
+                                            0,
+                                            Some(&wgpu_context_ref.bind_group),
+                                            &[],
+                                        );
+                                        render_pass.draw(0..3, 0..1);
+                                    }
+                                    wgpu_context_ref.queue.submit(Some(encoder.finish()));
+                                    window.pre_present_notify();
+                                    frame.present();
+                                }
+                                Err(SurfaceError::Timeout | SurfaceError::Occluded) => {
+                                    window.request_redraw(); // try again later
+                                }
+                                Err(err) => {
+                                    // TODO: reconfigure the surface instead
+                                    panic!("get_current_texture: {err}");
+                                }
                             }
-                            wgpu_context_ref.queue.submit(Some(encoder.finish()));
-                            window.pre_present_notify();
-                            frame.present();
                         }
                         _ => {}
                     }

--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -83,7 +83,7 @@ impl State {
         // (e.g., when the window is occluded on macOS).
         let surface_texture = match self.surface.get_current_texture() {
             Ok(texture) => texture,
-            Err(wgpu::SurfaceError::Timeout) => return,
+            Err(wgpu::SurfaceError::Occluded) => return, // Can't render right now. Try again later.
             Err(err) => panic!("failed to acquire next swapchain texture: {err}"),
         };
         let texture_view = surface_texture

--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -78,11 +78,14 @@ impl State {
     }
 
     fn render(&mut self) {
-        // Create texture view
-        let surface_texture = self
-            .surface
-            .get_current_texture()
-            .expect("failed to acquire next swapchain texture");
+        // Create texture view.
+        // NOTE: We must handle Timeout because the surface may be unavailable
+        // (e.g., when the window is occluded on macOS).
+        let surface_texture = match self.surface.get_current_texture() {
+            Ok(texture) => texture,
+            Err(wgpu::SurfaceError::Timeout) => return,
+            Err(err) => panic!("failed to acquire next swapchain texture: {err}"),
+        };
         let texture_view = surface_texture
             .texture
             .create_view(&wgpu::TextureViewDescriptor {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -5121,9 +5121,9 @@ impl Device {
                     Ok(()) => (),
                     Err(error) => {
                         break 'error match error {
-                            hal::SurfaceError::Outdated | hal::SurfaceError::Lost => {
-                                E::InvalidSurface
-                            }
+                            hal::SurfaceError::Outdated
+                            | hal::SurfaceError::Lost
+                            | hal::SurfaceError::Timeout => E::InvalidSurface,
                             hal::SurfaceError::Device(error) => {
                                 E::Device(self.handle_hal_error(error))
                             }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -5123,6 +5123,7 @@ impl Device {
                         break 'error match error {
                             hal::SurfaceError::Outdated
                             | hal::SurfaceError::Lost
+                            | hal::SurfaceError::Occluded
                             | hal::SurfaceError::Timeout => E::InvalidSurface,
                             hal::SurfaceError::Device(error) => {
                                 E::Device(self.handle_hal_error(error))

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -258,6 +258,7 @@ impl Surface {
                 None,
                 match err {
                     hal::SurfaceError::Timeout => Status::Timeout,
+                    hal::SurfaceError::Occluded => Status::Occluded,
                     hal::SurfaceError::Lost => Status::Lost,
                     hal::SurfaceError::Device(err) => {
                         return Err(device.handle_hal_error(err).into());
@@ -312,6 +313,7 @@ impl Surface {
             Ok(()) => Ok(Status::Good),
             Err(err) => match err {
                 hal::SurfaceError::Timeout => Ok(Status::Timeout),
+                hal::SurfaceError::Occluded => Ok(Status::Occluded),
                 hal::SurfaceError::Lost => Ok(Status::Lost),
                 hal::SurfaceError::Device(err) => {
                     Err(SurfaceError::from(device.handle_hal_error(err)))

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -173,7 +173,7 @@ impl Surface {
                 fence.as_ref(),
             )
         } {
-            Ok(Some(ast)) => {
+            Ok(ast) => {
                 drop(fence);
 
                 let texture_desc = wgt::TextureDescriptor {
@@ -254,10 +254,10 @@ impl Surface {
                 };
                 (Some(texture), status)
             }
-            Ok(None) => (None, Status::Timeout),
             Err(err) => (
                 None,
                 match err {
+                    hal::SurfaceError::Timeout => Status::Timeout,
                     hal::SurfaceError::Lost => Status::Lost,
                     hal::SurfaceError::Device(err) => {
                         return Err(device.handle_hal_error(err).into());
@@ -311,13 +311,14 @@ impl Surface {
         match result {
             Ok(()) => Ok(Status::Good),
             Err(err) => match err {
+                hal::SurfaceError::Timeout => Ok(Status::Timeout),
                 hal::SurfaceError::Lost => Ok(Status::Lost),
                 hal::SurfaceError::Device(err) => {
                     Err(SurfaceError::from(device.handle_hal_error(err)))
                 }
                 hal::SurfaceError::Outdated => Ok(Status::Outdated),
                 hal::SurfaceError::Other(msg) => {
-                    log::error!("acquire error: {msg}");
+                    log::error!("present error: {msg}");
                     Err(SurfaceError::Invalid)
                 }
             },

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -678,7 +678,6 @@ impl<A: hal::Api> Example<A> {
             self.surface
                 .acquire_texture(None, &ctx.fence)
                 .unwrap()
-                .unwrap()
                 .texture
         };
 

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -870,7 +870,6 @@ impl<A: hal::Api> Example<A> {
             self.surface
                 .acquire_texture(None, &ctx.fence)
                 .unwrap()
-                .unwrap()
                 .texture
         };
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -1500,7 +1500,7 @@ impl crate::Surface for Surface {
         &self,
         timeout: Option<core::time::Duration>,
         _fence: &Fence,
-    ) -> Result<Option<crate::AcquiredSurfaceTexture<Api>>, crate::SurfaceError> {
+    ) -> Result<crate::AcquiredSurfaceTexture<Api>, crate::SurfaceError> {
         let mut swapchain = self.swap_chain.write();
         let sc = swapchain.as_mut().unwrap();
 
@@ -1528,10 +1528,10 @@ impl crate::Surface for Surface {
                 sc.format.theoretical_memory_footprint(sc.size),
             ),
         };
-        Ok(Some(crate::AcquiredSurfaceTexture {
+        Ok(crate::AcquiredSurfaceTexture {
             texture,
             suboptimal: false,
-        }))
+        })
     }
     unsafe fn discard_texture(&self, _texture: Texture) {
         let mut swapchain = self.swap_chain.write();

--- a/wgpu-hal/src/dynamic/surface.rs
+++ b/wgpu-hal/src/dynamic/surface.rs
@@ -30,7 +30,7 @@ pub trait DynSurface: DynResource {
         &self,
         timeout: Option<Duration>,
         fence: &dyn DynFence,
-    ) -> Result<Option<DynAcquiredSurfaceTexture>, SurfaceError>;
+    ) -> Result<DynAcquiredSurfaceTexture, SurfaceError>;
 
     unsafe fn discard_texture(&self, texture: Box<dyn DynSurfaceTexture>);
 }
@@ -54,17 +54,15 @@ impl<S: Surface + DynResource> DynSurface for S {
         &self,
         timeout: Option<Duration>,
         fence: &dyn DynFence,
-    ) -> Result<Option<DynAcquiredSurfaceTexture>, SurfaceError> {
+    ) -> Result<DynAcquiredSurfaceTexture, SurfaceError> {
         let fence = fence.expect_downcast_ref();
-        unsafe { S::acquire_texture(self, timeout, fence) }.map(|acquired| {
-            acquired.map(|ast| {
-                let texture = Box::new(ast.texture);
-                let suboptimal = ast.suboptimal;
-                DynAcquiredSurfaceTexture {
-                    texture,
-                    suboptimal,
-                }
-            })
+        unsafe { S::acquire_texture(self, timeout, fence) }.map(|ast| {
+            let texture = Box::new(ast.texture);
+            let suboptimal = ast.suboptimal;
+            DynAcquiredSurfaceTexture {
+                texture,
+                suboptimal,
+            }
         })
     }
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1410,7 +1410,7 @@ impl crate::Surface for Surface {
         &self,
         _timeout_ms: Option<Duration>, //TODO
         _fence: &super::Fence,
-    ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
+    ) -> Result<crate::AcquiredSurfaceTexture<super::Api>, crate::SurfaceError> {
         let swapchain = self.swapchain.read();
         let sc = swapchain.as_ref().ok_or(crate::SurfaceError::Other(
             "Surface has no swap-chain configured",
@@ -1430,10 +1430,10 @@ impl crate::Surface for Surface {
                 depth: 1,
             },
         };
-        Ok(Some(crate::AcquiredSurfaceTexture {
+        Ok(crate::AcquiredSurfaceTexture {
             texture,
             suboptimal: false,
-        }))
+        })
     }
     unsafe fn discard_texture(&self, _texture: super::Texture) {}
 }

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -424,7 +424,7 @@ impl crate::Surface for Surface {
         &self,
         _timeout_ms: Option<core::time::Duration>, //TODO
         _fence: &super::Fence,
-    ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
+    ) -> Result<crate::AcquiredSurfaceTexture<super::Api>, crate::SurfaceError> {
         let swapchain = self.swapchain.read();
         let sc = swapchain.as_ref().unwrap();
         let texture = super::Texture {
@@ -443,10 +443,10 @@ impl crate::Surface for Surface {
                 depth: 1,
             },
         };
-        Ok(Some(crate::AcquiredSurfaceTexture {
+        Ok(crate::AcquiredSurfaceTexture {
             texture,
             suboptimal: false,
-        }))
+        })
     }
 
     unsafe fn discard_texture(&self, _texture: super::Texture) {}

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -873,7 +873,7 @@ impl crate::Surface for Surface {
         &self,
         _timeout_ms: Option<Duration>,
         _fence: &super::Fence,
-    ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
+    ) -> Result<crate::AcquiredSurfaceTexture<super::Api>, crate::SurfaceError> {
         let swapchain = self.swapchain.read();
         let sc = swapchain.as_ref().unwrap();
         let texture = super::Texture {
@@ -891,10 +891,10 @@ impl crate::Surface for Surface {
                 depth: 1,
             },
         };
-        Ok(Some(crate::AcquiredSurfaceTexture {
+        Ok(crate::AcquiredSurfaceTexture {
             texture,
             suboptimal: false,
-        }))
+        })
     }
     unsafe fn discard_texture(&self, _texture: super::Texture) {}
 }

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -529,6 +529,8 @@ pub enum SurfaceError {
     Outdated,
     #[error("Timed out waiting for a surface texture")]
     Timeout,
+    #[error("The window is occluded (e.g. minimized or behind another window)")]
+    Occluded,
     #[error(transparent)]
     Device(#[from] DeviceError),
     #[error("Other reason: {0}")]

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -527,6 +527,8 @@ pub enum SurfaceError {
     Lost,
     #[error("Surface is outdated, needs to be re-created")]
     Outdated,
+    #[error("Timed out waiting for a surface texture")]
+    Timeout,
     #[error(transparent)]
     Device(#[from] DeviceError),
     #[error("Other reason: {0}")]
@@ -691,8 +693,8 @@ pub trait Surface: WasmNotSendSync {
     /// `self`.
     ///
     /// If `timeout` elapses before `self` has a texture ready to be acquired,
-    /// return `Ok(None)`. If `timeout` is `None`, wait indefinitely, with no
-    /// timeout.
+    /// return `Err(SurfaceError::Timeout)`. If `timeout` is `None`, wait
+    /// indefinitely, with no timeout.
     ///
     /// # Using an [`AcquiredSurfaceTexture`]
     ///
@@ -716,9 +718,9 @@ pub trait Surface: WasmNotSendSync {
     /// Some backends can't support a timeout when acquiring a texture. On these
     /// backends, `timeout` is ignored.
     ///
-    /// On macOS, this returns `Ok(None)` when the window is not visible (minimized,
-    /// fully occluded, or on another virtual desktop) to avoid blocking in
-    /// `CAMetalLayer.nextDrawable()`.
+    /// On macOS, this returns `Err(SurfaceError::Timeout)` when the window is
+    /// not visible (minimized, fully occluded, or on another virtual desktop)
+    /// to avoid blocking in `CAMetalLayer.nextDrawable()`.
     ///
     /// # Safety
     ///
@@ -728,7 +730,7 @@ pub trait Surface: WasmNotSendSync {
     ///   [`Queue::submit`] that used [`Texture`]s acquired from this surface.
     ///
     /// - You may only have one texture acquired from `self` at a time. When
-    ///   `acquire_texture` returns `Ok(Some(ast))`, you must pass the returned
+    ///   `acquire_texture` returns `Ok(ast)`, you must pass the returned
     ///   [`SurfaceTexture`] `ast.texture` to either [`Queue::present`] or
     ///   [`Surface::discard_texture`] before calling `acquire_texture` again.
     ///
@@ -742,7 +744,7 @@ pub trait Surface: WasmNotSendSync {
         &self,
         timeout: Option<core::time::Duration>,
         fence: &<Self::A as Api>::Fence,
-    ) -> Result<Option<AcquiredSurfaceTexture<Self::A>>, SurfaceError>;
+    ) -> Result<AcquiredSurfaceTexture<Self::A>, SurfaceError>;
 
     /// Relinquish an acquired texture without presenting it.
     ///

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -529,7 +529,7 @@ pub enum SurfaceError {
     Outdated,
     #[error("Timed out waiting for a surface texture")]
     Timeout,
-    #[error("The window is occluded (e.g. minimized or behind another window)")]
+    #[error("The window is occluded (e.g. minimized or behind another window). Try again once the window is no longer occluded.")]
     Occluded,
     #[error(transparent)]
     Device(#[from] DeviceError),

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -716,6 +716,10 @@ pub trait Surface: WasmNotSendSync {
     /// Some backends can't support a timeout when acquiring a texture. On these
     /// backends, `timeout` is ignored.
     ///
+    /// On macOS, this returns `Ok(None)` when the window is not visible (minimized,
+    /// fully occluded, or on another virtual desktop) to avoid blocking in
+    /// `CAMetalLayer.nextDrawable()`.
+    ///
     /// # Safety
     ///
     /// - The surface `self` must currently be configured on some [`Device`].

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -115,10 +115,49 @@ impl crate::Surface for super::Surface {
 
     unsafe fn acquire_texture(
         &self,
-        _timeout_ms: Option<core::time::Duration>, //TODO
+        _timeout: Option<core::time::Duration>, // TODO
         _fence: &super::Fence,
     ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
         let render_layer = self.render_layer.lock();
+
+        #[cfg(target_os = "macos")]
+        {
+            // Workaround for https://github.com/gfx-rs/wgpu/issues/8309
+            // When the window is occluded on macOS, presented drawables get stuck waiting
+            // for vsync. Check the window's occlusion state and skip acquisition if
+            // the window is not visible - this avoids a 1-second hang in nextDrawable().
+            use objc2::rc::Retained;
+            use objc2::runtime::NSObject;
+            use objc2_quartz_core::CALayer;
+
+            // The CAMetalLayer is typically a sublayer, so we need to traverse up
+            // to find the root layer whose delegate is the NSView.
+            let mut current_layer: Option<Retained<CALayer>> =
+                Some(Retained::into_super(render_layer.clone()));
+
+            while let Some(layer) = current_layer {
+                if let Some(delegate) = layer.delegate() {
+                    // Found a layer with a delegate - this should be the NSView
+                    let window: Option<Retained<NSObject>> =
+                        unsafe { objc2::msg_send![&*delegate, window] };
+
+                    if let Some(window) = window {
+                        const NS_WINDOW_OCCLUSION_STATE_VISIBLE: usize = 1 << 1;
+                        let occlusion_state: usize =
+                            unsafe { objc2::msg_send![&*window, occlusionState] };
+                        let is_visible = (occlusion_state & NS_WINDOW_OCCLUSION_STATE_VISIBLE) != 0;
+
+                        if !is_visible {
+                            // Window is occluded. Skipping frame to avoid drawable stall
+                            return Ok(None);
+                        }
+                    }
+                    break;
+                }
+                current_layer = layer.superlayer();
+            }
+        }
+
         let (drawable, texture) = match autoreleasepool(|_| {
             render_layer
                 .nextDrawable()

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -117,7 +117,7 @@ impl crate::Surface for super::Surface {
         &self,
         _timeout: Option<core::time::Duration>, // TODO
         _fence: &super::Fence,
-    ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
+    ) -> Result<crate::AcquiredSurfaceTexture<super::Api>, crate::SurfaceError> {
         let render_layer = self.render_layer.lock();
 
         #[cfg(target_os = "macos")]
@@ -149,7 +149,7 @@ impl crate::Surface for super::Surface {
 
                         if !is_visible {
                             // Window is occluded. Skipping frame to avoid drawable stall
-                            return Ok(None);
+                            return Err(crate::SurfaceError::Timeout);
                         }
                     }
                     break;
@@ -164,7 +164,7 @@ impl crate::Surface for super::Surface {
                 .map(|drawable| (drawable.to_owned(), drawable.texture().to_owned()))
         }) {
             Some(pair) => pair,
-            None => return Ok(None),
+            None => return Err(crate::SurfaceError::Timeout),
         };
 
         let swapchain_format = self.swapchain_format.read().unwrap();
@@ -186,10 +186,10 @@ impl crate::Surface for super::Surface {
             present_with_transaction: render_layer.presentsWithTransaction(),
         };
 
-        Ok(Some(crate::AcquiredSurfaceTexture {
+        Ok(crate::AcquiredSurfaceTexture {
             texture: suf_texture,
             suboptimal: false,
-        }))
+        })
     }
 
     unsafe fn discard_texture(&self, _texture: super::SurfaceTexture) {}

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -148,8 +148,7 @@ impl crate::Surface for super::Surface {
                         let is_visible = (occlusion_state & NS_WINDOW_OCCLUSION_STATE_VISIBLE) != 0;
 
                         if !is_visible {
-                            // Window is occluded. Skipping frame to avoid drawable stall
-                            return Err(crate::SurfaceError::Timeout);
+                            return Err(crate::SurfaceError::Occluded);
                         }
                     }
                     break;

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -247,10 +247,10 @@ impl crate::Surface for Context {
 
     unsafe fn acquire_texture(
         &self,
-        timeout: Option<Duration>,
-        fence: &Fence,
-    ) -> Result<Option<crate::AcquiredSurfaceTexture<Api>>, crate::SurfaceError> {
-        Ok(None)
+        _timeout: Option<Duration>,
+        _fence: &Fence,
+    ) -> Result<crate::AcquiredSurfaceTexture<Api>, crate::SurfaceError> {
+        Err(crate::SurfaceError::Timeout)
     }
     unsafe fn discard_texture(&self, texture: Resource) {}
 }

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -1024,7 +1024,7 @@ impl crate::Surface for super::Surface {
         &self,
         timeout: Option<core::time::Duration>,
         fence: &super::Fence,
-    ) -> Result<Option<crate::AcquiredSurfaceTexture<super::Api>>, crate::SurfaceError> {
+    ) -> Result<crate::AcquiredSurfaceTexture<super::Api>, crate::SurfaceError> {
         let mut swapchain = self.swapchain.write();
         let swapchain = swapchain.as_mut().unwrap();
 

--- a/wgpu-hal/src/vulkan/swapchain/mod.rs
+++ b/wgpu-hal/src/vulkan/swapchain/mod.rs
@@ -53,12 +53,12 @@ pub(super) trait Swapchain: Send + Sync + 'static {
     /// `timeout` specifies the maximum time to wait for an image to become available.
     /// If `None` is specified, this function will wait indefinitely.
     ///
-    /// Returns `Ok(None)` if the timeout elapsed before an image became available.
+    /// Returns `Err(SurfaceError::Timeout)` if the timeout elapsed before an image became available.
     unsafe fn acquire(
         &mut self,
         timeout: Option<Duration>,
         fence: &super::Fence,
-    ) -> Result<Option<crate::AcquiredSurfaceTexture<crate::api::Vulkan>>, crate::SurfaceError>;
+    ) -> Result<crate::AcquiredSurfaceTexture<crate::api::Vulkan>, crate::SurfaceError>;
 
     /// Tries to discard the acquired texture without presenting it.
     ///

--- a/wgpu-hal/src/vulkan/swapchain/native.rs
+++ b/wgpu-hal/src/vulkan/swapchain/native.rs
@@ -382,8 +382,7 @@ impl Swapchain for NativeSwapchain {
         &mut self,
         timeout: Option<core::time::Duration>,
         fence: &crate::vulkan::Fence,
-    ) -> Result<Option<crate::AcquiredSurfaceTexture<crate::api::Vulkan>>, crate::SurfaceError>
-    {
+    ) -> Result<crate::AcquiredSurfaceTexture<crate::api::Vulkan>, crate::SurfaceError> {
         let mut timeout_ns = match timeout {
             Some(duration) => duration.as_nanos() as u64,
             None => u64::MAX,
@@ -445,7 +444,7 @@ impl Swapchain for NativeSwapchain {
             Ok(pair) => pair,
             Err(error) => {
                 return match error {
-                    vk::Result::TIMEOUT => Ok(None),
+                    vk::Result::TIMEOUT => Err(crate::SurfaceError::Timeout),
                     vk::Result::NOT_READY | vk::Result::ERROR_OUT_OF_DATE_KHR => {
                         Err(crate::SurfaceError::Outdated)
                     }
@@ -513,10 +512,10 @@ impl Swapchain for NativeSwapchain {
                 present_semaphores: present_semaphore_arc,
             }),
         };
-        Ok(Some(crate::AcquiredSurfaceTexture {
+        Ok(crate::AcquiredSurfaceTexture {
             texture,
             suboptimal,
-        }))
+        })
     }
 
     unsafe fn discard_texture(

--- a/wgpu-types/src/surface.rs
+++ b/wgpu-types/src/surface.rs
@@ -265,8 +265,16 @@ pub enum SurfaceStatus {
     /// match the surface. A re-configuration is needed.
     Suboptimal,
     /// Unable to get the next frame, timed out.
+    ///
+    /// Try reconfiguring your surface.
     Timeout,
+    /// The window is occluded (e.g. minimized or behind another window).
+    ///
+    /// Try again once the window is no longer occluded.
+    Occluded,
     /// The surface under the swap chain has changed.
+    ///
+    /// Try reconfiguring your surface.
     Outdated,
     /// The surface under the swap chain is lost.
     Lost,

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -114,6 +114,10 @@ impl Surface<'_> {
     ///
     /// If a SurfaceTexture referencing this surface is alive when the swapchain is recreated,
     /// recreating the swapchain will panic.
+    ///
+    /// This may return [`SurfaceError::Timeout`] if the surface is not visible
+    /// (e.g., the window is minimized, fully occluded, or on another virtual desktop).
+    /// Applications should handle this by skipping the current frame.
     pub fn get_current_texture(&self) -> Result<SurfaceTexture, SurfaceError> {
         let (texture, status, detail) = self.inner.get_current_texture();
 

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -125,6 +125,7 @@ impl Surface<'_> {
             SurfaceStatus::Good => false,
             SurfaceStatus::Suboptimal => true,
             SurfaceStatus::Timeout => return Err(SurfaceError::Timeout),
+            SurfaceStatus::Occluded => return Err(SurfaceError::Occluded),
             SurfaceStatus::Outdated => return Err(SurfaceError::Outdated),
             SurfaceStatus::Lost => return Err(SurfaceError::Lost),
             SurfaceStatus::Unknown => return Err(SurfaceError::Other),

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -57,6 +57,10 @@ impl Drop for SurfaceTexture {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum SurfaceError {
     /// A timeout was encountered while trying to acquire the next frame.
+    ///
+    /// This can happen when the window is not visible (e.g., minimized, occluded,
+    /// or on another virtual desktop) on some platforms, particularly macOS.
+    /// Applications should handle this gracefully by skipping the frame.
     Timeout,
     /// The underlying surface has changed, and therefore the swap chain must be updated.
     Outdated,

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -57,10 +57,6 @@ impl Drop for SurfaceTexture {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum SurfaceError {
     /// A timeout was encountered while trying to acquire the next frame.
-    ///
-    /// This can happen when the window is not visible (e.g., minimized, occluded,
-    /// or on another virtual desktop) on some platforms, particularly macOS.
-    /// Applications should handle this gracefully by skipping the frame.
     Timeout,
     /// The window is occluded (e.g. minimized or behind another window).
     ///

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -62,9 +62,17 @@ pub enum SurfaceError {
     /// or on another virtual desktop) on some platforms, particularly macOS.
     /// Applications should handle this gracefully by skipping the frame.
     Timeout,
+    /// The window is occluded (e.g. minimized or behind another window).
+    ///
+    /// Try again once the window is no longer occluded.
+    Occluded,
     /// The underlying surface has changed, and therefore the swap chain must be updated.
+    ///
+    /// Reconfigure your surface and try again.
     Outdated,
     /// The swap chain has been lost and needs to be recreated.
+    ///
+    /// Reconfigure your surface and try again.
     Lost,
     /// There is no more memory left to allocate a new frame.
     OutOfMemory,
@@ -77,6 +85,7 @@ impl fmt::Display for SurfaceError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", match self {
             Self::Timeout => "A timeout was encountered while trying to acquire the next frame",
+            Self::Occluded => "The window is occluded (e.g. minimized or behind another window)",
             Self::Outdated => "The underlying surface has changed, and therefore the swap chain must be updated",
             Self::Lost =>  "The swap chain has been lost and needs to be recreated",
             Self::OutOfMemory => "There is no more memory left to allocate a new frame",


### PR DESCRIPTION
**Connections**
* Closes https://github.com/gfx-rs/wgpu/issues/8309
* Related to https://github.com/gfx-rs/wgpu/issues/5613

**Description**
  - Fix 1-second hang when switching to a wgpu application that was in the background on macOS
  - ⚠️ `get_current_texture` can now return `SurfaceError::Occluded` (only on Mac currently)
  - Change return type of `fn acquire_texture` to return timeouts as an error variant
                                                                                                                                                              
On macOS, when a window is occluded (minimized, behind other windows, or on another virtual desktop), `CAMetalLayer.nextDrawable()` can block for up to 1 second. This happens because presented drawables get stuck waiting for vsync that isn't happening while the window is hidden.                                                                                                                                                                                               
                                                                                                                                                                                                                                             
When switching back to a wgpu application that was in the background, users experience a noticeable 1-second delay before the application becomes responsive.       

This PR adds a fix: in the top of `aquire_texture` we first check if the window is occluded. If it is, we return a new `SurfaceError::Occluded` error right away, avoiding the 1 second delay.

This then requires users to actually handle this new error by attempting again later.

Thanks to Claude and @Wumpf for helping me with this PR!

**Testing**
I ran `cargo r -p wgpu-example-02-hello-window`, switching the app to be behind and then in front of another opaque window.

* [x] `cargo run --bin wgpu-examples cube`
* [x] `cargo run --bin wgpu-examples hello_triangle`
* [x] `cargo run --bin wgpu-examples uniform_values`
* [x] `cargo r -p wgpu-example-02-hello-window`

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->

