### PR TITLE
fix: duplicated words in wgpu-hal lib.rs and wgpu-types surface/limits doc-comments

### DIFF
--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1937,7 +1937,7 @@ pub struct InstanceDescriptor<'a> {
     pub memory_budget_thresholds: wgt::MemoryBudgetThresholds,
     pub backend_options: wgt::BackendOptions,
     pub telemetry: Option<Telemetry>,
-    /// This is a borrow because the surrounding `core::Instance` keeps the the owned display handle
+    /// This is a borrow because the surrounding `core::Instance` keeps the owned display handle
     /// alive already.
     pub display: Option<DisplayHandle<'a>>,
 }

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -325,7 +325,7 @@ impl Default for Limits {
 }
 
 impl Limits {
-    /// These default limits are guaranteed to to work on all modern
+    /// These default limits are guaranteed to work on all modern
     /// backends and guaranteed to be supported by WebGPU
     ///
     /// Those limits are as follows:

--- a/wgpu-types/src/surface.rs
+++ b/wgpu-types/src/surface.rs
@@ -209,7 +209,7 @@ pub struct SurfaceConfiguration<V> {
     ///   a small amount of GPU work each frame that need low latency, this is a reasonable choice.
     /// * Choose `2` for a balance between latency and throughput. The CPU and GPU both can each use
     ///   a full monitor refresh to do their computations. This is a reasonable default for most applications.
-    /// * Choose `3` or higher to maximize throughput, sacrificing latency when the the CPU and GPU
+    /// * Choose `3` or higher to maximize throughput, sacrificing latency when the CPU and GPU
     ///   are using less than a full monitor refresh each. For applications that use CPU-side pipelining
     ///   of frames this may be a reasonable choice. ⚠️ On 60hz displays the latency can be very noticeable.
     ///


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in doc-comments:
- `wgpu-hal/src/lib.rs` — "/// This is a borrow because the surrounding `core::Instance` keeps the the owned display handle" → "...keeps the owned display handle"
- `wgpu-types/src/surface.rs` — "///   a full monitor refresh to do their computations. ... sacrificing latency when the the CPU and GPU" → "...when the CPU and GPU"
- `wgpu-types/src/limits.rs` — "/// These default limits are guaranteed to to work on all modern" → "/// These default limits are guaranteed to work on all modern"

No code/behavior change.