### PR TITLE
Add `STRICT_WEBGPU_COMPLIANCE` instance flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
   ```
   By @AdrianEddy in [#9496](https://github.com/gfx-rs/wgpu/pull/9496).
 - Extend `copy_texture_to_texture` to allow copying a single plane of a multi-planar source (NV12, P010) into a single-plane destination of the matching format (e.g. NV12 `Plane0` → `R8Unorm`, NV12 `Plane1` → `Rg8Unorm`). `copy_size` is interpreted in plane texels, not luma texels. By @AdrianEddy in [#9551](https://github.com/gfx-rs/wgpu/pull/9551).
+- Added `InstanceFlags::STRICT_WEBGPU_COMPLIANCE` flag, which restricts the available feature set to the one defined by the WebGPU specification. By @teoxoy in [#9586](https://github.com/gfx-rs/wgpu/pull/9586).
 
 #### Metal
 

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -105,10 +105,12 @@ pub fn initialize_instance(backends: wgpu::Backends, params: &TestParameters) ->
 }
 
 /// Initialize a wgpu adapter, using the given adapter report to match the adapter.
+///
+/// Returns `None` if the adapter from the report is not returned by `enumerate_adapters` due to `InstanceFlags::STRICT_WEBGPU_COMPLIANCE` being set.
 pub async fn initialize_adapter(
     adapter_report: Option<&AdapterReport>,
     params: &TestParameters,
-) -> (Instance, Adapter, Option<SurfaceGuard>) {
+) -> Option<(Instance, Adapter, Option<SurfaceGuard>)> {
     let backends = adapter_report
         .map(|report| Backends::from(report.info.backend))
         .unwrap_or_default();
@@ -157,24 +159,36 @@ pub async fn initialize_adapter(
                 } else {
                     true
                 });
-            let Some(adapter) = adapter else {
-                panic!(
-                    "Could not find adapter with info {:#?} in {:#?}",
-                    adapter_report.map(|r| &r.info),
-                    instance.enumerate_adapters(backends).await.into_iter().map(|a| a.get_info()).collect::<Vec<_>>(),
-                );
-            };
         } else {
             let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions {
                 compatible_surface: surface.as_ref(),
                 ..Default::default()
-            }).await.unwrap();
+            }).await.ok();
         }
     }
 
-    log::info!("Testing using adapter: {:#?}", adapter.get_info());
+    let Some(adapter) = adapter else {
+        if params
+            .required_instance_flags
+            .contains(wgpu::InstanceFlags::STRICT_WEBGPU_COMPLIANCE)
+        {
+            return None;
+        } else {
+            panic!(
+                "Could not find adapter with info {:#?} in {:#?}",
+                adapter_report.map(|r| &r.info),
+                instance
+                    .enumerate_adapters(backends)
+                    .await
+                    .into_iter()
+                    .map(|a| a.get_info())
+                    .collect::<Vec<_>>(),
+            );
+        }
+    };
 
-    (instance, adapter, surface_guard)
+    log::info!("Testing using adapter: {:#?}", adapter.get_info());
+    Some((instance, adapter, surface_guard))
 }
 
 /// Initialize a wgpu device from a given adapter.

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -43,8 +43,11 @@ pub async fn execute_test(
 
     let _test_guard = isolation::OneTestPerProcessGuard::new();
 
-    let (instance, adapter, _surface_guard) =
-        initialize_adapter(adapter_report, &config.params).await;
+    let Some((instance, adapter, _surface_guard)) =
+        initialize_adapter(adapter_report, &config.params).await
+    else {
+        return;
+    };
 
     let adapter_info = adapter.get_info();
     let adapter_downlevel_capabilities = adapter.get_downlevel_capabilities();

--- a/tests/tests/wgpu-gpu/adapter.rs
+++ b/tests/tests/wgpu-gpu/adapter.rs
@@ -1,0 +1,20 @@
+use wgpu_test::{gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(STRICT_WEBGPU_COMPLIANCE_ADAPTER);
+}
+
+#[gpu_test]
+static STRICT_WEBGPU_COMPLIANCE_ADAPTER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::STRICT_WEBGPU_COMPLIANCE)
+            .enable_noop(),
+    )
+    .run_sync(|ctx| {
+        assert!(ctx
+            .adapter
+            .get_downlevel_capabilities()
+            .is_webgpu_compliant());
+        assert!(wgpu::Limits::defaults().check_limits(&ctx.adapter.limits()));
+    });

--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -135,7 +135,9 @@ async fn request_device_error_message() {
     // Not using initialize_test() because that doesn't let us catch the error
     // nor .await anything
     let (_instance, adapter, _surface_guard) =
-        wgpu_test::initialize_adapter(None, &TestParameters::default()).await;
+        wgpu_test::initialize_adapter(None, &TestParameters::default())
+            .await
+            .unwrap();
 
     let device_error = adapter
         .request_device(&wgpu::DeviceDescriptor {

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -13,6 +13,7 @@ mod regression {
     pub mod issue_9115;
 }
 
+mod adapter;
 mod bgra8unorm_storage;
 mod bind_group_layout_dedup;
 mod bind_groups;
@@ -86,6 +87,7 @@ mod zero_init;
 fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     let mut tests = Vec::new();
 
+    adapter::all_tests(&mut tests);
     bgra8unorm_storage::all_tests(&mut tests);
     bind_group_layout_dedup::all_tests(&mut tests);
     bind_groups::all_tests(&mut tests);

--- a/tests/tests/wgpu-gpu/pass_ops/mod.rs
+++ b/tests/tests/wgpu-gpu/pass_ops/mod.rs
@@ -1,18 +1,23 @@
 use wgpu_test::{
-    gpu_test, image::ReadbackBuffers, GpuTestConfiguration, GpuTestInitializer, TestParameters,
-    TestingContext,
+    fail, gpu_test, image::ReadbackBuffers, GpuTestConfiguration, GpuTestInitializer,
+    TestParameters, TestingContext,
 };
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
-    vec.push(DONT_CARE);
+    vec.extend([
+        DONT_CARE,
+        DONT_CARE_COLOR_STRICT_WEBGPU_COMPLIANCE,
+        DONT_CARE_DEPTH_STRICT_WEBGPU_COMPLIANCE,
+        DONT_CARE_STENCIL_STRICT_WEBGPU_COMPLIANCE,
+    ]);
 }
 
 #[gpu_test]
 static DONT_CARE: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default())
-    .run_async(run_test);
+    .run_async(dont_care);
 
-async fn run_test(ctx: TestingContext) {
+async fn dont_care(ctx: TestingContext) {
     let shader_src = "
         const triangles = array<vec2f, 3>(vec2f(-1.0, -1.0), vec2f(3.0, -1.0), vec2f(-1.0, 3.0));
 
@@ -109,3 +114,137 @@ async fn run_test(ctx: TestingContext) {
         .assert_buffer_contents(&ctx, &[127, 127, 127, 127])
         .await;
 }
+
+#[gpu_test]
+static DONT_CARE_COLOR_STRICT_WEBGPU_COMPLIANCE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::STRICT_WEBGPU_COMPLIANCE)
+            .enable_noop(),
+    )
+    .run_sync(|ctx| {
+        let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            size: wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::DontCare(unsafe { wgpu::LoadOpDontCare::enabled() }),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            ..Default::default()
+        });
+        fail(
+            &ctx.device,
+            || encoder.finish(),
+            Some("STRICT_WEBGPU_COMPLIANCE"),
+        );
+    });
+
+#[gpu_test]
+static DONT_CARE_DEPTH_STRICT_WEBGPU_COMPLIANCE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .instance_flags(wgpu::InstanceFlags::STRICT_WEBGPU_COMPLIANCE)
+            .enable_noop(),
+    )
+    .run_sync(|ctx| {
+        let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            size: wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Depth16Unorm,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                view: &view,
+                depth_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::DontCare(unsafe { wgpu::LoadOpDontCare::enabled() }),
+                    store: wgpu::StoreOp::Store,
+                }),
+                stencil_ops: None,
+            }),
+            ..Default::default()
+        });
+        fail(
+            &ctx.device,
+            || encoder.finish(),
+            Some("STRICT_WEBGPU_COMPLIANCE"),
+        );
+    });
+
+#[gpu_test]
+static DONT_CARE_STENCIL_STRICT_WEBGPU_COMPLIANCE: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .instance_flags(wgpu::InstanceFlags::STRICT_WEBGPU_COMPLIANCE)
+                .enable_noop(),
+        )
+        .run_sync(|ctx| {
+            let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+                label: None,
+                size: wgpu::Extent3d {
+                    width: 1,
+                    height: 1,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Stencil8,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                view_formats: &[],
+            });
+            let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
+            let mut encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: &view,
+                    depth_ops: None,
+                    stencil_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::DontCare(unsafe { wgpu::LoadOpDontCare::enabled() }),
+                        store: wgpu::StoreOp::Store,
+                    }),
+                }),
+                ..Default::default()
+            });
+            fail(
+                &ctx.device,
+                || encoder.finish(),
+                Some("STRICT_WEBGPU_COMPLIANCE"),
+            );
+        });

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -6,8 +6,8 @@ use arrayvec::ArrayVec;
 use thiserror::Error;
 use wgt::{
     error::{ErrorType, WebGpuError},
-    BufferAddress, BufferSize, BufferUsages, Color, DynamicOffset, IndexFormat, TextureSelector,
-    TextureUsages, TextureViewDimension, VertexStepMode,
+    BufferAddress, BufferSize, BufferUsages, Color, DynamicOffset, IndexFormat, InstanceFlags,
+    TextureSelector, TextureUsages, TextureViewDimension, VertexStepMode,
 };
 
 use crate::{
@@ -109,6 +109,7 @@ pub struct PassChannel<V> {
 impl<V: Copy + Default> PassChannel<Option<V>> {
     fn resolve(
         &self,
+        instance_flags: InstanceFlags,
         handle_clear: impl Fn(Option<V>) -> Result<V, AttachmentError>,
     ) -> Result<ResolvedPassChannel<V>, AttachmentError> {
         if self.read_only {
@@ -123,7 +124,12 @@ impl<V: Copy + Default> PassChannel<Option<V>> {
             Ok(ResolvedPassChannel::Operational(wgt::Operations {
                 load: match self.load_op.ok_or(AttachmentError::NoLoad)? {
                     LoadOp::Clear(clear_value) => LoadOp::Clear(handle_clear(clear_value)?),
-                    LoadOp::DontCare(token) => LoadOp::DontCare(token),
+                    LoadOp::DontCare(token) => {
+                        if instance_flags.contains(InstanceFlags::STRICT_WEBGPU_COMPLIANCE) {
+                            return Err(AttachmentError::LoadOpDontCareUnderStrictWebgpuCompliance);
+                        }
+                        LoadOp::DontCare(token)
+                    }
                     LoadOp::Load => LoadOp::Load,
                 },
                 store: self.store_op.ok_or(AttachmentError::NoStore)?,
@@ -803,6 +809,8 @@ pub enum ColorAttachmentError {
     },
     #[error("Color attachment's usage contains {0:?}. This can only be used with StoreOp::{1:?}, but StoreOp::{2:?} was provided")]
     InvalidUsageForStoreOp(TextureUsages, StoreOp, StoreOp),
+    #[error("Color attachment's load op is `LoadOp::DontCare` but `InstanceFlags::STRICT_WEBGPU_COMPLIANCE` is set")]
+    LoadOpDontCareUnderStrictWebgpuCompliance,
 }
 
 impl WebGpuError for ColorAttachmentError {
@@ -838,6 +846,8 @@ pub enum AttachmentError {
     NoClearValue,
     #[error("Clear value ({0}) must be between 0.0 and 1.0, inclusive")]
     ClearValueOutOfRange(f32),
+    #[error("Load op is `DontCare` but `InstanceFlags::STRICT_WEBGPU_COMPLIANCE` is set")]
+    LoadOpDontCareUnderStrictWebgpuCompliance,
 }
 
 impl WebGpuError for AttachmentError {
@@ -1688,7 +1698,7 @@ impl RenderPassInfo {
         raw: &mut dyn hal::DynCommandEncoder,
         snatch_guard: &SnatchGuard,
         scope: &mut UsageScope<'_>,
-        instance_flags: wgt::InstanceFlags,
+        instance_flags: InstanceFlags,
     ) -> Result<(), RenderPassErrorInner> {
         profiling::scope!("RenderPassInfo::finish");
         unsafe {
@@ -1811,6 +1821,16 @@ impl Global {
                     let view = texture_views.get(*view_id).get()?;
                     view.same_device(device)?;
 
+                    if matches!(*load_op, LoadOp::DontCare(..))
+                        && device
+                            .instance_flags
+                            .contains(InstanceFlags::STRICT_WEBGPU_COMPLIANCE)
+                    {
+                        return Err(RenderPassErrorInner::ColorAttachment(
+                            ColorAttachmentError::LoadOpDontCareUnderStrictWebgpuCompliance,
+                        ));
+                    }
+
                     if view.desc.usage.contains(TextureUsages::TRANSIENT)
                         && *store_op != StoreOp::Discard
                     {
@@ -1862,7 +1882,7 @@ impl Global {
                     Some(ResolvedRenderPassDepthStencilAttachment {
                         view,
                         depth: if format.has_depth_aspect() {
-                            depth_stencil_attachment.depth.resolve(|clear| if let Some(clear) = clear {
+                            depth_stencil_attachment.depth.resolve(device.instance_flags, |clear| if let Some(clear) = clear {
                                 // If this.depthLoadOp is "clear", this.depthClearValue must be provided and must be between 0.0 and 1.0, inclusive.
                                 if !(0.0..=1.0).contains(&clear) {
                                     Err(AttachmentError::ClearValueOutOfRange(clear))
@@ -1882,7 +1902,7 @@ impl Global {
                             ResolvedPassChannel::ReadOnly
                         },
                         stencil: if format.has_stencil_aspect() {
-                            depth_stencil_attachment.stencil.resolve(|clear| {
+                            depth_stencil_attachment.stencil.resolve(device.instance_flags, |clear| {
                                 Ok(convert_stencil_value(clear.unwrap_or_default(), Some(format)))
                             })?
                         } else {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1,4 +1,5 @@
 use alloc::{borrow::ToOwned as _, boxed::Box, string::String, sync::Arc, vec, vec::Vec};
+use core::fmt;
 
 use hashbrown::HashMap;
 use thiserror::Error;
@@ -414,64 +415,13 @@ impl Instance {
         })
     }
 
-    /// This function checks that the adapter obeys WebGPU's adapter capability
-    /// guarantees. Most of the limits are adjusted in wgpu-hal's
-    /// `adjust_raw_limits` fn. So we only check the remaining properties here.
-    /// See <https://gpuweb.github.io/gpuweb/#adapter-capability-guarantees>.
     fn adapter_allowed(&self, raw: &hal::DynExposedAdapter) -> bool {
-        // Check "All alignment-class limits must be powers of 2."
-        //
-        // Even if the application has not requested strict WebGPU compliance,
-        // non-power-of-two alignment limits are nonsensical, so don't attempt
-        // to use such a device.
-        let min_uniform_buffer_offset_alignment =
-            raw.capabilities.limits.min_uniform_buffer_offset_alignment;
-        if !min_uniform_buffer_offset_alignment.is_power_of_two() {
-            log::error!(
-                "Adapter {:?} min_uniform_buffer_offset_alignment limit is not a power of 2: {:?}",
-                raw.info,
-                min_uniform_buffer_offset_alignment
-            );
-            return false;
-        }
-        let min_storage_buffer_offset_alignment =
-            raw.capabilities.limits.min_storage_buffer_offset_alignment;
-        if !min_storage_buffer_offset_alignment.is_power_of_two() {
-            log::error!(
-                "Adapter {:?} min_storage_buffer_offset_alignment limit is not a power of 2: {:?}",
-                raw.info,
-                min_storage_buffer_offset_alignment
-            );
-            return false;
-        }
-
-        // Following checks are only enabled if `STRICT_WEBGPU_COMPLIANCE` is set.
-        if !self.flags.contains(InstanceFlags::STRICT_WEBGPU_COMPLIANCE) {
-            return true;
-        }
-
-        // Check "All supported limits must be either the default value or better."
-        let failed_limits = check_limits(&wgt::Limits::defaults(), &raw.capabilities.limits);
-        if !failed_limits.is_empty() {
-            log::debug!(
-                "Adapter {:?} is not WebGPU compliant due to limits: {:?}",
-                raw.info,
-                failed_limits
-            );
-            return false;
-        }
-
-        if !raw.capabilities.downlevel.is_webgpu_compliant() {
-            let missing_flags = wgt::DownlevelFlags::compliant() - raw.capabilities.downlevel.flags;
-            log::debug!(
-                "Adapter {:?} is not WebGPU compliant due to missing downlevel flags: {:?}",
-                raw.info,
-                missing_flags
-            );
-            return false;
-        }
-
-        true
+        adapter_allowed(
+            self.flags,
+            &raw.info,
+            &raw.capabilities.limits,
+            &raw.capabilities.downlevel,
+        )
     }
 
     pub fn enumerate_adapters(
@@ -1313,5 +1263,172 @@ impl Global {
         resource_log!("Created Queue {:?}", queue_id);
 
         Ok((device_id, queue_id))
+    }
+}
+
+/// This function checks that the adapter obeys WebGPU's adapter capability
+/// guarantees. Most of the limits are adjusted in wgpu-hal's
+/// `adjust_raw_limits` fn. So we only check the remaining properties here.
+/// See <https://gpuweb.github.io/gpuweb/#adapter-capability-guarantees>.
+fn adapter_allowed(
+    flags: InstanceFlags,
+    info: &impl fmt::Debug,
+    limits: &wgt::Limits,
+    downlevel: &wgt::DownlevelCapabilities,
+) -> bool {
+    // Check "All alignment-class limits must be powers of 2."
+    //
+    // Even if the application has not requested strict WebGPU compliance,
+    // non-power-of-two alignment limits are nonsensical, so don't attempt
+    // to use such a device.
+    let min_uniform_buffer_offset_alignment = limits.min_uniform_buffer_offset_alignment;
+    if !min_uniform_buffer_offset_alignment.is_power_of_two() {
+        log::error!(
+            "Adapter {:?} min_uniform_buffer_offset_alignment limit is not a power of 2: {:?}",
+            info,
+            min_uniform_buffer_offset_alignment
+        );
+        return false;
+    }
+    let min_storage_buffer_offset_alignment = limits.min_storage_buffer_offset_alignment;
+    if !min_storage_buffer_offset_alignment.is_power_of_two() {
+        log::error!(
+            "Adapter {:?} min_storage_buffer_offset_alignment limit is not a power of 2: {:?}",
+            info,
+            min_storage_buffer_offset_alignment
+        );
+        return false;
+    }
+
+    // Following checks are only enabled if `STRICT_WEBGPU_COMPLIANCE` is set.
+    if !flags.contains(InstanceFlags::STRICT_WEBGPU_COMPLIANCE) {
+        return true;
+    }
+
+    // Check "All supported limits must be either the default value or better."
+    let failed_limits = check_limits(&wgt::Limits::defaults(), limits);
+    if !failed_limits.is_empty() {
+        log::debug!(
+            "Adapter {:?} is not WebGPU compliant due to limits: {:?}",
+            info,
+            failed_limits
+        );
+        return false;
+    }
+
+    if !downlevel.is_webgpu_compliant() {
+        let missing_flags = wgt::DownlevelFlags::compliant() - downlevel.flags;
+        log::debug!(
+            "Adapter {:?} is not WebGPU compliant due to missing downlevel flags: {:?}",
+            info,
+            missing_flags
+        );
+        return false;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compliant_downlevel() -> wgt::DownlevelCapabilities {
+        wgt::DownlevelCapabilities {
+            flags: wgt::DownlevelFlags::compliant(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn non_power_of_two_uniform_alignment_always_rejected() {
+        let limits = wgt::Limits {
+            min_uniform_buffer_offset_alignment: 3,
+            ..wgt::Limits::defaults()
+        };
+        assert!(!adapter_allowed(
+            InstanceFlags::empty(),
+            &"",
+            &limits,
+            &compliant_downlevel()
+        ));
+        assert!(!adapter_allowed(
+            InstanceFlags::STRICT_WEBGPU_COMPLIANCE,
+            &"",
+            &limits,
+            &compliant_downlevel()
+        ));
+    }
+
+    #[test]
+    fn non_power_of_two_storage_alignment_always_rejected() {
+        let limits = wgt::Limits {
+            min_storage_buffer_offset_alignment: 96,
+            ..wgt::Limits::defaults()
+        };
+        assert!(!adapter_allowed(
+            InstanceFlags::empty(),
+            &"",
+            &limits,
+            &compliant_downlevel()
+        ));
+        assert!(!adapter_allowed(
+            InstanceFlags::STRICT_WEBGPU_COMPLIANCE,
+            &"",
+            &limits,
+            &compliant_downlevel()
+        ));
+    }
+
+    #[test]
+    fn low_limits_allowed_without_strict_compliance() {
+        let limits = wgt::Limits {
+            max_texture_dimension_1d: 1,
+            ..wgt::Limits::defaults()
+        };
+        assert!(adapter_allowed(
+            InstanceFlags::empty(),
+            &"",
+            &limits,
+            &wgt::DownlevelCapabilities::default()
+        ));
+    }
+
+    #[test]
+    fn low_limits_rejected_with_strict_compliance() {
+        let limits = wgt::Limits {
+            max_texture_dimension_1d: 1,
+            ..wgt::Limits::defaults()
+        };
+        assert!(!adapter_allowed(
+            InstanceFlags::STRICT_WEBGPU_COMPLIANCE,
+            &"",
+            &limits,
+            &compliant_downlevel()
+        ));
+    }
+
+    #[test]
+    fn missing_downlevel_flags_rejected_with_strict_compliance() {
+        let downlevel = wgt::DownlevelCapabilities {
+            flags: wgt::DownlevelFlags::empty(),
+            ..Default::default()
+        };
+        assert!(!adapter_allowed(
+            InstanceFlags::STRICT_WEBGPU_COMPLIANCE,
+            &"",
+            &wgt::Limits::defaults(),
+            &downlevel
+        ));
+    }
+
+    #[test]
+    fn fully_compliant_adapter_always_allowed() {
+        assert!(adapter_allowed(
+            InstanceFlags::STRICT_WEBGPU_COMPLIANCE,
+            &"",
+            &wgt::Limits::defaults(),
+            &compliant_downlevel()
+        ));
     }
 }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -414,18 +414,53 @@ impl Instance {
         })
     }
 
+    /// This function checks that the adapter obeys WebGPU's adapter capability
+    /// guarantees. Most of the limits are adjusted in wgpu-hal's
+    /// `adjust_raw_limits` fn. So we only check the remaining properties here.
+    /// See <https://gpuweb.github.io/gpuweb/#adapter-capability-guarantees>.
     fn adapter_allowed(&self, raw: &hal::DynExposedAdapter) -> bool {
-        let allowed = !self.flags.contains(InstanceFlags::STRICT_WEBGPU_COMPLIANCE)
-            || raw.capabilities.downlevel.is_webgpu_compliant();
-        if !allowed {
+        // Check "All alignment-class limits must be powers of 2."
+        //
+        // Even if the application has not requested strict WebGPU compliance,
+        // non-power-of-two alignment limits are nonsensical, so don't attempt
+        // to use such a device.
+        let min_uniform_buffer_offset_alignment =
+            raw.capabilities.limits.min_uniform_buffer_offset_alignment;
+        if !min_uniform_buffer_offset_alignment.is_power_of_two() {
+            log::error!(
+                "Adapter {:?} min_uniform_buffer_offset_alignment limit is not a power of 2: {:?}",
+                raw.info,
+                min_uniform_buffer_offset_alignment
+            );
+            return false;
+        }
+        let min_storage_buffer_offset_alignment =
+            raw.capabilities.limits.min_storage_buffer_offset_alignment;
+        if !min_storage_buffer_offset_alignment.is_power_of_two() {
+            log::error!(
+                "Adapter {:?} min_storage_buffer_offset_alignment limit is not a power of 2: {:?}",
+                raw.info,
+                min_storage_buffer_offset_alignment
+            );
+            return false;
+        }
+
+        // Following checks are only enabled if `STRICT_WEBGPU_COMPLIANCE` is set.
+        if !self.flags.contains(InstanceFlags::STRICT_WEBGPU_COMPLIANCE) {
+            return true;
+        }
+
+        if !raw.capabilities.downlevel.is_webgpu_compliant() {
             let missing_flags = wgt::DownlevelFlags::compliant() - raw.capabilities.downlevel.flags;
             log::debug!(
                 "Adapter {:?} is not WebGPU compliant due to missing downlevel flags: {:?}",
                 raw.info,
                 missing_flags
             );
+            return false;
         }
-        allowed
+
+        true
     }
 
     pub fn enumerate_adapters(

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -450,6 +450,17 @@ impl Instance {
             return true;
         }
 
+        // Check "All supported limits must be either the default value or better."
+        let failed_limits = check_limits(&wgt::Limits::defaults(), &raw.capabilities.limits);
+        if !failed_limits.is_empty() {
+            log::debug!(
+                "Adapter {:?} is not WebGPU compliant due to limits: {:?}",
+                raw.info,
+                failed_limits
+            );
+            return false;
+        }
+
         if !raw.capabilities.downlevel.is_webgpu_compliant() {
             let missing_flags = wgt::DownlevelFlags::compliant() - raw.capabilities.downlevel.flags;
             log::debug!(

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -17,7 +17,7 @@ use crate::{
     DOWNLEVEL_WARNING_MESSAGE,
 };
 
-use wgt::{Backend, Backends, PowerPreference};
+use wgt::{Backend, Backends, InstanceFlags, PowerPreference};
 
 pub type RequestAdapterOptions = wgt::RequestAdapterOptions<SurfaceId>;
 
@@ -51,7 +51,7 @@ pub struct Instance {
     /// `instance_per_backend` instead.
     supported_backends: Backends,
 
-    pub flags: wgt::InstanceFlags,
+    pub flags: InstanceFlags,
 
     /// Non-lifetimed [`raw_window_handle::DisplayHandle`], for keepalive and validation purposes in
     /// [`Self::create_surface()`].
@@ -153,7 +153,7 @@ impl Instance {
             instance_per_backend: vec![(A::VARIANT, Box::new(hal_instance))],
             requested_backends: A::VARIANT.into(),
             supported_backends: A::VARIANT.into(),
-            flags: wgt::InstanceFlags::default(),
+            flags: InstanceFlags::default(),
             display: None, // TODO: Extract display from HAL instance if available?
         }
     }
@@ -414,6 +414,20 @@ impl Instance {
         })
     }
 
+    fn adapter_allowed(&self, raw: &hal::DynExposedAdapter) -> bool {
+        let allowed = !self.flags.contains(InstanceFlags::STRICT_WEBGPU_COMPLIANCE)
+            || raw.capabilities.downlevel.is_webgpu_compliant();
+        if !allowed {
+            let missing_flags = wgt::DownlevelFlags::compliant() - raw.capabilities.downlevel.flags;
+            log::debug!(
+                "Adapter {:?} is not WebGPU compliant due to missing downlevel flags: {:?}",
+                raw.info,
+                missing_flags
+            );
+        }
+        allowed
+    }
+
     pub fn enumerate_adapters(
         &self,
         backends: Backends,
@@ -441,6 +455,7 @@ impl Instance {
                         self.adjust_limits_for_indirect_validation(&mut raw.capabilities.limits);
                         raw
                     })
+                    .filter(|raw| self.adapter_allowed(raw))
                     .filter_map(|raw| {
                         if apply_limit_buckets {
                             limits::apply_limit_buckets(raw)
@@ -526,10 +541,13 @@ impl Instance {
                 }
             }
 
-            let backend_adapters = backend_adapters.into_iter().map(|mut raw| {
-                self.adjust_limits_for_indirect_validation(&mut raw.capabilities.limits);
-                raw
-            });
+            let backend_adapters = backend_adapters
+                .into_iter()
+                .map(|mut raw| {
+                    self.adjust_limits_for_indirect_validation(&mut raw.capabilities.limits);
+                    raw
+                })
+                .filter(|raw| self.adapter_allowed(raw));
 
             if desc.apply_limit_buckets {
                 adapters.extend(backend_adapters.filter_map(limits::apply_limit_buckets));
@@ -607,10 +625,7 @@ impl Instance {
     fn adjust_limits_for_indirect_validation(&self, limits: &mut wgt::Limits) {
         // Indirect draw validation can't support u64 offsets,
         // lower max buffer and binding size to fit in an u32.
-        if self
-            .flags
-            .contains(wgt::InstanceFlags::VALIDATION_INDIRECT_CALL)
-        {
+        if self.flags.contains(InstanceFlags::VALIDATION_INDIRECT_CALL) {
             limits.max_buffer_size = limits.max_buffer_size.min(u32::MAX as u64);
             limits.max_uniform_buffer_binding_size =
                 limits.max_uniform_buffer_binding_size.min(u32::MAX as u64);
@@ -820,7 +835,7 @@ impl Adapter {
         self: &Arc<Self>,
         hal_device: hal::DynOpenDevice,
         desc: &DeviceDescriptor,
-        instance_flags: wgt::InstanceFlags,
+        instance_flags: InstanceFlags,
     ) -> Result<(Arc<Device>, Arc<Queue>), RequestDeviceError> {
         api_log!("Adapter::create_device");
 
@@ -839,7 +854,7 @@ impl Adapter {
     pub fn create_device_and_queue(
         self: &Arc<Self>,
         desc: &DeviceDescriptor,
-        instance_flags: wgt::InstanceFlags,
+        instance_flags: InstanceFlags,
     ) -> Result<(Arc<Device>, Arc<Queue>), RequestDeviceError> {
         // Verify all features were exposed by the adapter
         if !self.raw.features.contains(desc.required_features) {

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -918,7 +918,7 @@ impl super::Adapter {
                     // 65536
                     max_uniform_buffer_binding_size:
                         Direct3D12::D3D12_REQ_CONSTANT_BUFFER_ELEMENT_COUNT as u64 * 16,
-                    // 254
+                    // 256
                     min_uniform_buffer_offset_alignment:
                         Direct3D12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT,
                     // 16

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -574,6 +574,15 @@ impl super::Adapter {
             );
         }
 
+        downlevel_flags.set(
+            wgt::DownlevelFlags::TEXTURE_COMPRESSION,
+            features.contains(wgt::Features::TEXTURE_COMPRESSION_BC)
+                || features.contains(
+                    wgt::Features::TEXTURE_COMPRESSION_ETC2
+                        | wgt::Features::TEXTURE_COMPRESSION_ASTC,
+                ),
+        );
+
         features.set(
             wgt::Features::FLOAT32_FILTERABLE,
             extensions.contains("GL_ARB_color_buffer_float")

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1314,6 +1314,10 @@ impl super::CapabilitiesQuery {
             wgt::DownlevelFlags::MSL2_1,
             self.msl_version >= MTLLanguageVersion::Version2_1,
         );
+        downlevel.flags.set(
+            wgt::DownlevelFlags::TEXTURE_COMPRESSION,
+            self.format_bc || (self.format_eac_etc && self.format_astc),
+        );
 
         let limits = crate::auxil::adjust_raw_limits(wgt::Limits {
             //

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -2270,6 +2270,15 @@ impl super::Instance {
             );
         }
 
+        downlevel_flags.set(
+            wgt::DownlevelFlags::TEXTURE_COMPRESSION,
+            available_features.contains(wgt::Features::TEXTURE_COMPRESSION_BC)
+                || available_features.contains(
+                    wgt::Features::TEXTURE_COMPRESSION_ETC2
+                        | wgt::Features::TEXTURE_COMPRESSION_ASTC,
+                ),
+        );
+
         let has_robust_buffer_access2 = phd_features
             .robustness2
             .as_ref()

--- a/wgpu-types/src/instance.rs
+++ b/wgpu-types/src/instance.rs
@@ -177,6 +177,11 @@ bitflags::bitflags! {
         /// This mainly applies to a Vulkan driver's compliance version. If the major compliance version
         /// is `0`, then the driver is ignored. This flag allows that driver to be enabled for testing.
         ///
+        /// This flag controls whether adapters that don't meet the *native*
+        /// API's own compliance requirements are returned, while
+        /// [`Self::STRICT_WEBGPU_COMPLIANCE`] controls whether adapters that
+        /// can't fully satisfy the *WebGPU v1* spec are excluded.
+        ///
         /// When `Self::from_env()` is used takes value from `WGPU_ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER` environment variable.
         const ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER = 1 << 3;
         /// Enable GPU-based validation. Implies [`Self::VALIDATION`]. Currently, this only changes
@@ -228,6 +233,11 @@ bitflags::bitflags! {
         ///
         #[doc = link_to_wgpu_docs!(["rqs"]: "struct.CommandEncoder.html#method.resolve_query_set")]
         const AUTOMATIC_TIMESTAMP_NORMALIZATION = 1 << 6;
+
+        /// Restrict the available feature set to the one defined by the WebGPU specification.
+        ///
+        /// When `Self::from_env()` is used takes value from `WGPU_STRICT_WEBGPU_COMPLIANCE` environment variable.
+        const STRICT_WEBGPU_COMPLIANCE = 1 << 7;
     }
 }
 
@@ -285,6 +295,7 @@ impl InstanceFlags {
     /// - `WGPU_ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER`
     /// - `WGPU_GPU_BASED_VALIDATION`
     /// - `WGPU_VALIDATION_INDIRECT_CALL`
+    /// - `WGPU_STRICT_WEBGPU_COMPLIANCE`
     #[must_use]
     pub fn with_env(mut self) -> Self {
         fn env(key: &str) -> Option<bool> {
@@ -312,6 +323,9 @@ impl InstanceFlags {
         }
         if let Some(bit) = env("WGPU_VALIDATION_INDIRECT_CALL") {
             self.set(Self::VALIDATION_INDIRECT_CALL, bit);
+        }
+        if let Some(bit) = env("WGPU_STRICT_WEBGPU_COMPLIANCE") {
+            self.set(Self::STRICT_WEBGPU_COMPLIANCE, bit);
         }
 
         self

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -1082,6 +1082,12 @@ bitflags::bitflags! {
 
         /// Supports features introduced in MSL 2.1.
         const MSL2_1 = 1 << 24;
+
+        /// The adapter supports the WebGPU texture compression requirement:
+        /// BC || (ETC2 && ASTC).
+        ///
+        /// See <https://www.w3.org/TR/webgpu/#adapter-capability-guarantees>.
+        const TEXTURE_COMPRESSION = 1 << 25;
     }
 }
 


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/3274.
Fixes https://github.com/gfx-rs/wgpu/issues/9436.
Fixes https://github.com/gfx-rs/wgpu/issues/3365.

**Description**
Adds the `STRICT_WEBGPU_COMPLIANCE` flag, intended to be used by wgpu-core users that want to strictly limit the behavior of `wgpu-core` to the one defined by the WebGPU spec.

**Testing**
Added some more tests.

**Squash or Rebase?**
Rebase.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
