### PR TITLE
Mask stencil clear value and reference value with 255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Fix incorrect checks for dynamic binding bounds when calling an encoder's `set_bind_group` in passes and bundles. By @ErichDonGubler in [#9308](https://github.com/gfx-rs/wgpu/pull/9308).
 - Writes from `Queue::write_buffer` are now flushed by calls to `Buffer::map_async` for that same buffer, to prevent reading stale data. `on_submitted_work_done` also now flushes pending writes. By @andyleiserson in [#9307](https://github.com/gfx-rs/wgpu/pull/9307).
 - Fix missing dependency feature activations when building wgpu-hal with gles/dx12 in isolation. By @wumpf in [#9325](https://github.com/gfx-rs/wgpu/pull/9325)
+- Stencil clear and reference values are now truncated to 8 bits. By @beicause in [#9607](https://github.com/gfx-rs/wgpu/pull/9607).
 
 #### naga
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -45,7 +45,7 @@ webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_t
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=true;stencilReadOnly=true
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="stencil8";*
 
-webgpu:api,operation,render_pass,storeOp:*
+webgpu:api,operation,render_pass,*
 webgpu:api,operation,render_pipeline,overrides:*
 webgpu:api,operation,render_pipeline,pipeline_output_targets:color,component_count,blend:*
 webgpu:api,operation,rendering,basic:clear:*

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -71,12 +71,16 @@ fn store_hal_ops(store: StoreOp) -> hal::AttachmentOps {
 }
 
 // Stencil clear and reference value should take the LSBs.
-//
-// Currently only 8-bit stencil formats are supported, so `value & 255` is OK.
-//
-// This fixes CTS `webgpu:api,operation,render_pass,clear_value:stencil_clear_value:*`
-// on metal and buggy drivers.
-fn truncate_stencil_value(value: u32) -> u32 {
+fn convert_stencil_value(value: u32, format: Option<wgt::TextureFormat>) -> u32 {
+    let Some(format) = format else {
+        return value;
+    };
+    let Some(stencil_format) = format.aspect_specific_format(wgt::TextureAspect::StencilOnly)
+    else {
+        return value;
+    };
+    // Currently only 8-bit stencil formats are supported
+    assert_eq!(stencil_format, wgt::TextureFormat::Stencil8);
     value & 255
 }
 
@@ -1879,7 +1883,7 @@ impl Global {
                         },
                         stencil: if format.has_stencil_aspect() {
                             depth_stencil_attachment.stencil.resolve(|clear| {
-                                Ok(truncate_stencil_value(clear.unwrap_or_default()))
+                                Ok(convert_stencil_value(clear.unwrap_or_default(), Some(format)))
                             })?
                         } else {
                             if depth_stencil_attachment.stencil.load_op.is_some() || depth_stencil_attachment.stencil.store_op.is_some() {
@@ -3514,7 +3518,12 @@ impl Global {
     ) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetStencilReference;
         let base = pass_base!(pass, scope);
-        let value = truncate_stencil_value(value);
+        let value = convert_stencil_value(
+            value,
+            pass.depth_stencil_attachment
+                .as_ref()
+                .map(|at| at.view.desc.format),
+        );
         base.commands
             .push(ArcRenderCommand::SetStencilReference(value));
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -70,6 +70,16 @@ fn store_hal_ops(store: StoreOp) -> hal::AttachmentOps {
     }
 }
 
+// Stencil clear and reference value should take the LSBs.
+//
+// Currently only 8-bit stencil formats are supported, so `value & 255` is OK.
+//
+// This fixes CTS `webgpu:api,operation,render_pass,clear_value:stencil_clear_value:*`
+// on metal and buggy drivers.
+fn truncate_stencil_value(value: u32) -> u32 {
+    value & 255
+}
+
 /// Describes an individual channel within a render pass, such as color, depth, or stencil.
 ///
 /// A channel must either be read-only, or it must specify both load and store
@@ -1833,7 +1843,7 @@ impl Global {
             }
 
             arc_desc.depth_stencil_attachment =
-            // https://gpuweb.github.io/gpuweb/#abstract-opdef-gpurenderpassdepthstencilattachment-gpurenderpassdepthstencilattachment-valid-usage
+                // https://gpuweb.github.io/gpuweb/#abstract-opdef-gpurenderpassdepthstencilattachment-gpurenderpassdepthstencilattachment-valid-usage
                 if let Some(depth_stencil_attachment) = desc.depth_stencil_attachment {
                     let view = texture_views.get(depth_stencil_attachment.view).get()?;
                     view.same_device(device)?;
@@ -1868,7 +1878,9 @@ impl Global {
                             ResolvedPassChannel::ReadOnly
                         },
                         stencil: if format.has_stencil_aspect() {
-                            depth_stencil_attachment.stencil.resolve(|clear| Ok(clear.unwrap_or_default()))?
+                            depth_stencil_attachment.stencil.resolve(|clear| {
+                                Ok(truncate_stencil_value(clear.unwrap_or_default()))
+                            })?
                         } else {
                             if depth_stencil_attachment.stencil.load_op.is_some() || depth_stencil_attachment.stencil.store_op.is_some() {
                                 return Err(RenderPassErrorInner::InvalidAttachment(AttachmentError::StencilOpsWithoutAspect {
@@ -3502,7 +3514,7 @@ impl Global {
     ) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetStencilReference;
         let base = pass_base!(pass, scope);
-
+        let value = truncate_stencil_value(value);
         base.commands
             .push(ArcRenderCommand::SetStencilReference(value));
 


### PR DESCRIPTION
**Connections**
Fix `webgpu:api,operation,render_pass,clear_value:stencil_clear_value:*` on metal.
Found this issue in #9568.

**Description**
See https://github.com/gpuweb/gpuweb/issues/2921 and https://issues.chromium.org/issues/42240605, we need to take the LSBs of stencil value. Currently only 8-bit stencil formats are supported so `value & 255`.

**Testing**
```
cargo xtask cts `webgpu:api,operation,render_pass,clear_value:stencil_clear_value:*`
```

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
