### PR TITLE
fix(core): `create_bind_group`: sort `dynamic_binding_info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Bottom level categories:
 #### General
 
 - Fix limit comparison logic for `max_inter_stage_shader_variables` By @ErichDonGubler in [#9264](https://github.com/gfx-rs/wgpu/pull/9264).
+- Fix incorrect checks for dynamic binding bounds when calling an encoder's `set_bind_group` in passes and bundles. By @ErichDonGubler in [#9308](https://github.com/gfx-rs/wgpu/pull/9308).
 
 #### naga
 

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -1236,6 +1236,7 @@ pub struct BindGroup {
     pub(crate) used: BindGroupStates,
     pub(crate) used_buffer_ranges: Vec<BufferInitTrackerAction>,
     pub(crate) used_texture_ranges: Vec<TextureInitTrackerAction>,
+    /// INVARIANT: Sorted by binding index order.
     pub(crate) dynamic_binding_info: Vec<BindGroupDynamicBindingData>,
     /// Actual binding sizes for buffers that don't have `min_binding_size`
     /// specified in BGL. Listed in the order of iteration of `BGL.entries`.

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3423,6 +3423,9 @@ impl Device {
                 return Err(Error::DuplicateBinding(a.binding));
             }
         }
+
+        dynamic_binding_info.sort_by_key(|i| i.binding_idx);
+
         let hal_desc = hal::BindGroupDescriptor {
             label: desc.label.to_hal(self.instance_flags),
             layout: layout.raw(),


### PR DESCRIPTION
**Connections**

\-

**Description**

`create_bind_group` populates the `BindGroup::dynamic_binding_info` field in the order the user specified. This later gets consumed by validation in passes and bundles `BindGroup::validate_dynamic_bindings`, in which `dynamic_binding_info` is assumed to be sorted in binding order. Eek! We're validating the wrong dynamic binding bounds!

Fix this by sorting `dynamic_binding_info` before it gets put into a `BindGroup`. Document the field with the invariant that it _must_ be sorted according to binding index order.

**Testing**

Not sure yet. I'd prefer to merge and do a fast follow-up over taking too long to find this, though.

**Squash or Rebase?**

sqoosh

**Checklist**

- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
