### PR TITLE
fix(02_hello_window): drop texture if surface texture is suboptimal

### DIFF
--- a/examples/bug-repro/01_texture_atomic_bug/src/main.rs
+++ b/examples/bug-repro/01_texture_atomic_bug/src/main.rs
@@ -274,7 +274,12 @@ impl State {
     fn render_frame(&mut self) {
         let frame = match self.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(f) => f,
-            wgpu::CurrentSurfaceTexture::Suboptimal(_) | wgpu::CurrentSurfaceTexture::Outdated => {
+            wgpu::CurrentSurfaceTexture::Suboptimal(texture) => {
+                drop(texture);
+                self.surface.configure(&self.device, &self.surface_config);
+                return;
+            }
+            wgpu::CurrentSurfaceTexture::Outdated => {
                 self.surface.configure(&self.device, &self.surface_config);
                 return;
             }

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -197,7 +197,16 @@ impl SurfaceWrapper {
             // If we timed out or the window is occluded, skip this frame:
             CurrentSurfaceTexture::Timeout | CurrentSurfaceTexture::Occluded => None,
             // If the surface is outdated or suboptimal, reconfigure and retry.
-            CurrentSurfaceTexture::Suboptimal(_) | CurrentSurfaceTexture::Outdated => {
+            CurrentSurfaceTexture::Suboptimal(texture) => {
+                drop(texture);
+                surface.configure(&context.device, self.config());
+                match surface.get_current_texture() {
+                    CurrentSurfaceTexture::Success(frame)
+                    | CurrentSurfaceTexture::Suboptimal(frame) => Some(frame),
+                    other => panic!("Failed to acquire next surface texture: {other:?}"),
+                }
+            }
+            CurrentSurfaceTexture::Outdated => {
                 surface.configure(&context.device, self.config());
                 match surface.get_current_texture() {
                     CurrentSurfaceTexture::Success(frame)

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -231,7 +231,18 @@ impl ApplicationHandler<TriangleAction> for App {
                         }
                         return;
                     }
-                    CurrentSurfaceTexture::Suboptimal(_) | CurrentSurfaceTexture::Outdated => {
+                    CurrentSurfaceTexture::Suboptimal(texture) => {
+                        drop(texture);
+
+                        wgpu_state
+                            .surface
+                            .configure(&wgpu_state.device, &wgpu_state.config);
+                        if let Some(window) = &self.window {
+                            window.request_redraw();
+                        }
+                        return;
+                    }
+                    CurrentSurfaceTexture::Outdated => {
                         wgpu_state
                             .surface
                             .configure(&wgpu_state.device, &wgpu_state.config);

--- a/examples/features/src/hello_windows/mod.rs
+++ b/examples/features/src/hello_windows/mod.rs
@@ -203,7 +203,13 @@ impl ApplicationHandler for App {
                             viewport.desc.window.request_redraw();
                             return;
                         }
-                        CurrentSurfaceTexture::Suboptimal(_) | CurrentSurfaceTexture::Outdated => {
+                        CurrentSurfaceTexture::Suboptimal(texture) => {
+                            drop(texture);
+                            viewport.desc.surface.configure(device, &viewport.config);
+                            viewport.desc.window.request_redraw();
+                            return;
+                        }
+                        CurrentSurfaceTexture::Outdated => {
                             viewport.desc.surface.configure(device, &viewport.config);
                             viewport.desc.window.request_redraw();
                             return;

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -401,7 +401,18 @@ impl ApplicationHandler<UniformAction> for App {
                         }
                         return;
                     }
-                    CurrentSurfaceTexture::Suboptimal(_) | CurrentSurfaceTexture::Outdated => {
+                    CurrentSurfaceTexture::Suboptimal(texture) => {
+                        drop(texture);
+
+                        wgpu_ctx
+                            .surface
+                            .configure(&wgpu_ctx.device, &wgpu_ctx.surface_config);
+                        if let Some(window) = &self.window {
+                            window.request_redraw();
+                        }
+                        return;
+                    }
+                    CurrentSurfaceTexture::Outdated => {
                         wgpu_ctx
                             .surface
                             .configure(&wgpu_ctx.device, &wgpu_ctx.surface_config);

--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -90,7 +90,7 @@ impl State {
                 drop(texture);
                 self.configure_surface();
                 return;
-            },
+            }
             wgpu::CurrentSurfaceTexture::Outdated => {
                 self.configure_surface();
                 return;

--- a/examples/standalone/02_hello_window/src/main.rs
+++ b/examples/standalone/02_hello_window/src/main.rs
@@ -86,7 +86,12 @@ impl State {
         let surface_texture = match self.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(texture) => texture,
             wgpu::CurrentSurfaceTexture::Occluded | wgpu::CurrentSurfaceTexture::Timeout => return,
-            wgpu::CurrentSurfaceTexture::Suboptimal(_) | wgpu::CurrentSurfaceTexture::Outdated => {
+            wgpu::CurrentSurfaceTexture::Suboptimal(texture) => {
+                drop(texture);
+                self.configure_surface();
+                return;
+            },
+            wgpu::CurrentSurfaceTexture::Outdated => {
                 self.configure_surface();
                 return;
             }

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -76,7 +76,7 @@ pub enum ConfigureSurfaceError {
     InvalidViewFormat(wgt::TextureFormat, wgt::TextureFormat),
     #[error(transparent)]
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),
-    #[error("The texture of the surface must be dropped before configuring the surface or a new texture of the surface is made.")]
+    #[error("The `SurfaceOutput` returned by `get_current_texture` must be dropped before re-configuring via `configure` or  retrieving a new texture via `get_current_texture`.")]
     PreviousOutputExists,
     #[error("Failed to wait for GPU to come idle before reconfiguring the Surface")]
     GpuWaitTimeout,

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -76,7 +76,7 @@ pub enum ConfigureSurfaceError {
     InvalidViewFormat(wgt::TextureFormat, wgt::TextureFormat),
     #[error(transparent)]
     MissingDownlevelFlags(#[from] MissingDownlevelFlags),
-    #[error("`SurfaceOutput` must be dropped before a new `Surface` is made")]
+    #[error("The texture of the surface must be dropped before configuring the surface or a new texture of the surface is made.")]
     PreviousOutputExists,
     #[error("Failed to wait for GPU to come idle before reconfiguring the Surface")]
     GpuWaitTimeout,


### PR DESCRIPTION
**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/9360

**Description**
- Added the `drop` invokation for the `Suboptimal` case
- Changed the error message to make it easier to understand (in my opinion)

**Testing**
Ran the example.

**Squash or Rebase?**

I don't know tbh. Maybe squash? <img src="https://emojis.tornaxo7.de/peepoShrug.png" width="30px"/>

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [ ] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
