### PR TITLE
Convert comments on lint attributes to reasons.

### DIFF
--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![expect(clippy::disallowed_types)] // We're outside of the main wgpu codebase
+#![expect(
+    clippy::disallowed_types,
+    reason = "We're outside of the main wgpu codebase"
+)]
 
 //! Benchmarking framework for `wgpu`.
 //!
@@ -134,7 +137,7 @@ pub fn main(benchmarks: Vec<Benchmark>) {
     // test mode, so we need to accept it.
     let _no_capture = args.contains("--no-capture");
 
-    #[expect(clippy::manual_map)] // So much clearer this way
+    #[expect(clippy::manual_map, reason = "So much clearer this way")]
     let mut override_iterations = if let Some(iters) = args.opt_value_from_str("--iters").unwrap() {
         Some(LoopControl::Iterations(iters))
     } else if let Some(seconds) = args.opt_value_from_str("--time").unwrap() {

--- a/examples/features/src/lib.rs
+++ b/examples/features/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::arc_with_non_send_sync)] // False positive on wasm
+#![allow(clippy::arc_with_non_send_sync, reason = "False positive on wasm")]
 #![warn(clippy::allow_attributes)]
 
 pub mod framework;

--- a/naga-test/src/lib.rs
+++ b/naga-test/src/lib.rs
@@ -1,6 +1,9 @@
-// A lot of the code can be unused based on configuration flags,
-// the corresponding warnings aren't helpful.
-#![allow(dead_code, unused_imports)]
+#![allow(
+    dead_code,
+    unused_imports,
+    reason = "A lot of the code can be unused based on configuration flags; \
+        the corresponding warnings aren't helpful."
+)]
 
 use core::fmt::Write;
 

--- a/naga/src/proc/overloads/list.rs
+++ b/naga/src/proc/overloads/list.rs
@@ -162,9 +162,11 @@ impl crate::proc::overloads::OverloadSet for List {
 }
 
 const fn len_to_full_mask(n: usize) -> u64 {
-    // This is a const function, which _sometimes_ gets called,
-    // so this lint is _sometimes_ triggered, depending on feature set.
-    #[expect(clippy::allow_attributes)]
+    #[expect(
+        clippy::allow_attributes,
+        reason = "This is a const function, which _sometimes_ gets called, \
+            so this lint is _sometimes_ triggered, depending on feature set."
+    )]
     #[allow(clippy::panic)]
     if n >= 64 {
         panic!("List::rules can only hold up to 63 rules");

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -408,9 +408,10 @@ enum TraceRayVertexReturnState {
     /// Trace ray calls have been found, at least
     /// one uses an acceleration structure that
     /// does not have the flag enabling vertex return.
-    // Don't yet have vertex return builtins to return.
-    // this error for.
-    #[expect(unused)]
+    #[expect(
+        unused,
+        reason = "Don't yet have vertex return builtins to return this error for."
+    )]
     NoVertexReturn(crate::Span),
     /// Trace ray calls have been found, all
     /// acceleration structures have the flag enabling

--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -319,7 +319,7 @@ impl FailureReason {
     };
 
     /// Match a validation error.
