### PR TITLE
Support SSBOs and compute shaders when provided through GL extensions

### DIFF
--- a/naga/src/back/glsl/features.rs
+++ b/naga/src/back/glsl/features.rs
@@ -124,7 +124,7 @@ impl FeaturesManager {
         check_feature!(CLIP_DISTANCE, 130, 300 /* with extension */);
         check_feature!(CULL_DISTANCE, 450, 300 /* with extension */);
         check_feature!(SAMPLE_VARIABLES, 400, 300);
-        check_feature!(DYNAMIC_ARRAY_SIZE, 400, 310);
+        check_feature!(DYNAMIC_ARRAY_SIZE, 400 /* with extension */, 310);
         check_feature!(DUAL_SOURCE_BLENDING, 330, 300 /* with extension */);
         check_feature!(SUBGROUP_OPERATIONS, 430, 310);
         check_feature!(TEXTURE_ATOMICS, 420, 310);

--- a/naga/src/back/glsl/features.rs
+++ b/naga/src/back/glsl/features.rs
@@ -124,7 +124,7 @@ impl FeaturesManager {
         check_feature!(CLIP_DISTANCE, 130, 300 /* with extension */);
         check_feature!(CULL_DISTANCE, 450, 300 /* with extension */);
         check_feature!(SAMPLE_VARIABLES, 400, 300);
-        check_feature!(DYNAMIC_ARRAY_SIZE, 430, 310);
+        check_feature!(DYNAMIC_ARRAY_SIZE, 400, 310);
         check_feature!(DUAL_SOURCE_BLENDING, 330, 300 /* with extension */);
         check_feature!(SUBGROUP_OPERATIONS, 430, 310);
         check_feature!(TEXTURE_ATOMICS, 420, 310);

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -226,7 +226,7 @@ impl Version {
     }
 
     fn supports_std430_layout(&self) -> bool {
-        *self >= Version::Desktop(430) || *self >= Version::new_gles(310)
+        *self >= Version::Desktop(400) || *self >= Version::new_gles(310)
     }
 
     fn supports_fma_function(&self) -> bool {

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -226,6 +226,7 @@ impl Version {
     }
 
     fn supports_std430_layout(&self) -> bool {
+        // std430 is available from 400 via GL_ARB_shader_storage_buffer_object.
         *self >= Version::Desktop(400) || *self >= Version::new_gles(310)
     }
 

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -311,11 +311,10 @@ impl super::Adapter {
             es_supported || full_supported
         };
 
-        // Naga won't let you emit storage buffers at versions below this, so
-        // we currently can't support GL_ARB_shader_storage_buffer_object.
-        let supports_storage = supported((3, 1), (4, 3));
-        // Same with compute shaders and GL_ARB_compute_shader
-        let supports_compute = supported((3, 1), (4, 3));
+        let supports_storage =
+            supported((3, 1), (4, 3)) || extensions.contains("GL_ARB_shader_storage_buffer_object");
+        let supports_compute =
+            supported((3, 1), (4, 3)) || extensions.contains("GL_ARB_compute_shader");
         let supports_work_group_params = supports_compute;
 
         // ANGLE provides renderer strings like: "ANGLE (Apple, Apple M1 Pro, OpenGL 4.1)"


### PR DESCRIPTION
`GL_ARB_shader_storage_buffer_object` provides SSBOs, `std430` layout, and runtime-sized arrays from OpenGL 4.0. Naga currently gates these features to GLSL 430, blocking use of the extension. Relax these checks to match the extension minimums.

Intel HD 4000 is one such device that supports OpenGL 4.2 with `GL_ARB_shader_storage_buffer_object`. I have confirmed that this patch (in combination with https://github.com/gfx-rs/wgpu/pull/9153) enables use of SSBOs in wgpu on this hardware.