### PR TITLE
fix: restore changelog entry and remove redundant atomic load guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Bottom level categories:
 - Disallow direct access to atomic variables in WGSL front-end (e.g. `let x = myAtomic;`). By @ecoricemon in [#9262](https://github.com/gfx-rs/wgpu/pull/9262).
 - Fixed handling of unterminated block comments. By @BKDaugherty in [#9356](https://github.com/gfx-rs/wgpu/pull/9356).
 - Enforce that `@must_use` appear only on function declarations. By @dnsn021 in [#9367](https://github.com/gfx-rs/wgpu/pull/9367).
+- Fix typo in `naga::back::msl::Error::UnsupportedWritable*` variant names. By @ErichDonGubler in [#9376](https://github.com/gfx-rs/wgpu/pull/9376).
 
 #### dx12
 

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -3786,10 +3786,6 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 write!(self.out, "{}", self.names[&func_ctx.name_key(handle)])?
             }
             Expression::Load { pointer } => {
-                let ty_inner = func_ctx.resolve_type(pointer, &module.types);
-                if ty_inner.is_atomic_pointer(&module.types) {
-                    return Err(Error::Custom("Atomic loads must be baked".into()));
-                }
                 match func_ctx
                     .resolve_type(pointer, &module.types)
                     .pointer_space()


### PR DESCRIPTION
**Connections**

Followup to #9387, addressing review feedback from @atlv24.

**Description**

Two small fixes from the review of #9387 that were missed before merge:

1. Restores a CHANGELOG entry for `naga::back::msl::Error::UnsupportedWritable*` (by @ErichDonGubler, #9376) that was accidentally dropped during a merge conflict resolution.
2. Removes a redundant error guard in `naga/src/back/hlsl/writer.rs` — the `"Atomic loads must be baked"` check is now unreachable since atomic loads are already handled upstream in `update_expressions_to_bake`. The `ty_inner` variable that existed solely to support that check is also removed.

**Testing**

No behavioral change — the removed guard was unreachable. Existing `cargo test -p naga` tests cover atomic load/store correctness.

**Squash or Rebase?**

Squash

**Checklist**
- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`.
- [x] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry.