### PR TITLE
fix(naga): Implement constant matrix add/sub/mul

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -154,7 +154,7 @@ webgpu:shader,validation,expression,call,builtin,unpack4xI8:* // 75%, missing co
 webgpu:shader,validation,expression,call,builtin,unpack4xU8:* // 75%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,value_constructor:* // 92%, value constructors lack must-use validation + abstract-float matrix validation issues
 webgpu:shader,validation,expression,early_evaluation:* // 67%, mixed override/runtime composite evaluation
-webgpu:shader,validation,expression,matrix,* // 83%, #5474, #8790, #8868
+webgpu:shader,validation,expression,matrix,* // 92%, #5474, #8868, overflow/underflow/atomic
 webgpu:shader,validation,expression,precedence:* // 76%, https://github.com/gfx-rs/wgpu/issues/4536
 webgpu:shader,validation,expression,unary,* // 99%, atomics #5474
 webgpu:shader,validation,extension,dual_source_blending:blend_src_usage:* // 61%, @blend_src validation gaps

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -2776,32 +2776,24 @@ impl<'a> ConstantEvaluator<'a> {
                     left_components,
                     self.expressions,
                     self.types,
-                );
+                )
+                .collect::<Vec<_>>();
                 let right_flattened = crate::proc::flatten_compose(
                     right_ty,
                     right_components,
                     self.expressions,
                     self.types,
-                );
+                )
+                .collect::<Vec<_>>();
 
-                // `flatten_compose` doesn't return an `ExactSizeIterator`, so
-                // make a reasonable guess of the capacity we'll need.
-                let mut flattened = Vec::with_capacity(left_components.len());
-                flattened.extend(left_flattened.zip(right_flattened));
-
-                match (&self.types[left_ty].inner, &self.types[right_ty].inner) {
-                    (
-                        &TypeInner::Vector {
-                            size: left_size, ..
-                        },
-                        &TypeInner::Vector {
-                            size: right_size, ..
-                        },
-                    ) if left_size == right_size => {
-                        self.binary_op_vector(op, left_size, &flattened, left_ty, span)?
-                    }
-                    _ => return Err(ConstantEvaluatorError::InvalidBinaryOpArgs),
-                }
+                self.binary_op_compose(
+                    op,
+                    &left_flattened,
+                    &right_flattened,
+                    left_ty,
+                    right_ty,
+                    span,
+                )?
             }
             _ => return Err(ConstantEvaluatorError::InvalidBinaryOpArgs),
         };
@@ -2827,11 +2819,105 @@ impl<'a> ConstantEvaluator<'a> {
         }
     }
 
+    fn binary_op_compose(
+        &mut self,
+        op: BinaryOperator,
+        left_components: &[Handle<Expression>],
+        right_components: &[Handle<Expression>],
+        left_ty: Handle<Type>,
+        right_ty: Handle<Type>,
+        span: Span,
+    ) -> Result<Expression, ConstantEvaluatorError> {
+        match (&self.types[left_ty].inner, &self.types[right_ty].inner) {
+            // Binary operation on vector-vector
+            (
+                &TypeInner::Vector {
+                    size: left_size, ..
+                },
+                &TypeInner::Vector {
+                    size: right_size, ..
+                },
+            ) if left_size == right_size => self.binary_op_vector(
+                op,
+                left_size,
+                left_components,
+                right_components,
+                left_ty,
+                span,
+            ),
+            // Binary operation on vector-matrix
+            (
+                &TypeInner::Vector { size, .. },
+                &TypeInner::Matrix {
+                    columns,
+                    rows,
+                    scalar,
+                },
+            ) if op == BinaryOperator::Multiply && size == rows => self.multiply_vector_matrix(
+                left_components,
+                right_components,
+                columns,
+                scalar,
+                span,
+            ),
+            // Binary operation on matrix-vector
+            (
+                &TypeInner::Matrix {
+                    columns,
+                    rows,
+                    scalar,
+                },
+                &TypeInner::Vector { size, .. },
+            ) if op == BinaryOperator::Multiply && size == columns => {
+                self.multiply_matrix_vector(left_components, right_components, rows, scalar, span)
+            }
+            // Binary operation on matrix-matrix
+            (
+                &TypeInner::Matrix {
+                    columns: left_columns,
+                    rows: left_rows,
+                    scalar,
+                },
+                &TypeInner::Matrix {
+                    columns: right_columns,
+                    rows: right_rows,
+                    ..
+                },
+            ) => match op {
+                BinaryOperator::Add | BinaryOperator::Subtract
+                    if left_columns == right_columns && left_rows == right_rows =>
+                {
+                    let components = left_components
+                        .iter()
+                        .zip(right_components)
+                        .map(|(&left, &right)| self.binary_op(op, left, right, span))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(Expression::Compose {
+                        ty: left_ty,
+                        components,
+                    })
+                }
+                BinaryOperator::Multiply if left_columns == right_rows => self
+                    .multiply_matrix_matrix(
+                        left_components,
+                        right_components,
+                        left_rows,
+                        right_columns,
+                        scalar,
+                        span,
+                    ),
+                _ => Err(ConstantEvaluatorError::InvalidBinaryOpArgs),
+            },
+            _ => Err(ConstantEvaluatorError::InvalidBinaryOpArgs),
+        }
+    }
+
     fn binary_op_vector(
         &mut self,
         op: BinaryOperator,
         size: crate::VectorSize,
-        components: &[(Handle<Expression>, Handle<Expression>)],
+        left_components: &[Handle<Expression>],
+        right_components: &[Handle<Expression>],
         left_ty: Handle<Type>,
         span: Span,
     ) -> Result<Expression, ConstantEvaluatorError> {
@@ -2872,12 +2958,165 @@ impl<'a> ConstantEvaluator<'a> {
             }
         };
 
-        let components = components
+        let components = left_components
             .iter()
