### PR TITLE
Add WebGL2 `Adapter::new_external()`  + context accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ By @teoxoy in [#9351](https://github.com/gfx-rs/wgpu/pull/9351).
 #### GLES
 
 - Added support for GLSL passthrough. By @inner-daemons in [#9064](https://github.com/gfx-rs/wgpu/pull/9064).
+- Implement `Adapter::new_external()` for WebGL2 (just like EGL/WGL) to import an external WebGL2 rendering context. By @pepperoni505 in [#9438](https://github.com/gfx-rs/wgpu/pull/9438).
 
 #### DX12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ By @teoxoy in [#9351](https://github.com/gfx-rs/wgpu/pull/9351).
 #### GLES
 
 - Added support for GLSL passthrough. By @inner-daemons in [#9064](https://github.com/gfx-rs/wgpu/pull/9064).
-- Implement `Adapter::new_external()` for WebGL2 (just like EGL/WGL) to import an external WebGL2 rendering context. By @pepperoni505 in [#9438](https://github.com/gfx-rs/wgpu/pull/9438).
+- Implement `Adapter::new_external()` for WebGL2 (just like EGL/WGL) to import an external WebGL2 rendering context, and expose the imported context back through `Adapter::adapter_context()` / `Device::context()`. By @pepperoni505 in [#9438](https://github.com/gfx-rs/wgpu/pull/9438).
 
 #### DX12
 

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -179,6 +179,33 @@ impl crate::Instance for Instance {
     }
 }
 
+impl super::Adapter {
+    /// Creates a new external adapter from an existing WebGL2 rendering context.
+    ///
+    /// # Safety
+    ///
+    /// - The underlying WebGL2 context must be valid (not lost).
+    /// - The underlying WebGL2 context must be valid when interfacing with any objects returned by
+    ///   wgpu-hal from this adapter.
+    /// - The underlying WebGL2 context must be valid when dropping this adapter and when
+    ///   dropping any objects returned from this adapter.
+    pub unsafe fn new_external(
+        webgl2_context: web_sys::WebGl2RenderingContext,
+        options: wgt::GlBackendOptions,
+    ) -> Option<crate::ExposedAdapter<super::Api>> {
+        let glow_context = glow::Context::from_webgl2_context(webgl2_context.clone());
+        unsafe {
+            Self::expose(
+                AdapterContext {
+                    glow_context,
+                    webgl2_context,
+                },
+                options,
+            )
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Surface {
     canvas: Canvas,

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -204,6 +204,17 @@ impl super::Adapter {
             )
         }
     }
+
+    pub fn adapter_context(&self) -> &AdapterContext {
+        &self.shared.context
+    }
+}
+
+impl super::Device {
+    /// Returns the underlying WebGL2 `AdapterContext`.
+    pub fn context(&self) -> &AdapterContext {
+        &self.shared.context
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
**Connections**
#6152, which added `Adapter::new_external` for WGL.

**Description**
This PR adds `Adapter::new_external` to the WebGL2 backend, mirroring the existing functions of the same name in `gles/egl.rs` and `gles/wgl.rs`. It accepts an externally-created `web_sys::WebGl2RenderingContext` and produces an ExposedAdapter`, so `wgpu-hal` can render into a context that another party owns.

It also adds `Adapter::adapter_context()` and `Device::context()` accessors that return the underlying `AdapterContext`, so an embedder who brought their own context can reach the shared `WebGl2RenderingContext` back for raw-GL interop

**Testing**
Validated end-to-end in a browser against Mapbox GL JS's internal `WebGl2RenderingContext`: the adapter is created successfully and its `AdapterInfo`, `Features`, and `Capabilities` populate correctly. No unit tests are added; this matches the existing pattern for `Adapter::new_external` on EGL and WGL, neither of which is covered by tests.

**Squash or Rebase?**
Squash

**Checklist**
- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
