### PR TITLE
Fix limit reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 - The various "max resources per stage" limits are now capped at 100, so that their total remains below `max_bindings_per_bind_group`, as required by WebGPU. By @andyleiserson in [#9118](https://github.com/gfx-rs/wgpu/pull/9118).
 - The `max_uniform_buffer_binding_size` and `max_storage_buffer_binding_size` limits are now `u64` instead of `u32`, to match WebGPU. By @wingertge in [#9146](https://github.com/gfx-rs/wgpu/pull/9146).
 - To ensure memory safety when accessing mapped memory, `MAP_WRITE` buffer mappings are no longer exposed as Rust `&mut [u8]`, but the new type `WriteOnly<[u8]>`, which does not allow reading. Similar methods are provided where possible, but changes to your code will likely be needed, particularly including replacing `view[start..end]` with `view.slice(start..end)`. By @kpreid in [#9042](https://github.com/gfx-rs/wgpu/pull/9042).
+- The main 3 native backends now report their limits properly. By @teoxoy in [#9196](https://github.com/gfx-rs/wgpu/pull/9196).
 
 #### Metal
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -20,7 +20,6 @@ webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:* // 0%
 webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,createBindGroup:external_texture,* // 0%, no external external texture in deno
 webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https://github.com/gfx-rs/wgpu/issues/7881
-webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:* // metal, https://github.com/gfx-rs/wgpu/issues/8173
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_buffer_type:* // 25%, writable storage buffers not allowed in VERTEX
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_storage_texture_access:* // 25%, write-access storage textures not allowed in VERTEX
 webgpu:api,validation,createBindGroupLayout:visibility:* // 25%, missing per-stage storage limits

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -57,12 +57,22 @@ webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribu
 webgpu:api,validation,buffer,create:*
 webgpu:api,validation,buffer,destroy:*
 webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
+webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:validate,*
 webgpu:api,validation,capability_checks,limits,maxBufferSize:*
+webgpu:api,validation,capability_checks,limits,maxComputeWorkgroupSizeX:validate,*
+webgpu:api,validation,capability_checks,limits,maxComputeWorkgroupSizeY:validate,*
+webgpu:api,validation,capability_checks,limits,maxComputeWorkgroupSizeZ:validate,*
+webgpu:api,validation,capability_checks,limits,maxComputeWorkgroupsPerDimension:validate,*
 //FAIL: other `maxInterStageShaderVariables` cases w/ limitTest ∈ [underDefault, overMaximum]
 // https://github.com/gfx-rs/wgpu/issues/8945
 webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";*
 webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atMaximum";*
 webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";*
+webgpu:api,validation,capability_checks,limits,maxStorageBufferBindingSize:validate,*
+webgpu:api,validation,capability_checks,limits,maxUniformBufferBindingSize:validate,*
+webgpu:api,validation,capability_checks,limits,maxVertexBufferArrayStride:validate,*
+webgpu:api,validation,capability_checks,limits,minStorageBufferOffsetAlignment:validate,*
+webgpu:api,validation,capability_checks,limits,minUniformBufferOffsetAlignment:validate,*
 webgpu:api,validation,compute_pipeline:basic:*
 webgpu:api,validation,compute_pipeline:limits,invocations_per_workgroup,each_component:*
 webgpu:api,validation,compute_pipeline:limits,invocations_per_workgroup:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -96,8 +96,7 @@ webgpu:api,validation,createBindGroup:texture_must_have_correct_component_type:*
 webgpu:api,validation,createBindGroup:texture_must_have_correct_dimension:*
 webgpu:api,validation,createBindGroupLayout:duplicate_bindings:*
 webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:*
-webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_bind_group_layout:*
-fails-if(metal) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:*
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,*
 webgpu:api,validation,createBindGroupLayout:maximum_binding_limit:*
 webgpu:api,validation,createBindGroupLayout:multisampled_validation:*
 webgpu:api,validation,createBindGroupLayout:storage_texture,formats:*

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -480,8 +480,7 @@ pub(crate) struct AutoConversionLeafScalarError {
 pub(crate) struct ConcretizationFailedError {
     pub expr_span: Span,
     pub expr_type: String,
-    pub scalar: String,
-    pub inner: ConstantEvaluatorError,
+    pub concretization_preferences: Vec<(String, ConstantEvaluatorError)>,
 }
 
 impl<'a> Error<'a> {
@@ -1161,19 +1160,20 @@ impl<'a> Error<'a> {
                 let ConcretizationFailedError {
                     expr_span,
                     ref expr_type,
-                    ref scalar,
-                    ref inner,
+                    ref concretization_preferences,
                 } = **error;
                 ParseError {
-                    message: format!("failed to convert expression to a concrete type: {inner}"),
+                    message: "failed to convert expression to a concrete type".to_string(),
                     labels: vec![(
                         expr_span,
                         format!("this expression has type {expr_type}").into(),
                     )],
-                    notes: vec![format!(
-                        "the expression should have been converted to have {} scalar type",
-                        scalar
-                    )],
+                    notes: concretization_preferences
+                        .iter()
+                        .map(|&(ref scalar, ref err)|
+                            format!("the expression couldn't be converted to have {scalar} scalar type: {err}")
+                        )
+                        .collect(),
                 }
             }
             Error::ExceededLimitForNestedBraces { span, limit } => ParseError {

--- a/naga/src/front/wgsl/lower/conversion.rs
+++ b/naga/src/front/wgsl/lower/conversion.rs
@@ -256,29 +256,44 @@ impl<'source> super::ExpressionContext<'source, '_, '_> {
     /// If `expr` is already concrete, return it unchanged.
     pub fn concretize(
         &mut self,
-        mut expr: Handle<crate::Expression>,
+        expr: Handle<crate::Expression>,
     ) -> Result<'source, Handle<crate::Expression>> {
         let inner = super::resolve_inner!(self, expr);
         if let Some(scalar) = inner.automatically_convertible_scalar(&self.module.types) {
-            let concretized = scalar.concretize();
-            if concretized != scalar {
-                assert!(scalar.is_abstract());
-                let expr_span = self.get_expression_span(expr);
-                expr = self
+            use crate::ScalarKind as Sk;
+            let concretization_preferences = match scalar.kind {
+                // already concrete
+                Sk::Sint | Sk::Uint | Sk::Float | Sk::Bool => return Ok(expr),
+                Sk::AbstractInt => {
+                    [crate::Scalar::I32, crate::Scalar::U32, crate::Scalar::F32].as_slice()
+                }
+                Sk::AbstractFloat => [crate::Scalar::F32].as_slice(),
+            };
+            let expr_span = self.get_expression_span(expr);
+            let mut errors = Vec::new();
+            for concrete_scalar in concretization_preferences {
+                match self
                     .as_const_evaluator()
-                    .cast_array(expr, concretized, expr_span)
-                    .map_err(|err| {
-                        // A `TypeResolution` includes the type's full name, if
-                        // it has one. Also, avoid holding the borrow of `inner`
-                        // across the call to `cast_array`.
-                        let expr_type = &self.typifier()[expr];
-                        super::Error::ConcretizationFailed(Box::new(ConcretizationFailedError {
-                            expr_span,
-                            expr_type: self.type_resolution_to_string(expr_type),
-                            scalar: concretized.to_wgsl_for_diagnostics(),
-                            inner: err,
-                        }))
-                    })?;
+                    .cast_array(expr, *concrete_scalar, expr_span)
+                {
+                    Ok(expr) => return Ok(expr),
+                    Err(err) => {
+                        errors.push((concrete_scalar.to_wgsl_for_diagnostics(), err));
+                    }
+                }
+            }
+            if !errors.is_empty() {
+                // A `TypeResolution` includes the type's full name, if
+                // it has one. Also, avoid holding the borrow of `inner`
+                // across the call to `cast_array`.
+                let expr_type = &self.typifier()[expr];
+                return Err(Box::new(super::Error::ConcretizationFailed(Box::new(
+                    ConcretizationFailedError {
+                        expr_span,
+                        expr_type: self.type_resolution_to_string(expr_type),
+                        concretization_preferences: errors,
+                    },
+                ))));
             }
         }
 

--- a/tests/tests/wgpu-gpu/bind_groups.rs
+++ b/tests/tests/wgpu-gpu/bind_groups.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU64;
 
-use wgpu::{BufferUsages, PollType};
+use wgpu::{util::DeviceExt, BufferUsages, PollType};
 use wgpu_test::{
     gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
 };
@@ -12,6 +12,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         BIND_GROUP_NONFILTERING_LAYOUT_MIN_SAMPLER,
         BIND_GROUP_NONFILTERING_LAYOUT_MAG_SAMPLER,
         BIND_GROUP_NONFILTERING_LAYOUT_MIPMAP_SAMPLER,
+        BIND_GROUP_WITH_MAX_BINDING_INDEX,
     ]);
 }
 
@@ -252,3 +253,133 @@ static BIND_GROUP_NONFILTERING_LAYOUT_MIPMAP_SAMPLER: GpuTestConfiguration =
                 false,
             );
         });
+
+#[gpu_test]
+static BIND_GROUP_WITH_MAX_BINDING_INDEX: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().limits(wgpu::Limits::downlevel_defaults()))
+    .run_async(|ctx| async move {
+        let (device, queue) = ctx
+            .adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                required_limits: wgpu::Limits {
+                    max_bindings_per_bind_group: ctx.adapter.limits().max_bindings_per_bind_group,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let max_binding_index = device.limits().max_bindings_per_bind_group - 1;
+        let src_binding_index = max_binding_index - 1;
+        let dst_binding_index = max_binding_index;
+
+        let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: None,
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: src_binding_index,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: dst_binding_index,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let pl = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+
+        let shader = format!(
+            "
+            @group(0) @binding({src_binding_index}) var<uniform> src: u32;
+            @group(0) @binding({dst_binding_index}) var<storage, read_write> dst: u32;
+            @compute @workgroup_size(1)
+            fn main() {{
+                dst = src;
+            }}"
+        );
+
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(shader.into()),
+        });
+
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: Some(&pl),
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            module: &module,
+            cache: None,
+        });
+
+        let test_value = 123u32;
+
+        let src = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: None,
+            usage: wgpu::BufferUsages::UNIFORM,
+            contents: &test_value.to_le_bytes(),
+        });
+        let dst = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let readback = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 4,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: src_binding_index,
+                    resource: wgpu::BindingResource::Buffer(src.as_entire_buffer_binding()),
+                },
+                wgpu::BindGroupEntry {
+                    binding: dst_binding_index,
+                    resource: wgpu::BindingResource::Buffer(dst.as_entire_buffer_binding()),
+                },
+            ],
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_bind_group(0, &bg, &[]);
+            pass.set_pipeline(&pipeline);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(&dst, 0, &readback, 0, 4);
+        queue.submit(Some(encoder.finish()));
+
+        readback.slice(..).map_async(wgpu::MapMode::Read, |_| ());
+        device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+
+        assert_eq!(
+            &*readback.slice(..).get_mapped_range(),
+            &test_value.to_le_bytes()
+        );
+    });

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -151,43 +151,25 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
         .max_color_attachments
         .min(crate::MAX_COLOR_ATTACHMENTS as u32);
 
-    // Vulkan and DX12 sometimes report large values for the "max resources per stage"
-    // limits. WebGPU requires that consuming the maximum number of resources of every type
-    // in every stage cannot exceed `max_bindings_per_bind_group`. To ensure this, we must
-    // clamp per-stage limits.
+    // WebGPU requires maxBindingsPerBindGroup to be at least the sum of all
+    // per-stage limits multiplied with the maximum shader stages per pipeline.
     //
-    // It is not expected that this clamping adjusts limits that are in a range where an
-    // application might reach them. (The main dilemma here being how WebGPU will eventually
-    // apply these or other limits to bindless. wgpu has separate `binding_array` limits for
-    // its native-only extension; those are not touched here.)
+    // Since backends already report their maximum maxBindingsPerBindGroup,
+    // we need to lower all per-stage limits to satisfy this guarantee.
     //
     // See <https://gpuweb.github.io/gpuweb/#adapter-capability-guarantees>.
     const MAX_SHADER_STAGES_PER_PIPELINE: u32 = 2;
     let max_per_stage_resources =
         limits.max_bindings_per_bind_group / MAX_SHADER_STAGES_PER_PIPELINE;
 
-    if limits.max_sampled_textures_per_shader_stage
-        + limits.max_samplers_per_shader_stage
-        + limits.max_storage_buffers_per_shader_stage
-        + limits.max_storage_textures_per_shader_stage
-        + limits.max_uniform_buffers_per_shader_stage
-        > max_per_stage_resources
-    {
-        // This is the "adjusted limits that are in a range where an application might reach
-        // them" case. (In reality, even something quite a bit less than the default
-        // `max_bindings_per_bind_group` of 1000 ought to be sufficient.)
-        log::warn!(
-            "Unexpected adjustment of per-stage resource limits to fit within max_bindings_per_bind_group."
-        );
-    }
-
     cap_limits_to_be_under_the_sum_limit(
         [
             &mut limits.max_sampled_textures_per_shader_stage,
-            &mut limits.max_samplers_per_shader_stage,
-            &mut limits.max_storage_buffers_per_shader_stage,
-            &mut limits.max_storage_textures_per_shader_stage,
             &mut limits.max_uniform_buffers_per_shader_stage,
+            &mut limits.max_storage_textures_per_shader_stage,
+            &mut limits.max_storage_buffers_per_shader_stage,
+            &mut limits.max_samplers_per_shader_stage,
+            &mut limits.max_acceleration_structures_per_shader_stage,
         ],
         max_per_stage_resources,
     );

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -131,12 +131,11 @@ impl crate::TextureCopy {
     }
 }
 
-/// Clamp the limits in `limits` to honor HAL-imposed maximums and WebGPU
-/// alignment requirements.
-///
-/// Other limits are left unchanged.
+/// Adjust `limits` to honor HAL-imposed maximums and comply with WebGPU's
+/// adapter capability guarantees.
 #[cfg_attr(not(any_backend), allow(dead_code))]
-pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
+pub(crate) fn adjust_raw_limits(mut limits: wgt::Limits) -> wgt::Limits {
+    // Apply hal limits.
     limits.max_bind_groups = limits.max_bind_groups.min(crate::MAX_BIND_GROUPS as u32);
     limits.max_vertex_buffers = limits
         .max_vertex_buffers
@@ -145,13 +144,14 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
         .max_color_attachments
         .min(crate::MAX_COLOR_ATTACHMENTS as u32);
 
+    // Adjust limits according to WebGPU adapter capability guarantees.
+    // See <https://gpuweb.github.io/gpuweb/#adapter-capability-guarantees>.
+
     // WebGPU requires maxBindingsPerBindGroup to be at least the sum of all
     // per-stage limits multiplied with the maximum shader stages per pipeline.
     //
     // Since backends already report their maximum maxBindingsPerBindGroup,
     // we need to lower all per-stage limits to satisfy this guarantee.
-    //
-    // See <https://gpuweb.github.io/gpuweb/#adapter-capability-guarantees>.
     const MAX_SHADER_STAGES_PER_PIPELINE: u32 = 2;
     let max_per_stage_resources =
         limits.max_bindings_per_bind_group / MAX_SHADER_STAGES_PER_PIPELINE;
@@ -168,6 +168,8 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
         max_per_stage_resources,
     );
 
+    // Not required by the spec but dynamic buffers count
+    // towards non-dynamic buffer limits as well.
     limits.max_dynamic_uniform_buffers_per_pipeline_layout = limits
         .max_dynamic_uniform_buffers_per_pipeline_layout
         .min(limits.max_uniform_buffers_per_shader_stage);
