### PR TITLE
fix(naga): Use wrapping arithmetic for dot on concrete ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 - Fixed constant evaluation for `sign()` builtin to return zero when the argument is zero. By @mandryskowski in [#8942](https://github.com/gfx-rs/wgpu/pull/8942).
 - Allow array generation to compile with the macOS 10.12 Metal compiler. By @madsmtm in [#8953](https://github.com/gfx-rs/wgpu/pull/8953)
 - Naga now detects bitwise shifts by a constant exceeding the operand bit width at compile time, and disallows scalar-by-vector and vector-by-scalar shifts in constant evaluation. By @andyleiserson in [#8907](https://github.com/gfx-rs/wgpu/pull/8907).
+- Naga uses wrapping arithmetic when evaluating dot products on concrete integer types (`u32` and `i32`). By @BKDaugherty in [#9142](https://github.com/gfx-rs/wgpu/pull/9142).
 
 #### Validation
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -298,6 +298,15 @@ webgpu:api,validation,texture,rg11b10ufloat_renderable:*
 
 webgpu:shader,execution,expression,call,builtin,atan2:f16:*
 webgpu:shader,execution,expression,call,builtin,atan2:f32:*
+webgpu:shader,execution,expression,call,builtin,dot:abstract_int_vec2:*
+webgpu:shader,execution,expression,call,builtin,dot:abstract_int_vec3:*
+webgpu:shader,execution,expression,call,builtin,dot:abstract_int_vec4:*
+webgpu:shader,execution,expression,call,builtin,dot:i32_vec2:*
+webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:*
+webgpu:shader,execution,expression,call,builtin,dot:i32_vec4:*
+webgpu:shader,execution,expression,call,builtin,dot:u32_vec2:*
+webgpu:shader,execution,expression,call,builtin,dot:u32_vec3:*
+webgpu:shader,execution,expression,call,builtin,dot:u32_vec4:*
 //FAIL: webgpu:shader,execution,expression,call,builtin,select:*
 // - Fails with `const`/abstract int cases on all platforms because of <https://github.com/gfx-rs/wgpu/issues/4507>.
 // - Fails with `vec3` & `f16` cases on macOS because of <https://github.com/gfx-rs/wgpu/issues/5262>.

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1763,7 +1763,7 @@ impl<'a> ConstantEvaluator<'a> {
                     return Err(ConstantEvaluatorError::InvalidMathArg);
                 }
 
-                fn int_dot<P>(a: &[P], b: &[P]) -> Result<P, ConstantEvaluatorError>
+                fn int_dot_checked<P>(a: &[P], b: &[P]) -> Result<P, ConstantEvaluatorError>
                 where
                     P: num_traits::PrimInt + num_traits::CheckedAdd + num_traits::CheckedMul,
                 {
@@ -1782,9 +1782,21 @@ impl<'a> ConstantEvaluator<'a> {
                         ))
                 }
 
+                fn int_dot_wrapping<P>(a: &[P], b: &[P]) -> P
+                where
+                    P: num_traits::PrimInt + num_traits::WrappingAdd + num_traits::WrappingMul,
+                {
+                    a.iter()
+                        .zip(b.iter())
+                        .map(|(&aa, bb)| aa.wrapping_mul(bb))
+                        .fold(P::zero(), |acc, x| acc.wrapping_add(&x))
+                }
+
                 let result = match_literal_vector!(match (e1, e2) => Literal {
                     Float => |e1, e2| { e1.iter().zip(e2.iter()).map(|(&aa, &bb)| aa * bb).sum() },
-                    Integer => |e1, e2| { int_dot(e1, e2)? },
+                    AbstractInt => |e1, e2 | { int_dot_checked(e1, e2)? },
+                    I32 => |e1, e2| { int_dot_wrapping(e1, e2) },
+                    U32 => |e1, e2| { int_dot_wrapping(e1, e2) },
                 })?;
                 self.register_evaluated_expr(Expression::Literal(result), span)
             }


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

Fixes: https://github.com/gfx-rs/wgpu/issues/9004#issue-3902831061

_When one pull request builds on another, please put "Depends on
#NNNN" towards the top of its description. This helps maintainers
notice that they shouldn't merge it until its ancestor has been
approved. Don't use draft PR status to indicate this._

**Description**
_Describe what problem this is solving, and how it's solved._

Adds a new helper function to use wrapping arithmetic for dot product when the integers are concrete.

**Testing**
_Explain how this change is tested._

Before my changes:
```
brendon@Brendons-MacBook-Pro wgpu % cargo xtask cts 'webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:*'
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/wgpu-xtask cts 'webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:*'`
[INFO  wgpu_xtask::cts] Checking out CTS
   Compiling naga v28.0.0 (/Users/brendon/Dev/wgpu/naga)
   Compiling wgpu-hal v28.0.0 (/Users/brendon/Dev/wgpu/wgpu-hal)
   Compiling wgpu-core-deps-apple v28.0.0 (/Users/brendon/Dev/wgpu/wgpu-core/platform-deps/apple)
   Compiling wgpu-core v28.0.0 (/Users/brendon/Dev/wgpu/wgpu-core)
   Compiling deno_webgpu v0.181.0 (/Users/brendon/Dev/wgpu/deno_webgpu)
   Compiling cts_runner v28.0.0 (/Users/brendon/Dev/wgpu/cts_runner)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.89s
[INFO  wgpu_xtask::cts] Running CTS
[INFO  wgpu_xtask::cts] Running webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:*
$ /Users/brendon/Dev/wgpu/target/debug/cts_runner ./tools/run_deno --verbose webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:*
DataCache: in-memory cache miss
DataCache: failed to load (webgpu/shader/execution/dot.bin): TypeError: sys.readFile is not a function
DataCache: cache: building (webgpu/shader/execution/dot.bin)
DataCache: added webgpu/shader/execution/dot.bin. new count: 1
[fail] webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:inputSource="const" (438ms). Log:
  - EXPECTATION FAILED: Pipeline Creation Error, validation: ShaderModule with '' label is invalid
      at (elided: below max severity)
  - EXPECTATION FAILED: Pipeline Creation Error, validation: ShaderModule with '' label is invalid
      at (elided: below max severity)
  - EXPECTATION FAILED: Pipeline Creation Error, validation: ShaderModule with '' label is invalid
      at (elided: only 2 shown)
  - EXPECTATION FAILED: Pipeline Creation Error, validation: ShaderModule with '' label is invalid
      at (elided: only 2 shown)
  - EXCEPTION: Error: Unexpected validation error occurred:
    Shader '' parsing error: in dot built-in operation overflowed
       ┌─ wgsl:44:3
       │
    44 │   dot(vec3(i32(2), i32(-2), i32(-256)), vec3(i32(1073741823), i32(-9), i32(9)))
       │   ^^^ see msg


        at DeviceHolder.attemptEndTestScope (file:///Users/brendon/Dev/wgpu/cts/out/webgpu/util/device_pool.js:466:13)
        at eventLoopTick (ext:core/01_core.js:179:7)
        at async DevicePool.release (file:///Users/brendon/Dev/wgpu/cts/out/webgpu/util/device_pool.js:104:7)
        at async Promise.allSettled (<anonymous>)
        at async AllFeaturesMaxLimitsGPUTestSubcaseBatchState.finalize (file:///Users/brendon/Dev/wgpu/cts/out/webgpu/gpu_test.js:154:21)
        at async RunCaseSpecific.run (file:///Users/brendon/Dev/wgpu/cts/out/common/internal/test_group.js:694:9)
        at async file:///Users/brendon/Dev/wgpu/cts/out/common/runtime/cmdline.js:218:5
DataCache: in-memory cache hit
[pass] webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:inputSource="uniform" (32ms). Log:
DataCache: in-memory cache hit
[pass] webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:inputSource="storage_r" (28ms). Log:
DataCache: in-memory cache hit
[pass] webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:inputSource="storage_rw" (26ms). Log:

** Failures **
[fail] webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:inputSource="const" (438ms). Log:
  - EXPECTATION FAILED: Pipeline Creation Error, validation: ShaderModule with '' label is invalid
      at (elided: below max severity)
  - EXPECTATION FAILED: Pipeline Creation Error, validation: ShaderModule with '' label is invalid
      at (elided: below max severity)
  - EXPECTATION FAILED: Pipeline Creation Error, validation: ShaderModule with '' label is invalid
      at (elided: only 2 shown)
  - EXPECTATION FAILED: Pipeline Creation Error, validation: ShaderModule with '' label is invalid
      at (elided: only 2 shown)
  - EXCEPTION: Error: Unexpected validation error occurred:
    Shader '' parsing error: in dot built-in operation overflowed
       ┌─ wgsl:44:3
       │
    44 │   dot(vec3(i32(2), i32(-2), i32(-256)), vec3(i32(1073741823), i32(-9), i32(9)))
       │   ^^^ see msg


        at DeviceHolder.attemptEndTestScope (file:///Users/brendon/Dev/wgpu/cts/out/webgpu/util/device_pool.js:466:13)
        at eventLoopTick (ext:core/01_core.js:179:7)
        at async DevicePool.release (file:///Users/brendon/Dev/wgpu/cts/out/webgpu/util/device_pool.js:104:7)
        at async Promise.allSettled (<anonymous>)
        at async AllFeaturesMaxLimitsGPUTestSubcaseBatchState.finalize (file:///Users/brendon/Dev/wgpu/cts/out/webgpu/gpu_test.js:154:21)
        at async RunCaseSpecific.run (file:///Users/brendon/Dev/wgpu/cts/out/common/internal/test_group.js:694:9)
        at async file:///Users/brendon/Dev/wgpu/cts/out/common/runtime/cmdline.js:218:5

** Summary **
Passed  w/o warnings = 3 / 4 =  75.00%
Passed with warnings = 0 / 4 =   0.00%
Skipped              = 0 / 4 =   0.00%
Failed               = 1 / 4 =  25.00%
Error: CTS failed

Caused by:
    command exited with non-zero code `/Users/brendon/Dev/wgpu/target/debug/cts_runner ./tools/run_deno --verbose webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:*`: 1
```

After my changes:

```
brendon@Brendons-MacBook-Pro wgpu % cargo xtask cts 'webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:*'
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/wgpu-xtask cts 'webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:*'`
[INFO  wgpu_xtask::cts] Checking out CTS
   Compiling naga v28.0.0 (/Users/brendon/Dev/wgpu/naga)
   Compiling wgpu-hal v28.0.0 (/Users/brendon/Dev/wgpu/wgpu-hal)
   Compiling wgpu-core-deps-apple v28.0.0 (/Users/brendon/Dev/wgpu/wgpu-core/platform-deps/apple)
   Compiling wgpu-core v28.0.0 (/Users/brendon/Dev/wgpu/wgpu-core)
   Compiling deno_webgpu v0.181.0 (/Users/brendon/Dev/wgpu/deno_webgpu)
   Compiling cts_runner v28.0.0 (/Users/brendon/Dev/wgpu/cts_runner)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.54s
[INFO  wgpu_xtask::cts] Running CTS
[INFO  wgpu_xtask::cts] Running webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:*
$ /Users/brendon/Dev/wgpu/target/debug/cts_runner ./tools/run_deno --verbose webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:*
DataCache: in-memory cache miss
DataCache: failed to load (webgpu/shader/execution/dot.bin): TypeError: sys.readFile is not a function
DataCache: cache: building (webgpu/shader/execution/dot.bin)
DataCache: added webgpu/shader/execution/dot.bin. new count: 1
[pass] webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:inputSource="const" (446ms). Log:
DataCache: in-memory cache hit
[pass] webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:inputSource="uniform" (30ms). Log:
DataCache: in-memory cache hit
[pass] webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:inputSource="storage_r" (28ms). Log:
DataCache: in-memory cache hit
[pass] webgpu:shader,execution,expression,call,builtin,dot:i32_vec3:inputSource="storage_rw" (28ms). Log:

** Summary **
Passed  w/o warnings = 4 / 4 = 100.00%
Passed with warnings = 0 / 4 =   0.00%
Skipped              = 0 / 4 =   0.00%
Failed               = 0 / 4 =   0.00%
```

**Squash or Rebase?**: Squash

_If your pull request contains multiple commits, please indicate whether
they need to be squashed into a single commit before they're merged,
or if they're ready to rebase onto `trunk` as they stand. In the
latter case, please ensure that each commit passes all CI tests, so
that we can continue to bisect along `trunk` to isolate bugs._

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
