### PR TITLE
fix(dx12): Map components properly for textureLoad from stencil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 - Fixed use of a texture view without `TextureUsage::TEXTURE_BINDING` as a read-only depth attachment. By @andyleiserson in [#9346](https://github.com/gfx-rs/wgpu/pull/9346).
 - Fixed a `debug_assert` during stride validation for indirect multi draw. By @kristoff3r in [#9332](https://github.com/gfx-rs/wgpu/pull/9332)
+- Fixed stencil values read with `textureLoad` appearing in G instead of R. By @andyleiserson in [#9520](https://github.com/gfx-rs/wgpu/pull/9520).
 
 #### Metal
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -11,6 +11,11 @@
 //
 // The `cts_runner` integration test `lst_files_are_sorted` verifies that test selectors
 // appear in this file in order -- including ones in comments.
+
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth24plus-stencil8";depthReadOnly=false;stencilReadOnly=true // https://github.com/gfx-rs/wgpu/issues/8705
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth24plus-stencil8";depthReadOnly=true;stencilReadOnly=false // https://github.com/gfx-rs/wgpu/issues/8705
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=false;stencilReadOnly=true // https://github.com/gfx-rs/wgpu/issues/8705
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=true;stencilReadOnly=false // https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,operation,rendering,3d_texture_slices:* // https://github.com/gfx-rs/wgpu/issues/9455
 
 webgpu:api,validation,buffer,mapping:* // crash

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -36,14 +36,14 @@ webgpu:api,operation,compute_pipeline,overrides:*
 //FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute,basic:memcpy:*
 webgpu:api,operation,device,lost:*
-webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="stencil8";*
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth16unorm";*
-webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float";*
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth24plus";*
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth24plus-stencil8";depthReadOnly=false;stencilReadOnly=false
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth24plus-stencil8";depthReadOnly=true;stencilReadOnly=true
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float";*
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=false;stencilReadOnly=false
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=true;stencilReadOnly=true
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="stencil8";*
 
 webgpu:api,operation,render_pass,storeOp:*
 webgpu:api,operation,render_pipeline,overrides:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -36,6 +36,15 @@ webgpu:api,operation,compute_pipeline,overrides:*
 //FAIL: webgpu:api,operation,compute,basic:large_dispatch:*
 webgpu:api,operation,compute,basic:memcpy:*
 webgpu:api,operation,device,lost:*
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="stencil8";*
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth16unorm";*
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float";*
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth24plus";*
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth24plus-stencil8";depthReadOnly=false;stencilReadOnly=false
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth24plus-stencil8";depthReadOnly=true;stencilReadOnly=true
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=false;stencilReadOnly=false
+webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=true;stencilReadOnly=true
+
 webgpu:api,operation,render_pass,storeOp:*
 webgpu:api,operation,render_pipeline,overrides:*
 webgpu:api,operation,render_pipeline,pipeline_output_targets:color,component_count,blend:*

--- a/wgpu-hal/src/dx12/conv.rs
+++ b/wgpu-hal/src/dx12/conv.rs
@@ -447,3 +447,21 @@ pub(crate) fn map_acceleration_structure_copy_mode(
         }
     }
 }
+
+pub(crate) const fn make_shader_component_mapping(
+    src0: Direct3D12::D3D12_SHADER_COMPONENT_MAPPING,
+    src1: Direct3D12::D3D12_SHADER_COMPONENT_MAPPING,
+    src2: Direct3D12::D3D12_SHADER_COMPONENT_MAPPING,
+    src3: Direct3D12::D3D12_SHADER_COMPONENT_MAPPING,
+) -> Direct3D12::D3D12_SHADER_COMPONENT_MAPPING {
+    const M: i32 = Direct3D12::D3D12_SHADER_COMPONENT_MAPPING_MASK as i32;
+    const S: i32 = Direct3D12::D3D12_SHADER_COMPONENT_MAPPING_SHIFT as i32;
+    Direct3D12::D3D12_SHADER_COMPONENT_MAPPING(
+        (src0.0 & M)
+            | (src1.0 & M) << S
+            | (src2.0 & M) << (S * 2)
+            | (src3.0 & M) << (S * 3)
+            | Direct3D12::D3D12_SHADER_COMPONENT_MAPPING_ALWAYS_SET_BIT_AVOIDING_ZEROMEM_MISTAKES
+                as i32,
+    )
+}

--- a/wgpu-hal/src/dx12/view.rs
+++ b/wgpu-hal/src/dx12/view.rs
@@ -41,12 +41,32 @@ fn aspects_to_plane(aspects: crate::FormatAspects) -> u32 {
     }
 }
 
