### PR TITLE
ci: Save caches only on trunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: clippy-${{ matrix.target }}-${{ matrix.kind }}-${{ env.CACHE_SUFFIX }}
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: (Linux `aarch64`) Install `aarch64-linux-gnu` `g++`
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -416,6 +417,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: wgpu-msrv-check-${{ matrix.target }}-${{ env.CACHE_SUFFIX }}
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Reduce MSRV on dependencies
         shell: bash
@@ -488,6 +490,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: core-msrv-check-${{ matrix.target }}-${{ env.CACHE_SUFFIX }}
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Reduce MSRV on dependencies
         shell: bash
@@ -635,6 +638,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: test-${{ matrix.os }}-${{ env.CACHE_SUFFIX }}
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
           workspaces: |
             . -> target
 
@@ -746,6 +750,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: doctests-${{ env.CACHE_SUFFIX }}
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Run doctests
         shell: bash
@@ -777,6 +782,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: miri-${{ env.CACHE_SUFFIX }}
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Run Miri on selected tests
         shell: bash
@@ -858,6 +864,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: cts-runner-${{ env.CACHE_SUFFIX }}
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Build Deno
         run: |

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -101,6 +101,9 @@ jobs:
           # The version number can be incremented for cache busting.
           prefix-key: v3-rust-${{ hashFiles('cts_runner/revision.txt') }}
           cache-directories: cts
+          # Save the cache from the `other` job because it also runs the cts_runner
+          # integration tests.
+          save-if: ${{ github.ref == 'refs/heads/trunk' && matrix.suite == 'other' }}
 
       # We enable line numbers for panics, but that's it
       - name: disable debug

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: doc-build
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Build the docs
         run: |

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -72,6 +72,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: cargo-generate-${{ matrix.name }}
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Install `cargo-generate`
         uses: taiki-e/install-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: publish-build
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Build examples
         run: cargo xtask run-wasm --no-serve

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -38,6 +38,8 @@ jobs:
           EOF
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       # We must have the FXC job before the DXC job, so the DXC PATH has priority
       # over the FXC PATH. This is because the windows kits also include an older
@@ -82,6 +84,8 @@ jobs:
           EOF
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - run: |
           cd naga
@@ -110,6 +114,8 @@ jobs:
           EOF
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - run: cd naga; cargo xtask validate spv
 


### PR DESCRIPTION
Save caches only on trunk. Caches saved by PR jobs can't be reused on any other branch, and churn through the rather limited cache storage quickly.

Also changes the CTS jobs to save cache only from the "other" job, which runs some additional `cts_runner` integration tests that the API validation/operation jobs don't. Possibly related to #9402.

**Squash or Rebase?** Squash
