### PR TITLE
Vulkan: Use Drop impl for swapchain and surface

### DIFF
--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -2,7 +2,6 @@ use alloc::{borrow::ToOwned as _, boxed::Box, ffi::CString, string::String, sync
 use core::{
     ffi::{c_void, CStr},
     marker::PhantomData,
-    mem::ManuallyDrop,
     slice,
     str::FromStr,
 };
@@ -550,8 +549,8 @@ impl super::Instance {
             crate::vulkan::swapchain::NativeSurface::from_vk_surface_khr(self, surface);
 
         super::Surface {
-            inner: ManuallyDrop::new(Box::new(native_surface)),
             swapchain: RwLock::new(None),
+            inner: Box::new(native_surface),
         }
     }
 
@@ -988,12 +987,6 @@ impl crate::Instance for super::Instance {
     }
 }
 
-impl Drop for super::Surface {
-    fn drop(&mut self) {
-        unsafe { ManuallyDrop::take(&mut self.inner).delete_surface() };
-    }
-}
-
 impl crate::Surface for super::Surface {
     type A = super::Api;
 
@@ -1020,7 +1013,6 @@ impl crate::Surface for super::Surface {
         if let Some(mut sc) = self.swapchain.write().take() {
             // SAFETY: `unconfigure`'s contract guarantees there are no resources derived from the swapchain in use.
             unsafe { sc.release_resources(device) };
-            unsafe { sc.delete_swapchain() };
         }
     }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -37,14 +37,7 @@ mod swapchain;
 pub use adapter::PhysicalDeviceFeatures;
 
 use alloc::{boxed::Box, ffi::CString, sync::Arc, vec::Vec};
-use core::{
-    borrow::Borrow,
-    ffi::CStr,
-    fmt,
-    marker::PhantomData,
-    mem::{self, ManuallyDrop},
-    num::NonZeroU32,
-};
+use core::{borrow::Borrow, ffi::CStr, fmt, marker::PhantomData, mem, num::NonZeroU32};
 
 use arrayvec::ArrayVec;
 use ash::{ext, khr, vk};
@@ -191,8 +184,8 @@ pub struct Instance {
 }
 
 pub struct Surface {
-    inner: ManuallyDrop<Box<dyn swapchain::Surface>>,
     swapchain: RwLock<Option<Box<dyn swapchain::Swapchain>>>,
+    inner: Box<dyn swapchain::Surface>,
 }
 
 impl Surface {

--- a/wgpu-hal/src/vulkan/swapchain/mod.rs
+++ b/wgpu-hal/src/vulkan/swapchain/mod.rs
@@ -32,7 +32,7 @@ pub(super) trait Surface: Send + Sync + 'static {
 pub(super) trait Swapchain: Send + Sync + 'static {
     /// Releases all resources associated with the swapchain, without
     /// destroying the swapchain itself. Must be called before calling
-    /// either [`Surface::create_swapchain`] or [`Swapchain::delete_swapchain`].
+    /// either [`Surface::create_swapchain`] or dropping the swapchain.
     ///
     /// The swapchain must not be in use when this is called.
     unsafe fn release_resources(&mut self, device: &super::Device);

--- a/wgpu-hal/src/vulkan/swapchain/mod.rs
+++ b/wgpu-hal/src/vulkan/swapchain/mod.rs
@@ -8,11 +8,6 @@ pub(super) use native::*;
 mod native;
 
 pub(super) trait Surface: Send + Sync + 'static {
-    /// Deletes the surface and associated resources.
-    ///
-    /// The surface must not be in use when it is deleted.
-    unsafe fn delete_surface(self: Box<Self>);
-
     /// Returns the surface capabilities for the given adapter.
     ///
     /// Returns `None` if the surface is not compatible with the adapter.
@@ -41,12 +36,6 @@ pub(super) trait Swapchain: Send + Sync + 'static {
     ///
     /// The swapchain must not be in use when this is called.
     unsafe fn release_resources(&mut self, device: &super::Device);
-
-    /// Deletes the swapchain.
-    ///
-    /// The swapchain must not be in use when it is deleted and
-    /// [`Swapchain::release_resources`] must have been called first.
-    unsafe fn delete_swapchain(self: Box<Self>);
 
     /// Acquires the next available surface texture for rendering.
     ///

--- a/wgpu-hal/src/vulkan/swapchain/native.rs
+++ b/wgpu-hal/src/vulkan/swapchain/native.rs
@@ -162,10 +162,10 @@ impl Surface for NativeSurface {
         profiling::scope!("Device::create_swapchain");
         let functor = khr::swapchain::Device::new(&self.instance.raw, &device.shared.raw);
 
-        let old_swapchain = match provided_old_swapchain {
-            Some(osc) => osc.as_any().downcast_ref::<NativeSwapchain>().unwrap().raw,
-            None => vk::SwapchainKHR::null(),
-        };
+        let old_swapchain = provided_old_swapchain
+            .as_ref()
+            .map(|osc| osc.as_any().downcast_ref::<NativeSwapchain>().unwrap().raw)
+            .unwrap_or(vk::SwapchainKHR::null());
 
         let color_space = if config.format == wgt::TextureFormat::Rgba16Float {
             // Enable wide color gamut mode
@@ -217,11 +217,6 @@ impl Surface for NativeSurface {
             profiling::scope!("vkCreateSwapchainKHR");
             unsafe { functor.create_swapchain(&info, None) }
         };
-
-        // doing this before bailing out with error
-        if old_swapchain != vk::SwapchainKHR::null() {
-            unsafe { functor.destroy_swapchain(old_swapchain, None) }
-        }
 
         let raw = match result {
             Ok(swapchain) => swapchain,

--- a/wgpu-hal/src/vulkan/swapchain/native.rs
+++ b/wgpu-hal/src/vulkan/swapchain/native.rs
@@ -34,13 +34,15 @@ impl NativeSurface {
     }
 }
 
-impl Surface for NativeSurface {
-    unsafe fn delete_surface(self: Box<Self>) {
+impl Drop for NativeSurface {
+    fn drop(&mut self) {
         unsafe {
             self.functor.destroy_surface(self.raw, None);
         }
     }
+}
 
+impl Surface for NativeSurface {
     fn surface_capabilities(
         &self,
         adapter: &crate::vulkan::Adapter,
@@ -336,6 +338,14 @@ pub(crate) struct NativeSwapchain {
     next_present_time: Option<vk::PresentTimeGOOGLE>,
 }
 
+impl Drop for NativeSwapchain {
+    fn drop(&mut self) {
+        unsafe {
+            self.functor.destroy_swapchain(self.raw, None);
+        }
+    }
+}
+
 impl Swapchain for NativeSwapchain {
     unsafe fn release_resources(&mut self, device: &crate::vulkan::Device) {
         profiling::scope!("Swapchain::release_resources");
@@ -372,10 +382,6 @@ impl Swapchain for NativeSwapchain {
 
             unsafe { mutex_removed.destroy(&device.shared.raw) };
         }
-    }
-
-    unsafe fn delete_swapchain(self: Box<Self>) {
-        unsafe { self.functor.destroy_swapchain(self.raw, None) };
     }
 
     unsafe fn acquire(


### PR DESCRIPTION
**Connections**
Closes #8431 

**Description**

**Problem**: The Vulkan backend in `wgpu-hal` previously relied on manual memory management for surfaces and swapchains via explicit `delete_surface` and `delete_swapchain` trait methods. This required wrapping the surface trait object in `ManuallyDrop` and manually writing the destruction order, which can be error prone with use-after-free or memory leak hazards.

**Solution**: This PR refactors the initialization and destruction semantics of the Vulkan backend to use Rust `Drop` implementations:
- Implemented `Drop` on `NativeSwapchain` and `NativeSurface` to handle `vkDestroySwapchainKHR` and `vkDestroySurfaceKHR` respectively.
- Removed the `delete_surface` and `delete_swapchain` methods from the traits.
- Removed the `ManuallyDrop` wrapper from the `Surface` wrapper struct in `hal/src/vulkan/mod.rs`.
- Reordered the fields in the `Surface` wrapper struct (moving `swapchain` above `inner`) to strictly adhere to Vulkan's lifetime invariants via Rust's struct Drop ordering. This guarantees the Swapchain is destroyed before the Surface.
- Kept the explicit `release_resources` call within `unconfigure` to safely await device idleness before dropping the Swapchain.

**Testing**
- Standard tests such as `cargo xtask test` and `cargo clippy --tests`.
- End-to-end rendering and correct drop behavior validated locally using `cargo run --example ray-traced-triangle`.

**Squash or Rebase?**
Squash

**Checklist**
- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.