### PR TITLE
fix(dx12): Fix textureNum{Levels,Layers,Samples} functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Fixed use of a texture view without `TextureUsage::TEXTURE_BINDING` as a read-only depth attachment. By @andyleiserson in [#9346](https://github.com/gfx-rs/wgpu/pull/9346).
 - Fixed a `debug_assert` during stride validation for indirect multi draw. By @kristoff3r in [#9332](https://github.com/gfx-rs/wgpu/pull/9332)
 - Fixed stencil values read with `textureLoad` appearing in G instead of R. By @andyleiserson in [#9520](https://github.com/gfx-rs/wgpu/pull/9520).
+- Fixed some cases where the `textureNum{Layers,Levels,Samples}` functions returned incorrect results. By @andyleiserson in [#9542](https://github.com/gfx-rs/wgpu/pull/9542).
 
 #### Metal
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -65,6 +65,7 @@ webgpu:api,validation,state,device_lost,destroy:* // crash
 webgpu:api,validation,texture,destroy:submit_a_destroyed_texture_as_attachment:* // 44%, https://github.com/gfx-rs/wgpu/issues/8714
 
 webgpu:shader,execution,expression,call,builtin,atan2:f16:* // dx12, fails with dxc, passes with fxc, https://github.com/gfx-rs/wgpu/issues/9179
+webgpu:shader,execution,expression,call,builtin,textureDimensions:* // dx12, https://github.com/gfx-rs/wgpu/issues/9541
 
 webgpu:shader,validation,decl,let:* // texture/sampler let
 webgpu:shader,validation,decl,override:* // 93%, unrestricted_pointer_parameters not implemented, https://github.com/gfx-rs/wgpu/issues/5158

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -359,6 +359,10 @@ webgpu:shader,execution,expression,call,builtin,firstLeadingBit:*
 //FAIL: webgpu:shader,execution,expression,call,builtin,select:*
 // - Fails with `const`/abstract int cases on all platforms because of <https://github.com/gfx-rs/wgpu/issues/4507>.
 // - Fails with `vec3` & `f16` cases on macOS because of <https://github.com/gfx-rs/wgpu/issues/5262>.
+fails-if(dx12) webgpu:shader,execution,expression,call,builtin,textureDimensions:*
+webgpu:shader,execution,expression,call,builtin,textureNumLayers:*
+webgpu:shader,execution,expression,call,builtin,textureNumLevels:*
+webgpu:shader,execution,expression,call,builtin,textureNumSamples:*
 webgpu:shader,execution,expression,call,builtin,textureSample:sampled_1d_coords:*
 webgpu:shader,execution,expression,call,builtin,textureSampleBaseClampToEdge:2d_coords:stage="c";textureType="texture_2d<f32>";*
 // NOTE: This is supposed to be an exhaustive listing underneath

--- a/naga/src/back/hlsl/help.rs
+++ b/naga/src/back/hlsl/help.rs
@@ -667,7 +667,8 @@ impl<W: Write> super::Writer<'_, W> {
 
                 // GetDimensions Overloaded Methods
                 // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-to-getdimensions#overloaded-methods
-                let (ret_swizzle, number_of_params) = match wiq.query {
+                // We rely on the validator to reject invalid queries.
+                let (ret_swizzle, number_of_out_params) = match wiq.query {
                     ImageQuery::Size | ImageQuery::SizeLevel => {
                         let ret = match wiq.dim {
                             IDim::D1 => "x",
@@ -677,13 +678,22 @@ impl<W: Write> super::Writer<'_, W> {
                         };
                         (ret, ret.len() + array_coords + extra_coords)
                     }
-                    ImageQuery::NumLevels | ImageQuery::NumSamples | ImageQuery::NumLayers => {
-                        if wiq.arrayed || wiq.dim == IDim::D3 {
-                            ("w", 4)
-                        } else {
-                            ("z", 3)
+                    ImageQuery::NumLevels | ImageQuery::NumSamples => {
+                        // We want `NumberOfLevels` or `Samples`
+                        match wiq.dim {
+                            IDim::D1 => ("y", 2),
+                            IDim::D3 => ("w", 4),
+                            IDim::D2 | IDim::Cube => {
+                                if wiq.arrayed {
+                                    ("w", 4)
+                                } else {
+                                    ("z", 3)
+                                }
+                            }
                         }
                     }
+                    // We want `Elements`
+                    ImageQuery::NumLayers => ("z", 3 + extra_coords),
                 };
 
                 // Write `GetDimensions` function.
@@ -704,7 +714,7 @@ impl<W: Write> super::Writer<'_, W> {
                     },
                 }
 
-                for component in COMPONENTS[..number_of_params - 1].iter() {
+                for component in COMPONENTS[..number_of_out_params - 1].iter() {
                     write!(self.out, "{RETURN_VARIABLE_NAME}.{component}, ")?;
                 }
 
@@ -713,7 +723,7 @@ impl<W: Write> super::Writer<'_, W> {
                     self.out,
                     "{}.{}",
                     RETURN_VARIABLE_NAME,
-                    COMPONENTS[number_of_params - 1]
+                    COMPONENTS[number_of_out_params - 1]
                 )?;
 
                 writeln!(self.out, ");")?;

--- a/naga/tests/out/hlsl/wgsl-binding-arrays.hlsl
+++ b/naga/tests/out/hlsl/wgsl-binding-arrays.hlsl
@@ -34,7 +34,7 @@ uint NagaNumLayers2DArray(Texture2DArray<float4> tex)
 {
     uint4 ret;
     tex.GetDimensions(0, ret.x, ret.y, ret.z, ret.w);
-    return ret.w;
+    return ret.z;
 }
 
 uint NagaNumLevels2D(Texture2D<float4> tex)

--- a/naga/tests/out/hlsl/wgsl-image.hlsl
+++ b/naga/tests/out/hlsl/wgsl-image.hlsl
@@ -198,7 +198,7 @@ uint NagaNumLayers2DArray(Texture2DArray<float4> tex)
 {
     uint4 ret;
     tex.GetDimensions(0, ret.x, ret.y, ret.z, ret.w);
-    return ret.w;
+    return ret.z;
 }
 
 uint NagaNumLevels2DArray(Texture2DArray<float4> tex)
@@ -226,7 +226,7 @@ uint NagaNumLayersCubeArray(TextureCubeArray<float4> tex)
 {
     uint4 ret;
     tex.GetDimensions(0, ret.x, ret.y, ret.z, ret.w);
-    return ret.w;
+    return ret.z;
 }
 
 uint NagaNumLevels3D(Texture3D<float4> tex)


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=2012288.

Updates image queries in HLSL to use correct [`GetDimension` overloads](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-to-getdimensions#overloaded-methods) and result swizzles. (Note that not all `GetDimensions` overloads in the table need to be handled, some of them are for texture types that WebGPU doesn't offer.)

I've also added `textureDimensions` to the test lists, but this doesn't change anything about `textureDimensions` behavior, I just looked at the `textureDimensions` failures in case they needed a similar fix.

**Testing**
Enables CTS tests. Also tested manually that it resolves the linked Firefox bug.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
