### PR TITLE
Fix a documentation typo for backend_options field

### DIFF
--- a/wgpu-types/src/instance.rs
+++ b/wgpu-types/src/instance.rs
@@ -45,7 +45,7 @@ pub struct InstanceDescriptor {
     pub flags: InstanceFlags,
     /// Memory budget thresholds used by some backends.
     pub memory_budget_thresholds: MemoryBudgetThresholds,
-    /// Options the control the behavior of specific backends.
+    /// Options for configuring the behavior of specific backends.
     pub backend_options: crate::BackendOptions,
     /// System platform or compositor connection to connect this `Instance` to.
     ///


### PR DESCRIPTION
**Description**
It... fixes a typo.