### PR TITLE
Make `with_limits!(…)` exhaustive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4867,6 +4867,7 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "log",
+ "macro_rules_attribute",
  "raw-window-handle",
  "serde",
  "serde_json",

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -52,6 +52,7 @@ web = ["dep:js-sys", "dep:web-sys"]
 bitflags.workspace = true
 bytemuck = { workspace = true, features = ["derive"] }
 log.workspace = true
+macro_rules_attribute = { workspace = true }
 raw-window-handle.workspace = true
 serde = { workspace = true, default-features = false, features = [
     "alloc",

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -2,85 +2,43 @@
 
 use core::cmp::Ordering;
 
+use macro_rules_attribute::macro_rules_derive;
+
 #[cfg(any(feature = "serde", test))]
 use serde::{Deserialize, Serialize};
 
 #[cfg(doc)]
 use crate::{Features, TextureFormat};
 
-/// Invoke a macro for each of the limits.
-///
-/// The supplied macro should take two arguments. The first is a limit name, as
-/// an identifier, typically used to access a member of `struct Limits`. The
-/// second is `Ordering::Less` if valid values are less than the limit (the
-/// common case), or `Ordering::Greater` if valid values are more than the limit
-/// (for limits like alignments, which are minima instead of maxima).
-macro_rules! with_limits {
-    ($macro_name:ident) => {
-        $macro_name!(max_texture_dimension_1d, Ordering::Less);
-        $macro_name!(max_texture_dimension_1d, Ordering::Less);
-        $macro_name!(max_texture_dimension_2d, Ordering::Less);
-        $macro_name!(max_texture_dimension_3d, Ordering::Less);
-        $macro_name!(max_texture_array_layers, Ordering::Less);
-        $macro_name!(max_bind_groups, Ordering::Less);
-        $macro_name!(max_bindings_per_bind_group, Ordering::Less);
-        $macro_name!(
-            max_dynamic_uniform_buffers_per_pipeline_layout,
-            Ordering::Less
-        );
-        $macro_name!(
-            max_dynamic_storage_buffers_per_pipeline_layout,
-            Ordering::Less
-        );
-        $macro_name!(max_sampled_textures_per_shader_stage, Ordering::Less);
-        $macro_name!(max_samplers_per_shader_stage, Ordering::Less);
-        $macro_name!(max_storage_buffers_per_shader_stage, Ordering::Less);
-        $macro_name!(max_storage_textures_per_shader_stage, Ordering::Less);
-        $macro_name!(max_uniform_buffers_per_shader_stage, Ordering::Less);
-        $macro_name!(max_binding_array_elements_per_shader_stage, Ordering::Less);
-        $macro_name!(
-            max_binding_array_acceleration_structure_elements_per_shader_stage,
-            Ordering::Less
-        );
-        $macro_name!(max_uniform_buffer_binding_size, Ordering::Less);
-        $macro_name!(max_storage_buffer_binding_size, Ordering::Less);
-        $macro_name!(max_vertex_buffers, Ordering::Less);
-        $macro_name!(max_buffer_size, Ordering::Less);
-        $macro_name!(max_vertex_attributes, Ordering::Less);
-        $macro_name!(max_vertex_buffer_array_stride, Ordering::Less);
-        $macro_name!(max_inter_stage_shader_variables, Ordering::Less);
-        $macro_name!(min_uniform_buffer_offset_alignment, Ordering::Greater);
-        $macro_name!(min_storage_buffer_offset_alignment, Ordering::Greater);
-        $macro_name!(max_color_attachments, Ordering::Less);
-        $macro_name!(max_color_attachment_bytes_per_sample, Ordering::Less);
-        $macro_name!(max_compute_workgroup_storage_size, Ordering::Less);
-        $macro_name!(max_compute_invocations_per_workgroup, Ordering::Less);
-        $macro_name!(max_compute_workgroup_size_x, Ordering::Less);
-        $macro_name!(max_compute_workgroup_size_y, Ordering::Less);
-        $macro_name!(max_compute_workgroup_size_z, Ordering::Less);
-        $macro_name!(max_compute_workgroups_per_dimension, Ordering::Less);
-
-        $macro_name!(max_immediate_size, Ordering::Less);
-        $macro_name!(max_non_sampler_bindings, Ordering::Less);
-
-        $macro_name!(max_task_mesh_workgroup_total_count, Ordering::Less);
-        $macro_name!(max_task_mesh_workgroups_per_dimension, Ordering::Less);
-        $macro_name!(max_task_invocations_per_workgroup, Ordering::Less);
-        $macro_name!(max_task_invocations_per_dimension, Ordering::Less);
-        $macro_name!(max_mesh_invocations_per_workgroup, Ordering::Less);
-        $macro_name!(max_mesh_invocations_per_dimension, Ordering::Less);
-
-        $macro_name!(max_task_payload_size, Ordering::Less);
-        $macro_name!(max_mesh_output_vertices, Ordering::Less);
-        $macro_name!(max_mesh_output_primitives, Ordering::Less);
-        $macro_name!(max_mesh_output_layers, Ordering::Less);
-        $macro_name!(max_mesh_multiview_view_count, Ordering::Less);
-
-        $macro_name!(max_blas_primitive_count, Ordering::Less);
-        $macro_name!(max_blas_geometry_count, Ordering::Less);
-        $macro_name!(max_tlas_instance_count, Ordering::Less);
-
-        $macro_name!(max_multiview_view_count, Ordering::Less);
+macro_rules! WithLimits {
+    (
+       $(#[$StructMeta:meta])*
+       $StructVis:vis
+       struct $Struct:ident {
+           $(
+               $(#[doc = $literal:literal])*
+               $(#[cfg_attr($Cond:meta, $Output:meta)])*
+               #[custom(ordering($Ordering:ident))]
+               $(#[$FieldMeta:meta])*
+               $FieldVis:vis
+               $Field:ident: $FieldType:ty
+           ),* $(,)?
+       }
+    ) => {
+        /// Invoke a macro for each of the limits.
+        ///
+        /// The supplied macro should take two arguments. The first is a limit name, as
+        /// an identifier, typically used to access a member of `struct Limits`. The
+        /// second is `Ordering::Less` if valid values are less than the limit (the
+        /// common case), or `Ordering::Greater` if valid values are more than the limit
+        /// (for limits like alignments, which are minima instead of maxima).
+        macro_rules! with_limits {
+            ($macro_name:ident) => {
+                $(
+                    $macro_name!($Field, Ordering::$Ordering);
+                )*
+            };
+        }
     };
 }
 
@@ -120,112 +78,146 @@ macro_rules! with_limits {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase", default))]
+#[macro_rules_derive(WithLimits)]
 pub struct Limits {
     /// Maximum allowed value for the `size.width` of a texture created with `TextureDimension::D1`.
     /// Defaults to 8192. Higher is "better".
     #[cfg_attr(feature = "serde", serde(rename = "maxTextureDimension1D"))]
+    #[custom(ordering(Less))]
     pub max_texture_dimension_1d: u32,
     /// Maximum allowed value for the `size.width` and `size.height` of a texture created with `TextureDimension::D2`.
     /// Defaults to 8192. Higher is "better".
     #[cfg_attr(feature = "serde", serde(rename = "maxTextureDimension2D"))]
+    #[custom(ordering(Less))]
     pub max_texture_dimension_2d: u32,
     /// Maximum allowed value for the `size.width`, `size.height`, and `size.depth_or_array_layers`
     /// of a texture created with `TextureDimension::D3`.
     /// Defaults to 2048. Higher is "better".
     #[cfg_attr(feature = "serde", serde(rename = "maxTextureDimension3D"))]
+    #[custom(ordering(Less))]
     pub max_texture_dimension_3d: u32,
     /// Maximum allowed value for the `size.depth_or_array_layers` of a texture created with `TextureDimension::D2`.
     /// Defaults to 256. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_texture_array_layers: u32,
     /// Amount of bind groups that can be attached to a pipeline at the same time. Defaults to 4. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_bind_groups: u32,
     /// Maximum binding index allowed in `create_bind_group_layout`. Defaults to 1000. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_bindings_per_bind_group: u32,
     /// Amount of uniform buffer bindings that can be dynamic in a single pipeline. Defaults to 8. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_dynamic_uniform_buffers_per_pipeline_layout: u32,
     /// Amount of storage buffer bindings that can be dynamic in a single pipeline. Defaults to 4. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_dynamic_storage_buffers_per_pipeline_layout: u32,
     /// Amount of sampled textures visible in a single shader stage. Defaults to 16. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_sampled_textures_per_shader_stage: u32,
     /// Amount of samplers visible in a single shader stage. Defaults to 16. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_samplers_per_shader_stage: u32,
     /// Amount of storage buffers visible in a single shader stage. Defaults to 8. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_storage_buffers_per_shader_stage: u32,
     /// Amount of storage textures visible in a single shader stage. Defaults to 4. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_storage_textures_per_shader_stage: u32,
     /// Amount of uniform buffers visible in a single shader stage. Defaults to 12. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_uniform_buffers_per_shader_stage: u32,
     /// Amount of individual resources within binding arrays that can be accessed in a single shader stage. Applies
     /// to all types of bindings except samplers.
     ///
     /// This "defaults" to 0. However if binding arrays are supported, all devices can support 500,000. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_binding_array_elements_per_shader_stage: u32,
     /// Amount of individual acceleration structures within binding arrays that can be accessed in a single shader stage.
     ///
     /// This "defaults" to 0. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_binding_array_acceleration_structure_elements_per_shader_stage: u32,
     /// Amount of individual samplers within binding arrays that can be accessed in a single shader stage.
     ///
     /// This "defaults" to 0. However if binding arrays are supported, all devices can support 1,000. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_binding_array_sampler_elements_per_shader_stage: u32,
     /// Maximum size in bytes of a binding to a uniform buffer. Defaults to 64 KiB. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_uniform_buffer_binding_size: u64,
     /// Maximum size in bytes of a binding to a storage buffer. Defaults to 128 MiB. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_storage_buffer_binding_size: u64,
     /// Maximum length of `VertexState::buffers` when creating a `RenderPipeline`.
     /// Defaults to 8. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_vertex_buffers: u32,
     /// A limit above which buffer allocations are guaranteed to fail.
     /// Defaults to 256 MiB. Higher is "better".
     ///
     /// Buffer allocations below the maximum buffer size may not succeed depending on available memory,
     /// fragmentation and other factors.
+    #[custom(ordering(Less))]
     pub max_buffer_size: u64,
     /// Maximum length of `VertexBufferLayout::attributes`, summed over all `VertexState::buffers`,
     /// when creating a `RenderPipeline`.
     /// Defaults to 16. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_vertex_attributes: u32,
     /// Maximum value for `VertexBufferLayout::array_stride` when creating a `RenderPipeline`.
     /// Defaults to 2048. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_vertex_buffer_array_stride: u32,
     /// Maximum value for the number of input or output variables for inter-stage communication
     /// (like vertex outputs or fragment inputs) `@location(…)`s (in WGSL parlance)
     /// when creating a `RenderPipeline`.
     /// Defaults to 16. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_inter_stage_shader_variables: u32,
     /// Required `BufferBindingType::Uniform` alignment for `BufferBinding::offset`
     /// when creating a `BindGroup`, or for `set_bind_group` `dynamicOffsets`.
     /// Defaults to 256. Lower is "better".
+    #[custom(ordering(Greater))]
     pub min_uniform_buffer_offset_alignment: u32,
     /// Required `BufferBindingType::Storage` alignment for `BufferBinding::offset`
     /// when creating a `BindGroup`, or for `set_bind_group` `dynamicOffsets`.
     /// Defaults to 256. Lower is "better".
+    #[custom(ordering(Greater))]
     pub min_storage_buffer_offset_alignment: u32,
     /// The maximum allowed number of color attachments.
+    #[custom(ordering(Less))]
     pub max_color_attachments: u32,
     /// The maximum number of bytes necessary to hold one sample (pixel or subpixel) of render
     /// pipeline output data, across all color attachments as described by [`TextureFormat::target_pixel_byte_cost`]
     /// and [`TextureFormat::target_component_alignment`]. Defaults to 32. Higher is "better".
     ///
     /// ⚠️ `Rgba8Unorm`/`Rgba8Snorm`/`Bgra8Unorm`/`Bgra8Snorm` are deceptively 8 bytes per sample. ⚠️
+    #[custom(ordering(Less))]
     pub max_color_attachment_bytes_per_sample: u32,
     /// Maximum number of bytes used for workgroup memory in a compute entry point. Defaults to
     /// 16384. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_compute_workgroup_storage_size: u32,
     /// Maximum value of the product of the `workgroup_size` dimensions for a compute entry-point.
     /// Defaults to 256. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_compute_invocations_per_workgroup: u32,
     /// The maximum value of the `workgroup_size` X dimension for a compute stage `ShaderModule` entry-point.
     /// Defaults to 256. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_compute_workgroup_size_x: u32,
     /// The maximum value of the `workgroup_size` Y dimension for a compute stage `ShaderModule` entry-point.
     /// Defaults to 256. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_compute_workgroup_size_y: u32,
     /// The maximum value of the `workgroup_size` Z dimension for a compute stage `ShaderModule` entry-point.
     /// Defaults to 64. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_compute_workgroup_size_z: u32,
     /// The maximum value for each dimension of a `ComputePass::dispatch(x, y, z)` operation.
     /// Defaults to 65535. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_compute_workgroups_per_dimension: u32,
 
     /// Amount of storage available for immediates in bytes. Defaults to 0. Higher is "better".
@@ -237,6 +229,7 @@ pub struct Limits {
     /// - Metal: 4096 bytes
     /// - OpenGL doesn't natively support immediates, and are emulated with uniforms,
     ///   so this number is less useful but likely 256.
+    #[custom(ordering(Less))]
     pub max_immediate_size: u32,
     /// Maximum number of live non-sampler bindings.
     ///
@@ -247,55 +240,72 @@ pub struct Limits {
     ///
     /// This limit only affects the d3d12 backend. Using a large number will allow the device
     /// to create many bind groups at the cost of a large up-front allocation at device creation.
+    #[custom(ordering(Less))]
     pub max_non_sampler_bindings: u32,
 
     /// The maximum total value for a `RenderPass::draw_mesh_tasks(x, y, z)` operation or the
     /// `@builtin(mesh_task_size)` returned from a task shader.  Higher is "better".
+    #[custom(ordering(Less))]
     pub max_task_mesh_workgroup_total_count: u32,
     /// The maximum value for each dimension of a `RenderPass::draw_mesh_tasks(x, y, z)` operation.
     /// Also for task shader outputs. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_task_mesh_workgroups_per_dimension: u32,
     // These are fundamentally different. It is very common for limits on mesh shaders to be much lower.
     /// Maximum total number of invocations, or threads, per task shader workgroup. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_task_invocations_per_workgroup: u32,
     /// The maximum value for each dimension of a task shader's workgroup size. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_task_invocations_per_dimension: u32,
     /// Maximum total number of invocations, or threads, per mesh shader workgroup. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_mesh_invocations_per_workgroup: u32,
     /// The maximum value for each dimension of a mesh shader's workgroup size. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_mesh_invocations_per_dimension: u32,
 
     /// The maximum size of the payload passed from task to mesh shader. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_task_payload_size: u32,
     /// The maximum number of vertices that a mesh shader may output. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_mesh_output_vertices: u32,
     /// The maximum number of primitives that a mesh shader may output. Higher is "better".
+    #[custom(ordering(Less))]
     pub max_mesh_output_primitives: u32,
     /// The maximum number of layers that can be output from a mesh shader. Higher is "better".
     /// See [#8509](https://github.com/gfx-rs/wgpu/issues/8509).
+    #[custom(ordering(Less))]
     pub max_mesh_output_layers: u32,
     /// The maximum number of views that can be used by a mesh shader in multiview rendering.
     /// Higher is "better".
+    #[custom(ordering(Less))]
     pub max_mesh_multiview_view_count: u32,
 
     /// The maximum number of primitive (ex: triangles, aabbs) a BLAS is allowed to have. Requesting
     /// more than 0 during device creation only makes sense if [`Features::EXPERIMENTAL_RAY_QUERY`]
     /// is enabled.
+    #[custom(ordering(Less))]
     pub max_blas_primitive_count: u32,
     /// The maximum number of geometry descriptors a BLAS is allowed to have. Requesting
     /// more than 0 during device creation only makes sense if [`Features::EXPERIMENTAL_RAY_QUERY`]
     /// is enabled.
+    #[custom(ordering(Less))]
     pub max_blas_geometry_count: u32,
     /// The maximum number of instances a TLAS is allowed to have. Requesting more than 0 during
     /// device creation only makes sense if [`Features::EXPERIMENTAL_RAY_QUERY`]
     /// is enabled.
+    #[custom(ordering(Less))]
     pub max_tlas_instance_count: u32,
     /// The maximum number of acceleration structures allowed to be used in a shader stage.
     /// Requesting more than 0 during device creation only makes sense if [`Features::EXPERIMENTAL_RAY_QUERY`]
     /// is enabled.
+    #[custom(ordering(Less))]
     pub max_acceleration_structures_per_shader_stage: u32,
 
     /// The maximum number of views that can be used in multiview rendering
+    #[custom(ordering(Less))]
     pub max_multiview_view_count: u32,
 }
 


### PR DESCRIPTION
**Connections**

Resolves #9266, albeit in a somewhat ugly way.

**Description**

Use `attribute_macro_rules` for an easy one-off "derive macro" named `WithLimits` that forces the specification of a `#[custom(ordering(…))]` attribute on each field of `Limits`.

LSP still works, so long as the expected structure of each field is honored. LSP is regressed in the case where the structure is not matched. We might, as follow-up work, use a full proc. macro attribute to alleviate this, but that seemed pretty heavyweight for an MVP.

**Testing**

This compiles, and I've confirmed locally that limits are being applied as before. Failures come up very early in several CTS tests, so I believe we are covered here.

**Squash or Rebase?**

sqoosh