### PR TITLE
feat(TextureFormat): implement `channels` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 - Added support for `insert_debug_marker`, `push_debug_group` and `pop_debug_group` on WebGPU. By @evilpie in [#9017](https://github.com/gfx-rs/wgpu/pull/9017).
 - Added support for `@builtin(draw_index)` to the vulkan backend. By @inner-daemons in #8883.
 - Added support for `enable primitive_index` and `@builtin(primitive_index)` with support on all platforms. By @inner-daemons in #8879.
+- Added `TextureFormat::channels` method to get some information about which color channels are covered by the texture format. By @TornaxO7 in [#9167](https://github.com/gfx-rs/wgpu/pull/9167)
 - BREAKING: Add `V6_8` variant to `DxcShaderModel` and `naga::back::hlsl::ShaderModel`. By @inner-daemons in [#8882](https://github.com/gfx-rs/wgpu/pull/8882) and @ErichDonGubler in [#9083](https://github.com/gfx-rs/wgpu/pull/9083).
 - BREAKING: Add `V6_9` variant to `DxcShaderModel` and `naga::back::hlsl::ShaderModel`. By @ErichDonGubler in [#????](https://github.com/gfx-rs/wgpu/pull/????).
 

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -505,15 +505,7 @@ impl TextureFormat {
     /// see <https://gpuweb.github.io/gpuweb/#depth-formats>
     #[must_use]
     pub fn is_depth_stencil_format(&self) -> bool {
-        match *self {
-            Self::Stencil8
-            | Self::Depth16Unorm
-            | Self::Depth24Plus
-            | Self::Depth24PlusStencil8
-            | Self::Depth32Float
-            | Self::Depth32FloatStencil8 => true,
-            _ => false,
-        }
+        TextureFormatChannel::DEPTH_STENCIL.intersects(self.channels())
     }
 
     /// Returns `true` if the format is a combined depth-stencil format
@@ -521,10 +513,8 @@ impl TextureFormat {
     /// see <https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format>
     #[must_use]
     pub fn is_combined_depth_stencil_format(&self) -> bool {
-        match *self {
-            Self::Depth24PlusStencil8 | Self::Depth32FloatStencil8 => true,
-            _ => false,
-        }
+        TextureFormatChannel::DEPTH_STENCIL.intersection(self.channels())
+            == TextureFormatChannel::DEPTH_STENCIL
     }
 
     /// Returns `true` if the format is a multi-planar format
@@ -683,29 +673,19 @@ impl TextureFormat {
     /// Returns `true` if the format has a color aspect
     #[must_use]
     pub fn has_color_aspect(&self) -> bool {
-        !self.is_depth_stencil_format()
+        TextureFormatChannel::RGBA.intersects(self.channels())
     }
 
     /// Returns `true` if the format has a depth aspect
     #[must_use]
     pub fn has_depth_aspect(&self) -> bool {
-        match *self {
-            Self::Depth16Unorm
-            | Self::Depth24Plus
-            | Self::Depth24PlusStencil8
-            | Self::Depth32Float
-            | Self::Depth32FloatStencil8 => true,
-            _ => false,
-        }
+        TextureFormatChannel::DEPTH.intersects(self.channels())
     }
 
     /// Returns `true` if the format has a stencil aspect
     #[must_use]
     pub fn has_stencil_aspect(&self) -> bool {
-        match *self {
-            Self::Stencil8 | Self::Depth24PlusStencil8 | Self::Depth32FloatStencil8 => true,
-            _ => false,
-        }
+        TextureFormatChannel::STENCIL.intersects(self.channels())
     }
 
     /// Returns the size multiple requirement for a texture using this format.
@@ -2636,5 +2616,134 @@ mod tests {
             serde_json::from_str::<TextureFormat>("\"eac-rg11snorm\"").unwrap(),
             TextureFormat::EacRg11Snorm
         );
+    }
+
+    /// test if `TextureFormat::is_depth_stencil_format` is behaving correctly
+    #[test]
+    fn is_depth_stencil_format() {
+        let depth_stencil_formats = [
+            TextureFormat::Stencil8,
+            TextureFormat::Depth16Unorm,
+            TextureFormat::Depth24Plus,
+            TextureFormat::Depth24PlusStencil8,
+            TextureFormat::Depth32Float,
+            TextureFormat::Depth32FloatStencil8,
+        ];
+
+        for format in depth_stencil_formats {
+            assert!(format.is_depth_stencil_format());
+        }
+
+        // some non-depth-stencil-formats shouldn't be accepted
+        let non_depth_stencil_formats = [
+            TextureFormat::R8Unorm,
+            TextureFormat::Rgba8Unorm,
+            TextureFormat::Rg16Uint,
+            TextureFormat::NV12,
+        ];
+
+        for format in non_depth_stencil_formats {
+            assert!(!format.is_depth_stencil_format());
+        }
+    }
+
+    /// test if `TextureFormat::is_combined_depth_stencil_format` is behaving correctly
+    #[test]
+    fn is_combined_depth_stencil_format() {
+        let valid_formats = [
+            TextureFormat::Depth24PlusStencil8,
+            TextureFormat::Depth32FloatStencil8,
+        ];
+
+        for format in valid_formats {
+            assert!(format.is_combined_depth_stencil_format());
+        }
+
+        let some_invalid_formats = [
+            TextureFormat::Depth16Unorm,
+            TextureFormat::Depth24Plus,
+            TextureFormat::Stencil8,
+            TextureFormat::Rgba8UnormSrgb,
+            TextureFormat::Rgba8Unorm,
+        ];
+
+        for format in some_invalid_formats {
+            assert!(!format.is_combined_depth_stencil_format());
+        }
+    }
+
+    /// test if `TextureFormat::has_color_aspect` is behaving correctly
+    #[test]
+    fn has_color_aspect() {
+        let some_valid_formats = [
+            TextureFormat::R8Unorm,
+            TextureFormat::Rg8Unorm,
+            TextureFormat::Bc7RgbaUnorm,
+            TextureFormat::Rgba8Unorm,
+        ];
+
+        for format in some_valid_formats {
+            assert!(format.has_color_aspect());
+        }
+
+        let some_invalid_formats = [
+            TextureFormat::NV12,
+            TextureFormat::Stencil8,
+            TextureFormat::Depth24PlusStencil8,
+        ];
+
+        for format in some_invalid_formats {
+            assert!(!format.has_color_aspect());
+        }
+    }
+
+    /// test if `TextureFormat::has_depth_aspect` is behaving correctly
+    #[test]
+    fn has_depth_aspect() {
+        let valid_formats = [
+            TextureFormat::Depth16Unorm,
+            TextureFormat::Depth24Plus,
+            TextureFormat::Depth24PlusStencil8,
+            TextureFormat::Depth32Float,
+            TextureFormat::Depth32FloatStencil8,
+        ];
+
+        for format in valid_formats {
+            assert!(format.has_depth_aspect());
+        }
+
+        let some_invalid_formats = [
+            TextureFormat::Rgba8Unorm,
+            TextureFormat::Bc7RgbaUnorm,
+            TextureFormat::Stencil8,
+        ];
+
+        for format in some_invalid_formats {
+            assert!(!format.has_depth_aspect());
+        }
+    }
+
+    /// test if `TextureFormat::has_stencil_aspect` is behaving correctly
+    #[test]
+    fn has_stencil_aspect() {
+        let valid_formats = [
+            TextureFormat::Stencil8,
+            TextureFormat::Depth24PlusStencil8,
+            TextureFormat::Depth32FloatStencil8,
+        ];
+
+        for format in valid_formats {
+            assert!(format.has_stencil_aspect());
+        }
+
+        let some_invalid_formats = [
+            TextureFormat::R8Unorm,
+            TextureFormat::Depth16Unorm,
+            TextureFormat::NV12,
+        ];
+
+        for format in some_invalid_formats {
+            assert!(!format.has_stencil_aspect());
+        }
     }
 }

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -65,7 +65,7 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[cfg_attr(feature = "serde", serde(transparent))]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct TextureFormatChannel: u8 {
+    pub struct TextureFormatChannel: u16 {
         /// Texture format contains a `red` channel.
         const RED = 1 << 0;
         /// Texture format contains a `green` channel.
@@ -80,8 +80,10 @@ bitflags::bitflags! {
         const DEPTH = 1 << 5;
         /// Texture format contains a `luminance` channel.
         const LUMINANCE = 1 << 6;
-        /// Texture format contains a `chrominance` channel.
-        const CHROMINANCE = 1 << 7;
+        /// Texture format contains a `blue-difference` channel.
+        const CHROMINANCE_BLUE = 1 << 7;
+        /// Texture format contains a `red-difference` channel.
+        const CHROMINANCE_RED = 1 << 8;
 
         /// Texture format contains channels for `red` and `green`.
         const RG = Self::RED.bits() | Self::GREEN.bits();
@@ -91,8 +93,8 @@ bitflags::bitflags! {
         const RGBA = Self::RGB.bits() | Self::ALPHA.bits();
         /// Texture format contains channels for `depth` and `stencil`.
         const DEPTH_STENCIL =  Self::DEPTH.bits() | Self::STENCIL.bits();
-        /// Texture format contains a `luminance` and `chrominance` channel.
-        const CHROMA = Self::LUMINANCE.bits() | Self::CHROMINANCE.bits();
+        /// Texture format contains a `luminance` (`Y`), `blue-difference` (`Cb`) and `red-difference` (`Cr`) channel.
+        const LUMINANCE_CHROMINANCE = Self::LUMINANCE.bits() | Self::CHROMINANCE_BLUE.bits() | Self::CHROMINANCE_RED.bits();
     }
 }
 
@@ -567,8 +569,8 @@ impl TextureFormat {
     ///
     /// // A stencil texture has a... stencil channel
     /// assert!(TextureFormat::Stencil8.channels().contains(TextureFormatChannel::STENCIL));
-    /// // And the `NV12` format should have a `luminance` and `chrominance` channel.
-    /// assert!(TextureFormat::NV12.channels().contains(TextureFormatChannel::CHROMA));
+    /// // And the `NV12` format should have a `luminance`, `blue-difference` and `red-difference` channel.
+    /// assert!(TextureFormat::NV12.channels().contains(TextureFormatChannel::LUMINANCE_CHROMINANCE));
     /// ```
     #[must_use]
     pub fn channels(&self) -> TextureFormatChannel {
@@ -655,7 +657,7 @@ impl TextureFormat {
                 TextureFormatChannel::DEPTH_STENCIL
             }
 
-            Self::NV12 | Self::P010 => TextureFormatChannel::CHROMA,
+            Self::NV12 | Self::P010 => TextureFormatChannel::LUMINANCE_CHROMINANCE,
         }
     }
 

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -505,7 +505,8 @@ impl TextureFormat {
     /// see <https://gpuweb.github.io/gpuweb/#depth-formats>
     #[must_use]
     pub fn is_depth_stencil_format(&self) -> bool {
-        self.channels().intersects(TextureFormatChannel::DEPTH_STENCIL)
+        self.channels()
+            .intersects(TextureFormatChannel::DEPTH_STENCIL)
     }
 
     /// Returns `true` if the format is a combined depth-stencil format
@@ -513,8 +514,8 @@ impl TextureFormat {
     /// see <https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format>
     #[must_use]
     pub fn is_combined_depth_stencil_format(&self) -> bool {
-        self.channels().contains(TextureFormatChannel::DEPTH_STENCIL)
-            == TextureFormatChannel::DEPTH_STENCIL
+        self.channels()
+            .contains(TextureFormatChannel::DEPTH_STENCIL)
     }
 
     /// Returns `true` if the format is a multi-planar format
@@ -554,32 +555,20 @@ impl TextureFormat {
     /// ```rust
     /// # use wgpu_types::{TextureFormat, TextureFormatChannel};
     ///
-    /// assert!(
-    ///     TextureFormat::Rgba8Unorm.channels().contains(TextureFormatChannel::RGBA),
-    ///     "`Rgba` has a `red`, `green`, `blue` and `alpha` channel!"
-    /// );
+    /// // `Rgba` has a `red`, `green`, `blue` and `alpha` channel!
+    /// assert!(TextureFormat::Rgba8Unorm.channels().contains(TextureFormatChannel::RGBA));
     ///
-    /// assert!(
-    ///     !TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::ALPHA),
-    ///     "`Rg` hasn't got an alpha channel..."
-    /// );
-    /// assert!(
-    ///     TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::RED),
-    ///     "... but it has a red channel ..."
-    /// );
-    /// assert!(
-    ///     TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::GREEN),
-    ///     "... and also a green channel (yay!)"
-    /// );
+    /// // `Rg` hasn't got an alpha channel...
+    /// assert!(!TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::ALPHA));
+    /// // ... but it has a red channel ...
+    /// assert!(TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::RED));
+    /// // ... and also a green channel (yay!)
+    /// assert!(TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::GREEN));
     ///
-    /// assert!(
-    ///     TextureFormat::Stencil8.channels().contains(TextureFormatChannel::STENCIL),
-    ///     "A stencil texture has a stencil channel _duh_"
-    /// );
-    /// assert!(
-    ///     TextureFormat::NV12.channels().contains(TextureFormatChannel::CHROMA),
-    ///     "And the `NV12` format should have a `luminance` and `chrominance` channel."
-    /// );
+    /// // A stencil texture has a... stencil channel
+    /// assert!(TextureFormat::Stencil8.channels().contains(TextureFormatChannel::STENCIL));
+    /// // And the `NV12` format should have a `luminance` and `chrominance` channel.
+    /// assert!(TextureFormat::NV12.channels().contains(TextureFormatChannel::CHROMA));
     /// ```
     #[must_use]
     pub fn channels(&self) -> TextureFormatChannel {

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -513,7 +513,7 @@ impl TextureFormat {
     /// see <https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format>
     #[must_use]
     pub fn is_combined_depth_stencil_format(&self) -> bool {
-        TextureFormatChannel::DEPTH_STENCIL.intersection(self.channels())
+        self.channels().contains(TextureFormatChannel::DEPTH_STENCIL)
             == TextureFormatChannel::DEPTH_STENCIL
     }
 

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use crate::{Features, TextureAspect, TextureSampleType, TextureUsages};
+use crate::{ColorWrites, Features, TextureAspect, TextureSampleType, TextureUsages};
 
 #[cfg(any(feature = "serde", test))]
 use serde::{Deserialize, Serialize};
@@ -517,6 +517,127 @@ impl TextureFormat {
                 None => unreachable!("the plane must be specified for multi-planar formats"),
             },
             _ => (1, 1),
+        }
+    }
+
+    /// Returns a [ColorWrites] struct with the bits set where the texture format contains
+    /// the color channels.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use wgpu_types::{TextureFormat, ColorWrites};
+    ///
+    /// assert!(
+    ///     TextureFormat::Rgba8Unorm.channels().contains(ColorWrites::all()),
+    ///     "`Rgba` has all four channels."
+    /// );
+    ///
+    /// assert!(
+    ///     !TextureFormat::Rg8Unorm.channels().contains(ColorWrites::ALPHA),
+    ///     "`Rg` hasn't got an alpha channel..."
+    /// );
+    /// assert!(
+    ///     TextureFormat::Rg8Unorm.channels().contains(ColorWrites::RED),
+    ///     "... but it has a red channel ..."
+    /// );
+    /// assert!(
+    ///     TextureFormat::Rg8Unorm.channels().contains(ColorWrites::GREEN),
+    ///     "... but also a green channel :)"
+    /// );
+    ///
+    /// assert!(
+    ///     TextureFormat::Stencil8.channels().is_empty(),
+    ///     "A stencil texture format doesn't have any channels..."
+    /// );
+    /// assert!(
+    ///     !TextureFormat::Stencil8.channels().contains(ColorWrites::RED),
+    ///     "... so this should return `false`"
+    /// );
+    /// ```
+    #[must_use]
+    pub fn channels(&self) -> ColorWrites {
+        match self {
+            Self::R8Unorm
+            | Self::R8Snorm
+            | Self::R8Uint
+            | Self::R8Sint
+            | Self::R16Uint
+            | Self::R16Sint
+            | Self::R16Unorm
+            | Self::R16Snorm
+            | Self::R32Uint
+            | Self::R32Sint
+            | Self::R32Float
+            | Self::R16Float
+            | Self::R64Uint
+            | Self::Bc4RUnorm
+            | Self::Bc4RSnorm
+            | Self::EacR11Unorm
+            | Self::EacR11Snorm => ColorWrites::RED,
+
+            Self::Rg8Unorm
+            | Self::Rg8Snorm
+            | Self::Rg8Uint
+            | Self::Rg8Sint
+            | Self::Rg16Uint
+            | Self::Rg16Sint
+            | Self::Rg16Unorm
+            | Self::Rg16Snorm
+            | Self::Rg16Float
+            | Self::Rg32Uint
+            | Self::Rg32Sint
+            | Self::Rg32Float
+            | Self::Bc5RgUnorm
+            | Self::Bc5RgSnorm
+            | Self::EacRg11Unorm
+            | Self::EacRg11Snorm => ColorWrites::RED | ColorWrites::GREEN,
+
+            Self::Rgb9e5Ufloat
+            | Self::Rg11b10Ufloat
+            | Self::Bc6hRgbUfloat
+            | Self::Bc6hRgbFloat
+            | Self::Etc2Rgb8Unorm
+            | Self::Etc2Rgb8UnormSrgb => ColorWrites::RED | ColorWrites::GREEN | ColorWrites::BLUE,
+
+            Self::Rgba8Unorm
+            | Self::Rgba8UnormSrgb
+            | Self::Rgba8Snorm
+            | Self::Rgba8Uint
+            | Self::Rgba8Sint
+            | Self::Bgra8Unorm
+            | Self::Bgra8UnormSrgb
+            | Self::Rgb10a2Uint
+            | Self::Rgb10a2Unorm
+            | Self::Rgba16Uint
+            | Self::Rgba16Sint
+            | Self::Rgba16Unorm
+            | Self::Rgba16Snorm
+            | Self::Rgba16Float
+            | Self::Rgba32Uint
+            | Self::Rgba32Sint
+            | Self::Rgba32Float
+            | Self::Bc1RgbaUnorm
+            | Self::Bc1RgbaUnormSrgb
+            | Self::Bc2RgbaUnorm
+            | Self::Bc2RgbaUnormSrgb
+            | Self::Bc3RgbaUnorm
+            | Self::Bc3RgbaUnormSrgb
+            | Self::Bc7RgbaUnorm
+            | Self::Bc7RgbaUnormSrgb
+            | Self::Etc2Rgb8A1Unorm
+            | Self::Etc2Rgb8A1UnormSrgb
+            | Self::Etc2Rgba8Unorm
+            | Self::Etc2Rgba8UnormSrgb
+            | Self::Astc { .. } => ColorWrites::all(),
+
+            Self::Stencil8
+            | Self::Depth16Unorm
+            | Self::Depth24Plus
+            | Self::Depth24PlusStencil8
+            | Self::Depth32Float
+            | Self::Depth32FloatStencil8
+            | Self::NV12
+            | Self::P010 => ColorWrites::empty(),
         }
     }
 

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -664,19 +664,19 @@ impl TextureFormat {
     /// Returns `true` if the format has a color aspect
     #[must_use]
     pub fn has_color_aspect(&self) -> bool {
-        TextureFormatChannel::RGBA.intersects(self.channels())
+        self.channels().intersects(TextureFormatChannel::RGBA)
     }
 
     /// Returns `true` if the format has a depth aspect
     #[must_use]
     pub fn has_depth_aspect(&self) -> bool {
-        TextureFormatChannel::DEPTH.intersects(self.channels())
+        self.channels().intersects(TextureFormatChannel::DEPTH)
     }
 
     /// Returns `true` if the format has a stencil aspect
     #[must_use]
     pub fn has_stencil_aspect(&self) -> bool {
-        TextureFormatChannel::STENCIL.intersects(self.channels())
+        self.channels().intersects(TextureFormatChannel::STENCIL)
     }
 
     /// Returns the size multiple requirement for a texture using this format.

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -65,7 +65,7 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[cfg_attr(feature = "serde", serde(transparent))]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct TextureFormatChannel: u16 {
+    pub struct TextureChannel: u16 {
         /// Texture format contains a `red` channel.
         const RED = 1 << 0;
         /// Texture format contains a `green` channel.
@@ -507,8 +507,7 @@ impl TextureFormat {
     /// see <https://gpuweb.github.io/gpuweb/#depth-formats>
     #[must_use]
     pub fn is_depth_stencil_format(&self) -> bool {
-        self.channels()
-            .intersects(TextureFormatChannel::DEPTH_STENCIL)
+        self.channels().intersects(TextureChannel::DEPTH_STENCIL)
     }
 
     /// Returns `true` if the format is a combined depth-stencil format
@@ -516,8 +515,7 @@ impl TextureFormat {
     /// see <https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format>
     #[must_use]
     pub fn is_combined_depth_stencil_format(&self) -> bool {
-        self.channels()
-            .contains(TextureFormatChannel::DEPTH_STENCIL)
+        self.channels().contains(TextureChannel::DEPTH_STENCIL)
     }
 
     /// Returns `true` if the format is a multi-planar format
@@ -550,30 +548,30 @@ impl TextureFormat {
         }
     }
 
-    /// Returns a [TextureFormatChannel] with the bits set where the texture format contains
+    /// Returns a [TextureChannel] with the bits set where the texture format contains
     /// the respective channels.
     ///
     /// # Example
     /// ```rust
-    /// # use wgpu_types::{TextureFormat, TextureFormatChannel};
+    /// # use wgpu_types::{TextureFormat, TextureChannel};
     ///
     /// // `Rgba` has a `red`, `green`, `blue` and `alpha` channel!
-    /// assert!(TextureFormat::Rgba8Unorm.channels().contains(TextureFormatChannel::RGBA));
+    /// assert!(TextureFormat::Rgba8Unorm.channels().contains(TextureChannel::RGBA));
     ///
     /// // `Rg` hasn't got an alpha channel...
-    /// assert!(!TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::ALPHA));
+    /// assert!(!TextureFormat::Rg8Unorm.channels().contains(TextureChannel::ALPHA));
     /// // ... but it has a red channel ...
-    /// assert!(TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::RED));
+    /// assert!(TextureFormat::Rg8Unorm.channels().contains(TextureChannel::RED));
     /// // ... and also a green channel (yay!)
-    /// assert!(TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::GREEN));
+    /// assert!(TextureFormat::Rg8Unorm.channels().contains(TextureChannel::GREEN));
     ///
     /// // A stencil texture has a... stencil channel
-    /// assert!(TextureFormat::Stencil8.channels().contains(TextureFormatChannel::STENCIL));
+    /// assert!(TextureFormat::Stencil8.channels().contains(TextureChannel::STENCIL));
     /// // And the `NV12` format should have a `luminance`, `blue-difference` and `red-difference` channel.
-    /// assert!(TextureFormat::NV12.channels().contains(TextureFormatChannel::LUMINANCE_CHROMINANCE));
+    /// assert!(TextureFormat::NV12.channels().contains(TextureChannel::LUMINANCE_CHROMINANCE));
     /// ```
     #[must_use]
-    pub fn channels(&self) -> TextureFormatChannel {
+    pub fn channels(&self) -> TextureChannel {
         match self {
             Self::R8Unorm
             | Self::R8Snorm
@@ -591,7 +589,7 @@ impl TextureFormat {
             | Self::Bc4RUnorm
             | Self::Bc4RSnorm
             | Self::EacR11Unorm
-            | Self::EacR11Snorm => TextureFormatChannel::RED,
+            | Self::EacR11Snorm => TextureChannel::RED,
 
             Self::Rg8Unorm
             | Self::Rg8Snorm
@@ -608,14 +606,14 @@ impl TextureFormat {
             | Self::Bc5RgUnorm
             | Self::Bc5RgSnorm
             | Self::EacRg11Unorm
-            | Self::EacRg11Snorm => TextureFormatChannel::RG,
+            | Self::EacRg11Snorm => TextureChannel::RG,
 
             Self::Rgb9e5Ufloat
             | Self::Rg11b10Ufloat
             | Self::Bc6hRgbUfloat
             | Self::Bc6hRgbFloat
             | Self::Etc2Rgb8Unorm
-            | Self::Etc2Rgb8UnormSrgb => TextureFormatChannel::RGB,
+            | Self::Etc2Rgb8UnormSrgb => TextureChannel::RGB,
 
             Self::Rgba8Unorm
             | Self::Rgba8UnormSrgb
@@ -646,37 +644,33 @@ impl TextureFormat {
             | Self::Etc2Rgb8A1UnormSrgb
             | Self::Etc2Rgba8Unorm
             | Self::Etc2Rgba8UnormSrgb
-            | Self::Astc { .. } => TextureFormatChannel::RGBA,
+            | Self::Astc { .. } => TextureChannel::RGBA,
 
-            Self::Stencil8 => TextureFormatChannel::STENCIL,
-            Self::Depth16Unorm | Self::Depth24Plus | Self::Depth32Float => {
-                TextureFormatChannel::DEPTH
-            }
+            Self::Stencil8 => TextureChannel::STENCIL,
+            Self::Depth16Unorm | Self::Depth24Plus | Self::Depth32Float => TextureChannel::DEPTH,
 
-            Self::Depth24PlusStencil8 | Self::Depth32FloatStencil8 => {
-                TextureFormatChannel::DEPTH_STENCIL
-            }
+            Self::Depth24PlusStencil8 | Self::Depth32FloatStencil8 => TextureChannel::DEPTH_STENCIL,
 
-            Self::NV12 | Self::P010 => TextureFormatChannel::LUMINANCE_CHROMINANCE,
+            Self::NV12 | Self::P010 => TextureChannel::LUMINANCE_CHROMINANCE,
         }
     }
 
     /// Returns `true` if the format has a color aspect
     #[must_use]
     pub fn has_color_aspect(&self) -> bool {
-        self.channels().intersects(TextureFormatChannel::RGBA)
+        self.channels().intersects(TextureChannel::RGBA)
     }
 
     /// Returns `true` if the format has a depth aspect
     #[must_use]
     pub fn has_depth_aspect(&self) -> bool {
-        self.channels().intersects(TextureFormatChannel::DEPTH)
+        self.channels().intersects(TextureChannel::DEPTH)
     }
 
     /// Returns `true` if the format has a stencil aspect
     #[must_use]
     pub fn has_stencil_aspect(&self) -> bool {
-        self.channels().intersects(TextureFormatChannel::STENCIL)
+        self.channels().intersects(TextureChannel::STENCIL)
     }
 
     /// Returns the size multiple requirement for a texture using this format.

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -505,7 +505,7 @@ impl TextureFormat {
     /// see <https://gpuweb.github.io/gpuweb/#depth-formats>
     #[must_use]
     pub fn is_depth_stencil_format(&self) -> bool {
-        TextureFormatChannel::DEPTH_STENCIL.intersects(self.channels())
+        self.channels().intersects(TextureFormatChannel::DEPTH_STENCIL)
     }
 
     /// Returns `true` if the format is a combined depth-stencil format

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -547,8 +547,8 @@ impl TextureFormat {
         }
     }
 
-    /// Returns a [ColorWrites] struct with the bits set where the texture format contains
-    /// the color channels.
+    /// Returns a [TextureFormatChannel] with the bits set where the texture format contains
+    /// the respective channels.
     ///
     /// # Example
     /// ```rust

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use crate::{ColorWrites, Features, TextureAspect, TextureSampleType, TextureUsages};
+use crate::{Features, TextureAspect, TextureSampleType, TextureUsages};
 
 #[cfg(any(feature = "serde", test))]
 use serde::{Deserialize, Serialize};
@@ -57,6 +57,43 @@ pub enum AstcChannel {
     ///
     /// [`Features::TEXTURE_COMPRESSION_ASTC_HDR`] must be enabled to use this channel.
     Hdr,
+}
+
+bitflags::bitflags! {
+    /// Represents the different format channels of a texture format.
+    #[repr(transparent)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serde", serde(transparent))]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct TextureFormatChannel: u8 {
+        /// Texture format contains a `red` channel.
+        const RED = 1 << 0;
+        /// Texture format contains a `green` channel.
+        const GREEN = 1 << 1;
+        /// Texture format contains a `blue` channel.
+        const BLUE = 1 << 2;
+        /// Texture format contains an `alpha` channel.
+        const ALPHA = 1 << 3;
+        /// Texture format contains a `stencil` channel.
+        const STENCIL = 1 << 4;
+        /// Texture format contains a `depth` channel.
+        const DEPTH = 1 << 5;
+        /// Texture format contains a `luminance` channel.
+        const LUMINANCE = 1 << 6;
+        /// Texture format contains a `chrominance` channel.
+        const CHROMINANCE = 1 << 7;
+
+        /// Texture format contains channels for `red` and `green`.
+        const RG = Self::RED.bits() | Self::GREEN.bits();
+        /// Texture format contains channels for `red`, `green` and `blue`.
+        const RGB = Self::RG.bits() | Self::BLUE.bits();
+        /// Texture format contains channels for `red`, `green`, `blue` and `alpha`.
+        const RGBA = Self::RGB.bits() | Self::ALPHA.bits();
+        /// Texture format contains channels for `depth` and `stencil`.
+        const DEPTH_STENCIL =  Self::DEPTH.bits() | Self::STENCIL.bits();
+        /// Texture format contains a `luminance` and `chrominance` channel.
+        const CHROMA = Self::LUMINANCE.bits() | Self::CHROMINANCE.bits();
+    }
 }
 
 /// Format in which a texture’s texels are stored in GPU memory.
@@ -525,37 +562,37 @@ impl TextureFormat {
     ///
     /// # Example
     /// ```rust
-    /// # use wgpu_types::{TextureFormat, ColorWrites};
+    /// # use wgpu_types::{TextureFormat, TextureFormatChannel};
     ///
     /// assert!(
-    ///     TextureFormat::Rgba8Unorm.channels().contains(ColorWrites::all()),
-    ///     "`Rgba` has all four channels."
+    ///     TextureFormat::Rgba8Unorm.channels().contains(TextureFormatChannel::RGBA),
+    ///     "`Rgba` has a `red`, `green`, `blue` and `alpha` channel!"
     /// );
     ///
     /// assert!(
-    ///     !TextureFormat::Rg8Unorm.channels().contains(ColorWrites::ALPHA),
+    ///     !TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::ALPHA),
     ///     "`Rg` hasn't got an alpha channel..."
     /// );
     /// assert!(
-    ///     TextureFormat::Rg8Unorm.channels().contains(ColorWrites::RED),
+    ///     TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::RED),
     ///     "... but it has a red channel ..."
     /// );
     /// assert!(
-    ///     TextureFormat::Rg8Unorm.channels().contains(ColorWrites::GREEN),
-    ///     "... but also a green channel :)"
+    ///     TextureFormat::Rg8Unorm.channels().contains(TextureFormatChannel::GREEN),
+    ///     "... and also a green channel (yay!)"
     /// );
     ///
     /// assert!(
-    ///     TextureFormat::Stencil8.channels().is_empty(),
-    ///     "A stencil texture format doesn't have any channels..."
+    ///     TextureFormat::Stencil8.channels().contains(TextureFormatChannel::STENCIL),
+    ///     "A stencil texture has a stencil channel _duh_"
     /// );
     /// assert!(
-    ///     !TextureFormat::Stencil8.channels().contains(ColorWrites::RED),
-    ///     "... so this should return `false`"
+    ///     TextureFormat::NV12.channels().contains(TextureFormatChannel::CHROMA),
+    ///     "And the `NV12` format should have a `luminance` and `chrominance` channel."
     /// );
     /// ```
     #[must_use]
-    pub fn channels(&self) -> ColorWrites {
+    pub fn channels(&self) -> TextureFormatChannel {
         match self {
             Self::R8Unorm
             | Self::R8Snorm
@@ -573,7 +610,7 @@ impl TextureFormat {
             | Self::Bc4RUnorm
             | Self::Bc4RSnorm
             | Self::EacR11Unorm
-            | Self::EacR11Snorm => ColorWrites::RED,
+            | Self::EacR11Snorm => TextureFormatChannel::RED,
 
             Self::Rg8Unorm
             | Self::Rg8Snorm
@@ -590,14 +627,14 @@ impl TextureFormat {
             | Self::Bc5RgUnorm
             | Self::Bc5RgSnorm
             | Self::EacRg11Unorm
-            | Self::EacRg11Snorm => ColorWrites::RED | ColorWrites::GREEN,
+            | Self::EacRg11Snorm => TextureFormatChannel::RG,
 
             Self::Rgb9e5Ufloat
             | Self::Rg11b10Ufloat
             | Self::Bc6hRgbUfloat
             | Self::Bc6hRgbFloat
             | Self::Etc2Rgb8Unorm
-            | Self::Etc2Rgb8UnormSrgb => ColorWrites::RED | ColorWrites::GREEN | ColorWrites::BLUE,
+            | Self::Etc2Rgb8UnormSrgb => TextureFormatChannel::RGB,
 
             Self::Rgba8Unorm
             | Self::Rgba8UnormSrgb
@@ -628,16 +665,18 @@ impl TextureFormat {
             | Self::Etc2Rgb8A1UnormSrgb
             | Self::Etc2Rgba8Unorm
             | Self::Etc2Rgba8UnormSrgb
-            | Self::Astc { .. } => ColorWrites::all(),
+            | Self::Astc { .. } => TextureFormatChannel::RGBA,
 
-            Self::Stencil8
-            | Self::Depth16Unorm
-            | Self::Depth24Plus
-            | Self::Depth24PlusStencil8
-            | Self::Depth32Float
-            | Self::Depth32FloatStencil8
-            | Self::NV12
-            | Self::P010 => ColorWrites::empty(),
+            Self::Stencil8 => TextureFormatChannel::STENCIL,
+            Self::Depth16Unorm | Self::Depth24Plus | Self::Depth32Float => {
+                TextureFormatChannel::DEPTH
+            }
+
+            Self::Depth24PlusStencil8 | Self::Depth32FloatStencil8 => {
+                TextureFormatChannel::DEPTH_STENCIL
+            }
+
+            Self::NV12 | Self::P010 => TextureFormatChannel::CHROMA,
         }
     }
 


### PR DESCRIPTION
**Connections**
None

**Description**
Adds a method to check if a texture format contains a given set of channels.

**Testing**
`cargo test --doc`

**Squash or Rebase?**

Eeeh... rebase? <img src="https://emojis.tornaxo7.de/catHmmm.png" width="30px"/>

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
