### PR TITLE
test: Simplify `xcrun metal` invocation for shader validation

### DIFF
--- a/naga/xtask/src/validate.rs
+++ b/naga/xtask/src/validate.rs
@@ -282,10 +282,10 @@ fn validate_metal(path: &Path, xcrun: &str) -> anyhow::Result<()> {
     };
     let warnings_as_errors = ["-Werror=constant-conversion"];
     EasyCommand::new(xcrun, |cmd| {
-        cmd.args(["-sdk", "macosx", "metal", "-mmacosx-version-min=10.11"])
+        cmd.arg("metal")
             .arg(std_arg)
             .args(warnings_as_errors)
-            .args(["-x", "metal", &*path.to_string_lossy(), "-o", "/dev/null"])
+            .args([&*path.to_string_lossy(), "-o", "/dev/null"])
     })
     .success()
 }


### PR DESCRIPTION
This matches how it is invoked in the passthrough shader GPU test.

Related to #9514

**Testing**
Covered by CI, although it's only really working if it passes reliably. 

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
