### PR TITLE
naga/spv-in: support OpIAddCarry and OpISubBorrow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Enforce that `@must_use` appear only on function declarations. By @dnsn021 in [#9367](https://github.com/gfx-rs/wgpu/pull/9367).
 - Fix typo in `naga::back::msl::Error::UnsupportedWritable*` variant names. By @ErichDonGubler in [#9376](https://github.com/gfx-rs/wgpu/pull/9376).
 - Added support for `enable wgpu_binding_array;`. By @39ali in [#9298](https://github.com/gfx-rs/wgpu/pull/9298).
+- SPIR-V frontend now accepts `OpIAddCarry` and `OpISubBorrow`, lowering them to plain add/sub plus a carry/borrow comparison.
 
 #### Vulkan
 

--- a/naga/src/front/spv/next_block.rs
+++ b/naga/src/front/spv/next_block.rs
@@ -823,6 +823,115 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                         SignAnchor::Result,
                     )?;
                 }
+                Op::IAddCarry | Op::ISubBorrow => {
+                    inst.expect(5)?;
+
+                    let start = self.data_offset;
+                    let result_type_id = self.next()?;
+                    let result_id = self.next()?;
+                    let p1_id = self.next()?;
+                    let p2_id = self.next()?;
+                    let span = self.span_from_with_op(start);
+
+                    let p1_lexp = self.lookup_expression.lookup(p1_id)?;
+                    let p1_type_id = p1_lexp.type_id;
+                    let mut left = get_expr_handle!(p1_id, p1_lexp);
+                    let p2_lexp = self.lookup_expression.lookup(p2_id)?;
+                    let p2_type_id = p2_lexp.type_id;
+                    let mut right = get_expr_handle!(p2_id, p2_lexp);
+
+                    // Result is `OpTypeStruct{T, T}` whose two members must
+                    // have the same type as the operands per the SPIR-V spec.
+                    let result_ty_handle = self.lookup_type.lookup(result_type_id)?.handle;
+                    let member_ty_id = self
+                        .lookup_member
+                        .get(&(result_ty_handle, 0))
+                        .ok_or(Error::InvalidAccessType(result_type_id))?
+                        .type_id;
+                    let member_ty_handle = self.lookup_type.lookup(member_ty_id)?.handle;
+                    let scalar = ctx.module.types[member_ty_handle]
+                        .inner
+                        .scalar()
+                        .ok_or(Error::InvalidAccessType(result_type_id))?;
+
+                    // SPIR-V integer types are signless, so when the operand's
+                    // declared `OpTypeInt` differs from the struct member's
+                    // (e.g. `signed` vs `unsigned`), bitcast it so the produced
+                    // naga IR expressions type-check.
+                    if p1_type_id != member_ty_id {
+                        left = ctx.expressions.append(
+                            crate::Expression::As {
+                                expr: left,
+                                kind: scalar.kind,
+                                convert: None,
+                            },
+                            span,
+                        );
+                    }
+                    if p2_type_id != member_ty_id {
+                        right = ctx.expressions.append(
+                            crate::Expression::As {
+                                expr: right,
+                                kind: scalar.kind,
+                                convert: None,
+                            },
+                            span,
+                        );
+                    }
+
+                    let arith_op = match inst.op {
+                        Op::IAddCarry => crate::BinaryOperator::Add,
+                        Op::ISubBorrow => crate::BinaryOperator::Subtract,
+                        _ => unreachable!(),
+                    };
+                    let arith = ctx.expressions.append(
+                        crate::Expression::Binary {
+                            op: arith_op,
+                            left,
+                            right,
+                        },
+                        span,
+                    );
+                    let (cmp_left, cmp_right) = match inst.op {
+                        // `a + b` carries iff the wrapped sum drops below `a`.
+                        Op::IAddCarry => (arith, left),
+                        // `a - b` borrows iff `a < b`.
+                        Op::ISubBorrow => (left, right),
+                        _ => unreachable!(),
+                    };
+                    let cmp = ctx.expressions.append(
+                        crate::Expression::Binary {
+                            op: crate::BinaryOperator::Less,
+                            left: cmp_left,
+                            right: cmp_right,
+                        },
+                        span,
+                    );
+                    let cmp_int = ctx.expressions.append(
+                        crate::Expression::As {
+                            expr: cmp,
+                            kind: scalar.kind,
+                            convert: Some(scalar.width),
+                        },
+                        span,
+                    );
+
+                    let composed = ctx.expressions.append(
+                        crate::Expression::Compose {
+                            ty: result_ty_handle,
+                            components: alloc::vec![arith, cmp_int],
+                        },
+                        span,
+                    );
+                    self.lookup_expression.insert(
+                        result_id,
+                        LookupExpression {
+                            handle: composed,
+                            type_id: result_type_id,
+                            block_id,
+                        },
+                    );
+                }
                 Op::IEqual | Op::INotEqual => {
                     inst.expect(5)?;
                     let operator = map_binary_operator(inst.op)?;

--- a/naga/tests/in/spv/add_carry_sub_borrow.spvasm
+++ b/naga/tests/in/spv/add_carry_sub_borrow.spvasm
@@ -1,0 +1,89 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 460
+               OpSourceExtension "GL_KHR_shader_subgroup_basic"
+               OpName %main "main"
+               OpName %Output "Output"
+               OpMemberName %Output 0 "sum"
+               OpMemberName %Output 1 "carry"
+               OpMemberName %Output 2 "diff"
+               OpMemberName %Output 3 "borrow"
+               OpName %outp "outp"
+               OpName %Input "Input"
+               OpMemberName %Input 0 "a"
+               OpMemberName %Input 1 "b"
+               OpName %inp "inp"
+               OpName %c "c"
+               OpName %d "d"
+               OpDecorate %Output BufferBlock
+               OpMemberDecorate %Output 0 Offset 0
+               OpMemberDecorate %Output 1 Offset 4
+               OpMemberDecorate %Output 2 Offset 8
+               OpMemberDecorate %Output 3 Offset 12
+               OpDecorate %outp Binding 1
+               OpDecorate %outp DescriptorSet 0
+               OpDecorate %Input BufferBlock
+               OpMemberDecorate %Input 0 Offset 0
+               OpMemberDecorate %Input 1 Offset 4
+               OpDecorate %inp Binding 0
+               OpDecorate %inp DescriptorSet 0
+               OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %Output = OpTypeStruct %uint %uint %uint %uint
+%_ptr_Uniform_Output = OpTypePointer Uniform %Output
+       %outp = OpVariable %_ptr_Uniform_Output Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %Input = OpTypeStruct %uint %uint
+%_ptr_Uniform_Input = OpTypePointer Uniform %Input
+        %inp = OpVariable %_ptr_Uniform_Input Uniform
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+      %int_1 = OpConstant %int 1
+%_ptr_Function_uint = OpTypePointer Function %uint
+      %int_2 = OpConstant %int 2
+      %int_3 = OpConstant %int 3
+     %v3uint = OpTypeVector %uint 3
+     %uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_1 %uint_1 %uint_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %c = OpVariable %_ptr_Function_uint Function
+          %d = OpVariable %_ptr_Function_uint Function
+         %16 = OpAccessChain %_ptr_Uniform_uint %inp %int_0
+         %17 = OpLoad %uint %16
+         %19 = OpAccessChain %_ptr_Uniform_uint %inp %int_1
+         %20 = OpLoad %uint %19
+         %23 = OpIAddCarry %Input %17 %20
+         %24 = OpCompositeExtract %uint %23 1
+               OpStore %c %24
+         %25 = OpCompositeExtract %uint %23 0
+         %26 = OpAccessChain %_ptr_Uniform_uint %outp %int_0
+               OpStore %26 %25
+         %27 = OpLoad %uint %c
+         %28 = OpAccessChain %_ptr_Uniform_uint %outp %int_1
+               OpStore %28 %27
+         %30 = OpAccessChain %_ptr_Uniform_uint %inp %int_0
+         %31 = OpLoad %uint %30
+         %32 = OpAccessChain %_ptr_Uniform_uint %inp %int_1
+         %33 = OpLoad %uint %32
+         %35 = OpISubBorrow %Input %31 %33
+         %36 = OpCompositeExtract %uint %35 1
+               OpStore %d %36
+         %37 = OpCompositeExtract %uint %35 0
+         %38 = OpAccessChain %_ptr_Uniform_uint %outp %int_2
+               OpStore %38 %37
+         %40 = OpLoad %uint %d
+         %41 = OpAccessChain %_ptr_Uniform_uint %outp %int_3
+               OpStore %41 %40
+               OpReturn
+               OpFunctionEnd

--- a/naga/tests/in/spv/add_carry_sub_borrow.toml
+++ b/naga/tests/in/spv/add_carry_sub_borrow.toml
@@ -1,0 +1,4 @@
+targets = "WGSL | SPIRV | GLSL | HLSL | METAL"
+
+[msl]
+lang_version = [2, 0]

--- a/naga/tests/in/spv/add_carry_sub_borrow_vec.spvasm
+++ b/naga/tests/in/spv/add_carry_sub_borrow_vec.spvasm
@@ -1,0 +1,89 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 46
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 460
+               OpName %main "main"
+               OpName %Output "Output"
+               OpMemberName %Output 0 "sum"
+               OpMemberName %Output 1 "carry"
+               OpMemberName %Output 2 "diff"
+               OpMemberName %Output 3 "borrow"
+               OpName %outp "outp"
+               OpName %Input "Input"
+               OpMemberName %Input 0 "a"
+               OpMemberName %Input 1 "b"
+               OpName %inp "inp"
+               OpName %c "c"
+               OpName %d "d"
+               OpDecorate %Output BufferBlock
+               OpMemberDecorate %Output 0 Offset 0
+               OpMemberDecorate %Output 1 Offset 8
+               OpMemberDecorate %Output 2 Offset 16
+               OpMemberDecorate %Output 3 Offset 24
+               OpDecorate %outp Binding 1
+               OpDecorate %outp DescriptorSet 0
+               OpDecorate %Input BufferBlock
+               OpMemberDecorate %Input 0 Offset 0
+               OpMemberDecorate %Input 1 Offset 8
+               OpDecorate %inp Binding 0
+               OpDecorate %inp DescriptorSet 0
+               OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v2uint = OpTypeVector %uint 2
+     %Output = OpTypeStruct %v2uint %v2uint %v2uint %v2uint
+%_ptr_Uniform_Output = OpTypePointer Uniform %Output
+       %outp = OpVariable %_ptr_Uniform_Output Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %Input = OpTypeStruct %v2uint %v2uint
+%_ptr_Uniform_Input = OpTypePointer Uniform %Input
+        %inp = OpVariable %_ptr_Uniform_Input Uniform
+%_ptr_Uniform_v2uint = OpTypePointer Uniform %v2uint
+      %int_1 = OpConstant %int 1
+%_ptr_Function_v2uint = OpTypePointer Function %v2uint
+      %int_2 = OpConstant %int 2
+      %int_3 = OpConstant %int 3
+     %v3uint = OpTypeVector %uint 3
+     %uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_1 %uint_1 %uint_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %c = OpVariable %_ptr_Function_v2uint Function
+          %d = OpVariable %_ptr_Function_v2uint Function
+         %17 = OpAccessChain %_ptr_Uniform_v2uint %inp %int_0
+         %18 = OpLoad %v2uint %17
+         %20 = OpAccessChain %_ptr_Uniform_v2uint %inp %int_1
+         %21 = OpLoad %v2uint %20
+         %24 = OpIAddCarry %Input %18 %21
+         %25 = OpCompositeExtract %v2uint %24 1
+               OpStore %c %25
+         %26 = OpCompositeExtract %v2uint %24 0
+         %27 = OpAccessChain %_ptr_Uniform_v2uint %outp %int_0
+               OpStore %27 %26
+         %28 = OpLoad %v2uint %c
+         %29 = OpAccessChain %_ptr_Uniform_v2uint %outp %int_1
+               OpStore %29 %28
+         %31 = OpAccessChain %_ptr_Uniform_v2uint %inp %int_0
+         %32 = OpLoad %v2uint %31
+         %33 = OpAccessChain %_ptr_Uniform_v2uint %inp %int_1
+         %34 = OpLoad %v2uint %33
+         %36 = OpISubBorrow %Input %32 %34
+         %37 = OpCompositeExtract %v2uint %36 1
+               OpStore %d %37
+         %38 = OpCompositeExtract %v2uint %36 0
+         %39 = OpAccessChain %_ptr_Uniform_v2uint %outp %int_2
+               OpStore %39 %38
+         %41 = OpLoad %v2uint %d
+         %42 = OpAccessChain %_ptr_Uniform_v2uint %outp %int_3
+               OpStore %42 %41
+               OpReturn
+               OpFunctionEnd

--- a/naga/tests/in/spv/add_carry_sub_borrow_vec.toml
+++ b/naga/tests/in/spv/add_carry_sub_borrow_vec.toml
@@ -1,0 +1,4 @@
+targets = "WGSL | SPIRV | GLSL | HLSL | METAL"
+
+[msl]
+lang_version = [2, 0]

--- a/naga/tests/out/glsl/spv-add_carry_sub_borrow.main.Compute.glsl
+++ b/naga/tests/out/glsl/spv-add_carry_sub_borrow.main.Compute.glsl
@@ -1,0 +1,47 @@
+#version 310 es
+
+precision highp float;
+precision highp int;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct Output {
+    uint sum;
+    uint carry;
+    uint diff;
+    uint borrow;
+};
+struct Input {
+    uint a;
+    uint b;
+};
+layout(std430) buffer Output_block_0Compute { Output _group_0_binding_1_cs; };
+
+layout(std430) buffer Input_block_1Compute { Input _group_0_binding_0_cs; };
+
+
+void main_1() {
+    uint c = 0u;
+    uint d = 0u;
+    uint _e5 = _group_0_binding_0_cs.a;
+    uint _e7 = _group_0_binding_0_cs.b;
+    uint _e8 = (_e5 + _e7);
+    Input _e11 = Input(_e8, uint((_e8 < _e5)));
+    c = _e11.b;
+    _group_0_binding_1_cs.sum = _e11.a;
+    uint _e15 = c;
+    _group_0_binding_1_cs.carry = _e15;
+    uint _e18 = _group_0_binding_0_cs.a;
+    uint _e20 = _group_0_binding_0_cs.b;
+    Input _e24 = Input((_e18 - _e20), uint((_e18 < _e20)));
+    d = _e24.b;
+    _group_0_binding_1_cs.diff = _e24.a;
+    uint _e28 = d;
+    _group_0_binding_1_cs.borrow = _e28;
+    return;
+}
+
+void main() {
+    main_1();
+}
+

--- a/naga/tests/out/glsl/spv-add_carry_sub_borrow_vec.main.Compute.glsl
+++ b/naga/tests/out/glsl/spv-add_carry_sub_borrow_vec.main.Compute.glsl
@@ -1,0 +1,47 @@
+#version 310 es
+
+precision highp float;
+precision highp int;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct Output {
+    uvec2 sum;
+    uvec2 carry;
+    uvec2 diff;
+    uvec2 borrow;
+};
+struct Input {
+    uvec2 a;
+    uvec2 b;
+};
+layout(std430) buffer Output_block_0Compute { Output _group_0_binding_1_cs; };
+
+layout(std430) buffer Input_block_1Compute { Input _group_0_binding_0_cs; };
+
+
+void main_1() {
+    uvec2 c = uvec2(0u);
+    uvec2 d = uvec2(0u);
+    uvec2 _e5 = _group_0_binding_0_cs.a;
+    uvec2 _e7 = _group_0_binding_0_cs.b;
+    uvec2 _e8 = (_e5 + _e7);
+    Input _e11 = Input(_e8, uvec2(lessThan(_e8, _e5)));
+    c = _e11.b;
+    _group_0_binding_1_cs.sum = _e11.a;
+    uvec2 _e15 = c;
+    _group_0_binding_1_cs.carry = _e15;
+    uvec2 _e18 = _group_0_binding_0_cs.a;
+    uvec2 _e20 = _group_0_binding_0_cs.b;
+    Input _e24 = Input((_e18 - _e20), uvec2(lessThan(_e18, _e20)));
+    d = _e24.b;
+    _group_0_binding_1_cs.diff = _e24.a;
+    uvec2 _e28 = d;
+    _group_0_binding_1_cs.borrow = _e28;
+    return;
+}
+
+void main() {
+    main_1();
+}
+

--- a/naga/tests/out/hlsl/spv-add_carry_sub_borrow.hlsl
+++ b/naga/tests/out/hlsl/spv-add_carry_sub_borrow.hlsl
@@ -1,0 +1,50 @@
+struct Output {
+    uint sum;
+    uint carry;
+    uint diff;
+    uint borrow;
+};
+
+struct Input {
+    uint a;
+    uint b;
+};
+
+RWByteAddressBuffer outp : register(u1);
+RWByteAddressBuffer inp : register(u0);
+
+Input ConstructInput(uint arg0, uint arg1) {
+    Input ret = (Input)0;
+    ret.a = arg0;
+    ret.b = arg1;
+    return ret;
+}
+
+void main_1()
+{
+    uint c = (uint)0;
+    uint d = (uint)0;
+
+    uint _e5 = asuint(inp.Load(0));
+    uint _e7 = asuint(inp.Load(4));
+    uint _e8 = (_e5 + _e7);
+    Input _e11 = ConstructInput(_e8, uint((_e8 < _e5)));
+    c = _e11.b;
+    outp.Store(0, asuint(_e11.a));
+    uint _e15 = c;
+    outp.Store(4, asuint(_e15));
+    uint _e18 = asuint(inp.Load(0));
+    uint _e20 = asuint(inp.Load(4));
+    Input _e24 = ConstructInput((_e18 - _e20), uint((_e18 < _e20)));
+    d = _e24.b;
+    outp.Store(8, asuint(_e24.a));
+    uint _e28 = d;
+    outp.Store(12, asuint(_e28));
+    return;
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    main_1();
+}

--- a/naga/tests/out/hlsl/spv-add_carry_sub_borrow.ron
+++ b/naga/tests/out/hlsl/spv-add_carry_sub_borrow.ron
@@ -1,0 +1,16 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"main",
+            target_profile:"cs_5_1",
+        ),
+    ],
+    task:[
+    ],
+    mesh:[
+    ],
+)

