### PR TITLE
Fix OpenGL robustness fallback when the robustness extension is unsupported

### DIFF
--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -572,12 +572,14 @@ impl Inner {
                         break result;
                     }
 
-                    // EGL 1.5 specification:
-                    // "An EGL_BAD_MATCH error is generated if an OpenGL or OpenGL ES context is
-                    // requested with robust buffer access, and the implementation does not
-                    // support the corresponding OpenGL or OpenGL ES extension."
+                    // Robust access context creation can fail with different
+                    // error codes depending on the EGL path.
                     (
-                        Err(khronos_egl::Error::BadMatch | khronos_egl::Error::BadAttribute),
+                        Err(
+                            khronos_egl::Error::BadAttribute
+                            | khronos_egl::Error::BadMatch
+                            | khronos_egl::Error::BadConfig,
+                        ),
                         Some(r),
                     ) => {
                         // Trying EXT robustness if Core robustness is not working

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -583,7 +583,7 @@ impl Inner {
             let result = if supports_opengl {
                 create_context(khronos_egl::OPENGL_API, &gl_context_attributes).or_else(
                     |gl_error| {
-                        log::info!("Failed to create desktop OpenGL context: {gl_error}, falling back to OpenGL ES");
+                        log::debug!("Failed to create desktop OpenGL context: {gl_error}, falling back to OpenGL ES");
                         create_context(khronos_egl::OPENGL_ES_API, &gles_context_attributes)
                     },
                 )

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -572,9 +572,14 @@ impl Inner {
                         break result;
                     }
 
-                    // BadAttribute could mean that context creation is not supported at the requested robustness level
-                    // We try the next robustness level.
-                    (Err(khronos_egl::Error::BadAttribute), Some(r)) => {
+                    // EGL 1.5 specification:
+                    // "An EGL_BAD_MATCH error is generated if an OpenGL or OpenGL ES context is
+                    // requested with robust buffer access, and the implementation does not
+                    // support the corresponding OpenGL or OpenGL ES extension."
+                    (
+                        Err(khronos_egl::Error::BadMatch | khronos_egl::Error::BadAttribute),
+                        Some(r),
+                    ) => {
                         // Trying EXT robustness if Core robustness is not working
                         // and EXT robustness is supported.
                         robustness = if matches!(r, Robustness::Core)

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -453,12 +453,6 @@ impl Inner {
         } else {
             false
         };
-        egl.bind_api(if supports_opengl {
-            khronos_egl::OPENGL_API
-        } else {
-            khronos_egl::OPENGL_ES_API
-        })
-        .map_err(instance_err("failed to bind API"))?;
 
         let mut khr_context_flags = 0;
         let supports_khr_context = display_extensions.contains("EGL_KHR_create_context");
@@ -506,12 +500,13 @@ impl Inner {
         gles_context_attributes.extend(&context_attributes);
 
         let context = {
+            #[derive(Copy, Clone)]
             enum Robustness {
                 Core,
                 Ext,
             }
 
-            let mut robustness = if version >= (1, 5) {
+            let robustness = if version >= (1, 5) {
                 Some(Robustness::Core)
             } else if display_extensions.contains("EGL_EXT_create_context_robustness") {
                 Some(Robustness::Ext)
@@ -519,87 +514,84 @@ impl Inner {
                 None
             };
 
-            loop {
-                let robustness_attributes = match robustness {
-                    Some(Robustness::Core) => {
-                        vec![
-                            khronos_egl::CONTEXT_OPENGL_ROBUST_ACCESS,
-                            khronos_egl::TRUE as _,
-                            khronos_egl::NONE,
-                        ]
-                    }
-                    Some(Robustness::Ext) => {
-                        vec![
-                            EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT,
-                            khronos_egl::TRUE as _,
-                            khronos_egl::NONE,
-                        ]
-                    }
-                    None => vec![khronos_egl::NONE],
-                };
+            let create_context = |api, base_attributes: &[khronos_egl::Int]| {
+                egl.bind_api(api)?;
 
-                let mut gl_context_attributes = gl_context_attributes.clone();
-                gl_context_attributes.extend(&robustness_attributes);
+                let mut robustness = robustness;
+                loop {
+                    let robustness_attributes = match robustness {
+                        Some(Robustness::Core) => {
+                            vec![
+                                khronos_egl::CONTEXT_OPENGL_ROBUST_ACCESS,
+                                khronos_egl::TRUE as _,
+                                khronos_egl::NONE,
+                            ]
+                        }
+                        Some(Robustness::Ext) => {
+                            vec![
+                                EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT,
+                                khronos_egl::TRUE as _,
+                                khronos_egl::NONE,
+                            ]
+                        }
+                        None => vec![khronos_egl::NONE],
+                    };
 
-                let mut gles_context_attributes = gles_context_attributes.clone();
-                gles_context_attributes.extend(&robustness_attributes);
+                    let mut context_attributes = base_attributes.to_vec();
+                    context_attributes.extend(&robustness_attributes);
 
-                let result = if supports_opengl {
-                    egl.create_context(display, config, None, &gl_context_attributes)
-                        .or_else(|_| {
-                            egl.bind_api(khronos_egl::OPENGL_ES_API)?;
-                            egl.create_context(display, config, None, &gles_context_attributes)
-                        })
-                } else {
-                    egl.create_context(display, config, None, &gles_context_attributes)
-                };
-
-                match (result, robustness) {
-                    // We have a context at the requested robustness level
-                    (Ok(_), robustness) => {
-                        match robustness {
-                            Some(Robustness::Core) => {
-                                log::debug!("\tEGL context: +robust access");
+                    match egl.create_context(display, config, None, &context_attributes) {
+                        Ok(context) => {
+                            match robustness {
+                                Some(Robustness::Core) => {
+                                    log::debug!("\tEGL context: +robust access");
+                                }
+                                Some(Robustness::Ext) => {
+                                    log::debug!("\tEGL context: +robust access EXT");
+                                }
+                                None => {
+                                    log::debug!("\tEGL context: -robust access");
+                                }
                             }
-                            Some(Robustness::Ext) => {
-                                log::debug!("\tEGL context: +robust access EXT");
-                            }
-                            None => {
-                                log::debug!("\tEGL context: -robust access");
-                            }
+                            return Ok(context);
                         }
 
-                        break result;
-                    }
-
-                    // Robust access context creation can fail with different
-                    // error codes depending on the EGL path.
-                    (
+                        // Robust access context creation can fail with different error codes
+                        // depending on the EGL path. Retry with a lower robustness level.
                         Err(
                             khronos_egl::Error::BadAttribute
                             | khronos_egl::Error::BadMatch
                             | khronos_egl::Error::BadConfig,
-                        ),
-                        Some(r),
-                    ) => {
-                        // Trying EXT robustness if Core robustness is not working
-                        // and EXT robustness is supported.
-                        robustness = if matches!(r, Robustness::Core)
-                            && display_extensions.contains("EGL_EXT_create_context_robustness")
-                        {
-                            Some(Robustness::Ext)
-                        } else {
-                            None
-                        };
+                        ) if robustness.is_some() => {
+                            robustness = match robustness {
+                                Some(Robustness::Core)
+                                    if display_extensions
+                                        .contains("EGL_EXT_create_context_robustness") =>
+                                {
+                                    Some(Robustness::Ext)
+                                }
+                                _ => None,
+                            };
+                            continue;
+                        }
 
-                        continue;
+                        Err(e) => return Err(e),
                     }
-
-                    // Any other error, or depleted robustness levels, we give up.
-                    _ => break result,
                 }
-            }
-            .map_err(|e| {
+            };
+
+            let result = if supports_opengl {
+                create_context(khronos_egl::OPENGL_API, &gl_context_attributes).or_else(
+                    |gl_error| {
+                        log::info!("Failed to create desktop OpenGL context: {gl_error}, falling back to OpenGL ES");
+                        create_context(khronos_egl::OPENGL_ES_API, &gles_context_attributes)
+                    },
+                )
+            } else {
+                create_context(khronos_egl::OPENGL_ES_API, &gles_context_attributes)
+            };
+
+            result.map_err(|e| {
                 crate::InstanceError::with_source(
                     String::from("unable to create OpenGL or GLES 3.x context"),
                     e,


### PR DESCRIPTION
We're seeing wgpu fail to find any adapters on some Linux systems with Intel HD 4000 GPUs.

Enabling wgpu debug logs reveals that GL initialization fails with the following error: https://github.com/zed-industries/zed/issues/50184#issuecomment-3979017667

> `Instance::new: failed to create Gl backend: InstanceError { message: "unable to create OpenGL or GLES 3.x context", source: Some(BadMatch) }`

The EGL specification says that creating the context may fail with the `EGL_BAD_MATCH` error if robust buffer access is not supported:

> An `EGL_BAD_MATCH` error is generated if an OpenGL or OpenGL ES context is requested with robust buffer access, and the implementation does not support the corresponding OpenGL or OpenGL ES extension.

Futhermore, the specification for `EGL_EXT_create_context_robustness` says that creating the context may fail with `EGL_BAD_CONFIG` under similar circumstances:

> `EGL_BAD_CONFIG` is generated if `EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT` is set to `EGL_TRUE` and no GL context supporting the `GL_EXT_robustness` extension and robust access as described therein can be created.

wgpu has code which attempts to handle these cases and fall back to creating the context without robust buffer access, but only checks the `EGL_BAD_ATTRIBUTE` error code. So, handle these other errors as well.