### PR TITLE
chore: restore correctness commentary removed in #9074

### DIFF
--- a/naga/src/back/spv/helpers.rs
+++ b/naga/src/back/spv/helpers.rs
@@ -189,6 +189,7 @@ impl StrUnstable for str {
                 .iter()
                 .rposition(|b| b.is_utf8_char_boundary_polyfill());
 
+            // We know that the character boundary will be within four bytes.
             lower_bound + new_index.unwrap()
         }
     }

--- a/naga/src/proc/layouter.rs
+++ b/naga/src/proc/layouter.rs
@@ -22,6 +22,7 @@ impl Alignment {
 
     pub const fn new(n: u32) -> Option<Self> {
         if n.is_power_of_two() {
+            // Value can't be 0 since we just checked if it's a power of 2.
             Some(Self(NonZeroU32::new(n).unwrap()))
         } else {
             None
@@ -70,6 +71,7 @@ impl ops::Mul for Alignment {
     type Output = Alignment;
 
     fn mul(self, rhs: Alignment) -> Self::Output {
+        // Both lhs and rhs are powers of 2, the result will be a power of 2.
         Self(NonZeroU32::new(self.0.get() * rhs.0.get()).unwrap())
     }
 }


### PR DESCRIPTION
Decided at @teoxoy's initiative in
<https://docs.google.com/document/d/1Z3qjy3m7eAYaTsh2n-iKxLV4Hjc6wZxgukzdQOgVH1c/edit?tab=t.v1fec2urzypm#heading=h.2mx2gk9c3m3e>.