### PR TITLE
Reduce binary bloat from error vtables

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -257,14 +257,14 @@ pub enum CreateBindGroupError {
 
 impl WebGpuError for CreateBindGroupError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::DestroyedResource(e) => e,
-            Self::BindingError(e) => e,
-            Self::MissingBufferUsage(e) => e,
-            Self::MissingTextureUsage(e) => e,
-            Self::ResourceUsageCompatibility(e) => e,
-            Self::InvalidResource(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
+            Self::BindingError(e) => e.webgpu_error_type(),
+            Self::MissingBufferUsage(e) => e.webgpu_error_type(),
+            Self::MissingTextureUsage(e) => e.webgpu_error_type(),
+            Self::ResourceUsageCompatibility(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
             Self::BindingArrayPartialLengthMismatch { .. }
             | Self::BindingArrayLengthMismatch { .. }
             | Self::BindingArrayZeroLength
@@ -288,9 +288,8 @@ impl WebGpuError for CreateBindGroupError {
             | Self::DepthStencilAspect
             | Self::MissingTLASVertexReturn { .. }
             | Self::InvalidExternalTextureMipLevelCount { .. }
-            | Self::InvalidExternalTextureFormat { .. } => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::InvalidExternalTextureFormat { .. } => ErrorType::Validation,
+        }
     }
 }
 
@@ -820,17 +819,16 @@ pub enum CreatePipelineLayoutError {
 
 impl WebGpuError for CreatePipelineLayoutError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::MissingFeatures(e) => e,
-            Self::InvalidResource(e) => e,
-            Self::TooManyBindings(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+            Self::TooManyBindings(e) => e.webgpu_error_type(),
             Self::MisalignedImmediateSize { .. }
             | Self::ImmediateRangeTooLarge { .. }
             | Self::TooManyGroups { .. }
-            | Self::BglHasExclusivePipeline { .. } => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::BglHasExclusivePipeline { .. } => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1501,15 +1501,14 @@ pub struct RenderBundleError {
 impl WebGpuError for RenderBundleError {
     fn webgpu_error_type(&self) -> ErrorType {
         let Self { scope: _, inner } = self;
-        let e: &dyn WebGpuError = match inner {
-            RenderBundleErrorInner::Device(e) => e,
-            RenderBundleErrorInner::RenderCommand(e) => e,
-            RenderBundleErrorInner::Draw(e) => e,
-            RenderBundleErrorInner::MissingDownlevelFlags(e) => e,
-            RenderBundleErrorInner::Bind(e) => e,
-            RenderBundleErrorInner::InvalidResource(e) => e,
-        };
-        e.webgpu_error_type()
+        match inner {
+            RenderBundleErrorInner::Device(e) => e.webgpu_error_type(),
+            RenderBundleErrorInner::RenderCommand(e) => e.webgpu_error_type(),
+            RenderBundleErrorInner::Draw(e) => e.webgpu_error_type(),
+            RenderBundleErrorInner::MissingDownlevelFlags(e) => e.webgpu_error_type(),
+            RenderBundleErrorInner::Bind(e) => e.webgpu_error_type(),
+            RenderBundleErrorInner::InvalidResource(e) => e.webgpu_error_type(),
+        }
     }
 }
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -81,13 +81,13 @@ whereas subesource range specified start {subresource_base_array_layer} and coun
 
 impl WebGpuError for ClearError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::DestroyedResource(e) => e,
-            Self::MissingFeatures(e) => e,
-            Self::MissingBufferUsage(e) => e,
-            Self::Device(e) => e,
-            Self::EncoderState(e) => e,
-            Self::InvalidResource(e) => e,
+        match self {
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
+            Self::MissingBufferUsage(e) => e.webgpu_error_type(),
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::EncoderState(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
             Self::NoValidTextureClearMode(..)
             | Self::UnalignedFillSize(..)
             | Self::UnalignedBufferOffset(..)
@@ -95,9 +95,8 @@ impl WebGpuError for ClearError {
             | Self::BufferOverrun { .. }
             | Self::MissingTextureAspect { .. }
             | Self::InvalidTextureLevelRange { .. }
-            | Self::InvalidTextureLayerRange { .. } => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::InvalidTextureLayerRange { .. } => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -224,22 +224,22 @@ where
 impl WebGpuError for ComputePassError {
     fn webgpu_error_type(&self) -> ErrorType {
         let Self { scope: _, inner } = self;
-        let e: &dyn WebGpuError = match inner {
-            ComputePassErrorInner::Device(e) => e,
-            ComputePassErrorInner::EncoderState(e) => e,
-            ComputePassErrorInner::DebugGroupError(e) => e,
-            ComputePassErrorInner::DestroyedResource(e) => e,
-            ComputePassErrorInner::ResourceUsageCompatibility(e) => e,
-            ComputePassErrorInner::MissingBufferUsage(e) => e,
-            ComputePassErrorInner::Dispatch(e) => e,
-            ComputePassErrorInner::Bind(e) => e,
-            ComputePassErrorInner::ImmediateData(e) => e,
-            ComputePassErrorInner::QueryUse(e) => e,
-            ComputePassErrorInner::MissingFeatures(e) => e,
-            ComputePassErrorInner::MissingDownlevelFlags(e) => e,
-            ComputePassErrorInner::InvalidResource(e) => e,
-            ComputePassErrorInner::TimestampWrites(e) => e,
-            ComputePassErrorInner::InvalidValuesOffset(e) => e,
+        match inner {
+            ComputePassErrorInner::Device(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::EncoderState(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::DebugGroupError(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::DestroyedResource(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::ResourceUsageCompatibility(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::MissingBufferUsage(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::Dispatch(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::Bind(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::ImmediateData(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::QueryUse(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::MissingFeatures(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::MissingDownlevelFlags(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::InvalidResource(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::TimestampWrites(e) => e.webgpu_error_type(),
+            ComputePassErrorInner::InvalidValuesOffset(e) => e.webgpu_error_type(),
 
             ComputePassErrorInner::InvalidParentEncoder
             | ComputePassErrorInner::BindGroupIndexOutOfRange { .. }
@@ -248,9 +248,8 @@ impl WebGpuError for ComputePassError {
             | ComputePassErrorInner::ImmediateOffsetAlignment
             | ComputePassErrorInner::ImmediateDataizeAlignment
             | ComputePassErrorInner::ImmediateOutOfMemory
-            | ComputePassErrorInner::PassEnded => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | ComputePassErrorInner::PassEnded => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -130,14 +130,14 @@ pub enum RenderCommandError {
 
 impl WebGpuError for RenderCommandError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::IncompatiblePipelineTargets(e) => e,
-            Self::ResourceUsageCompatibility(e) => e,
-            Self::DestroyedResource(e) => e,
-            Self::MissingBufferUsage(e) => e,
-            Self::MissingTextureUsage(e) => e,
-            Self::ImmediateData(e) => e,
-            Self::BindingError(e) => e,
+        match self {
+            Self::IncompatiblePipelineTargets(e) => e.webgpu_error_type(),
+            Self::ResourceUsageCompatibility(e) => e.webgpu_error_type(),
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
+            Self::MissingBufferUsage(e) => e.webgpu_error_type(),
+            Self::MissingTextureUsage(e) => e.webgpu_error_type(),
+            Self::ImmediateData(e) => e.webgpu_error_type(),
+            Self::BindingError(e) => e.webgpu_error_type(),
 
             Self::BindGroupIndexOutOfRange { .. }
             | Self::VertexBufferIndexOutOfRange { .. }
@@ -149,9 +149,8 @@ impl WebGpuError for RenderCommandError {
             | Self::InvalidViewportRectPosition { .. }
             | Self::InvalidViewportDepth(..)
             | Self::InvalidScissorRect(..)
-            | Self::Unimplemented(..) => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::Unimplemented(..) => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -1602,23 +1602,22 @@ impl CommandEncoderError {
 
 impl WebGpuError for CommandEncoderError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::InvalidResource(e) => e,
-            Self::DebugGroupError(e) => e,
-            Self::MissingFeatures(e) => e,
-            Self::State(e) => e,
-            Self::DestroyedResource(e) => e,
-            Self::Transfer(e) => e,
-            Self::Clear(e) => e,
-            Self::Query(e) => e,
-            Self::BuildAccelerationStructure(e) => e,
-            Self::TransitionResources(e) => e,
-            Self::ResourceUsage(e) => e,
-            Self::ComputePass(e) => e,
-            Self::RenderPass(e) => e,
-        };
-        e.webgpu_error_type()
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+            Self::DebugGroupError(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
+            Self::State(e) => e.webgpu_error_type(),
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
+            Self::Transfer(e) => e.webgpu_error_type(),
+            Self::Clear(e) => e.webgpu_error_type(),
+            Self::Query(e) => e.webgpu_error_type(),
+            Self::BuildAccelerationStructure(e) => e.webgpu_error_type(),
+            Self::TransitionResources(e) => e.webgpu_error_type(),
+            Self::ResourceUsage(e) => e.webgpu_error_type(),
+            Self::ComputePass(e) => e.webgpu_error_type(),
+            Self::RenderPass(e) => e.webgpu_error_type(),
+        }
     }
 }
 

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -112,16 +112,15 @@ pub enum QueryError {
 
 impl WebGpuError for QueryError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::EncoderState(e) => e,
-            Self::Use(e) => e,
-            Self::Resolve(e) => e,
-            Self::InvalidResource(e) => e,
-            Self::Device(e) => e,
-            Self::MissingFeature(e) => e,
-            Self::DestroyedResource(e) => e,
-        };
-        e.webgpu_error_type()
+        match self {
+            Self::EncoderState(e) => e.webgpu_error_type(),
+            Self::Use(e) => e.webgpu_error_type(),
+            Self::Resolve(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::MissingFeature(e) => e.webgpu_error_type(),
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
+        }
     }
 }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -870,23 +870,23 @@ impl<E: Into<RenderPassErrorInner>> MapPassErr<RenderPassError> for E {
 impl WebGpuError for RenderPassError {
     fn webgpu_error_type(&self) -> ErrorType {
         let Self { scope: _, inner } = self;
-        let e: &dyn WebGpuError = match inner {
-            RenderPassErrorInner::Device(e) => e,
-            RenderPassErrorInner::ColorAttachment(e) => e,
-            RenderPassErrorInner::EncoderState(e) => e,
-            RenderPassErrorInner::DebugGroupError(e) => e,
-            RenderPassErrorInner::MissingFeatures(e) => e,
-            RenderPassErrorInner::MissingDownlevelFlags(e) => e,
-            RenderPassErrorInner::RenderCommand(e) => e,
-            RenderPassErrorInner::Draw(e) => e,
-            RenderPassErrorInner::Bind(e) => e,
-            RenderPassErrorInner::QueryUse(e) => e,
-            RenderPassErrorInner::DestroyedResource(e) => e,
-            RenderPassErrorInner::InvalidResource(e) => e,
-            RenderPassErrorInner::IncompatibleBundleTargets(e) => e,
-            RenderPassErrorInner::InvalidAttachment(e) => e,
-            RenderPassErrorInner::TimestampWrites(e) => e,
-            RenderPassErrorInner::InvalidValuesOffset(e) => e,
+        match inner {
+            RenderPassErrorInner::Device(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::ColorAttachment(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::EncoderState(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::DebugGroupError(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::MissingFeatures(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::MissingDownlevelFlags(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::RenderCommand(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::Draw(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::Bind(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::QueryUse(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::DestroyedResource(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::InvalidResource(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::IncompatibleBundleTargets(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::InvalidAttachment(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::TimestampWrites(e) => e.webgpu_error_type(),
+            RenderPassErrorInner::InvalidValuesOffset(e) => e.webgpu_error_type(),
 
             RenderPassErrorInner::InvalidParentEncoder
             | RenderPassErrorInner::UnsupportedResolveTargetFormat { .. }
@@ -910,9 +910,8 @@ impl WebGpuError for RenderPassError {
             | RenderPassErrorInner::MultiViewDimensionMismatch
             | RenderPassErrorInner::TooManyMultiviewViews
             | RenderPassErrorInner::MissingOcclusionQuerySet
-            | RenderPassErrorInner::PassEnded => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | RenderPassErrorInner::PassEnded => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -186,10 +186,10 @@ pub enum TransferError {
 
 impl WebGpuError for TransferError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::MissingBufferUsage(e) => e,
-            Self::MissingTextureUsage(e) => e,
-            Self::MemoryInitFailure(e) => e,
+        match self {
+            Self::MissingBufferUsage(e) => e.webgpu_error_type(),
+            Self::MissingTextureUsage(e) => e.webgpu_error_type(),
+            Self::MemoryInitFailure(e) => e.webgpu_error_type(),
 
             Self::BufferEndOffsetOverrun { .. }
             | Self::TextureOverrun { .. }
@@ -225,9 +225,8 @@ impl WebGpuError for TransferError {
             | Self::SampleCountNotEqual { .. }
             | Self::InvalidMipLevel { .. }
             | Self::SameSourceDestinationBuffer
-            | Self::BufferNotAvailable => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::BufferNotAvailable => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -108,12 +108,11 @@ pub enum TransitionResourcesError {
 
 impl WebGpuError for TransitionResourcesError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::EncoderState(e) => e,
-            Self::InvalidResource(e) => e,
-            Self::ResourceUsage(e) => e,
-        };
-        e.webgpu_error_type()
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::EncoderState(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+            Self::ResourceUsage(e) => e.webgpu_error_type(),
+        }
     }
 }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -470,14 +470,13 @@ pub enum QueueWriteError {
 
 impl WebGpuError for QueueWriteError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Queue(e) => e,
-            Self::Transfer(e) => e,
-            Self::MemoryInitFailure(e) => e,
-            Self::DestroyedResource(e) => e,
-            Self::InvalidResource(e) => e,
-        };
-        e.webgpu_error_type()
+        match self {
+            Self::Queue(e) => e.webgpu_error_type(),
+            Self::Transfer(e) => e.webgpu_error_type(),
+            Self::MemoryInitFailure(e) => e.webgpu_error_type(),
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+        }
     }
 }
 
@@ -502,17 +501,14 @@ pub enum QueueSubmitError {
 
 impl WebGpuError for QueueSubmitError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Queue(e) => e,
-            Self::Unmap(e) => e,
-            Self::CommandEncoder(e) => e,
-            Self::ValidateAsActionsError(e) => e,
-            Self::InvalidResource(e) => e,
-            Self::DestroyedResource(_) | Self::BufferStillMapped(_) => {
-                return ErrorType::Validation
-            }
-        };
-        e.webgpu_error_type()
+        match self {
+            Self::Queue(e) => e.webgpu_error_type(),
+            Self::Unmap(e) => e.webgpu_error_type(),
+            Self::CommandEncoder(e) => e.webgpu_error_type(),
+            Self::ValidateAsActionsError(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+            Self::DestroyedResource(_) | Self::BufferStillMapped(_) => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -139,22 +139,21 @@ pub enum CreateShaderModuleError {
 
 impl WebGpuError for CreateShaderModuleError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::MissingFeatures(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
 
-            Self::Generation => return ErrorType::Internal,
+            Self::Generation => ErrorType::Internal,
 
-            Self::Validation(..) | Self::InvalidGroupIndex { .. } => return ErrorType::Validation,
+            Self::Validation(..) | Self::InvalidGroupIndex { .. } => ErrorType::Validation,
             #[cfg(feature = "wgsl")]
-            Self::Parsing(..) => return ErrorType::Validation,
+            Self::Parsing(..) => ErrorType::Validation,
             #[cfg(feature = "glsl")]
-            Self::ParsingGlsl(..) => return ErrorType::Validation,
+            Self::ParsingGlsl(..) => ErrorType::Validation,
             #[cfg(feature = "spirv")]
-            Self::ParsingSpirV(..) => return ErrorType::Validation,
-            Self::NotCompiledForBackend => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            Self::ParsingSpirV(..) => ErrorType::Validation,
+            Self::NotCompiledForBackend => ErrorType::Validation,
+        }
     }
 }
 
@@ -208,13 +207,12 @@ pub enum ImplicitLayoutError {
 
 impl WebGpuError for ImplicitLayoutError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::ReflectionError(_) => return ErrorType::Validation,
-            Self::BindGroup(e) => e,
-            Self::Pipeline(e) => e,
-            Self::Passthrough(_) => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+        match self {
+            Self::ReflectionError(_) => ErrorType::Validation,
+            Self::BindGroup(e) => e.webgpu_error_type(),
+            Self::Pipeline(e) => e.webgpu_error_type(),
+            Self::Passthrough(_) => ErrorType::Validation,
+        }
     }
 }
 
@@ -261,16 +259,15 @@ pub enum CreateComputePipelineError {
 
 impl WebGpuError for CreateComputePipelineError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::InvalidResource(e) => e,
-            Self::MissingDownlevelFlags(e) => e,
-            Self::Implicit(e) => e,
-            Self::Stage(e) => e,
-            Self::Internal(_) => return ErrorType::Internal,
-            Self::PipelineConstants(_) => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+            Self::MissingDownlevelFlags(e) => e.webgpu_error_type(),
+            Self::Implicit(e) => e.webgpu_error_type(),
+            Self::Stage(e) => e.webgpu_error_type(),
+            Self::Internal(_) => ErrorType::Internal,
+            Self::PipelineConstants(_) => ErrorType::Validation,
+        }
     }
 }
 
@@ -329,12 +326,11 @@ pub enum CreatePipelineCacheError {
 
 impl WebGpuError for CreatePipelineCacheError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::Validation(e) => e,
-            Self::MissingFeatures(e) => e,
-        };
-        e.webgpu_error_type()
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::Validation(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
+        }
     }
 }
 
@@ -739,13 +735,13 @@ pub enum CreateRenderPipelineError {
 
 impl WebGpuError for CreateRenderPipelineError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::InvalidResource(e) => e,
-            Self::MissingFeatures(e) => e,
-            Self::MissingDownlevelFlags(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
+            Self::MissingDownlevelFlags(e) => e.webgpu_error_type(),
 
-            Self::Internal { .. } => return ErrorType::Internal,
+            Self::Internal { .. } => ErrorType::Internal,
 
             Self::ColorAttachment(_)
             | Self::Implicit(_)
@@ -765,9 +761,8 @@ impl WebGpuError for CreateRenderPipelineError {
             | Self::UnalignedShader { .. }
             | Self::NoTargetSpecified
             | Self::PipelineConstants { .. }
-            | Self::VertexAttributeStrideTooLarge { .. } => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::VertexAttributeStrideTooLarge { .. } => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -55,14 +55,13 @@ pub enum SurfaceError {
 
 impl WebGpuError for SurfaceError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
             Self::Invalid
             | Self::NotConfigured
             | Self::AlreadyAcquired
-            | Self::TextureDestroyed => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::TextureDestroyed => ErrorType::Validation,
+        }
     }
 }
 
@@ -125,9 +124,9 @@ impl From<WaitIdleError> for ConfigureSurfaceError {
 
 impl WebGpuError for ConfigureSurfaceError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::MissingDownlevelFlags(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::MissingDownlevelFlags(e) => e.webgpu_error_type(),
             Self::InvalidSurface
             | Self::InvalidViewFormat(..)
             | Self::PreviousOutputExists
@@ -138,9 +137,8 @@ impl WebGpuError for ConfigureSurfaceError {
             | Self::UnsupportedFormat { .. }
             | Self::UnsupportedPresentMode { .. }
             | Self::UnsupportedAlphaMode { .. }
-            | Self::UnsupportedUsage { .. } => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::UnsupportedUsage { .. } => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/ray_tracing.rs
+++ b/wgpu-core/src/ray_tracing.rs
@@ -52,15 +52,14 @@ pub enum CreateBlasError {
 
 impl WebGpuError for CreateBlasError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::MissingFeatures(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
             Self::MissingIndexData
             | Self::InvalidVertexFormat(..)
             | Self::TooManyGeometries(..)
-            | Self::TooManyPrimitives(..) => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::TooManyPrimitives(..) => ErrorType::Validation,
+        }
     }
 }
 
@@ -78,12 +77,11 @@ pub enum CreateTlasError {
 
 impl WebGpuError for CreateTlasError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::MissingFeatures(e) => e,
-            Self::DisallowedFlag(..) | Self::TooManyInstances(..) => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
+            Self::DisallowedFlag(..) | Self::TooManyInstances(..) => ErrorType::Validation,
+        }
     }
 }
 
@@ -187,13 +185,13 @@ pub enum BuildAccelerationStructureError {
 
 impl WebGpuError for BuildAccelerationStructureError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::EncoderState(e) => e,
-            Self::Device(e) => e,
-            Self::InvalidResource(e) => e,
-            Self::DestroyedResource(e) => e,
-            Self::MissingBufferUsage(e) => e,
-            Self::MissingFeatures(e) => e,
+        match self {
+            Self::EncoderState(e) => e.webgpu_error_type(),
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
+            Self::MissingBufferUsage(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
             Self::InsufficientBufferSize(..)
             | Self::UnalignedIndexBufferOffset(..)
             | Self::UnalignedTransformBufferOffset(..)
@@ -214,9 +212,8 @@ impl WebGpuError for BuildAccelerationStructureError {
             | Self::TlasInstanceCountExceeded(..)
             | Self::TransformMissing(..)
             | Self::UseTransformMissing(..)
-            | Self::TlasDependentMissingVertexReturn(..) => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::TlasDependentMissingVertexReturn(..) => ErrorType::Validation,
+        }
     }
 }
 
@@ -237,13 +234,12 @@ pub enum ValidateAsActionsError {
 
 impl WebGpuError for ValidateAsActionsError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::DestroyedResource(e) => e,
+        match self {
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
             Self::UsedUnbuiltTlas(..) | Self::UsedUnbuiltBlas(..) | Self::BlasNewerThenTlas(..) => {
-                return ErrorType::Validation
+                ErrorType::Validation
             }
-        };
-        e.webgpu_error_type()
+        }
     }
 }
 
@@ -404,15 +400,14 @@ pub enum BlasPrepareCompactError {
 
 impl WebGpuError for BlasPrepareCompactError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::InvalidResource(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
             Self::CompactionPreparingAlready
             | Self::DoubleCompaction
             | Self::NotBuilt
-            | Self::CompactionUnsupported => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::CompactionUnsupported => ErrorType::Validation,
+        }
     }
 }
 
@@ -439,15 +434,14 @@ pub enum CompactBlasError {
 
 impl WebGpuError for CompactBlasError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Encoder(e) => e,
-            Self::Device(e) => e,
-            Self::InvalidResource(e) => e,
-            Self::DestroyedResource(e) => e,
-            Self::MissingFeatures(e) => e,
-            Self::BlasNotReady => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+        match self {
+            Self::Encoder(e) => e.webgpu_error_type(),
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
+            Self::BlasNotReady => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -324,10 +324,10 @@ pub enum BufferAccessError {
 
 impl WebGpuError for BufferAccessError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::InvalidResource(e) => e,
-            Self::DestroyedResource(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
 
             Self::Failed
             | Self::AlreadyMapped
@@ -342,9 +342,8 @@ impl WebGpuError for BufferAccessError {
             | Self::OutOfBoundsEndOffsetOverrun { .. }
             | Self::MapAborted
             | Self::MapStartOffsetOverrun { .. }
-            | Self::MapEndOffsetOverrun { .. } => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::MapEndOffsetOverrun { .. } => ErrorType::Validation,
+        }
     }
 }
 
@@ -1027,19 +1026,18 @@ crate::impl_trackable!(Buffer);
 
 impl WebGpuError for CreateBufferError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::AccessError(e) => e,
-            Self::MissingDownlevelFlags(e) => e,
-            Self::IndirectValidationBindGroup(e) => e,
-            Self::MissingFeatures(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::AccessError(e) => e.webgpu_error_type(),
+            Self::MissingDownlevelFlags(e) => e.webgpu_error_type(),
+            Self::IndirectValidationBindGroup(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
 
             Self::UnalignedSize
             | Self::InvalidUsage(_)
             | Self::UsageMismatch(_)
-            | Self::MaxBufferSize { .. } => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::MaxBufferSize { .. } => ErrorType::Validation,
+        }
     }
 }
 
@@ -1659,12 +1657,12 @@ impl Borrow<TextureSelector> for Texture {
 
 impl WebGpuError for CreateTextureError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::CreateTextureView(e) => e,
-            Self::InvalidDimension(e) => e,
-            Self::MissingFeatures(_, e) => e,
-            Self::MissingDownlevelFlags(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::CreateTextureView(e) => e.webgpu_error_type(),
+            Self::InvalidDimension(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(_, e) => e.webgpu_error_type(),
+            Self::MissingDownlevelFlags(e) => e.webgpu_error_type(),
 
             Self::InvalidUsage(_)
             | Self::IncompatibleUsage(_, _)
@@ -1677,9 +1675,8 @@ impl WebGpuError for CreateTextureError {
             | Self::InvalidMultisampledStorageBinding
             | Self::InvalidMultisampledFormat(_)
             | Self::InvalidSampleCount(..)
-            | Self::MultisampledNotRenderAttachment => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::MultisampledNotRenderAttachment => ErrorType::Validation,
+        }
     }
 }
 
@@ -1991,22 +1988,19 @@ pub enum CreateExternalTextureError {
 
 impl WebGpuError for CreateExternalTextureError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            CreateExternalTextureError::Device(e) => e,
-            CreateExternalTextureError::MissingFeatures(e) => e,
-            CreateExternalTextureError::InvalidResource(e) => e,
-            CreateExternalTextureError::CreateBuffer(e) => e,
-            CreateExternalTextureError::QueueWrite(e) => e,
-            CreateExternalTextureError::MissingTextureUsage(e) => e,
+        match self {
+            CreateExternalTextureError::Device(e) => e.webgpu_error_type(),
+            CreateExternalTextureError::MissingFeatures(e) => e.webgpu_error_type(),
+            CreateExternalTextureError::InvalidResource(e) => e.webgpu_error_type(),
+            CreateExternalTextureError::CreateBuffer(e) => e.webgpu_error_type(),
+            CreateExternalTextureError::QueueWrite(e) => e.webgpu_error_type(),
+            CreateExternalTextureError::MissingTextureUsage(e) => e.webgpu_error_type(),
             CreateExternalTextureError::IncorrectPlaneCount { .. }
             | CreateExternalTextureError::InvalidPlaneMultisample(_)
             | CreateExternalTextureError::InvalidPlaneSampleType { .. }
             | CreateExternalTextureError::InvalidPlaneDimension(_)
-            | CreateExternalTextureError::InvalidPlaneFormat { .. } => {
-                return ErrorType::Validation
-            }
-        };
-        e.webgpu_error_type()
+            | CreateExternalTextureError::InvalidPlaneFormat { .. } => ErrorType::Validation,
+        }
     }
 }
 
@@ -2130,17 +2124,16 @@ crate::impl_trackable!(Sampler);
 
 impl WebGpuError for CreateSamplerError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::MissingFeatures(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
 
             Self::InvalidLodMinClamp(_)
             | Self::InvalidLodMaxClamp { .. }
             | Self::InvalidAnisotropy(_)
             | Self::InvalidFilterModeWithAnisotropy { .. }
-            | Self::InvalidMipmapFilterModeWithAnisotropy { .. } => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::InvalidMipmapFilterModeWithAnisotropy { .. } => ErrorType::Validation,
+        }
     }
 }
 
@@ -2159,13 +2152,12 @@ pub enum CreateQuerySetError {
 
 impl WebGpuError for CreateQuerySetError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Device(e) => e,
-            Self::MissingFeatures(e) => e,
+        match self {
+            Self::Device(e) => e.webgpu_error_type(),
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
 
-            Self::TooManyQueries { .. } | Self::ZeroCount => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            Self::TooManyQueries { .. } | Self::ZeroCount => ErrorType::Validation,
+        }
     }
 }
 

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -405,19 +405,19 @@ pub enum StageError {
 
 impl WebGpuError for StageError {
     fn webgpu_error_type(&self) -> ErrorType {
-        let e: &dyn WebGpuError = match self {
-            Self::Binding(_, e) => e,
-            Self::InvalidResource(e) => e,
+        match self {
+            Self::Binding(_, e) => e.webgpu_error_type(),
+            Self::InvalidResource(e) => e.webgpu_error_type(),
             Self::Filtering {
                 texture: _,
                 sampler: _,
                 error,
-            } => error,
+            } => error.webgpu_error_type(),
             Self::Input {
                 location: _,
                 var: _,
                 error,
-            } => error,
+            } => error.webgpu_error_type(),
             Self::InvalidWorkgroupSize { .. }
             | Self::MissingEntryPoint(..)
             | Self::NoEntryPointFound
@@ -435,9 +435,8 @@ impl WebGpuError for StageError {
             | Self::MissingPrimitiveIndex
             | Self::DrawIdError
             | Self::InvalidDualSourceBlending
-            | Self::MissingFragDepthAttachment => return ErrorType::Validation,
-        };
-        e.webgpu_error_type()
+            | Self::MissingFragDepthAttachment => ErrorType::Validation,
+        }
     }
 }
 


### PR DESCRIPTION
In my build this saves 64 kB in the text section and 145 kB total from hello-window.

**Testing**
Passes existing tests.

**Squash or Rebase?** Squash
