### PR TITLE
naga: add take() method to Arena and UniqueArena

### DIFF
--- a/naga/src/arena/mod.rs
+++ b/naga/src/arena/mod.rs
@@ -196,6 +196,11 @@ impl<T> Arena<T> {
         self.data.clear()
     }
 
+    /// Replaces this arena with an empty one, returning the old data.
+    pub fn take(&mut self) -> Self {
+        core::mem::take(self)
+    }
+
     pub fn get_span(&self, handle: Handle<T>) -> Span {
         *self
             .span_info

--- a/naga/src/arena/unique_arena.rs
+++ b/naga/src/arena/unique_arena.rs
@@ -61,6 +61,11 @@ impl<T> UniqueArena<T> {
         self.span_info.clear();
     }
 
+    /// Replaces this arena with an empty one, returning the old data.
+    pub fn take(&mut self) -> Self {
+        core::mem::take(self)
+    }
+
     /// Return the span associated with `handle`.
     ///
     /// If a value has been inserted multiple times, the span returned is the

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -145,7 +145,7 @@ pub fn process_overrides<'a>(
 
     // An iterator through the original overrides table, consumed in
     // approximate tandem with the global expressions.
-    let mut overrides = mem::take(&mut module.overrides);
+    let mut overrides = module.overrides.take();
     let mut override_iter = overrides.iter_mut_span();
 
     // Do two things in tandem:
@@ -264,7 +264,7 @@ pub fn process_overrides<'a>(
         }
     }
 
-    let mut functions = mem::take(&mut module.functions);
+    let mut functions = module.functions.take();
     for (_, function) in functions.iter_mut() {
         process_function(&mut module, &override_map, &mut layouter, function)?;
     }
@@ -424,7 +424,7 @@ fn process_function(
 
     let mut local_expression_kind_tracker = crate::proc::ExpressionKindTracker::new();
 
-    let mut expressions = mem::take(&mut function.expressions);
+    let mut expressions = function.expressions.take();
 
     // Dummy `emitter` and `block` for the constant evaluator.
     // We can ignore the concept of emitting expressions here since

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -1816,7 +1816,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
             let mut nodes = petgraph::algo::toposort(&self.function_call_graph, None)
                 .map_err(|cycle| Error::FunctionCallCycle(cycle.node_id()))?;
             nodes.reverse(); // we need dominated first
-            let mut functions = mem::take(&mut module.functions);
+            let mut functions = module.functions.take();
             for fun_id in nodes {
                 if fun_id > !(functions.len() as u32) {
                     // skip all the fake IDs registered for the entry points


### PR DESCRIPTION
Adds a `take()` method to both `Arena` and `UniqueArena` that replaces the arena with an empty one and returns the old data.

This addresses the request in #6509 for a `take` method, providing a named wrapper around `core::mem::take` that users can call when they need to extract an arena's contents.

```rust
let mut arena = Arena::new();
arena.append(value, span);
let taken: Arena<T> = arena.take();  // arena is now empty
```

The `drain` method already uses `core::mem::take(self)` internally; this exposes the same capability as a public method.