### PR TITLE
fix(deno): Report the correct type of error for an invalid writeMask

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -55,7 +55,6 @@ webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,color_
 webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,use_blend_src:* // 62%, https://github.com/gfx-rs/wgpu/pull/8856
 webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets,blend:* // 95%, blend factors reading source alpha require vec4
 webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets:* // 3%, color target without shader output requires writeMask=0
-webgpu:api,validation,render_pipeline,fragment_state:targets_write_mask:* // 50%, TypeError instead of validation error
 webgpu:api,validation,render_pipeline,inter_stage:* // 15%, inter-stage type validation gaps and interpolation default handling
 webgpu:api,validation,render_pipeline,misc:external_texture:* // 0%, no external texture in deno
 webgpu:api,validation,render_pipeline,misc:storage_texture,format:* // 8%, similar to compute pipeline issue

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -251,6 +251,7 @@ webgpu:api,validation,render_pipeline,fragment_state:targets_blend:*
 webgpu:api,validation,render_pipeline,fragment_state:targets_format_filterable:*
 webgpu:api,validation,render_pipeline,fragment_state:targets_format_is_color_format:*
 webgpu:api,validation,render_pipeline,fragment_state:targets_format_renderable:*
+webgpu:api,validation,render_pipeline,fragment_state:targets_write_mask:*
 webgpu:api,validation,render_pipeline,inter_stage:location,*
 webgpu:api,validation,render_pipeline,inter_stage:max_shader_variable_location:*
 webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,*

--- a/deno_webgpu/webidl.rs
+++ b/deno_webgpu/webidl.rs
@@ -809,16 +809,11 @@ impl<'a> WebIdlConverter<'a> for GPUColorWriteFlags {
       },
     )?;
 
-    let flags =
-      wgpu_types::ColorWrites::from_bits(flags_value).ok_or_else(|| {
-        WebIdlError::other(
-          prefix,
-          context,
-          JsErrorBox::type_error("color write flags are not valid"),
-        )
-      })?;
-
-    Ok(GPUColorWriteFlags(flags))
+    // WebGPU specifies a validation error for invalid color write mask values.
+    // We propagate invalid bits here; wgpu_core will validate it.
+    Ok(GPUColorWriteFlags(
+      wgpu_types::ColorWrites::from_bits_retain(flags_value),
+    ))
   }
 }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4118,6 +4118,9 @@ impl Device {
             if let Some(cs) = cs.as_ref() {
                 target_specified = true;
                 let error = 'error: {
+                    // This is expected to be the operative check for illegal write mask
+                    // values (larger than 15), because WebGPU requires that it be validated
+                    // on the device timeline.
                     if cs.write_mask.contains_unknown_bits() {
                         break 'error Some(pipeline::ColorStateError::InvalidWriteMask(
                             cs.write_mask,


### PR DESCRIPTION
Trivial CTS fix; adds a comment in wgpu_core, but the fix only affects deno.

**Testing**
CTS

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
