### PR TITLE
Fix debug_assert in dx12 indirect multi draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Bottom level categories:
 #### dx12
 
 - Fixed use of a texture view without `TextureUsage::TEXTURE_BINDING` as a read-only depth attachment. By @andyleiserson in [#9346](https://github.com/gfx-rs/wgpu/pull/9346).
+- Fixed a `debug_assert` during stride validation for indirect multi draw. By @kristoff3r in [#9332](https://github.com/gfx-rs/wgpu/pull/9332)
 
 ## v29.0.1 (2026-03-26)
 

--- a/tests/tests/wgpu-gpu/draw_indirect.rs
+++ b/tests/tests/wgpu-gpu/draw_indirect.rs
@@ -27,6 +27,8 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         INSTANCED_INDEXED_DRAW_OOB_INSTANCE_START,
         INSTANCED_INDEXED_DRAW_OOB_INSTANCE_COUNT,
         INDIRECT_BUFFER_OFFSETS,
+        MULTI_DRAW_INDEXED_INDIRECT,
+        MULTI_DRAW_INDIRECT,
     ]);
 }
 
@@ -115,6 +117,15 @@ impl TestData {
 }
 
 async fn run_test(ctx: TestingContext, test_data: TestData, expect_noop: bool) {
+    run_test_inner(ctx, test_data, expect_noop, false).await;
+}
+
+async fn run_test_inner(
+    ctx: TestingContext,
+    test_data: TestData,
+    expect_noop: bool,
+    use_multi_draw: bool,
+) {
     let mut vertex_buffer_layouts = Vec::new();
     vertex_buffer_layouts.push(wgpu::VertexBufferLayout {
         array_stride: 8,
@@ -283,15 +294,23 @@ async fn run_test(ctx: TestingContext, test_data: TestData, expect_noop: bool) {
         if let Some(ref index_buffer) = index_buffer {
             rpass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint32);
         }
-        for draw_index in 0..draws {
+        if use_multi_draw {
             if index_buffer.is_some() {
-                let offset = pass_index * draw_index * 20;
-                rpass.draw_indexed_indirect(&indirect_buffer, offset);
-                rpass.draw_indexed_indirect(&indirect_buffer2, offset);
+                rpass.multi_draw_indexed_indirect(&indirect_buffer, 0, draws);
             } else {
-                let offset = pass_index * draw_index * 20;
-                rpass.draw_indirect(&indirect_buffer, offset);
-                rpass.draw_indirect(&indirect_buffer2, offset);
+                rpass.multi_draw_indirect(&indirect_buffer, 0, draws);
+            }
+        } else {
+            for draw_index in 0..draws {
+                if index_buffer.is_some() {
+                    let offset = (pass_index * draw_index * 20) as u64;
+                    rpass.draw_indexed_indirect(&indirect_buffer, offset);
+                    rpass.draw_indexed_indirect(&indirect_buffer2, offset);
+                } else {
+                    let offset = (pass_index * draw_index * 20) as u64;
+                    rpass.draw_indirect(&indirect_buffer, offset);
+                    rpass.draw_indirect(&indirect_buffer2, offset);
+                }
             }
         }
     }
@@ -796,3 +815,21 @@ async fn indirect_buffer_offsets(ctx: TestingContext) {
         data[..half].iter().all(|b| *b == u8::MAX) && data[half..].iter().all(|b| *b == 0);
     assert!(succeeded);
 }
+
+#[gpu_test]
+static MULTI_DRAW_INDEXED_INDIRECT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .downlevel_flags(wgpu::DownlevelFlags::INDIRECT_EXECUTION)
+            .limits(wgpu::Limits::downlevel_defaults()),
+    )
+    .run_async(|ctx| run_test_inner(ctx, get_indexed_draw_test_data(0, 6), false, true));
+
+#[gpu_test]
+static MULTI_DRAW_INDIRECT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .downlevel_flags(wgpu::DownlevelFlags::INDIRECT_EXECUTION)
+            .limits(wgpu::Limits::downlevel_defaults()),
+    )
+    .run_async(|ctx| run_test_inner(ctx, get_draw_test_data(0, 6), false, true));

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -894,7 +894,7 @@ fn multi_draw_indirect(
 
     let vertex_limits = super::VertexLimits::new(state.vertex_buffer_sizes(), &pipeline.steps);
 
-    let stride = super::get_stride_of_indirect_args(family);
+    let stride = super::get_src_stride_of_indirect_args(family);
     state
         .buffer_memory_init_actions
         .extend(buffer.initialization_status.read().create_action(

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -71,7 +71,7 @@ pub(crate) use self::{
     clear::clear_texture,
     encoder::EncodingState,
     memory_init::CommandBufferTextureMemoryActions,
-    render::{get_stride_of_indirect_args, VertexLimits},
+    render::{get_dst_stride_of_indirect_args, get_src_stride_of_indirect_args, VertexLimits},
     transfer::{
         extract_texture_selector, validate_linear_texture_data, validate_texture_buffer_copy,
         validate_texture_copy_dst_format, validate_texture_copy_range,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2799,7 +2799,7 @@ fn multi_draw_indirect(
         return Err(RenderPassErrorInner::UnalignedIndirectBufferOffset(offset));
     }
 
-    let stride = get_stride_of_indirect_args(family);
+    let stride = get_src_stride_of_indirect_args(family);
 
     let end_offset = offset + stride * count as u64;
     if end_offset > indirect_buffer.size {
@@ -2917,9 +2917,12 @@ fn multi_draw_indirect(
             let draw_data = draw_ctx.add(offset + stride * i as u64)?;
 
             if draw_data.buffer_index == current_draw_data.buffer_index {
+                #[cfg(debug_assertions)]
+                let dst_stride =
+                    get_dst_stride_of_indirect_args(state.pass.base.device.backend(), family);
                 debug_assert_eq!(
                     draw_data.offset,
-                    current_draw_data.offset + stride * current_draw_data.count as u64
+                    current_draw_data.offset + dst_stride * current_draw_data.count as u64
                 );
                 current_draw_data.count += 1;
             } else {
@@ -2971,7 +2974,7 @@ fn multi_draw_indirect_count(
         validate_mesh_draw_multiview(state)?;
     }
 
-    let stride = get_stride_of_indirect_args(family);
+    let stride = get_src_stride_of_indirect_args(family);
 
     state
         .pass
@@ -3840,10 +3843,23 @@ impl Global {
     }
 }
 
-pub(crate) const fn get_stride_of_indirect_args(family: DrawCommandFamily) -> u64 {
+pub(crate) const fn get_src_stride_of_indirect_args(family: DrawCommandFamily) -> u64 {
     match family {
         DrawCommandFamily::Draw => size_of::<wgt::DrawIndirectArgs>() as u64,
         DrawCommandFamily::DrawIndexed => size_of::<wgt::DrawIndexedIndirectArgs>() as u64,
         DrawCommandFamily::DrawMeshTasks => size_of::<wgt::DispatchIndirectArgs>() as u64,
     }
+}
+
+pub(crate) const fn get_dst_stride_of_indirect_args(
+    backend: wgt::Backend,
+    family: DrawCommandFamily,
+) -> u64 {
+    // space for D3D12 special constants
+    let extra = if matches!(backend, wgt::Backend::Dx12) {
+        3 * size_of::<u32>() as u64
+    } else {
+        0
+    };
+    extra + get_src_stride_of_indirect_args(family)
 }

--- a/wgpu-core/src/indirect_validation/draw.rs
+++ b/wgpu-core/src/indirect_validation/draw.rs
@@ -984,13 +984,7 @@ impl DrawBatcher {
         vertex_or_index_limit: u64,
         instance_limit: u64,
     ) -> Result<(usize, u64), DeviceError> {
-        // space for D3D12 special constants
-        let extra = if device.backend() == wgt::Backend::Dx12 {
-            3 * size_of::<u32>() as u64
-        } else {
-            0
-        };
-        let stride = extra + crate::command::get_stride_of_indirect_args(family);
+        let stride = crate::command::get_dst_stride_of_indirect_args(device.backend(), family);
 
         let (dst_resource_index, dst_offset) = indirect_draw_validation_resources
             .get_dst_subrange(stride, &mut self.current_dst_entry)?;


### PR DESCRIPTION
**Connections**
Fixes #7955 (and https://github.com/bevyengine/bevy/issues/23220)

**Description**
The stride validation was calculated incorrectly in dx12. I fixed it by refactoring a bit to make it more clear that the strides can differ, and that the destination stride is backend dependent.

**Testing**
I refactored the existing draw_indirect test to also cover multi draw, and I tested it without the fix on my Windows and could reproduce the issue. I'm not sure if this is the testing you had in mind.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
