### PR TITLE
fix(wgpu-hal/vk): don't use sequential bindings if pipeline layout is set explicitly

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2802,7 +2802,6 @@ impl Device {
         if origin == bgl::Origin::Derived {
             bgl_flags |= hal::BindGroupLayoutFlags::INTERNAL_SEQUENTIAL_BINDINGS;
         }
-        
         let hal_bindings = entry_map.values().copied().collect::<Vec<_>>();
         let hal_desc = hal::BindGroupLayoutDescriptor {
             label: label.to_hal(self.instance_flags),

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2798,8 +2798,11 @@ impl Device {
                 })?;
         }
 
-        let bgl_flags = conv::bind_group_layout_flags(self.features);
-
+        let mut bgl_flags = conv::bind_group_layout_flags(self.features);
+        if origin == bgl::Origin::Derived {
+            bgl_flags |= hal::BindGroupLayoutFlags::INTERNAL_SEQUENTIAL_BINDINGS;
+        }
+        
         let hal_bindings = entry_map.values().copied().collect::<Vec<_>>();
         let hal_desc = hal::BindGroupLayoutDescriptor {
             label: label.to_hal(self.instance_flags),

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1754,6 +1754,8 @@ bitflags!(
     pub struct BindGroupLayoutFlags: u32 {
         /// Allows for bind group binding arrays to be shorter than the array in the BGL.
         const PARTIALLY_BOUND = 1 << 0;
+        /// Internal: remap bindings to a dense 0..N range in declaration order.
+        const INTERNAL_SEQUENTIAL_BINDINGS = 1 << 1;
     }
 );
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1289,6 +1289,9 @@ impl crate::Device for super::Device {
         let mut binding_flags = Vec::new();
         let mut binding_map = Vec::new();
         let mut next_binding = 0;
+        let remap_to_sequential = desc
+            .flags
+            .contains(crate::BindGroupLayoutFlags::INTERNAL_SEQUENTIAL_BINDINGS);
         let mut contains_binding_arrays = false;
         let mut desc_count = gpu_descriptor::DescriptorTotalCount::default();
         for entry in desc.entries {
@@ -1311,8 +1314,16 @@ impl crate::Device for super::Device {
             match entry.ty {
                 wgt::BindingType::ExternalTexture => unimplemented!(),
                 _ => {
+                    let binding = if remap_to_sequential {
+                        let remapped = next_binding;
+                        next_binding += 1;
+                        remapped
+                    } else {
+                        entry.binding
+                    };
+
                     vk_bindings.push(vk::DescriptorSetLayoutBinding {
-                        binding: next_binding,
+                        binding,
                         descriptor_type: conv::map_binding_type(entry.ty),
                         descriptor_count: count,
                         stage_flags: conv::map_shader_stage(entry.visibility),
@@ -1323,11 +1334,10 @@ impl crate::Device for super::Device {
                     binding_map.push((
                         entry.binding,
                         super::BindingInfo {
-                            binding: next_binding,
+                            binding,
                             binding_array_size: entry.count,
                         },
                     ));
-                    next_binding += 1;
                 }
             }
 
@@ -1601,10 +1611,18 @@ impl crate::Device for super::Device {
                 .iter()
                 .find(|layout_entry| layout_entry.binding == entry.binding)
                 .expect("internal error: no layout entry found with binding slot");
-            (layout, entry)
+            let binding = desc
+                .layout
+                .binding_map
+                .iter()
+                .find_map(|&(mapped_binding, binding_info)| {
+                    (mapped_binding == entry.binding).then_some(binding_info.binding)
+                })
+                .expect("internal error: no mapped binding found for layout entry");
+            (layout, entry, binding)
         });
-        let mut next_binding = 0;
-        for (layout, entry) in layout_and_entry_iter {
+
+        for (layout, entry, binding) in layout_and_entry_iter {
             let write = vk::WriteDescriptorSet::default().dst_set(*set.raw());
 
             match layout.ty {
@@ -1618,11 +1636,10 @@ impl crate::Device for super::Device {
                         ));
                     writes.push(
                         write
-                            .dst_binding(next_binding)
+                            .dst_binding(binding)
                             .descriptor_type(conv::map_binding_type(layout.ty))
                             .image_info(local_image_infos),
                     );
-                    next_binding += 1;
                 }
                 wgt::BindingType::Texture { .. } | wgt::BindingType::StorageTexture { .. } => {
                     let start = entry.resource_index;
@@ -1640,11 +1657,10 @@ impl crate::Device for super::Device {
                         ));
                     writes.push(
                         write
-                            .dst_binding(next_binding)
+                            .dst_binding(binding)
                             .descriptor_type(conv::map_binding_type(layout.ty))
                             .image_info(local_image_infos),
                     );
-                    next_binding += 1;
                 }
                 wgt::BindingType::Buffer { .. } => {
                     let start = entry.resource_index;
@@ -1663,11 +1679,10 @@ impl crate::Device for super::Device {
                         ));
                     writes.push(
                         write
-                            .dst_binding(next_binding)
+                            .dst_binding(binding)
                             .descriptor_type(conv::map_binding_type(layout.ty))
                             .buffer_info(local_buffer_infos),
                     );
-                    next_binding += 1;
                 }
                 wgt::BindingType::AccelerationStructure { .. } => {
                     let start = entry.resource_index;
@@ -1694,12 +1709,11 @@ impl crate::Device for super::Device {
 
                     writes.push(
                         write
-                            .dst_binding(next_binding)
+                            .dst_binding(binding)
                             .descriptor_type(conv::map_binding_type(layout.ty))
                             .descriptor_count(entry.count)
                             .push_next(local_acceleration_structure_infos),
                     );
-                    next_binding += 1;
                 }
                 wgt::BindingType::ExternalTexture => unimplemented!(),
             }


### PR DESCRIPTION
**Connections**
#9326

**Description**
Currently descriptor bindings by default get built in a sequential fashion, not matching the binding indices that the user has set manually.

**Testing**
Tested some examples that use manual pipeline layouts.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
