### PR TITLE
renovate: Waive minimumReleaseAge for CTS

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -81,7 +81,8 @@
       "description": "CTS revision is pinned to a Git SHA.",
       "matchPackageNames": ["https://github.com/gpuweb/cts"],
       "changelogUrl": "https://github.com/gpuweb/cts/commits/main",
-      "versioning": "git"
+      "versioning": "git",
+      "minimumReleaseAge": "0"
     },
     {
       "description": "Rust toolchain should be stable - 3 in accordance with maximum-MSRV policy.",


### PR DESCRIPTION
In #9546 I set `minimumReleaseAge` of 1 week, but I don't think that's desirable for the CTS. This PR overrides it to zero for the CTS.

Apparently the effect of `minimumReleaseAge` is to report a pending check on the PR (see e.g. #9615), not to suppress opening the PR entirely. I would prefer if it suppressed the PR entirely to reduce notification noise, and getting the PRs anyways make the option less interesting to me.

**Squash or Rebase?** Squash

**Testing** Hopefully renovate will post a comment on this PR after validating the proposed config.