-            .map(|&(left, right)| self.binary_op(op, left, right, span))
+            .zip(right_components)
+            .map(|(&left, &right)| self.binary_op(op, left, right, span))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Expression::Compose { ty, components })
+    }
+
+    fn multiply_vector_matrix(
+        &mut self,
+        vec_components: &[Handle<Expression>],
+        mat_components: &[Handle<Expression>],
+        mat_columns: crate::VectorSize,
+        scalar: crate::Scalar,
+        span: Span,
+    ) -> Result<Expression, ConstantEvaluatorError> {
+        let ty = self.types.insert(
+            Type {
+                name: None,
+                inner: TypeInner::Vector {
+                    size: mat_columns,
+                    scalar,
+                },
+            },
+            span,
+        );
+        let components = mat_components
+            .iter()
+            .map(|&column| {
+                let Expression::Compose { ref components, .. } = self.expressions[column] else {
+                    unreachable!()
+                };
+                self.dot_exprs(
+                    vec_components.iter().cloned(),
+                    components.clone().into_iter(),
+                    span,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Expression::Compose { ty, components })
+    }
+
+    fn multiply_matrix_vector(
+        &mut self,
+        mat_components: &[Handle<Expression>],
+        vec_components: &[Handle<Expression>],
+        mat_rows: crate::VectorSize,
+        scalar: crate::Scalar,
+        span: Span,
+    ) -> Result<Expression, ConstantEvaluatorError> {
+        let ty = self.types.insert(
+            Type {
+                name: None,
+                inner: TypeInner::Vector {
+                    size: mat_rows,
+                    scalar,
+                },
+            },
+            span,
+        );
+
+        let flatten = self.flatten_matrix(mat_components);
+        let nr = mat_rows as usize;
+        let components = (0..nr)
+            .map(|r| {
+                let row = flatten.iter().skip(r).step_by(nr).cloned();
+                self.dot_exprs(row, vec_components.iter().cloned(), span)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Expression::Compose { ty, components })
+    }
+
+    fn multiply_matrix_matrix(
+        &mut self,
+        left_components: &[Handle<Expression>],
+        right_components: &[Handle<Expression>],
+        left_rows: crate::VectorSize,
+        right_columns: crate::VectorSize,
+        scalar: crate::Scalar,
+        span: Span,
+    ) -> Result<Expression, ConstantEvaluatorError> {
+        let left_nc = left_components.len();
+        let left_nr = left_rows as usize;
+        let right_nc = right_columns as usize;
+        let right_nr = left_nc;
+
+        let mut result = Vec::with_capacity(right_nc);
+        let result_ty = self.types.insert(
+            Type {
+                name: None,
+                inner: TypeInner::Matrix {
+                    columns: right_columns,
+                    rows: left_rows,
+                    scalar,
+                },
+            },
+            span,
+        );
+        let result_column_ty = self.types.insert(
+            Type {
+                name: None,
+                inner: TypeInner::Vector {
+                    size: left_rows,
+                    scalar,
+                },
+            },
+            span,
+        );
+
+        let left_flattened = self.flatten_matrix(left_components);
+        let right_flattened = self.flatten_matrix(right_components);
+        for c in 0..right_nc {
+            let result_column = (0..left_nr)
+                .map(|r| {
+                    let row = left_flattened.iter().skip(r).step_by(left_nr);
+                    let column = right_flattened.iter().skip(c * right_nr).take(right_nr);
+                    self.dot_exprs(row.cloned(), column.cloned(), span)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let expr = Expression::Compose {
+                ty: result_column_ty,
+                components: result_column,
+            };
+            let handle = self.register_evaluated_expr(expr, span)?;
+            result.push(handle);
+        }
+        Ok(Expression::Compose {
+            ty: result_ty,
+            components: result,
+        })
+    }
+
+    fn flatten_matrix(&self, columns: &[Handle<Expression>]) -> ArrayVec<Handle<Expression>, 16> {
+        let mut flattened = ArrayVec::<_, 16>::new();
+        for &column in columns {
+            let Expression::Compose { ref components, .. } = self.expressions[column] else {
+                unreachable!()
+            };
+            flattened.extend(components.iter().cloned());
+        }
+        flattened
+    }
+
+    fn dot_exprs(
+        &mut self,
+        left: impl Iterator<Item = Handle<Expression>>,
+        right: impl Iterator<Item = Handle<Expression>>,
+        span: Span,
+    ) -> Result<Handle<Expression>, ConstantEvaluatorError> {
+        let mut acc = None;
+        for (l, r) in left.zip(right) {
+            let result = self.binary_op(BinaryOperator::Multiply, l, r, span)?;
+            match acc.as_mut() {
+                Some(acc) => *acc = self.binary_op(BinaryOperator::Add, *acc, result, span)?,
+                None => acc = Some(result),
+            }
+        }
+        Ok(acc.unwrap())
     }
 
     fn relational(
@@ -3534,8 +3773,8 @@ mod tests {
     use alloc::{vec, vec::Vec};
 
     use crate::{
-        Arena, Constant, Expression, Literal, ScalarKind, Type, TypeInner, UnaryOperator,
-        UniqueArena, VectorSize,
+        Arena, BinaryOperator, Constant, Expression, FastHashMap, Handle, Literal, ScalarKind,
+        Type, TypeInner, UnaryOperator, UniqueArena, VectorSize,
     };
 
     use super::{Behavior, ConstantEvaluator, ExpressionKindTracker, WgslRestrictions};
@@ -3670,6 +3909,265 @@ mod tests {
                 assert!(components_iter.next().is_none());
             }
             _ => panic!("Expected vector"),
+        }
+    }
+
+    #[test]
+    fn matrix_op() {
+        let mut helper = MatrixTestHelper::new();
+
+        for nc in 2..=4 {
+            for nr in 2..=4 {
+                // Validates multiplication on vector-matrix.
+                // vecR(0, 1, .., r) * matCxR(0, 1, .., nc * nr)
+                let evaluated = helper.eval_vector_multiply_matrix(nc, nr);
+                let expected = (0..nc)
+                    .map(|c| (0..nr).map(|r| (r * (c * nr + r)) as f32).sum())
+                    .collect::<Vec<f32>>();
+                assert_eq!(evaluated, expected);
+
+                // Validates multiplication on matrix-vector.
+                // matCxR(0, 1, .., nc * nr) * vecC(0, 1, .., nc)
+                let evaluated = helper.eval_matrix_multiply_vector(nc, nr);
+                let expected = (0..nr)
+                    .map(|r| (0..nc).map(|c| (c * (c * nr + r)) as f32).sum())
+                    .collect::<Vec<f32>>();
+                assert_eq!(evaluated, expected);
+
+                for k in 2..=4 {
+                    // Validates multiplication on matrix-matrix.
+                    // matKxR(0, 1, .., k * nr) * matCxK(0, 1, .., nc * k)
+                    let evaluated = helper.eval_matrix_multiply_matrix(nr, nc, k);
+                    let expected = (0..nc)
+                        .flat_map(|c| {
+                            (0..nr).map(move |r| {
+                                (0..k).map(|v| ((v * nr + r) * (c * k + v)) as f32).sum()
+                            })
+                        })
+                        .collect::<Vec<f32>>();
+                    assert_eq!(evaluated, expected);
+                }
+            }
+        }
+    }
+
+    /// Test fixture providing pre-built f32 vector and matrix constant
+    /// expressions with sequential element values, used to evaluate and verify
+    /// matrix operations.
+    struct MatrixTestHelper {
+        types: UniqueArena<Type>,
+        expressions: Arena<Expression>,
+        /// Vector expressions from [0, 1] to [0, 1, 2, 3].
+        vec_exprs: FastHashMap<usize, Handle<Expression>>,
+        /// Matrix expressions from [0, .., 3] to [0, .., 15].
+        mat_exprs: FastHashMap<(usize, usize), Handle<Expression>>,
+    }
+
+    impl MatrixTestHelper {
+        fn new() -> Self {
+            let mut types = UniqueArena::new();
+            let mut expressions = Arena::new();
+            let span = crate::Span::default();
+
+            let (mut vec_tys, mut mat_tys) = (FastHashMap::default(), FastHashMap::default());
+            for c in 2..=4 {
+                let vec_ty = types.insert(
+                    Type {
+                        name: None,
+                        inner: TypeInner::Vector {
+                            size: Self::int_to_vector_size(c),
+                            scalar: crate::Scalar::F32,
+                        },
+                    },
+                    span,
+                );
+                vec_tys.insert(c, vec_ty);
+                for r in 2..=4 {
+                    let mat_ty = types.insert(
+                        Type {
+                            name: None,
+                            inner: TypeInner::Matrix {
+                                columns: Self::int_to_vector_size(c),
+                                rows: Self::int_to_vector_size(r),
+                                scalar: crate::Scalar::F32,
+                            },
+                        },
+                        span,
+                    );
+                    mat_tys.insert((c, r), mat_ty);
+                }
+            }
+
+            let mut lit_exprs = FastHashMap::default();
+            for i in 0..16 {
+                let expr = expressions.append(Expression::Literal(Literal::F32(i as f32)), span);
+                lit_exprs.insert(i, expr);
+            }
+
+            let mut vec_exprs = FastHashMap::default();
+            for c in 2..=4 {
+                let expr = expressions.append(
+                    Expression::Compose {
+                        ty: *vec_tys.get(&c).unwrap(),
+                        components: (0..c)
+                            .map(|i| *lit_exprs.get(&i).unwrap())
+                            .collect::<Vec<_>>(),
+                    },
+                    span,
+                );
+                vec_exprs.insert(c, expr);
+            }
+
+            let mut mat_exprs = FastHashMap::default();
+            for c in 2..=4 {
+                for r in 2..=4 {
+                    let mut columns = Vec::with_capacity(c);
+                    for cc in 0..c {
+                        let start = cc * r;
+                        let expr = expressions.append(
+                            Expression::Compose {
+                                ty: *vec_tys.get(&r).unwrap(),
+                                components: (start..start + r)
+                                    .map(|i| *lit_exprs.get(&i).unwrap())
+                                    .collect::<Vec<_>>(),
+                            },
+                            span,
+                        );
+                        columns.push(expr);
+                    }
+
+                    let expr = expressions.append(
+                        Expression::Compose {
+                            ty: *mat_tys.get(&(c, r)).unwrap(),
+                            components: columns,
+                        },
+                        span,
+                    );
+                    mat_exprs.insert((c, r), expr);
+                }
+            }
+
+            Self {
+                types,
+                expressions,
+                vec_exprs,
+                mat_exprs,
+            }
+        }
+
+        /// Evaluates vec[0..nr] * mat[0..nc*nr] and returns the result as f32s.
+        fn eval_vector_multiply_matrix(&mut self, nc: usize, nr: usize) -> Vec<f32> {
+            let expression_kind_tracker = &mut ExpressionKindTracker::from_arena(&self.expressions);
+            let mut solver = ConstantEvaluator {
+                behavior: Behavior::Wgsl(WgslRestrictions::Const(None)),
+                types: &mut self.types,
+                constants: &Arena::new(),
+                overrides: &Arena::new(),
+                expressions: &mut self.expressions,
+                expression_kind_tracker,
+                layouter: &mut crate::proc::Layouter::default(),
+            };
+
+            let result = solver
+                .try_eval_and_append(
+                    Expression::Binary {
+                        op: BinaryOperator::Multiply,
+                        left: *self.vec_exprs.get(&nr).unwrap(),
+                        right: *self.mat_exprs.get(&(nc, nr)).unwrap(),
+                    },
+                    Default::default(),
+                )
+                .unwrap();
+            self.flatten(result)
+        }
+
+        /// Evaluates mat[0..nc*nr] * vec[0..nc] and returns the result as f32s.
+        fn eval_matrix_multiply_vector(&mut self, nc: usize, nr: usize) -> Vec<f32> {
+            let expression_kind_tracker = &mut ExpressionKindTracker::from_arena(&self.expressions);
+            let mut solver = ConstantEvaluator {
+                behavior: Behavior::Wgsl(WgslRestrictions::Const(None)),
+                types: &mut self.types,
+                constants: &Arena::new(),
+                overrides: &Arena::new(),
+                expressions: &mut self.expressions,
+                expression_kind_tracker,
+                layouter: &mut crate::proc::Layouter::default(),
+            };
+
+            let result = solver
+                .try_eval_and_append(
+                    Expression::Binary {
+                        op: BinaryOperator::Multiply,
+                        left: *self.mat_exprs.get(&(nc, nr)).unwrap(),
+                        right: *self.vec_exprs.get(&nc).unwrap(),
+                    },
+                    Default::default(),
+                )
+                .unwrap();
+            self.flatten(result)
+        }
+
+        /// Evaluates mat[0..k*l_nr] * mat[0..r_nc*k] and returns the result as
+        /// f32s.
+        fn eval_matrix_multiply_matrix(&mut self, l_nr: usize, r_nc: usize, k: usize) -> Vec<f32> {
+            let expression_kind_tracker = &mut ExpressionKindTracker::from_arena(&self.expressions);
+            let mut solver = ConstantEvaluator {
+                behavior: Behavior::Wgsl(WgslRestrictions::Const(None)),
+                types: &mut self.types,
+                constants: &Arena::new(),
+                overrides: &Arena::new(),
+                expressions: &mut self.expressions,
+                expression_kind_tracker,
+                layouter: &mut crate::proc::Layouter::default(),
+            };
+
+            let result = solver
+                .try_eval_and_append(
+                    Expression::Binary {
+                        op: BinaryOperator::Multiply,
+                        left: *self.mat_exprs.get(&(k, l_nr)).unwrap(),
+                        right: *self.mat_exprs.get(&(r_nc, k)).unwrap(),
+                    },
+                    Default::default(),
+                )
+                .unwrap();
+            self.flatten(result)
+        }
+
+        fn flatten(&self, expr: Handle<Expression>) -> Vec<f32> {
+            let Expression::Compose {
+                ref components,
+                ref ty,
+            } = self.expressions[expr]
+            else {
+                unreachable!()
+            };
+
+            match self.types[*ty].inner {
+                TypeInner::Vector { .. } => components
+                    .iter()
+                    .map(|&comp| {
+                        let Expression::Literal(Literal::F32(v)) = self.expressions[comp] else {
+                            unreachable!()
+                        };
+                        v
+                    })
+                    .collect(),
+                TypeInner::Matrix { .. } => components
+                    .iter()
+                    .flat_map(|&comp| self.flatten(comp))
+                    .collect(),
+                _ => unreachable!(),
+            }
+        }
+
+        fn int_to_vector_size(int: usize) -> VectorSize {
+            match int {
+                2 => VectorSize::Bi,
+                3 => VectorSize::Tri,
+                4 => VectorSize::Quad,
+                _ => unreachable!(),
+            }
         }
     }
 
@@ -4105,7 +4603,7 @@ mod tests {
         let solved_add = solver
             .try_eval_and_append(
                 Expression::Binary {
-                    op: crate::BinaryOperator::Add,
+                    op: BinaryOperator::Add,
                     left: zero_splat,
                     right: five_splat,
                 },

--- a/naga/tests/out/glsl/wgsl-operators.main.Compute.glsl
+++ b/naga/tests/out/glsl/wgsl-operators.main.Compute.glsl
@@ -201,15 +201,15 @@ void arithmetic() {
         vec2 rem4_1 = (vec2(2.0) - vec2(1.0) * trunc(vec2(2.0) / vec2(1.0)));
         vec2 rem5_1 = (vec2(2.0) - vec2(1.0) * trunc(vec2(2.0) / vec2(1.0)));
     }
-    mat3x3 add = (mat3x3(0.0) + mat3x3(0.0));
-    mat3x3 sub = (mat3x3(0.0) - mat3x3(0.0));
+    mat3x3 add = mat3x3(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
+    mat3x3 sub = mat3x3(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
     mat3x3 mul_scalar0_ = (mat3x3(0.0) * 1.0);
     mat3x3 mul_scalar1_ = (2.0 * mat3x3(0.0));
     vec3 mul_vector0_ = (mat4x3(0.0) * vec4(1.0));
     vec4 mul_vector1_ = (vec3(2.0) * mat4x3(0.0));
-    mat3x3 mul = (mat4x3(0.0) * mat3x4(0.0));
-    int _e175 = prevent_const_eval;
-    wgpu_7437_ = (_e175 + -2147483648);
+    mat3x3 mul = mat3x3(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
+    int _e205 = prevent_const_eval;
+    wgpu_7437_ = (_e205 + -2147483648);
     return;
 }
 

--- a/naga/tests/out/hlsl/wgsl-operators.hlsl
+++ b/naga/tests/out/hlsl/wgsl-operators.hlsl
@@ -207,10 +207,6 @@ float4x3 ZeroValuefloat4x3() {
     return (float4x3)0;
 }
 
-float3x4 ZeroValuefloat3x4() {
-    return (float3x4)0;
-}
-
 void arithmetic()
 {
     int prevent_const_eval = (int)0;
@@ -281,15 +277,15 @@ void arithmetic()
         float2 rem4_1 = naga_mod((2.0).xx, (1.0).xx);
         float2 rem5_1 = naga_mod((2.0).xx, (1.0).xx);
     }
-    float3x3 add = (ZeroValuefloat3x3() + ZeroValuefloat3x3());
-    float3x3 sub = (ZeroValuefloat3x3() - ZeroValuefloat3x3());
+    float3x3 add = float3x3(float3(0.0, 0.0, 0.0), float3(0.0, 0.0, 0.0), float3(0.0, 0.0, 0.0));
+    float3x3 sub = float3x3(float3(0.0, 0.0, 0.0), float3(0.0, 0.0, 0.0), float3(0.0, 0.0, 0.0));
     float3x3 mul_scalar0_ = mul(1.0, ZeroValuefloat3x3());
     float3x3 mul_scalar1_ = mul(ZeroValuefloat3x3(), 2.0);
     float3 mul_vector0_ = mul((1.0).xxxx, ZeroValuefloat4x3());
     float4 mul_vector1_ = mul(ZeroValuefloat4x3(), (2.0).xxx);
-    float3x3 mul_ = mul(ZeroValuefloat3x4(), ZeroValuefloat4x3());
-    int _e175 = prevent_const_eval;
-    wgpu_7437_ = asint(asuint(_e175) + asuint(int(-2147483647 - 1)));
+    float3x3 mul_ = float3x3(float3(0.0, 0.0, 0.0), float3(0.0, 0.0, 0.0), float3(0.0, 0.0, 0.0));
+    int _e205 = prevent_const_eval;
+    wgpu_7437_ = asint(asuint(_e205) + asuint(int(-2147483647 - 1)));
     return;
 }
 

--- a/naga/tests/out/msl/wgsl-operators.metal
+++ b/naga/tests/out/msl/wgsl-operators.metal
@@ -263,15 +263,15 @@ void arithmetic(
         metal::float2 rem4_1 = metal::fmod(metal::float2(2.0), metal::float2(1.0));
         metal::float2 rem5_1 = metal::fmod(metal::float2(2.0), metal::float2(1.0));
     }
-    metal::float3x3 add = metal::float3x3 {} + metal::float3x3 {};
-    metal::float3x3 sub = metal::float3x3 {} - metal::float3x3 {};
+    metal::float3x3 add = metal::float3x3(metal::float3(0.0, 0.0, 0.0), metal::float3(0.0, 0.0, 0.0), metal::float3(0.0, 0.0, 0.0));
+    metal::float3x3 sub = metal::float3x3(metal::float3(0.0, 0.0, 0.0), metal::float3(0.0, 0.0, 0.0), metal::float3(0.0, 0.0, 0.0));
     metal::float3x3 mul_scalar0_ = metal::float3x3 {} * 1.0;
     metal::float3x3 mul_scalar1_ = 2.0 * metal::float3x3 {};
     metal::float3 mul_vector0_ = metal::float4x3 {} * metal::float4(1.0);
     metal::float4 mul_vector1_ = metal::float3(2.0) * metal::float4x3 {};
-    metal::float3x3 mul = metal::float4x3 {} * metal::float3x4 {};
-    int _e175 = prevent_const_eval;
-    wgpu_7437_ = as_type<int>(as_type<uint>(_e175) + as_type<uint>((-2147483647 - 1)));
+    metal::float3x3 mul = metal::float3x3(metal::float3(0.0, 0.0, 0.0), metal::float3(0.0, 0.0, 0.0), metal::float3(0.0, 0.0, 0.0));
+    int _e205 = prevent_const_eval;
+    wgpu_7437_ = as_type<int>(as_type<uint>(_e205) + as_type<uint>((-2147483647 - 1)));
     return;
 }
 

--- a/naga/tests/out/spv/wgsl-operators.spvasm
+++ b/naga/tests/out/spv/wgsl-operators.spvasm
@@ -1,13 +1,13 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 597
+; Bound: 576
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %580 "main" %577
-OpExecutionMode %580 LocalSize 1 1 1
-OpDecorate %577 BuiltIn WorkgroupId
+OpEntryPoint GLCompute %559 "main" %556
+OpExecutionMode %559 LocalSize 1 1 1
+OpDecorate %556 BuiltIn WorkgroupId
 %2 = OpTypeVoid
 %3 = OpTypeFloat 32
 %4 = OpTypeVector %3 4
@@ -20,716 +20,695 @@ OpDecorate %577 BuiltIn WorkgroupId
 %10 = OpTypeVector %11 3
 %12 = OpTypeMatrix %9 3
 %13 = OpTypeMatrix %9 4
-%14 = OpTypeMatrix %4 3
-%15 = OpTypeVector %5 3
-%16 = OpConstant  %3  1
-%17 = OpConstantComposite  %4  %16 %16 %16 %16
-%18 = OpConstant  %3  0
-%19 = OpConstantComposite  %4  %18 %18 %18 %18
-%20 = OpConstant  %3  0.5
-%21 = OpConstantComposite  %4  %20 %20 %20 %20
-%22 = OpConstant  %5  1
-%23 = OpConstantComposite  %6  %22 %22 %22 %22
-%24 = OpConstantFalse  %7
-%25 = OpConstantTrue  %7
-%28 = OpTypeFunction %4
-%29 = OpConstant  %5  0
-%30 = OpConstant  %3  0.1
-%31 = OpConstantComposite  %6  %29 %29 %29 %29
-%35 = OpTypeVector %7 4
-%52 = OpTypeFunction %6 %6 %6
-%56 = OpConstantComposite  %6  %29 %29 %29 %29
-%58 = OpConstant  %5  -2147483648
-%59 = OpConstant  %5  -1
+%14 = OpTypeVector %5 3
+%15 = OpConstant  %3  1
+%16 = OpConstantComposite  %4  %15 %15 %15 %15
+%17 = OpConstant  %3  0
+%18 = OpConstantComposite  %4  %17 %17 %17 %17
+%19 = OpConstant  %3  0.5
+%20 = OpConstantComposite  %4  %19 %19 %19 %19
+%21 = OpConstant  %5  1
+%22 = OpConstantComposite  %6  %21 %21 %21 %21
+%23 = OpConstantFalse  %7
+%24 = OpConstantTrue  %7
+%27 = OpTypeFunction %4
+%28 = OpConstant  %5  0
+%29 = OpConstant  %3  0.1
+%30 = OpConstantComposite  %6  %28 %28 %28 %28
+%34 = OpTypeVector %7 4
+%51 = OpTypeFunction %6 %6 %6
+%55 = OpConstantComposite  %6  %28 %28 %28 %28
+%57 = OpConstant  %5  -2147483648
+%58 = OpConstant  %5  -1
+%59 = OpConstantComposite  %6  %57 %57 %57 %57
 %60 = OpConstantComposite  %6  %58 %58 %58 %58
-%61 = OpConstantComposite  %6  %59 %59 %59 %59
-%66 = OpConstantComposite  %6  %22 %22 %22 %22
-%73 = OpTypeFunction %4 %3 %5
-%74 = OpConstant  %3  2
-%75 = OpConstantComposite  %8  %74 %74
-%76 = OpConstant  %3  4
-%77 = OpConstantComposite  %8  %76 %76
-%78 = OpConstant  %3  8
-%79 = OpConstantComposite  %8  %78 %78
-%80 = OpConstant  %5  2
-%81 = OpConstantComposite  %6  %80 %80 %80 %80
-%94 = OpTypeFunction %8
-%95 = OpConstantComposite  %8  %16 %16
-%96 = OpConstant  %3  3
-%97 = OpConstantComposite  %8  %96 %96
-%99 = OpTypePointer Function %8
-%111 = OpTypeFunction %9 %9
-%113 = OpTypeVector %7 3
-%114 = OpConstantComposite  %9  %18 %18 %18
-%116 = OpConstantComposite  %9  %16 %16 %16
-%120 = OpTypeFunction %7
-%133 = OpTypeFunction %2
-%134 = OpTypeVector %7 2
-%135 = OpConstantComposite  %134  %25 %25
-%136 = OpConstantComposite  %113  %25 %25 %25
-%137 = OpConstantComposite  %113  %24 %24 %24
-%138 = OpConstantComposite  %35  %25 %25 %25 %25
-%139 = OpConstantComposite  %35  %24 %24 %24 %24
-%141 = OpTypePointer Function %7
-%142 = OpConstantNull  %7
-%144 = OpConstantNull  %7
-%146 = OpConstantNull  %7
-%148 = OpConstantNull  %7
-%150 = OpConstantNull  %7
-%152 = OpConstantNull  %7
-%154 = OpConstantNull  %7
-%201 = OpTypeFunction %5 %5 %5
-%213 = OpTypeFunction %11 %11 %11
-%217 = OpConstant  %11  0
-%219 = OpConstant  %11  1
-%222 = OpTypeVector %5 2
-%224 = OpTypeFunction %222 %222 %222
-%228 = OpConstantComposite  %222  %29 %29
-%230 = OpConstantComposite  %222  %58 %58
-%231 = OpConstantComposite  %222  %59 %59
-%236 = OpConstantComposite  %222  %22 %22
-%240 = OpTypeFunction %10 %10 %10
-%244 = OpConstantComposite  %10  %217 %217 %217
-%246 = OpConstantComposite  %10  %219 %219 %219
-%285 = OpTypeVector %11 2
-%287 = OpTypeFunction %285 %285 %285
-%291 = OpConstantComposite  %285  %217 %217
-%293 = OpConstantComposite  %285  %219 %219
-%305 = OpConstant  %11  2
-%306 = OpConstantComposite  %222  %80 %80
-%307 = OpConstantComposite  %10  %305 %305 %305
-%308 = OpConstantComposite  %4  %74 %74 %74 %74
-%309 = OpConstantComposite  %4  %16 %16 %16 %16
-%310 = OpConstantComposite  %285  %305 %305
-%311 = OpConstantNull  %12
-%312 = OpConstantNull  %13
-%313 = OpConstantComposite  %9  %74 %74 %74
-%314 = OpConstantNull  %14
+%65 = OpConstantComposite  %6  %21 %21 %21 %21
+%72 = OpTypeFunction %4 %3 %5
+%73 = OpConstant  %3  2
+%74 = OpConstantComposite  %8  %73 %73
+%75 = OpConstant  %3  4
+%76 = OpConstantComposite  %8  %75 %75
+%77 = OpConstant  %3  8
+%78 = OpConstantComposite  %8  %77 %77
+%79 = OpConstant  %5  2
+%80 = OpConstantComposite  %6  %79 %79 %79 %79
+%93 = OpTypeFunction %8
+%94 = OpConstantComposite  %8  %15 %15
+%95 = OpConstant  %3  3
+%96 = OpConstantComposite  %8  %95 %95
+%98 = OpTypePointer Function %8
+%110 = OpTypeFunction %9 %9
+%112 = OpTypeVector %7 3
+%113 = OpConstantComposite  %9  %17 %17 %17
+%115 = OpConstantComposite  %9  %15 %15 %15
+%119 = OpTypeFunction %7
+%132 = OpTypeFunction %2
+%133 = OpTypeVector %7 2
+%134 = OpConstantComposite  %133  %24 %24
+%135 = OpConstantComposite  %112  %24 %24 %24
+%136 = OpConstantComposite  %112  %23 %23 %23
+%137 = OpConstantComposite  %34  %24 %24 %24 %24
+%138 = OpConstantComposite  %34  %23 %23 %23 %23
+%140 = OpTypePointer Function %7
+%141 = OpConstantNull  %7
+%143 = OpConstantNull  %7
+%145 = OpConstantNull  %7
+%147 = OpConstantNull  %7
+%149 = OpConstantNull  %7
+%151 = OpConstantNull  %7
+%153 = OpConstantNull  %7
+%200 = OpTypeFunction %5 %5 %5
+%212 = OpTypeFunction %11 %11 %11
+%216 = OpConstant  %11  0
+%218 = OpConstant  %11  1
+%221 = OpTypeVector %5 2
+%223 = OpTypeFunction %221 %221 %221
+%227 = OpConstantComposite  %221  %28 %28
+%229 = OpConstantComposite  %221  %57 %57
+%230 = OpConstantComposite  %221  %58 %58
+%235 = OpConstantComposite  %221  %21 %21
+%239 = OpTypeFunction %10 %10 %10
+%243 = OpConstantComposite  %10  %216 %216 %216
+%245 = OpConstantComposite  %10  %218 %218 %218
+%284 = OpTypeVector %11 2
+%286 = OpTypeFunction %284 %284 %284
+%290 = OpConstantComposite  %284  %216 %216
+%292 = OpConstantComposite  %284  %218 %218
+%304 = OpConstant  %11  2
+%305 = OpConstantComposite  %221  %79 %79
+%306 = OpConstantComposite  %10  %304 %304 %304
+%307 = OpConstantComposite  %4  %73 %73 %73 %73
+%308 = OpConstantComposite  %4  %15 %15 %15 %15
+%309 = OpConstantComposite  %284  %304 %304
+%310 = OpConstantComposite  %9  %17 %17 %17
+%311 = OpConstantComposite  %12  %310 %310 %310
+%312 = OpConstantNull  %12
+%313 = OpConstantNull  %13
+%314 = OpConstantComposite  %9  %73 %73 %73
 %316 = OpTypePointer Function %5
 %317 = OpConstantNull  %5
 %319 = OpConstantNull  %5
-%485 = OpConstantNull  %15
-%487 = OpConstantNull  %5
-%489 = OpTypePointer Function %15
-%578 = OpTypePointer Input %10
-%577 = OpVariable  %578  Input
-%581 = OpConstantComposite  %9  %16 %16 %16
-%27 = OpFunction  %4  None %28
-%26 = OpLabel
-OpBranch %32
-%32 = OpLabel
-%33 = OpSelect  %5  %25 %22 %29
-%36 = OpCompositeConstruct  %35  %25 %25 %25 %25
-%34 = OpSelect  %4  %36 %17 %19
-%37 = OpExtInst  %4  %1 FMix %19 %17 %21
-%39 = OpCompositeConstruct  %4  %30 %30 %30 %30
-%38 = OpExtInst  %4  %1 FMix %19 %17 %39
-%40 = OpBitcast  %3  %22
-%41 = OpBitcast  %4  %23
-%42 = OpCompositeConstruct  %6  %33 %33 %33 %33
-%43 = OpIAdd  %6  %42 %31
-%44 = OpConvertSToF  %4  %43
-%45 = OpFAdd  %4  %44 %34
+%464 = OpConstantNull  %14
+%466 = OpConstantNull  %5
+%468 = OpTypePointer Function %14
+%557 = OpTypePointer Input %10
+%556 = OpVariable  %557  Input
+%560 = OpConstantComposite  %9  %15 %15 %15
+%26 = OpFunction  %4  None %27
+%25 = OpLabel
+OpBranch %31
+%31 = OpLabel
+%32 = OpSelect  %5  %24 %21 %28
+%35 = OpCompositeConstruct  %34  %24 %24 %24 %24
+%33 = OpSelect  %4  %35 %16 %18
+%36 = OpExtInst  %4  %1 FMix %18 %16 %20
+%38 = OpCompositeConstruct  %4  %29 %29 %29 %29
+%37 = OpExtInst  %4  %1 FMix %18 %16 %38
+%39 = OpBitcast  %3  %21
+%40 = OpBitcast  %4  %22
+%41 = OpCompositeConstruct  %6  %32 %32 %32 %32
+%42 = OpIAdd  %6  %41 %30
+%43 = OpConvertSToF  %4  %42
+%44 = OpFAdd  %4  %43 %33
+%45 = OpFAdd  %4  %44 %36
 %46 = OpFAdd  %4  %45 %37
-%47 = OpFAdd  %4  %46 %38
-%48 = OpCompositeConstruct  %4  %40 %40 %40 %40
-%49 = OpFAdd  %4  %47 %48
-%50 = OpFAdd  %4  %49 %41
-OpReturnValue %50
+%47 = OpCompositeConstruct  %4  %39 %39 %39 %39
+%48 = OpFAdd  %4  %46 %47
+%49 = OpFAdd  %4  %48 %40
+OpReturnValue %49
 OpFunctionEnd
-%51 = OpFunction  %6  None %52
+%50 = OpFunction  %6  None %51
+%52 = OpFunctionParameter  %6
 %53 = OpFunctionParameter  %6
-%54 = OpFunctionParameter  %6
-%55 = OpLabel
-%57 = OpIEqual  %35  %54 %56
-%62 = OpIEqual  %35  %53 %60
-%63 = OpIEqual  %35  %54 %61
-%64 = OpLogicalAnd  %35  %62 %63
-%65 = OpLogicalOr  %35  %57 %64
-%67 = OpSelect  %6  %65 %66 %54
-%68 = OpSRem  %6  %53 %67
-OpReturnValue %68
+%54 = OpLabel
+%56 = OpIEqual  %34  %53 %55
+%61 = OpIEqual  %34  %52 %59
+%62 = OpIEqual  %34  %53 %60
+%63 = OpLogicalAnd  %34  %61 %62
+%64 = OpLogicalOr  %34  %56 %63
+%66 = OpSelect  %6  %64 %65 %53
+%67 = OpSRem  %6  %52 %66
+OpReturnValue %67
 OpFunctionEnd
-%72 = OpFunction  %4  None %73
-%70 = OpFunctionParameter  %3
-%71 = OpFunctionParameter  %5
-%69 = OpLabel
-OpBranch %82
-%82 = OpLabel
-%83 = OpCompositeConstruct  %8  %70 %70
-%84 = OpFAdd  %8  %75 %83
-%85 = OpFSub  %8  %84 %77
-%86 = OpFDiv  %8  %85 %79
-%87 = OpCompositeConstruct  %6  %71 %71 %71 %71
-%88 = OpFunctionCall  %6  %51 %87 %81
-%89 = OpVectorShuffle  %4  %86 %86 0 1 0 1
-%90 = OpConvertSToF  %4  %88
-%91 = OpFAdd  %4  %89 %90
-OpReturnValue %91
+%71 = OpFunction  %4  None %72
+%69 = OpFunctionParameter  %3
+%70 = OpFunctionParameter  %5
+%68 = OpLabel
+OpBranch %81
+%81 = OpLabel
+%82 = OpCompositeConstruct  %8  %69 %69
+%83 = OpFAdd  %8  %74 %82
+%84 = OpFSub  %8  %83 %76
+%85 = OpFDiv  %8  %84 %78
+%86 = OpCompositeConstruct  %6  %70 %70 %70 %70
+%87 = OpFunctionCall  %6  %50 %86 %80
+%88 = OpVectorShuffle  %4  %85 %85 0 1 0 1
+%89 = OpConvertSToF  %4  %87
+%90 = OpFAdd  %4  %88 %89
+OpReturnValue %90
 OpFunctionEnd
-%93 = OpFunction  %8  None %94
-%92 = OpLabel
-%98 = OpVariable  %99  Function %75
-OpBranch %100
-%100 = OpLabel
-%101 = OpLoad  %8  %98
-%102 = OpFAdd  %8  %101 %95
-OpStore %98 %102
-%103 = OpLoad  %8  %98
-%104 = OpFSub  %8  %103 %97
-OpStore %98 %104
-%105 = OpLoad  %8  %98
-%106 = OpFDiv  %8  %105 %77
-OpStore %98 %106
-%107 = OpLoad  %8  %98
-OpReturnValue %107
+%92 = OpFunction  %8  None %93
+%91 = OpLabel
+%97 = OpVariable  %98  Function %74
+OpBranch %99
+%99 = OpLabel
+%100 = OpLoad  %8  %97
+%101 = OpFAdd  %8  %100 %94
+OpStore %97 %101
+%102 = OpLoad  %8  %97
+%103 = OpFSub  %8  %102 %96
+OpStore %97 %103
+%104 = OpLoad  %8  %97
+%105 = OpFDiv  %8  %104 %76
+OpStore %97 %105
+%106 = OpLoad  %8  %97
+OpReturnValue %106
 OpFunctionEnd
-%110 = OpFunction  %9  None %111
-%109 = OpFunctionParameter  %9
-%108 = OpLabel
-OpBranch %112
-%112 = OpLabel
-%115 = OpFUnordNotEqual  %113  %109 %114
-%117 = OpSelect  %9  %115 %116 %114
-OpReturnValue %117
+%109 = OpFunction  %9  None %110
+%108 = OpFunctionParameter  %9
+%107 = OpLabel
+OpBranch %111
+%111 = OpLabel
+%114 = OpFUnordNotEqual  %112  %108 %113
+%116 = OpSelect  %9  %114 %115 %113
+OpReturnValue %116
 OpFunctionEnd
-%119 = OpFunction  %7  None %120
-%118 = OpLabel
-OpBranch %121
+%118 = OpFunction  %7  None %119
+%117 = OpLabel
+OpBranch %120
+%120 = OpLabel
+OpReturnValue %24
+OpFunctionEnd
+%122 = OpFunction  %7  None %119
 %121 = OpLabel
-OpReturnValue %25
+OpBranch %123
+%123 = OpLabel
+OpReturnValue %23
 OpFunctionEnd
-%123 = OpFunction  %7  None %120
-%122 = OpLabel
-OpBranch %124
+%125 = OpFunction  %7  None %119
 %124 = OpLabel
+OpBranch %126
+%126 = OpLabel
 OpReturnValue %24
 OpFunctionEnd
-%126 = OpFunction  %7  None %120
-%125 = OpLabel
-OpBranch %127
+%128 = OpFunction  %7  None %119
 %127 = OpLabel
-OpReturnValue %25
+OpBranch %129
+%129 = OpLabel
+OpReturnValue %23
 OpFunctionEnd
-%129 = OpFunction  %7  None %120
-%128 = OpLabel
-OpBranch %130
+%131 = OpFunction  %2  None %132
 %130 = OpLabel
-OpReturnValue %24
-OpFunctionEnd
-%132 = OpFunction  %2  None %133
-%131 = OpLabel
-%149 = OpVariable  %141  Function %150
-%143 = OpVariable  %141  Function %144
-%153 = OpVariable  %141  Function %154
-%147 = OpVariable  %141  Function %148
-%140 = OpVariable  %141  Function %142
-%151 = OpVariable  %141  Function %152
-%145 = OpVariable  %141  Function %146
-OpBranch %155
-%155 = OpLabel
-%156 = OpLogicalNot  %7  %25
-%157 = OpLogicalNot  %134  %135
-%158 = OpLogicalNot  %7  %25
-OpSelectionMerge %159 None
-OpBranchConditional %158 %160 %161
-%160 = OpLabel
-OpStore %140 %24
-OpBranch %159
-%161 = OpLabel
-OpStore %140 %25
-OpBranch %159
+%148 = OpVariable  %140  Function %149
+%142 = OpVariable  %140  Function %143
+%152 = OpVariable  %140  Function %153
+%146 = OpVariable  %140  Function %147
+%139 = OpVariable  %140  Function %141
+%150 = OpVariable  %140  Function %151
+%144 = OpVariable  %140  Function %145
+OpBranch %154
+%154 = OpLabel
+%155 = OpLogicalNot  %7  %24
+%156 = OpLogicalNot  %133  %134
+%157 = OpLogicalNot  %7  %24
+OpSelectionMerge %158 None
+OpBranchConditional %157 %159 %160
 %159 = OpLabel
-%162 = OpLoad  %7  %140
-OpSelectionMerge %163 None
-OpBranchConditional %25 %164 %165
-%164 = OpLabel
-OpStore %143 %24
-OpBranch %163
-%165 = OpLabel
-OpStore %143 %24
-OpBranch %163
+OpStore %139 %23
+OpBranch %158
+%160 = OpLabel
+OpStore %139 %24
+OpBranch %158
+%158 = OpLabel
+%161 = OpLoad  %7  %139
+OpSelectionMerge %162 None
+OpBranchConditional %24 %163 %164
 %163 = OpLabel
-%166 = OpLoad  %7  %143
-%167 = OpLogicalOr  %7  %25 %24
-%168 = OpLogicalOr  %113  %136 %137
-%169 = OpLogicalAnd  %7  %25 %24
-%170 = OpLogicalAnd  %35  %138 %139
-%171 = OpLogicalNot  %7  %24
-OpSelectionMerge %172 None
-OpBranchConditional %171 %173 %174
-%173 = OpLabel
-OpStore %145 %24
-OpBranch %172
-%174 = OpLabel
-OpStore %145 %25
-OpBranch %172
+OpStore %142 %23
+OpBranch %162
+%164 = OpLabel
+OpStore %142 %23
+OpBranch %162
+%162 = OpLabel
+%165 = OpLoad  %7  %142
+%166 = OpLogicalOr  %7  %24 %23
+%167 = OpLogicalOr  %112  %135 %136
+%168 = OpLogicalAnd  %7  %24 %23
+%169 = OpLogicalAnd  %34  %137 %138
+%170 = OpLogicalNot  %7  %23
+OpSelectionMerge %171 None
+OpBranchConditional %170 %172 %173
 %172 = OpLabel
-%175 = OpLoad  %7  %145
-%176 = OpLogicalNot  %7  %175
-%177 = OpFunctionCall  %7  %119
-%178 = OpLogicalNot  %7  %177
-OpSelectionMerge %179 None
-OpBranchConditional %178 %180 %181
-%180 = OpLabel
-%182 = OpFunctionCall  %7  %123
-OpStore %147 %182
-OpBranch %179
-%181 = OpLabel
-OpStore %147 %25
-OpBranch %179
+OpStore %144 %23
+OpBranch %171
+%173 = OpLabel
+OpStore %144 %24
+OpBranch %171
+%171 = OpLabel
+%174 = OpLoad  %7  %144
+%175 = OpLogicalNot  %7  %174
+%176 = OpFunctionCall  %7  %118
+%177 = OpLogicalNot  %7  %176
+OpSelectionMerge %178 None
+OpBranchConditional %177 %179 %180
 %179 = OpLabel
-%183 = OpLoad  %7  %147
-OpSelectionMerge %184 None
-OpBranchConditional %183 %185 %186
-%185 = OpLabel
-%187 = OpFunctionCall  %7  %126
-%188 = OpLogicalNot  %7  %187
-OpSelectionMerge %189 None
-OpBranchConditional %188 %190 %191
-%190 = OpLabel
-%192 = OpFunctionCall  %7  %129
-OpStore %151 %192
-OpBranch %189
-%191 = OpLabel
-OpStore %151 %25
-OpBranch %189
-%189 = OpLabel
-%193 = OpLoad  %7  %151
-OpStore %149 %193
-OpBranch %184
-%186 = OpLabel
-OpStore %149 %24
-OpBranch %184
+%181 = OpFunctionCall  %7  %122
+OpStore %146 %181
+OpBranch %178
+%180 = OpLabel
+OpStore %146 %24
+OpBranch %178
+%178 = OpLabel
+%182 = OpLoad  %7  %146
+OpSelectionMerge %183 None
+OpBranchConditional %182 %184 %185
 %184 = OpLabel
-%194 = OpLoad  %7  %149
-OpSelectionMerge %195 None
-OpBranchConditional %24 %196 %197
-%196 = OpLabel
-%198 = OpFunctionCall  %7  %123
-OpStore %153 %198
-OpBranch %195
-%197 = OpLabel
-OpStore %153 %25
-OpBranch %195
+%186 = OpFunctionCall  %7  %125
+%187 = OpLogicalNot  %7  %186
+OpSelectionMerge %188 None
+OpBranchConditional %187 %189 %190
+%189 = OpLabel
+%191 = OpFunctionCall  %7  %128
+OpStore %150 %191
+OpBranch %188
+%190 = OpLabel
+OpStore %150 %24
+OpBranch %188
+%188 = OpLabel
+%192 = OpLoad  %7  %150
+OpStore %148 %192
+OpBranch %183
+%185 = OpLabel
+OpStore %148 %23
+OpBranch %183
+%183 = OpLabel
+%193 = OpLoad  %7  %148
+OpSelectionMerge %194 None
+OpBranchConditional %23 %195 %196
 %195 = OpLabel
-%199 = OpLoad  %7  %153
+%197 = OpFunctionCall  %7  %122
+OpStore %152 %197
+OpBranch %194
+%196 = OpLabel
+OpStore %152 %24
+OpBranch %194
+%194 = OpLabel
+%198 = OpLoad  %7  %152
 OpReturn
 OpFunctionEnd
-%200 = OpFunction  %5  None %201
+%199 = OpFunction  %5  None %200
+%201 = OpFunctionParameter  %5
 %202 = OpFunctionParameter  %5
-%203 = OpFunctionParameter  %5
-%204 = OpLabel
-%205 = OpIEqual  %7  %203 %29
+%203 = OpLabel
+%204 = OpIEqual  %7  %202 %28
+%205 = OpIEqual  %7  %201 %57
 %206 = OpIEqual  %7  %202 %58
-%207 = OpIEqual  %7  %203 %59
-%208 = OpLogicalAnd  %7  %206 %207
-%209 = OpLogicalOr  %7  %205 %208
-%210 = OpSelect  %5  %209 %22 %203
-%211 = OpSDiv  %5  %202 %210
-OpReturnValue %211
+%207 = OpLogicalAnd  %7  %205 %206
+%208 = OpLogicalOr  %7  %204 %207
+%209 = OpSelect  %5  %208 %21 %202
+%210 = OpSDiv  %5  %201 %209
+OpReturnValue %210
 OpFunctionEnd
-%212 = OpFunction  %11  None %213
+%211 = OpFunction  %11  None %212
+%213 = OpFunctionParameter  %11
 %214 = OpFunctionParameter  %11
-%215 = OpFunctionParameter  %11
-%216 = OpLabel
-%218 = OpIEqual  %7  %215 %217
-%220 = OpSelect  %11  %218 %219 %215
-%221 = OpUDiv  %11  %214 %220
-OpReturnValue %221
+%215 = OpLabel
+%217 = OpIEqual  %7  %214 %216
+%219 = OpSelect  %11  %217 %218 %214
+%220 = OpUDiv  %11  %213 %219
+OpReturnValue %220
 OpFunctionEnd
-%223 = OpFunction  %222  None %224
-%225 = OpFunctionParameter  %222
-%226 = OpFunctionParameter  %222
-%227 = OpLabel
-%229 = OpIEqual  %134  %226 %228
-%232 = OpIEqual  %134  %225 %230
-%233 = OpIEqual  %134  %226 %231
-%234 = OpLogicalAnd  %134  %232 %233
-%235 = OpLogicalOr  %134  %229 %234
-%237 = OpSelect  %222  %235 %236 %226
-%238 = OpSDiv  %222  %225 %237
-OpReturnValue %238
+%222 = OpFunction  %221  None %223
+%224 = OpFunctionParameter  %221
+%225 = OpFunctionParameter  %221
+%226 = OpLabel
+%228 = OpIEqual  %133  %225 %227
+%231 = OpIEqual  %133  %224 %229
+%232 = OpIEqual  %133  %225 %230
+%233 = OpLogicalAnd  %133  %231 %232
+%234 = OpLogicalOr  %133  %228 %233
+%236 = OpSelect  %221  %234 %235 %225
+%237 = OpSDiv  %221  %224 %236
+OpReturnValue %237
 OpFunctionEnd
-%239 = OpFunction  %10  None %240
+%238 = OpFunction  %10  None %239
+%240 = OpFunctionParameter  %10
 %241 = OpFunctionParameter  %10
-%242 = OpFunctionParameter  %10
-%243 = OpLabel
-%245 = OpIEqual  %113  %242 %244
-%247 = OpSelect  %10  %245 %246 %242
-%248 = OpUDiv  %10  %241 %247
-OpReturnValue %248
+%242 = OpLabel
+%244 = OpIEqual  %112  %241 %243
+%246 = OpSelect  %10  %244 %245 %241
+%247 = OpUDiv  %10  %240 %246
+OpReturnValue %247
 OpFunctionEnd
-%249 = OpFunction  %5  None %201
+%248 = OpFunction  %5  None %200
+%249 = OpFunctionParameter  %5
 %250 = OpFunctionParameter  %5
-%251 = OpFunctionParameter  %5
-%252 = OpLabel
-%253 = OpIEqual  %7  %251 %29
+%251 = OpLabel
+%252 = OpIEqual  %7  %250 %28
+%253 = OpIEqual  %7  %249 %57
 %254 = OpIEqual  %7  %250 %58
-%255 = OpIEqual  %7  %251 %59
-%256 = OpLogicalAnd  %7  %254 %255
-%257 = OpLogicalOr  %7  %253 %256
-%258 = OpSelect  %5  %257 %22 %251
-%259 = OpSRem  %5  %250 %258
-OpReturnValue %259
+%255 = OpLogicalAnd  %7  %253 %254
+%256 = OpLogicalOr  %7  %252 %255
+%257 = OpSelect  %5  %256 %21 %250
+%258 = OpSRem  %5  %249 %257
+OpReturnValue %258
 OpFunctionEnd
-%260 = OpFunction  %11  None %213
+%259 = OpFunction  %11  None %212
+%260 = OpFunctionParameter  %11
 %261 = OpFunctionParameter  %11
-%262 = OpFunctionParameter  %11
-%263 = OpLabel
-%264 = OpIEqual  %7  %262 %217
-%265 = OpSelect  %11  %264 %219 %262
-%266 = OpUMod  %11  %261 %265
-OpReturnValue %266
+%262 = OpLabel
+%263 = OpIEqual  %7  %261 %216
+%264 = OpSelect  %11  %263 %218 %261
+%265 = OpUMod  %11  %260 %264
+OpReturnValue %265
 OpFunctionEnd
-%267 = OpFunction  %222  None %224
-%268 = OpFunctionParameter  %222
-%269 = OpFunctionParameter  %222
-%270 = OpLabel
-%271 = OpIEqual  %134  %269 %228
-%272 = OpIEqual  %134  %268 %230
-%273 = OpIEqual  %134  %269 %231
-%274 = OpLogicalAnd  %134  %272 %273
-%275 = OpLogicalOr  %134  %271 %274
-%276 = OpSelect  %222  %275 %236 %269
-%277 = OpSRem  %222  %268 %276
-OpReturnValue %277
+%266 = OpFunction  %221  None %223
+%267 = OpFunctionParameter  %221
+%268 = OpFunctionParameter  %221
+%269 = OpLabel
+%270 = OpIEqual  %133  %268 %227
+%271 = OpIEqual  %133  %267 %229
+%272 = OpIEqual  %133  %268 %230
+%273 = OpLogicalAnd  %133  %271 %272
+%274 = OpLogicalOr  %133  %270 %273
+%275 = OpSelect  %221  %274 %235 %268
+%276 = OpSRem  %221  %267 %275
+OpReturnValue %276
 OpFunctionEnd
-%278 = OpFunction  %10  None %240
+%277 = OpFunction  %10  None %239
+%278 = OpFunctionParameter  %10
 %279 = OpFunctionParameter  %10
-%280 = OpFunctionParameter  %10
-%281 = OpLabel
-%282 = OpIEqual  %113  %280 %244
-%283 = OpSelect  %10  %282 %246 %280
-%284 = OpUMod  %10  %279 %283
-OpReturnValue %284
+%280 = OpLabel
+%281 = OpIEqual  %112  %279 %243
+%282 = OpSelect  %10  %281 %245 %279
+%283 = OpUMod  %10  %278 %282
+OpReturnValue %283
 OpFunctionEnd
-%286 = OpFunction  %285  None %287
-%288 = OpFunctionParameter  %285
-%289 = OpFunctionParameter  %285
-%290 = OpLabel
-%292 = OpIEqual  %134  %289 %291
-%294 = OpSelect  %285  %292 %293 %289
-%295 = OpUDiv  %285  %288 %294
-OpReturnValue %295
+%285 = OpFunction  %284  None %286
+%287 = OpFunctionParameter  %284
+%288 = OpFunctionParameter  %284
+%289 = OpLabel
+%291 = OpIEqual  %133  %288 %290
+%293 = OpSelect  %284  %291 %292 %288
+%294 = OpUDiv  %284  %287 %293
+OpReturnValue %294
 OpFunctionEnd
-%296 = OpFunction  %285  None %287
-%297 = OpFunctionParameter  %285
-%298 = OpFunctionParameter  %285
-%299 = OpLabel
-%300 = OpIEqual  %134  %298 %291
-%301 = OpSelect  %285  %300 %293 %298
-%302 = OpUMod  %285  %297 %301
-OpReturnValue %302
+%295 = OpFunction  %284  None %286
+%296 = OpFunctionParameter  %284
+%297 = OpFunctionParameter  %284
+%298 = OpLabel
+%299 = OpIEqual  %133  %297 %290
+%300 = OpSelect  %284  %299 %292 %297
+%301 = OpUMod  %284  %296 %300
+OpReturnValue %301
 OpFunctionEnd
-%304 = OpFunction  %2  None %133
-%303 = OpLabel
+%303 = OpFunction  %2  None %132
+%302 = OpLabel
 %315 = OpVariable  %316  Function %317
 %318 = OpVariable  %316  Function %319
 OpBranch %320
 %320 = OpLabel
-%321 = OpFNegate  %3  %16
-%322 = OpSNegate  %222  %236
-%323 = OpFNegate  %8  %95
-%324 = OpIAdd  %5  %80 %22
-%325 = OpIAdd  %11  %305 %219
-%326 = OpFAdd  %3  %74 %16
-%327 = OpIAdd  %222  %306 %236
-%328 = OpIAdd  %10  %307 %246
-%329 = OpFAdd  %4  %308 %309
-%330 = OpISub  %5  %80 %22
-%331 = OpISub  %11  %305 %219
-%332 = OpFSub  %3  %74 %16
-%333 = OpISub  %222  %306 %236
-%334 = OpISub  %10  %307 %246
-%335 = OpFSub  %4  %308 %309
-%336 = OpIMul  %5  %80 %22
-%337 = OpIMul  %11  %305 %219
-%338 = OpFMul  %3  %74 %16
-%339 = OpIMul  %222  %306 %236
-%340 = OpIMul  %10  %307 %246
-%341 = OpFMul  %4  %308 %309
-%342 = OpFunctionCall  %5  %200 %80 %22
-%343 = OpFunctionCall  %11  %212 %305 %219
-%344 = OpFDiv  %3  %74 %16
-%345 = OpFunctionCall  %222  %223 %306 %236
-%346 = OpFunctionCall  %10  %239 %307 %246
-%347 = OpFDiv  %4  %308 %309
-%348 = OpFunctionCall  %5  %249 %80 %22
-%349 = OpFunctionCall  %11  %260 %305 %219
-%350 = OpFRem  %3  %74 %16
-%351 = OpFunctionCall  %222  %267 %306 %236
-%352 = OpFunctionCall  %10  %278 %307 %246
-%353 = OpFRem  %4  %308 %309
+%321 = OpFNegate  %3  %15
+%322 = OpSNegate  %221  %235
+%323 = OpFNegate  %8  %94
+%324 = OpIAdd  %5  %79 %21
+%325 = OpIAdd  %11  %304 %218
+%326 = OpFAdd  %3  %73 %15
+%327 = OpIAdd  %221  %305 %235
+%328 = OpIAdd  %10  %306 %245
+%329 = OpFAdd  %4  %307 %308
+%330 = OpISub  %5  %79 %21
+%331 = OpISub  %11  %304 %218
+%332 = OpFSub  %3  %73 %15
+%333 = OpISub  %221  %305 %235
+%334 = OpISub  %10  %306 %245
+%335 = OpFSub  %4  %307 %308
+%336 = OpIMul  %5  %79 %21
+%337 = OpIMul  %11  %304 %218
+%338 = OpFMul  %3  %73 %15
+%339 = OpIMul  %221  %305 %235
+%340 = OpIMul  %10  %306 %245
+%341 = OpFMul  %4  %307 %308
+%342 = OpFunctionCall  %5  %199 %79 %21
+%343 = OpFunctionCall  %11  %211 %304 %218
+%344 = OpFDiv  %3  %73 %15
+%345 = OpFunctionCall  %221  %222 %305 %235
+%346 = OpFunctionCall  %10  %238 %306 %245
+%347 = OpFDiv  %4  %307 %308
+%348 = OpFunctionCall  %5  %248 %79 %21
+%349 = OpFunctionCall  %11  %259 %304 %218
+%350 = OpFRem  %3  %73 %15
+%351 = OpFunctionCall  %221  %266 %305 %235
+%352 = OpFunctionCall  %10  %277 %306 %245
+%353 = OpFRem  %4  %307 %308
 OpBranch %354
 %354 = OpLabel
-%356 = OpIAdd  %222  %306 %236
-%357 = OpIAdd  %222  %306 %236
-%358 = OpIAdd  %285  %310 %293
-%359 = OpIAdd  %285  %310 %293
-%360 = OpFAdd  %8  %75 %95
-%361 = OpFAdd  %8  %75 %95
-%362 = OpISub  %222  %306 %236
-%363 = OpISub  %222  %306 %236
-%364 = OpISub  %285  %310 %293
-%365 = OpISub  %285  %310 %293
-%366 = OpFSub  %8  %75 %95
-%367 = OpFSub  %8  %75 %95
-%369 = OpCompositeConstruct  %222  %22 %22
-%368 = OpIMul  %222  %306 %369
-%371 = OpCompositeConstruct  %222  %80 %80
-%370 = OpIMul  %222  %236 %371
-%373 = OpCompositeConstruct  %285  %219 %219
-%372 = OpIMul  %285  %310 %373
-%375 = OpCompositeConstruct  %285  %305 %305
-%374 = OpIMul  %285  %293 %375
-%376 = OpVectorTimesScalar  %8  %75 %16
-%377 = OpVectorTimesScalar  %8  %95 %74
-%378 = OpFunctionCall  %222  %223 %306 %236
-%379 = OpFunctionCall  %222  %223 %306 %236
-%380 = OpFunctionCall  %285  %286 %310 %293
-%381 = OpFunctionCall  %285  %286 %310 %293
-%382 = OpFDiv  %8  %75 %95
-%383 = OpFDiv  %8  %75 %95
-%384 = OpFunctionCall  %222  %267 %306 %236
-%385 = OpFunctionCall  %222  %267 %306 %236
-%386 = OpFunctionCall  %285  %296 %310 %293
-%387 = OpFunctionCall  %285  %296 %310 %293
-%388 = OpFRem  %8  %75 %95
-%389 = OpFRem  %8  %75 %95
+%356 = OpIAdd  %221  %305 %235
+%357 = OpIAdd  %221  %305 %235
+%358 = OpIAdd  %284  %309 %292
+%359 = OpIAdd  %284  %309 %292
+%360 = OpFAdd  %8  %74 %94
+%361 = OpFAdd  %8  %74 %94
+%362 = OpISub  %221  %305 %235
+%363 = OpISub  %221  %305 %235
+%364 = OpISub  %284  %309 %292
+%365 = OpISub  %284  %309 %292
+%366 = OpFSub  %8  %74 %94
+%367 = OpFSub  %8  %74 %94
+%369 = OpCompositeConstruct  %221  %21 %21
+%368 = OpIMul  %221  %305 %369
+%371 = OpCompositeConstruct  %221  %79 %79
+%370 = OpIMul  %221  %235 %371
+%373 = OpCompositeConstruct  %284  %218 %218
+%372 = OpIMul  %284  %309 %373
+%375 = OpCompositeConstruct  %284  %304 %304
+%374 = OpIMul  %284  %292 %375
+%376 = OpVectorTimesScalar  %8  %74 %15
+%377 = OpVectorTimesScalar  %8  %94 %73
+%378 = OpFunctionCall  %221  %222 %305 %235
+%379 = OpFunctionCall  %221  %222 %305 %235
+%380 = OpFunctionCall  %284  %285 %309 %292
+%381 = OpFunctionCall  %284  %285 %309 %292
+%382 = OpFDiv  %8  %74 %94
+%383 = OpFDiv  %8  %74 %94
+%384 = OpFunctionCall  %221  %266 %305 %235
+%385 = OpFunctionCall  %221  %266 %305 %235
+%386 = OpFunctionCall  %284  %295 %309 %292
+%387 = OpFunctionCall  %284  %295 %309 %292
+%388 = OpFRem  %8  %74 %94
+%389 = OpFRem  %8  %74 %94
 OpBranch %355
 %355 = OpLabel
-%391 = OpCompositeExtract  %9  %311 0
-%392 = OpCompositeExtract  %9  %311 0
-%393 = OpFAdd  %9  %391 %392
-%394 = OpCompositeExtract  %9  %311 1
-%395 = OpCompositeExtract  %9  %311 1
-%396 = OpFAdd  %9  %394 %395
-%397 = OpCompositeExtract  %9  %311 2
-%398 = OpCompositeExtract  %9  %311 2
-%399 = OpFAdd  %9  %397 %398
-%390 = OpCompositeConstruct  %12  %393 %396 %399
-%401 = OpCompositeExtract  %9  %311 0
-%402 = OpCompositeExtract  %9  %311 0
-%403 = OpFSub  %9  %401 %402
-%404 = OpCompositeExtract  %9  %311 1
-%405 = OpCompositeExtract  %9  %311 1
-%406 = OpFSub  %9  %404 %405
-%407 = OpCompositeExtract  %9  %311 2
-%408 = OpCompositeExtract  %9  %311 2
-%409 = OpFSub  %9  %407 %408
-%400 = OpCompositeConstruct  %12  %403 %406 %409
-%410 = OpMatrixTimesScalar  %12  %311 %16
-%411 = OpMatrixTimesScalar  %12  %311 %74
-%412 = OpMatrixTimesVector  %9  %312 %309
-%413 = OpVectorTimesMatrix  %4  %313 %312
-%414 = OpMatrixTimesMatrix  %12  %312 %314
-%415 = OpLoad  %5  %315
-%416 = OpIAdd  %5  %415 %58
-OpStore %318 %416
+%390 = OpMatrixTimesScalar  %12  %312 %15
+%391 = OpMatrixTimesScalar  %12  %312 %73
+%392 = OpMatrixTimesVector  %9  %313 %308
+%393 = OpVectorTimesMatrix  %4  %314 %313
+%394 = OpLoad  %5  %315
+%395 = OpIAdd  %5  %394 %57
+OpStore %318 %395
 OpReturn
 OpFunctionEnd
-%418 = OpFunction  %2  None %133
-%417 = OpLabel
-OpBranch %419
-%419 = OpLabel
-%420 = OpNot  %5  %22
-%421 = OpNot  %11  %219
-%422 = OpNot  %222  %236
-%423 = OpNot  %10  %246
-%424 = OpBitwiseOr  %5  %80 %22
-%425 = OpBitwiseOr  %11  %305 %219
-%426 = OpBitwiseOr  %222  %306 %236
-%427 = OpBitwiseOr  %10  %307 %246
-%428 = OpBitwiseAnd  %5  %80 %22
-%429 = OpBitwiseAnd  %11  %305 %219
-%430 = OpBitwiseAnd  %222  %306 %236
-%431 = OpBitwiseAnd  %10  %307 %246
-%432 = OpBitwiseXor  %5  %80 %22
-%433 = OpBitwiseXor  %11  %305 %219
-%434 = OpBitwiseXor  %222  %306 %236
-%435 = OpBitwiseXor  %10  %307 %246
-%436 = OpShiftLeftLogical  %5  %80 %219
-%437 = OpShiftLeftLogical  %11  %305 %219
-%438 = OpShiftLeftLogical  %222  %306 %293
-%439 = OpShiftLeftLogical  %10  %307 %246
-%440 = OpShiftRightArithmetic  %5  %80 %219
-%441 = OpShiftRightLogical  %11  %305 %219
-%442 = OpShiftRightArithmetic  %222  %306 %293
-%443 = OpShiftRightLogical  %10  %307 %246
+%397 = OpFunction  %2  None %132
+%396 = OpLabel
+OpBranch %398
+%398 = OpLabel
+%399 = OpNot  %5  %21
+%400 = OpNot  %11  %218
+%401 = OpNot  %221  %235
+%402 = OpNot  %10  %245
+%403 = OpBitwiseOr  %5  %79 %21
+%404 = OpBitwiseOr  %11  %304 %218
+%405 = OpBitwiseOr  %221  %305 %235
+%406 = OpBitwiseOr  %10  %306 %245
+%407 = OpBitwiseAnd  %5  %79 %21
+%408 = OpBitwiseAnd  %11  %304 %218
+%409 = OpBitwiseAnd  %221  %305 %235
+%410 = OpBitwiseAnd  %10  %306 %245
+%411 = OpBitwiseXor  %5  %79 %21
+%412 = OpBitwiseXor  %11  %304 %218
+%413 = OpBitwiseXor  %221  %305 %235
+%414 = OpBitwiseXor  %10  %306 %245
+%415 = OpShiftLeftLogical  %5  %79 %218
+%416 = OpShiftLeftLogical  %11  %304 %218
+%417 = OpShiftLeftLogical  %221  %305 %292
+%418 = OpShiftLeftLogical  %10  %306 %245
+%419 = OpShiftRightArithmetic  %5  %79 %218
+%420 = OpShiftRightLogical  %11  %304 %218
+%421 = OpShiftRightArithmetic  %221  %305 %292
+%422 = OpShiftRightLogical  %10  %306 %245
 OpReturn
 OpFunctionEnd
-%445 = OpFunction  %2  None %133
-%444 = OpLabel
-OpBranch %446
-%446 = OpLabel
-%447 = OpIEqual  %7  %80 %22
-%448 = OpIEqual  %7  %305 %219
-%449 = OpFOrdEqual  %7  %74 %16
-%450 = OpIEqual  %134  %306 %236
-%451 = OpIEqual  %113  %307 %246
-%452 = OpFOrdEqual  %35  %308 %309
-%453 = OpINotEqual  %7  %80 %22
-%454 = OpINotEqual  %7  %305 %219
-%455 = OpFOrdNotEqual  %7  %74 %16
-%456 = OpINotEqual  %134  %306 %236
-%457 = OpINotEqual  %113  %307 %246
-%458 = OpFOrdNotEqual  %35  %308 %309
-%459 = OpSLessThan  %7  %80 %22
-%460 = OpULessThan  %7  %305 %219
-%461 = OpFOrdLessThan  %7  %74 %16
-%462 = OpSLessThan  %134  %306 %236
-%463 = OpULessThan  %113  %307 %246
-%464 = OpFOrdLessThan  %35  %308 %309
-%465 = OpSLessThanEqual  %7  %80 %22
-%466 = OpULessThanEqual  %7  %305 %219
-%467 = OpFOrdLessThanEqual  %7  %74 %16
-%468 = OpSLessThanEqual  %134  %306 %236
-%469 = OpULessThanEqual  %113  %307 %246
-%470 = OpFOrdLessThanEqual  %35  %308 %309
-%471 = OpSGreaterThan  %7  %80 %22
-%472 = OpUGreaterThan  %7  %305 %219
-%473 = OpFOrdGreaterThan  %7  %74 %16
-%474 = OpSGreaterThan  %134  %306 %236
-%475 = OpUGreaterThan  %113  %307 %246
-%476 = OpFOrdGreaterThan  %35  %308 %309
-%477 = OpSGreaterThanEqual  %7  %80 %22
-%478 = OpUGreaterThanEqual  %7  %305 %219
-%479 = OpFOrdGreaterThanEqual  %7  %74 %16
-%480 = OpSGreaterThanEqual  %134  %306 %236
-%481 = OpUGreaterThanEqual  %113  %307 %246
-%482 = OpFOrdGreaterThanEqual  %35  %308 %309
+%424 = OpFunction  %2  None %132
+%423 = OpLabel
+OpBranch %425
+%425 = OpLabel
+%426 = OpIEqual  %7  %79 %21
+%427 = OpIEqual  %7  %304 %218
+%428 = OpFOrdEqual  %7  %73 %15
+%429 = OpIEqual  %133  %305 %235
+%430 = OpIEqual  %112  %306 %245
+%431 = OpFOrdEqual  %34  %307 %308
+%432 = OpINotEqual  %7  %79 %21
+%433 = OpINotEqual  %7  %304 %218
+%434 = OpFOrdNotEqual  %7  %73 %15
+%435 = OpINotEqual  %133  %305 %235
+%436 = OpINotEqual  %112  %306 %245
+%437 = OpFOrdNotEqual  %34  %307 %308
+%438 = OpSLessThan  %7  %79 %21
+%439 = OpULessThan  %7  %304 %218
+%440 = OpFOrdLessThan  %7  %73 %15
+%441 = OpSLessThan  %133  %305 %235
+%442 = OpULessThan  %112  %306 %245
+%443 = OpFOrdLessThan  %34  %307 %308
+%444 = OpSLessThanEqual  %7  %79 %21
+%445 = OpULessThanEqual  %7  %304 %218
+%446 = OpFOrdLessThanEqual  %7  %73 %15
+%447 = OpSLessThanEqual  %133  %305 %235
+%448 = OpULessThanEqual  %112  %306 %245
+%449 = OpFOrdLessThanEqual  %34  %307 %308
+%450 = OpSGreaterThan  %7  %79 %21
+%451 = OpUGreaterThan  %7  %304 %218
+%452 = OpFOrdGreaterThan  %7  %73 %15
+%453 = OpSGreaterThan  %133  %305 %235
+%454 = OpUGreaterThan  %112  %306 %245
+%455 = OpFOrdGreaterThan  %34  %307 %308
+%456 = OpSGreaterThanEqual  %7  %79 %21
+%457 = OpUGreaterThanEqual  %7  %304 %218
+%458 = OpFOrdGreaterThanEqual  %7  %73 %15
+%459 = OpSGreaterThanEqual  %133  %305 %235
+%460 = OpUGreaterThanEqual  %112  %306 %245
+%461 = OpFOrdGreaterThanEqual  %34  %307 %308
 OpReturn
 OpFunctionEnd
-%484 = OpFunction  %2  None %133
-%483 = OpLabel
-%486 = OpVariable  %316  Function %487
-%488 = OpVariable  %489  Function %485
-OpBranch %490
-%490 = OpLabel
-OpStore %486 %22
-%491 = OpLoad  %5  %486
-%492 = OpIAdd  %5  %491 %22
-OpStore %486 %492
-%493 = OpLoad  %5  %486
-%494 = OpISub  %5  %493 %22
-OpStore %486 %494
-%495 = OpLoad  %5  %486
-%496 = OpLoad  %5  %486
-%497 = OpIMul  %5  %495 %496
-OpStore %486 %497
-%498 = OpLoad  %5  %486
-%499 = OpLoad  %5  %486
-%500 = OpFunctionCall  %5  %200 %498 %499
-OpStore %486 %500
-%501 = OpLoad  %5  %486
-%502 = OpFunctionCall  %5  %249 %501 %22
-OpStore %486 %502
-%503 = OpLoad  %5  %486
-%504 = OpBitwiseAnd  %5  %503 %29
-OpStore %486 %504
-%505 = OpLoad  %5  %486
-%506 = OpBitwiseOr  %5  %505 %29
-OpStore %486 %506
-%507 = OpLoad  %5  %486
-%508 = OpBitwiseXor  %5  %507 %29
-OpStore %486 %508
-%509 = OpLoad  %5  %486
-%510 = OpShiftLeftLogical  %5  %509 %305
-OpStore %486 %510
-%511 = OpLoad  %5  %486
-%512 = OpShiftRightArithmetic  %5  %511 %219
-OpStore %486 %512
-%513 = OpLoad  %5  %486
-%514 = OpIAdd  %5  %513 %22
-OpStore %486 %514
-%515 = OpLoad  %5  %486
-%516 = OpISub  %5  %515 %22
-OpStore %486 %516
-%517 = OpAccessChain  %316  %488 %219
-%518 = OpLoad  %5  %517
-%519 = OpIAdd  %5  %518 %22
-%520 = OpAccessChain  %316  %488 %219
-OpStore %520 %519
-%521 = OpAccessChain  %316  %488 %219
-%522 = OpLoad  %5  %521
-%523 = OpISub  %5  %522 %22
-%524 = OpAccessChain  %316  %488 %219
-OpStore %524 %523
+%463 = OpFunction  %2  None %132
+%462 = OpLabel
+%465 = OpVariable  %316  Function %466
+%467 = OpVariable  %468  Function %464
+OpBranch %469
+%469 = OpLabel
+OpStore %465 %21
+%470 = OpLoad  %5  %465
+%471 = OpIAdd  %5  %470 %21
+OpStore %465 %471
+%472 = OpLoad  %5  %465
+%473 = OpISub  %5  %472 %21
+OpStore %465 %473
+%474 = OpLoad  %5  %465
+%475 = OpLoad  %5  %465
+%476 = OpIMul  %5  %474 %475
+OpStore %465 %476
+%477 = OpLoad  %5  %465
+%478 = OpLoad  %5  %465
+%479 = OpFunctionCall  %5  %199 %477 %478
+OpStore %465 %479
+%480 = OpLoad  %5  %465
+%481 = OpFunctionCall  %5  %248 %480 %21
+OpStore %465 %481
+%482 = OpLoad  %5  %465
+%483 = OpBitwiseAnd  %5  %482 %28
+OpStore %465 %483
+%484 = OpLoad  %5  %465
+%485 = OpBitwiseOr  %5  %484 %28
+OpStore %465 %485
+%486 = OpLoad  %5  %465
+%487 = OpBitwiseXor  %5  %486 %28
+OpStore %465 %487
+%488 = OpLoad  %5  %465
+%489 = OpShiftLeftLogical  %5  %488 %304
+OpStore %465 %489
+%490 = OpLoad  %5  %465
+%491 = OpShiftRightArithmetic  %5  %490 %218
+OpStore %465 %491
+%492 = OpLoad  %5  %465
+%493 = OpIAdd  %5  %492 %21
+OpStore %465 %493
+%494 = OpLoad  %5  %465
+%495 = OpISub  %5  %494 %21
+OpStore %465 %495
+%496 = OpAccessChain  %316  %467 %218
+%497 = OpLoad  %5  %496
+%498 = OpIAdd  %5  %497 %21
+%499 = OpAccessChain  %316  %467 %218
+OpStore %499 %498
+%500 = OpAccessChain  %316  %467 %218
+%501 = OpLoad  %5  %500
+%502 = OpISub  %5  %501 %21
+%503 = OpAccessChain  %316  %467 %218
+OpStore %503 %502
 OpReturn
 OpFunctionEnd
-%526 = OpFunction  %2  None %133
-%525 = OpLabel
-OpBranch %527
-%527 = OpLabel
-%528 = OpSNegate  %5  %22
-%529 = OpSNegate  %5  %22
+%505 = OpFunction  %2  None %132
+%504 = OpLabel
+OpBranch %506
+%506 = OpLabel
+%507 = OpSNegate  %5  %21
+%508 = OpSNegate  %5  %21
+%509 = OpSNegate  %5  %508
+%510 = OpSNegate  %5  %21
+%511 = OpSNegate  %5  %510
+%512 = OpSNegate  %5  %21
+%513 = OpSNegate  %5  %512
+%514 = OpSNegate  %5  %21
+%515 = OpSNegate  %5  %514
+%516 = OpSNegate  %5  %515
+%517 = OpSNegate  %5  %21
+%518 = OpSNegate  %5  %517
+%519 = OpSNegate  %5  %518
+%520 = OpSNegate  %5  %519
+%521 = OpSNegate  %5  %21
+%522 = OpSNegate  %5  %521
+%523 = OpSNegate  %5  %522
+%524 = OpSNegate  %5  %523
+%525 = OpSNegate  %5  %524
+%526 = OpSNegate  %5  %21
+%527 = OpSNegate  %5  %526
+%528 = OpSNegate  %5  %527
+%529 = OpSNegate  %5  %528
 %530 = OpSNegate  %5  %529
-%531 = OpSNegate  %5  %22
-%532 = OpSNegate  %5  %531
-%533 = OpSNegate  %5  %22
-%534 = OpSNegate  %5  %533
-%535 = OpSNegate  %5  %22
-%536 = OpSNegate  %5  %535
-%537 = OpSNegate  %5  %536
-%538 = OpSNegate  %5  %22
-%539 = OpSNegate  %5  %538
-%540 = OpSNegate  %5  %539
-%541 = OpSNegate  %5  %540
-%542 = OpSNegate  %5  %22
-%543 = OpSNegate  %5  %542
-%544 = OpSNegate  %5  %543
-%545 = OpSNegate  %5  %544
-%546 = OpSNegate  %5  %545
-%547 = OpSNegate  %5  %22
-%548 = OpSNegate  %5  %547
-%549 = OpSNegate  %5  %548
-%550 = OpSNegate  %5  %549
-%551 = OpSNegate  %5  %550
-%552 = OpFNegate  %3  %16
-%553 = OpFNegate  %3  %16
+%531 = OpFNegate  %3  %15
+%532 = OpFNegate  %3  %15
+%533 = OpFNegate  %3  %532
+%534 = OpFNegate  %3  %15
+%535 = OpFNegate  %3  %534
+%536 = OpFNegate  %3  %15
+%537 = OpFNegate  %3  %536
+%538 = OpFNegate  %3  %15
+%539 = OpFNegate  %3  %538
+%540 = OpFNegate  %3  %539
+%541 = OpFNegate  %3  %15
+%542 = OpFNegate  %3  %541
+%543 = OpFNegate  %3  %542
+%544 = OpFNegate  %3  %543
+%545 = OpFNegate  %3  %15
+%546 = OpFNegate  %3  %545
+%547 = OpFNegate  %3  %546
+%548 = OpFNegate  %3  %547
+%549 = OpFNegate  %3  %548
+%550 = OpFNegate  %3  %15
+%551 = OpFNegate  %3  %550
+%552 = OpFNegate  %3  %551
+%553 = OpFNegate  %3  %552
 %554 = OpFNegate  %3  %553
-%555 = OpFNegate  %3  %16
-%556 = OpFNegate  %3  %555
-%557 = OpFNegate  %3  %16
-%558 = OpFNegate  %3  %557
-%559 = OpFNegate  %3  %16
-%560 = OpFNegate  %3  %559
-%561 = OpFNegate  %3  %560
-%562 = OpFNegate  %3  %16
-%563 = OpFNegate  %3  %562
-%564 = OpFNegate  %3  %563
-%565 = OpFNegate  %3  %564
-%566 = OpFNegate  %3  %16
-%567 = OpFNegate  %3  %566
-%568 = OpFNegate  %3  %567
-%569 = OpFNegate  %3  %568
-%570 = OpFNegate  %3  %569
-%571 = OpFNegate  %3  %16
-%572 = OpFNegate  %3  %571
-%573 = OpFNegate  %3  %572
-%574 = OpFNegate  %3  %573
-%575 = OpFNegate  %3  %574
 OpReturn
 OpFunctionEnd
-%580 = OpFunction  %2  None %133
-%576 = OpLabel
-%579 = OpLoad  %10  %577
-OpBranch %582
-%582 = OpLabel
-%583 = OpFunctionCall  %4  %27
-%584 = OpCompositeExtract  %11  %579 0
-%585 = OpConvertUToF  %3  %584
-%586 = OpCompositeExtract  %11  %579 1
-%587 = OpBitcast  %5  %586
-%588 = OpFunctionCall  %4  %72 %585 %587
-%589 = OpFunctionCall  %8  %93
-%590 = OpFunctionCall  %9  %110 %581
-%591 = OpFunctionCall  %2  %132
-%592 = OpFunctionCall  %2  %304
-%593 = OpFunctionCall  %2  %418
-%594 = OpFunctionCall  %2  %445
-%595 = OpFunctionCall  %2  %484
-%596 = OpFunctionCall  %2  %526
+%559 = OpFunction  %2  None %132
+%555 = OpLabel
+%558 = OpLoad  %10  %556
+OpBranch %561
+%561 = OpLabel
+%562 = OpFunctionCall  %4  %26
+%563 = OpCompositeExtract  %11  %558 0
+%564 = OpConvertUToF  %3  %563
+%565 = OpCompositeExtract  %11  %558 1
+%566 = OpBitcast  %5  %565
+%567 = OpFunctionCall  %4  %71 %564 %566
+%568 = OpFunctionCall  %8  %92
+%569 = OpFunctionCall  %9  %109 %560
+%570 = OpFunctionCall  %2  %131
+%571 = OpFunctionCall  %2  %303
+%572 = OpFunctionCall  %2  %397
+%573 = OpFunctionCall  %2  %424
+%574 = OpFunctionCall  %2  %463
+%575 = OpFunctionCall  %2  %505
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/wgsl/wgsl-operators.wgsl
+++ b/naga/tests/out/wgsl/wgsl-operators.wgsl
@@ -196,15 +196,15 @@ fn arithmetic() {
         let rem4_1 = (vec2(2f) % vec2(1f));
         let rem5_1 = (vec2(2f) % vec2(1f));
     }
-    let add = (mat3x3<f32>() + mat3x3<f32>());
-    let sub = (mat3x3<f32>() - mat3x3<f32>());
+    let add = mat3x3<f32>(vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f));
+    let sub = mat3x3<f32>(vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f));
     let mul_scalar0_ = (mat3x3<f32>() * 1f);
     let mul_scalar1_ = (2f * mat3x3<f32>());
     let mul_vector0_ = (mat4x3<f32>() * vec4(1f));
     let mul_vector1_ = (vec3(2f) * mat4x3<f32>());
-    let mul = (mat4x3<f32>() * mat3x4<f32>());
-    let _e175 = prevent_const_eval;
-    wgpu_7437_ = (_e175 + i32(-2147483648));
+    let mul = mat3x3<f32>(vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f), vec3<f32>(0f, 0f, 0f));
+    let _e205 = prevent_const_eval;
+    wgpu_7437_ = (_e205 + i32(-2147483648));
     return;
 }
 


### PR DESCRIPTION
**Connections**
Fixes issue #8790

**Description**
Implement binary operations in naga constant evaluator
- multiplication on vector-matrix, matrix-vector, and matrix-matrix
- addition/subtraction on matrix-matrix

**Testing**
* Existing tests and a new test for the implementation
* Related CTS webgpu:shader,validation,expression,matrix,* : 1678/1881 (89.21%) -> 1737/1881 (92.34%)
  - remaining fail : overflow/underflow (126), atomic (18)
* naga snapshots updated automatically

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
