### PR TITLE
fix Queue::writeBuffer : raise a validation error for out-of-bounds transfers on zero-size buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Bottom level categories:
 - `Features::CLIP_DISTANCE`, `naga::Capabilities::CLIP_DISTANCE`, and `naga::BuiltIn::ClipDistance` have been renamed to `CLIP_DISTANCES` and `ClipDistances` (viz., pluralized) as appropriate, to match the WebGPU spec. By @ErichDonGubler in [#9267](https://github.com/gfx-rs/wgpu/pull/9267).
 - Added more granular limits for mesh shaders. By @inner-daemons in [#8739](https://github.com/gfx-rs/wgpu/pull/8739).
 - Added new `InvalidWorkgroupSizeError`, which is now used by `DrawError::InvalidGroupSize` and `StageError::InvalidWorkgroupSize`. By @andyleiserson in [#9357](https://github.com/gfx-rs/wgpu/pull/9357).
+- Zero-size `Queue::write_buffer` now returns an error if the offset is invalid or the buffer lacks `COPY_DST`. By @39ali in [#9374](https://github.com/gfx-rs/wgpu/pull/9374).
 
 #### Validation
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -537,22 +537,7 @@ impl Queue {
             // we must still validate the copy operation. This ensures that invalid
             // API calls—like writing to a mapped buffer or out-of-bounds offsets—are
             // caught consistently, even if no data is actually moved.
-            buffer
-                .check_usage(wgt::BufferUsages::COPY_DST)
-                .map_err(TransferError::from)?;
-
-            if !matches!(&*buffer.map_state.lock(), BufferMapState::Idle) {
-                return Err(TransferError::BufferNotAvailable.into());
-            }
-
-            if buffer_offset > buffer.size {
-                return Err(TransferError::BufferStartOffsetOverrun {
-                    start_offset: buffer_offset,
-                    buffer_size: buffer.size,
-                    side: CopySide::Destination,
-                }
-                .into());
-            }
+            self.validate_write_buffer_impl(buffer.as_ref(), buffer_offset, 0)?;
 
             log::trace!("Ignoring write_buffer of size 0");
             return Ok(());
@@ -654,7 +639,7 @@ impl Queue {
 
         let buffer = buffer.get()?;
 
-        self.validate_write_buffer_impl(&buffer, buffer_offset, buffer_size)?;
+        self.validate_write_buffer_impl(&buffer, buffer_offset, buffer_size.into())?;
 
         Ok(())
     }
@@ -663,14 +648,14 @@ impl Queue {
         &self,
         buffer: &Buffer,
         buffer_offset: u64,
-        buffer_size: wgt::BufferSize,
+        buffer_size: u64,
     ) -> Result<(), TransferError> {
         if !matches!(&*buffer.map_state.lock(), BufferMapState::Idle) {
             return Err(TransferError::BufferNotAvailable);
         }
         buffer.check_usage(wgt::BufferUsages::COPY_DST)?;
-        if !buffer_size.get().is_multiple_of(wgt::COPY_BUFFER_ALIGNMENT) {
-            return Err(TransferError::UnalignedCopySize(buffer_size.get()));
+        if !buffer_size.is_multiple_of(wgt::COPY_BUFFER_ALIGNMENT) {
+            return Err(TransferError::UnalignedCopySize(buffer_size));
         }
         if !buffer_offset.is_multiple_of(wgt::COPY_BUFFER_ALIGNMENT) {
             return Err(TransferError::UnalignedBufferOffset(buffer_offset));
@@ -683,10 +668,10 @@ impl Queue {
                 side: CopySide::Destination,
             });
         }
-        if buffer_size.get() > buffer.size - buffer_offset {
+        if buffer_size > buffer.size - buffer_offset {
             return Err(TransferError::BufferEndOffsetOverrun {
                 start_offset: buffer_offset,
-                size: buffer_size.get(),
+                size: buffer_size,
                 buffer_size: buffer.size,
                 side: CopySide::Destination,
             });
@@ -716,7 +701,7 @@ impl Queue {
 
         self.same_device_as(buffer.as_ref())?;
 
-        self.validate_write_buffer_impl(&buffer, buffer_offset, staging_buffer.size)?;
+        self.validate_write_buffer_impl(&buffer, buffer_offset, staging_buffer.size.into())?;
 
         let region = hal::BufferCopy {
             src_offset: 0,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -533,8 +533,24 @@ impl Queue {
         let data_size = if let Some(data_size) = wgt::BufferSize::new(data_size) {
             data_size
         } else {
-            // This must happen after parameter validation (so that errors are reported
-            // as required by the spec), but before any side effects.
+            let validate_zero = || -> Result<(), TransferError> {
+                buffer.check_usage(wgt::BufferUsages::COPY_DST)?;
+
+                if !matches!(&*buffer.map_state.lock(), BufferMapState::Idle) {
+                    return Err(TransferError::BufferNotAvailable);
+                }
+
+                if buffer_offset > buffer.size {
+                    return Err(TransferError::BufferStartOffsetOverrun {
+                        start_offset: buffer_offset,
+                        buffer_size: buffer.size,
+                        side: CopySide::Destination,
+                    });
+                }
+                Ok(())
+            };
+
+            validate_zero()?;
             log::trace!("Ignoring write_buffer of size 0");
             return Ok(());
         };

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -533,24 +533,27 @@ impl Queue {
         let data_size = if let Some(data_size) = wgt::BufferSize::new(data_size) {
             data_size
         } else {
-            let validate_zero = || -> Result<(), TransferError> {
-                buffer.check_usage(wgt::BufferUsages::COPY_DST)?;
+            // even though a zero-length write is a no-op and no copy operation will occur,
+            // we must still validate the copy operation. This ensures that invalid
+            // API calls—like writing to a mapped buffer or out-of-bounds offsets—are
+            // caught consistently, even if no data is actually moved.
+            buffer
+                .check_usage(wgt::BufferUsages::COPY_DST)
+                .map_err(TransferError::from)?;
 
-                if !matches!(&*buffer.map_state.lock(), BufferMapState::Idle) {
-                    return Err(TransferError::BufferNotAvailable);
+            if !matches!(&*buffer.map_state.lock(), BufferMapState::Idle) {
+                return Err(TransferError::BufferNotAvailable.into());
+            }
+
+            if buffer_offset > buffer.size {
+                return Err(TransferError::BufferStartOffsetOverrun {
+                    start_offset: buffer_offset,
+                    buffer_size: buffer.size,
+                    side: CopySide::Destination,
                 }
+                .into());
+            }
 
-                if buffer_offset > buffer.size {
-                    return Err(TransferError::BufferStartOffsetOverrun {
-                        start_offset: buffer_offset,
-                        buffer_size: buffer.size,
-                        side: CopySide::Destination,
-                    });
-                }
-                Ok(())
-            };
-
-            validate_zero()?;
             log::trace!("Ignoring write_buffer of size 0");
             return Ok(());
         };


### PR DESCRIPTION

**Connections**
#8920 


**Description**


**Testing**


**Squash or Rebase?**




**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [ ] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
