### PR TITLE
Update copyright year for deno_webgpu

### DIFF
--- a/deno_webgpu/00_init.js
+++ b/deno_webgpu/00_init.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 import { core } from "ext:core/mod.js";
 

--- a/deno_webgpu/01_webgpu.js
+++ b/deno_webgpu/01_webgpu.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 // @ts-check
 /// <reference path="../../core/lib.deno_core.d.ts" />

--- a/deno_webgpu/02_surface.js
+++ b/deno_webgpu/02_surface.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 // @ts-check
 /// <reference path="../../core/lib.deno_core.d.ts" />

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2025 the Deno authors. MIT license.
+# Copyright 2018-2026 the Deno authors. MIT license.
 
 [package]
 name = "deno_webgpu"

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::ops::BitOr;
 use std::rc::Rc;

--- a/deno_webgpu/bind_group.rs
+++ b/deno_webgpu/bind_group.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
 

--- a/deno_webgpu/bind_group_layout.rs
+++ b/deno_webgpu/bind_group_layout.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use deno_core::op2;
 use deno_core::GarbageCollected;

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/deno_webgpu/byow.rs
+++ b/deno_webgpu/byow.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::cell::RefCell;
 use std::ffi::c_void;

--- a/deno_webgpu/command_buffer.rs
+++ b/deno_webgpu/command_buffer.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use deno_core::op2;
 use deno_core::GarbageCollected;

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
 use std::cell::RefCell;

--- a/deno_webgpu/compute_pass.rs
+++ b/deno_webgpu/compute_pass.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
 use std::cell::RefCell;

--- a/deno_webgpu/compute_pipeline.rs
+++ b/deno_webgpu/compute_pipeline.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use deno_core::cppgc::Ptr;
 use deno_core::op2;

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
 use std::cell::RefCell;

--- a/deno_webgpu/error.rs
+++ b/deno_webgpu/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::fmt::Display;
 use std::fmt::Formatter;

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 #![cfg(not(target_arch = "wasm32"))]
 #![warn(unsafe_op_in_unsafe_fn)]
 

--- a/deno_webgpu/pipeline_layout.rs
+++ b/deno_webgpu/pipeline_layout.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use deno_core::cppgc::Ptr;
 use deno_core::op2;

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use deno_core::op2;
 use deno_core::webidl::WebIdlInterfaceConverter;

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
 use std::cell::RefCell;

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
 use std::cell::RefCell;

--- a/deno_webgpu/render_pipeline.rs
+++ b/deno_webgpu/render_pipeline.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use deno_core::cppgc::Ptr;
 use deno_core::op2;

--- a/deno_webgpu/sampler.rs
+++ b/deno_webgpu/sampler.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use deno_core::op2;
 use deno_core::webidl::WebIdlInterfaceConverter;

--- a/deno_webgpu/shader.rs
+++ b/deno_webgpu/shader.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use deno_core::cppgc::make_cppgc_object;
 use deno_core::op2;

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::cell::RefCell;
 

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::sync::OnceLock;
 

--- a/deno_webgpu/webidl.rs
+++ b/deno_webgpu/webidl.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
 


### PR DESCRIPTION
**Connections**

While doing https://github.com/denoland/deno/pull/33916 I noticed that they have updated the copyright year range for their copy of this crate, so I guess that change should also be done here.

**Description**
Reduce the differences between the two copies of deno_webgpu.

**Testing**
I assume no testing is needed by me locally for this change.

**Squash or Rebase?**

Squash.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
