### PR TITLE
Fix minor issues with `@size` attribute

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -133,7 +133,6 @@ webgpu:shader,validation,shader_io,interpolate:*
 webgpu:shader,validation,shader_io,layout_constraints:* // 99%, struct alignment not inferred from @align on members
 webgpu:shader,validation,shader_io,locations:stage_inout:* // 66%, invalid usage @location in compute shaders
 webgpu:shader,validation,shader_io,pipeline_stage:* // 92%, stage attributes incorrectly accepted on var<private> and var<storage>
-webgpu:shader,validation,shader_io,size:* // 94%, large size validation, runtime-sized array
 webgpu:shader,validation,shader_io,workgroup_size:* // 88%, type mixing, attribute placement
 webgpu:shader,validation,statement,continue:* // 90%, continue bypassing declaration used in continuing block, https://github.com/gfx-rs/wgpu/issues/7650
 webgpu:shader,validation,statement,for:* // 93%, phony/increment in for-loop init/cont, empty loop behavior

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -59,7 +59,6 @@ webgpu:api,validation,texture,destroy:submit_a_destroyed_texture_as_attachment:*
 
 webgpu:shader,execution,expression,call,builtin,atan2:f16:* // dx12, fails with dxc, passes with fxc, https://github.com/gfx-rs/wgpu/issues/9179
 
-webgpu:shader,validation,decl,context_dependent_resolution:* // 92%, f16 as reserved keyword when enabled
 webgpu:shader,validation,decl,let:* // texture/sampler let
 webgpu:shader,validation,decl,override:* // 93%, unrestricted_pointer_parameters not implemented, https://github.com/gfx-rs/wgpu/issues/5158
 webgpu:shader,validation,decl,var:* // 99%, https://github.com/gfx-rs/wgpu/issues/8925 (trailing comma), atomics in read-only storage, shader stage restrictions
@@ -120,7 +119,7 @@ webgpu:shader,validation,expression,early_evaluation:* // 67%, mixed override/ru
 webgpu:shader,validation,expression,precedence:* // 76%, https://github.com/gfx-rs/wgpu/issues/4536
 webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:* // 50%, interaction w/ texture_formats_tier1, https://github.com/gfx-rs/wgpu/issues/8962#issuecomment-3819427894
 webgpu:shader,validation,functions,alias_analysis:* // 2%, https://github.com/gfx-rs/wgpu/issues/7650
-webgpu:shader,validation,functions,restrictions:*
+webgpu:shader,validation,functions,restrictions:* // 81%, @id/@workgroup_size accepted on plain functions, https://github.com/gfx-rs/wgpu/issues/8898
 webgpu:shader,validation,parse,attribute:* // 93%, group index validation at shader module creation
 webgpu:shader,validation,parse,blankspace:* // 95%, null in comments, https://github.com/gfx-rs/wgpu/issues/8877
 webgpu:shader,validation,parse,comments:* // 93%, unterminated block comments, https://github.com/gfx-rs/wgpu/issues/8877
@@ -128,7 +127,7 @@ webgpu:shader,validation,parse,diagnostic:* // 50%, https://github.com/gfx-rs/wg
 webgpu:shader,validation,parse,literal:* // 96%, https://github.com/gfx-rs/wgpu/issues/7046
 webgpu:shader,validation,parse,must_use:* // 97%, https://github.com/gfx-rs/wgpu/issues/8876
 webgpu:shader,validation,parse,shadow_builtins:* // 83%, function param shadowing parser issue; determinant const-eval; texture_external capability missing
-webgpu:shader,validation,shader_io,align:*
+webgpu:shader,validation,shader_io,align:* // 98%, @align(2^31) accepted but exceeds i32::MAX per WGSL spec
 webgpu:shader,validation,shader_io,id:* // 97%, @id on const
 webgpu:shader,validation,shader_io,interpolate:*
 webgpu:shader,validation,shader_io,layout_constraints:* // 99%, struct alignment not inferred from @align on members

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -355,6 +355,7 @@ webgpu:shader,validation,const_assert,const_assert:*
 webgpu:shader,validation,decl,assignment_statement:*
 webgpu:shader,validation,decl,compound_statement:*
 webgpu:shader,validation,decl,const:*
+webgpu:shader,validation,decl,context_dependent_resolution:*
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_neg"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_one"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_zero_signed"

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -466,6 +466,7 @@ webgpu:shader,validation,shader_io,locations:nesting:*
 webgpu:shader,validation,shader_io,locations:out_of_order:*
 webgpu:shader,validation,shader_io,locations:type:*
 webgpu:shader,validation,shader_io,locations:validation:*
