### PR TITLE
fix(naga msl-out): Fix invalid MSL when vertex data and shader type are both f16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 - Naga uses wrapping arithmetic when evaluating dot products on concrete integer types (`u32` and `i32`). By @BKDaugherty in [#9142](https://github.com/gfx-rs/wgpu/pull/9142).
 - Disallow negation of a matrix in WGSL. By @andyleiserson in [#9157](https://github.com/gfx-rs/wgpu/pull/9157).
 - Fix evaluation order of compound assignment (e.g. `+=`) LHS and RHS. By @andyleiserson in [#9181](https://github.com/gfx-rs/wgpu/pull/9181).
+- Fixed invalid MSL when `float16`-format vertex input data was accessed via an `f16`-type variable in a vertex shader. By @andyleiserson in [#9166](https://github.com/gfx-rs/wgpu/pull/9166).
 
 #### Validation
 

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -209,12 +209,11 @@ impl TypeContext<'_> {
         ty.inner.scalar()
     }
 
-    fn vertex_input_dimension(&self) -> u32 {
+    fn vector_size(&self) -> Option<crate::VectorSize> {
         let ty = &self.gctx.types[self.handle];
         match ty.inner {
-            crate::TypeInner::Scalar(_) => 1,
-            crate::TypeInner::Vector { size, .. } => size as u32,
-            _ => unreachable!(),
+            crate::TypeInner::Vector { size, .. } => Some(size),
+            _ => None,
         }
     }
 }
@@ -4887,7 +4886,8 @@ template <typename A>
     fn write_unpacking_function(
         &mut self,
         format: back::msl::VertexFormat,
-    ) -> Result<(String, u32, u32), Error> {
+    ) -> Result<(String, u32, Option<crate::VectorSize>, crate::Scalar), Error> {
+        use crate::{Scalar, VectorSize};
         use back::msl::VertexFormat::*;
         match format {
             Uint8 => {
@@ -4895,7 +4895,7 @@ template <typename A>
                 writeln!(self.out, "uint {name}(metal::uchar b0) {{")?;
                 writeln!(self.out, "{}return uint(b0);", back::INDENT)?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 1, 1))
+                Ok((name, 1, None, Scalar::U32))
             }
             Uint8x2 => {
                 let name = self.namer.call("unpackUint8x2");
@@ -4906,7 +4906,7 @@ template <typename A>
                 )?;
                 writeln!(self.out, "{}return metal::uint2(b0, b1);", back::INDENT)?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 2, 2))
+                Ok((name, 2, Some(VectorSize::Bi), Scalar::U32))
             }
             Uint8x4 => {
                 let name = self.namer.call("unpackUint8x4");
@@ -4923,14 +4923,14 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 4))
+                Ok((name, 4, Some(VectorSize::Quad), Scalar::U32))
             }
             Sint8 => {
                 let name = self.namer.call("unpackSint8");
                 writeln!(self.out, "int {name}(metal::uchar b0) {{")?;
                 writeln!(self.out, "{}return int(as_type<char>(b0));", back::INDENT)?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 1, 1))