@@ -175,11 +177,27 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
         .max_dynamic_storage_buffers_per_pipeline_layout
         .min(limits.max_storage_buffers_per_shader_stage);
 
-    // Round some limits down to the WebGPU alignment requirement, to avoid
-    // suggesting values that won't work. (In particular, the CTS queries limits
-    // and then tests the exact limit value.)
-    limits.max_storage_buffer_binding_size &= u64::from(!(wgt::STORAGE_BINDING_SIZE_ALIGNMENT - 1));
+    limits.min_uniform_buffer_offset_alignment = limits.min_uniform_buffer_offset_alignment.max(32);
+    limits.min_storage_buffer_offset_alignment = limits.min_storage_buffer_offset_alignment.max(32);
+
+    limits.max_uniform_buffer_binding_size = limits
+        .max_uniform_buffer_binding_size
+        .min(limits.max_buffer_size);
+    limits.max_storage_buffer_binding_size = limits
+        .max_storage_buffer_binding_size
+        .min(limits.max_buffer_size);
+
+    limits.max_storage_buffer_binding_size &= !(u64::from(wgt::STORAGE_BINDING_SIZE_ALIGNMENT) - 1);
     limits.max_vertex_buffer_array_stride &= !(wgt::VERTEX_ALIGNMENT as u32 - 1);
+
+    let x = limits.max_compute_workgroup_size_x;
+    let y = limits.max_compute_workgroup_size_y;
+    let z = limits.max_compute_workgroup_size_z;
+    let m = limits.max_compute_invocations_per_workgroup;
+    limits.max_compute_workgroup_size_x = x.min(m);
+    limits.max_compute_workgroup_size_y = y.min(m);
+    limits.max_compute_workgroup_size_z = z.min(m);
+    limits.max_compute_invocations_per_workgroup = m.min(x.saturating_mul(y).saturating_mul(z));
 
     limits
 }

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -153,8 +153,8 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
 
     // Vulkan and DX12 sometimes report large values for the "max resources per stage"
     // limits. WebGPU requires that consuming the maximum number of resources of every type
-    // in every stage cannot exceed `max_bindings_per_bind_group`. To ensure this, we clamp
-    // per-stage limit at an equal division of `max_bindings_per_bind_group`.
+    // in every stage cannot exceed `max_bindings_per_bind_group`. To ensure this, we must
+    // clamp per-stage limits.
     //
     // It is not expected that this clamping adjusts limits that are in a range where an
     // application might reach them. (The main dilemma here being how WebGPU will eventually
@@ -162,24 +162,16 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
     // its native-only extension; those are not touched here.)
     //
     // See <https://gpuweb.github.io/gpuweb/#adapter-capability-guarantees>.
-    const BINDING_TYPE_AND_STAGE_COUNT: u32 = 10;
-    let max_bindings = limits.max_bindings_per_bind_group / BINDING_TYPE_AND_STAGE_COUNT;
-    let mut did_clamp = false;
-    let mut clamp = |limit: &mut u32| {
-        if *limit > max_bindings {
-            *limit = max_bindings;
-            did_clamp = true;
-        }
-    };
-    clamp(&mut limits.max_dynamic_uniform_buffers_per_pipeline_layout);
-    clamp(&mut limits.max_dynamic_storage_buffers_per_pipeline_layout);
-    clamp(&mut limits.max_sampled_textures_per_shader_stage);
-    clamp(&mut limits.max_samplers_per_shader_stage);
-    clamp(&mut limits.max_storage_buffers_per_shader_stage);
-    clamp(&mut limits.max_storage_textures_per_shader_stage);
-    clamp(&mut limits.max_uniform_buffers_per_shader_stage);
-    if did_clamp
-        && limits.max_bindings_per_bind_group < wgt::Limits::defaults().max_bindings_per_bind_group
+    const MAX_SHADER_STAGES_PER_PIPELINE: u32 = 2;
+    let max_per_stage_resources =
+        limits.max_bindings_per_bind_group / MAX_SHADER_STAGES_PER_PIPELINE;
+
+    if limits.max_sampled_textures_per_shader_stage
+        + limits.max_samplers_per_shader_stage
+        + limits.max_storage_buffers_per_shader_stage
+        + limits.max_storage_textures_per_shader_stage
+        + limits.max_uniform_buffers_per_shader_stage
+        > max_per_stage_resources
     {
         // This is the "adjusted limits that are in a range where an application might reach
         // them" case. (In reality, even something quite a bit less than the default
@@ -188,6 +180,24 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
             "Unexpected adjustment of per-stage resource limits to fit within max_bindings_per_bind_group."
         );
     }