--- a/naga/tests/out/hlsl/spv-add_carry_sub_borrow_vec.hlsl
+++ b/naga/tests/out/hlsl/spv-add_carry_sub_borrow_vec.hlsl
@@ -1,0 +1,50 @@
+struct Output {
+    uint2 sum;
+    uint2 carry;
+    uint2 diff;
+    uint2 borrow;
+};
+
+struct Input {
+    uint2 a;
+    uint2 b;
+};
+
+RWByteAddressBuffer outp : register(u1);
+RWByteAddressBuffer inp : register(u0);
+
+Input ConstructInput(uint2 arg0, uint2 arg1) {
+    Input ret = (Input)0;
+    ret.a = arg0;
+    ret.b = arg1;
+    return ret;
+}
+
+void main_1()
+{
+    uint2 c = (uint2)0;
+    uint2 d = (uint2)0;
+
+    uint2 _e5 = asuint(inp.Load2(0));
+    uint2 _e7 = asuint(inp.Load2(8));
+    uint2 _e8 = (_e5 + _e7);
+    Input _e11 = ConstructInput(_e8, uint2((_e8 < _e5)));
+    c = _e11.b;
+    outp.Store2(0, asuint(_e11.a));
+    uint2 _e15 = c;
+    outp.Store2(8, asuint(_e15));
+    uint2 _e18 = asuint(inp.Load2(0));
+    uint2 _e20 = asuint(inp.Load2(8));
+    Input _e24 = ConstructInput((_e18 - _e20), uint2((_e18 < _e20)));
+    d = _e24.b;
+    outp.Store2(16, asuint(_e24.a));
+    uint2 _e28 = d;
+    outp.Store2(24, asuint(_e28));
+    return;
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    main_1();
+}

