### PR TITLE
29.0.1 Patch release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+#### General
+
+- Fix limit comparison logic for `max_inter_stage_shader_variables` By @ErichDonGubler in [9264](https://github.com/gfx-rs/wgpu/pull/9264).
+
 ## v29.0.0 (2026-03-18)
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ Bottom level categories:
 
 - Added guards to avoid calling some feature detection methods that are not implemented on `CaptureMTLDevice`. By @andyleiserson in [#9284](https://github.com/gfx-rs/wgpu/pull/9284).
 
+#### Validation
+
+- Don't crash in the `Display` implementation of `CreateTextureViewError::TooMany{MipLevels,ArrayLayers}` when their base and offset overflow. By @ErichDonGubler in [#8808](https://github.com/gfx-rs/wgpu/pull/8808).
 
 ## v29.0.0 (2026-03-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Bottom level categories:
 
 - Fix limit comparison logic for `max_inter_stage_shader_variables` By @ErichDonGubler in [9264](https://github.com/gfx-rs/wgpu/pull/9264).
 
+#### Metal
+
+- Added guards to avoid calling some feature detection methods that are not implemented on `CaptureMTLDevice`. By @andyleiserson in [#9284](https://github.com/gfx-rs/wgpu/pull/9284).
+
+
 ## v29.0.0 (2026-03-18)
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,15 +42,24 @@ Bottom level categories:
 
 ## Unreleased
 
+## v29.0.1 (2026-03-26)
+
+This release includes `wgpu-core`, `wgpu-hal` and `wgpu-types` version `29.0.1`. All other crates remain at their previous versions.
+
 ### Bug Fixes
 
 #### General
 
-- Fix limit comparison logic for `max_inter_stage_shader_variables` By @ErichDonGubler in [9264](https://github.com/gfx-rs/wgpu/pull/9264).
+- Fix limit comparison logic for `max_inter_stage_shader_variables`. By @ErichDonGubler in [#9264](https://github.com/gfx-rs/wgpu/pull/9264).
 
 #### Metal
 
 - Added guards to avoid calling some feature detection methods that are not implemented on `CaptureMTLDevice`. By @andyleiserson in [#9284](https://github.com/gfx-rs/wgpu/pull/9284).
+- Fix a regression where buffer limits were too conservative. This comes at the cost of non-compliant WebGPU limit validation. A future major release will keep the relaxed buffer limits on native while allowing WebGPU-mandated validation to be opted in. See [#9287](https://github.com/gfx-rs/wgpu/issues/9287).
+
+#### GLES / OpenGL
+
+- Fix texture height initialized incorrectly in `create_texture`. By @umajho in [#9302](https://github.com/gfx-rs/wgpu/pull/9302).
 
 #### Validation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "cts_runner"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "deno_console",
  "deno_core",
@@ -1778,7 +1778,7 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hlsl-snapshots"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "anyhow",
  "nanoserde",
@@ -2171,7 +2171,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock-analyzer"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "anyhow",
  "ron",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "naga-cli"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "anyhow",
  "argh",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "naga-fuzz"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "arbitrary",
  "cfg_aliases",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "naga-test"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "bitflags 2.11.0",
  "naga",
@@ -3012,7 +3012,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "player"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "bytemuck",
  "env_logger",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-benchmark"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -4605,7 +4605,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -4640,28 +4640,28 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "wgpu-hal",
 ]
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-examples"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4727,7 +4727,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -4784,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-info"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-macros"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "heck",
  "quote",
@@ -4808,7 +4808,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-test"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,13 +66,13 @@ keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 homepage = "https://wgpu.rs/"
 repository = "https://github.com/gfx-rs/wgpu"
-version = "29.0.0"
+version = "29.0.1"
 authors = ["gfx-rs developers"]
 
 [workspace.dependencies]
-naga = { version = "29.0.0", path = "./naga" }
+naga = { version = "29.0.1", path = "./naga" }
 naga-test = { path = "./naga-test" }
-wgpu = { version = "29.0.0", path = "./wgpu", default-features = false, features = [
+wgpu = { version = "29.0.1", path = "./wgpu", default-features = false, features = [
     "std",
     "serde",
     "wgsl",
@@ -85,12 +85,12 @@ wgpu = { version = "29.0.0", path = "./wgpu", default-features = false, features
     "static-dxc",
     "noop",               # This should be removed if we ever have non-test crates that depend on wgpu
 ] }
-wgpu-core = { version = "29.0.0", path = "./wgpu-core" }
-wgpu-hal = { version = "29.0.0", path = "./wgpu-hal" }
-wgpu-macros = { version = "29.0.0", path = "./wgpu-macros" }
-wgpu-naga-bridge = { version = "29.0.0", path = "./wgpu-naga-bridge" }
-wgpu-test = { version = "29.0.0", path = "./tests" }
-wgpu-types = { version = "29.0.0", path = "./wgpu-types", default-features = false }
+wgpu-core = { version = "29.0.1", path = "./wgpu-core" }
+wgpu-hal = { version = "29.0.1", path = "./wgpu-hal" }
+wgpu-macros = { version = "29.0.1", path = "./wgpu-macros" }
+wgpu-naga-bridge = { version = "29.0.1", path = "./wgpu-naga-bridge" }
+wgpu-test = { version = "29.0.1", path = "./tests" }
+wgpu-types = { version = "29.0.1", path = "./wgpu-types", default-features = false }
 
 # These _cannot_ have a version specified. If it does, crates.io will look
 # for a version of the package on crates when we publish naga. Path dependencies

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -20,6 +20,7 @@ webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:* // 0%
 webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,createBindGroup:external_texture,* // 0%, no external external texture in deno
 webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https://github.com/gfx-rs/wgpu/issues/7881
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:* // metal, https://github.com/gfx-rs/wgpu/issues/8173
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_buffer_type:* // 25%, writable storage buffers not allowed in VERTEX
 webgpu:api,validation,createBindGroupLayout:visibility,VERTEX_shader_stage_storage_texture_access:* // 25%, write-access storage textures not allowed in VERTEX
 webgpu:api,validation,createBindGroupLayout:visibility:* // 25%, missing per-stage storage limits

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -106,8 +106,8 @@ webgpu:api,validation,createBindGroup:texture_must_have_correct_component_type:*
 webgpu:api,validation,createBindGroup:texture_must_have_correct_dimension:*
 webgpu:api,validation,createBindGroupLayout:duplicate_bindings:*
 webgpu:api,validation,createBindGroupLayout:max_dynamic_buffers:*
-// Doesn't actually fail, but is very slow. https://github.com/gfx-rs/wgpu/issues/9229
-fails-if(dx12) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,*
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_bind_group_layout:*
+fails-if(metal) webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,in_pipeline_layout:*
 webgpu:api,validation,createBindGroupLayout:maximum_binding_limit:*
 webgpu:api,validation,createBindGroupLayout:multisampled_validation:*
 webgpu:api,validation,createBindGroupLayout:storage_texture,formats:*

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -63,7 +63,7 @@ Day of Release:
 ## Patch Release Process
 
 - Enumerate all PRs that haven't been backported yet. These use the `PR: needs back-porting` label. [GH Link](https://github.com/gfx-rs/wgpu/pulls?q=sort%3Aupdated-desc+is%3Apr+label%3A%22PR%3A+needs+back-porting%22)
-- On _your own branch_ based on the latest release branch. Cherry-pick the PRs that need to be backported. When modifying the commits, use --append to retain their original authorship.
+- On _your own branch_ based on the latest release branch. Cherry-pick the PRs that need to be backported. When modifying the commits, use --amend to retain their original authorship.
 - Remove the `needs-backport` label from the PRs.
 - Fix the changelogs items and add a new header for the patch release with the release version and date.
   - The release section should start with a header saying the following (for example)

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1838,9 +1838,8 @@ pub enum CreateTextureViewError {
     #[error("Array layer count is 0")]
     ZeroArrayLayerCount,
     #[error(
-        "TextureView spans mip levels [{base_mip_level}, {end_mip_level}) \
-        (mipLevelCount {mip_level_count}) but the texture view only has {total} total mip levels",
-        end_mip_level = base_mip_level + mip_level_count
+        "`TextureView` starts at mip level {base_mip_level} and spans {mip_level_count} mip \
+        levels, but the texture view only has {total} total mip level(s)"
     )]
     TooManyMipLevels {
         base_mip_level: u32,
@@ -1848,9 +1847,8 @@ pub enum CreateTextureViewError {
         total: u32,
     },
     #[error(
-        "TextureView spans array layers [{base_array_layer}, {end_array_layer}) \
-         (arrayLayerCount {array_layer_count}) but the texture view only has {total} total layers",
-        end_array_layer = base_array_layer + array_layer_count
+        "`TextureView` starts at array layer {base_array_layer} and spans {array_layer_count}) \
+        array layers, but the texture view only has {total} total layer(s)"
     )]
     TooManyArrayLayers {
         base_array_layer: u32,

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -121,7 +121,7 @@ impl crate::TextureCopy {
 
 /// Adjust `limits` to honor HAL-imposed maximums and comply with WebGPU's
 /// adapter capability guarantees.
-#[cfg_attr(not(any_backend), allow(dead_code))]
+#[cfg_attr(any(not(any_backend), metal), allow(dead_code))]
 pub(crate) fn adjust_raw_limits(mut limits: wgt::Limits) -> wgt::Limits {
     // Apply hal limits.
     limits.max_bind_groups = limits.max_bind_groups.min(crate::MAX_BIND_GROUPS as u32);

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -844,7 +844,7 @@ impl crate::Device for super::Device {
                         )
                     } else if target == glow::TEXTURE_3D {
                         let mut width = desc.size.width;
-                        let mut height = desc.size.width;
+                        let mut height = desc.size.height;
                         let mut depth = desc.size.depth_or_array_layers;
                         for i in 0..desc.mip_level_count {
                             gl.tex_image_3d(
@@ -865,7 +865,7 @@ impl crate::Device for super::Device {
                         }
                     } else {
                         let mut width = desc.size.width;
-                        let mut height = desc.size.width;
+                        let mut height = desc.size.height;
                         for i in 0..desc.mip_level_count {
                             gl.tex_image_3d(
                                 target,
@@ -911,7 +911,7 @@ impl crate::Device for super::Device {
                         )
                     } else if target == glow::TEXTURE_CUBE_MAP {
                         let mut width = desc.size.width;
-                        let mut height = desc.size.width;
+                        let mut height = desc.size.height;
                         for i in 0..desc.mip_level_count {
                             for face in [
                                 glow::TEXTURE_CUBE_MAP_POSITIVE_X,
@@ -938,7 +938,7 @@ impl crate::Device for super::Device {
                         }
                     } else {
                         let mut width = desc.size.width;
-                        let mut height = desc.size.width;
+                        let mut height = desc.size.height;
                         for i in 0..desc.mip_level_count {
                             gl.tex_image_2d(
                                 target,

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1,4 +1,5 @@
-use objc2::{available, runtime::ProtocolObject};
+use objc2::runtime::{AnyObject, ProtocolObject, Sel};
+use objc2::{available, sel};
 use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};
 use objc2_metal::{
     MTLArgumentBuffersTier, MTLCounterSamplingPoint, MTLDevice, MTLFeatureSet, MTLGPUFamily,
@@ -13,6 +14,16 @@ use core::sync::atomic;
 use crate::metal::QueueShared;
 
 use super::{OsFeatures, TimestampQuerySupport};
+
+/// Check if a device's class has a given method in its method table.
+///
+/// This mirrors the check that `objc2` performs internally (in debug builds)
+/// before sending a message. We use it to skip method calls that would panic
+/// on proxy objects like Apple's `CaptureMTLDevice`, which forwards messages
+/// at runtime but doesn't declare the methods in its class.
+fn device_class_responds_to(device: &ProtocolObject<dyn MTLDevice>, sel: Sel) -> bool {
+    AnyObject::class(device.as_ref()).responds_to(sel)
+}
 
 /// Maximum number of command buffers for `MTLCommandQueue`s that we create.
 ///
@@ -711,6 +722,7 @@ impl super::CapabilitiesQuery {
             texture_cube_array: Self::supports_any(device, TEXTURE_CUBE_ARRAY_SUPPORT),
             supports_float_filtering: os_type == super::OsType::Macos
                 || (available!(macos = 11.0, ios = 14.0, tvos = 16.0, visionos = 1.0)
+                    && device_class_responds_to(device, sel!(supports32BitFloatFiltering))
                     && device.supports32BitFloatFiltering()),
             format_depth24_stencil8: os_type == super::OsType::Macos
                 && device.isDepth24Stencil8PixelFormatSupported(),
@@ -983,7 +995,12 @@ impl super::CapabilitiesQuery {
                     || device.supportsFamily(MTLGPUFamily::Apple7)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
             // https://developer.apple.com/documentation/metal/mtldevice/hasunifiedmemory
-            has_unified_memory: if available!(macos = 15.0, ios = 13.0, tvos = 13.0, visionos = 1.0)
+            has_unified_memory: if available!(
+                macos = 10.15,
+                ios = 13.0,
+                tvos = 13.0,
+                visionos = 1.0
+            ) && device_class_responds_to(device, sel!(hasUnifiedMemory))
             {
                 Some(device.hasUnifiedMemory())
             } else {
@@ -1057,7 +1074,10 @@ impl super::CapabilitiesQuery {
                 tvos = 18.0,
                 visionos = 2.0,
             ) {
-                device.supportsRaytracing() && device.supportsRaytracingFromRender()
+                device_class_responds_to(device, sel!(supportsRaytracing))
+                    && device.supportsRaytracing()
+                    && device_class_responds_to(device, sel!(supportsRaytracingFromRender))
+                    && device.supportsRaytracingFromRender()
             } else {
                 false
             },

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -44,23 +44,6 @@ fn device_class_responds_to(device: &ProtocolObject<dyn MTLDevice>, sel: Sel) ->
 /// [new command buffer]: https://developer.apple.com/documentation/metal/mtlcommandqueue/makecommandbuffer()?language=objc
 pub(super) const MAX_COMMAND_BUFFERS: usize = 4096;
 
-// Metal has a single buffer limit that we must split across 3 WebGPU limits:
-// The Metal limit is: 31 "Maximum number of entries in the buffer argument table, per graphics or kernel function".
-// We must split it across:
-//  - maxStorageBuffersPerShaderStage; must be at least 8
-//  - maxUniformBuffersPerShaderStage; must be at least 12
-//  - maxVertexBuffers; must be at least 8
-// We require 2 additional internal buffers:
-//  - one for immediate data
-//  - one for sizes of other buffers
-// We use the last buffer for an acceleration structure.
-const MAX_STORAGE_BUFFERS_PER_SHADER_STAGE: u32 = 8;
-const MAX_UNIFORM_BUFFERS_PER_SHADER_STAGE: u32 = 12;
-const MAX_VERTEX_BUFFERS: u32 = 8;
-const MAX_ACCELERATION_STRUCTURES_PER_SHADER_STAGE: u32 = 1;
-// Use the end of the range for vertex buffers.
-pub const VERTEX_BUFFER_SLOT_START: u32 = 31 - 8;
-
 unsafe impl Send for super::Adapter {}
 unsafe impl Sync for super::Adapter {}
 
@@ -797,21 +780,18 @@ impl super::CapabilitiesQuery {
             format_depth32float_none: os_type != super::OsType::Macos,
             format_bgr10a2_all: Self::supports_any(device, BGR10A2_ALL),
             format_bgr10a2_no_write: !Self::supports_any(device, BGR10A2_ALL),
-            // "Maximum number of entries in the texture argument table, per graphics or kernel function"
-            // The tuple is (sampled, storage).
-            // The default limit split in WebGPU is 80%-20%.
-            //  - The default maxSampledTexturesPerShaderStage in WebGPU is 16.
-            //  - The default maxStorageTexturesPerShaderStage in WebGPU is 4.
-            // Use a split of 75%-25% which can exactly split 128 and 96.
+            max_buffers_per_stage: 31,
+            max_vertex_buffers: 31.min(crate::MAX_VERTEX_BUFFERS as u32), // duplicative of `apply_hal_limits`
             max_textures_per_stage: if os_type == super::OsType::Macos
                 || (family_check && device.supportsFamily(MTLGPUFamily::Apple6))
             {
-                (96, 32) // 128
+                128
             } else if family_check && device.supportsFamily(MTLGPUFamily::Apple4) {
-                (72, 24) // 96
+                96
             } else {
-                (23, 8) // 31
+                31
             },
+            max_samplers_per_stage: 16,
             max_binding_array_elements: if argument_buffers == Some(MTLArgumentBuffersTier::Tier2) {
                 1_000_000
             } else if family_check && device.supportsFamily(MTLGPUFamily::Apple4) {
@@ -834,24 +814,10 @@ impl super::CapabilitiesQuery {
             } else {
                 16
             },
-            // "Buffer alignment for copying an existing texture to a buffer"
             buffer_alignment: if matches!(os_type, super::OsType::Macos | super::OsType::VisionOs) {
                 256
-            } else if family_check && device.supportsFamily(MTLGPUFamily::Apple3) {
-                16
             } else {
                 64
-            },
-            // "Minimum constant buffer offset alignment"
-            constant_buffer_offset_alignment: if matches!(
-                os_type,
-                super::OsType::Macos | super::OsType::VisionOs
-            ) {
-                256
-            } else if device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily2_v1) {
-                32
-            } else {
-                4
             },
             max_buffer_size: if available!(macos = 10.14, ios = 12.0, tvos = 12.0, visionos = 1.0) {
                 device.maxBufferLength() as u64
@@ -860,12 +826,7 @@ impl super::CapabilitiesQuery {
             } else {
                 1 << 28 // 256MB on iOS 8.0+
             },
-            // "Maximum 1D texture width" &
-            // "Maximum 2D texture width and height" &
-            // "Maximum cube map texture width and height"
-            max_texture_size: if family_check && device.supportsFamily(MTLGPUFamily::Apple10) {
-                32768
-            } else if Self::supports_any(
+            max_texture_size: if Self::supports_any(
                 device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily3_v1,
@@ -877,9 +838,7 @@ impl super::CapabilitiesQuery {
             } else {
                 8192
             },
-            // "Maximum 3D texture width, height, and depth"
             max_texture_3d_size: 2048,
-            // "Maximum number of layers per 1D texture array, 2D texture array, or 3D texture"
             max_texture_layers: 2048,
             max_fragment_input_components: if os_type == super::OsType::Macos
                 || device.supportsFeatureSet(MTLFeatureSet::iOS_GPUFamily4_v1)
@@ -888,8 +847,8 @@ impl super::CapabilitiesQuery {
             } else {
                 60
             },
-            // "Maximum number of color render targets per render pass descriptor"
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=7
+            // 8 is supported on everything on that list
             max_color_render_targets: if Self::supports_any(
                 device,
                 &[
@@ -902,39 +861,29 @@ impl super::CapabilitiesQuery {
             } else {
                 4
             },
-            // "Maximum total render target size, per pixel, when using multiple color render targets"
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=7
             max_color_attachment_bytes_per_sample: if family_check
-                && device.supportsFamily(MTLGPUFamily::Apple4)
+                && device.supportsFamily(MTLGPUFamily::Apple7)
             {
-                64 // 512 bits
-            } else if family_check && device.supportsFamily(MTLGPUFamily::Apple2) {
-                32 // 256 bits
-            } else if device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily1_v1) {
-                // No Limit, use max_color_render_targets * MAX_TARGET_PIXEL_BYTE_COST
-                8 * wgt::TextureFormat::MAX_TARGET_PIXEL_BYTE_COST as u8 // 1024 bits
+                128
+            } else if family_check && device.supportsFamily(MTLGPUFamily::Apple4) {
+                64
             } else {
-                16 // 128 bits
+                32
             },
-            // This limit is the minimum of:
-            // - "Maximum scalar or vector inputs to a fragment function"
-            // - "Maximum number of input components to a fragment function" / 4
-            max_inter_stage_shader_variables: if (family_check
-                && device.supportsFamily(MTLGPUFamily::Apple4))
-                || device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily1_v1)
+            max_varying_components: if device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily1_v1)
             {
-                31 // min(32 or 124, 124 / 4)
+                124
             } else {
-                15 // min(60, 60 / 4)
+                60
             },
-            // "Maximum threads per threadgroup"
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=6
             // These are older checks but still hold true; no entry in this table supports
             // more than 1024 threads.
             max_threads_per_group: if Self::supports_any(
                 device,
                 &[
-                    MTLFeatureSet::iOS_GPUFamily4_v1,
+                    MTLFeatureSet::iOS_GPUFamily4_v2,
                     MTLFeatureSet::macOS_GPUFamily1_v1,
                 ],
             ) {
@@ -942,7 +891,6 @@ impl super::CapabilitiesQuery {
             } else {
                 512
             },
-            // "Maximum total threadgroup memory allocation"
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=6
             // These are older checks but still hold true; no entry in this table supports
             // more than 32kb.
@@ -950,7 +898,7 @@ impl super::CapabilitiesQuery {
                 device,
                 &[
                     MTLFeatureSet::iOS_GPUFamily4_v1,
-                    MTLFeatureSet::macOS_GPUFamily1_v1,
+                    MTLFeatureSet::macOS_GPUFamily1_v2,
                 ],
             ) {
                 32 << 10
@@ -1237,43 +1185,42 @@ impl super::CapabilitiesQuery {
             .flags
             .set(wgt::DownlevelFlags::ANISOTROPIC_FILTERING, true);
 
-        let limits = crate::auxil::adjust_raw_limits(wgt::Limits {
-            //
-            // WebGPU LIMITS:
-            // Based on https://gpuweb.github.io/gpuweb/correspondence/#limits
-            //
+        let base = wgt::Limits::default();
+        // Be careful adjusting limits here. The `AdapterShared` stores the
+        // original `PrivateCapabilities`, so code could accidentally use
+        // the wrong value. See <https://github.com/gfx-rs/wgpu/issues/8715>.
+
+        let limits = wgt::Limits {
             max_texture_dimension_1d: self.max_texture_size as u32,
             max_texture_dimension_2d: self.max_texture_size as u32,
             max_texture_dimension_3d: self.max_texture_3d_size as u32,
             max_texture_array_layers: self.max_texture_layers as u32,
-            // No real limit.
             max_bind_groups: 8,
-            // No real limit.
-            max_bindings_per_bind_group: u32::MAX,
-            // No limit, use maxUniformBuffersPerShaderStage.
-            max_dynamic_uniform_buffers_per_pipeline_layout: MAX_UNIFORM_BUFFERS_PER_SHADER_STAGE,
-            // No limit, use maxStorageBuffersPerShaderStage.
-            max_dynamic_storage_buffers_per_pipeline_layout: MAX_STORAGE_BUFFERS_PER_SHADER_STAGE,
-            // "Maximum number of entries in the sampler state argument table, per graphics or kernel function"
-            max_samplers_per_shader_stage: 16,
-            max_sampled_textures_per_shader_stage: self.max_textures_per_stage.0,
-            max_storage_textures_per_shader_stage: self.max_textures_per_stage.1,
-            max_storage_buffers_per_shader_stage: MAX_STORAGE_BUFFERS_PER_SHADER_STAGE,
-            max_uniform_buffers_per_shader_stage: MAX_UNIFORM_BUFFERS_PER_SHADER_STAGE,
-            max_vertex_buffers: MAX_VERTEX_BUFFERS,
-            max_buffer_size: self.max_buffer_size,
-            // No limit, use maxBufferSize.
-            max_uniform_buffer_binding_size: self.max_buffer_size,
-            // No limit, use maxBufferSize.
-            max_storage_buffer_binding_size: self.max_buffer_size,
-            min_uniform_buffer_offset_alignment: self.constant_buffer_offset_alignment,
-            // No documented limit. Use 32, which is the lowest allowed value.
-            min_storage_buffer_offset_alignment: 32,
-            // "Maximum number of vertex attributes, per vertex descriptor"
+            max_bindings_per_bind_group: 65535,
+            max_dynamic_uniform_buffers_per_pipeline_layout: base
+                .max_dynamic_uniform_buffers_per_pipeline_layout,
+            max_dynamic_storage_buffers_per_pipeline_layout: base
+                .max_dynamic_storage_buffers_per_pipeline_layout,
+            max_sampled_textures_per_shader_stage: self.max_textures_per_stage,
+            max_samplers_per_shader_stage: self.max_samplers_per_stage,
+            max_storage_buffers_per_shader_stage: self.max_buffers_per_stage,
+            max_storage_textures_per_shader_stage: self.max_textures_per_stage,
+            max_uniform_buffers_per_shader_stage: self.max_buffers_per_stage,
+            max_binding_array_elements_per_shader_stage: self.max_binding_array_elements,
+            max_binding_array_sampler_elements_per_shader_stage: self
+                .max_sampler_binding_array_elements,
+            max_binding_array_acceleration_structure_elements_per_shader_stage: 0,
+            // Note: any adjustment here will not be reflected in the stored `PrivateCapabilities`.
+            max_uniform_buffer_binding_size: self.max_buffer_size.min(!0u32 as u64),
+            max_storage_buffer_binding_size: self.max_buffer_size.min(!0u32 as u64)
+                & !(wgt::STORAGE_BINDING_SIZE_ALIGNMENT as u64 - 1),
+            max_vertex_buffers: self.max_vertex_buffers,
             max_vertex_attributes: 31,
-            // No documented limit, matches Vulkan's minimum limit and D3D12's static limit.
-            max_vertex_buffer_array_stride: 2048,
-            max_inter_stage_shader_variables: self.max_inter_stage_shader_variables,
+            max_vertex_buffer_array_stride: base.max_vertex_buffer_array_stride,
+            max_immediate_size: 0x1000,
+            max_inter_stage_shader_variables: self.max_varying_components / 4,
+            min_uniform_buffer_offset_alignment: self.buffer_alignment as u32,
+            min_storage_buffer_offset_alignment: self.buffer_alignment as u32,
             max_color_attachments: self.max_color_render_targets as u32,
             max_color_attachment_bytes_per_sample: self.max_color_attachment_bytes_per_sample
                 as u32,
@@ -1282,18 +1229,9 @@ impl super::CapabilitiesQuery {
             max_compute_workgroup_size_x: self.max_threads_per_group,
             max_compute_workgroup_size_y: self.max_threads_per_group,
             max_compute_workgroup_size_z: self.max_threads_per_group,
-            // No documented limit, matches Vulkan's minimum limit and D3D12's static limit.
             max_compute_workgroups_per_dimension: 0xFFFF,
-            max_immediate_size: 0x1000,
-            //
-            // NATIVE (Non-WebGPU) LIMITS:
-            //
+            max_buffer_size: self.max_buffer_size,
             max_non_sampler_bindings: u32::MAX,
-
-            max_binding_array_elements_per_shader_stage: self.max_binding_array_elements,
-            max_binding_array_sampler_elements_per_shader_stage: self
-                .max_sampler_binding_array_elements,
-            max_binding_array_acceleration_structure_elements_per_shader_stage: 0,
 
             // from https://developer.apple.com/documentation/metal/mtlaccelerationstructureusage/extendedlimits
             max_blas_primitive_count: 1 << 28,
@@ -1302,8 +1240,7 @@ impl super::CapabilitiesQuery {
             // From 2.17.7 in https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf
             // > [Acceleration structures] are opaque objects that can be bound directly using
             // buffer binding points or via argument buffers
-            max_acceleration_structures_per_shader_stage:
-                MAX_ACCELERATION_STRUCTURES_PER_SHADER_STAGE,
+            max_acceleration_structures_per_shader_stage: self.max_buffers_per_stage,
 
             max_multiview_view_count: if self.supported_vertex_amplification_factor > 1 {
                 self.supported_vertex_amplification_factor
@@ -1324,7 +1261,7 @@ impl super::CapabilitiesQuery {
             max_mesh_output_primitives: 256,
             max_mesh_output_layers: self.max_texture_layers as u32,
             max_mesh_multiview_view_count: 0,
-        });
+        };
 
         crate::Capabilities {
             limits,
@@ -1392,6 +1329,10 @@ impl super::CapabilitiesQuery {
             timestamp_query_support: self.timestamp_query_support,
             supports_memoryless_storage: self.supports_memoryless_storage,
             mesh_shaders: self.mesh_shaders,
+            max_buffers_per_stage: self.max_buffers_per_stage,
+            max_vertex_buffers: self.max_vertex_buffers,
+            max_textures_per_stage: self.max_textures_per_stage,
+            max_samplers_per_stage: self.max_samplers_per_stage,
         }
     }
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -13,10 +13,7 @@ use objc2_metal::{
     MTLVisibilityResultMode,
 };
 
-use super::{
-    adapter::{self, VERTEX_BUFFER_SLOT_START},
-    conv, TimestampQuerySupport,
-};
+use super::{adapter, conv, TimestampQuerySupport};
 use crate::CommandEncoder as _;
 use alloc::{
     borrow::{Cow, ToOwned as _},
@@ -439,7 +436,7 @@ impl super::CommandState {
         // they were added to the map.
         result_sizes.extend(stage_info.vertex_buffer_mappings.iter().map(|vbm| {
             self.vertex_buffer_size_map
-                .get(&vbm.id)
+                .get(&(vbm.id as u64))
                 .map(|size| u32::try_from(size.get()).unwrap_or(u32::MAX))
                 .unwrap_or_default()
         }));
@@ -1380,7 +1377,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         index: u32,
         binding: crate::BufferBinding<'a, super::Buffer>,
     ) {
-        let buffer_index = VERTEX_BUFFER_SLOT_START + index;
+        let buffer_index = self.shared.private_caps.max_vertex_buffers as u64 - 1 - index as u64;
         let encoder = self.state.render.as_ref().unwrap();
         unsafe {
             encoder.setVertexBuffer_offset_atIndex(

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -24,7 +24,7 @@ use objc2_metal::{
     MTLVertexStepFunction,
 };
 
-use super::{adapter::VERTEX_BUFFER_SLOT_START, conv, PassthroughShader, ShaderModuleSource};
+use super::{conv, PassthroughShader, ShaderModuleSource};
 use crate::{auxil::map_naga_stage, TlasInstance};
 
 type DeviceResult<T> = Result<T, crate::DeviceError>;
@@ -854,6 +854,14 @@ impl crate::Device for super::Device {
                 info.sizes_buffer = Some(info.counters.buffers);
                 info.counters.buffers += 1;
             }
+
+            if info.counters.buffers > self.shared.private_caps.max_buffers_per_stage
+                || info.counters.textures > self.shared.private_caps.max_textures_per_stage
+                || info.counters.samplers > self.shared.private_caps.max_samplers_per_stage
+            {
+                log::error!("Resource limit exceeded: {info:?}");
+                return Err(crate::DeviceError::OutOfMemory);
+            }
         }
 
         let immediates_infos = stage_data.map_ref(|info| {
@@ -862,6 +870,8 @@ impl crate::Device for super::Device {
                 buffer_index,
             })
         });
+
+        let total_counters = stage_data.map_ref(|info| info.counters.clone());
 
         let per_stage_map = stage_data.map(|info| naga::back::msl::EntryPointResources {
             immediates_buffer: info
@@ -878,6 +888,7 @@ impl crate::Device for super::Device {
         Ok(super::PipelineLayout {
             bind_group_infos,
             immediates_infos,
+            total_counters,
             total_immediates: desc.immediate_size,
             per_stage_map,
         })
@@ -1279,7 +1290,7 @@ impl crate::Device for super::Device {
                         }
 
                         let mapping = naga::back::msl::VertexBufferMapping {
-                            id: VERTEX_BUFFER_SLOT_START + i as u32,
+                            id: self.shared.private_caps.max_vertex_buffers - 1 - i as u32,
                             stride: if vbl.array_stride > 0 {
                                 vbl.array_stride.try_into().unwrap()
                             } else {
@@ -1339,11 +1350,27 @@ impl crate::Device for super::Device {
                         });
                     }
 
+                    // Validate vertex buffer count
+                    if desc.layout.total_counters.vs.buffers + (vertex_buffers.len() as u32)
+                        > self.shared.private_caps.max_vertex_buffers
+                    {
+                        let msg = format!(
+                            "pipeline needs too many buffers in the vertex stage: {} vertex and {} layout",
+                            vertex_buffers.len(),
+                            desc.layout.total_counters.vs.buffers
+                        );
+                        return Err(crate::PipelineError::Linkage(
+                            wgt::ShaderStages::VERTEX,
+                            msg,
+                        ));
+                    }
+
                     // Set the pipeline vertex buffer info
                     if !vertex_buffers.is_empty() {
                         let vertex_descriptor = MTLVertexDescriptor::new();
                         for (i, vb) in vertex_buffers.iter().enumerate() {
-                            let buffer_index = VERTEX_BUFFER_SLOT_START as usize + i;
+                            let buffer_index =
+                                self.shared.private_caps.max_vertex_buffers as usize - 1 - i;
                             let buffer_desc = unsafe {
                                 vertex_descriptor
                                     .layouts()

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -281,11 +281,18 @@ struct CapabilitiesQuery {
     format_depth32float_none: bool,
     format_bgr10a2_all: bool,
     format_bgr10a2_no_write: bool,
-    max_textures_per_stage: (ResourceIndex, ResourceIndex),
+    max_buffers_per_stage: ResourceIndex,
+    max_vertex_buffers: ResourceIndex,
+    max_textures_per_stage: ResourceIndex,
+    max_samplers_per_stage: ResourceIndex,
     max_binding_array_elements: ResourceIndex,
     max_sampler_binding_array_elements: ResourceIndex,
     buffer_alignment: u64,
-    constant_buffer_offset_alignment: u32,
+
+    /// Platform-reported maximum buffer size
+    ///
+    /// This value is clamped to `u32::MAX` for `wgt::Limits`, so you probably
+    /// shouldn't be looking at this copy.
     max_buffer_size: u64,
     max_texture_size: u64,
     max_texture_3d_size: u64,
@@ -293,7 +300,7 @@ struct CapabilitiesQuery {
     max_fragment_input_components: u64,
     max_color_render_targets: u8,
     max_color_attachment_bytes_per_sample: u8,
-    max_inter_stage_shader_variables: u32,
+    max_varying_components: u32,
     max_threads_per_group: u32,
     max_total_threadgroup_memory: u32,
     sample_count_mask: crate::TextureFormatCapabilities,
@@ -329,6 +336,10 @@ struct PrivateCapabilities {
     timestamp_query_support: TimestampQuerySupport,
     supports_memoryless_storage: bool,
     mesh_shaders: bool,
+    max_buffers_per_stage: ResourceIndex,
+    max_vertex_buffers: ResourceIndex,
+    max_textures_per_stage: ResourceIndex,
+    max_samplers_per_stage: ResourceIndex,
 }
 
 #[derive(Debug)]
@@ -798,6 +809,7 @@ struct ImmediateDataInfo {
 pub struct PipelineLayout {
     bind_group_infos: [Option<BindGroupLayoutInfo>; crate::MAX_BIND_GROUPS],
     immediates_infos: MultiStageData<Option<ImmediateDataInfo>>,
+    total_counters: MultiStageResourceCounters,
     total_immediates: u32,
     per_stage_map: MultiStageResources,
 }
@@ -1087,7 +1099,7 @@ struct CommandState {
     /// [`ResourceBinding`]: naga::ResourceBinding
     storage_buffer_length_map: FastHashMap<naga::ResourceBinding, wgt::BufferSize>,
 
-    vertex_buffer_size_map: FastHashMap<u32, wgt::BufferSize>,
+    vertex_buffer_size_map: FastHashMap<u64, wgt::BufferSize>,
 
     immediates: Vec<u32>,
 

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -48,6 +48,7 @@ macro_rules! with_limits {
         $macro_name!(max_buffer_size, Ordering::Less);
         $macro_name!(max_vertex_attributes, Ordering::Less);
         $macro_name!(max_vertex_buffer_array_stride, Ordering::Less);
+        $macro_name!(max_inter_stage_shader_variables, Ordering::Less);
         $macro_name!(min_uniform_buffer_offset_alignment, Ordering::Greater);
         $macro_name!(min_storage_buffer_offset_alignment, Ordering::Greater);
         $macro_name!(max_color_attachments, Ordering::Less);


### PR DESCRIPTION

## v29.0.1 (2026-03-26)

This release includes `wgpu-core`, `wgpu-hal` and `wgpu-types` version `29.0.1`. All other crates remain at their previous versions.

### Bug Fixes

#### General

- Fix limit comparison logic for `max_inter_stage_shader_variables`. By @ErichDonGubler in [#9264](https://github.com/gfx-rs/wgpu/pull/9264).

#### Metal

- Added guards to avoid calling some feature detection methods that are not implemented on `CaptureMTLDevice`. By @andyleiserson in [#9284](https://github.com/gfx-rs/wgpu/pull/9284).
- Fix a regression where buffer limits were too conservative. This comes at the cost of non-compliant WebGPU limit validation. A future major release will keep the relaxed buffer limits on native while allowing WebGPU-mandated validation to be opted in. See [#9287](https://github.com/gfx-rs/wgpu/issues/9287).

#### GLES / OpenGL

- Fix texture height initialized incorrectly in `create_texture`. By @umajho in [#9302](https://github.com/gfx-rs/wgpu/pull/9302).

#### Validation

- Don't crash in the `Display` implementation of `CreateTextureViewError::TooMany{MipLevels,ArrayLayers}` when their base and offset overflow. By @ErichDonGubler in [#8808](https://github.com/gfx-rs/wgpu/pull/8808).