### PR TITLE
Make DRM support optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,9 @@ Bottom level categories:
 #### Vulkan
 
 - Add `vulkan::Device::texture_from_dmabuf_fd()` for importing DMA-buf textures on Linux, with `VULKAN_EXTERNAL_MEMORY_FD` and `VULKAN_EXTERNAL_MEMORY_DMA_BUF` feature flags. By @TODO in [#TODO](https://github.com/gfx-rs/wgpu/pull/TODO).
-- Add support for RawWindowHandle::Drm on unix. By @rectalogic in [#9182](https://github.com/gfx-rs/wgpu/pull/9182).
+- Add support for RawWindowHandle::Drm on unix, conditional on the `"drm"` feature.
+  - DRM support by @rectalogic in [#9182](https://github.com/gfx-rs/wgpu/pull/9182).
+  - Conditional compilation by @jimblandy in [#9390](https://github.com/gfx-rs/wgpu/pull/9390)
 
 ### Changes
 

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -149,6 +149,9 @@ vulkan-portability = ["wgpu-core-deps-apple/vulkan-portability"]
 ## Renderdoc integration, only available on Windows, Linux, and Android
 renderdoc = ["wgpu-core-deps-windows-linux-android/renderdoc"]
 
+## Support creating textures from DRM display/window handles.
+drm = ["wgpu-core-deps-windows-linux-android/drm"]
+
 ## Enable the `noop` backend.
 # TODO(https://github.com/gfx-rs/wgpu/issues/7120): there should be a hal feature
 noop = []

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -20,6 +20,10 @@ fn main() {
             all(windows_linux_android, feature = "vulkan"), // Regular Vulkan
             all(target_vendor = "apple", feature = "vulkan-portability") // Vulkan Portability on Apple
         ) },
+        drm: { all(
+            feature = "drm",
+            any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")
+        ) },
         metal: { all(target_vendor = "apple", feature = "metal") },
 
         supports_64bit_atomics: { target_has_atomic = "64" }

--- a/wgpu-core/platform-deps/windows-linux-android/Cargo.toml
+++ b/wgpu-core/platform-deps/windows-linux-android/Cargo.toml
@@ -22,6 +22,9 @@ vulkan = ["wgpu-hal/vulkan"]
 dx12 = ["wgpu-hal/dx12"]
 renderdoc = ["wgpu-hal/renderdoc"]
 
+## Support creating textures from DRM display/window handles.
+drm = ["wgpu-hal/drm"]
+
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
 [target.'cfg(any(windows, target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 wgpu-hal.workspace = true

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -261,14 +261,10 @@ impl Instance {
     ///
     /// # Platform Support
     ///
-    /// This function is only available on non-apple Unix-like platforms (Linux, FreeBSD) and
-    /// currently only works with the Vulkan backend.
-    #[cfg(all(
-        unix,
-        not(target_vendor = "apple"),
-        not(target_family = "wasm"),
-        not(target_os = "netbsd")
-    ))]
+    /// This function requires the `"drm"` feature. It is only available on
+    /// non-apple Unix-like platforms (Linux, FreeBSD) and currently only works
+    /// with the Vulkan backend.
+    #[cfg(drm)]
     #[cfg_attr(not(vulkan), expect(unused_variables))]
     pub unsafe fn create_surface_from_drm(
         &self,
@@ -285,7 +281,7 @@ impl Instance {
         let mut surface_per_backend: HashMap<Backend, Box<dyn hal::DynSurface>> =
             HashMap::default();
 
-        #[cfg(all(vulkan, not(target_os = "netbsd")))]
+        #[cfg(vulkan)]
         {
             let instance = unsafe { self.as_hal::<hal::api::Vulkan>() }
                 .ok_or(CreateSurfaceError::BackendNotEnabled(Backend::Vulkan))?;
@@ -966,14 +962,10 @@ impl Global {
     ///
     /// # Platform Support
     ///
-    /// This function is only available on non-apple Unix-like platforms (Linux, FreeBSD) and
-    /// currently only works with the Vulkan backend.
-    #[cfg(all(
-        unix,
-        not(target_vendor = "apple"),
-        not(target_family = "wasm"),
-        not(target_os = "netbsd")
-    ))]
+    /// This function requires the `"drm"` feature, and is only available on
+    /// non-apple Unix-like platforms (Linux, FreeBSD) and currently only works
+    /// with the Vulkan backend.
+    #[cfg(drm)]
     pub unsafe fn instance_create_surface_from_drm(
         &self,
         fd: i32,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -265,7 +265,7 @@ impl Instance {
     /// non-apple Unix-like platforms (Linux, FreeBSD) and currently only works
     /// with the Vulkan backend.
     #[cfg(drm)]
-    #[cfg_attr(not(vulkan), expect(unused_variables))]
+    #[cfg_attr(not(vulkan), expect(unused_variables, unused_mut))]
     pub unsafe fn create_surface_from_drm(
         &self,
         fd: i32,

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -93,7 +93,6 @@ vulkan = [
     "dep:arrayvec",
     "dep:ash",
     "dep:bytemuck",
-    "dep:drm",
     "dep:gpu-descriptor",
     "dep:libc",
     "dep:libloading",
@@ -251,6 +250,7 @@ wayland-sys = { version = "0.31.3", features = [
     "egl",
 ], optional = true }
 
+## Support creating textures from DRM display/window handles.
 [target.'cfg(all(unix, not(target_vendor = "apple"), not(target_family = "wasm")))'.dependencies]
 drm = { version = "0.15", optional = true }
 

--- a/wgpu-hal/build.rs
+++ b/wgpu-hal/build.rs
@@ -23,6 +23,10 @@ fn main() {
         ) },
         metal: { all(target_vendor = "apple", feature = "metal") },
         vulkan: { all(not(target_arch = "wasm32"), feature = "vulkan") },
+        drm: { all(
+            feature = "drm",
+            any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")
+        ) },
         any_backend: { any(dx12, metal, vulkan, gles) },
         // ⚠️ Keep in sync with target.cfg() definition in Cargo.toml and cfg_alias in `wgpu` crate ⚠️
         static_dxc: { all(target_os = "windows", feature = "static-dxc", not(target_arch = "aarch64"), target_env = "msvc") },

--- a/wgpu-hal/src/vulkan/drm.rs
+++ b/wgpu-hal/src/vulkan/drm.rs
@@ -1,4 +1,4 @@
-#![cfg(all(unix, not(target_vendor = "apple"), not(target_family = "wasm")))]
+#![cfg(drm)]
 
 use alloc::{string::ToString, vec::Vec};
 use core::{mem::MaybeUninit, num::NonZeroU32};

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -264,11 +264,7 @@ impl super::Instance {
             extensions.push(ext::metal_surface::NAME);
             extensions.push(khr::portability_enumeration::NAME);
         }
-        if cfg!(all(
-            unix,
-            not(target_vendor = "apple"),
-            not(target_family = "wasm")
-        )) {
+        if cfg!(drm) {
             // VK_EXT_acquire_drm_display -> VK_EXT_direct_mode_display -> VK_KHR_display
             extensions.push(ext::acquire_drm_display::NAME);
             extensions.push(ext::direct_mode_display::NAME);
@@ -892,7 +888,7 @@ impl crate::Instance for super::Instance {
                 let connection = display.connection.expect("Pointer to X-Server is not set.");
                 self.create_surface_from_xcb(connection.as_ptr(), handle.window.get())
             }
-            #[cfg(all(unix, not(target_vendor = "apple"), not(target_family = "wasm")))]
+            #[cfg(drm)]
             (Rwh::Drm(handle), Rdh::Drm(display)) => {
                 self.create_surface_from_drm_plane(display.fd, handle.plane)
             }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -85,6 +85,11 @@ vulkan-portability = ["wgpu-core?/vulkan-portability"]
 ## Enables the GLES backend on WebAssembly only.
 webgl = ["web", "wgpu-core/webgl", "dep:wgpu-hal", "dep:smallvec"]
 
+#! ### Backend features
+
+## Support creating textures from DRM display/window handles.
+drm = ["wgpu-core?/drm"]
+
 ## Enables the noop backend for testing.
 ##
 ## This backend allows creating resources such as buffers and textures,

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -21,6 +21,10 @@ fn main() {
             // to explicitly opt-in to Vulkan since it's meant to be used with MoltenVK.
             all(target_vendor = "apple", feature = "vulkan-portability")
         ) },
+        drm: { all(
+            feature = "drm",
+            any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")
+        ) },
         gles: { any(
             // The `gles` feature enables the OpenGL/GLES backend only on "native OpenGL" platforms, i.e. Windows, Linux, Android, and Emscripten.
             // (Note that WebGL is also not included here!)

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -367,7 +367,7 @@ pub enum SurfaceTargetUnsafe {
     ///
     /// - All parameters must point to valid DRM values and remain valid for as long as the resulting [`Surface`] exists.
     /// - The file descriptor (`fd`), plane, connector, and mode configuration must be valid and compatible.
-    #[cfg(all(unix, not(target_vendor = "apple"), not(target_family = "wasm")))]
+    #[cfg(drm)]
     Drm {
         /// The file descriptor of the DRM device.
         fd: i32,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -792,12 +792,7 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
                     .instance_create_surface(raw_display_handle, raw_window_handle, None)
             },
 
-            #[cfg(all(
-                unix,
-                not(target_vendor = "apple"),
-                not(target_family = "wasm"),
-                not(target_os = "netbsd")
-            ))]
+            #[cfg(all(drm, not(target_os = "netbsd")))]
             SurfaceTargetUnsafe::Drm {
                 fd,
                 plane,
@@ -822,7 +817,7 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
                 self.0.instance_create_surface_metal(layer, None)
             },
 
-            #[cfg(target_os = "netbsd")]
+            #[cfg(all(drm, target_os = "netbsd"))]
             SurfaceTargetUnsafe::Drm { .. } => Err(
                 wgc::instance::CreateSurfaceError::BackendNotEnabled(wgt::Backend::Vulkan),
             ),


### PR DESCRIPTION
The DRM API is for interacting with GPUs and displays directly via system calls, without going through something like Mesa. Very few `wgpu` users are driving hardware directly, and those that are are sophisticated users, capable of finding and requesting the feature themselves.

Supporting DRM in `wgpu_hal` adds dependencies on `drm` and its supporting crates. The crates seem fine, but they do contribute to download and build time.

Firefox definitely does not want to have to vendor `drm` and its subcrates into its source tree, since Firefox should never be interacting with graphics hardware directly.

Use `cfg_aliases!` in the various crates' `build.rs` files to define a new cfg, `drm`, which is set when not only the `"drm"` *feature* is enabled, but we are also on a platform that supports DRM. Assume that DRM is available on Linux and all BSDs, including NetBSD. Use the `drm` cfg in all conditionals in the code.

In `wgpu_hal`, make support for `RawWindowHandle::Drm` and `RawDisplayHandle::Drm` require that the `"drm"` feature be explicitly requested, rather than supporting DRM handles by default.

Add a `"drm"` feature to `wgpu`, `wgpu-core`, and `wgpu-core-deps-windows-linux-android`, and make the relevant glue code conditional on that, with appropriate platform qualifications.