--- a/naga/tests/out/hlsl/spv-add_carry_sub_borrow_vec.ron
+++ b/naga/tests/out/hlsl/spv-add_carry_sub_borrow_vec.ron
@@ -1,0 +1,16 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"main",
+            target_profile:"cs_5_1",
+        ),
+    ],
+    task:[
+    ],
+    mesh:[
+    ],
+)

--- a/naga/tests/out/msl/spv-add_carry_sub_borrow.metal
+++ b/naga/tests/out/msl/spv-add_carry_sub_borrow.metal
@@ -1,0 +1,47 @@
+// language: metal2.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+struct Output {
+    uint sum;
+    uint carry;
+    uint diff;
+    uint borrow;
+};
+struct Input {
+    uint a;
+    uint b;
+};
+
+void main_1(
+    device Output& outp,
+    device Input const& inp
+) {
+    uint c = {};
+    uint d = {};
+    uint _e5 = inp.a;
+    uint _e7 = inp.b;
+    uint _e8 = _e5 + _e7;
+    Input _e11 = Input {_e8, static_cast<uint>(_e8 < _e5)};
+    c = _e11.b;
+    outp.sum = _e11.a;
+    uint _e15 = c;
+    outp.carry = _e15;
+    uint _e18 = inp.a;
+    uint _e20 = inp.b;
+    Input _e24 = Input {_e18 - _e20, static_cast<uint>(_e18 < _e20)};
+    d = _e24.b;
+    outp.diff = _e24.a;
+    uint _e28 = d;
+    outp.borrow = _e28;
+    return;
+}
+
+kernel void main_(
+  device Output& outp [[user(fake0)]]
+, device Input const& inp [[user(fake0)]]
+) {
+    main_1(outp, inp);
+}