+
+    cap_limits_to_be_under_the_sum_limit(
+        [
+            &mut limits.max_sampled_textures_per_shader_stage,
+            &mut limits.max_samplers_per_shader_stage,
+            &mut limits.max_storage_buffers_per_shader_stage,
+            &mut limits.max_storage_textures_per_shader_stage,
+            &mut limits.max_uniform_buffers_per_shader_stage,
+        ],
+        max_per_stage_resources,
+    );
+
+    limits.max_dynamic_uniform_buffers_per_pipeline_layout = limits
+        .max_dynamic_uniform_buffers_per_pipeline_layout
+        .min(limits.max_uniform_buffers_per_shader_stage);
+    limits.max_dynamic_storage_buffers_per_pipeline_layout = limits
+        .max_dynamic_storage_buffers_per_pipeline_layout
+        .min(limits.max_storage_buffers_per_shader_stage);
 
     // Round some limits down to the WebGPU alignment requirement, to avoid
     // suggesting values that won't work. (In particular, the CTS queries limits

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -137,12 +137,6 @@ impl crate::TextureCopy {
 /// Other limits are left unchanged.
 #[cfg_attr(not(any_backend), allow(dead_code))]
 pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
-    // The Metal backend maintains two copies of many limit values (one as
-    // `wgt::Limits` and one as `metal::PrivateCapabilities`). In order to avoid
-    // confusing discrepancies between the two, some of the logic here is
-    // duplicated in the initialization of `metal::PrivateCapabilities`.
-    // See <https://github.com/gfx-rs/wgpu/issues/8715>.
-
     limits.max_bind_groups = limits.max_bind_groups.min(crate::MAX_BIND_GROUPS as u32);
     limits.max_vertex_buffers = limits
         .max_vertex_buffers

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -197,3 +197,43 @@ pub(crate) fn apply_hal_limits(mut limits: wgt::Limits) -> wgt::Limits {
 
     limits
 }
+
+/// Evenly allocates space to each limit,
+/// capping them only if strictly necessary.
+pub fn cap_limits_to_be_under_the_sum_limit<const N: usize>(
+    mut limits: [&mut u32; N],
+    sum_limit: u32,
+) {
+    limits.sort();
+
+    let mut rem_limit = sum_limit;
+    let mut divisor = limits.len() as u32;
+    for limit_to_adjust in limits {
+        let limit = rem_limit / divisor;
+        *limit_to_adjust = (*limit_to_adjust).min(limit);
+        rem_limit -= *limit_to_adjust;
+        divisor -= 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cap_limits_to_be_under_the_sum_limit() {
+        test([3, 3, 3], 3, [1, 1, 1]);
+        test([3, 2, 1], 3, [1, 1, 1]);
+        test([1, 2, 3], 6, [1, 2, 3]);
+        test([1, 2, 3], 3, [1, 1, 1]);
+        test([1, 8, 100], 6, [1, 2, 3]);
+        test([2, 80, 80], 6, [2, 2, 2]);
+        test([2, 80, 80], 12, [2, 5, 5]);
+
+        #[track_caller]
+        fn test<const N: usize>(mut input: [u32; N], limit: u32, output: [u32; N]) {
+            cap_limits_to_be_under_the_sum_limit(input.each_mut(), limit);
+            assert_eq!(input, output);
+        }
+    }
+}

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -861,7 +861,7 @@ impl super::Adapter {
             info,
             features,
             capabilities: crate::Capabilities {
-                limits: auxil::apply_hal_limits(wgt::Limits {
+                limits: auxil::adjust_raw_limits(wgt::Limits {
                     //
                     // WebGPU LIMITS:
                     // Based on https://gpuweb.github.io/gpuweb/correspondence/#limits

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -729,6 +729,35 @@ impl super::Adapter {
 
         let downlevel = wgt::DownlevelCapabilities::default();
 
+        // Limits that must share D3D12's root signature size of
+        // D3D12_MAX_ROOT_COST 64 DWORDS (256 bytes).
+        //
+        // Root constants and root tables use 1 DWORD.
+        // Root descriptors use 2 DWORDs.
+        // Source: https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signature-limits#memory-limits-and-costs
+        //
+        // Per pipeline layout:
+        // - RootElement::Constant, (immediates) 32 root constants
+        //     (bounded by maxImmediateSize) = 32 x 4 bytes = 128 bytes
+        // - RootElement::SamplerHeap, a root table = 4 bytes
+        // - RootElement::SpecialConstantBuffer, 3 root constants = 3 x 4 bytes = 12 bytes
+        // - RootElement::DynamicOffsetsBuffer, a root constant per dynamic storage buffer
+        //     (bounded by maxDynamicStorageBuffersPerPipelineLayout) = 4 x 4 bytes = 16 bytes
+        // - RootElement::DynamicUniformBuffer, a root descriptor per dynamic uniform buffer
+        //     (bounded by maxDynamicUniformBuffersPerPipelineLayout) = 8 x 8 bytes = 64 bytes
+        // Per bind group:
+        // - RootElement::Table, a root table
+        //     (bounded by maxBindGroups) = 8 x 4 bytes = 32 bytes
+        //
+        // Source: logic in `create_pipeline_layout`
+        //
+        // Total: 128 + 4 + 12 + 16 + 64 + 32 = 256 bytes
+        //
+        let max_immediate_size = 128;
+        let max_bind_groups = 8;
+        let max_dynamic_uniform_buffers_per_pipeline_layout = 8;
+        let max_dynamic_storage_buffers_per_pipeline_layout = 4;
+
         // "Maximum number of descriptors in a Constant Buffer View (CBV), Shader Resource View (SRV), or Unordered Access View(UAV) heap used for rendering"
         let full_heap_count = match rbt {
             ResourceBindingTier::T1 | ResourceBindingTier::T2 => 1_000_000,
@@ -746,20 +775,24 @@ impl super::Adapter {
         };
 
         // "Maximum number of Shader Resource Views in all descriptor tables per shader stage"
-        let max_srv_per_shader_stage = match rbt {
+        let mut max_srv_per_shader_stage = match rbt {
             ResourceBindingTier::T1 => 128,
             _ => full_heap_count,
         };
 
+        // We use an extra SRV for all samplers in a bind group.
+        // See comment in `create_pipeline_layout`.
+        max_srv_per_shader_stage -= max_bind_groups;
+
         // If we also support acceleration structures these are shared so we must halve it.
         // It's unlikely that this affects anything because most devices that support ray tracing
         // probably have a higher binding tier than one.
-        let max_sampled_textures_per_shader_stage = if supports_ray_tracing {
+        let mut max_sampled_textures_per_shader_stage = if supports_ray_tracing {
             max_srv_per_shader_stage / 2
         } else {
             max_srv_per_shader_stage
         };
-        let max_acceleration_structures_per_shader_stage = if supports_ray_tracing {
+        let mut max_acceleration_structures_per_shader_stage = if supports_ray_tracing {
             max_srv_per_shader_stage / 2
         } else {
             0
@@ -778,7 +811,20 @@ impl super::Adapter {
         // We must share the UAV limit across both storage resource limits.
         let max_uav_per_shader_stage = max_uav_across_all_stages / MAX_SHADER_STAGES_PER_PIPELINE;
         let max_storage_textures_per_shader_stage = max_uav_per_shader_stage / 2;
-        let max_storage_buffers_per_shader_stage = max_uav_per_shader_stage / 2;
+        let mut max_storage_buffers_per_shader_stage = max_uav_per_shader_stage / 2;
+
+        // WebGPU storage buffers count as 1 SRV if they are read-only
+        // or as 1 UAV if they are read-write. See comment in
+        // `create_pipeline_layout`. Make sure we don't exceed
+        // the maximum number of SRVs for the relevant limits.
+        auxil::cap_limits_to_be_under_the_sum_limit(
+            [
+                &mut max_sampled_textures_per_shader_stage,
+                &mut max_acceleration_structures_per_shader_stage,
+                &mut max_storage_buffers_per_shader_stage,
+            ],
+            max_srv_per_shader_stage,
+        );
 
         // "Maximum number of Samplers in all descriptor tables per shader stage"
         let max_samplers_per_shader_stage = match rbt {
@@ -860,35 +906,10 @@ impl super::Adapter {
                     max_inter_stage_shader_variables: Direct3D12::D3D12_VS_OUTPUT_REGISTER_COUNT
                         .min(Direct3D12::D3D12_PS_INPUT_REGISTER_COUNT)
                         - 1, // - 1 for position
-                    // Limits that must share D3D12's root signature size of
-                    // D3D12_MAX_ROOT_COST 64 DWORDS (256 bytes).
-                    //
-                    // Root constants and root tables use 1 DWORD.
-                    // Root descriptors use 2 DWORDs.
-                    // Source: https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signature-limits#memory-limits-and-costs
-                    //
-                    // Per pipeline layout:
-                    // - RootElement::Constant, (immediates) 32 root constants
-                    //     (bounded by maxImmediateSize) = 32 x 4 bytes = 128 bytes
-                    // - RootElement::SamplerHeap, a root table = 4 bytes
-                    // - RootElement::SpecialConstantBuffer, 3 root constants = 3 x 4 bytes = 12 bytes
-                    // - RootElement::DynamicOffsetsBuffer, a root constant per dynamic storage buffer
-                    //     (bounded by maxDynamicStorageBuffersPerPipelineLayout) = 4 x 4 bytes = 16 bytes
-                    // - RootElement::DynamicUniformBuffer, a root descriptor per dynamic uniform buffer
-                    //     (bounded by maxDynamicUniformBuffersPerPipelineLayout) = 8 x 8 bytes = 64 bytes
-                    // Per bind group:
-                    // - RootElement::Table, a root table
-                    //     (bounded by maxBindGroups) = 8 x 4 bytes = 32 bytes
-                    //
-                    // Source: logic in `create_pipeline_layout`
-                    //
-                    // Total: 128 + 4 + 12 + 16 + 64 + 32 = 256 bytes
-                    //
-                    max_immediate_size: 128,
-                    max_bind_groups: crate::MAX_BIND_GROUPS as u32,
-                    max_dynamic_uniform_buffers_per_pipeline_layout: 8,
-                    max_dynamic_storage_buffers_per_pipeline_layout: 4,
-                    //
+                    max_immediate_size,
+                    max_bind_groups,
+                    max_dynamic_uniform_buffers_per_pipeline_layout,
+                    max_dynamic_storage_buffers_per_pipeline_layout,
                     // 8
                     max_color_attachments: Direct3D12::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT,
                     // 128 (No documented limit)

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -216,7 +216,26 @@ impl super::Adapter {
         }
         .unwrap();
 
-        if options.ResourceBindingTier.0 < Direct3D12::D3D12_RESOURCE_BINDING_TIER_2.0 {
+        /// Resource Binding Tiers: https://learn.microsoft.com/en-us/windows/win32/direct3d12/hardware-support#limits-dependant-on-hardware
+        #[derive(PartialEq, Eq, PartialOrd, Ord)]
+        enum ResourceBindingTier {
+            T1,
+            T2,
+            T3,
+        }
+        let rbt = match options.ResourceBindingTier {
+            Direct3D12::D3D12_RESOURCE_BINDING_TIER_1 => ResourceBindingTier::T1,
+            Direct3D12::D3D12_RESOURCE_BINDING_TIER_2 => ResourceBindingTier::T2,
+            tier if tier.0 >= Direct3D12::D3D12_RESOURCE_BINDING_TIER_3.0 => {
+                ResourceBindingTier::T3
+            }
+            other => {
+                log::debug!("Got zero or negative value for resource binding tier {other:?}");
+                ResourceBindingTier::T1
+            }
+        };
+
+        if rbt == ResourceBindingTier::T1 {
             if let Some(telemetry) = telemetry {
                 (telemetry.d3d12_expose_adapter)(
                     &desc,
@@ -432,38 +451,6 @@ impl super::Adapter {
             unrestricted_buffer_texture_copy_pitch_supported,
         };
 
-        // Theoretically vram limited, but in practice 2^20 is the limit
-        let tier3_practical_descriptor_limit = 1 << 20;
-
-        let (full_heap_count, uav_count) = match options.ResourceBindingTier {
-            Direct3D12::D3D12_RESOURCE_BINDING_TIER_1 => {
-                let uav_count = match max_feature_level {
-                    FeatureLevel::_11_0 => 8,
-                    _ => 64,
-                };
-
-                (
-                    Direct3D12::D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1,
-                    uav_count,
-                )
-            }
-            Direct3D12::D3D12_RESOURCE_BINDING_TIER_2 => (
-                Direct3D12::D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_2,
-                64,
-            ),
-            tier if tier.0 >= Direct3D12::D3D12_RESOURCE_BINDING_TIER_3.0 => (
-                tier3_practical_descriptor_limit,
-                tier3_practical_descriptor_limit,
-            ),
-            other => {
-                log::debug!("Got zero or negative value for resource binding tier {other:?}");
-                (
-                    Direct3D12::D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1,
-                    8,
-                )
-            }
-        };
-
         // these should always be available on d3d12
         let mut features = wgt::Features::empty()
             | wgt::Features::DEPTH_CLIP_CONTROL
@@ -516,8 +503,7 @@ impl super::Adapter {
                 | wgt::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
                 // See note below the table https://learn.microsoft.com/en-us/windows/win32/direct3d12/hardware-support
                 | wgt::Features::PARTIALLY_BOUND_BINDING_ARRAY,
-            shader_model >= naga::back::hlsl::ShaderModel::V5_1
-                && options.ResourceBindingTier.0 >= Direct3D12::D3D12_RESOURCE_BINDING_TIER_3.0,
+            shader_model >= naga::back::hlsl::ShaderModel::V5_1 && rbt >= ResourceBindingTier::T3,
         );
 
         let bgra8unorm_storage_supported = {
@@ -743,20 +729,61 @@ impl super::Adapter {
 
         let downlevel = wgt::DownlevelCapabilities::default();
 
-        // Resource Binding Tiers: https://learn.microsoft.com/en-us/windows/win32/direct3d12/hardware-support#limits-dependant-on-hardware
+        // "Maximum number of descriptors in a Constant Buffer View (CBV), Shader Resource View (SRV), or Unordered Access View(UAV) heap used for rendering"
+        let full_heap_count = match rbt {
+            ResourceBindingTier::T1 | ResourceBindingTier::T2 => 1_000_000,
+            // 1_000_000+
+            ResourceBindingTier::T3 => {
+                // Theoretically vram limited, but in practice 2^20 is the limit
+                1 << 20
+            }
+        };
 
-        let max_srv_count = match options.ResourceBindingTier {
-            Direct3D12::D3D12_RESOURCE_BINDING_TIER_1 => 128,
+        // "Maximum number of Constant Buffer Views in all descriptor tables per shader stage"
+        let max_uniform_buffers_per_shader_stage = match rbt {
+            ResourceBindingTier::T1 | ResourceBindingTier::T2 => 14,
+            _ => full_heap_count,
+        };
+
+        // "Maximum number of Shader Resource Views in all descriptor tables per shader stage"
+        let max_srv_per_shader_stage = match rbt {
+            ResourceBindingTier::T1 => 128,
             _ => full_heap_count,
         };
 
         // If we also support acceleration structures these are shared so we must halve it.
         // It's unlikely that this affects anything because most devices that support ray tracing
         // probably have a higher binding tier than one.
-        let max_sampled_textures_per_shader_stage = if !supports_ray_tracing {
-            max_srv_count
+        let max_sampled_textures_per_shader_stage = if supports_ray_tracing {
+            max_srv_per_shader_stage / 2
         } else {
-            max_srv_count / 2
+            max_srv_per_shader_stage
+        };
+        let max_acceleration_structures_per_shader_stage = if supports_ray_tracing {
+            max_srv_per_shader_stage / 2
+        } else {
+            0
+        };
+
+        // "Maximum number of Unordered Access Views in all descriptor tables across all stages"
+        let max_uav_across_all_stages = match rbt {
+            ResourceBindingTier::T1 => match max_feature_level {
+                FeatureLevel::_11_0 => 8,
+                _ => 64,
+            },
+            ResourceBindingTier::T2 => 64,
+            ResourceBindingTier::T3 => full_heap_count,
+        };
+        const MAX_SHADER_STAGES_PER_PIPELINE: u32 = 2;
+        // We must share the UAV limit across both storage resource limits.
+        let max_uav_per_shader_stage = max_uav_across_all_stages / MAX_SHADER_STAGES_PER_PIPELINE;
+        let max_storage_textures_per_shader_stage = max_uav_per_shader_stage / 2;
+        let max_storage_buffers_per_shader_stage = max_uav_per_shader_stage / 2;
+
+        // "Maximum number of Samplers in all descriptor tables per shader stage"
+        let max_samplers_per_shader_stage = match rbt {
+            ResourceBindingTier::T1 => 16,
+            _ => 2048,
         };
 
         // See https://microsoft.github.io/DirectX-Specs/d3d/ViewInstancing.html#maximum-viewinstancecount
@@ -805,23 +832,10 @@ impl super::Adapter {
                     // No real limit.
                     max_bindings_per_bind_group: u32::MAX,
                     max_sampled_textures_per_shader_stage,
-                    // 16 or 2048
-                    max_samplers_per_shader_stage: match options.ResourceBindingTier {
-                        Direct3D12::D3D12_RESOURCE_BINDING_TIER_1 => 16,
-                        _ => Direct3D12::D3D12_MAX_SHADER_VISIBLE_SAMPLER_HEAP_SIZE,
-                    },
-                    // These both count towards `uav_count`, but we can't
-                    // express the limit as as sum of the two, so we divide
-                    // it by 4 to account for the worst case scenario
-                    // (with 2 shader stages).
-                    max_storage_textures_per_shader_stage: uav_count / 4,
-                    max_storage_buffers_per_shader_stage: uav_count / 4,
-                    // 14 or FULL HEAP
-                    max_uniform_buffers_per_shader_stage: match options.ResourceBindingTier {
-                        Direct3D12::D3D12_RESOURCE_BINDING_TIER_1
-                        | Direct3D12::D3D12_RESOURCE_BINDING_TIER_2 => 14,
-                        _ => full_heap_count,
-                    },
+                    max_samplers_per_shader_stage,
+                    max_storage_textures_per_shader_stage,
+                    max_storage_buffers_per_shader_stage,
+                    max_uniform_buffers_per_shader_stage,
                     // See `InputSlot` param docs: https://learn.microsoft.com/en-ca/windows/win32/api/d3d12/ns-d3d12-d3d12_input_element_desc
                     max_vertex_buffers: 16,
                     // Dx12 does not expose a maximum buffer size in the API.
@@ -956,17 +970,9 @@ impl super::Adapter {
                     } else {
                         0
                     },
-                    max_acceleration_structures_per_shader_stage: if supports_ray_tracing {
-                        max_srv_count / 2
-                    } else {
-                        0
-                    },
+                    max_acceleration_structures_per_shader_stage,
                     max_binding_array_acceleration_structure_elements_per_shader_stage:
-                        if supports_ray_tracing {
-                            max_srv_count / 2
-                        } else {
-                            0
-                        },
+                        max_acceleration_structures_per_shader_stage,
                     max_multiview_view_count,
                 }),
                 alignments: crate::Alignments {

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -741,14 +741,9 @@ impl super::Adapter {
         // TODO: Determine if IPresentationManager is supported
         let presentation_timer = auxil::dxgi::time::PresentationTimer::new_dxgi();
 
-        let base = wgt::Limits::default();
-
         let downlevel = wgt::DownlevelCapabilities::default();
 
-        // See https://learn.microsoft.com/en-us/windows/win32/direct3d12/hardware-feature-levels#feature-level-support
-        let max_color_attachments = 8;
-        let max_color_attachment_bytes_per_sample =
-            max_color_attachments * wgt::TextureFormat::MAX_TARGET_PIXEL_BYTE_COST;
+        // Resource Binding Tiers: https://learn.microsoft.com/en-us/windows/win32/direct3d12/hardware-support#limits-dependant-on-hardware
 
         let max_srv_count = match options.ResourceBindingTier {
             Direct3D12::D3D12_RESOURCE_BINDING_TIER_1 => 128,
@@ -794,79 +789,119 @@ impl super::Adapter {
             features,
             capabilities: crate::Capabilities {
                 limits: auxil::apply_hal_limits(wgt::Limits {
+                    //
+                    // WebGPU LIMITS:
+                    // Based on https://gpuweb.github.io/gpuweb/correspondence/#limits
+                    //
+                    // 16384
                     max_texture_dimension_1d: Direct3D12::D3D12_REQ_TEXTURE1D_U_DIMENSION,
+                    // 16384
                     max_texture_dimension_2d: Direct3D12::D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION
                         .min(Direct3D12::D3D12_REQ_TEXTURECUBE_DIMENSION),
+                    // 2048
                     max_texture_dimension_3d: Direct3D12::D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION,
+                    // 2048
                     max_texture_array_layers: Direct3D12::D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION,
-                    max_bind_groups: crate::MAX_BIND_GROUPS as u32,
+                    // No real limit.
                     max_bindings_per_bind_group: 65535,
-                    // dynamic offsets take a root constant, so we expose the minimum here
-                    max_dynamic_uniform_buffers_per_pipeline_layout: base
-                        .max_dynamic_uniform_buffers_per_pipeline_layout,
-                    max_dynamic_storage_buffers_per_pipeline_layout: base
-                        .max_dynamic_storage_buffers_per_pipeline_layout,
                     max_sampled_textures_per_shader_stage,
+                    // 16 or 2048
                     max_samplers_per_shader_stage: match options.ResourceBindingTier {
                         Direct3D12::D3D12_RESOURCE_BINDING_TIER_1 => 16,
                         _ => Direct3D12::D3D12_MAX_SHADER_VISIBLE_SAMPLER_HEAP_SIZE,
                     },
-                    // these both account towards `uav_count`, but we can't express the limit as as sum
-                    // of the two, so we divide it by 4 to account for the worst case scenario
-                    // (2 shader stages, with both using 16 storage textures and 16 storage buffers)
-                    max_storage_buffers_per_shader_stage: uav_count / 4,
+                    // These both count towards `uav_count`, but we can't
+                    // express the limit as as sum of the two, so we divide
+                    // it by 4 to account for the worst case scenario
+                    // (with 2 shader stages).
                     max_storage_textures_per_shader_stage: uav_count / 4,
-                    max_uniform_buffers_per_shader_stage: full_heap_count,
-                    max_binding_array_elements_per_shader_stage: full_heap_count,
-                    max_binding_array_sampler_elements_per_shader_stage: full_heap_count,
-                    max_uniform_buffer_binding_size: u64::from(
-                        Direct3D12::D3D12_REQ_CONSTANT_BUFFER_ELEMENT_COUNT,
-                    ) * 16,
-                    max_storage_buffer_binding_size: u64::from(auxil::MAX_I32_BINDING_SIZE),
-                    max_vertex_buffers: Direct3D12::D3D12_VS_INPUT_REGISTER_COUNT,
-                    max_vertex_attributes: Direct3D12::D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT,
-                    max_vertex_buffer_array_stride: Direct3D12::D3D12_SO_BUFFER_MAX_STRIDE_IN_BYTES,
-                    // The immediates are part of the root signature which
-                    // has a limit of 64 DWORDS (256 bytes), but other resources
-                    // also share the root signature:
-                    //
-                    // - immediates consume a `DWORD` for each `4 bytes` of data
-                    // - If a bind group has buffers it will consume a `DWORD`
-                    //   for the descriptor table
-                    // - If a bind group has samplers it will consume a `DWORD`
-                    //   for the descriptor table
-                    // - Each dynamic uniform buffer will consume `2 DWORDs` for the
-                    //   root descriptor
-                    // - Each dynamic storage buffer will consume `1 DWORD` for a
-                    //   root constant representing the dynamic offset
-                    // - The special constants buffer count as constants
-                    //
-                    // Since we can't know beforehand all root signatures that
-                    // will be created, the max size to be used for push
-                    // constants needs to be set to a reasonable number instead.
-                    //
-                    // Source: https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signature-limits#memory-limits-and-costs
-                    max_immediate_size: 128,
-                    min_uniform_buffer_offset_alignment:
-                        Direct3D12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT,
-                    min_storage_buffer_offset_alignment: 4,
-                    max_inter_stage_shader_variables: base.max_inter_stage_shader_variables,
-                    max_color_attachments,
-                    max_color_attachment_bytes_per_sample,
-                    // From: https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#18.6.6%20Inter-Thread%20Data%20Sharing
-                    max_compute_workgroup_storage_size: 32768,
-                    max_compute_invocations_per_workgroup:
-                        Direct3D12::D3D12_CS_4_X_THREAD_GROUP_MAX_THREADS_PER_GROUP,
-                    max_compute_workgroup_size_x: Direct3D12::D3D12_CS_THREAD_GROUP_MAX_X,
-                    max_compute_workgroup_size_y: Direct3D12::D3D12_CS_THREAD_GROUP_MAX_Y,
-                    max_compute_workgroup_size_z: Direct3D12::D3D12_CS_THREAD_GROUP_MAX_Z,
-                    max_compute_workgroups_per_dimension:
-                        Direct3D12::D3D12_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION,
+                    max_storage_buffers_per_shader_stage: uav_count / 4,
+                    // 14 or FULL HEAP
+                    max_uniform_buffers_per_shader_stage: match options.ResourceBindingTier {
+                        Direct3D12::D3D12_RESOURCE_BINDING_TIER_1
+                        | Direct3D12::D3D12_RESOURCE_BINDING_TIER_2 => 14,
+                        _ => full_heap_count,
+                    },
+                    // See `InputSlot` param docs: https://learn.microsoft.com/en-ca/windows/win32/api/d3d12/ns-d3d12-d3d12_input_element_desc
+                    max_vertex_buffers: 16,
                     // Dx12 does not expose a maximum buffer size in the API.
                     // This limit is chosen to avoid potential issues with drivers should they internally
                     // store buffer sizes using 32 bit ints (a situation we have already encountered with vulkan).
                     max_buffer_size: i32::MAX as u64,
+                    max_storage_buffer_binding_size: auxil::MAX_I32_BINDING_SIZE as u64,
+                    // 65536
+                    max_uniform_buffer_binding_size:
+                        Direct3D12::D3D12_REQ_CONSTANT_BUFFER_ELEMENT_COUNT as u64 * 16,
+                    // 254
+                    min_uniform_buffer_offset_alignment:
+                        Direct3D12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT,
+                    // 16
+                    min_storage_buffer_offset_alignment:
+                        Direct3D12::D3D12_RAW_UAV_SRV_BYTE_ALIGNMENT,
+                    // 32
+                    max_vertex_attributes: Direct3D12::D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT,
+                    // 2048
+                    max_vertex_buffer_array_stride: Direct3D12::D3D12_SO_BUFFER_MAX_STRIDE_IN_BYTES,
+                    // 31
+                    max_inter_stage_shader_variables: Direct3D12::D3D12_VS_OUTPUT_REGISTER_COUNT
+                        .min(Direct3D12::D3D12_PS_INPUT_REGISTER_COUNT)
+                        - 1, // - 1 for position
+                    // Limits that must share D3D12's root signature size of
+                    // D3D12_MAX_ROOT_COST 64 DWORDS (256 bytes).
+                    //
+                    // Root constants and root tables use 1 DWORD.
+                    // Root descriptors use 2 DWORDs.
+                    // Source: https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signature-limits#memory-limits-and-costs
+                    //
+                    // Per pipeline layout:
+                    // - RootElement::Constant, (immediates) 32 root constants
+                    //     (bounded by maxImmediateSize) = 32 x 4 bytes = 128 bytes
+                    // - RootElement::SamplerHeap, a root table = 4 bytes
+                    // - RootElement::SpecialConstantBuffer, 3 root constants = 3 x 4 bytes = 12 bytes
+                    // - RootElement::DynamicOffsetsBuffer, a root constant per dynamic storage buffer
+                    //     (bounded by maxDynamicStorageBuffersPerPipelineLayout) = 4 x 4 bytes = 16 bytes
+                    // - RootElement::DynamicUniformBuffer, a root descriptor per dynamic uniform buffer
+                    //     (bounded by maxDynamicUniformBuffersPerPipelineLayout) = 8 x 8 bytes = 64 bytes
+                    // Per bind group:
+                    // - RootElement::Table, a root table
+                    //     (bounded by maxBindGroups) = 8 x 4 bytes = 32 bytes
+                    //
+                    // Source: logic in `create_pipeline_layout`
+                    //
+                    // Total: 128 + 4 + 12 + 16 + 64 + 32 = 256 bytes
+                    //
+                    max_immediate_size: 128,
+                    max_bind_groups: crate::MAX_BIND_GROUPS as u32,
+                    max_dynamic_uniform_buffers_per_pipeline_layout: 8,
+                    max_dynamic_storage_buffers_per_pipeline_layout: 4,
+                    //
+                    // 8
+                    max_color_attachments: Direct3D12::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT,
+                    // 128 (No documented limit)
+                    max_color_attachment_bytes_per_sample:
+                        Direct3D12::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT
+                            * wgt::TextureFormat::MAX_TARGET_PIXEL_BYTE_COST,
+                    // From: https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#18.6.6%20Inter-Thread%20Data%20Sharing
+                    max_compute_workgroup_storage_size: 32768,
+                    // 1024
+                    max_compute_invocations_per_workgroup:
+                        Direct3D12::D3D12_CS_THREAD_GROUP_MAX_THREADS_PER_GROUP,
+                    // 1024
+                    max_compute_workgroup_size_x: Direct3D12::D3D12_CS_THREAD_GROUP_MAX_X,
+                    // 1024
+                    max_compute_workgroup_size_y: Direct3D12::D3D12_CS_THREAD_GROUP_MAX_Y,
+                    // 64
+                    max_compute_workgroup_size_z: Direct3D12::D3D12_CS_THREAD_GROUP_MAX_Z,
+                    // 65535
+                    max_compute_workgroups_per_dimension:
+                        Direct3D12::D3D12_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION,
+                    //
+                    // NATIVE (Non-WebGPU) LIMITS:
+                    //
                     max_non_sampler_bindings: 1_000_000,
+
+                    max_binding_array_elements_per_shader_stage: full_heap_count,
+                    max_binding_array_sampler_elements_per_shader_stage: full_heap_count,
 
                     // Source: https://microsoft.github.io/DirectX-Specs/d3d/MeshShader.html#dispatchmesh-api
                     max_task_mesh_workgroup_total_count: if mesh_shader_supported {

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -803,7 +803,7 @@ impl super::Adapter {
                     // 2048
                     max_texture_array_layers: Direct3D12::D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION,
                     // No real limit.
-                    max_bindings_per_bind_group: 65535,
+                    max_bindings_per_bind_group: u32::MAX,
                     max_sampled_textures_per_shader_stage,
                     // 16 or 2048
                     max_samplers_per_shader_stage: match options.ResourceBindingTier {

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -874,17 +874,26 @@ impl crate::Device for super::Device {
         //
         // Immediates are implemented as root constants.
         //
-        // Each bind group layout will be one table entry of the root signature.
-        // We have the additional restriction that SRV/CBV/UAV and samplers need to be
-        // separated, so each set layout will actually occupy up to 2 entries!
-        // SRV/CBV/UAV tables are added to the signature first, then Sampler tables,
-        // and finally dynamic uniform descriptors.
+        // Each bind group layout might use one SRV/CBV/UAV descriptor table.
+        // With resources in the bind group layout using:
+        //  - 1 CBV per non-dynamic uniform buffer
+        //  - 1 SRV per acceleration structure
+        //  - 1 SRV for all samplers in a bind group
+        //  - 1 SRV per texture
+        //  - 1 SRV per read-only storage buffer
+        //  - 1 UAV per storage texture
+        //  - 1 UAV per read-write storage buffer
+        //  - 3 SRVs & 1 CBV per external texture
         //
-        // Uniform buffers with dynamic offsets are implemented as root descriptors.
+        // Each dynamic uniform buffer takes up a CBV root descriptor.
         // This is easier than trying to patch up the offset on the shader side.
         //
-        // Storage buffers with dynamic offsets are part of a descriptor table and
-        // the dynamic offsets are passed via root constants.
+        // Each dynamic storage buffer is an SRV or UAV in the descriptor table
+        // and its dynamic offsets are passed via root constants.
+        //
+        // All samplers go into a single sampler descriptor table.
+        //
+        // 3 additional root constants are used to populate built-in (shader) inputs.
         //
         // Root signature layout:
         // Root Constants: Parameter=0, Space=0

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -704,7 +704,7 @@ impl super::Adapter {
         let max_color_attachment_bytes_per_sample =
             max_color_attachments * wgt::TextureFormat::MAX_TARGET_PIXEL_BYTE_COST;
 
-        let limits = crate::auxil::apply_hal_limits(wgt::Limits {
+        let limits = crate::auxil::adjust_raw_limits(wgt::Limits {
             max_texture_dimension_1d: max_texture_size,
             max_texture_dimension_2d: max_texture_size,
             max_texture_dimension_3d: max_texture_3d_size,

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -712,7 +712,8 @@ impl super::Adapter {
                 gl.get_parameter_i32(glow::MAX_ARRAY_TEXTURE_LAYERS)
             } as u32,
             max_bind_groups: crate::MAX_BIND_GROUPS as u32,
-            max_bindings_per_bind_group: 65535,
+            // No real limit.
+            max_bindings_per_bind_group: u32::MAX,
             max_dynamic_uniform_buffers_per_pipeline_layout: max_uniform_buffers_per_shader_stage,
             max_dynamic_storage_buffers_per_pipeline_layout: max_storage_buffers_per_shader_stage,
             max_sampled_textures_per_shader_stage: super::MAX_TEXTURE_SLOTS as u32,

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -118,7 +118,8 @@ impl crate::Adapter for super::Adapter {
         use crate::TextureFormatCapabilities as Tfc;
         use wgt::TextureFormat as Tf;
 
-        let pc = &self.shared.private_caps;
+        let msl_version = self.shared.private_caps.msl_version;
+        let pc = &self.shared.private_texture_format_caps;
         // Affected formats documented at:
         // https://developer.apple.com/documentation/metal/mtlreadwritetexturetier/mtlreadwritetexturetier1?language=objc
         // https://developer.apple.com/documentation/metal/mtlreadwritetexturetier/mtlreadwritetexturetier2?language=objc
@@ -141,7 +142,7 @@ impl crate::Adapter for super::Adapter {
         } else {
             Tfc::empty()
         };
-        let is_not_apple1x = super::PrivateCapabilities::supports_any(
+        let is_not_apple1x = super::CapabilitiesQuery::supports_any(
             self.shared.device.as_ref(),
             &[
                 MTLFeatureSet::iOS_GPUFamily2_v1,
@@ -150,7 +151,7 @@ impl crate::Adapter for super::Adapter {
             ],
         );
 
-        let image_atomic_if = if pc.msl_version >= MTLLanguageVersion::Version3_1 {
+        let image_atomic_if = if msl_version >= MTLLanguageVersion::Version3_1 {
             Tfc::STORAGE_ATOMIC
         } else {
             Tfc::empty()
@@ -389,7 +390,11 @@ impl crate::Adapter for super::Adapter {
             wgt::TextureFormat::Bgra8UnormSrgb,
             wgt::TextureFormat::Rgba16Float,
         ];
-        if self.shared.private_caps.format_rgb10a2_unorm_all {
+        if self
+            .shared
+            .private_texture_format_caps
+            .format_rgb10a2_unorm_all
+        {
             formats.push(wgt::TextureFormat::Rgb10a2Unorm);
         }
 
@@ -542,7 +547,7 @@ const DEPTH_CLIP_MODE: &[MTLFeatureSet] = &[
     MTLFeatureSet::macOS_GPUFamily1_v1,
 ];
 
-impl super::PrivateCapabilities {
+impl super::CapabilitiesQuery {
     fn supports_any(raw: &ProtocolObject<dyn MTLDevice>, features_sets: &[MTLFeatureSet]) -> bool {
         features_sets
             .iter()
@@ -658,11 +663,6 @@ impl super::PrivateCapabilities {
             MTLLanguageVersion::Version1_0
         };
 
-        // The `PrivateCapabilities` we are constructing here duplicates many of the limits
-        // in `wgt::Limits`, creating a risk of confusion if the limits are adjusted between
-        // the initialization here and the final `wgt::Limits` values. To reduce this risk,
-        // some of the calculations here duplicate logic in `auxil::apply_hal_limits`.
-        // See <https://github.com/gfx-rs/wgpu/issues/8715>.
         Self {
             msl_version,
             // macOS 10.11 doesn't support read-write resources
@@ -1046,14 +1046,6 @@ impl super::PrivateCapabilities {
         }
     }
 
-    pub fn device_type(&self) -> wgt::DeviceType {
-        if self.has_unified_memory.unwrap_or(self.low_power) {
-            wgt::DeviceType::IntegratedGpu
-        } else {
-            wgt::DeviceType::DiscreteGpu
-        }
-    }
-
     pub fn features(&self) -> wgt::Features {
         use wgt::Features as F;
 
@@ -1210,11 +1202,7 @@ impl super::PrivateCapabilities {
             .flags
             .set(wgt::DownlevelFlags::ANISOTROPIC_FILTERING, true);
 
-        // Be careful adjusting limits here. The `AdapterShared` stores the
-        // original `PrivateCapabilities`, so code could accidentally use
-        // the wrong value. See <https://github.com/gfx-rs/wgpu/issues/8715>.
-
-        let limits = wgt::Limits {
+        let limits = crate::auxil::apply_hal_limits(wgt::Limits {
             //
             // WebGPU LIMITS:
             // Based on https://gpuweb.github.io/gpuweb/correspondence/#limits
@@ -1237,14 +1225,12 @@ impl super::PrivateCapabilities {
             max_storage_textures_per_shader_stage: self.max_textures_per_stage.1,
             max_storage_buffers_per_shader_stage: MAX_STORAGE_BUFFERS_PER_SHADER_STAGE,
             max_uniform_buffers_per_shader_stage: MAX_UNIFORM_BUFFERS_PER_SHADER_STAGE,
-            max_vertex_buffers: MAX_VERTEX_BUFFERS.min(crate::MAX_VERTEX_BUFFERS as u32), // duplicative of `apply_hal_limits`,
+            max_vertex_buffers: MAX_VERTEX_BUFFERS,
             max_buffer_size: self.max_buffer_size,
-            // Note: any adjustment here will not be reflected in the stored `PrivateCapabilities`.
             // No limit, use maxBufferSize.
             max_uniform_buffer_binding_size: self.max_buffer_size,
             // No limit, use maxBufferSize.
-            max_storage_buffer_binding_size: self.max_buffer_size
-                & !(wgt::STORAGE_BINDING_SIZE_ALIGNMENT as u64 - 1),
+            max_storage_buffer_binding_size: self.max_buffer_size,
             min_uniform_buffer_offset_alignment: self.constant_buffer_offset_alignment,
             // No documented limit. Use 32, which is the lowest allowed value.
             min_storage_buffer_offset_alignment: 32,
@@ -1303,18 +1289,7 @@ impl super::PrivateCapabilities {
             max_mesh_output_primitives: 256,
             max_mesh_output_layers: self.max_texture_layers as u32,
             max_mesh_multiview_view_count: 0,
-        };
-
-        // Since a bunch of the limits are duplicated between `Limits` and
-        // `PrivateCapabilities`, reducing the limits at this point could make
-        // things inconsistent and lead to confusion. Make sure that doesn't
-        // happen. See <https://github.com/gfx-rs/wgpu/issues/8715>.
-        debug_assert!(
-            crate::auxil::apply_hal_limits(limits.clone()) == limits,
-            "Limits were modified by apply_hal_limits\nOriginal:\n{:#?}\nModified:\n{:#?}",
-            limits,
-            crate::auxil::apply_hal_limits(limits.clone())
-        );
+        });
 
         crate::Capabilities {
             limits,
@@ -1373,6 +1348,56 @@ impl super::PrivateCapabilities {
         ]
     }
 
+    pub fn private_capabilities(&self) -> super::PrivateCapabilities {
+        super::PrivateCapabilities {
+            msl_version: self.msl_version,
+            low_power: self.low_power,
+            headless: self.headless,
+            has_unified_memory: self.has_unified_memory,
+            timestamp_query_support: self.timestamp_query_support,
+            supports_memoryless_storage: self.supports_memoryless_storage,
+            mesh_shaders: self.mesh_shaders,
+        }
+    }
+
+    pub fn private_texture_format_capabilities(&self) -> super::PrivateTextureFormatCapabilities {
+        super::PrivateTextureFormatCapabilities {
+            read_write_texture_tier: self.read_write_texture_tier,
+            sample_count_mask: self.sample_count_mask,
+            int64_atomics: self.int64_atomics,
+            msaa_desktop: self.msaa_desktop,
+            msaa_apple3: self.msaa_apple3,
+            msaa_apple7: self.msaa_apple7,
+            format_r32float_all: self.format_r32float_all,
+            format_rgba8_srgb_all: self.format_rgba8_srgb_all,
+            format_rgb10a2_uint_write: self.format_rgb10a2_uint_write,
+            format_rgb10a2_unorm_all: self.format_rgb10a2_unorm_all,
+            format_rg11b10_all: self.format_rg11b10_all,
+            format_rg32float_all: self.format_rg32float_all,
+            format_rgba32float_all: self.format_rgba32float_all,
+            format_depth16unorm: self.format_depth16unorm,
+            format_depth16unorm_filter: self.format_depth16unorm_filter,
+            format_depth32float_filter: self.format_depth32float_filter,
+            format_depth24_stencil8: self.format_depth24_stencil8,
+            format_bc: self.format_bc,
+            format_eac_etc: self.format_eac_etc,
+            format_astc: self.format_astc,
+            format_astc_hdr: self.format_astc_hdr,
+        }
+    }
+}
+
+impl super::PrivateCapabilities {
+    pub fn device_type(&self) -> wgt::DeviceType {
+        if self.has_unified_memory.unwrap_or(self.low_power) {
+            wgt::DeviceType::IntegratedGpu
+        } else {
+            wgt::DeviceType::DiscreteGpu
+        }
+    }
+}
+
+impl super::PrivateTextureFormatCapabilities {
     pub fn map_format(&self, format: wgt::TextureFormat) -> MTLPixelFormat {
         use wgt::TextureFormat as Tf;
         use MTLPixelFormat as MTL;

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -31,6 +31,23 @@ use super::{OsFeatures, TimestampQuerySupport};
 /// [new command buffer]: https://developer.apple.com/documentation/metal/mtlcommandqueue/makecommandbuffer()?language=objc
 const MAX_COMMAND_BUFFERS: usize = 4096;
 
+// Metal has a single buffer limit that we must split across 3 WebGPU limits:
+// The Metal limit is: 31 "Maximum number of entries in the buffer argument table, per graphics or kernel function".
+// We must split it across:
+//  - maxStorageBuffersPerShaderStage; must be at least 8
+//  - maxUniformBuffersPerShaderStage; must be at least 12
+//  - maxVertexBuffers; must be at least 8
+// We require 2 additional internal buffers:
+//  - one for immediate data
+//  - one for sizes of other buffers
+// We use the last buffer for an acceleration structure.
+const MAX_STORAGE_BUFFERS_PER_SHADER_STAGE: u32 = 8;
+const MAX_UNIFORM_BUFFERS_PER_SHADER_STAGE: u32 = 12;
+const MAX_VERTEX_BUFFERS: u32 = 8;
+const MAX_ACCELERATION_STRUCTURES_PER_SHADER_STAGE: u32 = 1;
+// Use the end of the range for vertex buffers.
+pub const VERTEX_BUFFER_SLOT_START: u32 = 31 - 8;
+
 unsafe impl Send for super::Adapter {}
 unsafe impl Sync for super::Adapter {}
 
@@ -750,18 +767,21 @@ impl super::PrivateCapabilities {
             format_depth32float_none: os_type != super::OsType::Macos,
             format_bgr10a2_all: Self::supports_any(device, BGR10A2_ALL),
             format_bgr10a2_no_write: !Self::supports_any(device, BGR10A2_ALL),
-            max_buffers_per_stage: 31,
-            max_vertex_buffers: 31.min(crate::MAX_VERTEX_BUFFERS as u32), // duplicative of `apply_hal_limits`
+            // "Maximum number of entries in the texture argument table, per graphics or kernel function"
+            // The tuple is (sampled, storage).
+            // The default limit split in WebGPU is 80%-20%.
+            //  - The default maxSampledTexturesPerShaderStage in WebGPU is 16.
+            //  - The default maxStorageTexturesPerShaderStage in WebGPU is 4.
+            // Use a split of 75%-25% which can exactly split 128 and 96.
             max_textures_per_stage: if os_type == super::OsType::Macos
                 || (family_check && device.supportsFamily(MTLGPUFamily::Apple6))
             {
-                128
+                (96, 32) // 128
             } else if family_check && device.supportsFamily(MTLGPUFamily::Apple4) {
-                96
+                (72, 24) // 96
             } else {
-                31
+                (23, 8) // 31
             },
-            max_samplers_per_stage: 16,
             max_binding_array_elements: if argument_buffers == Some(MTLArgumentBuffersTier::Tier2) {
                 1_000_000
             } else if family_check && device.supportsFamily(MTLGPUFamily::Apple4) {
@@ -784,10 +804,24 @@ impl super::PrivateCapabilities {
             } else {
                 16
             },
+            // "Buffer alignment for copying an existing texture to a buffer"
             buffer_alignment: if matches!(os_type, super::OsType::Macos | super::OsType::VisionOs) {
                 256
+            } else if family_check && device.supportsFamily(MTLGPUFamily::Apple3) {
+                16
             } else {
                 64
+            },
+            // "Minimum constant buffer offset alignment"
+            constant_buffer_offset_alignment: if matches!(
+                os_type,
+                super::OsType::Macos | super::OsType::VisionOs
+            ) {
+                256
+            } else if device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily2_v1) {
+                32
+            } else {
+                4
             },
             max_buffer_size: if available!(macos = 10.14, ios = 12.0, tvos = 12.0, visionos = 1.0) {
                 device.maxBufferLength() as u64
@@ -796,7 +830,12 @@ impl super::PrivateCapabilities {
             } else {
                 1 << 28 // 256MB on iOS 8.0+
             },
-            max_texture_size: if Self::supports_any(
+            // "Maximum 1D texture width" &
+            // "Maximum 2D texture width and height" &
+            // "Maximum cube map texture width and height"
+            max_texture_size: if family_check && device.supportsFamily(MTLGPUFamily::Apple10) {
+                32768
+            } else if Self::supports_any(
                 device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily3_v1,
@@ -808,7 +847,9 @@ impl super::PrivateCapabilities {
             } else {
                 8192
             },
+            // "Maximum 3D texture width, height, and depth"
             max_texture_3d_size: 2048,
+            // "Maximum number of layers per 1D texture array, 2D texture array, or 3D texture"
             max_texture_layers: 2048,
             max_fragment_input_components: if os_type == super::OsType::Macos
                 || device.supportsFeatureSet(MTLFeatureSet::iOS_GPUFamily4_v1)
@@ -817,8 +858,8 @@ impl super::PrivateCapabilities {
             } else {
                 60
             },
+            // "Maximum number of color render targets per render pass descriptor"
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=7
-            // 8 is supported on everything on that list
             max_color_render_targets: if Self::supports_any(
                 device,
                 &[
@@ -831,29 +872,39 @@ impl super::PrivateCapabilities {
             } else {
                 4
             },
+            // "Maximum total render target size, per pixel, when using multiple color render targets"
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=7
             max_color_attachment_bytes_per_sample: if family_check
-                && device.supportsFamily(MTLGPUFamily::Apple7)
+                && device.supportsFamily(MTLGPUFamily::Apple4)
             {
-                128
-            } else if family_check && device.supportsFamily(MTLGPUFamily::Apple4) {
-                64
+                64 // 512 bits
+            } else if family_check && device.supportsFamily(MTLGPUFamily::Apple2) {
+                32 // 256 bits
+            } else if device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily1_v1) {
+                // No Limit, use max_color_render_targets * MAX_TARGET_PIXEL_BYTE_COST
+                8 * wgt::TextureFormat::MAX_TARGET_PIXEL_BYTE_COST as u8 // 1024 bits
             } else {
-                32
+                16 // 128 bits
             },
-            max_varying_components: if device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily1_v1)
+            // This limit is the minimum of:
+            // - "Maximum scalar or vector inputs to a fragment function"
+            // - "Maximum number of input components to a fragment function" / 4
+            max_inter_stage_shader_variables: if (family_check
+                && device.supportsFamily(MTLGPUFamily::Apple4))
+                || device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily1_v1)
             {
-                124
+                31 // min(32 or 124, 124 / 4)
             } else {
-                60
+                15 // min(60, 60 / 4)
             },
+            // "Maximum threads per threadgroup"
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=6
             // These are older checks but still hold true; no entry in this table supports
             // more than 1024 threads.
             max_threads_per_group: if Self::supports_any(
                 device,
                 &[
-                    MTLFeatureSet::iOS_GPUFamily4_v2,
+                    MTLFeatureSet::iOS_GPUFamily4_v1,
                     MTLFeatureSet::macOS_GPUFamily1_v1,
                 ],
             ) {
@@ -861,6 +912,7 @@ impl super::PrivateCapabilities {
             } else {
                 512
             },
+            // "Maximum total threadgroup memory allocation"
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=6
             // These are older checks but still hold true; no entry in this table supports
             // more than 32kb.
@@ -868,7 +920,7 @@ impl super::PrivateCapabilities {
                 device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily4_v1,
-                    MTLFeatureSet::macOS_GPUFamily1_v2,
+                    MTLFeatureSet::macOS_GPUFamily1_v1,
                 ],
             ) {
                 32 << 10
@@ -1158,42 +1210,49 @@ impl super::PrivateCapabilities {
             .flags
             .set(wgt::DownlevelFlags::ANISOTROPIC_FILTERING, true);
 
-        let base = wgt::Limits::default();
         // Be careful adjusting limits here. The `AdapterShared` stores the
         // original `PrivateCapabilities`, so code could accidentally use
         // the wrong value. See <https://github.com/gfx-rs/wgpu/issues/8715>.
 
         let limits = wgt::Limits {
+            //
+            // WebGPU LIMITS:
+            // Based on https://gpuweb.github.io/gpuweb/correspondence/#limits
+            //
             max_texture_dimension_1d: self.max_texture_size as u32,
             max_texture_dimension_2d: self.max_texture_size as u32,
             max_texture_dimension_3d: self.max_texture_3d_size as u32,
             max_texture_array_layers: self.max_texture_layers as u32,
+            // No real limit.
             max_bind_groups: 8,
+            // No real limit.
             max_bindings_per_bind_group: 65535,
-            max_dynamic_uniform_buffers_per_pipeline_layout: base
-                .max_dynamic_uniform_buffers_per_pipeline_layout,
-            max_dynamic_storage_buffers_per_pipeline_layout: base
-                .max_dynamic_storage_buffers_per_pipeline_layout,
-            max_sampled_textures_per_shader_stage: self.max_textures_per_stage,
-            max_samplers_per_shader_stage: self.max_samplers_per_stage,
-            max_storage_buffers_per_shader_stage: self.max_buffers_per_stage,
-            max_storage_textures_per_shader_stage: self.max_textures_per_stage,
-            max_uniform_buffers_per_shader_stage: self.max_buffers_per_stage,
-            max_binding_array_elements_per_shader_stage: self.max_binding_array_elements,
-            max_binding_array_sampler_elements_per_shader_stage: self
-                .max_sampler_binding_array_elements,
-            max_binding_array_acceleration_structure_elements_per_shader_stage: 0,
+            // No limit, use maxUniformBuffersPerShaderStage.
+            max_dynamic_uniform_buffers_per_pipeline_layout: MAX_UNIFORM_BUFFERS_PER_SHADER_STAGE,
+            // No limit, use maxStorageBuffersPerShaderStage.
+            max_dynamic_storage_buffers_per_pipeline_layout: MAX_STORAGE_BUFFERS_PER_SHADER_STAGE,
+            // "Maximum number of entries in the sampler state argument table, per graphics or kernel function"
+            max_samplers_per_shader_stage: 16,
+            max_sampled_textures_per_shader_stage: self.max_textures_per_stage.0,
+            max_storage_textures_per_shader_stage: self.max_textures_per_stage.1,
+            max_storage_buffers_per_shader_stage: MAX_STORAGE_BUFFERS_PER_SHADER_STAGE,
+            max_uniform_buffers_per_shader_stage: MAX_UNIFORM_BUFFERS_PER_SHADER_STAGE,
+            max_vertex_buffers: MAX_VERTEX_BUFFERS.min(crate::MAX_VERTEX_BUFFERS as u32), // duplicative of `apply_hal_limits`,
+            max_buffer_size: self.max_buffer_size,
             // Note: any adjustment here will not be reflected in the stored `PrivateCapabilities`.
-            max_uniform_buffer_binding_size: self.max_buffer_size.min(!0u32 as u64),
-            max_storage_buffer_binding_size: self.max_buffer_size.min(!0u32 as u64)
+            // No limit, use maxBufferSize.
+            max_uniform_buffer_binding_size: self.max_buffer_size,
+            // No limit, use maxBufferSize.
+            max_storage_buffer_binding_size: self.max_buffer_size
                 & !(wgt::STORAGE_BINDING_SIZE_ALIGNMENT as u64 - 1),
-            max_vertex_buffers: self.max_vertex_buffers,
+            min_uniform_buffer_offset_alignment: self.constant_buffer_offset_alignment,
+            // No documented limit. Use 32, which is the lowest allowed value.
+            min_storage_buffer_offset_alignment: 32,
+            // "Maximum number of vertex attributes, per vertex descriptor"
             max_vertex_attributes: 31,
-            max_vertex_buffer_array_stride: base.max_vertex_buffer_array_stride,
-            max_immediate_size: 0x1000,
-            max_inter_stage_shader_variables: self.max_varying_components / 4,
-            min_uniform_buffer_offset_alignment: self.buffer_alignment as u32,
-            min_storage_buffer_offset_alignment: self.buffer_alignment as u32,
+            // No documented limit, matches Vulkan's minimum limit and D3D12's static limit.
+            max_vertex_buffer_array_stride: 2048,
+            max_inter_stage_shader_variables: self.max_inter_stage_shader_variables,
             max_color_attachments: self.max_color_render_targets as u32,
             max_color_attachment_bytes_per_sample: self.max_color_attachment_bytes_per_sample
                 as u32,
@@ -1202,9 +1261,18 @@ impl super::PrivateCapabilities {
             max_compute_workgroup_size_x: self.max_threads_per_group,
             max_compute_workgroup_size_y: self.max_threads_per_group,
             max_compute_workgroup_size_z: self.max_threads_per_group,
+            // No documented limit, matches Vulkan's minimum limit and D3D12's static limit.
             max_compute_workgroups_per_dimension: 0xFFFF,
-            max_buffer_size: self.max_buffer_size,
+            max_immediate_size: 0x1000,
+            //
+            // NATIVE (Non-WebGPU) LIMITS:
+            //
             max_non_sampler_bindings: u32::MAX,
+
+            max_binding_array_elements_per_shader_stage: self.max_binding_array_elements,
+            max_binding_array_sampler_elements_per_shader_stage: self
+                .max_sampler_binding_array_elements,
+            max_binding_array_acceleration_structure_elements_per_shader_stage: 0,
 
             // from https://developer.apple.com/documentation/metal/mtlaccelerationstructureusage/extendedlimits
             max_blas_primitive_count: 1 << 28,
@@ -1213,7 +1281,8 @@ impl super::PrivateCapabilities {
             // From 2.17.7 in https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf
             // > [Acceleration structures] are opaque objects that can be bound directly using
             // buffer binding points or via argument buffers
-            max_acceleration_structures_per_shader_stage: self.max_buffers_per_stage,
+            max_acceleration_structures_per_shader_stage:
+                MAX_ACCELERATION_STRUCTURES_PER_SHADER_STAGE,
 
             max_multiview_view_count: if self.supported_vertex_amplification_factor > 1 {
                 self.supported_vertex_amplification_factor

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1202,7 +1202,7 @@ impl super::CapabilitiesQuery {
             .flags
             .set(wgt::DownlevelFlags::ANISOTROPIC_FILTERING, true);
 
-        let limits = crate::auxil::apply_hal_limits(wgt::Limits {
+        let limits = crate::auxil::adjust_raw_limits(wgt::Limits {
             //
             // WebGPU LIMITS:
             // Based on https://gpuweb.github.io/gpuweb/correspondence/#limits

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1226,7 +1226,7 @@ impl super::PrivateCapabilities {
             // No real limit.
             max_bind_groups: 8,
             // No real limit.
-            max_bindings_per_bind_group: 65535,
+            max_bindings_per_bind_group: u32::MAX,
             // No limit, use maxUniformBuffersPerShaderStage.
             max_dynamic_uniform_buffers_per_pipeline_layout: MAX_UNIFORM_BUFFERS_PER_SHADER_STAGE,
             // No limit, use maxStorageBuffersPerShaderStage.

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -560,7 +560,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
         T: Iterator<Item = crate::TextureCopy>,
     {
         let dst_texture = if src.format != dst.format {
-            let raw_format = self.shared.private_caps.map_format(src.format);
+            let raw_format = self
+                .shared
+                .private_texture_format_caps
+                .map_format(src.format);
             Cow::Owned(autoreleasepool(|_| {
                 dst.raw.newTextureViewWithPixelFormat(raw_format).unwrap()
             }))

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -13,7 +13,7 @@ use objc2_metal::{
     MTLVisibilityResultMode,
 };
 
-use super::{conv, TimestampQuerySupport};
+use super::{adapter::VERTEX_BUFFER_SLOT_START, conv, TimestampQuerySupport};
 use crate::CommandEncoder as _;
 use alloc::{
     borrow::{Cow, ToOwned as _},
@@ -435,7 +435,7 @@ impl super::CommandState {
         // they were added to the map.
         result_sizes.extend(stage_info.vertex_buffer_mappings.iter().map(|vbm| {
             self.vertex_buffer_size_map
-                .get(&(vbm.id as u64))
+                .get(&vbm.id)
                 .map(|size| u32::try_from(size.get()).unwrap_or(u32::MAX))
                 .unwrap_or_default()
         }));
@@ -1344,7 +1344,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         index: u32,
         binding: crate::BufferBinding<'a, super::Buffer>,
     ) {
-        let buffer_index = self.shared.private_caps.max_vertex_buffers as u64 - 1 - index as u64;
+        let buffer_index = VERTEX_BUFFER_SLOT_START + index;
         let encoder = self.state.render.as_ref().unwrap();
         unsafe {
             encoder.setVertexBuffer_offset_atIndex(

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -377,8 +377,10 @@ impl super::Device {
         raw: Retained<ProtocolObject<dyn MTLDevice>>,
         features: wgt::Features,
     ) -> super::Device {
+        let capabilities_query = super::CapabilitiesQuery::new(&raw);
+        let shared = super::AdapterShared::new(raw, &capabilities_query);
         super::Device {
-            shared: Arc::new(super::AdapterShared::new(raw)),
+            shared: Arc::new(shared),
             features,
             counters: Default::default(),
         }
@@ -458,7 +460,10 @@ impl crate::Device for super::Device {
         &self,
         desc: &crate::TextureDescriptor,
     ) -> DeviceResult<super::Texture> {
-        let mtl_format = self.shared.private_caps.map_format(desc.format);
+        let mtl_format = self
+            .shared
+            .private_texture_format_caps
+            .map_format(desc.format);
 
         autoreleasepool(|_| {
             let descriptor = MTLTextureDescriptor::new();
@@ -545,10 +550,14 @@ impl crate::Device for super::Device {
 
         let raw_format = self
             .shared
-            .private_caps
+            .private_texture_format_caps
             .map_view_format(desc.format, aspects);
 
-        let format_equal = raw_format == self.shared.private_caps.map_format(texture.format);
+        let format_equal = raw_format
+            == self
+                .shared
+                .private_texture_format_caps
+                .map_format(texture.format);
         let type_equal = raw_type == texture.raw_type;
         let range_full_resource =
             desc.range
@@ -1509,7 +1518,10 @@ impl crate::Device for super::Device {
                     continue;
                 };
 
-                let raw_format = self.shared.private_caps.map_format(ct.format);
+                let raw_format = self
+                    .shared
+                    .private_texture_format_caps
+                    .map_format(ct.format);
                 at_descriptor.setPixelFormat(raw_format);
                 at_descriptor.setWriteMask(conv::map_color_write(ct.write_mask));
 
@@ -1531,7 +1543,10 @@ impl crate::Device for super::Device {
             // Setup depth stencil state
             let depth_stencil = match desc.depth_stencil {
                 Some(ref ds) => {
-                    let raw_format = self.shared.private_caps.map_format(ds.format);
+                    let raw_format = self
+                        .shared
+                        .private_texture_format_caps
+                        .map_format(ds.format);
                     let aspects = crate::FormatAspects::from(ds.format);
                     if aspects.contains(crate::FormatAspects::DEPTH) {
                         descriptor.setDepthAttachmentPixelFormat(raw_format);

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -24,7 +24,7 @@ use objc2_metal::{
     MTLVertexStepFunction,
 };
 
-use super::{conv, PassthroughShader, ShaderModuleSource};
+use super::{adapter::VERTEX_BUFFER_SLOT_START, conv, PassthroughShader, ShaderModuleSource};
 use crate::{auxil::map_naga_stage, TlasInstance};
 
 type DeviceResult<T> = Result<T, crate::DeviceError>;
@@ -845,14 +845,6 @@ impl crate::Device for super::Device {
                 info.sizes_buffer = Some(info.counters.buffers);
                 info.counters.buffers += 1;
             }
-
-            if info.counters.buffers > self.shared.private_caps.max_buffers_per_stage
-                || info.counters.textures > self.shared.private_caps.max_textures_per_stage
-                || info.counters.samplers > self.shared.private_caps.max_samplers_per_stage
-            {
-                log::error!("Resource limit exceeded: {info:?}");
-                return Err(crate::DeviceError::OutOfMemory);
-            }
         }
 
         let immediates_infos = stage_data.map_ref(|info| {
@@ -861,8 +853,6 @@ impl crate::Device for super::Device {
                 buffer_index,
             })
         });
-
-        let total_counters = stage_data.map_ref(|info| info.counters.clone());
 
         let per_stage_map = stage_data.map(|info| naga::back::msl::EntryPointResources {
             immediates_buffer: info
@@ -879,7 +869,6 @@ impl crate::Device for super::Device {
         Ok(super::PipelineLayout {
             bind_group_infos,
             immediates_infos,
-            total_counters,
             total_immediates: desc.immediate_size,
             per_stage_map,
         })
@@ -1281,7 +1270,7 @@ impl crate::Device for super::Device {
                         }
 
                         let mapping = naga::back::msl::VertexBufferMapping {
-                            id: self.shared.private_caps.max_vertex_buffers - 1 - i as u32,
+                            id: VERTEX_BUFFER_SLOT_START + i as u32,
                             stride: if vbl.array_stride > 0 {
                                 vbl.array_stride.try_into().unwrap()
                             } else {
@@ -1341,27 +1330,11 @@ impl crate::Device for super::Device {
                         });
                     }
 
-                    // Validate vertex buffer count
-                    if desc.layout.total_counters.vs.buffers + (vertex_buffers.len() as u32)
-                        > self.shared.private_caps.max_vertex_buffers
-                    {
-                        let msg = format!(
-                            "pipeline needs too many buffers in the vertex stage: {} vertex and {} layout",
-                            vertex_buffers.len(),
-                            desc.layout.total_counters.vs.buffers
-                        );
-                        return Err(crate::PipelineError::Linkage(
-                            wgt::ShaderStages::VERTEX,
-                            msg,
-                        ));
-                    }
-
                     // Set the pipeline vertex buffer info
                     if !vertex_buffers.is_empty() {
                         let vertex_descriptor = MTLVertexDescriptor::new();
                         for (i, vb) in vertex_buffers.iter().enumerate() {
-                            let buffer_index =
-                                self.shared.private_caps.max_vertex_buffers as usize - 1 - i;
+                            let buffer_index = VERTEX_BUFFER_SLOT_START as usize + i;
                             let buffer_desc = unsafe {
                                 vertex_descriptor
                                     .layouts()

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -119,7 +119,7 @@ crate::impl_dyn_resource!(
 /// Provides availability information about Mac APIs.
 ///
 /// This may include Metal features that depend only on software support.
-/// Features with varying hardware support are in [`PrivateCapabilities`]
+/// Features with varying hardware support are in [`CapabilitiesQuery`]
 ///
 /// When feature detection is only needed once, it may also be done inline.
 struct OsFeatures;
@@ -184,35 +184,8 @@ impl crate::Instance for Instance {
         _surface_hint: Option<&Surface>,
     ) -> Vec<crate::ExposedAdapter<Api>> {
         let devices = objc2_metal::MTLCopyAllDevices();
-        let mut adapters: Vec<crate::ExposedAdapter<Api>> = devices
-            .into_iter()
-            .map(|dev| {
-                let name = dev.name().to_string();
-                let shared = AdapterShared::new(dev);
-                crate::ExposedAdapter {
-                    info: wgt::AdapterInfo {
-                        name,
-                        vendor: 0,
-                        device: 0,
-                        device_type: shared.private_caps.device_type(),
-                        device_pci_bus_id: String::new(),
-                        driver: String::new(),
-                        driver_info: String::new(),
-                        backend: wgt::Backend::Metal,
-                        // These are hardcoded based on typical values for Metal devices
-                        //
-                        // See <https://github.com/gpuweb/gpuweb/blob/main/proposals/subgroups.md#adapter-info>
-                        // for more information.
-                        subgroup_min_size: 4,
-                        subgroup_max_size: 64,
-                        transient_saves_memory: shared.private_caps.supports_memoryless_storage,
-                    },
-                    features: shared.private_caps.features(),
-                    capabilities: shared.private_caps.capabilities(),
-                    adapter: Adapter::new(Arc::new(shared)),
-                }
-            })
-            .collect();
+        let mut adapters: Vec<crate::ExposedAdapter<Api>> =
+            devices.into_iter().map(AdapterShared::expose).collect();
         adapters.sort_by_key(|ad| {
             (
                 ad.adapter.shared.private_caps.low_power,
@@ -241,11 +214,8 @@ bitflags!(
     }
 );
 
-// TODO(https://github.com/gfx-rs/wgpu/issues/8715): Eliminate duplication with
-// `wgt::Limits`. Keeping multiple sets of limits creates a risk of confusion.
 #[allow(dead_code)]
-#[derive(Clone, Debug)]
-struct PrivateCapabilities {
+struct CapabilitiesQuery {
     msl_version: MTLLanguageVersion,
     fragment_rw_storage: bool,
     read_write_texture_tier: MTLReadWriteTextureTier,
@@ -316,11 +286,6 @@ struct PrivateCapabilities {
     max_sampler_binding_array_elements: ResourceIndex,
     buffer_alignment: u64,
     constant_buffer_offset_alignment: u32,
-
-    /// Platform-reported maximum buffer size
-    ///
-    /// This value is clamped to `u32::MAX` for `wgt::Limits`, so you probably
-    /// shouldn't be looking at this copy.
     max_buffer_size: u64,
     max_texture_size: u64,
     max_texture_3d_size: u64,
@@ -355,6 +320,42 @@ struct PrivateCapabilities {
     supports_raytracing: bool,
 }
 
+#[derive(Debug)]
+struct PrivateCapabilities {
+    msl_version: MTLLanguageVersion,
+    low_power: bool,
+    headless: bool,
+    has_unified_memory: Option<bool>,
+    timestamp_query_support: TimestampQuerySupport,
+    supports_memoryless_storage: bool,
+    mesh_shaders: bool,
+}
+
+#[derive(Debug)]
+struct PrivateTextureFormatCapabilities {
+    read_write_texture_tier: MTLReadWriteTextureTier,
+    sample_count_mask: crate::TextureFormatCapabilities,
+    int64_atomics: bool,
+    msaa_desktop: bool,
+    msaa_apple3: bool,
+    msaa_apple7: bool,
+    format_r32float_all: bool,
+    format_rgba8_srgb_all: bool,
+    format_rgb10a2_uint_write: bool,
+    format_rgb10a2_unorm_all: bool,
+    format_rg11b10_all: bool,
+    format_rg32float_all: bool,
+    format_rgba32float_all: bool,
+    format_depth16unorm: bool,
+    format_depth16unorm_filter: bool,
+    format_depth32float_filter: bool,
+    format_depth24_stencil8: bool,
+    format_bc: bool,
+    format_eac_etc: bool,
+    format_astc: bool,
+    format_astc_hdr: bool,
+}
+
 #[derive(Clone, Debug)]
 struct PrivateDisabilities {
     /// Near depth is not respected properly on some Intel GPUs.
@@ -381,6 +382,7 @@ struct AdapterShared {
     device: Retained<ProtocolObject<dyn MTLDevice>>,
     disabilities: PrivateDisabilities,
     private_caps: PrivateCapabilities,
+    private_texture_format_caps: PrivateTextureFormatCapabilities,
     settings: Settings,
     presentation_timer: time::PresentationTimer,
 }
@@ -389,16 +391,52 @@ unsafe impl Send for AdapterShared {}
 unsafe impl Sync for AdapterShared {}
 
 impl AdapterShared {
-    fn new(device: Retained<ProtocolObject<dyn MTLDevice>>) -> Self {
-        let private_caps = PrivateCapabilities::new(&device);
+    fn new(
+        device: Retained<ProtocolObject<dyn MTLDevice>>,
+        capabilities_query: &CapabilitiesQuery,
+    ) -> Self {
+        let private_caps = capabilities_query.private_capabilities();
+        let private_texture_format_caps = capabilities_query.private_texture_format_capabilities();
         log::debug!("{private_caps:#?}");
+        log::debug!("{private_texture_format_caps:#?}");
 
         Self {
             disabilities: PrivateDisabilities::new(&device),
             private_caps,
+            private_texture_format_caps,
             device,
             settings: Settings::default(),
             presentation_timer: time::PresentationTimer::new(),
+        }
+    }
+
+    fn expose(device: Retained<ProtocolObject<dyn MTLDevice>>) -> crate::ExposedAdapter<Api> {
+        let name = device.name().to_string();
+        let capabilities_query = CapabilitiesQuery::new(&device);
+        let shared = AdapterShared::new(device, &capabilities_query);
+        let features = capabilities_query.features();
+        let capabilities = capabilities_query.capabilities();
+        crate::ExposedAdapter {
+            info: wgt::AdapterInfo {
+                name,
+                vendor: 0,
+                device: 0,
+                device_type: shared.private_caps.device_type(),
+                device_pci_bus_id: String::new(),
+                driver: String::new(),
+                driver_info: String::new(),
+                backend: wgt::Backend::Metal,
+                // These are hardcoded based on typical values for Metal devices
+                //
+                // See <https://github.com/gpuweb/gpuweb/blob/main/proposals/subgroups.md#adapter-info>
+                // for more information.
+                subgroup_min_size: 4,
+                subgroup_max_size: 64,
+                transient_saves_memory: shared.private_caps.supports_memoryless_storage,
+            },
+            features,
+            capabilities,
+            adapter: Adapter::new(Arc::new(shared)),
         }
     }
 }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -311,13 +311,11 @@ struct PrivateCapabilities {
     format_depth32float_none: bool,
     format_bgr10a2_all: bool,
     format_bgr10a2_no_write: bool,
-    max_buffers_per_stage: ResourceIndex,
-    max_vertex_buffers: ResourceIndex,
-    max_textures_per_stage: ResourceIndex,
-    max_samplers_per_stage: ResourceIndex,
+    max_textures_per_stage: (ResourceIndex, ResourceIndex),
     max_binding_array_elements: ResourceIndex,
     max_sampler_binding_array_elements: ResourceIndex,
     buffer_alignment: u64,
+    constant_buffer_offset_alignment: u32,
 
     /// Platform-reported maximum buffer size
     ///
@@ -330,7 +328,7 @@ struct PrivateCapabilities {
     max_fragment_input_components: u64,
     max_color_render_targets: u8,
     max_color_attachment_bytes_per_sample: u8,
-    max_varying_components: u32,
+    max_inter_stage_shader_variables: u32,
     max_threads_per_group: u32,
     max_total_threadgroup_memory: u32,
     sample_count_mask: crate::TextureFormatCapabilities,
@@ -737,7 +735,6 @@ struct ImmediateDataInfo {
 pub struct PipelineLayout {
     bind_group_infos: [Option<BindGroupLayoutInfo>; crate::MAX_BIND_GROUPS],
     immediates_infos: MultiStageData<Option<ImmediateDataInfo>>,
-    total_counters: MultiStageResourceCounters,
     total_immediates: u32,
     per_stage_map: MultiStageResources,
 }
@@ -1027,7 +1024,7 @@ struct CommandState {
     /// [`ResourceBinding`]: naga::ResourceBinding
     storage_buffer_length_map: FastHashMap<naga::ResourceBinding, wgt::BufferSize>,
 
-    vertex_buffer_size_map: FastHashMap<u64, wgt::BufferSize>,
+    vertex_buffer_size_map: FastHashMap<u32, wgt::BufferSize>,
 
     immediates: Vec<u32>,
 

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -65,7 +65,7 @@ impl crate::Surface for super::Surface {
     ) -> Result<(), crate::SurfaceError> {
         log::debug!("build swapchain {config:?}");
 
-        let caps = &device.shared.private_caps;
+        let caps = &device.shared.private_texture_format_caps;
         *self.swapchain_format.write() = Some(config.format);
         *self.extent.write() = config.extent;
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1478,30 +1478,42 @@ impl PhysicalDeviceProperties {
         ]
         .contains(&self.properties.vendor_id);
 
-        if !ignore_max_fragment_combined_output_resources
-            && max_storage_textures_per_shader_stage
-                + max_storage_buffers_per_shader_stage
-                + max_color_attachments
-                > limits.max_fragment_combined_output_resources
-        {
-            // Divide the limit equally between the 3 limits while allowing
-            // unused limit capacity to be used by some limits that
-            // can make use of it.
-            let mut rem_limit = limits.max_fragment_combined_output_resources;
-            let limit = rem_limit / 3;
-            let diff = limit.saturating_sub(max_storage_textures_per_shader_stage);
-            max_storage_textures_per_shader_stage =
-                max_storage_textures_per_shader_stage.min(limit);
-
-            rem_limit -= limit + diff;
-            let limit = rem_limit / 2;
-            let diff = limit.saturating_sub(max_storage_buffers_per_shader_stage);
-            max_storage_buffers_per_shader_stage = max_storage_buffers_per_shader_stage.min(limit);
-
-            rem_limit -= limit + diff;
-            let limit = rem_limit;
-            max_color_attachments = max_color_attachments.min(limit);
+        if !ignore_max_fragment_combined_output_resources {
+            crate::auxil::cap_limits_to_be_under_the_sum_limit(
+                [
+                    &mut max_storage_textures_per_shader_stage,
+                    &mut max_storage_buffers_per_shader_stage,
+                    &mut max_color_attachments,
+                ],
+                limits.max_fragment_combined_output_resources,
+            );
         }
+
+        // When summed, the 5 limits below must be under Vulkan's maxPerStageResources.
+        //
+        // - maxUniformBuffersPerShaderStage, WebGPU default: 12
+        // - maxSampledTexturesPerShaderStage, WebGPU default: 16
+        // - maxStorageTexturesPerShaderStage, WebGPU default: 4
+        // - maxStorageBuffersPerShaderStage, WebGPU default: 8
+        // - maxColorAttachments, WebGPU default: 8
+        //
+        // Note: Vulkan's texel buffers and input attachments also count towards
+        // maxPerStageResources but we don't make use of them.
+        let mut max_sampled_textures_per_shader_stage =
+            limits.max_per_stage_descriptor_sampled_images;
+        let mut max_uniform_buffers_per_shader_stage =
+            limits.max_per_stage_descriptor_uniform_buffers;
+
+        crate::auxil::cap_limits_to_be_under_the_sum_limit(
+            [
+                &mut max_sampled_textures_per_shader_stage,
+                &mut max_uniform_buffers_per_shader_stage,
+                &mut max_storage_textures_per_shader_stage,
+                &mut max_storage_buffers_per_shader_stage,
+                &mut max_color_attachments,
+            ],
+            limits.max_per_stage_resources,
+        );
 
         // TODO: programmatically determine this, if possible. It's unclear whether we can
         // as of https://github.com/gpuweb/gpuweb/issues/2965#issuecomment-1361315447.
@@ -1552,10 +1564,10 @@ impl PhysicalDeviceProperties {
             max_dynamic_storage_buffers_per_pipeline_layout: limits
                 .max_descriptor_set_storage_buffers_dynamic,
             max_samplers_per_shader_stage: limits.max_per_stage_descriptor_samplers,
-            max_sampled_textures_per_shader_stage: limits.max_per_stage_descriptor_sampled_images,
+            max_sampled_textures_per_shader_stage,
             max_storage_textures_per_shader_stage,
             max_storage_buffers_per_shader_stage,
-            max_uniform_buffers_per_shader_stage: limits.max_per_stage_descriptor_uniform_buffers,
+            max_uniform_buffers_per_shader_stage,
             max_vertex_buffers: limits.max_vertex_input_bindings,
             max_buffer_size,
             max_uniform_buffer_binding_size: limits

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1450,6 +1450,8 @@ impl PhysicalDeviceProperties {
                 .min(descriptor_indexing.max_per_stage_descriptor_update_after_bind_samplers);
         }
 
+        const MAX_SHADER_STAGES_PER_PIPELINE: u32 = 2;
+
         // When summed, the 3 limits below must be under Vulkan's maxFragmentCombinedOutputResources.
         // https://gpuweb.github.io/gpuweb/correspondence/#vulkan-maxFragmentCombinedOutputResources
         //
@@ -1462,10 +1464,12 @@ impl PhysicalDeviceProperties {
         //
         // https://github.com/gpuweb/gpuweb/issues/3631#issuecomment-1498747606
         // https://github.com/gpuweb/gpuweb/issues/4018
-        let mut max_storage_textures_per_shader_stage =
-            limits.max_per_stage_descriptor_storage_images;
-        let mut max_storage_buffers_per_shader_stage =
-            limits.max_per_stage_descriptor_storage_buffers;
+        let mut max_storage_textures_per_shader_stage = limits
+            .max_per_stage_descriptor_storage_images
+            .min(limits.max_descriptor_set_storage_images / MAX_SHADER_STAGES_PER_PIPELINE);
+        let mut max_storage_buffers_per_shader_stage = limits
+            .max_per_stage_descriptor_storage_buffers
+            .min(limits.max_descriptor_set_storage_buffers / MAX_SHADER_STAGES_PER_PIPELINE);
         let mut max_color_attachments = limits
             .max_color_attachments
             .min(limits.max_fragment_output_attachments);
@@ -1499,10 +1503,12 @@ impl PhysicalDeviceProperties {
         //
         // Note: Vulkan's texel buffers and input attachments also count towards
         // maxPerStageResources but we don't make use of them.
-        let mut max_sampled_textures_per_shader_stage =
-            limits.max_per_stage_descriptor_sampled_images;
-        let mut max_uniform_buffers_per_shader_stage =
-            limits.max_per_stage_descriptor_uniform_buffers;
+        let mut max_sampled_textures_per_shader_stage = limits
+            .max_per_stage_descriptor_sampled_images
+            .min(limits.max_descriptor_set_sampled_images / MAX_SHADER_STAGES_PER_PIPELINE);
+        let mut max_uniform_buffers_per_shader_stage = limits
+            .max_per_stage_descriptor_uniform_buffers
+            .min(limits.max_descriptor_set_uniform_buffers / MAX_SHADER_STAGES_PER_PIPELINE);
 
         crate::auxil::cap_limits_to_be_under_the_sum_limit(
             [
@@ -1524,11 +1530,16 @@ impl PhysicalDeviceProperties {
             max_blas_geometry_count = properties.max_geometry_count as u32;
             max_blas_primitive_count = properties.max_primitive_count as u32;
             max_tlas_instance_count = properties.max_instance_count as u32;
-            max_acceleration_structures_per_shader_stage =
-                properties.max_per_stage_descriptor_acceleration_structures;
+            max_acceleration_structures_per_shader_stage = properties
+                .max_per_stage_descriptor_acceleration_structures
+                .min(
+                    properties.max_descriptor_set_acceleration_structures
+                        / MAX_SHADER_STAGES_PER_PIPELINE,
+                );
         }
 
-        // When summed, the 6 limits below must be under Vulkan's maxPerSetDescriptors / 2.
+        // When summed, the 6 limits below must be under Vulkan's
+        // maxPerSetDescriptors / MAX_SHADER_STAGES_PER_PIPELINE.
         //
         // - maxUniformBuffersPerShaderStage, WebGPU default: 12
         // - maxSampledTexturesPerShaderStage, WebGPU default: 16
@@ -1548,7 +1559,9 @@ impl PhysicalDeviceProperties {
             // https://vulkan.gpuinfo.org/displaycoreproperty.php?core=1.1&name=maxPerSetDescriptors&platform=all
             .unwrap_or(256);
 
-        let mut max_samplers_per_shader_stage = limits.max_per_stage_descriptor_samplers;
+        let mut max_samplers_per_shader_stage = limits
+            .max_per_stage_descriptor_samplers
+            .min(limits.max_descriptor_set_samplers / MAX_SHADER_STAGES_PER_PIPELINE);
 
         crate::auxil::cap_limits_to_be_under_the_sum_limit(
             [
@@ -1559,7 +1572,7 @@ impl PhysicalDeviceProperties {
                 &mut max_samplers_per_shader_stage,
                 &mut max_acceleration_structures_per_shader_stage,
             ],
-            max_per_set_descriptors / 2,
+            max_per_set_descriptors / MAX_SHADER_STAGES_PER_PIPELINE,
         );
 
         // Use max(default, maxPerSetDescriptors) since the spec requires this

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1367,10 +1367,6 @@ impl PhysicalDeviceProperties {
     fn to_wgpu_limits(&self) -> wgt::Limits {
         let limits = &self.properties.limits;
 
-        let max_compute_workgroup_sizes = limits.max_compute_work_group_size;
-        let max_compute_workgroups_per_dimension = limits.max_compute_work_group_count[0]
-            .min(limits.max_compute_work_group_count[1])
-            .min(limits.max_compute_work_group_count[2]);
         let (
             mut max_task_mesh_workgroup_total_count,
             mut max_task_mesh_workgroups_per_dimension,
@@ -1435,6 +1431,59 @@ impl PhysicalDeviceProperties {
                 .min(descriptor_indexing.max_per_stage_descriptor_update_after_bind_samplers);
         }
 
+        // When summed, the 3 limits below must be under Vulkan's maxFragmentCombinedOutputResources.
+        // https://gpuweb.github.io/gpuweb/correspondence/#vulkan-maxFragmentCombinedOutputResources
+        //
+        // - maxStorageTexturesPerShaderStage, WebGPU default: 4
+        // - maxStorageBuffersPerShaderStage, WebGPU default: 8
+        // - maxColorAttachments, WebGPU default: 8
+        //
+        // However, maxFragmentCombinedOutputResources should be ignored on
+        // intel/nvidia/amd/imgtec since it's not reported correctly.
+        //
+        // https://github.com/gpuweb/gpuweb/issues/3631#issuecomment-1498747606
+        // https://github.com/gpuweb/gpuweb/issues/4018
+        let mut max_storage_textures_per_shader_stage =
+            limits.max_per_stage_descriptor_storage_images;
+        let mut max_storage_buffers_per_shader_stage =
+            limits.max_per_stage_descriptor_storage_buffers;
+        let mut max_color_attachments = limits
+            .max_color_attachments
+            .min(limits.max_fragment_output_attachments);
+
+        let ignore_max_fragment_combined_output_resources = [
+            crate::auxil::db::intel::VENDOR,
+            crate::auxil::db::nvidia::VENDOR,
+            crate::auxil::db::amd::VENDOR,
+            crate::auxil::db::imgtec::VENDOR,
+        ]
+        .contains(&self.properties.vendor_id);
+
+        if !ignore_max_fragment_combined_output_resources
+            && max_storage_textures_per_shader_stage
+                + max_storage_buffers_per_shader_stage
+                + max_color_attachments
+                > limits.max_fragment_combined_output_resources
+        {
+            // Divide the limit equally between the 3 limits while allowing
+            // unused limit capacity to be used by some limits that
+            // can make use of it.
+            let mut rem_limit = limits.max_fragment_combined_output_resources;
+            let limit = rem_limit / 3;
+            let diff = limit.saturating_sub(max_storage_textures_per_shader_stage);
+            max_storage_textures_per_shader_stage =
+                max_storage_textures_per_shader_stage.min(limit);
+
+            rem_limit -= limit + diff;
+            let limit = rem_limit / 2;
+            let diff = limit.saturating_sub(max_storage_buffers_per_shader_stage);
+            max_storage_buffers_per_shader_stage = max_storage_buffers_per_shader_stage.min(limit);
+
+            rem_limit -= limit + diff;
+            let limit = rem_limit;
+            max_color_attachments = max_color_attachments.min(limit);
+        }
+
         // TODO: programmatically determine this, if possible. It's unclear whether we can
         // as of https://github.com/gpuweb/gpuweb/issues/2965#issuecomment-1361315447.
         //
@@ -1443,7 +1492,7 @@ impl PhysicalDeviceProperties {
         //
         // 16 bytes per sample is the maximum size for a color attachment.
         let max_color_attachment_bytes_per_sample =
-            limits.max_color_attachments * wgt::TextureFormat::MAX_TARGET_PIXEL_BYTE_COST;
+            max_color_attachments * wgt::TextureFormat::MAX_TARGET_PIXEL_BYTE_COST;
 
         let mut max_blas_geometry_count = 0;
         let mut max_blas_primitive_count = 0;
@@ -1463,21 +1512,66 @@ impl PhysicalDeviceProperties {
             .unwrap_or(0);
 
         crate::auxil::apply_hal_limits(wgt::Limits {
+            //
+            // WebGPU LIMITS:
+            // Based on https://gpuweb.github.io/gpuweb/correspondence/#limits
+            //
             max_texture_dimension_1d: limits.max_image_dimension1_d,
-            max_texture_dimension_2d: limits.max_image_dimension2_d,
+            max_texture_dimension_2d: limits
+                .max_image_dimension2_d
+                .min(limits.max_image_dimension_cube)
+                .min(limits.max_framebuffer_width)
+                .min(limits.max_framebuffer_height),
             max_texture_dimension_3d: limits.max_image_dimension3_d,
             max_texture_array_layers: limits.max_image_array_layers,
             max_bind_groups: limits.max_bound_descriptor_sets,
-            max_bindings_per_bind_group: wgt::Limits::default().max_bindings_per_bind_group,
+            // No real limit but use the default to avoid driver issues.
+            // https://github.com/gpuweb/gpuweb/issues/3279
+            max_bindings_per_bind_group: 1000,
             max_dynamic_uniform_buffers_per_pipeline_layout: limits
                 .max_descriptor_set_uniform_buffers_dynamic,
             max_dynamic_storage_buffers_per_pipeline_layout: limits
                 .max_descriptor_set_storage_buffers_dynamic,
-            max_sampled_textures_per_shader_stage: limits.max_per_stage_descriptor_sampled_images,
             max_samplers_per_shader_stage: limits.max_per_stage_descriptor_samplers,
-            max_storage_buffers_per_shader_stage: limits.max_per_stage_descriptor_storage_buffers,
-            max_storage_textures_per_shader_stage: limits.max_per_stage_descriptor_storage_images,
+            max_sampled_textures_per_shader_stage: limits.max_per_stage_descriptor_sampled_images,
+            max_storage_textures_per_shader_stage,
+            max_storage_buffers_per_shader_stage,
             max_uniform_buffers_per_shader_stage: limits.max_per_stage_descriptor_uniform_buffers,
+            max_vertex_buffers: limits.max_vertex_input_bindings,
+            max_buffer_size,
+            max_uniform_buffer_binding_size: limits
+                .max_uniform_buffer_range
+                .min(crate::auxil::MAX_I32_BINDING_SIZE)
+                .into(),
+            max_storage_buffer_binding_size: limits
+                .max_storage_buffer_range
+                .min(crate::auxil::MAX_I32_BINDING_SIZE)
+                .into(),
+            min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment as u32,
+            min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment as u32,
+            max_vertex_attributes: limits.max_vertex_input_attributes,
+            max_vertex_buffer_array_stride: limits.max_vertex_input_binding_stride,
+            max_inter_stage_shader_variables: limits
+                .max_vertex_output_components
+                .min(limits.max_fragment_input_components)
+                / 4
+                - 1, // -1 for position
+            max_color_attachments,
+            max_color_attachment_bytes_per_sample,
+            max_compute_workgroup_storage_size: limits.max_compute_shared_memory_size,
+            max_compute_invocations_per_workgroup: limits.max_compute_work_group_invocations,
+            max_compute_workgroup_size_x: limits.max_compute_work_group_size[0],
+            max_compute_workgroup_size_y: limits.max_compute_work_group_size[1],
+            max_compute_workgroup_size_z: limits.max_compute_work_group_size[2],
+            max_compute_workgroups_per_dimension: limits.max_compute_work_group_count[0]
+                .min(limits.max_compute_work_group_count[1])
+                .min(limits.max_compute_work_group_count[2]),
+            max_immediate_size: limits.max_push_constants_size,
+            //
+            // NATIVE (Non-WebGPU) LIMITS:
+            //
+            max_non_sampler_bindings: u32::MAX,
+
             max_binding_array_elements_per_shader_stage: max_binding_array_elements,
             max_binding_array_sampler_elements_per_shader_stage: max_sampler_binding_array_elements,
             max_binding_array_acceleration_structure_elements_per_shader_stage: if self
@@ -1488,34 +1582,6 @@ impl PhysicalDeviceProperties {
             } else {
                 0
             },
-            max_uniform_buffer_binding_size: limits
-                .max_uniform_buffer_range
-                .min(crate::auxil::MAX_I32_BINDING_SIZE)
-                .into(),
-            max_storage_buffer_binding_size: limits
-                .max_storage_buffer_range
-                .min(crate::auxil::MAX_I32_BINDING_SIZE)
-                .into(),
-            max_vertex_buffers: limits.max_vertex_input_bindings,
-            max_vertex_attributes: limits.max_vertex_input_attributes,
-            max_vertex_buffer_array_stride: limits.max_vertex_input_binding_stride,
-            max_immediate_size: limits.max_push_constants_size,
-            max_inter_stage_shader_variables: limits
-                .max_vertex_output_components
-                .min(limits.max_fragment_input_components)
-                / 4,
-            min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment as u32,
-            min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment as u32,
-            max_color_attachments: limits.max_color_attachments,
-            max_color_attachment_bytes_per_sample,
-            max_compute_workgroup_storage_size: limits.max_compute_shared_memory_size,
-            max_compute_invocations_per_workgroup: limits.max_compute_work_group_invocations,
-            max_compute_workgroup_size_x: max_compute_workgroup_sizes[0],
-            max_compute_workgroup_size_y: max_compute_workgroup_sizes[1],
-            max_compute_workgroup_size_z: max_compute_workgroup_sizes[2],
-            max_compute_workgroups_per_dimension,
-            max_buffer_size,
-            max_non_sampler_bindings: u32::MAX,
 
             max_task_mesh_workgroup_total_count,
             max_task_mesh_workgroups_per_dimension,

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1562,6 +1562,12 @@ impl PhysicalDeviceProperties {
             max_per_set_descriptors / 2,
         );
 
+        // Use max(default, maxPerSetDescriptors) since the spec requires this
+        // limit to be at least 1000. This is ok because we already lowered
+        // all the other relevant per stage limits so their sum is lower
+        // than maxPerSetDescriptors.
+        let max_bindings_per_bind_group = 1000.max(max_per_set_descriptors);
+
         // TODO: programmatically determine this, if possible. It's unclear whether we can
         // as of https://github.com/gpuweb/gpuweb/issues/2965#issuecomment-1361315447.
         //
@@ -1589,9 +1595,7 @@ impl PhysicalDeviceProperties {
             max_texture_dimension_3d: limits.max_image_dimension3_d,
             max_texture_array_layers: limits.max_image_array_layers,
             max_bind_groups: limits.max_bound_descriptor_sets,
-            // No real limit but use the default to avoid driver issues.
-            // https://github.com/gpuweb/gpuweb/issues/3279
-            max_bindings_per_bind_group: 1000,
+            max_bindings_per_bind_group,
             max_dynamic_uniform_buffers_per_pipeline_layout: limits
                 .max_descriptor_set_uniform_buffers_dynamic,
             max_dynamic_storage_buffers_per_pipeline_layout: limits

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1594,7 +1594,7 @@ impl PhysicalDeviceProperties {
             .map(|a| a.max_multiview_view_count.min(32))
             .unwrap_or(0);
 
-        crate::auxil::apply_hal_limits(wgt::Limits {
+        crate::auxil::adjust_raw_limits(wgt::Limits {
             //
             // WebGPU LIMITS:
             // Based on https://gpuweb.github.io/gpuweb/correspondence/#limits

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -118,7 +118,7 @@ pub struct PhysicalDeviceFeatures {
     /// Features provided by `VK_EXT_subgroup_size_control`, promoted to Vulkan 1.3.
     subgroup_size_control: Option<vk::PhysicalDeviceSubgroupSizeControlFeatures<'static>>,
 
-    /// Features proved by `VK_KHR_maintenance4`, needed for mesh shaders
+    /// Features provided by `VK_KHR_maintenance4`, promoted to Vulkan 1.3.
     maintenance4: Option<vk::PhysicalDeviceMaintenance4FeaturesKHR<'static>>,
 
     /// Features proved by `VK_EXT_mesh_shader`
@@ -553,9 +553,11 @@ impl PhysicalDeviceFeatures {
             } else {
                 None
             },
-            maintenance4: if enabled_extensions.contains(&khr::maintenance4::NAME) {
+            maintenance4: if device_api_version >= vk::API_VERSION_1_3
+                || enabled_extensions.contains(&khr::maintenance4::NAME)
+            {
                 let needed = requested_features.contains(wgt::Features::EXPERIMENTAL_MESH_SHADER);
-                Some(vk::PhysicalDeviceMaintenance4FeaturesKHR::default().maintenance4(needed))
+                Some(vk::PhysicalDeviceMaintenance4Features::default().maintenance4(needed))
             } else {
                 None
             },
@@ -1090,6 +1092,10 @@ pub struct PhysicalDeviceProperties {
     maintenance_3: Option<vk::PhysicalDeviceMaintenance3Properties<'static>>,
 
     /// Additional `vk::PhysicalDevice` properties from the
+    /// `VK_KHR_maintenance4` extension, promoted to Vulkan 1.3.
+    maintenance_4: Option<vk::PhysicalDeviceMaintenance4Properties<'static>>,
+
+    /// Additional `vk::PhysicalDevice` properties from the
     /// `VK_EXT_descriptor_indexing` extension, promoted to Vulkan 1.2.
     descriptor_indexing: Option<vk::PhysicalDeviceDescriptorIndexingPropertiesEXT<'static>>,
 
@@ -1237,6 +1243,11 @@ impl PhysicalDeviceProperties {
         }
 
         if self.device_api_version < vk::API_VERSION_1_3 {
+            // Optional `VK_KHR_maintenance4`
+            if self.supports_extension(khr::maintenance4::NAME) {
+                extensions.push(khr::maintenance4::NAME);
+            }
+
             // Optional `VK_EXT_image_robustness`
             if self.supports_extension(ext::image_robustness::NAME) {
                 extensions.push(ext::image_robustness::NAME);
@@ -1245,10 +1256,6 @@ impl PhysicalDeviceProperties {
             // Require `VK_EXT_subgroup_size_control` if the associated feature was requested
             if requested_features.contains(wgt::Features::SUBGROUP) {
                 extensions.push(ext::subgroup_size_control::NAME);
-            }
-
-            if requested_features.intersects(wgt::Features::EXPERIMENTAL_MESH_SHADER) {
-                extensions.push(khr::maintenance4::NAME);
             }
 
             // Optional `VK_KHR_shader_integer_dot_product`
@@ -1403,15 +1410,27 @@ impl PhysicalDeviceProperties {
             max_mesh_multiview_view_count = m.max_mesh_multiview_view_count;
         }
 
+        let max_memory_allocation_size = self
+            .maintenance_3
+            .map(|maintenance_3| maintenance_3.max_memory_allocation_size)
+            .unwrap_or(u64::MAX);
+        let max_buffer_size = self
+            .maintenance_4
+            .map(|maintenance_4| maintenance_4.max_buffer_size)
+            .unwrap_or(u64::MAX);
+        let max_buffer_size = max_buffer_size.min(max_memory_allocation_size);
+
         // Prevent very large buffers on mesa and most android devices, and in all cases
         // don't risk confusing JS by exceeding the range of a double.
         let is_nvidia = self.properties.vendor_id == crate::auxil::db::nvidia::VENDOR;
-        let max_buffer_size =
+        let max_buffer_size_cap =
             if (cfg!(target_os = "linux") || cfg!(target_os = "android")) && !is_nvidia {
                 i32::MAX as u64
             } else {
                 1u64 << 52
             };
+
+        let max_buffer_size = max_buffer_size.min(max_buffer_size_cap);
 
         let mut max_binding_array_elements = 0;
         let mut max_sampler_binding_array_elements = 0;
@@ -1668,6 +1687,8 @@ impl super::InstanceShared {
                 // Get these now to avoid borrowing conflicts later
                 let supports_maintenance3 = capabilities.device_api_version >= vk::API_VERSION_1_1
                     || capabilities.supports_extension(khr::maintenance3::NAME);
+                let supports_maintenance4 = capabilities.device_api_version >= vk::API_VERSION_1_3
+                    || capabilities.supports_extension(khr::maintenance4::NAME);
                 let supports_descriptor_indexing = capabilities.device_api_version
                     >= vk::API_VERSION_1_2
                     || capabilities.supports_extension(ext::descriptor_indexing::NAME);
@@ -1691,6 +1712,13 @@ impl super::InstanceShared {
                     let next = capabilities
                         .maintenance_3
                         .insert(vk::PhysicalDeviceMaintenance3Properties::default());
+                    properties2 = properties2.push_next(next);
+                }
+
+                if supports_maintenance4 {
+                    let next = capabilities
+                        .maintenance_4
+                        .insert(vk::PhysicalDeviceMaintenance4Properties::default());
                     properties2 = properties2.push_next(next);
                 }
 
@@ -1893,6 +1921,16 @@ impl super::InstanceShared {
                 let next = features
                     .position_fetch
                     .insert(vk::PhysicalDeviceRayTracingPositionFetchFeaturesKHR::default());
+                features2 = features2.push_next(next);
+            }
+
+            // `VK_KHR_maintenance4` is promoted to 1.3
+            if capabilities.device_api_version >= vk::API_VERSION_1_3
+                || capabilities.supports_extension(khr::maintenance4::NAME)
+            {
+                let next = features
+                    .maintenance4
+                    .insert(vk::PhysicalDeviceMaintenance4Features::default());
                 features2 = features2.push_next(next);
             }
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1515,16 +1515,7 @@ impl PhysicalDeviceProperties {
             limits.max_per_stage_resources,
         );
 
-        // TODO: programmatically determine this, if possible. It's unclear whether we can
-        // as of https://github.com/gpuweb/gpuweb/issues/2965#issuecomment-1361315447.
-        //
-        // In theory some tilers may not support this much. We can't tell however, and
-        // the driver will throw a DEVICE_REMOVED if it goes too high in usage. This is fine.
-        //
-        // 16 bytes per sample is the maximum size for a color attachment.
-        let max_color_attachment_bytes_per_sample =
-            max_color_attachments * wgt::TextureFormat::MAX_TARGET_PIXEL_BYTE_COST;
-
+        // Acceleration structure limits
         let mut max_blas_geometry_count = 0;
         let mut max_blas_primitive_count = 0;
         let mut max_tlas_instance_count = 0;
@@ -1536,6 +1527,48 @@ impl PhysicalDeviceProperties {
             max_acceleration_structures_per_shader_stage =
                 properties.max_per_stage_descriptor_acceleration_structures;
         }
+
+        // When summed, the 6 limits below must be under Vulkan's maxPerSetDescriptors / 2.
+        //
+        // - maxUniformBuffersPerShaderStage, WebGPU default: 12
+        // - maxSampledTexturesPerShaderStage, WebGPU default: 16
+        // - maxStorageTexturesPerShaderStage, WebGPU default: 4
+        // - maxStorageBuffersPerShaderStage, WebGPU default: 8
+        // - maxSamplersPerShaderStage, WebGPU default: 16
+        // - maxAccelerationStructuresPerShaderStage, Native only
+        //
+        // Note: All Vulkan's descriptor types count towards maxPerSetDescriptors but
+        // we don't use all of them.
+        // See https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-resources-limits
+        let max_per_set_descriptors = self
+            .maintenance_3
+            .map(|maintenance_3| maintenance_3.max_per_set_descriptors)
+            // The lowest value seen in reports is 312, use 256 as a safe default.
+            // https://vulkan.gpuinfo.org/displayextensionproperty.php?extensionname=VK_KHR_maintenance3&extensionproperty=maxPerSetDescriptors&platform=all
+            // https://vulkan.gpuinfo.org/displaycoreproperty.php?core=1.1&name=maxPerSetDescriptors&platform=all
+            .unwrap_or(256);
+
+        let mut max_samplers_per_shader_stage = limits.max_per_stage_descriptor_samplers;
+
+        crate::auxil::cap_limits_to_be_under_the_sum_limit(
+            [
+                &mut max_sampled_textures_per_shader_stage,
+                &mut max_uniform_buffers_per_shader_stage,
+                &mut max_storage_textures_per_shader_stage,
+                &mut max_storage_buffers_per_shader_stage,
+                &mut max_samplers_per_shader_stage,
+                &mut max_acceleration_structures_per_shader_stage,
+            ],
+            max_per_set_descriptors / 2,
+        );
+
+        // TODO: programmatically determine this, if possible. It's unclear whether we can
+        // as of https://github.com/gpuweb/gpuweb/issues/2965#issuecomment-1361315447.
+        //
+        // In theory some tilers may not support this much. We can't tell however, and
+        // the driver will throw a DEVICE_REMOVED if it goes too high in usage. This is fine.
+        let max_color_attachment_bytes_per_sample =
+            max_color_attachments * wgt::TextureFormat::MAX_TARGET_PIXEL_BYTE_COST;
 
         let max_multiview_view_count = self
             .multiview
@@ -1563,7 +1596,7 @@ impl PhysicalDeviceProperties {
                 .max_descriptor_set_uniform_buffers_dynamic,
             max_dynamic_storage_buffers_per_pipeline_layout: limits
                 .max_descriptor_set_storage_buffers_dynamic,
-            max_samplers_per_shader_stage: limits.max_per_stage_descriptor_samplers,
+            max_samplers_per_shader_stage,
             max_sampled_textures_per_shader_stage,
             max_storage_textures_per_shader_stage,
             max_storage_buffers_per_shader_stage,

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -232,7 +232,7 @@ pub struct Limits {
     ///
     /// Expect the size to be:
     /// - Vulkan: 128-256 bytes
-    /// - DX12: 256 bytes
+    /// - DX12: 128 bytes
     /// - Metal: 4096 bytes
     /// - OpenGL doesn't natively support immediates, and are emulated with uniforms,
     ///   so this number is less useful but likely 256.


### PR DESCRIPTION
**Connections**
Issues are linked in commits.

**Description**
Fixes limit reporting in accordance with https://gpuweb.github.io/gpuweb/correspondence/#limits + https://github.com/gpuweb/gpuweb/pull/5604.

**Testing**
It's not possible to test that we report the correct limits.
Other functionality is tested by existing tests/CTS or newly added tests.

**Squash or Rebase?**
Rebase.