### PR TITLE
doc: remove `D3D11` mentions

### DIFF
--- a/wgpu-types/src/backend.rs
+++ b/wgpu-types/src/backend.rs
@@ -907,7 +907,7 @@ impl Dx12UseFrameLatencyWaitableObject {
 
 /// Selects which OpenGL ES 3 minor version to request.
 ///
-/// When using ANGLE as an OpenGL ES/EGL implementation, explicitly requesting `Version1` can provide a non-conformant ES 3.1 on APIs like D3D11.
+/// When using ANGLE as an OpenGL ES/EGL implementation, explicitly requesting `Version1` can provide a non-conformant ES 3.1.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
 pub enum Gles3MinorVersion {
     /// No explicit minor version is requested, the driver automatically picks the highest available.

--- a/wgpu-types/src/backend.rs
+++ b/wgpu-types/src/backend.rs
@@ -907,7 +907,7 @@ impl Dx12UseFrameLatencyWaitableObject {
 
 /// Selects which OpenGL ES 3 minor version to request.
 ///
-/// When using ANGLE as an OpenGL ES/EGL implementation, explicitly requesting `Version1` can provide a non-conformant ES 3.1.
+/// When using ANGLE as an OpenGL ES/EGL implementation, explicitly requesting `Version1` can provide a non-conformant ES 3.1 on APIs like D3D11.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
 pub enum Gles3MinorVersion {
     /// No explicit minor version is requested, the driver automatically picks the highest available.

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -96,7 +96,7 @@ macro_rules! with_limits {
 ///
 /// We provide three different defaults.
 /// - [`Limits::downlevel_defaults()`]. This is a set of limits that is guaranteed to work on almost
-///   all backends, including "downlevel" backends such as OpenGL, other than WebGL. For
+///   all backends, including the "downlevel" OpenGL backend, but excluding WebGL2. For
 ///   most applications we recommend using these limits, assuming they are high enough for your
 ///   application, and you do not intend to support WebGL.
 /// - [`Limits::downlevel_webgl2_defaults()`] This is a set of limits that is lower even than the

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -96,7 +96,7 @@ macro_rules! with_limits {
 ///
 /// We provide three different defaults.
 /// - [`Limits::downlevel_defaults()`]. This is a set of limits that is guaranteed to work on almost
-///   all backends, including "downlevel" backends such as OpenGL and D3D11, other than WebGL. For
+///   all backends, including "downlevel" backends such as OpenGL, other than WebGL. For
 ///   most applications we recommend using these limits, assuming they are high enough for your
 ///   application, and you do not intend to support WebGL.
 /// - [`Limits::downlevel_webgl2_defaults()`] This is a set of limits that is lower even than the
@@ -454,7 +454,7 @@ impl Limits {
         }
     }
 
-    /// These default limits are guaranteed to be compatible with GLES-3.1, and D3D11
+    /// These default limits are guaranteed to be compatible with GLES-3.1.
     ///
     /// Those limits are as follows (different from default are marked with *):
     /// ```rust
@@ -535,7 +535,7 @@ impl Limits {
         }
     }
 
-    /// These default limits are guaranteed to be compatible with GLES-3.0, and D3D11, and WebGL2
+    /// These default limits are guaranteed to be compatible with GLES-3.0 and WebGL2
     ///
     /// Those limits are as follows (different from `downlevel_defaults` are marked with +,
     /// *'s from `downlevel_defaults` shown as well.):


### PR DESCRIPTION
**Connections**
From the discord:
<img width="1195" height="627" alt="image" src="https://github.com/user-attachments/assets/5b115b40-97f4-4fea-aab5-a27236c45934" />

**Description**
Removes the mentionings of `D3D11`.

This is the output (after this commit) of `rg -trust "D3D11"`:
```
wgpu-hal/src/metal/mod.rs
7:are all placed together in the native resource bindings, which work similarly to D3D11:

wgpu-hal/src/dx12/device.rs
188:        // which guarantees D3D11-like null binding behavior (reading 0s, writes are discarded)

wgpu-hal/src/dx12/adapter.rs
942:                    // From: https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#18.6.6%20Inter-Thread%20Data%20Sharing
1026:                    // https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#18.6.8.2%20Device%20Memory%20Reads

wgpu-hal/src/vulkan/device.rs
561:    /// - `VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT` flag is used because we need to hold a reference to the handle
578:            .handle_types(vk::ExternalMemoryHandleTypeFlags::D3D11_TEXTURE);
589:            .handle_type(vk::ExternalMemoryHandleTypeFlags::D3D11_TEXTURE)

naga/src/back/hlsl/writer.rs
3274:            // (https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm)
```
but I'm unsure how much more I need to remove. :eyes: 

**Testing**
None <img src="https://emojis.tornaxo7.de/peepoShy.gif" width="30px"/>

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.

@cwfitzgerald 