--- a/naga/tests/out/msl/spv-add_carry_sub_borrow_vec.metal
+++ b/naga/tests/out/msl/spv-add_carry_sub_borrow_vec.metal
@@ -1,0 +1,47 @@
+// language: metal2.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+struct Output {
+    metal::uint2 sum;
+    metal::uint2 carry;
+    metal::uint2 diff;
+    metal::uint2 borrow;
+};
+struct Input {
+    metal::uint2 a;
+    metal::uint2 b;
+};
+
+void main_1(
+    device Output& outp,
+    device Input const& inp
+) {
+    metal::uint2 c = {};
+    metal::uint2 d = {};
+    metal::uint2 _e5 = inp.a;
+    metal::uint2 _e7 = inp.b;
+    metal::uint2 _e8 = _e5 + _e7;
+    Input _e11 = Input {_e8, static_cast<metal::uint2>(_e8 < _e5)};
+    c = _e11.b;
+    outp.sum = _e11.a;
+    metal::uint2 _e15 = c;
+    outp.carry = _e15;
+    metal::uint2 _e18 = inp.a;
+    metal::uint2 _e20 = inp.b;
+    Input _e24 = Input {_e18 - _e20, static_cast<metal::uint2>(_e18 < _e20)};
+    d = _e24.b;
+    outp.diff = _e24.a;
+    metal::uint2 _e28 = d;
+    outp.borrow = _e28;
+    return;
+}
+
+kernel void main_(
+  device Output& outp [[user(fake0)]]
+, device Input const& inp [[user(fake0)]]
+) {
+    main_1(outp, inp);
+}

