### PR TITLE
Lock rank cleanup, part 1

### DIFF
--- a/lock-analyzer/src/main.rs
+++ b/lock-analyzer/src/main.rs
@@ -22,6 +22,10 @@ use std::{
 
 use anyhow::{Context, Result};
 
+// When printing the rank graph, include the source locations where the acquisitions were
+// observed. Setting this to `false` produces output that more closely matches `rank.rs`.
+const PRINT_ACQUISITION_LOCATIONS: bool = false;
+
 fn main() -> Result<()> {
     let mut ranks: BTreeMap<u32, Rank> = BTreeMap::default();
 
@@ -113,69 +117,82 @@ fn main() -> Result<()> {
         }
     }
 
-    for older_rank in ranks.values() {
+    let (order, connected) = order_ranks(&ranks);
+
+    // Assemble the ranks into three groups, in this list:
+    // 1. Non-leaf ranks, in the topological order.
+    // 2. Leaf ranks that are connected to the graph, alphabetically.
+    // 3. Ranks that aren't connected to the graph at all, alphabetically.
+    let mut grouped_order = Vec::with_capacity(order.len());
+
+    // Non-leaf ranks in topological order.
+    grouped_order.extend(order.iter().filter(|bit| !ranks[bit].is_leaf()));
+
+    // Leaf ranks that are connected to the graph, in alphabetical order.
+    grouped_order.extend({
+        let mut tmp = order
+            .iter()
+            .copied()
+            .filter(|bit| ranks[bit].is_leaf() && connected & (1 << *bit) != 0)
+            .collect::<Vec<_>>();
+        tmp.sort_by_key(|bit| &ranks[bit].const_name);
+        tmp
+    });
+
+    // Ranks that aren't connected to the graph at all, in alphabetical order.
+    grouped_order.extend({
+        let mut tmp = order
+            .iter()
+            .copied()
+            .filter(|bit| ranks[bit].is_leaf() && connected & (1 << *bit) == 0)
+            .collect::<Vec<_>>();
+        tmp.sort_by_key(|bit| &ranks[bit].const_name);
+        tmp
+    });
+
+    // Finally, compute indexes so we can sort the followers of each rank in the same order
+    // as the ranks themselves.
+    let mut place_in_group_order = vec![0; ranks.len()];
+    for (i, &bit) in grouped_order.iter().enumerate() {
+        place_in_group_order[bit as usize] = i;
+    }
+
+    for bit in &grouped_order {
+        let older_rank = &ranks[bit];
         if older_rank.is_leaf() {
-            // We'll print leaf locks separately, below.
+            println!(
+                "    rank {} {:?} followed by {{ }};",
+                older_rank.const_name, older_rank.member_name
+            );
             continue;
         }
         println!(
             "    rank {} {:?} followed by {{",
             older_rank.const_name, older_rank.member_name
         );
-        let mut acquired_any_leaf_locks = false;
-        let mut first_newer = true;
-        for (newer_rank, locations) in &older_rank.acquisitions {
-            // List acquisitions of leaf locks at the end.
-            if ranks[newer_rank].is_leaf() {
-                acquired_any_leaf_locks = true;
-                continue;
-            }
-            if !first_newer {
-                println!();
-            }
-            for (older_location, newer_locations) in locations {
-                if newer_locations.len() == 1 {
-                    for newer_loc in newer_locations {
-                        println!("        // holding {older_location} while locking {newer_loc}");
-                    }
-                } else {
-                    println!("        // holding {older_location} while locking:");
-                    for newer_loc in newer_locations {
-                        println!("        //     {newer_loc}");
+        let mut acquisitions = older_rank.acquisitions.iter().collect::<Vec<_>>();
+        acquisitions.sort_by_key(|(&newer_rank, _)| place_in_group_order[newer_rank as usize]);
+        for (newer_rank, locations) in acquisitions {
+            if PRINT_ACQUISITION_LOCATIONS {
+                for (older_location, newer_locations) in locations {
+                    if newer_locations.len() == 1 {
+                        for newer_loc in newer_locations {
+                            println!(
+                                "        // holding {older_location} while locking {newer_loc}"
+                            );
+                        }
+                    } else {
+                        println!("        // holding {older_location} while locking:");
+                        for newer_loc in newer_locations {
+                            println!("        //     {newer_loc}");
+                        }
                     }
                 }
             }
             println!("        {},", ranks[newer_rank].const_name);
-            first_newer = false;
         }
 
-        if acquired_any_leaf_locks {
-            // We checked that older_rank isn't a leaf lock, so we
-            // must have printed something above.
-            if !first_newer {
-                println!();
-            }
-            println!("        // leaf lock acquisitions:");
-            for newer_rank in older_rank.acquisitions.keys() {
-                if !ranks[newer_rank].is_leaf() {
-                    continue;
-                }
-                println!("        {},", ranks[newer_rank].const_name);
-            }
-        }
-        println!("    }};");
-        println!();
-    }
-
-    for older_rank in ranks.values() {
-        if !older_rank.is_leaf() {
-            continue;
-        }
-
-        println!(
-            "    rank {} {:?} followed by {{ }};",
-            older_rank.const_name, older_rank.member_name
-        );
+        println!("    }}");
     }
 
     Ok(())
@@ -251,4 +268,55 @@ impl fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.file, self.line)
     }
+}
+
+/// Generate a topological order for lock ranks, and find unconnected ranks.
+///
+/// Return a pair `(ranks, connected)` such that:
+///
+/// - `ranks` is a vector of rank numbers in which each rank R occurs
+///   before all other ranks acquired while R is held.
+///
+/// - `connected` is a bit mask of all ranks that are acquired while
+///   some other rank is held. In other words, this is the set of
+///   ranks that have predecessors in the partial order.
+fn order_ranks(ranks: &BTreeMap<u32, Rank>) -> (Vec<u32>, u64) {
+    let mut order = Vec::with_capacity(ranks.len());
+    let mut connected = 0; // mask of ranks that are connected to the graph
+
+    // Generate the ordering in reverse: traverse the graph in
+    // depth-first order, adding a rank to end of the list only after
+    // all other ranks reachable from it have been appended.
+
+    // A mask of the ranks already visited by the traversal.
+    let mut visited = 0;
+
+    fn visit(
+        bit: u32,
+        visited: &mut u64,
+        ranks: &BTreeMap<u32, Rank>,
+        order: &mut Vec<u32>,
+        connected: &mut u64,
+    ) {
+        if *visited & (1 << bit) != 0 {
+            return;
+        }
+        *visited |= 1 << bit;
+
+        for &next_rank_bit in ranks[&bit].acquisitions.keys() {
+            *connected |= 1 << next_rank_bit;
+            visit(next_rank_bit, visited, ranks, order, connected);
+        }
+
+        order.push(bit);
+    }
+
+    for &bit in ranks.keys() {
+        visit(bit, &mut visited, ranks, &mut order, &mut connected);
+    }
+
+    // Reverse the ordering, so visitors appear before the visited.
+    order.reverse();
+
+    (order, connected)
 }

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -342,9 +342,9 @@ impl RenderBundleEncoder {
                 .map_pass_err(scope)?;
         };
 
+        let buffer_guard = hub.buffers.read();
         let bind_group_guard = hub.bind_groups.read();
         let pipeline_guard = hub.render_pipelines.read();
-        let buffer_guard = hub.buffers.read();
 
         let mut state = State {
             trackers: RenderBundleScope::new(),

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -1271,9 +1271,9 @@ impl CommandEncoder {
         self: &Arc<Self>,
         desc: &wgt::CommandBufferDescriptor<Label>,
     ) -> (Arc<CommandBuffer>, Option<CommandEncoderError>) {
-        let mut cmd_enc_status = self.data.lock();
+        let status = self.data.lock().finish();
 
-        let res = match cmd_enc_status.finish() {
+        let res = match status {
             CommandEncoderStatus::Finished(mut cmd_buf_data) => {
                 match Self::encode_commands(&self.device, &mut cmd_buf_data) {
                     Ok(()) => Ok(cmd_buf_data),

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -124,6 +124,7 @@ use crate::{
     command::{CommandBuffer, CommandEncoder, RenderBundle},
     device::{queue::Queue, Device},
     instance::Adapter,
+    lock::rank,
     pipeline::{ComputePipeline, PipelineCache, RenderPipeline, ShaderModule},
     registry::{Registry, RegistryReport},
     resource::{
@@ -209,6 +210,13 @@ pub struct Hub {
 
 impl Hub {
     pub(crate) fn new() -> Self {
+        // Unique lock ranks are required only for registries that are accessed concurrently.
+        // This happens in render pass/bundle encoding, and bind group creation. (Concurrent
+        // access could probably be avoided even in those cases, but acquiring all the locks
+        // at once simplifies the code.)
+        //
+        // The _first_ concurrently-held registry lock uses REGISTRY_STORAGE. Others have
+        // their own named lock rank.
         Self {
             adapters: Registry::new(),
             devices: Registry::new(),
@@ -216,22 +224,22 @@ impl Hub {
             pipeline_layouts: Registry::new(),
             shader_modules: Registry::new(),
             bind_group_layouts: Registry::new(),
-            bind_groups: Registry::new(),
+            bind_groups: Registry::with_rank(rank::HUB_BIND_GROUPS),
             command_encoders: Registry::new(),
             command_buffers: Registry::new(),
             render_bundles: Registry::new(),
-            render_pipelines: Registry::new(),
+            render_pipelines: Registry::with_rank(rank::HUB_RENDER_PIPELINES),
             compute_pipelines: Registry::new(),
             pipeline_caches: Registry::new(),
             query_sets: Registry::new(),
             buffers: Registry::new(),
             staging_buffers: Registry::new(),
             textures: Registry::new(),
-            texture_views: Registry::new(),
-            external_textures: Registry::new(),
-            samplers: Registry::new(),
+            texture_views: Registry::with_rank(rank::HUB_TEXTURE_VIEWS),
+            external_textures: Registry::with_rank(rank::HUB_EXTERNAL_TEXTURES),
+            samplers: Registry::with_rank(rank::HUB_SAMPLERS),
             blas_s: Registry::new(),
-            tlas_s: Registry::new(),
+            tlas_s: Registry::with_rank(rank::HUB_TLAS),
         }
     }
 

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -113,7 +113,7 @@ define_lock_ranks! {
         BUFFER_POOL,
         DEVICE_TRACE,
         DEVICE_USAGE_SCOPES,
-        REGISTRY_STORAGE,
+        HUB_OTHER,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
     rank DEVICE_SNATCHABLE_LOCK "Device::snatchable_lock" followed by {
@@ -128,7 +128,7 @@ define_lock_ranks! {
         BUFFER_POOL,
         DEVICE_TRACE,
         DEVICE_USAGE_SCOPES,
-        REGISTRY_STORAGE,
+        HUB_OTHER,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
         TEXTURE_BIND_GROUPS,
         TEXTURE_CLEAR_MODE,
@@ -175,6 +175,25 @@ define_lock_ranks! {
     rank COMMAND_ALLOCATOR_FREE_ENCODERS "CommandAllocator::free_encoders" followed by {
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
+    rank HUB_OTHER "Hub (general)" followed by {
+        HUB_TEXTURE_VIEWS,
+        HUB_BIND_GROUPS,
+    }
+    rank HUB_BIND_GROUPS "Hub::bind_groups" followed by {
+        HUB_RENDER_PIPELINES,
+    }
+    rank HUB_RENDER_PIPELINES "Hub::render_pipelines" followed by {
+        SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
+    }
+    rank HUB_TEXTURE_VIEWS "Hub::texture_views" followed by {
+        HUB_SAMPLERS,
+    }
+    rank HUB_SAMPLERS "Hub::samplers" followed by {
+        HUB_TLAS,
+    }
+    rank HUB_TLAS "Hub::tlas" followed by {
+        HUB_EXTERNAL_TEXTURES,
+    }
 
     // Leaf ranks reachable from the graph above, alphabetical.
     rank BLAS_COMPACTION_STATE "Blas::compaction_state" followed by { }
@@ -184,7 +203,7 @@ define_lock_ranks! {
     rank DEVICE_DEFERRED_DESTROY "Device::deferred_destroy" followed by { }
     rank DEVICE_TRACE "Device::trace" followed by { }
     rank DEVICE_USAGE_SCOPES "Device::usage_scopes" followed by { }
-    rank REGISTRY_STORAGE "Registry::storage" followed by { }
+    rank HUB_EXTERNAL_TEXTURES "Hub::external_textures" followed by { }
     rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }
     rank QUERY_SET_INITIALIZED_SLOTS "QuerySet::initialized_slots" followed by { }
     rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { }

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -80,6 +80,7 @@ pub struct Mutex<T> {
 /// For details, see [the module documentation][self].
 pub struct MutexGuard<'a, T> {
     inner: parking_lot::MutexGuard<'a, T>,
+    #[cfg_attr(not(miri), expect(unused))] // but `Drop` has important side effects
     saved: LockStateGuard,
 }
 
@@ -163,17 +164,53 @@ fn acquire(new_rank: LockRank, location: &'static Location<'static>) -> LockStat
 /// Check that locks are being acquired in stacking order, and update the
 /// per-thread state accordingly.
 fn release(saved: LockState) {
+    let saved_info = saved.last_acquired;
+
     let prior = LOCK_STATE.replace(saved);
+
+    let (prior_rank, prior_location) = prior
+        .last_acquired
+        .expect("Releasing a lock, but no acquisition recorded");
 
     // Although Rust allows mutex guards to be dropped in any
     // order, this analysis requires that locks be acquired and
     // released in stack order: the next lock to be released must be
     // the most recently acquired lock still held.
-    assert_eq!(
-        prior.depth,
-        saved.depth + 1,
-        "Lock not released in stacking order"
-    );
+
+    match (saved.depth, saved_info) {
+        (saved_depth @ 0, None) => {
+            assert_eq!(
+                prior.depth,
+                saved_depth + 1,
+                "Lock not released in stacking order\n\
+                released {:<35} locked at {:?}\n\
+                when not expecting any locks to be held\n",
+                prior_rank.bit.member_name(),
+                prior_location,
+            );
+        }
+        (0, Some(_)) => {
+            panic!("Found previous lock acquisition information, but saved.depth = 0");
+        }
+        (saved_depth, Some((saved_rank, saved_location))) => {
+            assert_eq!(
+                prior.depth,
+                saved_depth + 1,
+                "Lock not released in stacking order\n\
+                expecting release of {:<35} locked at {:?}\n\
+                but instead released {:<35} locked at {:?}\n",
+                saved_rank.bit.member_name(),
+                saved_location,
+                prior_rank.bit.member_name(),
+                prior_location,
+            );
+        }
+        (saved_depth, None) => {
+            panic!(
+                "Found saved.depth = {saved_depth}, but no previous lock acquisition information"
+            );
+        }
+    }
 }
 
 impl<T> Mutex<T> {

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -3,12 +3,20 @@ use alloc::sync::Arc;
 use crate::{
     id::Id,
     identity::IdentityManager,
-    lock::{rank, RwLock, RwLockReadGuard},
+    lock::{
+        rank::{self, LockRank},
+        RwLock, RwLockReadGuard,
+    },
     storage::{Element, Storage, StorageItem},
 };
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct RegistryReport {
+    /// Count of IDs allocated by [`IdentityManager`]
+    ///
+    /// This may be inconsistent with other fields of the report if
+    /// IDs are allocated or released concurrently with report
+    /// generation.
     pub num_allocated: usize,
     pub num_kept_from_user: usize,
     pub num_released_from_user: usize,
@@ -41,9 +49,13 @@ pub(crate) struct Registry<T: StorageItem> {
 
 impl<T: StorageItem> Registry<T> {
     pub(crate) fn new() -> Self {
+        Self::with_rank(rank::HUB_OTHER)
+    }
+
+    pub(crate) fn with_rank(rank: LockRank) -> Self {
         Self {
             identity: Arc::new(IdentityManager::new()),
-            storage: RwLock::new(rank::REGISTRY_STORAGE, Storage::new()),
+            storage: RwLock::new(rank, Storage::new()),
         }
     }
 }
@@ -94,12 +106,18 @@ impl<T: StorageItem> Registry<T> {
     }
 
     pub(crate) fn generate_report(&self) -> RegistryReport {
-        let storage = self.storage.read();
         let mut report = RegistryReport {
             element_size: size_of::<T>(),
             ..Default::default()
         };
+
+        // Acquiring the identity values lock while holding the storage lock
+        // would require adding an edge in the lock graph, and would still not
+        // ensure a consistent report, because the storage lock is not otherwise
+        // acquired when managing IDs.
         report.num_allocated = self.identity.values.lock().count();
+
+        let storage = self.storage.read();
         for element in storage.map.iter() {
             match *element {
                 Element::Occupied(..) => report.num_kept_from_user += 1,


### PR DESCRIPTION
Progress towards #5937.

Does the following, in separate commits for each top-level bullet:
* Improvements to the lock analyzer
    * Groups the graph nodes by non-leaf, connected leaf, and disconnected leaf, instead of only by leaf and non-leaf.
    * List followers in the same order as the ranks themselves.
    * Don't print the acquisition locations by default. This makes the output closer to what appears in `rank.rs`.
* Release COMMAND_BUFFER_DATA before encoding commands. (This may sound dubious, but it's not. `COMMAND_BUFFER_DATA` is just protecting the command buffer mutable state. It is acquired just before encoding commands to move the mutable state out of the lock-protected location entirely. Once that is done, the mutable state only holds the empty `CommandEncoderStatus::Consumed` sentinel. There aren't any hazards between the sentinel and the encoding process itself.)
* Print more detail for lock release order violations
* Use unique lock ranks for concurrently-accessed registries. 

**Testing**
It is hard to use the lock validation build incrementally for each of the changes, but at the tip of my branch, the lock validation build can pass our test suite (including the enabled CTS tests). 

**Squash or Rebase?** Rebase

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works.
  - See above.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
  - Maybe one changelog entry after all the changes, mentioning deadlocks have been resolved?
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
  - Can be further split by commits if desired.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
