### PR TITLE
fix(naga): Fix const evaluation on bool

### DIFF
--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -2696,6 +2696,19 @@ impl<'a> ConstantEvaluator<'a> {
                     return Err(ConstantEvaluatorError::InvalidBinaryOpArgs);
                 }
 
+                if matches!(
+                    (left_value, op),
+                    (
+                        Literal::Bool(_),
+                        BinaryOperator::Less
+                            | BinaryOperator::LessEqual
+                            | BinaryOperator::Greater
+                            | BinaryOperator::GreaterEqual
+                    )
+                ) {
+                    return Err(ConstantEvaluatorError::InvalidBinaryOpArgs);
+                }
+
                 let literal = match op {
                     BinaryOperator::Equal => Literal::Bool(left_value == right_value),
                     BinaryOperator::NotEqual => Literal::Bool(left_value != right_value),
@@ -2849,6 +2862,8 @@ impl<'a> ConstantEvaluator<'a> {
                         (Literal::Bool(a), Literal::Bool(b)) => Literal::Bool(match op {
                             BinaryOperator::LogicalAnd => a && b,
                             BinaryOperator::LogicalOr => a || b,
+                            BinaryOperator::And => a & b,
+                            BinaryOperator::InclusiveOr => a | b,
                             _ => return Err(ConstantEvaluatorError::InvalidBinaryOpArgs),
                         }),
                         _ => return Err(ConstantEvaluatorError::InvalidBinaryOpArgs),


### PR DESCRIPTION
**Connections**
Partially fixes issue #9274 (item 1 and 4)

**Description**
In naga const evaluator,
- Added checking for invalid boolean operations something like `true < false`.
- Allowed logical boolean operations (not short-circuit and/or) something like `true & true`.
[spec](https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)

**Testing**
* Existing tests
* CTS change
webgpu:shader,validation,expression,binary,* : 4869 -> 4873 (+4)
webgpu:shader,validation,expression,binary,comparison:* : 468 -> 470 (+2)
webgpu:shader,validation,expression,binary,and_or_xor:* : 821 -> 823 (+2)

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. 

P.S.
The binary operation logic in the const evaluator is getting complex. I’m starting to think a refactoring might be necessary in the near future.