### PR TITLE
Fixes for `@interpolate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,29 @@ This allows gaps in `VertexState`'s `buffers` and adds support for unbinding ver
 
 By @teoxoy in [#9351](https://github.com/gfx-rs/wgpu/pull/9351).
 
+#### Integer shader I/O no longer defaults to `@interpolate(flat)`
+
+To align with shading language specifications, `naga` no longer assumes that integer-typed shader I/O should have `flat` interpolation, i.e., should not be interpolated. Even though flat interpolation is the only choice for integer I/O, it must be still specified explicitly.
+
+WGSL:
+
+```diff
+ struct FragmentInput {
+     @location(0) tex_coord: vec2<f32>,
+-    @location(1) index: i32,
++    @location(1) @interpolate(flat) index: i32,
+ }
+```
+
+GLSL:
+
+```diff
+-layout(location = 1) in int index;
++layout(location = 1) flat in int index;
+```
+
+By @andyleiserson in [#9321](https://github.com/gfx-rs/wgpu/pull/9321).
+
 ### Added/New Features
 
 #### General

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -128,7 +128,6 @@ webgpu:shader,validation,parse,literal:* // 96%, https://github.com/gfx-rs/wgpu/
 webgpu:shader,validation,parse,shadow_builtins:* // 83%, function param shadowing parser issue; determinant const-eval; texture_external capability missing
 webgpu:shader,validation,shader_io,align:* // 98%, @align(2^31) accepted but exceeds i32::MAX per WGSL spec
 webgpu:shader,validation,shader_io,id:* // 97%, @id on const
-webgpu:shader,validation,shader_io,interpolate:*
 webgpu:shader,validation,shader_io,layout_constraints:* // 99%, struct alignment not inferred from @align on members
 webgpu:shader,validation,shader_io,locations:stage_inout:* // 66%, invalid usage @location in compute shaders
 webgpu:shader,validation,shader_io,pipeline_stage:* // 92%, stage attributes incorrectly accepted on var<private> and var<storage>

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -467,6 +467,7 @@ webgpu:shader,validation,shader_io,entry_point:*
 // Uses external texture bindings
 fails-if(vulkan) webgpu:shader,validation,shader_io,group_and_binding:*
 webgpu:shader,validation,shader_io,group:*
+webgpu:shader,validation,shader_io,interpolate:*
 webgpu:shader,validation,shader_io,invariant:*
 webgpu:shader,validation,shader_io,locations:duplicates:*
 webgpu:shader,validation,shader_io,locations:location_fp16:*

--- a/examples/features/src/texture_arrays/indexing.wgsl
+++ b/examples/features/src/texture_arrays/indexing.wgsl
@@ -8,7 +8,7 @@ struct VertexInput {
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) tex_coord: vec2<f32>,
-    @location(1) index: i32,
+    @location(1) @interpolate(flat) index: i32,
 }
 
 @vertex
@@ -22,7 +22,7 @@ fn vert_main(vertex: VertexInput) -> VertexOutput {
 
 struct FragmentInput {
     @location(0) tex_coord: vec2<f32>,
-    @location(1) index: i32,
+    @location(1) @interpolate(flat) index: i32,
 }
 
 @group(0) @binding(0)

--- a/examples/features/src/texture_arrays/non_uniform_indexing.wgsl
+++ b/examples/features/src/texture_arrays/non_uniform_indexing.wgsl
@@ -1,7 +1,7 @@
 enable wgpu_binding_array;
 struct FragmentInput {
     @location(0) tex_coord: vec2<f32>,
-    @location(1) index: i32,
+    @location(1) @interpolate(flat) index: i32,
 }
 
 @group(0) @binding(0)

--- a/naga/src/front/glsl/variables.rs
+++ b/naga/src/front/glsl/variables.rs
@@ -7,9 +7,8 @@ use super::{
     Frontend, Result, Span,
 };
 use crate::{
-    AddressSpace, Binding, BuiltIn, Constant, Expression, GlobalVariable, Handle, Interpolation,
-    LocalVariable, Override, ResourceBinding, Scalar, ScalarKind, ShaderStage, SwizzleComponent,
-    Type, TypeInner, VectorSize,
+    AddressSpace, Binding, BuiltIn, Constant, Expression, GlobalVariable, Handle, LocalVariable,
+    Override, ResourceBinding, Scalar, ShaderStage, SwizzleComponent, Type, TypeInner, VectorSize,
 };
 
 pub struct VarDeclaration<'a, 'key> {
@@ -433,13 +432,8 @@ impl Frontend {
                 let location = qualifiers
                     .uint_layout_qualifier("location", &mut self.errors)
                     .unwrap_or(0);
-                let interpolation = qualifiers.interpolation.take().map(|(i, _)| i).or_else(|| {
-                    let kind = ctx.module.types[ty].inner.scalar_kind()?;
-                    Some(match kind {
-                        ScalarKind::Float => Interpolation::Perspective,
-                        _ => Interpolation::Flat,
-                    })
-                });
+
+                let interpolation = qualifiers.interpolation.take().map(|(i, _)| i);
                 let sampling = qualifiers.sampling.take().map(|(s, _)| s);
 
                 let handle = ctx.module.global_variables.append(
@@ -462,16 +456,20 @@ impl Frontend {
                         _ => None,
                     });
 
+                let mut binding = Binding::Location {
+                    location,
+                    interpolation,
+                    sampling,
+                    blend_src,
+                    per_primitive: false,
+                };
+
+                binding.apply_default_interpolation(&ctx.module.types[ty].inner);
+
                 let idx = self.entry_args.len();
                 self.entry_args.push(EntryArg {
                     name: name.clone(),
-                    binding: Binding::Location {
-                        location,
-                        interpolation,
-                        sampling,
-                        blend_src,
-                        per_primitive: false,
-                    },
+                    binding,
                     handle,
                     storage,
                 });

--- a/naga/src/front/interpolator.rs
+++ b/naga/src/front/interpolator.rs
@@ -3,7 +3,7 @@ Interpolation defaults.
 */
 
 impl crate::Binding {
-    /// Apply the usual default interpolation for `ty` to `binding`.
+    /// Apply default interpolation (if applicable) for `ty` to the binding.
     ///
     /// This function is a utility front ends may use to satisfy the Naga IR's
     /// requirement, meant to ensure that input languages' policies have been
@@ -12,25 +12,23 @@ impl crate::Binding {
     ///
     /// All the shader languages Naga supports have similar rules:
     /// perspective-correct, center-sampled interpolation is the default for any
-    /// binding that can vary, and everything else either defaults to flat, or
-    /// requires an explicit flat qualifier/attribute/what-have-you.
+    /// binding that can vary, and an explicit flat qualifier/attribute/what-have-you is
+    /// required for bindings that cannot.
     ///
-    /// If `binding` is not a [`Location`] binding, or if its [`interpolation`] is
-    /// already set, then make no changes. Otherwise, set `binding`'s interpolation
-    /// and sampling to reasonable defaults depending on `ty`, the type of the value
-    /// being interpolated:
+    /// - If `binding` is not a [`Location`] binding, or if its [`interpolation`] is
+    ///   already set, then this function makes no changes.
     ///
     /// - If `ty` is a floating-point scalar, vector, or matrix type, then
-    ///   default to [`Perspective`] interpolation and [`Center`] sampling.
+    ///   apply the default [`Perspective`] interpolation and [`Center`] sampling.
     ///
-    /// - If `ty` is an integral scalar or vector, then default to [`Flat`]
-    ///   interpolation, which has no associated sampling.
+    /// - If `ty` is an integral scalar or vector, make no changes; if the interpolation was
+    ///   `None`, it will remain so, and be rejected by the validator.
     ///
-    /// - For any other types, make no change. Such types are not permitted as
-    ///   user-defined IO values, and will probably be flagged by the verifier
+    /// For struct types, the bindings are defined on the members, so there is nothing to
+    /// adjust on the struct itself.
     ///
-    /// When structs appear in input or output types, each member ought to have its
-    /// own [`Binding`], so structs are simply covered by the third case.
+    /// Other non-struct types are not permitted as user-defined IO values, and will be
+    /// rejected by the validator.
     ///
     /// [`Binding`]: crate::Binding
     /// [`Location`]: crate::Binding::Location
@@ -38,26 +36,19 @@ impl crate::Binding {
     /// [`Perspective`]: crate::Interpolation::Perspective
     /// [`Flat`]: crate::Interpolation::Flat
     /// [`Center`]: crate::Sampling::Center
-    pub fn apply_default_interpolation(&mut self, ty: &crate::TypeInner) {
-        if let crate::Binding::Location {
-            location: _,
+    pub(crate) fn apply_default_interpolation(&mut self, ty: &crate::TypeInner) {
+        let crate::Binding::Location {
             interpolation: ref mut interpolation @ None,
             ref mut sampling,
-            blend_src: _,
-            per_primitive: _,
+            ..
         } = *self
-        {
-            match ty.scalar_kind() {
-                Some(crate::ScalarKind::Float) => {
-                    *interpolation = Some(crate::Interpolation::Perspective);
-                    *sampling = Some(crate::Sampling::Center);
-                }
-                Some(crate::ScalarKind::Sint | crate::ScalarKind::Uint) => {
-                    *interpolation = Some(crate::Interpolation::Flat);
-                    *sampling = None;
-                }
-                Some(_) | None => {}
-            }
+        else {
+            return;
+        };
+
+        if let Some(crate::ScalarKind::Float) = ty.scalar_kind() {
+            *interpolation = Some(crate::Interpolation::Perspective);
+            *sampling = Some(crate::Sampling::Center);
         }
     }
 }

--- a/naga/src/front/mod.rs
+++ b/naga/src/front/mod.rs
@@ -2,7 +2,8 @@
 Frontend parsers that consume binary and text shaders and load them into [`Module`](super::Module)s.
 */
 
-mod interpolator;
+#[cfg(any(feature = "spv-in", feature = "wgsl-in"))]
+pub(crate) mod interpolator;
 mod type_gen;
 
 #[cfg(feature = "spv-in")]

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -203,12 +203,14 @@ impl<'a> BindingParser<'a> {
                     conv::map_interpolation(&lexer.enable_extensions, raw, span)?,
                     name_span,
                 )?;
-                if lexer.next_if(Token::Separator(',')) {
+                if lexer.next_if(Token::Separator(','))
+                    && !matches!(lexer.peek().0, Token::Paren(')'))
+                {
                     let (raw, span) = lexer.next_ident_with_span()?;
                     self.sampling
                         .set(conv::map_sampling(raw, span)?, name_span)?;
+                    lexer.next_if(Token::Separator(','));
                 }
-                lexer.next_if(Token::Separator(','));
                 lexer.expect(Token::Paren(')'))?;
             }
 

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -65,8 +65,6 @@ pub enum VaryingError {
         Only numeric scalars and vectors are allowed."
     )]
     NotIOShareableType(Handle<crate::Type>),
-    #[error("Interpolation is not valid")]
-    InvalidInterpolation,
     #[error("Interpolation {0:?} is only valid for stage {1:?}")]
     InvalidInterpolationInStage(crate::Interpolation, crate::ShaderStage),
     #[error("Cannot combine {interpolation:?} interpolation with the {sampling:?} sample type")]
@@ -74,6 +72,8 @@ pub enum VaryingError {
         interpolation: crate::Interpolation,
         sampling: crate::Sampling,
     },
+    #[error("`@interpolate(flat) must be explicitly specified for integer I/O")]
+    InvalidInterpolationForInteger,
     #[error("Interpolation must be specified on vertex shader outputs and fragment shader inputs")]
     MissingInterpolation,
     #[error("Built-in {0:?} is not available at this stage")]
