### PR TITLE
fix webgpu backend: use unchecked_into for GpuCanvasContext

### DIFF
--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1141,19 +1141,13 @@ impl ContextWebGpu {
             }
         };
 
-        // An error here indicated that WebGPU is disabled in the browser.
-        let context: webgpu_sys::GpuCanvasContext =
-            context
-                .dyn_into()
-                .map_err(|actual| crate::CreateSurfaceError {
-                    inner: crate::CreateSurfaceErrorKind::Web(format!(
-                        "`canvas.getContext()` returned a value that did not coerce to \
-                        `GPUCanvasContext`. \
-                        This is likely because WebGPU is disabled in this browser. \
-                        Expected: `GPUCanvasContext`, Actual: `{}`",
-                        actual.to_string()
-                    )),
-                })?;
+        /* Use unchecked_into instead of dyn_into: the instanceof check that dyn_into
+         * performs for GpuCanvasContext fails in some wasm-bindgen configurations even
+         * when the object is correct (e.g. certain browser extensions or cross-realm
+         * scenarios interfere with the JS prototype chain). getContext("webgpu") already
+         * guarantees the returned object is a GPUCanvasContext when it succeeds, so the
+         * instanceof check is redundant and only causes spurious surface creation errors. */
+        let context: webgpu_sys::GpuCanvasContext = context.unchecked_into();
 
         Ok(WebSurface {
             gpu: self.gpu.clone(),


### PR DESCRIPTION
## Problem

`canvas.getContext("webgpu")` returns a `GpuCanvasContext` on success per the WebGPU spec. The current code then calls `.dyn_into::<GpuCanvasContext>()` on the result, which performs a JavaScript `instanceof` check against the `GpuCanvasContext` prototype.

This `instanceof` check fails in some wasm-bindgen configurations even when the object is a valid `GpuCanvasContext` — for example when the prototype chain is disrupted by certain browser extensions, or in cross-realm scenarios where the JS object was created in a different realm than the one wasm-bindgen's generated bindings use for the check. The result is a spurious `CreateSurfaceError` with a message blaming disabled WebGPU, even though WebGPU is available and working.

## Fix

Replace `.dyn_into()` with `.unchecked_into()`. Since `getContext("webgpu")` already guarantees the returned object is a `GpuCanvasContext` when it does not throw and does not return null (both of which are handled earlier in the function), the `instanceof` check is redundant. `unchecked_into` is safe here for the same reason the existing code assumed success before the type assertion.

## Testing

Verified that surface creation succeeds in a wasm-bindgen project where `dyn_into` was previously failing the instanceof check despite WebGPU being available.