### PR TITLE
[Breaking] Add an explicit `initial_state` to `create_texture_from_hal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
   +     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, wgpu_types::TextureUses::UNINITIALIZED)
     };
   ```
-  Foreign-import code that has already transitioned the wrapped resource to a known state (e.g. via a queue-family ownership-transfer acquire to   `VK_IMAGE_LAYOUT_GENERAL`) should pass `wgt::TextureUses::empty()` so the first wgpu-issued barrier preserves contents:
+  Foreign-import code that has already transitioned the wrapped resource to a known state (e.g. via a queue-family ownership-transfer acquire to `VK_IMAGE_LAYOUT_GENERAL`) should pass `wgt::TextureUses::empty()` so the first wgpu-issued barrier preserves contents:
   ```diff
     let texture = unsafe {
   -     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,32 @@ Bottom level categories:
 
 ### Major changes
 
+#### `Device::create_texture_from_hal` takes an explicit `initial_state`
+
+`Device::create_texture_from_hal` (and the corresponding `wgpu-core` entry points) now take an `initial_state: Option<wgt::TextureUses>` parameter declaring the state the wrapped foreign resource is already in. Previously the tracker hard-coded `TextureUses::UNINITIALIZED` for the wrapped texture, which is a content-discarding transition under the Vulkan spec, which corrupts producer-written data on images carrying vendor compression metadata (Mali AFBC, Adreno UBWC, AMD DCC). This affected zero-copy hardware-decoded video imports (DMA-BUF / VAAPI / GL→Vulkan / AHardwareBuffer paths) on the platforms where compressed modifiers are used.
+
+To migrate, pass `None` to preserve the previous behaviour:
+
+```diff
+  let texture = unsafe {
+-     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)
++     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, None)
+  };
+```
+
+Foreign-import code that has already transitioned the wrapped resource to a known state (e.g. via a queue-family ownership-transfer acquire to `VK_IMAGE_LAYOUT_GENERAL`) should pass `Some(wgt::TextureUses::empty())` so the first wgpu-issued barrier preserves contents:
+
+```diff
+  let texture = unsafe {
+-     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)
++     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, Some(wgpu::TextureUses::empty()))
+  };
+```
+
+The safety contract for the new parameter requires the actual driver-side layout/state of the wrapped resource at the moment of wrap to match what `initial_state` derives to under the backend's layout derivation; mismatching is undefined behaviour per the underlying API specs.
+
+By @AdrianEddy in [#9496](https://github.com/gfx-rs/wgpu/pull/9496).
+
 #### Optional vertex buffer slots
 
 This allows gaps in `VertexState`'s `buffers` and adds support for unbinding vertex buffers, bringing us in compliance with the WebGPU spec. As a result of this, `VertexState`'s `buffers` field now has type of `&[Option<VertexBufferLayout>]`. To migrate, wrap vertex buffer layouts in `Some`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,32 +44,6 @@ Bottom level categories:
 
 ### Major changes
 
-#### `Device::create_texture_from_hal` takes an explicit `initial_state`
-
-`Device::create_texture_from_hal` (and the corresponding `wgpu-core` entry points) now take an `initial_state: Option<wgt::TextureUses>` parameter declaring the state the wrapped foreign resource is already in. Previously the tracker hard-coded `TextureUses::UNINITIALIZED` for the wrapped texture, which is a content-discarding transition under the Vulkan spec, which corrupts producer-written data on images carrying vendor compression metadata (Mali AFBC, Adreno UBWC, AMD DCC). This affected zero-copy hardware-decoded video imports (DMA-BUF / VAAPI / GL→Vulkan / AHardwareBuffer paths) on the platforms where compressed modifiers are used.
-
-To migrate, pass `None` to preserve the previous behaviour:
-
-```diff
-  let texture = unsafe {
--     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)
-+     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, None)
-  };
-```
-
-Foreign-import code that has already transitioned the wrapped resource to a known state (e.g. via a queue-family ownership-transfer acquire to `VK_IMAGE_LAYOUT_GENERAL`) should pass `Some(wgt::TextureUses::empty())` so the first wgpu-issued barrier preserves contents:
-
-```diff
-  let texture = unsafe {
--     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)
-+     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, Some(wgpu::TextureUses::empty()))
-  };
-```
-
-The safety contract for the new parameter requires the actual driver-side layout/state of the wrapped resource at the moment of wrap to match what `initial_state` derives to under the backend's layout derivation; mismatching is undefined behaviour per the underlying API specs.
-
-By @AdrianEddy in [#9496](https://github.com/gfx-rs/wgpu/pull/9496).
-
 #### Optional vertex buffer slots
 
 This allows gaps in `VertexState`'s `buffers` and adds support for unbinding vertex buffers, bringing us in compliance with the WebGPU spec. As a result of this, `VertexState`'s `buffers` field now has type of `&[Option<VertexBufferLayout>]`. To migrate, wrap vertex buffer layouts in `Some`:
@@ -149,6 +123,21 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Make `wgpu_types::texture::format::TextureChannel` accessible as `wgpu::TextureChannel`. By @TornaxO7 in [#9394](https://github.com/gfx-rs/wgpu/pull/9349).
 - Add support for `per_vertex` in Metal and DX12, as well as some validation for `per_vertex`, and a new enable extension, `wgpu_per_vertex`. By @inner-daemons in [#9219](https://github.com/gfx-rs/wgpu/pull/9219).
 - Add `ComputePass` version of `CommandEncoder::transition_resources` that allows intra-pass transitions. By @wingertge in [#9371](https://github.com/gfx-rs/wgpu/pull/9371).
+- `Device::create_texture_from_hal` now takes an explicit `initial_state: wgt::TextureUses` parameter declaring the state the wrapped foreign resource is already in. Previously the tracker hard-coded `TextureUses::UNINITIALIZED` for the wrapped texture, which is a content-discarding transition under the Vulkan spec, which corrupts producer-written data on images carrying vendor compression metadata (Mali AFBC, Adreno UBWC, AMD DCC). This affected zero-copy hardware-decoded video imports (DMA-BUF / VAAPI / GL→Vulkan / AHardwareBuffer paths) on the platforms where compressed modifiers are used. To migrate, pass `wgpu_types::TextureUses::UNINITIALIZED` to preserve the previous behaviour:
+  ```diff
+    let texture = unsafe {
+  -     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)
+  +     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, wgpu_types::TextureUses::UNINITIALIZED)
+    };
+  ```
+  Foreign-import code that has already transitioned the wrapped resource to a known state (e.g. via a queue-family ownership-transfer acquire to   `VK_IMAGE_LAYOUT_GENERAL`) should pass `wgt::TextureUses::empty()` so the first wgpu-issued barrier preserves contents:
+  ```diff
+    let texture = unsafe {
+  -     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)
+  +     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, wgpu::TextureUses::empty())
+    };
+  ```
+  By @AdrianEddy in [#9496](https://github.com/gfx-rs/wgpu/pull/9496).
 
 #### Metal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,11 +123,11 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Make `wgpu_types::texture::format::TextureChannel` accessible as `wgpu::TextureChannel`. By @TornaxO7 in [#9394](https://github.com/gfx-rs/wgpu/pull/9349).
 - Add support for `per_vertex` in Metal and DX12, as well as some validation for `per_vertex`, and a new enable extension, `wgpu_per_vertex`. By @inner-daemons in [#9219](https://github.com/gfx-rs/wgpu/pull/9219).
 - Add `ComputePass` version of `CommandEncoder::transition_resources` that allows intra-pass transitions. By @wingertge in [#9371](https://github.com/gfx-rs/wgpu/pull/9371).
-- `Device::create_texture_from_hal` now takes an explicit `initial_state: wgt::TextureUses` parameter declaring the state the wrapped foreign resource is already in. Previously the tracker hard-coded `TextureUses::UNINITIALIZED` for the wrapped texture, which is a content-discarding transition under the Vulkan spec, which corrupts producer-written data on images carrying vendor compression metadata (Mali AFBC, Adreno UBWC, AMD DCC). This affected zero-copy hardware-decoded video imports (DMA-BUF / VAAPI / GL→Vulkan / AHardwareBuffer paths) on the platforms where compressed modifiers are used. To migrate, pass `wgpu_types::TextureUses::UNINITIALIZED` to preserve the previous behaviour:
+- `Device::create_texture_from_hal` now takes an explicit `initial_state: wgt::TextureUses` parameter declaring the state the wrapped foreign resource is already in. Previously the tracker hard-coded `TextureUses::UNINITIALIZED` for the wrapped texture, which is a content-discarding transition under the Vulkan spec, which corrupts producer-written data on images carrying vendor compression metadata (Mali AFBC, Adreno UBWC, AMD DCC). This affected zero-copy hardware-decoded video imports (DMA-BUF / VAAPI / GL→Vulkan / AHardwareBuffer paths) on the platforms where compressed modifiers are used. To migrate, pass `wgpu::TextureUses::UNINITIALIZED` to preserve the previous behaviour:
   ```diff
     let texture = unsafe {
   -     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)
