### PR TITLE
fix(wgpu-hal/vulkan): only request shaderDrawParameters when needed

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -618,9 +618,10 @@ impl PhysicalDeviceFeatures {
                 None
             },
             shader_draw_parameters: if device_api_version >= vk::API_VERSION_1_1 {
+                let needed = requested_features.contains(wgt::Features::SHADER_DRAW_INDEX);
                 Some(
                     vk::PhysicalDeviceShaderDrawParametersFeatures::default()
-                        .shader_draw_parameters(true),
+                        .shader_draw_parameters(needed),
                 )
             } else {
                 None


### PR DESCRIPTION
## Summary

`shader_draw_parameters` was unconditionally set to `true` for all Vulkan 1.1+ devices in `PhysicalDeviceProperties::to_features_and_config`. This causes a panic on drivers where `shaderDrawParameters` is not supported (e.g. Raspberry Pi 5's V3DV, SwiftShader).

The fix gates the request on `Features::SHADER_DRAW_INDEX`, matching the pattern used by every other optional feature in the same block.

Fixes #9293.

## Testing

Tested in the context of [reco-project/video-stitcher@4b5c302](https://github.com/reco-project/video-stitcher/commit/4b5c302) (wgpu 29, real-time GPU video stitching):

- Raspberry Pi 5 (V3DV, Vulkan 1.3, `shaderDrawParameters = false`) - device creation no longer panics, GPU rendering works
- Desktop NVIDIA (Vulkan 1.3, `shaderDrawParameters = true`) - device creation and rendering still work as expected