### PR TITLE
implements #8119 : Metal backend's wgpu_hal::Device::wait implementation polls instead of waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,8 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 #### Metal
 
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
+- Improved command buffer completion handling. By @39ali in [#9328](https://github.com/gfx-rs/wgpu/pull/9328).
+  - Wait using a condition variable, instead of polling.
 - Fixed structure field names incorrectly ignoring reserved keywords in the Metal (MSL) backend. By @39ali [#9379](https://github.com/gfx-rs/wgpu/pull/9379).
 - Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
 - Improved command buffer completion handling. By @39ali in [#9328](https://github.com/gfx-rs/wgpu/pull/9328).
   - Wait using a condition variable, instead of polling.
+  - Fixed a hang in `Device::poll(PollType::wait_indefinitely())` when a Metal command buffer exits with an error.
 - Fixed structure field names incorrectly ignoring reserved keywords in the Metal (MSL) backend. By @39ali [#9379](https://github.com/gfx-rs/wgpu/pull/9379).
 - Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).
 

--- a/tests/tests/wgpu-gpu/poll.rs
+++ b/tests/tests/wgpu-gpu/poll.rs
@@ -1,18 +1,20 @@
 use std::{num::NonZeroU64, time::Duration};
 
 use wgpu::{
-    BindGroupDescriptor, BindGroupEntry, BindGroupLayoutDescriptor, BindGroupLayoutEntry,
+    Backends, BindGroupDescriptor, BindGroupEntry, BindGroupLayoutDescriptor, BindGroupLayoutEntry,
     BindingResource, BindingType, BufferBindingType, BufferDescriptor, BufferUsages, CommandBuffer,
-    CommandEncoderDescriptor, ComputePassDescriptor, PollType, ShaderStages,
+    CommandEncoderDescriptor, ComputePassDescriptor, ComputePipelineDescriptor,
+    PipelineLayoutDescriptor, PollType, ShaderModuleDescriptor, ShaderSource, ShaderStages,
 };
 
 use wgpu_test::{
-    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+    gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
 };
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
         WAIT,
+        WAIT_INDEFINITELY_LONG_RUNNING,
         WAIT_WITH_TIMEOUT,
         WAIT_WITH_TIMEOUT_MAX,
         DOUBLE_WAIT,
@@ -83,6 +85,110 @@ static WAIT: GpuTestConfiguration = GpuTestConfiguration::new()
         })
         .await
         .unwrap();
+    });
+
+/// Regression test for <https://github.com/gfx-rs/wgpu/issues/9531>. In common
+/// configurations, Metal will terminate this command buffer due to "impacting
+/// interactivity". Depending on which wait-for-completion code path was used, `wgpu` could
+/// previously hang waiting for `MTLCommandBufferStatus::Completed`, when the actual status
+/// was the terminal `MTLCommandBufferStatus::Error`.
+///
+/// At present this test expects no hang. <https://github.com/gfx-rs/wgpu/issues/9545>
+/// proposes propagating the failure by losing the device. If that is implemented, this test
+/// should be updated accordingly. Care may be needed to avoid flakiness in cases where no
+/// termination occurs.
+#[gpu_test]
+static WAIT_INDEFINITELY_LONG_RUNNING: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .skip(FailureCase::backend(!Backends::METAL)),
+    )
+    .run_async(|ctx| async move {
+        const SHADER: &str = r#"
+@group(0) @binding(0) var<storage, read_write> buf: array<u32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    var x: u32 = gid.x ^ 0xDEADBEEFu;
+    for (var i: u32 = 0u; i < 5000000u; i++) {
+        x ^= x << 13u;
+        x ^= x >> 17u;
+        x ^= x << 5u;
+    }
+    buf[gid.x] = x;
+}
+"#;
+
+        const N_THREADS: u32 = 1024 * 64;
+
+        let module = ctx.device.create_shader_module(ShaderModuleDescriptor {
+            label: None,
+            source: ShaderSource::Wgsl(SHADER.into()),
+        });
+        let buffer = ctx.device.create_buffer(&BufferDescriptor {
+            label: None,
+            size: (N_THREADS as u64) * 4,
+            usage: BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+        let bind_group_layout = ctx
+            .device
+            .create_bind_group_layout(&BindGroupLayoutDescriptor {
+                label: None,
+                entries: &[BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+        let pipeline_layout = ctx
+            .device
+            .create_pipeline_layout(&PipelineLayoutDescriptor {
+                label: None,
+                bind_group_layouts: &[Some(&bind_group_layout)],
+                immediate_size: 0,
+            });
+        let pipeline = ctx
+            .device
+            .create_compute_pipeline(&ComputePipelineDescriptor {
+                label: None,
+                layout: Some(&pipeline_layout),
+                module: &module,
+                entry_point: Some("main"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+        let bind_group = ctx.device.create_bind_group(&BindGroupDescriptor {
+            label: None,
+            layout: &bind_group_layout,
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: buffer.as_entire_binding(),
+            }],
+        });
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor::default());
+        {
+            let mut cpass = encoder.begin_compute_pass(&ComputePassDescriptor::default());
+            cpass.set_pipeline(&pipeline);
+            cpass.set_bind_group(0, &bind_group, &[]);
+            cpass.dispatch_workgroups(N_THREADS / 64, 1, 1);
+        }
+        ctx.queue.submit(Some(encoder.finish()));
+
+        // TODO(https://github.com/gfx-rs/wgpu/issues/9545): `wgpu` should raise an error
+        // for the terminated command buffer (e.g. lose the device), and this test should
+        // check for the expected error. Care may be needed to avoid flakiness in cases
+        // where no termination occurs.
+
+        ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
     });
 
 #[gpu_test]

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -122,6 +122,7 @@ impl crate::Adapter for super::Adapter {
                 shared: Arc::new(QueueShared {
                     raw: queue,
                     command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
+                    sync: Arc::clone(&self.shared.queue_sync),
                 }),
                 timestamp_period,
             },

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1,6 +1,5 @@
 use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
 use core::{ptr::NonNull, sync::atomic};
-use std::{thread, time};
 
 use bytemuck::TransparentWrapper;
 use objc2::{
@@ -1871,30 +1870,36 @@ impl crate::Device for super::Device {
             return Ok(true);
         }
 
-        let cmd_buf = match fence
+        if !fence
             .pending_command_buffers
             .iter()
-            .find(|&&(value, _)| value >= wait_value)
+            .any(|&(value, _)| value >= wait_value)
         {
-            Some((_, cmd_buf)) => cmd_buf,
-            None => {
-                log::error!("No active command buffers for fence value {wait_value}");
-                return Err(crate::DeviceError::Lost);
-            }
-        };
+            log::error!("No active command buffers for fence value {wait_value}");
+            return Err(crate::DeviceError::Lost);
+        }
 
-        let start = time::Instant::now();
-        loop {
-            if let MTLCommandBufferStatus::Completed = cmd_buf.status() {
-                return Ok(true);
-            }
-            if let Some(timeout) = timeout {
-                if start.elapsed() >= timeout {
-                    return Ok(false);
+        let (ref mutex, ref condvar) = *self.shared.queue_sync;
+        let mut lock = mutex.lock();
+
+        if let Some(deadline) =
+            timeout.and_then(|timeout| std::time::Instant::now().checked_add(timeout))
+        {
+            while fence.completed_value.load(atomic::Ordering::Acquire) < wait_value {
+                let result = condvar.wait_until(&mut lock, deadline);
+                if result.timed_out() {
+                    // check again and return false if we timed out and the value still isn't met
+                    return Ok(fence.completed_value.load(atomic::Ordering::Acquire) >= wait_value);
                 }
             }
-            thread::sleep(core::time::Duration::from_millis(1));
+        } else {
+            // wait indefinitely until the condition is met
+            while fence.completed_value.load(atomic::Ordering::Acquire) < wait_value {
+                condvar.wait(&mut lock);
+            }
         }
+
+        Ok(true)
     }
 
     unsafe fn start_graphics_debugger_capture(&self) -> bool {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1,7 +1,5 @@
 use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
-use core::{ptr::NonNull, sync::atomic};
-use parking_lot::RwLock;
-use std::{thread, time};
+use core::ptr::NonNull;
 
 use bytemuck::TransparentWrapper;
 use objc2::{
@@ -12,11 +10,11 @@ use objc2::{
 use objc2_foundation::{ns_string, NSError, NSRange, NSString, NSUInteger};
 use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureInstanceOptions, MTLBuffer,
-    MTLCaptureManager, MTLCaptureScope, MTLCommandBuffer, MTLCommandBufferStatus,
-    MTLCompileOptions, MTLComputePipelineDescriptor, MTLComputePipelineState,
-    MTLCounterSampleBufferDescriptor, MTLCounterSet, MTLDepthClipMode, MTLDepthStencilDescriptor,
-    MTLDevice, MTLFunction, MTLIndirectAccelerationStructureInstanceDescriptor, MTLLanguageVersion,
-    MTLLibrary, MTLMeshRenderPipelineDescriptor, MTLMutability, MTLPackedFloat3, MTLPackedFloat4x3,
+    MTLCaptureManager, MTLCaptureScope, MTLCompileOptions, MTLComputePipelineDescriptor,
+    MTLComputePipelineState, MTLCounterSampleBufferDescriptor, MTLCounterSet, MTLDepthClipMode,
+    MTLDepthStencilDescriptor, MTLDevice, MTLFunction,
+    MTLIndirectAccelerationStructureInstanceDescriptor, MTLLanguageVersion, MTLLibrary,
+    MTLMeshRenderPipelineDescriptor, MTLMutability, MTLPackedFloat3, MTLPackedFloat4x3,
     MTLPipelineBufferDescriptorArray, MTLPipelineOption, MTLPixelFormat, MTLPrimitiveTopologyClass,
     MTLRenderPipelineColorAttachmentDescriptorArray, MTLRenderPipelineDescriptor, MTLResource,
     MTLResourceID, MTLResourceOptions, MTLSamplerAddressMode, MTLSamplerDescriptor,
@@ -24,6 +22,7 @@ use objc2_metal::{
     MTLTexture, MTLTextureDescriptor, MTLTextureType, MTLTriangleFillMode, MTLVertexDescriptor,
     MTLVertexStepFunction,
 };
+use parking_lot::{Condvar, Mutex, RwLock};
 
 use super::{adapter::VERTEX_BUFFER_SLOT_START, conv, PassthroughShader, ShaderModuleSource};
 use crate::{auxil::map_naga_stage, TlasInstance};
@@ -1886,7 +1885,7 @@ impl crate::Device for super::Device {
             None
         };
         Ok(super::Fence {
-            completed_value: Arc::new(atomic::AtomicU64::new(0)),
+            sync: Arc::new((Mutex::new(0), Condvar::new())),
             pending_command_buffers: RwLock::new(Vec::new()),
             shared_event,
         })
@@ -1897,14 +1896,7 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn get_fence_value(&self, fence: &super::Fence) -> DeviceResult<crate::FenceValue> {
-        let mut max_value = fence.completed_value.load(atomic::Ordering::Acquire);
-        let pending_command_buffers = fence.pending_command_buffers.read();
-        for &(value, ref cmd_buf) in pending_command_buffers.iter() {
-            if cmd_buf.status() == MTLCommandBufferStatus::Completed {
-                max_value = value;
-            }
-        }
-        Ok(max_value)
+        Ok(fence.get_latest())
     }
     unsafe fn wait(
         &self,
@@ -1912,38 +1904,40 @@ impl crate::Device for super::Device {
         wait_value: crate::FenceValue,
         timeout: Option<core::time::Duration>,
     ) -> DeviceResult<bool> {
-        if wait_value <= fence.completed_value.load(atomic::Ordering::Acquire) {
+        let (ref mutex, ref condvar) = *fence.sync;
+        let mut lock = mutex.lock();
+
+        if wait_value <= *lock {
             return Ok(true);
         }
 
-        let pending_command_buffers = fence.pending_command_buffers.read();
-
-        let cmd_buf = match pending_command_buffers
-            .iter()
-            .find(|&&(value, _)| value >= wait_value)
         {
-            Some((_, cmd_buf)) => cmd_buf.clone(),
-            None => {
+            let pending_command_buffers = fence.pending_command_buffers.read();
+            if !pending_command_buffers
+                .iter()
+                .any(|&(value, _)| value >= wait_value)
+            {
                 log::error!("No active command buffers for fence value {wait_value}");
                 return Err(crate::DeviceError::Lost);
             }
-        };
+        }
 
-        // Make sure that nothing is blocked during the actual wait.
-        drop(pending_command_buffers);
-
-        let start = time::Instant::now();
-        loop {
-            if let MTLCommandBufferStatus::Completed = cmd_buf.status() {
-                return Ok(true);
-            }
-            if let Some(timeout) = timeout {
-                if start.elapsed() >= timeout {
-                    return Ok(false);
+        if let Some(deadline) =
+            timeout.and_then(|timeout| std::time::Instant::now().checked_add(timeout))
+        {
+            while *lock < wait_value {
+                let result = condvar.wait_until(&mut lock, deadline);
+                if result.timed_out() {
+                    return Ok(*lock >= wait_value);
                 }
             }
-            thread::sleep(core::time::Duration::from_millis(1));
+        } else {
+            while *lock < wait_value {
+                condvar.wait(&mut lock);
+            }
         }
+
+        Ok(true)
     }
 
     unsafe fn start_graphics_debugger_capture(&self) -> bool {

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1922,19 +1922,13 @@ impl crate::Device for super::Device {
             }
         }
 
-        if let Some(deadline) =
-            timeout.and_then(|timeout| std::time::Instant::now().checked_add(timeout))
-        {
-            while *lock < wait_value {
-                let result = condvar.wait_until(&mut lock, deadline);
-                if result.timed_out() {
-                    return Ok(*lock >= wait_value);
-                }
+        if let Some(timeout) = timeout {
+            let result = condvar.wait_while_for(&mut lock, |value| *value < wait_value, timeout);
+            if result.timed_out() {
+                return Ok(*lock >= wait_value);
             }
         } else {
-            while *lock < wait_value {
-                condvar.wait(&mut lock);
-            }
+            condvar.wait_while(&mut lock, |value| *value < wait_value);
         }
 
         Ok(true)

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -51,7 +51,7 @@ use objc2_metal::{
     MTLTriangleFillMode, MTLWinding,
 };
 use objc2_quartz_core::CAMetalLayer;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::{Condvar, Mutex, RwLock};
 
 #[derive(Clone, Debug)]
 pub struct Api;
@@ -385,6 +385,7 @@ struct AdapterShared {
     private_texture_format_caps: PrivateTextureFormatCapabilities,
     settings: Settings,
     presentation_timer: time::PresentationTimer,
+    queue_sync: Arc<(Mutex<()>, Condvar)>,
 }
 
 unsafe impl Send for AdapterShared {}
@@ -407,6 +408,7 @@ impl AdapterShared {
             device,
             settings: Settings::default(),
             presentation_timer: time::PresentationTimer::new(),
+            queue_sync: Arc::new((Mutex::new(()), Condvar::new())),
         }
     }
 
@@ -456,6 +458,7 @@ impl Queue {
             shared: Arc::new(QueueShared {
                 raw,
                 command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
+                sync: Arc::new((Mutex::new(()), Condvar::new())),
             }),
             timestamp_period,
         }
@@ -473,6 +476,7 @@ pub struct QueueShared {
     // to create command buffers for internal purposes. In those cases we always
     // commit the buffer immediately, so we don't adjust the counter for them.)
     command_buffer_created_not_submitted: atomic::AtomicUsize,
+    sync: Arc<(Mutex<()>, Condvar)>,
 }
 
 pub struct Device {
@@ -529,8 +533,11 @@ impl crate::Queue for Queue {
         autoreleasepool(|_| {
             let extra_command_buffer = {
                 let completed_value = Arc::clone(&signal_fence.completed_value);
+                let sync = Arc::clone(&self.shared.sync);
                 let block = block2::RcBlock::new(move |_cmd_buf| {
                     completed_value.store(signal_value, atomic::Ordering::Release);
+                    let _lock = sync.0.lock();
+                    sync.1.notify_all();
                 });
 
                 let raw = match command_buffers.last() {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -1050,8 +1050,11 @@ impl Fence {
         let mut max_value = *self.sync.0.lock();
         let pending_command_buffers = self.pending_command_buffers.read();
         for &(value, ref cmd_buf) in pending_command_buffers.iter() {
-            if cmd_buf.status() == MTLCommandBufferStatus::Completed {
-                max_value = value;
+            match cmd_buf.status() {
+                MTLCommandBufferStatus::Completed | MTLCommandBufferStatus::Error => {
+                    max_value = value;
+                }
+                _ => {}
             }
         }
         max_value

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -55,7 +55,7 @@ use objc2_metal::{
     MTLTriangleFillMode, MTLWinding,
 };
 use objc2_quartz_core::CAMetalLayer;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::{Condvar, Mutex, RwLock};
 
 #[derive(Clone, Debug)]
 pub struct Api;
@@ -542,9 +542,10 @@ impl crate::Queue for Queue {
     ) -> Result<(), crate::DeviceError> {
         autoreleasepool(|_| {
             let extra_command_buffer = {
-                let completed_value = Arc::clone(&signal_fence.completed_value);
+                let fence_sync = Arc::clone(&signal_fence.sync);
                 let block = block2::RcBlock::new(move |_cmd_buf| {
-                    completed_value.store(signal_value, atomic::Ordering::Release);
+                    *fence_sync.0.lock() = signal_value;
+                    fence_sync.1.notify_all();
                 });
 
                 let raw = match command_buffers.last() {
@@ -1028,7 +1029,7 @@ unsafe impl Sync for QuerySet {}
 
 #[derive(Debug)]
 pub struct Fence {
-    completed_value: Arc<atomic::AtomicU64>,
+    sync: Arc<(Mutex<crate::FenceValue>, Condvar)>,
     /// The pending fence values have to be ascending.
     pending_command_buffers: RwLock<Vec<PendingCommandBuffer>>,
     shared_event: Option<Retained<ProtocolObject<dyn MTLSharedEvent>>>,
@@ -1046,7 +1047,7 @@ unsafe impl Sync for Fence {}
 
 impl Fence {
     fn get_latest(&self) -> crate::FenceValue {
-        let mut max_value = self.completed_value.load(atomic::Ordering::Acquire);
+        let mut max_value = *self.sync.0.lock();
         let pending_command_buffers = self.pending_command_buffers.read();
         for &(value, ref cmd_buf) in pending_command_buffers.iter() {
             if cmd_buf.status() == MTLCommandBufferStatus::Completed {


### PR DESCRIPTION
**Connections**
#8119 
#9531 

**Description**
this uses a CondVar and lets the thread sleep instead of polling every 1ms

**Testing**
ran poll tests 

**Squash or Rebase?**
Rebase

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
