### PR TITLE
Add TextureFormat::srgb_view_formats

### DIFF
--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -1615,6 +1615,123 @@ impl TextureFormat {
         }
     }
 
+    /// Provides texture srgb view formats with static lifetime for `TextureDescriptor.view_formats`.
+    /// Returns the srgb view formats if the format has an srgb variant, otherwise returns an empty slice.
+    ///
+    /// The return result covers all the results of [`TextureFormat::add_srgb_suffix`].
+    pub fn srgb_view_formats(&self) -> &'static [TextureFormat] {
+        match self {
+            TextureFormat::Rgba8Unorm => &[TextureFormat::Rgba8UnormSrgb],
+            TextureFormat::Bgra8Unorm => &[TextureFormat::Bgra8UnormSrgb],
+            TextureFormat::Bc1RgbaUnorm => &[TextureFormat::Bc1RgbaUnormSrgb],
+            TextureFormat::Bc2RgbaUnorm => &[TextureFormat::Bc2RgbaUnormSrgb],
+            TextureFormat::Bc3RgbaUnorm => &[TextureFormat::Bc3RgbaUnormSrgb],
+            TextureFormat::Bc7RgbaUnorm => &[TextureFormat::Bc7RgbaUnormSrgb],
+            TextureFormat::Etc2Rgb8Unorm => &[TextureFormat::Etc2Rgb8UnormSrgb],
+            TextureFormat::Etc2Rgb8A1Unorm => &[TextureFormat::Etc2Rgb8A1UnormSrgb],
+            TextureFormat::Etc2Rgba8Unorm => &[TextureFormat::Etc2Rgba8UnormSrgb],
+            TextureFormat::Astc {
+                block: AstcBlock::B4x4,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B4x4,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B5x4,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B5x4,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B5x5,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B5x5,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B6x5,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B6x5,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B6x6,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B6x6,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B8x5,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B8x5,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B8x6,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B8x6,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B8x8,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B8x8,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B10x5,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B10x5,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B10x6,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B10x6,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B10x8,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B10x8,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B10x10,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B10x10,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B12x10,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B12x10,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            TextureFormat::Astc {
+                block: AstcBlock::B12x12,
+                channel: AstcChannel::Unorm,
+            } => &[TextureFormat::Astc {
+                block: AstcBlock::B12x12,
+                channel: AstcChannel::UnormSrgb,
+            }],
+            _ => &[],
+        }
+    }
+
     /// Returns `true` for srgb formats.
     #[must_use]
     pub fn is_srgb(&self) -> bool {


### PR DESCRIPTION
**Description**
Bevy needs this functionality because of `TextureDescriptor::view_formats` taking a `&'static [TextureFormat]`:

https://github.com/bevyengine/bevy/blob/2d39c4f8e4cdd021881d0bba1ab4dd174d6db0ab/crates/bevy_image/src/image.rs#L57

https://github.com/bevyengine/bevy/blob/2d39c4f8e4cdd021881d0bba1ab4dd174d6db0ab/crates/bevy_image/src/image.rs#L1267

We don't need exactly this, we could do a more straightforward `TextureFormat -> &[TextureFormat]` function that doesnt add srgb, and combine it with the existing add_srgb_suffix, but that ends up being 400 lines of code and not really more useful: view_formats only allows diverging from the actual texture format by srgb suffix. The only other argument in favor of it is that it would be an exhaustive implementation, which would ensure that when new TextureFormats are added the function must be updated. If this is preferred I can PR that instead. Either way, it just feels wrong for this code to live in bevy, as it is paving over a wgpu api deficiency and likely will be needed by other wgpu users.

**Testing**
Its been in use in bevy for a while.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo xtask test` to run tests.
- [ ] If this contains user-facing changes, add a `CHANGELOG.md` entry. <!-- See instructions at the top of `CHANGELOG.md`. -->
