### PR TITLE
add  Metal support for `MULTISAMPLE_ARRAY`

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1107,6 +1107,32 @@ impl super::CapabilitiesQuery {
                 false
             },
             shader_per_vertex: family_check && device.supportsFamily(MTLGPUFamily::Apple10),
+
+            supports_multisample_array: {
+                let mut supported = false;
+
+                if available!(macos = 10.15, ios = 13.0, tvos = 13.0, visionos = 1.0) {
+                    // According to Metal Feature Set Tables:
+                    // Multisample 2D Array textures are supported on:
+                    // - Apple Family 3 and higher (A10 chips/iPhone 7 and newer)
+                    // - Mac Family 1 and higher (All Intel/AMD/Apple Silicon Macs)
+                    if device.supportsFamily(MTLGPUFamily::Apple3)
+                        || device.supportsFamily(MTLGPUFamily::Mac1)
+                    {
+                        supported = true;
+                    }
+                } else {
+                    // Fallback for older OS versions using legacy feature set queries
+                    // MTLFeatureSet_iOS_GPUFamily3_v2 or MTLFeatureSet_macOS_GPUFamily1_v1
+                    if device.supportsFeatureSet(MTLFeatureSet::iOS_GPUFamily3_v2)
+                        || device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily1_v1)
+                    {
+                        supported = true;
+                    }
+                }
+
+                supported
+            },
         }
     }
 
@@ -1241,6 +1267,8 @@ impl super::CapabilitiesQuery {
         }
 
         features.set(F::EXPERIMENTAL_RAY_QUERY, self.supports_raytracing);
+
+        features.set(F::MULTISAMPLE_ARRAY, self.supports_multisample_array);
 
         features
     }

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1108,19 +1108,13 @@ impl super::CapabilitiesQuery {
             },
             shader_per_vertex: family_check && device.supportsFamily(MTLGPUFamily::Apple10),
 
-            supports_multisample_array: {
-                //https://developer.apple.com/documentation/metal/mtltexturetype/type2dmultisamplearray
-                // According to Metal Feature Set Tables:
-                // Multisample 2D Array textures are supported on:
-                // - Apple Family 3 and higher (A10 chips/iPhone 7 and newer)
-                // - Mac Family 1 and higher (All Intel/AMD/Apple Silicon Macs)
-                if available!(macos = 10.14, ios = 14.0, tvos = 16.0, visionos = 1.0) {
-                    device.supportsFamily(MTLGPUFamily::Apple3)
-                        || device.supportsFamily(MTLGPUFamily::Mac1)
-                } else {
-                    false
-                }
-            },
+            //https://developer.apple.com/documentation/metal/mtltexturetype/type2dmultisamplearray
+            supports_multisample_array: available!(
+                macos = 10.14,
+                ios = 14.0,
+                tvos = 16.0,
+                visionos = 1.0
+            ),
         }
     }
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1109,29 +1109,17 @@ impl super::CapabilitiesQuery {
             shader_per_vertex: family_check && device.supportsFamily(MTLGPUFamily::Apple10),
 
             supports_multisample_array: {
-                let mut supported = false;
-
-                if available!(macos = 10.15, ios = 13.0, tvos = 13.0, visionos = 1.0) {
-                    // According to Metal Feature Set Tables:
-                    // Multisample 2D Array textures are supported on:
-                    // - Apple Family 3 and higher (A10 chips/iPhone 7 and newer)
-                    // - Mac Family 1 and higher (All Intel/AMD/Apple Silicon Macs)
-                    if device.supportsFamily(MTLGPUFamily::Apple3)
+                //https://developer.apple.com/documentation/metal/mtltexturetype/type2dmultisamplearray
+                // According to Metal Feature Set Tables:
+                // Multisample 2D Array textures are supported on:
+                // - Apple Family 3 and higher (A10 chips/iPhone 7 and newer)
+                // - Mac Family 1 and higher (All Intel/AMD/Apple Silicon Macs)
+                if available!(macos = 10.14, ios = 14.0, tvos = 16.0, visionos = 1.0) {
+                    device.supportsFamily(MTLGPUFamily::Apple3)
                         || device.supportsFamily(MTLGPUFamily::Mac1)
-                    {
-                        supported = true;
-                    }
                 } else {
-                    // Fallback for older OS versions using legacy feature set queries
-                    // MTLFeatureSet_iOS_GPUFamily3_v2 or MTLFeatureSet_macOS_GPUFamily1_v1
-                    if device.supportsFeatureSet(MTLFeatureSet::iOS_GPUFamily3_v2)
-                        || device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily1_v1)
-                    {
-                        supported = true;
-                    }
+                    false
                 }
-
-                supported
             },
         }
     }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -490,7 +490,15 @@ impl crate::Device for super::Device {
                 wgt::TextureDimension::D2 => {
                     if desc.sample_count > 1 {
                         unsafe { descriptor.setSampleCount(desc.sample_count as usize) };
-                        MTLTextureType::Type2DMultisample
+
+                        if desc.size.depth_or_array_layers > 1 {
+                            unsafe {
+                                descriptor.setArrayLength(desc.size.depth_or_array_layers as usize)
+                            };
+                            MTLTextureType::Type2DMultisampleArray
+                        } else {
+                            MTLTextureType::Type2DMultisample
+                        }
                     } else if desc.size.depth_or_array_layers > 1 {
                         unsafe {
                             descriptor.setArrayLength(desc.size.depth_or_array_layers as usize)
@@ -557,7 +565,9 @@ impl crate::Device for super::Device {
         texture: &super::Texture,
         desc: &crate::TextureViewDescriptor,
     ) -> DeviceResult<super::TextureView> {
-        let raw_type = if texture.raw_type == MTLTextureType::Type2DMultisample {
+        let raw_type = if texture.raw_type == MTLTextureType::Type2DMultisample
+            || texture.raw_type == MTLTextureType::Type2DMultisampleArray
+        {
             texture.raw_type
         } else {
             conv::map_texture_view_dimension(desc.dimension)

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -318,6 +318,7 @@ struct CapabilitiesQuery {
     supports_memoryless_storage: bool,
     supports_raytracing: bool,
     shader_per_vertex: bool,
+    supports_multisample_array: bool,
 }
 
 #[derive(Debug)]

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -1360,6 +1360,7 @@ bitflags_array! {
         ///
         /// Supported platforms:
         /// - Vulkan (except VK_KHR_portability_subset if multisampleArrayImage is not available)
+        /// - Metal (with macos 10.14+, ios 14.0+, tvos 16.0+, visionos 1.0+)
         #[name("wgpu-multisample-array")]
         const MULTISAMPLE_ARRAY = 1 << 56;
 


### PR DESCRIPTION
**Connections**
#8593 


**Description**
add  Metal support for `MULTISAMPLE_ARRAY`

**Testing**
no tests where added 

**Squash or Rebase?**


**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
