### PR TITLE
ci: Include the runner image version in the cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: clippy-${{ matrix.target }}-${{ matrix.kind }}-${{ env.CACHE_SUFFIX }}
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: (Linux `aarch64`) Install `aarch64-linux-gnu` `g++`
@@ -417,6 +418,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: wgpu-msrv-check-${{ matrix.target }}-${{ env.CACHE_SUFFIX }}
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Reduce MSRV on dependencies
@@ -490,6 +492,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: core-msrv-check-${{ matrix.target }}-${{ env.CACHE_SUFFIX }}
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Reduce MSRV on dependencies
@@ -638,6 +641,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: test-${{ matrix.os }}-${{ env.CACHE_SUFFIX }}
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
           workspaces: |
             . -> target
@@ -750,6 +754,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: doctests-${{ env.CACHE_SUFFIX }}
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Run doctests
@@ -782,6 +787,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: miri-${{ env.CACHE_SUFFIX }}
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Run Miri on selected tests
@@ -864,6 +870,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: cts-runner-${{ env.CACHE_SUFFIX }}
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Build Deno

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -100,6 +100,7 @@ jobs:
         with:
           # The version number can be incremented for cache busting.
           prefix-key: v3-rust-${{ hashFiles('cts_runner/revision.txt') }}
+          env-vars: ImageVersion
           cache-directories: cts
           # Save the cache from the `other` job because it also runs the cts_runner
           # integration tests.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: doc-build
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Build the docs

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -72,6 +72,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: cargo-generate-${{ matrix.name }}
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Install `cargo-generate`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: publish-build
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Build examples

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -39,6 +39,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       # We must have the FXC job before the DXC job, so the DXC PATH has priority
@@ -85,6 +86,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - run: |
@@ -115,6 +117,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - run: cd naga; cargo xtask validate spv


### PR DESCRIPTION
My theory of #9543 is that something bad happens when the cache was created on a different runner image version. So add the image version to the cache key.

Fixes #9543 ~and maybe #9514~. (Edit: definitely not #9514; https://github.com/gfx-rs/wgpu/actions/runs/25771977381/job/75696847466?pr=9544.)

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
  - "Fully understand" seems a bit of a tall claim w.r.t. GitHub actions 
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
