### PR TITLE
fix(core): Add validation in create_render_bundle_encoder

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -33,7 +33,6 @@ webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoder
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20pass";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,setBindGroup:u32array_start_and_length:* // deno unwrap
 webgpu:api,validation,encoding,cmds,setImmediates:* // 0%, feature not implemented
-webgpu:api,validation,encoding,createRenderBundleEncoder:* // 26%, empty attachments, format compatibility
 webgpu:api,validation,encoding,encoder_open_state:* // https://github.com/gfx-rs/wgpu/issues/7857
 webgpu:api,validation,encoding,queries,resolveQuerySet:* // 93%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,render_bundle:* // 81%, readonly flag normalization mismatch

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -170,6 +170,7 @@ webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoder
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20bundle";state="valid";*
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20pass";state="invalid";*
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20pass";state="valid";*
+webgpu:api,validation,encoding,createRenderBundleEncoder:*
 webgpu:api,validation,encoding,encoder_open_state:compute_pass_commands:*
 webgpu:api,validation,encoding,encoder_open_state:non_pass_commands:*
 //FAIL: webgpu:api,validation,encoding,encoder_open_state:render_bundle_commands:*

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -672,15 +672,9 @@ impl GPUDevice {
       multiview: None,
     };
 
-    let res =
-      wgpu_core::command::RenderBundleEncoder::new(&wgpu_descriptor, self.id);
-    let (encoder, err) = match res {
-      Ok(encoder) => (encoder, None),
-      Err(e) => (
-        wgpu_core::command::RenderBundleEncoder::dummy(self.id),
-        Some(e),
-      ),
-    };
+    let (encoder, err) = self
+      .instance
+      .device_create_render_bundle_encoder(self.id, &wgpu_descriptor);
 
     self.error_handler.push_error(err);
 

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -34,7 +34,7 @@ pub struct GPURenderBundleEncoder {
   pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
-  pub encoder: RefCell<Option<wgpu_core::command::RenderBundleEncoder>>,
+  pub encoder: RefCell<Option<Box<wgpu_core::command::RenderBundleEncoder>>>,
   pub label: String,
 }
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -104,7 +104,10 @@ use crate::{
         bind::Binder, BasePass, BindGroupStateChange, ColorAttachmentError, DrawError,
         IdReferences, MapPassErr, PassErrorScope, RenderCommand, RenderCommandError, StateChange,
     },
-    device::{AttachmentData, Device, DeviceError, MissingDownlevelFlags, RenderPassContext},
+    device::{
+        AttachmentData, Device, DeviceError, MissingDownlevelFlags, MissingFeatures,
+        RenderPassContext,
+    },
     hub::Hub,
     id,
     init_tracker::{BufferInitTrackerAction, MemoryInitKind, TextureInitTrackerAction},
@@ -116,6 +119,7 @@ use crate::{
     resource_log,
     snatch::SnatchGuard,
     track::RenderBundleScope,
+    validation::{check_color_attachment_count, validate_color_attachment_bytes_per_sample},
     Label, LabelHelpers,
 };
 
@@ -166,55 +170,85 @@ pub struct RenderBundleEncoder {
     current_pipeline: StateChange<id::RenderPipelineId>,
 }
 
