### PR TITLE
Fix wrong binding array sampler limit in dx12

### DIFF
--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -942,7 +942,8 @@ impl super::Adapter {
                     max_non_sampler_bindings: 1_000_000,
 
                     max_binding_array_elements_per_shader_stage: full_heap_count,
-                    max_binding_array_sampler_elements_per_shader_stage: full_heap_count,
+                    max_binding_array_sampler_elements_per_shader_stage:
+                        Direct3D12::D3D12_MAX_SHADER_VISIBLE_SAMPLER_HEAP_SIZE,
 
                     // Source: https://microsoft.github.io/DirectX-Specs/d3d/MeshShader.html#dispatchmesh-api
                     max_task_mesh_workgroup_total_count: if mesh_shader_supported {


### PR DESCRIPTION
**Connections**
https://github.com/bevyengine/bevy/issues/23573

**Description**
I was doing some AI-assisted triaging of the above bevy issue, and it pointed to a wrong dx12 sampler limit. I don't know much about dx12 but the documentation I could find [seems to corroborate it](https://learn.microsoft.com/en-us/windows/win32/direct3d12/hardware-support), and hardcoding the limit to 2048 fixes the issue for me.

**Testing**
Tested in bevy on commit 25a2a385e6aea895799f8005c665e0f2538a2433 with the following patch:

```diff
index 541624de1..b194ba6e2 100644
--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -305,6 +305,10 @@ pub async fn initialize_renderer(
         }

         limits = adapter.limits();
+
+        if adapter_info.backend == wgpu::Backend::Dx12 {
+            limits.max_binding_array_sampler_elements_per_shader_stage = 2048;
+        }
     }
```
Using

```
$Env:WGPU_BACKEND="dx12"
cargo run --example blend_modes
```