### PR TITLE
[metal] Implement PipelineCache via MTLBinaryArchive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 #### Metal
 
-- Implement `Features::PIPELINE_CACHE` via `MTLBinaryArchive`, so compiled compute and render pipelines can be serialized and reloaded across runs instead of recompiled. By @michaelnorman-au in [#99999](https://github.com/gfx-rs/wgpu/pull/99999).
+- Implement `Features::PIPELINE_CACHE` via `MTLBinaryArchive`, so compiled compute and render pipelines can be serialized and reloaded across runs instead of recompiled. By @michaelnorman-au in [#9623](https://github.com/gfx-rs/wgpu/pull/9623).
 - Unconditionally enable `Features::CLIP_DISTANCES`. By @ErichDonGubler in [#9270](https://github.com/gfx-rs/wgpu/pull/9270).
 - Added full support for mesh shaders, including in WGSL shaders. By @inner-daemons in [#8739](https://github.com/gfx-rs/wgpu/pull/8739).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 #### Metal
 
+- Implement `Features::PIPELINE_CACHE` via `MTLBinaryArchive`, so compiled compute and render pipelines can be serialized and reloaded across runs instead of recompiled. By @michaelnorman-au in [#99999](https://github.com/gfx-rs/wgpu/pull/99999).
 - Unconditionally enable `Features::CLIP_DISTANCES`. By @ErichDonGubler in [#9270](https://github.com/gfx-rs/wgpu/pull/9270).
 - Added full support for mesh shaders, including in WGSL shaders. By @inner-daemons in [#8739](https://github.com/gfx-rs/wgpu/pull/8739).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,7 @@ objc2-metal = { version = "0.3.2", default-features = false, features = [
     "std",
     "block2",
     "MTLAllocation",
+    "MTLBinaryArchive",
     "MTLBlitCommandEncoder",
     "MTLBlitPass",
     "MTLBuffer",

--- a/tests/tests/wgpu-gpu/pipeline_cache.rs
+++ b/tests/tests/wgpu-gpu/pipeline_cache.rs
@@ -4,6 +4,7 @@ use wgpu_test::{gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
 pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
     vec.push(PIPELINE_CACHE);
+    vec.push(PIPELINE_CACHE_RENDER);
 }
 
 /// We want to test that using a pipeline cache doesn't cause failure
@@ -190,6 +191,211 @@ async fn validate_pipeline(
     assert_eq!(arrays.len(), ARRAY_SIZE as usize);
     for (idx, value) in arrays.iter().copied().enumerate() {
         assert_eq!(value as usize, idx);
+    }
+    drop(data);
+    cpu_buffer.unmap();
+}
+
+/// Render-pipeline analogue of [`PIPELINE_CACHE`]. The test above only covers
+/// compute pipelines; backends thread the pipeline cache through render-pipeline
+/// creation on a separate path (e.g. the Metal backend sets `binaryArchives` on
+/// the render descriptor and grows the archive with `addRenderPipelineFunctions`),
+/// so exercise that here too: create a render pipeline with a cache, draw with it,
+/// `get_data`, then reseed a second cache from that data and draw again.
+#[gpu_test]
+static PIPELINE_CACHE_RENDER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .features(wgpu::Features::PIPELINE_CACHE),
+    )
+    .run_async(pipeline_cache_render_test);
+
+/// 64 wide so the texture→buffer copy's bytes-per-row (64 * 4 = 256) is already
+/// `COPY_BYTES_PER_ROW_ALIGNMENT`-aligned (no row padding to account for).
+const RENDER_WIDTH: u32 = 64;
+const RENDER_HEIGHT: u32 = 64;
+const RENDER_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+/// The constant colour the fragment shader writes, as stored in `Rgba8Unorm`
+/// (linear — no sRGB encoding): `round([0.25, 0.5, 0.75, 1.0] * 255)`.
+const RENDER_EXPECTED: [u8; 4] = [64, 128, 191, 255];
+
+fn render_shader() -> &'static str {
+    r#"
+        @vertex
+        fn vs_main(@builtin(vertex_index) idx: u32) -> @builtin(position) vec4<f32> {
+            // Oversized triangle that covers the whole framebuffer.
+            var positions = array<vec2<f32>, 3>(
+                vec2<f32>(-1.0, -3.0),
+                vec2<f32>(-1.0,  1.0),
+                vec2<f32>( 3.0,  1.0),
+            );
+            return vec4<f32>(positions[idx], 0.0, 1.0);
+        }
+
+        @fragment
+        fn fs_main() -> @location(0) vec4<f32> {
+            return vec4<f32>(0.25, 0.5, 0.75, 1.0);
+        }
+    "#
+}
+
+async fn pipeline_cache_render_test(ctx: TestingContext) {
+    let sm = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("render shader"),
+            source: wgpu::ShaderSource::Wgsl(render_shader().into()),
+        });
+
+    let pipeline_layout = ctx
+        .device
+        .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("render pipeline_layout"),
+            bind_group_layouts: &[],
+            immediate_size: 0,
+        });
+
+    let make_pipeline = |cache: &wgpu::PipelineCache| {
+        ctx.device
+            .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("render pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    buffers: &[],
+                    module: &sm,
+                    entry_point: Some("vs_main"),
+                    compilation_options: Default::default(),
+                },
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                fragment: Some(wgpu::FragmentState {
+                    module: &sm,
+                    entry_point: Some("fs_main"),
+                    compilation_options: Default::default(),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: RENDER_FORMAT,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                }),
+                multiview_mask: None,
+                cache: Some(cache),
+            })
+    };
+
+    let first_cache_data;
+    {
+        let first_cache = unsafe {
+            ctx.device
+                .create_pipeline_cache(&wgpu::PipelineCacheDescriptor {
+                    label: Some("render pipeline_cache"),
+                    data: None,
+                    fallback: false,
+                })
+        };
+        let pipeline = make_pipeline(&first_cache);
+        validate_render_pipeline(&ctx, &pipeline).await;
+        first_cache_data = first_cache.get_data();
+    }
+    assert!(first_cache_data.is_some());
+
+    let second_cache = unsafe {
+        ctx.device
+            .create_pipeline_cache(&wgpu::PipelineCacheDescriptor {
+                label: Some("render pipeline_cache"),
+                data: first_cache_data.as_deref(),
+                fallback: false,
+            })
+    };
+    let pipeline = make_pipeline(&second_cache);
+    validate_render_pipeline(&ctx, &pipeline).await;
+}
+
+async fn validate_render_pipeline(ctx: &TestingContext, pipeline: &wgpu::RenderPipeline) {
+    let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("render target"),
+        size: wgpu::Extent3d {
+            width: RENDER_WIDTH,
+            height: RENDER_HEIGHT,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: RENDER_FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let cpu_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("render readback"),
+        size: u64::from(RENDER_WIDTH * RENDER_HEIGHT * 4),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    {
+        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("render pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+                resolve_target: None,
+                view: &view,
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        rpass.set_pipeline(pipeline);
+        rpass.draw(0..3, 0..1);
+    }
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &cpu_buffer,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(RENDER_WIDTH * 4),
+                rows_per_image: Some(RENDER_HEIGHT),
+            },
+        },
+        wgpu::Extent3d {
+            width: RENDER_WIDTH,
+            height: RENDER_HEIGHT,
+            depth_or_array_layers: 1,
+        },
+    );
+    ctx.queue.submit([encoder.finish()]);
+    cpu_buffer.slice(..).map_async(wgpu::MapMode::Read, |_| ());
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
+
+    let data = cpu_buffer.slice(..).get_mapped_range().unwrap();
+    // Every pixel should be the fragment shader's constant colour (±1 for rounding).
+    for px in data.chunks_exact(4) {
+        for (channel, (&got, &want)) in px.iter().zip(RENDER_EXPECTED.iter()).enumerate() {
+            assert!(
+                i16::from(got).abs_diff(i16::from(want)) <= 1,
+                "channel {channel}: got {got}, expected ~{want}"
+            );
+        }
     }
     drop(data);
     cpu_buffer.unmap();

