### PR TITLE
chore(deps): Update WARP to 1.0.19

### DIFF
--- a/xtask/src/install_warp.rs
+++ b/xtask/src/install_warp.rs
@@ -3,7 +3,7 @@ use pico_args::Arguments;
 use xshell::Shell;
 
 /// Keep this in sync with .github/actions/install-warp/action.yml
-const WARP_VERSION: &str = "1.0.16.1";
+const WARP_VERSION: &str = "1.0.17";
 
 /// Run the install-warp subcommand
 pub fn run_install_warp(shell: Shell, mut args: Arguments) -> anyhow::Result<()> {


### PR DESCRIPTION
This seems to resolve the failure of the `textureNumSamples` test. (e.g. https://github.com/gfx-rs/wgpu/actions/runs/25813083500/job/75834310863)

**Testing**
Let's see what CI thinks.

**Squash or Rebase?** Squash