### PR TITLE
Make vertex buffer slots optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,26 @@ Bottom level categories:
 
 ## Unreleased
 
+### Major changes
+
+#### Optional vertex buffer slots
+
+This allows gaps in `VertexState`'s `buffers` and adds support for unbinding vertex buffers, bringing us in compliance with the WebGPU spec. As a result of this, `VertexState`'s `buffers` field now has type of `&[Option<VertexBufferLayout>]`. To migrate, wrap vertex buffer layouts in `Some`:
+
+```diff
+  let vertex_state = wgpu::VertexState {
+      module: &vs_module,
+      entry_point: Some("vs_main"),
+      compilation_options: wgpu::PipelineCompilationOptions::default(),
+      buffers: &[
+-         &vertex_buffer_layout
++         Some(&vertex_buffer_layout)
+      ],
+  };
+```
+
+By @teoxoy in [#9351](https://github.com/gfx-rs/wgpu/pull/9351).
+
 ### Added/New Features
 
 #### General

--- a/benches/benches/wgpu-benchmark/renderpass.rs
+++ b/benches/benches/wgpu-benchmark/renderpass.rs
@@ -183,11 +183,11 @@ impl RenderpassState {
 
         let mut vertex_buffer_layouts = Vec::with_capacity(VERTEX_BUFFERS_PER_DRAW as usize);
         for attributes in &vertex_buffer_attributes {
-            vertex_buffer_layouts.push(wgpu::VertexBufferLayout {
+            vertex_buffer_layouts.push(Some(wgpu::VertexBufferLayout {
                 array_stride: 16,
                 step_mode: wgpu::VertexStepMode::Vertex,
                 attributes,
-            });
+            }));
         }
 
         let pipeline =

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -23,7 +23,9 @@ webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https:/
 webgpu:api,validation,createView:texture_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:* // ***, https://github.com/gfx-rs/wgpu/issues/8118
 webgpu:api,validation,encoding,cmds,debug:* // 92%, https://github.com/gfx-rs/wgpu/issues/8039
-webgpu:api,validation,encoding,cmds,render,* // https://github.com/gfx-rs/wgpu/issues/7912
+webgpu:api,validation,encoding,cmds,render,draw:max_draw_count:* // https://github.com/gfx-rs/wgpu/issues/8737
+webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_offset_alignment:* // render bundle
+webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_offset_oob:* // unwrap on None in wgpu-core/src/indirect_validation/draw.rs:432:18
 webgpu:api,validation,encoding,cmds,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:* // deno unwrap
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="compute%20pass";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20bundle";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
@@ -48,8 +50,6 @@ webgpu:api,validation,render_pipeline,inter_stage:* // 15%, inter-stage type val
 webgpu:api,validation,render_pipeline,misc:external_texture:* // 0%, no external texture in deno
 webgpu:api,validation,render_pipeline,multisample_state:* // 60%, https://github.com/gfx-rs/wgpu/issues/8779
 webgpu:api,validation,render_pipeline,overrides:* // 17%, missing validation: invalid pipeline constant identifiers silently ignored
-webgpu:api,validation,render_pipeline,vertex_state:max_vertex_attribute_limit:* // 0%, empty vertex buffers not counted, GPUInternalError no message
-webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_limit:* // 0%, empty vertex buffers not counted toward limit
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:* // fails on metal in CI https://github.com/gfx-rs/wgpu/issues/8312
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_offset_alignment:* // fails on metal in CI
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_color:* // 92%, https://github.com/gfx-rs/wgpu/issues/3126

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -153,9 +153,12 @@ webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="rend
 webgpu:api,validation,encoding,cmds,debug:debug_group:*
 webgpu:api,validation,encoding,cmds,debug:debug_marker:*
 webgpu:api,validation,encoding,cmds,index_access:*
+webgpu:api,validation,encoding,cmds,render,draw:buffer_binding_overlap:*
 webgpu:api,validation,encoding,cmds,render,draw:index_buffer_OOB:*
 webgpu:api,validation,encoding,cmds,render,draw:unused_buffer_bound:*
+webgpu:api,validation,encoding,cmds,render,draw:vertex_buffer_OOB:*
 webgpu:api,validation,encoding,cmds,render,dynamic_state:*
+webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_buffer_state:*
 webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_buffer_usage:*
 webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_buffer,device_mismatch:*
 webgpu:api,validation,encoding,cmds,render,setIndexBuffer:*
@@ -271,7 +274,9 @@ webgpu:api,validation,render_pipeline,primitive_state:*
 webgpu:api,validation,render_pipeline,resource_compatibility:*
 webgpu:api,validation,render_pipeline,shader_module:*
 webgpu:api,validation,render_pipeline,vertex_state:many_attributes_overlapping:*
+webgpu:api,validation,render_pipeline,vertex_state:max_vertex_attribute_limit:*
 webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_array_stride_limit:*
+webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_limit:*
 fails-if(metal) webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:*
 fails-if(metal) webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_offset_alignment:*
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_shaderLocation_limit:*

--- a/deno_webgpu/01_webgpu.js
+++ b/deno_webgpu/01_webgpu.js
@@ -271,8 +271,7 @@ ObjectDefineProperty(GPUSupportedLimitsPrototype, privateCustomInspect, {
           "maxTextureDimension3D",
           "maxTextureArrayLayers",
           "maxBindGroups",
-          // TODO(@crowlKats): support max_bind_groups_plus_vertex_buffers
-          // "maxBindGroupsPlusVertexBuffers",
+          "maxBindGroupsPlusVertexBuffers",
           "maxBindingsPerBindGroup",
           "maxDynamicUniformBuffersPerPipelineLayout",
           "maxDynamicStorageBuffersPerPipelineLayout",

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -297,7 +297,10 @@ impl GPUSupportedLimits {
     self.0.max_bind_groups
   }
 
-  // TODO(@crowlKats): support max_bind_groups_plus_vertex_buffers
+  #[getter]
+  fn maxBindGroupsPlusVertexBuffers(&self) -> u32 {
+    self.0.max_bind_groups_plus_vertex_buffers
+  }
 
   #[getter]
   fn maxBindingsPerBindGroup(&self) -> u32 {

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -834,9 +834,8 @@ impl GPUDevice {
           .buffers
           .into_iter()
           .map(|b| {
-            b.into_option().map_or_else(
-              wgpu_core::pipeline::VertexBufferLayout::default,
-              |layout| wgpu_core::pipeline::VertexBufferLayout {
+            b.into_option().map(|layout| {
+              wgpu_core::pipeline::VertexBufferLayout {
                 array_stride: layout.array_stride,
                 step_mode: layout.step_mode.into(),
                 attributes: Cow::Owned(
@@ -850,8 +849,8 @@ impl GPUDevice {
                     })
                     .collect(),
                 ),
-              },
-            )
+              }
+            })
           })
           .collect(),
       ),

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -275,7 +275,7 @@ impl GPURenderBundleEncoder {
   fn set_vertex_buffer(
     &self,
     #[webidl(options(enforce_range = true))] slot: u32,
-    #[webidl] buffer: Ptr<GPUBuffer>, // TODO(wgpu): support nullable buffer
+    #[webidl] buffer: Nullable<Ptr<GPUBuffer>>,
     #[webidl(default = 0, options(enforce_range = true))] offset: u64,
     #[webidl(options(enforce_range = true))] size: Option<u64>,
   ) -> Result<(), JsErrorBox> {
@@ -287,7 +287,7 @@ impl GPURenderBundleEncoder {
     wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_vertex_buffer(
       encoder,
       slot,
-      buffer.id,
+      buffer.into_option().map(|buffer| buffer.id),
       offset,
       size.and_then(NonZeroU64::new),
     );

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -347,7 +347,7 @@ impl GPURenderPassEncoder {
   fn set_vertex_buffer(
     &self,
     #[webidl(options(enforce_range = true))] slot: u32,
-    #[webidl] buffer: Ptr<GPUBuffer>, // TODO(wgpu): support nullable buffer
+    #[webidl] buffer: Nullable<Ptr<GPUBuffer>>,
     #[webidl(default = 0, options(enforce_range = true))] offset: u64,
     #[webidl(options(enforce_range = true))] size: Option<u64>,
   ) {
@@ -356,7 +356,7 @@ impl GPURenderPassEncoder {
       .render_pass_set_vertex_buffer(
         &mut self.render_pass.borrow_mut(),
         slot,
-        buffer.id,
+        buffer.into_option().map(|buffer| buffer.id),
         offset,
         size.and_then(NonZeroU64::new),
       )

--- a/examples/features/src/boids/mod.rs
+++ b/examples/features/src/boids/mod.rs
@@ -127,16 +127,16 @@ impl crate::framework::Example for Example {
                 entry_point: Some("main_vs"),
                 compilation_options: Default::default(),
                 buffers: &[
-                    wgpu::VertexBufferLayout {
+                    Some(wgpu::VertexBufferLayout {
                         array_stride: 4 * 4,
                         step_mode: wgpu::VertexStepMode::Instance,
                         attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2],
-                    },
-                    wgpu::VertexBufferLayout {
+                    }),
+                    Some(wgpu::VertexBufferLayout {
                         array_stride: 2 * 4,
                         step_mode: wgpu::VertexStepMode::Vertex,
                         attributes: &wgpu::vertex_attr_array![2 => Float32x2],
-                    },
+                    }),
                 ],
             },
             fragment: Some(wgpu::FragmentState {

--- a/examples/features/src/cube/mod.rs
+++ b/examples/features/src/cube/mod.rs
@@ -218,7 +218,7 @@ impl crate::framework::Example for Example {
 
         let shader = device.create_shader_module(wgpu::include_wgsl!("shader.wgsl"));
 
-        let vertex_buffers = [wgpu::VertexBufferLayout {
+        let vertex_buffers = [Some(wgpu::VertexBufferLayout {
             array_stride: vertex_size as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &[
@@ -233,7 +233,7 @@ impl crate::framework::Example for Example {
                     shader_location: 1,
                 },
             ],
-        }];
+        })];
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: None,

--- a/examples/features/src/msaa_line/mod.rs
+++ b/examples/features/src/msaa_line/mod.rs
@@ -55,11 +55,11 @@ impl Example {
                 module: shader,
                 entry_point: Some("vs_main"),
                 compilation_options: Default::default(),
-                buffers: &[wgpu::VertexBufferLayout {
+                buffers: &[Some(wgpu::VertexBufferLayout {
                     array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x4],
-                }],
+                })],
             },
             fragment: Some(wgpu::FragmentState {
                 module: shader,

--- a/examples/features/src/ray_shadows/mod.rs
+++ b/examples/features/src/ray_shadows/mod.rs
@@ -196,11 +196,11 @@ impl crate::framework::Example for Example {
                 module: &shader,
                 entry_point: Some("vs_main"),
                 compilation_options: Default::default(),
-                buffers: &[VertexBufferLayout {
+                buffers: &[Some(VertexBufferLayout {
                     array_stride: mem::size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: Default::default(),
                     attributes: &vertex_attr_array![0 => Float32x3, 1 => Float32x3],
-                }],
+                })],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,

--- a/examples/features/src/shadow/mod.rs
+++ b/examples/features/src/shadow/mod.rs
@@ -438,11 +438,11 @@ impl crate::framework::Example for Example {
         });
 
         let vertex_attr = wgpu::vertex_attr_array![0 => Sint8x4, 1 => Sint8x4];
-        let vb_desc = wgpu::VertexBufferLayout {
+        let vertex_buffers = [Some(wgpu::VertexBufferLayout {
             array_stride: vertex_size as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &vertex_attr,
-        };
+        })];
 
         let shader = device.create_shader_module(wgpu::include_wgsl!("shader.wgsl"));
 
@@ -494,7 +494,7 @@ impl crate::framework::Example for Example {
                     module: &shader,
                     entry_point: Some("vs_bake"),
                     compilation_options: Default::default(),
-                    buffers: std::slice::from_ref(&vb_desc),
+                    buffers: &vertex_buffers,
                 },
                 fragment: None,
                 primitive: wgpu::PrimitiveState {
@@ -628,7 +628,7 @@ impl crate::framework::Example for Example {
                     module: &shader,
                     entry_point: Some("vs_main"),
                     compilation_options: Default::default(),
-                    buffers: &[vb_desc],
+                    buffers: &vertex_buffers,
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &shader,

--- a/examples/features/src/skybox/mod.rs
+++ b/examples/features/src/skybox/mod.rs
@@ -228,11 +228,11 @@ impl crate::framework::Example for Example {
                 module: &shader,
                 entry_point: Some("vs_entity"),
                 compilation_options: Default::default(),
-                buffers: &[wgpu::VertexBufferLayout {
+                buffers: &[Some(wgpu::VertexBufferLayout {
                     array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3],
-                }],
+                })],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,

--- a/examples/features/src/srgb_blend/mod.rs
+++ b/examples/features/src/srgb_blend/mod.rs
@@ -104,7 +104,7 @@ impl<const SRGB: bool> crate::framework::Example for Example<SRGB> {
 
         let shader = device.create_shader_module(wgpu::include_wgsl!("shader.wgsl"));
 
-        let vertex_buffers = [wgpu::VertexBufferLayout {
+        let vertex_buffers = [Some(wgpu::VertexBufferLayout {
             array_stride: vertex_size as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &[
@@ -119,7 +119,7 @@ impl<const SRGB: bool> crate::framework::Example for Example<SRGB> {
                     shader_location: 1,
                 },
             ],
-        }];
+        })];
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: None,

--- a/examples/features/src/stencil_triangles/mod.rs
+++ b/examples/features/src/stencil_triangles/mod.rs
@@ -53,7 +53,7 @@ impl crate::framework::Example for Example {
 
         let shader = device.create_shader_module(wgpu::include_wgsl!("shader.wgsl"));
 
-        let vertex_buffers = [wgpu::VertexBufferLayout {
+        let vertex_buffers = [Some(wgpu::VertexBufferLayout {
             array_stride: vertex_size as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &[wgpu::VertexAttribute {
@@ -61,7 +61,7 @@ impl crate::framework::Example for Example {
                 offset: 0,
                 shader_location: 0,
             }],
-        }];
+        })];
 
         let mask_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: None,

--- a/examples/features/src/texture_arrays/mod.rs
+++ b/examples/features/src/texture_arrays/mod.rs
@@ -340,11 +340,11 @@ impl crate::framework::Example for Example {
                 module: &base_shader_module,
                 entry_point: Some("vert_main"),
                 compilation_options: Default::default(),
-                buffers: &[wgpu::VertexBufferLayout {
+                buffers: &[Some(wgpu::VertexBufferLayout {
                     array_stride: vertex_size as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2, 2 => Sint32],
-                }],
+                })],
             },
             fragment: Some(wgpu::FragmentState {
                 module: fragment_shader_module,

--- a/examples/features/src/water/mod.rs
+++ b/examples/features/src/water/mod.rs
@@ -512,11 +512,11 @@ impl crate::framework::Example for Example {
                 // ensured by tagging on either a `#[repr(C)]` onto a
                 // struct, or a `#[repr(transparent)]` if it only contains
                 // one item, which is itself `repr(C)`.
-                buffers: &[wgpu::VertexBufferLayout {
+                buffers: &[Some(wgpu::VertexBufferLayout {
                     array_stride: water_vertex_size as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &wgpu::vertex_attr_array![0 => Sint16x2, 1 => Sint8x4],
-                }],
+                })],
             },
             // Fragment shader and output targets
             fragment: Some(wgpu::FragmentState {
@@ -579,11 +579,11 @@ impl crate::framework::Example for Example {
                 module: &terrain_module,
                 entry_point: Some("vs_main"),
                 compilation_options: Default::default(),
-                buffers: &[wgpu::VertexBufferLayout {
+                buffers: &[Some(wgpu::VertexBufferLayout {
                     array_stride: terrain_vertex_size as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3, 2 => Unorm8x4],
-                }],
+                })],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &terrain_module,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -1136,7 +1136,7 @@ impl Player {
                 size,
             } => C::SetVertexBuffer {
                 slot,
-                buffer: self.resolve_buffer_id(buffer),
+                buffer: buffer.map(|buffer| self.resolve_buffer_id(buffer)),
                 offset,
                 size,
             },

--- a/tests/tests/wgpu-gpu/draw_indirect.rs
+++ b/tests/tests/wgpu-gpu/draw_indirect.rs
@@ -127,11 +127,11 @@ async fn run_test_inner(
     use_multi_draw: bool,
 ) {
     let mut vertex_buffer_layouts = Vec::new();
-    vertex_buffer_layouts.push(wgpu::VertexBufferLayout {
+    vertex_buffer_layouts.push(Some(wgpu::VertexBufferLayout {
         array_stride: 8,
         step_mode: wgpu::VertexStepMode::Vertex,
         attributes: &vertex_attr_array![0 => Float32x2],
-    });
+    }));
     let vertex_buffer = ctx.device.create_buffer_init(&BufferInitDescriptor {
         label: None,
         contents: bytemuck::cast_slice(test_data.vertex_buffer_content()),
@@ -151,11 +151,11 @@ async fn run_test_inner(
     };
 
     let instance_buffer = test_data.instanced.as_ref().map(|instanced| {
-        vertex_buffer_layouts.push(wgpu::VertexBufferLayout {
+        vertex_buffer_layouts.push(Some(wgpu::VertexBufferLayout {
             array_stride: 8,
             step_mode: wgpu::VertexStepMode::Instance,
             attributes: &vertex_attr_array![1 => Float32x2],
-        });
+        }));
         ctx.device.create_buffer_init(&BufferInitDescriptor {
             label: None,
             contents: bytemuck::cast_slice(instanced.instance_buffer_content),
@@ -689,16 +689,16 @@ async fn indirect_buffer_offsets(ctx: TestingContext) {
         layout: None,
         vertex: wgpu::VertexState {
             buffers: &[
-                wgpu::VertexBufferLayout {
+                Some(wgpu::VertexBufferLayout {
                     array_stride: 8,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &vertex_attr_array![0 => Float32x2],
-                },
-                wgpu::VertexBufferLayout {
+                }),
+                Some(wgpu::VertexBufferLayout {
                     array_stride: 8,
                     step_mode: wgpu::VertexStepMode::Instance,
                     attributes: &vertex_attr_array![1 => Float32x2],
-                },
+                }),
             ],
             module: &shader,
             entry_point: Some("vs_main"),

--- a/tests/tests/wgpu-gpu/per_vertex/mod.rs
+++ b/tests/tests/wgpu-gpu/per_vertex/mod.rs
@@ -83,7 +83,7 @@ async fn per_vertex(ctx: TestingContext) {
                 module: &shader,
                 entry_point: Some("vs_main"),
                 compilation_options: Default::default(),
-                buffers: &[wgpu::VertexBufferLayout {
+                buffers: &[Some(wgpu::VertexBufferLayout {
                     array_stride: 12,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &[wgpu::VertexAttribute {
@@ -91,7 +91,7 @@ async fn per_vertex(ctx: TestingContext) {
                         offset: 0,
                         shader_location: 0,
                     }],
-                }],
+                })],
             },
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleStrip,

--- a/tests/tests/wgpu-gpu/regression/issue_3457.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_3457.rs
@@ -59,16 +59,16 @@ static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration = GpuTestConfiguration::ne
                     entry_point: Some("double_buffer_vert"),
                     compilation_options: Default::default(),
                     buffers: &[
-                        VertexBufferLayout {
+                        Some(VertexBufferLayout {
                             array_stride: 16,
                             step_mode: VertexStepMode::Vertex,
                             attributes: &vertex_attr_array![0 => Float32x4],
-                        },
-                        VertexBufferLayout {
+                        }),
+                        Some(VertexBufferLayout {
                             array_stride: 4,
                             step_mode: VertexStepMode::Vertex,
                             attributes: &vertex_attr_array![5 => Float32],
-                        },
+                        }),
                     ],
                 },
                 primitive: PrimitiveState::default(),
@@ -97,11 +97,11 @@ static PASS_RESET_VERTEX_BUFFER: GpuTestConfiguration = GpuTestConfiguration::ne
                     module: &module,
                     entry_point: Some("single_buffer_vert"),
                     compilation_options: Default::default(),
-                    buffers: &[VertexBufferLayout {
+                    buffers: &[Some(VertexBufferLayout {
                         array_stride: 16,
                         step_mode: VertexStepMode::Vertex,
                         attributes: &vertex_attr_array![0 => Float32x4],
-                    }],
+                    })],
                 },
                 primitive: PrimitiveState::default(),
                 depth_stencil: None,

--- a/tests/tests/wgpu-gpu/render_pass_ownership.rs
+++ b/tests/tests/wgpu-gpu/render_pass_ownership.rs
@@ -520,11 +520,11 @@ fn resource_setup(ctx: &TestingContext) -> ResourceSetup {
                 module: &sm,
                 entry_point: Some("vs_main"),
                 compilation_options: Default::default(),
-                buffers: &[wgpu::VertexBufferLayout {
+                buffers: &[Some(wgpu::VertexBufferLayout {
                     array_stride: 4,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &wgpu::vertex_attr_array![0 => Uint32],
-                }],
+                })],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &sm,

--- a/tests/tests/wgpu-gpu/render_target.rs
+++ b/tests/tests/wgpu-gpu/render_target.rs
@@ -80,11 +80,11 @@ async fn run_test(
         label: None,
         layout: None,
         vertex: wgpu::VertexState {
-            buffers: &[wgpu::VertexBufferLayout {
+            buffers: &[Some(wgpu::VertexBufferLayout {
                 array_stride: 8,
                 step_mode: wgpu::VertexStepMode::Vertex,
                 attributes: &vertex_attr_array![0 => Float32x2],
-            }],
+            })],
             module: &shader,
             entry_point: Some("vs_main"),
             compilation_options: Default::default(),
@@ -305,11 +305,11 @@ async fn run_test_3d(ctx: TestingContext) {
         label: None,
         layout: None,
         vertex: wgpu::VertexState {
-            buffers: &[wgpu::VertexBufferLayout {
+            buffers: &[Some(wgpu::VertexBufferLayout {
                 array_stride: 8,
                 step_mode: wgpu::VertexStepMode::Vertex,
                 attributes: &vertex_attr_array![0 => Float32x2],
-            }],
+            })],
             module: &shader,
             entry_point: Some("vs_main"),
             compilation_options: Default::default(),

--- a/tests/tests/wgpu-gpu/shader_barycentric/mod.rs
+++ b/tests/tests/wgpu-gpu/shader_barycentric/mod.rs
@@ -82,7 +82,7 @@ async fn barycentric(ctx: TestingContext, no_perspective: bool) {
                 module: &shader,
                 entry_point: Some("vs_main"),
                 compilation_options: Default::default(),
-                buffers: &[wgpu::VertexBufferLayout {
+                buffers: &[Some(wgpu::VertexBufferLayout {
                     array_stride: 8,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &[wgpu::VertexAttribute {
@@ -90,7 +90,7 @@ async fn barycentric(ctx: TestingContext, no_perspective: bool) {
                         offset: 0,
                         shader_location: 0,
                     }],
-                }],
+                })],
             },
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,

--- a/tests/tests/wgpu-gpu/shader_primitive_index/mod.rs
+++ b/tests/tests/wgpu-gpu/shader_primitive_index/mod.rs
@@ -127,7 +127,7 @@ async fn pulling_common(
                 module: &shader,
                 entry_point: Some("vs_main"),
                 compilation_options: Default::default(),
-                buffers: &[wgpu::VertexBufferLayout {
+                buffers: &[Some(wgpu::VertexBufferLayout {
                     array_stride: 8,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &[wgpu::VertexAttribute {
@@ -135,7 +135,7 @@ async fn pulling_common(
                         offset: 0,
                         shader_location: 0,
                     }],
-                }],
+                })],
             },
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,

--- a/tests/tests/wgpu-gpu/vertex_formats/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_formats/mod.rs
@@ -292,11 +292,11 @@ async fn vertex_formats_common(ctx: TestingContext, tests: &[Test<'_>]) {
             label: None,
             layout: Some(&ppl),
             vertex: wgpu::VertexState {
-                buffers: &[wgpu::VertexBufferLayout {
+                buffers: &[Some(wgpu::VertexBufferLayout {
                     array_stride: 0, // Calculate, please!
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: test.attributes,
-                }],
+                })],
                 module: &shader,
                 entry_point: Some(test.entry_point),
                 compilation_options: Default::default(),

--- a/tests/tests/wgpu-gpu/vertex_indices/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_indices/mod.rs
@@ -266,16 +266,16 @@ async fn vertex_index_common(ctx: TestingContext) {
 
     pipeline_desc.vertex.entry_point = Some("vs_main_buffers");
     pipeline_desc.vertex.buffers = &[
-        wgpu::VertexBufferLayout {
+        Some(wgpu::VertexBufferLayout {
             array_stride: 4,
             step_mode: wgpu::VertexStepMode::Instance,
             attributes: &wgpu::vertex_attr_array![0 => Uint32],
-        },
-        wgpu::VertexBufferLayout {
+        }),
+        Some(wgpu::VertexBufferLayout {
             array_stride: 4,
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &wgpu::vertex_attr_array![1 => Uint32],
-        },
+        }),
     ];
     let buffer_pipeline = ctx.device.create_render_pipeline(&pipeline_desc);
 
@@ -391,8 +391,8 @@ async fn vertex_index_common(ctx: TestingContext) {
                 .map(|r| r as &mut dyn RenderEncoder)
                 .unwrap_or(&mut rpass);
 
-            render_encoder.set_vertex_buffer(0, identity_buffer.slice(..));
-            render_encoder.set_vertex_buffer(1, identity_buffer.slice(..));
+            render_encoder.set_vertex_buffer(0, Some(identity_buffer.slice(..)));
+            render_encoder.set_vertex_buffer(1, Some(identity_buffer.slice(..)));
             render_encoder.set_index_buffer(identity_buffer.slice(..), wgpu::IndexFormat::Uint32);
             render_encoder.set_pipeline(pipeline);
             render_encoder.set_bind_group(0, Some(&bg), &[]);

--- a/tests/tests/wgpu-gpu/vertex_state.rs
+++ b/tests/tests/wgpu-gpu/vertex_state.rs
@@ -74,16 +74,16 @@ async fn set_array_stride_to_0(ctx: TestingContext) {
         });
 
     let vbl = [
-        wgpu::VertexBufferLayout {
+        Some(wgpu::VertexBufferLayout {
             array_stride: 8,
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &vertex_attr_array![0 => Float32x2],
-        },
-        wgpu::VertexBufferLayout {
+        }),
+        Some(wgpu::VertexBufferLayout {
             array_stride: 0,
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &vertex_attr_array![1 => Float32x4],
-        },
+        }),
     ];
     let pipeline_desc = wgpu::RenderPipelineDescriptor {
         label: None,
@@ -112,7 +112,7 @@ async fn set_array_stride_to_0(ctx: TestingContext) {
     };
     let mut first_pipeline_desc = pipeline_desc.clone();
     let mut first_vbl = vbl.clone();
-    first_vbl[1].array_stride = 16;
+    first_vbl[1].as_mut().unwrap().array_stride = 16;
     first_pipeline_desc.vertex.buffers = &first_vbl;
     let pipeline = ctx.device.create_render_pipeline(&pipeline_desc);
     let first_pipeline = ctx.device.create_render_pipeline(&first_pipeline_desc);

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -118,15 +118,20 @@ pub enum BindingError {
         offset: wgt::BufferAddress,
         buffer_size: u64,
     },
+    #[error("Unbinding vertex buffer at slot {slot} expects offset to be 0. However an offset of {offset} was provided.")]
+    UnbindingVertexBufferOffsetNotZero { slot: u32, offset: u64 },
+    #[error("Unbinding vertex buffer at slot {slot} expects size to be 0. However a size of {size} was provided.")]
+    UnbindingVertexBufferSizeNotZero { slot: u32, size: u64 },
 }
 
 impl WebGpuError for BindingError {
     fn webgpu_error_type(&self) -> ErrorType {
         match self {
             Self::DestroyedResource(e) => e.webgpu_error_type(),
-            Self::BindingRangeTooLarge { .. } | Self::BindingOffsetTooLarge { .. } => {
-                ErrorType::Validation
-            }
+            Self::BindingRangeTooLarge { .. }
+            | Self::BindingOffsetTooLarge { .. }
+            | BindingError::UnbindingVertexBufferOffsetNotZero { .. }
+            | BindingError::UnbindingVertexBufferSizeNotZero { .. } => ErrorType::Validation,
         }
     }
 }

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -48,6 +48,10 @@ mod compat {
             }
         }
 
+        fn is_assigned(&self) -> bool {
+            self.assigned.is_some()
+        }
+
         fn is_active(&self) -> bool {
             self.assigned.is_some() && self.expected.is_some()
         }
@@ -250,6 +254,13 @@ mod compat {
             self.entries[index].assigned = None;
         }
 
+        pub fn list_assigned(&self) -> impl Iterator<Item = usize> + '_ {
+            self.entries
+                .iter()
+                .enumerate()
+                .filter_map(|(i, e)| if e.is_assigned() { Some(i) } else { None })
+        }
+
         pub fn list_active(&self) -> impl Iterator<Item = usize> + '_ {
             self.entries
                 .iter()
@@ -437,6 +448,10 @@ impl Binder {
                     payloads[index].dynamic_offsets.as_slice(),
                 )
             })
+    }
+
+    pub(super) fn last_assigned_index(&self) -> Option<usize> {
+        self.manager.list_assigned().last()
     }
 
     pub(super) fn list_active(&self) -> impl Iterator<Item = &Arc<BindGroup>> + '_ {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -111,7 +111,7 @@ use crate::{
     hub::Hub,
     id,
     init_tracker::{BufferInitTrackerAction, MemoryInitKind, TextureInitTrackerAction},
-    pipeline::{PipelineFlags, RenderPipeline, VertexStep},
+    pipeline::{PipelineFlags, RenderPipeline},
     resource::{
         Buffer, DestroyedResourceError, Fallible, InvalidResourceError, Labeled, ParentDevice,
         RawResourceAccess, TrackingData,
@@ -662,13 +662,11 @@ fn set_pipeline(
         return Err(RenderCommandError::IncompatibleStencilAccess(pipeline.error_ident()).into());
     }
 
-    let pipeline_state = PipelineState::new(&pipeline);
-
     state
         .commands
         .push(ArcRenderCommand::SetPipeline(pipeline.clone()));
 
-    state.pipeline = Some(pipeline_state);
+    state.pipeline = Some(pipeline.clone());
 
     state
         .binder
@@ -791,10 +789,9 @@ fn set_immediates(
     size_bytes: u32,
     values_offset: Option<u32>,
 ) -> Result<(), RenderBundleErrorInner> {
-    let pipeline_state = state.pipeline()?;
+    let pipeline = state.pipeline()?;
 
-    pipeline_state
-        .pipeline
+    pipeline
         .layout
         .validate_immediates_ranges(offset, size_bytes)?;
 
@@ -817,7 +814,8 @@ fn draw(
     state.is_ready(DrawCommandFamily::Draw)?;
     let pipeline = state.pipeline()?;
 
-    let vertex_limits = super::VertexLimits::new(state.vertex_buffer_sizes(), &pipeline.steps);
+    let vertex_limits =
+        super::VertexLimits::new(state.vertex_buffer_sizes(), &pipeline.vertex_steps);
     vertex_limits.validate_vertex_limit(first_vertex, vertex_count)?;
     vertex_limits.validate_instance_limit(first_instance, instance_count)?;
 
@@ -847,7 +845,8 @@ fn draw_indexed(
 
     let index = state.index.as_ref().unwrap();
 
-    let vertex_limits = super::VertexLimits::new(state.vertex_buffer_sizes(), &pipeline.steps);
+    let vertex_limits =
+        super::VertexLimits::new(state.vertex_buffer_sizes(), &pipeline.vertex_steps);
 
     let last_index = first_index as u64 + index_count as u64;
     let index_limit = index.limit();
@@ -884,18 +883,17 @@ fn draw_mesh_tasks(
     state.is_ready(DrawCommandFamily::DrawMeshTasks)?;
 
     let limits = &state.device.limits;
-    let (groups_size_limit, max_groups) =
-        if state.pipeline.as_ref().unwrap().pipeline.has_task_shader {
-            (
-                limits.max_task_workgroups_per_dimension,
-                limits.max_task_workgroup_total_count,
-            )
-        } else {
-            (
-                limits.max_mesh_workgroups_per_dimension,
-                limits.max_mesh_workgroup_total_count,
-            )
-        };
+    let (groups_size_limit, max_groups) = if state.pipeline.as_ref().unwrap().has_task_shader {
+        (
+            limits.max_task_workgroups_per_dimension,
+            limits.max_task_workgroup_total_count,
+        )
+    } else {
+        (
+            limits.max_mesh_workgroups_per_dimension,
+            limits.max_mesh_workgroup_total_count,
+        )
+    };
 
     let total_count = check_workgroup_sizes(
         &[group_count_x, group_count_y, group_count_z],
@@ -936,7 +934,8 @@ fn multi_draw_indirect(
     buffer.same_device(&state.device)?;
     buffer.check_usage(wgt::BufferUsages::INDIRECT)?;
 
-    let vertex_limits = super::VertexLimits::new(state.vertex_buffer_sizes(), &pipeline.steps);
+    let vertex_limits =
+        super::VertexLimits::new(state.vertex_buffer_sizes(), &pipeline.vertex_steps);
 
     let stride = super::get_src_stride_of_indirect_args(family);
     // TODO(https://github.com/gfx-rs/wgpu/issues/8051): It would be better to report this
@@ -1391,25 +1390,6 @@ impl VertexState {
     }
 }
 
-/// The bundle's current pipeline, and some cached information needed for validation.
-struct PipelineState {
-    /// The pipeline
-    pipeline: Arc<RenderPipeline>,
-
-    /// How this pipeline's vertex shader traverses each vertex buffer, indexed
-    /// by vertex buffer slot number. `None` signifies unused vertex buffer slots.
-    steps: Vec<Option<VertexStep>>,
-}
-
-impl PipelineState {
-    fn new(pipeline: &Arc<RenderPipeline>) -> Self {
-        Self {
-            pipeline: pipeline.clone(),
-            steps: pipeline.vertex_steps.to_vec(),
-        }
-    }
-}
-
 /// State for analyzing and cleaning up bundle command streams.
 ///
 /// To minimize state updates, [`RenderBundleEncoder::finish`]
@@ -1425,7 +1405,7 @@ struct State {
     trackers: RenderBundleScope,
 
     /// The currently set pipeline, if any.
-    pipeline: Option<PipelineState>,
+    pipeline: Option<Arc<RenderPipeline>>,
 
     /// The state of each vertex buffer slot.
     vertex: [Option<VertexState>; hal::MAX_VERTEX_BUFFERS],
@@ -1455,9 +1435,9 @@ struct State {
 
 impl State {
     /// Return the current pipeline state. Return an error if none is set.
-    fn pipeline(&self) -> Result<&PipelineState, RenderBundleErrorInner> {
+    fn pipeline(&self) -> Result<&RenderPipeline, RenderBundleErrorInner> {
         self.pipeline
-            .as_ref()
+            .as_deref()
             .ok_or(DrawError::MissingPipeline(pass::MissingPipeline).into())
     }
 
@@ -1508,20 +1488,19 @@ impl State {
     /// This should be further deduplicated with similar validation on render/compute passes.
     fn is_ready(&mut self, family: DrawCommandFamily) -> Result<(), DrawError> {
         if let Some(pipeline) = self.pipeline.as_ref() {
-            self.binder
-                .check_compatibility(pipeline.pipeline.as_ref())?;
+            self.binder.check_compatibility(pipeline.as_ref())?;
             self.binder.check_late_buffer_bindings()?;
 
             // Check all needed vertex buffers have been bound
             for index in pipeline
-                .steps
+                .vertex_steps
                 .iter()
                 .enumerate()
                 .filter_map(|(index, step)| step.map(|_| index))
             {
                 if self.vertex.get(index).is_none() {
                     return Err(DrawError::MissingVertexBuffer {
-                        pipeline: pipeline.pipeline.error_ident(),
+                        pipeline: pipeline.error_ident(),
                         index,
                     });
                 }
@@ -1548,7 +1527,6 @@ impl State {
             }
 
             if family == DrawCommandFamily::DrawIndexed {
-                let pipeline = &pipeline.pipeline;
                 let index_format = match &self.index {
                     Some(index) => index.format,
                     None => return Err(DrawError::MissingIndexBuffer),
@@ -1566,11 +1544,10 @@ impl State {
 
             if !self
                 .immediate_slots_set
-                .contains(pipeline.pipeline.immediate_slots_required)
+                .contains(pipeline.immediate_slots_required)
             {
                 return Err(DrawError::MissingImmediateData {
                     missing: pipeline
-                        .pipeline
                         .immediate_slots_required
                         .difference(self.immediate_slots_set),
                 });

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -722,7 +722,7 @@ fn set_vertex_buffer(
     state: &mut State,
     buffer_guard: &crate::storage::Storage<Fallible<Buffer>>,
     slot: u32,
-    buffer_id: id::Id<id::markers::Buffer>,
+    buffer_id: Option<id::Id<id::markers::Buffer>>,
     offset: u64,
     size: Option<NonZeroU64>,
 ) -> Result<(), RenderBundleErrorInner> {
@@ -735,29 +735,53 @@ fn set_vertex_buffer(
         .into());
     }
 
-    let buffer = buffer_guard.get(buffer_id).get()?;
+    if let Some(buffer_id) = buffer_id {
+        let buffer = buffer_guard.get(buffer_id).get()?;
 
-    state
-        .trackers
-        .buffers
-        .merge_single(&buffer, wgt::BufferUses::VERTEX)?;
+        state
+            .trackers
+            .buffers
+            .merge_single(&buffer, wgt::BufferUses::VERTEX)?;
 
-    buffer.same_device(&state.device)?;
-    buffer.check_usage(wgt::BufferUsages::VERTEX)?;
+        buffer.same_device(&state.device)?;
+        buffer.check_usage(wgt::BufferUsages::VERTEX)?;
 
-    if !offset.is_multiple_of(wgt::VERTEX_ALIGNMENT) {
-        return Err(RenderCommandError::UnalignedVertexBuffer { slot, offset }.into());
+        if !offset.is_multiple_of(wgt::VERTEX_ALIGNMENT) {
+            return Err(RenderCommandError::UnalignedVertexBuffer { slot, offset }.into());
+        }
+        let end = offset + buffer.resolve_binding_size(offset, size)?;
+
+        state
+            .buffer_memory_init_actions
+            .extend(buffer.initialization_status.read().create_action(
+                &buffer,
+                offset..end.get(),
+                MemoryInitKind::NeedsInitializedMemory,
+            ));
+        state.vertex[slot as usize] = Some(VertexState::new(buffer, offset..end.get()));
+    } else {
+        if offset != 0 {
+            return Err(RenderCommandError::from(
+                crate::binding_model::BindingError::UnbindingVertexBufferOffsetNotZero {
+                    slot,
+                    offset,
+                },
+            )
+            .into());
+        }
+        if let Some(size) = size {
+            return Err(RenderCommandError::from(
+                crate::binding_model::BindingError::UnbindingVertexBufferSizeNotZero {
+                    slot,
+                    size: size.get(),
+                },
+            )
+            .into());
+        }
+
+        state.vertex[slot as usize] = None;
     }
-    let end = offset + buffer.resolve_binding_size(offset, size)?;
 
-    state
-        .buffer_memory_init_actions
-        .extend(buffer.initialization_status.read().create_action(
-            &buffer,
-            offset..end.get(),
-            MemoryInitKind::NeedsInitializedMemory,
-        ));
-    state.vertex[slot as usize] = Some(VertexState::new(buffer, offset..end.get()));
     Ok(())
 }
 
@@ -1111,7 +1135,7 @@ impl RenderBundle {
                     offset,
                     size,
                 } => {
-                    let buffer = buffer.try_raw(snatch_guard)?;
+                    let buffer = buffer.as_ref().unwrap().try_raw(snatch_guard)?;
                     // SAFETY: The binding size was checked against the buffer size
                     // in `set_vertex_buffer` and again in `VertexState::flush`.
                     let bb = hal::BufferBinding::new_unchecked(buffer, *offset, *size);
@@ -1357,7 +1381,7 @@ impl VertexState {
             self.is_dirty = false;
             Some(ArcRenderCommand::SetVertexBuffer {
                 slot,
-                buffer: self.buffer.clone(),
+                buffer: Some(self.buffer.clone()),
                 offset: self.range.start,
                 size: NonZeroU64::new(binding_size),
             })
@@ -1373,8 +1397,8 @@ struct PipelineState {
     pipeline: Arc<RenderPipeline>,
 
     /// How this pipeline's vertex shader traverses each vertex buffer, indexed
-    /// by vertex buffer slot number.
-    steps: Vec<VertexStep>,
+    /// by vertex buffer slot number. `None` signifies unused vertex buffer slots.
+    steps: Vec<Option<VertexStep>>,
 }
 
 impl PipelineState {
@@ -1487,6 +1511,21 @@ impl State {
             self.binder
                 .check_compatibility(pipeline.pipeline.as_ref())?;
             self.binder.check_late_buffer_bindings()?;
+
+            // Check all needed vertex buffers have been bound
+            for index in pipeline
+                .steps
+                .iter()
+                .enumerate()
+                .filter_map(|(index, step)| step.map(|_| index))
+            {
+                if self.vertex.get(index).is_none() {
+                    return Err(DrawError::MissingVertexBuffer {
+                        pipeline: pipeline.pipeline.error_ident(),
+                        index,
+                    });
+                }
+            }
 
             if family == DrawCommandFamily::DrawIndexed {
                 let pipeline = &pipeline.pipeline;
@@ -1681,7 +1720,7 @@ pub mod bundle_ffi {
     pub fn wgpu_render_bundle_set_vertex_buffer(
         bundle: &mut RenderBundleEncoder,
         slot: u32,
-        buffer_id: id::BufferId,
+        buffer_id: Option<id::BufferId>,
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -672,6 +672,8 @@ fn set_pipeline(
         .binder
         .change_pipeline_layout(&pipeline.layout, &pipeline.late_sized_buffer_groups);
 
+    state.vertex.update_limits(&pipeline.vertex_steps);
+
     state.trackers.render_pipelines.insert_single(pipeline);
     Ok(())
 }
@@ -747,16 +749,20 @@ fn set_vertex_buffer(
         if !offset.is_multiple_of(wgt::VERTEX_ALIGNMENT) {
             return Err(RenderCommandError::UnalignedVertexBuffer { slot, offset }.into());
         }
-        let end = offset + buffer.resolve_binding_size(offset, size)?;
+        let binding_size = buffer.resolve_binding_size(offset, size)?;
+        let buffer_range = offset..(offset + binding_size);
 
         state
             .buffer_memory_init_actions
             .extend(buffer.initialization_status.read().create_action(
                 &buffer,
-                offset..end.get(),
+                buffer_range.clone(),
                 MemoryInitKind::NeedsInitializedMemory,
             ));
-        state.vertex[slot as usize] = Some(VertexState::new(buffer, offset..end.get()));
+        state.vertex.set_buffer(slot as usize, buffer, buffer_range);
+        if let Some(pipeline) = state.pipeline.as_deref() {
+            state.vertex.update_limits(&pipeline.vertex_steps);
+        }
     } else {
         if offset != 0 {
             return Err(RenderCommandError::from(
@@ -777,7 +783,10 @@ fn set_vertex_buffer(
             .into());
         }
 
-        state.vertex[slot as usize] = None;
+        state.vertex.clear_buffer(slot as usize);
+        if let Some(pipeline) = state.pipeline.as_deref() {
+            state.vertex.update_limits(&pipeline.vertex_steps);
+        }
     }
 
     Ok(())
@@ -789,7 +798,10 @@ fn set_immediates(
     size_bytes: u32,
     values_offset: Option<u32>,
 ) -> Result<(), RenderBundleErrorInner> {
-    let pipeline = state.pipeline()?;
+    let pipeline = state
+        .pipeline
+        .as_deref()
+        .ok_or(DrawError::MissingPipeline(pass::MissingPipeline))?;
 
     pipeline
         .layout
@@ -812,15 +824,18 @@ fn draw(
     first_instance: u32,
 ) -> Result<(), RenderBundleErrorInner> {
     state.is_ready(DrawCommandFamily::Draw)?;
-    let pipeline = state.pipeline()?;
 
-    let vertex_limits =
-        super::VertexLimits::new(state.vertex_buffer_sizes(), &pipeline.vertex_steps);
-    vertex_limits.validate_vertex_limit(first_vertex, vertex_count)?;
-    vertex_limits.validate_instance_limit(first_instance, instance_count)?;
+    state
+        .vertex
+        .limits
+        .validate_vertex_limit(first_vertex, vertex_count)?;
+    state
+        .vertex
+        .limits
+        .validate_instance_limit(first_instance, instance_count)?;
 
     if instance_count > 0 && vertex_count > 0 {
-        state.flush_vertices();
+        state.flush_vertex_buffers();
         state.flush_bindings();
         state.commands.push(ArcRenderCommand::Draw {
             vertex_count,
@@ -841,12 +856,8 @@ fn draw_indexed(
     first_instance: u32,
 ) -> Result<(), RenderBundleErrorInner> {
     state.is_ready(DrawCommandFamily::DrawIndexed)?;
-    let pipeline = state.pipeline()?;
 
     let index = state.index.as_ref().unwrap();
-
-    let vertex_limits =
-        super::VertexLimits::new(state.vertex_buffer_sizes(), &pipeline.vertex_steps);
 
     let last_index = first_index as u64 + index_count as u64;
     let index_limit = index.limit();
@@ -857,11 +868,14 @@ fn draw_indexed(
         }
         .into());
     }
-    vertex_limits.validate_instance_limit(first_instance, instance_count)?;
+    state
+        .vertex
+        .limits
+        .validate_instance_limit(first_instance, instance_count)?;
 
     if instance_count > 0 && index_count > 0 {
         state.flush_index();
-        state.flush_vertices();
+        state.flush_vertex_buffers();
         state.flush_bindings();
         state.commands.push(ArcRenderCommand::DrawIndexed {
             index_count,
@@ -927,15 +941,10 @@ fn multi_draw_indirect(
         .device
         .require_downlevel_flags(wgt::DownlevelFlags::INDIRECT_EXECUTION)?;
 
-    let pipeline = state.pipeline()?;
-
     let buffer = buffer_guard.get(buffer_id).get()?;
 
     buffer.same_device(&state.device)?;
     buffer.check_usage(wgt::BufferUsages::INDIRECT)?;
-
-    let vertex_limits =
-        super::VertexLimits::new(state.vertex_buffer_sizes(), &pipeline.vertex_steps);
 
     let stride = super::get_src_stride_of_indirect_args(family);
     // TODO(https://github.com/gfx-rs/wgpu/issues/8051): It would be better to report this
@@ -955,9 +964,9 @@ fn multi_draw_indirect(
         state.commands.extend(index.flush());
         index.limit()
     } else {
-        vertex_limits.vertex_limit
+        state.vertex.limits.vertex_limit
     };
-    let instance_limit = vertex_limits.instance_limit;
+    let instance_limit = state.vertex.limits.instance_limit;
 
     let buffer_uses = if state.device.indirect_validation.is_some() {
         wgt::BufferUses::STORAGE_READ_ONLY
@@ -967,7 +976,7 @@ fn multi_draw_indirect(
 
     state.trackers.buffers.merge_single(&buffer, buffer_uses)?;
 
-    state.flush_vertices();
+    state.flush_vertex_buffers();
     state.flush_bindings();
     state.commands.push(ArcRenderCommand::DrawIndirect {
         buffer,
@@ -1347,49 +1356,6 @@ impl IndexState {
 ///
 /// [`flush`]: IndexState::flush
 #[derive(Debug)]
-struct VertexState {
-    buffer: Arc<Buffer>,
-    range: Range<wgt::BufferAddress>,
-    is_dirty: bool,
-}
-
-impl VertexState {
-    /// Create a new `VertexState`.
-    ///
-    /// The `range` must be contained within `buffer`.
-    fn new(buffer: Arc<Buffer>, range: Range<wgt::BufferAddress>) -> Self {
-        Self {
-            buffer,
-            range,
-            is_dirty: true,
-        }
-    }
-
-    /// Generate a `SetVertexBuffer` command for this slot, if necessary.
-    ///
-    /// `slot` is the index of the vertex buffer slot that `self` tracks.
-    fn flush(&mut self, slot: u32) -> Option<ArcRenderCommand> {
-        let binding_size = self
-            .range
-            .end
-            .checked_sub(self.range.start)
-            .filter(|_| self.range.end <= self.buffer.size)
-            .expect("vertex range must be contained in buffer");
-
-        if self.is_dirty {
-            self.is_dirty = false;
-            Some(ArcRenderCommand::SetVertexBuffer {
-                slot,
-                buffer: Some(self.buffer.clone()),
-                offset: self.range.start,
-                size: NonZeroU64::new(binding_size),
-            })
-        } else {
-            None
-        }
-    }
-}
-
 /// State for analyzing and cleaning up bundle command streams.
 ///
 /// To minimize state updates, [`RenderBundleEncoder::finish`]
@@ -1408,7 +1374,7 @@ struct State {
     pipeline: Option<Arc<RenderPipeline>>,
 
     /// The state of each vertex buffer slot.
-    vertex: [Option<VertexState>; hal::MAX_VERTEX_BUFFERS],
+    vertex: super::VertexState,
 
     /// The current index buffer, if one has been set. We flush this state
     /// before indexed draw commands.
@@ -1434,13 +1400,6 @@ struct State {
 }
 
 impl State {
-    /// Return the current pipeline state. Return an error if none is set.
-    fn pipeline(&self) -> Result<&RenderPipeline, RenderBundleErrorInner> {
-        self.pipeline
-            .as_deref()
-            .ok_or(DrawError::MissingPipeline(pass::MissingPipeline).into())
-    }
-
     /// Set the bundle's current index buffer and its associated parameters.
     fn set_index_buffer(
         &mut self,
@@ -1474,13 +1433,17 @@ impl State {
         self.commands.extend(commands);
     }
 
-    fn flush_vertices(&mut self) {
-        let commands = self
-            .vertex
-            .iter_mut()
-            .enumerate()
-            .flat_map(|(i, vs)| vs.as_mut().and_then(|vs| vs.flush(i as u32)));
-        self.commands.extend(commands);
+    fn flush_vertex_buffers(&mut self) {
+        let vertex = &mut self.vertex;
+        let commands = &mut self.commands;
+        vertex.flush(|slot, buffer, offset, size| {
+            commands.push(ArcRenderCommand::SetVertexBuffer {
+                slot,
+                buffer: Some(buffer.clone()),
+                offset,
+                size,
+            });
+        });
     }
 
     /// Validation for a draw command.
@@ -1498,7 +1461,7 @@ impl State {
                 .enumerate()
                 .filter_map(|(index, step)| step.map(|_| index))
             {
-                if self.vertex.get(index).is_none() {
+                if self.vertex.slots[index].is_none() {
                     return Err(DrawError::MissingVertexBuffer {
                         pipeline: pipeline.error_ident(),
                         index,
@@ -1507,13 +1470,7 @@ impl State {
             }
 
             let bind_group_space_used = self.binder.last_assigned_index().map_or(0, |i| i + 1);
-            let vertex_buffer_space_used = self
-                .vertex
-                .iter()
-                .enumerate()
-                .filter_map(|(i, state)| state.as_ref().map(|_| i))
-                .next_back()
-                .map_or(0, |i| i + 1);
+            let vertex_buffer_space_used = self.vertex.last_assigned_index().map_or(0, |i| i + 1);
 
             let bind_groups_plus_vertex_buffers =
                 u32::try_from(bind_group_space_used + vertex_buffer_space_used).unwrap();
@@ -1581,12 +1538,6 @@ impl State {
                     num_dynamic_offsets: dynamic_offsets.len(),
                 }
             }));
-    }
-
-    fn vertex_buffer_sizes(&self) -> impl Iterator<Item = Option<wgt::BufferAddress>> + '_ {
-        self.vertex
-            .iter()
-            .map(|vbs| vbs.as_ref().map(|vbs| vbs.range.end - vbs.range.start))
     }
 }
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1454,34 +1454,7 @@ impl State {
             self.binder.check_compatibility(pipeline.as_ref())?;
             self.binder.check_late_buffer_bindings()?;
 
-            // Check all needed vertex buffers have been bound
-            for index in pipeline
-                .vertex_steps
-                .iter()
-                .enumerate()
-                .filter_map(|(index, step)| step.map(|_| index))
-            {
-                if self.vertex.slots[index].is_none() {
-                    return Err(DrawError::MissingVertexBuffer {
-                        pipeline: pipeline.error_ident(),
-                        index,
-                    });
-                }
-            }
-
-            let bind_group_space_used = self.binder.last_assigned_index().map_or(0, |i| i + 1);
-            let vertex_buffer_space_used = self.vertex.last_assigned_index().map_or(0, |i| i + 1);
-
-            let bind_groups_plus_vertex_buffers =
-                u32::try_from(bind_group_space_used + vertex_buffer_space_used).unwrap();
-            if bind_groups_plus_vertex_buffers
-                > self.device.limits.max_bind_groups_plus_vertex_buffers
-            {
-                return Err(DrawError::TooManyBindGroupsPlusVertexBuffers {
-                    given: bind_groups_plus_vertex_buffers,
-                    limit: self.device.limits.max_bind_groups_plus_vertex_buffers,
-                });
-            }
+            self.vertex.validate(pipeline.as_ref(), &self.binder)?;
 
             if family == DrawCommandFamily::DrawIndexed {
                 let index_format = match &self.index {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1527,6 +1527,26 @@ impl State {
                 }
             }
 
+            let bind_group_space_used = self.binder.last_assigned_index().map_or(0, |i| i + 1);
+            let vertex_buffer_space_used = self
+                .vertex
+                .iter()
+                .enumerate()
+                .filter_map(|(i, state)| state.as_ref().map(|_| i))
+                .next_back()
+                .map_or(0, |i| i + 1);
+
+            let bind_groups_plus_vertex_buffers =
+                u32::try_from(bind_group_space_used + vertex_buffer_space_used).unwrap();
+            if bind_groups_plus_vertex_buffers
+                > self.device.limits.max_bind_groups_plus_vertex_buffers
+            {
+                return Err(DrawError::TooManyBindGroupsPlusVertexBuffers {
+                    given: bind_groups_plus_vertex_buffers,
+                    limit: self.device.limits.max_bind_groups_plus_vertex_buffers,
+                });
+            }
+
             if family == DrawCommandFamily::DrawIndexed {
                 let pipeline = &pipeline.pipeline;
                 let index_format = match &self.index {

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -27,7 +27,7 @@ pub enum DrawError {
     #[error("Currently set {pipeline} requires vertex buffer {index} to be set")]
     MissingVertexBuffer {
         pipeline: ResourceErrorIdent,
-        index: u32,
+        index: usize,
     },
     #[error("Index buffer must be set")]
     MissingIndexBuffer,

--- a/wgpu-core/src/command/draw.rs
+++ b/wgpu-core/src/command/draw.rs
@@ -74,6 +74,8 @@ pub enum DrawError {
     MissingImmediateData {
         missing: naga::valid::ImmediateSlots,
     },
+    #[error("The number of bind groups + vertex buffers {given} exceeds the limit {limit}")]
+    TooManyBindGroupsPlusVertexBuffers { given: u32, limit: u32 },
 }
 
 impl WebGpuError for DrawError {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -71,7 +71,7 @@ pub(crate) use self::{
     clear::clear_texture,
     encoder::EncodingState,
     memory_init::CommandBufferTextureMemoryActions,
-    render::{get_dst_stride_of_indirect_args, get_src_stride_of_indirect_args, VertexLimits},
+    render::{get_dst_stride_of_indirect_args, get_src_stride_of_indirect_args, VertexState},
     transfer::{
         extract_texture_selector, validate_linear_texture_data, validate_texture_buffer_copy,
         validate_texture_copy_dst_format, validate_texture_copy_range,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -38,7 +38,7 @@ use crate::{
     init_tracker::{MemoryInitKind, TextureInitRange, TextureInitTrackerAction},
     pipeline::{PipelineFlags, RenderPipeline, VertexStep},
     resource::{
-        DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
+        Buffer, DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
         MissingTextureUsageError, ParentDevice, QuerySet, RawResourceAccess, ResourceErrorIdent,
         Texture, TextureView, TextureViewNotRenderableReason,
     },
@@ -409,7 +409,7 @@ pub(crate) struct VertexLimits {
 
 impl VertexLimits {
     pub(crate) fn new(
-        buffer_sizes: impl Iterator<Item = Option<BufferAddress>>,
+        buffer_sizes: impl ExactSizeIterator<Item = Option<BufferAddress>>,
         pipeline_steps: &[Option<VertexStep>],
     ) -> Self {
         // Implements the validation from https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-draw
@@ -509,15 +509,81 @@ impl VertexLimits {
     }
 }
 
+/// State of a single vertex buffer slot.
+#[derive(Debug)]
+pub(crate) struct VertexSlot {
+    pub(crate) buffer: Arc<Buffer>,
+    pub(crate) range: Range<BufferAddress>,
+    pub(crate) is_dirty: bool,
+}
+
+/// Vertex buffer tracking state, shared between render passes and render bundles.
+///
+/// Tracks which vertex buffer slots are set, and caches the vertex and instance limits
+/// derived from those buffers and the current pipeline, avoiding recomputation on each draw.
 #[derive(Debug, Default)]
-struct VertexState {
-    buffer_sizes: [Option<BufferAddress>; hal::MAX_VERTEX_BUFFERS],
-    limits: VertexLimits,
+pub(crate) struct VertexState {
+    pub(crate) slots: [Option<VertexSlot>; hal::MAX_VERTEX_BUFFERS],
+    pub(crate) limits: VertexLimits,
 }
 
 impl VertexState {
-    fn update_limits(&mut self, pipeline_steps: &[Option<VertexStep>]) {
-        self.limits = VertexLimits::new(self.buffer_sizes.iter().copied(), pipeline_steps);
+    /// Set a vertex buffer slot, marking it dirty.
+    pub(crate) fn set_buffer(
+        &mut self,
+        slot: usize,
+        buffer: Arc<Buffer>,
+        range: Range<BufferAddress>,
+    ) {
+        self.slots[slot] = Some(VertexSlot {
+            buffer,
+            range,
+            is_dirty: true,
+        });
+    }
+
+    /// Clear a vertex buffer slot.
+    pub(crate) fn clear_buffer(&mut self, slot: usize) {
+        self.slots[slot] = None;
+    }
+
+    /// Recompute the cached vertex and instance limits based on the current slots and pipeline.
+    pub(crate) fn update_limits(&mut self, pipeline_steps: &[Option<VertexStep>]) {
+        self.limits = VertexLimits::new(
+            self.slots
+                .iter()
+                .map(|s| s.as_ref().map(|s| s.range.end - s.range.start)),
+            pipeline_steps,
+        );
+    }
+
+    pub(crate) fn last_assigned_index(&self) -> Option<usize> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| s.as_ref().map(|_| i))
+            .next_back()
+    }
+
+    /// Call `f` for each dirty slot with `(slot_index, buffer, offset, size)` and mark them clean.
+    pub(crate) fn flush<F>(&mut self, mut f: F)
+    where
+        F: FnMut(u32, &Arc<Buffer>, BufferAddress, Option<BufferSize>),
+    {
+        for (i, slot) in self.slots.iter_mut().enumerate() {
+            let Some(slot) = slot.as_mut() else { continue };
+            if !slot.is_dirty {
+                continue;
+            }
+            slot.is_dirty = false;
+            let size = slot.range.end - slot.range.start;
+            f(
+                i as u32,
+                &slot.buffer,
+                slot.range.start,
+                BufferSize::new(size),
+            );
+        }
     }
 }
 
@@ -558,7 +624,7 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
                 .enumerate()
                 .filter_map(|(index, step)| step.map(|_| index))
             {
-                if self.vertex.buffer_sizes.get(index).is_none() {
+                if self.vertex.slots[index].is_none() {
                     return Err(DrawError::MissingVertexBuffer {
                         pipeline: pipeline.error_ident(),
                         index,
@@ -567,14 +633,7 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
             }
 
             let bind_group_space_used = self.pass.binder.last_assigned_index().map_or(0, |i| i + 1);
-            let vertex_buffer_space_used = self
-                .vertex
-                .buffer_sizes
-                .iter()
-                .enumerate()
-                .filter_map(|(i, size)| size.map(|_| i))
-                .next_back()
-                .map_or(0, |i| i + 1);
+            let vertex_buffer_space_used = self.vertex.last_assigned_index().map_or(0, |i| i + 1);
 
             let bind_groups_plus_vertex_buffers =
                 u32::try_from(bind_group_space_used + vertex_buffer_space_used).unwrap();
@@ -642,6 +701,30 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
         self.index.reset();
         self.vertex = Default::default();
         self.immediate_slots_set = Default::default();
+    }
+
+    /// Flush dirty vertex buffer slots to the HAL encoder in preparation for a draw call.
+    fn flush_vertex_buffers(&mut self) -> Result<(), RenderPassErrorInner> {
+        let vertex = &mut self.vertex;
+        let raw_encoder: &mut dyn hal::DynCommandEncoder = self.pass.base.raw_encoder;
+        let snatch_guard = self.pass.base.snatch_guard;
+        let mut result = Ok(());
+        vertex.flush(|slot, buffer, offset, size| {
+            if result.is_err() {
+                return;
+            }
+            match buffer.try_raw(snatch_guard) {
+                Ok(raw) => unsafe {
+                    // SAFETY: The offset and size were validated in set_vertex_buffer.
+                    raw_encoder.set_vertex_buffer(
+                        slot,
+                        hal::BufferBinding::new_unchecked(raw, offset, size),
+                    );
+                },
+                Err(e) => result = Err(e.into()),
+            }
+        });
+        result
     }
 }
 
@@ -2452,7 +2535,7 @@ fn set_pipeline(
 fn set_index_buffer(
     state: &mut State,
     device: &Arc<Device>,
-    buffer: Arc<crate::resource::Buffer>,
+    buffer: Arc<Buffer>,
     index_format: IndexFormat,
     offset: u64,
     size: Option<BufferSize>,
@@ -2505,7 +2588,7 @@ fn set_vertex_buffer(
     state: &mut State,
     device: &Arc<Device>,
     slot: u32,
-    buffer: Option<Arc<crate::resource::Buffer>>,
+    buffer: Option<Arc<Buffer>>,
     offset: u64,
     size: Option<BufferSize>,
 ) -> Result<(), RenderPassErrorInner> {
@@ -2534,9 +2617,10 @@ fn set_vertex_buffer(
         if !offset.is_multiple_of(wgt::VERTEX_ALIGNMENT) {
             return Err(RenderCommandError::UnalignedVertexBuffer { slot, offset }.into());
         }
-        let (binding, buffer_size) = buffer
-            .binding(offset, size, state.pass.base.snatch_guard)
+        let binding_size = buffer
+            .resolve_binding_size(offset, size)
             .map_err(RenderCommandError::from)?;
+        let buffer_range = offset..(offset + binding_size);
 
         state
             .pass
@@ -2544,21 +2628,19 @@ fn set_vertex_buffer(
             .buffers
             .merge_single(&buffer, wgt::BufferUses::VERTEX)?;
 
-        state.vertex.buffer_sizes[slot as usize] = Some(buffer_size);
-        if let Some(pipeline) = state.pipeline.as_ref() {
-            state.vertex.update_limits(&pipeline.vertex_steps);
-        }
-
         state.pass.base.buffer_memory_init_actions.extend(
             buffer.initialization_status.read().create_action(
                 &buffer,
-                offset..(offset + buffer_size),
+                buffer_range.clone(),
                 MemoryInitKind::NeedsInitializedMemory,
             ),
         );
 
-        unsafe {
-            hal::DynCommandEncoder::set_vertex_buffer(state.pass.base.raw_encoder, slot, binding);
+        state
+            .vertex
+            .set_buffer(slot as usize, buffer, buffer_range.clone());
+        if let Some(pipeline) = state.pipeline.as_ref() {
+            state.vertex.update_limits(&pipeline.vertex_steps);
         }
     } else {
         if offset != 0 {
@@ -2580,7 +2662,7 @@ fn set_vertex_buffer(
             .into());
         }
 
-        state.vertex.buffer_sizes[slot as usize] = None;
+        state.vertex.clear_buffer(slot as usize);
         if let Some(pipeline) = state.pipeline.as_ref() {
             state.vertex.update_limits(&pipeline.vertex_steps);
         }
@@ -2725,6 +2807,7 @@ fn draw(
     api_log!("RenderPass::draw {vertex_count} {instance_count} {first_vertex} {first_instance}");
 
     state.is_ready(DrawCommandFamily::Draw)?;
+    state.flush_vertex_buffers()?;
     state.flush_bindings()?;
 
     state
@@ -2760,6 +2843,7 @@ fn draw_indexed(
     api_log!("RenderPass::draw_indexed {index_count} {instance_count} {first_index} {base_vertex} {first_instance}");
 
     state.is_ready(DrawCommandFamily::DrawIndexed)?;
+    state.flush_vertex_buffers()?;
     state.flush_bindings()?;
 
     let last_index = first_index as u64 + index_count as u64;
@@ -2841,7 +2925,7 @@ fn multi_draw_indirect(
     state: &mut State,
     indirect_draw_validation_batcher: &mut crate::indirect_validation::DrawBatcher,
     device: &Arc<Device>,
-    indirect_buffer: Arc<crate::resource::Buffer>,
+    indirect_buffer: Arc<Buffer>,
     offset: u64,
     count: u32,
     family: DrawCommandFamily,
@@ -2852,6 +2936,7 @@ fn multi_draw_indirect(
     );
 
     state.is_ready(family)?;
+    state.flush_vertex_buffers()?;
     state.flush_bindings()?;
 
     if family == DrawCommandFamily::DrawMeshTasks {
@@ -2933,7 +3018,7 @@ fn multi_draw_indirect(
             indirect_draw_validation_resources: &'a mut crate::indirect_validation::DrawResources,
             indirect_draw_validation_batcher: &'a mut crate::indirect_validation::DrawBatcher,
 
-            indirect_buffer: Arc<crate::resource::Buffer>,
+            indirect_buffer: Arc<Buffer>,
             family: DrawCommandFamily,
             vertex_or_index_limit: u64,
             instance_limit: u64,
@@ -3030,9 +3115,9 @@ fn multi_draw_indirect(
 fn multi_draw_indirect_count(
     state: &mut State,
     device: &Arc<Device>,
-    indirect_buffer: Arc<crate::resource::Buffer>,
+    indirect_buffer: Arc<Buffer>,
     offset: u64,
-    count_buffer: Arc<crate::resource::Buffer>,
+    count_buffer: Arc<Buffer>,
     count_buffer_offset: u64,
     max_count: u32,
     family: DrawCommandFamily,
@@ -3044,6 +3129,7 @@ fn multi_draw_indirect_count(
     );
 
     state.is_ready(family)?;
+    state.flush_vertex_buffers()?;
     state.flush_bindings()?;
 
     if family == DrawCommandFamily::DrawMeshTasks {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -566,6 +566,27 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
                 }
             }
 
+            let bind_group_space_used = self.pass.binder.last_assigned_index().map_or(0, |i| i + 1);
+            let vertex_buffer_space_used = self
+                .vertex
+                .buffer_sizes
+                .iter()
+                .enumerate()
+                .filter_map(|(i, size)| size.map(|_| i))
+                .next_back()
+                .map_or(0, |i| i + 1);
+
+            let bind_groups_plus_vertex_buffers =
+                u32::try_from(bind_group_space_used + vertex_buffer_space_used).unwrap();
+            if bind_groups_plus_vertex_buffers
+                > pipeline.device.limits.max_bind_groups_plus_vertex_buffers
+            {
+                return Err(DrawError::TooManyBindGroupsPlusVertexBuffers {
+                    given: bind_groups_plus_vertex_buffers,
+                    limit: pipeline.device.limits.max_bind_groups_plus_vertex_buffers,
+                });
+            }
+
             if family == DrawCommandFamily::DrawIndexed {
                 // Pipeline expects an index buffer
                 // We have a buffer bound

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -523,7 +523,7 @@ pub(crate) struct VertexSlot {
 /// derived from those buffers and the current pipeline, avoiding recomputation on each draw.
 #[derive(Debug, Default)]
 pub(crate) struct VertexState {
-    pub(crate) slots: [Option<VertexSlot>; hal::MAX_VERTEX_BUFFERS],
+    slots: [Option<VertexSlot>; hal::MAX_VERTEX_BUFFERS],
     pub(crate) limits: VertexLimits,
 }
 
@@ -557,12 +557,49 @@ impl VertexState {
         );
     }
 
-    pub(crate) fn last_assigned_index(&self) -> Option<usize> {
+    fn last_assigned_index(&self) -> Option<usize> {
         self.slots
             .iter()
             .enumerate()
             .filter_map(|(i, s)| s.as_ref().map(|_| i))
             .next_back()
+    }
+
+    pub(super) fn validate(
+        &self,
+        pipeline: &RenderPipeline,
+        binder: &Binder,
+    ) -> Result<(), DrawError> {
+        // Check all needed vertex buffers have been bound
+        for index in pipeline
+            .vertex_steps
+            .iter()
+            .enumerate()
+            .filter_map(|(index, step)| step.map(|_| index))
+        {
+            if self.slots[index].is_none() {
+                return Err(DrawError::MissingVertexBuffer {
+                    pipeline: pipeline.error_ident(),
+                    index,
+                });
+            }
+        }
+
+        let bind_group_space_used = binder.last_assigned_index().map_or(0, |i| i + 1);
+        let vertex_buffer_space_used = self.last_assigned_index().map_or(0, |i| i + 1);
+
+        let bind_groups_plus_vertex_buffers =
+            u32::try_from(bind_group_space_used + vertex_buffer_space_used).unwrap();
+        if bind_groups_plus_vertex_buffers
+            > pipeline.device.limits.max_bind_groups_plus_vertex_buffers
+        {
+            return Err(DrawError::TooManyBindGroupsPlusVertexBuffers {
+                given: bind_groups_plus_vertex_buffers,
+                limit: pipeline.device.limits.max_bind_groups_plus_vertex_buffers,
+            });
+        }
+
+        Ok(())
     }
 
     /// Call `f` for each dirty slot with `(slot_index, buffer, offset, size)` and mark them clean.
@@ -617,34 +654,7 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
                 return Err(DrawError::MissingBlendConstant);
             }
 
-            // Check all needed vertex buffers have been bound
-            for index in pipeline
-                .vertex_steps
-                .iter()
-                .enumerate()
-                .filter_map(|(index, step)| step.map(|_| index))
-            {
-                if self.vertex.slots[index].is_none() {
-                    return Err(DrawError::MissingVertexBuffer {
-                        pipeline: pipeline.error_ident(),
-                        index,
-                    });
-                }
-            }
-
-            let bind_group_space_used = self.pass.binder.last_assigned_index().map_or(0, |i| i + 1);
-            let vertex_buffer_space_used = self.vertex.last_assigned_index().map_or(0, |i| i + 1);
-
-            let bind_groups_plus_vertex_buffers =
-                u32::try_from(bind_group_space_used + vertex_buffer_space_used).unwrap();
-            if bind_groups_plus_vertex_buffers
-                > pipeline.device.limits.max_bind_groups_plus_vertex_buffers
-            {
-                return Err(DrawError::TooManyBindGroupsPlusVertexBuffers {
-                    given: bind_groups_plus_vertex_buffers,
-                    limit: pipeline.device.limits.max_bind_groups_plus_vertex_buffers,
-                });
-            }
+            self.vertex.validate(pipeline.as_ref(), &self.pass.binder)?;
 
             if family == DrawCommandFamily::DrawIndexed {
                 // Pipeline expects an index buffer

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -410,7 +410,7 @@ pub(crate) struct VertexLimits {
 impl VertexLimits {
     pub(crate) fn new(
         buffer_sizes: impl Iterator<Item = Option<BufferAddress>>,
-        pipeline_steps: &[VertexStep],
+        pipeline_steps: &[Option<VertexStep>],
     ) -> Self {
         // Implements the validation from https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-draw
         // Except that the formula is shuffled to extract the number of vertices in order
@@ -424,6 +424,10 @@ impl VertexLimits {
         let mut instance_limit_slot = 0;
 
         for (idx, (buffer_size, step)) in buffer_sizes.zip(pipeline_steps).enumerate() {
+            let Some(step) = step else {
+                continue;
+            };
+
             let Some(buffer_size) = buffer_size else {
                 // Missing required vertex buffer
                 return Self::default();
@@ -512,7 +516,7 @@ struct VertexState {
 }
 
 impl VertexState {
-    fn update_limits(&mut self, pipeline_steps: &[VertexStep]) {
+    fn update_limits(&mut self, pipeline_steps: &[Option<VertexStep>]) {
         self.limits = VertexLimits::new(self.buffer_sizes.iter().copied(), pipeline_steps);
     }
 }
@@ -547,19 +551,19 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
                 return Err(DrawError::MissingBlendConstant);
             }
 
-            // Determine how many vertex buffers have already been bound
-            let vertex_buffer_count = self
-                .vertex
-                .buffer_sizes
+            // Check all needed vertex buffers have been bound
+            for index in pipeline
+                .vertex_steps
                 .iter()
-                .take_while(|v| v.is_some())
-                .count() as u32;
-            // Compare with the needed quantity
-            if vertex_buffer_count < pipeline.vertex_steps.len() as u32 {
-                return Err(DrawError::MissingVertexBuffer {
-                    pipeline: pipeline.error_ident(),
-                    index: vertex_buffer_count,
-                });
+                .enumerate()
+                .filter_map(|(index, step)| step.map(|_| index))
+            {
+                if self.vertex.buffer_sizes.get(index).is_none() {
+                    return Err(DrawError::MissingVertexBuffer {
+                        pipeline: pipeline.error_ident(),
+                        index,
+                    });
+                }
             }
 
             if family == DrawCommandFamily::DrawIndexed {
@@ -2480,22 +2484,18 @@ fn set_vertex_buffer(
     state: &mut State,
     device: &Arc<Device>,
     slot: u32,
-    buffer: Arc<crate::resource::Buffer>,
+    buffer: Option<Arc<crate::resource::Buffer>>,
     offset: u64,
     size: Option<BufferSize>,
 ) -> Result<(), RenderPassErrorInner> {
-    api_log!(
-        "RenderPass::set_vertex_buffer {slot} {}",
-        buffer.error_ident()
-    );
-
-    state
-        .pass
-        .scope
-        .buffers
-        .merge_single(&buffer, wgt::BufferUses::VERTEX)?;
-
-    buffer.same_device(device)?;
+    if let Some(ref buffer) = buffer {
+        api_log!(
+            "RenderPass::set_vertex_buffer {slot} {}",
+            buffer.error_ident()
+        );
+    } else {
+        api_log!("RenderPass::set_vertex_buffer {slot} None");
+    }
 
     let max_vertex_buffers = state.pass.base.device.limits.max_vertex_buffers;
     if slot >= max_vertex_buffers {
@@ -2506,30 +2506,65 @@ fn set_vertex_buffer(
         .into());
     }
 
-    buffer.check_usage(BufferUsages::VERTEX)?;
+    if let Some(buffer) = buffer {
+        buffer.same_device(device)?;
+        buffer.check_usage(BufferUsages::VERTEX)?;
 
-    if !offset.is_multiple_of(wgt::VERTEX_ALIGNMENT) {
-        return Err(RenderCommandError::UnalignedVertexBuffer { slot, offset }.into());
-    }
-    let (binding, buffer_size) = buffer
-        .binding(offset, size, state.pass.base.snatch_guard)
-        .map_err(RenderCommandError::from)?;
-    state.vertex.buffer_sizes[slot as usize] = Some(buffer_size);
+        if !offset.is_multiple_of(wgt::VERTEX_ALIGNMENT) {
+            return Err(RenderCommandError::UnalignedVertexBuffer { slot, offset }.into());
+        }
+        let (binding, buffer_size) = buffer
+            .binding(offset, size, state.pass.base.snatch_guard)
+            .map_err(RenderCommandError::from)?;
 
-    state.pass.base.buffer_memory_init_actions.extend(
-        buffer.initialization_status.read().create_action(
-            &buffer,
-            offset..(offset + buffer_size),
-            MemoryInitKind::NeedsInitializedMemory,
-        ),
-    );
+        state
+            .pass
+            .scope
+            .buffers
+            .merge_single(&buffer, wgt::BufferUses::VERTEX)?;
 
-    unsafe {
-        hal::DynCommandEncoder::set_vertex_buffer(state.pass.base.raw_encoder, slot, binding);
+        state.vertex.buffer_sizes[slot as usize] = Some(buffer_size);
+        if let Some(pipeline) = state.pipeline.as_ref() {
+            state.vertex.update_limits(&pipeline.vertex_steps);
+        }
+
+        state.pass.base.buffer_memory_init_actions.extend(
+            buffer.initialization_status.read().create_action(
+                &buffer,
+                offset..(offset + buffer_size),
+                MemoryInitKind::NeedsInitializedMemory,
+            ),
+        );
+
+        unsafe {
+            hal::DynCommandEncoder::set_vertex_buffer(state.pass.base.raw_encoder, slot, binding);
+        }
+    } else {
+        if offset != 0 {
+            return Err(RenderCommandError::from(
+                crate::binding_model::BindingError::UnbindingVertexBufferOffsetNotZero {
+                    slot,
+                    offset,
+                },
+            )
+            .into());
+        }
+        if let Some(size) = size {
+            return Err(RenderCommandError::from(
+                crate::binding_model::BindingError::UnbindingVertexBufferSizeNotZero {
+                    slot,
+                    size: size.get(),
+                },
+            )
+            .into());
+        }
+
+        state.vertex.buffer_sizes[slot as usize] = None;
+        if let Some(pipeline) = state.pipeline.as_ref() {
+            state.vertex.update_limits(&pipeline.vertex_steps);
+        }
     }
-    if let Some(pipeline) = state.pipeline.as_ref() {
-        state.vertex.update_limits(&pipeline.vertex_steps);
-    }
+
     Ok(())
 }
 
@@ -3284,16 +3319,22 @@ impl Global {
         &self,
         pass: &mut RenderPass,
         slot: u32,
-        buffer_id: id::BufferId,
+        buffer_id: Option<id::BufferId>,
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetVertexBuffer;
         let base = pass_base!(pass, scope);
 
+        let buffer = if let Some(buffer_id) = buffer_id {
+            Some(pass_try!(base, scope, self.resolve_buffer_id(buffer_id)))
+        } else {
+            None
+        };
+
         base.commands.push(ArcRenderCommand::SetVertexBuffer {
             slot,
-            buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+            buffer,
             offset,
             size,
         });

--- a/wgpu-core/src/command/render_command.rs
+++ b/wgpu-core/src/command/render_command.rs
@@ -27,7 +27,7 @@ pub enum RenderCommand<R: ReferenceType> {
     },
     SetVertexBuffer {
         slot: u32,
-        buffer: R::Buffer,
+        buffer: Option<R::Buffer>,
         offset: BufferAddress,
         size: Option<BufferSize>,
     },

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4687,6 +4687,20 @@ impl Device {
             }
         };
 
+        if let pipeline::RenderPipelineVertexProcessor::Vertex(ref vertex) = desc.vertex {
+            let bind_groups_plus_vertex_buffers =
+                u32::try_from(pipeline_layout.bind_group_layouts.len() + vertex.buffers.len())
+                    .unwrap();
+            if bind_groups_plus_vertex_buffers > self.limits.max_bind_groups_plus_vertex_buffers {
+                return Err(
+                    pipeline::CreateRenderPipelineError::TooManyBindGroupsPlusVertexBuffers {
+                        given: bind_groups_plus_vertex_buffers,
+                        limit: self.limits.max_bind_groups_plus_vertex_buffers,
+                    },
+                );
+            }
+        }
+
         // Multiview is only supported if the feature is enabled
         if let Some(mv_mask) = desc.multiview_mask {
             self.require_features(wgt::Features::MULTIVIEW)?;

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4037,15 +4037,28 @@ impl Device {
         let mut validated_stages = wgt::ShaderStages::empty();
 
         let mut vertex_steps;
-        let mut vertex_buffers;
+        let mut hal_vertex_buffer_layouts;
         let mut total_attributes;
         let mut dual_source_blending = false;
         let mut has_depth_attachment = false;
         if let pipeline::RenderPipelineVertexProcessor::Vertex(ref vertex) = desc.vertex {
+            if vertex.buffers.len() > self.limits.max_vertex_buffers as usize {
+                return Err(pipeline::CreateRenderPipelineError::TooManyVertexBuffers {
+                    given: vertex.buffers.len() as u32,
+                    limit: self.limits.max_vertex_buffers,
+                });
+            }
+
             vertex_steps = Vec::with_capacity(vertex.buffers.len());
-            vertex_buffers = Vec::with_capacity(vertex.buffers.len());
+            hal_vertex_buffer_layouts = Vec::with_capacity(vertex.buffers.len());
             total_attributes = 0;
             for (i, vb_state) in vertex.buffers.iter().enumerate() {
+                let Some(vb_state) = vb_state else {
+                    vertex_steps.push(None);
+                    hal_vertex_buffer_layouts.push(None);
+                    continue;
+                };
+
                 // https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-gpuvertexbufferlayout
 
                 if vb_state.array_stride > self.limits.max_vertex_buffer_array_stride as u64 {
@@ -4101,18 +4114,20 @@ impl Device {
 
                     last_stride = last_stride.max(attribute_stride);
                 }
-                vertex_steps.push(pipeline::VertexStep {
+
+                vertex_steps.push(Some(pipeline::VertexStep {
                     stride: vb_state.array_stride,
                     last_stride,
                     mode: vb_state.step_mode,
-                });
-                if vb_state.attributes.is_empty() {
-                    continue;
-                }
-                vertex_buffers.push(hal::VertexBufferLayout {
-                    array_stride: vb_state.array_stride,
-                    step_mode: vb_state.step_mode,
-                    attributes: vb_state.attributes.as_ref(),
+                }));
+                hal_vertex_buffer_layouts.push(if vb_state.attributes.is_empty() {
+                    None
+                } else {
+                    Some(hal::VertexBufferLayout {
+                        array_stride: vb_state.array_stride,
+                        step_mode: vb_state.step_mode,
+                        attributes: vb_state.attributes.as_ref(),
+                    })
                 });
 
                 for attribute in vb_state.attributes.iter() {
@@ -4147,12 +4162,6 @@ impl Device {
                 total_attributes += vb_state.attributes.len();
             }
 
-            if vertex_buffers.len() > self.limits.max_vertex_buffers as usize {
-                return Err(pipeline::CreateRenderPipelineError::TooManyVertexBuffers {
-                    given: vertex_buffers.len() as u32,
-                    limit: self.limits.max_vertex_buffers,
-                });
-            }
             if total_attributes > self.limits.max_vertex_attributes as usize {
                 return Err(
                     pipeline::CreateRenderPipelineError::TooManyVertexAttributes {
@@ -4163,7 +4172,7 @@ impl Device {
             }
         } else {
             vertex_steps = Vec::new();
-            vertex_buffers = Vec::new();
+            hal_vertex_buffer_layouts = Vec::new();
         };
 
         if desc.primitive.strip_index_format.is_some() && !desc.primitive.topology.is_strip() {
@@ -4721,7 +4730,7 @@ impl Device {
                 layout: pipeline_layout.raw(),
                 vertex_processor: match vertex_stage {
                     Some(vertex_stage) => hal::VertexProcessor::Standard {
-                        vertex_buffers: &vertex_buffers,
+                        vertex_buffers: &hal_vertex_buffer_layouts,
                         vertex_stage,
                     },
                     None => hal::VertexProcessor::Mesh {

--- a/wgpu-core/src/limits.rs
+++ b/wgpu-core/src/limits.rs
@@ -291,7 +291,7 @@ const UPLEVEL: Bucket = Bucket {
     name: "uplevel-defaults",
     limits: Limits {
         max_bind_groups: 8,
-        // wgpu does not implement max_bind_groups_plus_vertex_buffers
+        // use default max_bind_groups_plus_vertex_buffers
         // use default max_bindings_per_bind_group
         max_buffer_size: 1 << 30, // 1 GB
         max_color_attachment_bytes_per_sample: 64,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -698,6 +698,8 @@ pub enum CreateRenderPipelineError {
     InvalidSampleCount(u32),
     #[error("The number of vertex buffers {given} exceeds the limit {limit}")]
     TooManyVertexBuffers { given: u32, limit: u32 },
+    #[error("The number of bind groups + vertex buffers {given} exceeds the limit {limit}")]
+    TooManyBindGroupsPlusVertexBuffers { given: u32, limit: u32 },
     #[error("The total number of vertex attributes {given} exceeds the limit {limit}")]
     TooManyVertexAttributes { given: u32, limit: u32 },
     #[error("Vertex attribute location {given} must be less than limit {limit}")]
@@ -778,6 +780,7 @@ impl WebGpuError for CreateRenderPipelineError {
             | Self::DepthStencilState(_)
             | Self::InvalidSampleCount(_)
             | Self::TooManyVertexBuffers { .. }
+            | Self::TooManyBindGroupsPlusVertexBuffers { .. }
             | Self::TooManyVertexAttributes { .. }
             | Self::VertexAttributeLocationTooLarge { .. }
             | Self::VertexStrideTooLarge { .. }

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -422,7 +422,7 @@ pub struct VertexState<'a, SM = ShaderModuleId> {
     /// The compiled vertex stage and its entry point.
     pub stage: ProgrammableStageDescriptor<'a, SM>,
     /// The format of any vertex buffers used with this pipeline.
-    pub buffers: Cow<'a, [VertexBufferLayout<'a>]>,
+    pub buffers: Cow<'a, [Option<VertexBufferLayout<'a>>]>,
 }
 
 /// cbindgen:ignore
@@ -840,7 +840,7 @@ pub struct RenderPipeline {
     pub(crate) flags: PipelineFlags,
     pub(crate) topology: wgt::PrimitiveTopology,
     pub(crate) strip_index_format: Option<wgt::IndexFormat>,
-    pub(crate) vertex_steps: Vec<VertexStep>,
+    pub(crate) vertex_steps: Vec<Option<VertexStep>>,
     pub(crate) late_sized_buffer_groups: ArrayVec<LateSizedBufferGroup, { hal::MAX_BIND_GROUPS }>,
     pub(crate) immediate_slots_required: naga::valid::ImmediateSlots,
     /// The `label` from the descriptor used to create the resource.

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -128,6 +128,11 @@ pub(crate) fn adjust_raw_limits(mut limits: wgt::Limits) -> wgt::Limits {
     limits.max_vertex_buffers = limits
         .max_vertex_buffers
         .min(crate::MAX_VERTEX_BUFFERS as u32);
+    // Once we allow the 2 limits above to be higher than 24 we should use
+    // `cap_limits_to_be_under_the_sum_limit` to cap them under
+    // `max_bind_groups_plus_vertex_buffers`.
+    const { assert!(crate::MAX_BIND_GROUPS + crate::MAX_VERTEX_BUFFERS == 24) };
+    limits.max_bind_groups_plus_vertex_buffers = limits.max_bind_groups_plus_vertex_buffers.min(24);
     limits.max_color_attachments = limits
         .max_color_attachments
         .min(crate::MAX_COLOR_ATTACHMENTS as u32);

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -894,7 +894,9 @@ impl super::Adapter {
                     max_texture_dimension_3d: Direct3D12::D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION,
                     // 2048
                     max_texture_array_layers: Direct3D12::D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION,
-                    // No real limit.
+                    // No limit.
+                    max_bind_groups_plus_vertex_buffers: u32::MAX,
+                    // No limit.
                     max_bindings_per_bind_group: u32::MAX,
                     max_sampled_textures_per_shader_stage,
                     max_samplers_per_shader_stage,

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -2056,6 +2056,9 @@ impl crate::Device for super::Device {
 
                 for (i, (stride, vbuf)) in vertex_strides.iter_mut().zip(vertex_buffers).enumerate()
                 {
+                    let Some(vbuf) = vbuf else {
+                        continue;
+                    };
                     *stride = Some(vbuf.array_stride as u32);
                     let (slot_class, step_rate) = match vbuf.step_mode {
                         wgt::VertexStepMode::Vertex => {

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -714,8 +714,10 @@ impl super::Adapter {
             max_texture_array_layers: unsafe {
                 gl.get_parameter_i32(glow::MAX_ARRAY_TEXTURE_LAYERS)
             } as u32,
-            max_bind_groups: crate::MAX_BIND_GROUPS as u32,
-            // No real limit.
+            max_bind_groups: u32::MAX,
+            // No limit.
+            max_bind_groups_plus_vertex_buffers: u32::MAX,
+            // No limit.
             max_bindings_per_bind_group: u32::MAX,
             max_dynamic_uniform_buffers_per_pipeline_layout: max_uniform_buffers_per_shader_stage,
             max_dynamic_storage_buffers_per_pipeline_layout: max_storage_buffers_per_shader_stage,

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -16,8 +16,10 @@ pub(super) struct State {
     primitive: super::PrimitiveState,
     index_format: wgt::IndexFormat,
     index_offset: wgt::BufferAddress,
-    vertex_buffers:
-        [(super::VertexBufferDesc, Option<super::BufferBinding>); crate::MAX_VERTEX_BUFFERS],
+    vertex_buffers: [(
+        Option<super::VertexBufferDesc>,
+        Option<super::BufferBinding>,
+    ); crate::MAX_VERTEX_BUFFERS],
     vertex_attributes: ArrayVec<super::AttributeDesc, { super::MAX_VERTEX_ATTRIBUTES }>,
     color_targets: ArrayVec<super::ColorTargetDesc, { crate::MAX_COLOR_ATTACHMENTS }>,
     stencil: super::StencilState,
@@ -139,9 +141,9 @@ impl super::CommandEncoder {
                     continue;
                 }
                 let (buffer_desc, vb) = match *pair {
+                    (Some(ref vb_desc), Some(ref vb)) => (vb_desc.clone(), vb),
                     // Not all dirty bindings are necessarily filled. Some may be unused.
-                    (_, None) => continue,
-                    (ref vb_desc, Some(ref vb)) => (vb_desc.clone(), vb),
+                    (_, _) => continue,
                 };
                 let instance_offset = match buffer_desc.step {
                     wgt::VertexStepMode::Vertex => 0,
@@ -166,9 +168,9 @@ impl super::CommandEncoder {
                 }
                 let (buffer_desc, vb) =
                     match self.state.vertex_buffers[attribute.buffer_index as usize] {
+                        (Some(ref vb_desc), Some(ref vb)) => (vb_desc.clone(), vb),
                         // Not all dirty bindings are necessarily filled. Some may be unused.
-                        (_, None) => continue,
-                        (ref vb_desc, Some(ref vb)) => (vb_desc.clone(), vb),
+                        (_, _) => continue,
                     };
 
                 let mut attribute_desc = attribute.clone();
@@ -875,7 +877,9 @@ impl crate::CommandEncoder for super::CommandEncoder {
             .contains(super::PrivateCapabilities::VERTEX_BUFFER_LAYOUT)
         {
             for vat in pipeline.vertex_attributes.iter() {
-                let vb = &pipeline.vertex_buffers[vat.buffer_index as usize];
+                let vb = pipeline.vertex_buffers[vat.buffer_index as usize]
+                    .as_ref()
+                    .unwrap();
                 // set the layout
                 self.cmd_buffer.commands.push(C::SetVertexAttribute {
                     buffer: None,
@@ -909,12 +913,15 @@ impl crate::CommandEncoder for super::CommandEncoder {
             .zip(pipeline.vertex_buffers.iter())
             .enumerate()
         {
+            let Some(pipe_desc) = pipe_desc else {
+                continue;
+            };
             if pipe_desc.step == wgt::VertexStepMode::Instance {
                 self.state.instance_vbuf_mask |= 1 << index;
             }
-            if state_desc != pipe_desc {
+            if state_desc.as_ref() != Some(pipe_desc) {
                 self.state.dirty_vbuf_mask |= 1 << index;
-                *state_desc = pipe_desc.clone();
+                *state_desc = Some(pipe_desc.clone());
             }
         }
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1439,19 +1439,24 @@ impl crate::Device for super::Device {
             let mut buffers = Vec::new();
             let mut attributes = Vec::new();
             for (index, vb_layout) in vertex_buffers.iter().enumerate() {
-                buffers.push(super::VertexBufferDesc {
-                    step: vb_layout.step_mode,
-                    stride: vb_layout.array_stride as u32,
-                });
-                for vat in vb_layout.attributes.iter() {
-                    let format_desc = conv::describe_vertex_format(vat.format);
-                    attributes.push(super::AttributeDesc {
-                        location: vat.shader_location,
-                        offset: vat.offset as u32,
-                        buffer_index: index as u32,
-                        format_desc,
-                    });
-                }
+                let vb_desc = if let Some(vb_layout) = vb_layout {
+                    for vat in vb_layout.attributes.iter() {
+                        let format_desc = conv::describe_vertex_format(vat.format);
+                        attributes.push(super::AttributeDesc {
+                            location: vat.shader_location,
+                            offset: vat.offset as u32,
+                            buffer_index: index as u32,
+                            format_desc,
+                        });
+                    }
+                    Some(super::VertexBufferDesc {
+                        step: vb_layout.step_mode,
+                        stride: vb_layout.array_stride as u32,
+                    })
+                } else {
+                    None
+                };
+                buffers.push(vb_desc);
             }
             (buffers.into_boxed_slice(), attributes.into_boxed_slice())
         };

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -729,7 +729,7 @@ type ProgramCache = FastHashMap<ProgramCacheKey, Result<Arc<PipelineInner>, crat
 pub struct RenderPipeline {
     inner: Arc<PipelineInner>,
     primitive: wgt::PrimitiveState,
-    vertex_buffers: Box<[VertexBufferDesc]>,
+    vertex_buffers: Box<[Option<VertexBufferDesc>]>,
     vertex_attributes: Box<[AttributeDesc]>,
     color_targets: Box<[ColorTargetDesc]>,
     depth: Option<DepthState>,

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2461,7 +2461,7 @@ pub struct VertexBufferLayout<'a> {
 pub enum VertexProcessor<'a, M: DynShaderModule + ?Sized> {
     Standard {
         /// The format of any vertex buffers used with this pipeline.
-        vertex_buffers: &'a [VertexBufferLayout<'a>],
+        vertex_buffers: &'a [Option<VertexBufferLayout<'a>>],
         /// The vertex stage for this pipeline.
         vertex_stage: ProgrammableStage<'a, M>,
     },

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1316,9 +1316,11 @@ impl super::CapabilitiesQuery {
             max_texture_dimension_2d: self.max_texture_size as u32,
             max_texture_dimension_3d: self.max_texture_3d_size as u32,
             max_texture_array_layers: self.max_texture_layers as u32,
-            // No real limit.
-            max_bind_groups: 8,
-            // No real limit.
+            // No limit.
+            max_bind_groups: u32::MAX,
+            // No limit. Once we start using argument buffers we should set this appropriately.
+            max_bind_groups_plus_vertex_buffers: u32::MAX,
+            // No limit.
             max_bindings_per_bind_group: u32::MAX,
             // No limit, use maxUniformBuffersPerShaderStage.
             max_dynamic_uniform_buffers_per_pipeline_layout: MAX_UNIFORM_BUFFERS_PER_SHADER_STAGE,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1298,6 +1298,9 @@ impl crate::Device for super::Device {
                     let mut vertex_buffer_mappings =
                         Vec::<naga::back::msl::VertexBufferMapping>::new();
                     for (i, vbl) in vertex_buffers.iter().enumerate() {
+                        let Some(vbl) = vbl else {
+                            continue;
+                        };
                         let mut attributes = Vec::<naga::back::msl::AttributeMapping>::new();
                         for attribute in vbl.attributes.iter() {
                             attributes.push(naga::back::msl::AttributeMapping {
@@ -1372,6 +1375,10 @@ impl crate::Device for super::Device {
                     if !vertex_buffers.is_empty() {
                         let vertex_descriptor = MTLVertexDescriptor::new();
                         for (i, vb) in vertex_buffers.iter().enumerate() {
+                            let Some(vb) = vb else {
+                                continue;
+                            };
+
                             let buffer_index = VERTEX_BUFFER_SLOT_START as usize + i;
                             let buffer_desc = unsafe {
                                 vertex_descriptor

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1627,6 +1627,8 @@ impl PhysicalDeviceProperties {
             max_texture_dimension_3d: limits.max_image_dimension3_d,
             max_texture_array_layers: limits.max_image_array_layers,
             max_bind_groups: limits.max_bound_descriptor_sets,
+            // No limit.
+            max_bind_groups_plus_vertex_buffers: u32::MAX,
             max_bindings_per_bind_group,
             max_dynamic_uniform_buffers_per_pipeline_layout: limits
                 .max_descriptor_set_uniform_buffers_dynamic,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1999,6 +1999,9 @@ impl crate::Device for super::Device {
         {
             vertex_buffers = Vec::with_capacity(desc_vertex_buffers.len());
             for (i, vb) in desc_vertex_buffers.iter().enumerate() {
+                let Some(vb) = vb else {
+                    continue;
+                };
                 vertex_buffers.push(vk::VertexInputBindingDescription {
                     binding: i as u32,
                     stride: vb.array_stride as u32,

--- a/wgpu-info/src/human.rs
+++ b/wgpu-info/src/human.rs
@@ -151,6 +151,7 @@ fn print_adapter(output: &mut impl io::Write, report: &AdapterReport, idx: usize
         max_texture_dimension_3d,
         max_texture_array_layers,
         max_bind_groups,
+        max_bind_groups_plus_vertex_buffers,
         max_bindings_per_bind_group,
         max_dynamic_uniform_buffers_per_pipeline_layout,
         max_dynamic_storage_buffers_per_pipeline_layout,
@@ -208,6 +209,7 @@ fn print_adapter(output: &mut impl io::Write, report: &AdapterReport, idx: usize
     writeln!(output, "\t\t                           Max Texture Dimension 3d: {max_texture_dimension_3d}")?;
     writeln!(output, "\t\t                           Max Texture Array Layers: {max_texture_array_layers}")?;
     writeln!(output, "\t\t                                    Max Bind Groups: {max_bind_groups}")?;
+    writeln!(output, "\t\t                Max Bind Groups Plus Vertex Buffers: {max_bind_groups_plus_vertex_buffers}")?;
     writeln!(output, "\t\t                        Max Bindings Per Bind Group: {max_bindings_per_bind_group}")?;
     writeln!(output, "\t\t    Max Dynamic Uniform Buffers Per Pipeline Layout: {max_dynamic_uniform_buffers_per_pipeline_layout}")?;
     writeln!(output, "\t\t    Max Dynamic Storage Buffers Per Pipeline Layout: {max_dynamic_storage_buffers_per_pipeline_layout}")?;

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -22,6 +22,7 @@ macro_rules! with_limits {
         $macro_name!(max_texture_dimension_3d, Ordering::Less);
         $macro_name!(max_texture_array_layers, Ordering::Less);
         $macro_name!(max_bind_groups, Ordering::Less);
+        $macro_name!(max_bind_groups_plus_vertex_buffers, Ordering::Less);
         $macro_name!(max_bindings_per_bind_group, Ordering::Less);
         $macro_name!(
             max_dynamic_uniform_buffers_per_pipeline_layout,
@@ -146,6 +147,9 @@ pub struct Limits {
     pub max_texture_array_layers: u32,
     /// Amount of bind groups that can be attached to a pipeline at the same time. Defaults to 4. Higher is "better".
     pub max_bind_groups: u32,
+    /// The maximum number of bind group and vertex buffer slots used simultaneously, counting any empty slots below the highest index.
+    /// Defaults to 24. Higher is "better".
+    pub max_bind_groups_plus_vertex_buffers: u32,
     /// Maximum binding index allowed in `create_bind_group_layout`. Defaults to 1000. Higher is "better".
     pub max_bindings_per_bind_group: u32,
     /// Amount of uniform buffer bindings that can be dynamic in a single pipeline. Defaults to 8. Higher is "better".
@@ -333,6 +337,7 @@ impl Limits {
     ///     max_texture_dimension_3d: 2048,
     ///     max_texture_array_layers: 256,
     ///     max_bind_groups: 4,
+    ///     max_bind_groups_plus_vertex_buffers: 24,
     ///     max_bindings_per_bind_group: 1000,
     ///     max_dynamic_uniform_buffers_per_pipeline_layout: 8,
     ///     max_dynamic_storage_buffers_per_pipeline_layout: 4,
@@ -394,6 +399,7 @@ impl Limits {
             max_texture_dimension_3d: 2048,
             max_texture_array_layers: 256,
             max_bind_groups: 4,
+            max_bind_groups_plus_vertex_buffers: 24,
             max_bindings_per_bind_group: 1000,
             max_dynamic_uniform_buffers_per_pipeline_layout: 8,
             max_dynamic_storage_buffers_per_pipeline_layout: 4,
@@ -459,6 +465,7 @@ impl Limits {
     ///     max_texture_dimension_3d: 256, // *
     ///     max_texture_array_layers: 256,
     ///     max_bind_groups: 4,
+    ///     max_bind_groups_plus_vertex_buffers: 24,
     ///     max_bindings_per_bind_group: 1000,
     ///     max_dynamic_uniform_buffers_per_pipeline_layout: 8,
     ///     max_dynamic_storage_buffers_per_pipeline_layout: 4,
@@ -540,6 +547,7 @@ impl Limits {
     ///     max_texture_dimension_3d: 256, // *
     ///     max_texture_array_layers: 256,
     ///     max_bind_groups: 4,
+    ///     max_bind_groups_plus_vertex_buffers: 24,
     ///     max_bindings_per_bind_group: 1000,
     ///     max_dynamic_uniform_buffers_per_pipeline_layout: 8,
     ///     max_dynamic_storage_buffers_per_pipeline_layout: 0, // +
@@ -637,6 +645,7 @@ impl Limits {
             max_texture_dimension_3d: ALLOC_MAX_U32,
             max_texture_array_layers: ALLOC_MAX_U32,
             max_bind_groups: ALLOC_MAX_U32,
+            max_bind_groups_plus_vertex_buffers: ALLOC_MAX_U32,
             max_bindings_per_bind_group: ALLOC_MAX_U32,
             max_dynamic_uniform_buffers_per_pipeline_layout: ALLOC_MAX_U32,
             max_dynamic_storage_buffers_per_pipeline_layout: ALLOC_MAX_U32,

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -107,13 +107,21 @@ impl<'a> RenderBundleEncoder<'a> {
     ///
     /// [`draw`]: RenderBundleEncoder::draw
     /// [`draw_indexed`]: RenderBundleEncoder::draw_indexed
-    pub fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'a>) {
-        self.inner.set_vertex_buffer(
-            slot,
-            &buffer_slice.buffer.inner,
-            buffer_slice.offset,
-            Some(buffer_slice.size),
-        );
+    pub fn set_vertex_buffer<'b, B>(&mut self, slot: u32, buffer_slice: B)
+    where
+        Option<BufferSlice<'b>>: From<B>,
+    {
+        let buffer_slice: Option<BufferSlice<'b>> = buffer_slice.into();
+        if let Some(buffer_slice) = buffer_slice {
+            self.inner.set_vertex_buffer(
+                slot,
+                Some(&buffer_slice.buffer.inner),
+                buffer_slice.offset,
+                Some(buffer_slice.size),
+            );
+        } else {
+            self.inner.set_vertex_buffer(slot, None, 0, None);
+        }
     }
 
     /// Draws primitives from the active vertex buffer(s).

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -121,13 +121,21 @@ impl RenderPass<'_> {
     ///
     /// [`draw`]: RenderPass::draw
     /// [`draw_indexed`]: RenderPass::draw_indexed
-    pub fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'_>) {
-        self.inner.set_vertex_buffer(
-            slot,
-            &buffer_slice.buffer.inner,
-            buffer_slice.offset,
-            Some(buffer_slice.size),
-        );
+    pub fn set_vertex_buffer<'b, B>(&mut self, slot: u32, buffer_slice: B)
+    where
+        Option<BufferSlice<'b>>: From<B>,
+    {
+        let buffer_slice: Option<BufferSlice<'b>> = buffer_slice.into();
+        if let Some(buffer_slice) = buffer_slice {
+            self.inner.set_vertex_buffer(
+                slot,
+                Some(&buffer_slice.buffer.inner),
+                buffer_slice.offset,
+                Some(buffer_slice.size),
+            );
+        } else {
+            self.inner.set_vertex_buffer(slot, None, 0, None);
+        }
     }
 
     /// Sets the scissor rectangle used during the rasterization stage.

--- a/wgpu/src/api/render_pipeline.rs
+++ b/wgpu/src/api/render_pipeline.rs
@@ -112,7 +112,7 @@ pub struct VertexState<'a> {
     ///
     /// The attribute locations and types specified in this layout must match the
     /// locations and types of the inputs to the `entry_point` function.
-    pub buffers: &'a [VertexBufferLayout<'a>],
+    pub buffers: &'a [Option<VertexBufferLayout<'a>>],
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(VertexState<'_>: Send, Sync);

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -818,6 +818,7 @@ fn map_wgt_limits(limits: webgpu_sys::GpuSupportedLimits) -> wgt::Limits {
         max_texture_dimension_3d: limits.max_texture_dimension_3d(),
         max_texture_array_layers: limits.max_texture_array_layers(),
         max_bind_groups: limits.max_bind_groups(),
+        max_bind_groups_plus_vertex_buffers: limits.max_bind_groups_plus_vertex_buffers(),
         max_bindings_per_bind_group: limits.max_bindings_per_bind_group(),
         max_dynamic_uniform_buffers_per_pipeline_layout: limits
             .max_dynamic_uniform_buffers_per_pipeline_layout(),
@@ -925,7 +926,7 @@ fn map_js_sys_limits(limits: &wgt::Limits) -> js_sys::Object<js_sys::Number> {
         (maxTextureDimension3D, max_texture_dimension_3d),
         (maxTextureArrayLayers, max_texture_array_layers),
         (maxBindGroups, max_bind_groups),
-        // TODO: (maxBindGroupsPlusVertexBuffers, max_bind_groups_plus_vertex_buffers),
+        (maxBindGroupsPlusVertexBuffers, max_bind_groups_plus_vertex_buffers),
         (maxBindingsPerBindGroup, max_bindings_per_bind_group),
         (maxDynamicUniformBuffersPerPipelineLayout, max_dynamic_uniform_buffers_per_pipeline_layout),
         (maxDynamicStorageBuffersPerPipelineLayout, max_dynamic_storage_buffers_per_pipeline_layout),

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2215,25 +2215,28 @@ impl dispatch::DeviceInterface for WebDevice {
             .vertex
             .buffers
             .iter()
-            .map(|vbuf| {
-                let mapped_attributes = vbuf
-                    .attributes
-                    .iter()
-                    .map(|attr| {
-                        webgpu_sys::GpuVertexAttribute::new_with_f64(
-                            map_vertex_format(attr.format),
-                            attr.offset as f64,
-                            attr.shader_location,
-                        )
-                    })
-                    .collect::<Vec<webgpu_sys::GpuVertexAttribute>>();
+            .map(|vbuf| match vbuf {
+                Some(vbuf) => {
+                    let mapped_attributes = vbuf
+                        .attributes
+                        .iter()
+                        .map(|attr| {
+                            webgpu_sys::GpuVertexAttribute::new_with_f64(
+                                map_vertex_format(attr.format),
+                                attr.offset as f64,
+                                attr.shader_location,
+                            )
+                        })
+                        .collect::<Vec<webgpu_sys::GpuVertexAttribute>>();
 
-                let mapped_vbuf = webgpu_sys::GpuVertexBufferLayout::new_with_f64(
-                    vbuf.array_stride as f64,
-                    &mapped_attributes,
-                );
-                mapped_vbuf.set_step_mode(map_vertex_step_mode(vbuf.step_mode));
-                js_sys::JsOption::wrap(mapped_vbuf)
+                    let mapped_vbuf = webgpu_sys::GpuVertexBufferLayout::new_with_f64(
+                        vbuf.array_stride as f64,
+                        &mapped_attributes,
+                    );
+                    mapped_vbuf.set_step_mode(map_vertex_step_mode(vbuf.step_mode));
+                    js_sys::JsOption::wrap(mapped_vbuf)
+                }
+                None => js_sys::JsOption::new(),
             })
             .collect::<Vec<js_sys::JsOption<webgpu_sys::GpuVertexBufferLayout>>>();
 
@@ -3513,22 +3516,22 @@ impl dispatch::RenderPassInterface for WebRenderPassEncoder {
     fn set_vertex_buffer(
         &mut self,
         slot: u32,
-        buffer: &dispatch::DispatchBuffer,
+        buffer: Option<&dispatch::DispatchBuffer>,
         offset: crate::BufferAddress,
         size: Option<crate::BufferSize>,
     ) {
-        let buffer = buffer.as_webgpu();
+        let buffer = buffer.map(|buffer| &buffer.as_webgpu().inner);
 
         if let Some(size) = size {
             self.inner.set_vertex_buffer_with_f64_and_f64(
                 slot,
-                Some(&buffer.inner),
+                buffer,
                 offset as f64,
                 size.get() as f64,
             );
         } else {
             self.inner
-                .set_vertex_buffer_with_f64(slot, Some(&buffer.inner), offset as f64);
+                .set_vertex_buffer_with_f64(slot, buffer, offset as f64);
         }
     }
 
@@ -3804,22 +3807,22 @@ impl dispatch::RenderBundleEncoderInterface for WebRenderBundleEncoder {
     fn set_vertex_buffer(
         &mut self,
         slot: u32,
-        buffer: &dispatch::DispatchBuffer,
+        buffer: Option<&dispatch::DispatchBuffer>,
         offset: crate::BufferAddress,
         size: Option<crate::BufferSize>,
     ) {
-        let buffer = buffer.as_webgpu();
+        let buffer = buffer.map(|buffer| &buffer.as_webgpu().inner);
 
         if let Some(size) = size {
             self.inner.set_vertex_buffer_with_f64_and_f64(
                 slot,
-                Some(&buffer.inner),
+                buffer,
                 offset as f64,
                 size.get() as f64,
             );
         } else {
             self.inner
-                .set_vertex_buffer_with_f64(slot, Some(&buffer.inner), offset as f64);
+                .set_vertex_buffer_with_f64(slot, buffer, offset as f64);
         }
     }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1338,10 +1338,12 @@ impl dispatch::DeviceInterface for CoreDevice {
             .vertex
             .buffers
             .iter()
-            .map(|vbuf| pipe::VertexBufferLayout {
-                array_stride: vbuf.array_stride,
-                step_mode: vbuf.step_mode,
-                attributes: Borrowed(vbuf.attributes),
+            .map(|vbuf| {
+                Some(pipe::VertexBufferLayout {
+                    array_stride: vbuf.array_stride,
+                    step_mode: vbuf.step_mode,
+                    attributes: Borrowed(vbuf.attributes),
+                })
             })
             .collect();
 
@@ -3236,7 +3238,7 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
         if let Err(cause) = self.context.0.render_pass_set_vertex_buffer(
             &mut self.pass,
             slot,
-            buffer.id,
+            Some(buffer.id),
             offset,
             size,
         ) {
@@ -3818,7 +3820,7 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let buffer = buffer.as_core();
 
-        wgpu_render_bundle_set_vertex_buffer(&mut self.encoder, slot, buffer.id, offset, size)
+        wgpu_render_bundle_set_vertex_buffer(&mut self.encoder, slot, Some(buffer.id), offset, size)
     }
 
     fn set_immediates(&mut self, offset: u32, data: &[u8]) {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1339,7 +1339,7 @@ impl dispatch::DeviceInterface for CoreDevice {
             .buffers
             .iter()
             .map(|vbuf| {
-                Some(pipe::VertexBufferLayout {
+                vbuf.as_ref().map(|vbuf| pipe::VertexBufferLayout {
                     array_stride: vbuf.array_stride,
                     step_mode: vbuf.step_mode,
                     attributes: Borrowed(vbuf.attributes),
@@ -3229,19 +3229,17 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     fn set_vertex_buffer(
         &mut self,
         slot: u32,
-        buffer: &dispatch::DispatchBuffer,
+        buffer: Option<&dispatch::DispatchBuffer>,
         offset: crate::BufferAddress,
         size: Option<crate::BufferSize>,
     ) {
-        let buffer = buffer.as_core();
+        let buffer = buffer.map(|buffer| buffer.as_core().id);
 
-        if let Err(cause) = self.context.0.render_pass_set_vertex_buffer(
-            &mut self.pass,
-            slot,
-            Some(buffer.id),
-            offset,
-            size,
-        ) {
+        if let Err(cause) =
+            self.context
+                .0
+                .render_pass_set_vertex_buffer(&mut self.pass, slot, buffer, offset, size)
+        {
             self.context.handle_error(
                 &self.error_sink,
                 cause,
@@ -3814,13 +3812,13 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     fn set_vertex_buffer(
         &mut self,
         slot: u32,
-        buffer: &dispatch::DispatchBuffer,
+        buffer: Option<&dispatch::DispatchBuffer>,
         offset: crate::BufferAddress,
         size: Option<crate::BufferSize>,
     ) {
-        let buffer = buffer.as_core();
+        let buffer = buffer.map(|buffer| buffer.as_core().id);
 
-        wgpu_render_bundle_set_vertex_buffer(&mut self.encoder, slot, Some(buffer.id), offset, size)
+        wgpu_render_bundle_set_vertex_buffer(&mut self.encoder, slot, buffer, offset, size)
     }
 
     fn set_immediates(&mut self, offset: u32, data: &[u8]) {

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -436,7 +436,7 @@ pub trait RenderPassInterface: CommonTraits + Drop {
     fn set_vertex_buffer(
         &mut self,
         slot: u32,
-        buffer: &DispatchBuffer,
+        buffer: Option<&DispatchBuffer>,
         offset: crate::BufferAddress,
         size: Option<crate::BufferSize>,
     );
@@ -547,7 +547,7 @@ pub trait RenderBundleEncoderInterface: CommonTraits {
     fn set_vertex_buffer(
         &mut self,
         slot: u32,
-        buffer: &DispatchBuffer,
+        buffer: Option<&DispatchBuffer>,
         offset: crate::BufferAddress,
         size: Option<crate::BufferSize>,
     );

--- a/wgpu/src/util/encoder.rs
+++ b/wgpu/src/util/encoder.rs
@@ -38,7 +38,7 @@ pub trait RenderEncoder<'a> {
     ///
     /// [`draw`]: RenderEncoder::draw
     /// [`draw_indexed`]: RenderEncoder::draw_indexed
-    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'a>);
+    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: Option<BufferSlice<'a>>);
 
     /// Draws primitives from the active vertex buffer(s).
     ///
@@ -106,7 +106,7 @@ impl<'a> RenderEncoder<'a> for RenderPass<'a> {
     }
 
     #[inline(always)]
-    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'a>) {
+    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: Option<BufferSlice<'a>>) {
         Self::set_vertex_buffer(self, slot, buffer_slice);
     }
 
@@ -162,7 +162,7 @@ impl<'a> RenderEncoder<'a> for RenderBundleEncoder<'a> {
     }
 
     #[inline(always)]
-    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: BufferSlice<'a>) {
+    fn set_vertex_buffer(&mut self, slot: u32, buffer_slice: Option<BufferSlice<'a>>) {
         Self::set_vertex_buffer(self, slot, buffer_slice);
     }
 


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/7354.
Fixes https://github.com/gfx-rs/wgpu/issues/8832.
Fixes https://github.com/gfx-rs/wgpu/issues/7912.

**Description**
Makes vertex buffer slots optional.

**Testing**
Enabled more CTS tests.

**Squash or Rebase?**
Rebase.