-  +     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, wgpu_types::TextureUses::UNINITIALIZED)
+  +     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, wgpu::TextureUses::UNINITIALIZED)
     };
   ```
   Foreign-import code that has already transitioned the wrapped resource to a known state (e.g. via a queue-family ownership-transfer acquire to `VK_IMAGE_LAYOUT_GENERAL`) should pass `wgt::TextureUses::empty()` so the first wgpu-issued barrier preserves contents:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,18 +124,11 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Make `wgpu_types::texture::format::TextureChannel` accessible as `wgpu::TextureChannel`. By @TornaxO7 in [#9394](https://github.com/gfx-rs/wgpu/pull/9349).
 - Add support for `per_vertex` in Metal and DX12, as well as some validation for `per_vertex`, and a new enable extension, `wgpu_per_vertex`. By @inner-daemons in [#9219](https://github.com/gfx-rs/wgpu/pull/9219).
 - Add `ComputePass` version of `CommandEncoder::transition_resources` that allows intra-pass transitions. By @wingertge in [#9371](https://github.com/gfx-rs/wgpu/pull/9371).
-- `Device::create_texture_from_hal` now takes an explicit `initial_state: wgt::TextureUses` parameter declaring the state the wrapped foreign resource is already in. Previously the tracker hard-coded `TextureUses::UNINITIALIZED` for the wrapped texture, which is a content-discarding transition under the Vulkan spec, which corrupts producer-written data on images carrying vendor compression metadata (Mali AFBC, Adreno UBWC, AMD DCC). This affected zero-copy hardware-decoded video imports (DMA-BUF / VAAPI / GL→Vulkan / AHardwareBuffer paths) on the platforms where compressed modifiers are used. To migrate, pass `wgpu::TextureUses::UNINITIALIZED` to preserve the previous behaviour:
+- `Device::create_texture_from_hal` now takes an explicit `initial_state: wgt::TextureUses` parameter declaring the state the wrapped foreign resource is already in. Previously the tracker hard-coded `TextureUses::UNINITIALIZED` for the wrapped texture, which is a content-discarding transition under the Vulkan spec. This affected zero-copy hardware-decoded video imports on the platforms where compressed modifiers are used. To migrate, pass `wgpu::TextureUses::UNINITIALIZED` to preserve the previous behaviour:
   ```diff
     let texture = unsafe {
   -     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)
   +     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, wgpu::TextureUses::UNINITIALIZED)
