### PR TITLE
test(cts): Move some config from actions yaml to xtask

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -17,7 +17,6 @@ env:
   REPO_MSRV: "1.93"
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
-  DENO_WEBGPU_DX12_COMPILER: dynamicdxc
   RUST_BACKTRACE: full
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
@@ -156,7 +155,6 @@ jobs:
         shell: bash
         run: |
           export LLVM_PROFILE_FILE=${{ github.workspace }}/target/wgpu-%p-%m.profraw
-          export DENO_WEBGPU_BACKEND=${{ matrix.backend }}
           cargo --locked test -p cts_runner
 
       - name: Run CTS

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -155,6 +155,7 @@ jobs:
         shell: bash
         run: |
           export LLVM_PROFILE_FILE=${{ github.workspace }}/target/wgpu-%p-%m.profraw
+          export DENO_WEBGPU_BACKEND=${{ matrix.backend }}
           cargo --locked test -p cts_runner
 
       - name: Run CTS

--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -137,9 +137,24 @@ pub fn run_cts(
         })
         .collect::<Vec<_>>();
 
-    if running_on_backend.is_none() && (!list_files.is_empty() || tests.is_empty()) {
+    if let Some(backend) = &running_on_backend {
+        shell.set_var("DENO_WEBGPU_BACKEND", backend);
+    } else if !list_files.is_empty() || tests.is_empty() {
         log::warn!("The `--backend` option was not provided. `fails-if` conditions and external");
         log::warn!("texture support are handled correctly only when a backend is specified.");
+    }
+
+    #[cfg(windows)]
+    if running_on_backend.as_ref().is_none_or(|b| b == "dx12") {
+        const DEFAULT_DX12_COMPILER: &str = "dynamicdxc";
+
+        match shell.var("DENO_WEBGPU_DX12_COMPILER") {
+            Ok(value) => log::info!("Using DENO_WEBGPU_DX12_COMPILER = {value} from environment"),
+            Err(_) => {
+                shell.set_var("DENO_WEBGPU_DX12_COMPILER", DEFAULT_DX12_COMPILER);
+                log::info!("Using default DENO_WEBGPU_DX12_COMPILER = {DEFAULT_DX12_COMPILER}");
+            }
+        }
     }
 
     let mut default_output_filter = PrintOutputWhen::Always;


### PR DESCRIPTION
Reduces the number of things that have to be set up manually in order to reproduce CI results locally.

There's still the issue of the default backend on Windows being Vulkan. I considered having cts_runner default to dx12 on Windows, but I haven't done that, not sure whether it makes things more or less confusing.

**Testing**
Tested locally and will be by CI as well, although it wouldn't hurt to sanity-check the log messages in the CI runs.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
