### PR TITLE
[Vulkan] Add external semaphore to device extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ By @andyleiserson in [#9321](https://github.com/gfx-rs/wgpu/pull/9321).
 #### Vulkan
 
 - Add `vulkan::Device::texture_from_dmabuf_fd()` for importing DMA-buf textures on Linux, with `VULKAN_EXTERNAL_MEMORY_FD` and `VULKAN_EXTERNAL_MEMORY_DMA_BUF` feature flags. By @TODO in [#TODO](https://github.com/gfx-rs/wgpu/pull/TODO).
+- Enable `VK_KHR_external_semaphore_win32` / `VK_KHR_external_semaphore_fd` on the Vulkan device when supported, and expose them through the new `VULKAN_EXTERNAL_SEMAPHORE_WIN32` / `VULKAN_EXTERNAL_SEMAPHORE_FD` feature flags. This enables importing/exporting `VkSemaphore` handles for cross-API synchronisation. By @AdrianEddy in [#9453](https://github.com/gfx-rs/wgpu/pull/9453).
 - Add support for RawWindowHandle::Drm on unix, conditional on the `"drm"` feature.
   - DRM support by @rectalogic in [#9182](https://github.com/gfx-rs/wgpu/pull/9182).
   - Conditional compilation by @jimblandy in [#9390](https://github.com/gfx-rs/wgpu/pull/9390)

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1031,6 +1031,14 @@ impl PhysicalDeviceFeatures {
                 && caps.supports_extension(ext::image_drm_format_modifier::NAME),
         );
         features.set(
+            F::VULKAN_EXTERNAL_SEMAPHORE_WIN32,
+            caps.supports_extension(khr::external_semaphore_win32::NAME),
+        );
+        features.set(
+            F::VULKAN_EXTERNAL_SEMAPHORE_FD,
+            caps.supports_extension(khr::external_semaphore_fd::NAME),
+        );
+        features.set(
             F::EXPERIMENTAL_MESH_SHADER,
             caps.supports_extension(ext::mesh_shader::NAME),
         );
@@ -1304,6 +1312,16 @@ impl PhysicalDeviceProperties {
         // Optional `VK_EXT_image_drm_format_modifier`
         if self.supports_extension(ext::image_drm_format_modifier::NAME) {
             extensions.push(ext::image_drm_format_modifier::NAME);
+        }
+
+        // Optional `VK_KHR_external_semaphore_win32`
+        if self.supports_extension(khr::external_semaphore_win32::NAME) {
+            extensions.push(khr::external_semaphore_win32::NAME);
+        }
+
+        // Optional `VK_KHR_external_semaphore_fd`
+        if self.supports_extension(khr::external_semaphore_fd::NAME) {
+            extensions.push(khr::external_semaphore_fd::NAME);
         }
 
         // Optional `VK_EXT_memory_budget`

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -1232,6 +1232,39 @@ bitflags_array! {
         #[name("wgpu-vulkan-external-memory-dma-buf")]
         const VULKAN_EXTERNAL_MEMORY_DMA_BUF = 1 << 63;
 
+        /// Allows using the [VK_KHR_external_semaphore_win32] Vulkan extension.
+        ///
+        /// Enables importing/exporting Vulkan semaphores as NT / KMT Win32
+        /// handles, so the caller can synchronise with other APIs.
+        /// Typically combined with `VULKAN_EXTERNAL_MEMORY_WIN32` for
+        /// zero-copy shared-texture interop.
+        ///
+        /// Supported platforms:
+        /// - Vulkan (with [VK_KHR_external_semaphore_win32])
+        ///
+        /// This is a native only feature.
+        ///
+        /// [VK_KHR_external_semaphore_win32]: https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_external_semaphore_win32.html
+        #[name("wgpu-vulkan-external-semaphore-win32")]
+        const VULKAN_EXTERNAL_SEMAPHORE_WIN32 = 1 << 24;
+
+        /// Allows using the [VK_KHR_external_semaphore_fd] Vulkan extension.
+        ///
+        /// Enables importing/exporting Vulkan semaphores as POSIX file
+        /// descriptors (opaque-fd or sync-fd), so the caller can synchronise
+        /// with other APIs. Typically combined with `VULKAN_EXTERNAL_MEMORY_FD`
+        /// / `VULKAN_EXTERNAL_MEMORY_DMA_BUF` for zero-copy shared-texture
+        /// interop.
+        ///
+        /// Supported platforms:
+        /// - Vulkan (with [VK_KHR_external_semaphore_fd])
+        ///
+        /// This is a native only feature.
+        ///
+        /// [VK_KHR_external_semaphore_fd]: https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_external_semaphore_fd.html
+        #[name("wgpu-vulkan-external-semaphore-fd")]
+        const VULKAN_EXTERNAL_SEMAPHORE_FD = 1 << 25;
+
         /// Enables R64Uint image atomic min and max.
         ///
         /// Supported platforms:


### PR DESCRIPTION
**Description**
This PR enables `VK_KHR_external_semaphore_win32` / `VK_KHR_external_semaphore_fd` on the Vulkan device when supported, in order to allow importing/exporting `VkSemaphore` handles for cross-API synchronisation.
It's useful in combination with the `vulkan-external-memory` extensions wgpu already enables.

**Testing**
_Explain how this change is tested._

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