--- a/naga/tests/out/spv/spv-add_carry_sub_borrow.spvasm
+++ b/naga/tests/out/spv/spv-add_carry_sub_borrow.spvasm
@@ -1,0 +1,97 @@
+; SPIR-V
+; Version: 1.1
+; Generator: rspirv
+; Bound: 63
+OpCapability Shader
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %58 "main"
+OpExecutionMode %58 LocalSize 1 1 1
+OpMemberDecorate %4 0 Offset 0
+OpMemberDecorate %4 1 Offset 4
+OpMemberDecorate %4 2 Offset 8
+OpMemberDecorate %4 3 Offset 12
+OpMemberDecorate %5 0 Offset 0
+OpMemberDecorate %5 1 Offset 4
+OpDecorate %6 DescriptorSet 0
+OpDecorate %6 Binding 1
+OpDecorate %7 Block
+OpMemberDecorate %7 0 Offset 0
+OpDecorate %9 DescriptorSet 0
+OpDecorate %9 Binding 0
+OpDecorate %10 Block
+OpMemberDecorate %10 0 Offset 0
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%4 = OpTypeStruct %3 %3 %3 %3
+%5 = OpTypeStruct %3 %3
+%7 = OpTypeStruct %4
+%8 = OpTypePointer StorageBuffer %7
+%6 = OpVariable  %8  StorageBuffer
+%10 = OpTypeStruct %5
+%11 = OpTypePointer StorageBuffer %10
+%9 = OpVariable  %11  StorageBuffer
+%14 = OpTypeFunction %2
+%15 = OpTypePointer StorageBuffer %4
+%16 = OpConstant  %3  0
+%18 = OpTypePointer StorageBuffer %5
+%21 = OpTypePointer Function %3
+%22 = OpConstantNull  %3
+%24 = OpConstantNull  %3
+%26 = OpTypePointer StorageBuffer %3
+%29 = OpConstant  %3  1
+%33 = OpTypeBool
+%52 = OpConstant  %3  2
+%55 = OpConstant  %3  3
+%13 = OpFunction  %2  None %14
+%12 = OpLabel
+%20 = OpVariable  %21  Function %22
+%23 = OpVariable  %21  Function %24
+%17 = OpAccessChain  %15  %6 %16
+%19 = OpAccessChain  %18  %9 %16
+OpBranch %25
+%25 = OpLabel
+%27 = OpAccessChain  %26  %19 %16
+%28 = OpLoad  %3  %27
+%30 = OpAccessChain  %26  %19 %29
+%31 = OpLoad  %3  %30
+%32 = OpIAdd  %3  %28 %31
+%34 = OpULessThan  %33  %32 %28
+%35 = OpSelect  %3  %34 %29 %16
+%36 = OpCompositeConstruct  %5  %32 %35
+%37 = OpCompositeExtract  %3  %36 1
+OpStore %20 %37
+%38 = OpCompositeExtract  %3  %36 0
+%39 = OpAccessChain  %26  %17 %16
+OpStore %39 %38
+%40 = OpLoad  %3  %20
+%41 = OpAccessChain  %26  %17 %29
+OpStore %41 %40
+%42 = OpAccessChain  %26  %19 %16
+%43 = OpLoad  %3  %42
+%44 = OpAccessChain  %26  %19 %29
+%45 = OpLoad  %3  %44
+%46 = OpISub  %3  %43 %45
+%47 = OpULessThan  %33  %43 %45
+%48 = OpSelect  %3  %47 %29 %16
+%49 = OpCompositeConstruct  %5  %46 %48
+%50 = OpCompositeExtract  %3  %49 1
+OpStore %23 %50
+%51 = OpCompositeExtract  %3  %49 0
+%53 = OpAccessChain  %26  %17 %52
+OpStore %53 %51
+%54 = OpLoad  %3  %23
+%56 = OpAccessChain  %26  %17 %55
+OpStore %56 %54
+OpReturn
+OpFunctionEnd
+%58 = OpFunction  %2  None %14
+%57 = OpLabel
+%59 = OpAccessChain  %15  %6 %16
+%60 = OpAccessChain  %18  %9 %16
+OpBranch %61
+%61 = OpLabel
+%62 = OpFunctionCall  %2  %13
+OpReturn
+OpFunctionEnd

