### PR TITLE
Implements #8875: Using binding_array should require an enable extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,7 +362,6 @@ Migrated from the `max_inter_stage_shader_components` limit to `max_inter_stage_
     - `front::wgsl::Frontend::set_options`
     - `ir::Block::is_empty`
     - `ir::Block::len`
-
 #### GLES
 
 - Added `GlDebugFns` option in `GlBackendOptions` to control OpenGL debug functions (`glPushDebugGroup`, `glPopDebugGroup`, `glObjectLabel`, etc.). Automatically disables them on Mali GPUs to work around a driver crash. By @Xavientois in [#8931](https://github.com/gfx-rs/wgpu/pull/8931).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ Bottom level categories:
 - Fixed handling of unterminated block comments. By @BKDaugherty in [#9356](https://github.com/gfx-rs/wgpu/pull/9356).
 - Enforce that `@must_use` appear only on function declarations. By @dnsn021 in [#9367](https://github.com/gfx-rs/wgpu/pull/9367).
 - Fix typo in `naga::back::msl::Error::UnsupportedWritable*` variant names. By @ErichDonGubler in [#9376](https://github.com/gfx-rs/wgpu/pull/9376).
-- Added support for `enable wgpu_binding_array;`. by @39ali in [#9298](https://github.com/gfx-rs/wgpu/pull/9298).
+- Added support for `enable wgpu_binding_array;`. By @39ali in [#9298](https://github.com/gfx-rs/wgpu/pull/9298).
 
 #### Vulkan
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Bottom level categories:
 - Fixed handling of unterminated block comments. By @BKDaugherty in [#9356](https://github.com/gfx-rs/wgpu/pull/9356).
 - Enforce that `@must_use` appear only on function declarations. By @dnsn021 in [#9367](https://github.com/gfx-rs/wgpu/pull/9367).
 - Fix typo in `naga::back::msl::Error::UnsupportedWritable*` variant names. By @ErichDonGubler in [#9376](https://github.com/gfx-rs/wgpu/pull/9376).
+- Added support for `enable wgpu_binding_array;`. by @39ali in [#9298](https://github.com/gfx-rs/wgpu/pull/9298).
 
 #### Vulkan
 
@@ -362,6 +363,7 @@ Migrated from the `max_inter_stage_shader_components` limit to `max_inter_stage_
     - `front::wgsl::Frontend::set_options`
     - `ir::Block::is_empty`
     - `ir::Block::len`
+
 #### GLES
 
 - Added `GlDebugFns` option in `GlBackendOptions` to control OpenGL debug functions (`glPushDebugGroup`, `glPopDebugGroup`, `glObjectLabel`, etc.). Automatically disables them on Mali GPUs to work around a driver crash. By @Xavientois in [#8931](https://github.com/gfx-rs/wgpu/pull/8931).

--- a/benches/benches/wgpu-benchmark/computepass-bindless.wgsl
+++ b/benches/benches/wgpu-benchmark/computepass-bindless.wgsl
@@ -1,3 +1,4 @@
+enable wgpu_binding_array;
 @group(0) @binding(0)
 var tex: binding_array<texture_2d<f32>>;
 

--- a/benches/benches/wgpu-benchmark/renderpass-bindless.wgsl
+++ b/benches/benches/wgpu-benchmark/renderpass-bindless.wgsl
@@ -1,3 +1,4 @@
+enable wgpu_binding_array;
 @group(0) @binding(0)
 var tex: binding_array<texture_2d<f32>>;
 

--- a/examples/features/src/big_compute_buffers/shader.wgsl
+++ b/examples/features/src/big_compute_buffers/shader.wgsl
@@ -1,3 +1,5 @@
+enable wgpu_binding_array;
+
 const OFFSET: u32 = 1u << 8u;
 const BUFFER_MAX_ELEMENTS: u32 = 1u << 25u; // Think `buffer.len()`
 const NUM_BUFFERS: u32 = 8u;

--- a/examples/features/src/texture_arrays/indexing.wgsl
+++ b/examples/features/src/texture_arrays/indexing.wgsl
@@ -1,3 +1,4 @@
+enable wgpu_binding_array;
 struct VertexInput {
     @location(0) position: vec2<f32>,
     @location(1) tex_coord: vec2<f32>,

--- a/examples/features/src/texture_arrays/non_uniform_indexing.wgsl
+++ b/examples/features/src/texture_arrays/non_uniform_indexing.wgsl
@@ -1,3 +1,4 @@
+enable wgpu_binding_array;
 struct FragmentInput {
     @location(0) tex_coord: vec2<f32>,
     @location(1) index: i32,

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -297,6 +297,7 @@ impl<W: Write> Writer<W> {
             draw_index: bool,
             ray_tracing_pipeline: bool,
             per_vertex: bool,
+            binding_array: bool,
         }
         let mut needed = RequiredEnabled {
             mesh_shaders: module.uses_mesh_shaders(),
@@ -366,6 +367,9 @@ impl<W: Write> Writer<W> {
                 }
                 TypeInner::AccelerationStructure { .. } => {
                     needed.ray_tracing_pipeline = true;
+                }
+                TypeInner::BindingArray { .. } => {
+                    needed.binding_array = true;
                 }
                 _ => {}
             }
@@ -439,6 +443,10 @@ impl<W: Write> Writer<W> {
         }
         if module.uses_mesh_shaders() {
             writeln!(self.out, "enable wgpu_mesh_shader;")?;
+            any_written = true;
+        }
+        if needed.binding_array {
+            writeln!(self.out, "enable wgpu_binding_array;")?;
             any_written = true;
         }
         if needed.draw_index {

--- a/naga/src/front/wgsl/parse/conv.rs
+++ b/naga/src/front/wgsl/parse/conv.rs
@@ -583,6 +583,9 @@ pub fn map_predeclared_type(
         PredeclaredType::TypeGenerator(TypeGenerator::CooperativeMatrix { .. }) => {
             Some(&[ImplementedEnableExtension::WgpuCooperativeMatrix])
         }
+        PredeclaredType::TypeGenerator(TypeGenerator::BindingArray) => {
+            Some(&[ImplementedEnableExtension::WgpuBindingArray])
+        }
         _ => None,
     };
     if let Some(extensions_needed) = extensions_needed {

--- a/naga/src/front/wgsl/parse/directive/enable_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/enable_extension.rs
@@ -22,6 +22,7 @@ pub(crate) struct EnableExtensions {
     draw_index: bool,
     primitive_index: bool,
     per_vertex: bool,
+    wgpu_binding_array: bool,
 }
 
 impl EnableExtensions {
@@ -38,6 +39,7 @@ impl EnableExtensions {
             draw_index: false,
             primitive_index: false,
             per_vertex: false,
+            wgpu_binding_array: false,
         }
     }
 
@@ -59,6 +61,7 @@ impl EnableExtensions {
             ImplementedEnableExtension::DrawIndex => &mut self.draw_index,
             ImplementedEnableExtension::PrimitiveIndex => &mut self.primitive_index,
             ImplementedEnableExtension::PerVertex => &mut self.per_vertex,
+            ImplementedEnableExtension::WgpuBindingArray => &mut self.wgpu_binding_array,
         };
         *field = true;
     }
@@ -79,6 +82,7 @@ impl EnableExtensions {
             ImplementedEnableExtension::DrawIndex => self.draw_index,
             ImplementedEnableExtension::PrimitiveIndex => self.primitive_index,
             ImplementedEnableExtension::PerVertex => self.per_vertex,
+            ImplementedEnableExtension::WgpuBindingArray => self.wgpu_binding_array,
         }
     }
 
@@ -132,6 +136,7 @@ impl EnableExtension {
     const PRIMITIVE_INDEX: &'static str = "primitive_index";
     const DRAW_INDEX: &'static str = "draw_index";
     const PER_VERTEX: &'static str = "wgpu_per_vertex";
+    const BINDING_ARRAY: &'static str = "wgpu_binding_array";
 
     /// Convert from a sentinel word in WGSL into its associated [`EnableExtension`], if possible.
     pub(crate) fn from_ident(word: &str, span: Span) -> Result<'_, Self> {
@@ -156,6 +161,7 @@ impl EnableExtension {
             Self::DRAW_INDEX => Self::Implemented(ImplementedEnableExtension::DrawIndex),
             Self::PRIMITIVE_INDEX => Self::Implemented(ImplementedEnableExtension::PrimitiveIndex),
             Self::PER_VERTEX => Self::Implemented(ImplementedEnableExtension::PerVertex),
+            Self::BINDING_ARRAY => Self::Implemented(ImplementedEnableExtension::WgpuBindingArray),
             _ => return Err(Box::new(Error::UnknownEnableExtension(span, word))),
         })
     }
@@ -177,6 +183,7 @@ impl EnableExtension {
                 ImplementedEnableExtension::PrimitiveIndex => Self::PRIMITIVE_INDEX,
                 ImplementedEnableExtension::WgpuRayTracingPipeline => Self::RAY_TRACING_PIPELINE,
                 ImplementedEnableExtension::PerVertex => Self::PER_VERTEX,
+                ImplementedEnableExtension::WgpuBindingArray => Self::BINDING_ARRAY,
             },
             Self::Unimplemented(kind) => match kind {
                 UnimplementedEnableExtension::Subgroups => Self::SUBGROUPS,
@@ -227,6 +234,8 @@ pub enum ImplementedEnableExtension {
     PrimitiveIndex,
     /// Enables the `wgpu_per_vertex` extension, allows using `@interpolate(per_vertex)` attribute in WGSL, native only.
     PerVertex,
+    /// Enables the `wgpu_binding_array` extension, native only.
+    WgpuBindingArray,
 }
 
 impl ImplementedEnableExtension {
@@ -243,6 +252,7 @@ impl ImplementedEnableExtension {
         Self::DrawIndex,
         Self::PrimitiveIndex,
         Self::PerVertex,
+        Self::WgpuBindingArray,
     ];
 
     /// Returns slice of all variants of [`ImplementedEnableExtension`].
@@ -265,6 +275,14 @@ impl ImplementedEnableExtension {
             Self::DrawIndex => C::DRAW_INDEX,
             Self::PrimitiveIndex => C::PRIMITIVE_INDEX,
             Self::PerVertex => C::PER_VERTEX,
+            Self::WgpuBindingArray => C::BUFFER_BINDING_ARRAY
+                .union(C::BUFFER_BINDING_ARRAY_NON_UNIFORM_INDEXING)
+                .union(C::STORAGE_BUFFER_BINDING_ARRAY)
+                .union(C::STORAGE_BUFFER_BINDING_ARRAY_NON_UNIFORM_INDEXING)
+                .union(C::STORAGE_TEXTURE_BINDING_ARRAY)
+                .union(C::STORAGE_TEXTURE_BINDING_ARRAY_NON_UNIFORM_INDEXING)
+                .union(C::TEXTURE_AND_SAMPLER_BINDING_ARRAY)
+                .union(C::TEXTURE_AND_SAMPLER_BINDING_ARRAY_NON_UNIFORM_INDEXING),
         }
     }
 }

--- a/naga/src/front/wgsl/parse/directive/enable_extension.rs
+++ b/naga/src/front/wgsl/parse/directive/enable_extension.rs
@@ -282,7 +282,8 @@ impl ImplementedEnableExtension {
                 .union(C::STORAGE_TEXTURE_BINDING_ARRAY)
                 .union(C::STORAGE_TEXTURE_BINDING_ARRAY_NON_UNIFORM_INDEXING)
                 .union(C::TEXTURE_AND_SAMPLER_BINDING_ARRAY)
-                .union(C::TEXTURE_AND_SAMPLER_BINDING_ARRAY_NON_UNIFORM_INDEXING),
+                .union(C::TEXTURE_AND_SAMPLER_BINDING_ARRAY_NON_UNIFORM_INDEXING)
+                .union(C::ACCELERATION_STRUCTURE_BINDING_ARRAY),
         }
     }
 }

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -2273,7 +2273,7 @@ impl Parser {
                             };
                             // Check if the required capability is supported
                             let required_capability = extension.capability();
-                            if !options.capabilities.contains(required_capability) {
+                            if !options.capabilities.intersects(required_capability) {
                                 return Err(Box::new(Error::EnableExtensionNotSupported {
                                     kind,
                                     span,

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -238,6 +238,16 @@ impl Capabilities {
             Self::COOPERATIVE_MATRIX => Some(Ext::WgpuCooperativeMatrix),
             Self::RAY_TRACING_PIPELINE => Some(Ext::WgpuRayTracingPipeline),
             Self::PER_VERTEX => Some(Ext::PerVertex),
+            Self::BUFFER_BINDING_ARRAY
+            | Self::BUFFER_BINDING_ARRAY_NON_UNIFORM_INDEXING
+            | Self::STORAGE_BUFFER_BINDING_ARRAY
+            | Self::STORAGE_BUFFER_BINDING_ARRAY_NON_UNIFORM_INDEXING
+            | Self::STORAGE_TEXTURE_BINDING_ARRAY
+            | Self::STORAGE_TEXTURE_BINDING_ARRAY_NON_UNIFORM_INDEXING
+            | Self::TEXTURE_AND_SAMPLER_BINDING_ARRAY
+            | Self::TEXTURE_AND_SAMPLER_BINDING_ARRAY_NON_UNIFORM_INDEXING => {
+                Some(Ext::WgpuBindingArray)
+            }
             _ => None,
         }
     }

--- a/naga/tests/in/wgsl/binding-arrays.wgsl
+++ b/naga/tests/in/wgsl/binding-arrays.wgsl
@@ -1,3 +1,4 @@
+enable wgpu_binding_array;
 struct UniformIndex {
     index: u32
 };

--- a/naga/tests/in/wgsl/binding-buffer-arrays.wgsl
+++ b/naga/tests/in/wgsl/binding-buffer-arrays.wgsl
@@ -1,3 +1,4 @@
+enable wgpu_binding_array;
 struct UniformIndex {
     index: u32
 }

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -3317,7 +3317,8 @@ fn global_initialization_type_mismatch() {
 #[test]
 fn binding_array_local() {
     check_validation! {
-        "fn f() { var x: binding_array<sampler, 4>; }":
+        "enable wgpu_binding_array;
+         fn f() { var x: binding_array<sampler, 4>; }":
         Err(_)
     }
 }
@@ -3325,7 +3326,8 @@ fn binding_array_local() {
 #[test]
 fn binding_array_private() {
     check_validation! {
-        "var<private> x: binding_array<sampler, 4>;":
+        "enable wgpu_binding_array;
+         var<private> x: binding_array<sampler, 4>;":
         Err(_)
     }
 }
@@ -3333,7 +3335,8 @@ fn binding_array_private() {
 #[test]
 fn binding_array_non_struct() {
     check_validation! {
-        "var<storage> x: binding_array<i32, 4>;":
+        "enable wgpu_binding_array;
+         var<storage> x: binding_array<i32, 4>;":
         Err(naga::valid::ValidationError::Type {
             source: naga::valid::TypeError::BindingArrayBaseTypeNotStruct(_),
             ..
@@ -3343,6 +3346,7 @@ fn binding_array_non_struct() {
     check_validation! {
         r#"
             enable wgpu_ray_query;
+            enable wgpu_binding_array;
             @group(0) @binding(0)
             var<storage> ray_query_array: binding_array<ray_query, 10>;
         "#:
@@ -4694,16 +4698,172 @@ fn ray_query_vertex_return_enable_extension() {
 }
 
 #[test]
+fn binding_array_enable_extension() {
+    //buffers
+
+    check_extension_validation!(
+        Capabilities::BUFFER_BINDING_ARRAY,
+        r#"struct UniformBuffer { data: u32 }
+@group(0) @binding(0)
+var<uniform> uniform_array: binding_array<UniformBuffer, 5>;"#,
+        r#"error: the `wgpu_binding_array` enable extension is not enabled
+  ┌─ wgsl:3:29
+  │
+3 │ var<uniform> uniform_array: binding_array<UniformBuffer, 5>;
+  │                             ^^^^^^^^^^^^^ the `wgpu_binding_array` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_binding_array;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::GlobalVariable {
+            source: naga::valid::GlobalVariableError::UnsupportedCapability(
+                Capabilities::BUFFER_BINDING_ARRAY
+            ),
+            ..
+        })
+    );
+
+    check_extension_validation!(
+        Capabilities::STORAGE_BUFFER_BINDING_ARRAY,
+        r#"struct Buffer { data: u32 }
+@group(0) @binding(0)
+var<storage, read> storage_array: binding_array<Buffer, 5>;"#,
+        r#"error: the `wgpu_binding_array` enable extension is not enabled
+  ┌─ wgsl:3:35
+  │
+3 │ var<storage, read> storage_array: binding_array<Buffer, 5>;
+  │                                   ^^^^^^^^^^^^^ the `wgpu_binding_array` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_binding_array;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::GlobalVariable {
+            source: naga::valid::GlobalVariableError::UnsupportedCapability(
+                Capabilities::STORAGE_BUFFER_BINDING_ARRAY
+            ),
+            ..
+        })
+    );
+
+    //textures and samplers
+    check_extension_validation!(
+        Capabilities::TEXTURE_AND_SAMPLER_BINDING_ARRAY,
+        r#"@group(0) @binding(0)
+        var texture_array_unbounded: binding_array<texture_2d<f32>>;"#,
+        r#"error: the `wgpu_binding_array` enable extension is not enabled
+  ┌─ wgsl:2:38
+  │
+2 │         var texture_array_unbounded: binding_array<texture_2d<f32>>;
+  │                                      ^^^^^^^^^^^^^ the `wgpu_binding_array` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_binding_array;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::GlobalVariable {
+            source: naga::valid::GlobalVariableError::UnsupportedCapability(
+                Capabilities::TEXTURE_AND_SAMPLER_BINDING_ARRAY
+            ),
+            ..
+        })
+    );
+
+    check_extension_validation!(
+        Capabilities::TEXTURE_AND_SAMPLER_BINDING_ARRAY,
+        r#"@group(0) @binding(0)
+        var texture_array_bounded: binding_array<texture_2d<f32>, 5>;"#,
+        r#"error: the `wgpu_binding_array` enable extension is not enabled
+  ┌─ wgsl:2:36
+  │
+2 │         var texture_array_bounded: binding_array<texture_2d<f32>, 5>;
+  │                                    ^^^^^^^^^^^^^ the `wgpu_binding_array` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_binding_array;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::GlobalVariable {
+            source: naga::valid::GlobalVariableError::UnsupportedCapability(
+                Capabilities::TEXTURE_AND_SAMPLER_BINDING_ARRAY
+            ),
+            ..
+        })
+    );
+
+    check_extension_validation!(
+        Capabilities::TEXTURE_AND_SAMPLER_BINDING_ARRAY,
+        r#"@group(0) @binding(0)
+        var texture_array_2darray: binding_array<texture_2d_array<f32>, 5>;"#,
+        r#"error: the `wgpu_binding_array` enable extension is not enabled
+  ┌─ wgsl:2:36
+  │
+2 │         var texture_array_2darray: binding_array<texture_2d_array<f32>, 5>;
+  │                                    ^^^^^^^^^^^^^ the `wgpu_binding_array` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_binding_array;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::GlobalVariable {
+            source: naga::valid::GlobalVariableError::UnsupportedCapability(
+                Capabilities::TEXTURE_AND_SAMPLER_BINDING_ARRAY
+            ),
+            ..
+        })
+    );
+
+    check_extension_validation!(
+        Capabilities::TEXTURE_AND_SAMPLER_BINDING_ARRAY,
+        r#"@group(0) @binding(0)
+        var samp: binding_array<sampler, 5>;"#,
+        r#"error: the `wgpu_binding_array` enable extension is not enabled
+  ┌─ wgsl:2:19
+  │
+2 │         var samp: binding_array<sampler, 5>;
+  │                   ^^^^^^^^^^^^^ the `wgpu_binding_array` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_binding_array;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::GlobalVariable {
+            source: naga::valid::GlobalVariableError::UnsupportedCapability(
+                Capabilities::TEXTURE_AND_SAMPLER_BINDING_ARRAY
+            ),
+            ..
+        })
+    );
+
+    check_extension_validation!(
+        Capabilities::STORAGE_TEXTURE_BINDING_ARRAY,
+        r#"@group(0) @binding(0)
+        var texture_array_storage: binding_array<texture_storage_2d<rgba32float, write>, 5>;"#,
+        r#"error: the `wgpu_binding_array` enable extension is not enabled
+  ┌─ wgsl:2:36
+  │
+2 │         var texture_array_storage: binding_array<texture_storage_2d<rgba32float, write>, 5>;
+  │                                    ^^^^^^^^^^^^^ the `wgpu_binding_array` "Enable Extension" is needed for this functionality, but it is not currently enabled.
+  │
+  = note: You can enable this extension by adding `enable wgpu_binding_array;` at the top of the shader, before any other items.
+
+"#,
+        Err(naga::valid::ValidationError::GlobalVariable {
+            source: naga::valid::GlobalVariableError::UnsupportedCapability(
+                Capabilities::STORAGE_TEXTURE_BINDING_ARRAY
+            ),
+            ..
+        })
+    );
+}
+
+#[test]
 fn binding_array_requires_capability() {
     check_validation! {
         r#"
+            enable wgpu_binding_array;
             struct Buffer { data: u32 }
             @group(0) @binding(0)
             var<storage> storage_array: binding_array<Buffer, 10>;
         "#:
         Err(naga::valid::ValidationError::GlobalVariable {
             source: naga::valid::GlobalVariableError::UnsupportedCapability(
-                Capabilities::STORAGE_BUFFER_BINDING_ARRAY
+               Capabilities::STORAGE_BUFFER_BINDING_ARRAY
             ),
             ..
         })
@@ -4711,6 +4871,7 @@ fn binding_array_requires_capability() {
 
     check_validation! {
         r#"
+            enable wgpu_binding_array; 
             struct Buffer { data: u32 }
             @group(0) @binding(0)
             var<uniform> uniform_array: binding_array<Buffer, 10>;
@@ -4725,6 +4886,7 @@ fn binding_array_requires_capability() {
 
     check_validation! {
         r#"
+            enable wgpu_binding_array;
             @group(0) @binding(0)
             var storage_texture_array: binding_array<texture_storage_2d<rgba8unorm, write>, 10>;
         "#:
@@ -4738,6 +4900,7 @@ fn binding_array_requires_capability() {
 
     check_validation! {
         r#"
+            enable wgpu_binding_array;
             @group(0) @binding(0)
             var sampled_texture_array: binding_array<texture_2d<f32>, 10>;
         "#:
@@ -4751,6 +4914,7 @@ fn binding_array_requires_capability() {
 
     check_validation! {
         r#"
+            enable wgpu_binding_array;
             @group(0) @binding(0)
             var sampler_array: binding_array<sampler, 10>;
         "#:
@@ -4765,6 +4929,7 @@ fn binding_array_requires_capability() {
     // Binding arrays of external textures are not yet supported.
     check_validation! {
         r#"
+            enable wgpu_binding_array;
             @group(0) @binding(0)
             var external_texture_array: binding_array<texture_external, 10>;
         "#:
@@ -4778,6 +4943,7 @@ fn binding_array_requires_capability() {
     // Binding arrays of acceleration structures require a capability.
     check_validation! {
         r#"
+            enable wgpu_binding_array;
             enable wgpu_ray_query;
             @group(0) @binding(0)
             var acc_struct_array: binding_array<acceleration_structure, 10>;

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -4863,7 +4863,7 @@ fn binding_array_requires_capability() {
         "#:
         Err(naga::valid::ValidationError::GlobalVariable {
             source: naga::valid::GlobalVariableError::UnsupportedCapability(
-               Capabilities::STORAGE_BUFFER_BINDING_ARRAY
+                Capabilities::STORAGE_BUFFER_BINDING_ARRAY
             ),
             ..
         })

--- a/naga/tests/out/wgsl/spv-binding-arrays.dynamic.wgsl
+++ b/naga/tests/out/wgsl/spv-binding-arrays.dynamic.wgsl
@@ -1,3 +1,4 @@
+enable wgpu_binding_array;
 @group(0) @binding(0) 
 var global: binding_array<texture_2d<f32>>;
 @group(0) @binding(1) 

--- a/naga/tests/out/wgsl/spv-binding-arrays.dynamic.wgsl
+++ b/naga/tests/out/wgsl/spv-binding-arrays.dynamic.wgsl
@@ -1,4 +1,5 @@
 enable wgpu_binding_array;
+
 @group(0) @binding(0) 
 var global: binding_array<texture_2d<f32>>;
 @group(0) @binding(1) 

--- a/naga/tests/out/wgsl/spv-binding-arrays.runtime.wgsl
+++ b/naga/tests/out/wgsl/spv-binding-arrays.runtime.wgsl
@@ -1,4 +1,5 @@
 enable wgpu_binding_array;
+
 var<private> input_u002e_texture_coordinates_1: vec2<f32>;
 var<private> input_u002e_texture_index_1: u32;
 @group(0) @binding(0) 

--- a/naga/tests/out/wgsl/spv-binding-arrays.runtime.wgsl
+++ b/naga/tests/out/wgsl/spv-binding-arrays.runtime.wgsl
@@ -1,3 +1,4 @@
+enable wgpu_binding_array;
 var<private> input_u002e_texture_coordinates_1: vec2<f32>;
 var<private> input_u002e_texture_index_1: u32;
 @group(0) @binding(0) 

--- a/naga/tests/out/wgsl/spv-binding-arrays.static.wgsl
+++ b/naga/tests/out/wgsl/spv-binding-arrays.static.wgsl
@@ -1,4 +1,5 @@
 enable wgpu_binding_array;
+
 @group(0) @binding(0) 
 var global: binding_array<texture_2d<f32>, 256>;
 @group(0) @binding(1) 

--- a/naga/tests/out/wgsl/spv-binding-arrays.static.wgsl
+++ b/naga/tests/out/wgsl/spv-binding-arrays.static.wgsl
@@ -1,3 +1,4 @@
+enable wgpu_binding_array;
 @group(0) @binding(0) 
 var global: binding_array<texture_2d<f32>, 256>;
 @group(0) @binding(1) 

--- a/naga/tests/out/wgsl/wgsl-binding-arrays.wgsl
+++ b/naga/tests/out/wgsl/wgsl-binding-arrays.wgsl
@@ -1,3 +1,5 @@
+enable wgpu_binding_array;
+
 struct UniformIndex {
     index: u32,
 }

--- a/naga/tests/out/wgsl/wgsl-binding-buffer-arrays.wgsl
+++ b/naga/tests/out/wgsl/wgsl-binding-buffer-arrays.wgsl
@@ -1,3 +1,5 @@
+enable wgpu_binding_array;
+
 struct UniformIndex {
     index: u32,
 }

--- a/tests/tests/wgpu-gpu/binding_array/buffers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/buffers.rs
@@ -107,6 +107,7 @@ async fn binding_array_buffers(
     };
 
     let shader = r#"
+        enable wgpu_binding_array;
         struct ImAU32 {
             value: u32,
             _padding: u32,

--- a/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
@@ -65,6 +65,7 @@ static PARTIAL_BINDING_ARRAY_SAMPLED_TEXTURES: GpuTestConfiguration = GpuTestCon
 /// output due to non-native support for non-uniform indexing within a WARP.
 async fn binding_array_sampled_textures(ctx: TestingContext, partially_bound: bool) {
     let shader = r#"
+        enable wgpu_binding_array;
         @group(0) @binding(0)
         var textures: binding_array<texture_2d<f32>>;
 

--- a/tests/tests/wgpu-gpu/binding_array/samplers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/samplers.rs
@@ -58,6 +58,7 @@ static PARTIAL_BINDING_ARRAY_SAMPLERS: GpuTestConfiguration = GpuTestConfigurati
 
 async fn binding_array_samplers(ctx: TestingContext, partially_bound: bool) {
     let shader = r#"
+        enable wgpu_binding_array;
         @group(0) @binding(0)
         var samplers: binding_array<sampler>;
         @group(0) @binding(1)

--- a/tests/tests/wgpu-gpu/binding_array/storage_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/storage_textures.rs
@@ -52,6 +52,7 @@ static PARTIAL_BINDING_ARRAY_STORAGE_TEXTURES: GpuTestConfiguration = GpuTestCon
 
 async fn binding_array_storage_textures(ctx: TestingContext, partially_bound: bool) {
     let shader = r#"
+        enable wgpu_binding_array;
         @group(0) @binding(0)
         var textures: binding_array<texture_storage_2d<rgba8unorm, read_write> >;
 

--- a/tests/tests/wgpu-gpu/binding_array/tlas.rs
+++ b/tests/tests/wgpu-gpu/binding_array/tlas.rs
@@ -39,6 +39,7 @@ async fn binding_array_tlas(ctx: TestingContext) {
     // Creating a `ray_query` and initializing it against element 0 forces the binding to be used.
     let shader = r#"
         enable wgpu_ray_query;
+        enable wgpu_binding_array;
 
         @group(0) @binding(0)
         var tlas_array: binding_array<acceleration_structure>;


### PR DESCRIPTION
**Connections**
Fixes #8875 


**Description**
this requires `wgpu_binding_array` to be enabled in the shader to use `binding_array`

**Testing**
i added some tests to test this feature


<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
