### PR TITLE
[d3d12] always expose `Features::FLOAT32_BLENDABLE`

### DIFF
--- a/wgpu-core/src/limits.rs
+++ b/wgpu-core/src/limits.rs
@@ -345,7 +345,7 @@ const UPLEVEL: Bucket = Bucket {
         .union(Features::RG11B10UFLOAT_RENDERABLE)
         .union(Features::BGRA8UNORM_STORAGE)
         .union(Features::FLOAT32_FILTERABLE)
-        // FLOAT32_BLENDABLE not implemented in wgpu dx12 backend; https://github.com/gfx-rs/wgpu/issues/6555
+        .union(Features::FLOAT32_BLENDABLE)
         // CLIP_DISTANCES not implemented in wgpu dx12 backend; https://github.com/gfx-rs/wgpu/issues/6236
         .union(Features::DUAL_SOURCE_BLENDING)
         // TIER1/TIER2 not implemented in wgpu; https://github.com/gfx-rs/wgpu/issues/8122
@@ -376,7 +376,6 @@ const BUCKET_M1: Bucket = Bucket {
         .union(Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D)
         .union(Features::TEXTURE_COMPRESSION_ETC2)
         .union(Features::SHADER_F16)
-        .union(Features::FLOAT32_BLENDABLE)
         .union(Features::CLIP_DISTANCES),
 };
 

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -480,6 +480,7 @@ impl super::Adapter {
             | wgt::Features::DUAL_SOURCE_BLENDING
             | wgt::Features::TEXTURE_FORMAT_NV12
             | wgt::Features::FLOAT32_FILTERABLE
+            | wgt::Features::FLOAT32_BLENDABLE
             | wgt::Features::TEXTURE_ATOMIC
             | wgt::Features::PASSTHROUGH_SHADERS
             | wgt::Features::EXTERNAL_TEXTURE


### PR DESCRIPTION
**Connections**
Closes https://github.com/gfx-rs/wgpu/issues/6555.

**Description**
This is always supported, see https://github.com/gpuweb/gpuweb/issues/3556#issuecomment-1431979258.

**Testing**
CTS test is already enabled.