--- a/wgpu-core/src/pipeline_cache.rs
+++ b/wgpu-core/src/pipeline_cache.rs
@@ -233,6 +233,19 @@ fn adapter_key(adapter: &AdapterInfo) -> Result<[u8; 15], PipelineCacheValidatio
             ];
             Ok(adapter)
         }
+        wgt::Backend::Metal => {
+            // The Metal backend's `MTLBinaryArchive`-backed cache supports
+            // serialization (`pipeline_cache_validation_key` returns `Some`). The
+            // finer GPU discrimination lives in that validation key (the device's
+            // registry id); this adapter key is the coarse vendor/device identity,
+            // namespaced with a distinct sentinel (254) from Vulkan (255).
+            let v: [u8; 4] = adapter.vendor.to_be_bytes();
+            let d: [u8; 4] = adapter.device.to_be_bytes();
+            let adapter = [
+                254, 254, 254, v[0], v[1], v[2], v[3], d[0], d[1], d[2], d[3], 254, 254, 254, 254,
+            ];
+            Ok(adapter)
+        }
         _ => Err(PipelineCacheValidationError::Unsupported),
     }
 }

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1190,6 +1190,13 @@ impl super::CapabilitiesQuery {
         features.set(F::DEPTH_CLIP_CONTROL, self.supports_depth_clip_control);
         features.set(F::PRIMITIVE_INDEX, self.supports_shader_primitive_index);
 
+        // Persistent pipeline caching is backed by `MTLBinaryArchive` (macOS 11+,
+        // iOS 14+). See `Device::{create_pipeline_cache, pipeline_cache_get_data}`.
+        features.set(
+            F::PIPELINE_CACHE,
+            available!(macos = 11.0, ios = 14.0, tvos = 14.0, visionos = 1.0),
+        );
+
         features.set(
             F::TEXTURE_BINDING_ARRAY
                 | F::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -9,14 +9,15 @@ use objc2::{
     rc::{autoreleasepool, Retained},
     runtime::ProtocolObject,
 };
-use objc2_foundation::{ns_string, NSError, NSRange, NSString, NSUInteger};
+use objc2_foundation::{ns_string, NSArray, NSError, NSRange, NSString, NSUInteger, NSURL};
 use objc2_metal::{
-    MTLAccelerationStructure, MTLAccelerationStructureInstanceOptions, MTLBuffer,
-    MTLCaptureManager, MTLCaptureScope, MTLCommandBuffer, MTLCommandBufferStatus,
-    MTLCompileOptions, MTLComputePipelineDescriptor, MTLComputePipelineState,
-    MTLCounterSampleBufferDescriptor, MTLCounterSet, MTLDepthClipMode, MTLDepthStencilDescriptor,
-    MTLDevice, MTLFunction, MTLIndirectAccelerationStructureInstanceDescriptor, MTLLanguageVersion,
-    MTLLibrary, MTLMeshRenderPipelineDescriptor, MTLMutability, MTLPackedFloat3, MTLPackedFloat4x3,
+    MTLAccelerationStructure, MTLAccelerationStructureInstanceOptions, MTLBinaryArchive,
+    MTLBinaryArchiveDescriptor, MTLBuffer, MTLCaptureManager, MTLCaptureScope, MTLCommandBuffer,
+    MTLCommandBufferStatus, MTLCompileOptions, MTLComputePipelineDescriptor,
+    MTLComputePipelineState, MTLCounterSampleBufferDescriptor, MTLCounterSet, MTLDepthClipMode,
+    MTLDepthStencilDescriptor, MTLDevice, MTLFunction,
+    MTLIndirectAccelerationStructureInstanceDescriptor, MTLLanguageVersion, MTLLibrary,
+    MTLMeshRenderPipelineDescriptor, MTLMutability, MTLPackedFloat3, MTLPackedFloat4x3,
     MTLPipelineBufferDescriptorArray, MTLPipelineOption, MTLPixelFormat, MTLPrimitiveTopologyClass,
     MTLRenderPipelineColorAttachmentDescriptorArray, MTLRenderPipelineDescriptor, MTLResource,
     MTLResourceID, MTLResourceOptions, MTLSamplerAddressMode, MTLSamplerDescriptor,
@@ -1763,6 +1764,14 @@ impl crate::Device for super::Device {
                 descriptor.setLabel(Some(&NSString::from_str(name)));
             }
 
+            // Bind the pipeline cache's archive so the driver loads this pipeline
+            // from it on a hit instead of recompiling (no `FailOnBinaryArchiveMiss`
+            // — a miss just compiles normally).
+            if let Some(cache) = desc.cache {
+                let archives = NSArray::from_slice(&[cache.archive.as_ref()]);
+                descriptor.setBinaryArchives(Some(&archives));
+            }
+
             let raw = self
                 .shared
                 .device
@@ -1780,6 +1789,16 @@ impl crate::Device for super::Device {
                     )
                 })?;
 
+            // Grow the archive with this pipeline so a later `pipeline_cache_get_data`
+            // serializes it. Adding an already-present pipeline is a no-op; caching is
+            // best-effort, so errors are ignored. (Possible future optimization: only
+            // add on a real miss, detected via a `FailOnBinaryArchiveMiss` probe.)
+            if let Some(cache) = desc.cache {
+                let _ = cache
+                    .archive
+                    .addComputePipelineFunctionsWithDescriptor_error(&descriptor);
+            }
+
             self.counters.compute_pipelines.add(1);
 
             Ok(super::ComputePipeline { raw, cs_info })
@@ -1792,11 +1811,69 @@ impl crate::Device for super::Device {
 
     unsafe fn create_pipeline_cache(
         &self,
-        _desc: &crate::PipelineCacheDescriptor<'_>,
+        desc: &crate::PipelineCacheDescriptor<'_>,
     ) -> Result<super::PipelineCache, crate::PipelineCacheError> {
-        Ok(super::PipelineCache)
+        autoreleasepool(|_| {
+            // `MTLBinaryArchive` only seeds from a file URL, so if we were handed
+            // previously-serialized bytes, round-trip them through a scratch file.
+            // A stale or corrupt archive (different GPU / OS / Metal version) makes
+            // creation fail — in that case we fall back to an empty archive and let
+            // pipelines recompile, never erroring on a bad cache.
+            let archive = desc
+                .data
+                .and_then(|data| {
+                    let scratch = super::PipelineCacheScratch::new();
+                    std::fs::write(scratch.path(), data).ok()?;
+                    let url = NSURL::from_file_path(scratch.path())?;
+                    let archive_desc = MTLBinaryArchiveDescriptor::new();
+                    archive_desc.setUrl(Some(&url));
+                    self.shared
+                        .device
+                        .newBinaryArchiveWithDescriptor_error(&archive_desc)
+                        .ok()
+                })
+                .map(Ok)
+                .unwrap_or_else(|| {
+                    let archive_desc = MTLBinaryArchiveDescriptor::new();
+                    self.shared
+                        .device
+                        .newBinaryArchiveWithDescriptor_error(&archive_desc)
+                        .map_err(|_| {
+                            crate::PipelineCacheError::Device(crate::DeviceError::Unexpected)
+                        })
+                })?;
+            Ok(super::PipelineCache { archive })
+        })
     }
-    unsafe fn destroy_pipeline_cache(&self, _: super::PipelineCache) {}
+
+    fn pipeline_cache_validation_key(&self) -> Option<[u8; 16]> {
+        // Partition caches by GPU (the device's IORegistry id) so a blob from a
+        // different device is rejected at the wgpu-core layer before it reaches
+        // `create_pipeline_cache`. Staleness across OS / driver / Metal updates is
+        // additionally caught by `MTLBinaryArchive`'s own validation plus the
+        // empty-archive fallback above.
+        const SCHEMA: u64 = 0x7767_7075_6d70_6c63; // bump if the encoding changes
+        let registry_id = self.shared.device.registryID();
+        let mut key = [0u8; 16];
+        key[..8].copy_from_slice(&registry_id.to_le_bytes());
+        key[8..].copy_from_slice(&SCHEMA.to_le_bytes());
+        Some(key)
+    }
+
+    unsafe fn pipeline_cache_get_data(&self, cache: &super::PipelineCache) -> Option<Vec<u8>> {
+        // `MTLBinaryArchive` only serializes to a file URL; serialize to a scratch
+        // file and read it back as the byte blob wgpu-core persists.
+        autoreleasepool(|_| {
+            let scratch = super::PipelineCacheScratch::new();
+            let url = NSURL::from_file_path(scratch.path())?;
+            cache.archive.serializeToURL_error(&url).ok()?;
+            std::fs::read(scratch.path()).ok()
+        })
+    }
+
+    unsafe fn destroy_pipeline_cache(&self, _cache: super::PipelineCache) {
+        // Dropping the `PipelineCache` releases the `MTLBinaryArchive` (ARC).
+    }
 
     unsafe fn create_query_set(
         &self,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
+use alloc::{borrow::ToOwned as _, string::ToString as _, sync::Arc, vec::Vec};
 use core::{ptr::NonNull, sync::atomic};
 use parking_lot::RwLock;
 use std::{thread, time};
@@ -1652,32 +1652,39 @@ impl crate::Device for super::Device {
                 };
             }
 
-            // Bind the pipeline cache's archive on the standard render path so the
-            // driver loads this pipeline from it on a hit instead of recompiling
-            // (no `FailOnBinaryArchiveMiss` — a miss just compiles). Mesh render
-            // pipeline descriptors don't expose `binaryArchives`, so mesh pipelines
-            // are not archive-cached.
-            if let (Some(cache), MetalGenericRenderPipelineDescriptor::Standard(d)) =
-                (desc.cache, &descriptor)
-            {
-                let archives = NSArray::from_slice(&[cache.archive.as_ref()]);
-                d.setBinaryArchives(Some(&archives));
-            }
-
             // Create the pipeline from descriptor
             let raw = match descriptor {
                 MetalGenericRenderPipelineDescriptor::Standard(d) => {
-                    let raw = self
-                        .shared
-                        .device
-                        .newRenderPipelineStateWithDescriptor_error(&d);
+                    // Bind the cache's archive so the driver loads this pipeline from
+                    // it on a hit instead of recompiling (no `FailOnBinaryArchiveMiss`
+                    // — a miss just compiles). Held under the read lock so a load is
+                    // not raced by a concurrent grow. (Mesh render pipeline descriptors
+                    // don't expose `binaryArchives`, so the Mesh arm below can't be
+                    // archive-cached.)
+                    let raw = {
+                        let _read = desc.cache.map(|cache| {
+                            let guard = cache.archive_lock.read();
+                            let archives = NSArray::from_slice(&[cache.archive.as_ref()]);
+                            d.setBinaryArchives(Some(&archives));
+                            guard
+                        });
+                        self.shared
+                            .device
+                            .newRenderPipelineStateWithDescriptor_error(&d)
+                    };
                     // Grow the archive with this pipeline so a later
-                    // `pipeline_cache_get_data` serializes it (best-effort; adding an
-                    // already-present pipeline is a no-op).
+                    // `pipeline_cache_get_data` serializes it (best-effort). The write
+                    // lock excludes concurrent loads/grows.
                     if let Some(cache) = desc.cache {
-                        let _ = cache
+                        let _guard = cache.archive_lock.write();
+                        if let Err(e) = cache
                             .archive
-                            .addRenderPipelineFunctionsWithDescriptor_error(&d);
+                            .addRenderPipelineFunctionsWithDescriptor_error(&d)
+                        {
+                            log::debug!(
+                                "metal: failed to add render pipeline to binary archive: {e:?}"
+                            );
+                        }
                     }
                     raw
                 }
@@ -1789,11 +1796,16 @@ impl crate::Device for super::Device {
 
             // Bind the pipeline cache's archive so the driver loads this pipeline
             // from it on a hit instead of recompiling (no `FailOnBinaryArchiveMiss`
-            // — a miss just compiles normally).
-            if let Some(cache) = desc.cache {
+            // — a miss just compiles normally). The read lock lets concurrent
+            // compiles load from the archive in parallel while excluding a
+            // concurrent grow/serialize (see `PipelineCache::archive_lock`); it is
+            // held across creation so the load isn't raced by an `add`.
+            let cache_read = desc.cache.map(|cache| {
+                let guard = cache.archive_lock.read();
                 let archives = NSArray::from_slice(&[cache.archive.as_ref()]);
                 descriptor.setBinaryArchives(Some(&archives));
-            }
+                guard
+            });
 
             let raw = self
                 .shared
@@ -1803,6 +1815,7 @@ impl crate::Device for super::Device {
                     MTLPipelineOption::empty(),
                     None,
                 );
+            drop(cache_read);
 
             let raw: Retained<ProtocolObject<dyn MTLComputePipelineState>> =
                 raw.map_err(|e: Retained<NSError>| {
@@ -1814,12 +1827,17 @@ impl crate::Device for super::Device {
 
             // Grow the archive with this pipeline so a later `pipeline_cache_get_data`
             // serializes it. Adding an already-present pipeline is a no-op; caching is
-            // best-effort, so errors are ignored. (Possible future optimization: only
-            // add on a real miss, detected via a `FailOnBinaryArchiveMiss` probe.)
+            // best-effort. The write lock excludes concurrent loads/grows. (Possible
+            // future optimization: only add on a real miss, detected via a
+            // `FailOnBinaryArchiveMiss` probe.)
             if let Some(cache) = desc.cache {
-                let _ = cache
+                let _guard = cache.archive_lock.write();
+                if let Err(e) = cache
                     .archive
-                    .addComputePipelineFunctionsWithDescriptor_error(&descriptor);
+                    .addComputePipelineFunctionsWithDescriptor_error(&descriptor)
+                {
+                    log::debug!("metal: failed to add compute pipeline to binary archive: {e:?}");
+                }
             }
 
             self.counters.compute_pipelines.add(1);
@@ -1865,28 +1883,40 @@ impl crate::Device for super::Device {
                             crate::PipelineCacheError::Device(crate::DeviceError::Unexpected)
                         })
                 })?;
-            Ok(super::PipelineCache { archive })
+            Ok(super::PipelineCache {
+                archive,
+                archive_lock: RwLock::new(()),
+            })
         })
     }
 
     fn pipeline_cache_validation_key(&self) -> Option<[u8; 16]> {
-        // Partition caches by GPU (the device's IORegistry id) so a blob from a
-        // different device is rejected at the wgpu-core layer before it reaches
-        // `create_pipeline_cache`. Staleness across OS / driver / Metal updates is
-        // additionally caught by `MTLBinaryArchive`'s own validation plus the
-        // empty-archive fallback above.
+        // Partition caches by GPU so a blob from a different device is rejected at
+        // the wgpu-core layer before it reaches `create_pipeline_cache`. We key off
+        // the GPU *name* (e.g. "Apple M4 Pro") rather than `registryID`: the name is
+        // stable across reboots, whereas a registry id can change (e.g. eGPU
+        // hot-plug), which would spuriously invalidate a good cache every boot.
+        // Staleness across OS / driver / Metal updates is caught by
+        // `MTLBinaryArchive`'s own validation plus the empty-archive fallback above.
         const SCHEMA: u64 = 0x7767_7075_6d70_6c63; // bump if the encoding changes
-        let registry_id = self.shared.device.registryID();
+        let name = self.shared.device.name().to_string();
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a offset basis
+        for b in name.as_bytes() {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x100_0000_01b3);
+        }
         let mut key = [0u8; 16];
-        key[..8].copy_from_slice(&registry_id.to_le_bytes());
+        key[..8].copy_from_slice(&h.to_le_bytes());
         key[8..].copy_from_slice(&SCHEMA.to_le_bytes());
         Some(key)
     }
 
     unsafe fn pipeline_cache_get_data(&self, cache: &super::PipelineCache) -> Option<Vec<u8>> {
         // `MTLBinaryArchive` only serializes to a file URL; serialize to a scratch
-        // file and read it back as the byte blob wgpu-core persists.
+        // file and read it back as the byte blob wgpu-core persists. Take the write
+        // lock so serialization sees a consistent archive (no concurrent grow).
         autoreleasepool(|_| {
+            let _guard = cache.archive_lock.write();
             let scratch = super::PipelineCacheScratch::new();
             let url = NSURL::from_file_path(scratch.path())?;
             cache.archive.serializeToURL_error(&url).ok()?;

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1652,12 +1652,35 @@ impl crate::Device for super::Device {
                 };
             }
 
+            // Bind the pipeline cache's archive on the standard render path so the
+            // driver loads this pipeline from it on a hit instead of recompiling
+            // (no `FailOnBinaryArchiveMiss` — a miss just compiles). Mesh render
+            // pipeline descriptors don't expose `binaryArchives`, so mesh pipelines
+            // are not archive-cached.
+            if let (Some(cache), MetalGenericRenderPipelineDescriptor::Standard(d)) =
+                (desc.cache, &descriptor)
+            {
+                let archives = NSArray::from_slice(&[cache.archive.as_ref()]);
+                d.setBinaryArchives(Some(&archives));
+            }
+
             // Create the pipeline from descriptor
             let raw = match descriptor {
-                MetalGenericRenderPipelineDescriptor::Standard(d) => self
-                    .shared
-                    .device
-                    .newRenderPipelineStateWithDescriptor_error(&d),
+                MetalGenericRenderPipelineDescriptor::Standard(d) => {
+                    let raw = self
+                        .shared
+                        .device
+                        .newRenderPipelineStateWithDescriptor_error(&d);
+                    // Grow the archive with this pipeline so a later
+                    // `pipeline_cache_get_data` serializes it (best-effort; adding an
+                    // already-present pipeline is a no-op).
+                    if let Some(cache) = desc.cache {
+                        let _ = cache
+                            .archive
+                            .addRenderPipelineFunctionsWithDescriptor_error(&d);
+                    }
+                    raw
+                }
                 MetalGenericRenderPipelineDescriptor::Mesh(d) => self
                     .shared
                     .device

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -1159,10 +1159,21 @@ unsafe impl Sync for CommandBuffer {}
 #[derive(Debug)]
 pub struct PipelineCache {
     pub(super) archive: Retained<ProtocolObject<dyn MTLBinaryArchive>>,
+    /// Serializes mutation of `archive`. wgpu allows pipeline creation from
+    /// multiple threads against one cache, but Apple does **not** document
+    /// `MTLBinaryArchive`'s `add*PipelineFunctions` / `serializeToURL` as
+    /// thread-safe (unlike Vulkan's `VkPipelineCache`, which is). We model the
+    /// access conservatively: pipeline creation takes a **read** lock (loading
+    /// from the archive concurrently is fine), while growing the archive
+    /// (`add*PipelineFunctions`) and serializing it take the **write** lock, so a
+    /// grow never races a load or another grow. If Apple confirms these are
+    /// internally synchronized, this can be dropped to allow lock-free parallel
+    /// cached compiles.
+    pub(super) archive_lock: RwLock<()>,
 }
 
-// SAFETY: `MTLBinaryArchive` is an Obj-C object that Apple documents as usable
-// across threads; pipeline creation may add to it from any thread.
+// SAFETY: `MTLBinaryArchive` is an Obj-C object usable across threads; access to
+// its non-thread-safe mutators is serialized via `archive_lock` (see above).
 unsafe impl Send for PipelineCache {}
 unsafe impl Sync for PipelineCache {}
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -46,9 +46,9 @@ use objc2::{
 use objc2_foundation::ns_string;
 use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLArgumentBuffersTier,
-    MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue,
-    MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer, MTLCullMode,
-    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLIndexType,
+    MTLBinaryArchive, MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus,
+    MTLCommandQueue, MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer,
+    MTLCullMode, MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLIndexType,
     MTLLanguageVersion, MTLLibrary, MTLPrimitiveType, MTLReadWriteTextureTier,
     MTLRenderCommandEncoder, MTLRenderPipelineState, MTLRenderStages, MTLResource,
     MTLResourceUsage, MTLSamplerState, MTLSharedEvent, MTLSize, MTLTexture, MTLTextureType,
@@ -1150,10 +1150,56 @@ impl crate::DynCommandBuffer for CommandBuffer {}
 unsafe impl Send for CommandBuffer {}
 unsafe impl Sync for CommandBuffer {}
 
+/// A persistent pipeline cache backed by an [`MTLBinaryArchive`].
+///
+/// Holds compiled pipeline binaries that can be serialized to bytes
+/// (`Device::pipeline_cache_get_data`) and reloaded into a later archive
+/// (`Device::create_pipeline_cache`), so a pipeline compiled in a previous run
+/// is loaded from the archive instead of recompiled by the driver.
 #[derive(Debug)]
-pub struct PipelineCache;
+pub struct PipelineCache {
+    pub(super) archive: Retained<ProtocolObject<dyn MTLBinaryArchive>>,
+}
+
+// SAFETY: `MTLBinaryArchive` is an Obj-C object that Apple documents as usable
+// across threads; pipeline creation may add to it from any thread.
+unsafe impl Send for PipelineCache {}
+unsafe impl Sync for PipelineCache {}
 
 impl crate::DynPipelineCache for PipelineCache {}
+
+/// A uniquely-named scratch file in the temp dir, removed on drop.
+///
+/// Bridges wgpu's byte-oriented pipeline-cache HAL (`PipelineCacheDescriptor::data`,
+/// `pipeline_cache_get_data -> Vec<u8>`) to [`MTLBinaryArchive`], which can only load
+/// from / serialize to a *file URL* — there is no in-memory API. The seed bytes are
+/// written here to be loaded, and serialization targets here to be read back.
+pub(super) struct PipelineCacheScratch {
+    path: std::path::PathBuf,
+}
+
+impl PipelineCacheScratch {
+    pub(super) fn new() -> Self {
+        use core::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "wgpu-metal-pipeline-cache-{}-{unique}.bin",
+            std::process::id(),
+        ));
+        Self { path }
+    }
+
+    pub(super) fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for PipelineCacheScratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
 
 #[derive(Debug)]
 pub struct AccelerationStructure {

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -1161,10 +1161,10 @@ bitflags_array! {
         ///
         /// Supported platforms:
         /// - Vulkan
+        /// - Metal (via `MTLBinaryArchive`)
         ///
         /// Unimplemented Platforms:
         /// - DX12
-        /// - Metal
         #[name("wgpu-pipeline-cache")]
         const PIPELINE_CACHE = 1 << 41;
         /// Allows shaders to use i64 and u64 atomic min and max.


### PR DESCRIPTION
**Connections**

Implements the Metal portion of #5293 (pipeline caching between program executions), which until now was Vulkan-only — on Metal `PipelineCache` was a no-op stub and the `PIPELINE_CACHE` feature was unimplemented. Related: #3103 (precompiled shaders), and the long-standing goal in gfx-rs/gfx#3716 to implement `get_pipeline_cache_data` on all modern platforms including Metal.

**Description**

Back `PipelineCache` on the Metal backend with [`MTLBinaryArchive`](https://developer.apple.com/documentation/metal/mtlbinaryarchive) (macOS 11+ / iOS 14+), so a compiled compute or render pipeline can be serialized to bytes and reloaded on a later run instead of recompiled by the driver — the same capability the Vulkan backend already provides.

What's here, mirroring the Vulkan HAL impl:

- `create_pipeline_cache` builds an `MTLBinaryArchive`, seeded from `PipelineCacheDescriptor::data` when present; `pipeline_cache_get_data` serializes it back to bytes; `destroy_pipeline_cache`; `pipeline_cache_validation_key`; and the Metal adapter now reports `Features::PIPELINE_CACHE` on capable OS versions.
- Compute and standard render pipeline creation bind the cache's archive (`setBinaryArchives`) so the driver loads on a hit, and call `add{Compute,Render}PipelineFunctions` after creation so the pipeline persists on the next `get_data`.
- `wgpu-core`'s `adapter_key` gains a `Backend::Metal` arm so Metal is recognised as supporting cache data.

**One design question I'd like input on (the temp-file bridge).** wgpu's HAL pipeline-cache API is byte-oriented (`data: Option<&[u8]>`, `get_data -> Vec<u8>`), but `MTLBinaryArchive` has *no* in-memory API — it only seeds from a file URL (`MTLBinaryArchiveDescriptor.url`) and serializes to a file URL (`serializeToURL:`). So the Metal impl round-trips through a scratch file in the temp dir on both ends, entirely inside the HAL (no public API change). This is the only real wrinkle. Is round-tripping via `std::env::temp_dir()` acceptable, or would you prefer a Metal-specific accommodation (e.g. a backend hook that owns the on-disk path directly)? Happy to go either way.

**Concurrency.** Unlike `VkPipelineCache`, Apple does not document `MTLBinaryArchive`'s `add*`/`serialize` as thread-safe, and wgpu allows pipeline creation from multiple threads against one cache. I've guarded the archive with an `RwLock`: pipeline creation takes a read lock (concurrent loads are fine) while growing/serializing take the write lock. It's conservative — if a maintainer knows these are internally synchronized, the lock can be dropped to allow lock-free parallel cached compiles.

**Known limitations (called out deliberately):**

- **Mesh render pipelines are not cached** — `MTLMeshRenderPipelineDescriptor` doesn't expose `binaryArchives`; the cache is simply ignored for them.
- The archive is grown on **every** create, including cache hits (a no-op for an already-present pipeline). A future optimization could add only on a true miss, detected via a `FailOnBinaryArchiveMiss` probe.
- The validation key is keyed off the GPU **name** (stable across reboots) rather than `registryID` (which can change, e.g. on eGPU hot-plug, and would spuriously invalidate a good cache). Staleness across OS/driver/Metal updates is caught by `MTLBinaryArchive`'s own validation plus an empty-archive fallback (a bad/stale cache never errors — it recompiles).
- Scratch files use process-id + counter names rather than `mkstemp`-style random names, to avoid pulling a new runtime dependency into `wgpu-hal`. Pipeline binaries aren't secret and the window is tiny, but I'm happy to harden this if preferred.

**Testing**

- The existing `pipeline_cache` GPU test (`tests/tests/wgpu-gpu/pipeline_cache.rs`) was previously **skipped on Metal** because the backend didn't advertise the feature. It now runs and **passes on Metal (Apple M4 Pro)** — it exercises empty-cache compile → `get_data` (which now returns real bytes; the old stub returned `None`) → reseed a second cache from those bytes → recompile, validating pipeline output throughout.
- Added a **render-pipeline** analogue (`pipeline_cache_render`) since the existing test was compute-only and render threads the archive on a separate path: it creates a render pipeline with a cache, draws a constant colour to a texture and verifies the readback, `get_data`, then reseeds and draws again. `cargo xtask test pipeline_cache` → **14/14 pass** on Metal.
- Full suite (`cargo xtask test`, 927 tests) run on Metal/Apple M4 Pro. The only failures (`mesh_shader::*`, `passthrough::all_passthrough_shaders_*`, and a naga `convert_snapshots_spv` snapshot) were **confirmed pre-existing on clean `trunk`** (reproduced on the merge-base with this change reverted), so this PR regresses nothing. This is also structurally guaranteed: the new code paths only execute when `desc.cache` is `Some`, and `pipeline_cache` is the only cache-using test.
- `cargo fmt` and `cargo clippy` are clean on `wgpu-hal --features metal`, `wgpu-core`, `wgpu-types`, and the `wgpu-gpu` test target.

I also validated the underlying primitive in isolation first (a standalone `MTLBinaryArchive` round-trip outside wgpu, using `FailOnBinaryArchiveMiss` to prove the warm path genuinely loads from the archive rather than recompiling) before integrating.

**Squash or Rebase?**

Logically-scoped commits — compute path, render path, a self-review hardening pass (concurrency guard, stable validation key, docs, CHANGELOG), and the render-pipeline test. Each builds and passes `pipeline_cache`. Fine to rebase onto `trunk` as-is; happy to squash to a single commit if you prefer.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally. <!-- native-only feature; no WebGPU behavioral change -->
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
