### PR TITLE
Fix late bindings not being updated for identical pipeline layouts

### DIFF
--- a/tests/tests/wgpu-gpu/bind_groups.rs
+++ b/tests/tests/wgpu-gpu/bind_groups.rs
@@ -177,8 +177,7 @@ static MULTIPLE_BINDINGS_WITH_DIFFERENT_SIZES: GpuTestConfiguration = GpuTestCon
     .parameters(
         TestParameters::default()
             .limits(wgpu::Limits::downlevel_defaults())
-            .expect_fail(FailureCase::always())
-            .enable_noop(), // https://github.com/gfx-rs/wgpu/issues/7359
+            .enable_noop(),
     )
     .run_sync(multiple_bindings_with_differing_sizes);
 

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -349,6 +349,8 @@ impl Binder {
         new: &Arc<PipelineLayout>,
         late_sized_buffer_groups: &[LateSizedBufferGroup],
     ) -> bool {
+        self.update_late_buffer_bindings(late_sized_buffer_groups);
+
         if let Some(old) = self.pipeline_layout.as_ref() {
             if old.is_equal(new) {
                 return false;
@@ -358,33 +360,6 @@ impl Binder {
         let old = self.pipeline_layout.replace(new.clone());
 
         self.manager.update_expectations(&new.bind_group_layouts);
-
-        // Update the buffer binding sizes that are required by shaders.
-
-        for (payload, late_group) in self.payloads.iter_mut().zip(late_sized_buffer_groups) {
-            payload.late_bindings_effective_count = late_group.shader_sizes.len();
-            // Update entries that already exist as the bind group was bound before the pipeline
-            // was bound.
-            for (late_binding, &shader_expect_size) in payload
-                .late_buffer_bindings
-                .iter_mut()
-                .zip(late_group.shader_sizes.iter())
-            {
-                late_binding.shader_expect_size = shader_expect_size;
-            }
-            // Add new entries for the bindings that were not known when the bind group was bound.
-            if late_group.shader_sizes.len() > payload.late_buffer_bindings.len() {
-                for &shader_expect_size in
-                    late_group.shader_sizes[payload.late_buffer_bindings.len()..].iter()
-                {
-                    payload.late_buffer_bindings.push(LateBufferBinding {
-                        binding_index: 0,
-                        shader_expect_size,
-                        bound_size: 0,
-                    });
-                }
-            }
-        }
 
         if let Some(old) = old {
             // root constants are the base compatibility property
@@ -523,5 +498,37 @@ impl Binder {
             }
         }
         Ok(())
+    }
+
+    /// This must be called even when a new pipeline has the same layout
+    /// as the previous one, because different pipelines can have different
+    /// shader-expected buffer sizes even with identical layouts.
+    fn update_late_buffer_bindings(&mut self, late_sized_buffer_groups: &[LateSizedBufferGroup]) {
+        for (payload, late_group) in self.payloads.iter_mut().zip(late_sized_buffer_groups) {
+            payload.late_bindings_effective_count = late_group.shader_sizes.len();
+
+            // Update entries that already exist as the bind group was bound before the pipeline
+            // was bound.
+            for (late_binding, &shader_expect_size) in payload
+                .late_buffer_bindings
+                .iter_mut()
+                .zip(late_group.shader_sizes.iter())
+            {
+                late_binding.shader_expect_size = shader_expect_size;
+            }
+
+            // Add new entries for the bindings that were not known when the bind group was bound.
+            if late_group.shader_sizes.len() > payload.late_buffer_bindings.len() {
+                for &shader_expect_size in
+                    late_group.shader_sizes[payload.late_buffer_bindings.len()..].iter()
+                {
+                    payload.late_buffer_bindings.push(LateBufferBinding {
+                        binding_index: 0,
+                        shader_expect_size,
+                        bound_size: 0,
+                    });
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
**Connections**
Fixes https://github.com/james-j-obrien/bevy_vector_shapes/issues/67
Fixes https://github.com/gfx-rs/wgpu/issues/7359

**Description**
In `change_pipeline_layout` no work is done if the layouts are identical. However, that function is also responsible for updating late buffer bindings, and so this wouldn't happen for situations with identical layouts but differing late bindings.

To fix it I moved the logic before the check, so it always happens.

**Testing**
I marked the test contributed in #7360 as not `expect_fail`. I also tested the issue from `bevy_vector_shapes` with a similar patch on top of wgpu 27.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
