### PR TITLE
fix(naga): Don't panic on oversize types

### DIFF
--- a/naga/src/front/wgsl/lower/construction.rs
+++ b/naga/src/front/wgsl/lower/construction.rs
@@ -527,15 +527,25 @@ impl<'source> Lowerer<'source, '_> {
 
                 let base = ctx.register_type(components[0])?;
 
+                ctx.layouter.update(ctx.module.to_ctx()).map_err(|err| {
+                    let crate::proc::LayoutErrorInner::TooLarge = err.inner else {
+                        unreachable!("unexpected layout error: {err:?}");
+                    };
+                    // This error could be for any type that was pending layout. Lots of
+                    // type definitions don't get spans, so the error message may not be
+                    // very useful.
+                    Box::new(Error::TypeTooLarge {
+                        span: ctx.module.types.get_span(err.ty),
+                    })
+                })?;
+                let stride = ctx.layouter[base].to_stride();
+
                 let inner = crate::TypeInner::Array {
                     base,
                     size: crate::ArraySize::Constant(
                         NonZeroU32::new(u32::try_from(components.len()).unwrap()).unwrap(),
                     ),
-                    stride: {
-                        ctx.layouter.update(ctx.module.to_ctx()).unwrap();
-                        ctx.layouter[base].to_stride()
-                    },
+                    stride,
                 };
                 let ty = ctx.ensure_type_exists(inner);
 

--- a/naga/src/front/wgsl/lower/conversion.rs
+++ b/naga/src/front/wgsl/lower/conversion.rs
@@ -277,6 +277,13 @@ impl<'source> super::ExpressionContext<'source, '_, '_> {
                     .cast_array(expr, *concrete_scalar, expr_span)
                 {
                     Ok(expr) => return Ok(expr),
+                    Err(crate::proc::ConstantEvaluatorError::TypeTooLarge(ty)) => {
+                        // Special case where the error is not actually related to the
+                        // particular scalar we tried to concretize.
+                        return Err(Box::new(super::Error::TypeTooLarge {
+                            span: self.module.types.get_span(ty),
+                        }));
+                    }
                     Err(err) => {
                         errors.push((concrete_scalar.to_wgsl_for_diagnostics(), err));
                     }

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -952,6 +952,8 @@ pub enum ConstantEvaluatorError {
     SelectAcceptRejectTypeMismatch,
     #[error("Cooperative operations can't be constant")]
     CooperativeOperation,
+    #[error("Type is too large")]
+    TypeTooLarge(Handle<Type>),
 }
 
 impl<'a> ConstantEvaluator<'a> {
@@ -2652,7 +2654,14 @@ impl<'a> ConstantEvaluator<'a> {
             }
         };
         let mut layouter = core::mem::take(self.layouter);
-        layouter.update(self.to_ctx()).unwrap();
+        layouter.update(self.to_ctx()).map_err(|err| {
+            // The layouter operates lazily, so the error
+            // could be for any pending type.
+            let crate::proc::LayoutErrorInner::TooLarge = err.inner else {
+                unreachable!("unexpected layout error: {err:?}");
+            };
+            ConstantEvaluatorError::TypeTooLarge(err.ty)
+        })?;
         *self.layouter = layouter;
 
         let new_base_stride = self.layouter[new_base].to_stride();

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -4715,6 +4715,50 @@ fn max_type_size_array_of_structs() {
 }
 
 #[test]
+fn max_type_size_array_constructor_with_oversize_type() {
+    // An `array(...)` constructor expression invokes the layouter to compute
+    // the stride of the constructed array. If a previously declared type is
+    // oversize, the layouter encounters it and the error must be reported
+    // rather than panicking.
+    //
+    // Regression test for <https://github.com/gfx-rs/wgpu/issues/9440>.
+    check(
+        r#"
+            var<workgroup> big: array<u32, 1 << 29>;
+            const A = array(1);
+        "#,
+        r#"error: type is too large
+ = note: the maximum size is 2147483647 bytes
+
+"#,
+    );
+}
+
+#[test]
+fn max_type_size_concretize_with_oversize_type() {
+    // Concretizing an abstract array (here, indexing it with a non-constant
+    // index forces concretization to a concrete element type) invokes the
+    // layouter to compute the new array's stride. If a previously declared
+    // type is oversize, the layouter encounters it and the error must be
+    // reported rather than panicking.
+    //
+    // Regression test for <https://github.com/gfx-rs/wgpu/issues/9440>.
+    check(
+        r#"
+            const a = array(0.);
+            var<workgroup> big: array<u32, 1 << 29>;
+            fn main(i: u32) {
+                let x = a[i];
+            }
+        "#,
+        r#"error: type is too large
+ = note: the maximum size is 2147483647 bytes
+
+"#,
+    );
+}
+
+#[test]
 fn source_with_control_char() {
     check(
         "\x07",


### PR DESCRIPTION
Fixes #9440 a.k.a. https://bugzilla.mozilla.org/show_bug.cgi?id=2020561 and https://bugzilla.mozilla.org/show_bug.cgi?id=2031636.

Changes some panics on oversize types to be errors instead.

The messy thing here is that the `Layouter` operates lazily, so when we get an error from `update()`, it's not necessarily related to what we're working on at that moment. This is particularly problematic in the constant evaluator where the context for the error is assumed farther up the call stack, so I've made `ConstantEvaluatorError::TypeTooLarge` include the type, unlike the rest of the constant evaluator errors.

This could probably all be refactored to be cleaner, but this was as much time as I could justify spending on it right now. The type size limit is 2 GB; shaders that exceed it are pathological and unlikely to be useful in any current WebGPU deployment.

**Testing**
Adds directed tests in wgsl_errors.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present.
   - I suppose we could changelog this? But seems pretty minor.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
