### PR TITLE
[Metal/hal] Expose `raw_device()` from Metal `Adapter`

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1,4 +1,4 @@
-use objc2::rc::autoreleasepool;
+use objc2::rc::{autoreleasepool, Retained};
 use objc2::runtime::{AnyObject, ProtocolObject, Sel};
 use objc2::{available, sel};
 use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -69,6 +69,9 @@ impl super::Adapter {
     pub(super) fn new(shared: Arc<super::AdapterShared>) -> Self {
         Self { shared }
     }
+    pub fn raw_device(&self) -> &Retained<ProtocolObject<dyn MTLDevice>> {
+        &self.shared.device
+    }
 }
 
 impl crate::Adapter for super::Adapter {

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1,4 +1,4 @@
-use objc2::rc::{autoreleasepool, Retained};
+use objc2::rc::autoreleasepool;
 use objc2::runtime::{AnyObject, ProtocolObject, Sel};
 use objc2::{available, sel};
 use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -69,7 +69,7 @@ impl super::Adapter {
     pub(super) fn new(shared: Arc<super::AdapterShared>) -> Self {
         Self { shared }
     }
-    pub fn raw_device(&self) -> &Retained<ProtocolObject<dyn MTLDevice>> {
+    pub fn raw_device(&self) -> &ProtocolObject<dyn MTLDevice> {
         &self.shared.device
     }
 }


### PR DESCRIPTION
**Description**
This PR adds a `raw_device()` method on Metal's `Adapter`. It returns the underlying `MTLDevice` that adapter wraps.

Mirrors `Device::raw_device()` for the device side. Useful for callers that need to query Metal-only adapter metadata (e.g. `registryID`, `location`, `isHeadless`) without first requesting a logical device.

**Testing**
_Explain how this change is tested._

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
