### PR TITLE
test(cts): Skip max_resources_per_stage on dx12

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -106,7 +106,8 @@ webgpu:api,validation,createBindGroup:texture_must_have_correct_component_type:*
 webgpu:api,validation,createBindGroup:texture_must_have_correct_dimension:*
 webgpu:api,validation,createBindGroupLayout:duplicate_bindings:*
 webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:*
-webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,*
+// Doesn't actually fail, but is very slow. https://github.com/gfx-rs/wgpu/issues/9229
+fails-if(dx12) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,*
 webgpu:api,validation,createBindGroupLayout:maximum_binding_limit:*
 webgpu:api,validation,createBindGroupLayout:multisampled_validation:*
 webgpu:api,validation,createBindGroupLayout:storage_texture,formats:*


### PR DESCRIPTION
Related to #9229

This test is very slow, so don't run it on dx12. I will update the bug to discuss the underlying issue and whether/how we want to address it.
