### PR TITLE
Fix up and enable `clip-distances` unconditionally for Metal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Added/New Features
+
+#### Metal
+
+- Unconditionally enable `Features::CLIP_DISTANCES`. By @ErichDonGubler in [#9270](https://github.com/gfx-rs/wgpu/pull/9270).
+
 ### Changes
 
 #### General

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -841,7 +841,7 @@ pub fn supported_capabilities() -> crate::valid::Capabilities {
         // No BUFFER_BINDING_ARRAY
         | Caps::STORAGE_TEXTURE_BINDING_ARRAY
         | Caps::STORAGE_BUFFER_BINDING_ARRAY
-        | Caps::CLIP_DISTANCES // CLIP_DISTANCES isn't supported by metal backend? But is supported by MSL writer
+        | Caps::CLIP_DISTANCES
         // No CULL_DISTANCE
         | Caps::STORAGE_TEXTURE_16BIT_NORM_FORMATS
         | Caps::MULTIVIEW

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -7190,10 +7190,10 @@ template <typename A>
                         };
                         let resolved = options.resolve_local_binding(binding, out_mode)?;
                         write!(self.out, "{}{} {}", back::INDENT, ty_name, name)?;
+                        resolved.try_fmt(&mut self.out)?;
                         if let Some(array_len) = array_len {
                             write!(self.out, " [{array_len}]")?;
                         }
-                        resolved.try_fmt(&mut self.out)?;
                         writeln!(self.out, ";")?;
                     }
 

--- a/naga/tests/in/wgsl/clip-distances.toml
+++ b/naga/tests/in/wgsl/clip-distances.toml
@@ -1,5 +1,5 @@
 capabilities = "CLIP_DISTANCES"
-targets = "SPIRV | GLSL | WGSL"
+targets = "SPIRV | GLSL | WGSL | METAL"
 
 [glsl]
 version.Desktop = 330

--- a/naga/tests/out/msl/wgsl-clip-distances.metal
+++ b/naga/tests/out/msl/wgsl-clip-distances.metal
@@ -1,0 +1,27 @@
+// language: metal1.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+struct type_2 {
+    float inner[1];
+};
+struct VertexOutput {
+    metal::float4 position;
+    type_2 clip_distances;
+    char _pad2[12];
+};
+
+struct main_Output {
+    metal::float4 position [[position]];
+    float clip_distances [[clip_distance]] [1];
+};
+vertex main_Output main_(
+) {
+    VertexOutput out = {};
+    out.clip_distances.inner[0] = 0.5;
+    VertexOutput _e4 = out;
+    const auto _tmp = _e4;
+    return main_Output { _tmp.position, {_tmp.clip_distances.inner[0]} };
+}

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1094,6 +1094,7 @@ impl super::CapabilitiesQuery {
             self.timestamp_query_support
                 .contains(TimestampQuerySupport::INSIDE_WGPU_PASSES),
         );
+        features.set(F::CLIP_DISTANCES, true);
         features.set(
             F::DUAL_SOURCE_BLENDING,
             self.msl_version >= MTLLanguageVersion::Version1_2 && self.dual_source_blending,


### PR DESCRIPTION
**Connections**

Based on #8762.

**Description**

I believe this is valid because:

- Chromium/Dawn enables this feature unconditionally also: https://dawn-review.googlesource.com/c/dawn/+/204436/10/src/dawn/native/metal/PhysicalDeviceMTL.mm
- Metal Shading Language specifications as far as I could find (back to 1.2) document support for `[[clip_distance]]`.

**Testing**

Existing CTS coverage should be good for this. I've added some snapshot coverage for a fix for incorrectly ordered printing of resolved binding attributes in the case of an array type. 

**Squash or Rebase?**

Rebase.

**Checklist**


- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
