### PR TITLE
metal: fix Simulator and Catalyst GPU capability detection

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -15,6 +15,8 @@ skip = [
 
     # Winit uses an old version
     { name = "windows-sys", version = "0.52.0" },
+    # Windows versions are finicky.
+    { name = "windows-sys", version = "0.59.0" },
 ]
 wildcards = "deny"
 allow-wildcard-paths = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ Bottom level categories:
 
 ## Unreleased
 
+## v28.0.1 (2025-03-01)
+
+### Metal
+- Re-added support for TRANSIENT textures on Apple A7 chips. By @Opstic in [#8725](https://github.com/gfx-rs/wgpu/pull/8725).
+
 ## v28.0.0 (2025-12-17)
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Bottom level categories:
 
 ## v28.0.1 (2025-03-01)
 
+### Vulkan
+- Fixed crash on some Mali drivers on Android. By @beicause in [#8769](https://github.com/gfx-rs/wgpu/pull/8769).
+
 ### Metal
 - Re-added support for TRANSIENT textures on Apple A7 chips. By @Opstic in [#8725](https://github.com/gfx-rs/wgpu/pull/8725).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Bottom level categories:
 
 ## v28.0.1 (2025-03-01)
 
+### General
+- Fixed crash on nvidia cards when presenting from another thread. By @inner-daemons in [#9036](https://github.com/gfx-rs/wgpu/pull/9036).
+
 ### Vulkan
 - Fixed crash on some Mali drivers on Android. By @beicause in [#8769](https://github.com/gfx-rs/wgpu/pull/8769).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -165,7 +165,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -478,9 +478,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calloop"
@@ -901,7 +901,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "cts_runner"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "deno_console",
  "deno_core",
@@ -1339,7 +1339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1845,7 +1845,7 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hlsl-snapshots"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "nanoserde",
@@ -2237,7 +2237,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock-analyzer"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "ron",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "naga-cli"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "argh",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "naga-fuzz"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "arbitrary",
  "cfg_aliases 0.2.1",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "naga-test"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "bitflags 2.10.0",
  "naga",
@@ -2596,7 +2596,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3083,7 +3083,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "player"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "bytemuck",
  "env_logger",
@@ -3467,7 +3467,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3480,7 +3480,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3900,7 +3900,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "arrayvec",
  "bitflags 2.10.0",
@@ -4681,7 +4681,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-benchmark"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -4736,28 +4736,28 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "wgpu-hal",
 ]
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-examples"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4824,7 +4824,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-info"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-macros"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "heck",
  "quote",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-test"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -4942,7 +4942,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -5010,7 +5010,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 homepage = "https://wgpu.rs/"
 repository = "https://github.com/gfx-rs/wgpu"
-version = "28.0.0"
+version = "28.0.1"
 authors = ["gfx-rs developers"]
 
 [workspace.dependencies]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,3 @@
-> [!NOTE]  
-> These are the examples for the development version of wgpu. If you want to see the examples for the latest crates.io release
-> of wgpu, go to the [latest release branch](https://github.com/gfx-rs/wgpu/tree/v28/examples#readme).
-
 # Examples
 
 If you are just starting your graphics programming journey entirely, we recommend going through [Learn-wgpu](https://sotrh.github.io/learn-wgpu/)

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -302,6 +302,7 @@ impl Surface {
             Some(resource::TextureInner::Surface { raw }) => {
                 let raw_surface = self.raw(device.backend()).unwrap();
                 let raw_queue = queue.raw();
+                let _fence_lock = device.fence.write();
                 unsafe { raw_queue.present(raw_surface, raw) }
             }
             _ => unreachable!(),

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -960,8 +960,17 @@ impl super::PrivateCapabilities {
                 || (version.at_least((10, 15), (14, 0), (16, 0), (1, 0), os_type)
                     && device.supports_shader_barycentric_coordinates()),
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=3
+            // See https://github.com/gfx-rs/wgpu/pull/8725 for more details
             supports_memoryless_storage: metal4
-                || (family_check && device.supports_family(MTLGPUFamily::Apple2)),
+                || if family_check {
+                    // Apple A7 (MTLGPUFamily::Apple1) has been tested to have support.
+                    device.supports_family(MTLGPUFamily::Apple1)
+                } else {
+                    // macOS: Always rely on family check
+                    // iOS/tvOS: API added in 10.0
+                    // visionOS: Always rely on family check
+                    version.at_least(OS_NOT_SUPPORT, (10, 0), (10, 0), OS_NOT_SUPPORT, os_type)
+                },
             supported_vertex_amplification_factor: {
                 let mut factor = 1;
                 // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=8

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -533,6 +533,11 @@ impl super::PrivateCapabilities {
         };
 
         let os_type = super::OsType::new(version, device);
+
+        // Whether the actual GPU is Mac hardware (Simulator / Catalyst).
+        let runs_on_mac: bool =
+            cfg!(any(target_os = "macos", target_abi = "macabi", target_abi = "sim"));
+
         let family_check = version.at_least((10, 15), (13, 0), (13, 0), (1, 0), os_type);
         let metal3 = family_check && device.supports_family(MTLGPUFamily::Metal3);
         let metal4 = family_check && device.supports_family(MTLGPUFamily::Metal4);
@@ -635,11 +640,12 @@ impl super::PrivateCapabilities {
                 MUTABLE_COMPARISON_SAMPLER_SUPPORT,
             ),
             sampler_clamp_to_border: Self::supports_any(device, SAMPLER_CLAMP_TO_BORDER_SUPPORT),
-            indirect_draw_dispatch: Self::supports_any(device, INDIRECT_DRAW_DISPATCH_SUPPORT),
+            indirect_draw_dispatch: Self::supports_any(device, INDIRECT_DRAW_DISPATCH_SUPPORT)
+                || runs_on_mac,
             base_vertex_first_instance_drawing: Self::supports_any(
                 device,
                 BASE_VERTEX_FIRST_INSTANCE_SUPPORT,
-            ),
+            ) || runs_on_mac,
             dual_source_blending: Self::supports_any(device, DUAL_SOURCE_BLEND_SUPPORT),
             low_power: os_type != super::OsType::Macos || device.is_low_power(),
             headless: os_type == super::OsType::Macos && device.is_headless(),
@@ -756,7 +762,9 @@ impl super::PrivateCapabilities {
             } else {
                 16
             },
-            buffer_alignment: if matches!(os_type, super::OsType::Macos | super::OsType::VisionOs) {
+            buffer_alignment: if matches!(os_type, super::OsType::Macos | super::OsType::VisionOs)
+                || runs_on_mac
+            {
                 256
             } else {
                 64

--- a/wgpu-hal/src/vulkan/swapchain/native.rs
+++ b/wgpu-hal/src/vulkan/swapchain/native.rs
@@ -468,9 +468,10 @@ impl Swapchain for NativeSwapchain {
         // latency, depending on how the platform implements waiting within
         // acquire.
         unsafe {
+            // The `wait_all` argument must be `true` to avoid crash on some Android devices. See https://github.com/gfx-rs/wgpu/pull/8769
             self.device
                 .raw
-                .wait_for_fences(&[self.fence], false, timeout_ns)
+                .wait_for_fences(&[self.fence], true, timeout_ns)
                 .map_err(map_host_device_oom_and_lost_err)?;
 
             self.device


### PR DESCRIPTION
**Connections**
  Fixes #7057                                                                                                                     
                                                                                                                                  
  **Description**                                                                                                                 
  Simulator and Catalyst run on Mac GPU but Metal reports iOS-level                                                               
  capabilities. This causes wrong buffer alignment and missing feature                                                            
  flags like indirect execution.                                                                                                  
                                                                                                                                  
  Added a `runs_on_mac` compile-time flag using `target_abi` to apply                                                             
  Mac hardware constraints for buffer alignment, constant buffer offset                                                           
  alignment, indirect draw/dispatch, and base vertex/first instance.                                                              
                                                                                                                                  
  **Testing**                                                                                                                     
  Tested with Vello 0.8 on iPhone 16 Pro Max Simulator (iOS 18.2, Apple Silicon).                                                 
  iPad simulator also verified working. 