### PR TITLE
fix: provide default display handle for web canvas surface targets

### DIFF
--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -221,12 +221,13 @@ impl Instance {
                 let value: &wasm_bindgen::JsValue = &canvas;
                 let obj = core::ptr::NonNull::from(value).cast();
                 let raw_window_handle = raw_window_handle::WebCanvasWindowHandle::new(obj).into();
+                let raw_display_handle = raw_window_handle::WebDisplayHandle::new().into();
 
                 // Note that we need to call this while we still have `value` around.
                 // This is safe without storing canvas to `handle_origin` since the surface will create a copy internally.
                 unsafe {
                     self.create_surface_unsafe(SurfaceTargetUnsafe::RawHandle {
-                        raw_display_handle: None,
+                        raw_display_handle: Some(raw_display_handle),
                         raw_window_handle,
                     })
                 }?
@@ -239,12 +240,13 @@ impl Instance {
                 let obj = core::ptr::NonNull::from(value).cast();
                 let raw_window_handle =
                     raw_window_handle::WebOffscreenCanvasWindowHandle::new(obj).into();
+                let raw_display_handle = raw_window_handle::WebDisplayHandle::new().into();
 
                 // Note that we need to call this while we still have `value` around.
                 // This is safe without storing canvas to `handle_origin` since the surface will create a copy internally.
                 unsafe {
                     self.create_surface_unsafe(SurfaceTargetUnsafe::RawHandle {
-                        raw_display_handle: None,
+                        raw_display_handle: Some(raw_display_handle),
                         raw_window_handle,
                     })
                 }?


### PR DESCRIPTION
**Description**
Since `wgpu` version 29, creating a surface from a web canvas using `Instance::create_surface` with `SurfaceTarget::Canvas` or `SurfaceTarget::OffscreenCanvas` fails with `CreateSurfaceError::MismatchingDisplayHandle`.

This occurs because both `SurfaceTarget::Canvas` and `SurfaceTarget::OffscreenCanvas` set `raw_display_handle: None`. However, in `wgpu_core::instance::Instance::create_surface`, there is a requirement that either `instance_display_handle` or `display_handle` must be present. Since `raw_display_handle` is always `None`, it always matches the `(None, None) => return Err(CreateSurfaceError::MissingDisplayHandle)` arm.

Note: this change does not affect the examples (`examples/features`) because it utilizes `winit` which provides a valid `RawDisplayHandle` when creating windows (including web canvases) and which never hits the `(None, None)` case.

**Testing**
Tested in browser using:
```rust
 let surface = instance
        .create_surface(SurfaceTarget::Canvas(canvas.clone()))
        .unwrap();
```

**Squash or Rebase?**
Squash
