### PR TITLE
Small lock fixes and update lock graph

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -220,7 +220,7 @@ impl Queue {
         };
 
         self.submit_with_pending_writes(
-            &mut pending_writes,
+            pending_writes,
             Vec::new(),
             surface_textures,
             fence.as_mut(),
@@ -1435,10 +1435,10 @@ impl Queue {
                 }
             }
 
-            let mut pending_writes = self.pending_writes.lock();
+            let pending_writes = self.pending_writes.lock();
 
             if let Err(e) = self.submit_with_pending_writes(
-                &mut pending_writes,
+                pending_writes,
                 active_executions,
                 submit_surface_textures_owned,
                 fence.as_mut(),
@@ -1449,8 +1449,6 @@ impl Queue {
             }
 
             drop(command_index_guard);
-
-            drop(pending_writes);
 
             profiling::scope!("cleanup");
 
@@ -1497,7 +1495,7 @@ impl Queue {
     /// Advances `last_successful_submission_index` and registers the submission with the lifetime tracker.
     fn submit_with_pending_writes(
         &self,
-        pending_writes: &mut PendingWrites,
+        mut pending_writes: MutexGuard<'_, PendingWrites>,
         mut active_executions: Vec<EncoderInFlight>,
         mut surface_textures: FastHashMap<*const Texture, Arc<Texture>>,
         fence: &mut dyn hal::DynFence,
@@ -1578,6 +1576,9 @@ impl Queue {
                 .last_successful_submission_index
                 .fetch_max(submit_index, Ordering::SeqCst);
         }
+
+        drop(pending_writes);
+
         // this will register the new submission to the life time tracker
         self.lock_life()
             .track_submission(submit_index, active_executions);

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -137,8 +137,7 @@ impl Queue {
                 .is_some_and(|mip| mip.check(0..1).is_some())
         };
 
-        // Fence lock must be acquired after the snatch lock and before
-        // pending_writes to match the lock ordering in Queue::submit.
+        // Note required lock order: snatch -> fence -> pending writes
         let mut fence = device.fence.write();
         let mut pending_writes = self.pending_writes.lock();
 

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -136,11 +136,6 @@ define_lock_ranks! {
         // Uncomment this to see an interesting cycle.
         // COMMAND_BUFFER_DATA,
     }
-    rank BUFFER_MAP_STATE "Buffer::map_state" followed by {
-        QUEUE_PENDING_WRITES,
-        DEVICE_TRACE,
-        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
-    }
     rank DEVICE_FENCE "Device::fence" followed by {
         DEVICE_COMMAND_INDICES,
         QUEUE_LIFE_TRACKER,
@@ -154,6 +149,10 @@ define_lock_ranks! {
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
     rank QUEUE_PENDING_WRITES "Queue::pending_writes" followed by {
+        BUFFER_MAP_STATE,
+        DEVICE_TRACKERS,
+        COMMAND_ALLOCATOR_FREE_ENCODERS,
+        BUFFER_INITIALIZATION_STATUS,
         TEXTURE_INITIALIZATION_STATUS,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
@@ -164,8 +163,15 @@ define_lock_ranks! {
         TEXTURE_CLEAR_MODE,
     }
     rank QUEUE_LIFE_TRACKER "Queue::life_tracker" followed by {
+        BUFFER_MAP_STATE,
+        BUFFER_INITIALIZATION_STATUS,
+        BUFFER_POOL,
         COMMAND_ALLOCATOR_FREE_ENCODERS,
         DEVICE_DEFERRED_DESTROY,
+        DEVICE_TRACE,
+        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
+    }
+    rank BUFFER_MAP_STATE "Buffer::map_state" followed by {
         DEVICE_TRACE,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -18,6 +18,14 @@
 /// `Mutex`, and its rank here is the constant
 /// [`COMMAND_BUFFER_DATA`].
 ///
+/// Building with `RUSTFLAGS="--cfg wgpu_validate_locks"`, replaces the
+/// lock implementation in `lock::vanilla` with in `lock::ranked`, which
+/// checks that the observed sequences of lock acquisition respect the
+/// ordering defined here.
+///
+/// TODO(<https://github.com/gfx-rs/wgpu/issues/5572>): Resolve invalid
+/// acquisitions of DEVICE_COMMAND_INDICES followed by COMMAND_BUFFER_DATA.
+///
 /// [`Mutex`]: parking_lot::Mutex
 /// [`RwLock`]: parking_lot::RwLock
 /// [`SnatchLock`]: crate::snatch::SnatchLock
@@ -97,60 +105,96 @@ macro_rules! define_lock_ranks {
 }
 
 define_lock_ranks! {
+    // Non-leaf ranks, in topological order.
     rank COMMAND_BUFFER_DATA "CommandBuffer::data" followed by {
         DEVICE_SNATCHABLE_LOCK,
-        DEVICE_USAGE_SCOPES,
-        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
         BUFFER_MAP_STATE,
+        COMMAND_ALLOCATOR_FREE_ENCODERS,
+        BUFFER_POOL,
+        DEVICE_TRACE,
+        DEVICE_USAGE_SCOPES,
+        REGISTRY_STORAGE,
+        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
     rank DEVICE_SNATCHABLE_LOCK "Device::snatchable_lock" followed by {
-        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
-        DEVICE_TRACE,
         BUFFER_MAP_STATE,
+        DEVICE_FENCE,
+        QUEUE_PENDING_WRITES,
+        TEXTURE_INITIALIZATION_STATUS,
+        QUEUE_LIFE_TRACKER,
+        BLAS_COMPACTION_STATE,
+        BUFFER_BIND_GROUPS,
+        BUFFER_INITIALIZATION_STATUS,
+        BUFFER_POOL,
+        DEVICE_TRACE,
+        DEVICE_USAGE_SCOPES,
+        REGISTRY_STORAGE,
+        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
+        TEXTURE_BIND_GROUPS,
+        TEXTURE_CLEAR_MODE,
+        TEXTURE_VIEWS,
         // Uncomment this to see an interesting cycle.
         // COMMAND_BUFFER_DATA,
     }
     rank BUFFER_MAP_STATE "Buffer::map_state" followed by {
         QUEUE_PENDING_WRITES,
-        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
         DEVICE_TRACE,
+        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
+    }
+    rank DEVICE_FENCE "Device::fence" followed by {
+        DEVICE_COMMAND_INDICES,
+        QUEUE_LIFE_TRACKER,
+    }
+    rank DEVICE_COMMAND_INDICES "Device::command_indices" followed by {
+        BUFFER_POOL,
+        QUEUE_PENDING_WRITES,
+        QUEUE_LIFE_TRACKER,
+        COMMAND_ALLOCATOR_FREE_ENCODERS,
+        DEVICE_DEFERRED_DESTROY,
+        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
     rank QUEUE_PENDING_WRITES "Queue::pending_writes" followed by {
-        COMMAND_ALLOCATOR_FREE_ENCODERS,
+        TEXTURE_INITIALIZATION_STATUS,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
-        QUEUE_LIFE_TRACKER,
+    }
+    rank TEXTURE_INITIALIZATION_STATUS "Texture::initialization_status" followed by {
+        DEVICE_TRACKERS,
+    }
+    rank DEVICE_TRACKERS "Device::trackers" followed by {
+        TEXTURE_CLEAR_MODE,
     }
     rank QUEUE_LIFE_TRACKER "Queue::life_tracker" followed by {
         COMMAND_ALLOCATOR_FREE_ENCODERS,
+        DEVICE_DEFERRED_DESTROY,
         DEVICE_TRACE,
+        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
     rank COMMAND_ALLOCATOR_FREE_ENCODERS "CommandAllocator::free_encoders" followed by {
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
 
+    // Leaf ranks reachable from the graph above, alphabetical.
+    rank BLAS_COMPACTION_STATE "Blas::compaction_state" followed by { }
     rank BUFFER_BIND_GROUPS "Buffer::bind_groups" followed by { }
     rank BUFFER_INITIALIZATION_STATUS "Buffer::initialization_status" followed by { }
-    rank DEVICE_COMMAND_INDICES "Device::command_indices" followed by {}
-    rank DEVICE_DEFERRED_DESTROY "Device::deferred_destroy" followed by {}
-    rank DEVICE_FENCE "Device::fence" followed by { }
+    rank BUFFER_POOL "BufferPool::buffers" followed by { }
+    rank DEVICE_DEFERRED_DESTROY "Device::deferred_destroy" followed by { }
     rank DEVICE_TRACE "Device::trace" followed by { }
-    rank DEVICE_TRACKERS "Device::trackers" followed by { }
-    rank DEVICE_LOST_CLOSURE "Device::device_lost_closure" followed by { }
     rank DEVICE_USAGE_SCOPES "Device::usage_scopes" followed by { }
-    rank IDENTITY_MANAGER_VALUES "IdentityManager::values" followed by { }
     rank REGISTRY_STORAGE "Registry::storage" followed by { }
-    rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }
     rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }
-    rank SURFACE_PRESENTATION "Surface::presentation" followed by { }
     rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { }
-    rank TEXTURE_INITIALIZATION_STATUS "Texture::initialization_status" followed by { }
     rank TEXTURE_CLEAR_MODE "Texture::clear_mode" followed by { }
     rank TEXTURE_VIEWS "Texture::views" followed by { }
+
+    // Ranks not connected to the graph, alphabetical.
     rank BLAS_BUILT_INDEX "Blas::built_index" followed by { }
-    rank BLAS_COMPACTION_STATE "Blas::compaction_size" followed by { }
+    rank DEVICE_LOST_CLOSURE "Device::device_lost_closure" followed by { }
+    rank IDENTITY_MANAGER_VALUES "IdentityManager::values" followed by { }
+    rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }
+    rank SURFACE_PRESENTATION "Surface::presentation" followed by { }
     rank TLAS_BUILT_INDEX "Tlas::built_index" followed by { }
     rank TLAS_DEPENDENCIES "Tlas::dependencies" followed by { }
-    rank BUFFER_POOL "BufferPool::buffers" followed by { }
 
     #[cfg(test)]
     rank PAWN "pawn" followed by { ROOK, BISHOP }

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -192,6 +192,10 @@ impl<T> Mutex<T> {
             saved: LockStateGuard(saved),
         }
     }
+
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner()
+    }
 }
 
 impl<'a, T> ops::Deref for MutexGuard<'a, T> {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -887,7 +887,8 @@ impl Buffer {
         let device = &self.device;
         let snatch_guard = device.snatchable_lock.read();
         let raw_buf = self.try_raw(&snatch_guard)?;
-        match mem::replace(&mut *self.map_state.lock(), BufferMapState::Idle) {
+        let map_state = mem::replace(&mut *self.map_state.lock(), BufferMapState::Idle);
+        match map_state {
             BufferMapState::Init { staging_buffer } => {
                 #[cfg(feature = "trace")]
                 if let Some(ref mut trace) = *device.trace.lock() {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1019,17 +1019,22 @@ impl Buffer {
             })
         };
 
-        if let Some(queue) = device.get_queue() {
+        let Some(queue) = device.get_queue() else {
+            return;
+        };
+
+        {
             let mut pending_writes = queue.pending_writes.lock();
             if pending_writes.contains_buffer(self) {
                 pending_writes.consume_temp(temp);
-            } else {
-                let mut life_lock = queue.lock_life();
-                let last_submit_index = life_lock.get_buffer_latest_submission_index(self);
-                if let Some(last_submit_index) = last_submit_index {
-                    life_lock.schedule_resource_destruction(temp, last_submit_index);
-                }
+                return;
             }
+        }
+
+        let mut life_lock = queue.lock_life();
+        let last_submit_index = life_lock.get_buffer_latest_submission_index(self);
+        if let Some(last_submit_index) = last_submit_index {
+            life_lock.schedule_resource_destruction(temp, last_submit_index);
         }
     }
 }
@@ -1516,17 +1521,22 @@ impl Texture {
             })
         };
 
-        if let Some(queue) = device.get_queue() {
+        let Some(queue) = device.get_queue() else {
+            return;
+        };
+
+        {
             let mut pending_writes = queue.pending_writes.lock();
             if pending_writes.contains_texture(self) {
                 pending_writes.consume_temp(temp);
-            } else {
-                let mut life_lock = queue.lock_life();
-                let last_submit_index = life_lock.get_texture_latest_submission_index(self);
-                if let Some(last_submit_index) = last_submit_index {
-                    life_lock.schedule_resource_destruction(temp, last_submit_index);
-                }
+                return;
             }
+        }
+
+        let mut life_lock = queue.lock_life();
+        let last_submit_index = life_lock.get_texture_latest_submission_index(self);
+        if let Some(last_submit_index) = last_submit_index {
+            life_lock.schedule_resource_destruction(temp, last_submit_index);
         }
     }
 }


### PR DESCRIPTION
Related to #5572

None of this is used by default (#5937 is about changing that). Not realizing that we had known deadlocks, I turned it on, added a bunch of observed acquisitions to the graph, and found one (DEVICE_COMMAND_INDICES → COMMAND_BUFFER_DATA) that cannot be added without creating a cycle, which is noted in a code comment in this PR and in https://github.com/gfx-rs/wgpu/issues/5572#issuecomment-4257146534.

There are a couple others noted in https://github.com/gfx-rs/wgpu/issues/5572#issuecomment-4257146534 that I was able to fix with small tweaks to locking behavior. These were BUFFER_MAP_STATE → QUEUE_PENDING_WRITES → BUFFER_MAP_STATE and BUFFER_MAP_STATE → QUEUE_PENDING_WRITES → QUEUE_LIFE_TRACKER → BUFFER_MAP_STATE.

(There are a few places where the list of dependent locks are reordered to match the order in the top-level list. None moved far, they are pretty easy to spot in the diff. Other places, top-level locks moved to maintain topological order of the definitions for the main part of the graph. Also fixed one typo `rank BLAS_COMPACTION_STATE "Blas::compaction_size"` -> `rank BLAS_COMPACTION_STATE "Blas::compaction_state"`.)

**Testing**
Tested locally that it reduces the number of lock order violations.

**Squash or Rebase?** Rebase (after squashing fixups)

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] There are no user-facing effects of this change that need to be noted in `CHANGELOG.md`.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
