### PR TITLE
test(cts): Disable `textureNumSamples` test on dx12

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -66,6 +66,7 @@ webgpu:api,validation,texture,destroy:submit_a_destroyed_texture_as_attachment:*
 
 webgpu:shader,execution,expression,call,builtin,atan2:f16:* // dx12, fails with dxc, passes with fxc, https://github.com/gfx-rs/wgpu/issues/9179
 webgpu:shader,execution,expression,call,builtin,textureDimensions:* // dx12, https://github.com/gfx-rs/wgpu/issues/9541
+webgpu:shader,execution,expression,call,builtin,textureNumSamples:* // dx12, fails intermittently on WARP < 1.0.17
 
 webgpu:shader,validation,decl,let:* // texture/sampler let
 webgpu:shader,validation,decl,override:* // 93%, unrestricted_pointer_parameters not implemented, https://github.com/gfx-rs/wgpu/issues/5158

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -362,7 +362,7 @@ webgpu:shader,execution,expression,call,builtin,firstLeadingBit:*
 fails-if(dx12) webgpu:shader,execution,expression,call,builtin,textureDimensions:*
 webgpu:shader,execution,expression,call,builtin,textureNumLayers:*
 webgpu:shader,execution,expression,call,builtin,textureNumLevels:*
-webgpu:shader,execution,expression,call,builtin,textureNumSamples:*
+fails-if(dx12) webgpu:shader,execution,expression,call,builtin,textureNumSamples:*
 webgpu:shader,execution,expression,call,builtin,textureSample:sampled_1d_coords:*
 webgpu:shader,execution,expression,call,builtin,textureSampleBaseClampToEdge:2d_coords:stage="c";textureType="texture_2d<f32>";*
 // NOTE: This is supposed to be an exhaustive listing underneath


### PR DESCRIPTION
It seems to fail intermittently in CI (e.g. https://github.com/gfx-rs/wgpu/actions/runs/25813083500/job/75834310863, maybe it depends on the runner?); it fails 100% for me running against WARP 1.0.16.1 locally. It passes locally running with WARP 1.0.17+, but in CI that hit #9554.

**Squash or Rebase?** Squash