### PR TITLE
[wgpu-core] fix potential crash when device is not supplied to `validate_render_bundle_encoder_descriptor`

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -185,12 +185,11 @@ fn validate_render_bundle_encoder_descriptor(
 ) -> Result<(bool, bool), CreateRenderBundleError> {
     let mut have_attachment = false;
 
-    if let Some(device) = device {
-        check_color_attachment_count(
-            desc.color_formats.len(),
-            device.limits.max_color_attachments,
-        )?;
-    }
+    let max_color_attachments = device.map_or(hal::MAX_COLOR_ATTACHMENTS as u32, |device| {
+        assert!(device.limits.max_color_attachments <= hal::MAX_COLOR_ATTACHMENTS as u32);
+        device.limits.max_color_attachments
+    });
+    check_color_attachment_count(desc.color_formats.len(), max_color_attachments)?;
 
     for &format in desc.color_formats.iter().flatten() {
         have_attachment = true;


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/pull/9404 & [Bug 2028585](https://bugzilla.mozilla.org/show_bug.cgi?id=2028585).

**Description**
The source of the crash was in `RenderBundleEncoder::new`; when collecting the color formats into the `ArrayVec` (since it has a max capacity of `hal::MAX_COLOR_ATTACHMENTS`).

**Testing**
Tested locally by always supplying `validate_render_bundle_encoder_descriptor` with a `None` device in `RenderBundleEncoder::new`.