### PR TITLE
Change `map_label_and_view_formats` to take `view_formats` by reference

### DIFF
--- a/wgpu-types/src/texture.rs
+++ b/wgpu-types/src/texture.rs
@@ -531,11 +531,8 @@ impl<L, V> TextureDescriptor<L, V> {
     pub fn map_label_and_view_formats<K, M>(
         &self,
         l_fun: impl FnOnce(&L) -> K,
-        v_fun: impl FnOnce(V) -> M,
-    ) -> TextureDescriptor<K, M>
-    where
-        V: Clone,
-    {
+        v_fun: impl FnOnce(&V) -> M,
+    ) -> TextureDescriptor<K, M> {
         TextureDescriptor {
             label: l_fun(&self.label),
             size: self.size,
@@ -544,7 +541,7 @@ impl<L, V> TextureDescriptor<L, V> {
             dimension: self.dimension,
             format: self.format,
             usage: self.usage,
-            view_formats: v_fun(self.view_formats.clone()),
+            view_formats: v_fun(&self.view_formats),
         }
     }
 


### PR DESCRIPTION
**Description**
`map_label_and_view_formats` passes cloned `view_formats` by value, which doesn't make sense, as you can't map `Vec<TextureFormat>` to `&[TextureFormat]` because the cloned `Vec<TextureFormat>` is dropped.

**Testing**
CI

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
