### PR TITLE
Fix `max_vertex_attributes` on D3D12 & `max_inter_stage_shader_variables` on Metal

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -303,6 +303,7 @@ webgpu:api,validation,texture,destroy:invalid_texture:*
 webgpu:api,validation,texture,destroy:twice:*
 webgpu:api,validation,texture,float32_filterable:create_bind_group:*
 webgpu:api,validation,texture,rg11b10ufloat_renderable:*
+webgpu:compat,api,validation,render_pipeline,vertex_state:maxVertexAttributesVertexIndexInstanceIndex:*
 
 fails-if(dx12) webgpu:shader,execution,expression,call,builtin,atan2:f16:*
 webgpu:shader,execution,expression,call,builtin,atan2:f32:*

--- a/wgpu-core/src/limits.rs
+++ b/wgpu-core/src/limits.rs
@@ -277,7 +277,7 @@ pub(crate) fn buckets() -> impl Iterator<Item = &'static Bucket> {
 // are to avoid introducing platform or backend dependencies.
 //
 // **`max_vertex_attributes`:** While there is broad support for 32, Intel hardware with
-// Vulkan only supports 29.
+// Vulkan only supports 29; the D3D12 backend is also limited to 30.
 // See <https://gitlab.freedesktop.org/mesa/mesa/-/blob/465c186fc5f72c51bda943ac0e19f6512f8e6262/src/intel/vulkan/anv_private.h#L188>.
 //
 // **`max_dynamic_{storage,uniform}_buffers_per_pipeline_layout`:** These are limited to
@@ -389,7 +389,7 @@ const BUCKET_A2: Bucket = Bucket {
         max_sampled_textures_per_shader_stage: 48,
         max_storage_buffer_binding_size: 1 << 30, // 1 GB,
         max_storage_buffers_per_shader_stage: 16,
-        max_vertex_attributes: 32,
+        max_vertex_attributes: 30,
         ..UPLEVEL.limits
     },
     info: BucketedAdapterInfo {
@@ -427,7 +427,7 @@ const BUCKET_N1: Bucket = Bucket {
         max_sampled_textures_per_shader_stage: 48,
         max_storage_buffer_binding_size: 1 << 30, // 1 GB,
         max_storage_buffers_per_shader_stage: 16,
-        max_vertex_attributes: 32,
+        max_vertex_attributes: 30,
         ..UPLEVEL.limits
     },
     info: BucketedAdapterInfo {
@@ -446,7 +446,7 @@ const BUCKET_A1: Bucket = Bucket {
         max_sampled_textures_per_shader_stage: 48,
         max_storage_buffer_binding_size: 1 << 30, // 1 GB,
         max_storage_buffers_per_shader_stage: 16,
-        max_vertex_attributes: 32,
+        max_vertex_attributes: 30,
         ..UPLEVEL.limits
     },
     info: BucketedAdapterInfo {
@@ -466,7 +466,7 @@ const BUCKET_NO_F16: Bucket = Bucket {
         max_sampled_textures_per_shader_stage: 48,
         max_storage_buffer_binding_size: 1 << 30, // 1 GB
         max_storage_buffers_per_shader_stage: 16,
-        max_vertex_attributes: 32,
+        max_vertex_attributes: 30,
         ..UPLEVEL.limits
     },
     info: BucketedAdapterInfo {
@@ -504,7 +504,7 @@ const BUCKET_WARP: Bucket = Bucket {
         max_color_attachment_bytes_per_sample: 128,
         max_sampled_textures_per_shader_stage: 48,
         max_storage_buffers_per_shader_stage: 16,
-        max_vertex_attributes: 32,
+        max_vertex_attributes: 30,
         ..UPLEVEL.limits
     },
     info: BucketedAdapterInfo {

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -917,8 +917,9 @@ impl super::Adapter {
                     // 16
                     min_storage_buffer_offset_alignment:
                         Direct3D12::D3D12_RAW_UAV_SRV_BYTE_ALIGNMENT,
-                    // 32
-                    max_vertex_attributes: Direct3D12::D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT,
+                    // 30
+                    max_vertex_attributes: Direct3D12::D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT
+                        - 2, // -2 for `SV_VertexID` and `SV_InstanceID`
                     // 2048
                     max_vertex_buffer_array_stride: Direct3D12::D3D12_SO_BUFFER_MAX_STRIDE_IN_BYTES,
                     // 31

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -922,11 +922,30 @@ impl super::CapabilitiesQuery {
             // This limit is the minimum of:
             // - "Maximum scalar or vector inputs to a fragment function"
             // - "Maximum number of input components to a fragment function" / 4
-            max_inter_stage_shader_variables: if (family_check
-                && device.supportsFamily(MTLGPUFamily::Apple4))
-                || device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily1_v1)
+            //
+            // On non-Apple GPUs only, the Metal validation layers will error with:
+            //
+            // "number of shader varying components (125) exceeds limit (124).
+            // Note that on macOS the following attributes count towards the
+            // limit: [[position]], [[clip_distance]], [[point_size]],
+            // [[point_coord]], and, when read in the fragment shader,
+            // [[viewport_array_index]] & [[render_target_array_index]]."
+            //
+            // if the limit in the feature tables is crossed while also using
+            // one of the built-ins mentioned above.
+            //
+            // Note that the error says "on macOS" but it actually only applies
+            // to non-Apple GPUs.
+            //
+            // We only need to account for the position built-in since the others
+            // are either not used or they already count towards the limit
+            // calculation as specified by WebGPU.
+            max_inter_stage_shader_variables: if family_check
+                && device.supportsFamily(MTLGPUFamily::Apple4)
             {
-                31 // min(32 or 124, 124 / 4)
+                31 // min(124, 124 / 4)
+            } else if device.supportsFeatureSet(MTLFeatureSet::macOS_GPUFamily1_v1) {
+                30 // min(32, 124 / 4) - 1
             } else {
                 15 // min(60, 60 / 4)
             },


### PR DESCRIPTION
**Connections**
- https://github.com/gpuweb/gpuweb/pull/5604#discussion_r2967504832
- https://github.com/gpuweb/gpuweb/pull/5604#discussion_r2918342742

**Description**
Fixes limits.

**Testing**
Enabled a CTS test, the other limit fix can't be tested since we would need non-Apple GPUs running macOS in CI.

**Squash or Rebase?**
Rebase.