### PR TITLE
refactor(hal): Remove unnecessary unsafe Send/Sync impls

### DIFF
--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -1128,8 +1128,8 @@ pub struct Sampler {
 
 impl crate::DynSampler for Sampler {}
 
-unsafe impl Send for Sampler {}
-unsafe impl Sync for Sampler {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(Sampler: Send, Sync);
 
 #[derive(Debug)]
 pub struct QuerySet {

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -1332,6 +1332,11 @@ impl super::AdapterShared {
     }
 }
 
+#[cfg(send_sync)]
+unsafe impl Sync for super::Adapter {}
+#[cfg(send_sync)]
+unsafe impl Send for super::Adapter {}
+
 #[cfg(test)]
 mod tests {
     use super::super::Adapter;

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -1332,11 +1332,6 @@ impl super::AdapterShared {
     }
 }
 
-#[cfg(send_sync)]
-unsafe impl Sync for super::Adapter {}
-#[cfg(send_sync)]
-unsafe impl Send for super::Adapter {}
-
 #[cfg(test)]
 mod tests {
     use super::super::Adapter;

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -344,6 +344,11 @@ struct Inner {
     srgb_kind: SrgbFrameBufferKind,
 }
 
+#[cfg(send_sync)]
+unsafe impl Send for Inner {}
+#[cfg(send_sync)]
+unsafe impl Sync for Inner {}
+
 // Different calls to `eglGetPlatformDisplay` may return the same `Display`, making it a global
 // state of all our `EglContext`s. This forces us to track the number of such context to prevent
 // terminating the display if it's currently used by another `EglContext`.
@@ -707,8 +712,8 @@ impl Instance {
     }
 }
 
-unsafe impl Send for Instance {}
-unsafe impl Sync for Instance {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(Instance: Send, Sync);
 
 impl crate::Instance for Instance {
     type A = super::Api;

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -292,6 +292,9 @@ pub struct Adapter {
     shared: Arc<AdapterShared>,
 }
 
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(Adapter: Send, Sync);
+
 pub struct Device {
     shared: Arc<AdapterShared>,
     main_vao: glow::VertexArray,
@@ -692,6 +695,11 @@ struct PipelineInner {
     clip_distance_count: u32,
 }
 
+#[cfg(send_sync)]
+unsafe impl Sync for PipelineInner {}
+#[cfg(send_sync)]
+unsafe impl Send for PipelineInner {}
+
 #[derive(Clone, Debug)]
 struct DepthState {
     function: u32,
@@ -750,9 +758,7 @@ pub struct RenderPipeline {
 impl crate::DynRenderPipeline for RenderPipeline {}
 
 #[cfg(send_sync)]
-unsafe impl Sync for RenderPipeline {}
-#[cfg(send_sync)]
-unsafe impl Send for RenderPipeline {}
+static_assertions::assert_impl_all!(RenderPipeline: Send, Sync);
 
 #[derive(Debug)]
 pub struct ComputePipeline {
@@ -762,9 +768,7 @@ pub struct ComputePipeline {
 impl crate::DynComputePipeline for ComputePipeline {}
 
 #[cfg(send_sync)]
-unsafe impl Sync for ComputePipeline {}
-#[cfg(send_sync)]
-unsafe impl Send for ComputePipeline {}
+static_assertions::assert_impl_all!(ComputePipeline: Send, Sync);
 
 #[derive(Debug)]
 pub struct QuerySet {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -292,9 +292,6 @@ pub struct Adapter {
     shared: Arc<AdapterShared>,
 }
 
-#[cfg(send_sync)]
-static_assertions::assert_impl_all!(Adapter: Send, Sync);
-
 pub struct Device {
     shared: Arc<AdapterShared>,
     main_vao: glow::VertexArray,

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -107,9 +107,7 @@ impl Instance {
 }
 
 #[cfg(send_sync)]
-unsafe impl Sync for Instance {}
-#[cfg(send_sync)]
-unsafe impl Send for Instance {}
+static_assertions::assert_impl_all!(Instance: Send, Sync);
 
 impl crate::Instance for Instance {
     type A = super::Api;

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -41,8 +41,8 @@ pub struct AdapterContext {
     inner: Arc<Mutex<Inner>>,
 }
 
-unsafe impl Sync for AdapterContext {}
-unsafe impl Send for AdapterContext {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(AdapterContext: Send, Sync);
 
 impl AdapterContext {
     pub fn is_owned(&self) -> bool {
@@ -182,8 +182,8 @@ pub struct Instance {
     inner: Arc<Mutex<Inner>>,
 }
 
-unsafe impl Send for Instance {}
-unsafe impl Sync for Instance {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(Instance: Send, Sync);
 
 fn load_gl_func(name: &str, module: Option<Foundation::HMODULE>) -> *const c_void {
     let addr = CString::new(name.as_bytes()).unwrap();
@@ -676,8 +676,8 @@ pub struct Surface {
     srgb_capable: bool,
 }
 
-unsafe impl Send for Surface {}
-unsafe impl Sync for Surface {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(Surface: Send, Sync);
 
 impl Surface {
     pub(super) unsafe fn present(

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -676,8 +676,8 @@ pub struct Surface {
     srgb_capable: bool,
 }
 
-#[cfg(send_sync)]
-static_assertions::assert_impl_all!(Surface: Send, Sync);
+unsafe impl Send for Surface {}
+unsafe impl Sync for Surface {}
 
 impl Surface {
     pub(super) unsafe fn present(

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -219,8 +219,6 @@
     clippy::single_match,
     // Push commands are more regular than macros.
     clippy::vec_init_then_push,
-    // We unsafe impl `Send` for a reason.
-    clippy::non_send_fields_in_send_ty,
     // TODO!
     clippy::missing_safety_doc,
     // It gets in the way a lot and does not prevent bugs in practice.

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -62,9 +62,6 @@ const MAX_ACCELERATION_STRUCTURES_PER_SHADER_STAGE: u32 = 1;
 // Use the end of the range for vertex buffers.
 pub const VERTEX_BUFFER_SLOT_START: u32 = 31 - 8;
 
-unsafe impl Send for super::Adapter {}
-unsafe impl Sync for super::Adapter {}
-
 impl super::Adapter {
     pub(super) fn new(shared: Arc<super::AdapterShared>) -> Self {
         Self { shared }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -392,8 +392,8 @@ struct AdapterShared {
     presentation_timer: time::PresentationTimer,
 }
 
-unsafe impl Send for AdapterShared {}
-unsafe impl Sync for AdapterShared {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(AdapterShared: Send, Sync);
 
 impl AdapterShared {
     fn new(
@@ -446,13 +446,16 @@ pub struct Adapter {
     shared: Arc<AdapterShared>,
 }
 
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(Adapter: Send, Sync);
+
 pub struct Queue {
     shared: Arc<QueueShared>,
     timestamp_period: f32,
 }
 
-unsafe impl Send for Queue {}
-unsafe impl Sync for Queue {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(Queue: Send, Sync);
 
 impl Queue {
     pub unsafe fn queue_from_raw(
@@ -703,8 +706,8 @@ pub struct Sampler {
 
 impl crate::DynSampler for Sampler {}
 
-unsafe impl Send for Sampler {}
-unsafe impl Sync for Sampler {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(Sampler: Send, Sync);
 
 impl Sampler {
     fn as_raw(&self) -> NonNull<ProtocolObject<dyn MTLSamplerState>> {
@@ -887,8 +890,8 @@ pub struct PassthroughShader {
     pub num_workgroups: HashMap<String, (u32, u32, u32)>,
 }
 
-unsafe impl Send for PassthroughShader {}
-unsafe impl Sync for PassthroughShader {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(PassthroughShader: Send, Sync);
 
 #[derive(Debug)]
 pub struct ShaderModule {
@@ -993,8 +996,8 @@ pub struct RenderPipeline {
     )>,
 }
 
-unsafe impl Send for RenderPipeline {}
-unsafe impl Sync for RenderPipeline {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(RenderPipeline: Send, Sync);
 
 impl crate::DynRenderPipeline for RenderPipeline {}
 
@@ -1004,8 +1007,8 @@ pub struct ComputePipeline {
     cs_info: PipelineStageInfo,
 }
 
-unsafe impl Send for ComputePipeline {}
-unsafe impl Sync for ComputePipeline {}
+#[cfg(send_sync)]
+static_assertions::assert_impl_all!(ComputePipeline: Send, Sync);
 
 impl crate::DynComputePipeline for ComputePipeline {}
 


### PR DESCRIPTION
Related to #9508, but this is just the easy part (removing it from structs that don't have any `!Send` / `!Sync` fields). The harder part is modifying structs where there's one intended and safe `!Sync` member in a struct with many members, where the `unsafe impl` could allow unintentionally adding other `!Sync` members. (As a reminder, the `Cell<bool>` in #9505 is an example of how things can go wrong.) 

There are a few cases where the removed impls are `for super::Foo` and the replacement assertion is located adjacent to `struct Foo` in `super` rather than in place of the unsafe impl. There's also a few cases where I remove `unsafe impl`s for `Foo` and add them for `FooInner`.

I have also removed the waiver for `non_send_fields_in_send_ty` from `wgpu-hal`. This lint is actually not enabled by default right now; were it enabled, we do have violations. I'm more bothered by the mysterious "we unsafe impl `Send` for a reason" comment than the waiver itself. Seems easy enough to add it back in the future if needed (or to apply it to individual structs where it is relevant, which would also serve as a nearby warning about adding `!Sync` members).

See https://github.com/rust-lang/rust-clippy/issues/8045 for some discussion about this lint. It was briefly enabled by default, which may by what prompted our waiver. It seems likely that it will not be re-enabled without improvements to reduce false-positives, which might render the waiver unnecessary. (The heuristic also means that the waiver isn't required on every struct that has `unsafe impl Send`, which makes the aforementioned usage as a warning less effective.)

**Testing**
`static_assertion`s that the structs are still `Send + Sync`.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