--- a/naga/tests/out/spv/spv-add_carry_sub_borrow_vec.spvasm
+++ b/naga/tests/out/spv/spv-add_carry_sub_borrow_vec.spvasm
@@ -1,0 +1,101 @@
+; SPIR-V
+; Version: 1.1
+; Generator: rspirv
+; Bound: 67
+OpCapability Shader
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %62 "main"
+OpExecutionMode %62 LocalSize 1 1 1
+OpMemberDecorate %5 0 Offset 0
+OpMemberDecorate %5 1 Offset 8
+OpMemberDecorate %5 2 Offset 16
+OpMemberDecorate %5 3 Offset 24
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 8
+OpDecorate %7 DescriptorSet 0
+OpDecorate %7 Binding 1
+OpDecorate %8 Block
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %10 DescriptorSet 0
+OpDecorate %10 Binding 0
+OpDecorate %11 Block
+OpMemberDecorate %11 0 Offset 0
+%2 = OpTypeVoid
+%4 = OpTypeInt 32 0
+%3 = OpTypeVector %4 2
+%5 = OpTypeStruct %3 %3 %3 %3
+%6 = OpTypeStruct %3 %3
+%8 = OpTypeStruct %5
+%9 = OpTypePointer StorageBuffer %8
+%7 = OpVariable  %9  StorageBuffer
+%11 = OpTypeStruct %6
+%12 = OpTypePointer StorageBuffer %11
+%10 = OpVariable  %12  StorageBuffer
+%15 = OpTypeFunction %2
+%16 = OpTypePointer StorageBuffer %5
+%17 = OpConstant  %4  0
+%19 = OpTypePointer StorageBuffer %6
+%22 = OpTypePointer Function %3
+%23 = OpConstantNull  %3
+%25 = OpConstantNull  %3
+%27 = OpTypePointer StorageBuffer %3
+%30 = OpConstant  %4  1
+%35 = OpTypeBool
+%34 = OpTypeVector %35 2
+%37 = OpConstantComposite  %3  %17 %17
+%38 = OpConstantComposite  %3  %30 %30
+%56 = OpConstant  %4  2
+%59 = OpConstant  %4  3
+%14 = OpFunction  %2  None %15
+%13 = OpLabel
+%21 = OpVariable  %22  Function %23
+%24 = OpVariable  %22  Function %25
+%18 = OpAccessChain  %16  %7 %17
+%20 = OpAccessChain  %19  %10 %17
+OpBranch %26
+%26 = OpLabel
+%28 = OpAccessChain  %27  %20 %17
+%29 = OpLoad  %3  %28
+%31 = OpAccessChain  %27  %20 %30
+%32 = OpLoad  %3  %31
+%33 = OpIAdd  %3  %29 %32
+%36 = OpULessThan  %34  %33 %29
+%39 = OpSelect  %3  %36 %38 %37
+%40 = OpCompositeConstruct  %6  %33 %39
+%41 = OpCompositeExtract  %3  %40 1
+OpStore %21 %41
+%42 = OpCompositeExtract  %3  %40 0
+%43 = OpAccessChain  %27  %18 %17
+OpStore %43 %42
+%44 = OpLoad  %3  %21
+%45 = OpAccessChain  %27  %18 %30
+OpStore %45 %44
+%46 = OpAccessChain  %27  %20 %17
+%47 = OpLoad  %3  %46
+%48 = OpAccessChain  %27  %20 %30
+%49 = OpLoad  %3  %48
+%50 = OpISub  %3  %47 %49
+%51 = OpULessThan  %34  %47 %49
+%52 = OpSelect  %3  %51 %38 %37
+%53 = OpCompositeConstruct  %6  %50 %52
+%54 = OpCompositeExtract  %3  %53 1
+OpStore %24 %54
+%55 = OpCompositeExtract  %3  %53 0
+%57 = OpAccessChain  %27  %18 %56
+OpStore %57 %55
+%58 = OpLoad  %3  %24
+%60 = OpAccessChain  %27  %18 %59
+OpStore %60 %58
+OpReturn
+OpFunctionEnd
+%62 = OpFunction  %2  None %15
+%61 = OpLabel
+%63 = OpAccessChain  %16  %7 %17
+%64 = OpAccessChain  %19  %10 %17
+OpBranch %65
+%65 = OpLabel
+%66 = OpFunctionCall  %2  %14
+OpReturn
+OpFunctionEnd

