### PR TITLE
fix(naga): Reject matrix negation in WGSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 - Allow array generation to compile with the macOS 10.12 Metal compiler. By @madsmtm in [#8953](https://github.com/gfx-rs/wgpu/pull/8953)
 - Naga now detects bitwise shifts by a constant exceeding the operand bit width at compile time, and disallows scalar-by-vector and vector-by-scalar shifts in constant evaluation. By @andyleiserson in [#8907](https://github.com/gfx-rs/wgpu/pull/8907).
 - Naga uses wrapping arithmetic when evaluating dot products on concrete integer types (`u32` and `i32`). By @BKDaugherty in [#9142](https://github.com/gfx-rs/wgpu/pull/9142).
+- Disallow negation of a matrix. By @andyleiserson in [#9157](https://github.com/gfx-rs/wgpu/pull/9157).
 
 #### Validation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,7 +187,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 - Allow array generation to compile with the macOS 10.12 Metal compiler. By @madsmtm in [#8953](https://github.com/gfx-rs/wgpu/pull/8953)
 - Naga now detects bitwise shifts by a constant exceeding the operand bit width at compile time, and disallows scalar-by-vector and vector-by-scalar shifts in constant evaluation. By @andyleiserson in [#8907](https://github.com/gfx-rs/wgpu/pull/8907).
 - Naga uses wrapping arithmetic when evaluating dot products on concrete integer types (`u32` and `i32`). By @BKDaugherty in [#9142](https://github.com/gfx-rs/wgpu/pull/9142).
-- Disallow negation of a matrix. By @andyleiserson in [#9157](https://github.com/gfx-rs/wgpu/pull/9157).
+- Disallow negation of a matrix in WGSL. By @andyleiserson in [#9157](https://github.com/gfx-rs/wgpu/pull/9157).
 
 #### Validation
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -160,7 +160,7 @@ webgpu:shader,validation,expression,call,builtin,value_constructor:* // 92%, val
 webgpu:shader,validation,expression,early_evaluation:* // 67%, mixed override/runtime composite evaluation
 webgpu:shader,validation,expression,matrix,* // 83%, #5474, #8790, #8868
 webgpu:shader,validation,expression,precedence:* // 76%, https://github.com/gfx-rs/wgpu/issues/4536
-webgpu:shader,validation,expression,unary,* // 99%, matrix negation accepted, #5474
+webgpu:shader,validation,expression,unary,* // 99%, atomics #5474
 webgpu:shader,validation,extension,dual_source_blending:blend_src_usage:* // 61%, @blend_src validation gaps
 webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:* // 0%, CTS bug https://github.com/gpuweb/cts/pull/4567
 webgpu:shader,validation,functions,alias_analysis:* // 2%, https://github.com/gfx-rs/wgpu/issues/7650

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -998,7 +998,27 @@ impl<'a> Context<'a> {
                     .lower_expect_inner(stmt, frontend, expr, ExprPos::Rhs)?
                     .0;
 
-                self.add_expression(Expression::Unary { op, expr }, meta)?
+                if let TypeInner::Matrix { scalar, .. } = *self.resolve_type(expr, meta)? {
+                    // Naga IR doesn't support matrix negation, so we need to turn it into
+                    // multiplication by scalar -1.
+                    let minus_one = Literal::minus_one(scalar).ok_or_else(|| Error {
+                        kind: ErrorKind::SemanticError(
+                            format!("Cannot apply operator {op:?} to type {scalar:?}").into(),
+                        ),
+                        meta,
+                    })?;
+                    let lhs = self.add_expression(Expression::Literal(minus_one), meta)?;
+                    self.add_expression(
+                        Expression::Binary {
+                            op: BinaryOperator::Multiply,
+                            left: lhs,
+                            right: expr,
+                        },
+                        meta,
+                    )?
+                } else {
+                    self.add_expression(Expression::Unary { op, expr }, meta)?
+                }
             }
             HirExprKind::Variable(ref var) => match pos {
                 ExprPos::Lhs => {

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -144,6 +144,18 @@ impl crate::Literal {
         Self::new(1, scalar)
     }
 
+    pub const fn minus_one(scalar: crate::Scalar) -> Option<Self> {
+        match (scalar.kind, scalar.width) {
+            (crate::ScalarKind::Float, 8) => Some(Self::F64(-1.0)),
+            (crate::ScalarKind::Float, 4) => Some(Self::F32(-1.0)),
+            (crate::ScalarKind::Float, 2) => Some(Self::F16(half::f16::from_f32_const(-1.0))),
+            (crate::ScalarKind::Sint, 8) => Some(Self::I64(-1)),
+            (crate::ScalarKind::Sint, 4) => Some(Self::I32(-1)),
+            (crate::ScalarKind::AbstractInt, 8) => Some(Self::AbstractInt(-1)),
+            _ => None,
+        }
+    }
+
     pub const fn width(&self) -> crate::Bytes {
         match *self {
             Self::F64(_) | Self::I64(_) | Self::U64(_) => 8,

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -864,15 +864,14 @@ impl super::Validator {
             }
             E::Unary { op, expr } => {
                 use crate::UnaryOperator as Uo;
-                let inner = &resolver[expr];
-                match (op, inner.scalar_kind()) {
-                    (Uo::Negate, Some(Sk::Float | Sk::Sint))
-                    | (Uo::LogicalNot, Some(Sk::Bool))
-                    | (Uo::BitwiseNot, Some(Sk::Sint | Sk::Uint)) => {}
-                    other => {
-                        log::debug!("Op {op:?} kind {other:?}");
-                        return Err(ExpressionError::InvalidUnaryOperandType(op, expr));
-                    }
+                let Some((_, scalar)) = resolver[expr].vector_size_and_scalar() else {
+                    return Err(ExpressionError::InvalidUnaryOperandType(op, expr));
+                };
+                match (op, scalar.kind) {
+                    (Uo::Negate, Sk::Float | Sk::Sint) => {}
+                    (Uo::LogicalNot, Sk::Bool) => {}
+                    (Uo::BitwiseNot, Sk::Sint | Sk::Uint) => {}
+                    _ => return Err(ExpressionError::InvalidUnaryOperandType(op, expr)),
                 }
                 ShaderStages::all()
             }

--- a/naga/tests/out/wgsl/glsl-expressions.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-expressions.frag.wgsl
@@ -266,16 +266,16 @@ fn testUnaryOpMat(a_16: mat3x3<f32>) {
 
     a_17 = a_16;
     let _e3 = a_17;
-    v_8 = -(_e3);
-    let _e5 = a_17;
-    let _e7 = vec3(1f);
-    let _e9 = (_e5 - mat3x3<f32>(_e7, _e7, _e7));
-    a_17 = _e9;
-    v_8 = _e9;
-    let _e10 = a_17;
-    let _e12 = vec3(1f);
-    a_17 = (_e10 - mat3x3<f32>(_e12, _e12, _e12));
+    v_8 = (-1f * _e3);
+    let _e6 = a_17;
+    let _e8 = vec3(1f);
+    let _e10 = (_e6 - mat3x3<f32>(_e8, _e8, _e8));
+    a_17 = _e10;
     v_8 = _e10;
+    let _e11 = a_17;
+    let _e13 = vec3(1f);
+    a_17 = (_e11 - mat3x3<f32>(_e13, _e13, _e13));
+    v_8 = _e11;
     return;
 }
 


### PR DESCRIPTION
Disallow matrix negation in WGSL. Because it is allowed in GLSL, convert matrix negation to multiplication by scalar -1 in the glsl frontend.

Note that the revised version uses the `vector_size_and_scalar` helper to reject matrices. There are some revisions to the comment on that helper in #9154.

**Testing**
Tested with the CTS suite `webgpu:shader,validation,expression,unary,*`, but there are still unrelated failures, so I have not added it to the test list.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
