### PR TITLE
Return helpful error when WebGPU is disabled

### DIFF
--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1124,9 +1124,12 @@ impl ContextWebGpu {
         let context: webgpu_sys::GpuCanvasContext =
             context
                 .dyn_into()
-                .map_err(|_| crate::CreateSurfaceError {
+                .map_err(|actual| crate::CreateSurfaceError {
                     inner: crate::CreateSurfaceErrorKind::Web(
-                        "canvas.getContext() failed: This is likely because WebGPU is disabled in this browser.".into(),
+                        format!(
+                        "canvas.getContext() returned a value that did not coerce to GPUCanvasContext. This is likely because WebGPU is disabled in this browser. Expected: GPUCanvasContext, Actual: {}",
+                        actual.to_string()
+                        )
                     ),
                 })?;
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1125,9 +1125,9 @@ impl ContextWebGpu {
             context
                 .dyn_into()
                 .map_err(|_| crate::CreateSurfaceError {
-                    inner: crate::CreateSurfaceErrorKind::Web(format!(
-                        "canvas.getContext() failed: This is likely because WebGPU is disabled in this browser.",
-                    )),
+                    inner: crate::CreateSurfaceErrorKind::Web(
+                        "canvas.getContext() failed: This is likely because WebGPU is disabled in this browser.".to_owned(),
+                    ),
                 })?;
 
         Ok(WebSurface {

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1120,11 +1120,15 @@ impl ContextWebGpu {
             }
         };
 
-        // Not returning this error because it is a type error that shouldn't happen unless
-        // the browser, JS builtin objects, or wasm bindings are misbehaving somehow.
-        let context: webgpu_sys::GpuCanvasContext = context
-            .dyn_into()
-            .expect("canvas context is not a GPUCanvasContext");
+        // An error here indicated that WebGPU is disabled in the browser.
+        let context: webgpu_sys::GpuCanvasContext =
+            context
+                .dyn_into()
+                .map_err(|_| crate::CreateSurfaceError {
+                    inner: crate::CreateSurfaceErrorKind::Web(format!(
+                        "canvas.getContext() failed: This is likely because WebGPU is disabled in this browser.",
+                    )),
+                })?;
 
         Ok(WebSurface {
             gpu: self.gpu.clone(),

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1125,12 +1125,13 @@ impl ContextWebGpu {
             context
                 .dyn_into()
                 .map_err(|actual| crate::CreateSurfaceError {
-                    inner: crate::CreateSurfaceErrorKind::Web(
-                        format!(
-                        "canvas.getContext() returned a value that did not coerce to GPUCanvasContext. This is likely because WebGPU is disabled in this browser. Expected: GPUCanvasContext, Actual: {}",
+                    inner: crate::CreateSurfaceErrorKind::Web(format!(
+                        "`canvas.getContext()` returned a value that did not coerce to \
+                        `GPUCanvasContext`. \
+                        This is likely because WebGPU is disabled in this browser. \
+                        Expected: `GPUCanvasContext`, Actual: `{}`",
                         actual.to_string()
-                        )
-                    ),
+                    )),
                 })?;
 
         Ok(WebSurface {

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1126,7 +1126,7 @@ impl ContextWebGpu {
                 .dyn_into()
                 .map_err(|_| crate::CreateSurfaceError {
                     inner: crate::CreateSurfaceErrorKind::Web(
-                        "canvas.getContext() failed: This is likely because WebGPU is disabled in this browser.".to_owned(),
+                        "canvas.getContext() failed: This is likely because WebGPU is disabled in this browser.".into(),
                     ),
                 })?;
 


### PR DESCRIPTION
* Related: https://github.com/emilk/eframe_template/issues/223
* Related: https://github.com/emilk/egui/pull/8038

Previously, if WebGPU was disabled in the browser, `wgpu` would crash with a very unhelpful error message:

> panicked at ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-29.0.1/src/backend/webgpu.rs:1126:14:
canvas context is not a GPUCanvasContext: Object { obj: JsValue(GPUCanvasContext), generics: PhantomData<wasm_bindgen::JsValue> }

Tested in Firefox