+webgpu:shader,validation,shader_io,size:*
 webgpu:shader,validation,statement,break_if:*
 webgpu:shader,validation,statement,break:*
 webgpu:shader,validation,statement,compound:*

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -219,6 +219,7 @@ pub(crate) enum Error<'a> {
     UnknownLanguageExtension(Span, &'a str),
     UnknownDiagnosticRuleName(Span),
     SizeAttributeTooLow(Span, u32),
+    SizeAttributeRequiresFixedFootprint(Span),
     AlignAttributeTooLow(Span, Alignment),
     NonPowerOfTwoAlignAttribute(Span),
     InconsistentBinding(Span),
@@ -751,6 +752,11 @@ impl<'a> Error<'a> {
             Error::SizeAttributeTooLow(bad_span, min_size) => ParseError {
                 message: format!("struct member size must be at least {min_size}"),
                 labels: vec![(bad_span, format!("must be at least {min_size}").into())],
+                notes: vec![],
+            },
+            Error::SizeAttributeRequiresFixedFootprint(bad_span) => ParseError {
+                message: "@size attribute requires a type with creation-fixed footprint".to_string(),
+                labels: vec![(bad_span, "type does not have creation-fixed footprint".into())],
                 notes: vec![],
             },
             Error::AlignAttributeTooLow(bad_span, min_align) => ParseError {

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -4603,6 +4603,13 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
             let member_size = if let Some(size_expr) = member.size {
                 let (size, span) = self.const_u32(size_expr, &mut ctx.as_const())?;
+                if let ir::TypeInner::Array {
+                    size: ir::ArraySize::Dynamic | ir::ArraySize::Pending(_),
+                    ..
+                } = ctx.module.types[ty].inner
+                {
+                    return Err(Box::new(Error::SizeAttributeRequiresFixedFootprint(span)));
+                }
                 if size < member_min_size {
                     return Err(Box::new(Error::SizeAttributeTooLow(span, member_min_size)));
                 } else {

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -36,7 +36,7 @@ pub use r#type::{Disalignment, ImmediateError, TypeError, TypeFlags, WidthError}
 use self::handles::InvalidHandleError;
 
 /// Maximum size of a type, in bytes.
-pub const MAX_TYPE_SIZE: u32 = 0x4000_0000; // 1GB
+pub const MAX_TYPE_SIZE: u32 = i32::MAX as u32;
 
 bitflags::bitflags! {
     /// Validation flags.

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -590,13 +590,13 @@ fn struct_member_size_too_low() {
     check(
         r#"
             struct Bar {
-                @size(0) data: array<f32>
+                @size(0) data: array<f32, 1>
             }
         "#,
         r#"error: struct member size must be at least 4
   ┌─ wgsl:3:23
   │
-3 │                 @size(0) data: array<f32>
+3 │                 @size(0) data: array<f32, 1>
   │                       ^ must be at least 4
 
 "#,
@@ -4396,7 +4396,7 @@ fn max_type_size_large_array() {
     // The total size of an array is not resolved until validation. Type aliases
     // don't get spans so the error isn't very helpful.
     check_validation! {
-        "alias LargeArray = array<u32, (1 << 28) + 1>;":
+        "alias LargeArray = array<u32, 1 << 29>;":
         Err(naga::valid::ValidationError::Layouter(
                 naga::proc::LayoutError {
                     inner: naga::proc::LayoutErrorInner::TooLarge,
@@ -4412,9 +4412,9 @@ fn max_type_size_array_of_arrays() {
     // during lowering. Anonymous types don't get spans so this error isn't very
     // helpful.
     check(
-        "alias ArrayOfArrays = array<array<u32, (1 << 28) + 1>, 22>;",
+        "alias ArrayOfArrays = array<array<u32, 1 << 29>, 22>;",
         r#"error: type is too large
- = note: the maximum size is 1073741824 bytes
+ = note: the maximum size is 2147483647 bytes
 
 "#,
     );
@@ -4441,7 +4441,7 @@ fn max_type_size_override_array() {
         .validate(&module)
         .expect("module should validate");
 
-    let overrides = hashbrown::HashMap::from([(String::from("SIZE"), f64::from((1 << 28) + 1))]);
+    let overrides = hashbrown::HashMap::from([(String::from("SIZE"), f64::from(1 << 29))]);
     let err = naga::back::pipeline_constants::process_overrides(&module, &info, None, &overrides)
         .unwrap_err();
     let naga::back::pipeline_constants::PipelineConstantError::ValidationError(err) = err else {
@@ -4463,16 +4463,16 @@ fn max_type_size_array_in_struct() {
     check(
         r#"
             struct ContainsLargeArray {
-                arr: array<u32, (1 << 28) + 1>,
+                arr: array<u32, 1 << 29>,
             }
         "#,
         r#"error: struct member is too large
   ┌─ wgsl:3:17
   │
-3 │                 arr: array<u32, (1 << 28) + 1>,
+3 │                 arr: array<u32, 1 << 29>,
   │                 ^^^ this member exceeds the maximum size
   │
-  = note: the maximum size is 1073741824 bytes
+  = note: the maximum size is 2147483647 bytes
 
 "#,
     );
@@ -4485,20 +4485,20 @@ fn max_type_size_two_arrays_in_struct() {
     check(
         r#"
             struct TwoArrays {
-                arr1: array<u32, 1 << 27>,
-                arr2: array<u32, (1 << 27) + 1>,
+                arr1: array<u32, 1 << 28>,
+                arr2: array<u32, 1 << 28>,
             }
         "#,
         "error: type is too large
   ┌─ wgsl:2:13
   │\x20\x20
 2 │ ╭             struct TwoArrays {
-3 │ │                 arr1: array<u32, 1 << 27>,
-4 │ │                 arr2: array<u32, (1 << 27) + 1>,
+3 │ │                 arr1: array<u32, 1 << 28>,
+4 │ │                 arr2: array<u32, 1 << 28>,
 5 │ │             }
   │ ╰─────────────^ this type exceeds the maximum size
   │\x20\x20
-  = note: the maximum size is 1073741824 bytes
+  = note: the maximum size is 2147483647 bytes
 
 ",
     );
@@ -4513,7 +4513,7 @@ fn max_type_size_array_of_structs() {
             struct NotVeryBigStruct {
                 data: u32,
             }
-            alias BigArrayOfStructs = array<NotVeryBigStruct, (1 << 28) + 1>;
+            alias BigArrayOfStructs = array<NotVeryBigStruct, 1 << 29>;
         "#:
         Err(naga::valid::ValidationError::Layouter(
                 naga::proc::LayoutError {


### PR DESCRIPTION
- Increase our `MAX_TYPE_SIZE` to `i32::MAX` because the CTS wants that to work with `@size`.
- Disallow `@size` on override- and runtime-sized arrays.

**Testing**
Enables CTS test

**Squash or Rebase?** Squash
