### PR TITLE
fix(naga): report offending index in IndexOutOfBounds for AccessIndex

### DIFF
--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -483,7 +483,7 @@ impl super::Validator {
 
                 let limit = resolve_index_limit(module, base, &resolver[base], true)?;
                 if index >= limit {
-                    return Err(ExpressionError::IndexOutOfBounds(base, limit));
+                    return Err(ExpressionError::IndexOutOfBounds(base, index));
                 }
                 ShaderStages::all()
             }


### PR DESCRIPTION
## Summary

`ExpressionError::IndexOutOfBounds` is formatted as `Accessing index {1} is out of {0:?} bounds`, so the second field must be the **index** that was accessed, not the upper bound. The `AccessIndex` validation path incorrectly passed `limit`; it now passes `index`, consistent with the `Access` const-index path (which already uses `value`).

## Testing

- `cargo fmt -p naga`
- `cargo clippy -p naga --tests --no-deps`