### PR TITLE
Annotate expected failures on Metal, MoltenVK, and KosmicKrisp

### DIFF
--- a/examples/features/src/big_compute_buffers/tests.rs
+++ b/examples/features/src/big_compute_buffers/tests.rs
@@ -16,7 +16,13 @@ pub static TWO_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
                 max_buffer_size: MAX_BUFFER_SIZE,
                 max_binding_array_elements_per_shader_stage: 8,
                 ..Default::default()
-            }),
+            })
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline"),
+            ),
     )
     .run_async(|ctx| {
         // The test environment's GPU reports 134MB as the max storage buffer size.https://github.com/gfx-rs/wgpu/actions/runs/11001397782/job/30546188996#step:12:1096

--- a/examples/features/src/ray_cube_compute/mod.rs
+++ b/examples/features/src/ray_cube_compute/mod.rs
@@ -469,7 +469,9 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     width: 1024,
     height: 768,
     optional_features: wgpu::Features::default(),
-    base_test_parameters: wgpu_test::TestParameters::default(),
+    base_test_parameters: wgpu_test::TestParameters::default()
+        // https://github.com/gfx-rs/wgpu/issues/9100
+        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/examples/features/src/ray_cube_fragment/mod.rs
+++ b/examples/features/src/ray_cube_fragment/mod.rs
@@ -355,7 +355,9 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     width: 1024,
     height: 768,
     optional_features: wgpu::Features::default(),
-    base_test_parameters: wgpu_test::TestParameters::default(),
+    base_test_parameters: wgpu_test::TestParameters::default()
+        // https://github.com/gfx-rs/wgpu/issues/9100
+        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/examples/features/src/ray_scene/mod.rs
+++ b/examples/features/src/ray_scene/mod.rs
@@ -535,7 +535,9 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     width: 1024,
     height: 768,
     optional_features: wgpu::Features::default(),
-    base_test_parameters: wgpu_test::TestParameters::default(),
+    base_test_parameters: wgpu_test::TestParameters::default()
+        // https://github.com/gfx-rs/wgpu/issues/9100
+        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/examples/features/src/ray_shadows/mod.rs
+++ b/examples/features/src/ray_shadows/mod.rs
@@ -352,7 +352,9 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     width: 1024,
     height: 768,
     optional_features: wgpu::Features::default(),
-    base_test_parameters: wgpu_test::TestParameters::default(),
+    base_test_parameters: wgpu_test::TestParameters::default()
+        // https://github.com/gfx-rs/wgpu/issues/9100
+        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/examples/features/src/ray_traced_triangle/mod.rs
+++ b/examples/features/src/ray_traced_triangle/mod.rs
@@ -438,7 +438,9 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     width: 1024,
     height: 768,
     optional_features: wgpu::Features::default(),
-    base_test_parameters: wgpu_test::TestParameters::default(),
+    base_test_parameters: wgpu_test::TestParameters::default()
+        // https://github.com/gfx-rs/wgpu/issues/9100
+        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/examples/features/src/texture_arrays/mod.rs
+++ b/examples/features/src/texture_arrays/mod.rs
@@ -439,7 +439,13 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     height: 768,
     optional_features: wgpu::Features::empty(),
     base_test_parameters: wgpu_test::TestParameters::default()
-        .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION),
+        .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
+        // https://github.com/gfx-rs/wgpu/issues/9184
+        .expect_fail(
+            wgpu_test::FailureCase::molten_vk()
+                .validation_error("Shader library compile failed")
+                .validation_error("could not be compiled into pipeline"),
+        ),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.0001)],
     _phantom: std::marker::PhantomData::<Example>,
 };
@@ -454,7 +460,13 @@ pub static TEST_UNIFORM: crate::framework::ExampleTestParams =
         height: 768,
         optional_features: wgpu::Features::empty(),
         base_test_parameters: wgpu_test::TestParameters::default()
-            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION),
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline"),
+            ),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.0001)],
         _phantom: std::marker::PhantomData::<Example>,
     };
