### PR TITLE
More `map_label` changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,9 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
   - Added new `InvalidWorkgroupSizeError`, which is now used by `DrawError::InvalidGroupSize` and `StageError::InvalidWorkgroupSize`.
   - Added `BuildAccelerationStructureError` variant `OffsetLimitedTo4GB` and changed `IndirectBufferOverrun` to contain offset and size rather than start and end offsets.
   - `IndexFormat::byte_size` now returns `u32` instead of `usize`.
+- BREAKING: `map_label` helpers have changed slightly. By @beicause and @andyleiserson in [#9480](https://github.com/gfx-rs/wgpu/pull/9480), [#9481](https://github.com/gfx-rs/wgpu/pull/9481), and [#9526](https://github.com/gfx-rs/wgpu/pull/9526).
+  - `SurfaceConfiguration::map_label` and `SurfaceConfiguration::map_view_formats` now take `FnOnce(&V)` instead of `FnOnce(V)`.
+  - All `map_label` helpers except `CreateShaderModuleDescriptorPassthrough` now have the signature `map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K)` (previously the lifetimes were implicit and thus could differ).
 
 #### Validation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
   - Added `BuildAccelerationStructureError` variant `OffsetLimitedTo4GB` and changed `IndirectBufferOverrun` to contain offset and size rather than start and end offsets.
   - `IndexFormat::byte_size` now returns `u32` instead of `usize`.
 - BREAKING: `map_label` helpers have changed slightly. By @beicause and @andyleiserson in [#9480](https://github.com/gfx-rs/wgpu/pull/9480), [#9481](https://github.com/gfx-rs/wgpu/pull/9481), and [#9526](https://github.com/gfx-rs/wgpu/pull/9526).
-  - `SurfaceConfiguration::map_label` and `SurfaceConfiguration::map_view_formats` now take `FnOnce(&V)` instead of `FnOnce(V)`.
+  - `TextureDescriptor::map_label_and_view_formats` and `SurfaceConfiguration::map_view_formats` now take `FnOnce(&V)` instead of `FnOnce(V)`.
   - All `map_label` helpers except `CreateShaderModuleDescriptorPassthrough` now have the signature `map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K)` (previously the lifetimes were implicit and thus could differ).
 
 #### Validation

--- a/wgpu-types/src/buffer.rs
+++ b/wgpu-types/src/buffer.rs
@@ -34,7 +34,7 @@ pub struct BufferDescriptor<L> {
 impl<L> BufferDescriptor<L> {
     /// Takes a closure and maps the label of the buffer descriptor into another.
     #[must_use]
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> BufferDescriptor<K> {
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> BufferDescriptor<K> {
         BufferDescriptor {
             label: fun(&self.label),
             size: self.size,

--- a/wgpu-types/src/device.rs
+++ b/wgpu-types/src/device.rs
@@ -37,7 +37,7 @@ pub struct DeviceDescriptor<L> {
 impl<L> DeviceDescriptor<L> {
     /// Takes a closure and maps the label of the device descriptor into another.
     #[must_use]
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> DeviceDescriptor<K> {
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> DeviceDescriptor<K> {
         DeviceDescriptor {
             label: fun(&self.label),
             required_features: self.required_features,

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -403,7 +403,7 @@ pub struct CommandEncoderDescriptor<L> {
 impl<L> CommandEncoderDescriptor<L> {
     /// Takes a closure and maps the label of the command encoder descriptor into another.
     #[must_use]
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> CommandEncoderDescriptor<K> {
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> CommandEncoderDescriptor<K> {
         CommandEncoderDescriptor {
             label: fun(&self.label),
         }
@@ -489,7 +489,7 @@ pub struct CommandBufferDescriptor<L> {
 impl<L> CommandBufferDescriptor<L> {
     /// Takes a closure and maps the label of the command buffer descriptor into another.
     #[must_use]
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> CommandBufferDescriptor<K> {
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> CommandBufferDescriptor<K> {
         CommandBufferDescriptor {
             label: fun(&self.label),
         }

--- a/wgpu-types/src/ray_tracing.rs
+++ b/wgpu-types/src/ray_tracing.rs
@@ -86,7 +86,7 @@ pub struct CreateBlasDescriptor<L> {
 
 impl<L> CreateBlasDescriptor<L> {
     /// Takes a closure and maps the label of the blas descriptor into another.
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> CreateBlasDescriptor<K> {
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> CreateBlasDescriptor<K> {
         CreateBlasDescriptor {
             label: fun(&self.label),
             flags: self.flags,
@@ -112,7 +112,7 @@ pub struct CreateTlasDescriptor<L> {
 
 impl<L> CreateTlasDescriptor<L> {
     /// Takes a closure and maps the label of the blas descriptor into another.
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> CreateTlasDescriptor<K> {
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> CreateTlasDescriptor<K> {
         CreateTlasDescriptor {
             label: fun(&self.label),
             flags: self.flags,

--- a/wgpu-types/src/render.rs
+++ b/wgpu-types/src/render.rs
@@ -929,7 +929,7 @@ pub struct RenderBundleDescriptor<L> {
 impl<L> RenderBundleDescriptor<L> {
     /// Takes a closure and maps the label of the render bundle descriptor into another.
     #[must_use]
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> RenderBundleDescriptor<K> {
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> RenderBundleDescriptor<K> {
         RenderBundleDescriptor {
             label: fun(&self.label),
         }

--- a/wgpu-types/src/surface.rs
+++ b/wgpu-types/src/surface.rs
@@ -241,7 +241,10 @@ pub struct SurfaceConfiguration<V> {
 
 impl<V: Clone> SurfaceConfiguration<V> {
     /// Map `view_formats` of the texture descriptor into another.
-    pub fn map_view_formats<M>(&self, fun: impl FnOnce(V) -> M) -> SurfaceConfiguration<M> {
+    pub fn map_view_formats<'a, M>(
+        &'a self,
+        fun: impl FnOnce(&'a V) -> M,
+    ) -> SurfaceConfiguration<M> {
         SurfaceConfiguration {
             usage: self.usage,
             format: self.format,
@@ -250,7 +253,7 @@ impl<V: Clone> SurfaceConfiguration<V> {
             present_mode: self.present_mode,
             desired_maximum_frame_latency: self.desired_maximum_frame_latency,
             alpha_mode: self.alpha_mode,
-            view_formats: fun(self.view_formats.clone()),
+            view_formats: fun(&self.view_formats),
         }
     }
 }

--- a/wgpu-types/src/texture.rs
+++ b/wgpu-types/src/texture.rs
@@ -480,7 +480,7 @@ pub struct TextureViewDescriptor<L> {
 impl<L> TextureViewDescriptor<L> {
     /// Takes a closure and maps the label of the texture view descriptor into another.
     #[must_use]
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> TextureViewDescriptor<K> {
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> TextureViewDescriptor<K> {
         TextureViewDescriptor {
             label: fun(&self.label),
             format: self.format,
@@ -530,7 +530,7 @@ pub struct TextureDescriptor<L, V> {
 impl<L, V> TextureDescriptor<L, V> {
     /// Takes a closure and maps the label of the texture descriptor into another.
     #[must_use]
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> TextureDescriptor<K, V>
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> TextureDescriptor<K, V>
     where
         V: Clone,
     {
@@ -548,10 +548,10 @@ impl<L, V> TextureDescriptor<L, V> {
 
     /// Maps the label and view formats of the texture descriptor into another.
     #[must_use]
-    pub fn map_label_and_view_formats<K, M>(
-        &self,
-        l_fun: impl FnOnce(&L) -> K,
-        v_fun: impl FnOnce(&V) -> M,
+    pub fn map_label_and_view_formats<'a, K, M>(
+        &'a self,
+        l_fun: impl FnOnce(&'a L) -> K,
+        v_fun: impl FnOnce(&'a V) -> M,
     ) -> TextureDescriptor<K, M> {
         TextureDescriptor {
             label: l_fun(&self.label),
@@ -703,7 +703,7 @@ impl<L: Default> Default for SamplerDescriptor<L> {
 impl<L> SamplerDescriptor<L> {
     /// Takes a closure and maps the label of the sampler descriptor into another.
     #[must_use]
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> SamplerDescriptor<K> {
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> SamplerDescriptor<K> {
         SamplerDescriptor {
             label: fun(&self.label),
             address_mode_u: self.address_mode_u,

--- a/wgpu-types/src/texture/external_texture.rs
+++ b/wgpu-types/src/texture/external_texture.rs
@@ -141,7 +141,10 @@ pub struct ExternalTextureDescriptor<L> {
 impl<L> ExternalTextureDescriptor<L> {
     /// Takes a closure and maps the label of the external texture descriptor into another.
     #[must_use]
-    pub fn map_label<K>(&self, fun: impl FnOnce(&L) -> K) -> ExternalTextureDescriptor<K> {
+    pub fn map_label<'a, K>(
+        &'a self,
+        fun: impl FnOnce(&'a L) -> K,
+    ) -> ExternalTextureDescriptor<K> {
         ExternalTextureDescriptor {
             label: fun(&self.label),
             width: self.width,


### PR DESCRIPTION
Small follow-up to #9480 and #9481:

* Adds a changelog entry for #9481 since it's technically an API change
* Changes all the `map_label`-style helpers (except for `CreateShaderModuleDescriptorPassthrough`) to have explicit lifetimes on references in the arguments. This allows doing `foo.map_label(|l| l.as_ref())`, with the lifetime passing through.
  * `CreateShaderModuleDescriptorPassthrough` is excluded because it has a lifetime parameter that is also passed through as a lifetime parameter on embedded structs, which prevents re-borrowing a `&CreateShaderModuleDescriptorPassthrough` with a shorter lifetime, which makes a mess of things if the lifetimes are bound.

**Testing**
Refactoring checked by Rust type system. It builds ⇒ shippit.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
