### PR TITLE
Fix for render_with_compute in browsers

### DIFF
--- a/examples/features/src/render_with_compute/mod.rs
+++ b/examples/features/src/render_with_compute/mod.rs
@@ -3,7 +3,7 @@
 //! therefore not recommended to use this code, at least until
 //! <https://bugzilla.mozilla.org/show_bug.cgi?id=1870699> (and possibly further work) is resolved.
 
-use std::time::Instant;
+use web_time::Instant;
 
 #[derive(bytemuck::Pod, bytemuck::Zeroable, Clone, Copy, Debug)]
 #[repr(C)]

--- a/examples/features/src/render_with_compute/mod.rs
+++ b/examples/features/src/render_with_compute/mod.rs
@@ -70,7 +70,7 @@ impl crate::framework::Example for Example {
             compilation_options: Default::default(),
             cache: None,
         });
-        let blitter = wgpu::util::TextureBlitter::new(device, config.format);
+        let blitter = wgpu::util::TextureBlitter::new(device, config.view_formats[0]);
         let global_params = device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size: size_of::<GlobalParams>() as u64,


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/9528

**Description**

render_with_compute example doesn't render and throws an exception in the browser dev console:
https://wgpu.rs/examples/?backend=webgpu&example=render_with_compute

```
panicked at library/std/src/sys/pal/wasm/../unsupported/time.rs:13:9:
time not implemented on this platform
```

Fixing the time issue uncovered a different minor issue:
```
Attachment state of [RenderPipeline "wgpu::util::TextureBlitter::pipeline"] is not compatible with [RenderPassEncoder
  "wgpu::util::TextureBlitter::pass"].
  [RenderPassEncoder "wgpu::util::TextureBlitter::pass"] expects an attachment state of { colorTargets: [0={format:TextureFormat::BGRA8UnormSrgb}],
  sampleCount: 1 }.
  [RenderPipeline "wgpu::util::TextureBlitter::pipeline"] has an attachment state of { colorTargets: [0={format:TextureFormat::BGRA8Unorm}],
  sampleCount: 1 }.
   - While encoding [RenderPassEncoder "wgpu::util::TextureBlitter::pass"].SetPipeline([RenderPipeline "wgpu::util::TextureBlitter::pipeline"]).
   - While finishing [CommandEncoder (unlabeled)].
```

**Testing**
Tested locally native / in browser

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
