### PR TITLE
feat(types): Add conversions to/from feature name strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,7 @@ By @kpreid in [#9042](https://github.com/gfx-rs/wgpu/pull/9042).
 #### deno_webgpu
 
 - Expose the `GPU.wgslLanguageFeatures` property. By @andyleiserson in [#8884](https://github.com/gfx-rs/wgpu/pull/8884).
+- `GPUFeatureName` now includes all `wgpu` extensions. Feature names for extensions should be written with a `wgpu-` prefix, although unprefixed names that were accepted previously are still accepted. By @andyleiserson in [#9163](https://github.com/gfx-rs/wgpu/pull/9163).
 
 #### Hal
 

--- a/cts_runner/src/bootstrap.js
+++ b/cts_runner/src/bootstrap.js
@@ -242,11 +242,11 @@ webgpu.GPUAdapter.prototype.requestDevice = function(desc) {
         // an option to enable it anyways to allow running some CTS tests that
         // do pass.
         if (!desc) {
-            desc = { requiredFeatures: ['external-texture'] };
+            desc = { requiredFeatures: ['wgpu-external-texture'] };
         } else if (!desc.requiredFeatures) {
-            desc.requiredFeatures = ['external-texture'];
+            desc.requiredFeatures = ['wgpu-external-texture'];
         } else {
-            desc.requiredFeatures.push('external-texture');
+            desc.requiredFeatures.push('wgpu-external-texture');
         }
     }
 

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-#[allow(clippy::disallowed_types)]
-use std::collections::HashSet;
+use std::ops::BitOr;
 use std::rc::Rc;
 
 use deno_core::cppgc::SameObject;
@@ -16,7 +15,6 @@ use super::device::GPUDevice;
 use super::device::DEVICE_EXTERNAL_MEMORY_SIZE;
 use super::queue::GPUQueue;
 use crate::error::GPUGenericError;
-use crate::webidl::features_to_feature_names;
 use crate::webidl::GPUFeatureName;
 use crate::Instance;
 
@@ -96,7 +94,6 @@ impl GPUAdapter {
       let features = self.instance.adapter_features(self.id);
       // Only expose WebGPU features, not wgpu native-only features
       let features = features & wgpu_types::Features::all_webgpu_mask();
-      let features = features_to_feature_names(features);
       GPUSupportedFeatures::new(scope, features)
     })
   }
@@ -118,14 +115,12 @@ impl GPUAdapter {
     scope: &mut v8::HandleScope,
     #[webidl] descriptor: GPUDeviceDescriptor,
   ) -> Result<v8::Global<v8::Value>, CreateDeviceError> {
-    let features = self.instance.adapter_features(self.id);
-    let supported_features = features_to_feature_names(features);
-    #[allow(clippy::disallowed_types)]
+    let supported_features = self.instance.adapter_features(self.id);
     let required_features = descriptor
       .required_features
       .iter()
-      .cloned()
-      .collect::<HashSet<_>>();
+      .map(|f| wgpu_types::Features::from(*f))
+      .fold(wgpu_types::Features::empty(), BitOr::bitor);
 
     // External textures are a required part of WebGPU, and `external-texture`
     // is not a WebGPU-defined feature. `wgpu` has it behind a feature for now,
@@ -135,9 +130,9 @@ impl GPUAdapter {
     // There is probably not anything useful that Deno applications can do with
     // external textures, but it is useful to be able to enable it in
     // `cts_runner`.
-    if required_features
-      .difference(&supported_features)
-      .any(|feat| *feat != GPUFeatureName::ExternalTexture)
+    if !required_features
+      .difference(supported_features | wgpu_types::Features::EXTERNAL_TEXTURE)
+      .is_empty()
     {
       return Err(CreateDeviceError::RequiredFeaturesNotASubset);
     }
@@ -159,9 +154,7 @@ impl GPUAdapter {
 
     let wgpu_descriptor = wgpu_types::DeviceDescriptor {
       label: crate::transform_label(descriptor.label.clone()),
-      required_features: super::webidl::feature_names_to_features(
-        descriptor.required_features,
-      ),
+      required_features,
       required_limits,
       experimental_features: wgpu_types::ExperimentalFeatures::disabled(),
       memory_hints: Default::default(),
@@ -472,15 +465,14 @@ impl GarbageCollected for GPUSupportedFeatures {
 }
 
 impl GPUSupportedFeatures {
-  #[allow(clippy::disallowed_types)]
   pub fn new(
     scope: &mut v8::HandleScope,
-    features: HashSet<GPUFeatureName>,
+    features: wgpu_types::Features,
   ) -> Self {
     let set = v8::Set::new(scope);
 
-    for feature in features {
-      let key = v8::String::new(scope, feature.as_str()).unwrap();
+    for feature in features.iter() {
+      let key = v8::String::new(scope, feature.as_str().unwrap()).unwrap();
       set.add(scope, key.into());
     }
 

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -34,7 +34,6 @@ use crate::query_set::GPUQuerySet;
 use crate::render_bundle::GPURenderBundleEncoder;
 use crate::render_pipeline::GPURenderPipeline;
 use crate::shader::GPUCompilationInfo;
-use crate::webidl::features_to_feature_names;
 use crate::Instance;
 
 /// External memory associated with device and queue, to encourage V8 to garbage
@@ -104,7 +103,6 @@ impl GPUDevice {
   fn features(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
     self.features.get(scope, |scope| {
       let features = self.instance.device_features(self.id);
-      let features = features_to_feature_names(features);
       GPUSupportedFeatures::new(scope, features)
     })
   }

--- a/deno_webgpu/webidl.rs
+++ b/deno_webgpu/webidl.rs
@@ -1,8 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 use std::borrow::Cow;
-#[allow(clippy::disallowed_types)]
-use std::collections::HashSet;
 
 use deno_core::cppgc::Ptr;
 use deno_core::v8;
@@ -365,332 +363,42 @@ impl<'a> WebIdlConverter<'a> for GPUPipelineLayoutOrGPUAutoLayoutMode {
   }
 }
 
-#[derive(WebIDL, Clone, Hash, Eq, PartialEq)]
-#[webidl(enum)]
-pub enum GPUFeatureName {
-  #[webidl(rename = "depth-clip-control")]
-  DepthClipControl,
-  #[webidl(rename = "timestamp-query")]
-  TimestampQuery,
-  #[webidl(rename = "indirect-first-instance")]
-  IndirectFirstInstance,
-  #[webidl(rename = "shader-f16")]
-  ShaderF16,
-  #[webidl(rename = "depth32float-stencil8")]
-  Depth32floatStencil8,
-  #[webidl(rename = "texture-compression-bc")]
-  TextureCompressionBc,
-  #[webidl(rename = "texture-compression-bc-sliced-3d")]
-  TextureCompressionBcSliced3d,
-  #[webidl(rename = "texture-compression-etc2")]
-  TextureCompressionEtc2,
-  #[webidl(rename = "texture-compression-astc")]
-  TextureCompressionAstc,
-  #[webidl(rename = "texture-compression-astc-sliced-3d")]
-  TextureCompressionAstcSliced3d,
-  #[webidl(rename = "rg11b10ufloat-renderable")]
-  Rg11b10ufloatRenderable,
-  #[webidl(rename = "bgra8unorm-storage")]
-  Bgra8unormStorage,
-  #[webidl(rename = "float32-filterable")]
-  Float32Filterable,
-  #[webidl(rename = "float32-blendable")]
-  Float32Blendable,
-  #[webidl(rename = "dual-source-blending")]
-  DualSourceBlending,
-  #[webidl(rename = "subgroups")]
-  Subgroups,
-  #[webidl(rename = "primitive-index")]
-  PrimitiveIndex,
+impl<'a> WebIdlConverter<'a> for GPUFeatureName {
+  type Options = ();
 
-  // standard feature, but not default yet in wgpu due to incomplete support
-  // (and even if enabled in wgpu, doing so may not be appropriate in Deno)
-  #[webidl(rename = "external-texture")]
-  ExternalTexture,
-
-  // extended from spec
-  #[webidl(rename = "texture-format-16-bit-norm")]
-  TextureFormat16BitNorm,
-  #[webidl(rename = "texture-compression-astc-hdr")]
-  TextureCompressionAstcHdr,
-  #[webidl(rename = "texture-adapter-specific-format-features")]
-  TextureAdapterSpecificFormatFeatures,
-  #[webidl(rename = "pipeline-statistics-query")]
-  PipelineStatisticsQuery,
-  #[webidl(rename = "timestamp-query-inside-passes")]
-  TimestampQueryInsidePasses,
-  #[webidl(rename = "mappable-primary-buffers")]
-  MappablePrimaryBuffers,
-  #[webidl(rename = "texture-binding-array")]
-  TextureBindingArray,
-  #[webidl(rename = "buffer-binding-array")]
-  BufferBindingArray,
-  #[webidl(rename = "storage-resource-binding-array")]
-  StorageResourceBindingArray,
-  #[webidl(
-    rename = "sampled-texture-and-storage-buffer-array-non-uniform-indexing"
-  )]
-  SampledTextureAndStorageBufferArrayNonUniformIndexing,
-  #[webidl(rename = "storage-texture-array-non-uniform-indexing")]
-  StorageTextureArrayNonUniformIndexing,
-  #[webidl(rename = "uniform-buffer-binding-arrays")]
-  UniformBufferBindingArrays,
-  #[webidl(rename = "partially-bound-binding-array")]
-  PartiallyBoundBindingArray,
-  #[webidl(rename = "multi-draw-indirect-count")]
-  MultiDrawIndirectCount,
-  #[webidl(rename = "immediate-data")]
-  ImmediateData,
-  #[webidl(rename = "address-mode-clamp-to-zero")]
-  AddressModeClampToZero,
-  #[webidl(rename = "address-mode-clamp-to-border")]
-  AddressModeClampToBorder,
-  #[webidl(rename = "polygon-mode-line")]
-  PolygonModeLine,
-  #[webidl(rename = "polygon-mode-point")]
-  PolygonModePoint,
-  #[webidl(rename = "conservative-rasterization")]
-  ConservativeRasterization,
-  #[webidl(rename = "vertex-writable-storage")]
-  VertexWritableStorage,
-  #[webidl(rename = "clear-texture")]
-  ClearTexture,
-  #[webidl(rename = "multiview")]
-  Multiview,
-  #[webidl(rename = "vertex-attribute-64-bit")]
-  VertexAttribute64Bit,
-  #[webidl(rename = "shader-f64")]
-  ShaderF64,
-  #[webidl(rename = "shader-i16")]
-  ShaderI16,
-  #[webidl(rename = "shader-early-depth-test")]
-  ShaderEarlyDepthTest,
-  #[webidl(rename = "passthrough-shaders")]
-  PassthroughShaders,
+  fn convert<'b>(
+    scope: &mut v8::HandleScope<'a>,
+    value: v8::Local<'a, v8::Value>,
+    prefix: Cow<'static, str>,
+    context: ContextFn<'b>,
+    _options: &Self::Options,
+  ) -> Result<Self, WebIdlError> {
+    let s = value.to_rust_string_lossy(scope);
+    s.parse().map(Self).map_err(|()| {
+      WebIdlError::new(
+        prefix,
+        context,
+        WebIdlErrorKind::InvalidEnumVariant {
+          converter: "GPUFeatureName",
+          variant: s,
+        },
+      )
+    })
+  }
 }
 
-pub fn feature_names_to_features(
-  names: Vec<GPUFeatureName>,
-) -> wgpu_types::Features {
-  use wgpu_types::Features;
-  let mut features = Features::empty();
+/// A WebGPU optional feature.
+///
+/// Named after the WebIDL enum, which represents features as strings, but we store the
+/// feature as bitflag, which must always have exactly one bit set (across both the WebGPU
+/// and wgpu native features).
+#[derive(Clone, Copy, Hash, Eq, PartialEq)]
+pub struct GPUFeatureName(wgpu_types::Features);
 
-  for name in names {
-    #[rustfmt::skip]
-    let feature = match name {
-      GPUFeatureName::DepthClipControl => Features::DEPTH_CLIP_CONTROL,
-      GPUFeatureName::TimestampQuery => Features::TIMESTAMP_QUERY,
-      GPUFeatureName::IndirectFirstInstance => Features::INDIRECT_FIRST_INSTANCE,
-      GPUFeatureName::ShaderF16 => Features::SHADER_F16,
-      GPUFeatureName::Depth32floatStencil8 => Features::DEPTH32FLOAT_STENCIL8,
-      GPUFeatureName::TextureCompressionBc => Features::TEXTURE_COMPRESSION_BC,
-      GPUFeatureName::TextureCompressionBcSliced3d => Features::TEXTURE_COMPRESSION_BC_SLICED_3D,
-      GPUFeatureName::TextureCompressionEtc2 => Features::TEXTURE_COMPRESSION_ETC2,
-      GPUFeatureName::TextureCompressionAstc => Features::TEXTURE_COMPRESSION_ASTC,
-      GPUFeatureName::TextureCompressionAstcSliced3d => Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D,
-      GPUFeatureName::Rg11b10ufloatRenderable => Features::RG11B10UFLOAT_RENDERABLE,
-      GPUFeatureName::Bgra8unormStorage => Features::BGRA8UNORM_STORAGE,
-      GPUFeatureName::Float32Filterable => Features::FLOAT32_FILTERABLE,
-      GPUFeatureName::Float32Blendable => Features::FLOAT32_BLENDABLE,
-      GPUFeatureName::DualSourceBlending => Features::DUAL_SOURCE_BLENDING,
-      GPUFeatureName::Subgroups => Features::SUBGROUP,
-      GPUFeatureName::ExternalTexture => Features::EXTERNAL_TEXTURE,
-      GPUFeatureName::TextureFormat16BitNorm => Features::TEXTURE_FORMAT_16BIT_NORM,
-      GPUFeatureName::TextureCompressionAstcHdr => Features::TEXTURE_COMPRESSION_ASTC_HDR,
-      GPUFeatureName::TextureAdapterSpecificFormatFeatures => Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
-      GPUFeatureName::PipelineStatisticsQuery => Features::PIPELINE_STATISTICS_QUERY,
-      GPUFeatureName::TimestampQueryInsidePasses => Features::TIMESTAMP_QUERY_INSIDE_PASSES,
-      GPUFeatureName::MappablePrimaryBuffers => Features::MAPPABLE_PRIMARY_BUFFERS,
-      GPUFeatureName::TextureBindingArray => Features::TEXTURE_BINDING_ARRAY,
-      GPUFeatureName::BufferBindingArray => Features::BUFFER_BINDING_ARRAY,
-      GPUFeatureName::StorageResourceBindingArray => Features::STORAGE_RESOURCE_BINDING_ARRAY,
-      GPUFeatureName::SampledTextureAndStorageBufferArrayNonUniformIndexing => Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
-      GPUFeatureName::StorageTextureArrayNonUniformIndexing => Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
-      GPUFeatureName::UniformBufferBindingArrays => Features::UNIFORM_BUFFER_BINDING_ARRAYS,
-      GPUFeatureName::PartiallyBoundBindingArray => Features::PARTIALLY_BOUND_BINDING_ARRAY,
-      GPUFeatureName::MultiDrawIndirectCount => Features::MULTI_DRAW_INDIRECT_COUNT,
-      GPUFeatureName::ImmediateData => Features::IMMEDIATES,
-      GPUFeatureName::AddressModeClampToZero => Features::ADDRESS_MODE_CLAMP_TO_ZERO,
-      GPUFeatureName::AddressModeClampToBorder => Features::ADDRESS_MODE_CLAMP_TO_BORDER,
-      GPUFeatureName::PolygonModeLine => Features::POLYGON_MODE_LINE,
-      GPUFeatureName::PolygonModePoint => Features::POLYGON_MODE_POINT,
-      GPUFeatureName::ConservativeRasterization => Features::CONSERVATIVE_RASTERIZATION,
-      GPUFeatureName::VertexWritableStorage => Features::VERTEX_WRITABLE_STORAGE,
-      GPUFeatureName::ClearTexture => Features::CLEAR_TEXTURE,
-      GPUFeatureName::Multiview => Features::MULTIVIEW,
-      GPUFeatureName::VertexAttribute64Bit => Features::VERTEX_ATTRIBUTE_64BIT,
-      GPUFeatureName::ShaderF64 => Features::SHADER_F64,
-      GPUFeatureName::ShaderI16 => Features::SHADER_I16,
-      GPUFeatureName::PrimitiveIndex => Features::PRIMITIVE_INDEX,
-      GPUFeatureName::ShaderEarlyDepthTest => Features::SHADER_EARLY_DEPTH_TEST,
-      GPUFeatureName::PassthroughShaders => Features::PASSTHROUGH_SHADERS,
-    };
-    features.set(feature, true);
+impl From<GPUFeatureName> for wgpu_types::Features {
+  fn from(value: GPUFeatureName) -> wgpu_types::Features {
+    value.0
   }
-
-  features
-}
-
-#[allow(clippy::disallowed_types)]
-pub fn features_to_feature_names(
-  features: wgpu_types::Features,
-) -> HashSet<GPUFeatureName> {
-  use GPUFeatureName::*;
-  let mut return_features = HashSet::new();
-
-  // api
-  if features.contains(wgpu_types::Features::DEPTH_CLIP_CONTROL) {
-    return_features.insert(DepthClipControl);
-  }
-  if features.contains(wgpu_types::Features::TIMESTAMP_QUERY) {
-    return_features.insert(TimestampQuery);
-  }
-  if features.contains(wgpu_types::Features::INDIRECT_FIRST_INSTANCE) {
-    return_features.insert(IndirectFirstInstance);
-  }
-  // shader
-  if features.contains(wgpu_types::Features::SHADER_F16) {
-    return_features.insert(ShaderF16);
-  }
-  // texture formats
-  if features.contains(wgpu_types::Features::DEPTH32FLOAT_STENCIL8) {
-    return_features.insert(Depth32floatStencil8);
-  }
-  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_BC) {
-    return_features.insert(TextureCompressionBc);
-  }
-  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_BC_SLICED_3D) {
-    return_features.insert(TextureCompressionBcSliced3d);
-  }
-  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ETC2) {
-    return_features.insert(TextureCompressionEtc2);
-  }
-  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC) {
-    return_features.insert(TextureCompressionAstc);
-  }
-  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D)
-  {
-    return_features.insert(TextureCompressionAstcSliced3d);
-  }
-  if features.contains(wgpu_types::Features::RG11B10UFLOAT_RENDERABLE) {
-    return_features.insert(Rg11b10ufloatRenderable);
-  }
-  if features.contains(wgpu_types::Features::BGRA8UNORM_STORAGE) {
-    return_features.insert(Bgra8unormStorage);
-  }
-  if features.contains(wgpu_types::Features::FLOAT32_FILTERABLE) {
-    return_features.insert(Float32Filterable);
-  }
-  if features.contains(wgpu_types::Features::FLOAT32_BLENDABLE) {
-    return_features.insert(Float32Blendable);
-  }
-  if features.contains(wgpu_types::Features::DUAL_SOURCE_BLENDING) {
-    return_features.insert(DualSourceBlending);
-  }
-  if features.contains(wgpu_types::Features::SUBGROUP) {
-    return_features.insert(Subgroups);
-  }
-
-  // extended from spec
-
-  // texture formats
-  if features.contains(wgpu_types::Features::TEXTURE_FORMAT_16BIT_NORM) {
-    return_features.insert(TextureFormat16BitNorm);
-  }
-  if features.contains(wgpu_types::Features::TEXTURE_COMPRESSION_ASTC_HDR) {
-    return_features.insert(TextureCompressionAstcHdr);
-  }
-  if features
-    .contains(wgpu_types::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES)
-  {
-    return_features.insert(TextureAdapterSpecificFormatFeatures);
-  }
-  // api
-  if features.contains(wgpu_types::Features::PIPELINE_STATISTICS_QUERY) {
-    return_features.insert(PipelineStatisticsQuery);
-  }
-  if features.contains(wgpu_types::Features::TIMESTAMP_QUERY_INSIDE_PASSES) {
-    return_features.insert(TimestampQueryInsidePasses);
-  }
-  if features.contains(wgpu_types::Features::MAPPABLE_PRIMARY_BUFFERS) {
-    return_features.insert(MappablePrimaryBuffers);
-  }
-  if features.contains(wgpu_types::Features::TEXTURE_BINDING_ARRAY) {
-    return_features.insert(TextureBindingArray);
-  }
-  if features.contains(wgpu_types::Features::BUFFER_BINDING_ARRAY) {
-    return_features.insert(BufferBindingArray);
-  }
-  if features.contains(wgpu_types::Features::STORAGE_RESOURCE_BINDING_ARRAY) {
-    return_features.insert(StorageResourceBindingArray);
-  }
-  if features.contains(
-        wgpu_types::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
-    ) {
-        return_features.insert(SampledTextureAndStorageBufferArrayNonUniformIndexing);
-    }
-  if features
-    .contains(wgpu_types::Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING)
-  {
-    return_features.insert(StorageTextureArrayNonUniformIndexing);
-  }
-  if features.contains(wgpu_types::Features::UNIFORM_BUFFER_BINDING_ARRAYS) {
-    return_features.insert(UniformBufferBindingArrays);
-  }
-  if features.contains(wgpu_types::Features::PARTIALLY_BOUND_BINDING_ARRAY) {
-    return_features.insert(PartiallyBoundBindingArray);
-  }
-  if features.contains(wgpu_types::Features::MULTI_DRAW_INDIRECT_COUNT) {
-    return_features.insert(MultiDrawIndirectCount);
-  }
-  if features.contains(wgpu_types::Features::IMMEDIATES) {
-    return_features.insert(ImmediateData);
-  }
-  if features.contains(wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_ZERO) {
-    return_features.insert(AddressModeClampToZero);
-  }
-  if features.contains(wgpu_types::Features::ADDRESS_MODE_CLAMP_TO_BORDER) {
-    return_features.insert(AddressModeClampToBorder);
-  }
-  if features.contains(wgpu_types::Features::POLYGON_MODE_LINE) {
-    return_features.insert(PolygonModeLine);
-  }
-  if features.contains(wgpu_types::Features::POLYGON_MODE_POINT) {
-    return_features.insert(PolygonModePoint);
-  }
-  if features.contains(wgpu_types::Features::CONSERVATIVE_RASTERIZATION) {
-    return_features.insert(ConservativeRasterization);
-  }
-  if features.contains(wgpu_types::Features::VERTEX_WRITABLE_STORAGE) {
-    return_features.insert(VertexWritableStorage);
-  }
-  if features.contains(wgpu_types::Features::CLEAR_TEXTURE) {
-    return_features.insert(ClearTexture);
-  }
-  if features.contains(wgpu_types::Features::MULTIVIEW) {
-    return_features.insert(Multiview);
-  }
-  if features.contains(wgpu_types::Features::VERTEX_ATTRIBUTE_64BIT) {
-    return_features.insert(VertexAttribute64Bit);
-  }
-  // shader
-  if features.contains(wgpu_types::Features::SHADER_F64) {
-    return_features.insert(ShaderF64);
-  }
-  if features.contains(wgpu_types::Features::SHADER_I16) {
-    return_features.insert(ShaderI16);
-  }
-  if features.contains(wgpu_types::Features::PRIMITIVE_INDEX) {
-    return_features.insert(PrimitiveIndex);
-  }
-  if features.contains(wgpu_types::Features::SHADER_EARLY_DEPTH_TEST) {
-    return_features.insert(ShaderEarlyDepthTest);
-  }
-  if features.contains(wgpu_types::Features::PASSTHROUGH_SHADERS) {
-    return_features.insert(PassthroughShaders);
-  }
-
-  return_features
 }
 
 #[derive(Clone, Copy)]

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -1,3 +1,20 @@
+//! # Features
+//!
+//! Types identifying optional features of WebGPU and wgpu. Availability varies
+//! by hardware and can be checked when requesting an adapter and device.
+//!
+//! The `wgpu` Rust API always uses the `Features` bit flag type to represent a
+//! set of features. However, the WebGPU-defined JavaScript API uses
+//! `kebab-case` feature name strings, so some utilities are provided for
+//! working with those names. See [`Features::as_str`] and [`<Features as
+//! FromStr>::from_str`].
+//!
+//! The [`bitflags`] crate names flags by stringifying the
+//! `SCREAMING_SNAKE_CASE` identifier. These names are returned by
+//! [`Features::iter_names`] and parsed by [`Features::from_name`].
+//! [`bitflags`] does not currently support customized flag naming.
+//! See <https://github.com/bitflags/bitflags/issues/470>.
+
 use crate::{link_to_wgpu_docs, link_to_wgpu_item, VertexFormat};
 #[cfg(feature = "serde")]
 use alloc::fmt;
@@ -138,7 +155,8 @@ macro_rules! bitflags_array {
             $(#[$bit_outer:meta])*
             $vis:vis struct $inner_name:ident $lower_inner_name:ident {
                 $(
-                    $(#[$inner:ident $($args:tt)*])*
+                    $(#[doc $($args:tt)*])*
+                    #[name($str_name:literal $(, $alias:literal)*)]
                     const $Flag:tt = $value:expr;
                 )*
             }
@@ -149,7 +167,7 @@ macro_rules! bitflags_array {
                 $(#[$bit_outer])*
                 $vis struct $inner_name: $T {
                     $(
-                        $(#[$inner $($args)*])*
+                        $(#[doc $($args)*])*
                         const $Flag = $value;
                     )*
                 }
@@ -457,8 +475,12 @@ macro_rules! bitflags_array {
                 Self { $($lower_inner_name: $inner_name::from_bits_retain($lower_inner_name),)* }
             }
 
-            /// Takes in a name and returns Self if it matches or none if the name does not match
-            /// the name of any of the flags. Name is capitalisation dependent.
+            /// Takes in a bitflags flag name (in `SCREAMING_SNAKE_CASE`) and returns Self
+            /// if it matches or none if the name does not match the name of any of the
+            /// flags. Name is capitalisation dependent.
+            ///
+            /// [`impl FromStr`] can be used to recognize kebab-case names, like are used in
+            /// the WebGPU spec.
             pub fn from_name(name: &str) -> Option<Self> {
                 match name {
                     $(
@@ -483,13 +505,25 @@ macro_rules! bitflags_array {
             }
 
             /// Returns an iterator over the set flags and their names.
+            ///
+            /// These are bitflags names in `SCREAMING_SNAKE_CASE`.
             pub const fn iter_names(&self) -> bitflags::iter::IterNames<$name> {
                 bitflags::iter::IterNames::__private_const_new($name::FLAGS, *self, *self)
             }
 
+            /// If the argument is a single [`Features`] flag, returns the corresponding
+            /// `kebab-case` feature name, otherwise `None`.
+            #[must_use]
+            pub fn as_str(&self) -> Option<&'static str> {
+                Some(match *self {
+                    $($(Self::$Flag => $str_name,)*)*
+                    _ => return None,
+                })
+            }
+
             $(
                 $(
-                    $(#[$inner $($args)*])*
+                    $(#[doc $($args)*])*
                     // We need this for structs with only a member.
                     #[allow(clippy::needless_update)]
                     pub const $Flag: Self = Self {
@@ -498,6 +532,19 @@ macro_rules! bitflags_array {
                     };
                 )*
             )*
+        }
+
+        // Parses kebab-case feature names (i.e. the names given in the spec, for features
+        // in FeaturesWebGPU, and otherwise the `wgpu-` prefixed names).
+        impl FromStr for $name {
+            type Err = ();
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(match s {
+                    $($($str_name $(| $alias)* => Self::$Flag,)*)*
+                    _ => return Err(()),
+                })
+            }
         }
 
         $(
@@ -571,6 +618,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [VK_EXT_shader_atomic_float]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_atomic_float.html
+        #[name("wgpu-shader-float32-atomic")]
         const SHADER_FLOAT32_ATOMIC = 1 << 0;
 
         // The features starting with a ? are features that might become part of the spec or
@@ -597,6 +645,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
+        #[name("wgpu-texture-format-16-bit-norm", "texture-format-16-bit-norm")]
         const TEXTURE_FORMAT_16BIT_NORM = 1 << 1;
         /// Enables ASTC HDR family of compressed textures.
         ///
@@ -612,6 +661,7 @@ bitflags_array! {
         /// - OpenGL
         ///
         /// This is a native only feature.
+        #[name("wgpu-texture-compression-astc-hdr", "texture-compression-astc-hdr")]
         const TEXTURE_COMPRESSION_ASTC_HDR = 1 << 2;
         /// Enables device specific texture format features.
         ///
@@ -624,6 +674,7 @@ bitflags_array! {
         /// This extension does not enable additional formats.
         ///
         /// This is a native only feature.
+        #[name("wgpu-texture-adapter-specific-format-features", "texture-adapter-specific-format-features")]
         const TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 1 << 3;
 
         // API:
@@ -645,6 +696,7 @@ bitflags_array! {
         #[doc = link_to_wgpu_docs!(["`RenderPass::end_pipeline_statistics_query`"]: "struct.RenderPass.html#method.end_pipeline_statistics_query")]
         #[doc = link_to_wgpu_docs!(["`CommandEncoder::resolve_query_set`"]: "struct.CommandEncoder.html#method.resolve_query_set")]
         /// [`PipelineStatisticsTypes`]: super::PipelineStatisticsTypes
+        #[name("wgpu-pipeline-statistics-query", "pipeline-statistics-query")]
         const PIPELINE_STATISTICS_QUERY = 1 << 4;
         /// Allows for timestamp queries directly on command encoders.
         ///
@@ -662,6 +714,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         #[doc = link_to_wgpu_docs!(["`CommandEncoder::write_timestamp`"]: "struct.CommandEncoder.html#method.write_timestamp")]
+        #[name("wgpu-timestamp-query-inside-encoders")]
         const TIMESTAMP_QUERY_INSIDE_ENCODERS = 1 << 5;
         /// Allows for timestamp queries directly on command encoders.
         ///
@@ -683,6 +736,7 @@ bitflags_array! {
         ///
         #[doc = link_to_wgpu_docs!(["`RenderPass::write_timestamp`"]: "struct.RenderPass.html#method.write_timestamp")]
         #[doc = link_to_wgpu_docs!(["`ComputePass::write_timestamp`"]: "struct.ComputePass.html#method.write_timestamp")]
+        #[name("wgpu-timestamp-query-inside-passes", "timestamp-query-inside-passes")]
         const TIMESTAMP_QUERY_INSIDE_PASSES = 1 << 6;
         /// Webgpu only allows the MAP_READ and MAP_WRITE buffer usage to be matched with
         /// COPY_DST and COPY_SRC respectively. This removes this requirement.
@@ -697,6 +751,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
+        #[name("wgpu-mappable-primary-buffers", "mappable-primary-buffers")]
         const MAPPABLE_PRIMARY_BUFFERS = 1 << 7;
         /// Allows the user to create uniform arrays of textures in shaders:
         ///
@@ -720,6 +775,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native only feature.
+        #[name("wgpu-texture-binding-array", "texture-binding-array")]
         const TEXTURE_BINDING_ARRAY = 1 << 8;
         /// Allows the user to create arrays of buffers in shaders:
         ///
@@ -741,6 +797,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native only feature.
+        #[name("wgpu-buffer-binding-array", "buffer-binding-array")]
         const BUFFER_BINDING_ARRAY = 1 << 9;
         /// Allows the user to create uniform arrays of storage buffers or textures in shaders,
         /// if resp. [`Features::BUFFER_BINDING_ARRAY`] or [`Features::TEXTURE_BINDING_ARRAY`]
@@ -754,6 +811,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native only feature.
+        #[name("wgpu-storage-resource-binding-array", "storage-resource-binding-array")]
         const STORAGE_RESOURCE_BINDING_ARRAY = 1 << 10;
         /// Allows shaders to index sampled texture and storage buffer resource arrays with dynamically non-uniform values:
         ///
@@ -779,6 +837,7 @@ bitflags_array! {
         /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s shaderSampledImageArrayNonUniformIndexing & shaderStorageBufferArrayNonUniformIndexing feature)
         ///
         /// This is a native only feature.
+        #[name("wgpu-sampled-texture-and-storage-buffer-array-non-uniform-indexing", "sampled-texture-and-storage-buffer-array-non-uniform-indexing")]
         const SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING = 1 << 11;
         /// Allows shaders to index storage texture resource arrays with dynamically non-uniform values:
         ///
@@ -790,6 +849,7 @@ bitflags_array! {
         /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s shaderStorageTextureArrayNonUniformIndexing feature)
         ///
         /// This is a native only feature.
+        #[name("wgpu-storage-texture-array-non-uniform-indexing", "storage-texture-array-non-uniform-indexing")]
         const STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING = 1 << 12;
         /// Allows the user to create bind groups containing arrays with less bindings than the BindGroupLayout.
         ///
@@ -798,6 +858,7 @@ bitflags_array! {
         /// - DX12
         ///
         /// This is a native only feature.
+        #[name("wgpu-partially-bound-binding-array", "partially-bound-binding-array")]
         const PARTIALLY_BOUND_BINDING_ARRAY = 1 << 13;
         /// Allows the user to call [`RenderPass::multi_draw_indirect_count`] and [`RenderPass::multi_draw_indexed_indirect_count`].
         ///
@@ -815,6 +876,7 @@ bitflags_array! {
         #[doc = link_to_wgpu_docs!(["`RenderPass::multi_draw_indexed_indirect`"]: "struct.RenderPass.html#method.multi_draw_indexed_indirect")]
         #[doc = link_to_wgpu_docs!(["`RenderPass::multi_draw_indirect_count`"]: "struct.RenderPass.html#method.multi_draw_indirect_count")]
         #[doc = link_to_wgpu_docs!(["`RenderPass::multi_draw_indexed_indirect_count`"]: "struct.RenderPass.html#method.multi_draw_indexed_indirect_count")]
+        #[name("wgpu-multi-draw-indirect-count", "multi-draw-indirect-count")]
         const MULTI_DRAW_INDIRECT_COUNT = 1 << 15;
         /// Allows the use of [`AddressMode::ClampToBorder`] with a border color
         /// of [`SamplerBorderColor::Zero`].
@@ -829,6 +891,7 @@ bitflags_array! {
         ///
         /// [`AddressMode::ClampToBorder`]: super::AddressMode::ClampToBorder
         /// [`SamplerBorderColor::Zero`]: super::SamplerBorderColor::Zero
+        #[name("wgpu-address-mode-clamp-to-zero", "address-mode-clamp-to-zero")]
         const ADDRESS_MODE_CLAMP_TO_ZERO = 1 << 17;
         /// Allows the use of [`AddressMode::ClampToBorder`] with a border color
         /// other than [`SamplerBorderColor::Zero`].
@@ -843,6 +906,7 @@ bitflags_array! {
         ///
         /// [`AddressMode::ClampToBorder`]: super::AddressMode::ClampToBorder
         /// [`SamplerBorderColor::Zero`]: super::SamplerBorderColor::Zero
+        #[name("wgpu-address-mode-clamp-to-border", "address-mode-clamp-to-border")]
         const ADDRESS_MODE_CLAMP_TO_BORDER = 1 << 18;
         /// Allows the user to set [`PolygonMode::Line`] in [`PrimitiveState::polygon_mode`]
         ///
@@ -857,6 +921,7 @@ bitflags_array! {
         ///
         /// [`PrimitiveState::polygon_mode`]: super::PrimitiveState
         /// [`PolygonMode::Line`]: super::PolygonMode::Line
+        #[name("wgpu-polygon-mode-line", "polygon-mode-line")]
         const POLYGON_MODE_LINE = 1 << 19;
         /// Allows the user to set [`PolygonMode::Point`] in [`PrimitiveState::polygon_mode`]
         ///
@@ -869,6 +934,7 @@ bitflags_array! {
         ///
         /// [`PrimitiveState::polygon_mode`]: super::PrimitiveState
         /// [`PolygonMode::Point`]: super::PolygonMode::Point
+        #[name("wgpu-polygon-mode-point", "polygon-mode-point")]
         const POLYGON_MODE_POINT = 1 << 20;
         /// Allows the user to set a overestimation-conservative-rasterization in [`PrimitiveState::conservative`]
         ///
@@ -881,6 +947,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [`PrimitiveState::conservative`]: super::PrimitiveState::conservative
+        #[name("wgpu-conservative-rasterization", "conservative-rasterization")]
         const CONSERVATIVE_RASTERIZATION = 1 << 21;
         /// Enables bindings of writable storage buffers and textures visible to vertex shaders.
         ///
@@ -890,6 +957,7 @@ bitflags_array! {
         /// - All
         ///
         /// This is a native only feature.
+        #[name("wgpu-vertex-writable-storage", "vertex-writable-storage")]
         const VERTEX_WRITABLE_STORAGE = 1 << 22;
         /// Enables clear to zero for textures.
         ///
@@ -897,6 +965,7 @@ bitflags_array! {
         /// - All
         ///
         /// This is a native only feature.
+        #[name("wgpu-clear-texture", "clear-texture")]
         const CLEAR_TEXTURE = 1 << 23;
         /// Enables multiview render passes and `builtin(view_index)` in vertex/mesh shaders.
         ///
@@ -907,6 +976,7 @@ bitflags_array! {
         /// - OpenGL (web only)
         ///
         /// This is a native only feature.
+        #[name("wgpu-multiview", "multiview")]
         const MULTIVIEW = 1 << 26;
         /// Enables using 64-bit types for vertex attributes.
         ///
@@ -915,6 +985,7 @@ bitflags_array! {
         /// Supported Platforms: N/A
         ///
         /// This is a native only feature.
+        #[name("wgpu-vertex-attribute-64-bit", "vertex-attribute-64-bit")]
         const VERTEX_ATTRIBUTE_64BIT = 1 << 27;
         /// Enables image atomic fetch add, and, xor, or, min, and max for R32Uint and R32Sint textures.
         ///
@@ -924,6 +995,7 @@ bitflags_array! {
         /// - Metal (with MSL 3.1+)
         ///
         /// This is a native only feature.
+        #[name("wgpu-texture-atomic")]
         const TEXTURE_ATOMIC = 1 << 28;
         /// Allows for creation of textures of format [`TextureFormat::NV12`]
         ///
@@ -934,6 +1006,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [`TextureFormat::NV12`]: super::TextureFormat::NV12
+        #[name("wgpu-texture-format-nv12")]
         const TEXTURE_FORMAT_NV12 = 1 << 29;
         /// Allows for creation of textures of format [`TextureFormat::P010`]
         ///
@@ -944,6 +1017,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [`TextureFormat::P010`]: super::TextureFormat::P010
+        #[name("wgpu-texture-format-p010")]
         const TEXTURE_FORMAT_P010 = 1 << 30;
 
         /// Allows for the creation and usage of `ExternalTexture`s, and bind
@@ -960,6 +1034,7 @@ bitflags_array! {
         /// Supported platforms:
         /// - DX12
         /// - Metal
+        #[name("wgpu-external-texture", "external-texture")]
         const EXTERNAL_TEXTURE = 1 << 31;
 
         // Shader:
@@ -974,6 +1049,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native-only feature.
+        #[name("wgpu-ray-query")]
         const EXPERIMENTAL_RAY_QUERY = 1 << 32;
         /// Enables 64-bit floating point types in SPIR-V shaders.
         ///
@@ -984,6 +1060,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native only feature.
+        #[name("wgpu-shader-f64", "shader-f64")]
         const SHADER_F64 = 1 << 33;
         /// Allows shaders to use i16. Not currently supported in `naga`, only available through `spirv-passthrough`.
         ///
@@ -991,6 +1068,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native only feature.
+        #[name("wgpu-shader-i16", "shader-i16")]
         const SHADER_I16 = 1 << 34;
 
         // Bit 35 (formerly SHADER_PRIMITIVE_INDEX) is available.
@@ -1022,6 +1100,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [`EarlyDepthTest`]: https://docs.rs/naga/latest/naga/ir/enum.EarlyDepthTest.html
+        #[name("wgpu-shader-early-depth-test", "shader-early-depth-test")]
         const SHADER_EARLY_DEPTH_TEST = 1 << 36;
         /// Allows shaders to use i64 and u64.
         ///
@@ -1031,6 +1110,7 @@ bitflags_array! {
         /// - Metal (with MSL 2.3+)
         ///
         /// This is a native only feature.
+        #[name("wgpu-shader-int64")]
         const SHADER_INT64 = 1 << 37;
         /// Allows compute and fragment shaders to use the subgroup operation
         /// built-ins and perform subgroup operations (except barriers).
@@ -1040,7 +1120,14 @@ bitflags_array! {
         /// - DX12
         /// - Metal
         ///
-        /// This is a native only feature.
+        /// The `subgroups` feature has been added to WebGPU, but there may be
+        /// differences between the standard and the `wgpu` implementation,
+        /// so it remains a native-only feature in wgpu for now.
+        /// See <https://github.com/gfx-rs/wgpu/issues/5555>.
+        ///
+        /// Because it is expected to move to the WebGPU feature set in the
+        /// not-too-distant future, the name omits the `wgpu-` prefix.
+        #[name("subgroups")]
         const SUBGROUP = 1 << 38;
         /// Allows vertex shaders to use the subgroup operation built-ins and
         /// perform subgroup operations (except barriers).
@@ -1049,6 +1136,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native only feature.
+        #[name("wgpu-subgroup-vertex")]
         const SUBGROUP_VERTEX = 1 << 39;
         /// Allows compute shaders to use the subgroup barrier.
         ///
@@ -1059,6 +1147,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
+        #[name("wgpu-subgroup-barrier")]
         const SUBGROUP_BARRIER = 1 << 40;
         /// Allows the use of pipeline cache objects
         ///
@@ -1068,6 +1157,7 @@ bitflags_array! {
         /// Unimplemented Platforms:
         /// - DX12
         /// - Metal
+        #[name("wgpu-pipeline-cache")]
         const PIPELINE_CACHE = 1 << 41;
         /// Allows shaders to use i64 and u64 atomic min and max.
         ///
@@ -1077,6 +1167,7 @@ bitflags_array! {
         /// - Metal (with MSL 2.4+)
         ///
         /// This is a native only feature.
+        #[name("wgpu-shader-int64-atomic-min-max")]
         const SHADER_INT64_ATOMIC_MIN_MAX = 1 << 42;
         /// Allows shaders to use all i64 and u64 atomic operations.
         ///
@@ -1085,6 +1176,7 @@ bitflags_array! {
         /// - DX12 (with SM 6.6+)
         ///
         /// This is a native only feature.
+        #[name("wgpu-shader-int64-atomic-all-ops")]
         const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 43;
         /// Allows using the [VK_GOOGLE_display_timing] Vulkan extension.
         ///
@@ -1101,6 +1193,7 @@ bitflags_array! {
         ///
         /// [VK_GOOGLE_display_timing]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_GOOGLE_display_timing.html
         #[doc = link_to_wgpu_docs!(["`Surface::as_hal()`"]: "struct.Surface.html#method.as_hal")]
+        #[name("wgpu-vulkan-google-display-timing")]
         const VULKAN_GOOGLE_DISPLAY_TIMING = 1 << 44;
 
         /// Allows using the [VK_KHR_external_memory_win32] Vulkan extension.
@@ -1111,6 +1204,7 @@ bitflags_array! {
         /// This is a native only feature.
         ///
         /// [VK_KHR_external_memory_win32]: https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_external_memory_win32.html
+        #[name("wgpu-vulkan-external-memory-win32")]
         const VULKAN_EXTERNAL_MEMORY_WIN32 = 1 << 45;
 
         /// Enables R64Uint image atomic min and max.
@@ -1121,6 +1215,7 @@ bitflags_array! {
         /// - Metal (with MSL 3.1+)
         ///
         /// This is a native only feature.
+        #[name("wgpu-texture-int64-atomic")]
         const TEXTURE_INT64_ATOMIC = 1 << 46;
 
         /// Allows uniform buffers to be bound as binding arrays.
@@ -1138,6 +1233,7 @@ bitflags_array! {
         /// - Vulkan 1.2+ (or VK_EXT_descriptor_indexing)'s `shaderUniformBufferArrayNonUniformIndexing` feature)
         ///
         /// This is a native only feature.
+        #[name("wgpu-uniform-buffer-binding-arrays", "uniform-buffer-binding-arrays")]
         const UNIFORM_BUFFER_BINDING_ARRAYS = 1 << 47;
 
         /// Enables mesh shaders and task shaders in mesh shader pipelines. This extension does NOT imply support for
@@ -1164,6 +1260,7 @@ bitflags_array! {
         ///
         /// [`Device::create_shader_module_trusted`]: https://docs.rs/wgpu/latest/wgpu/struct.Device.html#method.create_shader_module_trusted
         /// [`ShaderRuntimeChecks::unchecked()`]: crate::ShaderRuntimeChecks::unchecked
+        #[name("wgpu-mesh-shader")]
         const EXPERIMENTAL_MESH_SHADER = 1 << 48;
 
         /// ***THIS IS EXPERIMENTAL:*** Features enabled by this may have
@@ -1179,6 +1276,7 @@ bitflags_array! {
         /// This is a native only feature
         ///
         /// [`AccelerationStructureFlags::ALLOW_RAY_HIT_VERTEX_RETURN`]: super::AccelerationStructureFlags::ALLOW_RAY_HIT_VERTEX_RETURN
+        #[name("wgpu-ray-hit-vertex-return")]
         const EXPERIMENTAL_RAY_HIT_VERTEX_RETURN = 1 << 49;
 
         /// Enables multiview in mesh shader pipelines
@@ -1191,6 +1289,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
+        #[name("wgpu-mesh-shader-multiview")]
         const EXPERIMENTAL_MESH_SHADER_MULTIVIEW = 1 << 50;
 
         /// Allows usage of additional vertex formats in [BlasTriangleGeometrySizeDescriptor::vertex_format]
@@ -1200,6 +1299,7 @@ bitflags_array! {
         /// - DX12
         ///
         /// [BlasTriangleGeometrySizeDescriptor::vertex_format]: super::BlasTriangleGeometrySizeDescriptor
+        #[name("wgpu-extended-acceleration-structure-vertex-formats")]
         const EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS = 1 << 51;
 
         /// Enables creating shaders from passthrough with reflection info (unsafe)
@@ -1218,6 +1318,7 @@ bitflags_array! {
         /// [this comment](https://github.com/gfx-rs/wgpu/issues/3103#issuecomment-2833058367).
         ///
         #[doc = link_to_wgpu_docs!(["`Device::create_shader_module_passthrough`"]: "struct.Device.html#method.create_shader_module_passthrough")]
+        #[name("wgpu-passthrough-shaders", "passthrough-shaders")]
         const PASSTHROUGH_SHADERS = 1 << 52;
 
         /// Enables shader barycentric coordinates.
@@ -1228,6 +1329,7 @@ bitflags_array! {
         /// - Metal (with MSL 2.2+)
         ///
         /// This is a native only feature.
+        #[name("wgpu-shader-barycentrics")]
         const SHADER_BARYCENTRICS = 1 << 53;
 
         /// Enables using multiview where not all texture array layers are rendered to in a single render pass/render pipeline. Making
@@ -1239,6 +1341,7 @@ bitflags_array! {
         ///
         ///
         /// While metal supports this in theory, the behavior of `view_index` differs from vulkan and dx12 so the feature isn't exposed.
+        #[name("wgpu-selective-multiview")]
         const SELECTIVE_MULTIVIEW = 1 << 54;
 
         /// Enables the use of point-primitive outputs from mesh shaders. Making use of this feature also requires enabling
@@ -1249,6 +1352,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
+        #[name("wgpu-mesh-shader-points")]
         const EXPERIMENTAL_MESH_SHADER_POINTS = 1 << 55;
 
         /// Enables creating texture arrays that are also multisampled.
@@ -1258,6 +1362,7 @@ bitflags_array! {
         ///
         /// Supported platforms:
         /// - Vulkan (except VK_KHR_portability_subset if multisampleArrayImage is not available)
+        #[name("wgpu-multisample-array")]
         const MULTISAMPLE_ARRAY = 1 << 56;
 
         /// Enables cooperative matrix operations (also known as tensor cores on NVIDIA GPUs
@@ -1277,6 +1382,7 @@ bitflags_array! {
         /// - Vulkan (with [VK_KHR_cooperative_matrix](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_cooperative_matrix.html), if 8x8 f32 is supported)
         ///
         /// This is a native only feature.
+        #[name("wgpu-cooperative-matrix")]
         const EXPERIMENTAL_COOPERATIVE_MATRIX = 1 << 57;
 
         /// Enables shader per-vertex attributes.
@@ -1285,6 +1391,7 @@ bitflags_array! {
         /// - Vulkan (with VK_KHR_fragment_shader_barycentric)
         ///
         /// This is a native only feature.
+        #[name("wgpu-shader-per-vertex")]
         const SHADER_PER_VERTEX = 1 << 58;
 
         /// Enables shader `draw_index` builtin.
@@ -1298,6 +1405,7 @@ bitflags_array! {
         /// - Metal
         ///
         /// This is a native only feature.
+        #[name("wgpu-shader-draw-index")]
         const SHADER_DRAW_INDEX = 1 << 59;
         /// Allows the user to create arrays of acceleration structures in shaders:
         ///
@@ -1311,6 +1419,7 @@ bitflags_array! {
         /// - Vulkan
         ///
         /// This is a native only feature.
+        #[name("wgpu-acceleration-structure-binding-array")]
         const ACCELERATION_STRUCTURE_BINDING_ARRAY = 1 << 60;
 
         /// Enables the `@coherent` memory decoration on storage buffer variables.
@@ -1322,6 +1431,7 @@ bitflags_array! {
         /// - GLES (ES 3.1+ / GL 4.3+)
         ///
         /// This is a native only feature.
+        #[name("wgpu-memory-decoration-coherent")]
         const MEMORY_DECORATION_COHERENT = 1 << 61;
 
         /// Enables the `@volatile` memory decoration on storage buffer variables.
@@ -1331,6 +1441,7 @@ bitflags_array! {
         /// - GLES (ES 3.1+ / GL 4.3+)
         ///
         /// This is a native only feature.
+        #[name("wgpu-memory-decoration-volatile")]
         const MEMORY_DECORATION_VOLATILE = 1 << 62;
 
         // Adding a new feature? Bit 35 (formerly SHADER_PRIMITIVE_INDEX) is available.
@@ -1365,6 +1476,7 @@ bitflags_array! {
         /// - WebGPU
         ///
         /// This is a web and native feature.
+        #[name("depth-clip-control")]
         const DEPTH_CLIP_CONTROL = WEBGPU_FEATURE_DEPTH_CLIP_CONTROL;
 
         /// Allows for explicit creation of textures of format [`TextureFormat::Depth32FloatStencil8`]
@@ -1379,6 +1491,7 @@ bitflags_array! {
         /// This is a web and native feature.
         ///
         /// [`TextureFormat::Depth32FloatStencil8`]: super::TextureFormat::Depth32FloatStencil8
+        #[name("depth32float-stencil8")]
         const DEPTH32FLOAT_STENCIL8 = WEBGPU_FEATURE_DEPTH32FLOAT_STENCIL8;
 
         /// Enables BCn family of compressed textures. All BCn textures use 4x4 pixel blocks
@@ -1398,6 +1511,7 @@ bitflags_array! {
         /// - WebGPU
         ///
         /// This is a web and native feature.
+        #[name("texture-compression-bc")]
         const TEXTURE_COMPRESSION_BC = WEBGPU_FEATURE_TEXTURE_COMPRESSION_BC;
 
 
@@ -1412,6 +1526,7 @@ bitflags_array! {
         /// - WebGPU
         ///
         /// This is a web and native feature.
+        #[name("texture-compression-bc-sliced-3d")]
         const TEXTURE_COMPRESSION_BC_SLICED_3D = WEBGPU_FEATURE_TEXTURE_COMPRESSION_BC_SLICED_3D;
 
         /// Enables ETC family of compressed textures. All ETC textures use 4x4 pixel blocks.
@@ -1429,6 +1544,7 @@ bitflags_array! {
         /// - WebGPU
         ///
         /// This is a web and native feature.
+        #[name("texture-compression-etc2")]
         const TEXTURE_COMPRESSION_ETC2 = WEBGPU_FEATURE_TEXTURE_COMPRESSION_ETC2;
 
         /// Enables ASTC family of compressed textures. ASTC textures use pixel blocks varying from 4x4 to 12x12.
@@ -1449,6 +1565,7 @@ bitflags_array! {
         /// - WebGPU
         ///
         /// This is a web and native feature.
+        #[name("texture-compression-astc")]
         const TEXTURE_COMPRESSION_ASTC = WEBGPU_FEATURE_TEXTURE_COMPRESSION_ASTC;
 
 
@@ -1467,6 +1584,7 @@ bitflags_array! {
         /// - DX12
         ///
         /// This is a web and native feature.
+        #[name("texture-compression-astc-sliced-3d")]
         const TEXTURE_COMPRESSION_ASTC_SLICED_3D = WEBGPU_FEATURE_TEXTURE_COMPRESSION_ASTC_SLICED_3D;
 
         /// Enables use of Timestamp Queries. These queries tell the current gpu timestamp when
@@ -1498,6 +1616,7 @@ bitflags_array! {
         #[doc = link_to_wgpu_docs!(["`ComputePassDescriptor::timestamp_writes`"]: "struct.ComputePassDescriptor.html#structfield.timestamp_writes")]
         #[doc = link_to_wgpu_docs!(["`CommandEncoder::resolve_query_set`"]: "struct.CommandEncoder.html#method.resolve_query_set")]
         #[doc = link_to_wgpu_docs!(["`Queue::get_timestamp_period`"]: "struct.Queue.html#method.get_timestamp_period")]
+        #[name("timestamp-query")]
         const TIMESTAMP_QUERY = WEBGPU_FEATURE_TIMESTAMP_QUERY;
 
         /// Allows non-zero value for the `first_instance` member in indirect draw calls.
@@ -1518,6 +1637,7 @@ bitflags_array! {
         /// - OpenGL ES / WebGL
         ///
         /// This is a web and native feature.
+        #[name("indirect-first-instance")]
         const INDIRECT_FIRST_INSTANCE = WEBGPU_FEATURE_INDIRECT_FIRST_INSTANCE;
 
         /// Allows shaders to use 16-bit floating point types. You may use them uniform buffers,
@@ -1533,6 +1653,7 @@ bitflags_array! {
         /// - WebGPU
         ///
         /// This is a web and native feature.
+        #[name("shader-f16")]
         const SHADER_F16 = WEBGPU_FEATURE_SHADER_F16;
 
         /// Allows for usage of textures of format [`TextureFormat::Rg11b10Ufloat`] as a render target
@@ -1546,6 +1667,7 @@ bitflags_array! {
         /// This is a web and native feature.
         ///
         /// [`TextureFormat::Rg11b10Ufloat`]: super::TextureFormat::Rg11b10Ufloat
+        #[name("rg11b10ufloat-renderable")]
         const RG11B10UFLOAT_RENDERABLE = WEBGPU_FEATURE_RG11B10UFLOAT_RENDERABLE;
 
         /// Allows the [`TextureUsages::STORAGE_BINDING`] usage on textures with format [`TextureFormat::Bgra8Unorm`]
@@ -1560,6 +1682,7 @@ bitflags_array! {
         ///
         /// [`TextureFormat::Bgra8Unorm`]: super::TextureFormat::Bgra8Unorm
         /// [`TextureUsages::STORAGE_BINDING`]: super::TextureUsages::STORAGE_BINDING
+        #[name("bgra8unorm-storage")]
         const BGRA8UNORM_STORAGE = WEBGPU_FEATURE_BGRA8UNORM_STORAGE;
 
 
@@ -1573,6 +1696,7 @@ bitflags_array! {
         /// - WebGPU
         ///
         /// This is a web and native feature.
+        #[name("float32-filterable")]
         const FLOAT32_FILTERABLE = WEBGPU_FEATURE_FLOAT32_FILTERABLE;
 
         /// Allows textures with formats "r32float", "rg32float", and "rgba32float" to be blendable.
@@ -1580,6 +1704,7 @@ bitflags_array! {
         /// Supported Platforms:
         /// - Vulkan
         /// - WebGPU
+        #[name("float32-blendable")]
         const FLOAT32_BLENDABLE = WEBGPU_FEATURE_FLOAT32_BLENDABLE;
 
         /// Allows two outputs from a shader to be used for blending.
@@ -1595,6 +1720,7 @@ bitflags_array! {
         /// - WebGPU
         ///
         /// This is a web and native feature.
+        #[name("dual-source-blending")]
         const DUAL_SOURCE_BLENDING = WEBGPU_FEATURE_DUAL_SOURCE_BLENDING;
 
         /// Allows the use of `@builtin(clip_distances)` in WGSL.
@@ -1606,6 +1732,7 @@ bitflags_array! {
         /// - WebGPU
         ///
         /// This is a web and native feature.
+        #[name("clip-distances")]
         const CLIP_DISTANCES = WEBGPU_FEATURE_CLIP_DISTANCES;
 
         /// Allows the use of immediate data: small, fast bits of memory that can be updated
@@ -1638,6 +1765,7 @@ bitflags_array! {
         #[doc = link_to_wgpu_item!(struct PipelineLayoutDescriptor)]
         #[doc = link_to_wgpu_docs!(["`RenderPass::set_immediates`"]: "struct.RenderPass.html#method.set_immediates")]
         /// [`Limits::max_immediate_size`]: super::Limits
+        #[name("immediates")]
         const IMMEDIATES = WEBGPU_FEATURE_IMMEDIATES;
 
         /// Enables `builtin(primitive_index)` in fragment shaders.
@@ -1652,7 +1780,10 @@ bitflags_array! {
         /// - Metal (some)
         /// - OpenGL (some)
         ///
-        /// This is a web and native feature.
+        /// This is a web and native feature. `primitive-index` is its
+        /// WebGPU-defined name, and `shader-primitive-index` is accepted to
+        /// remain compatible with previous wgpu behavior.
+        #[name("primitive-index", "shader-primitive-index")]
         const PRIMITIVE_INDEX = WEBGPU_FEATURE_PRIMITIVE_INDEX;
     }
 }
@@ -1705,250 +1836,6 @@ impl Features {
             formats.push(VertexFormat::Snorm16x4);
         }
         formats
-    }
-
-    /// If the argument is a single [`Features`] flag, returns the corresponding
-    /// feature name, otherwise `None`.
-    #[must_use]
-    pub fn as_str(&self) -> Option<&'static str> {
-        Some(match *self {
-            // WebGPU features
-            Features::DEPTH_CLIP_CONTROL => "depth-clip-control",
-            Features::DEPTH32FLOAT_STENCIL8 => "depth32float-stencil8",
-            Features::TEXTURE_COMPRESSION_BC => "texture-compression-bc",
-            Features::TEXTURE_COMPRESSION_BC_SLICED_3D => "texture-compression-bc-sliced-3d",
-            Features::TEXTURE_COMPRESSION_ETC2 => "texture-compression-etc2",
-            Features::TEXTURE_COMPRESSION_ASTC => "texture-compression-astc",
-            Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D => "texture-compression-astc-sliced-3d",
-            Features::TIMESTAMP_QUERY => "timestamp-query",
-            Features::INDIRECT_FIRST_INSTANCE => "indirect-first-instance",
-            Features::SHADER_F16 => "shader-f16",
-            Features::RG11B10UFLOAT_RENDERABLE => "rg11b10ufloat-renderable",
-            Features::BGRA8UNORM_STORAGE => "bgra8unorm-storage",
-            Features::FLOAT32_FILTERABLE => "float32-filterable",
-            Features::FLOAT32_BLENDABLE => "float32-blendable",
-            Features::DUAL_SOURCE_BLENDING => "dual-source-blending",
-            Features::CLIP_DISTANCES => "clip-distances",
-            Features::IMMEDIATES => "immediates",
-            Features::PRIMITIVE_INDEX => "primitive-index",
-            // Note: The `subgroup` standard-track feature is in the native-only section below.
-
-            // Core WebGPU functionality, but still under a feature in wgpu due to incomplete support
-            Features::EXTERNAL_TEXTURE => "wgpu-external-texture",
-
-            // wgpu native-only features
-            Features::SHADER_FLOAT32_ATOMIC => "wgpu-shader-float32-atomic",
-            Features::TEXTURE_FORMAT_16BIT_NORM => "wgpu-texture-format-16-bit-norm",
-            Features::TEXTURE_COMPRESSION_ASTC_HDR => "wgpu-texture-compression-astc-hdr",
-            Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES => {
-                "wgpu-texture-adapter-specific-format-features"
-            }
-            Features::PIPELINE_STATISTICS_QUERY => "wgpu-pipeline-statistics-query",
-            Features::TIMESTAMP_QUERY_INSIDE_ENCODERS => "wgpu-timestamp-query-inside-encoders",
-            Features::TIMESTAMP_QUERY_INSIDE_PASSES => "wgpu-timestamp-query-inside-passes",
-            Features::MAPPABLE_PRIMARY_BUFFERS => "wgpu-mappable-primary-buffers",
-            Features::TEXTURE_BINDING_ARRAY => "wgpu-texture-binding-array",
-            Features::BUFFER_BINDING_ARRAY => "wgpu-buffer-binding-array",
-            Features::STORAGE_RESOURCE_BINDING_ARRAY => "wgpu-storage-resource-binding-array",
-            Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING => {
-                "wgpu-sampled-texture-and-storage-buffer-array-non-uniform-indexing"
-            }
-            Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING => {
-                "wgpu-storage-texture-array-non-uniform-indexing"
-            }
-            Features::PARTIALLY_BOUND_BINDING_ARRAY => "wgpu-partially-bound-binding-array",
-            Features::MULTI_DRAW_INDIRECT_COUNT => "wgpu-multi-draw-indirect-count",
-            Features::ADDRESS_MODE_CLAMP_TO_ZERO => "wgpu-address-mode-clamp-to-zero",
-            Features::ADDRESS_MODE_CLAMP_TO_BORDER => "wgpu-address-mode-clamp-to-border",
-            Features::POLYGON_MODE_LINE => "wgpu-polygon-mode-line",
-            Features::POLYGON_MODE_POINT => "wgpu-polygon-mode-point",
-            Features::CONSERVATIVE_RASTERIZATION => "wgpu-conservative-rasterization",
-            Features::VERTEX_WRITABLE_STORAGE => "wgpu-vertex-writable-storage",
-            Features::CLEAR_TEXTURE => "wgpu-clear-texture",
-            Features::MULTIVIEW => "wgpu-multiview",
-            Features::VERTEX_ATTRIBUTE_64BIT => "wgpu-vertex-attribute-64-bit",
-            Features::TEXTURE_ATOMIC => "wgpu-texture-atomic",
-            Features::TEXTURE_FORMAT_NV12 => "wgpu-texture-format-nv12",
-            Features::TEXTURE_FORMAT_P010 => "wgpu-texture-format-p010",
-            // External texture appears above
-            Features::EXPERIMENTAL_RAY_QUERY => "wgpu-ray-query",
-            Features::SHADER_F64 => "wgpu-shader-f64",
-            Features::SHADER_I16 => "wgpu-shader-i16",
-            Features::SHADER_EARLY_DEPTH_TEST => "wgpu-shader-early-depth-test",
-            Features::SHADER_INT64 => "wgpu-shader-int64",
-            Features::SUBGROUP => "subgroups", // standard-track feature
-            Features::SUBGROUP_VERTEX => "wgpu-subgroup-vertex",
-            Features::SUBGROUP_BARRIER => "wgpu-subgroup-barrier",
-            Features::PIPELINE_CACHE => "wgpu-pipeline-cache",
-            Features::SHADER_INT64_ATOMIC_MIN_MAX => "wgpu-shader-int64-atomic-min-max",
-            Features::SHADER_INT64_ATOMIC_ALL_OPS => "wgpu-shader-int64-atomic-all-ops",
-            Features::VULKAN_GOOGLE_DISPLAY_TIMING => "wgpu-vulkan-google-display-timing",
-            Features::VULKAN_EXTERNAL_MEMORY_WIN32 => "wgpu-vulkan-external-memory-win32",
-            Features::TEXTURE_INT64_ATOMIC => "wgpu-texture-int64-atomic",
-            Features::UNIFORM_BUFFER_BINDING_ARRAYS => "wgpu-uniform-buffer-binding-arrays",
-            Features::EXPERIMENTAL_MESH_SHADER => "wgpu-mesh-shader",
-            Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN => "wgpu-ray-hit-vertex-return",
-            Features::EXPERIMENTAL_MESH_SHADER_MULTIVIEW => "wgpu-mesh-shader-multiview",
-            Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS => {
-                "wgpu-extended-acceleration-structure-vertex-formats"
-            }
-            Features::PASSTHROUGH_SHADERS => "wgpu-passthrough-shaders",
-            Features::SHADER_BARYCENTRICS => "wgpu-shader-barycentrics",
-            Features::SELECTIVE_MULTIVIEW => "wgpu-selective-multiview",
-            Features::EXPERIMENTAL_MESH_SHADER_POINTS => "wgpu-mesh-shader-points",
-            Features::MULTISAMPLE_ARRAY => "wgpu-multisample-array",
-            Features::EXPERIMENTAL_COOPERATIVE_MATRIX => "wgpu-cooperative-matrix",
-            Features::SHADER_PER_VERTEX => "wgpu-shader-per-vertex",
-            Features::SHADER_DRAW_INDEX => "wgpu-shader-draw-index",
-            Features::ACCELERATION_STRUCTURE_BINDING_ARRAY => {
-                "wgpu-acceleration-structure-binding-array"
-            }
-            Features::MEMORY_DECORATION_COHERENT => "wgpu-memory-decoration-coherent",
-            Features::MEMORY_DECORATION_VOLATILE => "wgpu-memory-decoration-volatile",
-            _ => return None,
-        })
-    }
-}
-
-impl FromStr for Features {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            // WebGPU features
-            "depth-clip-control" => Features::DEPTH_CLIP_CONTROL,
-            "depth32float-stencil8" => Features::DEPTH32FLOAT_STENCIL8,
-            "texture-compression-bc" => Features::TEXTURE_COMPRESSION_BC,
-            "texture-compression-bc-sliced-3d" => Features::TEXTURE_COMPRESSION_BC_SLICED_3D,
-            "texture-compression-etc2" => Features::TEXTURE_COMPRESSION_ETC2,
-            "texture-compression-astc" => Features::TEXTURE_COMPRESSION_ASTC,
-            "texture-compression-astc-sliced-3d" => Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D,
-            "timestamp-query" => Features::TIMESTAMP_QUERY,
-            "indirect-first-instance" => Features::INDIRECT_FIRST_INSTANCE,
-            "shader-f16" => Features::SHADER_F16,
-            "rg11b10ufloat-renderable" => Features::RG11B10UFLOAT_RENDERABLE,
-            "bgra8unorm-storage" => Features::BGRA8UNORM_STORAGE,
-            "float32-filterable" => Features::FLOAT32_FILTERABLE,
-            "float32-blendable" => Features::FLOAT32_BLENDABLE,
-            "dual-source-blending" => Features::DUAL_SOURCE_BLENDING,
-            "clip-distances" => Features::CLIP_DISTANCES,
-            "immediates" => Features::IMMEDIATES,
-            // backcompat for previous wgpu extension name (only applies to Deno, probably will never matter)
-            "primitive-index" | "shader-primitive-index" => Features::PRIMITIVE_INDEX,
-            // Note: The `subgroup` standard-track feature is in the native-only section below.
-
-            // Core WebGPU functionality, but still under a feature in wgpu due to incomplete support
-            "wgpu-external-texture" | "external-texture" => Features::EXTERNAL_TEXTURE,
-
-            // wgpu native-only features
-            // Some of these were previously exposed in Deno with the non-wgpu-prefixed
-            // names, so we accept those for backwards compatibility.
-            "wgpu-shader-float32-atomic" => Features::SHADER_FLOAT32_ATOMIC,
-            "wgpu-texture-format-16-bit-norm" | "texture-format-16-bit-norm" => {
-                Features::TEXTURE_FORMAT_16BIT_NORM
-            }
-            "wgpu-texture-compression-astc-hdr" | "texture-compression-astc-hdr" => {
-                Features::TEXTURE_COMPRESSION_ASTC_HDR
-            }
-            "wgpu-texture-adapter-specific-format-features"
-            | "texture-adapter-specific-format-features" => {
-                Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            }
-            "wgpu-pipeline-statistics-query" | "pipeline-statistics-query" => {
-                Features::PIPELINE_STATISTICS_QUERY
-            }
-            "wgpu-timestamp-query-inside-encoders" => Features::TIMESTAMP_QUERY_INSIDE_ENCODERS,
-            "wgpu-timestamp-query-inside-passes" | "timestamp-query-inside-passes" => {
-                Features::TIMESTAMP_QUERY_INSIDE_PASSES
-            }
-            "wgpu-mappable-primary-buffers" | "mappable-primary-buffers" => {
-                Features::MAPPABLE_PRIMARY_BUFFERS
-            }
-            "wgpu-texture-binding-array" | "texture-binding-array" => {
-                Features::TEXTURE_BINDING_ARRAY
-            }
-            "wgpu-buffer-binding-array" | "buffer-binding-array" => Features::BUFFER_BINDING_ARRAY,
-            "wgpu-storage-resource-binding-array" | "storage-resource-binding-array" => {
-                Features::STORAGE_RESOURCE_BINDING_ARRAY
-            }
-            "wgpu-sampled-texture-and-storage-buffer-array-non-uniform-indexing"
-            | "sampled-texture-and-storage-buffer-array-non-uniform-indexing" => {
-                Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
-            }
-            "wgpu-storage-texture-array-non-uniform-indexing"
-            | "storage-texture-array-non-uniform-indexing" => {
-                Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING
-            }
-            "wgpu-partially-bound-binding-array" | "partially-bound-binding-array" => {
-                Features::PARTIALLY_BOUND_BINDING_ARRAY
-            }
-            "wgpu-multi-draw-indirect-count" | "multi-draw-indirect-count" => {
-                Features::MULTI_DRAW_INDIRECT_COUNT
-            }
-            "wgpu-address-mode-clamp-to-zero" | "address-mode-clamp-to-zero" => {
-                Features::ADDRESS_MODE_CLAMP_TO_ZERO
-            }
-            "wgpu-address-mode-clamp-to-border" | "address-mode-clamp-to-border" => {
-                Features::ADDRESS_MODE_CLAMP_TO_BORDER
-            }
-            "wgpu-polygon-mode-line" | "polygon-mode-line" => Features::POLYGON_MODE_LINE,
-            "wgpu-polygon-mode-point" | "polygon-mode-point" => Features::POLYGON_MODE_POINT,
-            "wgpu-conservative-rasterization" | "conservative-rasterization" => {
-                Features::CONSERVATIVE_RASTERIZATION
-            }
-            "wgpu-vertex-writable-storage" | "vertex-writable-storage" => {
-                Features::VERTEX_WRITABLE_STORAGE
-            }
-            "wgpu-clear-texture" | "clear-texture" => Features::CLEAR_TEXTURE,
-            "wgpu-multiview" | "multiview" => Features::MULTIVIEW,
-            "wgpu-vertex-attribute-64-bit" | "vertex-attribute-64-bit" => {
-                Features::VERTEX_ATTRIBUTE_64BIT
-            }
-            "wgpu-texture-atomic" => Features::TEXTURE_ATOMIC,
-            "wgpu-texture-format-nv12" => Features::TEXTURE_FORMAT_NV12,
-            "wgpu-texture-format-p010" => Features::TEXTURE_FORMAT_P010,
-            // external-texture appears above
-            "wgpu-ray-query" => Features::EXPERIMENTAL_RAY_QUERY,
-            "wgpu-shader-f64" | "shader-f64" => Features::SHADER_F64,
-            "wgpu-shader-i16" | "shader-i16" => Features::SHADER_I16,
-            "wgpu-shader-early-depth-test" | "shader-early-depth-test" => {
-                Features::SHADER_EARLY_DEPTH_TEST
-            }
-            "wgpu-shader-int64" => Features::SHADER_INT64,
-            "subgroups" => Features::SUBGROUP, // standard-track feature
-            "wgpu-subgroup-vertex" => Features::SUBGROUP_VERTEX,
-            "wgpu-subgroup-barrier" => Features::SUBGROUP_BARRIER,
-            "wgpu-pipeline-cache" => Features::PIPELINE_CACHE,
-            "wgpu-shader-int64-atomic-min-max" => Features::SHADER_INT64_ATOMIC_MIN_MAX,
-            "wgpu-shader-int64-atomic-all-ops" => Features::SHADER_INT64_ATOMIC_ALL_OPS,
-            "wgpu-vulkan-google-display-timing" => Features::VULKAN_GOOGLE_DISPLAY_TIMING,
-            "wgpu-vulkan-external-memory-win32" => Features::VULKAN_EXTERNAL_MEMORY_WIN32,
-            "wgpu-texture-int64-atomic" => Features::TEXTURE_INT64_ATOMIC,
-            "wgpu-uniform-buffer-binding-arrays" | "uniform-buffer-binding-arrays" => {
-                Features::UNIFORM_BUFFER_BINDING_ARRAYS
-            }
-            "wgpu-mesh-shader" => Features::EXPERIMENTAL_MESH_SHADER,
-            "wgpu-ray-hit-vertex-return" => Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN,
-            "wgpu-mesh-shader-multiview" => Features::EXPERIMENTAL_MESH_SHADER_MULTIVIEW,
-            "wgpu-extended-acceleration-structure-vertex-formats" => {
-                Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS
-            }
-            "wgpu-passthrough-shaders" | "passthrough-shaders" => Features::PASSTHROUGH_SHADERS,
-            "wgpu-shader-barycentrics" => Features::SHADER_BARYCENTRICS,
-            "wgpu-selective-multiview" => Features::SELECTIVE_MULTIVIEW,
-            "wgpu-mesh-shader-points" => Features::EXPERIMENTAL_MESH_SHADER_POINTS,
-            "wgpu-multisample-array" => Features::MULTISAMPLE_ARRAY,
-            "wgpu-cooperative-matrix" => Features::EXPERIMENTAL_COOPERATIVE_MATRIX,
-            "wgpu-shader-per-vertex" => Features::SHADER_PER_VERTEX,
-            "wgpu-shader-draw-index" => Features::SHADER_DRAW_INDEX,
-            "wgpu-acceleration-structure-binding-array" => {
-                Features::ACCELERATION_STRUCTURE_BINDING_ARRAY
-            }
-            "wgpu-memory-decoration-coherent" => Features::MEMORY_DECORATION_COHERENT,
-            "wgpu-memory-decoration-volatile" => Features::MEMORY_DECORATION_VOLATILE,
-
-            _ => return Err(()),
-        })
     }
 }
 
@@ -2058,7 +1945,6 @@ mod tests {
 
             // Native-only features that are accepted without `wgpu-` prefix for backwards compatibility
             let prefix_backcompat_features = [
-                Features::EXTERNAL_TEXTURE,
                 Features::TEXTURE_FORMAT_16BIT_NORM,
                 Features::TEXTURE_COMPRESSION_ASTC_HDR,
                 Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
@@ -2082,6 +1968,7 @@ mod tests {
                 Features::CLEAR_TEXTURE,
                 Features::MULTIVIEW,
                 Features::VERTEX_ATTRIBUTE_64BIT,
+                Features::EXTERNAL_TEXTURE,
                 Features::SHADER_F64,
                 Features::SHADER_I16,
                 Features::SHADER_EARLY_DEPTH_TEST,

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -9,6 +9,7 @@ use bitflags::Bits;
 use bitflags::Flags;
 #[cfg(feature = "serde")]
 use core::mem::size_of;
+use core::str::FromStr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -1705,11 +1706,256 @@ impl Features {
         }
         formats
     }
+
+    /// If the argument is a single [`Features`] flag, returns the corresponding
+    /// feature name, otherwise `None`.
+    #[must_use]
+    pub fn as_str(&self) -> Option<&'static str> {
+        Some(match *self {
+            // WebGPU features
+            Features::DEPTH_CLIP_CONTROL => "depth-clip-control",
+            Features::DEPTH32FLOAT_STENCIL8 => "depth32float-stencil8",
+            Features::TEXTURE_COMPRESSION_BC => "texture-compression-bc",
+            Features::TEXTURE_COMPRESSION_BC_SLICED_3D => "texture-compression-bc-sliced-3d",
+            Features::TEXTURE_COMPRESSION_ETC2 => "texture-compression-etc2",
+            Features::TEXTURE_COMPRESSION_ASTC => "texture-compression-astc",
+            Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D => "texture-compression-astc-sliced-3d",
+            Features::TIMESTAMP_QUERY => "timestamp-query",
+            Features::INDIRECT_FIRST_INSTANCE => "indirect-first-instance",
+            Features::SHADER_F16 => "shader-f16",
+            Features::RG11B10UFLOAT_RENDERABLE => "rg11b10ufloat-renderable",
+            Features::BGRA8UNORM_STORAGE => "bgra8unorm-storage",
+            Features::FLOAT32_FILTERABLE => "float32-filterable",
+            Features::FLOAT32_BLENDABLE => "float32-blendable",
+            Features::DUAL_SOURCE_BLENDING => "dual-source-blending",
+            Features::CLIP_DISTANCES => "clip-distances",
+            Features::IMMEDIATES => "immediates",
+            Features::PRIMITIVE_INDEX => "primitive-index",
+            // Note: The `subgroup` standard-track feature is in the native-only section below.
+
+            // Core WebGPU functionality, but still under a feature in wgpu due to incomplete support
+            Features::EXTERNAL_TEXTURE => "wgpu-external-texture",
+
+            // wgpu native-only features
+            Features::SHADER_FLOAT32_ATOMIC => "wgpu-shader-float32-atomic",
+            Features::TEXTURE_FORMAT_16BIT_NORM => "wgpu-texture-format-16-bit-norm",
+            Features::TEXTURE_COMPRESSION_ASTC_HDR => "wgpu-texture-compression-astc-hdr",
+            Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES => {
+                "wgpu-texture-adapter-specific-format-features"
+            }
+            Features::PIPELINE_STATISTICS_QUERY => "wgpu-pipeline-statistics-query",
+            Features::TIMESTAMP_QUERY_INSIDE_ENCODERS => "wgpu-timestamp-query-inside-encoders",
+            Features::TIMESTAMP_QUERY_INSIDE_PASSES => "wgpu-timestamp-query-inside-passes",
+            Features::MAPPABLE_PRIMARY_BUFFERS => "wgpu-mappable-primary-buffers",
+            Features::TEXTURE_BINDING_ARRAY => "wgpu-texture-binding-array",
+            Features::BUFFER_BINDING_ARRAY => "wgpu-buffer-binding-array",
+            Features::STORAGE_RESOURCE_BINDING_ARRAY => "wgpu-storage-resource-binding-array",
+            Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING => {
+                "wgpu-sampled-texture-and-storage-buffer-array-non-uniform-indexing"
+            }
+            Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING => {
+                "wgpu-storage-texture-array-non-uniform-indexing"
+            }
+            Features::PARTIALLY_BOUND_BINDING_ARRAY => "wgpu-partially-bound-binding-array",
+            Features::MULTI_DRAW_INDIRECT_COUNT => "wgpu-multi-draw-indirect-count",
+            Features::ADDRESS_MODE_CLAMP_TO_ZERO => "wgpu-address-mode-clamp-to-zero",
+            Features::ADDRESS_MODE_CLAMP_TO_BORDER => "wgpu-address-mode-clamp-to-border",
+            Features::POLYGON_MODE_LINE => "wgpu-polygon-mode-line",
+            Features::POLYGON_MODE_POINT => "wgpu-polygon-mode-point",
+            Features::CONSERVATIVE_RASTERIZATION => "wgpu-conservative-rasterization",
+            Features::VERTEX_WRITABLE_STORAGE => "wgpu-vertex-writable-storage",
+            Features::CLEAR_TEXTURE => "wgpu-clear-texture",
+            Features::MULTIVIEW => "wgpu-multiview",
+            Features::VERTEX_ATTRIBUTE_64BIT => "wgpu-vertex-attribute-64-bit",
+            Features::TEXTURE_ATOMIC => "wgpu-texture-atomic",
+            Features::TEXTURE_FORMAT_NV12 => "wgpu-texture-format-nv12",
+            Features::TEXTURE_FORMAT_P010 => "wgpu-texture-format-p010",
+            // External texture appears above
+            Features::EXPERIMENTAL_RAY_QUERY => "wgpu-ray-query",
+            Features::SHADER_F64 => "wgpu-shader-f64",
+            Features::SHADER_I16 => "wgpu-shader-i16",
+            Features::SHADER_EARLY_DEPTH_TEST => "wgpu-shader-early-depth-test",
+            Features::SHADER_INT64 => "wgpu-shader-int64",
+            Features::SUBGROUP => "subgroups", // standard-track feature
+            Features::SUBGROUP_VERTEX => "wgpu-subgroup-vertex",
+            Features::SUBGROUP_BARRIER => "wgpu-subgroup-barrier",
+            Features::PIPELINE_CACHE => "wgpu-pipeline-cache",
+            Features::SHADER_INT64_ATOMIC_MIN_MAX => "wgpu-shader-int64-atomic-min-max",
+            Features::SHADER_INT64_ATOMIC_ALL_OPS => "wgpu-shader-int64-atomic-all-ops",
+            Features::VULKAN_GOOGLE_DISPLAY_TIMING => "wgpu-vulkan-google-display-timing",
+            Features::VULKAN_EXTERNAL_MEMORY_WIN32 => "wgpu-vulkan-external-memory-win32",
+            Features::TEXTURE_INT64_ATOMIC => "wgpu-texture-int64-atomic",
+            Features::UNIFORM_BUFFER_BINDING_ARRAYS => "wgpu-uniform-buffer-binding-arrays",
+            Features::EXPERIMENTAL_MESH_SHADER => "wgpu-mesh-shader",
+            Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN => "wgpu-ray-hit-vertex-return",
+            Features::EXPERIMENTAL_MESH_SHADER_MULTIVIEW => "wgpu-mesh-shader-multiview",
+            Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS => {
+                "wgpu-extended-acceleration-structure-vertex-formats"
+            }
+            Features::PASSTHROUGH_SHADERS => "wgpu-passthrough-shaders",
+            Features::SHADER_BARYCENTRICS => "wgpu-shader-barycentrics",
+            Features::SELECTIVE_MULTIVIEW => "wgpu-selective-multiview",
+            Features::EXPERIMENTAL_MESH_SHADER_POINTS => "wgpu-mesh-shader-points",
+            Features::MULTISAMPLE_ARRAY => "wgpu-multisample-array",
+            Features::EXPERIMENTAL_COOPERATIVE_MATRIX => "wgpu-cooperative-matrix",
+            Features::SHADER_PER_VERTEX => "wgpu-shader-per-vertex",
+            Features::SHADER_DRAW_INDEX => "wgpu-shader-draw-index",
+            Features::ACCELERATION_STRUCTURE_BINDING_ARRAY => {
+                "wgpu-acceleration-structure-binding-array"
+            }
+            Features::MEMORY_DECORATION_COHERENT => "wgpu-memory-decoration-coherent",
+            Features::MEMORY_DECORATION_VOLATILE => "wgpu-memory-decoration-volatile",
+            _ => return None,
+        })
+    }
+}
+
+impl FromStr for Features {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            // WebGPU features
+            "depth-clip-control" => Features::DEPTH_CLIP_CONTROL,
+            "depth32float-stencil8" => Features::DEPTH32FLOAT_STENCIL8,
+            "texture-compression-bc" => Features::TEXTURE_COMPRESSION_BC,
+            "texture-compression-bc-sliced-3d" => Features::TEXTURE_COMPRESSION_BC_SLICED_3D,
+            "texture-compression-etc2" => Features::TEXTURE_COMPRESSION_ETC2,
+            "texture-compression-astc" => Features::TEXTURE_COMPRESSION_ASTC,
+            "texture-compression-astc-sliced-3d" => Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D,
+            "timestamp-query" => Features::TIMESTAMP_QUERY,
+            "indirect-first-instance" => Features::INDIRECT_FIRST_INSTANCE,
+            "shader-f16" => Features::SHADER_F16,
+            "rg11b10ufloat-renderable" => Features::RG11B10UFLOAT_RENDERABLE,
+            "bgra8unorm-storage" => Features::BGRA8UNORM_STORAGE,
+            "float32-filterable" => Features::FLOAT32_FILTERABLE,
+            "float32-blendable" => Features::FLOAT32_BLENDABLE,
+            "dual-source-blending" => Features::DUAL_SOURCE_BLENDING,
+            "clip-distances" => Features::CLIP_DISTANCES,
+            "immediates" => Features::IMMEDIATES,
+            // backcompat for previous wgpu extension name (only applies to Deno, probably will never matter)
+            "primitive-index" | "shader-primitive-index" => Features::PRIMITIVE_INDEX,
+            // Note: The `subgroup` standard-track feature is in the native-only section below.
+
+            // Core WebGPU functionality, but still under a feature in wgpu due to incomplete support
+            "wgpu-external-texture" | "external-texture" => Features::EXTERNAL_TEXTURE,
+
+            // wgpu native-only features
+            // Some of these were previously exposed in Deno with the non-wgpu-prefixed
+            // names, so we accept those for backwards compatibility.
+            "wgpu-shader-float32-atomic" => Features::SHADER_FLOAT32_ATOMIC,
+            "wgpu-texture-format-16-bit-norm" | "texture-format-16-bit-norm" => {
+                Features::TEXTURE_FORMAT_16BIT_NORM
+            }
+            "wgpu-texture-compression-astc-hdr" | "texture-compression-astc-hdr" => {
+                Features::TEXTURE_COMPRESSION_ASTC_HDR
+            }
+            "wgpu-texture-adapter-specific-format-features"
+            | "texture-adapter-specific-format-features" => {
+                Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
+            }
+            "wgpu-pipeline-statistics-query" | "pipeline-statistics-query" => {
+                Features::PIPELINE_STATISTICS_QUERY
+            }
+            "wgpu-timestamp-query-inside-encoders" => Features::TIMESTAMP_QUERY_INSIDE_ENCODERS,
+            "wgpu-timestamp-query-inside-passes" | "timestamp-query-inside-passes" => {
+                Features::TIMESTAMP_QUERY_INSIDE_PASSES
+            }
+            "wgpu-mappable-primary-buffers" | "mappable-primary-buffers" => {
+                Features::MAPPABLE_PRIMARY_BUFFERS
+            }
+            "wgpu-texture-binding-array" | "texture-binding-array" => {
+                Features::TEXTURE_BINDING_ARRAY
+            }
+            "wgpu-buffer-binding-array" | "buffer-binding-array" => Features::BUFFER_BINDING_ARRAY,
+            "wgpu-storage-resource-binding-array" | "storage-resource-binding-array" => {
+                Features::STORAGE_RESOURCE_BINDING_ARRAY
+            }
+            "wgpu-sampled-texture-and-storage-buffer-array-non-uniform-indexing"
+            | "sampled-texture-and-storage-buffer-array-non-uniform-indexing" => {
+                Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
+            }
+            "wgpu-storage-texture-array-non-uniform-indexing"
+            | "storage-texture-array-non-uniform-indexing" => {
+                Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING
+            }
+            "wgpu-partially-bound-binding-array" | "partially-bound-binding-array" => {
+                Features::PARTIALLY_BOUND_BINDING_ARRAY
+            }
+            "wgpu-multi-draw-indirect-count" | "multi-draw-indirect-count" => {
+                Features::MULTI_DRAW_INDIRECT_COUNT
+            }
+            "wgpu-address-mode-clamp-to-zero" | "address-mode-clamp-to-zero" => {
+                Features::ADDRESS_MODE_CLAMP_TO_ZERO
+            }
+            "wgpu-address-mode-clamp-to-border" | "address-mode-clamp-to-border" => {
+                Features::ADDRESS_MODE_CLAMP_TO_BORDER
+            }
+            "wgpu-polygon-mode-line" | "polygon-mode-line" => Features::POLYGON_MODE_LINE,
+            "wgpu-polygon-mode-point" | "polygon-mode-point" => Features::POLYGON_MODE_POINT,
+            "wgpu-conservative-rasterization" | "conservative-rasterization" => {
+                Features::CONSERVATIVE_RASTERIZATION
+            }
+            "wgpu-vertex-writable-storage" | "vertex-writable-storage" => {
+                Features::VERTEX_WRITABLE_STORAGE
+            }
+            "wgpu-clear-texture" | "clear-texture" => Features::CLEAR_TEXTURE,
+            "wgpu-multiview" | "multiview" => Features::MULTIVIEW,
+            "wgpu-vertex-attribute-64-bit" | "vertex-attribute-64-bit" => {
+                Features::VERTEX_ATTRIBUTE_64BIT
+            }
+            "wgpu-texture-atomic" => Features::TEXTURE_ATOMIC,
+            "wgpu-texture-format-nv12" => Features::TEXTURE_FORMAT_NV12,
+            "wgpu-texture-format-p010" => Features::TEXTURE_FORMAT_P010,
+            // external-texture appears above
+            "wgpu-ray-query" => Features::EXPERIMENTAL_RAY_QUERY,
+            "wgpu-shader-f64" | "shader-f64" => Features::SHADER_F64,
+            "wgpu-shader-i16" | "shader-i16" => Features::SHADER_I16,
+            "wgpu-shader-early-depth-test" | "shader-early-depth-test" => {
+                Features::SHADER_EARLY_DEPTH_TEST
+            }
+            "wgpu-shader-int64" => Features::SHADER_INT64,
+            "subgroups" => Features::SUBGROUP, // standard-track feature
+            "wgpu-subgroup-vertex" => Features::SUBGROUP_VERTEX,
+            "wgpu-subgroup-barrier" => Features::SUBGROUP_BARRIER,
+            "wgpu-pipeline-cache" => Features::PIPELINE_CACHE,
+            "wgpu-shader-int64-atomic-min-max" => Features::SHADER_INT64_ATOMIC_MIN_MAX,
+            "wgpu-shader-int64-atomic-all-ops" => Features::SHADER_INT64_ATOMIC_ALL_OPS,
+            "wgpu-vulkan-google-display-timing" => Features::VULKAN_GOOGLE_DISPLAY_TIMING,
+            "wgpu-vulkan-external-memory-win32" => Features::VULKAN_EXTERNAL_MEMORY_WIN32,
+            "wgpu-texture-int64-atomic" => Features::TEXTURE_INT64_ATOMIC,
+            "wgpu-uniform-buffer-binding-arrays" | "uniform-buffer-binding-arrays" => {
+                Features::UNIFORM_BUFFER_BINDING_ARRAYS
+            }
+            "wgpu-mesh-shader" => Features::EXPERIMENTAL_MESH_SHADER,
+            "wgpu-ray-hit-vertex-return" => Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN,
+            "wgpu-mesh-shader-multiview" => Features::EXPERIMENTAL_MESH_SHADER_MULTIVIEW,
+            "wgpu-extended-acceleration-structure-vertex-formats" => {
+                Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS
+            }
+            "wgpu-passthrough-shaders" | "passthrough-shaders" => Features::PASSTHROUGH_SHADERS,
+            "wgpu-shader-barycentrics" => Features::SHADER_BARYCENTRICS,
+            "wgpu-selective-multiview" => Features::SELECTIVE_MULTIVIEW,
+            "wgpu-mesh-shader-points" => Features::EXPERIMENTAL_MESH_SHADER_POINTS,
+            "wgpu-multisample-array" => Features::MULTISAMPLE_ARRAY,
+            "wgpu-cooperative-matrix" => Features::EXPERIMENTAL_COOPERATIVE_MATRIX,
+            "wgpu-shader-per-vertex" => Features::SHADER_PER_VERTEX,
+            "wgpu-shader-draw-index" => Features::SHADER_DRAW_INDEX,
+            "wgpu-acceleration-structure-binding-array" => {
+                Features::ACCELERATION_STRUCTURE_BINDING_ARRAY
+            }
+            "wgpu-memory-decoration-coherent" => Features::MEMORY_DECORATION_COHERENT,
+            "wgpu-memory-decoration-volatile" => Features::MEMORY_DECORATION_VOLATILE,
+
+            _ => return Err(()),
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{Features, FeaturesWGPU, FeaturesWebGPU};
+    use bitflags::{Flag, Flags};
 
     #[cfg(feature = "serde")]
     #[test]
@@ -1770,26 +2016,97 @@ mod tests {
             assert_eq!(Features::from_bits_retain(bits), *feature.value());
         }
 
-        let bits = Features::all().bits();
-        assert_eq!(Features::from_bits_truncate(bits), Features::all());
+        let bits = FeaturesWebGPU::all().bits();
+        assert_eq!(
+            FeaturesWebGPU::from_bits_truncate(bits),
+            FeaturesWebGPU::all()
+        );
 
-        let bits = Features::empty().bits();
-        assert_eq!(Features::from_bits_truncate(bits), Features::empty());
+        let bits = FeaturesWebGPU::empty().bits();
+        assert_eq!(
+            FeaturesWebGPU::from_bits_truncate(bits),
+            FeaturesWebGPU::empty()
+        );
 
-        for feature in Features::FLAGS {
+        for feature in FeaturesWebGPU::FLAGS {
             let bits = feature.value().bits();
-            assert_eq!(Features::from_bits_truncate(bits), *feature.value());
+            assert_eq!(FeaturesWebGPU::from_bits_truncate(bits), *feature.value());
         }
 
-        let bits = Features::all().bits();
-        assert_eq!(Features::from_bits(bits).unwrap(), Features::all());
+        let bits = FeaturesWGPU::all().bits();
+        assert_eq!(FeaturesWGPU::from_bits(bits).unwrap(), FeaturesWGPU::all());
 
-        let bits = Features::empty().bits();
-        assert_eq!(Features::from_bits(bits).unwrap(), Features::empty());
+        let bits = FeaturesWGPU::empty().bits();
+        assert_eq!(
+            FeaturesWGPU::from_bits(bits).unwrap(),
+            FeaturesWGPU::empty()
+        );
 
-        for feature in Features::FLAGS {
+        for feature in FeaturesWGPU::FLAGS {
             let bits = feature.value().bits();
-            assert_eq!(Features::from_bits(bits).unwrap(), *feature.value());
+            assert_eq!(FeaturesWGPU::from_bits(bits).unwrap(), *feature.value());
+        }
+    }
+
+    #[test]
+    fn features_names() {
+        for feature in Features::FLAGS.iter().map(Flag::value).copied() {
+            let Some(name) = feature.as_str() else {
+                panic!("`.as_str()` for {feature:?} returned `None`");
+            };
+            assert_eq!(name.parse(), Ok(feature));
+
+            // Native-only features that are accepted without `wgpu-` prefix for backwards compatibility
+            let prefix_backcompat_features = [
+                Features::EXTERNAL_TEXTURE,
+                Features::TEXTURE_FORMAT_16BIT_NORM,
+                Features::TEXTURE_COMPRESSION_ASTC_HDR,
+                Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
+                Features::PIPELINE_STATISTICS_QUERY,
+                Features::TIMESTAMP_QUERY_INSIDE_PASSES,
+                Features::MAPPABLE_PRIMARY_BUFFERS,
+                Features::TEXTURE_BINDING_ARRAY,
+                Features::BUFFER_BINDING_ARRAY,
+                Features::STORAGE_RESOURCE_BINDING_ARRAY,
+                Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
+                Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
+                Features::UNIFORM_BUFFER_BINDING_ARRAYS,
+                Features::PARTIALLY_BOUND_BINDING_ARRAY,
+                Features::MULTI_DRAW_INDIRECT_COUNT,
+                Features::ADDRESS_MODE_CLAMP_TO_ZERO,
+                Features::ADDRESS_MODE_CLAMP_TO_BORDER,
+                Features::POLYGON_MODE_LINE,
+                Features::POLYGON_MODE_POINT,
+                Features::CONSERVATIVE_RASTERIZATION,
+                Features::VERTEX_WRITABLE_STORAGE,
+                Features::CLEAR_TEXTURE,
+                Features::MULTIVIEW,
+                Features::VERTEX_ATTRIBUTE_64BIT,
+                Features::SHADER_F64,
+                Features::SHADER_I16,
+                Features::SHADER_EARLY_DEPTH_TEST,
+                Features::PASSTHROUGH_SHADERS,
+            ];
+
+            if feature == Features::SUBGROUP {
+                // Standard-track feature that does not have `wgpu-` prefix
+                assert_eq!(name.parse(), Ok(feature));
+            } else if feature & Features::all_native_mask() != Features::empty() {
+                let stripped_name = name.strip_prefix("wgpu-").unwrap_or_else(|| {
+                    panic!("Native feature `{name}` should have `wgpu-` prefix")
+                });
+                let expected = if prefix_backcompat_features.contains(&feature) {
+                    Ok(feature)
+                } else {
+                    Err(())
+                };
+                assert_eq!(stripped_name.parse(), expected);
+            }
+
+            // Special backcompat case
+            if feature == Features::PRIMITIVE_INDEX {
+                assert_eq!("shader-primitive-index".parse(), Ok(feature));
+            }
         }
     }
 


### PR DESCRIPTION
Moves feature name logic from deno to wgpu-types so we can use it in other clients, and so that it will stay up-to-date as features are added.

Adds the `wgpu-` prefix to all the native features, but for the ones that were previously accepted without it, continues to do so. Exceptions: `subgroups` and `primitive-index` are currently grouped with the wgpu features, but are standard-track features, so they use the standard-defined feature name. There is also a special backcompat case to accept `shader-primitive-index` as an alias for `primitive-index`. I'm not sure how necessary all the backcompat handling is.

**Testing**
Adds a unit test.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] Needs a `CHANGELOG.md` entry, although really it's the Deno changelog that matters.