### PR TITLE
build: Exclude wgpu-core when building the WebGPU-backend samples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ wgpu = { version = "29.0.0", path = "./wgpu", default-features = false, features
     "vulkan-portability",
     "angle",
     "static-dxc",
-    "noop",               # This should be removed if we ever have non-test crates that depend on wgpu
 ] }
 wgpu-core = { version = "29.0.0", path = "./wgpu-core" }
 wgpu-hal = { version = "29.0.0", path = "./wgpu-hal" }

--- a/tests/tests/wgpu-dependency/main.rs
+++ b/tests/tests/wgpu-dependency/main.rs
@@ -45,7 +45,11 @@ fn check_feature_dependency(requirement: Requirement) {
 
     let output = match Command::new("cargo").args(&args).output() {
         Ok(o) if o.status.success() => o.stdout,
-        Ok(o) => panic!("cargo tree failed ({}):\n{}", o.status, String::from_utf8_lossy(&o.stderr)),
+        Ok(o) => panic!(
+            "cargo tree failed ({}):\n{}",
+            o.status,
+            String::from_utf8_lossy(&o.stderr)
+        ),
         Err(e) => panic!("Failed to run cargo tree: {e}"),
     };
     let output = String::from_utf8(output).expect("Output is not valid UTF-8");
@@ -119,8 +123,7 @@ fn wasm32_without_webgl_or_noop_does_not_depend_on_wgpu_core() {
     });
 
     check_feature_dependency(Requirement {
-        human_readable_name:
-            "wasm32 with only `webgpu` feature does not depend on `wgpu-core`",
+        human_readable_name: "wasm32 with only `webgpu` feature does not depend on `wgpu-core`",
         target: "wasm32-unknown-unknown",
         packages: &["wgpu-examples"],
         features: &["webgpu"],

--- a/tests/tests/wgpu-dependency/main.rs
+++ b/tests/tests/wgpu-dependency/main.rs
@@ -24,7 +24,7 @@ fn check_feature_dependency(requirement: Requirement) {
     println!("Checking: {}", requirement.human_readable_name);
 
     let mut args = Vec::new();
-    args.extend(["tree", "--target", requirement.target]);
+    args.extend(["tree", "--edges", "no-dev", "--target", requirement.target]);
 
     for package in requirement.packages {
         args.push("--package");
@@ -43,11 +43,11 @@ fn check_feature_dependency(requirement: Requirement) {
 
     println!("$ cargo {}", args.join(" "));
 
-    let output = Command::new("cargo")
-        .args(&args)
-        .output()
-        .expect("Failed to run cargo tree")
-        .stdout;
+    let output = match Command::new("cargo").args(&args).output() {
+        Ok(o) if o.status.success() => o.stdout,
+        Ok(o) => panic!("cargo tree failed ({}):\n{}", o.status, String::from_utf8_lossy(&o.stderr)),
+        Err(e) => panic!("Failed to run cargo tree: {e}"),
+    };
     let output = String::from_utf8(output).expect("Output is not valid UTF-8");
 
     let mut any_failed = false;
@@ -117,6 +117,16 @@ fn wasm32_without_webgl_or_noop_does_not_depend_on_wgpu_core() {
         default_features: false,
         search_terms: &[Search::Negative("wgpu-core")],
     });
+
+    check_feature_dependency(Requirement {
+        human_readable_name:
+            "wasm32 with only `webgpu` feature does not depend on `wgpu-core`",
+        target: "wasm32-unknown-unknown",
+        packages: &["wgpu-examples"],
+        features: &["webgpu"],
+        default_features: false,
+        search_terms: &[Search::Negative("wgpu-core")],
+    });
 }
 
 #[test]
@@ -126,6 +136,15 @@ fn wasm32_with_webgpu_and_wgsl_does_not_depend_on_naga() {
         target: "wasm32-unknown-unknown",
         packages: &["wgpu"],
         features: &["webgpu", "wgsl"],
+        default_features: false,
+        search_terms: &[Search::Negative("naga")],
+    });
+
+    check_feature_dependency(Requirement {
+        human_readable_name: "wasm32 with only `webgpu` feature does not depend on `naga`",
+        target: "wasm32-unknown-unknown",
+        packages: &["wgpu-examples"],
+        features: &["webgpu"],
         default_features: false,
         search_terms: &[Search::Negative("naga")],
     });

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -44,7 +44,7 @@ serde = ["dep:serde", "bitflags/serde"]
 # Enables some internal instrumentation for debugging purposes.
 counters = []
 # Enables variants of `Trace` other than `Trace::Off`
-trace = ["std"]
+trace = ["std", "serde/std"]
 # Enable web-specific dependencies for wasm.
 web = ["dep:js-sys", "dep:web-sys"]
 exhaust = ["dep:exhaust"]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -130,8 +130,8 @@ strict_asserts = ["wgpu-core?/strict_asserts", "wgpu-types/strict_asserts"]
 ## Enables serialization via `serde` on common wgpu types.
 serde = ["wgpu-core?/serde", "wgpu-types/serde"]
 
-# ## Allow writing of trace capture files. See [`Adapter::request_device`].
-trace = ["serde", "wgpu-core?/trace"]
+## Allow writing of trace capture files. See [`Adapter::request_device`].
+trace = ["serde", "wgpu-core?/trace", "wgpu-types/trace"]
 
 #! ### External libraries
 # --------------------------------------------------------------------

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -2,7 +2,7 @@ use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use core::{
     error, fmt,
     num::NonZero,
-    ops::{Bound, Deref, Range, RangeBounds},
+    ops::{Bound, Range, RangeBounds},
 };
 
 use crate::util::Mutex;
@@ -287,7 +287,7 @@ impl Buffer {
     #[cfg(wgpu_core)]
     pub unsafe fn as_hal<A: hal::Api>(
         &self,
-    ) -> Option<impl Deref<Target = A::Buffer> + WasmNotSendSync> {
+    ) -> Option<impl core::ops::Deref<Target = A::Buffer> + WasmNotSendSync> {
         let buffer = self.inner.as_core_opt()?;
         unsafe { buffer.context.buffer_as_hal::<A>(buffer) }
     }

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -1,5 +1,5 @@
 use alloc::boxed::Box;
-use core::ops::{Deref, RangeBounds};
+use core::ops::RangeBounds;
 
 use crate::{api::DeferredCommandBufferActions, *};
 
@@ -338,7 +338,7 @@ impl Queue {
     #[cfg(wgpu_core)]
     pub unsafe fn as_hal<A: hal::Api>(
         &self,
-    ) -> Option<impl Deref<Target = A::Queue> + WasmNotSendSync> {
+    ) -> Option<impl core::ops::Deref<Target = A::Queue> + WasmNotSendSync> {
         let queue = self.inner.as_core_opt()?;
         unsafe { queue.context.queue_as_hal::<A>(queue) }
     }

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -603,6 +603,8 @@ pub trait QueueWriteBufferInterface: CommonTraits {
 }
 
 pub trait BufferMappedRangeInterface: CommonTraits {
+    // Used only in wgpu_core's `impl QueueWriteBufferInterface`
+    #[cfg_attr(not(wgpu_core), expect(unused))]
     fn len(&self) -> usize;
 
     /// # Safety

--- a/wgpu/src/macros/mod.rs
+++ b/wgpu/src/macros/mod.rs
@@ -1,4 +1,5 @@
 //! Convenience macros
+#![cfg_attr(not(wgpu_core), expect(unused_macros, unused_imports))]
 
 #[cfg(doc)]
 use crate::{VertexAttribute, VertexBufferLayout, VertexFormat};


### PR DESCRIPTION
In trying to reproduce the error discussed in https://github.com/gfx-rs/wgpu/pull/9537#discussion_r3222739324, I found that I was getting a different failure:

```
panicked at examples/features/src/hello_triangle/mod.rs:127:67:
called `Result::unwrap()` on an `Err` value: CreateSurfaceError { inner: Hal(FailedToCreateSurfaceForAnyBackend({})) }
```

This was because `wgpu-core` was being pulled into the sample build for the WebGPU backend because `noop` appears in the workspace feature list. To fix this, remove `noop` from the workspace feature list. Also fix some build warnings exposed by that change.

There are two other subtle interactions that appear in the diff:
* `wgpu-examples` includes the `trace` feature. To build without `wgpu-core`, I've added a direct dependency from `wgpu` to `wgpu-types/trace` (normally it is pulled in indirectly via `wgpu` -> `wgpu-core?/trace` -> `wgpu-types/trace`). It would also be possible to fix this by adding a `trace` feature to `wgpu-examples` or by removing tracing from the examples entirely.
* I added `--edges no-dev` to the `wgpu-dependency` test because `wgpu-examples` has a dev-dependency on `wgpu-core` via `wgpu-test`. However, this test could previously pass without `--edges no-dev`, not sure if we might want to maintain that property where it holds for some reason.

**Testing**
Adds `wgpu-examples` to the `wgpu-dependency` test.

**Squash or Rebase?** Squash

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
