### PR TITLE
metal: use setMeshBytes for mesh shader immediates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,7 @@ By @kpreid in [#9042](https://github.com/gfx-rs/wgpu/pull/9042).
 
 - Fix one-second delay when switching a wgpu app to the foreground. By [@emilk](https://github.com/emilk) in [#9141](https://github.com/gfx-rs/wgpu/pull/9141)
 - Work around Metal driver bug with atomic textures. By @atlv24 in [#9185](https://github.com/gfx-rs/wgpu/pull/9185)
+- Fix setting an immediate for a Mesh shader. By [@waywardmonkeys](https://github.com/waywardmonkeys) in [#9254](https://github.com/gfx-rs/wgpu/pull/9254)
 
 #### GLES
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1210,7 +1210,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
             if let Some(ms) = layout.immediates_infos.ms {
                 if self.shared.private_caps.mesh_shaders {
                     unsafe {
-                        render.setObjectBytes_length_atIndex(
+                        render.setMeshBytes_length_atIndex(
                             bytes,
                             layout.total_immediates as usize * WORD_SIZE,
                             ms.buffer_index as _,


### PR DESCRIPTION
**Connections**
None

**Description**
Other mesh-stage byte bindings already use `setMeshBytes`, but the immediates path still used `setObjectBytes`. Switch that call site to the mesh-stage encoder entry point.

**Testing**
Wrote a small test for it. It failed before this fix and passed after. Also, visual inspection of the code.

**Squash or Rebase?**
N/A

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