-    };
-  ```
-  Foreign-import code that has already transitioned the wrapped resource to a known state (e.g. via a queue-family ownership-transfer acquire to `VK_IMAGE_LAYOUT_GENERAL`) should pass `wgt::TextureUses::empty()` so the first wgpu-issued barrier preserves contents:
-  ```diff
-    let texture = unsafe {
-  -     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)
-  +     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, wgpu::TextureUses::empty())
     };
   ```
   By @AdrianEddy in [#9496](https://github.com/gfx-rs/wgpu/pull/9496).

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -322,11 +322,15 @@ impl Global {
     /// - `hal_texture` must be created from `device_id` corresponding raw handle.
     /// - `hal_texture` must be created respecting `desc`
     /// - `hal_texture` must be initialized
+    /// - When `initial_state` is `Some(state)`, the actual driver-side state of
+    ///   the wrapped resource at the moment of wrap MUST match what `state`
+    ///   derives to under the backend's layout/state derivation.
     pub unsafe fn create_texture_from_hal(
         &self,
         hal_texture: Box<dyn hal::DynTexture>,
         device_id: DeviceId,
         desc: &resource::TextureDescriptor,
+        initial_state: Option<wgt::TextureUses>,
         id_in: Option<id::TextureId>,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
         profiling::scope!("Device::create_texture_from_hal");
@@ -338,7 +342,7 @@ impl Global {
         let error = 'error: {
             let device = self.hub.devices.get(device_id);
 
-            let texture = match device.create_texture_from_hal(hal_texture, desc) {
+            let texture = match device.create_texture_from_hal(hal_texture, desc, initial_state) {
                 Ok(texture) => texture,
                 Err(error) => break 'error error,
             };

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -322,9 +322,8 @@ impl Global {
     /// - `hal_texture` must be created from `device_id` corresponding raw handle.
     /// - `hal_texture` must be created respecting `desc`
     /// - `hal_texture` must be initialized
-    /// - When `initial_state` is `Some(state)`, the actual driver-side state of
-    ///   the wrapped resource at the moment of wrap MUST match what `state`
-    ///   derives to under the backend's layout/state derivation.
+    /// - The `initial_state` must match the actual driver-side state of
+    ///   the wrapped resource at the moment of wrap.
     pub unsafe fn create_texture_from_hal(
         &self,
         hal_texture: Box<dyn hal::DynTexture>,

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -330,7 +330,7 @@ impl Global {
         hal_texture: Box<dyn hal::DynTexture>,
         device_id: DeviceId,
         desc: &resource::TextureDescriptor,
-        initial_state: Option<wgt::TextureUses>,
+        initial_state: wgt::TextureUses,
         id_in: Option<id::TextureId>,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
         profiling::scope!("Device::create_texture_from_hal");

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1244,6 +1244,7 @@ impl Device {
         self: &Arc<Self>,
         hal_texture: Box<dyn hal::DynTexture>,
         desc: &resource::TextureDescriptor,
+        initial_state: Option<wgt::TextureUses>,
     ) -> Result<Arc<Texture>, resource::CreateTextureError> {
         let format_features = self
             .describe_format_features(desc.format)
@@ -1263,10 +1264,10 @@ impl Device {
 
         let texture = Arc::new(texture);
 
-        self.trackers
-            .lock()
-            .textures
-            .insert_single(&texture, wgt::TextureUses::UNINITIALIZED);
+        self.trackers.lock().textures.insert_single(
+            &texture,
+            initial_state.unwrap_or(wgt::TextureUses::UNINITIALIZED),
+        );
 
         Ok(texture)
     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1244,7 +1244,7 @@ impl Device {
         self: &Arc<Self>,
         hal_texture: Box<dyn hal::DynTexture>,
         desc: &resource::TextureDescriptor,
-        initial_state: Option<wgt::TextureUses>,
+        initial_state: wgt::TextureUses,
     ) -> Result<Arc<Texture>, resource::CreateTextureError> {
         let format_features = self
             .describe_format_features(desc.format)
@@ -1264,10 +1264,10 @@ impl Device {
 
         let texture = Arc::new(texture);
 
-        self.trackers.lock().textures.insert_single(
-            &texture,
-            initial_state.unwrap_or(wgt::TextureUses::UNINITIALIZED),
-        );
+        self.trackers
+            .lock()
+            .textures
+            .insert_single(&texture, initial_state);
 
         Ok(texture)
     }

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -315,23 +315,40 @@ impl Device {
     #[doc = crate::macros::hal_type_dx12!("Texture")]
     #[doc = crate::macros::hal_type_gles!("Texture")]
     ///
+    /// # `initial_state`
+    ///
+    /// The [`wgt::TextureUses`] state the wrapped resource is already in;
+    /// used as the source state (`oldLayout` / `StateBefore`) of the first
+    /// barrier emitted on the texture.
+    ///
+    /// `None` defaults to [`wgt::TextureUses::UNINITIALIZED`], which is
+    /// content-discarding on Vulkan (may invalidate vendor compression metadata like AFBC/UBWC/DCC).
+    ///
     /// # Safety
     ///
     /// - `hal_texture` must be created from this device internal handle
     /// - `hal_texture` must be created respecting `desc`
     /// - `hal_texture` must be initialized
+    /// - When `initial_state` is `Some(state)`, the actual driver-side
+    ///   layout/state of the wrapped resource at the moment of wrap MUST
+    ///   match what `state` derives to under the backend's layout
+    ///   derivation.
     #[cfg(wgpu_core)]
     #[must_use]
     pub unsafe fn create_texture_from_hal<A: hal::Api>(
         &self,
         hal_texture: A::Texture,
         desc: &TextureDescriptor<'_>,
+        initial_state: Option<wgt::TextureUses>,
     ) -> Texture {
         let texture = unsafe {
             let core_device = self.inner.as_core();
-            core_device
-                .context
-                .create_texture_from_hal::<A>(hal_texture, core_device, desc)
+            core_device.context.create_texture_from_hal::<A>(
+                hal_texture,
+                core_device,
+                desc,
+                initial_state,
+            )
         };
         Texture {
             inner: texture.into(),

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -339,7 +339,7 @@ impl Device {
         &self,
         hal_texture: A::Texture,
         desc: &TextureDescriptor<'_>,
-        initial_state: Option<wgt::TextureUses>,
+        initial_state: wgt::TextureUses,
     ) -> Texture {
         let texture = unsafe {
             let core_device = self.inner.as_core();

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -321,18 +321,13 @@ impl Device {
     /// used as the source state (`oldLayout` / `StateBefore`) of the first
     /// barrier emitted on the texture.
     ///
-    /// `None` defaults to [`wgt::TextureUses::UNINITIALIZED`], which is
-    /// content-discarding on Vulkan (may invalidate vendor compression metadata like AFBC/UBWC/DCC).
-    ///
     /// # Safety
     ///
     /// - `hal_texture` must be created from this device internal handle
     /// - `hal_texture` must be created respecting `desc`
     /// - `hal_texture` must be initialized
-    /// - When `initial_state` is `Some(state)`, the actual driver-side
-    ///   layout/state of the wrapped resource at the moment of wrap MUST
-    ///   match what `state` derives to under the backend's layout
-    ///   derivation.
+    /// - The `initial_state` must match the actual driver-side
+    ///   layout/state of the wrapped resource at the moment of wrap.
     #[cfg(wgpu_core)]
     #[must_use]
     pub unsafe fn create_texture_from_hal<A: hal::Api>(

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -326,7 +326,6 @@ impl Device {
     /// may be discarded), `initial_state` may be set to
     /// `TextureUses::UNINITIALIZED`.
     ///
-
     /// # Safety
     ///
     /// - `hal_texture` must be created from this device internal handle

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -332,8 +332,9 @@ impl Device {
     /// - `hal_texture` must be created from this device internal handle
     /// - `hal_texture` must be created respecting `desc`
     /// - `hal_texture` must be initialized
-    /// - The `initial_state` must match the actual driver-side
-    ///   layout/state of the wrapped resource at the moment of wrap.
+    /// - `initial_state`, if it is not `TextureUses::UNINITIALIZED`, must
+    ///   match the actual driver-side layout/state of the wrapped resource at
+    ///   the moment of wrap.
     #[cfg(wgpu_core)]
     #[must_use]
     pub unsafe fn create_texture_from_hal<A: hal::Api>(

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -317,10 +317,16 @@ impl Device {
     ///
     /// # `initial_state`
     ///
-    /// The [`wgt::TextureUses`] state the wrapped resource is already in;
-    /// used as the source state (`oldLayout` / `StateBefore`) of the first
+    /// If the resource has already been initialized, `initial_state` should be
+    /// set to the [`wgt::TextureUses`] state of the wrapped resource.  It will
+    /// be used as the source state (`oldLayout` / `StateBefore`) of the first
     /// barrier emitted on the texture.
     ///
+    /// If the resource has not been initialized (or if the existing contents
+    /// may be discarded), `initial_state` may be set to
+    /// `TextureUses::UNINITIALIZED`.
+    ///
+
     /// # Safety
     ///
     /// - `hal_texture` must be created from this device internal handle

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -140,7 +140,7 @@ impl ContextWgpuCore {
         hal_texture: A::Texture,
         device: &CoreDevice,
         desc: &TextureDescriptor<'_>,
-        initial_state: Option<wgt::TextureUses>,
+        initial_state: wgt::TextureUses,
     ) -> CoreTexture {
         let descriptor = desc.map_label_and_view_formats(|l| l.map(Borrowed), |v| v.to_vec());
         let (id, error) = unsafe {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -140,11 +140,17 @@ impl ContextWgpuCore {
         hal_texture: A::Texture,
         device: &CoreDevice,
         desc: &TextureDescriptor<'_>,
+        initial_state: Option<wgt::TextureUses>,
     ) -> CoreTexture {
         let descriptor = desc.map_label_and_view_formats(|l| l.map(Borrowed), |v| v.to_vec());
         let (id, error) = unsafe {
-            self.0
-                .create_texture_from_hal(Box::new(hal_texture), device.id, &descriptor, None)
+            self.0.create_texture_from_hal(
+                Box::new(hal_texture),
+                device.id,
+                &descriptor,
+                initial_state,
+                None,
+            )
         };
         if let Some(cause) = error {
             self.handle_error(


### PR DESCRIPTION
**Description**
This PR adds an explicit `initial_state: wgt::TextureUses` parameter to `create_texture_from_hal`, letting foreign-import callers declare the state the wrapped resource is in. 

When you wrap a foreign `vk::Image` via `create_texture_from_hal`:

1. wgpu records `TextureUses::UNINITIALIZED` in the tracker.
2. On first use, wgpu emits `vkCmdPipelineBarrier(oldLayout = UNDEFINED, newLayout = <use>)`.
3. Per Vulkan spec, `oldLayout = UNDEFINED` permits the driver to discard contents.

For LINEAR-tiled or uncompressed-OPTIMAL images, the driver has no compression metadata to invalidate - discard is a no-op, contents survive in practice. For images with vendor compression (AFBC on Mali, UBWC on Adreno, DCC on AMD), the driver resets the compression metadata block to its default state. The pixel bytes in main memory stay the same, but the GPU now interprets them through fresh metadata that doesn't match - sampling reads garbage.

This affects real-world zero-copy hardware-decoded video import paths:
- DMA-BUF imports from VAAPI / V4L2 m2m on AMD desktop and mobile SoCs.
- AHardwareBuffer imports on Android (Mali / Adreno).
- GL→Vulkan interop via `GL_EXT_memory_object_fd` where the GL texture was allocated with vendor compression.
- Any cross-Vulkan-instance OPAQUE_FD import where the producer used compressed tiling.

The bug doesn't manifest on Metal (implicit hazard tracking) or GL (no layout concept) - but the abstraction is cross-backend so the API surface stays cross-backend too.

I considered these alternatives:

1. **A separate `create_texture_from_hal_with_initial_state` function.** Duplicates the entire entry point and its safety contract; reviewers have to keep two functions in sync forever.
2. **A `Texture::declare_initial_state` setter.** Two-step API with a window where the tracker state is wrong; sharp edge for callers that submit work between the two calls.
3. **A backend-specific hal field (`hal::vulkan::Texture::set_initial_layout`).** Smaller surface but Vulkan-only - D3D12 has the same abstraction issue (state mismatch on non-COMMON foreign imports), and a parallel D3D12 setter would just duplicate the same shape.

### Migration

```diff
  let texture = unsafe {
-     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc)
+     device.create_texture_from_hal::<Vulkan>(hal_texture, &desc, wgpu::TextureUses::UNINITIALIZED)
  };
```


This PR is pure plumbing - nothing changes in behavior when user passes `wgpu::TextureUses::UNINITIALIZED`

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
