### PR TITLE
fix(core): implement value comparison for `Limits::max_inter_stage_shader_variables`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+#### General
+
+- Fix limit comparison logic for `max_inter_stage_shader_variables` By @ErichDonGubler in [9264](https://github.com/gfx-rs/wgpu/pull/9264).
+
 ## v29.0.0 (2026-03-18)
 
 ### Major Changes

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -48,6 +48,7 @@ macro_rules! with_limits {
         $macro_name!(max_buffer_size, Ordering::Less);
         $macro_name!(max_vertex_attributes, Ordering::Less);
         $macro_name!(max_vertex_buffer_array_stride, Ordering::Less);
+        $macro_name!(max_inter_stage_shader_variables, Ordering::Less);
         $macro_name!(min_uniform_buffer_offset_alignment, Ordering::Greater);
         $macro_name!(min_storage_buffer_offset_alignment, Ordering::Greater);
         $macro_name!(max_color_attachments, Ordering::Less);


### PR DESCRIPTION
**Connections**

Noticed to be incorrect while testing a Metal implementation of the [`clip-distances` feature](https://www.w3.org/TR/webgpu/#dom-gpufeaturename-clip-distances).

**Description**

Without this, limit-capping logic doesn't work properly for the `max_inter_stage_shader_variables` limit. Eek!

**Testing**

I've manually tested this with `webgpu:api,validation,capability_checks,features,clip_distances:*`, which is passing after fixing this (along with an actual implementation of the `clip-distances` feature). This limit applies to more than just the `clip-distances` feature and its `clip_distances` built-in, so it's interesting to fix this separately.

**Squash or Rebase?**

squashplz

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
