### PR TITLE
Enable ray tracing example tests on metal

### DIFF
--- a/examples/features/src/ray_cube_compute/mod.rs
+++ b/examples/features/src/ray_cube_compute/mod.rs
@@ -471,7 +471,7 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     optional_features: wgpu::Features::default(),
     base_test_parameters: wgpu_test::TestParameters::default()
         // https://github.com/gfx-rs/wgpu/issues/9100
-        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
+        .disable_mtl_shader_validation(),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/examples/features/src/ray_cube_fragment/mod.rs
+++ b/examples/features/src/ray_cube_fragment/mod.rs
@@ -357,7 +357,7 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     optional_features: wgpu::Features::default(),
     base_test_parameters: wgpu_test::TestParameters::default()
         // https://github.com/gfx-rs/wgpu/issues/9100
-        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
+        .disable_mtl_shader_validation(),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/examples/features/src/ray_scene/mod.rs
+++ b/examples/features/src/ray_scene/mod.rs
@@ -537,7 +537,7 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     optional_features: wgpu::Features::default(),
     base_test_parameters: wgpu_test::TestParameters::default()
         // https://github.com/gfx-rs/wgpu/issues/9100
-        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
+        .disable_mtl_shader_validation(),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/examples/features/src/ray_shadows/mod.rs
+++ b/examples/features/src/ray_shadows/mod.rs
@@ -354,7 +354,7 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     optional_features: wgpu::Features::default(),
     base_test_parameters: wgpu_test::TestParameters::default()
         // https://github.com/gfx-rs/wgpu/issues/9100
-        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
+        .disable_mtl_shader_validation(),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/examples/features/src/ray_traced_triangle/mod.rs
+++ b/examples/features/src/ray_traced_triangle/mod.rs
@@ -440,7 +440,7 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     optional_features: wgpu::Features::default(),
     base_test_parameters: wgpu_test::TestParameters::default()
         // https://github.com/gfx-rs/wgpu/issues/9100
-        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
+        .disable_mtl_shader_validation(),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };

--- a/tests/src/native.rs
+++ b/tests/src/native.rs
@@ -65,6 +65,10 @@ impl NativeTest {
                 if std::env::var("GITHUB_ACTIONS").as_deref() != Ok("true") && !config.params.disable_mtl_shader_validation {
                     // Metal Shader Validation is entirely broken in the paravirtualized CI environment.
                     std::env::set_var("MTL_SHADER_VALIDATION", env_value);
+                } else if config.params.disable_mtl_shader_validation {
+                    // For ray tracing, where MTL_SHADER_VALIDATION causes acceleration structure ids to be
+                    // completely incorrect.
+                    std::env::set_var("MTL_SHADER_VALIDATION", "0");
                 }
 
                 execute_test(Some(&adapter_report), config, Some(test_info)).await;

--- a/tests/src/native.rs
+++ b/tests/src/native.rs
@@ -62,7 +62,9 @@ impl NativeTest {
 
                 let env_value = if metal_validation { "1" } else { "0" };
                 std::env::set_var("MTL_DEBUG_LAYER", env_value);
-                if std::env::var("GITHUB_ACTIONS").as_deref() != Ok("true") && !config.params.disable_mtl_shader_validation {
+                if std::env::var("GITHUB_ACTIONS").as_deref() != Ok("true")
+                    && !config.params.disable_mtl_shader_validation
+                {
                     // Metal Shader Validation is entirely broken in the paravirtualized CI environment.
                     std::env::set_var("MTL_SHADER_VALIDATION", env_value);
                 } else if config.params.disable_mtl_shader_validation {

--- a/tests/src/native.rs
+++ b/tests/src/native.rs
@@ -62,7 +62,7 @@ impl NativeTest {
 
                 let env_value = if metal_validation { "1" } else { "0" };
                 std::env::set_var("MTL_DEBUG_LAYER", env_value);
-                if std::env::var("GITHUB_ACTIONS").as_deref() != Ok("true") {
+                if std::env::var("GITHUB_ACTIONS").as_deref() != Ok("true") && !config.params.disable_mtl_shader_validation {
                     // Metal Shader Validation is entirely broken in the paravirtualized CI environment.
                     std::env::set_var("MTL_SHADER_VALIDATION", env_value);
                 }

--- a/tests/src/params.rs
+++ b/tests/src/params.rs
@@ -31,6 +31,10 @@ pub struct TestParameters {
 
     /// Conditions under which this test should be run, but is expected to fail.
     pub failures: Vec<FailureCase>,
+
+    /// For certain features (ray tracing), metal shader validation is completely
+    /// broken
+    pub disable_mtl_shader_validation: bool,
 }
 
 impl Default for TestParameters {
@@ -45,6 +49,7 @@ impl Default for TestParameters {
             // parameters ask us to remove it.
             skips: vec![FailureCase::backend(wgpu::Backends::NOOP)],
             failures: Vec::new(),
+            disable_mtl_shader_validation: false,
         }
     }
 }
@@ -104,6 +109,15 @@ impl TestParameters {
     pub fn enable_noop(mut self) -> Self {
         self.skips
             .retain(|case| *case != FailureCase::backend(wgpu::Backends::NOOP));
+        self
+    }
+
+    /// Disable metal shader validation.
+    /// 
+    /// Metal shader validation can cause features (ray tracing specifically)
+    /// to break. This disables it so it can be tested.
+    pub fn disable_mtl_shader_validation(mut self) -> Self {
+        self.disable_mtl_shader_validation = true;
         self
     }
 }

--- a/tests/src/params.rs
+++ b/tests/src/params.rs
@@ -113,7 +113,7 @@ impl TestParameters {
     }
 
     /// Disable metal shader validation.
-    /// 
+    ///
     /// Metal shader validation can cause features (ray tracing specifically)
     /// to break. This disables it so it can be tested.
     pub fn disable_mtl_shader_validation(mut self) -> Self {

--- a/tests/tests/wgpu-gpu/ray_tracing/shader.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/shader.rs
@@ -115,7 +115,7 @@ static PREVENT_INVALID_RAY_QUERY_CALLS: GpuTestConfiguration = GpuTestConfigurat
             .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
             // Otherwise, mistakes in the generated code won't be caught.
             .instance_flags(InstanceFlags::GPU_BASED_VALIDATION)
-            // not yet implemented in directx12
+            // not yet implemented in metal
             .skip(FailureCase::backend(Backends::METAL)),
     )
     .run_sync(prevent_invalid_ray_query_calls);

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -705,7 +705,8 @@ impl Limits {
             max_blas_geometry_count: (1 << 24) - 1, // 2^24 - 1: Vulkan's minimum
             max_tlas_instance_count: (1 << 24) - 1, // 2^24 - 1: Vulkan's minimum
             max_blas_primitive_count: 1 << 28,      // 2^28: Metal's minimum
-            max_acceleration_structures_per_shader_stage: 16, // Vulkan's minimum
+            // On metal acceleration structures are limited because they share buffer slots
+            max_acceleration_structures_per_shader_stage: 1,
             ..self
         }
     }


### PR DESCRIPTION
**Connections**
Prevents #9100 from happening on tests.

**Description**
Disables metal shader validation (see https://github.com/gfx-rs/wgpu/issues/9100#issuecomment-4144863462) on the ray tracing examples as it seems to fail to map the fake id it generates to a real id. Also brings max acceleration structures per stage default down to one to align with metal.

**Testing**
Enables tests

**Squash or Rebase?**
Squash
<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy --tests`. If applicable, add:
- [x] Run `cargo xtask test` to run tests.
- If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. --> Not really applicable
