### PR TITLE
fix(metal): Check respondsToSelector before feature detection calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ Bottom level categories:
 
 - Fixed overflow detection and argument domain validation for `acosh`, `length`, `normalize`, and `pow` in constant evaluation. By @ecoricemon in [#9249](https://github.com/gfx-rs/wgpu/pull/9249).
 
+#### Metal
+
+- Added guards to avoid calling some feature detection methods that are not implemented on `CaptureMTLDevice`. By @andyleiserson in [#9284](https://github.com/gfx-rs/wgpu/pull/9284).
+
 ## v29.0.0 (2026-03-18)
 
 ### Major Changes

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -983,8 +983,12 @@ impl super::CapabilitiesQuery {
                     || device.supportsFamily(MTLGPUFamily::Apple7)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
             // https://developer.apple.com/documentation/metal/mtldevice/hasunifiedmemory
-            has_unified_memory: if available!(macos = 15.0, ios = 13.0, tvos = 13.0, visionos = 1.0)
-            {
+            has_unified_memory: if available!(
+                macos = 10.15,
+                ios = 13.0,
+                tvos = 13.0,
+                visionos = 1.0
+            ) {
                 Some(device.hasUnifiedMemory())
             } else {
                 None

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1,4 +1,5 @@
-use objc2::{available, runtime::ProtocolObject};
+use objc2::runtime::{AnyObject, ProtocolObject, Sel};
+use objc2::{available, sel};
 use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};
 use objc2_metal::{
     MTLArgumentBuffersTier, MTLCounterSamplingPoint, MTLDevice, MTLFeatureSet, MTLGPUFamily,
@@ -13,6 +14,16 @@ use core::sync::atomic;
 use crate::metal::QueueShared;
 
 use super::{OsFeatures, TimestampQuerySupport};
+
+/// Check if a device's class has a given method in its method table.
+///
+/// This mirrors the check that `objc2` performs internally (in debug builds)
+/// before sending a message. We use it to skip method calls that would panic
+/// on proxy objects like Apple's `CaptureMTLDevice`, which forwards messages
+/// at runtime but doesn't declare the methods in its class.
+fn device_class_responds_to(device: &ProtocolObject<dyn MTLDevice>, sel: Sel) -> bool {
+    AnyObject::class(device.as_ref()).responds_to(sel)
+}
 
 /// Maximum number of command buffers for `MTLCommandQueue`s that we create.
 ///
@@ -711,6 +722,7 @@ impl super::CapabilitiesQuery {
             texture_cube_array: Self::supports_any(device, TEXTURE_CUBE_ARRAY_SUPPORT),
             supports_float_filtering: os_type == super::OsType::Macos
                 || (available!(macos = 11.0, ios = 14.0, tvos = 16.0, visionos = 1.0)
+                    && device_class_responds_to(device, sel!(supports32BitFloatFiltering))
                     && device.supports32BitFloatFiltering()),
             format_depth24_stencil8: os_type == super::OsType::Macos
                 && device.isDepth24Stencil8PixelFormatSupported(),
@@ -988,7 +1000,8 @@ impl super::CapabilitiesQuery {
                 ios = 13.0,
                 tvos = 13.0,
                 visionos = 1.0
-            ) {
+            ) && device_class_responds_to(device, sel!(hasUnifiedMemory))
+            {
                 Some(device.hasUnifiedMemory())
             } else {
                 None
@@ -1061,7 +1074,10 @@ impl super::CapabilitiesQuery {
                 tvos = 18.0,
                 visionos = 2.0,
             ) {
-                device.supportsRaytracing() && device.supportsRaytracingFromRender()
+                device_class_responds_to(device, sel!(supportsRaytracing))
+                    && device.supportsRaytracing()
+                    && device_class_responds_to(device, sel!(supportsRaytracingFromRender))
+                    && device.supportsRaytracingFromRender()
             } else {
                 false
             },


### PR DESCRIPTION
Fix/workaround for #9282. CC @madsmtm in case you want to change anything about how the method validity checks in debug builds operate.

Also fixes a typo from #8952 that happens to be on one of the same calls, but that's not related to the problem.

**Testing**
Tested manually by running `wgpu-info` with Metal capture in Xcode.

**Squash or Rebase?** Rebase

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [x] Included a CHANGELOG entry mostly in case we backport this.