### PR TITLE
fix(doc): fix wording wrt TIMESTAMP_QUERY features

### DIFF
--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -698,7 +698,9 @@ bitflags_array! {
         const PIPELINE_STATISTICS_QUERY = 1 << 4;
         /// Allows for timestamp queries directly on command encoders.
         ///
-        /// Implies [`Features::TIMESTAMP_QUERY`] is supported.
+        /// Adapters that support this feature also support
+        /// [`Features::TIMESTAMP_QUERY`]. Both features must be requested
+        /// explicitly to use timestamp queries on command encoders.
         ///
         /// Additionally allows for timestamp writes on command encoders
         /// using [`CommandEncoder::write_timestamp`].
@@ -714,9 +716,13 @@ bitflags_array! {
         #[doc = link_to_wgpu_docs!(["`CommandEncoder::write_timestamp`"]: "struct.CommandEncoder.html#method.write_timestamp")]
         #[name("wgpu-timestamp-query-inside-encoders")]
         const TIMESTAMP_QUERY_INSIDE_ENCODERS = 1 << 5;
-        /// Allows for timestamp queries directly on command encoders.
+        /// Allows for timestamp queries directly inside render and compute passes.
         ///
-        /// Implies [`Features::TIMESTAMP_QUERY`] & [`Features::TIMESTAMP_QUERY_INSIDE_ENCODERS`] is supported.
+        /// Adapters that support this feature also support
+        /// [`Features::TIMESTAMP_QUERY`] and [`Features::TIMESTAMP_QUERY_INSIDE_ENCODERS`].
+        /// This feature must be requested with [`Features::TIMESTAMP_QUERY`] to use timestamp
+        /// queries inside passes. Additionally, [`Features::TIMESTAMP_QUERY_INSIDE_ENCODERS`]
+        /// must be requested to use timestamp queries on command encoders.
         ///
         /// Additionally allows for timestamp queries to be used inside render & compute passes using:
         /// - [`RenderPass::write_timestamp`]


### PR DESCRIPTION
**Connections**
Fix #9504.

**Description**
Revises the misleading wording of `TIMESTAMP_QUERY_INSIDE_ENCODERS` & `TIMESTAMP_QUERY_INSIDE_PASSES`.

**Testing**
Doc change only; no test needed

**Squash or Rebase?**
Single commit only

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] ~WebGPU implementations built with `wgpu` may be affected behaviorally.~
- [ ] ~Validation and feature gates are in place to confine behavioral changes.~
- [ ] ~Tests demonstrate the validation and altered logic works.~ <!-- See `docs/testing.md` -->
- [ ] ~`CHANGELOG.md` entries for the user-facing effects of this change are present.~ <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