+                Ok((name, 1, None, Scalar::I32))
             }
             Sint8x2 => {
                 let name = self.namer.call("unpackSint8x2");
@@ -4946,7 +4946,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 2, 2))
+                Ok((name, 2, Some(VectorSize::Bi), Scalar::I32))
             }
             Sint8x4 => {
                 let name = self.namer.call("unpackSint8x4");
@@ -4966,7 +4966,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 4))
+                Ok((name, 4, Some(VectorSize::Quad), Scalar::I32))
             }
             Unorm8 => {
                 let name = self.namer.call("unpackUnorm8");
@@ -4977,7 +4977,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 1, 1))
+                Ok((name, 1, None, Scalar::F32))
             }
             Unorm8x2 => {
                 let name = self.namer.call("unpackUnorm8x2");
@@ -4993,7 +4993,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 2, 2))
+                Ok((name, 2, Some(VectorSize::Bi), Scalar::F32))
             }
             Unorm8x4 => {
                 let name = self.namer.call("unpackUnorm8x4");
@@ -5013,7 +5013,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 4))
+                Ok((name, 4, Some(VectorSize::Quad), Scalar::F32))
             }
             Snorm8 => {
                 let name = self.namer.call("unpackSnorm8");
@@ -5024,7 +5024,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 1, 1))
+                Ok((name, 1, None, Scalar::F32))
             }
             Snorm8x2 => {
                 let name = self.namer.call("unpackSnorm8x2");
@@ -5040,7 +5040,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 2, 2))
+                Ok((name, 2, Some(VectorSize::Bi), Scalar::F32))
             }
             Snorm8x4 => {
                 let name = self.namer.call("unpackSnorm8x4");
@@ -5060,7 +5060,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 4))
+                Ok((name, 4, Some(VectorSize::Quad), Scalar::F32))
             }
             Uint16 => {
                 let name = self.namer.call("unpackUint16");
@@ -5075,7 +5075,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 2, 1))
+                Ok((name, 2, None, Scalar::U32))
             }
             Uint16x2 => {
                 let name = self.namer.call("unpackUint16x2");
@@ -5093,7 +5093,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 2))
+                Ok((name, 4, Some(VectorSize::Bi), Scalar::U32))
             }
             Uint16x4 => {
                 let name = self.namer.call("unpackUint16x4");
@@ -5117,7 +5117,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 8, 4))
+                Ok((name, 8, Some(VectorSize::Quad), Scalar::U32))
             }
             Sint16 => {
                 let name = self.namer.call("unpackSint16");
@@ -5132,7 +5132,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 2, 1))
+                Ok((name, 2, None, Scalar::I32))
             }
             Sint16x2 => {
                 let name = self.namer.call("unpackSint16x2");
@@ -5150,7 +5150,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 2))
+                Ok((name, 4, Some(VectorSize::Bi), Scalar::I32))
             }
             Sint16x4 => {
                 let name = self.namer.call("unpackSint16x4");
@@ -5174,7 +5174,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 8, 4))
+                Ok((name, 8, Some(VectorSize::Quad), Scalar::I32))
             }
             Unorm16 => {
                 let name = self.namer.call("unpackUnorm16");
@@ -5189,7 +5189,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 2, 1))
+                Ok((name, 2, None, Scalar::F32))
             }
             Unorm16x2 => {
                 let name = self.namer.call("unpackUnorm16x2");
@@ -5207,7 +5207,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 2))
+                Ok((name, 4, Some(VectorSize::Bi), Scalar::F32))
             }
             Unorm16x4 => {
                 let name = self.namer.call("unpackUnorm16x4");
@@ -5231,7 +5231,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 8, 4))
+                Ok((name, 8, Some(VectorSize::Quad), Scalar::F32))
             }
             Snorm16 => {
                 let name = self.namer.call("unpackSnorm16");
@@ -5246,7 +5246,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 2, 1))
+                Ok((name, 2, None, Scalar::F32))
             }
             Snorm16x2 => {
                 let name = self.namer.call("unpackSnorm16x2");
@@ -5263,7 +5263,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 2))
+                Ok((name, 4, Some(VectorSize::Bi), Scalar::F32))
             }
             Snorm16x4 => {
                 let name = self.namer.call("unpackSnorm16x4");
@@ -5285,7 +5285,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 8, 4))
+                Ok((name, 8, Some(VectorSize::Quad), Scalar::F32))
             }
             Float16 => {
                 let name = self.namer.call("unpackFloat16");
@@ -5300,7 +5300,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 2, 1))
+                Ok((name, 2, None, Scalar::F32))
             }
             Float16x2 => {
                 let name = self.namer.call("unpackFloat16x2");
@@ -5318,7 +5318,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 2))
+                Ok((name, 4, Some(VectorSize::Bi), Scalar::F32))
             }
             Float16x4 => {
                 let name = self.namer.call("unpackFloat16x4");
@@ -5342,7 +5342,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 8, 4))
+                Ok((name, 8, Some(VectorSize::Quad), Scalar::F32))
             }
             Float32 => {
                 let name = self.namer.call("unpackFloat32");
@@ -5359,7 +5359,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 1))
+                Ok((name, 4, None, Scalar::F32))
             }
             Float32x2 => {
                 let name = self.namer.call("unpackFloat32x2");
@@ -5381,7 +5381,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 8, 2))
+                Ok((name, 8, Some(VectorSize::Bi), Scalar::F32))
             }
             Float32x3 => {
                 let name = self.namer.call("unpackFloat32x3");
@@ -5408,7 +5408,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 12, 3))
+                Ok((name, 12, Some(VectorSize::Tri), Scalar::F32))
             }
             Float32x4 => {
                 let name = self.namer.call("unpackFloat32x4");
@@ -5440,7 +5440,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 16, 4))
+                Ok((name, 16, Some(VectorSize::Quad), Scalar::F32))
             }
             Uint32 => {
                 let name = self.namer.call("unpackUint32");
@@ -5457,7 +5457,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 1))
+                Ok((name, 4, None, Scalar::U32))
             }
             Uint32x2 => {
                 let name = self.namer.call("unpackUint32x2");
@@ -5479,7 +5479,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 8, 2))
+                Ok((name, 8, Some(VectorSize::Bi), Scalar::U32))
             }
             Uint32x3 => {
                 let name = self.namer.call("unpackUint32x3");
@@ -5506,7 +5506,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 12, 3))
+                Ok((name, 12, Some(VectorSize::Tri), Scalar::U32))
             }
             Uint32x4 => {
                 let name = self.namer.call("unpackUint32x4");
@@ -5538,7 +5538,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 16, 4))
+                Ok((name, 16, Some(VectorSize::Quad), Scalar::U32))
             }
             Sint32 => {
                 let name = self.namer.call("unpackSint32");
@@ -5555,7 +5555,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 1))
+                Ok((name, 4, None, Scalar::I32))
             }
             Sint32x2 => {
                 let name = self.namer.call("unpackSint32x2");
@@ -5577,7 +5577,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 8, 2))
+                Ok((name, 8, Some(VectorSize::Bi), Scalar::I32))
             }
             Sint32x3 => {
                 let name = self.namer.call("unpackSint32x3");
@@ -5604,7 +5604,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 12, 3))
+                Ok((name, 12, Some(VectorSize::Tri), Scalar::I32))
             }
             Sint32x4 => {
                 let name = self.namer.call("unpackSint32x4");
@@ -5636,7 +5636,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 16, 4))
+                Ok((name, 16, Some(VectorSize::Quad), Scalar::I32))
             }
             Unorm10_10_10_2 => {
                 let name = self.namer.call("unpackUnorm10_10_10_2");
@@ -5664,7 +5664,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 4))
+                Ok((name, 4, Some(VectorSize::Quad), Scalar::F32))
             }
             Unorm8x4Bgra => {
                 let name = self.namer.call("unpackUnorm8x4Bgra");
@@ -5684,7 +5684,7 @@ template <typename A>
                     back::INDENT
                 )?;
                 writeln!(self.out, "}}")?;
