### PR TITLE
chore(deps): Add changelogUrl to CTS renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,7 @@
     {
       "description": "CTS revision is pinned to a Git SHA.",
       "matchPackageNames": ["https://github.com/gpuweb/cts"],
+      "changelogUrl": "https://github.com/gpuweb/cts/commits/main",
       "versioning": "git"
     }
   ],


### PR DESCRIPTION
To make it easier to review the changes in a CTS update.

**Testing**
Renovate has annotated the PR commit as passing `renovate/config-validation`, whatever that entails.

**Squash or Rebase?** Squash