### PR TITLE
Don't use `{buffer,texture}_init_actions` for usage tracking

### DIFF
--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -1,5 +1,7 @@
 use wgpu::util::DeviceExt;
-use wgpu_test::{fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+use wgpu_test::{
+    fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
@@ -7,6 +9,8 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         TEXTURE_DESTROY,
         BUFFER_DESTROY_BEFORE_SUBMIT,
         TEXTURE_DESTROY_BEFORE_SUBMIT,
+        EXTERNAL_TEXTURE_DESTROY_BEFORE_SUBMIT,
+        REPLACED_BIND_GROUP,
     ]);
 }
 
@@ -126,12 +130,195 @@ static TEXTURE_DESTROY: GpuTestConfiguration = GpuTestConfiguration::new()
         texture.destroy();
     });
 
-// Test that destroying a buffer between command buffer recording and
-// submission fails gracefully.
-#[gpu_test]
-static BUFFER_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().enable_noop())
-    .run_sync(|ctx| {
+#[derive(Copy, Clone)]
+enum UsageKind {
+    Direct,
+    RenderPass,
+    ComputePass,
+    RenderBundle,
+}
+
+const BUFFER_RENDER_SHADER: &str = "\
+@group(0) @binding(0) var<uniform> buf: vec4<f32>;
+@vertex fn vs() -> @builtin(position) vec4<f32> { return buf; }
+@fragment fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0); }";
+
+const BUFFER_COMPUTE_SHADER: &str = "\
+@group(0) @binding(0) var<uniform> buf: vec4<f32>;
+@compute @workgroup_size(1) fn main() { _ = buf; }";
+
+const TEXTURE_RENDER_SHADER: &str = "\
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@vertex fn vs() -> @builtin(position) vec4<f32> { return vec4<f32>(0); }
+@fragment fn fs() -> @location(0) vec4<f32> { return textureLoad(tex, vec2(0), 0); }";
+
+const TEXTURE_COMPUTE_SHADER: &str = "\
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@compute @workgroup_size(1) fn main() { _ = textureLoad(tex, vec2(0), 0); }";
+
+const EXTERNAL_TEXTURE_RENDER_SHADER: &str = "\
+@group(0) @binding(0) var tex: texture_external;
+@vertex fn vs() -> @builtin(position) vec4<f32> { return vec4<f32>(0); }
+@fragment fn fs() -> @location(0) vec4<f32> { return textureLoad(tex, vec2(0)); }";
+
+const EXTERNAL_TEXTURE_COMPUTE_SHADER: &str = "\
+@group(0) @binding(0) var tex: texture_external;
+@compute @workgroup_size(1) fn main() { _ = textureLoad(tex, vec2(0)); }";
+
+fn create_render_target(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureView) {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: None,
+        size: wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    (texture, view)
+}
+
+fn create_render_pipeline(device: &wgpu::Device, shader_src: &str) -> wgpu::RenderPipeline {
+    let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: None,
+        source: wgpu::ShaderSource::Wgsl(shader_src.into()),
+    });
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: None,
+        layout: None,
+        vertex: wgpu::VertexState {
+            module: &module,
+            entry_point: None,
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+            buffers: &[],
+        },
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        fragment: Some(wgpu::FragmentState {
+            module: &module,
+            entry_point: None,
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+            targets: &[Some(wgpu::ColorTargetState {
+                format: wgpu::TextureFormat::Rgba8Unorm,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+        }),
+        multiview_mask: None,
+        cache: None,
+    })
+}
+
+fn create_compute_pipeline(device: &wgpu::Device, shader_src: &str) -> wgpu::ComputePipeline {
+    let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: None,
+        source: wgpu::ShaderSource::Wgsl(shader_src.into()),
+    });
+    device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: None,
+        layout: None,
+        module: &module,
+        entry_point: None,
+        compilation_options: wgpu::PipelineCompilationOptions::default(),
+        cache: None,
+    })
+}
+
+/// Records a bind group usage into an encoder and returns the encoder.
+fn record_encoder_with_resource(
+    ctx: &TestingContext,
+    usage: UsageKind,
+    resource: wgpu::BindingResource<'_>,
+    render_shader: &str,
+    compute_shader: &str,
+) -> wgpu::CommandEncoder {
+    let (_render_target, rt_view) = create_render_target(&ctx.device);
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+
+    match usage {
+        UsageKind::Direct => unreachable!(),
+        UsageKind::RenderPass | UsageKind::RenderBundle => {
+            let pipeline = create_render_pipeline(&ctx.device, render_shader);
+            let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &pipeline.get_bind_group_layout(0),
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource,
+                }],
+            });
+
+            let color_attachment = [Some(wgpu::RenderPassColorAttachment {
+                view: &rt_view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })];
+
+            if matches!(usage, UsageKind::RenderPass) {
+                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &color_attachment,
+                    ..Default::default()
+                });
+                pass.set_pipeline(&pipeline);
+                pass.set_bind_group(0, &bind_group, &[]);
+                pass.draw(0..0, 0..0);
+            } else {
+                let mut rbe =
+                    ctx.device
+                        .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+                            label: None,
+                            color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
+                            depth_stencil: None,
+                            sample_count: 1,
+                            multiview: None,
+                        });
+                rbe.set_pipeline(&pipeline);
+                rbe.set_bind_group(0, &bind_group, &[]);
+                rbe.draw(0..0, 0..0);
+                let bundle = rbe.finish(&wgpu::RenderBundleDescriptor::default());
+                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &color_attachment,
+                    ..Default::default()
+                });
+                pass.execute_bundles([&bundle]);
+            }
+        }
+        UsageKind::ComputePass => {
+            let pipeline = create_compute_pipeline(&ctx.device, compute_shader);
+            let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &pipeline.get_bind_group_layout(0),
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource,
+                }],
+            });
+
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.dispatch_workgroups(0, 0, 0);
+        }
+    }
+
+    encoder
+}
+
+fn test_buffer_destroy_before_submit(ctx: &TestingContext, usage: UsageKind) {
+    if matches!(usage, UsageKind::Direct) {
         let buffer_source = ctx
             .device
             .create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -154,21 +341,55 @@ static BUFFER_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration
         buffer_source.destroy();
         buffer_dest.destroy();
 
-        let cmd_buffer = encoder.finish();
-
         fail(
             &ctx.device,
-            || ctx.queue.submit([cmd_buffer]),
+            || ctx.queue.submit([encoder.finish()]),
             Some("Buffer with '' label has been destroyed"),
         );
+        return;
+    }
+
+    let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 16,
+        usage: wgpu::BufferUsages::UNIFORM,
+        mapped_at_creation: false,
     });
 
