### PR TITLE
xtask(changelog): hint at fix for released-section hunks

### DIFF
--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -65,6 +65,13 @@ pub(crate) fn check_changelog(shell: Shell, mut args: Arguments) -> anyhow::Resu
         for hunk in &hunks_in_a_released_section {
             eprintln!("{hunk}");
         }
+
+        eprintln!();
+        eprintln!(
+            "hint: a release likely happened after this change was first added to `## Unreleased`. \
+             Move the affected entries back up under `## Unreleased` in `{CHANGELOG_PATH_RELATIVE}` \
+             and try again."
+        );
     }
 
     if failed {


### PR DESCRIPTION
Closes #9318.

When the changelog check fails because a hunk has landed inside a released section, the current error just lists the offending hunk and bails. The fix is usually the same one @ErichDonGubler spelled out in the issue: a release happened after the PR was opened, and the entry needs to be moved back under `## Unreleased`.

This adds that hint after the hunk list so a contributor hitting the CI failure can see the likely cause and fix without having to cross-reference the repo's release history.

Example output (after the hunks are printed):

```
hint: a release likely happened after this change was first added to `## Unreleased`. Move the affected entries back up under `## Unreleased` in `./CHANGELOG.md` and try again.
```

Verified with `cargo build -p wgpu-xtask`, `cargo clippy -p wgpu-xtask`, and `cargo fmt -p wgpu-xtask --check`.