### PR TITLE
fix(types): remove duplicate `max_texture_dimension_1d` in `with_limits!`

### DIFF
--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -18,7 +18,6 @@ use crate::{Features, TextureFormat};
 macro_rules! with_limits {
     ($macro_name:ident) => {
         $macro_name!(max_texture_dimension_1d, Ordering::Less);
-        $macro_name!(max_texture_dimension_1d, Ordering::Less);
         $macro_name!(max_texture_dimension_2d, Ordering::Less);
         $macro_name!(max_texture_dimension_3d, Ordering::Less);
         $macro_name!(max_texture_array_layers, Ordering::Less);


### PR DESCRIPTION
## Summary

Removes a duplicated `max_texture_dimension_1d` entry in the `with_limits!` macro list in `wgpu-types/src/limits.rs`. The duplicate was redundant with the exhaustive `with_limits!` check added in #9294.

## Testing

- Not run (one-line dedupe).