### PR TITLE
ci: Waive cargo deny warning for redox_syscall

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -45,6 +45,9 @@ skip = [
 
     # parking-lot and winit use old versions
     { name = "redox_syscall", version = "0.4.1" },
+    # winit uses this old version
+    { name = "redox_syscall", version = "0.4.1" },
+    # parking-lot uses this old version
     { name = "redox_syscall", version = "0.5.18" },
 
     # deno uses an old version

--- a/.deny.toml
+++ b/.deny.toml
@@ -43,7 +43,8 @@ skip = [
     # getrandom 0.3 uses an old version
     { name = "r-efi", version = "5" },
 
-    # parking-lot uses an old version
+    # parking-lot and winit use old versions
+    { name = "redox_syscall", version = "0.4.1" },
     { name = "redox_syscall", version = "0.5.18" },
 
     # deno uses an old version

--- a/.deny.toml
+++ b/.deny.toml
@@ -43,8 +43,6 @@ skip = [
     # getrandom 0.3 uses an old version
     { name = "r-efi", version = "5" },
 
-    # parking-lot and winit use old versions
-    { name = "redox_syscall", version = "0.4.1" },
     # winit uses this old version
     { name = "redox_syscall", version = "0.4.1" },
     # parking-lot uses this old version


### PR DESCRIPTION
Hopefully fixes the failure in https://github.com/gfx-rs/wgpu/actions/runs/24240352078/job/70779723507?pr=9407.

I do not have an explanation for why this just started showing up. I can't reproduce it locally. 

**Squash or Rebase?** Squash