-// Test that destroying a texture between command buffer recording and
-// submission fails gracefully.
+    let encoder = record_encoder_with_resource(
+        ctx,
+        usage,
+        buffer.as_entire_binding(),
+        BUFFER_RENDER_SHADER,
+        BUFFER_COMPUTE_SHADER,
+    );
+
+    buffer.destroy();
+
+    fail(
+        &ctx.device,
+        || ctx.queue.submit([encoder.finish()]),
+        Some("Buffer with '' label has been destroyed"),
+    );
+}
+
+// Test that destroying a buffer between command encoding and submission fails gracefully.
 #[gpu_test]
-static TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().enable_noop())
+static BUFFER_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop(),
+    )
     .run_sync(|ctx| {
+        test_buffer_destroy_before_submit(&ctx, UsageKind::Direct);
+        test_buffer_destroy_before_submit(&ctx, UsageKind::RenderPass);
+        test_buffer_destroy_before_submit(&ctx, UsageKind::ComputePass);
+        test_buffer_destroy_before_submit(&ctx, UsageKind::RenderBundle);
+    });
+
+fn test_texture_destroy_before_submit(ctx: &TestingContext, usage: UsageKind) {
+    if matches!(usage, UsageKind::Direct) {
         let descriptor = wgpu::TextureDescriptor {
             label: None,
             size: wgpu::Extent3d {
@@ -177,12 +398,10 @@ static TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguratio
                 depth_or_array_layers: 1,
             },
             mip_level_count: 1,
-            sample_count: 1, // multisampling is not supported for clear
+            sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Rgba8Snorm,
-            usage: wgpu::TextureUsages::COPY_DST
-                | wgpu::TextureUsages::COPY_SRC
-                | wgpu::TextureUsages::TEXTURE_BINDING,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
         };
 
@@ -215,11 +434,262 @@ static TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguratio
         texture_1.destroy();
         texture_2.destroy();
 
-        let cmd_buffer = encoder.finish();
-
         fail(
             &ctx.device,
-            || ctx.queue.submit([cmd_buffer]),
+            || ctx.queue.submit([encoder.finish()]),
             Some("Texture with '' label has been destroyed"),
         );
+        return;
+    }
+
+    let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: None,
+        size: wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let encoder = record_encoder_with_resource(
+        ctx,
+        usage,
+        wgpu::BindingResource::TextureView(&view),
+        TEXTURE_RENDER_SHADER,
+        TEXTURE_COMPUTE_SHADER,
+    );
+
+    texture.destroy();
+
+    fail(
+        &ctx.device,
+        || ctx.queue.submit([encoder.finish()]),
+        Some("Texture with '' label has been destroyed"),
+    );
+}
+
+// Test that destroying a texture between command encoding and submission fails gracefully.
+#[gpu_test]
+static TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop()
+            .features(wgpu::Features::CLEAR_TEXTURE),
+    )
+    .run_sync(|ctx| {
+        test_texture_destroy_before_submit(&ctx, UsageKind::Direct);
+        test_texture_destroy_before_submit(&ctx, UsageKind::RenderPass);
+        test_texture_destroy_before_submit(&ctx, UsageKind::ComputePass);
+        test_texture_destroy_before_submit(&ctx, UsageKind::RenderBundle);
+    });
+
+fn test_external_texture_destroy_before_submit(ctx: &TestingContext, usage: UsageKind) {
+    let plane_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: None,
+        size: wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    });
+
+    let external_texture = ctx.device.create_external_texture(
+        &wgpu::ExternalTextureDescriptor {
+            label: None,
+            width: 1,
+            height: 1,
+            format: wgpu::ExternalTextureFormat::Rgba,
+            yuv_conversion_matrix: [0.0; 16],
+            gamut_conversion_matrix: [0.0; 9],
+            src_transfer_function: Default::default(),
+            dst_transfer_function: Default::default(),
+            sample_transform: [0.0; 6],
+            load_transform: [0.0; 6],
+        },
+        &[&plane_texture.create_view(&wgpu::TextureViewDescriptor::default())],
+    );
+
+    let encoder = record_encoder_with_resource(
+        ctx,
+        usage,
+        wgpu::BindingResource::ExternalTexture(&external_texture),
+        EXTERNAL_TEXTURE_RENDER_SHADER,
+        EXTERNAL_TEXTURE_COMPUTE_SHADER,
+    );
+
+    plane_texture.destroy();
+    external_texture.destroy();
+
+    // External textures use a buffer and several textures internally. We consider which one
+    // triggers the error to be an implementation detail and match either.
+    fail(
+        &ctx.device,
+        || ctx.queue.submit([encoder.finish()]),
+        Some("with '' label has been destroyed"),
+    );
+}
+
+// Test that destroying an external texture between command encoding and submission fails
+// gracefully.
+#[gpu_test]
+static EXTERNAL_TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop()
+            .features(wgpu::Features::EXTERNAL_TEXTURE | wgpu::Features::CLEAR_TEXTURE),
+    )
+    .run_sync(|ctx| {
+        // UsageKind::Direct does not apply because external textures only support TEXTURE_BINDING.
+        test_external_texture_destroy_before_submit(&ctx, UsageKind::RenderPass);
+        test_external_texture_destroy_before_submit(&ctx, UsageKind::ComputePass);
+        test_external_texture_destroy_before_submit(&ctx, UsageKind::RenderBundle);
+    });
+
+fn test_replaced_bind_group(ctx: &TestingContext, usage: UsageKind) {
+    let buffer_a = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 16,
+        usage: wgpu::BufferUsages::UNIFORM,
+        mapped_at_creation: false,
+    });
+    let buffer_b = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 16,
+        usage: wgpu::BufferUsages::UNIFORM,
+        mapped_at_creation: false,
+    });
+
+    let (_render_target, rt_view) = create_render_target(&ctx.device);
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+
+    match usage {
+        UsageKind::RenderPass | UsageKind::RenderBundle => {
+            let pipeline = create_render_pipeline(&ctx.device, BUFFER_RENDER_SHADER);
+            let layout = pipeline.get_bind_group_layout(0);
+            let bind_group_a = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: buffer_a.as_entire_binding(),
+                }],
+            });
+            let bind_group_b = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: buffer_b.as_entire_binding(),
+                }],
+            });
+
+            let color_attachment = [Some(wgpu::RenderPassColorAttachment {
+                view: &rt_view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })];
+
+            if matches!(usage, UsageKind::RenderPass) {
+                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &color_attachment,
+                    ..Default::default()
+                });
+                pass.set_pipeline(&pipeline);
+                pass.set_bind_group(0, &bind_group_a, &[]);
+                pass.set_bind_group(0, &bind_group_b, &[]);
+                pass.draw(0..0, 0..0);
+            } else {
+                let mut rbe =
+                    ctx.device
+                        .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+                            label: None,
+                            color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
+                            depth_stencil: None,
+                            sample_count: 1,
+                            multiview: None,
+                        });
+                rbe.set_pipeline(&pipeline);
+                rbe.set_bind_group(0, &bind_group_a, &[]);
+                rbe.set_bind_group(0, &bind_group_b, &[]);
+                rbe.draw(0..0, 0..0);
+                let bundle = rbe.finish(&wgpu::RenderBundleDescriptor::default());
+                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &color_attachment,
+                    ..Default::default()
+                });
+                pass.execute_bundles([&bundle]);
+            }
+        }
+        UsageKind::ComputePass => {
+            let pipeline = create_compute_pipeline(&ctx.device, BUFFER_COMPUTE_SHADER);
+            let layout = pipeline.get_bind_group_layout(0);
+            let bind_group_a = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: buffer_a.as_entire_binding(),
+                }],
+            });
+            let bind_group_b = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: buffer_b.as_entire_binding(),
+                }],
+            });
+
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &bind_group_a, &[]);
+            pass.set_bind_group(0, &bind_group_b, &[]);
+            pass.dispatch_workgroups(0, 0, 0);
+        }
+        UsageKind::Direct => unreachable!(),
+    }
+
+    buffer_a.destroy();
+
+    fail(
+        &ctx.device,
+        || ctx.queue.submit([encoder.finish()]),
+        Some("Buffer with '' label has been destroyed"),
+    );
+}
+
+/// Test that bind groups that are replaced before use in a draw/dispatch are still
+/// considered in submit-time liveness checks.
+#[gpu_test]
+static REPLACED_BIND_GROUP: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop(),
+    )
+    .run_sync(|ctx| {
+        test_replaced_bind_group(&ctx, UsageKind::RenderPass);
+        test_replaced_bind_group(&ctx, UsageKind::ComputePass);
+        test_replaced_bind_group(&ctx, UsageKind::RenderBundle);
     });

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -1277,13 +1277,11 @@ impl BindGroup {
         &'a self,
         guard: &'a SnatchGuard,
     ) -> Result<&'a dyn hal::DynBindGroup, DestroyedResourceError> {