-                Ok((name, 4, 4))
+                Ok((name, 4, Some(VectorSize::Quad), Scalar::F32))
             }
         }
     }
@@ -6633,8 +6633,8 @@ template <typename A>
         // their attributes.
         struct AttributeMappingResolved {
             ty_name: String,
-            dimension: u32,
-            ty_is_int: bool,
+            dimension: Option<crate::VectorSize>,
+            scalar: crate::Scalar,
             name: String,
         }
         let mut am_resolved = FastHashMap::<u32, AttributeMappingResolved>::default();
@@ -6654,7 +6654,8 @@ template <typename A>
         struct UnpackingFunction {
             name: String,
             byte_count: u32,
-            dimension: u32,
+            dimension: Option<crate::VectorSize>,
+            scalar: crate::Scalar,
         }
         let mut unpacking_functions = FastHashMap::<VertexFormat, UnpackingFunction>::default();
 
@@ -6707,9 +6708,11 @@ template <typename A>
                     if unpacking_functions.contains_key(&attribute.format) {
                         continue;
                     }
-                    let (name, byte_count, dimension) =
+                    let (name, byte_count, dimension, scalar) =
                         match self.write_unpacking_function(attribute.format) {
-                            Ok((name, byte_count, dimension)) => (name, byte_count, dimension),
+                            Ok((name, byte_count, dimension, scalar)) => {
+                                (name, byte_count, dimension, scalar)
+                            }
                             _ => {
                                 continue;
                             }
@@ -6720,6 +6723,7 @@ template <typename A>
                             name,
                             byte_count,
                             dimension,
+                            scalar,
                         },
                     );
                 }
@@ -7085,8 +7089,8 @@ template <typename A>
                             location,
                             AttributeMappingResolved {
                                 ty_name: ty_name.to_string(),
-                                dimension: ty_name.vertex_input_dimension(),
-                                ty_is_int: ty_name.scalar().is_some_and(scalar_is_int),
+                                dimension: ty_name.vector_size(),
+                                scalar: ty_name.scalar().unwrap(),
                                 name: name.to_string(),
                             },
                         );
@@ -7619,8 +7623,11 @@ template <typename A>
                         // pad out the unpack value from a vec4(0, 0, 0, 1) of matching
                         // scalar type. Otherwise, if attribute dimension is < unpack
                         // dimension, then we need to explicitly truncate the result.
-
                         let needs_padding_or_truncation = am.dimension.cmp(&func.dimension);
+
+                        // We need an extra type conversion if the shader type does not
+                        // match the type returned from the unpacking function.
+                        let needs_conversion = am.scalar != func.scalar;
 
                         if needs_padding_or_truncation != Ordering::Equal {
                             // Emit a comment flagging that a conversion is happening,
@@ -7641,35 +7648,48 @@ template <typename A>
                         }
 
                         // Emit call to unpacking function
