### PR TITLE
Expose notes from wgsl::ParseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 #### naga
 
 - spirv-out ray tracing pipelines. By @Vecvec in [#9085](https://github.com/gfx-rs/wgpu/pull/9085).
+- Add `naga::front::wgsl::ParseError::notes()`. By @kwillemsen in [#9572](https://github.com/gfx-rs/wgpu/pull/9572).
 
 ### Changes
 

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -46,6 +46,10 @@ impl ParseError {
         &self.message
     }
 
+    pub fn notes(&self) -> impl ExactSizeIterator<Item = &str> + '_ {
+        self.notes.iter().map(|note| note.as_str())
+    }
+
     fn diagnostic(&self) -> Diagnostic<()> {
         let diagnostic = Diagnostic::error()
             .with_message(self.message.to_string())
@@ -129,6 +133,35 @@ impl core::fmt::Display for ParseError {
 }
 
 impl core::error::Error for ParseError {}
+
+#[cfg(test)]
+mod parse_error_tests {
+    #[test]
+    fn test_notes() {
+        use crate::front::wgsl::parse_str;
+        // wgsl code and notes taken from: `cross_vec2()` in naga/tests/naga/wgsl_errors.rs
+        assert_eq!(
+            parse_str(
+                r#"
+            fn x() -> f32 {
+                return cross(vec2(0., 1.), vec2(0., 1.));
+            }
+        "#,
+            )
+            .unwrap_err()
+            .notes()
+            .collect::<std::vec::Vec<_>>(),
+            [
+                "`cross` accepts the following types for argument #1:",
+                "allowed type: vec3<{AbstractFloat}>",
+                "allowed type: vec3<f32>",
+                "allowed type: vec3<f16>",
+                "allowed type: vec3<f64>"
+            ]
+            .to_vec()
+        );
+    }
+}
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ExpectedToken<'a> {

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -136,6 +136,7 @@ impl core::error::Error for ParseError {}
 
 #[cfg(test)]
 mod parse_error_tests {
+
     #[test]
     fn test_notes() {
         use crate::front::wgsl::parse_str;
@@ -150,7 +151,7 @@ mod parse_error_tests {
             )
             .unwrap_err()
             .notes()
-            .collect::<std::vec::Vec<_>>(),
+            .collect::<super::Vec<_>>(),
             [
                 "`cross` accepts the following types for argument #1:",
                 "allowed type: vec3<{AbstractFloat}>",


### PR DESCRIPTION
**Description**

Add a `naga::front::wgsl::ParseError::notes()` method. Together with the already existing `ParseError::message()` and `ParseError::labels()` this allows to do custom diagnostic messages.

The specific use-case that triggered this change was a custom "shader module system" that stitches together snippets of shader code from different files. To be able to point to the correct file in case of errors, the system keeps a "source-map" that can translate a span of the full shader to a span of the corresponding shader snippet. These are then used to render the final diagnostic message.

**Testing**

A new unit-test parses an incorrect WGSL string (taken from another test) and checks the generated error's notes.

**Squash or Rebase?**

Squash

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
