### PR TITLE
Prevent deserializing or defaulting `LoadOp::DontCare`, for soundness.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Bottom level categories:
 - `Buffer::get_mapped_range` and variants now return `Result<_, MapRangeError>>` instead of panicking, in line with WebGPU spec. By @atlv24 in [#9281](https://github.com/gfx-rs/wgpu/pull/9281).
 - Passthrough shaders now require a list of entry points when being created. by @inner-daemons in [#9064](https://github.com/gfx-rs/wgpu/pull/9064).
 - BREAKING: The `dispatch` and `dispatch_indirect` methods on pass and bundle encoders have been renamed to `dispatch_workgroups` and `dispatch_workgroups_indirect`, respectively, to match the WebGPU spec. By @ErichDonGubler in [#9362](https://github.com/gfx-rs/wgpu/pull/9362).
+- `LoadOp::DontCare` can no longer be deserialized, and the `LoadOpDontCare` token no longer implements `Default`. This ensures that `DontCare` can only be used with `unsafe`, as intended. By @kpreid in [#9428](https://github.com/gfx-rs/wgpu/pull/9428).
 
 #### Validation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4975,6 +4975,7 @@ dependencies = [
  "raw-window-handle",
  "serde",
  "serde_json",
+ "static_assertions",
  "web-sys",
 ]
 

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -59,6 +59,7 @@ serde = { workspace = true, default-features = false, features = [
     "alloc",
     "derive",
 ], optional = true }
+static_assertions.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { workspace = true, optional = true, default-features = false }

--- a/wgpu-types/src/render.rs
+++ b/wgpu-types/src/render.rs
@@ -739,7 +739,8 @@ pub enum LoadOp<V> {
     ///
     /// - All pixels in the render target must be written to before
     ///   any read or a [`StoreOp::Store`] occurs.
-    DontCare(#[cfg_attr(feature = "serde", serde(skip))] LoadOpDontCare) = 2,
+    #[cfg_attr(feature = "serde", serde(skip))] // unsafe to use, so cannot be (de)serialized
+    DontCare(LoadOpDontCare) = 2,
 }
 
 impl<V> LoadOp<V> {

--- a/wgpu-types/src/tokens.rs
+++ b/wgpu-types/src/tokens.rs
@@ -45,7 +45,14 @@ impl ExperimentalFeatures {
 }
 
 /// Token of the user agreeing to use [`LoadOp::DontCare`](crate::LoadOp::DontCare).
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+//
+// Maintenance note: This type MUST NOT implement Default, Deserialize, or anything else which
+// allows safely constructing it. This differs from `ExperimentalFeatures` because it doesn't have
+// an "enabled" flag, because its role is to prevent its container (an enum variant) from being
+// constructed at all. We could change that if necessary (e.g. perhaps for the wgpu trace/player),
+// but if we did, we would have to give `LoadOp::DontCare` a specific fallback behavior when the
+// token is disabled/invalid.
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct LoadOpDontCare {
     // Private to prevent construction outside of the unsafe
     // enabled() function.
@@ -72,3 +79,7 @@ impl LoadOpDontCare {
         Self { _private: () }
     }
 }
+
+static_assertions::assert_not_impl_any!(LoadOpDontCare: Default);
+#[cfg(feature = "serde")]
+static_assertions::assert_not_impl_any!(LoadOpDontCare: serde::Deserialize<'static>);


### PR DESCRIPTION
**Connections**
Fixes #8780.

**Description**
Removes `derive(Default)` from the `LoadOpDontCare` token, and applies the `#[serde::skip]` attribute to the *variant* `DontCare`. This means it is not possible to create `DontCare` without an unsafe block, as was intended. Attempted deserializing is an error.

If in the future we resurrect the wgpu trace/player functionality and want to be able to intentionally deserialize `DontCare`, we can refine this later as a non-breaking change.

**Testing**
Added static assertions.

**Squash or Rebase?**
Rebase

**Checklist**

- [X] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [X] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [X] Run `cargo xtask test` to run tests.
- [x] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
