### PR TITLE
[vulkan] Offset `AccelerationStructureGeometryTrianglesDataKHR::vertex_data` instead of using `first_vertex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,7 @@ depth_stencil: Some(wgpu::DepthStencilState::stencil(
 #### Vulkan
 
 - Fixed a variety of mesh shader SPIR-V writer issues from the original implementation. By @inner-daemons in [#8756](https://github.com/gfx-rs/wgpu/pull/8756)
+- Offset the vertex buffer device address when building a BLAS instead of using the `first_vertex` field. By @Vecvec in [#9220](https://github.com/gfx-rs/wgpu/pull/9220) 
 
 #### Metal / macOS
 

--- a/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
@@ -891,19 +891,19 @@ fn blas_first_vertex(ctx: TestingContext) {
         .create_command_encoder(&CommandEncoderDescriptor::default());
 
     let entry = BlasBuildEntry {
-            blas: &blas,
-            geometry: BlasGeometries::TriangleGeometries(vec![BlasTriangleGeometry {
-                size: &blas_size,
-                vertex_buffer: &large_buffer,
-                // Leaves 3 at the end to build with.
-                first_vertex: 9,
-                vertex_stride: size_of::<[f32; 3]>() as BufferAddress,
-                index_buffer: None,
-                first_index: None,
-                transform_buffer: None,
-                transform_buffer_offset: None,
-            }]),
-        };
+        blas: &blas,
+        geometry: BlasGeometries::TriangleGeometries(vec![BlasTriangleGeometry {
+            size: &blas_size,
+            vertex_buffer: &large_buffer,
+            // Leaves 3 at the end to build with.
+            first_vertex: 9,
+            vertex_stride: size_of::<[f32; 3]>() as BufferAddress,
+            index_buffer: None,
+            first_index: None,
+            transform_buffer: None,
+            transform_buffer_offset: None,
+        }]),
+    };
 
     encoder.build_acceleration_structures([&entry], []);
 

--- a/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
@@ -24,6 +24,7 @@ pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
         EXTRA_FORMAT_BUILD,
         MISALIGNED_BUILD,
         TOO_SMALL_STRIDE_BUILD,
+        BLAS_FIRST_VERTEX,
     ]);
 }
 
@@ -846,4 +847,65 @@ fn test_as_build_format_stride(
     if !invalid_combination {
         ctx.queue.submit([command_buffer]);
     }
+}
+
+#[gpu_test]
+static BLAS_FIRST_VERTEX: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_sync(blas_first_vertex);
+
+fn blas_first_vertex(ctx: TestingContext) {
+    let blas_size = BlasTriangleGeometrySizeDescriptor {
+        vertex_format: VertexFormat::Float32x3,
+        vertex_count: 3,
+        index_format: None,
+        index_count: None,
+        flags: AccelerationStructureGeometryFlags::empty(),
+    };
+
+    let blas = ctx.device.create_blas(
+        &CreateBlasDescriptor {
+            label: Some("BLAS"),
+            flags: AccelerationStructureFlags::PREFER_FAST_TRACE,
+            update_mode: AccelerationStructureUpdateMode::Build,
+        },
+        BlasGeometrySizeDescriptors::Triangles {
+            descriptors: vec![blas_size.clone()],
+        },
+    );
+
+    let large_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Large blas building buffer"),
+        size: (size_of::<[f32; 3]>() * 12) as _,
+        usage: BufferUsages::BLAS_INPUT,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&CommandEncoderDescriptor::default());
+
+    let entry = BlasBuildEntry {
+            blas: &blas,
+            geometry: BlasGeometries::TriangleGeometries(vec![BlasTriangleGeometry {
+                size: &blas_size,
+                vertex_buffer: &large_buffer,
+                // Leaves 3 at the end to build with.
+                first_vertex: 9,
+                vertex_stride: size_of::<[f32; 3]>() as BufferAddress,
+                index_buffer: None,
+                first_index: None,
+                transform_buffer: None,
+                transform_buffer_offset: None,
+            }]),
+        };
+
+    encoder.build_acceleration_structures([&entry], []);
+
+    ctx.queue.submit([encoder.finish()]);
 }

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -609,7 +609,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                                 // index buffer we need to have IndexType::NONE_KHR as our index type.
                                 .index_type(vk::IndexType::NONE_KHR)
                                 .vertex_data(vk::DeviceOrHostAddressConstKHR {
-                                    device_address: get_device_address(triangles.vertex_buffer),
+                                    device_address: get_device_address(triangles.vertex_buffer) + (triangles.first_vertex as u64 * triangles.vertex_stride),
                                 })
                                 .vertex_format(conv::map_vertex_format(triangles.vertex_format))
                                 .max_vertex(triangles.vertex_count)
@@ -626,12 +626,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
                             range = range
                                 .primitive_count(indices.count / 3)
-                                .primitive_offset(indices.offset)
-                                .first_vertex(triangles.first_vertex);
+                                .primitive_offset(indices.offset);
                         } else {
                             range = range
-                                .primitive_count(triangles.vertex_count / 3)
-                                .first_vertex(triangles.first_vertex);
+                                .primitive_count(triangles.vertex_count / 3);
                         }
 
                         if let Some(ref transform) = triangles.transform {

--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -609,7 +609,8 @@ impl crate::CommandEncoder for super::CommandEncoder {
                                 // index buffer we need to have IndexType::NONE_KHR as our index type.
                                 .index_type(vk::IndexType::NONE_KHR)
                                 .vertex_data(vk::DeviceOrHostAddressConstKHR {
-                                    device_address: get_device_address(triangles.vertex_buffer) + (triangles.first_vertex as u64 * triangles.vertex_stride),
+                                    device_address: get_device_address(triangles.vertex_buffer)
+                                        + (triangles.first_vertex as u64 * triangles.vertex_stride),
                                 })
                                 .vertex_format(conv::map_vertex_format(triangles.vertex_format))
                                 .max_vertex(triangles.vertex_count)
@@ -628,8 +629,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                                 .primitive_count(indices.count / 3)
                                 .primitive_offset(indices.offset);
                         } else {
-                            range = range
-                                .primitive_count(triangles.vertex_count / 3);
+                            range = range.primitive_count(triangles.vertex_count / 3);
                         }
 
                         if let Some(ref transform) = triangles.transform {


### PR DESCRIPTION
**Connections**
Fixes #9216 

**Description**
Using `first_vertex` is actually unnecessary, we can just offset the vertex data, this has less restrictions on alignment (only needs the element alignment not a multiple of the vertex stride), but sadly these requirements cannot be removed due to metal requiring the buffer offset to be a multiple of the vertex stride.  I suspect Vulkan's `first_vertex` is actually intended for partially building a BLAS or something...

**Testing**
Adds a test

**Squash or Rebase?**
squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`.
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