@@ -470,7 +482,13 @@ pub static TEST_NON_UNIFORM: crate::framework::ExampleTestParams =
         optional_features:
             wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
         base_test_parameters: wgpu_test::TestParameters::default()
-            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION),
+            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline"),
+            ),
         comparisons: &[wgpu_test::ComparisonType::Mean(0.0001)],
         _phantom: std::marker::PhantomData::<Example>,
     };

--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -157,6 +157,20 @@ impl FailureCase {
         }
     }
 
+    /// Tests running on the KosmicKrisp Vulkan driver on macOS.
+    pub fn kosmic_krisp() -> Self {
+        FailureCase {
+            backends: Some(wgpu::Backends::VULKAN),
+            driver: Some("KosmicKrisp"),
+            ..FailureCase::default()
+        }
+    }
+
+    /// Tests running on either Vulkan driver on macOS.
+    pub fn mac_vulkan(f: impl Fn(FailureCase) -> FailureCase) -> Vec<Self> {
+        vec![f(FailureCase::molten_vk()), f(FailureCase::kosmic_krisp())]
+    }
+
     /// Return the reasons why this case should fail.
     pub fn reasons(&self) -> &[FailureReason] {
         if self.reasons.is_empty() {

--- a/tests/src/native.rs
+++ b/tests/src/native.rs
@@ -26,13 +26,23 @@ impl NativeTest {
         adapter_report: AdapterReport,
         adapter_index: usize,
     ) -> Self {
-        let backend = adapter_report.info.backend;
         let device_name = &adapter_report.info.name;
+        let backend = adapter_report.info.backend;
+        let driver = &adapter_report.info.driver;
+        let report_driver_as_backend = [
+            (wgpu::Backend::Vulkan, "MoltenVK"),
+            (wgpu::Backend::Vulkan, "KosmicKrisp"),
+        ];
+        let backend_str = if report_driver_as_backend.contains(&(backend, driver.as_ref())) {
+            driver.clone()
+        } else {
+            format!("{backend:?}")
+        };
 
         let test_info = TestInfo::from_configuration(&config, &adapter_report);
 
         let full_name = format!(
-            "[{running_msg}] [{backend:?}/{device_name}/{adapter_index}] {base_name}",
+            "[{running_msg}] [{backend_str}/{device_name}/{adapter_index}] {base_name}",
             running_msg = test_info.running_msg,
             base_name = config.name,
         );

--- a/tests/tests/wgpu-gpu/binding_array/buffers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/buffers.rs
@@ -58,41 +58,37 @@ static PARTIAL_BINDING_ARRAY_UNIFORM_BUFFERS: GpuTestConfiguration = GpuTestConf
 
 #[gpu_test]
 static BINDING_ARRAY_STORAGE_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
-            .features(
-                Features::BUFFER_BINDING_ARRAY
-                    | Features::STORAGE_RESOURCE_BINDING_ARRAY
-                    | Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
-            )
-            .limits(Limits {
-                max_binding_array_elements_per_shader_stage: 17,
-                ..Limits::default()
-            })
-            // See https://github.com/gfx-rs/wgpu/issues/6745.
-            .expect_fail(FailureCase::molten_vk()),
-    )
+    .parameters(TestParameters {
+        required_instance_flags: wgpu::InstanceFlags::GPU_BASED_VALIDATION,
+        required_features: Features::BUFFER_BINDING_ARRAY
+            | Features::STORAGE_RESOURCE_BINDING_ARRAY
+            | Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
+        required_limits: Limits {
+            max_binding_array_elements_per_shader_stage: 17,
+            ..Limits::default()
+        },
+        // See https://github.com/gfx-rs/wgpu/issues/6745.
+        failures: FailureCase::mac_vulkan(|case| case.panic("bad SPIR-V wrapper struct inference")),
+        ..Default::default()
+    })
     .run_async(|ctx| async move { binding_array_buffers(ctx, BufferType::Storage, false).await });
 
 #[gpu_test]
 static PARTIAL_BINDING_ARRAY_STORAGE_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
-            .features(
-                Features::BUFFER_BINDING_ARRAY
-                    | Features::PARTIALLY_BOUND_BINDING_ARRAY
-                    | Features::STORAGE_RESOURCE_BINDING_ARRAY
-                    | Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
-            )
-            .limits(Limits {
-                max_binding_array_elements_per_shader_stage: 33,
-                ..Limits::default()
-            })
-            // See https://github.com/gfx-rs/wgpu/issues/6745.
-            .expect_fail(FailureCase::molten_vk()),
-    )
+    .parameters(TestParameters {
+        required_instance_flags: wgpu::InstanceFlags::GPU_BASED_VALIDATION,
+        required_features: Features::BUFFER_BINDING_ARRAY
+            | Features::PARTIALLY_BOUND_BINDING_ARRAY
+            | Features::STORAGE_RESOURCE_BINDING_ARRAY
+            | Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
+        required_limits: Limits {
+            max_binding_array_elements_per_shader_stage: 33,
+            ..Limits::default()
+        },
+        // See https://github.com/gfx-rs/wgpu/issues/6745.
+        failures: FailureCase::mac_vulkan(|case| case.panic("bad SPIR-V wrapper struct inference")),
+        ..Default::default()
+    })
     .run_async(|ctx| async move { binding_array_buffers(ctx, BufferType::Storage, true).await });
 
 enum BufferType {

--- a/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
@@ -25,7 +25,13 @@ static BINDING_ARRAY_SAMPLED_TEXTURES: GpuTestConfiguration = GpuTestConfigurati
             .limits(Limits {
                 max_binding_array_elements_per_shader_stage: 16,
                 ..Limits::default()
-            }),
+            })
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline"),
+            ),
     )
     .run_async(|ctx| async move { binding_array_sampled_textures(ctx, false).await });
 
