### PR TITLE
Make more `WriteOnly` methods `const`.

### DIFF
--- a/wgpu-types/src/write_only.rs
+++ b/wgpu-types/src/write_only.rs
@@ -96,7 +96,7 @@ impl<'a, T: ?Sized> WriteOnly<'a, T> {
     /// “de-initialize” the memory.
     #[inline]
     #[must_use]
-    pub unsafe fn new(ptr: NonNull<T>) -> Self {
+    pub const unsafe fn new(ptr: NonNull<T>) -> Self {
         Self {
             ptr,
             _phantom: PhantomData,
@@ -124,7 +124,7 @@ impl<'a, T: ?Sized> WriteOnly<'a, T> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn from_mut(reference: &mut T) -> Self {
+    pub const fn from_mut(reference: &mut T) -> Self {
         // SAFETY: `&mut`’s safety conditions imply ours.
         // FIXME: Use `NonNull::from_mut()` when MSRV ≥ 1.89.0
         unsafe { Self::new(NonNull::new_unchecked(&raw mut *reference)) }
@@ -136,7 +136,7 @@ impl<'a, T: ?Sized> WriteOnly<'a, T> {
     /// For slices, use [`copy_from_slice()`][Self::copy_from_slice] or
     /// [`write_iter()`][Self::write_iter] instead.
     #[inline]
-    pub fn write(self, value: T)
+    pub const fn write(self, value: T)
     where
         // Ideally, we want "does not have a destructor" to avoid any need for dropping (which
         // would imply reading) or forgetting the values that write operations overwrite.
@@ -170,7 +170,7 @@ impl<'a, T: ?Sized> WriteOnly<'a, T> {
     ///
     /// [write combining]: https://en.wikipedia.org/wiki/Write_combining
     #[inline]
-    pub fn as_raw_ptr(&mut self) -> NonNull<T> {
+    pub const fn as_raw_ptr(&mut self) -> NonNull<T> {
         self.ptr
     }
 }
@@ -491,7 +491,7 @@ impl<'a, T> WriteOnly<'a, [T]> {
     ///
     /// Otherwise, if `mid > len`, returns [`Err`] with the original slice.
     #[inline]
-    pub fn split_at_checked(self, mid: usize) -> Result<(Self, Self), Self> {
+    pub const fn split_at_checked(self, mid: usize) -> Result<(Self, Self), Self> {
         if mid <= self.len() {
             let Self { ptr, _phantom: _ } = self;
             let element_ptr = ptr.cast::<T>();
@@ -584,7 +584,7 @@ impl<'a, T> WriteOnly<'a, [T]> {
     /// Returns `None` if `self` is empty.
     #[inline]
     #[must_use]
-    pub fn split_off_first(&mut self) -> Option<WriteOnly<'a, T>> {
+    pub const fn split_off_first(&mut self) -> Option<WriteOnly<'a, T>> {
         let len = self.len();
         if let Some(new_len) = len.checked_sub(1) {
             let ptr: NonNull<T> = self.as_raw_element_ptr();
@@ -605,7 +605,7 @@ impl<'a, T> WriteOnly<'a, [T]> {
     /// Returns `None` if `self` is empty.
     #[inline]
     #[must_use]
-    pub fn split_off_last(&mut self) -> Option<WriteOnly<'a, T>> {
+    pub const fn split_off_last(&mut self) -> Option<WriteOnly<'a, T>> {
         let len = self.len();
         if let Some(new_len) = len.checked_sub(1) {
             let ptr: NonNull<T> = self.as_raw_element_ptr();
@@ -675,7 +675,7 @@ impl<'a, T> WriteOnly<'a, [T]> {
     /// See [`WriteOnly::as_raw_ptr()`] for information on how this pointer is, or is not,
     /// sound to use.
     #[inline]
-    pub fn as_raw_element_ptr(&mut self) -> NonNull<T> {
+    pub const fn as_raw_element_ptr(&mut self) -> NonNull<T> {
         self.ptr.cast::<T>()
     }
 }
@@ -889,6 +889,28 @@ mod tests {
         let wo = WriteOnly::from_mut(&mut val);
         wo.write(2);
         assert_eq!(val, 2);
+    }
+
+    /// Test that we can construct an empty `WriteOnly` in const eval.
+    const _: WriteOnly<'static, [u8]> = WriteOnly::from_mut(&mut []);
+
+    /// Test that we can use a non-empty `WriteOnly` in const eval.
+    #[test]
+    fn const_write() {
+        let output = const {
+            let mut array = [0u8; 4];
+            let mut wo = WriteOnly::from_mut(array.as_mut_slice());
+
+            // We can't use iterators in const yet, but we can do this.
+            wo.split_off_first().unwrap().write(1);
+            wo.split_off_first().unwrap().write(2);
+            wo.split_off_first().unwrap().write(3);
+            wo.split_off_first().unwrap().write(4);
+
+            array
+        };
+
+        assert_eq!(output, [1, 2, 3, 4]);
     }
 
     #[test]


### PR DESCRIPTION
**Connections**
Followup to #9042.

**Description**
Make more `WriteOnly` methods `const`. In particular, conversions to and from pointers and references are now const. This allows constructing `WriteOnly::from_mut(&mut [])` in const eval, which may be useful for applications wishing to have constant empty values.

I can’t think of a reason to actually write through a `WriteOnly` in const, but we might as well allow the amount of it we can, too.

**Testing**
Added unit tests.

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