--- a/naga/tests/out/wgsl/spv-add_carry_sub_borrow.wgsl
+++ b/naga/tests/out/wgsl/spv-add_carry_sub_borrow.wgsl
@@ -1,0 +1,43 @@
+struct Output {
+    sum: u32,
+    carry: u32,
+    diff: u32,
+    borrow: u32,
+}
+
+struct Input {
+    a: u32,
+    b: u32,
+}
+
+@group(0) @binding(1) 
+var<storage, read_write> outp: Output;
+@group(0) @binding(0) 
+var<storage, read_write> inp: Input;
+
+fn main_1() {
+    var c: u32;
+    var d: u32;
+
+    let _e5 = inp.a;
+    let _e7 = inp.b;
+    let _e8 = (_e5 + _e7);
+    let _e11 = Input(_e8, u32((_e8 < _e5)));
+    c = _e11.b;
+    outp.sum = _e11.a;
+    let _e15 = c;
+    outp.carry = _e15;
+    let _e18 = inp.a;
+    let _e20 = inp.b;
+    let _e24 = Input((_e18 - _e20), u32((_e18 < _e20)));
+    d = _e24.b;
+    outp.diff = _e24.a;
+    let _e28 = d;
+    outp.borrow = _e28;
+    return;
+}
+
+@compute @workgroup_size(1, 1, 1) 
+fn main() {
+    main_1();
+}

