### PR TITLE
renovate: only update Rust toolchain to 3 releases ago

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,6 +82,11 @@
       "matchPackageNames": ["https://github.com/gpuweb/cts"],
       "changelogUrl": "https://github.com/gpuweb/cts/commits/main",
       "versioning": "git"
+    },
+    {
+      "description": "Rust toolchain should be stable - 3 in accordance with maximum-MSRV policy.",
+      "matchManager": "rust-toolchain",
+      "minimumReleaseAge": "18 weeks",
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -86,7 +86,7 @@
     {
       "description": "Rust toolchain should be stable - 3 in accordance with maximum-MSRV policy.",
       "matchManager": "rust-toolchain",
-      "minimumReleaseAge": "18 weeks",
+      "minimumReleaseAge": "18 weeks"
     }
   ],
   "customManagers": [


### PR DESCRIPTION

**Connections**
Prevents unwanted update PRs like #9584.

**Description**
Our MSRV policy is “The repository MSRV should never require an MSRV higher than stable - 3.” Therefore, the repository toolchain configuration should be stable - 3. Teach Renovate to do this by delaying updates for (6 week release cycle) * 3 = 18 weeks.

Relevant Renovate docs:

* https://docs.renovatebot.com/configuration-options/#packagerulesmatchmanagers
* https://docs.renovatebot.com/configuration-options/#minimumreleaseage
* https://docs.renovatebot.com/modules/manager/#supported-managers

**Testing**
🤞

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