+/// Shader component mapping for stencil-only views
+///
+/// Stencil views use `DXGI_FORMAT_X24_TYPELESS_G8_UINT`, which places
+/// the value in the green component. WebGPU specifies that it be in
+/// the red component, and that the remaining components _should_ be
+/// (0, 0, 1), but may have an unspecified value.
+const STENCIL_COMPONENT_MAPPING: Direct3D12::D3D12_SHADER_COMPONENT_MAPPING =
+    super::conv::make_shader_component_mapping(
+        Direct3D12::D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_1,
+        Direct3D12::D3D12_SHADER_COMPONENT_MAPPING_FORCE_VALUE_0,
+        Direct3D12::D3D12_SHADER_COMPONENT_MAPPING_FORCE_VALUE_0,
+        Direct3D12::D3D12_SHADER_COMPONENT_MAPPING_FORCE_VALUE_1,
+    );
+
 impl ViewDescriptor {
     pub(crate) unsafe fn to_srv(&self) -> Option<Direct3D12::D3D12_SHADER_RESOURCE_VIEW_DESC> {
+        let swizzle = if self.aspects == crate::FormatAspects::STENCIL {
+            STENCIL_COMPONENT_MAPPING.0 as u32
+        } else {
+            Direct3D12::D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING
+        };
+
         let mut desc = Direct3D12::D3D12_SHADER_RESOURCE_VIEW_DESC {
             Format: self.srv_uav_format?,
             ViewDimension: Direct3D12::D3D12_SRV_DIMENSION_UNKNOWN,
-            Shader4ComponentMapping: Direct3D12::D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
+            Shader4ComponentMapping: swizzle,
             Anonymous: Default::default(),
         };
 

--- a/wgpu-hal/src/dx12/view.rs
+++ b/wgpu-hal/src/dx12/view.rs
@@ -41,12 +41,13 @@ fn aspects_to_plane(aspects: crate::FormatAspects) -> u32 {
     }
 }
 
-/// Shader component mapping for stencil-only views
+/// Shader component mapping for stencil views
 ///
-/// Stencil views use `DXGI_FORMAT_X24_TYPELESS_G8_UINT`, which places
-/// the value in the green component. WebGPU specifies that it be in
-/// the red component, and that the remaining components _should_ be
-/// (0, 0, 1), but may have an unspecified value.
+/// Stencil views use `DXGI_FORMAT_X24_TYPELESS_G8_UINT` or
+/// `DXGI_FORMAT_X32_TYPELESS_G8X24_UINT`, which have the stencil value in
+/// the green component. WebGPU specifies that the stencil value be in the
+/// red component. It also specifies that the remaining components _should_
+/// be (0, 0, 1), but may have an unspecified value.
 const STENCIL_COMPONENT_MAPPING: Direct3D12::D3D12_SHADER_COMPONENT_MAPPING =
     super::conv::make_shader_component_mapping(
         Direct3D12::D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_1,


### PR DESCRIPTION
The shader view format used by the dx12 backend for stencil-only views, `DXGI_FORMAT_X24_TYPELESS_G8_UINT`, places the value in the green component. WebGPU requires it in the red component.

Fixes #6620 using the approach suggested by the reporter: configure a `D3D12_SHADER_COMPONENT_MAPPING` swizzle in the view.

**Testing**
Enables CTS tests (it's not clear that this coverage is the primary goal of these CTS tests, but I couldn't find anything better, and coverage is coverage). This change fixes the two `format="stencil8"` tests; it also adds other tests that were already passing to `test.lst`, and other pre-existing failures to `fail.lst`.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