@@ -42,7 +48,13 @@ static PARTIAL_BINDING_ARRAY_SAMPLED_TEXTURES: GpuTestConfiguration = GpuTestCon
             .limits(Limits {
                 max_binding_array_elements_per_shader_stage: 32,
                 ..Limits::default()
-            }),
+            })
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline"),
+            ),
     )
     .run_async(|ctx| async move { binding_array_sampled_textures(ctx, false).await });
 

--- a/tests/tests/wgpu-gpu/binding_array/samplers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/samplers.rs
@@ -22,7 +22,13 @@ static BINDING_ARRAY_SAMPLERS: GpuTestConfiguration = GpuTestConfiguration::new(
                 max_binding_array_elements_per_shader_stage: 2,
                 max_binding_array_sampler_elements_per_shader_stage: 2,
                 ..Limits::default()
-            }),
+            })
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline"),
+            ),
     )
     .run_async(|ctx| async move { binding_array_samplers(ctx, false).await });
 
@@ -40,7 +46,13 @@ static PARTIAL_BINDING_ARRAY_SAMPLERS: GpuTestConfiguration = GpuTestConfigurati
                 max_binding_array_elements_per_shader_stage: 4,
                 max_binding_array_sampler_elements_per_shader_stage: 4,
                 ..Limits::default()
-            }),
+            })
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline"),
+            ),
     )
     .run_async(|ctx| async move { binding_array_samplers(ctx, true).await });
 

