### PR TITLE
fix(naga): Raise an error on division by zero

### DIFF
--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -2709,20 +2709,20 @@ impl<'a> ConstantEvaluator<'a> {
                             BinaryOperator::Add => a.wrapping_add(b),
                             BinaryOperator::Subtract => a.wrapping_sub(b),
                             BinaryOperator::Multiply => a.wrapping_mul(b),
-                            BinaryOperator::Divide => {
+                            BinaryOperator::Divide => a.checked_div(b).ok_or_else(|| {
                                 if b == 0 {
-                                    return Err(ConstantEvaluatorError::DivisionByZero);
+                                    ConstantEvaluatorError::DivisionByZero
                                 } else {
-                                    a.wrapping_div(b)
+                                    ConstantEvaluatorError::Overflow("division".into())
                                 }
-                            }
-                            BinaryOperator::Modulo => {
+                            })?,
+                            BinaryOperator::Modulo => a.checked_rem(b).ok_or_else(|| {
                                 if b == 0 {
-                                    return Err(ConstantEvaluatorError::RemainderByZero);
+                                    ConstantEvaluatorError::RemainderByZero
                                 } else {
-                                    a.wrapping_rem(b)
+                                    ConstantEvaluatorError::Overflow("remainder".into())
                                 }
-                            }
+                            })?,
                             BinaryOperator::And => a & b,
                             BinaryOperator::ExclusiveOr => a ^ b,
                             BinaryOperator::InclusiveOr => a | b,

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -156,6 +156,8 @@ pub enum ExpressionError {
         lhs_type: crate::TypeInner,
         rhs_expr: Handle<crate::Expression>,
     },
+    #[error("Division by zero")]
+    DivideByZero,
 }
 
 #[derive(Clone, Debug, thiserror::Error)]
@@ -314,6 +316,60 @@ impl super::Validator {
                 lhs_type: left_ty.clone(),
                 rhs_expr: right,
             })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Return an error if a constant divisor in `right` evaluates to zero for
+    /// an integer division or remainder operation.
+    ///
+    /// This function promises to return an error in cases where (1) the
+    /// expression is well-typed, (2) `left_ty` is a concrete integer or a
+    /// vector, and (3) `right` is a const-expression that evaluates to zero.
+    /// It does not return an error in cases where the expression is not
+    /// well-typed (e.g. vector dimension mismatch), because those will be
+    /// rejected elsewhere.
+    fn validate_constant_divisor(
+        left_ty: &crate::TypeInner,
+        right: Handle<crate::Expression>,
+        module: &crate::Module,
+        function: &crate::Function,
+    ) -> Result<(), ExpressionError> {
+        fn contains_zero(
+            handle: Handle<crate::Expression>,
+            expressions: &crate::Arena<crate::Expression>,
+            module: &crate::Module,
+        ) -> bool {
+            match expressions[handle] {
+                crate::Expression::Literal(_) | crate::Expression::ZeroValue(_) => module
+                    .to_ctx()
+                    .get_const_val_from::<u32, _>(handle, expressions)
+                    .ok()
+                    .is_some_and(|v| v == 0),
+                crate::Expression::Splat { value, .. } => contains_zero(value, expressions, module),
+                crate::Expression::Compose { ref components, .. } => components
+                    .iter()
+                    .any(|&comp| contains_zero(comp, expressions, module)),
+                crate::Expression::Constant(c) => {
+                    contains_zero(module.constants[c].init, &module.global_expressions, module)
+                }
+                _ => false,
+            }
+        }
+
+        let Some((_, scalar)) = left_ty.vector_size_and_scalar() else {
+            return Ok(());
+        };
+        if !matches!(
+            scalar.kind,
+            crate::ScalarKind::Sint | crate::ScalarKind::Uint
+        ) {
+            return Ok(());
+        }
+
+        if contains_zero(right, &function.expressions, module) {
+            Err(ExpressionError::DivideByZero)
         } else {
             Ok(())
         }
@@ -1070,6 +1126,10 @@ impl super::Validator {
                 // For shift operations, check if the constant shift amount exceeds the bit width
                 if matches!(op, Bo::ShiftLeft | Bo::ShiftRight) {
                     Self::validate_constant_shift_amounts(left_inner, right, module, function)?;
+                }
+                // For integer division or remainer, check if the constant divisor is zero
+                if matches!(op, Bo::Divide | Bo::Modulo) {
+                    Self::validate_constant_divisor(left_inner, right, module, function)?;
                 }
                 ShaderStages::all()
             }

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -1127,7 +1127,7 @@ impl super::Validator {
                 if matches!(op, Bo::ShiftLeft | Bo::ShiftRight) {
                     Self::validate_constant_shift_amounts(left_inner, right, module, function)?;
                 }
-                // For integer division or remainer, check if the constant divisor is zero
+                // For integer division or remainder, check if the constant divisor is zero
                 if matches!(op, Bo::Divide | Bo::Modulo) {
                     Self::validate_constant_divisor(left_inner, right, module, function)?;
                 }


### PR DESCRIPTION
**Connections**
Partially fixes issue #9274 (item 2)

**Description**
Added validation about division by zero in validator. 
Plus, fixed division and remainder on i32 in constant evaluator.
The [spec](https://gpuweb.github.io/gpuweb/wgsl/#arithmetic-expr) says "MIN / -1" is overflow error for signed integer, which is exercised by CTS.
> If e1 is most negative value in T, and e2 is -1: ... shader-creation error

**Testing**
* Existing tests
* Affected CTS
webgpu:shader,validation,expression,binary,div_rem:* : 804 -> 862 (+58)

**Squash or Rebase?**
Squash

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. 
