### PR TITLE
test: Enable ray_aabb_compute test on metal

### DIFF
--- a/examples/features/src/ray_aabb_compute/mod.rs
+++ b/examples/features/src/ray_aabb_compute/mod.rs
@@ -397,10 +397,8 @@ pub static TEST: crate::framework::ExampleTestParams = crate::framework::Example
     height: 768,
     optional_features: wgpu::Features::default(),
     base_test_parameters: wgpu_test::TestParameters::default()
-        // Metal has no AABB intersection in ray queries yet; image compare fails.
-        // https://github.com/gfx-rs/wgpu/pull/9304
         // https://github.com/gfx-rs/wgpu/issues/9100
-        .expect_fail(wgpu_test::FailureCase::backend(wgpu::Backends::METAL)),
+        .disable_mtl_shader_validation(),
     comparisons: &[wgpu_test::ComparisonType::Mean(0.02)],
     _phantom: std::marker::PhantomData::<Example>,
 };


### PR DESCRIPTION
This test seems to be okay, I guess it was fixed by #9304?

(I don't have a failure without `disable_mtl_shader_validation` either, but I've made this one match the rest of the ray tracing tests.)

**Squash or Rebase?** Squash
