### PR TITLE
fix(naga): Reject direct access to atomic variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Bottom level categories:
 
 - Fixed overflow detection and argument domain validation for `acosh`, `length`, `normalize`, and `pow` in constant evaluation. By @ecoricemon in [#9249](https://github.com/gfx-rs/wgpu/pull/9249).
 - Naga no longer allows derivative operations on `f16`. WGSL does not currently allow this, although [it may be added in the future](https://github.com/gpuweb/gpuweb/issues/5482). By @andyleiserson in [#9154](https://github.com/gfx-rs/wgpu/pull/9154).
+- Disallow direct access to atomic variables in WGSL front-end (e.g. `let x = myAtomic;`). By @ecoricemon in [#9262](https://github.com/gfx-rs/wgpu/pull/9262).
 
 #### Metal
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -72,8 +72,6 @@ webgpu:shader,validation,decl,var:* // 99%, https://github.com/gfx-rs/wgpu/issue
 webgpu:shader,validation,expression,access,array:* // 97%, runtime indexing with compile-time-known values, https://github.com/gfx-rs/wgpu/issues/4390
 webgpu:shader,validation,expression,access,matrix:* // 93%, runtime OOB matrix access with literal indices incorrectly rejected
 webgpu:shader,validation,expression,access,vector:* // 52%, https://github.com/gfx-rs/wgpu/issues/4390, and missing swizzle validation
-webgpu:shader,validation,expression,binary,and_or_xor:* // 99%, bool
-webgpu:shader,validation,expression,binary,comparison:* // 99%, bool
 webgpu:shader,validation,expression,binary,div_rem:* // 86%, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:* // 92%, https://github.com/gfx-rs/wgpu/issues/8440
 webgpu:shader,validation,expression,call,builtin,atomics:* // 86%, atomics in vertex shaders, invalid address spaces/access modes

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -72,31 +72,23 @@ webgpu:shader,validation,decl,var:* // 99%, https://github.com/gfx-rs/wgpu/issue
 webgpu:shader,validation,expression,access,array:* // 97%, runtime indexing with compile-time-known values, https://github.com/gfx-rs/wgpu/issues/4390
 webgpu:shader,validation,expression,access,matrix:* // 93%, runtime OOB matrix access with literal indices incorrectly rejected
 webgpu:shader,validation,expression,access,vector:* // 52%, https://github.com/gfx-rs/wgpu/issues/4390, and missing swizzle validation
-webgpu:shader,validation,expression,binary,add_sub_mul:* // 95%, u32 const-eval overflow incorrectly rejected, f16 const-eval overflow not rejected, atomics #5474
-webgpu:shader,validation,expression,binary,and_or_xor:* // 96%, https://github.com/gfx-rs/wgpu/issues/5474
-webgpu:shader,validation,expression,binary,bitwise_shift:invalid_types:* // 93%, atomics #5474
-webgpu:shader,validation,expression,binary,comparison:* // 74%, https://github.com/gfx-rs/wgpu/issues/5474
+webgpu:shader,validation,expression,binary,and_or_xor:* // 99%, bool
+webgpu:shader,validation,expression,binary,comparison:* // 99%, bool
 webgpu:shader,validation,expression,binary,div_rem:* // 86%, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:* // 92%, https://github.com/gfx-rs/wgpu/issues/8440
-webgpu:shader,validation,expression,call,builtin,abs:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,expression,call,builtin,atomics:* // 86%, atomics in vertex shaders, invalid address spaces/access modes
 webgpu:shader,validation,expression,call,builtin,bitcast:* // 57%, bitcast const-eval unimplemented; size validation missing; f16 vector validation incorrect
 webgpu:shader,validation,expression,call,builtin,clamp:* // 71%, clamp low<=high constraint not checked for const/override parameters
-webgpu:shader,validation,expression,call,builtin,countLeadingZeros:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
-webgpu:shader,validation,expression,call,builtin,countOneBits:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
-webgpu:shader,validation,expression,call,builtin,countTrailingZeros:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,expression,call,builtin,cross:* // 86%, abstract int/float overflow issues in const eval
 webgpu:shader,validation,expression,call,builtin,determinant:* // 71%, abstract int/float const eval issues
 webgpu:shader,validation,expression,call,builtin,distance:* // 66%, scalar distance uses wrong formula (sqrt instead of abs)
 webgpu:shader,validation,expression,call,builtin,dot4I8Packed:* // 91%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,dot4U8Packed:* // 91%, missing const eval (#4507)
-webgpu:shader,validation,expression,call,builtin,extractBits:* // 55%, const eval issues
+webgpu:shader,validation,expression,call,builtin,extractBits:* // 62%, const eval issues
 webgpu:shader,validation,expression,call,builtin,faceForward:* // 68%, const eval overflow for abstract/f16
-webgpu:shader,validation,expression,call,builtin,firstLeadingBit:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
-webgpu:shader,validation,expression,call,builtin,firstTrailingBit:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,expression,call,builtin,fma:* // 85%, const eval issues
 webgpu:shader,validation,expression,call,builtin,frexp:* // 39%, const/override eval not supported
-webgpu:shader,validation,expression,call,builtin,insertBits:* // 73%, missing const eval support
+webgpu:shader,validation,expression,call,builtin,insertBits:* // 76%, missing const eval support
 webgpu:shader,validation,expression,call,builtin,inverseSqrt:* // 61%, const eval overflow for abstract/f16
 webgpu:shader,validation,expression,call,builtin,ldexp:* // 43%, const eval not implemented
 webgpu:shader,validation,expression,call,builtin,mix:* // 66%, const eval issues
@@ -113,8 +105,6 @@ webgpu:shader,validation,expression,call,builtin,pack4xU8Clamp:* // 74%, missing
 webgpu:shader,validation,expression,call,builtin,quantizeToF16:* // 77%, overflow validation issues
 webgpu:shader,validation,expression,call,builtin,reflect:* // 39%, const eval not implemented
 webgpu:shader,validation,expression,call,builtin,refract:* // 44%, const eval not implemented
-webgpu:shader,validation,expression,call,builtin,reverseBits:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
-webgpu:shader,validation,expression,call,builtin,select:* // >99%, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,expression,call,builtin,smoothstep:* // 69%, const eval issues
 webgpu:shader,validation,expression,call,builtin,textureDimensions:* // >99%, no external texture in deno
 webgpu:shader,validation,expression,call,builtin,textureGather:* // 99%, https://github.com/gfx-rs/wgpu/issues/8876
@@ -136,9 +126,7 @@ webgpu:shader,validation,expression,call,builtin,unpack4x8unorm:* // 81%, missin
 webgpu:shader,validation,expression,call,builtin,unpack4xI8:* // 75%, missing const eval (#4507)
 webgpu:shader,validation,expression,call,builtin,unpack4xU8:* // 75%, missing const eval (#4507)
 webgpu:shader,validation,expression,early_evaluation:* // 67%, mixed override/runtime composite evaluation
-webgpu:shader,validation,expression,matrix,* // 99%, #5474, #8868, atomic
 webgpu:shader,validation,expression,precedence:* // 76%, https://github.com/gfx-rs/wgpu/issues/4536
-webgpu:shader,validation,expression,unary,* // 99%, atomics #5474
 webgpu:shader,validation,extension,dual_source_blending:blend_src_usage:* // 61%, @blend_src validation gaps
 webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:* // 0%, CTS bug https://github.com/gpuweb/cts/pull/4567
 webgpu:shader,validation,functions,alias_analysis:* // 2%, https://github.com/gfx-rs/wgpu/issues/7650
@@ -163,10 +151,7 @@ webgpu:shader,validation,shader_io,size:* // 92%, https://github.com/gfx-rs/wgpu
 webgpu:shader,validation,shader_io,workgroup_size:* // 83%, https://github.com/gfx-rs/wgpu/issues/8892, type mixing, attribute placement
 webgpu:shader,validation,statement,continue:* // 90%, continue bypassing declaration used in continuing block, https://github.com/gfx-rs/wgpu/issues/7650
 webgpu:shader,validation,statement,for:* // 93%, phony/increment in for-loop init/cont, empty loop behavior
-webgpu:shader,validation,statement,increment_decrement:* // 98%, atomic type validation gap, https://github.com/gfx-rs/wgpu/issues/5474
 webgpu:shader,validation,statement,loop:* // 92%, https://github.com/gfx-rs/wgpu/issues/7650
-webgpu:shader,validation,statement,phony:* // 90%, phony assignment in for-loops with semicolons
 webgpu:shader,validation,statement,statement_behavior:* // https://github.com/gfx-rs/wgpu/issues/7650
-webgpu:shader,validation,statement,switch:* // https://github.com/gfx-rs/wgpu/issues/7650
 webgpu:shader,validation,types,* // 95%, texture_external not supported (2 tests), atomic validation gaps (8 tests), pointer validation gaps (5 tests), 16-bit normalized storage texture formats (36 tests)
 webgpu:shader,validation,uniformity,* // 21%, https://github.com/gfx-rs/wgpu/issues/4369

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -357,6 +357,7 @@ webgpu:shader,validation,expression,access,array:early_eval_errors:case="overrid
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_in_bounds"
 webgpu:shader,validation,expression,access,structure:*
 webgpu:shader,validation,expression,binary,add_sub_mul:*
+webgpu:shader,validation,expression,binary,and_or_xor:*
 webgpu:shader,validation,expression,binary,bitwise_shift:invalid_types:*
 webgpu:shader,validation,expression,binary,bitwise_shift:partial_eval_errors:*
 webgpu:shader,validation,expression,binary,bitwise_shift:scalar_vector:*
@@ -364,6 +365,7 @@ webgpu:shader,validation,expression,binary,bitwise_shift:shift_left_abstract:*
 webgpu:shader,validation,expression,binary,bitwise_shift:shift_left_concrete:*
 webgpu:shader,validation,expression,binary,bitwise_shift:shift_right_abstract:*
 webgpu:shader,validation,expression,binary,bitwise_shift:shift_right_concrete:*
+webgpu:shader,validation,expression,binary,comparison:*
 webgpu:shader,validation,expression,binary,parse:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:array_override:op="%26%26";a_val=1;b_val=1
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -356,8 +356,8 @@ webgpu:shader,validation,expression,access,array:early_eval_errors:case="overrid
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_zero_unsigned"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_in_bounds"
 webgpu:shader,validation,expression,access,structure:*
-webgpu:shader,validation,expression,binary,add_sub_mul:scalar_vector_out_of_range:lhs="i32";*
-webgpu:shader,validation,expression,binary,add_sub_mul:scalar_vector_out_of_range:lhs="u32";*
+webgpu:shader,validation,expression,binary,add_sub_mul:*
+webgpu:shader,validation,expression,binary,bitwise_shift:invalid_types:*
 webgpu:shader,validation,expression,binary,bitwise_shift:partial_eval_errors:*
 webgpu:shader,validation,expression,binary,bitwise_shift:scalar_vector:*
 webgpu:shader,validation,expression,binary,bitwise_shift:shift_left_abstract:*
@@ -368,6 +368,7 @@ webgpu:shader,validation,expression,binary,parse:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:array_override:op="%26%26";a_val=1;b_val=1
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:invalid_types:*
 webgpu:shader,validation,expression,binary,short_circuiting_and_or:scalar_vector:op="%26%26";lhs="bool";rhs="bool"
+webgpu:shader,validation,expression,call,builtin,abs:*
 webgpu:shader,validation,expression,call,builtin,acos:*
 webgpu:shader,validation,expression,call,builtin,acosh:*
 webgpu:shader,validation,expression,call,builtin,all:*
@@ -382,12 +383,17 @@ webgpu:shader,validation,expression,call,builtin,barriers:*
 webgpu:shader,validation,expression,call,builtin,ceil:*
 webgpu:shader,validation,expression,call,builtin,cos:*
 webgpu:shader,validation,expression,call,builtin,cosh:*
+webgpu:shader,validation,expression,call,builtin,countLeadingZeros:*
+webgpu:shader,validation,expression,call,builtin,countOneBits:*
+webgpu:shader,validation,expression,call,builtin,countTrailingZeros:*
 webgpu:shader,validation,expression,call,builtin,degrees:*
 webgpu:shader,validation,expression,call,builtin,derivatives:*
 webgpu:shader,validation,expression,call,builtin,distance:values:stage="constant";type="f32"
 webgpu:shader,validation,expression,call,builtin,dot:*
 webgpu:shader,validation,expression,call,builtin,exp:*
 webgpu:shader,validation,expression,call,builtin,exp2:*
+webgpu:shader,validation,expression,call,builtin,firstLeadingBit:*
+webgpu:shader,validation,expression,call,builtin,firstTrailingBit:*
 webgpu:shader,validation,expression,call,builtin,floor:*
 webgpu:shader,validation,expression,call,builtin,fract:*
 webgpu:shader,validation,expression,call,builtin,length:*
@@ -398,8 +404,10 @@ webgpu:shader,validation,expression,call,builtin,min:*
 webgpu:shader,validation,expression,call,builtin,normalize:*
 webgpu:shader,validation,expression,call,builtin,pow:*
 webgpu:shader,validation,expression,call,builtin,radians:*
+webgpu:shader,validation,expression,call,builtin,reverseBits:*
 webgpu:shader,validation,expression,call,builtin,round:*
 webgpu:shader,validation,expression,call,builtin,saturate:*
+webgpu:shader,validation,expression,call,builtin,select:*
 webgpu:shader,validation,expression,call,builtin,sign:*
 webgpu:shader,validation,expression,call,builtin,sin:*
 webgpu:shader,validation,expression,call,builtin,sinh:*
@@ -418,7 +426,9 @@ webgpu:shader,validation,expression,call,builtin,textureStore:*
 webgpu:shader,validation,expression,call,builtin,trunc:*
 webgpu:shader,validation,expression,call,builtin,value_constructor:*
 webgpu:shader,validation,expression,call,builtin,workgroupUniformLoad:*
+webgpu:shader,validation,expression,matrix,*
 webgpu:shader,validation,expression,overload_resolution:*
+webgpu:shader,validation,expression,unary,*
 webgpu:shader,validation,extension,clip_distances:*
 webgpu:shader,validation,extension,dual_source_blending:*
 webgpu:shader,validation,extension,pointer_composite_access:*
@@ -451,6 +461,8 @@ webgpu:shader,validation,statement,const_assert:*
 webgpu:shader,validation,statement,continuing:*
 webgpu:shader,validation,statement,discard:*
 webgpu:shader,validation,statement,if:*
+webgpu:shader,validation,statement,increment_decrement:*
+webgpu:shader,validation,statement,phony:*
 webgpu:shader,validation,statement,return:*
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break_if"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="break"
@@ -463,5 +475,6 @@ webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="l
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="loop6"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="loop8"
 webgpu:shader,validation,statement,statement_behavior:invalid_statements:body="switch1"
+webgpu:shader,validation,statement,switch:*
 webgpu:shader,validation,statement,while:*
 webgpu:util,texture,texture_ok:*

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -235,6 +235,7 @@ pub(crate) enum Error<'a> {
     InvalidAddrOfOperand(Span),
     InvalidAtomicPointer(Span),
     InvalidAtomicOperandType(Span),
+    InvalidAtomicAccess(Span),
     InvalidRayQueryPointer(Span),
     NotPointer(Span),
     NotReference(&'static str, Span),
@@ -822,6 +823,11 @@ impl<'a> Error<'a> {
             Error::InvalidAtomicOperandType(span) => ParseError {
                 message: "atomic operand type is inconsistent with the operation".to_string(),
                 labels: vec![(span, "atomic operand type is invalid".into())],
+                notes: vec![],
+            },
+            Error::InvalidAtomicAccess(span) => ParseError {
+                message: "atomic variables cannot be accessed directly; use atomic built-in functions".to_string(),
+                labels: vec![(span, "direct access to atomic variable is not allowed".into())],
                 notes: vec![],
             },
             Error::InvalidRayQueryPointer(span) => ParseError {

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -901,8 +901,15 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
     ) -> Result<'source, Handle<ir::Expression>> {
         match expr {
             Typed::Reference(pointer) => {
-                let load = ir::Expression::Load { pointer };
                 let span = self.get_expression_span(pointer);
+
+                // Reject direct access to atomic variables that does not go
+                // through a built-in function.
+                if resolve_inner!(self, pointer).is_atomic_pointer(&self.module.types) {
+                    return Err(Box::new(Error::InvalidAtomicAccess(span)));
+                }
+
+                let load = ir::Expression::Load { pointer };
                 self.append_expression(load, span)
             }
             Typed::Plain(handle) => Ok(handle),

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -1794,10 +1794,13 @@ fn invalid_functions() {
 
     check_validation! {
         "
+        struct Atom {
+            a: atomic<u32>
+        }
         @group(0) @binding(0)
-        var<storage> atom: atomic<u32>;
+        var<storage> atom: Atom;
 
-        fn return_atomic() -> atomic<u32> {
+        fn return_atomic() -> Atom {
            return atom;
         }
         ":


### PR DESCRIPTION
**Connections**
Fixes #5474
A follow-up PR for #9126

**Description**
This PR raises a WGSL front-end error in `apply_load_rule` when the load rule is applied to a reference whose pointee type is atomic.

* Test changes 
The existing `invalid_functions` test for return_atomic was slightly adjusted. The original test used a bare atomic<u32> return type; since the new front-end error fires during module lowering before the validator runs, the test was updated to use a struct  wrapping an atomic so that NonConstructibleReturnType is still exercised through the validator as originally intended.

* Affected CTS
webgpu:shader,validation,expression,binary,add_sub_mul:* : 901 -> 904 (100%)
webgpu:shader,validation,expression,binary,and_or_xor:* : 823 -> 826 (100%)
webgpu:shader,validation,expression,binary,comparison:* : 470 -> 476 (100%)
webgpu:shader,validation,expression,binary,bitwise_shift:invalid_types:* : 26 -> 28 (100%)
webgpu:shader,validation,expression,call,builtin,abs:* : 56 -> 57 (100%)
webgpu:shader,validation,expression,call,builtin,countLeadingZeros:* : 47 -> 48 (100%)
webgpu:shader,validation,expression,call,builtin,countOneBits:* : 47 -> 48 (100%)
webgpu:shader,validation,expression,call,builtin,countTrailingZeros:* : 47 -> 48 (100%)
webgpu:shader,validation,expression,call,builtin,firstLeadingBit:* : 47 -> 48 (100%)
webgpu:shader,validation,expression,call,builtin,firstTrailingBit:* : 47 -> 48 (100%)
webgpu:shader,validation,expression,call,builtin,reverseBits:* : 47 -> 48 (100%)
webgpu:shader,validation,expression,call,builtin,select:* : 842 -> 843 (100%)
webgpu:shader,validation,expression,matrix,* : 1863 -> 1881 (100%)
webgpu:shader,validation,expression,unary,* : 302 -> 304 (100%)
webgpu:shader,validation,statement,increment_decrement:* : 218 -> 222 (100%)
webgpu:shader,validation,statement,phony:* : 58 -> 62 (100%)
webgpu:shader,validation,statement,switch:* : 87 -> 88 (100%)
webgpu:shader,validation,expression,call,builtin,clamp:* : 161 -> 162 (71.68%)
webgpu:shader,validation,expression,call,builtin,extractBits:* : 29 -> 33 (62.26%)
webgpu:shader,validation,expression,call,builtin,insertBits:* : 85 -> 89 (76.07%)
webgpu:shader,validation,types,* : 1450 -> 1453 (95.22%)

<mark>**Uncertainty**</mark>
 I'm not fully confident this is the right approach. Please review. If the approach looks correct, I will identify any affected CTS tests and update them accordingly.    

**Testing**
Existing tests

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
