### PR TITLE
Docs: Clarify `Unorm8x4Bgra` and `Unorm10_10_10_2 ` vertex formats

### DIFF
--- a/wgpu-types/src/vertex.rs
+++ b/wgpu-types/src/vertex.rs
@@ -197,7 +197,7 @@ pub enum VertexFormat {
     Float64x3 = 41,
     /// Four double-precision floats (f64). `vec4<f32>` in shaders. Requires [`Features::VERTEX_ATTRIBUTE_64BIT`].
     Float64x4 = 42,
-    /// Three unsigned 10-bit integers and one 2-bit integer, packed into a 32-bit integer (u32). [0, 1024] converted to float [0, 1] `vec4<f32>` in shaders.
+    /// Three unsigned 10-bit integers and one 2-bit integer, packed into a 32-bit integer (u32). [0, 1023] and [0, 3] converted to float [0, 1] `vec4<f32>` in shaders.
     #[cfg_attr(feature = "serde", serde(rename = "unorm10-10-10-2"))]
     Unorm10_10_10_2 = 43,
     /// Four unsigned 8-bit integers (u8) in BGRA. [0, 255] converted to float [0, 1] `vec4<f32>` RGBA in shaders.

--- a/wgpu-types/src/vertex.rs
+++ b/wgpu-types/src/vertex.rs
@@ -200,7 +200,7 @@ pub enum VertexFormat {
     /// Three unsigned 10-bit integers and one 2-bit integer, packed into a 32-bit integer (u32). [0, 1024] converted to float [0, 1] `vec4<f32>` in shaders.
     #[cfg_attr(feature = "serde", serde(rename = "unorm10-10-10-2"))]
     Unorm10_10_10_2 = 43,
-    /// Four unsigned 8-bit integers, packed into a 32-bit integer (u32). [0, 255] converted to float [0, 1] `vec4<f32>` in shaders.
+    /// Four unsigned 8-bit integers (u8) in BGRA. [0, 255] converted to float [0, 1] `vec4<f32>` RGBA in shaders.
     #[cfg_attr(feature = "serde", serde(rename = "unorm8x4-bgra"))]
     Unorm8x4Bgra = 44,
 }


### PR DESCRIPTION
**Connections**
N/A

**Description**
The comments in `VertexFormat::Unorm8x4Bgra` are somewhat misleading. It's four 8-bit integers but isn't necessarily packed to u32.

And fix comments about ranges of `Unorm10_10_10_2`

**Testing**
N/A

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
