### PR TITLE
fix(gles): texture height initialized incorrectly in `create_texture`

### DIFF
--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -844,7 +844,7 @@ impl crate::Device for super::Device {
                         )
                     } else if target == glow::TEXTURE_3D {
                         let mut width = desc.size.width;
-                        let mut height = desc.size.width;
+                        let mut height = desc.size.height;
                         let mut depth = desc.size.depth_or_array_layers;
                         for i in 0..desc.mip_level_count {
                             gl.tex_image_3d(
@@ -865,7 +865,7 @@ impl crate::Device for super::Device {
                         }
                     } else {
                         let mut width = desc.size.width;
-                        let mut height = desc.size.width;
+                        let mut height = desc.size.height;
                         for i in 0..desc.mip_level_count {
                             gl.tex_image_3d(
                                 target,
@@ -911,7 +911,7 @@ impl crate::Device for super::Device {
                         )
                     } else if target == glow::TEXTURE_CUBE_MAP {
                         let mut width = desc.size.width;
-                        let mut height = desc.size.width;
+                        let mut height = desc.size.height;
                         for i in 0..desc.mip_level_count {
                             for face in [
                                 glow::TEXTURE_CUBE_MAP_POSITIVE_X,
@@ -938,7 +938,7 @@ impl crate::Device for super::Device {
                         }
                     } else {
                         let mut width = desc.size.width;
-                        let mut height = desc.size.width;
+                        let mut height = desc.size.height;
                         for i in 0..desc.mip_level_count {
                             gl.tex_image_2d(
                                 target,


### PR DESCRIPTION
**Connections**
- https://github.com/emilk/egui/issues/8012

**Description**
In the `create_texture` function in `wgpu-hal/src/gles/device.rs`, the texture height is incorrectly initialized using `desc.size.width` instead of `desc.size.height`.
This occurs in 4 places.

This issue was identified by GitHub Copilot while investigating https://github.com/emilk/egui/issues/8012.

**Testing**
No changes to existing tests.

**Squash or Rebase?**
Single commit.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] ~~If this contains user-facing changes, add a `CHANGELOG.md` entry.~~

---

`cargo xtask test` results in 3 failing tests. They were already present prior to this PR (9c5adb73a7792c45da742efd8572e75df0ed4e89).

```
     Summary [  13.253s] 878 tests run: 875 passed (1 leaky), 3 failed, 6 skipped
        FAIL [   0.009s] naga::naga snapshots::convert_snapshots_spv
        FAIL [   0.311s] wgpu-test::wgpu-gpu [Executed] [Metal/Apple M4 Max/0] wgpu_gpu::passthrough::all_passthrough_shaders_binary
        FAIL [   0.313s] wgpu-test::wgpu-gpu [Executed] [Metal/Apple M4 Max/0] wgpu_gpu::passthrough::all_passthrough_shaders_source
```