+/// Validate a render bundle descriptor
+///
+/// Returns a tuple (is_depth_read_only, is_stencil_read_only).
+fn validate_render_bundle_encoder_descriptor(
+    desc: &RenderBundleEncoderDescriptor,
+    device: &Arc<Device>,
+) -> Result<(bool, bool), CreateRenderBundleError> {
+    let mut have_attachment = false;
+
+    check_color_attachment_count(
+        desc.color_formats.len(),
+        device.limits.max_color_attachments,
+    )?;
+
+    for &format in desc.color_formats.iter().flatten() {
+        have_attachment = true;
+        let format_features = device.describe_format_features(format)?;
+        if !format.has_color_aspect() {
+            return Err(CreateRenderBundleError::FormatNotColor(format));
+        }
+        if !format_features
+            .allowed_usages
+            .contains(wgt::TextureUsages::RENDER_ATTACHMENT)
+        {
+            return Err(CreateRenderBundleError::FormatNotRenderable(format));
+        }
+    }
+
+    validate_color_attachment_bytes_per_sample(
+        desc.color_formats.iter().flatten().copied(),
+        device.limits.max_color_attachment_bytes_per_sample,
+    )?;
+
+    let (is_depth_read_only, is_stencil_read_only) = match desc.depth_stencil {
+        Some(ds) => {
+            have_attachment = true;
+            let has_depth = ds.format.has_depth_aspect();
+            let has_stencil = ds.format.has_stencil_aspect();
+            if !has_depth && !has_stencil {
+                return Err(CreateRenderBundleError::FormatNotDepthOrStencil(ds.format));
+            } else {
+                (
+                    !has_depth || ds.depth_read_only,
+                    !has_stencil || ds.stencil_read_only,
+                )
+            }
+        }
+        // There's no depth/stencil attachment, so these values just don't
+        // matter.  Choose the most accommodating value, to simplify
+        // validation.
+        None => (true, true),
+    };
+
+    if !have_attachment {
+        return Err(CreateRenderBundleError::NoAttachment);
+    }
+
+    Ok((is_depth_read_only, is_stencil_read_only))
+}
+
 impl RenderBundleEncoder {
     pub fn new(
         desc: &RenderBundleEncoderDescriptor,
+        device: &Arc<Device>,
         parent_id: id::DeviceId,
     ) -> Result<Self, CreateRenderBundleError> {
-        let (is_depth_read_only, is_stencil_read_only) = match desc.depth_stencil {
-            Some(ds) => {
-                let aspects = hal::FormatAspects::from(ds.format);
-                (
-                    !aspects.contains(hal::FormatAspects::DEPTH) || ds.depth_read_only,
-                    !aspects.contains(hal::FormatAspects::STENCIL) || ds.stencil_read_only,
-                )
-            }
-            // There's no depth/stencil attachment, so these values just don't
-            // matter.  Choose the most accommodating value, to simplify
-            // validation.
-            None => (true, true),
-        };
+        let (is_depth_read_only, is_stencil_read_only) =
+            validate_render_bundle_encoder_descriptor(desc, device)?;
 
-        // TODO: should be device.limits.max_color_attachments
-        let max_color_attachments = hal::MAX_COLOR_ATTACHMENTS;
-
-        //TODO: validate that attachment formats are renderable,
-        // have expected aspects, support multisampling.
         Ok(Self {
             base: BasePass::new(&desc.label),
             parent_id,
             context: RenderPassContext {
                 attachments: AttachmentData {
-                    colors: if desc.color_formats.len() > max_color_attachments {
-                        return Err(CreateRenderBundleError::ColorAttachment(
-                            ColorAttachmentError::TooMany {
-                                given: desc.color_formats.len(),
-                                limit: max_color_attachments,
-                            },
-                        ));
-                    } else {
-                        desc.color_formats.iter().cloned().collect()
-                    },
+                    colors: desc.color_formats.iter().cloned().collect(),
                     resolves: ArrayVec::new(),
                     depth_stencil: desc.depth_stencil.map(|ds| ds.format),
                 },
-                sample_count: {
-                    let sc = desc.sample_count;
-                    if sc == 0 || sc > 32 || !sc.is_power_of_two() {
-                        return Err(CreateRenderBundleError::InvalidSampleCount(sc));
-                    }
-                    sc
-                },
+                sample_count: desc.sample_count,
                 multiview_mask: desc.multiview,
             },
 
@@ -269,6 +303,29 @@ impl RenderBundleEncoder {
         let scope = PassErrorScope::Bundle;
 
         device.check_is_valid().map_pass_err(scope)?;
+
+        {
+            // Reconstruct and revalidate the encoder descriptor, because
+            // `RenderBundleEncoder` is serializable and could have been tampered.
+            let encoder_desc = RenderBundleEncoderDescriptor {
+                label: self.base.label.as_ref().map(Cow::from),
+                color_formats: Cow::Borrowed(&self.context.attachments.colors),
+                depth_stencil: self.context.attachments.depth_stencil.map(|format| {
+                    wgt::RenderBundleDepthStencil {
+                        format,
+                        depth_read_only: self.is_depth_read_only,
+                        stencil_read_only: self.is_stencil_read_only,
+                    }
+                }),
+                sample_count: self.context.sample_count,
+                multiview: self.context.multiview_mask,
+            };
+
+            validate_render_bundle_encoder_descriptor(&encoder_desc, device).expect(
+                "Invalid render bundle descriptor \
+                    should have been rejected by RenderBundleEncoder::new",
+            );
+        };
 
         let bind_group_guard = hub.bind_groups.read();
         let pipeline_guard = hub.render_pipelines.read();
@@ -883,15 +940,30 @@ fn multi_draw_indirect(
 pub enum CreateRenderBundleError {
     #[error(transparent)]
     ColorAttachment(#[from] ColorAttachmentError),
+    #[error("Format {0:?} does not have a color aspect")]
+    FormatNotColor(wgt::TextureFormat),
+    #[error("Color attachment format {0:?} is not renderable")]
+    FormatNotRenderable(wgt::TextureFormat),
+    #[error("Format {0:?} is not a depth/stencil format")]
+    FormatNotDepthOrStencil(wgt::TextureFormat),
+    #[error("Render bundle must have at least one attachment (color or depth/stencil)")]
+    NoAttachment,
     #[error("Invalid number of samples {0}")]
     InvalidSampleCount(u32),
+    #[error(transparent)]
+    MissingFeatures(#[from] MissingFeatures),
 }
 
 impl WebGpuError for CreateRenderBundleError {
     fn webgpu_error_type(&self) -> ErrorType {
         match self {
             Self::ColorAttachment(e) => e.webgpu_error_type(),
-            Self::InvalidSampleCount(_) => ErrorType::Validation,
+            Self::FormatNotColor(_)
+            | Self::FormatNotRenderable(_)
+            | Self::FormatNotDepthOrStencil(_)
+            | Self::NoAttachment
+            | Self::InvalidSampleCount(_) => ErrorType::Validation,
+            Self::MissingFeatures(e) => e.webgpu_error_type(),
         }
     }
 }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1196,21 +1196,22 @@ impl Global {
         device_id: DeviceId,
         desc: &command::RenderBundleEncoderDescriptor,
     ) -> (
-        *mut command::RenderBundleEncoder,
+        Box<command::RenderBundleEncoder>,
         Option<command::CreateRenderBundleError>,
     ) {
         profiling::scope!("Device::create_render_bundle_encoder");
         api_log!("Device::device_create_render_bundle_encoder");
-        let (encoder, error) = match command::RenderBundleEncoder::new(desc, device_id) {
+        let device = self.hub.devices.get(device_id);
+        let (encoder, error) = match command::RenderBundleEncoder::new(desc, &device, device_id) {
             Ok(encoder) => (encoder, None),
             Err(e) => (command::RenderBundleEncoder::dummy(device_id), Some(e)),
         };
-        (Box::into_raw(Box::new(encoder)), error)
+        (Box::new(encoder), error)
     }
 
     pub fn render_bundle_encoder_finish(
         &self,
-        bundle_encoder: command::RenderBundleEncoder,
+        bundle_encoder: Box<command::RenderBundleEncoder>,
         desc: &command::RenderBundleDescriptor,
         id_in: Option<id::RenderBundleId>,
     ) -> (id::RenderBundleId, Option<command::RenderBundleError>) {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -54,7 +54,7 @@ use crate::{
     snatch::{SnatchGuard, SnatchLock, Snatchable},
     timestamp_normalization::TIMESTAMP_NORMALIZATION_BUFFER_USES,
     track::{BindGroupStates, DeviceTracker, TrackerIndexAllocators, UsageScope, UsageScopePool},
-    validation,
+    validation::{self, check_color_attachment_count},
     weak_vec::WeakVec,
     FastHashMap, LabelHelpers, OnceCellOrLock,
 };
@@ -3968,22 +3968,13 @@ impl Device {
 
         let mut shader_binding_sizes = FastHashMap::default();
 
-        let num_attachments = desc.fragment.as_ref().map(|f| f.targets.len()).unwrap_or(0);
-        let max_attachments = self.limits.max_color_attachments as usize;
-        if num_attachments > max_attachments {
-            return Err(pipeline::CreateRenderPipelineError::ColorAttachment(
-                command::ColorAttachmentError::TooMany {
-                    given: num_attachments,
-                    limit: max_attachments,
-                },
-            ));
-        }
-
         let color_targets = desc
             .fragment
             .as_ref()
             .map_or(&[][..], |fragment| &fragment.targets);
         let depth_stencil_state = desc.depth_stencil.as_ref();
+
+        check_color_attachment_count(color_targets.len(), self.limits.max_color_attachments)?;
 
         {
             let cts: ArrayVec<_, { hal::MAX_COLOR_ATTACHMENTS }> =
@@ -4843,7 +4834,7 @@ impl Device {
         format_features
     }
 
-    fn describe_format_features(
+    pub(crate) fn describe_format_features(
         &self,
         format: TextureFormat,
     ) -> Result<wgt::TextureFormatFeatures, MissingFeatures> {

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -16,7 +16,7 @@ use wgt::{
 };
 
 use crate::{
-    device::bgl, resource::InvalidResourceError,
+    command::ColorAttachmentError, device::bgl, resource::InvalidResourceError,
     validation::shader_io_deductions::MaxFragmentShaderInputDeduction, FastHashMap, FastHashSet,
 };
 
@@ -1880,6 +1880,21 @@ impl Interface {
     }
 }
 
+pub fn check_color_attachment_count(
+    num_attachments: usize,
+    limit: u32,
+) -> Result<(), ColorAttachmentError> {
+    let limit = usize::try_from(limit).unwrap();
+    if num_attachments > limit {
+        return Err(ColorAttachmentError::TooMany {
+            given: num_attachments,
+            limit,
+        });
+    }
+
+    Ok(())
+}
+
 /// Validate a list of color attachment formats against `maxColorAttachmentBytesPerSample`.
 ///
 /// The color attachments can be from a render pass descriptor or a pipeline descriptor.
@@ -1888,7 +1903,7 @@ impl Interface {
 pub fn validate_color_attachment_bytes_per_sample(
     attachment_formats: impl IntoIterator<Item = wgt::TextureFormat>,
     limit: u32,
-) -> Result<(), crate::command::ColorAttachmentError> {
+) -> Result<(), ColorAttachmentError> {
     let mut total_bytes_per_sample: u32 = 0;
     for format in attachment_formats {
         let byte_cost = format.target_pixel_byte_cost().unwrap();
@@ -1899,12 +1914,10 @@ pub fn validate_color_attachment_bytes_per_sample(
     }
 
     if total_bytes_per_sample > limit {
-        return Err(
-            crate::command::ColorAttachmentError::TooManyBytesPerSample {
-                total: total_bytes_per_sample,
-                limit,
-            },
-        );
+        return Err(ColorAttachmentError::TooManyBytesPerSample {
+            total: total_bytes_per_sample,
+            limit,
+        });
     }
 
     Ok(())

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -541,7 +541,7 @@ pub struct CoreCommandBuffer {
 #[derive(Debug)]
 pub struct CoreRenderBundleEncoder {
     pub(crate) context: ContextWgpuCore,
-    encoder: wgc::command::RenderBundleEncoder,
+    encoder: Box<wgc::command::RenderBundleEncoder>,
     id: crate::cmp::Identifier,
 }
 
@@ -1805,10 +1805,18 @@ impl dispatch::DeviceInterface for CoreDevice {
             sample_count: desc.sample_count,
             multiview: desc.multiview,
         };
-        let encoder = match wgc::command::RenderBundleEncoder::new(&descriptor, self.id) {
-            Ok(encoder) => encoder,
-            Err(e) => panic!("Error in Device::create_render_bundle_encoder: {e}"),
-        };
+        let (encoder, error) = self
+            .context
+            .0
+            .device_create_render_bundle_encoder(self.id, &descriptor);
+        if let Some(cause) = error {
+            self.context.handle_error(
+                &self.error_sink,
+                cause,
+                desc.label,
+                "Device::create_render_bundle_encoder",
+            );
+        }
 
         CoreRenderBundleEncoder {
             context: self.context.clone(),


### PR DESCRIPTION
Updates the validation in `create_render_bundle_encoder` (`RenderBundleEncoder::new`) to match the spec.

**Testing**
Enables CTS test.

**Squash or Rebase?** Squash

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
