### PR TITLE
Validate LoadOp and StoreOp are None for attachments without corresponding depth or stencil aspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 - Add clip distances validation for `maxInterStageShaderVariables`. By @ErichDonGubler in [#8762](https://github.com/gfx-rs/wgpu/pull/8762). This may break some existing programs, but it compiles with the WebGPU spec.
 - Bring immediates in line with webgpu spec. By @atlv24 in [#9280](https://github.com/gfx-rs/wgpu/pull/9280).
+- Validate `LoadOp` and `StoreOp` are None for attachments without corresponding depth or stencil aspect. By @beicause in [#9567](https://github.com/gfx-rs/wgpu/pull/9567).
 
 #### DX12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,7 +186,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 - Add clip distances validation for `maxInterStageShaderVariables`. By @ErichDonGubler in [#8762](https://github.com/gfx-rs/wgpu/pull/8762). This may break some existing programs, but it compiles with the WebGPU spec.
 - Bring immediates in line with webgpu spec. By @atlv24 in [#9280](https://github.com/gfx-rs/wgpu/pull/9280).
-- Validate `LoadOp` and `StoreOp` are None for attachments without corresponding depth or stencil aspect. By @beicause in [#9567](https://github.com/gfx-rs/wgpu/pull/9567).
+- Validate `LoadOp` and `StoreOp` are `None` for attachments without corresponding depth or stencil aspect. By @beicause in [#9567](https://github.com/gfx-rs/wgpu/pull/9567).
 
 #### DX12
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -254,8 +254,7 @@ fails-if(dx12) webgpu:api,validation,render_pass,attachment_compatibility:render
 webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,sample_count:*
 webgpu:api,validation,render_pass,render_pass_descriptor:attachments,*
 webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,*
-webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,depth_clear_value:*
-webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,sample_counts_mismatch:*
+webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,*
 webgpu:api,validation,render_pass,render_pass_descriptor:occlusionQuerySet,query_set_type:*
 webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,*
 webgpu:api,validation,render_pass,render_pass_descriptor:timestampWrite,query_index:*

--- a/tests/tests/wgpu-gpu/zero_init_texture_after_discard.rs
+++ b/tests/tests/wgpu-gpu/zero_init_texture_after_discard.rs
@@ -274,7 +274,7 @@ impl<'ctx> TestCase<'ctx> {
                 depth_stencil_attachment: self.format.is_depth_stencil_format().then_some(
                     RenderPassDepthStencilAttachment {
                         view: &self.texture.create_view(&TextureViewDescriptor::default()),
-                        depth_ops: Some(Operations {
+                        depth_ops: self.format.has_depth_aspect().then_some(Operations {
                             load: LoadOp::Load,
                             store: StoreOp::Discard,
                         }),
@@ -304,7 +304,7 @@ impl<'ctx> TestCase<'ctx> {
                             load: LoadOp::Clear(0.0),
                             store: StoreOp::Store,
                         }),
-                        stencil_ops: Some(Operations {
+                        stencil_ops: self.format.has_stencil_aspect().then_some(Operations {
                             load: LoadOp::Load,
                             store: StoreOp::Discard,
                         }),

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -806,12 +806,12 @@ pub enum AttachmentError {
     ReadOnlyWithLoad,
     #[error("StoreOp must be None for read-only attachments")]
     ReadOnlyWithStore,
-    #[error("Depth LoadOp and StoreOp ({ops:?}) must be None for attachments ({format:?}) without depth aspect")]
+    #[error("Depth `LoadOp and `StoreOp` (`{ops:?}`) must be `None` for attachments (`{format:?}`) without depth aspect")]
     DepthOpsWithoutAspect {
         format: wgt::TextureFormat,
         ops: (Option<LoadOp<Option<f32>>>, Option<StoreOp>),
     },
-    #[error("Stencil LoadOp and StoreOp ({ops:?}) must be None for attachments ({format:?}) without stencil aspect")]
+    #[error("Stencil `LoadOp` and `StoreOp` (`{ops:?}`) must be `None` for attachments (`{format:?}`) without stencil aspect")]
     StencilOpsWithoutAspect {
         format: wgt::TextureFormat,
         ops: (Option<LoadOp<Option<u32>>>, Option<StoreOp>),

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -806,7 +806,7 @@ pub enum AttachmentError {
     ReadOnlyWithLoad,
     #[error("StoreOp must be None for read-only attachments")]
     ReadOnlyWithStore,
-    #[error("Depth `LoadOp and `StoreOp` (`{ops:?}`) must be `None` for attachments (`{format:?}`) without depth aspect")]
+    #[error("Depth `LoadOp` and `StoreOp` (`{ops:?}`) must be `None` for attachments (`{format:?}`) without depth aspect")]
     DepthOpsWithoutAspect {
         format: wgt::TextureFormat,
         ops: (Option<LoadOp<Option<f32>>>, Option<StoreOp>),

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -806,6 +806,16 @@ pub enum AttachmentError {
     ReadOnlyWithLoad,
     #[error("StoreOp must be None for read-only attachments")]
     ReadOnlyWithStore,
+    #[error("Depth LoadOp and StoreOp ({ops:?}) must be None for attachments ({format:?}) without depth aspect")]
+    DepthOpsWithoutAspect {
+        format: wgt::TextureFormat,
+        ops: (Option<LoadOp<Option<f32>>>, Option<StoreOp>),
+    },
+    #[error("Stencil LoadOp and StoreOp ({ops:?}) must be None for attachments ({format:?}) without stencil aspect")]
+    StencilOpsWithoutAspect {
+        format: wgt::TextureFormat,
+        ops: (Option<LoadOp<Option<u32>>>, Option<StoreOp>),
+    },
     #[error("Attachment without load")]
     NoLoad,
     #[error("Attachment without store")]
@@ -1849,11 +1859,23 @@ impl Global {
                                 Err(AttachmentError::NoClearValue)
                             })?
                         } else {
+                            if depth_stencil_attachment.depth.load_op.is_some() || depth_stencil_attachment.depth.store_op.is_some() {
+                                return Err(RenderPassErrorInner::InvalidAttachment(AttachmentError::DepthOpsWithoutAspect {
+                                    format,
+                                    ops: (depth_stencil_attachment.depth.load_op, depth_stencil_attachment.depth.store_op)
+                                }));
+                            }
                             ResolvedPassChannel::ReadOnly
                         },
                         stencil: if format.has_stencil_aspect() {
                             depth_stencil_attachment.stencil.resolve(|clear| Ok(clear.unwrap_or_default()))?
                         } else {
+                            if depth_stencil_attachment.stencil.load_op.is_some() || depth_stencil_attachment.stencil.store_op.is_some() {
+                                return Err(RenderPassErrorInner::InvalidAttachment(AttachmentError::StencilOpsWithoutAspect {
+                                    format,
+                                    ops: (depth_stencil_attachment.stencil.load_op, depth_stencil_attachment.stencil.store_op)
+                                }));
+                            }
                             ResolvedPassChannel::ReadOnly
                         },
                     })


### PR DESCRIPTION
**Connections**
None

**Description**
Fix cts `webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadOnly`

The spec https://gpuweb.github.io/gpuweb/#abstract-opdef-gpurenderpassdepthstencilattachment-gpurenderpassdepthstencilattachment-valid-usage says:
<img width="517" height="428" alt="屏幕截图_20260519_135540" src="https://github.com/user-attachments/assets/8cae0ba6-cdff-47b0-ae5c-a93235b020df" />

So without depth or stencil aspect, the `LoadOp` and `StoreOp` need to be None too, not only with `depthReadOnly=false` or `stencilReadOnly=false`.

**Testing**
`cargo xtask cts 'webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,*'`

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
