### PR TITLE
test(cts): Move copy_ranges out of fail.lst

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -23,7 +23,6 @@ webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%, https://git
 webgpu:api,validation,createBindGroup:external_texture,* // 0%, no external external texture in deno
 webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,createView:texture_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:* // ***, https://github.com/gfx-rs/wgpu/issues/8118
 webgpu:api,validation,encoding,cmds,debug:* // 92%, https://github.com/gfx-rs/wgpu/issues/8039
 webgpu:api,validation,encoding,cmds,render,draw:max_draw_count:* // https://github.com/gfx-rs/wgpu/issues/8737
 webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_offset_alignment:* // render bundle

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -133,19 +133,7 @@ webgpu:api,validation,encoding,beginRenderPass:*
 webgpu:api,validation,encoding,cmds,clearBuffer:*
 webgpu:api,validation,encoding,cmds,compute_pass:*
 webgpu:api,validation,encoding,cmds,copyBufferToBuffer:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_aspects:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges_with_compressed_texture_formats:*
-// Intermittently fails on dx12, https://github.com/gfx-rs/wgpu/issues/8118
-fails-if(dx12) webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_ranges:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_with_invalid_or_destroyed_texture:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_within_same_texture:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:depth_stencil_copy_restrictions:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:mipmap_level:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:multisampled_copy_restrictions:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:sample_count:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_format_compatibility:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_usage:*
-webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture,device_mismatch:*
+webgpu:api,validation,encoding,cmds,copyTextureToTexture:*
 webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="compute%20pass"
 webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="non-pass"
 //FAIL: webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:encoderType="render%20bundle"


### PR DESCRIPTION
Closes #8118.

This failure seems to have been resolved. I couldn't reproduce it in numerous runs of wgpu CI, Firefox CTS, or locally. (Although I also couldn't reproduce it locally on an old build.)

**Squash or Rebase?** Squash
