### PR TITLE
Add `BlendState::ADDITIVE` for additive blending

### DIFF
--- a/wgpu-types/src/render.rs
+++ b/wgpu-types/src/render.rs
@@ -192,6 +192,20 @@ impl BlendState {
         color: BlendComponent::OVER,
         alpha: BlendComponent::OVER,
     };
+
+    /// Blend mode that does standard additive blending.
+    pub const ADDITIVE: Self = Self {
+        color: BlendComponent {
+            src_factor: BlendFactor::One,
+            dst_factor: BlendFactor::One,
+            operation: BlendOperation::Add,
+        },
+        alpha: BlendComponent {
+            src_factor: BlendFactor::One,
+            dst_factor: BlendFactor::One,
+            operation: BlendOperation::Add,
+        },
+    };
 }
 
 /// Describes the color state of a render pipeline.


### PR DESCRIPTION
**Description**
The `BlendState` implementation is currently missing a very commonly used blend mode (additive blending).
I believe it is common enough to be part of the library, otherwise users have to define their own additive blending every time and it would be much nicer if it were baked in already.

**Testing**
This change just introduces a new constant with the standard additive blending formula.

**Squash or Rebase?**
Squash