--- a/tests/tests/wgpu-gpu/clip_distances.rs
+++ b/tests/tests/wgpu-gpu/clip_distances.rs
@@ -8,7 +8,17 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 
 #[gpu_test]
 static CLIP_DISTANCES: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(wgpu::Features::CLIP_DISTANCES))
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::CLIP_DISTANCES)
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline")
+                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+            ),
+    )
     .run_async(clip_distances);
 
 async fn clip_distances(ctx: TestingContext) {

--- a/tests/tests/wgpu-gpu/draw_index.rs
+++ b/tests/tests/wgpu-gpu/draw_index.rs
@@ -66,7 +66,17 @@ fn fragment() -> @location(0) vec4<f32> {
 
 #[gpu_test]
 static DRAW_INDEX: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().features(Features::SHADER_DRAW_INDEX))
+    .parameters(
+        TestParameters::default()
+            .features(Features::SHADER_DRAW_INDEX)
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("could not be compiled into pipeline")
+                    .validation_error("vkDestroyDevice")
+                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+            ),
+    )
     .run_async(test);
 
 async fn test_mesh(ctx: TestingContext, use_task: bool, mesh_uses_draw_id: bool) {

--- a/tests/tests/wgpu-gpu/multiview/mod.rs
+++ b/tests/tests/wgpu-gpu/multiview/mod.rs
@@ -38,14 +38,20 @@ static DRAW_MULTIVIEW: GpuTestConfiguration = GpuTestConfiguration::new()
 
 #[gpu_test]
 static DRAW_MULTIVIEW_NONCONTIGUOUS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .features(Features::MULTIVIEW | Features::SELECTIVE_MULTIVIEW)
-            .limits(Limits {
-                max_multiview_view_count: 4,
-                ..Limits::defaults()
-            }),
-    )
+    .parameters(TestParameters {
+        required_features: Features::MULTIVIEW | Features::SELECTIVE_MULTIVIEW,
+        required_limits: Limits {
+            max_multiview_view_count: 4,
+            ..Limits::defaults()
+        },
+        // https://github.com/gfx-rs/wgpu/issues/9184 and https://github.com/gfx-rs/wgpu/issues/9187
+        failures: wgpu_test::FailureCase::mac_vulkan(|case| {
+            case.panic(
+                "assertion `left == right` failed: Expected 0\n  left: Some(255)\n right: None",
+            )
+        }),
+        ..Default::default()
+    })
     .run_async(|ctx| run_test(ctx, 0b1001, 1));
 
 #[gpu_test]

--- a/tests/tests/wgpu-gpu/oob_indexing.rs
+++ b/tests/tests/wgpu-gpu/oob_indexing.rs
@@ -17,7 +17,14 @@ static RESTRICT_WORKGROUP_PRIVATE_FUNCTION_LET: GpuTestConfiguration = GpuTestCo
         TestParameters::default()
             .downlevel_flags(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             .limits(wgpu::Limits::downlevel_defaults())
-            .skip(FailureCase::backend(Backends::GL)),
+            .skip(FailureCase::backend(Backends::GL))
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline")
+                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+            ),
     )
     .run_async(|ctx| async move {
         let test_resources = TestResources::new(&ctx);

--- a/tests/tests/wgpu-gpu/per_vertex/mod.rs
+++ b/tests/tests/wgpu-gpu/per_vertex/mod.rs
@@ -35,7 +35,13 @@ static PER_VERTEX: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::SHADER_PER_VERTEX),
+            .features(wgpu::Features::SHADER_PER_VERTEX)
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("could not be compiled into pipeline")
+                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+            ),
     )
     .run_async(per_vertex);
 

--- a/tests/tests/wgpu-gpu/render_target.rs
+++ b/tests/tests/wgpu-gpu/render_target.rs
@@ -251,10 +251,18 @@ async fn run_test(
 
 #[gpu_test]
 static DRAW_TO_3D_VIEW: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().limits(wgpu::Limits {
-        max_texture_dimension_3d: 512,
-        ..wgpu::Limits::downlevel_webgl2_defaults()
-    }))
+    .parameters(
+        TestParameters::default()
+            .limits(wgpu::Limits {
+                max_texture_dimension_3d: 512,
+                ..wgpu::Limits::downlevel_webgl2_defaults()
+            })
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT"),
+            ),
+    )
     .run_async(run_test_3d);
 
 async fn run_test_3d(ctx: TestingContext) {

--- a/tests/tests/wgpu-gpu/shader/array_size_overrides.rs
+++ b/tests/tests/wgpu-gpu/shader/array_size_overrides.rs
@@ -52,7 +52,17 @@ const SHADER: &str = r#"
 
 #[gpu_test]
 static ARRAY_SIZE_OVERRIDES: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().limits(wgpu::Limits::default()))
