### PR TITLE
Added fix and regression test for primitive id on FXC

### DIFF
--- a/naga/src/ir/mod.rs
+++ b/naga/src/ir/mod.rs
@@ -401,6 +401,11 @@ pub enum AddressSpace {
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum BuiltIn {
+    // This must be at the top so that it gets sorted to the top. PrimitiveIndex is considered a non SV
+    // by FXC so it must appear before any other SVs.
+    /// Read in fragment shaders, written in mesh shaders, read in any and closest hit shaders.
+    PrimitiveIndex,
+
     /// Written in vertex/mesh shaders, read in fragment shaders
     Position { invariant: bool },
     /// Read in task, mesh, vertex, and fragment shaders
@@ -429,8 +434,6 @@ pub enum BuiltIn {
     PointCoord,
     /// Read in fragment shaders
     FrontFacing,
-    /// Read in fragment shaders, written in mesh shaders, read in any and closest hit shaders.
-    PrimitiveIndex,
     /// Read in fragment shaders
     Barycentric { perspective: bool },
     /// Read in fragment shaders

--- a/naga/tests/in/wgsl/9105-primitive-index-ordering.toml
+++ b/naga/tests/in/wgsl/9105-primitive-index-ordering.toml
@@ -1,0 +1,5 @@
+targets = "HLSL"
+capabilities = "PRIMITIVE_INDEX"
+
+[hlsl]
+shader_model = "V5_0"

--- a/naga/tests/in/wgsl/9105-primitive-index-ordering.wgsl
+++ b/naga/tests/in/wgsl/9105-primitive-index-ordering.wgsl
@@ -1,0 +1,9 @@
+// FXC requires that all non-system values get written first, but doesn't consider SV_PrimitiveID a system value.
+// This test ensures that the inputs are written in the right order
+
+enable primitive_index;
+
+@fragment
+fn func(@location(0) input_location: f32, @builtin(position) arbitrary_position: vec4<f32>, @builtin(primitive_index) index: u32) -> @location(0) vec4<f32> {
+    return vec4(arbitrary_position.xy, input_location, f32(index));
+}

--- a/naga/tests/out/hlsl/wgsl-9105-primitive-index-ordering.hlsl
+++ b/naga/tests/out/hlsl/wgsl-9105-primitive-index-ordering.hlsl
@@ -1,0 +1,13 @@
+struct FragmentInput_func {
+    float input_location_1 : LOC0;
+    uint index_1 : SV_PrimitiveID;
+    float4 arbitrary_position_1 : SV_Position;
+};
+
+float4 func(FragmentInput_func fragmentinput_func) : SV_Target0
+{
+    float input_location = fragmentinput_func.input_location_1;
+    float4 arbitrary_position = fragmentinput_func.arbitrary_position_1;
+    uint index = fragmentinput_func.index_1;
+    return float4(arbitrary_position.xy, input_location, float(index));
+}

--- a/naga/tests/out/hlsl/wgsl-9105-primitive-index-ordering.ron
+++ b/naga/tests/out/hlsl/wgsl-9105-primitive-index-ordering.ron
@@ -1,0 +1,12 @@
+(
+    vertex:[
+    ],
+    fragment:[
+        (
+            entry_point:"func",
+            target_profile:"ps_5_0",
+        ),
+    ],
+    compute:[
+    ],
+)


### PR DESCRIPTION
**Connections**
Closes #9105 

**Description**
Explained in the code too, but FXC treats primitive ID as a non SV so it must appear before all other SVs.

No changelog entry is required because primitive ID will be added in this release.

**Testing**
Tested using a regression test

**Squash or Rebase?**
Doesn't matter

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
