### PR TITLE
Trigger a surface resize to deal with window resize race condition

### DIFF
--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -56,6 +56,24 @@ impl App {
             state: AppState::Uninitialized,
         }
     }
+
+    fn resize_surface(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
+        let AppState::Running(wgpu_state) = &mut self.state else {
+            return;
+        };
+
+        // Reconfigure the surface with the new size
+        wgpu_state.config.width = new_size.width.max(1);
+        wgpu_state.config.height = new_size.height.max(1);
+        wgpu_state
+            .surface
+            .configure(&wgpu_state.device, &wgpu_state.config);
+
+        // On macos the window needs to be redrawn manually after resizing
+        if let Some(window) = &self.window {
+            window.request_redraw();
+        }
+    }
 }
 
 impl ApplicationHandler<TriangleAction> for App {
@@ -173,6 +191,7 @@ impl ApplicationHandler<TriangleAction> for App {
             let config = surface
                 .get_default_config(&adapter, size.width, size.height)
                 .unwrap();
+
             surface.configure(&device, &config);
 
             let _ = proxy.send_event(TriangleAction::Initialized(WgpuState {
@@ -191,8 +210,11 @@ impl ApplicationHandler<TriangleAction> for App {
         match event {
             TriangleAction::Initialized(wgpu_state) => {
                 self.state = AppState::Running(wgpu_state);
+
+                // winit might have updated the window size while we were
+                // creating the surface asynchronously, so resize the surface.
                 if let Some(window) = &self.window {
-                    window.request_redraw();
+                    self.resize_surface(window.inner_size());
                 }
             }
         }
@@ -210,16 +232,7 @@ impl ApplicationHandler<TriangleAction> for App {
 
         match event {
             WindowEvent::Resized(new_size) => {
-                // Reconfigure the surface with the new size
-                wgpu_state.config.width = new_size.width.max(1);
-                wgpu_state.config.height = new_size.height.max(1);
-                wgpu_state
-                    .surface
-                    .configure(&wgpu_state.device, &wgpu_state.config);
-                // On macos the window needs to be redrawn manually after resizing
-                if let Some(window) = &self.window {
-                    window.request_redraw();
-                }
+                self.resize_surface(new_size);
             }
             WindowEvent::RedrawRequested => {
                 let frame = match wgpu_state.surface.get_current_texture() {


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/9515

**Description**
Address race condition where hello triangle on webgpu can sometimes draw a fully-red screen since:
  - the surface size is 0x0 when async initialization occurs
  - winit's `Resized` event with the real window size may be ignored since it can be fired before the async initialization's `Initialized` event has been processed.

**Testing**
_Explain how this change is tested._

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
