### PR TITLE
[Vulkan/hal] Add `Queue::add_wait_semaphore` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ By @andyleiserson in [#9321](https://github.com/gfx-rs/wgpu/pull/9321).
 
 #### Vulkan
 
+- Add `vulkan::Queue::add_wait_semaphore` and `vulkan::Queue::remove_wait_semaphore`. Lets external producers (CUDA / OpenCL / D3D12 imported via `VK_KHR_external_semaphore_*`) be waited on at the next `Queue::submit` call without a CPU block. By @AdrianEddy in [#9461](https://github.com/gfx-rs/wgpu/pull/9461).
 - Add `vulkan::Device::texture_from_dmabuf_fd()` for importing DMA-buf textures on Linux, with `VULKAN_EXTERNAL_MEMORY_FD` and `VULKAN_EXTERNAL_MEMORY_DMA_BUF` feature flags. By @TODO in [#9412](https://github.com/gfx-rs/wgpu/pull/9412).
 - Add support for RawWindowHandle::Drm on unix, conditional on the `"drm"` feature.
   - DRM support by @rectalogic in [#9182](https://github.com/gfx-rs/wgpu/pull/9182).

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -2817,6 +2817,7 @@ impl super::Adapter {
             family_index,
             relay_semaphores: Mutex::new(relay_semaphores),
             signal_semaphores: Mutex::new(SemaphoreList::new(SemaphoreListMode::Signal)),
+            wait_semaphores: Mutex::new(SemaphoreList::new(SemaphoreListMode::Wait)),
         };
 
         let allocation_sizes = AllocationSizes::from_memory_hints(memory_hints).into();

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -620,6 +620,7 @@ pub struct Queue {
     family_index: u32,
     relay_semaphores: Mutex<RelaySemaphores>,
     signal_semaphores: Mutex<SemaphoreList>,
+    wait_semaphores: Mutex<SemaphoreList>,
 }
 
 impl Queue {
@@ -1291,6 +1292,11 @@ impl crate::Queue for Queue {
             signal_semaphores.append(&mut guard);
         }
 
+        let mut wait_guard = self.wait_semaphores.lock();
+        if !wait_guard.is_empty() {
+            wait_semaphores.append(&mut wait_guard);
+        }
+
         // In order for submissions to be strictly ordered, we encode a dependency between each submission
         // using a pair of semaphores. This adds a wait if it is needed, and signals the next semaphore.
         let semaphore_state = self.relay_semaphores.lock().advance(&self.device)?;
@@ -1392,6 +1398,39 @@ impl Queue {
     /// already consumed it, this is a harmless no-op that returns `false`.
     pub fn remove_signal_semaphore(&self, semaphore: vk::Semaphore) -> bool {
         self.signal_semaphores.lock().remove(semaphore)
+    }
+
+    /// Stage a semaphore wait on the next [`crate::Queue::submit`] call.
+    ///
+    /// `semaphore_value` selects the kind of payload the wait targets:
+    ///
+    /// - `Some(value)` - wait until `semaphore` (a timeline semaphore) has been signalled to at least `value`.
+    /// - `None` - wait on a binary semaphore signal.
+    ///
+    /// `stage` is the pipeline stage at which the wait blocks downstream
+    /// work (e.g. `vk::PipelineStageFlags::TOP_OF_PIPE` to gate the
+    /// entire submission, or a more specific stage when only that stage
+    /// reads the synchronised resource).
+    pub fn add_wait_semaphore(
+        &self,
+        semaphore: vk::Semaphore,
+        semaphore_value: Option<u64>,
+        stage: vk::PipelineStageFlags,
+    ) {
+        let mut guard = self.wait_semaphores.lock();
+        if let Some(value) = semaphore_value {
+            guard.push_wait(SemaphoreType::Timeline(semaphore, value), stage);
+        } else {
+            guard.push_wait(SemaphoreType::Binary(semaphore), stage);
+        }
+    }
+
+    /// Remove `semaphore` from the pending wait list if it is still present.
+    ///
+    /// Returns `true` if the semaphore was found and removed. If the submit
+    /// already consumed it, this is a no-op that returns `false`.
+    pub fn remove_wait_semaphore(&self, semaphore: vk::Semaphore) -> bool {
+        self.wait_semaphores.lock().remove(semaphore)
     }
 }
 


### PR DESCRIPTION
**Description**
This PR adds a `add_wait_semaphore` function to `wgpu_hal::vulkan::Queue` which allows user to add semaphores to wait on on the next `Queue::submit()` call. This enables coordination with externally imported resources without resorting to the CPU wait.

It mirrors the existing `add_signal_semaphore` functions.

**Testing**

**Squash or Rebase?**

Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