+    .parameters(
+        TestParameters::default()
+            .limits(wgpu::Limits::default())
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline")
+                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+            ),
+    )
     .run_async(move |ctx| async move {
         array_size_overrides(&ctx, None, &[534], false).await;
         array_size_overrides(&ctx, Some(14), &[286480122], false).await;

--- a/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
@@ -19,7 +19,14 @@ static ZERO_INIT_WORKGROUP_MEMORY: GpuTestConfiguration = GpuTestConfiguration::
     .parameters(
         TestParameters::default()
             .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
-            .limits(Limits::downlevel_defaults()),
+            .limits(Limits::downlevel_defaults())
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline")
+                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+            ),
     )
     .run_async(|ctx| async move {
         let bgl = ctx

--- a/tests/tests/wgpu-gpu/timestamp_normalization/utils.rs
+++ b/tests/tests/wgpu-gpu/timestamp_normalization/utils.rs
@@ -67,7 +67,9 @@ static U64_MUL_U32: GpuTestConfiguration = GpuTestConfiguration::new()
             .limits(Limits {
                 max_storage_buffer_binding_size: 256 * 1024 * 1024,
                 ..Limits::downlevel_defaults()
-            }),
+            })
+            // https://github.com/gfx-rs/wgpu/issues/9187
+            .expect_fail(wgpu_test::FailureCase::kosmic_krisp().panic("18446744073709551615 * 4294967295 should be 79228162495817593515539431425 but is 39614081238685424718767456257\n  left: 39614081238685424718767456257\n right: 79228162495817593515539431425")),
     )
     .run_sync(test_u64_mul_u32);
 

--- a/tests/tests/wgpu-gpu/vertex_formats/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_formats/mod.rs
@@ -418,7 +418,12 @@ static VERTEX_FORMATS_ALL: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::VERTEX_WRITABLE_STORAGE),
+            .features(wgpu::Features::VERTEX_WRITABLE_STORAGE)
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("vertexAttributeAccessBeyondStride"),
+            ),
     )
     .run_async(vertex_formats_all);
 
@@ -429,6 +434,11 @@ static VERTEX_FORMATS_10_10_10_2: GpuTestConfiguration = GpuTestConfiguration::n
     .parameters(
         TestParameters::default()
             .test_features_limits()
-            .features(wgpu::Features::VERTEX_WRITABLE_STORAGE),
+            .features(wgpu::Features::VERTEX_WRITABLE_STORAGE)
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("vertexAttributeAccessBeyondStride"),
+            ),
     )
     .run_async(vertex_formats_10_10_10_2);

--- a/tests/tests/wgpu-gpu/vertex_state.rs
+++ b/tests/tests/wgpu-gpu/vertex_state.rs
@@ -12,7 +12,15 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 
 #[gpu_test]
 static SET_ARRAY_STRIDE_TO_0: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().limits(wgpu::Limits::downlevel_defaults()))
+    .parameters(
+        TestParameters::default()
+            .limits(wgpu::Limits::downlevel_defaults())
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("vertexAttributeAccessBeyondStride"),
+            ),
+    )
     .run_async(set_array_stride_to_0);
 
 /// Tests that draws using a vertex buffer with stride of 0 works correctly (especially on the


### PR DESCRIPTION
Annotate expected failures tracked by #6745, #9100, #9184, and #9187.

There are various failures running against MoltenVK and KosmicKrisp (fewer on the latter). There's also some ray tracing tests failing on native Metal.

Also changes the test harness to identify Mac Vulkan adapters as `MoltenVK/Device` or `KosmicKrisp/Device` rather than `Vulkan/Device` (in which case it is still possible to distinguish by cross-referencing the adapter index with gpuconfig, but that's kind of a pain).

**Testing**
A few clean test runs on my machine, but that doesn't rule out issues in CI, low frequency intermittents, or issues on other configs.

**Squash or Rebase?** Rebase
