### PR TITLE
Fix violations and enable wgpu_validate_locks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,7 @@
 [alias]
 xtask = "run -p wgpu-xtask --"
+
+[build]
+# Note that any rustflags set here will be overridden by the `RUSTFLAGS`
+# environment variable, if set (e.g. in CI).
+rustflags = ["--cfg", "wgpu_validate_locks_debug"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ env:
   RUST_LOG: debug,wasm_bindgen_wasm_interpreter=warn,wasm_bindgen_cli_support=warn,walrus=warn,naga=info
   RUST_BACKTRACE: full
   PKG_CONFIG_ALLOW_CROSS: 1 # allow android to work
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: -D warnings --cfg wgpu_validate_locks_debug
   RUSTDOCFLAGS: -D warnings
   WASM_BINDGEN_TEST_TIMEOUT: 300 # 5 minutes
   CACHE_SUFFIX: e # cache busting

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -19,7 +19,7 @@ env:
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: -D warnings --cfg wgpu_validate_locks_debug
   RUSTDOCFLAGS: -D warnings
 
   #

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -2919,7 +2919,6 @@ async fn check_mark_externally_initialized_case<A: hal::Api>(ctx: &TestingContex
     // by wgpu-core.
     unsafe {
         let hal_device = ctx.device.as_hal::<A>().expect("adapter backend mismatch");
-        let hal_texture = texture.as_hal::<A>().expect("adapter backend mismatch");
 
         let staging_buffer = hal_device
             .create_buffer(&hal::BufferDescriptor {
@@ -2940,6 +2939,7 @@ async fn check_mark_externally_initialized_case<A: hal::Api>(ctx: &TestingContex
             hal_device.unmap_buffer(&staging_buffer);
         }
 
+        let hal_texture = texture.as_hal::<A>().expect("adapter backend mismatch");
         let mut encoder = ctx
             .device
             .create_command_encoder(&CommandEncoderDescriptor { label: None });

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -30,7 +30,10 @@ ignored = ["cfg_aliases"]
 
 [lints.rust]
 missing_debug_implementations = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wgpu_validate_locks)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(wgpu_validate_locks)',
+    'cfg(wgpu_validate_locks_debug)',
+] }
 
 [lib]
 

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -25,5 +25,15 @@ fn main() {
             any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")
         ) },
         metal: { all(target_vendor = "apple", feature = "metal") },
+
+        // `wgpu_validate_locks` can also be set directly, if desired.
+        // See `wgpu-core/src/lock/mod.rs`.
+        wgpu_validate_locks: {
+            all(
+                debug_assertions,
+                wgpu_validate_locks_debug,
+                not(target_family = "wasm")
+            )
+        }
     }
 }

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -557,45 +557,28 @@ impl CommandBufferMutable {
 
     pub(crate) fn set_acceleration_structure_dependencies(&self, snatch_guard: &SnatchGuard) {
         profiling::scope!("CommandEncoder::[submission]::set_acceleration_structure_dependencies");
-        let tlas_dependencies_locks: Vec<_> = self
-            .as_actions
-            .iter()
-            .filter_map(|action| {
-                if let AsAction::UseTlas(tlas) = action {
-                    Some(tlas.dependencies.read())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        let mut tlas_dependencies_lock_iter = tlas_dependencies_locks.iter();
         let mut dependencies = Vec::new();
         for action in &self.as_actions {
             match action {
                 AsAction::Build(build) => {
-                    for tlas_build in build.tlas_s_built.iter() {
-                        for dependency in &tlas_build.dependencies {
-                            if let Some(dependency) = dependency.raw(snatch_guard) {
-                                dependencies.push(dependency);
-                            }
-                        }
-                    }
+                    dependencies.extend(build.blas_s_built.iter().map(Arc::clone));
                 }
-                AsAction::UseTlas(_tlas) => {
-                    let tlas_dependencies = tlas_dependencies_lock_iter.next().unwrap(); // _tlas.dependencies.read();
-                    for dependency in tlas_dependencies.iter() {
-                        if let Some(dependency) = dependency.raw(snatch_guard) {
-                            dependencies.push(dependency);
-                        }
-                    }
+                AsAction::UseTlas(tlas) => {
+                    dependencies.extend(tlas.dependencies.read().iter().map(Arc::clone));
                 }
             }
         }
+
+        let raw_dependencies = dependencies
+            .iter()
+            .flat_map(|blas| blas.raw(snatch_guard))
+            .collect::<Vec<_>>();
+
         if !dependencies.is_empty() {
             unsafe {
                 self.encoder
                     .raw
-                    .set_acceleration_structure_dependencies(&self.encoder.list, &dependencies);
+                    .set_acceleration_structure_dependencies(&self.encoder.list, &raw_dependencies);
             }
         }
     }

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -425,7 +425,7 @@ impl LifetimeTracker {
             Vec::with_capacity(self.ready_to_compact.len());
 
         for blas in self.ready_to_compact.drain(..) {
-            match blas.read_back_compact_size() {
+            match blas.read_back_compact_size(blas.compacted_state.lock()) {
                 Some(cb) => pending_callbacks.push(cb),
                 None => continue,
             }

--- a/wgpu-core/src/lock/mod.rs
+++ b/wgpu-core/src/lock/mod.rs
@@ -17,10 +17,14 @@
 //!   uninstrumented, no-overhead wrappers around the standard lock
 //!   types.
 //!
-//! If the `wgpu_validate_locks` config is set (for example, with
-//! `RUSTFLAGS='--cfg wgpu_validate_locks'`), `wgpu-core` uses the
-//! [`ranked`] module's locks. We hope to make this the default for
-//! debug builds soon.
+//! If the `wgpu_validate_locks` config is set (either directly, i.e. with
+//! `RUSTFLAGS='--cfg wgpu_validate_locks'`, or via the
+//! `wgpu_validate_locks_debug` `cfg` alias in `build.rs` that conditionally
+//! enables it when debug assertions are also enabled), `wgpu-core` uses the
+//! [`ranked`] module's locks. `.config/cargo.toml` in the `wgpu` tree specifies
+//! `wgpu_validate_locks_debug`, so lock validation is active by default in
+//! `wgpu` CI and `wgpu` development trees, but not in `wgpu`-using applications
+//! unless specifically requested.
 //!
 //! If the `observe_locks` feature is enabled, `wgpu-core` uses the
 //! [`observing`] module's locks.
@@ -38,6 +42,7 @@ pub mod rank;
 mod ranked;
 
 #[cfg(feature = "observe_locks")]
+#[cfg_attr(wgpu_validate_locks, allow(dead_code))]
 mod observing;
 
 #[cfg_attr(any(wgpu_validate_locks, feature = "observe_locks"), allow(dead_code))]
@@ -46,7 +51,7 @@ mod vanilla;
 #[cfg(wgpu_validate_locks)]
 use ranked as chosen;
 
-#[cfg(feature = "observe_locks")]
+#[cfg(all(not(wgpu_validate_locks), feature = "observe_locks"))]
 use observing as chosen;
 
 #[cfg(not(any(wgpu_validate_locks, feature = "observe_locks")))]

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -106,43 +106,65 @@ macro_rules! define_lock_ranks {
 
 define_lock_ranks! {
     // Non-leaf ranks, in topological order.
-    rank COMMAND_BUFFER_DATA "CommandBuffer::data" followed by {
+    rank INSTANCE_DEVICES "InstanceDevices" followed by {
         DEVICE_SNATCHABLE_LOCK,
-        BUFFER_MAP_STATE,
-        COMMAND_ALLOCATOR_FREE_ENCODERS,
-        BUFFER_POOL,
+        QUEUE_PENDING_WRITES,
+        DEVICE_TRACKERS,
+        QUEUE_LIFE_TRACKER,
+        BUFFER_BIND_GROUPS,
         DEVICE_TRACE,
-        DEVICE_USAGE_SCOPES,
-        INSTANCE_DEVICES,
-        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
+        TEXTURE_BIND_GROUPS,
+        TEXTURE_CLEAR_MODE,
+        TEXTURE_VIEWS,
+        DEVICE_DEFERRED_DESTROY,
+        DEVICE_LOST_CLOSURE,
     }
     rank DEVICE_SNATCHABLE_LOCK "Device::snatchable_lock" followed by {
         BUFFER_MAP_STATE,
         DEVICE_COMMAND_INDICES,
         QUEUE_PENDING_WRITES,
-        TEXTURE_INITIALIZATION_STATUS,
+        DEVICE_TRACKERS,
         QUEUE_LIFE_TRACKER,
         BLAS_COMPACTION_STATE,
         BUFFER_BIND_GROUPS,
         BUFFER_INITIALIZATION_STATUS,
         BUFFER_POOL,
+        DEVICE_LOST_CLOSURE,
         DEVICE_TRACE,
         DEVICE_USAGE_SCOPES,
-        INSTANCE_DEVICES,
+        QUERY_SET_INITIALIZED_SLOTS,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
         TEXTURE_BIND_GROUPS,
         TEXTURE_CLEAR_MODE,
+        TEXTURE_INITIALIZATION_STATUS,
         TEXTURE_VIEWS,
-        QUERY_SET_INITIALIZED_SLOTS,
-        // Uncomment this to see an interesting cycle.
-        // COMMAND_BUFFER_DATA,
     }
     rank DEVICE_COMMAND_INDICES "Device::command_indices" followed by {
+        COMMAND_BUFFER_DATA,
+        BUFFER_MAP_STATE,
         BUFFER_POOL,
+        DEVICE_TRACKERS,
         QUEUE_PENDING_WRITES,
         QUEUE_LIFE_TRACKER,
+        BLAS_COMPACTION_STATE,
+        BLAS_BUILT_INDEX,
         COMMAND_ALLOCATOR_FREE_ENCODERS,
         DEVICE_DEFERRED_DESTROY,
+        DEVICE_TRACE,
+        QUERY_SET_INITIALIZED_SLOTS,
+        RESOURCE_POOL_INNER,
+        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
+        TEXTURE_CLEAR_MODE,
+        TLAS_BUILT_INDEX,
+        TLAS_DEPENDENCIES,
+    }
+    rank COMMAND_BUFFER_DATA "CommandBuffer::data" followed by {
+        BUFFER_MAP_STATE,
+        COMMAND_ALLOCATOR_FREE_ENCODERS,
+        BLAS_COMPACTION_STATE,
+        BUFFER_POOL,
+        DEVICE_TRACE,
+        DEVICE_USAGE_SCOPES,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
     rank QUEUE_PENDING_WRITES "Queue::pending_writes" followed by {
@@ -153,20 +175,29 @@ define_lock_ranks! {
         TEXTURE_INITIALIZATION_STATUS,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
-    rank TEXTURE_INITIALIZATION_STATUS "Texture::initialization_status" followed by {
-        DEVICE_TRACKERS,
-    }
     rank DEVICE_TRACKERS "Device::trackers" followed by {
+        BUFFER_BIND_GROUPS,
+        BUFFER_INITIALIZATION_STATUS,
+        DEVICE_DEFERRED_DESTROY,
+        TEXTURE_BIND_GROUPS,
         TEXTURE_CLEAR_MODE,
+        TEXTURE_INITIALIZATION_STATUS,
+        TEXTURE_VIEWS,
     }
     rank QUEUE_LIFE_TRACKER "Queue::life_tracker" followed by {
+        BLAS_COMPACTION_STATE,
         BUFFER_MAP_STATE,
+        COMMAND_ALLOCATOR_FREE_ENCODERS,
         BUFFER_INITIALIZATION_STATUS,
         BUFFER_POOL,
-        COMMAND_ALLOCATOR_FREE_ENCODERS,
         DEVICE_DEFERRED_DESTROY,
         DEVICE_TRACE,
+        RESOURCE_POOL_INNER,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
+        TEXTURE_CLEAR_MODE,
+    }
+    rank BLAS_COMPACTION_STATE "Blas::compaction_state" followed by {
+        BLAS_BUILT_INDEX,
     }
     rank BUFFER_MAP_STATE "Buffer::map_state" followed by {
         BUFFER_INITIALIZATION_STATUS,
@@ -176,30 +207,32 @@ define_lock_ranks! {
     rank COMMAND_ALLOCATOR_FREE_ENCODERS "CommandAllocator::free_encoders" followed by {
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
-    rank INSTANCE_DEVICES "InstanceDevices" followed by {
+    rank TLAS_BUILT_INDEX "Tlas::built_index" followed by {
+        TLAS_DEPENDENCIES,
+    }
+    rank TLAS_DEPENDENCIES "Tlas::dependencies" followed by {
+        BLAS_BUILT_INDEX,
     }
 
     // Leaf ranks reachable from the graph above, alphabetical.
-    rank BLAS_COMPACTION_STATE "Blas::compaction_state" followed by { }
+    rank BLAS_BUILT_INDEX "Blas::built_index" followed by { }
     rank BUFFER_BIND_GROUPS "Buffer::bind_groups" followed by { }
     rank BUFFER_INITIALIZATION_STATUS "Buffer::initialization_status" followed by { }
     rank BUFFER_POOL "BufferPool::buffers" followed by { }
     rank DEVICE_DEFERRED_DESTROY "Device::deferred_destroy" followed by { }
+    rank DEVICE_LOST_CLOSURE "Device::device_lost_closure" followed by { }
     rank DEVICE_TRACE "Device::trace" followed by { }
     rank DEVICE_USAGE_SCOPES "Device::usage_scopes" followed by { }
-    rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }
     rank QUERY_SET_INITIALIZED_SLOTS "QuerySet::initialized_slots" followed by { }
+    rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }
+    rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }
     rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { }
     rank TEXTURE_CLEAR_MODE "Texture::clear_mode" followed by { }
+    rank TEXTURE_INITIALIZATION_STATUS "Texture::initialization_status" followed by { }
     rank TEXTURE_VIEWS "Texture::views" followed by { }
 
     // Ranks not connected to the graph, alphabetical.
-    rank BLAS_BUILT_INDEX "Blas::built_index" followed by { }
-    rank DEVICE_LOST_CLOSURE "Device::device_lost_closure" followed by { }
-    rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }
     rank SURFACE_PRESENTATION "Surface::presentation" followed by { }
-    rank TLAS_BUILT_INDEX "Tlas::built_index" followed by { }
-    rank TLAS_DEPENDENCIES "Tlas::dependencies" followed by { }
 
     #[cfg(test)]
     rank PAWN "pawn" followed by { ROOK, BISHOP }

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -121,11 +121,13 @@ define_lock_ranks! {
     }
     rank DEVICE_SNATCHABLE_LOCK "Device::snatchable_lock" followed by {
         BUFFER_MAP_STATE,
+        COMMAND_BUFFER_DATA,
         DEVICE_COMMAND_INDICES,
         QUEUE_PENDING_WRITES,
         DEVICE_TRACKERS,
         QUEUE_LIFE_TRACKER,
         BLAS_COMPACTION_STATE,
+        COMMAND_ALLOCATOR_FREE_ENCODERS,
         BUFFER_BIND_GROUPS,
         BUFFER_INITIALIZATION_STATUS,
         BUFFER_POOL,

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -335,9 +335,13 @@ impl<'a, T> RwLockReadGuard<'a, T> {
     // Equivalent to std::mem::forget, but preserves the information about the lock
     // rank.
     pub fn forget(this: Self) -> RankData {
+        // Skip `Drop` for both the actual lock guard (`this.inner`) and the
+        // rank-checking state guard (`this.saved`)
+        let saved = core::mem::ManuallyDrop::new(this.saved);
         core::mem::forget(this.inner);
 
-        this.saved.0
+        // Return the `RankData` so the caller can pass it to `force_unlock_read`.
+        saved.0
     }
 }
 

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -289,6 +289,7 @@ pub struct RwLockReadGuard<'a, T> {
 /// For details, see [the module documentation][self].
 pub struct RwLockWriteGuard<'a, T> {
     inner: wgpu_sync::RwLockWriteGuard<'a, T>,
+    #[cfg_attr(not(miri), expect(unused))] // but `Drop` has important side effects
     saved: LockStateGuard,
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     hal_label,
     init_tracker::{BufferInitTracker, TextureInitTracker},
-    lock::{rank, Mutex, RwLock},
+    lock::{rank, Mutex, MutexGuard, RwLock},
     ray_tracing::{BlasCompactReadyPendingClosure, BlasPrepareCompactError},
     resource_log,
     snatch::{SnatchGuard, Snatchable},
@@ -3444,10 +3444,11 @@ impl Blas {
         };
 
         let submit_index = if let Some(queue) = device.get_queue() {
+            drop(state);
             queue.lock_life().prepare_compact(self).unwrap_or(0) // '0' means no wait is necessary
         } else {
             // We can safely unwrap below since we just set the `compacted_state` to `BlasCompactState::Waiting`.
-            let (mut callback, status) = self.read_back_compact_size().unwrap();
+            let (mut callback, status) = self.read_back_compact_size(state).unwrap();
             if let Some(callback) = callback.take() {
                 callback(status);
             }
@@ -3459,8 +3460,10 @@ impl Blas {
 
     /// This function returns [`None`] only if [`Self::compacted_state`] is not [`BlasCompactState::Waiting`].
     #[must_use]
-    pub(crate) fn read_back_compact_size(&self) -> Option<BlasCompactReadyPendingClosure> {
-        let mut state = self.compacted_state.lock();
+    pub(crate) fn read_back_compact_size(
+        &self,
+        mut state: MutexGuard<'_, BlasCompactState>,
+    ) -> Option<BlasCompactReadyPendingClosure> {
         let pending_compact = match mem::replace(&mut *state, BlasCompactState::Idle) {
             BlasCompactState::Waiting(pending_mapping) => pending_mapping,
             // Compaction cancelled e.g. by rebuild


### PR DESCRIPTION
This PR has two final fixes for concurrent locks, updates the lock graph based on observed edges in the CI test suite (including CTS), and enables lock rank validation in debug builds via `.cargo/config.toml`. Enabling in `.cargo/config.toml` means that debug builds running in a `wgpu` tree get lock rank validation, but debug builds of `wgpu` in the context of some other project do not. (Note that the setting in `.cargo/config.toml` is overridden by the `RUSTFLAGS` environment variable, if it is set, which is the case in CI.)

**Connections**

Final in a series with #9524 and #9728. Some localized fixes were also merged in separate PRs (#9960, #10118).

Fixes #5695
Fixes #5737
Fixes #6412
Fixes #5572
Fixes #5937 

**Squash or Rebase?** Rebase

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.