### PR TITLE
Use `llvm-cov show-env` for cts_runner integration tests

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -115,12 +115,28 @@ jobs:
           debug = "line-tables-only"
           EOF
 
+      # Unlike regular `llvm-cov run`, which builds artifacts in `target/llvm-cov-target`,
+      # `llvm-cov show-env` uses the regular target directory for artifacts. Because of this,
+      # this job configures the `install-mesa` and `install-warp` actions with the regular
+      # target directory, not the `llvm-cov-target` directory.
+      #
+      # The `GITHUB_ENV` file is not subject to shell expansion, so we need to un-escape the
+      # `llvm-cov show-env` output.
+      - name: Set llvm-cov environment
+        shell: bash
+        run: |
+          cargo llvm-cov --no-cfg-coverage show-env | while read -r assignment; do
+            key="${assignment%%=*}"
+            eval "$assignment"
+            echo "$key=${!key}" >> "$GITHUB_ENV"
+          done
+
       - name: (Windows) Install DXC
         if: matrix.os == 'windows-2022'
         uses: ./.github/actions/install-dxc
 
       # Note: `target-dir` is intentionally different from other jobs.
-      # See note in xtask about `llvm-cov show-env`.
+      # See note above about `llvm-cov show-env`.
       - name: (Windows) Install WARP
         if: matrix.os == 'windows-2022'
         uses: ./.github/actions/install-warp
@@ -141,7 +157,7 @@ jobs:
         run: |
           export LLVM_PROFILE_FILE=${{ github.workspace }}/target/wgpu-%p-%m.profraw
           export DENO_WEBGPU_BACKEND=${{ matrix.backend }}
-          cargo --locked llvm-cov --no-cfg-coverage --no-report test -p cts_runner
+          cargo --locked test -p cts_runner
 
       - name: Run CTS
         shell: bash
@@ -153,7 +169,6 @@ jobs:
         run: |
           set -e
 
-          source <(cargo llvm-cov --no-cfg-coverage show-env --sh)
           cargo --locked llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload coverage report to Codecov

--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -34,7 +34,7 @@ use anyhow::{anyhow, bail, Context};
 use core::fmt;
 use pico_args::Arguments;
 use regex_lite::{Regex, RegexBuilder};
-use std::{ffi::OsString, sync::LazyLock};
+use std::{env, ffi::OsString, sync::LazyLock};
 use xshell::Shell;
 
 use crate::util::{git_version_at_least, parse_binary_from_cargo_json};
@@ -323,15 +323,17 @@ pub fn run_cts(
         cargo_opts.push("--release".into());
     }
 
-    let env_vars = if llvm_cov {
-        // Typically coverage runs are done via cargo with `cargo llvm-cov run`. Running the
-        // coverage-instrumented binary directly requires setting some environment variables. See
+    let env_vars = if llvm_cov && env::var("CARGO_LLVM_COV_SHOW_ENV").is_err() {
+        // Typically coverage runs are done via cargo with `cargo llvm-cov run`, but we want
+        // to run the coverage-instrumented binary directly because that is much faster than
+        // invoking `cargo` repeatedly for each CTS test selector. Running it directly requires
+        // setting some environment variables output by `cargo llvm-cov show-env`. See
         // <https://github.com/taiki-e/cargo-llvm-cov/blob/main/README.md#get-coverage-of-external-tests>
         //
-        // Unlike regular `llvm-cov run`, which builds artifacts in `target/llvm-cov-target`,
-        // `llvm-cov show-env` uses the regular target directory for artifacts. Because of this,
-        // the CTS job configures the `install-mesa` and `install-warp` actions with the regular
-        // target directory, not the `llvm-cov-target` directory.
+        // In CI the variables are set by the GitHub workflow, which we detect by checking
+        // whether `CARGO_LLVM_COV_SHOW_ENV` is already set. If the environment variables
+        // have not been set already, query them now so we can add them to the commands
+        // we run.
         let env = shell
             .cmd("cargo")
             .args(&["llvm-cov", "--no-cfg-coverage", "show-env"])


### PR DESCRIPTION
May help with #9402, or it may not, I'm not really sure.

The CTS jobs, as the name suggests, run CTS tests. The "other" CTS jobs additionally run the Rust integration tests for `cts_runner`. Previously, the xtask used `llvm-cov show-env` so we can run the binary directly instead of via cargo, which makes the runs much faster. But the integration tests were still using `cargo llvm-cov run`. The `show-env` method puts build products in their usual locations in `target`, while `llvm-cov run` puts them in something like `target/llvm-cov-target`.

I have two theories of #9402. The one relevant here is that things are generally unhappy switching between the two build directories, so to try and avoid any problems of that sort, this configures the CTS jobs to consistently use `show-env`.

(The other theory is that when the GitHub actions cache gets saved from a non-"other" job and then used to run the "other", something gets confused about the incremental build state, resulting in the `v8` link error. #9403 addressed this by saving caches only from the "other" CTS jobs. (And also only on trunk, but that part is an unrelated optimization.))

**Testing**
CI, but it's not clear what the precise conditions are for #9402 to show up.

**Squash or Rebase?** Squash