### PR TITLE
fix(metal): use isVisible instead of occlusionState for window visibility check

### DIFF
--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -142,10 +142,18 @@ impl crate::Surface for super::Surface {
                         unsafe { objc2::msg_send![&*delegate, window] };
 
                     if let Some(window) = window {
-                        const NS_WINDOW_OCCLUSION_STATE_VISIBLE: usize = 1 << 1;
-                        let occlusion_state: usize =
-                            unsafe { objc2::msg_send![&*window, occlusionState] };
-                        let is_visible = (occlusion_state & NS_WINDOW_OCCLUSION_STATE_VISIBLE) != 0;
+                        // Use `isVisible` instead of `occlusionState` to determine
+                        // if the window can be rendered to. `occlusionState` does not
+                        // have the `NSWindowOcclusionStateVisible` bit set when the
+                        // app is launched from Terminal or another CLI environment on
+                        // macOS, causing `get_current_texture()` to return `Occluded`
+                        // indefinitely — even though the window is on-screen and
+                        // interactive. `isVisible` correctly reflects the window's
+                        // actual visibility in all launch contexts.
+                        //
+                        // See: https://github.com/gfx-rs/wgpu/issues/8309
+                        let is_visible: bool =
+                            unsafe { objc2::msg_send![&*window, isVisible] };
 
                         if !is_visible {
                             return Err(crate::SurfaceError::Occluded);


### PR DESCRIPTION
## Summary

`occlusionState` does not have the `NSWindowOcclusionStateVisible` bit set when the app is launched from Terminal or other CLI environments on macOS, causing `get_current_texture()` to return `Occluded` indefinitely — even though the window is visible and interactive.

Replaced with `isVisible` which correctly reflects the window's actual visibility regardless of how the application was launched.

## Problem

When a wgpu application is launched from Terminal.app (or any CLI), the Metal backend's occlusion check in `surface.rs` always returns `Occluded`:

1. `NSWindow.occlusionState` is queried
2. The `NSWindowOcclusionStateVisible` bit is never set for Terminal-launched apps
3. `get_current_texture()` returns `SurfaceError::Occluded` every frame
4. The application renders a blank screen forever

This affects any wgpu app launched from CLI — not just specific applications.

## Fix

Replace `occlusionState` bit-flag check with `isVisible` message send. `isVisible` returns `true` when the window is on-screen regardless of launch context.

## Testing

- Tested on macOS 14.5 (Sonoma), Apple Silicon
- App launched from Terminal.app: renders correctly (was blank before)
- App launched from Finder/.app bundle: renders correctly (no regression)
- App launched via `open` command: renders correctly

Fixes #8309