### PR TITLE
naga: include OpAtomicCompareExchange result access in emitted range

### DIFF
--- a/naga/src/front/spv/next_block.rs
+++ b/naga/src/front/spv/next_block.rs
@@ -3015,6 +3015,8 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                         ctx.expressions.append(expr, span)
                     };
 
+                    emitter.start(ctx.expressions);
+
                     // Create an dot accessor to extract the value from the
                     // result struct __atomic_compare_exchange_result<T> and use that
                     // as the expression for the result_id
@@ -3034,8 +3036,6 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                             },
                         );
                     }
-
-                    emitter.start(ctx.expressions);
 
                     // Create a statement for the op itself
                     let stmt = crate::Statement::Atomic {

--- a/naga/tests/naga/main.rs
+++ b/naga/tests/naga/main.rs
@@ -1,5 +1,6 @@
 mod example_wgsl;
 mod snapshots;
 mod spirv_capabilities;
+mod spirv_roundtrip;
 mod validation;
 mod wgsl_errors;

--- a/naga/tests/naga/spirv_roundtrip.rs
+++ b/naga/tests/naga/spirv_roundtrip.rs
@@ -1,0 +1,41 @@
+fn words_to_bytes(words: &[u32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(words.len() * 4);
+    for word in words {
+        bytes.extend_from_slice(&word.to_le_bytes());
+    }
+    bytes
+}
+
+#[test]
+fn atomic_compare_exchange_roundtrip_to_spirv() {
+    let source = include_str!("../in/wgsl/atomicCompareExchange.wgsl");
+    let module = naga::front::wgsl::parse_str(source).unwrap();
+
+    let mut validator = naga::valid::Validator::new(
+        naga::valid::ValidationFlags::all(),
+        naga::valid::Capabilities::empty(),
+    );
+    let info = validator.validate(&module).unwrap();
+
+    let pipeline_options = naga::back::spv::PipelineOptions {
+        entry_point: "test_atomic_compare_exchange_u32".to_string(),
+        shader_stage: naga::ShaderStage::Compute,
+    };
+    let options = naga::back::spv::Options::default();
+    let spv_words =
+        naga::back::spv::write_vec(&module, &info, &options, Some(&pipeline_options)).unwrap();
+
+    let spv_bytes = words_to_bytes(&spv_words);
+    let parsed = naga::front::spv::parse_u8_slice(
+        &spv_bytes,
+        &naga::front::spv::Options {
+            adjust_coordinate_space: true,
+            strict_capabilities: false,
+            block_ctx_dump_prefix: None,
+        },
+    )
+    .unwrap();
+
+    let parsed_info = validator.validate(&parsed).unwrap();
+    naga::back::spv::write_vec(&parsed, &parsed_info, &options, Some(&pipeline_options)).unwrap();
+}


### PR DESCRIPTION
This fixes a SPIR-V round-trip panic for shaders using `OpAtomicCompareExchange`.

A simple repro on current `trunk` is:

```sh
cargo run -p naga-cli -- \
  naga/tests/in/wgsl/atomicCompareExchange.wgsl \
  target/cas-roundtrip/atomicCompareExchange-u32.spv \
  --entry-point test_atomic_compare_exchange_u32

cargo run -p naga-cli -- \
  target/cas-roundtrip/atomicCompareExchange-u32.spv \
  target/cas-roundtrip/atomicCompareExchange-u32-roundtrip.spv \
  --entry-point test_atomic_compare_exchange_u32
```

The second step currently panics in the SPIR-V backend:

```text
internal error: entered unreachable code: Expression [54] is not cached!
```

The issue is in the SPIR-V frontend handling for `OpAtomicCompareExchange`. It creates an `AtomicResult` expression and then a synthetic `AccessIndex` expression for the returned old value. However, the emitter range starts after that synthetic `AccessIndex`, so the parsed module can contain an expression that is never covered by an `Emit` statement. When the SPIR-V backend later writes the module, it expects that expression to have been emitted/cached and hits the panic above.

This moves the emitter start point so the synthetic result access is included in the emitted range.

I added a targeted round-trip test using the existing `atomicCompareExchange.wgsl` fixture.

Tested with:

```sh
cargo fmt --check

cargo test -p naga --test naga \
  --features wgsl-in,spv-in,spv-out \
  atomic_compare_exchange_roundtrip_to_spirv

NAGA_SNAPSHOT=atomicCompareExchange \
  cargo test -p naga --test naga \
  --features wgsl-in,spv-in,spv-out \
  convert_snapshots_wgsl

NAGA_SNAPSHOT=atomic_compare_exchange \
  cargo test -p naga --test naga \
  --features spv-in,spv-out,wgsl-out \
  convert_snapshots_spv
```

Related to #7315.