-                        write!(self.out, "{func_name}({elem_name}.data[{offset}]",)?;
+                        if needs_conversion {
+                            put_numeric_type(&mut self.out, am.scalar, func.dimension.as_slice())?;
+                            write!(self.out, "(")?;
+                        }
+                        write!(self.out, "{func_name}({elem_name}.data[{offset}]")?;
                         for i in (offset + 1)..(offset + func.byte_count) {
                             write!(self.out, ", {elem_name}.data[{i}]")?;
                         }
                         write!(self.out, ")")?;
+                        if needs_conversion {
+                            write!(self.out, ")")?;
+                        }
 
                         match needs_padding_or_truncation {
                             Ordering::Greater => {
                                 // Padding
-                                let zero_value = if am.ty_is_int { "0" } else { "0.0" };
-                                let one_value = if am.ty_is_int { "1" } else { "1.0" };
-                                for i in func.dimension..am.dimension {
+                                let ty_is_int = scalar_is_int(am.scalar);
+                                let zero_value = if ty_is_int { "0" } else { "0.0" };
+                                let one_value = if ty_is_int { "1" } else { "1.0" };
+                                for i in func.dimension.map_or(1, u8::from)
+                                    ..am.dimension.map_or(1, u8::from)
+                                {
                                     write!(
                                         self.out,
                                         ", {}",
                                         if i == 3 { one_value } else { zero_value }
                                     )?;
                                 }
-                                write!(self.out, ")")?;
                             }
                             Ordering::Less => {
                                 // Truncate to the first `am.dimension` components
                                 write!(
                                     self.out,
                                     ".{}",
-                                    &"xyzw"[0..usize::try_from(am.dimension).unwrap()]
+                                    &"xyzw"[0..usize::from(am.dimension.map_or(1, u8::from))]
                                 )?;
                             }
                             Ordering::Equal => {}
+                        }
+
+                        if needs_padding_or_truncation == Ordering::Greater {
+                            write!(self.out, ")")?;
                         }
 
                         writeln!(self.out, ";")?;

--- a/naga/tests/in/wgsl/msl-vpt-formats-x1.toml
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x1.toml
@@ -1,4 +1,5 @@
 targets = "METAL"
+capabilities = "SHADER_FLOAT16"
 
 [msl_pipeline]
 allow_and_force_point_size = false
@@ -47,7 +48,10 @@ attributes = [
     { offset = 608, shader_location = 38, format = "Sint32x4" },
     { offset = 624, shader_location = 39, format = "unorm10-10-10-2" },
     { offset = 640, shader_location = 40, format = "unorm8x4-bgra" },
+    { offset = 656, shader_location = 41, format = "Float16" },
+    { offset = 672, shader_location = 42, format = "Float16x2" },
+    { offset = 688, shader_location = 43, format = "Float16x4" },
 ]
 id = 1
 step_mode = "ByVertex"
-stride = 644
+stride = 704

--- a/naga/tests/in/wgsl/msl-vpt-formats-x1.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x1.wgsl
@@ -5,6 +5,8 @@
 // (Note: only the wgsl files are different for each of the -formats-xN tests.
 // The toml files are all the same.)
 
+enable f16;
+
 struct VertexOutput {
   @builtin(position) position: vec4<f32>,
 }
@@ -51,6 +53,10 @@ struct VertexInput {
   @location(38) v_sint32x4  : i32,
   @location(39) v_unorm10_10_10_2: f32,
   @location(40) v_unorm8x4_bgra: f32,
+
+  @location(41) v_float16_as_f16   : f16,
+  @location(42) v_float16x2_as_f16 : f16,
+  @location(43) v_float16x4_as_f16 : f16,
 }
 
 @vertex

--- a/naga/tests/in/wgsl/msl-vpt-formats-x2.toml
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x2.toml
@@ -1,4 +1,5 @@
 targets = "METAL"
+capabilities = "SHADER_FLOAT16"
 
 [msl_pipeline]
 allow_and_force_point_size = false
@@ -47,7 +48,10 @@ attributes = [
     { offset = 608, shader_location = 38, format = "Sint32x4" },
     { offset = 624, shader_location = 39, format = "unorm10-10-10-2" },
     { offset = 640, shader_location = 40, format = "unorm8x4-bgra" },
+    { offset = 656, shader_location = 41, format = "Float16" },
+    { offset = 672, shader_location = 42, format = "Float16x2" },
+    { offset = 688, shader_location = 43, format = "Float16x4" },
 ]
 id = 1
 step_mode = "ByVertex"
-stride = 644
+stride = 704

--- a/naga/tests/in/wgsl/msl-vpt-formats-x2.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x2.wgsl
@@ -5,6 +5,8 @@
 // (Note: only the wgsl files are different for each of the -formats-xN tests.
 // The toml files are all the same.)
 
+enable f16;
+
 struct VertexOutput {
   @builtin(position) position: vec4<f32>,
 }
@@ -51,6 +53,10 @@ struct VertexInput {
   @location(38) v_sint32x4  : vec2<i32>,
   @location(39) v_unorm10_10_10_2: vec2<f32>,
   @location(40) v_unorm8x4_bgra: vec2<f32>,
+
+  @location(41) v_float16_as_f16   : vec2<f16>,
+  @location(42) v_float16x2_as_f16 : vec2<f16>,
+  @location(43) v_float16x4_as_f16 : vec2<f16>,
 }
 
 @vertex

--- a/naga/tests/in/wgsl/msl-vpt-formats-x3.toml
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x3.toml
@@ -1,4 +1,5 @@
 targets = "METAL"
+capabilities = "SHADER_FLOAT16"
 
 [msl_pipeline]
 allow_and_force_point_size = false
@@ -47,7 +48,10 @@ attributes = [
     { offset = 608, shader_location = 38, format = "Sint32x4" },
     { offset = 624, shader_location = 39, format = "unorm10-10-10-2" },
     { offset = 640, shader_location = 40, format = "unorm8x4-bgra" },
+    { offset = 656, shader_location = 41, format = "Float16" },
+    { offset = 672, shader_location = 42, format = "Float16x2" },
+    { offset = 688, shader_location = 43, format = "Float16x4" },
 ]
 id = 1
 step_mode = "ByVertex"
-stride = 644
+stride = 704

--- a/naga/tests/in/wgsl/msl-vpt-formats-x3.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x3.wgsl
@@ -5,6 +5,8 @@
 // (Note: only the wgsl files are different for each of the -formats-xN tests.
 // The toml files are all the same.)
 
+enable f16;
+
 struct VertexOutput {
   @builtin(position) position: vec4<f32>,
 }
@@ -51,6 +53,10 @@ struct VertexInput {
   @location(38) v_sint32x4  : vec3<i32>,
   @location(39) v_unorm10_10_10_2: vec3<f32>,
   @location(40) v_unorm8x4_bgra: vec3<f32>,
+
+  @location(41) v_float16_as_f16   : vec3<f16>,
+  @location(42) v_float16x2_as_f16 : vec3<f16>,
+  @location(43) v_float16x4_as_f16 : vec3<f16>,
 }
 
 @vertex

--- a/naga/tests/in/wgsl/msl-vpt-formats-x4.toml
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x4.toml
@@ -1,4 +1,5 @@
 targets = "METAL"
+capabilities = "SHADER_FLOAT16"
 
 [msl_pipeline]
 allow_and_force_point_size = false
@@ -47,7 +48,10 @@ attributes = [
     { offset = 608, shader_location = 38, format = "Sint32x4" },
     { offset = 624, shader_location = 39, format = "unorm10-10-10-2" },
     { offset = 640, shader_location = 40, format = "unorm8x4-bgra" },
+    { offset = 656, shader_location = 41, format = "Float16" },
+    { offset = 672, shader_location = 42, format = "Float16x2" },
+    { offset = 688, shader_location = 43, format = "Float16x4" },
 ]
 id = 1
 step_mode = "ByVertex"
-stride = 644
+stride = 704

--- a/naga/tests/in/wgsl/msl-vpt-formats-x4.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x4.wgsl
@@ -5,6 +5,8 @@
 // (Note: only the wgsl files are different for each of the -formats-xN tests.
 // The toml files are all the same.)
 
+enable f16;
+
 struct VertexOutput {
   @builtin(position) position: vec4<f32>,
 }
@@ -51,6 +53,10 @@ struct VertexInput {
   @location(38) v_sint32x4  : vec4<i32>,
   @location(39) v_unorm10_10_10_2: vec4<f32>,
   @location(40) v_unorm8x4_bgra: vec4<f32>,
+
+  @location(41) v_float16_as_f16   : vec4<f16>,
+  @location(42) v_float16x2_as_f16 : vec4<f16>,
+  @location(43) v_float16x4_as_f16 : vec4<f16>,
 }
 
 @vertex

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x1.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x1.metal
@@ -53,6 +53,10 @@ struct VertexInput {
     int v_sint32x4_;
     float v_unorm10_10_10_2_;
     float v_unorm8x4_bgra;
+    half v_float16_as_f16_;
+    half v_float16x2_as_f16_;
+    half v_float16x4_as_f16_;
+    char _pad44[2];
 };
 uint unpackUint8_(metal::uchar b0) {
     return uint(b0);
@@ -181,7 +185,7 @@ metal::float4 unpackUnorm8x4Bgra(metal::uchar b0, metal::uchar b1, metal::uchar 
 struct render_vertexOutput {
     metal::float4 position [[position]];
 };
-struct vb_1_type { metal::uchar data[644]; };
+struct vb_1_type { metal::uchar data[704]; };
 vertex render_vertexOutput render_vertex(
   uint v_id [[vertex_id]]
 , const device vb_1_type* vb_1_in [[buffer(1)]]
@@ -228,7 +232,10 @@ vertex render_vertexOutput render_vertex(
     int v_sint32x4_ = {};
     float v_unorm10_10_10_2_ = {};
     float v_unorm8x4_bgra = {};
-    if (v_id < (_buffer_sizes.buffer_size1 / 644)) {
+    half v_float16_as_f16_ = {};
+    half v_float16x2_as_f16_ = {};
+    half v_float16x4_as_f16_ = {};
+    if (v_id < (_buffer_sizes.buffer_size1 / 704)) {
         const vb_1_type vb_1_elem = vb_1_in[v_id];
         v_uint8_ = unpackUint8_(vb_1_elem.data[0]);
         // uint <- Uint8x2
@@ -300,8 +307,13 @@ vertex render_vertexOutput render_vertex(
         v_unorm10_10_10_2_ = unpackUnorm10_10_10_2_(vb_1_elem.data[624], vb_1_elem.data[625], vb_1_elem.data[626], vb_1_elem.data[627]).x;
         // float <- Unorm8x4Bgra
         v_unorm8x4_bgra = unpackUnorm8x4Bgra(vb_1_elem.data[640], vb_1_elem.data[641], vb_1_elem.data[642], vb_1_elem.data[643]).x;
+        v_float16_as_f16_ = half(unpackFloat16_(vb_1_elem.data[656], vb_1_elem.data[657]));
+        // half <- Float16x2
+        v_float16x2_as_f16_ = metal::half2(unpackFloat16x2_(vb_1_elem.data[672], vb_1_elem.data[673], vb_1_elem.data[674], vb_1_elem.data[675])).x;
+        // half <- Float16x4
+        v_float16x4_as_f16_ = metal::half4(unpackFloat16x4_(vb_1_elem.data[688], vb_1_elem.data[689], vb_1_elem.data[690], vb_1_elem.data[691], vb_1_elem.data[692], vb_1_elem.data[693], vb_1_elem.data[694], vb_1_elem.data[695])).x;
     }
-    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra };
+    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_ };
     const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_)};
     return render_vertexOutput { _tmp.position };
 }

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x2.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x2.metal
@@ -53,6 +53,10 @@ struct VertexInput {
     metal::int2 v_sint32x4_;
     metal::float2 v_unorm10_10_10_2_;
     metal::float2 v_unorm8x4_bgra;
+    metal::half2 v_float16_as_f16_;
+    metal::half2 v_float16x2_as_f16_;
+    metal::half2 v_float16x4_as_f16_;
+    char _pad44[4];
 };
 uint unpackUint8_(metal::uchar b0) {
     return uint(b0);
@@ -181,7 +185,7 @@ metal::float4 unpackUnorm8x4Bgra(metal::uchar b0, metal::uchar b1, metal::uchar 
 struct render_vertexOutput {
     metal::float4 position [[position]];
 };
-struct vb_1_type { metal::uchar data[644]; };
+struct vb_1_type { metal::uchar data[704]; };
 vertex render_vertexOutput render_vertex(
   uint v_id [[vertex_id]]
 , const device vb_1_type* vb_1_in [[buffer(1)]]
@@ -228,7 +232,10 @@ vertex render_vertexOutput render_vertex(
     metal::int2 v_sint32x4_ = {};
     metal::float2 v_unorm10_10_10_2_ = {};
     metal::float2 v_unorm8x4_bgra = {};
-    if (v_id < (_buffer_sizes.buffer_size1 / 644)) {
+    metal::half2 v_float16_as_f16_ = {};
+    metal::half2 v_float16x2_as_f16_ = {};
+    metal::half2 v_float16x4_as_f16_ = {};
+    if (v_id < (_buffer_sizes.buffer_size1 / 704)) {
         const vb_1_type vb_1_elem = vb_1_in[v_id];
         // metal::uint2 <- Uint8
         v_uint8_ = metal::uint2(unpackUint8_(vb_1_elem.data[0]), 0);
@@ -300,8 +307,13 @@ vertex render_vertexOutput render_vertex(
         v_unorm10_10_10_2_ = unpackUnorm10_10_10_2_(vb_1_elem.data[624], vb_1_elem.data[625], vb_1_elem.data[626], vb_1_elem.data[627]).xy;
         // metal::float2 <- Unorm8x4Bgra
         v_unorm8x4_bgra = unpackUnorm8x4Bgra(vb_1_elem.data[640], vb_1_elem.data[641], vb_1_elem.data[642], vb_1_elem.data[643]).xy;
+        // metal::half2 <- Float16
+        v_float16_as_f16_ = metal::half2(half(unpackFloat16_(vb_1_elem.data[656], vb_1_elem.data[657])), 0.0);
+        v_float16x2_as_f16_ = metal::half2(unpackFloat16x2_(vb_1_elem.data[672], vb_1_elem.data[673], vb_1_elem.data[674], vb_1_elem.data[675]));
+        // metal::half2 <- Float16x4
+        v_float16x4_as_f16_ = metal::half4(unpackFloat16x4_(vb_1_elem.data[688], vb_1_elem.data[689], vb_1_elem.data[690], vb_1_elem.data[691], vb_1_elem.data[692], vb_1_elem.data[693], vb_1_elem.data[694], vb_1_elem.data[695])).xy;
     }
-    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra };
+    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_ };
     const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_.x)};
     return render_vertexOutput { _tmp.position };
 }

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x3.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x3.metal
@@ -53,6 +53,10 @@ struct VertexInput {
     metal::int3 v_sint32x4_;
     metal::float3 v_unorm10_10_10_2_;
     metal::float3 v_unorm8x4_bgra;
+    metal::half3 v_float16_as_f16_;
+    metal::half3 v_float16x2_as_f16_;
+    metal::half3 v_float16x4_as_f16_;
+    char _pad44[8];
 };
 uint unpackUint8_(metal::uchar b0) {
     return uint(b0);
@@ -181,7 +185,7 @@ metal::float4 unpackUnorm8x4Bgra(metal::uchar b0, metal::uchar b1, metal::uchar 
 struct render_vertexOutput {
     metal::float4 position [[position]];
 };
-struct vb_1_type { metal::uchar data[644]; };
+struct vb_1_type { metal::uchar data[704]; };
 vertex render_vertexOutput render_vertex(
   uint v_id [[vertex_id]]
 , const device vb_1_type* vb_1_in [[buffer(1)]]
@@ -228,7 +232,10 @@ vertex render_vertexOutput render_vertex(
     metal::int3 v_sint32x4_ = {};
     metal::float3 v_unorm10_10_10_2_ = {};
     metal::float3 v_unorm8x4_bgra = {};
-    if (v_id < (_buffer_sizes.buffer_size1 / 644)) {
+    metal::half3 v_float16_as_f16_ = {};
+    metal::half3 v_float16x2_as_f16_ = {};
+    metal::half3 v_float16x4_as_f16_ = {};
+    if (v_id < (_buffer_sizes.buffer_size1 / 704)) {
         const vb_1_type vb_1_elem = vb_1_in[v_id];
         // metal::uint3 <- Uint8
         v_uint8_ = metal::uint3(unpackUint8_(vb_1_elem.data[0]), 0, 0);
@@ -309,8 +316,14 @@ vertex render_vertexOutput render_vertex(
         v_unorm10_10_10_2_ = unpackUnorm10_10_10_2_(vb_1_elem.data[624], vb_1_elem.data[625], vb_1_elem.data[626], vb_1_elem.data[627]).xyz;
         // metal::float3 <- Unorm8x4Bgra
         v_unorm8x4_bgra = unpackUnorm8x4Bgra(vb_1_elem.data[640], vb_1_elem.data[641], vb_1_elem.data[642], vb_1_elem.data[643]).xyz;
+        // metal::half3 <- Float16
+        v_float16_as_f16_ = metal::half3(half(unpackFloat16_(vb_1_elem.data[656], vb_1_elem.data[657])), 0.0, 0.0);
+        // metal::half3 <- Float16x2
+        v_float16x2_as_f16_ = metal::half3(metal::half2(unpackFloat16x2_(vb_1_elem.data[672], vb_1_elem.data[673], vb_1_elem.data[674], vb_1_elem.data[675])), 0.0);
+        // metal::half3 <- Float16x4
+        v_float16x4_as_f16_ = metal::half4(unpackFloat16x4_(vb_1_elem.data[688], vb_1_elem.data[689], vb_1_elem.data[690], vb_1_elem.data[691], vb_1_elem.data[692], vb_1_elem.data[693], vb_1_elem.data[694], vb_1_elem.data[695])).xyz;
     }
-    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra };
+    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_ };
     const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_.x)};
     return render_vertexOutput { _tmp.position };
 }

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x4.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x4.metal
@@ -53,6 +53,10 @@ struct VertexInput {
     metal::int4 v_sint32x4_;
     metal::float4 v_unorm10_10_10_2_;
     metal::float4 v_unorm8x4_bgra;
+    metal::half4 v_float16_as_f16_;
+    metal::half4 v_float16x2_as_f16_;
+    metal::half4 v_float16x4_as_f16_;
+    char _pad44[8];
 };
 uint unpackUint8_(metal::uchar b0) {
     return uint(b0);
@@ -181,7 +185,7 @@ metal::float4 unpackUnorm8x4Bgra(metal::uchar b0, metal::uchar b1, metal::uchar 
 struct render_vertexOutput {
     metal::float4 position [[position]];
 };
-struct vb_1_type { metal::uchar data[644]; };
+struct vb_1_type { metal::uchar data[704]; };
 vertex render_vertexOutput render_vertex(
   uint v_id [[vertex_id]]
 , const device vb_1_type* vb_1_in [[buffer(1)]]
@@ -228,7 +232,10 @@ vertex render_vertexOutput render_vertex(
     metal::int4 v_sint32x4_ = {};
     metal::float4 v_unorm10_10_10_2_ = {};
     metal::float4 v_unorm8x4_bgra = {};
-    if (v_id < (_buffer_sizes.buffer_size1 / 644)) {
+    metal::half4 v_float16_as_f16_ = {};
+    metal::half4 v_float16x2_as_f16_ = {};
+    metal::half4 v_float16x4_as_f16_ = {};
+    if (v_id < (_buffer_sizes.buffer_size1 / 704)) {
         const vb_1_type vb_1_elem = vb_1_in[v_id];
         // metal::uint4 <- Uint8
         v_uint8_ = metal::uint4(unpackUint8_(vb_1_elem.data[0]), 0, 0, 1);
@@ -298,8 +305,13 @@ vertex render_vertexOutput render_vertex(
         v_sint32x4_ = unpackSint32x4_(vb_1_elem.data[608], vb_1_elem.data[609], vb_1_elem.data[610], vb_1_elem.data[611], vb_1_elem.data[612], vb_1_elem.data[613], vb_1_elem.data[614], vb_1_elem.data[615], vb_1_elem.data[616], vb_1_elem.data[617], vb_1_elem.data[618], vb_1_elem.data[619], vb_1_elem.data[620], vb_1_elem.data[621], vb_1_elem.data[622], vb_1_elem.data[623]);
         v_unorm10_10_10_2_ = unpackUnorm10_10_10_2_(vb_1_elem.data[624], vb_1_elem.data[625], vb_1_elem.data[626], vb_1_elem.data[627]);
         v_unorm8x4_bgra = unpackUnorm8x4Bgra(vb_1_elem.data[640], vb_1_elem.data[641], vb_1_elem.data[642], vb_1_elem.data[643]);
+        // metal::half4 <- Float16
+        v_float16_as_f16_ = metal::half4(half(unpackFloat16_(vb_1_elem.data[656], vb_1_elem.data[657])), 0.0, 0.0, 1.0);
+        // metal::half4 <- Float16x2
+        v_float16x2_as_f16_ = metal::half4(metal::half2(unpackFloat16x2_(vb_1_elem.data[672], vb_1_elem.data[673], vb_1_elem.data[674], vb_1_elem.data[675])), 0.0, 1.0);
+        v_float16x4_as_f16_ = metal::half4(unpackFloat16x4_(vb_1_elem.data[688], vb_1_elem.data[689], vb_1_elem.data[690], vb_1_elem.data[691], vb_1_elem.data[692], vb_1_elem.data[693], vb_1_elem.data[694], vb_1_elem.data[695]));
     }
-    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra };
+    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_ };
     const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_.x)};
     return render_vertexOutput { _tmp.position };
 }


### PR DESCRIPTION
Fix for [Firefox bug 2014998](https://bugzilla.mozilla.org/show_bug.cgi?id=2014998). 

For reasons that aren't clear to me, the unpacking functions for f16 vertex data return f32. My understanding is that Metal has universal f16 support, which should mean that the unpacking functions can return f16 and it can be implicitly promoted to f32 if that's what the shader wants. But I tried that first, and there were CTS failures. I didn't fully debug the CTS failures, but one thing I noticed is that the CTS always uses f32 to transfer expected data, so possibly the failure is due to some sort of accuracy issue?

**Testing**
Updates the vertex-pulling snapshot tests.

**Squash or Rebase?** Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
