### PR TITLE
[msl-out] Switch to intersection queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ Bottom level categories:
 
 - Prefix `FeatureLevel` and `ShaderModel` enum variants with `V` instead of `_`. By @teoxoy in [#9337](https://github.com/gfx-rs/wgpu/pull/9337).
 
+#### naga
+
+- Switched from using an `intersector` to using an `intersection_query` on metal so AABBs and non-opaque triangles can be handled. By @Vecvec in [#9304](https://github.com/gfx-rs/wgpu/pull/9304).
+
 ### Bug Fixes
 
 #### General

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -81,6 +81,7 @@ mod keywords;
 mod mesh_shader;
 pub mod sampler;
 mod writer;
+mod ray;
 
 pub use writer::Writer;
 

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -79,9 +79,9 @@ use crate::{arena::Handle, back::TaskDispatchLimits, ir, proc::index, valid::Mod
 
 mod keywords;
 mod mesh_shader;
+mod ray;
 pub mod sampler;
 mod writer;
-mod ray;
 
 pub use writer::Writer;
 

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -18,6 +18,7 @@ use crate::{
 
 pub(super) const RT_NAMESPACE: &str = "metal::raytracing";
 
+/// The ray query type, needs to be a function so it can format the constants.
 pub(super) fn metal_intersector_ty() -> String {
     format!("{RT_NAMESPACE}::intersection_query<{RT_NAMESPACE}::instancing, {RT_NAMESPACE}::triangle_data>")
 }
@@ -25,6 +26,11 @@ pub(super) fn metal_intersector_ty() -> String {
 pub(super) const INTERSECTION_FUNCTION_NAME: &str = "ray_query_get_intersection";
 
 impl<W: Write> Writer<W> {
+    /// Writes a function to get the current intersection from the ray query
+    /// 
+    /// Like other backends, this is needed to have a single branch for constructing
+    /// the parts of the intersection that need to be checked whether they do or don't
+    /// hit.
     pub(super) fn write_rq_get_intersection_function(
         &mut self,
         module: &crate::Module,
@@ -52,11 +58,13 @@ impl<W: Write> Writer<W> {
             "{intersection} {INTERSECTION_FUNCTION_NAME}_{committed}({} intersector) {{",
             metal_intersector_ty()
         )?;
+        // Initialize the intersection to its default values (which should be zero).
         writeln!(
             self.out,
             "{level}{intersection} intersection = {intersection} {{}};"
         )?;
         writeln!(self.out, "{level}{RT_NAMESPACE}::intersection_type ty = intersector.get_{ty}_intersection_type();")?;
+        // If the ray hit a triangle, call all methods that require that and set the intersection type.
         writeln!(
             self.out,
             "{level}if (ty == {RT_NAMESPACE}::intersection_type::triangle) {{"
@@ -77,6 +85,8 @@ impl<W: Write> Writer<W> {
             self.out,
             "{level}{level}intersection.front_face = intersector.is_{ty}_triangle_front_facing();"
         )?;
+        // Otherwise, if the ray hit an AABB (called a bounding box in metal) set the intersection type
+        // (which depends on whether this is a committed or candidate intersection).
         writeln!(
             self.out,
             "{level}}} else if (ty == {RT_NAMESPACE}::intersection_type::bounding_box) {{"
@@ -87,9 +97,17 @@ impl<W: Write> Writer<W> {
                 "{level}{level}intersection.kind = {};",
                 crate::RayQueryIntersection::Generated as u32
             )?;
+        } else {
+            writeln!(
+                self.out,
+                "{level}{level}intersection.kind = {};",
+                crate::RayQueryIntersection::Aabb as u32
+            )?;
         }
         writeln!(self.out, "{level}}}")?;
 
+
+        // If the ray hit anything at all, call all methods that require that.
         writeln!(
             self.out,
             "{level}if (ty != {RT_NAMESPACE}::intersection_type::none) {{"
@@ -105,7 +123,7 @@ impl<W: Write> Writer<W> {
             self.out,
             "{level}{level}intersection.instance_index = intersector.get_{ty}_instance_id();"
         )?;
-        // TODO
+        // Metal does not appear to support obtaining the intersection offset from a ray query.
         //writeln!(self.out, "{level}{level}intersection.sbt_record_offset = intersector.get_{ty}_user_instance_id();")?;
         writeln!(
             self.out,
@@ -135,14 +153,16 @@ impl<W: Write> Writer<W> {
             return Err(Error::UnsupportedRayTracing);
         }
 
+        // TODO: check for misuse.
         match *fun {
             crate::RayQueryFunction::Initialize {
                 acceleration_structure,
                 descriptor,
             } => {
-                //TODO: how to deal with winding?
+                //TODO: how to deal with winding? Is it by default the same as the other APIs?
 
-                // put everything in a block so it doesn't interfere
+                // Put everything in a block so that the variable names
+                // do not conflict with user variable names
                 writeln!(self.out, "{level}{{")?;
 
                 let inner_level = level.next();
@@ -158,7 +178,7 @@ impl<W: Write> Writer<W> {
                 )?;
 
                 {
-                    // determine whether or not to cull
+                    // Determine whether or not to cull opaque/non-opaques
                     let f_opaque = back::RayFlag::CULL_OPAQUE.bits();
                     let f_no_opaque = back::RayFlag::CULL_NO_OPAQUE.bits();
                     writeln!(
@@ -171,6 +191,7 @@ impl<W: Write> Writer<W> {
                     )?;
                 }
                 {
+                    // Determine whether to force a particular opacity
                     let f_opaque = back::RayFlag::OPAQUE.bits();
                     let f_no_opaque = back::RayFlag::NO_OPAQUE.bits();
                     writeln!(self.out, "{inner_level}params.force_opacity(
@@ -193,6 +214,9 @@ impl<W: Write> Writer<W> {
                 )?;
 
                 write!(self.out, "{inner_level}")?;
+                // A ray query can by initialized in metal by either using a "non-default constructor"
+                // or by calling reset. Ray queries cannot be assigned to in metal, so reset needs to
+                // be called.
                 self.put_expression(query, &context.expression, true)?;
                 write!(self.out, ".reset(ray,")?;
                 self.put_expression(acceleration_structure, &context.expression, true)?;
@@ -204,7 +228,6 @@ impl<W: Write> Writer<W> {
                 let name = Baked(result).to_string();
                 self.start_baking_expression(result, &context.expression, &name)?;
                 self.named_expressions.insert(result, name);
-                // next returns bool
                 self.put_expression(query, &context.expression, true)?;
                 writeln!(self.out, ".next();")?;
             }
@@ -223,6 +246,8 @@ impl<W: Write> Writer<W> {
             crate::RayQueryFunction::Terminate => {
                 write!(self.out, "{level}")?;
                 self.put_expression(query, &context.expression, true)?;
+                // Terminate appears to map to abort in spirv-cross, but metal only documents
+                // the existance of this method, not what it does.
                 writeln!(self.out, ".abort();")?;
             }
         }

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -1,0 +1,120 @@
+use core::fmt::Write;
+use alloc::string::ToString;
+
+use crate::{Handle, back::{self, Baked, msl::{BackendResult, Error, Writer, writer::{RAY_QUERY_FIELD_INTERSECTION, RAY_QUERY_FIELD_INTERSECTOR, RAY_QUERY_FIELD_READY, RAY_QUERY_MODERN_SUPPORT, RT_NAMESPACE, StatementContext}}}};
+
+impl<W: Write> Writer<W> {
+    pub(super) fn write_ray_query_stmt(&mut self, level: back::Level, context: &StatementContext, query: Handle<crate::Expression>, fun: &crate::RayQueryFunction) -> BackendResult {
+        if context.expression.lang_version < (2, 4) {
+            return Err(Error::UnsupportedRayTracing);
+        }
+
+        match *fun {
+            crate::RayQueryFunction::Initialize {
+                acceleration_structure,
+                descriptor,
+            } => {
+                //TODO: how to deal with winding?
+                write!(self.out, "{level}")?;
+                self.put_expression(query, &context.expression, true)?;
+                writeln!(self.out, ".{RAY_QUERY_FIELD_INTERSECTOR}.assume_geometry_type({RT_NAMESPACE}::geometry_type::triangle);")?;
+                {
+                    let f_opaque = back::RayFlag::CULL_OPAQUE.bits();
+                    let f_no_opaque = back::RayFlag::CULL_NO_OPAQUE.bits();
+                    write!(self.out, "{level}")?;
+                    self.put_expression(query, &context.expression, true)?;
+                    write!(
+                        self.out,
+                        ".{RAY_QUERY_FIELD_INTERSECTOR}.set_opacity_cull_mode(("
+                    )?;
+                    self.put_expression(descriptor, &context.expression, true)?;
+                    write!(self.out, ".flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::opaque : (")?;
+                    self.put_expression(descriptor, &context.expression, true)?;
+                    write!(self.out, ".flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::non_opaque : ")?;
+                    writeln!(self.out, "{RT_NAMESPACE}::opacity_cull_mode::none);")?;
+                }
+                {
+                    let f_opaque = back::RayFlag::OPAQUE.bits();
+                    let f_no_opaque = back::RayFlag::NO_OPAQUE.bits();
+                    write!(self.out, "{level}")?;
+                    self.put_expression(query, &context.expression, true)?;
+                    write!(self.out, ".{RAY_QUERY_FIELD_INTERSECTOR}.force_opacity((")?;
+                    self.put_expression(descriptor, &context.expression, true)?;
+                    write!(self.out, ".flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::opaque : (")?;
+                    self.put_expression(descriptor, &context.expression, true)?;
+                    write!(self.out, ".flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::non_opaque : ")?;
+                    writeln!(self.out, "{RT_NAMESPACE}::forced_opacity::none);")?;
+                }
+                {
+                    let flag = back::RayFlag::TERMINATE_ON_FIRST_HIT.bits();
+                    write!(self.out, "{level}")?;
+                    self.put_expression(query, &context.expression, true)?;
+                    write!(
+                        self.out,
+                        ".{RAY_QUERY_FIELD_INTERSECTOR}.accept_any_intersection(("
+                    )?;
+                    self.put_expression(descriptor, &context.expression, true)?;
+                    writeln!(self.out, ".flags & {flag}) != 0);")?;
+                }
+
+                write!(self.out, "{level}")?;
+                self.put_expression(query, &context.expression, true)?;
+                write!(self.out, ".{RAY_QUERY_FIELD_INTERSECTION} = ")?;
+                self.put_expression(query, &context.expression, true)?;
+                write!(
+                    self.out,
+                    ".{RAY_QUERY_FIELD_INTERSECTOR}.intersect({RT_NAMESPACE}::ray("
+                )?;
+                self.put_expression(descriptor, &context.expression, true)?;
+                write!(self.out, ".origin, ")?;
+                self.put_expression(descriptor, &context.expression, true)?;
+                write!(self.out, ".dir, ")?;
+                self.put_expression(descriptor, &context.expression, true)?;
+                write!(self.out, ".tmin, ")?;
+                self.put_expression(descriptor, &context.expression, true)?;
+                write!(self.out, ".tmax), ")?;
+                self.put_expression(acceleration_structure, &context.expression, true)?;
+                write!(self.out, ", ")?;
+                self.put_expression(descriptor, &context.expression, true)?;
+                write!(self.out, ".cull_mask);")?;
+
+                write!(self.out, "{level}")?;
+                self.put_expression(query, &context.expression, true)?;
+                writeln!(self.out, ".{RAY_QUERY_FIELD_READY} = true;")?;
+            }
+            crate::RayQueryFunction::Proceed { result } => {
+                write!(self.out, "{level}")?;
+                let name = Baked(result).to_string();
+                self.start_baking_expression(result, &context.expression, &name)?;
+                self.named_expressions.insert(result, name);
+                // next returns bool
+                self.put_expression(query, &context.expression, true)?;
+                writeln!(self.out, ".?.next();")?;
+            }
+            crate::RayQueryFunction::GenerateIntersection { hit_t } => {
+                write!(self.out, "{level}")?;
+                self.put_expression(query, &context.expression, true)?;
+                write!(self.out, ".?.commit_bounding_box_intersection(")?;
+                self.put_expression(hit_t, &context.expression, true)?;
+                writeln!(self.out, ");")?;
+            }
+            crate::RayQueryFunction::ConfirmIntersection => {
+                write!(self.out, "{level}")?;
+                self.put_expression(query, &context.expression, true)?;
+                writeln!(self.out, ".?.commit_triangle_intersection();")?;
+            }
+            crate::RayQueryFunction::Terminate => {
+                if RAY_QUERY_MODERN_SUPPORT {
+                    write!(self.out, "{level}")?;
+                    self.put_expression(query, &context.expression, true)?;
+                    writeln!(self.out, ".?.abort();")?;
+                }
+                write!(self.out, "{level}")?;
+                self.put_expression(query, &context.expression, true)?;
+                writeln!(self.out, ".{RAY_QUERY_FIELD_READY} = false;")?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -86,7 +86,7 @@ impl<W: Write> Writer<W> {
                 writeln!(self.out, ";")?;
 
                 // Set up intersection parameters
-                writeln!(self.out, "{inner_level}intersection_params params;")?;
+                writeln!(self.out, "{inner_level}{RT_NAMESPACE}::intersection_params params;")?;
 
                 {
                     // determine whether or not to cull 
@@ -94,7 +94,7 @@ impl<W: Write> Writer<W> {
                     let f_no_opaque = back::RayFlag::CULL_NO_OPAQUE.bits();
                     writeln!(
                         self.out,
-                        "{inner_level}intersection_params.set_opacity_cull_mode(
+                        "{inner_level}params.set_opacity_cull_mode(
 {inner_level}    (desc.flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::opaque : (
 {inner_level}        (desc.flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::non_opaque : {RT_NAMESPACE}::opacity_cull_mode::none
 {inner_level}    )
@@ -104,7 +104,7 @@ impl<W: Write> Writer<W> {
                 {
                     let f_opaque = back::RayFlag::OPAQUE.bits();
                     let f_no_opaque = back::RayFlag::NO_OPAQUE.bits();
-                    writeln!(self.out, "{inner_level}intersection_params.force_opacity(
+                    writeln!(self.out, "{inner_level}params.force_opacity(
 {inner_level}    (desc.flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::opaque : (
 {inner_level}        (desc.flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::non_opaque : {RT_NAMESPACE}::forced_opacity::none
 {inner_level}    )
@@ -112,7 +112,7 @@ impl<W: Write> Writer<W> {
                 }
                 {
                     let flag = back::RayFlag::TERMINATE_ON_FIRST_HIT.bits();
-                    writeln!(self.out, "{inner_level}intersection_params.accept_any_intersection((desc.flags & {flag}) != 0);")?;
+                    writeln!(self.out, "{inner_level}params.accept_any_intersection((desc.flags & {flag}) != 0);")?;
                 }
 
                 write!(

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -259,7 +259,7 @@ impl<W: Write> Writer<W> {
                 write!(self.out, "{level}")?;
                 self.put_expression(query, &context.expression, true)?;
                 // Terminate appears to map to abort in spirv-cross, but metal only documents
-                // the existance of this method, not what it does.
+                // the existence of this method, not what it does.
                 writeln!(self.out, ".abort();")?;
             }
         }

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -31,7 +31,7 @@ impl<W: Write> Writer<W> {
         let level = back::Level(1);
         writeln!(self.out, "{intersection} {INTERSECTION_FUNCTION_NAME}_{committed}({} intersector) {{", metal_intersector_ty())?;
         writeln!(self.out, "{level}{intersection} intersection = {intersection} {{}};")?;
-        writeln!(self.out, "{level}intersection_type ty = intersector.get_{ty}_intersection_type();")?;
+        writeln!(self.out, "{level}{RT_NAMESPACE}::intersection_type ty = intersector.get_{ty}_intersection_type();")?;
         writeln!(self.out, "{level}if (ty == {RT_NAMESPACE}::intersection_type::triangle) {{")?;
         writeln!(self.out, "{level}{level}intersection.kind = {};", crate::RayQueryIntersection::Triangle as u32)?;
         if !committed {

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -6,7 +6,7 @@ use crate::{Handle, back::{self, Baked, msl::{BackendResult, Error, Writer, writ
 pub(super) const RT_NAMESPACE: &'static str = "metal::raytracing";
 
 pub(super) fn metal_intersector_ty() -> String {
-    format!("{RT_NAMESPACE}::intersection_query<{RT_NAMESPACE}::instancing, {RT_NAMESPACE}::triangle_data, {RT_NAMESPACE}::world_space_data>")
+    format!("{RT_NAMESPACE}::intersection_query<{RT_NAMESPACE}::instancing, {RT_NAMESPACE}::triangle_data>")
 }
 
 pub(super) const INTERSECTION_FUNCTION_NAME: &'static str = "ray_query_get_intersection";
@@ -58,7 +58,7 @@ impl<W: Write> Writer<W> {
         writeln!(self.out, "{level}{level}intersection.object_to_world = intersector.get_{ty}_user_instance_id();")?;
         writeln!(self.out, "{level}{level}intersection.world_to_object = intersector.get_{ty}_user_instance_id();")?;
         writeln!(self.out, "{level}}}")?;
-        writeln!(self.out, "return intersection;")?;
+        writeln!(self.out, "{level}return intersection;")?;
         writeln!(self.out, "}}")?;
 
         Ok(())
@@ -81,7 +81,7 @@ impl<W: Write> Writer<W> {
 
                 let inner_level = level.next();
 
-                write!(self.out, "{inner_level}RayDesc desc = ")?;
+                write!(self.out, "{inner_level}{RT_NAMESPACE}::RayDesc desc = ")?;
                 self.put_expression(descriptor, &context.expression, false)?;
                 writeln!(self.out, ";")?;
 

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -1,7 +1,13 @@
 use core::fmt::Write;
-use alloc::string::ToString;
+use alloc::{string::{ToString, String}, format};
 
-use crate::{Handle, back::{self, Baked, msl::{BackendResult, Error, Writer, writer::{RAY_QUERY_FIELD_INTERSECTION, RAY_QUERY_FIELD_INTERSECTOR, RAY_QUERY_FIELD_READY, RAY_QUERY_MODERN_SUPPORT, RT_NAMESPACE, StatementContext}}}};
+use crate::{Handle, back::{self, Baked, msl::{BackendResult, Error, Writer, writer::StatementContext}}};
+
+pub(super) const RT_NAMESPACE: &str = "metal::raytracing";
+
+pub(super) fn metal_intersector_ty() -> String {
+    format!("{RT_NAMESPACE}::intersection_query<{RT_NAMESPACE}::instancing, {RT_NAMESPACE}::triangle_data, {RT_NAMESPACE}::world_space_data>")
+}
 
 impl<W: Write> Writer<W> {
     pub(super) fn write_ray_query_stmt(&mut self, level: back::Level, context: &StatementContext, query: Handle<crate::Expression>, fun: &crate::RayQueryFunction) -> BackendResult {
@@ -15,72 +21,58 @@ impl<W: Write> Writer<W> {
                 descriptor,
             } => {
                 //TODO: how to deal with winding?
-                write!(self.out, "{level}")?;
-                self.put_expression(query, &context.expression, true)?;
-                writeln!(self.out, ".{RAY_QUERY_FIELD_INTERSECTOR}.assume_geometry_type({RT_NAMESPACE}::geometry_type::triangle);")?;
+
+                // put everything in a block so it doesn't interfere
+
+                writeln!(self.out, "{level}{{")?;
+
+                let inner_level = level.next();
+
+                write!(self.out, "{inner_level}RayDesc desc = ")?;
+                self.put_expression(descriptor, &context.expression, false);
+                writeln!(self.out, ";")?;
+
+                // Set up intersection parameters
+                writeln!(self.out, "{inner_level}intersection_params params;")?;
+
                 {
+                    // determine whether or not to cull 
                     let f_opaque = back::RayFlag::CULL_OPAQUE.bits();
                     let f_no_opaque = back::RayFlag::CULL_NO_OPAQUE.bits();
-                    write!(self.out, "{level}")?;
-                    self.put_expression(query, &context.expression, true)?;
-                    write!(
+                    writeln!(
                         self.out,
-                        ".{RAY_QUERY_FIELD_INTERSECTOR}.set_opacity_cull_mode(("
+                        "{inner_level}intersection_params.set_opacity_cull_mode(
+{inner_level}    (desc.flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::opaque : (
+{inner_level}        (desc.flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::non_opaque : {RT_NAMESPACE}::opacity_cull_mode::none
+{inner_level}    )
+{inner_level});"
                     )?;
-                    self.put_expression(descriptor, &context.expression, true)?;
-                    write!(self.out, ".flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::opaque : (")?;
-                    self.put_expression(descriptor, &context.expression, true)?;
-                    write!(self.out, ".flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::non_opaque : ")?;
-                    writeln!(self.out, "{RT_NAMESPACE}::opacity_cull_mode::none);")?;
                 }
                 {
                     let f_opaque = back::RayFlag::OPAQUE.bits();
                     let f_no_opaque = back::RayFlag::NO_OPAQUE.bits();
-                    write!(self.out, "{level}")?;
-                    self.put_expression(query, &context.expression, true)?;
-                    write!(self.out, ".{RAY_QUERY_FIELD_INTERSECTOR}.force_opacity((")?;
-                    self.put_expression(descriptor, &context.expression, true)?;
-                    write!(self.out, ".flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::opaque : (")?;
-                    self.put_expression(descriptor, &context.expression, true)?;
-                    write!(self.out, ".flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::non_opaque : ")?;
-                    writeln!(self.out, "{RT_NAMESPACE}::forced_opacity::none);")?;
+                    writeln!(self.out, "{inner_level}intersection_params.force_opacity(
+{inner_level}    (desc.flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::opaque : (
+{inner_level}        (desc.flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::non_opaque : {RT_NAMESPACE}::forced_opacity::none
+{inner_level}    )
+{inner_level});")?;
                 }
                 {
                     let flag = back::RayFlag::TERMINATE_ON_FIRST_HIT.bits();
-                    write!(self.out, "{level}")?;
-                    self.put_expression(query, &context.expression, true)?;
-                    write!(
-                        self.out,
-                        ".{RAY_QUERY_FIELD_INTERSECTOR}.accept_any_intersection(("
-                    )?;
-                    self.put_expression(descriptor, &context.expression, true)?;
-                    writeln!(self.out, ".flags & {flag}) != 0);")?;
+                    writeln!(self.out, "{inner_level}intersection_params.accept_any_intersection((desc.flags & {flag}) != 0);")?;
                 }
 
-                write!(self.out, "{level}")?;
-                self.put_expression(query, &context.expression, true)?;
-                write!(self.out, ".{RAY_QUERY_FIELD_INTERSECTION} = ")?;
-                self.put_expression(query, &context.expression, true)?;
                 write!(
                     self.out,
-                    ".{RAY_QUERY_FIELD_INTERSECTOR}.intersect({RT_NAMESPACE}::ray("
+                    "{inner_level}{RT_NAMESPACE}::ray ray = {RT_NAMESPACE}::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);"
                 )?;
-                self.put_expression(descriptor, &context.expression, true)?;
-                write!(self.out, ".origin, ")?;
-                self.put_expression(descriptor, &context.expression, true)?;
-                write!(self.out, ".dir, ")?;
-                self.put_expression(descriptor, &context.expression, true)?;
-                write!(self.out, ".tmin, ")?;
-                self.put_expression(descriptor, &context.expression, true)?;
-                write!(self.out, ".tmax), ")?;
-                self.put_expression(acceleration_structure, &context.expression, true)?;
-                write!(self.out, ", ")?;
-                self.put_expression(descriptor, &context.expression, true)?;
-                write!(self.out, ".cull_mask);")?;
 
-                write!(self.out, "{level}")?;
+                write!(self.out, "{inner_level}")?;
                 self.put_expression(query, &context.expression, true)?;
-                writeln!(self.out, ".{RAY_QUERY_FIELD_READY} = true;")?;
+                write!(self.out, ".reset(ray,")?;
+                self.put_expression(acceleration_structure, &context.expression, true)?;
+                writeln!(self.out, ", desc.cull_mask, params);")?;
+                writeln!(self.out, "{level}}}");
             }
             crate::RayQueryFunction::Proceed { result } => {
                 write!(self.out, "{level}")?;
@@ -89,29 +81,24 @@ impl<W: Write> Writer<W> {
                 self.named_expressions.insert(result, name);
                 // next returns bool
                 self.put_expression(query, &context.expression, true)?;
-                writeln!(self.out, ".?.next();")?;
+                writeln!(self.out, ".next();")?;
             }
             crate::RayQueryFunction::GenerateIntersection { hit_t } => {
                 write!(self.out, "{level}")?;
                 self.put_expression(query, &context.expression, true)?;
-                write!(self.out, ".?.commit_bounding_box_intersection(")?;
+                write!(self.out, ".commit_bounding_box_intersection(")?;
                 self.put_expression(hit_t, &context.expression, true)?;
                 writeln!(self.out, ");")?;
             }
             crate::RayQueryFunction::ConfirmIntersection => {
                 write!(self.out, "{level}")?;
                 self.put_expression(query, &context.expression, true)?;
-                writeln!(self.out, ".?.commit_triangle_intersection();")?;
+                writeln!(self.out, ".commit_triangle_intersection();")?;
             }
             crate::RayQueryFunction::Terminate => {
-                if RAY_QUERY_MODERN_SUPPORT {
-                    write!(self.out, "{level}")?;
-                    self.put_expression(query, &context.expression, true)?;
-                    writeln!(self.out, ".?.abort();")?;
-                }
                 write!(self.out, "{level}")?;
                 self.put_expression(query, &context.expression, true)?;
-                writeln!(self.out, ".{RAY_QUERY_FIELD_READY} = false;")?;
+                writeln!(self.out, ".abort();")?;
             }
         }
 

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -23,7 +23,6 @@ impl<W: Write> Writer<W> {
                 //TODO: how to deal with winding?
 
                 // put everything in a block so it doesn't interfere
-
                 writeln!(self.out, "{level}{{")?;
 
                 let inner_level = level.next();

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -27,7 +27,7 @@ pub(super) const INTERSECTION_FUNCTION_NAME: &str = "ray_query_get_intersection"
 
 impl<W: Write> Writer<W> {
     /// Writes a function to get the current intersection from the ray query
-    /// 
+    ///
     /// Like other backends, this is needed to have a single branch for constructing
     /// the parts of the intersection that need to be checked whether they do or don't
     /// hit.
@@ -106,7 +106,6 @@ impl<W: Write> Writer<W> {
         }
         writeln!(self.out, "{level}}}")?;
 
-
         // If the ray hit anything at all, call all methods that require that.
         writeln!(
             self.out,
@@ -167,7 +166,20 @@ impl<W: Write> Writer<W> {
 
                 let inner_level = level.next();
 
-                write!(self.out, "{inner_level}RayDesc desc = ")?;
+                let naga_ray_desc_ty = TypeContext {
+                    handle: context
+                        .expression
+                        .module
+                        .special_types
+                        .ray_desc
+                        .expect("ray desc is required as an argument so should be there"),
+                    gctx: context.expression.module.to_ctx(),
+                    names: &self.names,
+                    access: crate::StorageAccess::empty(),
+                    first_time: false,
+                };
+
+                write!(self.out, "{inner_level}{naga_ray_desc_ty} desc = ")?;
                 self.put_expression(descriptor, &context.expression, false)?;
                 writeln!(self.out, ";")?;
 

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -16,13 +16,13 @@ use crate::{
     Handle,
 };
 
-pub(super) const RT_NAMESPACE: &'static str = "metal::raytracing";
+pub(super) const RT_NAMESPACE: &str = "metal::raytracing";
 
 pub(super) fn metal_intersector_ty() -> String {
     format!("{RT_NAMESPACE}::intersection_query<{RT_NAMESPACE}::instancing, {RT_NAMESPACE}::triangle_data>")
 }
 
-pub(super) const INTERSECTION_FUNCTION_NAME: &'static str = "ray_query_get_intersection";
+pub(super) const INTERSECTION_FUNCTION_NAME: &str = "ray_query_get_intersection";
 
 impl<W: Write> Writer<W> {
     pub(super) fn write_rq_get_intersection_function(

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -220,7 +220,7 @@ impl<W: Write> Writer<W> {
                     )?;
                 }
 
-                write!(
+                writeln!(
                     self.out,
                     "{inner_level}{RT_NAMESPACE}::ray ray = {RT_NAMESPACE}::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);"
                 )?;

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -1,15 +1,66 @@
 use core::fmt::Write;
 use alloc::{string::{ToString, String}, format};
 
-use crate::{Handle, back::{self, Baked, msl::{BackendResult, Error, Writer, writer::StatementContext}}};
+use crate::{Handle, back::{self, Baked, msl::{BackendResult, Error, Writer, writer::{StatementContext, TypeContext, WrappedFunction}}}};
 
-pub(super) const RT_NAMESPACE: &str = "metal::raytracing";
+pub(super) const RT_NAMESPACE: &'static str = "metal::raytracing";
 
 pub(super) fn metal_intersector_ty() -> String {
     format!("{RT_NAMESPACE}::intersection_query<{RT_NAMESPACE}::instancing, {RT_NAMESPACE}::triangle_data, {RT_NAMESPACE}::world_space_data>")
 }
 
+pub(super) const INTERSECTION_FUNCTION_NAME: &'static str = "ray_query_get_intersection";
+
 impl<W: Write> Writer<W> {
+    pub(super) fn write_rq_get_intersection_function(&mut self, module: &crate::Module, committed: bool) -> BackendResult {
+        let wrapped = WrappedFunction::RayQueryGetIntersection {
+            committed
+        };
+        if !self.wrapped_functions.insert(wrapped) {
+            return Ok(());
+        }
+        
+        let ty = if committed { "committed" } else { "candidate" };
+        let intersection = TypeContext {
+            handle: module.special_types.ray_intersection.expect("intersection ty should be there for intersection function"),
+            gctx: module.to_ctx(),
+            names: &self.names,
+            access: crate::StorageAccess::empty(),
+            first_time: false,
+        };
+        let level = back::Level(1);
+        writeln!(self.out, "{intersection} {INTERSECTION_FUNCTION_NAME}_{committed}({} intersector) {{", metal_intersector_ty())?;
+        writeln!(self.out, "{level}{intersection} intersection = {intersection} {{}};")?;
+        writeln!(self.out, "{level}intersection_type ty = intersector.get_{ty}_intersection_type();")?;
+        writeln!(self.out, "{level}if (ty == {RT_NAMESPACE}::intersection_type::triangle) {{")?;
+        writeln!(self.out, "{level}{level}intersection.kind = {};", crate::RayQueryIntersection::Triangle as u32)?;
+        if !committed {
+            writeln!(self.out, "{level}{level}intersection.t = intersector.get_candidate_triangle_distance();")?;
+        }
+        writeln!(self.out, "{level}{level}intersection.barycentrics = intersector.get_{ty}_triangle_barycentric_coord();")?;
+        writeln!(self.out, "{level}{level}intersection.front_face = intersector.is_{ty}_triangle_front_facing();")?;
+        writeln!(self.out, "{level}}} else if (ty == {RT_NAMESPACE}::intersection_type::bounding_box) {{")?;
+        if committed {
+            writeln!(self.out, "{level}{level}intersection.kind = {};", crate::RayQueryIntersection::Generated as u32)?;
+        }
+        writeln!(self.out, "{level}}}")?;
+
+        writeln!(self.out, "{level}if (ty != {RT_NAMESPACE}::intersection_type::none) {{")?;
+        if committed {
+            writeln!(self.out, "{level}{level}intersection.t = intersector.get_committed_distance();")?;
+        }
+        writeln!(self.out, "{level}{level}intersection.instance_custom_data = intersector.get_{ty}_user_instance_id();")?;
+        writeln!(self.out, "{level}{level}intersection.instance_index = intersector.get_{ty}_instance_id();")?;
+        writeln!(self.out, "{level}{level}intersection.sbt_record_offset = intersector.get_{ty}_user_instance_id();")?;
+        writeln!(self.out, "{level}{level}intersection.geometry_index = intersector.get_{ty}_geometry_id();")?;
+        writeln!(self.out, "{level}{level}intersection.primitive_index = intersector.get_{ty}_primitive_id();")?;
+        writeln!(self.out, "{level}{level}intersection.object_to_world = intersector.get_{ty}_user_instance_id();")?;
+        writeln!(self.out, "{level}{level}intersection.world_to_object = intersector.get_{ty}_user_instance_id();")?;
+        writeln!(self.out, "{level}}}")?;
+
+        Ok(())
+    }
+
     pub(super) fn write_ray_query_stmt(&mut self, level: back::Level, context: &StatementContext, query: Handle<crate::Expression>, fun: &crate::RayQueryFunction) -> BackendResult {
         if context.expression.lang_version < (2, 4) {
             return Err(Error::UnsupportedRayTracing);
@@ -28,7 +79,7 @@ impl<W: Write> Writer<W> {
                 let inner_level = level.next();
 
                 write!(self.out, "{inner_level}RayDesc desc = ")?;
-                self.put_expression(descriptor, &context.expression, false);
+                self.put_expression(descriptor, &context.expression, false)?;
                 writeln!(self.out, ";")?;
 
                 // Set up intersection parameters
@@ -71,7 +122,7 @@ impl<W: Write> Writer<W> {
                 write!(self.out, ".reset(ray,")?;
                 self.put_expression(acceleration_structure, &context.expression, true)?;
                 writeln!(self.out, ", desc.cull_mask, params);")?;
-                writeln!(self.out, "{level}}}");
+                writeln!(self.out, "{level}}}")?;
             }
             crate::RayQueryFunction::Proceed { result } => {
                 write!(self.out, "{level}")?;

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -55,8 +55,8 @@ impl<W: Write> Writer<W> {
         //writeln!(self.out, "{level}{level}intersection.sbt_record_offset = intersector.get_{ty}_user_instance_id();")?;
         writeln!(self.out, "{level}{level}intersection.geometry_index = intersector.get_{ty}_geometry_id();")?;
         writeln!(self.out, "{level}{level}intersection.primitive_index = intersector.get_{ty}_primitive_id();")?;
-        writeln!(self.out, "{level}{level}intersection.object_to_world = intersector.get_{ty}_user_instance_id();")?;
-        writeln!(self.out, "{level}{level}intersection.world_to_object = intersector.get_{ty}_user_instance_id();")?;
+        writeln!(self.out, "{level}{level}intersection.object_to_world = intersector.get_{ty}_object_to_world_transform();")?;
+        writeln!(self.out, "{level}{level}intersection.world_to_object = intersector.get_{ty}_world_to_object_transform();")?;
         writeln!(self.out, "{level}}}")?;
         writeln!(self.out, "{level}return intersection;")?;
         writeln!(self.out, "}}")?;
@@ -81,7 +81,7 @@ impl<W: Write> Writer<W> {
 
                 let inner_level = level.next();
 
-                write!(self.out, "{inner_level}{RT_NAMESPACE}::RayDesc desc = ")?;
+                write!(self.out, "{inner_level}RayDesc desc = ")?;
                 self.put_expression(descriptor, &context.expression, false)?;
                 writeln!(self.out, ";")?;
 

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -1,7 +1,20 @@
+use alloc::{
+    format,
+    string::{String, ToString},
+};
 use core::fmt::Write;
-use alloc::{string::{ToString, String}, format};
 
-use crate::{Handle, back::{self, Baked, msl::{BackendResult, Error, Writer, writer::{StatementContext, TypeContext, WrappedFunction}}}};
+use crate::{
+    back::{
+        self,
+        msl::{
+            writer::{StatementContext, TypeContext, WrappedFunction},
+            BackendResult, Error, Writer,
+        },
+        Baked,
+    },
+    Handle,
+};
 
 pub(super) const RT_NAMESPACE: &'static str = "metal::raytracing";
 
@@ -12,49 +25,96 @@ pub(super) fn metal_intersector_ty() -> String {
 pub(super) const INTERSECTION_FUNCTION_NAME: &'static str = "ray_query_get_intersection";
 
 impl<W: Write> Writer<W> {
-    pub(super) fn write_rq_get_intersection_function(&mut self, module: &crate::Module, committed: bool) -> BackendResult {
-        let wrapped = WrappedFunction::RayQueryGetIntersection {
-            committed
-        };
+    pub(super) fn write_rq_get_intersection_function(
+        &mut self,
+        module: &crate::Module,
+        committed: bool,
+    ) -> BackendResult {
+        let wrapped = WrappedFunction::RayQueryGetIntersection { committed };
         if !self.wrapped_functions.insert(wrapped) {
             return Ok(());
         }
-        
+
         let ty = if committed { "committed" } else { "candidate" };
         let intersection = TypeContext {
-            handle: module.special_types.ray_intersection.expect("intersection ty should be there for intersection function"),
+            handle: module
+                .special_types
+                .ray_intersection
+                .expect("intersection ty should be there for intersection function"),
             gctx: module.to_ctx(),
             names: &self.names,
             access: crate::StorageAccess::empty(),
             first_time: false,
         };
         let level = back::Level(1);
-        writeln!(self.out, "{intersection} {INTERSECTION_FUNCTION_NAME}_{committed}({} intersector) {{", metal_intersector_ty())?;
-        writeln!(self.out, "{level}{intersection} intersection = {intersection} {{}};")?;
+        writeln!(
+            self.out,
+            "{intersection} {INTERSECTION_FUNCTION_NAME}_{committed}({} intersector) {{",
+            metal_intersector_ty()
+        )?;
+        writeln!(
+            self.out,
+            "{level}{intersection} intersection = {intersection} {{}};"
+        )?;
         writeln!(self.out, "{level}{RT_NAMESPACE}::intersection_type ty = intersector.get_{ty}_intersection_type();")?;
-        writeln!(self.out, "{level}if (ty == {RT_NAMESPACE}::intersection_type::triangle) {{")?;
-        writeln!(self.out, "{level}{level}intersection.kind = {};", crate::RayQueryIntersection::Triangle as u32)?;
+        writeln!(
+            self.out,
+            "{level}if (ty == {RT_NAMESPACE}::intersection_type::triangle) {{"
+        )?;
+        writeln!(
+            self.out,
+            "{level}{level}intersection.kind = {};",
+            crate::RayQueryIntersection::Triangle as u32
+        )?;
         if !committed {
-            writeln!(self.out, "{level}{level}intersection.t = intersector.get_candidate_triangle_distance();")?;
+            writeln!(
+                self.out,
+                "{level}{level}intersection.t = intersector.get_candidate_triangle_distance();"
+            )?;
         }
         writeln!(self.out, "{level}{level}intersection.barycentrics = intersector.get_{ty}_triangle_barycentric_coord();")?;
-        writeln!(self.out, "{level}{level}intersection.front_face = intersector.is_{ty}_triangle_front_facing();")?;
-        writeln!(self.out, "{level}}} else if (ty == {RT_NAMESPACE}::intersection_type::bounding_box) {{")?;
+        writeln!(
+            self.out,
+            "{level}{level}intersection.front_face = intersector.is_{ty}_triangle_front_facing();"
+        )?;
+        writeln!(
+            self.out,
+            "{level}}} else if (ty == {RT_NAMESPACE}::intersection_type::bounding_box) {{"
+        )?;
         if committed {
-            writeln!(self.out, "{level}{level}intersection.kind = {};", crate::RayQueryIntersection::Generated as u32)?;
+            writeln!(
+                self.out,
+                "{level}{level}intersection.kind = {};",
+                crate::RayQueryIntersection::Generated as u32
+            )?;
         }
         writeln!(self.out, "{level}}}")?;
 
-        writeln!(self.out, "{level}if (ty != {RT_NAMESPACE}::intersection_type::none) {{")?;
+        writeln!(
+            self.out,
+            "{level}if (ty != {RT_NAMESPACE}::intersection_type::none) {{"
+        )?;
         if committed {
-            writeln!(self.out, "{level}{level}intersection.t = intersector.get_committed_distance();")?;
+            writeln!(
+                self.out,
+                "{level}{level}intersection.t = intersector.get_committed_distance();"
+            )?;
         }
         writeln!(self.out, "{level}{level}intersection.instance_custom_data = intersector.get_{ty}_user_instance_id();")?;
-        writeln!(self.out, "{level}{level}intersection.instance_index = intersector.get_{ty}_instance_id();")?;
+        writeln!(
+            self.out,
+            "{level}{level}intersection.instance_index = intersector.get_{ty}_instance_id();"
+        )?;
         // TODO
         //writeln!(self.out, "{level}{level}intersection.sbt_record_offset = intersector.get_{ty}_user_instance_id();")?;
-        writeln!(self.out, "{level}{level}intersection.geometry_index = intersector.get_{ty}_geometry_id();")?;
-        writeln!(self.out, "{level}{level}intersection.primitive_index = intersector.get_{ty}_primitive_id();")?;
+        writeln!(
+            self.out,
+            "{level}{level}intersection.geometry_index = intersector.get_{ty}_geometry_id();"
+        )?;
+        writeln!(
+            self.out,
+            "{level}{level}intersection.primitive_index = intersector.get_{ty}_primitive_id();"
+        )?;
         writeln!(self.out, "{level}{level}intersection.object_to_world = intersector.get_{ty}_object_to_world_transform();")?;
         writeln!(self.out, "{level}{level}intersection.world_to_object = intersector.get_{ty}_world_to_object_transform();")?;
         writeln!(self.out, "{level}}}")?;
@@ -64,7 +124,13 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    pub(super) fn write_ray_query_stmt(&mut self, level: back::Level, context: &StatementContext, query: Handle<crate::Expression>, fun: &crate::RayQueryFunction) -> BackendResult {
+    pub(super) fn write_ray_query_stmt(
+        &mut self,
+        level: back::Level,
+        context: &StatementContext,
+        query: Handle<crate::Expression>,
+        fun: &crate::RayQueryFunction,
+    ) -> BackendResult {
         if context.expression.lang_version < (2, 4) {
             return Err(Error::UnsupportedRayTracing);
         }
@@ -86,10 +152,13 @@ impl<W: Write> Writer<W> {
                 writeln!(self.out, ";")?;
 
                 // Set up intersection parameters
-                writeln!(self.out, "{inner_level}{RT_NAMESPACE}::intersection_params params;")?;
+                writeln!(
+                    self.out,
+                    "{inner_level}{RT_NAMESPACE}::intersection_params params;"
+                )?;
 
                 {
-                    // determine whether or not to cull 
+                    // determine whether or not to cull
                     let f_opaque = back::RayFlag::CULL_OPAQUE.bits();
                     let f_no_opaque = back::RayFlag::CULL_NO_OPAQUE.bits();
                     writeln!(
@@ -112,7 +181,10 @@ impl<W: Write> Writer<W> {
                 }
                 {
                     let flag = back::RayFlag::TERMINATE_ON_FIRST_HIT.bits();
-                    writeln!(self.out, "{inner_level}params.accept_any_intersection((desc.flags & {flag}) != 0);")?;
+                    writeln!(
+                        self.out,
+                        "{inner_level}params.accept_any_intersection((desc.flags & {flag}) != 0);"
+                    )?;
                 }
 
                 write!(

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -51,12 +51,15 @@ impl<W: Write> Writer<W> {
         }
         writeln!(self.out, "{level}{level}intersection.instance_custom_data = intersector.get_{ty}_user_instance_id();")?;
         writeln!(self.out, "{level}{level}intersection.instance_index = intersector.get_{ty}_instance_id();")?;
-        writeln!(self.out, "{level}{level}intersection.sbt_record_offset = intersector.get_{ty}_user_instance_id();")?;
+        // TODO
+        //writeln!(self.out, "{level}{level}intersection.sbt_record_offset = intersector.get_{ty}_user_instance_id();")?;
         writeln!(self.out, "{level}{level}intersection.geometry_index = intersector.get_{ty}_geometry_id();")?;
         writeln!(self.out, "{level}{level}intersection.primitive_index = intersector.get_{ty}_primitive_id();")?;
         writeln!(self.out, "{level}{level}intersection.object_to_world = intersector.get_{ty}_user_instance_id();")?;
         writeln!(self.out, "{level}{level}intersection.world_to_object = intersector.get_{ty}_user_instance_id();")?;
         writeln!(self.out, "{level}}}")?;
+        writeln!(self.out, "return intersection;")?;
+        writeln!(self.out, "}}")?;
 
         Ok(())
     }

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -41,7 +41,6 @@ use core::ptr;
 // Some more general handling of pointers is needed to be implemented here.
 const ATOMIC_REFERENCE: &str = "&";
 
-pub(super) const RT_NAMESPACE: &str = "metal::raytracing";
 pub(super) const RAY_QUERY_TYPE: &str = "_RayQuery";
 pub(super) const RAY_QUERY_FIELD_INTERSECTOR: &str = "intersector";
 pub(super) const RAY_QUERY_FIELD_INTERSECTION: &str = "intersection";

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -15,8 +15,7 @@ use half::f16;
 
 use super::{
     sampler as sm, Error, LocationMode, Options, PipelineOptions, TranslationInfo, NAMESPACE,
-    WRAPPED_ARRAY_FIELD,
-};
+    WRAPPED_ARRAY_FIELD, ray::RT_NAMESPACE};
 use crate::{
     arena::{Handle, HandleSet},
     back::{
@@ -4385,10 +4384,6 @@ impl<W: Write> Writer<W> {
             }
         }
 
-        if uses_ray_query {
-            self.put_ray_query_type()?;
-        }
-
         if options
             .bounds_check_policies
             .contains(index::BoundsCheckPolicy::ReadZeroSkipWrite)
@@ -4458,32 +4453,6 @@ impl<W: Write> Writer<W> {
         writeln!(self.out, "{tab}{tab}return T {{}};")?;
         writeln!(self.out, "{tab}}}")?;
         writeln!(self.out, "}};")?;
-        Ok(())
-    }
-
-    fn put_ray_query_type(&mut self) -> BackendResult {
-        let tab = back::INDENT;
-        writeln!(self.out, "struct {RAY_QUERY_TYPE} {{")?;
-        let full_type = format!("{RT_NAMESPACE}::intersector<{RT_NAMESPACE}::instancing, {RT_NAMESPACE}::triangle_data, {RT_NAMESPACE}::world_space_data>");
-        writeln!(self.out, "{tab}{full_type} {RAY_QUERY_FIELD_INTERSECTOR};")?;
-        writeln!(
-            self.out,
-            "{tab}{full_type}::result_type {RAY_QUERY_FIELD_INTERSECTION};"
-        )?;
-        writeln!(self.out, "{tab}bool {RAY_QUERY_FIELD_READY} = false;")?;
-        writeln!(self.out, "}};")?;
-        writeln!(self.out, "constexpr {NAMESPACE}::uint {RAY_QUERY_FUN_MAP_INTERSECTION}(const {RT_NAMESPACE}::intersection_type ty) {{")?;
-        let v_triangle = back::RayIntersectionType::Triangle as u32;
-        let v_bbox = back::RayIntersectionType::BoundingBox as u32;
-        writeln!(
-            self.out,
-            "{tab}return ty=={RT_NAMESPACE}::intersection_type::triangle ? {v_triangle} : "
-        )?;
-        writeln!(
-            self.out,
-            "{tab}{tab}ty=={RT_NAMESPACE}::intersection_type::bounding_box ? {v_bbox} : 0;"
-        )?;
-        writeln!(self.out, "}}")?;
         Ok(())
     }
 

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -41,13 +41,13 @@ use core::ptr;
 // Some more general handling of pointers is needed to be implemented here.
 const ATOMIC_REFERENCE: &str = "&";
 
-const RT_NAMESPACE: &str = "metal::raytracing";
-const RAY_QUERY_TYPE: &str = "_RayQuery";
-const RAY_QUERY_FIELD_INTERSECTOR: &str = "intersector";
-const RAY_QUERY_FIELD_INTERSECTION: &str = "intersection";
-const RAY_QUERY_MODERN_SUPPORT: bool = false; //TODO
-const RAY_QUERY_FIELD_READY: &str = "ready";
-const RAY_QUERY_FUN_MAP_INTERSECTION: &str = "_map_intersection_type";
+pub(super) const RT_NAMESPACE: &str = "metal::raytracing";
+pub(super) const RAY_QUERY_TYPE: &str = "_RayQuery";
+pub(super) const RAY_QUERY_FIELD_INTERSECTOR: &str = "intersector";
+pub(super) const RAY_QUERY_FIELD_INTERSECTION: &str = "intersection";
+pub(super) const RAY_QUERY_MODERN_SUPPORT: bool = false; //TODO
+pub(super) const RAY_QUERY_FIELD_READY: &str = "ready";
+pub(super) const RAY_QUERY_FUN_MAP_INTERSECTION: &str = "_map_intersection_type";
 
 pub(crate) const ATOMIC_COMP_EXCH_FUNCTION: &str = "naga_atomic_compare_exchange_weak_explicit";
 pub(crate) const MODF_FUNCTION: &str = "naga_modf";
@@ -782,21 +782,21 @@ struct TexelAddress {
 }
 
 pub(super) struct ExpressionContext<'a> {
-    function: &'a crate::Function,
+    pub(super) function: &'a crate::Function,
     origin: FunctionOrigin,
-    info: &'a valid::FunctionInfo,
-    module: &'a crate::Module,
-    mod_info: &'a valid::ModuleInfo,
-    pipeline_options: &'a PipelineOptions,
-    lang_version: (u8, u8),
-    policies: index::BoundsCheckPolicies,
+    pub(super) info: &'a valid::FunctionInfo,
+    pub(super) module: &'a crate::Module,
+    pub(super) mod_info: &'a valid::ModuleInfo,
+    pub(super) pipeline_options: &'a PipelineOptions,
+    pub(super) lang_version: (u8, u8),
+    pub(super) policies: index::BoundsCheckPolicies,
 
     /// The set of expressions used as indices in `ReadZeroSkipWrite`-policy
     /// accesses. These may need to be cached in temporary variables. See
     /// `index::find_checked_indexes` for details.
-    guarded_indices: HandleSet<crate::Expression>,
+    pub(super) guarded_indices: HandleSet<crate::Expression>,
     /// See [`Writer::gen_force_bounded_loop_statements`] for details.
-    force_loop_bounding: bool,
+    pub(super) force_loop_bounding: bool,
 }
 
 impl<'a> ExpressionContext<'a> {
@@ -874,9 +874,9 @@ impl<'a> ExpressionContext<'a> {
     }
 }
 
-struct StatementContext<'a> {
-    expression: ExpressionContext<'a>,
-    result_struct: Option<&'a str>,
+pub(super) struct StatementContext<'a> {
+    pub(super) expression: ExpressionContext<'a>,
+    pub(super) result_struct: Option<&'a str>,
 }
 
 impl<W: Write> Writer<W> {
@@ -3570,7 +3570,7 @@ impl<W: Write> Writer<W> {
         }
     }
 
-    fn start_baking_expression(
+    pub(super) fn start_baking_expression(
         &mut self,
         handle: Handle<crate::Expression>,
         context: &ExpressionContext,
@@ -4093,127 +4093,7 @@ impl<W: Write> Writer<W> {
                     self.write_barrier(crate::Barrier::WORK_GROUP, level)?;
                 }
                 crate::Statement::RayQuery { query, ref fun } => {
-                    if context.expression.lang_version < (2, 4) {
-                        return Err(Error::UnsupportedRayTracing);
-                    }
-
-                    match *fun {
-                        crate::RayQueryFunction::Initialize {
-                            acceleration_structure,
-                            descriptor,
-                        } => {
-                            //TODO: how to deal with winding?
-                            write!(self.out, "{level}")?;
-                            self.put_expression(query, &context.expression, true)?;
-                            writeln!(self.out, ".{RAY_QUERY_FIELD_INTERSECTOR}.assume_geometry_type({RT_NAMESPACE}::geometry_type::triangle);")?;
-                            {
-                                let f_opaque = back::RayFlag::CULL_OPAQUE.bits();
-                                let f_no_opaque = back::RayFlag::CULL_NO_OPAQUE.bits();
-                                write!(self.out, "{level}")?;
-                                self.put_expression(query, &context.expression, true)?;
-                                write!(
-                                    self.out,
-                                    ".{RAY_QUERY_FIELD_INTERSECTOR}.set_opacity_cull_mode(("
-                                )?;
-                                self.put_expression(descriptor, &context.expression, true)?;
-                                write!(self.out, ".flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::opaque : (")?;
-                                self.put_expression(descriptor, &context.expression, true)?;
-                                write!(self.out, ".flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::non_opaque : ")?;
-                                writeln!(self.out, "{RT_NAMESPACE}::opacity_cull_mode::none);")?;
-                            }
-                            {
-                                let f_opaque = back::RayFlag::OPAQUE.bits();
-                                let f_no_opaque = back::RayFlag::NO_OPAQUE.bits();
-                                write!(self.out, "{level}")?;
-                                self.put_expression(query, &context.expression, true)?;
-                                write!(self.out, ".{RAY_QUERY_FIELD_INTERSECTOR}.force_opacity((")?;
-                                self.put_expression(descriptor, &context.expression, true)?;
-                                write!(self.out, ".flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::opaque : (")?;
-                                self.put_expression(descriptor, &context.expression, true)?;
-                                write!(self.out, ".flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::non_opaque : ")?;
-                                writeln!(self.out, "{RT_NAMESPACE}::forced_opacity::none);")?;
-                            }
-                            {
-                                let flag = back::RayFlag::TERMINATE_ON_FIRST_HIT.bits();
-                                write!(self.out, "{level}")?;
-                                self.put_expression(query, &context.expression, true)?;
-                                write!(
-                                    self.out,
-                                    ".{RAY_QUERY_FIELD_INTERSECTOR}.accept_any_intersection(("
-                                )?;
-                                self.put_expression(descriptor, &context.expression, true)?;
-                                writeln!(self.out, ".flags & {flag}) != 0);")?;
-                            }
-
-                            write!(self.out, "{level}")?;
-                            self.put_expression(query, &context.expression, true)?;
-                            write!(self.out, ".{RAY_QUERY_FIELD_INTERSECTION} = ")?;
-                            self.put_expression(query, &context.expression, true)?;
-                            write!(
-                                self.out,
-                                ".{RAY_QUERY_FIELD_INTERSECTOR}.intersect({RT_NAMESPACE}::ray("
-                            )?;
-                            self.put_expression(descriptor, &context.expression, true)?;
-                            write!(self.out, ".origin, ")?;
-                            self.put_expression(descriptor, &context.expression, true)?;
-                            write!(self.out, ".dir, ")?;
-                            self.put_expression(descriptor, &context.expression, true)?;
-                            write!(self.out, ".tmin, ")?;
-                            self.put_expression(descriptor, &context.expression, true)?;
-                            write!(self.out, ".tmax), ")?;
-                            self.put_expression(acceleration_structure, &context.expression, true)?;
-                            write!(self.out, ", ")?;
-                            self.put_expression(descriptor, &context.expression, true)?;
-                            write!(self.out, ".cull_mask);")?;
-
-                            write!(self.out, "{level}")?;
-                            self.put_expression(query, &context.expression, true)?;
-                            writeln!(self.out, ".{RAY_QUERY_FIELD_READY} = true;")?;
-                        }
-                        crate::RayQueryFunction::Proceed { result } => {
-                            write!(self.out, "{level}")?;
-                            let name = Baked(result).to_string();
-                            self.start_baking_expression(result, &context.expression, &name)?;
-                            self.named_expressions.insert(result, name);
-                            self.put_expression(query, &context.expression, true)?;
-                            writeln!(self.out, ".{RAY_QUERY_FIELD_READY};")?;
-                            if RAY_QUERY_MODERN_SUPPORT {
-                                write!(self.out, "{level}")?;
-                                self.put_expression(query, &context.expression, true)?;
-                                writeln!(self.out, ".?.next();")?;
-                            }
-                        }
-                        crate::RayQueryFunction::GenerateIntersection { hit_t } => {
-                            if RAY_QUERY_MODERN_SUPPORT {
-                                write!(self.out, "{level}")?;
-                                self.put_expression(query, &context.expression, true)?;
-                                write!(self.out, ".?.commit_bounding_box_intersection(")?;
-                                self.put_expression(hit_t, &context.expression, true)?;
-                                writeln!(self.out, ");")?;
-                            } else {
-                                log::warn!("Ray Query GenerateIntersection is not yet supported");
-                            }
-                        }
-                        crate::RayQueryFunction::ConfirmIntersection => {
-                            if RAY_QUERY_MODERN_SUPPORT {
-                                write!(self.out, "{level}")?;
-                                self.put_expression(query, &context.expression, true)?;
-                                writeln!(self.out, ".?.commit_triangle_intersection();")?;
-                            } else {
-                                log::warn!("Ray Query ConfirmIntersection is not yet supported");
-                            }
-                        }
-                        crate::RayQueryFunction::Terminate => {
-                            if RAY_QUERY_MODERN_SUPPORT {
-                                write!(self.out, "{level}")?;
-                                self.put_expression(query, &context.expression, true)?;
-                                writeln!(self.out, ".?.abort();")?;
-                            }
-                            write!(self.out, "{level}")?;
-                            self.put_expression(query, &context.expression, true)?;
-                            writeln!(self.out, ".{RAY_QUERY_FIELD_READY} = false;")?;
-                        }
-                    }
+                    self.write_ray_query_stmt(level, context, query, fun)?;
                 }
                 crate::Statement::SubgroupBallot { result, predicate } => {
                     write!(self.out, "{level}")?;

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -40,10 +40,6 @@ use core::ptr;
 // Some more general handling of pointers is needed to be implemented here.
 const ATOMIC_REFERENCE: &str = "&";
 
-pub(super) const RAY_QUERY_TYPE: &str = "_RayQuery";
-pub(super) const RAY_QUERY_FIELD_INTERSECTION: &str = "intersection";
-pub(super) const RAY_QUERY_FUN_MAP_INTERSECTION: &str = "_map_intersection_type";
-
 pub(crate) const ATOMIC_COMP_EXCH_FUNCTION: &str = "naga_atomic_compare_exchange_weak_explicit";
 pub(crate) const MODF_FUNCTION: &str = "naga_modf";
 pub(crate) const FREXP_FUNCTION: &str = "naga_frexp";
@@ -373,7 +369,7 @@ impl Display for TypeContext<'_> {
                 if vertex_return {
                     unimplemented!("metal does not support vertex ray hit return")
                 }
-                write!(out, "{RAY_QUERY_TYPE}")
+                write!(out, "{}", super::ray::metal_intersector_ty())
             }
             crate::TypeInner::BindingArray { base, .. } => {
                 let base_tyname = Self {
@@ -522,6 +518,9 @@ pub(super) enum WrappedFunction {
         intermediate: crate::CooperativeSize,
         scalar: crate::Scalar,
     },
+    RayQueryGetIntersection {
+        committed: bool,
+    }
 }
 
 pub struct Writer<W> {
@@ -2897,40 +2896,15 @@ impl<W: Write> Writer<W> {
             }
             crate::Expression::RayQueryGetIntersection {
                 query,
-                committed: _,
+                committed,
             } => {
                 if context.lang_version < (2, 4) {
                     return Err(Error::UnsupportedRayTracing);
                 }
 
-                let ty = context.module.special_types.ray_intersection.unwrap();
-                let type_name = &self.names[&NameKey::Type(ty)];
-                write!(self.out, "{type_name} {{{RAY_QUERY_FUN_MAP_INTERSECTION}(")?;
+                write!(self.out, "{}_{committed}(", super::ray::INTERSECTION_FUNCTION_NAME)?;
                 self.put_expression(query, context, true)?;
-                write!(self.out, ".{RAY_QUERY_FIELD_INTERSECTION}.type)")?;
-                let fields = [
-                    "distance",
-                    "user_instance_id", // req Metal 2.4
-                    "instance_id",
-                    "", // SBT offset
-                    "geometry_id",
-                    "primitive_id",
-                    "triangle_barycentric_coord",
-                    "triangle_front_facing",
-                    "",                          // padding
-                    "object_to_world_transform", // req Metal 2.4
-                    "world_to_object_transform", // req Metal 2.4
-                ];
-                for field in fields {
-                    write!(self.out, ", ")?;
-                    if field.is_empty() {
-                        write!(self.out, "{{}}")?;
-                    } else {
-                        self.put_expression(query, context, true)?;
-                        write!(self.out, ".{RAY_QUERY_FIELD_INTERSECTION}.{field}")?;
-                    }
-                }
-                write!(self.out, "}}")?;
+                write!(self.out, ")")?;
             }
             crate::Expression::CooperativeLoad { ref data, .. } => {
                 if context.lang_version < (2, 3) {
@@ -6514,6 +6488,9 @@ template <typename A>
                 crate::Expression::CooperativeMultiplyAdd { a, b, c: _ } => {
                     let space = crate::AddressSpace::Private;
                     self.write_wrapped_cooperative_multiply_add(module, func_ctx, space, a, b)?;
+                }
+                crate::Expression::RayQueryGetIntersection { committed, .. } => {
+                    self.write_rq_get_intersection_function(module, committed)?;
                 }
                 _ => {}
             }

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -41,10 +41,7 @@ use core::ptr;
 const ATOMIC_REFERENCE: &str = "&";
 
 pub(super) const RAY_QUERY_TYPE: &str = "_RayQuery";
-pub(super) const RAY_QUERY_FIELD_INTERSECTOR: &str = "intersector";
 pub(super) const RAY_QUERY_FIELD_INTERSECTION: &str = "intersection";
-pub(super) const RAY_QUERY_MODERN_SUPPORT: bool = false; //TODO
-pub(super) const RAY_QUERY_FIELD_READY: &str = "ready";
 pub(super) const RAY_QUERY_FUN_MAP_INTERSECTION: &str = "_map_intersection_type";
 
 pub(crate) const ATOMIC_COMP_EXCH_FUNCTION: &str = "naga_atomic_compare_exchange_weak_explicit";
@@ -4357,24 +4354,6 @@ impl<W: Write> Writer<W> {
             .entry_points
             .iter()
             .any(|e| e.stage == crate::ShaderStage::Task && e.task_payload.is_some());
-
-        let mut uses_ray_query = false;
-        for (_, ty) in module.types.iter() {
-            match ty.inner {
-                crate::TypeInner::AccelerationStructure { .. } => {
-                    if options.lang_version < (2, 4) {
-                        return Err(Error::UnsupportedRayTracing);
-                    }
-                }
-                crate::TypeInner::RayQuery { .. } => {
-                    if options.lang_version < (2, 4) {
-                        return Err(Error::UnsupportedRayTracing);
-                    }
-                    uses_ray_query = true;
-                }
-                _ => (),
-            }
-        }
 
         if module.special_types.ray_desc.is_some()
             || module.special_types.ray_intersection.is_some()

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -4306,7 +4306,10 @@ impl<W: Write> Writer<W> {
             &super::keywords::RESERVED_SET,
             proc::KeywordSet::empty(),
             proc::CaseInsensitiveKeywordSet::empty(),
-            &[CLAMPED_LOD_LOAD_PREFIX],
+            &[
+                CLAMPED_LOD_LOAD_PREFIX,
+                super::ray::INTERSECTION_FUNCTION_NAME,
+            ],
             &mut self.names,
         );
         self.wrapped_functions.clear();

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -14,8 +14,9 @@ use num_traits::real::Real as _;
 use half::f16;
 
 use super::{
-    sampler as sm, Error, LocationMode, Options, PipelineOptions, TranslationInfo, NAMESPACE,
-    WRAPPED_ARRAY_FIELD, ray::RT_NAMESPACE};
+    ray::RT_NAMESPACE, sampler as sm, Error, LocationMode, Options, PipelineOptions,
+    TranslationInfo, NAMESPACE, WRAPPED_ARRAY_FIELD,
+};
 use crate::{
     arena::{Handle, HandleSet},
     back::{
@@ -520,7 +521,7 @@ pub(super) enum WrappedFunction {
     },
     RayQueryGetIntersection {
         committed: bool,
-    }
+    },
 }
 
 pub struct Writer<W> {
@@ -2894,15 +2895,16 @@ impl<W: Write> Writer<W> {
             crate::Expression::RayQueryVertexPositions { .. } => {
                 unimplemented!()
             }
-            crate::Expression::RayQueryGetIntersection {
-                query,
-                committed,
-            } => {
+            crate::Expression::RayQueryGetIntersection { query, committed } => {
                 if context.lang_version < (2, 4) {
                     return Err(Error::UnsupportedRayTracing);
                 }
 
-                write!(self.out, "{}_{committed}(", super::ray::INTERSECTION_FUNCTION_NAME)?;
+                write!(
+                    self.out,
+                    "{}_{committed}(",
+                    super::ray::INTERSECTION_FUNCTION_NAME
+                )?;
                 self.put_expression(query, context, true)?;
                 write!(self.out, ")")?;
             }

--- a/naga/tests/out/msl/wgsl-aliased-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-aliased-ray-query.metal
@@ -56,18 +56,18 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
         RayDesc desc = _e12;
-        intersection_params params;
-        intersection_params.set_opacity_cull_mode(
+        metal::raytracing::intersection_params params;
+        params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
                 (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
             )
         );
-        intersection_params.force_opacity(
+        params.force_opacity(
             (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
                 (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
             )
         );
-        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        params.accept_any_intersection((desc.flags & 4) != 0);
         metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq_1.reset(ray,acc_struct, desc.cull_mask, params);
     }
     RayIntersection intersection = ray_query_get_intersection_false(rq_1);

--- a/naga/tests/out/msl/wgsl-aliased-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-aliased-ray-query.metal
@@ -28,7 +28,7 @@ struct RayIntersection {
 };
 RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
     RayIntersection intersection = RayIntersection {};
-    intersection_type ty = intersector.get_candidate_intersection_type();
+    metal::raytracing::intersection_type ty = intersector.get_candidate_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
         intersection.kind = 1;
         intersection.t = intersector.get_candidate_triangle_distance();
@@ -39,12 +39,13 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
     if (ty != metal::raytracing::intersection_type::none) {
         intersection.instance_custom_data = intersector.get_candidate_user_instance_id();
         intersection.instance_index = intersector.get_candidate_instance_id();
-        intersection.sbt_record_offset = intersector.get_candidate_user_instance_id();
         intersection.geometry_index = intersector.get_candidate_geometry_id();
         intersection.primitive_index = intersector.get_candidate_primitive_id();
         intersection.object_to_world = intersector.get_candidate_user_instance_id();
         intersection.world_to_object = intersector.get_candidate_user_instance_id();
     }
+return intersection;
+}
 
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]

--- a/naga/tests/out/msl/wgsl-aliased-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-aliased-ray-query.metal
@@ -3,15 +3,6 @@
 #include <simd/simd.h>
 
 using metal::uint;
-struct _RayQuery {
-    metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector;
-    metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data>::result_type intersection;
-    bool ready = false;
-};
-constexpr metal::uint _map_intersection_type(const metal::raytracing::intersection_type ty) {
-    return ty==metal::raytracing::intersection_type::triangle ? 1 : 
-        ty==metal::raytracing::intersection_type::bounding_box ? 4 : 0;
-}
 
 struct RayDesc {
     uint flags;
@@ -35,27 +26,59 @@ struct RayIntersection {
     metal::float4x3 object_to_world;
     metal::float4x3 world_to_object;
 };
+RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
+    RayIntersection intersection = RayIntersection {};
+    intersection_type ty = intersector.get_candidate_intersection_type();
+    if (ty == metal::raytracing::intersection_type::triangle) {
+        intersection.kind = 1;
+        intersection.t = intersector.get_candidate_triangle_distance();
+        intersection.barycentrics = intersector.get_candidate_triangle_barycentric_coord();
+        intersection.front_face = intersector.is_candidate_triangle_front_facing();
+    } else if (ty == metal::raytracing::intersection_type::bounding_box) {
+    }
+    if (ty != metal::raytracing::intersection_type::none) {
+        intersection.instance_custom_data = intersector.get_candidate_user_instance_id();
+        intersection.instance_index = intersector.get_candidate_instance_id();
+        intersection.sbt_record_offset = intersector.get_candidate_user_instance_id();
+        intersection.geometry_index = intersector.get_candidate_geometry_id();
+        intersection.primitive_index = intersector.get_candidate_primitive_id();
+        intersection.object_to_world = intersector.get_candidate_user_instance_id();
+        intersection.world_to_object = intersector.get_candidate_user_instance_id();
+    }
 
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    _RayQuery rq_1 = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq_1 = {};
     metal::float3 pos = metal::float3(0.0);
     metal::float3 dir = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
-    rq_1.intersector.assume_geometry_type(metal::raytracing::geometry_type::triangle);
-    rq_1.intersector.set_opacity_cull_mode((_e12.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (_e12.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none);
-    rq_1.intersector.force_opacity((_e12.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (_e12.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
-    rq_1.intersector.accept_any_intersection((_e12.flags & 4) != 0);
-    rq_1.intersection = rq_1.intersector.intersect(metal::raytracing::ray(_e12.origin, _e12.dir, _e12.tmin, _e12.tmax), acc_struct, _e12.cull_mask);    rq_1.ready = true;
-    RayIntersection intersection = RayIntersection {_map_intersection_type(rq_1.intersection.type), rq_1.intersection.distance, rq_1.intersection.user_instance_id, rq_1.intersection.instance_id, {}, rq_1.intersection.geometry_id, rq_1.intersection.primitive_id, rq_1.intersection.triangle_barycentric_coord, rq_1.intersection.triangle_front_facing, {}, rq_1.intersection.object_to_world_transform, rq_1.intersection.world_to_object_transform};
+    {
+        RayDesc desc = _e12;
+        intersection_params params;
+        intersection_params.set_opacity_cull_mode(
+            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+            )
+        );
+        intersection_params.force_opacity(
+            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+            )
+        );
+        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq_1.reset(ray,acc_struct, desc.cull_mask, params);
+    }
+    RayIntersection intersection = ray_query_get_intersection_false(rq_1);
     if (intersection.kind == 3u) {
+        rq_1.commit_bounding_box_intersection(10.0);
         return;
     } else {
         if (intersection.kind == 1u) {
+            rq_1.commit_triangle_intersection();
             return;
         } else {
-            rq_1.ready = false;
+            rq_1.abort();
             return;
         }
     }

--- a/naga/tests/out/msl/wgsl-aliased-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-aliased-ray-query.metal
@@ -69,7 +69,8 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
             )
         );
         params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq_1.reset(ray,acc_struct, desc.cull_mask, params);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
+        rq_1.reset(ray,acc_struct, desc.cull_mask, params);
     }
     RayIntersection intersection = ray_query_get_intersection_false(rq_1);
     if (intersection.kind == 3u) {

--- a/naga/tests/out/msl/wgsl-aliased-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-aliased-ray-query.metal
@@ -26,7 +26,7 @@ struct RayIntersection {
     metal::float4x3 object_to_world;
     metal::float4x3 world_to_object;
 };
-RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
+RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> intersector) {
     RayIntersection intersection = RayIntersection {};
     metal::raytracing::intersection_type ty = intersector.get_candidate_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
@@ -44,18 +44,18 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
         intersection.object_to_world = intersector.get_candidate_user_instance_id();
         intersection.world_to_object = intersector.get_candidate_user_instance_id();
     }
-return intersection;
+    return intersection;
 }
 
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq_1 = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq_1 = {};
     metal::float3 pos = metal::float3(0.0);
     metal::float3 dir = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
-        RayDesc desc = _e12;
+        metal::raytracing::RayDesc desc = _e12;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (

--- a/naga/tests/out/msl/wgsl-aliased-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-aliased-ray-query.metal
@@ -35,6 +35,7 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
         intersection.barycentrics = intersector.get_candidate_triangle_barycentric_coord();
         intersection.front_face = intersector.is_candidate_triangle_front_facing();
     } else if (ty == metal::raytracing::intersection_type::bounding_box) {
+        intersection.kind = 3;
     }
     if (ty != metal::raytracing::intersection_type::none) {
         intersection.instance_custom_data = intersector.get_candidate_user_instance_id();

--- a/naga/tests/out/msl/wgsl-aliased-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-aliased-ray-query.metal
@@ -41,8 +41,8 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
         intersection.instance_index = intersector.get_candidate_instance_id();
         intersection.geometry_index = intersector.get_candidate_geometry_id();
         intersection.primitive_index = intersector.get_candidate_primitive_id();
-        intersection.object_to_world = intersector.get_candidate_user_instance_id();
-        intersection.world_to_object = intersector.get_candidate_user_instance_id();
+        intersection.object_to_world = intersector.get_candidate_object_to_world_transform();
+        intersection.world_to_object = intersector.get_candidate_world_to_object_transform();
     }
     return intersection;
 }
@@ -55,7 +55,7 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
     metal::float3 dir = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
-        metal::raytracing::RayDesc desc = _e12;
+        RayDesc desc = _e12;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (

--- a/naga/tests/out/msl/wgsl-overrides-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-overrides-ray-query.metal
@@ -33,7 +33,8 @@ constant float o = 2.0;
             )
         );
         params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq.reset(ray,acc_struct, desc.cull_mask, params);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
+        rq.reset(ray,acc_struct, desc.cull_mask, params);
     }
     uint2 loop_bound = uint2(4294967295u);
     while(true) {

--- a/naga/tests/out/msl/wgsl-overrides-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-overrides-ray-query.metal
@@ -3,15 +3,6 @@
 #include <simd/simd.h>
 
 using metal::uint;
-struct _RayQuery {
-    metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector;
-    metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data>::result_type intersection;
-    bool ready = false;
-};
-constexpr metal::uint _map_intersection_type(const metal::raytracing::intersection_type ty) {
-    return ty==metal::raytracing::intersection_type::triangle ? 1 : 
-        ty==metal::raytracing::intersection_type::bounding_box ? 4 : 0;
-}
 
 struct RayDesc {
     uint flags;
@@ -26,18 +17,29 @@ constant float o = 2.0;
 [[max_total_threads_per_threadgroup(1)]] kernel void main_(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    _RayQuery rq = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq = {};
     RayDesc desc = RayDesc {4u, 255u, 34.0, 38.0, metal::float3(46.0), metal::float3(58.0, 62.0, 74.0)};
-    rq.intersector.assume_geometry_type(metal::raytracing::geometry_type::triangle);
-    rq.intersector.set_opacity_cull_mode((desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none);
-    rq.intersector.force_opacity((desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
-    rq.intersector.accept_any_intersection((desc.flags & 4) != 0);
-    rq.intersection = rq.intersector.intersect(metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax), acc_struct, desc.cull_mask);    rq.ready = true;
+    {
+        RayDesc desc = desc;
+        intersection_params params;
+        intersection_params.set_opacity_cull_mode(
+            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+            )
+        );
+        intersection_params.force_opacity(
+            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+            )
+        );
+        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq.reset(ray,acc_struct, desc.cull_mask, params);
+    }
     uint2 loop_bound = uint2(4294967295u);
     while(true) {
         if (metal::all(loop_bound == uint2(0u))) { break; }
         loop_bound -= uint2(loop_bound.y == 0u, 1u);
-        bool _e31 = rq.ready;
+        bool _e31 = rq.next();
         if (_e31) {
         } else {
             break;

--- a/naga/tests/out/msl/wgsl-overrides-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-overrides-ray-query.metal
@@ -21,18 +21,18 @@ constant float o = 2.0;
     RayDesc desc = RayDesc {4u, 255u, 34.0, 38.0, metal::float3(46.0), metal::float3(58.0, 62.0, 74.0)};
     {
         RayDesc desc = desc;
-        intersection_params params;
-        intersection_params.set_opacity_cull_mode(
+        metal::raytracing::intersection_params params;
+        params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
                 (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
             )
         );
-        intersection_params.force_opacity(
+        params.force_opacity(
             (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
                 (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
             )
         );
-        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        params.accept_any_intersection((desc.flags & 4) != 0);
         metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq.reset(ray,acc_struct, desc.cull_mask, params);
     }
     uint2 loop_bound = uint2(4294967295u);

--- a/naga/tests/out/msl/wgsl-overrides-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-overrides-ray-query.metal
@@ -17,10 +17,10 @@ constant float o = 2.0;
 [[max_total_threads_per_threadgroup(1)]] kernel void main_(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq = {};
     RayDesc desc = RayDesc {4u, 255u, 34.0, 38.0, metal::float3(46.0), metal::float3(58.0, 62.0, 74.0)};
     {
-        RayDesc desc = desc;
+        metal::raytracing::RayDesc desc = desc;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (

--- a/naga/tests/out/msl/wgsl-overrides-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-overrides-ray-query.metal
@@ -20,7 +20,7 @@ constant float o = 2.0;
     metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq = {};
     RayDesc desc = RayDesc {4u, 255u, 34.0, 38.0, metal::float3(46.0), metal::float3(58.0, 62.0, 74.0)};
     {
-        metal::raytracing::RayDesc desc = desc;
+        RayDesc desc = desc;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (

--- a/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
+++ b/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
@@ -74,7 +74,8 @@ RayIntersection query_loop(
             )
         );
         params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq_1.reset(ray,acs, desc.cull_mask, params);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
+        rq_1.reset(ray,acs, desc.cull_mask, params);
     }
     uint2 loop_bound = uint2(4294967295u);
     while(true) {
@@ -155,7 +156,8 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
             )
         );
         params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq.reset(ray,acc_struct, desc.cull_mask, params);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
+        rq.reset(ray,acc_struct, desc.cull_mask, params);
     }
     RayIntersection intersection_1 = ray_query_get_intersection_false(rq);
     if (intersection_1.kind == 3u) {

--- a/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
+++ b/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
@@ -121,6 +121,7 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
         intersection.barycentrics = intersector.get_candidate_triangle_barycentric_coord();
         intersection.front_face = intersector.is_candidate_triangle_front_facing();
     } else if (ty == metal::raytracing::intersection_type::bounding_box) {
+        intersection.kind = 3;
     }
     if (ty != metal::raytracing::intersection_type::none) {
         intersection.instance_custom_data = intersector.get_candidate_user_instance_id();

--- a/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
+++ b/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
@@ -62,18 +62,18 @@ RayIntersection query_loop(
     RayDesc _e8 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
         RayDesc desc = _e8;
-        intersection_params params;
-        intersection_params.set_opacity_cull_mode(
+        metal::raytracing::intersection_params params;
+        params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
                 (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
             )
         );
-        intersection_params.force_opacity(
+        params.force_opacity(
             (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
                 (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
             )
         );
-        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        params.accept_any_intersection((desc.flags & 4) != 0);
         metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq_1.reset(ray,acs, desc.cull_mask, params);
     }
     uint2 loop_bound = uint2(4294967295u);
@@ -142,18 +142,18 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos_2, dir_2};
     {
         RayDesc desc = _e12;
-        intersection_params params;
-        intersection_params.set_opacity_cull_mode(
+        metal::raytracing::intersection_params params;
+        params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
                 (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
             )
         );
-        intersection_params.force_opacity(
+        params.force_opacity(
             (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
                 (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
             )
         );
-        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        params.accept_any_intersection((desc.flags & 4) != 0);
         metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq.reset(ray,acc_struct, desc.cull_mask, params);
     }
     RayIntersection intersection_1 = ray_query_get_intersection_false(rq);

--- a/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
+++ b/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
@@ -32,7 +32,7 @@ struct Output {
     metal::float3 normal;
 };
 
-RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
+RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> intersector) {
     RayIntersection intersection = RayIntersection {};
     metal::raytracing::intersection_type ty = intersector.get_committed_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
@@ -51,17 +51,17 @@ RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_
         intersection.object_to_world = intersector.get_committed_user_instance_id();
         intersection.world_to_object = intersector.get_committed_user_instance_id();
     }
-return intersection;
+    return intersection;
 }
 RayIntersection query_loop(
     metal::float3 pos,
     metal::float3 dir,
     metal::raytracing::instance_acceleration_structure acs
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq_1 = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq_1 = {};
     RayDesc _e8 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
-        RayDesc desc = _e8;
+        metal::raytracing::RayDesc desc = _e8;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
@@ -112,7 +112,7 @@ metal::float3 get_torus_normal(
     return;
 }
 
-RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
+RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> intersector) {
     RayIntersection intersection = RayIntersection {};
     metal::raytracing::intersection_type ty = intersector.get_candidate_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
@@ -130,18 +130,18 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
         intersection.object_to_world = intersector.get_candidate_user_instance_id();
         intersection.world_to_object = intersector.get_candidate_user_instance_id();
     }
-return intersection;
+    return intersection;
 }
 
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq = {};
     metal::float3 pos_2 = metal::float3(0.0);
     metal::float3 dir_2 = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos_2, dir_2};
     {
-        RayDesc desc = _e12;
+        metal::raytracing::RayDesc desc = _e12;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (

--- a/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
+++ b/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
@@ -48,8 +48,8 @@ RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_
         intersection.instance_index = intersector.get_committed_instance_id();
         intersection.geometry_index = intersector.get_committed_geometry_id();
         intersection.primitive_index = intersector.get_committed_primitive_id();
-        intersection.object_to_world = intersector.get_committed_user_instance_id();
-        intersection.world_to_object = intersector.get_committed_user_instance_id();
+        intersection.object_to_world = intersector.get_committed_object_to_world_transform();
+        intersection.world_to_object = intersector.get_committed_world_to_object_transform();
     }
     return intersection;
 }
@@ -61,7 +61,7 @@ RayIntersection query_loop(
     metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq_1 = {};
     RayDesc _e8 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
-        metal::raytracing::RayDesc desc = _e8;
+        RayDesc desc = _e8;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
@@ -127,8 +127,8 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
         intersection.instance_index = intersector.get_candidate_instance_id();
         intersection.geometry_index = intersector.get_candidate_geometry_id();
         intersection.primitive_index = intersector.get_candidate_primitive_id();
-        intersection.object_to_world = intersector.get_candidate_user_instance_id();
-        intersection.world_to_object = intersector.get_candidate_user_instance_id();
+        intersection.object_to_world = intersector.get_candidate_object_to_world_transform();
+        intersection.world_to_object = intersector.get_candidate_world_to_object_transform();
     }
     return intersection;
 }
@@ -141,7 +141,7 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
     metal::float3 dir_2 = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos_2, dir_2};
     {
-        metal::raytracing::RayDesc desc = _e12;
+        RayDesc desc = _e12;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (

--- a/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
+++ b/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
@@ -34,7 +34,7 @@ struct Output {
 
 RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
     RayIntersection intersection = RayIntersection {};
-    intersection_type ty = intersector.get_committed_intersection_type();
+    metal::raytracing::intersection_type ty = intersector.get_committed_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
         intersection.kind = 1;
         intersection.barycentrics = intersector.get_committed_triangle_barycentric_coord();
@@ -46,12 +46,13 @@ RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_
         intersection.t = intersector.get_committed_distance();
         intersection.instance_custom_data = intersector.get_committed_user_instance_id();
         intersection.instance_index = intersector.get_committed_instance_id();
-        intersection.sbt_record_offset = intersector.get_committed_user_instance_id();
         intersection.geometry_index = intersector.get_committed_geometry_id();
         intersection.primitive_index = intersector.get_committed_primitive_id();
         intersection.object_to_world = intersector.get_committed_user_instance_id();
         intersection.world_to_object = intersector.get_committed_user_instance_id();
     }
+return intersection;
+}
 RayIntersection query_loop(
     metal::float3 pos,
     metal::float3 dir,
@@ -113,7 +114,7 @@ metal::float3 get_torus_normal(
 
 RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
     RayIntersection intersection = RayIntersection {};
-    intersection_type ty = intersector.get_candidate_intersection_type();
+    metal::raytracing::intersection_type ty = intersector.get_candidate_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
         intersection.kind = 1;
         intersection.t = intersector.get_candidate_triangle_distance();
@@ -124,12 +125,13 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
     if (ty != metal::raytracing::intersection_type::none) {
         intersection.instance_custom_data = intersector.get_candidate_user_instance_id();
         intersection.instance_index = intersector.get_candidate_instance_id();
-        intersection.sbt_record_offset = intersector.get_candidate_user_instance_id();
         intersection.geometry_index = intersector.get_candidate_geometry_id();
         intersection.primitive_index = intersector.get_candidate_primitive_id();
         intersection.object_to_world = intersector.get_candidate_user_instance_id();
         intersection.world_to_object = intersector.get_candidate_user_instance_id();
     }
+return intersection;
+}
 
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]

--- a/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
+++ b/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
@@ -3,15 +3,6 @@
 #include <simd/simd.h>
 
 using metal::uint;
-struct _RayQuery {
-    metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector;
-    metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data>::result_type intersection;
-    bool ready = false;
-};
-constexpr metal::uint _map_intersection_type(const metal::raytracing::intersection_type ty) {
-    return ty==metal::raytracing::intersection_type::triangle ? 1 : 
-        ty==metal::raytracing::intersection_type::bounding_box ? 4 : 0;
-}
 
 struct RayIntersection {
     uint kind;
@@ -41,29 +32,60 @@ struct Output {
     metal::float3 normal;
 };
 
+RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
+    RayIntersection intersection = RayIntersection {};
+    intersection_type ty = intersector.get_committed_intersection_type();
+    if (ty == metal::raytracing::intersection_type::triangle) {
+        intersection.kind = 1;
+        intersection.barycentrics = intersector.get_committed_triangle_barycentric_coord();
+        intersection.front_face = intersector.is_committed_triangle_front_facing();
+    } else if (ty == metal::raytracing::intersection_type::bounding_box) {
+        intersection.kind = 2;
+    }
+    if (ty != metal::raytracing::intersection_type::none) {
+        intersection.t = intersector.get_committed_distance();
+        intersection.instance_custom_data = intersector.get_committed_user_instance_id();
+        intersection.instance_index = intersector.get_committed_instance_id();
+        intersection.sbt_record_offset = intersector.get_committed_user_instance_id();
+        intersection.geometry_index = intersector.get_committed_geometry_id();
+        intersection.primitive_index = intersector.get_committed_primitive_id();
+        intersection.object_to_world = intersector.get_committed_user_instance_id();
+        intersection.world_to_object = intersector.get_committed_user_instance_id();
+    }
 RayIntersection query_loop(
     metal::float3 pos,
     metal::float3 dir,
     metal::raytracing::instance_acceleration_structure acs
 ) {
-    _RayQuery rq_1 = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq_1 = {};
     RayDesc _e8 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
-    rq_1.intersector.assume_geometry_type(metal::raytracing::geometry_type::triangle);
-    rq_1.intersector.set_opacity_cull_mode((_e8.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (_e8.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none);
-    rq_1.intersector.force_opacity((_e8.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (_e8.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
-    rq_1.intersector.accept_any_intersection((_e8.flags & 4) != 0);
-    rq_1.intersection = rq_1.intersector.intersect(metal::raytracing::ray(_e8.origin, _e8.dir, _e8.tmin, _e8.tmax), acs, _e8.cull_mask);    rq_1.ready = true;
+    {
+        RayDesc desc = _e8;
+        intersection_params params;
+        intersection_params.set_opacity_cull_mode(
+            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+            )
+        );
+        intersection_params.force_opacity(
+            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+            )
+        );
+        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq_1.reset(ray,acs, desc.cull_mask, params);
+    }
     uint2 loop_bound = uint2(4294967295u);
     while(true) {
         if (metal::all(loop_bound == uint2(0u))) { break; }
         loop_bound -= uint2(loop_bound.y == 0u, 1u);
-        bool _e9 = rq_1.ready;
+        bool _e9 = rq_1.next();
         if (_e9) {
         } else {
             break;
         }
     }
-    return RayIntersection {_map_intersection_type(rq_1.intersection.type), rq_1.intersection.distance, rq_1.intersection.user_instance_id, rq_1.intersection.instance_id, {}, rq_1.intersection.geometry_id, rq_1.intersection.primitive_id, rq_1.intersection.triangle_barycentric_coord, rq_1.intersection.triangle_front_facing, {}, rq_1.intersection.object_to_world_transform, rq_1.intersection.world_to_object_transform};
+    return ray_query_get_intersection_true(rq_1);
 }
 
 metal::float3 get_torus_normal(
@@ -89,27 +111,59 @@ metal::float3 get_torus_normal(
     return;
 }
 
+RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
+    RayIntersection intersection = RayIntersection {};
+    intersection_type ty = intersector.get_candidate_intersection_type();
+    if (ty == metal::raytracing::intersection_type::triangle) {
+        intersection.kind = 1;
+        intersection.t = intersector.get_candidate_triangle_distance();
+        intersection.barycentrics = intersector.get_candidate_triangle_barycentric_coord();
+        intersection.front_face = intersector.is_candidate_triangle_front_facing();
+    } else if (ty == metal::raytracing::intersection_type::bounding_box) {
+    }
+    if (ty != metal::raytracing::intersection_type::none) {
+        intersection.instance_custom_data = intersector.get_candidate_user_instance_id();
+        intersection.instance_index = intersector.get_candidate_instance_id();
+        intersection.sbt_record_offset = intersector.get_candidate_user_instance_id();
+        intersection.geometry_index = intersector.get_candidate_geometry_id();
+        intersection.primitive_index = intersector.get_candidate_primitive_id();
+        intersection.object_to_world = intersector.get_candidate_user_instance_id();
+        intersection.world_to_object = intersector.get_candidate_user_instance_id();
+    }
 
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    _RayQuery rq = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq = {};
     metal::float3 pos_2 = metal::float3(0.0);
     metal::float3 dir_2 = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos_2, dir_2};
-    rq.intersector.assume_geometry_type(metal::raytracing::geometry_type::triangle);
-    rq.intersector.set_opacity_cull_mode((_e12.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (_e12.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none);
-    rq.intersector.force_opacity((_e12.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (_e12.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
-    rq.intersector.accept_any_intersection((_e12.flags & 4) != 0);
-    rq.intersection = rq.intersector.intersect(metal::raytracing::ray(_e12.origin, _e12.dir, _e12.tmin, _e12.tmax), acc_struct, _e12.cull_mask);    rq.ready = true;
-    RayIntersection intersection_1 = RayIntersection {_map_intersection_type(rq.intersection.type), rq.intersection.distance, rq.intersection.user_instance_id, rq.intersection.instance_id, {}, rq.intersection.geometry_id, rq.intersection.primitive_id, rq.intersection.triangle_barycentric_coord, rq.intersection.triangle_front_facing, {}, rq.intersection.object_to_world_transform, rq.intersection.world_to_object_transform};
+    {
+        RayDesc desc = _e12;
+        intersection_params params;
+        intersection_params.set_opacity_cull_mode(
+            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+            )
+        );
+        intersection_params.force_opacity(
+            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+            )
+        );
+        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq.reset(ray,acc_struct, desc.cull_mask, params);
+    }
+    RayIntersection intersection_1 = ray_query_get_intersection_false(rq);
     if (intersection_1.kind == 3u) {
+        rq.commit_bounding_box_intersection(10.0);
         return;
     } else {
         if (intersection_1.kind == 1u) {
+            rq.commit_triangle_intersection();
             return;
         } else {
-            rq.ready = false;
+            rq.abort();
             return;
         }
     }

--- a/naga/tests/out/msl/wgsl-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-ray-query.metal
@@ -74,7 +74,8 @@ RayIntersection query_loop(
             )
         );
         params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq_1.reset(ray,acs, desc.cull_mask, params);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
+        rq_1.reset(ray,acs, desc.cull_mask, params);
     }
     uint2 loop_bound = uint2(4294967295u);
     while(true) {
@@ -155,7 +156,8 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
             )
         );
         params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq.reset(ray,acc_struct, desc.cull_mask, params);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
+        rq.reset(ray,acc_struct, desc.cull_mask, params);
     }
     RayIntersection intersection_1 = ray_query_get_intersection_false(rq);
     if (intersection_1.kind == 3u) {

--- a/naga/tests/out/msl/wgsl-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-ray-query.metal
@@ -121,6 +121,7 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
         intersection.barycentrics = intersector.get_candidate_triangle_barycentric_coord();
         intersection.front_face = intersector.is_candidate_triangle_front_facing();
     } else if (ty == metal::raytracing::intersection_type::bounding_box) {
+        intersection.kind = 3;
     }
     if (ty != metal::raytracing::intersection_type::none) {
         intersection.instance_custom_data = intersector.get_candidate_user_instance_id();

--- a/naga/tests/out/msl/wgsl-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-ray-query.metal
@@ -62,18 +62,18 @@ RayIntersection query_loop(
     RayDesc _e8 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
         RayDesc desc = _e8;
-        intersection_params params;
-        intersection_params.set_opacity_cull_mode(
+        metal::raytracing::intersection_params params;
+        params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
                 (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
             )
         );
-        intersection_params.force_opacity(
+        params.force_opacity(
             (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
                 (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
             )
         );
-        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        params.accept_any_intersection((desc.flags & 4) != 0);
         metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq_1.reset(ray,acs, desc.cull_mask, params);
     }
     uint2 loop_bound = uint2(4294967295u);
@@ -142,18 +142,18 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos_2, dir_2};
     {
         RayDesc desc = _e12;
-        intersection_params params;
-        intersection_params.set_opacity_cull_mode(
+        metal::raytracing::intersection_params params;
+        params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
                 (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
             )
         );
-        intersection_params.force_opacity(
+        params.force_opacity(
             (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
                 (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
             )
         );
-        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        params.accept_any_intersection((desc.flags & 4) != 0);
         metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq.reset(ray,acc_struct, desc.cull_mask, params);
     }
     RayIntersection intersection_1 = ray_query_get_intersection_false(rq);

--- a/naga/tests/out/msl/wgsl-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-ray-query.metal
@@ -32,7 +32,7 @@ struct Output {
     metal::float3 normal;
 };
 
-RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
+RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> intersector) {
     RayIntersection intersection = RayIntersection {};
     metal::raytracing::intersection_type ty = intersector.get_committed_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
@@ -51,17 +51,17 @@ RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_
         intersection.object_to_world = intersector.get_committed_user_instance_id();
         intersection.world_to_object = intersector.get_committed_user_instance_id();
     }
-return intersection;
+    return intersection;
 }
 RayIntersection query_loop(
     metal::float3 pos,
     metal::float3 dir,
     metal::raytracing::instance_acceleration_structure acs
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq_1 = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq_1 = {};
     RayDesc _e8 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
-        RayDesc desc = _e8;
+        metal::raytracing::RayDesc desc = _e8;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
@@ -112,7 +112,7 @@ metal::float3 get_torus_normal(
     return;
 }
 
-RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
+RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> intersector) {
     RayIntersection intersection = RayIntersection {};
     metal::raytracing::intersection_type ty = intersector.get_candidate_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
@@ -130,18 +130,18 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
         intersection.object_to_world = intersector.get_candidate_user_instance_id();
         intersection.world_to_object = intersector.get_candidate_user_instance_id();
     }
-return intersection;
+    return intersection;
 }
 
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq = {};
     metal::float3 pos_2 = metal::float3(0.0);
     metal::float3 dir_2 = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos_2, dir_2};
     {
-        RayDesc desc = _e12;
+        metal::raytracing::RayDesc desc = _e12;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (

--- a/naga/tests/out/msl/wgsl-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-ray-query.metal
@@ -48,8 +48,8 @@ RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_
         intersection.instance_index = intersector.get_committed_instance_id();
         intersection.geometry_index = intersector.get_committed_geometry_id();
         intersection.primitive_index = intersector.get_committed_primitive_id();
-        intersection.object_to_world = intersector.get_committed_user_instance_id();
-        intersection.world_to_object = intersector.get_committed_user_instance_id();
+        intersection.object_to_world = intersector.get_committed_object_to_world_transform();
+        intersection.world_to_object = intersector.get_committed_world_to_object_transform();
     }
     return intersection;
 }
@@ -61,7 +61,7 @@ RayIntersection query_loop(
     metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq_1 = {};
     RayDesc _e8 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
-        metal::raytracing::RayDesc desc = _e8;
+        RayDesc desc = _e8;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
@@ -127,8 +127,8 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
         intersection.instance_index = intersector.get_candidate_instance_id();
         intersection.geometry_index = intersector.get_candidate_geometry_id();
         intersection.primitive_index = intersector.get_candidate_primitive_id();
-        intersection.object_to_world = intersector.get_candidate_user_instance_id();
-        intersection.world_to_object = intersector.get_candidate_user_instance_id();
+        intersection.object_to_world = intersector.get_candidate_object_to_world_transform();
+        intersection.world_to_object = intersector.get_candidate_world_to_object_transform();
     }
     return intersection;
 }
@@ -141,7 +141,7 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
     metal::float3 dir_2 = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos_2, dir_2};
     {
-        metal::raytracing::RayDesc desc = _e12;
+        RayDesc desc = _e12;
         intersection_params params;
         intersection_params.set_opacity_cull_mode(
             (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (

--- a/naga/tests/out/msl/wgsl-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-ray-query.metal
@@ -34,7 +34,7 @@ struct Output {
 
 RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
     RayIntersection intersection = RayIntersection {};
-    intersection_type ty = intersector.get_committed_intersection_type();
+    metal::raytracing::intersection_type ty = intersector.get_committed_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
         intersection.kind = 1;
         intersection.barycentrics = intersector.get_committed_triangle_barycentric_coord();
@@ -46,12 +46,13 @@ RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_
         intersection.t = intersector.get_committed_distance();
         intersection.instance_custom_data = intersector.get_committed_user_instance_id();
         intersection.instance_index = intersector.get_committed_instance_id();
-        intersection.sbt_record_offset = intersector.get_committed_user_instance_id();
         intersection.geometry_index = intersector.get_committed_geometry_id();
         intersection.primitive_index = intersector.get_committed_primitive_id();
         intersection.object_to_world = intersector.get_committed_user_instance_id();
         intersection.world_to_object = intersector.get_committed_user_instance_id();
     }
+return intersection;
+}
 RayIntersection query_loop(
     metal::float3 pos,
     metal::float3 dir,
@@ -113,7 +114,7 @@ metal::float3 get_torus_normal(
 
 RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
     RayIntersection intersection = RayIntersection {};
-    intersection_type ty = intersector.get_candidate_intersection_type();
+    metal::raytracing::intersection_type ty = intersector.get_candidate_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
         intersection.kind = 1;
         intersection.t = intersector.get_candidate_triangle_distance();
@@ -124,12 +125,13 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
     if (ty != metal::raytracing::intersection_type::none) {
         intersection.instance_custom_data = intersector.get_candidate_user_instance_id();
         intersection.instance_index = intersector.get_candidate_instance_id();
-        intersection.sbt_record_offset = intersector.get_candidate_user_instance_id();
         intersection.geometry_index = intersector.get_candidate_geometry_id();
         intersection.primitive_index = intersector.get_candidate_primitive_id();
         intersection.object_to_world = intersector.get_candidate_user_instance_id();
         intersection.world_to_object = intersector.get_candidate_user_instance_id();
     }
+return intersection;
+}
 
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]

--- a/naga/tests/out/msl/wgsl-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-ray-query.metal
@@ -3,15 +3,6 @@
 #include <simd/simd.h>
 
 using metal::uint;
-struct _RayQuery {
-    metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector;
-    metal::raytracing::intersector<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data>::result_type intersection;
-    bool ready = false;
-};
-constexpr metal::uint _map_intersection_type(const metal::raytracing::intersection_type ty) {
-    return ty==metal::raytracing::intersection_type::triangle ? 1 : 
-        ty==metal::raytracing::intersection_type::bounding_box ? 4 : 0;
-}
 
 struct RayIntersection {
     uint kind;
@@ -41,29 +32,60 @@ struct Output {
     metal::float3 normal;
 };
 
+RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
+    RayIntersection intersection = RayIntersection {};
+    intersection_type ty = intersector.get_committed_intersection_type();
+    if (ty == metal::raytracing::intersection_type::triangle) {
+        intersection.kind = 1;
+        intersection.barycentrics = intersector.get_committed_triangle_barycentric_coord();
+        intersection.front_face = intersector.is_committed_triangle_front_facing();
+    } else if (ty == metal::raytracing::intersection_type::bounding_box) {
+        intersection.kind = 2;
+    }
+    if (ty != metal::raytracing::intersection_type::none) {
+        intersection.t = intersector.get_committed_distance();
+        intersection.instance_custom_data = intersector.get_committed_user_instance_id();
+        intersection.instance_index = intersector.get_committed_instance_id();
+        intersection.sbt_record_offset = intersector.get_committed_user_instance_id();
+        intersection.geometry_index = intersector.get_committed_geometry_id();
+        intersection.primitive_index = intersector.get_committed_primitive_id();
+        intersection.object_to_world = intersector.get_committed_user_instance_id();
+        intersection.world_to_object = intersector.get_committed_user_instance_id();
+    }
 RayIntersection query_loop(
     metal::float3 pos,
     metal::float3 dir,
     metal::raytracing::instance_acceleration_structure acs
 ) {
-    _RayQuery rq_1 = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq_1 = {};
     RayDesc _e8 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
-    rq_1.intersector.assume_geometry_type(metal::raytracing::geometry_type::triangle);
-    rq_1.intersector.set_opacity_cull_mode((_e8.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (_e8.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none);
-    rq_1.intersector.force_opacity((_e8.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (_e8.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
-    rq_1.intersector.accept_any_intersection((_e8.flags & 4) != 0);
-    rq_1.intersection = rq_1.intersector.intersect(metal::raytracing::ray(_e8.origin, _e8.dir, _e8.tmin, _e8.tmax), acs, _e8.cull_mask);    rq_1.ready = true;
+    {
+        RayDesc desc = _e8;
+        intersection_params params;
+        intersection_params.set_opacity_cull_mode(
+            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+            )
+        );
+        intersection_params.force_opacity(
+            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+            )
+        );
+        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq_1.reset(ray,acs, desc.cull_mask, params);
+    }
     uint2 loop_bound = uint2(4294967295u);
     while(true) {
         if (metal::all(loop_bound == uint2(0u))) { break; }
         loop_bound -= uint2(loop_bound.y == 0u, 1u);
-        bool _e9 = rq_1.ready;
+        bool _e9 = rq_1.next();
         if (_e9) {
         } else {
             break;
         }
     }
-    return RayIntersection {_map_intersection_type(rq_1.intersection.type), rq_1.intersection.distance, rq_1.intersection.user_instance_id, rq_1.intersection.instance_id, {}, rq_1.intersection.geometry_id, rq_1.intersection.primitive_id, rq_1.intersection.triangle_barycentric_coord, rq_1.intersection.triangle_front_facing, {}, rq_1.intersection.object_to_world_transform, rq_1.intersection.world_to_object_transform};
+    return ray_query_get_intersection_true(rq_1);
 }
 
 metal::float3 get_torus_normal(
@@ -89,27 +111,59 @@ metal::float3 get_torus_normal(
     return;
 }
 
+RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> intersector) {
+    RayIntersection intersection = RayIntersection {};
+    intersection_type ty = intersector.get_candidate_intersection_type();
+    if (ty == metal::raytracing::intersection_type::triangle) {
+        intersection.kind = 1;
+        intersection.t = intersector.get_candidate_triangle_distance();
+        intersection.barycentrics = intersector.get_candidate_triangle_barycentric_coord();
+        intersection.front_face = intersector.is_candidate_triangle_front_facing();
+    } else if (ty == metal::raytracing::intersection_type::bounding_box) {
+    }
+    if (ty != metal::raytracing::intersection_type::none) {
+        intersection.instance_custom_data = intersector.get_candidate_user_instance_id();
+        intersection.instance_index = intersector.get_candidate_instance_id();
+        intersection.sbt_record_offset = intersector.get_candidate_user_instance_id();
+        intersection.geometry_index = intersector.get_candidate_geometry_id();
+        intersection.primitive_index = intersector.get_candidate_primitive_id();
+        intersection.object_to_world = intersector.get_candidate_user_instance_id();
+        intersection.world_to_object = intersector.get_candidate_user_instance_id();
+    }
 
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    _RayQuery rq = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data, metal::raytracing::world_space_data> rq = {};
     metal::float3 pos_2 = metal::float3(0.0);
     metal::float3 dir_2 = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos_2, dir_2};
-    rq.intersector.assume_geometry_type(metal::raytracing::geometry_type::triangle);
-    rq.intersector.set_opacity_cull_mode((_e12.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (_e12.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none);
-    rq.intersector.force_opacity((_e12.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (_e12.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none);
-    rq.intersector.accept_any_intersection((_e12.flags & 4) != 0);
-    rq.intersection = rq.intersector.intersect(metal::raytracing::ray(_e12.origin, _e12.dir, _e12.tmin, _e12.tmax), acc_struct, _e12.cull_mask);    rq.ready = true;
-    RayIntersection intersection_1 = RayIntersection {_map_intersection_type(rq.intersection.type), rq.intersection.distance, rq.intersection.user_instance_id, rq.intersection.instance_id, {}, rq.intersection.geometry_id, rq.intersection.primitive_id, rq.intersection.triangle_barycentric_coord, rq.intersection.triangle_front_facing, {}, rq.intersection.object_to_world_transform, rq.intersection.world_to_object_transform};
+    {
+        RayDesc desc = _e12;
+        intersection_params params;
+        intersection_params.set_opacity_cull_mode(
+            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+            )
+        );
+        intersection_params.force_opacity(
+            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+            )
+        );
+        intersection_params.accept_any_intersection((desc.flags & 4) != 0);
+        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);        rq.reset(ray,acc_struct, desc.cull_mask, params);
+    }
+    RayIntersection intersection_1 = ray_query_get_intersection_false(rq);
     if (intersection_1.kind == 3u) {
+        rq.commit_bounding_box_intersection(10.0);
         return;
     } else {
         if (intersection_1.kind == 1u) {
+            rq.commit_triangle_intersection();
             return;
         } else {
-            rq.ready = false;
+            rq.abort();
             return;
         }
     }


### PR DESCRIPTION
**Connections**


**Description**
Re-writes the msl naga backend to use intersection queries instead of the intersector. This provides the notable benefit of supporting AABBs and non-opaque triangles. It also behave more like ray queries. The intersector matches ray tracing pipelines more than ray queries (though w/ significant differences).

**Testing**
Ran existing tests *with shader validation disabled* (which seems to help #9100 ).

**Squash or Rebase?**
Squash: this was originally started to see if it helped #9100, so I was initially ignoring CI failures .

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`.
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