-        // Clippy insist on writing it this way. The idea is to return None
-        // if any of the raw buffer is not valid anymore.
-        for buffer in &self.buffer_init_actions {
-            buffer.buffer.try_raw(guard)?;
+        for buffer in self.used.buffers.used_resources() {
+            buffer.try_raw(guard)?;
         }
-        for texture in &self.texture_init_actions {
-            texture.texture.try_raw(guard)?;
+        for texture in self.used.views.used_textures() {
+            texture.try_raw(guard)?;
         }
 
         self.raw

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -1252,8 +1252,8 @@ pub struct BindGroup {
     pub(crate) label: String,
     pub(crate) tracking_data: TrackingData,
     pub(crate) used: BindGroupStates,
-    pub(crate) used_buffer_ranges: Vec<BufferInitTrackerAction>,
-    pub(crate) used_texture_ranges: Vec<TextureInitTrackerAction>,
+    pub(crate) buffer_init_actions: Vec<BufferInitTrackerAction>,
+    pub(crate) texture_init_actions: Vec<TextureInitTrackerAction>,
     /// INVARIANT: Sorted by binding index order.
     pub(crate) dynamic_binding_info: Vec<BindGroupDynamicBindingData>,
     /// Actual binding sizes for buffers that don't have `min_binding_size`
@@ -1279,10 +1279,10 @@ impl BindGroup {
     ) -> Result<&'a dyn hal::DynBindGroup, DestroyedResourceError> {
         // Clippy insist on writing it this way. The idea is to return None
         // if any of the raw buffer is not valid anymore.
-        for buffer in &self.used_buffer_ranges {
+        for buffer in &self.buffer_init_actions {
             buffer.buffer.try_raw(guard)?;
         }
-        for texture in &self.used_texture_ranges {
+        for texture in &self.texture_init_actions {
             texture.texture.try_raw(guard)?;
         }
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1499,9 +1499,9 @@ impl State {
         self.commands
             .extend(entries.map(|(i, bind_group, dynamic_offsets)| {
                 self.buffer_memory_init_actions
-                    .extend_from_slice(&bind_group.used_buffer_ranges);
+                    .extend_from_slice(&bind_group.buffer_init_actions);
                 self.texture_memory_init_actions
-                    .extend_from_slice(&bind_group.used_texture_ranges);
+                    .extend_from_slice(&bind_group.texture_init_actions);
 
                 self.flat_dynamic_offsets.extend_from_slice(dynamic_offsets);
 

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -148,7 +148,7 @@ pub(super) fn flush_bindings_helper(state: &mut PassState) -> Result<(), Destroy
 
     for (i, bind_group, dynamic_offsets) in entries {
         state.base.buffer_memory_init_actions.extend(
-            bind_group.used_buffer_ranges.iter().filter_map(|action| {
+            bind_group.buffer_init_actions.iter().filter_map(|action| {
                 action
                     .buffer
                     .initialization_status
@@ -156,7 +156,7 @@ pub(super) fn flush_bindings_helper(state: &mut PassState) -> Result<(), Destroy
                     .check_action(action)
             }),
         );
-        for action in bind_group.used_texture_ranges.iter() {
+        for action in bind_group.texture_init_actions.iter() {
             state.pending_discard_init_fixups.extend(
                 state
                     .base

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2874,7 +2874,7 @@ impl Device {
         bb: &'a binding_model::ResolvedBufferBinding,
         binding: u32,
         decl: &wgt::BindGroupLayoutEntry,
-        used_buffer_ranges: &mut Vec<BufferInitTrackerAction>,
+        buffer_init_actions: &mut Vec<BufferInitTrackerAction>,
         dynamic_binding_info: &mut Vec<binding_model::BindGroupDynamicBindingData>,
         late_buffer_binding_sizes: &mut FastHashMap<u32, wgt::BufferSize>,
         used: &mut BindGroupStates,
@@ -2999,7 +2999,7 @@ impl Device {
             binding_model::buffer_binding_type_bounds_check_alignment(&self.alignments, binding_ty);
         let visible_size = align_to(bind_size, bounds_check_alignment);
 
-        used_buffer_ranges.extend(buffer.initialization_status.read().create_action(
+        buffer_init_actions.extend(buffer.initialization_status.read().create_action(
             buffer,
             bb.offset..bb.offset + visible_size,
             MemoryInitKind::NeedsInitializedMemory,
@@ -3063,7 +3063,7 @@ impl Device {
         decl: &wgt::BindGroupLayoutEntry,
         view: &'a Arc<TextureView>,
         used: &mut BindGroupStates,
-        used_texture_ranges: &mut Vec<TextureInitTrackerAction>,
+        texture_init_actions: &mut Vec<TextureInitTrackerAction>,
         snatch_guard: &'a SnatchGuard<'a>,
     ) -> Result<hal::TextureBinding<'a, dyn hal::DynTextureView>, CreateBindGroupError> {
         view.same_device(self)?;
@@ -3079,7 +3079,7 @@ impl Device {
 
         let texture = &view.parent;
 
-        used_texture_ranges.push(TextureInitTrackerAction {
+        texture_init_actions.push(TextureInitTrackerAction {
             texture: texture.clone(),
             range: TextureInitRange {
                 mip_range: view.desc.range.mip_range(texture.desc.mip_level_count),
@@ -3277,8 +3277,8 @@ impl Device {
         // fill out the descriptors
         let mut used = BindGroupStates::new();
 
-        let mut used_buffer_ranges = Vec::new();
-        let mut used_texture_ranges = Vec::new();
+        let mut buffer_init_actions = Vec::new();
+        let mut texture_init_actions = Vec::new();
         let mut hal_entries = Vec::with_capacity(desc.entries.len());
         let mut hal_buffers = Vec::new();
         let mut hal_samplers = Vec::new();
@@ -3299,7 +3299,7 @@ impl Device {
                         bb,
                         binding,
                         decl,
-                        &mut used_buffer_ranges,
+                        &mut buffer_init_actions,
                         &mut dynamic_binding_info,
                         &mut late_buffer_binding_sizes,
                         &mut used,
@@ -3320,7 +3320,7 @@ impl Device {
                             bb,
                             binding,
                             decl,
-                            &mut used_buffer_ranges,
+                            &mut buffer_init_actions,
                             &mut dynamic_binding_info,
                             &mut late_buffer_binding_sizes,
                             &mut used,
@@ -3370,7 +3370,7 @@ impl Device {
                             decl,
                             view,
                             &mut used,
-                            &mut used_texture_ranges,
+                            &mut texture_init_actions,
                             &snatch_guard,
                         )?;
                         let res_index = hal_textures.len();
@@ -3389,7 +3389,7 @@ impl Device {
                             decl,
                             view,
                             &mut used,
-                            &mut used_texture_ranges,
+                            &mut texture_init_actions,
                             &snatch_guard,
                         )?;
 
@@ -3490,8 +3490,8 @@ impl Device {
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.bind_groups.clone()),
             used,
-            used_buffer_ranges,
-            used_texture_ranges,
+            buffer_init_actions,
+            texture_init_actions,
             dynamic_binding_info,
             late_buffer_binding_infos,
         };
@@ -3499,11 +3499,11 @@ impl Device {
         let bind_group = Arc::new(bind_group);
 
         let weak_ref = Arc::downgrade(&bind_group);
-        for range in &bind_group.used_texture_ranges {
+        for range in &bind_group.texture_init_actions {
             let mut bind_groups = range.texture.bind_groups.lock();
             bind_groups.push(weak_ref.clone());
         }
-        for range in &bind_group.used_buffer_ranges {
+        for range in &bind_group.buffer_init_actions {
             let mut bind_groups = range.buffer.bind_groups.lock();
             bind_groups.push(weak_ref.clone());
         }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -728,6 +728,7 @@ impl Device {
     /// implementation of a reference-counted structure).
     /// The snatch lock must not be held while this function is called.
     pub(crate) fn deferred_resource_destruction(&self) {
+        // Note that the deferred_destroy list may contain duplicate entries.
         let deferred_destroy = mem::take(&mut *self.deferred_destroy.lock());
         for item in deferred_destroy {
             match item {
@@ -3499,12 +3500,12 @@ impl Device {
         let bind_group = Arc::new(bind_group);
 
         let weak_ref = Arc::downgrade(&bind_group);
-        for range in &bind_group.texture_init_actions {
-            let mut bind_groups = range.texture.bind_groups.lock();
+        for texture in bind_group.used.views.used_textures() {
+            let mut bind_groups = texture.bind_groups.lock();
             bind_groups.push(weak_ref.clone());
         }
-        for range in &bind_group.buffer_init_actions {
-            let mut bind_groups = range.buffer.bind_groups.lock();
+        for buffer in bind_group.used.buffers.used_resources() {
+            let mut bind_groups = buffer.bind_groups.lock();
             bind_groups.push(weak_ref.clone());
         }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -455,6 +455,7 @@ pub struct Buffer {
     pub(crate) label: String,
     pub(crate) tracking_data: TrackingData,
     pub(crate) map_state: Mutex<BufferMapState>,
+    // Bind groups that reference this buffer. May contain duplicates.
     pub(crate) bind_groups: Mutex<WeakVec<BindGroup>>,
     pub(crate) timestamp_normalization_bind_group: Snatchable<TimestampNormalizationBindGroup>,
     pub(crate) indirect_validation_bind_groups: Snatchable<crate::indirect_validation::BindGroups>,
@@ -1366,6 +1367,7 @@ pub struct Texture {
     pub(crate) tracking_data: TrackingData,
     pub(crate) clear_mode: RwLock<TextureClearMode>,
     pub(crate) views: Mutex<WeakVec<TextureView>>,
+    // Bind groups that reference this texture. May contain duplicates.
     pub(crate) bind_groups: Mutex<WeakVec<BindGroup>>,
 }
 

--- a/wgpu-core/src/track/buffer.rs
+++ b/wgpu-core/src/track/buffer.rs
@@ -57,13 +57,9 @@ impl BufferBindGroupState {
             .sort_unstable_by_key(|(b, _)| b.tracker_index());
     }
 
-    /// Returns a list of all buffers tracked. May contain duplicates.
-    pub fn used_tracker_indices(&self) -> impl Iterator<Item = TrackerIndex> + '_ {
-        self.buffers
-            .iter()
-            .map(|(b, _)| b.tracker_index())
-            .collect::<Vec<_>>()
-            .into_iter()
+    /// Returns an iterator over the tracked buffers. May contain duplicates.
+    pub fn used_resources(&self) -> impl Iterator<Item = &Arc<Buffer>> {
+        self.buffers.iter().map(|(b, _)| b)
     }
 
     /// Adds the given resource with the given state.

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -106,7 +106,7 @@ use crate::{
     binding_model, command,
     lock::{rank, Mutex},
     pipeline,
-    resource::{self, Labeled, RawResourceAccess, ResourceErrorIdent},
+    resource::{self, Labeled, RawResourceAccess, ResourceErrorIdent, Trackable},
     snatch::SnatchGuard,
     track::blas::BlasTracker,
 };
@@ -697,7 +697,10 @@ impl Tracker {
     ) {
         self.buffers.set_and_remove_from_usage_scope_sparse(
             &mut scope.buffers,
-            bind_group.buffers.used_tracker_indices(),
+            bind_group
+                .buffers
+                .used_resources()
+                .map(|b| b.tracker_index()),
         );
         self.textures
             .set_and_remove_from_usage_scope_sparse(&mut scope.textures, &bind_group.views);

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -160,6 +160,12 @@ impl TextureViewBindGroupState {
     pub fn insert_single(&mut self, view: Arc<TextureView>, usage: TextureUses) {
         self.views.push((view, usage));
     }
+
+    /// Returns an iterator over the parent textures of the tracked views. May contain
+    /// duplicates.
+    pub fn used_textures(&self) -> impl Iterator<Item = &Arc<Texture>> {
+        self.views.iter().map(|(v, _)| &v.parent)
+    }
 }
 
 /// Container for corresponding simple and complex texture states.


### PR DESCRIPTION
Fixes #9576.

Renames the `used_{buffer,texture}_ranges` members of `struct BindGroup` to `{buffer,texture}_init_actions`, to better reflect their purpose. Fixes some places where they were misused for usage tracking, and adds a test.

**Squash or Rebase?** Rebase

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
  - Unlikely to matter for most applications, but can change behavior in corner cases.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
