### PR TITLE
test: Check for device loss

### DIFF
--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -201,6 +201,23 @@ impl FailureCase {
         self
     }
 
+    /// Matches this failure case against an unexpected driver error.
+    ///
+    /// Depending on build configuration, the error may surface as either a
+    /// panic raised by the `internal_error_panic` feature (with the supplied
+    /// message as a substring), or as a device-loss. Either behavior is
+    /// accepted. In the device loss case, the original message has been
+    /// discarded, and there is some risk this accepts a different error than
+    /// intended (but it must be a device loss due to an unexpected driver
+    /// error, which should be rare).
+    pub fn unexpected_error(mut self, msg: &'static str) -> Self {
+        self.reasons.push(FailureReason::panic().with_message(msg));
+        self.reasons.push(FailureReason::panic().with_message(
+            "Device lost: Unexpected error variant (driver implementation is at fault)",
+        ));
+        self
+    }
+
     /// Test is flaky with the given configuration. Do not assert failure.
     ///
     /// Use this _very_ sparyingly, and match as tightly as you can, including giving a specific failure message.

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -2,6 +2,18 @@ use wgpu::{Adapter, Backends, Device, Features, Instance, Limits, Queue};
 
 use crate::{report::AdapterReport, TestParameters};
 
+/// Default device-lost callback installed by [`initialize_device`]. Panics on
+/// any non-[`wgpu::DeviceLostReason::Destroyed`] device loss, which will
+/// cause the test to be treated as a failure.
+///
+/// Tests intentionally provoking device loss should install their own callback
+/// with [`wgpu::Device::set_device_lost_callback`].
+fn default_device_lost_callback(reason: wgpu::DeviceLostReason, message: String) {
+    if reason != wgpu::DeviceLostReason::Destroyed {
+        panic!("Device lost: {message}");
+    }
+}
+
 /// Initialize the logger for the test runner.
 pub fn init_logger() {
     // We don't actually care if it fails
@@ -182,10 +194,14 @@ pub async fn initialize_device(
         })
         .await;
 
-    match bundle {
-        Ok(b) => b,
+    let (device, queue) = match bundle {
+        Ok((device, queue)) => (device, queue),
         Err(e) => panic!("Failed to initialize device: {e}"),
-    }
+    };
+
+    device.set_device_lost_callback(default_device_lost_callback);
+
+    (device, queue)
 }
 
 /// Create a canvas for testing.

--- a/tests/tests/wgpu-gpu/clip_distances.rs
+++ b/tests/tests/wgpu-gpu/clip_distances.rs
@@ -16,7 +16,7 @@ static CLIP_DISTANCES: GpuTestConfiguration = GpuTestConfiguration::new()
                 wgpu_test::FailureCase::molten_vk()
                     .validation_error("Shader library compile failed")
                     .validation_error("could not be compiled into pipeline")
-                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+                    .unexpected_error("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
             ),
     )
     .run_async(clip_distances);

--- a/tests/tests/wgpu-gpu/draw_index.rs
+++ b/tests/tests/wgpu-gpu/draw_index.rs
@@ -74,7 +74,7 @@ static DRAW_INDEX: GpuTestConfiguration = GpuTestConfiguration::new()
                 wgpu_test::FailureCase::molten_vk()
                     .validation_error("could not be compiled into pipeline")
                     .validation_error("vkDestroyDevice")
-                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+                    .unexpected_error("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
             ),
     )
     .run_async(test);

--- a/tests/tests/wgpu-gpu/oob_indexing.rs
+++ b/tests/tests/wgpu-gpu/oob_indexing.rs
@@ -23,7 +23,7 @@ static RESTRICT_WORKGROUP_PRIVATE_FUNCTION_LET: GpuTestConfiguration = GpuTestCo
                 FailureCase::molten_vk()
                     .validation_error("Shader library compile failed")
                     .validation_error("could not be compiled into pipeline")
-                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+                    .unexpected_error("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
             ),
     )
     .run_async(|ctx| async move {

--- a/tests/tests/wgpu-gpu/per_vertex/mod.rs
+++ b/tests/tests/wgpu-gpu/per_vertex/mod.rs
@@ -40,7 +40,7 @@ static PER_VERTEX: GpuTestConfiguration = GpuTestConfiguration::new()
             .expect_fail(
                 wgpu_test::FailureCase::molten_vk()
                     .validation_error("could not be compiled into pipeline")
-                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+                    .unexpected_error("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
             ),
     )
     .run_async(per_vertex);

--- a/tests/tests/wgpu-gpu/shader/array_size_overrides.rs
+++ b/tests/tests/wgpu-gpu/shader/array_size_overrides.rs
@@ -60,7 +60,7 @@ static ARRAY_SIZE_OVERRIDES: GpuTestConfiguration = GpuTestConfiguration::new()
                 wgpu_test::FailureCase::molten_vk()
                     .validation_error("Shader library compile failed")
                     .validation_error("could not be compiled into pipeline")
-                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+                    .unexpected_error("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
             ),
     )
     .run_async(move |ctx| async move {

--- a/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
@@ -25,7 +25,7 @@ static ZERO_INIT_WORKGROUP_MEMORY: GpuTestConfiguration = GpuTestConfiguration::
                 wgpu_test::FailureCase::molten_vk()
                     .validation_error("Shader library compile failed")
                     .validation_error("could not be compiled into pipeline")
-                    .panic("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
+                    .unexpected_error("Unexpected Vulkan error: ERROR_INITIALIZATION_FAILED"),
             ),
     )
     .run_async(|ctx| async move {


### PR DESCRIPTION
This does two things:

1. Installs a panicking device loss handler when running GPU tests.
2. Allows expect-failure cases looking for an "unexpected" driver error to match even when `internal_error_panic` is off.

Normally, `cargo xtask test` runs with `--all-features`, enabling `internal_error_panic`, which always panics immediately on an unexpected driver error. To avoid confusion if running tests without that feature, also match such errors when the feature is disabled and they manifest as device loss.

Tests should fail anyways if the device is lost, because polling the device will return an error. But in expect-fail cases where the  harness is looking for a particular failure behavior, not panicking immediately means the test may throw other errors that do not directly reflect the cause of the device loss. Panicking on device loss seems like a reasonable default behavior, even if in most cases it doesn't matter. Tests can set their own callback if they want different behavior.

**Testing**
Tested locally with expect-fail MoltenVK tests.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
