### PR TITLE
chore(deps): Remove unused dependency `ctor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,23 +799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "ctor"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
-dependencies = [
- "ctor-proc-macro",
- "dtor",
- "link-section",
-]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
-
-[[package]]
 name = "cts_runner"
 version = "29.0.0"
 dependencies = [
@@ -1198,21 +1181,6 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.9.4",
 ]
-
-[[package]]
-name = "dtor"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2647271c92754afcb174e758003cfd1cbf1e43e5a7853d7b1813e63e19e39a73"
 
 [[package]]
 name = "either"
@@ -2207,12 +2175,6 @@ dependencies = [
  "clap",
  "escape8259",
 ]
-
-[[package]]
-name = "link-section"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b685d66585d646efe09fec763d796c291049c8b6bf84e04954bffc8748341f0d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4960,7 +4922,6 @@ dependencies = [
  "cargo_metadata",
  "cfg-if",
  "console_log",
- "ctor",
  "env_logger",
  "futures-lite",
  "glam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,6 @@ cargo_metadata = "0.23"
 cfg_aliases = "0.2.1"
 cfg-if = "1"
 codespan-reporting = { version = "0.13", default-features = false }
-ctor = "0.10"
 diff = "0.1"
 document-features = "0.2.10"
 encase = "0.12"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -62,7 +62,6 @@ arrayvec.workspace = true
 bitflags.workspace = true
 bytemuck.workspace = true
 cfg-if.workspace = true
-ctor.workspace = true
 futures-lite.workspace = true
 libtest-mimic.workspace = true
 log.workspace = true

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -18,8 +18,6 @@ pub use init::initialize_html_canvas;
 
 pub use self::image::ComparisonType;
 pub use config::{GpuTestConfiguration, GpuTestInitializer};
-#[doc(hidden)]
-pub use ctor;
 pub use expectations::{FailureApplicationReasons, FailureBehavior, FailureCase, FailureReason};
 pub use init::{initialize_adapter, initialize_device, initialize_instance};
 pub use params::TestParameters;


### PR DESCRIPTION
`ctor` was previously used for automatic test enumeration, but that was removed in #7940.

**Squash or Rebase?** Squash