### PR TITLE
docs: Clarify description of newly-optional fields in DepthStencilState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,12 +69,15 @@ By @cwfitzgerald in [#8999](https://github.com/gfx-rs/wgpu/pull/8999).
 
 #### Depth/stencil state changes
 
-BREAKING CHANGE: The `depth_write_enabled` and `depth_compare` members of `DepthStencilState` are now optional, to match WebGPU.
+BREAKING CHANGE: The `depth_write_enabled` and `depth_compare` members of `DepthStencilState` are now optional, and may be omitted when they do not apply, to match WebGPU.
 
-The `depth_write_enabled` member must be `Some` if `format` has a depth aspect.
+`depth_write_enabled` is applicable, and must be `Some`, if `format` has a depth aspect, i.e., is a depth or depth/stencil format. Otherwise, a value of `None` best reflects that it does not apply, although `Some(false)` is also accepted.
 
-The `depth_compare_required` member must be `Some` if `depth_write_enabled` is `Some(true)`, or if `depth_fail_op` for either stencil face is not `Keep`.
+`depth_compare` is applicable, and must be `Some`, if `depth_write_enabled` is `Some(true)`, or if `depth_fail_op` for either stencil face is not `Keep`. Otherwise, a value of `None` best reflects that it does not apply, although `Some(CompareFunction::Always)` is also accepted.
 
+There is also a new constructor `DepthStencilState::stencil` which may be used instead of a struct literal for stencil operations.
+
+Example 1: A configuration that does a depth test and writes updated values:
 ```diff
  depth_stencil: Some(wgpu::DepthStencilState {
      format: wgpu::TextureFormat::Depth32Float,
@@ -87,12 +90,24 @@ The `depth_compare_required` member must be `Some` if `depth_write_enabled` is `
  }),
 ```
 
-There is also a new constructor `DepthStencilState::stencil` which may be used instead of a struct literal for stencil operations.
-
+Example 2: A configuration with only stencil:
+```diff
+ depth_stencil: Some(wgpu::DepthStencilState {
+     format: wgpu::TextureFormat::Stencil8,
+-    depth_write_enabled: false,
+-    depth_compare: wgpu::CompareFunction::Always,
++    depth_write_enabled: None,
++    depth_compare: None,
+     stencil: wgpu::StencilState::default(),
+     bias: wgpu::DepthBiasState::default(),
+ }),
 ```
+
+Example 3: The previous example written using the new `stencil()` constructor:
+```rust
 depth_stencil: Some(wgpu::DepthStencilState::stencil(
     wgpu::TextureFormat::Stencil8,
-    wgpu::StencilState { .. },
+    wgpu::StencilState::default(),
 )),
 ```
 

--- a/wgpu-types/src/render.rs
+++ b/wgpu-types/src/render.rs
@@ -808,12 +808,17 @@ pub struct DepthStencilState {
     ///
     #[doc = link_to_wgpu_docs!(["CEbrp"]: "struct.CommandEncoder.html#method.begin_render_pass")]
     pub format: crate::TextureFormat,
-    /// If disabled, depth will not be written to. Must be `Some` if `format` is
-    /// a depth format.
+    /// Whether to write updated depth values to the depth attachment.
+    ///
+    /// If `format` is a depth or depth/stencil format, then this must be `Some`.
+    /// Otherwise, specifying `None` is preferred, but `Some(false)` is also
+    /// accepted.
     pub depth_write_enabled: Option<bool>,
     /// Comparison function used to compare depth values in the depth test.
-    /// Must be `Some` if `depth_write_enabled` is `true` or either stencil face
-    /// `depth_fail_op` is not `Keep`.
+    ///
+    /// If `depth_write_enabled` is `Some(true)` or if `depth_fail_op` for either
+    /// stencil face is not `Keep`, then this must be `Some`. Otherwise, specifying
+    /// `None` is preferred, but `Some(CompareFunction::Always)` is also accepted.
     pub depth_compare: Option<CompareFunction>,
     /// Stencil state.
     #[cfg_attr(feature = "serde", serde(default))]


### PR DESCRIPTION
Related to #9178.

Updates the CHANGELOG and rustdoc of the `depth_write_enabled` and `depth_compare` fields in `DepthStencilState`, which were made optional in #8840.

The intent is to clarify:
1. These fields must be `Some` when they are applicable to the configuration.
2. The conditions when that is the case.
3. When not applicable to the configuration, the fields may be `None`, and it is probably clearest if they are `None`, but specific `Some` values are also accepted.

**Testing**
n/a

**Squash or Rebase?** Squash
