### PR TITLE
fix(gles): Remove `debug_assert_eq!(gl_fence.value, wait_value)`

### DIFF
--- a/tests/tests/wgpu-gpu/poll.rs
+++ b/tests/tests/wgpu-gpu/poll.rs
@@ -22,6 +22,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         DOUBLE_WAIT_ON_SUBMISSION,
         WAIT_OUT_OF_ORDER,
         WAIT_AFTER_BAD_SUBMISSION,
+        WAIT_ON_FAILED_SUBMISSION,
     ]);
 }
 
@@ -260,4 +261,90 @@ async fn wait_after_bad_submission(ctx: TestingContext) {
     // be allocated that will not be signalled until further work is
     // successfully submitted, causing a greater fence value to be signalled.
     device2.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+}
+
+/// Wait on a submission index that corresponds to a *failed* submission,
+/// where a *later* submission succeeded — i.e. the failed index is a "hole"
+/// below `last_successful_submission_index`.
+///
+/// This bypasses the wgpu-core `maintain()` guard (which only rejects indices
+/// strictly greater than `last_successful_submission_index`) and exercises a
+/// corner case of the HAL `wait` precondition documented at
+/// `wgpu-hal/src/lib.rs`:
+///
+/// > The `value` argument must not exceed the highest value that an actual
+/// > operation you have already presented to the device is going to store in
+/// > `fence`.
+///
+/// Regression test for <https://github.com/gfx-rs/wgpu/issues/9498>.
+#[gpu_test]
+static WAIT_ON_FAILED_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(wgpu_test::TestParameters::default())
+    .run_async(wait_on_failed_submission);
+
+async fn wait_on_failed_submission(ctx: TestingContext) {
+    // Create an alternate device; we will produce a failed submission by
+    // submitting a command buffer to the wrong device.
+    let (device2, queue2) =
+        wgpu_test::initialize_device(&ctx.adapter, ctx.device_features, ctx.device_limits.clone())
+            .await;
+
+    // 1. Successful empty submit. Advances `last_successful_submission_index`.
+    let _idx_before = queue2.submit([]);
+
+    // 2. Failed submit (cross-device cmd buffer). Burns an index but does not
+    //    advance `last_successful_submission_index`. Capture the returned
+    //    index using an error scope so the validation error is not fatal.
+    let command_buffer_wrong_device = ctx
+        .device
+        .create_command_encoder(&CommandEncoderDescriptor::default())
+        .finish();
+    let scope = device2.push_error_scope(wgpu::ErrorFilter::Validation);
+    let bad_index = queue2.submit([command_buffer_wrong_device]);
+    let scope_error = scope.pop().await;
+    assert!(
+        scope_error.is_some(),
+        "expected the cross-device submission to produce a validation error"
+    );
+
+    // 3. Another successful submit, this time with substantial work, so the
+    //    GPU is still busy when we issue the poll below.
+    //
+    //    Several backends' HAL `wait` implementations have a fast path "if
+    //    last_completed >= wait_value, return immediately". Per-submit
+    //    bookkeeping (e.g. GLES `Fence::get_latest`) probes pending fences
+    //    for completion and advances `last_completed`, so an empty submit
+    //    here would let the fast path apply and mask the code path we
+    //    want to exercise — the pending-fence search where the only
+    //    candidate fence has a value strictly greater than `wait_value`.
+    let big_size = 64 * 1024 * 1024;
+    let src = device2.create_buffer(&BufferDescriptor {
+        label: Some("src"),
+        size: big_size,
+        usage: BufferUsages::COPY_SRC | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let dst = device2.create_buffer(&BufferDescriptor {
+        label: Some("dst"),
+        size: big_size,
+        usage: BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device2.create_command_encoder(&CommandEncoderDescriptor::default());
+    // Stack several copies to extend the GPU work duration.
+    for _ in 0..16 {
+        encoder.copy_buffer_to_buffer(&src, 0, &dst, 0, Some(big_size));
+    }
+    let _idx_after = queue2.submit([encoder.finish()]);
+
+    // 4. The interesting wait: pass the hole index to `poll(Wait)`. The
+    //    wgpu-core guard sees `bad_index <= last_successful_submission_index`
+    //    and lets it through to the HAL `wait`, which is being asked to wait
+    //    on a fence value no operation actually presented. Must not panic or
+    //    hang.
+    let result = device2.poll(wgpu::PollType::Wait {
+        submission_index: Some(bad_index),
+        timeout: Some(Duration::from_secs(5)),
+    });
+    let _ = result;
 }

--- a/wgpu-hal/src/gles/fence.rs
+++ b/wgpu-hal/src/gles/fence.rs
@@ -119,16 +119,12 @@ impl Fence {
         let gl_fence = self
             .pending
             .iter()
-            // Greater or equal as an abundance of caution, but there should be one fence per value
             .find(|gl_fence| gl_fence.value >= wait_value);
 
         let Some(gl_fence) = gl_fence else {
             log::warn!("Tried to wait for {wait_value} but that value has not been signalled yet");
             return Ok(false);
         };
-
-        // We should have found a fence with the exact value.
-        debug_assert_eq!(gl_fence.value, wait_value);
 
         let status = unsafe {
             gl.client_wait_sync(
@@ -148,7 +144,8 @@ impl Fence {
         };
 
         if signalled {
-            self.last_completed.fetch_max(wait_value, Ordering::AcqRel);
+            self.last_completed
+                .fetch_max(gl_fence.value, Ordering::AcqRel);
         }
 
         Ok(signalled)

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1091,12 +1091,12 @@ pub trait Device: WasmNotSendSync {
     /// [`FenceValue`] to store in it, so you can use this `wait` function
     /// to wait for a given queue submission to finish execution.
     ///
-    /// The `value` argument must be a value that some actual operation you have
-    /// already presented to the device is going to store in `fence`. You cannot
-    /// wait for values yet to be submitted. (This restriction accommodates
-    /// implementations like the `vulkan` backend's [`FencePool`] that must
-    /// allocate a distinct synchronization object for each fence value one is
-    /// able to wait for.)
+    /// The `value` argument must not exceed the highest value that an actual
+    /// operation you have already presented to the device is going to store in
+    /// `fence`. You cannot wait for values yet to be submitted. (This
+    /// restriction accommodates implementations like the `vulkan` backend's
+    /// [`FencePool`] that must allocate a distinct synchronization object for
+    /// each fence value one is able to wait for.)
     ///
     /// Calling `wait` with a lower [`FenceValue`] than `fence`'s current value
     /// returns immediately.


### PR DESCRIPTION
Removes an unnecessary debug assert in the GLES backend. This fixes a minor problem identified while triaging #9498.

Also updates the HAL rustdocs to clarify the contract.

**Testing**
Adds a directed test.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
