### PR TITLE
Add missing `map_label` and ser/de to wgpu-types/texture

### DIFF
--- a/wgpu-types/src/texture.rs
+++ b/wgpu-types/src/texture.rs
@@ -37,6 +37,7 @@ pub enum TextureDimension {
 
 /// Order in which texture data is laid out in memory.
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TextureDataOrder {
     /// The texture is laid out densely in memory as:
     ///
@@ -447,6 +448,7 @@ pub enum StorageTextureAccess {
 #[doc = link_to_wgpu_item!(struct TextureView)]
 #[doc = link_to_wgpu_docs!(["`Texture::create_view()`"]: "struct.Texture.html#method.create_view")]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TextureViewDescriptor<L> {
     /// Debug label of the texture view. This will show up in graphics debuggers for easy identification.
     pub label: L,
@@ -473,6 +475,24 @@ pub struct TextureViewDescriptor<L> {
     /// If `Some(count)`, `base_array_layer + count` must be less or equal to the underlying array count.
     /// If `None`, considered to include the rest of the array layers, but at least 1 in total.
     pub array_layer_count: Option<u32>,
+}
+
+impl<L> TextureViewDescriptor<L> {
+    /// Takes a closure and maps the label of the texture view descriptor into another.
+    #[must_use]
+    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> TextureViewDescriptor<K> {
+        TextureViewDescriptor {
+            label: fun(&self.label),
+            format: self.format,
+            dimension: self.dimension,
+            usage: self.usage,
+            aspect: self.aspect,
+            base_mip_level: self.base_mip_level,
+            mip_level_count: self.mip_level_count,
+            base_array_layer: self.base_array_layer,
+            array_layer_count: self.array_layer_count,
+        }
+    }
 }
 
 /// Describes a [`Texture`](../wgpu/struct.Texture.html).
@@ -679,6 +699,27 @@ impl<L: Default> Default for SamplerDescriptor<L> {
             compare: None,
             anisotropy_clamp: 1,
             border_color: None,
+        }
+    }
+}
+
+impl<L> SamplerDescriptor<L> {
+    /// Takes a closure and maps the label of the sampler descriptor into another.
+    #[must_use]
+    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> SamplerDescriptor<K> {
+        SamplerDescriptor {
+            label: fun(&self.label),
+            address_mode_u: self.address_mode_u,
+            address_mode_v: self.address_mode_v,
+            address_mode_w: self.address_mode_w,
+            mag_filter: self.mag_filter,
+            min_filter: self.min_filter,
+            mipmap_filter: self.mipmap_filter,
+            lod_min_clamp: self.lod_min_clamp,
+            lod_max_clamp: self.lod_max_clamp,
+            compare: self.compare,
+            anisotropy_clamp: self.anisotropy_clamp,
+            border_color: self.border_color,
         }
     }
 }


### PR DESCRIPTION
**Description**
`TextureViewDescriptor` and `TextureDataOrder` should derive Serialize and Deserialize with `serde` feature. Bevy currently uses wrappers to ser/de them https://github.com/bevyengine/bevy/blob/638c5dd29778c9ea718d44996b4832ed600c0169/crates/bevy_image/src/serialized_image.rs#L35-L99

`TextureViewDescriptor` and `SamplerDescriptor` are missing `map_label` method, which is inconvenient to create them when the labels aren't `Option<&str>`.

**Testing**
CI

**Squash or Rebase?**
Squash

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
