### PR TITLE
[hal/dx12] Add CommandEncoder::raw_command_list() accessor (#8888)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 - Added support for mesh shaders in naga's HLSL writer, completing DX12 support for mesh shaders. By @inner-daemons in [#8752](https://github.com/gfx-rs/wgpu/pull/8752).
 - Added `dx12::Queue::add_wait_fence` / `add_signal_fence` (and matching `remove_*` companions). They stage `ID3D12CommandQueue::Wait` / `Signal` calls on the next `Queue::submit`. The wait calls are issued before the submit's `ExecuteCommandLists`, the signal calls after wgpu's own `Signal(signal_fence, signal_value)`. Cross-API interop crates use this to GPU-side gate / publish wgpu submits against foreign-API fences. By @AdrianEddy in [#9463](https://github.com/gfx-rs/wgpu/pull/9463).
+- Added `dx12::CommandEncoder::raw_command_list()`, exposing the recording `ID3D12GraphicsCommandList` (returns `Some` while the encoder is encoding) so native D3D12 libraries — NVIDIA NGX/DLSS, AMD FidelityFX — can record onto wgpu's in-flight command list via `as_hal_mut`, mirroring the Vulkan backend's `CommandEncoder::raw_handle()`. By @jtbirdsell in [#9613](https://github.com/gfx-rs/wgpu/pull/9613).
 
 #### Vulkan
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -991,6 +991,27 @@ pub struct CommandEncoder {
 unsafe impl Send for CommandEncoder {}
 unsafe impl Sync for CommandEncoder {}
 
+impl CommandEncoder {
+    /// Returns the raw D3D12 graphics command list currently being recorded, or `None` when the
+    /// encoder is not recording (outside a `begin_encoding`/`end_encoding` pair).
+    ///
+    /// This mirrors the Vulkan backend's `CommandEncoder::raw_handle()`, exposing the in-flight
+    /// list so native libraries that must record onto wgpu's command list (NVIDIA NGX/DLSS, AMD
+    /// FidelityFX, etc.) can interoperate through `as_hal_mut`. See
+    /// <https://github.com/gfx-rs/wgpu/issues/8888>.
+    ///
+    /// # Safety
+    ///
+    /// - The returned reference must not outlive the current encoding; do not retain it past
+    ///   `end_encoding`/`discard_encoding`.
+    /// - The caller must not `Close` or `Reset` the list, and must restore any pipeline,
+    ///   descriptor-heap, and root-signature state it changes before returning control to wgpu, or
+    ///   subsequent wgpu commands may misbehave.
+    pub unsafe fn raw_command_list(&self) -> Option<&Direct3D12::ID3D12GraphicsCommandList> {
+        self.list.as_ref()
+    }
+}
+
 impl fmt::Debug for CommandEncoder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CommandEncoder")


### PR DESCRIPTION
**Connections**

Fixes #8888.

**Description**

`wgpu_hal::dx12::CommandEncoder` keeps its recording `ID3D12GraphicsCommandList` in a private `list` field with no accessor, so external libraries cannot record onto wgpu's in-flight command list. This adds an inherent `unsafe fn raw_command_list(&self) -> Option<&ID3D12GraphicsCommandList>`, mirroring the Vulkan backend's `CommandEncoder::raw_handle()` and the existing dx12 `Buffer::raw_resource` / `Texture::raw_resource` / `Fence::raw_fence` accessors.

This unblocks `as_hal_mut`-based interop with native D3D12 libraries that must record onto the same command list wgpu is encoding — e.g. NVIDIA NGX/DLSS and AMD FidelityFX. It returns `Some` only while the encoder is recording (between `begin_encoding` and `end_encoding`/`discard_encoding`); the accessor is `unsafe` and documents the encoding-lifetime + state-restoration contract.

There is no behavioral change to wgpu itself — it only adds a read accessor for an existing private field.

**Testing**

`cargo check` and `cargo clippy -p wgpu-hal --features dx12 -- -D warnings` pass on Windows. The accessor is additive (returns a reference to an existing field) with no logic change, so no new tests are included. It has been exercised downstream against NVIDIA NGX/DLSS — Super Resolution, Ray Reconstruction, and Frame Generation — on an RTX 4090.

**Squash or Rebase?**

Single commit — ready to rebase onto `trunk` as-is.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally. _(No — additive read accessor only.)_
- [x] Validation and feature gates are in place to confine behavioral changes. _(No behavioral change; dx12-only, `unsafe` with a documented contract.)_
- [ ] Tests demonstrate the validation and altered logic works. _(No logic change; the accessor returns an existing field.)_
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
