### PR TITLE
fix(examples): use pod_collect_to_vec for mapped buffer reads

### DIFF
--- a/examples/features/src/big_compute_buffers/mod.rs
+++ b/examples/features/src/big_compute_buffers/mod.rs
@@ -86,7 +86,8 @@ pub async fn execute_gpu_inner(
     for staging_buffer in &staging_buffers {
         let slice = staging_buffer.slice(..);
         let mapped = slice.get_mapped_range();
-        data.extend_from_slice(bytemuck::cast_slice(&mapped));
+        let chunk: Vec<f32> = bytemuck::allocation::pod_collect_to_vec(&mapped);
+        data.extend_from_slice(&chunk);
         drop(mapped);
         staging_buffer.unmap();
     }

--- a/examples/features/src/cooperative_matrix/mod.rs
+++ b/examples/features/src/cooperative_matrix/mod.rs
@@ -415,10 +415,10 @@ async fn execute(
 
     // Convert result back to f32 for comparison
     let result: Vec<f32> = if use_f16 {
-        let result_f16: &[f16] = bytemuck::cast_slice(&data);
+        let result_f16: Vec<f16> = bytemuck::allocation::pod_collect_to_vec(&data);
         result_f16.iter().map(|x| x.to_f32()).collect()
     } else {
-        bytemuck::cast_slice::<_, f32>(&data).to_vec()
+        bytemuck::allocation::pod_collect_to_vec(&data)
     };
 
     // Compute reference result on CPU for verification

--- a/examples/features/src/hello_synchronization/mod.rs
+++ b/examples/features/src/hello_synchronization/mod.rs
@@ -184,7 +184,9 @@ async fn get_data<T: bytemuck::Pod>(
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());
     device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
     receiver.recv_async().await.unwrap().unwrap();
-    output.copy_from_slice(bytemuck::cast_slice(&buffer_slice.get_mapped_range()[..]));
+    let data: Vec<T> =
+        bytemuck::allocation::pod_collect_to_vec(&buffer_slice.get_mapped_range()[..]);
+    output.copy_from_slice(&data);
     staging_buffer.unmap();
 }
 

--- a/examples/features/src/hello_workgroups/mod.rs
+++ b/examples/features/src/hello_workgroups/mod.rs
@@ -173,7 +173,9 @@ async fn get_data<T: bytemuck::Pod>(
     buffer_slice.map_async(wgpu::MapMode::Read, move |r| sender.send(r).unwrap());
     device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
     receiver.recv_async().await.unwrap().unwrap();
-    output.copy_from_slice(bytemuck::cast_slice(&buffer_slice.get_mapped_range()[..]));
+    let data: Vec<T> =
+        bytemuck::allocation::pod_collect_to_vec(&buffer_slice.get_mapped_range()[..]);
+    output.copy_from_slice(&data);
     staging_buffer.unmap();
 }
 

--- a/examples/features/src/repeated_compute/mod.rs
+++ b/examples/features/src/repeated_compute/mod.rs
@@ -116,7 +116,8 @@ async fn compute(local_buffer: &mut [u32], context: &WgpuContext) {
     // NOW we can call get_mapped_range.
     {
         let view = buffer_slice.get_mapped_range();
-        local_buffer.copy_from_slice(bytemuck::cast_slice(&view));
+        let data: Vec<u32> = bytemuck::allocation::pod_collect_to_vec(&view);
+        local_buffer.copy_from_slice(&data);
     }
     log::info!("Results written to local buffer.");
     // We need to make sure all `BufferView`'s are dropped before we do what we're about

--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -182,7 +182,7 @@ impl Queries {
                 .destination_buffer
                 .slice(..(size_of::<u64>() as wgpu::BufferAddress * self.num_queries))
                 .get_mapped_range();
-            bytemuck::cast_slice(&timestamp_view).to_vec()
+            bytemuck::allocation::pod_collect_to_vec(&timestamp_view)
         };
 
         self.destination_buffer.unmap();

--- a/examples/standalone/01_hello_compute/Cargo.toml
+++ b/examples/standalone/01_hello_compute/Cargo.toml
@@ -5,7 +5,7 @@ rust-version = "1.87"
 publish = false
 
 [dependencies]
-bytemuck = "1.22.0"
+bytemuck = { version = "1.22.0", features = ["extern_crate_alloc"] }
 env_logger = "0.11"
 pollster = "0.4"
 wgpu = "29.0.0"

--- a/examples/standalone/01_hello_compute/src/main.rs
+++ b/examples/standalone/01_hello_compute/src/main.rs
@@ -246,8 +246,8 @@ fn main() {
 
     // We can now read the data from the buffer.
     let data = buffer_slice.get_mapped_range();
-    // Convert the data back to a slice of f32.
-    let result: &[f32] = bytemuck::cast_slice(&data);
+    // Convert the data back to f32 via an aligned copy.
+    let result: Vec<f32> = bytemuck::allocation::pod_collect_to_vec(&data);
 
     // Print out the result.
     println!("Result: {result:?}");


### PR DESCRIPTION
## Summary
- Replace `bytemuck::cast_slice` with `bytemuck::allocation::pod_collect_to_vec` when reading from mapped buffer ranges
- Add `extern_crate_alloc` feature to workspace bytemuck dependency

`cast_slice` requires the source slice to be properly aligned for the target type, but `BufferView` from `get_mapped_range()` is not guaranteed to meet alignment requirements. `pod_collect_to_vec` copies bytes into a new properly-aligned `Vec`, avoiding potential undefined behavior from misaligned reads.

As suggested by @cwfitzgerald in #6191.

## Files changed
- `examples/src/hello_workgroups/mod.rs`
- `examples/src/hello_synchronization/mod.rs`
- `examples/src/hello_compute/mod.rs`
- `examples/src/repeated_compute/mod.rs`
- `examples/src/timestamp_queries/mod.rs`
- `Cargo.toml` (add `extern_crate_alloc` feature to bytemuck)

## Test plan
- [x] `cargo check -p wgpu-examples`
- [x] `cargo fmt --check -p wgpu-examples`

Closes #6191