### PR TITLE
fix(naga): Validate math builtin in const-eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Bottom level categories:
 
 - Fix limit comparison logic for `max_inter_stage_shader_variables` By @ErichDonGubler in [9264](https://github.com/gfx-rs/wgpu/pull/9264).
 
+#### naga
+
+- Fixed overflow detection and argument domain validation for `acosh`, `length`, `normalize`, and `pow` in constant evaluation. By @ecoricemon in [#9249](https://github.com/gfx-rs/wgpu/pull/9249).
+
 ## v29.0.0 (2026-03-18)
 
 ### Major Changes

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -79,7 +79,6 @@ webgpu:shader,validation,expression,binary,comparison:* // 74%, https://github.c
 webgpu:shader,validation,expression,binary,div_rem:* // 86%, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:* // 92%, https://github.com/gfx-rs/wgpu/issues/8440
 webgpu:shader,validation,expression,call,builtin,abs:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
-webgpu:shader,validation,expression,call,builtin,acosh:* // 56%, missing domain validation [1,∞) in const eval
 webgpu:shader,validation,expression,call,builtin,atomics:* // 86%, atomics in vertex shaders, invalid address spaces/access modes
 webgpu:shader,validation,expression,call,builtin,bitcast:* // 57%, bitcast const-eval unimplemented; size validation missing; f16 vector validation incorrect
 webgpu:shader,validation,expression,call,builtin,clamp:* // 71%, clamp low<=high constraint not checked for const/override parameters
@@ -101,10 +100,8 @@ webgpu:shader,validation,expression,call,builtin,frexp:* // 39%, const/override 
 webgpu:shader,validation,expression,call,builtin,insertBits:* // 73%, missing const eval support
 webgpu:shader,validation,expression,call,builtin,inverseSqrt:* // 61%, const eval overflow for abstract/f16
 webgpu:shader,validation,expression,call,builtin,ldexp:* // 43%, const eval not implemented
-webgpu:shader,validation,expression,call,builtin,length:* // 74%, const eval overflow for abstract/f16
 webgpu:shader,validation,expression,call,builtin,mix:* // 66%, const eval issues
 webgpu:shader,validation,expression,call,builtin,modf:* // 52%, const eval not fully implemented
-webgpu:shader,validation,expression,call,builtin,normalize:* // 63%, missing const/override eval overflow validation (intermediate values overflow to infinity)
 webgpu:shader,validation,expression,call,builtin,pack2x16float:* // 80%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,pack2x16snorm:* // 88%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,pack2x16unorm:* // 88%, missing const eval (#4507)
@@ -114,7 +111,6 @@ webgpu:shader,validation,expression,call,builtin,pack4xI8:* // 74%, missing cons
 webgpu:shader,validation,expression,call,builtin,pack4xI8Clamp:* // 74%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,pack4xU8:* // 74%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,pack4xU8Clamp:* // 74%, missing const eval (#4507)
-webgpu:shader,validation,expression,call,builtin,pow:* // 63%, missing const/override eval validation (negative base, zero^non-positive, overflow), http://github.com/gpuweb/issues/4527
 webgpu:shader,validation,expression,call,builtin,quantizeToF16:* // 77%, overflow validation issues
 webgpu:shader,validation,expression,call,builtin,reflect:* // 39%, const eval not implemented
 webgpu:shader,validation,expression,call,builtin,refract:* // 44%, const eval not implemented

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -368,6 +368,7 @@ webgpu:shader,validation,expression,binary,short_circuiting_and_or:array_overrid
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:scalar_vector:op="%26%26";lhs="bool";rhs="bool"
 webgpu:shader,validation,expression,call,builtin,acos:*
+webgpu:shader,validation,expression,call,builtin,acosh:*
 webgpu:shader,validation,expression,call,builtin,all:*
 webgpu:shader,validation,expression,call,builtin,any:*
 webgpu:shader,validation,expression,call,builtin,arrayLength:*
@@ -387,11 +388,13 @@ webgpu:shader,validation,expression,call,builtin,exp:*
 webgpu:shader,validation,expression,call,builtin,exp2:*
 webgpu:shader,validation,expression,call,builtin,floor:*
 webgpu:shader,validation,expression,call,builtin,fract:*
-webgpu:shader,validation,expression,call,builtin,length:scalar:stage="constant";type="f32"
+webgpu:shader,validation,expression,call,builtin,length:*
 webgpu:shader,validation,expression,call,builtin,log:*
 webgpu:shader,validation,expression,call,builtin,log2:*
 webgpu:shader,validation,expression,call,builtin,max:*
 webgpu:shader,validation,expression,call,builtin,min:*
+webgpu:shader,validation,expression,call,builtin,normalize:*
+webgpu:shader,validation,expression,call,builtin,pow:*
 webgpu:shader,validation,expression,call,builtin,radians:*
 webgpu:shader,validation,expression,call,builtin,round:*
 webgpu:shader,validation,expression,call,builtin,saturate:*

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1461,7 +1461,7 @@ impl<'a> ConstantEvaluator<'a> {
         }
 
         // NOTE: We try to match the declaration order of `MathFunction` here.
-        match fun {
+        return match fun {
             // comparison
             crate::MathFunction::Abs => {
                 component_wise_scalar(self, span, [arg], |args| match args {
@@ -1571,20 +1571,12 @@ impl<'a> ConstantEvaluator<'a> {
                 Float::F32([e]) => Ok(Float::F32([(e as f64).asinh() as f32])),
                 Float::F16([e]) => Ok(Float::F16([e.asinh()])),
             }),
-            crate::MathFunction::Acosh => {
-                let _ = component_wise_float!(self, span, [arg], |e| {
-                    if e >= One::one() {
-                        Ok([e])
-                    } else {
-                        Err(ConstantEvaluatorError::InvalidMathArgValue("acosh".into()))
-                    }
-                })?;
-                component_wise_float(self, span, [arg], |e| match e {
-                    Float::Abstract([e]) => Ok(Float::Abstract([libm::acosh(e)])),
-                    Float::F32([e]) => Ok(Float::F32([(e as f64).acosh() as f32])),
-                    Float::F16([e]) => Ok(Float::F16([e.acosh()])),
-                })
-            }
+            crate::MathFunction::Acosh => component_wise_float(self, span, [arg], |e| match e {
+                Float::Abstract([e]) if e >= One::one() => Ok(Float::Abstract([libm::acosh(e)])),
+                Float::F32([e]) if e >= One::one() => Ok(Float::F32([(e as f64).acosh() as f32])),
+                Float::F16([e]) if e >= One::one() => Ok(Float::F16([e.acosh()])),
+                _ => Err(ConstantEvaluatorError::InvalidMathArgValue("acosh".into())),
+            }),
             crate::MathFunction::Atanh => {
                 component_wise_float!(self, span, [arg], |e| {
                     if e.abs() < One::one() {
@@ -1876,26 +1868,10 @@ impl<'a> ConstantEvaluator<'a> {
                 // https://www.w3.org/TR/WGSL/#length-builtin
                 let e1 = self.extract_vec(arg, true)?;
 
-                fn float_length<F>(e: &[F]) -> Result<F, ConstantEvaluatorError>
-                where
-                    F: core::ops::Mul<F>,
-                    F: num_traits::Float + iter::Sum,
-                {
-                    if e.len() == 1 {
-                        // Avoids possible overflow in squaring
-                        Ok(e[0].abs())
-                    } else {
-                        let result = e.iter().map(|&ei| ei * ei).sum::<F>().sqrt();
-                        if result.is_finite() {
-                            Ok(result)
-                        } else {
-                            Err(ConstantEvaluatorError::Overflow("length".into()))
-                        }
-                    }
-                }
-
                 let result = match_literal_vector!(match e1 => Literal {
-                    Float => |e1| { float_length(e1)? },
+                    Float => |e1| {
+                        float_length(e1).ok_or_else(|| ConstantEvaluatorError::Overflow("length".into()))?
+                    },
                 })?;
                 self.register_evaluated_expr(Expression::Literal(result), span)
             }
@@ -1940,23 +1916,13 @@ impl<'a> ConstantEvaluator<'a> {
                     F: core::ops::Mul<F>,
                     F: num_traits::Float + iter::Sum,
                 {
-                    let len = if e.len() == 1 {
-                        // Avoids possible overflow in squaring
-                        e[0].abs()
-                    } else {
-                        let len = e.iter().map(|&ei| ei * ei).sum::<F>().sqrt();
-                        if len.is_finite() {
-                            len
-                        } else {
-                            return Err(ConstantEvaluatorError::Overflow("normalize".into()));
-                        }
-                    };
-
-                    if len.is_zero() {
-                        return Err(ConstantEvaluatorError::InvalidMathArgValue(
+                    let len = match float_length(e) {
+                        Some(len) if !len.is_zero() => Ok(len),
+                        Some(_) => Err(ConstantEvaluatorError::InvalidMathArgValue(
                             "normalize".into(),
-                        ));
-                    }
+                        )),
+                        None => Err(ConstantEvaluatorError::Overflow("normalize".into())),
+                    }?;
 
                     let mut out = ArrayVec::new();
                     for &ei in e {
@@ -2005,6 +1971,19 @@ impl<'a> ConstantEvaluator<'a> {
             | crate::MathFunction::Unpack4xU8 => Err(ConstantEvaluatorError::NotImplemented(
                 format!("{fun:?} built-in function"),
             )),
+        };
+
+        fn float_length<F>(e: &[F]) -> Option<F>
+        where
+            F: core::ops::Mul<F> + num_traits::Float + iter::Sum,
+        {
+            if e.len() == 1 {
+                // Avoids possible overflow in squaring
+                Some(e[0].abs())
+            } else {
+                let result = e.iter().map(|&ei| ei * ei).sum::<F>().sqrt();
+                result.is_finite().then_some(result)
+            }
         }
     }
 

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -609,6 +609,19 @@ macro_rules! match_literal_vector {
     };
 }
 
+fn float_length<F>(e: &[F]) -> Option<F>
+where
+    F: core::ops::Mul<F> + num_traits::Float + iter::Sum,
+{
+    if e.len() == 1 {
+        // Avoids possible overflow in squaring
+        Some(e[0].abs())
+    } else {
+        let result = e.iter().map(|&ei| ei * ei).sum::<F>().sqrt();
+        result.is_finite().then_some(result)
+    }
+}
+
 #[derive(Debug)]
 enum Behavior<'a> {
     Wgsl(WgslRestrictions<'a>),
@@ -1461,7 +1474,7 @@ impl<'a> ConstantEvaluator<'a> {
         }
 
         // NOTE: We try to match the declaration order of `MathFunction` here.
-        return match fun {
+        match fun {
             // comparison
             crate::MathFunction::Abs => {
                 component_wise_scalar(self, span, [arg], |args| match args {
@@ -1971,19 +1984,6 @@ impl<'a> ConstantEvaluator<'a> {
             | crate::MathFunction::Unpack4xU8 => Err(ConstantEvaluatorError::NotImplemented(
                 format!("{fun:?} built-in function"),
             )),
-        };
-
-        fn float_length<F>(e: &[F]) -> Option<F>
-        where
-            F: core::ops::Mul<F> + num_traits::Float + iter::Sum,
-        {
-            if e.len() == 1 {
-                // Avoids possible overflow in squaring
-                Some(e[0].abs())
-            } else {
-                let result = e.iter().map(|&ei| ei * ei).sum::<F>().sqrt();
-                result.is_finite().then_some(result)
-            }
         }
     }
 

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -1572,7 +1572,18 @@ impl<'a> ConstantEvaluator<'a> {
                 Float::F16([e]) => Ok(Float::F16([e.asinh()])),
             }),
             crate::MathFunction::Acosh => {
-                component_wise_float!(self, span, [arg], |e| { Ok([e.acosh()]) })
+                let _ = component_wise_float!(self, span, [arg], |e| {
+                    if e >= One::one() {
+                        Ok([e])
+                    } else {
+                        Err(ConstantEvaluatorError::InvalidMathArgValue("acosh".into()))
+                    }
+                })?;
+                component_wise_float(self, span, [arg], |e| match e {
+                    Float::Abstract([e]) => Ok(Float::Abstract([libm::acosh(e)])),
+                    Float::F32([e]) => Ok(Float::F32([(e as f64).acosh() as f32])),
+                    Float::F16([e]) => Ok(Float::F16([e.acosh()])),
+                })
             }
             crate::MathFunction::Atanh => {
                 component_wise_float!(self, span, [arg], |e| {
@@ -1687,7 +1698,22 @@ impl<'a> ConstantEvaluator<'a> {
             }
             crate::MathFunction::Pow => {
                 component_wise_float!(self, span, [arg, arg1.unwrap()], |e1, e2| {
-                    Ok([e1.powf(e2)])
+                    // 0.pow(0) is an error since exp2(0 * log2(0)) is NaN.
+                    // https://www.w3.org/TR/WGSL/#pow-builtin
+                    if e1 < Zero::zero()
+                        || e1.is_one() && e2.is_infinite()
+                        || e1.is_infinite() && e2.is_zero()
+                        || e1.is_zero() && e2.is_zero()
+                    {
+                        Err(ConstantEvaluatorError::InvalidMathArgValue("pow".into()))
+                    } else {
+                        let result = e1.powf(e2);
+                        if result.is_finite() {
+                            Ok([result])
+                        } else {
+                            Err(ConstantEvaluatorError::Overflow("pow".into()))
+                        }
+                    }
                 })
             }
 
@@ -1850,21 +1876,26 @@ impl<'a> ConstantEvaluator<'a> {
                 // https://www.w3.org/TR/WGSL/#length-builtin
                 let e1 = self.extract_vec(arg, true)?;
 
-                fn float_length<F>(e: &[F]) -> F
+                fn float_length<F>(e: &[F]) -> Result<F, ConstantEvaluatorError>
                 where
                     F: core::ops::Mul<F>,
                     F: num_traits::Float + iter::Sum,
                 {
                     if e.len() == 1 {
                         // Avoids possible overflow in squaring
-                        e[0].abs()
+                        Ok(e[0].abs())
                     } else {
-                        e.iter().map(|&ei| ei * ei).sum::<F>().sqrt()
+                        let result = e.iter().map(|&ei| ei * ei).sum::<F>().sqrt();
+                        if result.is_finite() {
+                            Ok(result)
+                        } else {
+                            Err(ConstantEvaluatorError::Overflow("length".into()))
+                        }
                     }
                 }
 
                 let result = match_literal_vector!(match e1 => Literal {
-                    Float => |e1| { float_length(e1) },
+                    Float => |e1| { float_length(e1)? },
                 })?;
                 self.register_evaluated_expr(Expression::Literal(result), span)
             }
@@ -1902,21 +1933,40 @@ impl<'a> ConstantEvaluator<'a> {
                 // https://www.w3.org/TR/WGSL/#normalize-builtin
                 let e1 = self.extract_vec(arg, true)?;
 
-                fn float_normalize<F>(e: &[F]) -> ArrayVec<F, { crate::VectorSize::MAX }>
+                fn float_normalize<F>(
+                    e: &[F],
+                ) -> Result<ArrayVec<F, { crate::VectorSize::MAX }>, ConstantEvaluatorError>
                 where
                     F: core::ops::Mul<F>,
                     F: num_traits::Float + iter::Sum,
                 {
-                    let len = e.iter().map(|&ei| ei * ei).sum::<F>().sqrt();
+                    let len = if e.len() == 1 {
+                        // Avoids possible overflow in squaring
+                        e[0].abs()
+                    } else {
+                        let len = e.iter().map(|&ei| ei * ei).sum::<F>().sqrt();
+                        if len.is_finite() {
+                            len
+                        } else {
+                            return Err(ConstantEvaluatorError::Overflow("normalize".into()));
+                        }
+                    };
+
+                    if len.is_zero() {
+                        return Err(ConstantEvaluatorError::InvalidMathArgValue(
+                            "normalize".into(),
+                        ));
+                    }
+
                     let mut out = ArrayVec::new();
                     for &ei in e {
                         out.push(ei / len);
                     }
-                    out
+                    Ok(out)
                 }
 
                 let result = match_literal_vector!(match e1 => LiteralVector {
-                    Float => |e1| { float_normalize(e1) },
+                    Float => |e1| { float_normalize(e1)? },
                 })?;
                 result.register_as_evaluated_expr(self, span)
             }

--- a/naga/src/proc/overloads/mathfunction.rs
+++ b/naga/src/proc/overloads/mathfunction.rs
@@ -97,8 +97,8 @@ impl ir::MathFunction {
             Mf::Distance => {
                 regular!(2, SCALAR|VECN of FLOAT_ABSTRACT_UNIMPLEMENTED -> Scalar).into()
             }
-            Mf::Length => regular!(1, SCALAR|VECN of FLOAT_ABSTRACT_UNIMPLEMENTED -> Scalar).into(),
-            Mf::Normalize => regular!(1, VECN of FLOAT_ABSTRACT_UNIMPLEMENTED).into(),
+            Mf::Length => regular!(1, SCALAR|VECN of FLOAT -> Scalar).into(),
+            Mf::Normalize => regular!(1, VECN of FLOAT).into(),
             Mf::FaceForward => regular!(3, VECN of FLOAT_ABSTRACT_UNIMPLEMENTED).into(),
             Mf::Reflect => regular!(2, VECN of FLOAT_ABSTRACT_UNIMPLEMENTED).into(),
             Mf::Refract => refract().into(),


### PR DESCRIPTION
**Connections**
Fixes issue #8900
A follow-up PR for #9224

**Description**
Added validation on builtin math functions `acosh`, `length`, `normalize`, and `pow` during const evaluation.

**Testing**
* Existing tests
* CTS change
webgpu:shader,validation,expression,call,builtin,acosh:* : pass
webgpu:shader,validation,expression,call,builtin,length:* : pass webgpu:shader,validation,expression,call,builtin,normalize:* : pass webgpu:shader,validation,expression,call,builtin,pow:* : pass

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry.