### PR TITLE
feat(deno): Add DXC env var to Deno; use DXC in cts_runner

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -17,7 +17,7 @@ env:
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
-  MSRV: "1.93"
+  REPO_MSRV: "1.93"
 
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times
@@ -83,8 +83,8 @@ jobs:
 
       - name: Install Repo MSRV toolchain
         run: |
-          rustup toolchain install ${{ env.MSRV }} --no-self-update --profile=minimal --target ${{ matrix.target }} --component llvm-tools
-          rustup override set ${{ env.MSRV }}
+          rustup toolchain install ${{ env.REPO_MSRV }} --no-self-update --profile=minimal --target ${{ matrix.target }} --component llvm-tools
+          rustup override set ${{ env.REPO_MSRV }}
           cargo -V
 
       - name: Install `cargo-llvm-cov`

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -14,10 +14,12 @@ on:
   merge_group:
 
 env:
+  REPO_MSRV: "1.93"
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
-  REPO_MSRV: "1.93"
+  RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings
 
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -17,6 +17,7 @@ env:
   REPO_MSRV: "1.93"
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
+  DENO_WEBGPU_DX12_COMPILER: dynamicdxc
   RUST_BACKTRACE: full
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,7 @@ dependencies = [
  "deno_webgpu",
  "deno_webidl",
  "env_logger",
+ "log",
  "pico-args",
  "tempfile",
  "termcolor",

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Testing, examples, and `::from_env()` methods use a standardized set of environm
 
 See the [documentation](https://docs.rs/wgpu/latest/wgpu/index.html?search=env) for more environment variables.
 
-When running the CTS, use the variables `DENO_WEBGPU_ADAPTER_NAME`, `DENO_WEBGPU_BACKEND`, `DENO_WEBGPU_POWER_PREFERENCE`.
+When running the CTS, use the variables `DENO_WEBGPU_ADAPTER_NAME`, `DENO_WEBGPU_BACKEND`, `DENO_WEBGPU_POWER_PREFERENCE`, and `DENO_WEBGPU_DX12_COMPILER`.
 
 ## Repo Overview
 

--- a/cts_runner/Cargo.toml
+++ b/cts_runner/Cargo.toml
@@ -20,6 +20,7 @@ deno_url.workspace = true
 deno_web.workspace = true
 deno_webidl.workspace = true
 deno_webgpu.workspace = true
+log.workspace = true
 pico-args.workspace = true
 tokio = { workspace = true, features = ["full"] }
 termcolor.workspace = true

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -64,6 +64,8 @@ webgpu:api,validation,resource_usages,texture,in_render_common:subresources,dept
 webgpu:api,validation,state,device_lost,destroy:* // crash
 webgpu:api,validation,texture,destroy:submit_a_destroyed_texture_as_attachment:* // 44%, https://github.com/gfx-rs/wgpu/issues/8714
 
+webgpu:shader,execution,expression,call,builtin,atan2:f16:* // dx12, fails with dxc, passes with fxc, https://github.com/gfx-rs/wgpu/issues/9179
+
 webgpu:shader,validation,decl,context_dependent_resolution:* // 92%, f16 as reserved keyword when enabled
 webgpu:shader,validation,decl,let:* // texture/sampler let
 webgpu:shader,validation,decl,override:* // 93%, unrestricted_pointer_parameters not implemented, https://github.com/gfx-rs/wgpu/issues/5158

--- a/cts_runner/src/main.rs
+++ b/cts_runner/src/main.rs
@@ -32,6 +32,28 @@ pub async fn run() -> Result<(), AnyError> {
         .ok_or_else(|| anyhow!("missing specifier in first command line argument"))?;
     let specifier = resolve_url_or_path(&url, &env::current_dir()?)?;
 
+    #[cfg(target_os = "windows")]
+    match env::var(deno_webgpu::DX12_COMPILER_ENV_VAR) {
+        Ok(val) => {
+            log::info!(
+                "Environment variable `{}` is set to `{val}`.",
+                deno_webgpu::DX12_COMPILER_ENV_VAR,
+            );
+        }
+        Err(_) => {
+            log::info!(
+                "cts_runner uses DXC by default. Configure with `{}` environment variable.",
+                deno_webgpu::DX12_COMPILER_ENV_VAR
+            );
+            unsafe {
+                // SAFETY: Both of the following conditions apply; either is sufficient.
+                // 1. Calling `env::set_var` is always safe on Windows.
+                // 2. We are single-threaded at this point.
+                env::set_var(deno_webgpu::DX12_COMPILER_ENV_VAR, "dynamicdxc");
+            }
+        }
+    }
+
     let options = RuntimeOptions {
         module_loader: Some(Rc::new(deno_core::FsModuleLoader)),
         extensions: vec![

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -289,7 +289,7 @@ webgpu:api,validation,texture,destroy:twice:*
 webgpu:api,validation,texture,float32_filterable:create_bind_group:*
 webgpu:api,validation,texture,rg11b10ufloat_renderable:*
 
-webgpu:shader,execution,expression,call,builtin,atan2:f16:*
+fails-if(dx12) webgpu:shader,execution,expression,call,builtin,atan2:f16:*
 webgpu:shader,execution,expression,call,builtin,atan2:f32:*
 webgpu:shader,execution,expression,call,builtin,dot:abstract_int_vec2:*
 webgpu:shader,execution,expression,call,builtin,dot:abstract_int_vec3:*

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -171,6 +171,9 @@ impl GPU {
   ) -> Option<adapter::GPUAdapter> {
     let mut state = state.borrow_mut();
 
+    let dx12_compiler = std::env::var("DENO_WEBGPU_DX12_COMPILER")
+      .ok()
+      .and_then(|s| s.parse().ok());
     let backends = std::env::var("DENO_WEBGPU_BACKEND").map_or_else(
       |_| wgpu_types::Backends::all(),
       |s| wgpu_types::Backends::from_comma_list(&s),
@@ -189,7 +192,8 @@ impl GPU {
           },
           backend_options: wgpu_types::BackendOptions {
             dx12: wgpu_types::Dx12BackendOptions {
-              shader_compiler: wgpu_types::Dx12Compiler::Fxc,
+              shader_compiler: dx12_compiler
+                .unwrap_or(wgpu_types::Dx12Compiler::Fxc),
               ..Default::default()
             },
             gl: wgpu_types::GlBackendOptions::default(),

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -44,6 +44,8 @@ mod webidl;
 
 pub const UNSTABLE_FEATURE_NAME: &str = "webgpu";
 
+pub const DX12_COMPILER_ENV_VAR: &str = "DENO_WEBGPU_DX12_COMPILER";
+
 #[allow(clippy::print_stdout)]
 pub fn print_linker_flags(name: &str) {
   if cfg!(windows) {
@@ -171,7 +173,7 @@ impl GPU {
   ) -> Option<adapter::GPUAdapter> {
     let mut state = state.borrow_mut();
 
-    let dx12_compiler = std::env::var("DENO_WEBGPU_DX12_COMPILER")
+    let dx12_compiler = std::env::var(DX12_COMPILER_ENV_VAR)
       .ok()
       .and_then(|s| s.parse().ok());
     let backends = std::env::var("DENO_WEBGPU_BACKEND").map_or_else(

--- a/wgpu-types/src/backend.rs
+++ b/wgpu-types/src/backend.rs
@@ -1,7 +1,7 @@
 //! [`Backend`], [`Backends`], and backend-specific options.
 
 use alloc::string::String;
-use core::hash::Hash;
+use core::{hash::Hash, str::FromStr};
 
 #[cfg(any(feature = "serde", test))]
 use serde::{Deserialize, Serialize};
@@ -632,16 +632,13 @@ impl Dx12Compiler {
     /// - `StaticDxc`
     #[must_use]
     pub fn from_env() -> Option<Self> {
-        let value = crate::env::var("WGPU_DX12_COMPILER")
-            .as_deref()?
-            .to_lowercase();
-        match value.as_str() {
-            "dxc" | "dynamicdxc" => Some(Self::default_dynamic_dxc()),
-            "staticdxc" => Some(Self::StaticDxc),
-            "fxc" => Some(Self::Fxc),
-            "auto" => Some(Self::Auto),
-            _ => None,
-        }
+        let env = crate::env::var("WGPU_DX12_COMPILER")?;
+        env.parse().map_err(|expected_msg| {
+            log::warn!(
+                "Unknown value `{env:?}` for `WGPU_DX12_COMPILER` environment variable. {expected_msg}"
+            )
+        })
+        .ok()
     }
 
     /// Takes the given compiler, modifies it based on the `WGPU_DX12_COMPILER` environment variable, and returns the result.
@@ -654,6 +651,20 @@ impl Dx12Compiler {
         } else {
             self
         }
+    }
+}
+
+impl FromStr for Dx12Compiler {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(match value.to_lowercase().as_str() {
+            "dxc" | "dynamicdxc" => Self::default_dynamic_dxc(),
+            "staticdxc" => Self::StaticDxc,
+            "fxc" => Self::Fxc,
+            "auto" => Self::Auto,
+            _ => return Err("Expected `dynamicdxc` (alias `dxc`), `staticdxc`, `fxc`, or `auto`."),
+        })
     }
 }
 


### PR DESCRIPTION
Add the environment variable `DENO_WEBGPU_DX12_COMPILER` to configure the DX12 shader compiler in Deno. Use it to select DXC in cts_runner.

Also syncs a few other env vars from `ci.yml` to `cts.yml`.

**Connections**
Fixes #9105.

**Testing**
Passes the currently enabled CTS tests, with one exception, filed as #9179.

**Squash or Rebase?** Rebase (after squashing fixup commit)