@@ -150,8 +150,6 @@ pub enum EntryPointError {
     Argument(u32, #[source] VaryingError),
     #[error(transparent)]
     Result(#[from] VaryingError),
-    #[error("Location {location} interpolation of an integer has to be flat")]
-    InvalidIntegerInterpolation { location: u32 },
     #[error(transparent)]
     Function(#[from] FunctionError),
     #[error("Capability {0:?} is not supported")]
@@ -798,18 +796,21 @@ impl VaryingContext<'_> {
                 if interpolation != Some(crate::Interpolation::PerVertex) {
                     match ty_inner.scalar_kind() {
                         Some(crate::ScalarKind::Float) => {
+                            // Default interpolation is applied in the front end.
                             if needs_interpolation && interpolation.is_none() {
                                 return Err(VaryingError::MissingInterpolation);
                             }
                         }
-                        Some(_) => {
+                        Some(crate::ScalarKind::Sint | crate::ScalarKind::Uint) => {
+                            // Integers do not have a default interpolation; `flat` must be
+                            // specified explicitly.
                             if needs_interpolation
                                 && interpolation != Some(crate::Interpolation::Flat)
                             {
-                                return Err(VaryingError::InvalidInterpolation);
+                                return Err(VaryingError::InvalidInterpolationForInteger);
                             }
                         }
-                        None => return Err(VaryingError::InvalidType(ty)),
+                        Some(_) | None => return Err(VaryingError::InvalidType(ty)),
                     }
                 }
             }

--- a/naga/tests/in/glsl/interpolate.frag
+++ b/naga/tests/in/glsl/interpolate.frag
@@ -1,0 +1,10 @@
+#version 450
+
+layout(location = 0) in vec2 tex_coord;
+layout(location = 1) in int index;
+
+layout(location = 0) out vec4 o_color;
+
+void main() {
+    o_color = vec4(tex_coord, 0.0, float(index));
+}

--- a/naga/tests/in/glsl/interpolate.frag
+++ b/naga/tests/in/glsl/interpolate.frag
@@ -1,7 +1,7 @@
 #version 450
 
 layout(location = 0) in vec2 tex_coord;
-layout(location = 1) in int index;
+layout(location = 1) flat in int index;
 
 layout(location = 0) out vec4 o_color;
 

--- a/naga/tests/in/wgsl/binding-arrays.wgsl
+++ b/naga/tests/in/wgsl/binding-arrays.wgsl
@@ -23,7 +23,7 @@ var samp_comp: binding_array<sampler_comparison, 5>;
 var<uniform> uni: UniformIndex;
 
 struct FragmentIn {
-    @location(0) index: u32,
+    @location(0) @interpolate(flat) index: u32,
 };
 
 @fragment

--- a/naga/tests/in/wgsl/binding-buffer-arrays.wgsl
+++ b/naga/tests/in/wgsl/binding-buffer-arrays.wgsl
@@ -10,7 +10,7 @@ var<storage, read> storage_array: binding_array<Foo, 1>;
 var<uniform> uni: UniformIndex;
 
 struct FragmentIn {
-    @location(0) index: u32,
+    @location(0) @interpolate(flat) index: u32,
 }
 
 @fragment

--- a/naga/tests/in/wgsl/debug-symbol-large-source.wgsl
+++ b/naga/tests/in/wgsl/debug-symbol-large-source.wgsl
@@ -7291,7 +7291,7 @@ struct GenData {
 var<uniform> gen_data: GenData;
 
 struct GenVertexOutput {
-    @location(0)
+    @location(0) @interpolate(flat)
     index: u32,
     @builtin(position)
     position: vec4<f32>,

--- a/naga/tests/in/wgsl/debug-symbol-terrain.wgsl
+++ b/naga/tests/in/wgsl/debug-symbol-terrain.wgsl
@@ -149,6 +149,7 @@ var<uniform> gen_data: GenData;
 
 struct GenVertexOutput {
     @location(0)
+    @interpolate(flat)
     index: u32,
     @builtin(position)
     position: vec4<f32>,

--- a/naga/tests/out/hlsl/wgsl-fragment-output.hlsl
+++ b/naga/tests/out/hlsl/wgsl-fragment-output.hlsl
@@ -1,19 +1,19 @@
 struct FragmentOutputVec4Vec3_ {
     float4 vec4f : SV_Target0;
-    nointerpolation int4 vec4i : SV_Target1;
-    nointerpolation uint4 vec4u : SV_Target2;
+    int4 vec4i : SV_Target1;
+    uint4 vec4u : SV_Target2;
     float3 vec3f : SV_Target3;
-    nointerpolation int3 vec3i : SV_Target4;
-    nointerpolation uint3 vec3u : SV_Target5;
+    int3 vec3i : SV_Target4;
+    uint3 vec3u : SV_Target5;
 };
 
 struct FragmentOutputVec2Scalar {
     float2 vec2f : SV_Target0;
-    nointerpolation int2 vec2i : SV_Target1;
-    nointerpolation uint2 vec2u : SV_Target2;
+    int2 vec2i : SV_Target1;
+    uint2 vec2u : SV_Target2;
     float scalarf : SV_Target3;
-    nointerpolation int scalari : SV_Target4;
-    nointerpolation uint scalaru : SV_Target5;
+    int scalari : SV_Target4;
+    uint scalaru : SV_Target5;
 };
 
 FragmentOutputVec4Vec3_ main_vec4vec3_()

--- a/naga/tests/out/spv/wgsl-debug-symbol-large-source.spvasm
+++ b/naga/tests/out/spv/wgsl-debug-symbol-large-source.spvasm
@@ -7330,7 +7330,7 @@ struct GenData {
 var<uniform> gen_data: GenData;
 
 struct GenVertexOutput {
-    @location(0)
+    @location(0) @interpolate(flat)
     index: u32,
     @builtin(position)
     position: vec4<f32>,

--- a/naga/tests/out/spv/wgsl-debug-symbol-terrain.spvasm
+++ b/naga/tests/out/spv/wgsl-debug-symbol-terrain.spvasm
@@ -166,6 +166,7 @@ var<uniform> gen_data: GenData;
 
 struct GenVertexOutput {
     @location(0)
+    @interpolate(flat)
     index: u32,
     @builtin(position)
     position: vec4<f32>,
@@ -1054,27 +1055,27 @@ OpFunctionEnd
 %340 = OpLabel
 OpBranch %350
 %350 = OpLabel
-OpLine %3 270 9
+OpLine %3 271 9
 %351 = OpFunctionCall  %4  %67 %341
-OpLine %3 270 9
+OpLine %3 271 9
 %352 = OpFMul  %4  %351 %78
-OpLine %3 270 9
+OpLine %3 271 9
 %353 = OpFAdd  %4  %352 %78
-OpLine %3 271 17
-%354 = OpFAdd  %6  %341 %346
-OpLine %3 271 9
-%355 = OpFunctionCall  %4  %67 %354
-OpLine %3 271 9
-%356 = OpFMul  %4  %355 %78
-OpLine %3 271 9
-%357 = OpFAdd  %4  %356 %78
 OpLine %3 272 17
+%354 = OpFAdd  %6  %341 %346
+OpLine %3 272 9
+%355 = OpFunctionCall  %4  %67 %354
+OpLine %3 272 9
+%356 = OpFMul  %4  %355 %78
+OpLine %3 272 9
+%357 = OpFAdd  %4  %356 %78
+OpLine %3 273 17
 %358 = OpFAdd  %6  %341 %349
-OpLine %3 272 9
+OpLine %3 273 9
 %359 = OpFunctionCall  %4  %67 %358
-OpLine %3 272 9
+OpLine %3 273 9
 %360 = OpFMul  %4  %359 %78
-OpLine %3 269 12
+OpLine %3 270 12
 %361 = OpFAdd  %4  %360 %78
 %362 = OpCompositeConstruct  %5  %353 %357 %361
 OpReturnValue %362
@@ -1192,37 +1193,37 @@ OpFunctionEnd
 %446 = OpAccessChain  %445  %36 %135
 OpBranch %449
 %449 = OpLabel
-OpLine %3 161 19
+OpLine %3 162 19
 %450 = OpIAdd  %8  %437 %372
-OpLine %3 161 18
+OpLine %3 162 18
 %451 = OpFunctionCall  %8  %313 %450 %373
-OpLine %3 161 13
+OpLine %3 162 13
 %452 = OpFunctionCall  %8  %427 %451 %372
 %453 = OpConvertUToF  %4  %452
-OpLine %3 162 19
+OpLine %3 163 19
 %454 = OpIAdd  %8  %437 %126
-OpLine %3 162 18
+OpLine %3 163 18
 %455 = OpFunctionCall  %8  %313 %454 %373
-OpLine %3 162 13
+OpLine %3 163 13
 %456 = OpFunctionCall  %8  %427 %455 %372
 %457 = OpConvertUToF  %4  %456
-OpLine %3 163 14
+OpLine %3 164 14
 %458 = OpCompositeConstruct  %6  %453 %457
-OpLine %3 165 30
+OpLine %3 166 30
 %459 = OpVectorTimesScalar  %6  %458 %81
-OpLine %3 165 30
+OpLine %3 166 30
 %460 = OpFAdd  %6  %448 %459
-OpLine %3 165 20
+OpLine %3 166 20
 %461 = OpCompositeConstruct  %7  %460 %74 %56
-OpLine %3 168 21
+OpLine %3 169 21
 %462 = OpCompositeExtract  %4  %458 0
-OpLine %3 168 21
+OpLine %3 169 21
 %463 = OpAccessChain  %393  %446 %373
 %464 = OpLoad  %8  %463
 %465 = OpConvertUToF  %4  %464
 %466 = OpFMul  %4  %462 %465
 %467 = OpCompositeExtract  %4  %458 1
-OpLine %3 168 17
+OpLine %3 169 17
 %468 = OpAccessChain  %393  %446 %373
 %469 = OpLoad  %8  %468
 %470 = OpConvertUToF  %4  %469
@@ -1230,11 +1231,11 @@ OpLine %3 168 17
 %472 = OpFAdd  %4  %466 %471
 %474 = OpExtInst  %4  %1 FClamp %472 %74 %473
 %475 = OpConvertFToU  %8  %474
-OpLine %3 168 17
+OpLine %3 169 17
 %476 = OpAccessChain  %393  %446 %374
 %477 = OpLoad  %8  %476
 %478 = OpIAdd  %8  %475 %477
-OpLine %3 170 12
+OpLine %3 171 12
 %479 = OpCompositeConstruct  %21  %478 %461 %458
 %480 = OpCompositeExtract  %8  %479 0
 OpStore %438 %480
@@ -1255,20 +1256,20 @@ OpFunctionEnd
 %496 = OpAccessChain  %445  %36 %135
 OpBranch %500
 %500 = OpLabel
-OpLine %3 181 17
+OpLine %3 182 17
 %501 = OpCompositeExtract  %6  %484 2
 %502 = OpCompositeExtract  %4  %501 0
-OpLine %3 181 17
+OpLine %3 182 17
 %503 = OpAccessChain  %393  %496 %373
 %504 = OpLoad  %8  %503
 %505 = OpConvertUToF  %4  %504
 %506 = OpFMul  %4  %502 %505
 %507 = OpCompositeExtract  %6  %484 2
 %508 = OpCompositeExtract  %4  %507 1
-OpLine %3 181 70
+OpLine %3 182 70
 %509 = OpAccessChain  %393  %496 %373
 %510 = OpLoad  %8  %509
-OpLine %3 181 13
+OpLine %3 182 13
 %511 = OpAccessChain  %393  %496 %373
 %512 = OpLoad  %8  %511
 %513 = OpIMul  %8  %510 %512
@@ -1277,125 +1278,125 @@ OpLine %3 181 13
 %516 = OpFAdd  %4  %506 %515
 %517 = OpExtInst  %4  %1 FClamp %516 %74 %473
 %518 = OpConvertFToU  %8  %517
-OpLine %3 181 13
+OpLine %3 182 13
 %519 = OpAccessChain  %393  %496 %374
 %520 = OpLoad  %8  %519
 %521 = OpIAdd  %8  %518 %520
-OpLine %3 182 32
+OpLine %3 183 32
 %522 = OpConvertUToF  %4  %521
-OpLine %3 182 22
+OpLine %3 183 22
 %523 = OpFDiv  %4  %522 %497
 %524 = OpExtInst  %4  %1 Floor %523
 %525 = OpExtInst  %4  %1 FClamp %524 %74 %473
 %526 = OpConvertFToU  %8  %525
-OpLine %3 183 22
+OpLine %3 184 22
 %527 = OpFunctionCall  %8  %427 %521 %371
-OpLine %3 185 36
+OpLine %3 186 36
 %528 = OpAccessChain  %377  %496 %135
 %529 = OpLoad  %10  %528
-OpLine %3 185 57
+OpLine %3 186 57
 %530 = OpAccessChain  %380  %496 %126
 %531 = OpLoad  %11  %530
-OpLine %3 185 13
+OpLine %3 186 13
 %532 = OpFunctionCall  %6  %325 %526 %529 %531
-OpLine %3 186 31
+OpLine %3 187 31
 %533 = OpAccessChain  %386  %496 %372
 %534 = OpLoad  %6  %533
-OpLine %3 186 13
+OpLine %3 187 13
 %535 = OpFunctionCall  %14  %284 %532 %534
-OpLine %3 190 5
+OpLine %3 191 5
 OpSelectionMerge %536 None
 OpSwitch %527 %543 0 %537 1 %538 2 %539 3 %540 4 %541 5 %542
 %537 = OpLabel
-OpLine %3 191 37
+OpLine %3 192 37
 %544 = OpCompositeExtract  %5  %535 0
 %545 = OpCompositeExtract  %4  %544 0
-OpLine %3 191 20
+OpLine %3 192 20
 OpStore %498 %545
 OpBranch %536
 %538 = OpLabel
-OpLine %3 192 37
+OpLine %3 193 37
 %546 = OpCompositeExtract  %5  %535 0
 %547 = OpCompositeExtract  %4  %546 1
-OpLine %3 192 20
+OpLine %3 193 20
 OpStore %498 %547
 OpBranch %536
 %539 = OpLabel
-OpLine %3 193 37
+OpLine %3 194 37
 %548 = OpCompositeExtract  %5  %535 0
 %549 = OpCompositeExtract  %4  %548 2
-OpLine %3 193 20
+OpLine %3 194 20
 OpStore %498 %549
 OpBranch %536
 %540 = OpLabel
-OpLine %3 194 37
+OpLine %3 195 37
 %550 = OpCompositeExtract  %5  %535 1
 %551 = OpCompositeExtract  %4  %550 0
-OpLine %3 194 20
+OpLine %3 195 20
 OpStore %498 %551
 OpBranch %536
 %541 = OpLabel
-OpLine %3 195 37
+OpLine %3 196 37
 %552 = OpCompositeExtract  %5  %535 1
 %553 = OpCompositeExtract  %4  %552 1
-OpLine %3 195 20
+OpLine %3 196 20
 OpStore %498 %553
 OpBranch %536
 %542 = OpLabel
-OpLine %3 196 37
+OpLine %3 197 37
 %554 = OpCompositeExtract  %5  %535 1
 %555 = OpCompositeExtract  %4  %554 2
-OpLine %3 196 20
+OpLine %3 197 20
 OpStore %498 %555
 OpBranch %536
 %543 = OpLabel
 OpBranch %536
 %536 = OpLabel
-OpLine %3 200 15
+OpLine %3 201 15
 %556 = OpAccessChain  %393  %496 %135 %135
 %557 = OpLoad  %8  %556
 %558 = OpFunctionCall  %8  %313 %526 %557
 %559 = OpIAdd  %8  %526 %558
-OpLine %3 201 15
-%560 = OpIAdd  %8  %559 %126
 OpLine %3 202 15
+%560 = OpIAdd  %8  %559 %126
+OpLine %3 203 15
 %561 = OpAccessChain  %393  %496 %135 %135
 %562 = OpLoad  %8  %561
 %563 = OpIAdd  %8  %559 %562
-OpLine %3 202 15
-%564 = OpIAdd  %8  %563 %126
 OpLine %3 203 15
+%564 = OpIAdd  %8  %563 %126
+OpLine %3 204 15
 %565 = OpIAdd  %8  %564 %126
-OpLine %3 206 5
+OpLine %3 207 5
 OpSelectionMerge %566 None
 OpSwitch %527 %571 0 %567 3 %567 2 %568 4 %568 1 %569 5 %570
 %567 = OpLabel
-OpLine %3 207 24
+OpLine %3 208 24
 OpStore %499 %559
 OpBranch %566
 %568 = OpLabel
-OpLine %3 208 24
+OpLine %3 209 24
 OpStore %499 %565
 OpBranch %566
 %569 = OpLabel
-OpLine %3 209 20
+OpLine %3 210 20
 OpStore %499 %564
 OpBranch %566
 %570 = OpLabel
-OpLine %3 210 20
+OpLine %3 211 20
 OpStore %499 %560
 OpBranch %566
 %571 = OpLabel
 OpBranch %566
 %566 = OpLabel
-OpLine %3 213 13
+OpLine %3 214 13
 %572 = OpCompositeExtract  %8  %484 0
-OpLine %3 213 5
+OpLine %3 214 5
 OpStore %499 %572
-OpLine %3 222 27
+OpLine %3 223 27
 %573 = OpLoad  %4  %498
 %574 = OpBitcast  %8  %573
-OpLine %3 223 12
+OpLine %3 224 12
 %575 = OpLoad  %8  %499
 %576 = OpCompositeConstruct  %22  %574 %575
 %577 = OpCompositeExtract  %8  %576 0
@@ -1412,16 +1413,16 @@ OpFunctionEnd
 %592 = OpAccessChain  %591  %39 %135
 OpBranch %593
 %593 = OpLabel
-OpLine %3 254 25
+OpLine %3 255 25
 %595 = OpAccessChain  %594  %592 %126
 %596 = OpLoad  %23  %595
 %597 = OpCompositeExtract  %5  %580 0
-OpLine %3 254 25
+OpLine %3 255 25
 %598 = OpCompositeConstruct  %7  %597 %56
 %599 = OpMatrixTimesVector  %7  %596 %598
-OpLine %3 255 18
+OpLine %3 256 18
 %600 = OpCompositeExtract  %5  %580 1
-OpLine %3 256 12
+OpLine %3 257 12
 %601 = OpCompositeExtract  %5  %580 0
 %602 = OpCompositeConstruct  %26  %599 %600 %601
 %603 = OpCompositeExtract  %7  %602 0
@@ -1447,19 +1448,19 @@ OpFunctionEnd
 %622 = OpLoad  %28  %50
 OpBranch %631
 %631 = OpLabel
-OpLine %3 283 13
-OpLine %3 283 13
-OpLine %3 283 5
+OpLine %3 284 13
+OpLine %3 284 13
+OpLine %3 284 5
 %632 = OpFunctionCall  %5  %342 %623
-OpLine %3 285 28
-OpLine %3 285 17
+OpLine %3 286 28
+OpLine %3 286 17
 %633 = OpCompositeExtract  %5  %607 2
 %634 = OpExtInst  %5  %1 Fract %633
 %635 = OpExtInst  %5  %1 SmoothStep %80 %624 %634
-OpLine %3 285 5
+OpLine %3 286 5
 OpStore %629 %635
-OpLine %3 286 17
-OpLine %3 286 13
+OpLine %3 287 17
+OpLine %3 287 13
 %636 = OpAccessChain  %125  %629 %135
 %637 = OpLoad  %4  %636
 %638 = OpAccessChain  %125  %629 %126
@@ -1470,54 +1471,54 @@ OpLine %3 286 13
 %643 = OpFMul  %4  %640 %642
 %644 = OpCompositeConstruct  %5  %643 %643 %643
 %645 = OpExtInst  %5  %1 FMix %626 %628 %644
-OpLine %3 286 5
+OpLine %3 287 5
 OpStore %629 %645
-OpLine %3 289 25
+OpLine %3 290 25
 %647 = OpAccessChain  %646  %618 %126
 %648 = OpLoad  %5  %647
 %649 = OpVectorTimesScalar  %5  %648 %286
-OpLine %3 291 21
+OpLine %3 292 21
 %650 = OpAccessChain  %646  %618 %135
 %651 = OpLoad  %5  %650
 %652 = OpCompositeExtract  %5  %607 2
 %653 = OpFSub  %5  %651 %652
 %654 = OpExtInst  %5  %1 Normalize %653
-OpLine %3 292 20
+OpLine %3 293 20
 %656 = OpAccessChain  %655  %616 %135
 %657 = OpLoad  %7  %656
 %658 = OpVectorShuffle  %5  %657 %657 0 1 2
 %659 = OpCompositeExtract  %5  %607 2
 %660 = OpFSub  %5  %658 %659
 %661 = OpExtInst  %5  %1 Normalize %660
-OpLine %3 293 20
+OpLine %3 294 20
 %662 = OpFAdd  %5  %661 %654
 %663 = OpExtInst  %5  %1 Normalize %662
-OpLine %3 295 32
+OpLine %3 296 32
 %664 = OpCompositeExtract  %5  %607 1
 %665 = OpDot  %4  %664 %654
-OpLine %3 295 28
+OpLine %3 296 28
 %666 = OpExtInst  %4  %1 FMax %665 %74
-OpLine %3 296 25
+OpLine %3 297 25
 %667 = OpAccessChain  %646  %618 %126
 %668 = OpLoad  %5  %667
 %669 = OpVectorTimesScalar  %5  %668 %666
-OpLine %3 298 37
+OpLine %3 299 37
 %670 = OpCompositeExtract  %5  %607 1
 %671 = OpDot  %4  %670 %663
-OpLine %3 298 33
+OpLine %3 299 33
 %672 = OpExtInst  %4  %1 FMax %671 %74
-OpLine %3 298 29
+OpLine %3 299 29
 %673 = OpExtInst  %4  %1 Pow %672 %345
-OpLine %3 299 26
+OpLine %3 300 26
 %674 = OpAccessChain  %646  %618 %126
 %675 = OpLoad  %5  %674
 %676 = OpVectorTimesScalar  %5  %675 %673
-OpLine %3 301 18
+OpLine %3 302 18
 %677 = OpFAdd  %5  %649 %669
 %678 = OpFAdd  %5  %677 %676
 %679 = OpLoad  %5  %629
 %680 = OpFMul  %5  %678 %679
-OpLine %3 303 12
+OpLine %3 304 12
 %681 = OpCompositeConstruct  %7  %680 %56
 OpStore %614 %681
 OpReturn

--- a/naga/tests/out/wgsl/glsl-interpolate.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-interpolate.frag.wgsl
@@ -1,0 +1,23 @@
+struct FragmentOutput {
+    @location(0) o_color: vec4<f32>,
+}
+
+var<private> tex_coord_1: vec2<f32>;
+var<private> index_1: i32;
+var<private> o_color: vec4<f32>;
+
+fn main_1() {
+    let _e3 = tex_coord_1;
+    let _e5 = index_1;
+    o_color = vec4<f32>(_e3.x, _e3.y, 0f, f32(_e5));
+    return;
+}
+
+@fragment 
+fn main(@location(0) tex_coord: vec2<f32>, @location(1) @interpolate(flat) index: i32) -> FragmentOutput {
+    tex_coord_1 = tex_coord;
+    index_1 = index;
+    main_1();
+    let _e5 = o_color;
+    return FragmentOutput(_e5);
+}

--- a/naga/tests/out/wgsl/wgsl-binding-buffer-arrays.wgsl
+++ b/naga/tests/out/wgsl/wgsl-binding-buffer-arrays.wgsl
@@ -19,7 +19,7 @@ var<storage> storage_array: binding_array<Foo, 1>;
 var<uniform> uni: UniformIndex;
 
 @fragment 
-fn main(fragment_in: FragmentIn) -> @location(0) @interpolate(flat) u32 {
+fn main(fragment_in: FragmentIn) -> @location(0) u32 {
     var u1_: u32 = 0u;
 
     let uniform_index = uni.index;

--- a/naga/tests/out/wgsl/wgsl-fragment-output.wgsl
+++ b/naga/tests/out/wgsl/wgsl-fragment-output.wgsl
@@ -1,19 +1,19 @@
 struct FragmentOutputVec4Vec3_ {
     @location(0) vec4f: vec4<f32>,
-    @location(1) @interpolate(flat) vec4i: vec4<i32>,
-    @location(2) @interpolate(flat) vec4u: vec4<u32>,
+    @location(1) vec4i: vec4<i32>,
+    @location(2) vec4u: vec4<u32>,
     @location(3) vec3f: vec3<f32>,
-    @location(4) @interpolate(flat) vec3i: vec3<i32>,
-    @location(5) @interpolate(flat) vec3u: vec3<u32>,
+    @location(4) vec3i: vec3<i32>,
+    @location(5) vec3u: vec3<u32>,
 }
 
 struct FragmentOutputVec2Scalar {
     @location(0) vec2f: vec2<f32>,
-    @location(1) @interpolate(flat) vec2i: vec2<i32>,
-    @location(2) @interpolate(flat) vec2u: vec2<u32>,
+    @location(1) vec2i: vec2<i32>,
+    @location(2) vec2u: vec2<u32>,
     @location(3) scalarf: f32,
-    @location(4) @interpolate(flat) scalari: i32,
-    @location(5) @interpolate(flat) scalaru: u32,
+    @location(4) scalari: i32,
+    @location(5) scalaru: u32,
 }
 
 @fragment 

--- a/naga/tests/out/wgsl/wgsl-interface.wgsl
+++ b/naga/tests/out/wgsl/wgsl-interface.wgsl
@@ -20,7 +20,7 @@ struct Input2_ {
 var<workgroup> output: array<u32, 1>;
 
 @vertex 
-fn vertex(@builtin(vertex_index) vertex_index: u32, @builtin(instance_index) instance_index: u32, @location(10) @interpolate(flat) color: u32) -> VertexOutput {
+fn vertex(@builtin(vertex_index) vertex_index: u32, @builtin(instance_index) instance_index: u32, @location(10) color: u32) -> VertexOutput {
     let tmp: u32 = ((vertex_index + instance_index) + color);
     return VertexOutput(vec4(1f), f32(tmp));
 }

--- a/naga/tests/out/wgsl/wgsl-shadow.wgsl
+++ b/naga/tests/out/wgsl/wgsl-shadow.wgsl
@@ -48,7 +48,7 @@ fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
 }
 
 @vertex 
-fn vs_main(@location(0) @interpolate(flat) position: vec4<i32>, @location(1) @interpolate(flat) normal: vec4<i32>) -> VertexOutput {
+fn vs_main(@location(0) position: vec4<i32>, @location(1) normal: vec4<i32>) -> VertexOutput {
     var out: VertexOutput;
 
     let w = u_entity.world;

--- a/tests/tests/wgpu-gpu/immediates.rs
+++ b/tests/tests/wgpu-gpu/immediates.rs
@@ -193,7 +193,7 @@ const SHADER2: &str = "
 
     struct VertexOutput {
         @builtin(position) position: vec4f,
-        @location(0) index: u32,
+        @location(0) @interpolate(flat) index: u32,
     }
 
     @vertex fn vertex(
@@ -204,7 +204,7 @@ const SHADER2: &str = "
     }
 
     @fragment fn fragment(
-        @location(0) ix: u32,
+        @location(0) @interpolate(flat) ix: u32,
      ) -> @location(0) vec4f {
         result[ix + 4u] = immediates.fragment_constants[ix];
         return vec4f();


### PR DESCRIPTION
Fixes a couple problems with `interpolate` specifications:

- In WGSL, allow a trailing comma in the 1-argument form of `@interpolate`.
- Do not assume `@interpolate(flat)` for integers in WGSL, nor the equivalents in GLSL or SPIR-V. It is the only choice, but it must be specified explicitly. (Fixes #6990)

(Originally, this PR only added the explicit-flat requirement to WGSL. It was later updated to apply it to GLSL and SPIR-V as well.)

**Testing**
Enables CTS test, and snapshot tests.

**Squash or Rebase?** Rebase

**Checklist**

- [x] Needs a `CHANGELOG.md` entry.
