### PR TITLE
Improve PR template checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,9 +29,13 @@ person(s) who reviewed your changes. This will make sure it gets re-added to the
 
 **Checklist**
 
-- [ ] Run `cargo fmt`.
-- [ ] Run `taplo format`.
-- [ ] Run `cargo clippy --tests`. If applicable, add:
-  - [ ] `--target wasm32-unknown-unknown`
-- [ ] Run `cargo xtask test` to run tests.
-- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
+<!-- Note that checking all the boxes is not necessary to open a PR. -->
+
+- [ ] I self-reviewed this PR and fully understand it.
+- [ ] This PR potentially affects behavior on WebGPU.
+- [ ] I added all necessary validation to ensure behavior changes are confined to where they should be.
+  - [ ] I added validation tests demonstrating that any behavior changes are in fact confined with proper error messages.
+- [ ] I added all necessary `CHANGELOG.md` entries for this change. <!-- See instructions at the top of `CHANGELOG.md`. -->
+- [ ] I think this PR is a minimal change that doesn't make sense to land as multiple separate PRs.
+- [ ] I think the commit history is logical and decently reviewable.
+- [ ] The PR description contains enough context for a reviewer to understand the motivation for this PR, and the solution it implements.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,11 +31,11 @@ person(s) who reviewed your changes. This will make sure it gets re-added to the
 
 <!-- Note that checking all the boxes is not necessary to open a PR. -->
 
-- [ ] I self-reviewed this PR and fully understand it.
-- [ ] This PR potentially affects behavior on WebGPU.
-- [ ] I added all necessary validation to ensure behavior changes are confined to where they should be.
-  - [ ] I added validation tests demonstrating that any behavior changes are in fact confined with proper error messages.
-- [ ] I added all necessary `CHANGELOG.md` entries for this change. <!-- See instructions at the top of `CHANGELOG.md`. -->
-- [ ] I think this PR is a minimal change that doesn't make sense to land as multiple separate PRs.
-- [ ] I think the commit history is logical and decently reviewable.
-- [ ] The PR description contains enough context for a reviewer to understand the motivation for this PR, and the solution it implements.
+- [ ] I self-reviewed and fully understand this PR.
+- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
+- [ ] Validation and feature gates are in place to confine behavioral changes.
+- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
+- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
+- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
+- [ ] Commits are logically scoped and individually reviewable.
+- [ ] The PR description has enough context to understand the motivation and solution implemented.


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/9385#issuecomment-4208112891

**Description**
Our current PR template checklist is largely enforced by CI. This means that the checklist is glossed over, as it is made redundant by the green CI checkmark. We should be making the most of the PR template: let's instead only include items that are *not* checked by CI. This restores meaning to the checklist as a human-needed action. I used the new template in this PR itself so you can see what it would look like. The intent is to call attention to potential issues that reviewers will check regardless, and hopefully let contributors address them before a reviewer needs to spend time asking them to.

**Testing**
Ship it and pray

**Squash or Rebase?**

Squash

**Checklist**

- [x] I self-reviewed this PR and fully understand it.
- [ ] This PR potentially affects behavior on WebGPU.
- [ ] I added all necessary validation to ensure behavior changes are confined to where they should be.
  - [ ] I added validation tests demonstrating that any behavior changes are in fact confined with proper error messages.
- [ ] I added all necessary `CHANGELOG.md` entries for this change. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] I think this PR is a minimal change that doesn't make sense to land as multiple separate PRs.
- [x] I think the commit history is logical and decently reviewable.
- [x] The PR description contains enough context for a reviewer to understand the motivation for this PR, and the solution it implements.