-    #[allow(dead_code)] // Not constructed on wasm
+    #[allow(dead_code, reason = "Not constructed on wasm")]
     pub fn validation_error() -> Self {
         Self {
             kind: Some(FailureResultKind::ValidationError),
@@ -364,7 +364,7 @@ pub enum FailureBehavior {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum FailureResultKind {
-    #[allow(dead_code)] // Not constructed on wasm
+    #[allow(dead_code, reason = "Not constructed on wasm")]
     ValidationError,
     Panic,
 }
@@ -394,7 +394,7 @@ impl FailureResult {
     }
 
     /// Failure result is a validation error.
-    #[allow(dead_code)] // Not constructed on wasm
+    #[allow(dead_code, reason = "Not constructed on wasm")]
     pub(super) fn validation_error() -> Self {
         Self {
             kind: FailureResultKind::ValidationError,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,6 +1,6 @@
 //! Test utilities for the wgpu repository.
 
-#![allow(clippy::arc_with_non_send_sync)] // False positive on wasm
+#![allow(clippy::arc_with_non_send_sync, reason = "False positive on wasm")]
 
 mod config;
 mod expectations;

--- a/tests/tests/wgpu-gpu/create_surface_error.rs
+++ b/tests/tests/wgpu-gpu/create_surface_error.rs
@@ -16,7 +16,10 @@ fn canvas_get_context_returned_null() {
     // Using a context id that is not "webgl2" or "webgpu" will render the canvas unusable by wgpu.
     canvas.get_context("2d").unwrap();
 
-    #[allow(clippy::redundant_clone)] // false positive — can't and shouldn't move out.
+    #[allow(
+        clippy::redundant_clone,
+        reason = "false positive — can't and shouldn't move out."
+    )]
     let error = instance
         .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
         .unwrap_err();

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2353,9 +2353,7 @@ impl Blas {
                 match map_res {
                     Ok(mapping) => {
                         if !mapping.is_coherent {
-                            // Clippy complains about this because it might not be intended, but
-                            // this is intentional.
-                            #[expect(clippy::single_range_in_vec_init)]
+                            #[expect(clippy::single_range_in_vec_init, reason = "intentional")]
                             self.device.raw().invalidate_mapped_ranges(
                                 compaction_buffer,
                                 &[0..size_of::<wgpu_types::BufferAddress>() as wgt::BufferAddress],

--- a/wgpu-hal/src/auxil/dxgi/time.rs
+++ b/wgpu-hal/src/auxil/dxgi/time.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] // IPresentationManager is unused currently
+#![allow(dead_code, reason = "IPresentationManager is unused currently")]
 
 use windows::Win32::System::Performance::{QueryPerformanceCounter, QueryPerformanceFrequency};
 

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -1073,7 +1073,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
         instance_count: u32,
     ) {
         self.prepare_draw(first_instance);
-        #[allow(clippy::clone_on_copy)] // False positive when cloning glow::UniformLocation
+        #[allow(
+            clippy::clone_on_copy,
+            reason = "False positive when cloning glow::UniformLocation"
+        )]
         self.cmd_buffer.commands.push(C::Draw {
             topology: self.state.topology,
             first_vertex,
@@ -1097,7 +1100,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
             wgt::IndexFormat::Uint32 => (4, glow::UNSIGNED_INT),
         };
         let index_offset = self.state.index_offset + index_size * first_index as wgt::BufferAddress;
-        #[allow(clippy::clone_on_copy)] // False positive when cloning glow::UniformLocation
+        #[allow(
+            clippy::clone_on_copy,
+            reason = "False positive when cloning glow::UniformLocation"
+        )]
         self.cmd_buffer.commands.push(C::DrawIndexed {
             topology: self.state.topology,
             index_type,
@@ -1127,7 +1133,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
         for draw in 0..draw_count as wgt::BufferAddress {
             let indirect_offset =
                 offset + draw * size_of::<wgt::DrawIndirectArgs>() as wgt::BufferAddress;
-            #[allow(clippy::clone_on_copy)] // False positive when cloning glow::UniformLocation
+            #[allow(
+                clippy::clone_on_copy,
+                reason = "False positive when cloning glow::UniformLocation"
+            )]
             self.cmd_buffer.commands.push(C::DrawIndirect {
                 topology: self.state.topology,
                 indirect_buf: buffer.raw.unwrap(),
@@ -1150,7 +1159,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
         for draw in 0..draw_count as wgt::BufferAddress {
             let indirect_offset =
                 offset + draw * size_of::<wgt::DrawIndexedIndirectArgs>() as wgt::BufferAddress;
-            #[allow(clippy::clone_on_copy)] // False positive when cloning glow::UniformLocation
+            #[allow(
+                clippy::clone_on_copy,
+                reason = "False positive when cloning glow::UniformLocation"
+            )]
             self.cmd_buffer.commands.push(C::DrawIndexedIndirect {
                 topology: self.state.topology,
                 index_type,

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -817,8 +817,10 @@ impl crate::Instance for Instance {
                 log::debug!(
                     "No (or unknown) windowing system ({x:?}) present. Using surfaceless platform"
                 );
-                #[allow(clippy::unnecessary_literal_unwrap)]
-                // This is only a literal on Emscripten
+                #[allow(
+                    clippy::unnecessary_literal_unwrap,
+                    reason = "this is only a literal on Emscripten"
+                )]
                 // TODO: This extension is also supported on EGL 1.4 with EGL_EXT_platform_base: https://registry.khronos.org/EGL/extensions/MESA/EGL_MESA_platform_surfaceless.txt
                 let egl = egl1_5.expect("Failed to get EGL 1.5 for surfaceless");
                 let display = unsafe {

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -430,7 +430,7 @@ pub(crate) struct AllocationSizes {
 }
 
 impl AllocationSizes {
-    #[allow(dead_code)] // may be unused on some platforms
+    #[allow(dead_code, reason = "may be unused on some platforms")]
     pub(crate) fn from_memory_hints(memory_hints: &wgt::MemoryHints) -> Self {
         // TODO: the allocator's configuration should take hardware capability into
         // account.
@@ -483,13 +483,13 @@ impl From<AllocationSizes> for gpu_allocator::AllocationSizes {
     }
 }
 
-#[allow(dead_code)] // may be unused on some platforms
+#[allow(dead_code, reason = "may be unused on some platforms")]
 #[cold]
 fn hal_usage_error<T: fmt::Display>(txt: T) -> ! {
     panic!("wgpu-hal invariant was violated (usage error): {txt}")
 }
 
-#[allow(dead_code)] // may be unused on some platforms
+#[allow(dead_code, reason = "may be unused on some platforms")]
 #[cold]
 fn hal_internal_error<T: fmt::Display>(txt: T) -> ! {
     panic!("wgpu-hal ran into a preventable internal error: {txt}")
@@ -555,14 +555,14 @@ pub struct InstanceError {
 }
 
 impl InstanceError {
-    #[allow(dead_code)] // may be unused on some platforms
+    #[allow(dead_code, reason = "may be unused on some platforms")]
     pub(crate) fn new(message: String) -> Self {
         Self {
             message,
             source: None,
         }
     }
-    #[allow(dead_code)] // may be unused on some platforms
+    #[allow(dead_code, reason = "may be unused on some platforms")]
     pub(crate) fn with_source(message: String, source: impl Error + Send + Sync + 'static) -> Self {
         cfg_if::cfg_if! {
             if #[cfg(supports_ptr_atomics)] {

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -233,8 +233,7 @@ impl super::CommandEncoder {
                 self.state.blit = Some(cmd_buf.blitCommandEncoder().unwrap());
             });
 
-            // Clippy 1.93 hates this (it was patched in 1.93.1)
-            #[allow(clippy::panicking_unwrap, reason = "false positive")]
+            #[allow(clippy::panicking_unwrap, reason = "false positive (fixed by 1.93.1)")]
             let encoder = self.state.blit.as_ref().unwrap();
 
             // UNTESTED:

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -13,11 +13,13 @@ end of the VS buffer table.
 
 !*/
 
-// `MTLFeatureSet` is superseded by `MTLGpuFamily`.
-// However, `MTLGpuFamily` is only supported starting MacOS 10.15, whereas our minimum target is MacOS 10.13,
-// See https://github.com/gpuweb/gpuweb/issues/1069 for minimum spec.
-// TODO: Eventually all deprecated features should be abstracted and use new api when available.
-#[allow(deprecated)]
+#[allow(
+    deprecated,
+    reason = "MTLFeatureSet` is superseded by `MTLGpuFamily`.
+        However, `MTLGpuFamily` is only supported starting MacOS 10.15, whereas our minimum target is MacOS 10.13,
+        See https://github.com/gpuweb/gpuweb/issues/1069 for minimum spec.
+        TODO: Eventually all deprecated features should be abstracted and use new api when available."
+)]
 mod adapter;
 mod command;
 mod conv;

--- a/wgpu-hal/src/validation_canary.rs
+++ b/wgpu-hal/src/validation_canary.rs
@@ -26,7 +26,7 @@ pub struct ValidationCanary {
 }
 
 impl ValidationCanary {
-    #[allow(dead_code)] // in some configurations this function is dead
+    #[allow(dead_code, reason = "in some configurations this function is dead")]
     pub(crate) fn add(&self, msg: String) {
         self.inner.lock().push(msg);
     }

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -524,8 +524,7 @@ macro_rules! bitflags_array {
             $(
                 $(
                     $(#[doc $($args)*])*
-                    // We need this for structs with only a member.
-                    #[allow(clippy::needless_update)]
+                    #[allow(clippy::needless_update, reason = "only useless if there is 1 member")]
                     pub const $Flag: Self = Self {
                         $lower_inner_name: $inner_name::from_bits_truncate($value),
                         ..Self::empty()
@@ -549,8 +548,7 @@ macro_rules! bitflags_array {
 
         $(
             impl From<$inner_name> for Features {
-                // We need this for structs with only a member.
-                #[allow(clippy::needless_update)]
+                #[allow(clippy::needless_update, reason = "only useless if there is 1 member")]
                 fn from($lower_inner_name: $inner_name) -> Self {
                     Self {
                         $lower_inner_name,

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -52,7 +52,7 @@ pub fn run_tests(
     let mut cargo_args = flatten_args(args, passthrough_args);
 
     // Re-add profile flags that were consumed during argument parsing
-    #[expect(clippy::manual_map)] // This is much clearer than using map()
+    #[expect(clippy::manual_map, reason = "This is much clearer than using map()")]
     let profile_arg = if is_release {
         Some(OsString::from("--release"))
     } else if let Some(ref p) = custom_profile {


### PR DESCRIPTION
**Description**
Since Rust 1.81 (well below MSRV), lint attributes (`allow`, `deny`, etc.) can have `reason = "arbitrary text"`, which is superior to separate comments because the association with the lint attribute is explicit rather than mere adjacency. This PR converts all such comments to reasons.

Some of the text could perhaps be more concise, now, but I did not try to consistently make such changes.

**Testing**
The code still compiles and this has no run-time effect.

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