--- a/naga/tests/out/wgsl/spv-add_carry_sub_borrow_vec.wgsl
+++ b/naga/tests/out/wgsl/spv-add_carry_sub_borrow_vec.wgsl
@@ -1,0 +1,43 @@
+struct Output {
+    sum: vec2<u32>,
+    carry: vec2<u32>,
+    diff: vec2<u32>,
+    borrow: vec2<u32>,
+}
+
+struct Input {
+    a: vec2<u32>,
+    b: vec2<u32>,
+}
+
+@group(0) @binding(1) 
+var<storage, read_write> outp: Output;
+@group(0) @binding(0) 
+var<storage, read_write> inp: Input;
+
+fn main_1() {
+    var c: vec2<u32>;
+    var d: vec2<u32>;
+
+    let _e5 = inp.a;
+    let _e7 = inp.b;
+    let _e8 = (_e5 + _e7);
+    let _e11 = Input(_e8, vec2<u32>((_e8 < _e5)));
+    c = _e11.b;
+    outp.sum = _e11.a;
+    let _e15 = c;
+    outp.carry = _e15;
+    let _e18 = inp.a;
+    let _e20 = inp.b;
+    let _e24 = Input((_e18 - _e20), vec2<u32>((_e18 < _e20)));
+    d = _e24.b;
+    outp.diff = _e24.a;
+    let _e28 = d;
+    outp.borrow = _e28;
+    return;
+}
+
+@compute @workgroup_size(1, 1, 1) 
+fn main() {
+    main_1();
+}


### PR DESCRIPTION

  **Connections**

Fixes #4392.

  **Description**

  `naga`'s SPIR-V frontend rejected `OpIAddCarry` and `OpISubBorrow`, blocking `rust-gpu`'s overflow-checked arithmetic.

  Lowered to the polyfill from the issue:

  ```
  arith   = a +/- b
  cmp     = (arith < a)  // IAddCarry
          | (a < b)      // ISubBorrow
  carry   = u32(cmp)
  result  = struct(arith, carry)  // Compose
  ```

  Caveats:

  - **Round-trip loses the original op.** SPIR-V output is the polyfill, not the original instruction. Is there a way to annotate so we can round trip?
  - **Defensive operand cast is untested.** I bitcast for signless-integer mismatches between operand and struct-member type. Kept for parity with `parse_expr_binary_op_sign_adjusted`. Happy to drop.
  - **`Compose` isn't folded.** Each lowering survives as a literal struct construction; a peephole could collapse it but that's a bigger optimizer change.

  **Testing**

  Added snapshots.

  **Squash or Rebase?**

Squash

  **Checklist**

  - [x] I self-reviewed and fully understand this PR.
  - [ ] WebGPU implementations built with `wgpu` may be affected behaviorally. _(frontend-only; previously-rejected SPIR-V now
  compiles)_
  - [x] Validation and feature gates are in place to confine behavioral changes.
  - [x] Tests demonstrate the validation and altered logic works.
  - [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
  - [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
  - [x] Commits are logically scoped and individually reviewable.
  - [x] The PR description has enough context to understand the motivation and solution implemented.