### PR TITLE
fix(wgsl-in): Handle Unterminated Block Comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Bottom level categories:
 - Fixed overflow detection and argument domain validation for `acosh`, `length`, `normalize`, and `pow` in constant evaluation. By @ecoricemon in [#9249](https://github.com/gfx-rs/wgpu/pull/9249).
 - Naga no longer allows derivative operations on `f16`. WGSL does not currently allow this, although [it may be added in the future](https://github.com/gpuweb/gpuweb/issues/5482). By @andyleiserson in [#9154](https://github.com/gfx-rs/wgpu/pull/9154).
 - Disallow direct access to atomic variables in WGSL front-end (e.g. `let x = myAtomic;`). By @ecoricemon in [#9262](https://github.com/gfx-rs/wgpu/pull/9262).
+- Fixed handling of unterminated block comments. By @BKDaugherty in [#9356](https://github.com/gfx-rs/wgpu/pull/9356).
 
 #### dx12
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -447,6 +447,7 @@ webgpu:shader,validation,parse,blankspace:bom:*
 webgpu:shader,validation,parse,blankspace:null_characters:contains_null=false;*
 webgpu:shader,validation,parse,blankspace:null_characters:contains_null=true;placement="delimiter"
 webgpu:shader,validation,parse,blankspace:null_characters:contains_null=true;placement="eol"
+webgpu:shader,validation,parse,comments:unterminated_block_comment:terminated=false
 webgpu:shader,validation,parse,enable:*
 webgpu:shader,validation,parse,identifiers:*
 webgpu:shader,validation,parse,requires:*

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -1517,7 +1517,7 @@ impl<'a> Error<'a> {
                 message: "unterminated block comment".to_string(),
                 labels: vec![(
                     span,
-                    "must be closed with */".into(),
+                    "must be closed with `*/`".into(),
                 )],
                 notes: vec![],
             }

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -442,6 +442,7 @@ pub(crate) enum Error<'a> {
     },
     UnexpectedExprForTypeExpression(Span),
     MissingIncomingPayload(Span),
+    UnterminatedBlockComment(Span),
 }
 
 impl From<ConflictingDiagnosticRuleError> for Error<'_> {
@@ -516,6 +517,7 @@ impl<'a> Error<'a> {
                         Token::DocComment(s) => format!("doc comment ('{s}')"),
                         Token::ModuleDocComment(s) => format!("module doc comment ('{s}')"),
                         Token::End => "end".to_string(),
+                        Token::UnterminatedBlockComment(s) => format!("unterminated doc comment ('{s}'")
                     },
                     ExpectedToken::Identifier => "identifier".to_string(),
                     ExpectedToken::LhsExpression => "LHS expression (identifier component_or_swizzle_specifier?, (`lhs_expression`) component_or_swizzle_specifier?, &`lhs_expression`, *`lhs_expression`)".to_string(),
@@ -1511,6 +1513,14 @@ impl<'a> Error<'a> {
                 )],
                 notes: vec![],
             },
+            Error::UnterminatedBlockComment(span) => ParseError {
+                message: "unterminated block comment".to_string(),
+                labels: vec![(
+                    span,
+                    "must be closed with */".into(),
+                )],
+                notes: vec![],
+            }
         }
     }
 }

--- a/naga/src/front/wgsl/parse/lexer.rs
+++ b/naga/src/front/wgsl/parse/lexer.rs
@@ -89,6 +89,11 @@ pub enum Token<'a> {
     /// A module-level doc comment, beginning with `//!` or `/*!`.
     ModuleDocComment(&'a str),
 
+    /// A block comment that is incomplete, and has not been closed with */.
+    ///
+    /// It's expected that the parser will consider this to be an error.
+    UnterminatedBlockComment(&'a str),
+
     /// The end of the input.
     End,
 }
@@ -360,7 +365,7 @@ fn consume_token(
                         }
                     }
 
-                    (Token::End, "")
+                    (Token::UnterminatedBlockComment(input), "")
                 }
                 Some('=') => (Token::AssignmentOperation(cur), chars.as_str()),
                 _ => (Token::Operation(cur), og_chars),
@@ -1261,5 +1266,13 @@ fn test_doc_comments_module() {
             Token::Word("const"),
             Token::ModuleDocComment("//! After anything else is not."),
         ],
+    );
+}
+
+#[test]
+fn test_block_comment_unclosed() {
+    sub_test_with_and_without_doc_comments(
+        "/** Unclosed Doc Comment",
+        &[Token::UnterminatedBlockComment("/** Unclosed Doc Comment")],
     );
 }

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -2192,6 +2192,9 @@ impl Parser {
                 Some(ast::GlobalDeclKind::ConstAssert(condition))
             }
             (Token::End, _) => return Ok(()),
+            (Token::UnterminatedBlockComment(_), span) => {
+                return Err(Box::new(Error::UnterminatedBlockComment(span)))
+            }
             other => {
                 return Err(Box::new(Error::Unexpected(
                     other.1,

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -5237,3 +5237,18 @@ fn bitwise_shift_errors() {
         naga::valid::Capabilities::SHADER_INT64
     }
 }
+
+#[test]
+fn unterminated_block_comment_errors() {
+    check_success("/* Closed */");
+
+    check_error_matches("/* unterminated", "unterminated block comment");
+    check_error_matches(
+        "/* unterminated /* terimated inner */",
+        "unterminated block comment",
+    );
+    check_error_matches(
+        "const N: u32 = 1u; /* Trailing unterminated",
+        "unterminated block comment",
+    )
+}


### PR DESCRIPTION
Adds a new token to keep track of unterminated block comments in order to emit an error to the user highlighting the offending unterminated block comment.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

https://github.com/gfx-rs/wgpu/issues/8877#issue-3819537940

_When one pull request builds on another, please put "Depends on
#NNNN" towards the top of its description. This helps maintainers
notice that they shouldn't merge it until its ancestor has been
approved. Don't use draft PR status to indicate this._

**Description**
_Describe what problem this is solving, and how it's solved._

Block comments that aren't terminated before this changeset were lexed as Token::End. This didn't give the parser enough information to report an error. 

This PR introduces a new token so that this can be tracked, and reports errors when an unterminated block comment is found.

**Testing**
_Explain how this change is tested._

This CTS test passes now. I also wrote tests.

```
[INFO  wgpu_xtask::cts] Running CTS
[INFO  wgpu_xtask::cts] Running webgpu:shader,validation,parse,comments:unterminated_block_comment:terminated=false
$ /Users/brendon/Dev/wgpu/target/debug/cts_runner ./tools/run_deno --verbose webgpu:shader,validation,parse,comments:unterminated_block_comment:terminated=false
[pass] webgpu:shader,validation,parse,comments:unterminated_block_comment:terminated=false (348ms). Log:
  - (in subcase: ) INFO: subcase ran

** Summary **
Passed  w/o warnings = 1 / 1 = 100.00%
Passed with warnings = 0 / 1 =   0.00%
Skipped              = 0 / 1 =   0.00%
Failed               = 0 / 1 =   0.00%
```

**Squash or Rebase?**

Squash.

_If your pull request contains multiple commits, please indicate whether
they need to be squashed into a single commit before they're merged,
or if they're ready to rebase onto `trunk` as they stand. In the
latter case, please ensure that each commit passes all CI tests, so
that we can continue to bisect along `trunk` to isolate bugs._

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
