### PR TITLE
Change `get_current_texture` output to a unified enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,32 @@ Bottom level categories:
 
 ### Major Changes
 
+#### `Surface::get_current_texture` now returns `CurrentSurfaceTexture` enum
+
+`Surface::get_current_texture` no longer returns `Result<SurfaceTexture, SurfaceError>`.
+Instead, it returns a single `CurrentSurfaceTexture` enum that represents all possible outcomes as variants.
+`SurfaceError` has been removed, and the `suboptimal` field on `SurfaceTexture` has been replaced by a dedicated `Suboptimal` variant.
+
+```diff
+- match surface.get_current_texture() {
+-     Ok(frame) => { /* render */ }
+-     Err(wgpu::SurfaceError::Timeout | wgpu::SurfaceError::Occluded) => { /* skip frame */ }
+-     Err(wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost) => { /* reconfigure */ }
+-     Err(err) => panic!("{err}"),
+- }
++ match surface.get_current_texture() {
++     wgpu::CurrentSurfaceTexture::Success(frame) => { /* render */ }
++     wgpu::CurrentSurfaceTexture::Timeout
++     | wgpu::CurrentSurfaceTexture::Occluded => { /* skip frame */ }
++     wgpu::CurrentSurfaceTexture::Outdated
++     | wgpu::CurrentSurfaceTexture::Suboptimal(frame) => { /* reconfigure surface */ }
++     wgpu::CurrentSurfaceTexture::Lost => { /* reconfigure surface, or recreate device if device lost */ }
++     wgpu::CurrentSurfaceTexture::Other => { /* try again? 🤷 */ }
++ }
+```
+
+By @cwfitzgerald, @Wumpf and @emilk in [#9141](https://github.com/gfx-rs/wgpu/pull/9141) and [#????](https://github.com/gfx-rs/wgpu/pull/????).
+
 #### `InstanceDescriptor` initialization APIs
 
 `InstanceDescriptor`'s convenience constructors (an implementation of `Default` and the static `from_env_or_default` method) have been removed. In their place are new static methods that force recognition of whether a display handle is used:
@@ -164,7 +190,6 @@ By @kpreid in [#9042](https://github.com/gfx-rs/wgpu/pull/9042).
 
 #### Other Breaking Changes
 
-- `Surface::get_current_texture` can now return `SurfaceError::Occluded`. By @emilk in [#9141](https://github.com/gfx-rs/wgpu/pull/9141).
 - Use clearer field names for `StageError::InvalidWorkgroupSize`. By @ErichDonGubler in [#9192](https://github.com/gfx-rs/wgpu/pull/9192).
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,25 +50,22 @@ Bottom level categories:
 Instead, it returns a single `CurrentSurfaceTexture` enum that represents all possible outcomes as variants.
 `SurfaceError` has been removed, and the `suboptimal` field on `SurfaceTexture` has been replaced by a dedicated `Suboptimal` variant.
 
-```diff
-- match surface.get_current_texture() {
--     Ok(frame) => { /* render */ }
--     Err(wgpu::SurfaceError::Timeout | wgpu::SurfaceError::Occluded) => { /* skip frame */ }
--     Err(wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost) => { /* reconfigure */ }
--     Err(err) => panic!("{err}"),
-- }
-+ match surface.get_current_texture() {
-+     wgpu::CurrentSurfaceTexture::Success(frame) => { /* render */ }
-+     wgpu::CurrentSurfaceTexture::Timeout
-+     | wgpu::CurrentSurfaceTexture::Occluded => { /* skip frame */ }
-+     wgpu::CurrentSurfaceTexture::Outdated
-+     | wgpu::CurrentSurfaceTexture::Suboptimal(frame) => { /* reconfigure surface */ }
-+     wgpu::CurrentSurfaceTexture::Lost => { /* reconfigure surface, or recreate device if device lost */ }
-+     wgpu::CurrentSurfaceTexture::Other => { /* try again? 🤷 */ }
-+ }
+```rust
+match surface.get_current_texture() {
+    wgpu::CurrentSurfaceTexture::Success(frame) => { /* render */ }
+    wgpu::CurrentSurfaceTexture::Timeout
+      | wgpu::CurrentSurfaceTexture::Occluded => { /* skip frame */ }
+    wgpu::CurrentSurfaceTexture::Outdated
+      | wgpu::CurrentSurfaceTexture::Suboptimal(frame) => { /* reconfigure surface */ }
+    wgpu::CurrentSurfaceTexture::Lost => { /* reconfigure surface, or recreate device if device lost */ }
+    wgpu::CurrentSurfaceTexture::Validation => {
+        /* Only happens if there is a validation error and you
+           have registered a error scope or uncaptured error handler. */
+    }
+}
 ```
 
-By @cwfitzgerald, @Wumpf and @emilk in [#9141](https://github.com/gfx-rs/wgpu/pull/9141) and [#????](https://github.com/gfx-rs/wgpu/pull/????).
+By @cwfitzgerald, @Wumpf, and @emilk in [#9141](https://github.com/gfx-rs/wgpu/pull/9141) and [#????](https://github.com/gfx-rs/wgpu/pull/????).
 
 #### `InstanceDescriptor` initialization APIs
 

--- a/examples/bug-repro/01_texture_atomic_bug/src/main.rs
+++ b/examples/bug-repro/01_texture_atomic_bug/src/main.rs
@@ -274,8 +274,7 @@ impl State {
     fn render_frame(&mut self) {
         let frame = match self.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(f) => f,
-            wgpu::CurrentSurfaceTexture::Suboptimal(_)
-            | wgpu::CurrentSurfaceTexture::Outdated => {
+            wgpu::CurrentSurfaceTexture::Suboptimal(_) | wgpu::CurrentSurfaceTexture::Outdated => {
                 self.surface.configure(&self.device, &self.surface_config);
                 return;
             }

--- a/examples/bug-repro/01_texture_atomic_bug/src/main.rs
+++ b/examples/bug-repro/01_texture_atomic_bug/src/main.rs
@@ -26,6 +26,7 @@ struct App {
 }
 
 struct State {
+    instance: wgpu::Instance,
     window: Arc<Window>,
     device: wgpu::Device,
     queue: wgpu::Queue,
@@ -250,6 +251,7 @@ impl State {
         });
 
         State {
+            instance,
             window,
             device,
             queue,
@@ -271,12 +273,21 @@ impl State {
 
     fn render_frame(&mut self) {
         let frame = match self.surface.get_current_texture() {
-            Ok(f) => f,
-            Err(wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost) => {
+            wgpu::CurrentSurfaceTexture::Success(f) => f,
+            wgpu::CurrentSurfaceTexture::Suboptimal(f) => {
+                self.surface.configure(&self.device, &self.surface_config);
+                f
+            }
+            wgpu::CurrentSurfaceTexture::Outdated => {
                 self.surface.configure(&self.device, &self.surface_config);
                 return;
             }
-            Err(_) => return,
+            wgpu::CurrentSurfaceTexture::Lost => {
+                self.surface = self.instance.create_surface(self.window.clone()).unwrap();
+                self.surface.configure(&self.device, &self.surface_config);
+                return;
+            }
+            _ => return,
         };
         let frame_view = frame.texture.create_view(&Default::default());
         let mut enc = self.device.create_command_encoder(&Default::default());

--- a/examples/bug-repro/01_texture_atomic_bug/src/main.rs
+++ b/examples/bug-repro/01_texture_atomic_bug/src/main.rs
@@ -274,11 +274,8 @@ impl State {
     fn render_frame(&mut self) {
         let frame = match self.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(f) => f,
-            wgpu::CurrentSurfaceTexture::Suboptimal(f) => {
-                self.surface.configure(&self.device, &self.surface_config);
-                f
-            }
-            wgpu::CurrentSurfaceTexture::Outdated => {
+            wgpu::CurrentSurfaceTexture::Suboptimal(_)
+            | wgpu::CurrentSurfaceTexture::Outdated => {
                 self.surface.configure(&self.device, &self.surface_config);
                 return;
             }

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -194,14 +194,12 @@ impl SurfaceWrapper {
 
         match surface.get_current_texture() {
             CurrentSurfaceTexture::Success(frame) => Some(frame),
-            CurrentSurfaceTexture::Suboptimal(frame) => {
-                surface.configure(&context.device, self.config());
-                Some(frame)
-            }
             // If we timed out or the window is occluded, skip this frame:
             CurrentSurfaceTexture::Timeout | CurrentSurfaceTexture::Occluded => None,
-            // If the surface is outdated, reconfigure it.
-            CurrentSurfaceTexture::Outdated | CurrentSurfaceTexture::Other => {
+            // If the surface is outdated or suboptimal, reconfigure and retry.
+            CurrentSurfaceTexture::Suboptimal(_)
+            | CurrentSurfaceTexture::Outdated
+            | CurrentSurfaceTexture::Other => {
                 surface.configure(&context.device, self.config());
                 match surface.get_current_texture() {
                     CurrentSurfaceTexture::Success(frame)

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -183,25 +183,44 @@ impl SurfaceWrapper {
     /// Acquire the next surface texture.
     ///
     /// Returns `None` on failure.
-    fn acquire(&mut self, context: &ExampleContext) -> Option<wgpu::SurfaceTexture> {
+    fn acquire(
+        &mut self,
+        context: &ExampleContext,
+        window: Arc<Window>,
+    ) -> Option<wgpu::SurfaceTexture> {
+        use wgpu::CurrentSurfaceTexture;
+
         let surface = self.surface.as_ref().unwrap();
 
         match surface.get_current_texture() {
-            Ok(frame) => Some(frame),
-            // If we timed out or the window is occluded, skip this frame:
-            Err(wgpu::SurfaceError::Timeout | wgpu::SurfaceError::Occluded) => None,
-            Err(
-                // If the surface is outdated, or was lost, reconfigure it.
-                wgpu::SurfaceError::Outdated
-                | wgpu::SurfaceError::Lost
-                | wgpu::SurfaceError::Other
-                // If OutOfMemory happens, reconfiguring may not help, but we might as well try
-                | wgpu::SurfaceError::OutOfMemory,
-            ) => {
+            CurrentSurfaceTexture::Success(frame) => Some(frame),
+            CurrentSurfaceTexture::Suboptimal(frame) => {
                 surface.configure(&context.device, self.config());
-                Some(surface
-                    .get_current_texture()
-                    .expect("Failed to acquire next surface texture!"))
+                Some(frame)
+            }
+            // If we timed out or the window is occluded, skip this frame:
+            CurrentSurfaceTexture::Timeout | CurrentSurfaceTexture::Occluded => None,
+            // If the surface is outdated, reconfigure it.
+            CurrentSurfaceTexture::Outdated | CurrentSurfaceTexture::Other => {
+                surface.configure(&context.device, self.config());
+                match surface.get_current_texture() {
+                    CurrentSurfaceTexture::Success(frame)
+                    | CurrentSurfaceTexture::Suboptimal(frame) => Some(frame),
+                    other => panic!("Failed to acquire next surface texture: {other:?}"),
+                }
+            }
+            // If the surface is lost, recreate and reconfigure it.
+            CurrentSurfaceTexture::Lost => {
+                self.surface = Some(context.instance.create_surface(window).unwrap());
+                self.surface
+                    .as_ref()
+                    .unwrap()
+                    .configure(&context.device, self.config());
+                match self.surface.as_ref().unwrap().get_current_texture() {
+                    CurrentSurfaceTexture::Success(frame)
+                    | CurrentSurfaceTexture::Suboptimal(frame) => Some(frame),
+                    other => panic!("Failed to acquire next surface texture: {other:?}"),
+                }
             }
         }
     }
@@ -518,7 +537,8 @@ impl<E: Example> ApplicationHandler<AppAction> for App<E> {
 
                 self.frame_counter.update();
 
-                if let Some(frame) = surface.acquire(context) {
+                let window_arc = self.window.clone().unwrap();
+                if let Some(frame) = surface.acquire(context, window_arc) {
                     let view = frame.texture.create_view(&wgpu::TextureViewDescriptor {
                         format: Some(surface.config().view_formats[0]),
                         ..wgpu::TextureViewDescriptor::default()

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -197,15 +197,16 @@ impl SurfaceWrapper {
             // If we timed out or the window is occluded, skip this frame:
             CurrentSurfaceTexture::Timeout | CurrentSurfaceTexture::Occluded => None,
             // If the surface is outdated or suboptimal, reconfigure and retry.
-            CurrentSurfaceTexture::Suboptimal(_)
-            | CurrentSurfaceTexture::Outdated
-            | CurrentSurfaceTexture::Other => {
+            CurrentSurfaceTexture::Suboptimal(_) | CurrentSurfaceTexture::Outdated => {
                 surface.configure(&context.device, self.config());
                 match surface.get_current_texture() {
                     CurrentSurfaceTexture::Success(frame)
                     | CurrentSurfaceTexture::Suboptimal(frame) => Some(frame),
                     other => panic!("Failed to acquire next surface texture: {other:?}"),
                 }
+            }
+            CurrentSurfaceTexture::Validation => {
+                unreachable!("No error scope registered, so validation errors will panic")
             }
             // If the surface is lost, recreate and reconfigure it.
             CurrentSurfaceTexture::Lost => {

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -224,12 +224,6 @@ impl ApplicationHandler<TriangleAction> for App {
             WindowEvent::RedrawRequested => {
                 let frame = match wgpu_state.surface.get_current_texture() {
                     CurrentSurfaceTexture::Success(frame) => frame,
-                    CurrentSurfaceTexture::Suboptimal(frame) => {
-                        wgpu_state
-                            .surface
-                            .configure(&wgpu_state.device, &wgpu_state.config);
-                        frame
-                    }
                     CurrentSurfaceTexture::Timeout | CurrentSurfaceTexture::Occluded => {
                         // Try again later
                         if let Some(window) = &self.window {
@@ -237,7 +231,9 @@ impl ApplicationHandler<TriangleAction> for App {
                         }
                         return;
                     }
-                    CurrentSurfaceTexture::Outdated | CurrentSurfaceTexture::Other => {
+                    CurrentSurfaceTexture::Suboptimal(_)
+                    | CurrentSurfaceTexture::Outdated
+                    | CurrentSurfaceTexture::Other => {
                         wgpu_state
                             .surface
                             .configure(&wgpu_state.device, &wgpu_state.config);

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -231,9 +231,7 @@ impl ApplicationHandler<TriangleAction> for App {
                         }
                         return;
                     }
-                    CurrentSurfaceTexture::Suboptimal(_)
-                    | CurrentSurfaceTexture::Outdated
-                    | CurrentSurfaceTexture::Other => {
+                    CurrentSurfaceTexture::Suboptimal(_) | CurrentSurfaceTexture::Outdated => {
                         wgpu_state
                             .surface
                             .configure(&wgpu_state.device, &wgpu_state.config);
@@ -241,6 +239,9 @@ impl ApplicationHandler<TriangleAction> for App {
                             window.request_redraw();
                         }
                         return;
+                    }
+                    CurrentSurfaceTexture::Validation => {
+                        unreachable!("No error scope registered, so validation errors will panic")
                     }
                     CurrentSurfaceTexture::Lost => {
                         wgpu_state.surface = wgpu_state

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -1,5 +1,5 @@
 use std::{borrow::Cow, future::Future, sync::Arc};
-use wgpu::SurfaceError;
+use wgpu::CurrentSurfaceTexture;
 use winit::{
     application::ApplicationHandler,
     event::WindowEvent,
@@ -22,6 +22,8 @@ fn spawn(f: impl Future<Output = ()> + 'static) {
 }
 
 struct WgpuState {
+    instance: wgpu::Instance,
+    window: Arc<Window>,
     device: wgpu::Device,
     queue: wgpu::Queue,
     surface: wgpu::Surface<'static>,
@@ -174,6 +176,8 @@ impl ApplicationHandler<TriangleAction> for App {
             surface.configure(&device, &config);
 
             let _ = proxy.send_event(TriangleAction::Initialized(WgpuState {
+                instance,
+                window,
                 device,
                 queue,
                 surface,
@@ -218,53 +222,77 @@ impl ApplicationHandler<TriangleAction> for App {
                 }
             }
             WindowEvent::RedrawRequested => {
-                match wgpu_state.surface.get_current_texture() {
-                    Ok(frame) => {
-                        let view = frame
-                            .texture
-                            .create_view(&wgpu::TextureViewDescriptor::default());
-                        let mut encoder = wgpu_state.device.create_command_encoder(
-                            &wgpu::CommandEncoderDescriptor { label: None },
-                        );
-                        {
-                            let mut rpass =
-                                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                    label: None,
-                                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                        view: &view,
-                                        depth_slice: None,
-                                        resolve_target: None,
-                                        ops: wgpu::Operations {
-                                            load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
-                                            store: wgpu::StoreOp::Store,
-                                        },
-                                    })],
-                                    depth_stencil_attachment: None,
-                                    timestamp_writes: None,
-                                    occlusion_query_set: None,
-                                    multiview_mask: None,
-                                });
-                            rpass.set_pipeline(&wgpu_state.render_pipeline);
-                            rpass.draw(0..3, 0..1);
-                        }
-
-                        wgpu_state.queue.submit(Some(encoder.finish()));
-                        if let Some(window) = &self.window {
-                            window.pre_present_notify();
-                        }
-                        frame.present();
+                let frame = match wgpu_state.surface.get_current_texture() {
+                    CurrentSurfaceTexture::Success(frame) => frame,
+                    CurrentSurfaceTexture::Suboptimal(frame) => {
+                        wgpu_state
+                            .surface
+                            .configure(&wgpu_state.device, &wgpu_state.config);
+                        frame
                     }
-                    Err(SurfaceError::Timeout | SurfaceError::Occluded) => {
+                    CurrentSurfaceTexture::Timeout | CurrentSurfaceTexture::Occluded => {
                         // Try again later
                         if let Some(window) = &self.window {
                             window.request_redraw();
                         }
+                        return;
                     }
-                    Err(err) => {
-                        // TODO: reconfigure the surface instead
-                        panic!("get_current_texture: {err}");
+                    CurrentSurfaceTexture::Outdated | CurrentSurfaceTexture::Other => {
+                        wgpu_state
+                            .surface
+                            .configure(&wgpu_state.device, &wgpu_state.config);
+                        if let Some(window) = &self.window {
+                            window.request_redraw();
+                        }
+                        return;
                     }
+                    CurrentSurfaceTexture::Lost => {
+                        wgpu_state.surface = wgpu_state
+                            .instance
+                            .create_surface(wgpu_state.window.clone())
+                            .unwrap();
+                        wgpu_state
+                            .surface
+                            .configure(&wgpu_state.device, &wgpu_state.config);
+                        if let Some(window) = &self.window {
+                            window.request_redraw();
+                        }
+                        return;
+                    }
+                };
+
+                let view = frame
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+                let mut encoder = wgpu_state
+                    .device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+                {
+                    let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: None,
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &view,
+                            depth_slice: None,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                        multiview_mask: None,
+                    });
+                    rpass.set_pipeline(&wgpu_state.render_pipeline);
+                    rpass.draw(0..3, 0..1);
                 }
+
+                wgpu_state.queue.submit(Some(encoder.finish()));
+                if let Some(window) = &self.window {
+                    window.pre_present_notify();
+                }
+                frame.present();
             }
             WindowEvent::Occluded(is_occluded) => {
                 if !is_occluded {

--- a/examples/features/src/hello_windows/mod.rs
+++ b/examples/features/src/hello_windows/mod.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(target_arch = "wasm32", allow(dead_code, unused_imports))]
 
 use std::{collections::HashMap, sync::Arc};
-use wgpu::SurfaceError;
+use wgpu::CurrentSurfaceTexture;
 use winit::{
     application::ApplicationHandler,
     event::WindowEvent,
@@ -48,7 +48,7 @@ impl Viewport {
         self.desc.surface.configure(device, &self.config);
     }
 
-    fn get_current_texture(&mut self) -> Result<wgpu::SurfaceTexture, SurfaceError> {
+    fn get_current_texture(&mut self) -> CurrentSurfaceTexture {
         self.desc.surface.get_current_texture()
     }
 }
@@ -63,6 +63,7 @@ const COLUMNS: u32 = 4;
 enum AppState {
     Uninitialized,
     Running {
+        instance: wgpu::Instance,
         device: wgpu::Device,
         queue: wgpu::Queue,
         viewports: HashMap<WindowId, Viewport>,
@@ -162,6 +163,7 @@ impl ApplicationHandler for App {
             .collect();
 
         self.state = AppState::Running {
+            instance,
             device,
             queue,
             viewports,
@@ -175,6 +177,7 @@ impl ApplicationHandler for App {
         event: WindowEvent,
     ) {
         let AppState::Running {
+            instance,
             device,
             queue,
             viewports,
@@ -194,51 +197,58 @@ impl ApplicationHandler for App {
             }
             WindowEvent::RedrawRequested => {
                 if let Some(viewport) = viewports.get_mut(&window_id) {
-                    match viewport.get_current_texture() {
-                        Ok(frame) => {
-                            let view = frame
-                                .texture
-                                .create_view(&wgpu::TextureViewDescriptor::default());
-                            let mut encoder =
-                                device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                                    label: None,
-                                });
-                            {
-                                let _rpass =
-                                    encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                        label: None,
-                                        color_attachments: &[Some(
-                                            wgpu::RenderPassColorAttachment {
-                                                view: &view,
-                                                depth_slice: None,
-                                                resolve_target: None,
-                                                ops: wgpu::Operations {
-                                                    load: wgpu::LoadOp::Clear(
-                                                        viewport.desc.background,
-                                                    ),
-                                                    store: wgpu::StoreOp::Store,
-                                                },
-                                            },
-                                        )],
-                                        depth_stencil_attachment: None,
-                                        timestamp_writes: None,
-                                        occlusion_query_set: None,
-                                        multiview_mask: None,
-                                    });
-                            }
-
-                            queue.submit(Some(encoder.finish()));
-                            viewport.desc.window.pre_present_notify();
-                            frame.present();
+                    let frame = match viewport.get_current_texture() {
+                        CurrentSurfaceTexture::Success(frame) => frame,
+                        CurrentSurfaceTexture::Suboptimal(frame) => {
+                            viewport.desc.surface.configure(device, &viewport.config);
+                            frame
                         }
-                        Err(SurfaceError::Timeout | SurfaceError::Occluded) => {
+                        CurrentSurfaceTexture::Timeout | CurrentSurfaceTexture::Occluded => {
                             viewport.desc.window.request_redraw();
+                            return;
                         }
-                        Err(err) => {
-                            // TODO: reconfigure the surface instead
-                            panic!("get_current_texture: {err}");
+                        CurrentSurfaceTexture::Outdated | CurrentSurfaceTexture::Other => {
+                            viewport.desc.surface.configure(device, &viewport.config);
+                            viewport.desc.window.request_redraw();
+                            return;
                         }
+                        CurrentSurfaceTexture::Lost => {
+                            viewport.desc.surface = instance
+                                .create_surface(viewport.desc.window.clone())
+                                .unwrap();
+                            viewport.desc.surface.configure(device, &viewport.config);
+                            viewport.desc.window.request_redraw();
+                            return;
+                        }
+                    };
+
+                    let view = frame
+                        .texture
+                        .create_view(&wgpu::TextureViewDescriptor::default());
+                    let mut encoder = device
+                        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+                    {
+                        let _rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                            label: None,
+                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                view: &view,
+                                depth_slice: None,
+                                resolve_target: None,
+                                ops: wgpu::Operations {
+                                    load: wgpu::LoadOp::Clear(viewport.desc.background),
+                                    store: wgpu::StoreOp::Store,
+                                },
+                            })],
+                            depth_stencil_attachment: None,
+                            timestamp_writes: None,
+                            occlusion_query_set: None,
+                            multiview_mask: None,
+                        });
                     }
+
+                    queue.submit(Some(encoder.finish()));
+                    viewport.desc.window.pre_present_notify();
+                    frame.present();
                 }
             }
             WindowEvent::Occluded(is_occluded) => {

--- a/examples/features/src/hello_windows/mod.rs
+++ b/examples/features/src/hello_windows/mod.rs
@@ -199,15 +199,13 @@ impl ApplicationHandler for App {
                 if let Some(viewport) = viewports.get_mut(&window_id) {
                     let frame = match viewport.get_current_texture() {
                         CurrentSurfaceTexture::Success(frame) => frame,
-                        CurrentSurfaceTexture::Suboptimal(frame) => {
-                            viewport.desc.surface.configure(device, &viewport.config);
-                            frame
-                        }
                         CurrentSurfaceTexture::Timeout | CurrentSurfaceTexture::Occluded => {
                             viewport.desc.window.request_redraw();
                             return;
                         }
-                        CurrentSurfaceTexture::Outdated | CurrentSurfaceTexture::Other => {
+                        CurrentSurfaceTexture::Suboptimal(_)
+                        | CurrentSurfaceTexture::Outdated
+                        | CurrentSurfaceTexture::Other => {
                             viewport.desc.surface.configure(device, &viewport.config);
                             viewport.desc.window.request_redraw();
                             return;

--- a/examples/features/src/hello_windows/mod.rs
+++ b/examples/features/src/hello_windows/mod.rs
@@ -203,12 +203,15 @@ impl ApplicationHandler for App {
                             viewport.desc.window.request_redraw();
                             return;
                         }
-                        CurrentSurfaceTexture::Suboptimal(_)
-                        | CurrentSurfaceTexture::Outdated
-                        | CurrentSurfaceTexture::Other => {
+                        CurrentSurfaceTexture::Suboptimal(_) | CurrentSurfaceTexture::Outdated => {
                             viewport.desc.surface.configure(device, &viewport.config);
                             viewport.desc.window.request_redraw();
                             return;
+                        }
+                        CurrentSurfaceTexture::Validation => {
+                            unreachable!(
+                                "No error scope registered, so validation errors will panic"
+                            )
                         }
                         CurrentSurfaceTexture::Lost => {
                             viewport.desc.surface = instance

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -401,9 +401,7 @@ impl ApplicationHandler<UniformAction> for App {
                         }
                         return;
                     }
-                    CurrentSurfaceTexture::Suboptimal(_)
-                    | CurrentSurfaceTexture::Outdated
-                    | CurrentSurfaceTexture::Other => {
+                    CurrentSurfaceTexture::Suboptimal(_) | CurrentSurfaceTexture::Outdated => {
                         wgpu_ctx
                             .surface
                             .configure(&wgpu_ctx.device, &wgpu_ctx.surface_config);
@@ -411,6 +409,9 @@ impl ApplicationHandler<UniformAction> for App {
                             window.request_redraw();
                         }
                         return;
+                    }
+                    CurrentSurfaceTexture::Validation => {
+                        unreachable!("No error scope registered, so validation errors will panic")
                     }
                     CurrentSurfaceTexture::Lost => {
                         wgpu_ctx.surface = wgpu_ctx

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -20,7 +20,7 @@ use std::{future::Future, sync::Arc};
 // We won't bring StorageBuffer into scope as that might be too easy to confuse
 // with actual GPU-allocated wgpu storage buffers.
 use encase::ShaderType;
-use wgpu::SurfaceError;
+use wgpu::CurrentSurfaceTexture;
 use winit::{
     application::ApplicationHandler,
     event::{KeyEvent, WindowEvent},
@@ -97,6 +97,8 @@ impl Default for ShaderState {
 }
 
 struct WgpuContext {
+    pub instance: wgpu::Instance,
+    pub window: Arc<Window>,
     pub surface: wgpu::Surface<'static>,
     pub surface_config: wgpu::SurfaceConfiguration,
     pub device: wgpu::Device,
@@ -212,6 +214,8 @@ impl WgpuContext {
 
         // (5)
         WgpuContext {
+            instance,
+            window,
             surface,
             surface_config,
             device,
@@ -389,63 +393,87 @@ impl ApplicationHandler<UniformAction> for App {
                 }
             }
             WindowEvent::RedrawRequested => {
-                match wgpu_ctx.surface.get_current_texture() {
-                    Ok(frame) => {
-                        let view = frame
-                            .texture
-                            .create_view(&wgpu::TextureViewDescriptor::default());
-
-                        // (8)
-                        wgpu_ctx.queue.write_buffer(
-                            &wgpu_ctx.uniform_buffer,
-                            0,
-                            &shader_state.as_wgsl_bytes().expect(
-                                "Error in encase translating ShaderState \
-                            struct to WGSL bytes.",
-                            ),
-                        );
-                        let mut encoder = wgpu_ctx.device.create_command_encoder(
-                            &wgpu::CommandEncoderDescriptor { label: None },
-                        );
-                        {
-                            let mut render_pass =
-                                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                    label: None,
-                                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                        view: &view,
-                                        depth_slice: None,
-                                        resolve_target: None,
-                                        ops: wgpu::Operations {
-                                            load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
-                                            store: wgpu::StoreOp::Store,
-                                        },
-                                    })],
-                                    depth_stencil_attachment: None,
-                                    occlusion_query_set: None,
-                                    timestamp_writes: None,
-                                    multiview_mask: None,
-                                });
-                            render_pass.set_pipeline(&wgpu_ctx.pipeline);
-                            // (9)
-                            render_pass.set_bind_group(0, Some(&wgpu_ctx.bind_group), &[]);
-                            render_pass.draw(0..3, 0..1);
-                        }
-                        wgpu_ctx.queue.submit(Some(encoder.finish()));
-                        if let Some(window) = &self.window {
-                            window.pre_present_notify();
-                        }
-                        frame.present();
+                let frame = match wgpu_ctx.surface.get_current_texture() {
+                    CurrentSurfaceTexture::Success(frame) => frame,
+                    CurrentSurfaceTexture::Suboptimal(frame) => {
+                        wgpu_ctx
+                            .surface
+                            .configure(&wgpu_ctx.device, &wgpu_ctx.surface_config);
+                        frame
                     }
-                    Err(SurfaceError::Timeout | SurfaceError::Occluded) => {
+                    CurrentSurfaceTexture::Timeout | CurrentSurfaceTexture::Occluded => {
                         if let Some(window) = &self.window {
                             window.request_redraw();
                         }
+                        return;
                     }
-                    Err(err) => {
-                        // TODO: reconfigure the surface instead
-                        panic!("get_current_texture: {err}");
+                    CurrentSurfaceTexture::Outdated | CurrentSurfaceTexture::Other => {
+                        wgpu_ctx
+                            .surface
+                            .configure(&wgpu_ctx.device, &wgpu_ctx.surface_config);
+                        if let Some(window) = &self.window {
+                            window.request_redraw();
+                        }
+                        return;
                     }
+                    CurrentSurfaceTexture::Lost => {
+                        wgpu_ctx.surface = wgpu_ctx
+                            .instance
+                            .create_surface(wgpu_ctx.window.clone())
+                            .unwrap();
+                        wgpu_ctx
+                            .surface
+                            .configure(&wgpu_ctx.device, &wgpu_ctx.surface_config);
+                        if let Some(window) = &self.window {
+                            window.request_redraw();
+                        }
+                        return;
+                    }
+                };
+
+                let view = frame
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+
+                // (8)
+                wgpu_ctx.queue.write_buffer(
+                    &wgpu_ctx.uniform_buffer,
+                    0,
+                    &shader_state.as_wgsl_bytes().expect(
+                        "Error in encase translating ShaderState \
+                    struct to WGSL bytes.",
+                    ),
+                );
+                let mut encoder = wgpu_ctx
+                    .device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+                {
+                    let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: None,
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &view,
+                            depth_slice: None,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        occlusion_query_set: None,
+                        timestamp_writes: None,
+                        multiview_mask: None,
+                    });
+                    render_pass.set_pipeline(&wgpu_ctx.pipeline);
+                    // (9)
+                    render_pass.set_bind_group(0, Some(&wgpu_ctx.bind_group), &[]);
+                    render_pass.draw(0..3, 0..1);
                 }
+                wgpu_ctx.queue.submit(Some(encoder.finish()));
+                if let Some(window) = &self.window {
+                    window.pre_present_notify();
+                }
+                frame.present();
             }
             WindowEvent::Occluded(is_occluded) => {
                 if !is_occluded {

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -395,19 +395,15 @@ impl ApplicationHandler<UniformAction> for App {
             WindowEvent::RedrawRequested => {
                 let frame = match wgpu_ctx.surface.get_current_texture() {
                     CurrentSurfaceTexture::Success(frame) => frame,
-                    CurrentSurfaceTexture::Suboptimal(frame) => {
-                        wgpu_ctx
-                            .surface
-                            .configure(&wgpu_ctx.device, &wgpu_ctx.surface_config);
-                        frame
-                    }
                     CurrentSurfaceTexture::Timeout | CurrentSurfaceTexture::Occluded => {
                         if let Some(window) = &self.window {
                             window.request_redraw();
                         }
                         return;
                     }
-                    CurrentSurfaceTexture::Outdated | CurrentSurfaceTexture::Other => {
+                    CurrentSurfaceTexture::Suboptimal(_)
+                    | CurrentSurfaceTexture::Outdated
+                    | CurrentSurfaceTexture::Other => {
                         wgpu_ctx
                             .surface
                             .configure(&wgpu_ctx.device, &wgpu_ctx.surface_config);

--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -85,12 +85,10 @@ impl State {
         // (e.g., when the window is occluded on macOS).
         let surface_texture = match self.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(texture) => texture,
-            wgpu::CurrentSurfaceTexture::Suboptimal(texture) => {
-                self.configure_surface();
-                texture
-            }
             wgpu::CurrentSurfaceTexture::Occluded | wgpu::CurrentSurfaceTexture::Timeout => return,
-            wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Other => {
+            wgpu::CurrentSurfaceTexture::Suboptimal(_)
+            | wgpu::CurrentSurfaceTexture::Outdated
+            | wgpu::CurrentSurfaceTexture::Other => {
                 self.configure_surface();
                 return;
             }

--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -86,11 +86,12 @@ impl State {
         let surface_texture = match self.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(texture) => texture,
             wgpu::CurrentSurfaceTexture::Occluded | wgpu::CurrentSurfaceTexture::Timeout => return,
-            wgpu::CurrentSurfaceTexture::Suboptimal(_)
-            | wgpu::CurrentSurfaceTexture::Outdated
-            | wgpu::CurrentSurfaceTexture::Other => {
+            wgpu::CurrentSurfaceTexture::Suboptimal(_) | wgpu::CurrentSurfaceTexture::Outdated => {
                 self.configure_surface();
                 return;
+            }
+            wgpu::CurrentSurfaceTexture::Validation => {
+                unreachable!("No error scope registered, so validation errors will panic")
             }
             wgpu::CurrentSurfaceTexture::Lost => {
                 self.surface = self.instance.create_surface(self.window.clone()).unwrap();

--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -8,6 +8,7 @@ use winit::{
 };
 
 struct State {
+    instance: wgpu::Instance,
     window: Arc<Window>,
     device: wgpu::Device,
     queue: wgpu::Queue,
@@ -37,6 +38,7 @@ impl State {
         let surface_format = cap.formats[0];
 
         let state = State {
+            instance,
             window,
             device,
             queue,
@@ -82,9 +84,21 @@ impl State {
         // NOTE: We must handle Timeout because the surface may be unavailable
         // (e.g., when the window is occluded on macOS).
         let surface_texture = match self.surface.get_current_texture() {
-            Ok(texture) => texture,
-            Err(wgpu::SurfaceError::Occluded) => return, // Can't render right now. Try again later.
-            Err(err) => panic!("failed to acquire next swapchain texture: {err}"),
+            wgpu::CurrentSurfaceTexture::Success(texture) => texture,
+            wgpu::CurrentSurfaceTexture::Suboptimal(texture) => {
+                self.configure_surface();
+                texture
+            }
+            wgpu::CurrentSurfaceTexture::Occluded | wgpu::CurrentSurfaceTexture::Timeout => return,
+            wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Other => {
+                self.configure_surface();
+                return;
+            }
+            wgpu::CurrentSurfaceTexture::Lost => {
+                self.surface = self.instance.create_surface(self.window.clone()).unwrap();
+                self.configure_surface();
+                return;
+            }
         };
         let texture_view = surface_texture
             .texture

--- a/wgpu-types/src/surface.rs
+++ b/wgpu-types/src/surface.rs
@@ -278,8 +278,9 @@ pub enum SurfaceStatus {
     Outdated,
     /// The surface under the swap chain is lost.
     Lost,
-    /// The surface status is not known since `Surface::get_current_texture` previously failed.
-    Unknown,
+    /// `Surface::get_current_texture` has hit a validation error which was caught
+    /// by a error scope.
+    Validation,
 }
 
 /// Nanosecond timestamp used by the presentation engine.

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -115,20 +115,20 @@ impl Surface<'_> {
     /// If a SurfaceTexture referencing this surface is alive when the swapchain is recreated,
     /// recreating the swapchain will panic.
     ///
-    /// This may return [`SurfaceError::Timeout`] if the surface is not visible
+    /// This may return [`CurrentSurfaceTexture::Timeout`] if the surface is not visible
     /// (e.g., the window is minimized, fully occluded, or on another virtual desktop).
     /// Applications should handle this by skipping the current frame.
-    pub fn get_current_texture(&self) -> Result<SurfaceTexture, SurfaceError> {
+    pub fn get_current_texture(&self) -> CurrentSurfaceTexture {
         let (texture, status, detail) = self.inner.get_current_texture();
 
         let suboptimal = match status {
             SurfaceStatus::Good => false,
             SurfaceStatus::Suboptimal => true,
-            SurfaceStatus::Timeout => return Err(SurfaceError::Timeout),
-            SurfaceStatus::Occluded => return Err(SurfaceError::Occluded),
-            SurfaceStatus::Outdated => return Err(SurfaceError::Outdated),
-            SurfaceStatus::Lost => return Err(SurfaceError::Lost),
-            SurfaceStatus::Unknown => return Err(SurfaceError::Other),
+            SurfaceStatus::Timeout => return CurrentSurfaceTexture::Timeout,
+            SurfaceStatus::Occluded => return CurrentSurfaceTexture::Occluded,
+            SurfaceStatus::Outdated => return CurrentSurfaceTexture::Outdated,
+            SurfaceStatus::Lost => return CurrentSurfaceTexture::Lost,
+            SurfaceStatus::Unknown => return CurrentSurfaceTexture::Other,
         };
 
         let guard = self.config.lock();
@@ -151,17 +151,24 @@ impl Surface<'_> {
             view_formats: &[],
         };
 
-        texture
-            .map(|texture| SurfaceTexture {
-                texture: Texture {
-                    inner: texture,
-                    descriptor,
-                },
-                suboptimal,
-                presented: false,
-                detail,
-            })
-            .ok_or(SurfaceError::Lost)
+        match texture {
+            Some(texture) => {
+                let surface_texture = SurfaceTexture {
+                    texture: Texture {
+                        inner: texture,
+                        descriptor,
+                    },
+                    presented: false,
+                    detail,
+                };
+                if suboptimal {
+                    CurrentSurfaceTexture::Suboptimal(surface_texture)
+                } else {
+                    CurrentSurfaceTexture::Success(surface_texture)
+                }
+            }
+            None => CurrentSurfaceTexture::Lost,
+        }
     }
 
     /// Get the [`wgpu_hal`] surface from this `Surface`.

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -106,18 +106,17 @@ impl Surface<'_> {
         self.config.lock().clone()
     }
 
-    /// Returns the next texture to be presented by the swapchain for drawing.
+    /// Returns the next texture to be presented by the surface for drawing.
     ///
     /// In order to present the [`SurfaceTexture`] returned by this method,
     /// first a [`Queue::submit`] needs to be done with some work rendering to this texture.
     /// Then [`SurfaceTexture::present`] needs to be called.
     ///
-    /// If a SurfaceTexture referencing this surface is alive when the swapchain is recreated,
-    /// recreating the swapchain will panic.
+    /// If a [`SurfaceTexture`] referencing this surface is alive when [`Surface::configure()`]
+    /// is called, the configure call will panic.
     ///
-    /// This may return [`CurrentSurfaceTexture::Timeout`] if the surface is not visible
-    /// (e.g., the window is minimized, fully occluded, or on another virtual desktop).
-    /// Applications should handle this by skipping the current frame.
+    /// See the documentation of [`CurrentSurfaceTexture`] for how each possible result
+    /// should be handled.
     pub fn get_current_texture(&self) -> CurrentSurfaceTexture {
         let (texture, status, detail) = self.inner.get_current_texture();
 

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -127,7 +127,7 @@ impl Surface<'_> {
             SurfaceStatus::Occluded => return CurrentSurfaceTexture::Occluded,
             SurfaceStatus::Outdated => return CurrentSurfaceTexture::Outdated,
             SurfaceStatus::Lost => return CurrentSurfaceTexture::Lost,
-            SurfaceStatus::Unknown => return CurrentSurfaceTexture::Other,
+            SurfaceStatus::Validation => return CurrentSurfaceTexture::Validation,
         };
 
         let guard = self.config.lock();

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -57,8 +57,8 @@ impl Drop for SurfaceTexture {
 pub enum CurrentSurfaceTexture {
     /// Successfully acquired a surface texture with no issues.
     Success(SurfaceTexture),
-    /// Successfully acquired a surface texture, but the surface should be
-    /// reconfigured for optimal performance.
+    /// Successfully acquired a surface texture, but texture no longer matches the properties of the underlying surface.
+    /// It's highly recommended to call [`Surface::configure`] again for optimal performance.
     Suboptimal(SurfaceTexture),
     /// A timeout was encountered while trying to acquire the next frame.
     ///

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use crate::*;
 
 /// Surface texture that can be rendered to.
@@ -52,7 +50,7 @@ impl Drop for SurfaceTexture {
 
 /// Result of a call to [`Surface::get_current_texture`].
 ///
-/// See variant documentation of how to handle failed acquisitions.
+/// See variant documentation for how to handle each case.
 #[derive(Debug)]
 pub enum CurrentSurfaceTexture {
     /// Successfully acquired a surface texture with no issues.
@@ -69,32 +67,19 @@ pub enum CurrentSurfaceTexture {
     /// Applications should skip the current frame and try again once the window
     /// is no longer occluded.
     Occluded,
-    /// The underlying surface has changed, and therefore the swap chain must be updated.
+    /// The underlying surface has changed, and therefore the surface configuration is outdated.
     ///
-    /// Reconfigure your surface and try again.
+    /// Call [`Surface::configure()`] and try again.
     Outdated,
-    /// The swap chain has been lost and needs to be recreated.
+    /// The surface has been lost and needs to be recreated.
     ///
-    /// If the device as a whole is lost (see [crate::Device::set_device_lost_callback])
+    /// If the device as a whole is lost (see [`set_device_lost_callback()`][crate::Device::set_device_lost_callback]), then
     /// you need to recreate the device and all resources.
-    /// Otherwise, recreate the surface and try again.
+    /// Otherwise, call [`Instance::create_surface()`] to recreate the surface,
+    /// then [`Surface::configure()`], and try again.
     Lost,
     /// Acquiring a texture failed with a generic error.
     Other,
-}
-
-impl fmt::Display for CurrentSurfaceTexture {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", match self {
-            Self::Success(_) => "Successfully acquired surface texture",
-            Self::Suboptimal(_) => "Acquired surface texture (suboptimal, reconfiguration recommended)",
-            Self::Timeout => "A timeout was encountered while trying to acquire the next frame",
-            Self::Occluded => "The window is occluded (e.g. minimized or behind another window)",
-            Self::Outdated => "The underlying surface has changed, and therefore the swap chain must be updated",
-            Self::Lost => "The swap chain has been lost and needs to be recreated",
-            Self::Other => "Acquiring a texture failed with a generic error",
-        })
-    }
 }
 
 fn thread_panicking() -> bool {

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -78,8 +78,12 @@ pub enum CurrentSurfaceTexture {
     /// Otherwise, call [`Instance::create_surface()`] to recreate the surface,
     /// then [`Surface::configure()`], and try again.
     Lost,
-    /// Acquiring a texture failed with a generic error.
-    Other,
+    /// A validation error inside [`Surface::get_current_texture()`] was raised
+    /// and caught by an [error scope](crate::Device::push_error_scope) or
+    /// [`on_uncaptured_error()`][crate::Device::on_uncaptured_error].
+    ///
+    /// Applications should attend to the validation error and try again.
+    Validation,
 }
 
 fn thread_panicking() -> bool {

--- a/wgpu/src/api/surface_texture.rs
+++ b/wgpu/src/api/surface_texture.rs
@@ -1,4 +1,4 @@
-use core::{error, fmt};
+use core::fmt;
 
 use crate::*;
 
@@ -12,9 +12,6 @@ use crate::*;
 pub struct SurfaceTexture {
     /// Accessible view of the frame.
     pub texture: Texture,
-    /// `true` if the acquired buffer can still be used for rendering,
-    /// but should be recreated for maximum performance.
-    pub suboptimal: bool,
     pub(crate) presented: bool,
     pub(crate) detail: dispatch::DispatchSurfaceOutputDetail,
 }
@@ -53,14 +50,24 @@ impl Drop for SurfaceTexture {
     }
 }
 
-/// Result of an unsuccessful call to [`Surface::get_current_texture`].
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum SurfaceError {
+/// Result of a call to [`Surface::get_current_texture`].
+///
+/// See variant documentation of how to handle failed acquisitions.
+#[derive(Debug)]
+pub enum CurrentSurfaceTexture {
+    /// Successfully acquired a surface texture with no issues.
+    Success(SurfaceTexture),
+    /// Successfully acquired a surface texture, but the surface should be
+    /// reconfigured for optimal performance.
+    Suboptimal(SurfaceTexture),
     /// A timeout was encountered while trying to acquire the next frame.
+    ///
+    /// Applications should skip the current frame and try again later.
     Timeout,
     /// The window is occluded (e.g. minimized or behind another window).
     ///
-    /// Try again once the window is no longer occluded.
+    /// Applications should skip the current frame and try again once the window
+    /// is no longer occluded.
     Occluded,
     /// The underlying surface has changed, and therefore the swap chain must be updated.
     ///
@@ -68,29 +75,27 @@ pub enum SurfaceError {
     Outdated,
     /// The swap chain has been lost and needs to be recreated.
     ///
-    /// Reconfigure your surface and try again.
+    /// If the device as a whole is lost (see [crate::Device::set_device_lost_callback])
+    /// you need to recreate the device and all resources.
+    /// Otherwise, recreate the surface and try again.
     Lost,
-    /// There is no more memory left to allocate a new frame.
-    OutOfMemory,
-    /// Acquiring a texture failed with a generic error. Check error callbacks for more information.
+    /// Acquiring a texture failed with a generic error.
     Other,
 }
-static_assertions::assert_impl_all!(SurfaceError: Send, Sync);
 
-impl fmt::Display for SurfaceError {
+impl fmt::Display for CurrentSurfaceTexture {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", match self {
+            Self::Success(_) => "Successfully acquired surface texture",
+            Self::Suboptimal(_) => "Acquired surface texture (suboptimal, reconfiguration recommended)",
             Self::Timeout => "A timeout was encountered while trying to acquire the next frame",
             Self::Occluded => "The window is occluded (e.g. minimized or behind another window)",
             Self::Outdated => "The underlying surface has changed, and therefore the swap chain must be updated",
-            Self::Lost =>  "The swap chain has been lost and needs to be recreated",
-            Self::OutOfMemory => "There is no more memory left to allocate a new frame",
-            Self::Other => "Acquiring a texture failed with a generic error. Check error callbacks for more information",
+            Self::Lost => "The swap chain has been lost and needs to be recreated",
+            Self::Other => "Acquiring a texture failed with a generic error",
         })
     }
 }
-
-impl error::Error for SurfaceError {}
 
 fn thread_panicking() -> bool {
     cfg_if::cfg_if! {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -3927,7 +3927,7 @@ impl dispatch::SurfaceInterface for CoreSurface {
                             err,
                             "Surface::get_current_texture_view",
                         );
-                        (None, crate::SurfaceStatus::Unknown, output_detail)
+                        (None, crate::SurfaceStatus::Validation, output_detail)
                     }
                     None => self
                         .context


### PR DESCRIPTION
**Connections**

* Needs rebase and sample fixup once https://github.com/gfx-rs/wgpu/pull/9089 is in

**Description**
We've grown a bit unhappy with the way surface errors can be ignored and lack guidance on what to do with them.
This iteration by @cwfitzgerald and myself addresses this by unifying the output of `get_current_texture` into a new output enum

**Testing**
it compiles

**Squash or Rebase?**
squash ofc.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
