### PR TITLE
fix panic on `cargo xtask cts`

### DIFF
--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -160,6 +160,7 @@ fn test_git_version_parsing() {
     test_ok!("git version 0.255.0", [0, 255, 0]);
     test_ok!("git version 4.5.6", [4, 5, 6]);
     test_ok!("git version 2.3.0.windows.1", [2, 3, 0]);
+    test_ok!("git version 2.50.1 (Apple Git-155)", [2, 50, 1]);
 
     macro_rules! test_err {
         ($input:expr, $msg:expr) => {

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -113,8 +113,9 @@ fn parse_git_version_output(output: &str) -> anyhow::Result<GitVersion> {
 
     let raw_version = raw_version
         .split_once("(Apple")
-        .map_or(raw_version, |(before, _after)| before).trim();
-    
+        .map_or(raw_version, |(before, _after)| before)
+        .trim();
+
     let parsed = GitVersion::try_from(
         raw_version
             .splitn(3, '.')

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -111,6 +111,10 @@ fn parse_git_version_output(output: &str) -> anyhow::Result<GitVersion> {
         .split_once(".windows")
         .map_or(raw_version, |(before, _after)| before);
 
+    let raw_version = raw_version
+        .split_once("(Apple")
+        .map_or(raw_version, |(before, _after)| before).trim();
+    
     let parsed = GitVersion::try_from(
         raw_version
             .splitn(3, '.')


### PR DESCRIPTION
**Connections**
#9313 

**Description**
 small fix for how we check for git version on mac
**Testing**


**Squash or Rebase?**




**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
