### PR TITLE
[Vulkan] Add `drop_guard` to `Buffer` for externally owned buffers

### DIFF
--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -350,9 +350,13 @@ pub struct DropGuard {
 #[cfg(all(any(gles, vulkan), any(native, Emscripten)))]
 impl DropGuard {
     fn from_option(callback: Option<DropCallback>) -> Option<Self> {
-        callback.map(|callback| Self {
+        callback.map(Self::new)
+    }
+
+    fn new(callback: DropCallback) -> Self {
+        Self {
             callback: Some(callback),
-        })
+        }
     }
 }
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1129,11 +1129,14 @@ impl crate::Device for super::Device {
 
         Ok(super::Buffer {
             raw,
+            drop_guard: None,
             allocation: Some(Mutex::new(super::BufferMemoryBacking::Managed(allocation))),
         })
     }
     unsafe fn destroy_buffer(&self, buffer: super::Buffer) {
-        unsafe { self.shared.raw.destroy_buffer(buffer.raw, None) };
+        if buffer.drop_guard.is_none() {
+            unsafe { self.shared.raw.destroy_buffer(buffer.raw, None) };
+        }
         if let Some(allocation) = buffer.allocation {
             let allocation = allocation.into_inner();
             self.counters.buffer_memory.sub(allocation.size() as isize);

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -235,7 +235,7 @@ impl super::DeviceShared {
         buffer: &'a super::Buffer,
         ranges: I,
     ) -> Option<impl 'a + Iterator<Item = vk::MappedMemoryRange<'a>>> {
-        let super::BufferOwnership::Managed(allocation) = buffer.ownership.as_ref() else {
+        let super::BufferOwnership::Managed(ref allocation) = buffer.ownership else {
             return None;
         };
         let allocation = allocation.lock();

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -235,7 +235,10 @@ impl super::DeviceShared {
         buffer: &'a super::Buffer,
         ranges: I,
     ) -> Option<impl 'a + Iterator<Item = vk::MappedMemoryRange<'a>>> {
-        let allocation = buffer.allocation.as_ref()?.lock();
+        let super::BufferOwnership::Managed(allocation) = buffer.ownership.as_ref() else {
+            return None;
+        };
+        let allocation = allocation.lock();
         let mask = self.private_caps.non_coherent_map_mask;
         Some(ranges.map(move |range| {
             vk::MappedMemoryRange::default()
@@ -1129,27 +1132,35 @@ impl crate::Device for super::Device {
 
         Ok(super::Buffer {
             raw,
-            drop_guard: None,
-            allocation: Some(Mutex::new(super::BufferMemoryBacking::Managed(allocation))),
+            ownership: super::BufferOwnership::Managed(Mutex::new(
+                super::BufferMemoryBacking::Managed(allocation),
+            )),
         })
     }
     unsafe fn destroy_buffer(&self, buffer: super::Buffer) {
-        if buffer.drop_guard.is_none() {
-            unsafe { self.shared.raw.destroy_buffer(buffer.raw, None) };
-        }
-        if let Some(allocation) = buffer.allocation {
-            let allocation = allocation.into_inner();
-            self.counters.buffer_memory.sub(allocation.size() as isize);
-            match allocation {
-                super::BufferMemoryBacking::Managed(allocation) => {
-                    let result = self.mem_allocator.lock().free(allocation);
-                    if let Err(err) = result {
-                        log::warn!("Failed to free buffer allocation: {err}");
+        match buffer.ownership {
+            super::BufferOwnership::Managed(allocation) => {
+                unsafe { self.shared.raw.destroy_buffer(buffer.raw, None) };
+                let allocation = allocation.into_inner();
+                self.counters.buffer_memory.sub(allocation.size() as isize);
+                match allocation {
+                    super::BufferMemoryBacking::Managed(allocation) => {
+                        let result = self.mem_allocator.lock().free(allocation);
+                        if let Err(err) = result {
+                            log::warn!("Failed to free buffer allocation: {err}");
+                        }
                     }
+                    super::BufferMemoryBacking::VulkanMemory { memory, .. } => unsafe {
+                        self.shared.raw.free_memory(memory, None);
+                    },
                 }
-                super::BufferMemoryBacking::VulkanMemory { memory, .. } => unsafe {
-                    self.shared.raw.free_memory(memory, None);
-                },
+            }
+            super::BufferOwnership::RawHandle => {
+                unsafe { self.shared.raw.destroy_buffer(buffer.raw, None) };
+            }
+            super::BufferOwnership::External(_drop_guard) => {
+                // The caller owns the `vk::Buffer` and its memory. Dropping
+                // `_drop_guard` at the end of this arm runs the cleanup callback.
             }
         }
 
@@ -1165,35 +1176,36 @@ impl crate::Device for super::Device {
         buffer: &super::Buffer,
         range: crate::MemoryRange,
     ) -> Result<crate::BufferMapping, crate::DeviceError> {
-        if let Some(ref allocation) = buffer.allocation {
-            let mut allocation = allocation.lock();
-            if let super::BufferMemoryBacking::Managed(ref mut allocation) = *allocation {
-                let is_coherent = allocation
-                    .memory_properties()
-                    .contains(vk::MemoryPropertyFlags::HOST_COHERENT);
-                Ok(crate::BufferMapping {
-                    ptr: unsafe {
-                        allocation
-                            .mapped_ptr()
-                            .unwrap()
-                            .cast()
-                            .offset(range.start as isize)
-                    },
-                    is_coherent,
-                })
-            } else {
-                crate::hal_usage_error("tried to map externally created buffer")
-            }
-        } else {
+        let super::BufferOwnership::Managed(ref allocation) = buffer.ownership else {
             crate::hal_usage_error("tried to map external buffer")
-        }
+        };
+        let mut allocation = allocation.lock();
+        let super::BufferMemoryBacking::Managed(ref mut allocation) = *allocation else {
+            crate::hal_usage_error("tried to map externally created buffer")
+        };
+        let is_coherent = allocation
+            .memory_properties()
+            .contains(vk::MemoryPropertyFlags::HOST_COHERENT);
+        Ok(crate::BufferMapping {
+            ptr: unsafe {
+                allocation
+                    .mapped_ptr()
+                    .unwrap()
+                    .cast()
+                    .offset(range.start as isize)
+            },
+            is_coherent,
+        })
     }
 
     unsafe fn unmap_buffer(&self, buffer: &super::Buffer) {
-        if buffer.allocation.is_some() {
-            // gpu-allocator maps the buffer when allocated and unmap it when free'd
-        } else {
-            crate::hal_usage_error("tried to unmap external buffer")
+        match buffer.ownership {
+            super::BufferOwnership::Managed(_) => {
+                // gpu-allocator maps the buffer when allocated and unmaps it when free'd
+            }
+            super::BufferOwnership::RawHandle | super::BufferOwnership::External(_) => {
+                crate::hal_usage_error("tried to unmap external buffer")
+            }
         }
     }
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -666,6 +666,10 @@ impl BufferMemoryBacking {
 pub struct Buffer {
     raw: vk::Buffer,
     allocation: Option<Mutex<BufferMemoryBacking>>,
+
+    // The `drop_guard` field must be the last field of this struct so it is dropped last.
+    // Do not add new fields after it.
+    drop_guard: Option<crate::DropGuard>,
 }
 impl Buffer {
     /// # Safety
@@ -675,9 +679,27 @@ impl Buffer {
     pub unsafe fn from_raw(vk_buffer: vk::Buffer) -> Self {
         Self {
             raw: vk_buffer,
+            drop_guard: None,
             allocation: None,
         }
     }
+
+    /// # Safety
+    /// - `vk_buffer` must outlive the returned `Buffer`.
+    /// - wgpu-hal will NOT call `vkDestroyBuffer`; the caller remains responsible for the buffer handle's destruction.
+    ///   The `drop_callback` runs when the `Buffer` drops and may be used to release caller-side bookkeeping.
+    /// - Externally imported buffers can't be mapped by `wgpu`.
+    pub unsafe fn from_raw_externally_owned(
+        vk_buffer: vk::Buffer,
+        drop_callback: crate::DropCallback,
+    ) -> Self {
+        Self {
+            raw: vk_buffer,
+            drop_guard: crate::DropGuard::from_option(Some(drop_callback)),
+            allocation: None,
+        }
+    }
+
     /// # Safety
     /// - We will use this buffer and the buffer's backing memory range as if we have exclusive ownership over it, until the wgpu resource is dropped and the wgpu-hal object is cleaned up
     /// - Externally imported buffers can't be mapped by `wgpu`
@@ -690,6 +712,7 @@ impl Buffer {
     ) -> Self {
         Self {
             raw: vk_buffer,
+            drop_guard: None,
             allocation: Some(Mutex::new(BufferMemoryBacking::VulkanMemory {
                 memory,
                 offset,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -662,14 +662,28 @@ impl BufferMemoryBacking {
         }
     }
 }
+/// Describes who owns a [`Buffer`]'s `vk::Buffer` handle and its backing memory,
+/// and therefore what cleanup is required when the buffer is destroyed.
+#[derive(Debug)]
+enum BufferOwnership {
+    /// wgpu-hal owns the `vk::Buffer` and its backing memory. On cleanup the buffer
+    /// handle is destroyed and the memory is released.
+    Managed(Mutex<BufferMemoryBacking>),
+    /// wgpu-hal owns the `vk::Buffer` handle but the backing memory is kept alive
+    /// by the caller. On cleanup only the buffer handle is destroyed.
+    RawHandle,
+    /// Caller owns the `vk::Buffer` and its backing memory. On cleanup the
+    /// [`crate::DropGuard`] runs the caller's cleanup callback and wgpu-hal touches
+    /// neither the handle nor the memory.
+    External(crate::DropGuard),
+}
+
 #[derive(Debug)]
 pub struct Buffer {
     raw: vk::Buffer,
-    allocation: Option<Mutex<BufferMemoryBacking>>,
 
-    // The `drop_guard` field must be the last field of this struct so it is dropped last.
-    // Do not add new fields after it.
-    drop_guard: Option<crate::DropGuard>,
+    // This field must be last, because it may contain a `DropGuard` which needs to be dropped after all other fields.
+    ownership: BufferOwnership,
 }
 impl Buffer {
     /// # Safety
@@ -679,8 +693,7 @@ impl Buffer {
     pub unsafe fn from_raw(vk_buffer: vk::Buffer) -> Self {
         Self {
             raw: vk_buffer,
-            drop_guard: None,
-            allocation: None,
+            ownership: BufferOwnership::RawHandle,
         }
     }
 
@@ -695,8 +708,7 @@ impl Buffer {
     ) -> Self {
         Self {
             raw: vk_buffer,
-            drop_guard: crate::DropGuard::from_option(Some(drop_callback)),
-            allocation: None,
+            ownership: BufferOwnership::External(crate::DropGuard::new(drop_callback)),
         }
     }
 
@@ -712,8 +724,7 @@ impl Buffer {
     ) -> Self {
         Self {
             raw: vk_buffer,
-            drop_guard: None,
-            allocation: Some(Mutex::new(BufferMemoryBacking::VulkanMemory {
+            ownership: BufferOwnership::Managed(Mutex::new(BufferMemoryBacking::VulkanMemory {
                 memory,
                 offset,
                 size,


### PR DESCRIPTION
**Description**
This PR adds a `drop_guard` to `Buffer` on Vulkan in `wgpu-hal`, similar to what `Texture` already has. This is useful for importing externally owned `vk::Buffer`s to wgpu.

Before this PR, `wgpu-hal` would unconditionally destroy every `vk:Buffer` on drop. 

**Squash or Rebase?**
Squash

**Testing**
_Explain how this change is tested._

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
