### PR TITLE
fix(naga): Validate matrix constructors

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -154,7 +154,6 @@ webgpu:shader,validation,expression,call,builtin,unpack4x8snorm:* // 81%, missin
 webgpu:shader,validation,expression,call,builtin,unpack4x8unorm:* // 81%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,unpack4xI8:* // 75%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,unpack4xU8:* // 75%, missing const eval (#4507)
-webgpu:shader,validation,expression,call,builtin,value_constructor:* // 92%, value constructors lack must-use validation + abstract-float matrix validation issues
 webgpu:shader,validation,expression,early_evaluation:* // 67%, mixed override/runtime composite evaluation
 webgpu:shader,validation,expression,matrix,* // 92%, #5474, #8868, overflow/underflow/atomic
 webgpu:shader,validation,expression,precedence:* // 76%, https://github.com/gfx-rs/wgpu/issues/4536

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -379,20 +379,7 @@ webgpu:shader,validation,expression,call,builtin,textureNumSamples:*
 fails-if(vulkan) webgpu:shader,validation,expression,call,builtin,textureSampleBaseClampToEdge:*
 webgpu:shader,validation,expression,call,builtin,textureStore:*
 webgpu:shader,validation,expression,call,builtin,trunc:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:array_value:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:array_zero_value:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:matrix_zero_value:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:must_use:ctor="mat4x4";use=true
-webgpu:shader,validation,expression,call,builtin,value_constructor:partial_eval:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_value:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:scalar_zero_value:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:struct_value:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:struct_zero_value:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:vector_copy:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:vector_elementwise:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:vector_mixed:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:vector_splat:*
-webgpu:shader,validation,expression,call,builtin,value_constructor:vector_zero_value:*
+webgpu:shader,validation,expression,call,builtin,value_constructor:*
 webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:*
 webgpu:shader,validation,expression,overload_resolution:*
 webgpu:shader,validation,extension,clip_distances:*

--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -451,7 +451,7 @@ impl<'source> Lowerer<'source, '_> {
                     spans,
                 },
                 Constructor::PartialMatrix { columns, rows },
-            ) => {
+            ) if components.len() == columns as usize => {
                 let consensus_scalar = ctx
                     .automatic_conversion_consensus(
                         Some(crate::Scalar::ABSTRACT_FLOAT),
@@ -460,7 +460,17 @@ impl<'source> Lowerer<'source, '_> {
                     .map_err(|index| {
                         Error::InvalidConstructorComponentType(spans[index], index as i32)
                     })?;
-                ctx.convert_slice_to_common_leaf_scalar(&mut components, consensus_scalar)?;
+
+                let component_ty = crate::TypeInner::Vector {
+                    size: rows,
+                    scalar: consensus_scalar,
+                };
+                ctx.try_automatic_conversions_slice(
+                    &mut components,
+                    &Tr::Value(component_ty),
+                    ty_span,
+                )?;
+
                 let ty = ctx.ensure_type_exists(crate::TypeInner::Matrix {
                     columns,
                     rows,
@@ -475,12 +485,12 @@ impl<'source> Lowerer<'source, '_> {
                 Constructor::Type((
                     ty,
                     &crate::TypeInner::Matrix {
-                        columns: _,
+                        columns,
                         rows,
                         scalar,
                     },
                 )),
-            ) => {
+            ) if components.len() == columns as usize => {
                 let component_ty = crate::TypeInner::Vector { size: rows, scalar };
                 ctx.try_automatic_conversions_slice(
                     &mut components,


### PR DESCRIPTION
**Connections**
Fixes issue #9155

**Description**
Added column validation in matrix constructors to prevent something like this.
e.g. mat2x2(vec2(1, 2)) // Two columns are required, but just one is given

**Testing**
- Existing tests
- CTS change
webgpu:shader,validation,expression,call,builtin,value_constructor:* 481/483 -> 483/483 (100%)

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
