### PR TITLE
fix(core): Correctly track texture init state after writing one aspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Writes from `Queue::write_buffer` are now flushed by calls to `Buffer::map_async` for that same buffer, to prevent reading stale data. `on_submitted_work_done` also now flushes pending writes. By @andyleiserson in [#9307](https://github.com/gfx-rs/wgpu/pull/9307).
 - Fix missing dependency feature activations when building wgpu-hal with gles/dx12 in isolation. By @wumpf in [#9325](https://github.com/gfx-rs/wgpu/pull/9325)
 - Stencil clear and reference values are now truncated to 8 bits. By @beicause in [#9607](https://github.com/gfx-rs/wgpu/pull/9607).
+- Fixed missing initialization of other aspects when writing to a single aspect of a multi-aspect texture. By @andyleiserson in [#9626](https://github.com/gfx-rs/wgpu/pull/9626).
 
 #### naga
 

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -81,7 +81,7 @@ mod vertex_formats;
 mod vertex_indices;
 mod vertex_state;
 mod write_texture;
-mod zero_init_texture_after_discard;
+mod zero_init;
 
 fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     let mut tests = Vec::new();
@@ -163,7 +163,7 @@ fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     vertex_indices::all_tests(&mut tests);
     vertex_state::all_tests(&mut tests);
     write_texture::all_tests(&mut tests);
-    zero_init_texture_after_discard::all_tests(&mut tests);
+    zero_init::all_tests(&mut tests);
     naga_capabilities::all_tests(&mut tests);
 
     tests

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -442,7 +442,12 @@ static WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
-                .limits(Limits::downlevel_defaults()),
+                .limits(Limits::downlevel_defaults())
+                .expect_fail(
+                    // https://github.com/gfx-rs/wgpu/issues/9627
+                    FailureCase::backend(wgpu::Backends::DX12)
+                        .panic("called `Option::unwrap()` on a `None` value"),
+                ),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -462,7 +467,12 @@ static WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_NV12: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
-                .limits(Limits::downlevel_defaults()),
+                .limits(Limits::downlevel_defaults())
+                .expect_fail(
+                    // https://github.com/gfx-rs/wgpu/issues/9627
+                    FailureCase::backend(wgpu::Backends::DX12)
+                        .panic("called `Option::unwrap()` on a `None` value"),
+                ),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -482,7 +492,12 @@ static WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_P010: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_P010 | Features::TEXTURE_FORMAT_16BIT_NORM)
-                .limits(Limits::downlevel_defaults()),
+                .limits(Limits::downlevel_defaults())
+                .expect_fail(
+                    // https://github.com/gfx-rs/wgpu/issues/9627
+                    FailureCase::backend(wgpu::Backends::DX12)
+                        .panic("called `Option::unwrap()` on a `None` value"),
+                ),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -502,7 +517,12 @@ static WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_P010: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_P010 | Features::TEXTURE_FORMAT_16BIT_NORM)
-                .limits(Limits::downlevel_defaults()),
+                .limits(Limits::downlevel_defaults())
+                .expect_fail(
+                    // https://github.com/gfx-rs/wgpu/issues/9627
+                    FailureCase::backend(wgpu::Backends::DX12)
+                        .panic("called `Option::unwrap()` on a `None` value"),
+                ),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -545,7 +565,12 @@ static COPY_BUFFER_TO_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12: GpuTestConfigura
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
-                .limits(Limits::downlevel_defaults()),
+                .limits(Limits::downlevel_defaults())
+                .expect_fail(
+                    // https://github.com/gfx-rs/wgpu/issues/9627
+                    FailureCase::backend(wgpu::Backends::DX12)
+                        .panic("called `Option::unwrap()` on a `None` value"),
+                ),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -6,10 +6,18 @@ use wgpu_test::{
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
+        COPY_BUFFER_TO_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12,
+        COPY_BUFFER_TO_TEXTURE_STENCIL_LEAVES_DEPTH_UNINIT_DEPTH32FLOAT_STENCIL8,
         DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_AFTER_SUBMIT,
         DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_IN_SAME_ENCODER,
         DISCARDING_DEPTH_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_IN_SAME_ENCODER,
         DISCARDING_EITHER_DEPTH_OR_STENCIL_ASPECT_TEST,
+        WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12,
+        WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_P010,
+        WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_NV12,
+        WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_P010,
+        WRITE_TEXTURE_STENCIL_LEAVES_DEPTH_UNINIT_DEPTH24PLUS_STENCIL8,
+        WRITE_TEXTURE_STENCIL_LEAVES_DEPTH_UNINIT_DEPTH32FLOAT_STENCIL8,
     ]);
 }
 
@@ -330,4 +338,460 @@ impl<'ctx> DiscardTestCase<'ctx> {
             "texture was not fully cleared"
         );
     }
+}
+
+// Tests that a full-extent, single-aspect `write_texture` does not cause
+// *other* aspects of a multi-aspect texture to be considered initialized.
+
+#[gpu_test]
+static WRITE_TEXTURE_STENCIL_LEAVES_DEPTH_UNINIT_DEPTH32FLOAT_STENCIL8: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .features(Features::DEPTH32FLOAT_STENCIL8)
+                .downlevel_flags(DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES)
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            check_depth_stencil_write_leaves_other_uninit(
+                &ctx,
+                TextureFormat::Depth32FloatStencil8,
+                /* depth_bpp */ 4,
+                TextureAspect::StencilOnly,
+                WriteMethod::WriteTexture,
+            )
+            .await;
+        });
+
+// Note: there aren't corresponding `WRITE_TEXTURE_DEPTH_LEAVES_STENCIL_UNINIT_*`
+// cases because the depth aspect of the combined depth/stencil formats cannot
+// be the destination of a `write_texture` call.
+#[gpu_test]
+static WRITE_TEXTURE_STENCIL_LEAVES_DEPTH_UNINIT_DEPTH24PLUS_STENCIL8: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .downlevel_flags(
+                    DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES
+                        | DownlevelFlags::COMPUTE_SHADERS,
+                )
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            let size = Extent3d {
+                width: 256,
+                height: 256,
+                depth_or_array_layers: 1,
+            };
+
+            // Depth aspect of Depth24PlusStencil8 cannot be the source of a direct
+            // copy_texture_to_buffer, so we cannot use the same readback strategy
+            // as the other depth/stencil format. Use the shared ReadbackBuffers
+            // helper, which reads the depth aspect through a compute shader.
+            // Because that helper checks both aspects, we write zeros (not a
+            // sentinel byte) to the stencil aspect.
+            let texture = ctx.device.create_texture(&TextureDescriptor {
+                label: Some("depth24plus-stencil8 aspect-init test"),
+                size,
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: TextureDimension::D2,
+                format: TextureFormat::Depth24PlusStencil8,
+                usage: TextureUsages::COPY_DST
+                    | TextureUsages::COPY_SRC
+                    | TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            });
+
+            let stencil_bytes_per_row = size.width;
+            let stencil_data = vec![0u8; (stencil_bytes_per_row * size.height) as usize];
+            ctx.queue.write_texture(
+                TexelCopyTextureInfo {
+                    texture: &texture,
+                    mip_level: 0,
+                    origin: Origin3d::ZERO,
+                    aspect: TextureAspect::StencilOnly,
+                },
+                &stencil_data,
+                TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(stencil_bytes_per_row),
+                    rows_per_image: Some(size.height),
+                },
+                size,
+            );
+            ctx.queue.submit(None);
+
+            let readback_buffers = ReadbackBuffers::new(&ctx.device, &texture);
+            let mut encoder = ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor { label: None });
+            readback_buffers.copy_from(&ctx.device, &mut encoder, &texture);
+            ctx.queue.submit([encoder.finish()]);
+
+            assert!(
+                readback_buffers.are_zero(&ctx).await,
+                "depth aspect of Depth24PlusStencil8 read back non-zero after \
+             stencil-only write_texture",
+            );
+        });
+
+#[gpu_test]
+static WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .features(Features::TEXTURE_FORMAT_NV12)
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            check_plane_write_leaves_other_plane_uninit(
+                &ctx,
+                TextureFormat::NV12,
+                /* plane0_bpp */ 1,
+                /* plane1_bpp */ 2,
+                TextureAspect::Plane0,
+                WriteMethod::WriteTexture,
+            )
+            .await;
+        });
+
+#[gpu_test]
+static WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_NV12: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .features(Features::TEXTURE_FORMAT_NV12)
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            check_plane_write_leaves_other_plane_uninit(
+                &ctx,
+                TextureFormat::NV12,
+                /* plane0_bpp */ 1,
+                /* plane1_bpp */ 2,
+                TextureAspect::Plane1,
+                WriteMethod::WriteTexture,
+            )
+            .await;
+        });
+
+#[gpu_test]
+static WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_P010: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .features(Features::TEXTURE_FORMAT_P010 | Features::TEXTURE_FORMAT_16BIT_NORM)
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            check_plane_write_leaves_other_plane_uninit(
+                &ctx,
+                TextureFormat::P010,
+                /* plane0_bpp */ 2,
+                /* plane1_bpp */ 4,
+                TextureAspect::Plane0,
+                WriteMethod::WriteTexture,
+            )
+            .await;
+        });
+
+#[gpu_test]
+static WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_P010: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .features(Features::TEXTURE_FORMAT_P010 | Features::TEXTURE_FORMAT_16BIT_NORM)
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            check_plane_write_leaves_other_plane_uninit(
+                &ctx,
+                TextureFormat::P010,
+                /* plane0_bpp */ 2,
+                /* plane1_bpp */ 4,
+                TextureAspect::Plane1,
+                WriteMethod::WriteTexture,
+            )
+            .await;
+        });
+
+// The write_texture tests exhaustively cover all the relevant format/aspect combinations.
+// These copy_buffer_to_texture tests only sanity-check one depth/stencil format and one
+// multi-planar format.
+#[gpu_test]
+static COPY_BUFFER_TO_TEXTURE_STENCIL_LEAVES_DEPTH_UNINIT_DEPTH32FLOAT_STENCIL8:
+    GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(Features::DEPTH32FLOAT_STENCIL8)
+            .downlevel_flags(DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES)
+            .limits(Limits::downlevel_defaults()),
+    )
+    .run_async(|ctx| async move {
+        check_depth_stencil_write_leaves_other_uninit(
+            &ctx,
+            TextureFormat::Depth32FloatStencil8,
+            /* depth_bpp */ 4,
+            TextureAspect::StencilOnly,
+            WriteMethod::CopyBufferToTexture,
+        )
+        .await;
+    });
+
+#[gpu_test]
+static COPY_BUFFER_TO_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .features(Features::TEXTURE_FORMAT_NV12)
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            check_plane_write_leaves_other_plane_uninit(
+                &ctx,
+                TextureFormat::NV12,
+                /* plane0_bpp */ 1,
+                /* plane1_bpp */ 2,
+                TextureAspect::Plane0,
+                WriteMethod::CopyBufferToTexture,
+            )
+            .await;
+        });
+
+struct AspectInfo {
+    aspect: TextureAspect,
+    size: Extent3d,
+    bpp: u32,
+}
+
+#[derive(Clone, Copy)]
+enum WriteMethod {
+    WriteTexture,
+    CopyBufferToTexture,
+}
+
+impl WriteMethod {
+    fn name(self) -> &'static str {
+        match self {
+            WriteMethod::WriteTexture => "write_texture",
+            WriteMethod::CopyBufferToTexture => "copy_buffer_to_texture",
+        }
+    }
+}
+
+async fn check_depth_stencil_write_leaves_other_uninit(
+    ctx: &TestingContext,
+    format: TextureFormat,
+    depth_bpp: u32,
+    write_aspect: TextureAspect,
+    method: WriteMethod,
+) {
+    let size = Extent3d {
+        width: 256,
+        height: 256,
+        depth_or_array_layers: 1,
+    };
+    let (write_bpp, read_aspect, read_bpp) = match write_aspect {
+        TextureAspect::StencilOnly => (1, TextureAspect::DepthOnly, depth_bpp),
+        TextureAspect::DepthOnly => (depth_bpp, TextureAspect::StencilOnly, 1),
+        _ => panic!("expected DepthOnly or StencilOnly"),
+    };
+    check_write_aspect_leaves_other_uninit(
+        ctx,
+        format,
+        AspectInfo {
+            aspect: write_aspect,
+            size,
+            bpp: write_bpp,
+        },
+        AspectInfo {
+            aspect: read_aspect,
+            size,
+            bpp: read_bpp,
+        },
+        method,
+    )
+    .await;
+}
+
+async fn check_plane_write_leaves_other_plane_uninit(
+    ctx: &TestingContext,
+    format: TextureFormat,
+    plane0_bpp: u32,
+    plane1_bpp: u32,
+    write_plane: TextureAspect,
+    method: WriteMethod,
+) {
+    // Plane 1 of NV12/P010 is half resolution in each dimension.
+    let full_size = Extent3d {
+        width: 256,
+        height: 256,
+        depth_or_array_layers: 1,
+    };
+    let half_size = Extent3d {
+        width: 128,
+        height: 128,
+        depth_or_array_layers: 1,
+    };
+    let (write_size, write_bpp, read_aspect, read_size, read_bpp) = match write_plane {
+        TextureAspect::Plane0 => (
+            full_size,
+            plane0_bpp,
+            TextureAspect::Plane1,
+            half_size,
+            plane1_bpp,
+        ),
+        TextureAspect::Plane1 => (
+            half_size,
+            plane1_bpp,
+            TextureAspect::Plane0,
+            full_size,
+            plane0_bpp,
+        ),
+        _ => panic!("expected Plane0 or Plane1"),
+    };
+    check_write_aspect_leaves_other_uninit(
+        ctx,
+        format,
+        AspectInfo {
+            aspect: write_plane,
+            size: write_size,
+            bpp: write_bpp,
+        },
+        AspectInfo {
+            aspect: read_aspect,
+            size: read_size,
+            bpp: read_bpp,
+        },
+        method,
+    )
+    .await;
+}
+
+async fn check_write_aspect_leaves_other_uninit(
+    ctx: &TestingContext,
+    format: TextureFormat,
+    write: AspectInfo,
+    read: AspectInfo,
+    method: WriteMethod,
+) {
+    let texture = ctx.device.create_texture(&TextureDescriptor {
+        label: Some("aspect-init test"),
+        size: Extent3d {
+            width: 256,
+            height: 256,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: TextureDimension::D2,
+        format,
+        usage: TextureUsages::COPY_DST | TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+
+    let write_bytes_per_row = write.size.width * write.bpp;
+    assert_eq!(write_bytes_per_row % COPY_BYTES_PER_ROW_ALIGNMENT, 0);
+    let write_data = vec![0xAA_u8; (write_bytes_per_row * write.size.height) as usize];
+    let write_layout = TexelCopyBufferLayout {
+        offset: 0,
+        bytes_per_row: Some(write_bytes_per_row),
+        rows_per_image: Some(write.size.height),
+    };
+    let write_texture_info = TexelCopyTextureInfo {
+        texture: &texture,
+        mip_level: 0,
+        origin: Origin3d::ZERO,
+        aspect: write.aspect,
+    };
+    match method {
+        WriteMethod::WriteTexture => {
+            ctx.queue
+                .write_texture(write_texture_info, &write_data, write_layout, write.size);
+            ctx.queue.submit(None);
+        }
+        WriteMethod::CopyBufferToTexture => {
+            let src_buffer = ctx.device.create_buffer(&BufferDescriptor {
+                label: Some("aspect-init source"),
+                size: write_data.len() as u64,
+                usage: BufferUsages::COPY_SRC,
+                mapped_at_creation: true,
+            });
+            {
+                let mut view = src_buffer.slice(..).get_mapped_range_mut().unwrap();
+                view.copy_from_slice(&write_data);
+            }
+            src_buffer.unmap();
+
+            let mut encoder = ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor { label: None });
+            encoder.copy_buffer_to_texture(
+                TexelCopyBufferInfo {
+                    buffer: &src_buffer,
+                    layout: write_layout,
+                },
+                write_texture_info,
+                write.size,
+            );
+            ctx.queue.submit(Some(encoder.finish()));
+        }
+    }
+
+    let read_bytes_per_row = read.size.width * read.bpp;
+    assert_eq!(read_bytes_per_row % COPY_BYTES_PER_ROW_ALIGNMENT, 0);
+    let read_size_bytes = (read_bytes_per_row * read.size.height) as u64;
+    let readback = ctx.device.create_buffer(&BufferDescriptor {
+        label: Some("aspect readback"),
+        size: read_size_bytes,
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        mapped_at_creation: true,
+    });
+    {
+        let mut view = readback.slice(..).get_mapped_range_mut().unwrap();
+        let len = view.len();
+        view.copy_from_slice(&vec![0xCD_u8; len]);
+    }
+    readback.unmap();
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&CommandEncoderDescriptor { label: None });
+    encoder.copy_texture_to_buffer(
+        TexelCopyTextureInfo {
+            texture: &texture,
+            mip_level: 0,
+            origin: Origin3d::ZERO,
+            aspect: read.aspect,
+        },
+        TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(read_bytes_per_row),
+                rows_per_image: Some(read.size.height),
+            },
+        },
+        read.size,
+    );
+    ctx.queue.submit(Some(encoder.finish()));
+
+    let slice = readback.slice(..);
+    slice.map_async(MapMode::Read, |_| ());
+    ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
+    let data: Vec<u8> = slice.get_mapped_range().unwrap().to_vec();
+
+    let nonzero = data.iter().position(|&b| b != 0);
+    assert!(
+        nonzero.is_none(),
+        "{:?} aspect of {:?} read back non-zero after {:?} {}; \
+         first non-zero byte at offset {} = 0x{:02x}",
+        read.aspect,
+        format,
+        write.aspect,
+        method.name(),
+        nonzero.unwrap(),
+        data[nonzero.unwrap()],
+    );
 }

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -19,7 +19,7 @@ static DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_A
     GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().expect_fail(FailureCase::webgl2()))
     .run_async(|mut ctx| async move {
-        let mut case = TestCase::new(&mut ctx, TextureFormat::Rgba8UnormSrgb);
+        let mut case = DiscardTestCase::new(&mut ctx, TextureFormat::Rgba8UnormSrgb);
         case.create_command_encoder();
         case.discard();
         case.submit_command_encoder();
@@ -36,7 +36,7 @@ static DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_I
     GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().expect_fail(FailureCase::webgl2()))
     .run_async(|mut ctx| async move {
-        let mut case = TestCase::new(&mut ctx, TextureFormat::Rgba8UnormSrgb);
+        let mut case = DiscardTestCase::new(&mut ctx, TextureFormat::Rgba8UnormSrgb);
         case.create_command_encoder();
         case.discard();
         case.copy_texture_to_buffer();
@@ -63,7 +63,7 @@ static DISCARDING_DEPTH_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_I
             TextureFormat::Depth24PlusStencil8,
             TextureFormat::Depth32Float,
         ] {
-            let mut case = TestCase::new(&mut ctx, format);
+            let mut case = DiscardTestCase::new(&mut ctx, format);
             case.create_command_encoder();
             case.discard();
             case.copy_texture_to_buffer();
@@ -92,7 +92,7 @@ static DISCARDING_EITHER_DEPTH_OR_STENCIL_ASPECT_TEST: GpuTestConfiguration =
                 TextureFormat::Depth24PlusStencil8,
                 TextureFormat::Depth32Float,
             ] {
-                let mut case = TestCase::new(&mut ctx, format);
+                let mut case = DiscardTestCase::new(&mut ctx, format);
                 case.create_command_encoder();
                 case.discard_depth();
                 case.submit_command_encoder();
@@ -109,7 +109,7 @@ static DISCARDING_EITHER_DEPTH_OR_STENCIL_ASPECT_TEST: GpuTestConfiguration =
             }
         });
 
-struct TestCase<'ctx> {
+struct DiscardTestCase<'ctx> {
     ctx: &'ctx mut TestingContext,
     format: TextureFormat,
     texture: Texture,
@@ -117,7 +117,7 @@ struct TestCase<'ctx> {
     encoder: Option<CommandEncoder>,
 }
 
-impl<'ctx> TestCase<'ctx> {
+impl<'ctx> DiscardTestCase<'ctx> {
     pub fn new(ctx: &'ctx mut TestingContext, format: TextureFormat) -> Self {
         let extra_usages = match format {
             TextureFormat::Depth24Plus | TextureFormat::Depth24PlusStencil8 => {

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -725,15 +725,12 @@ fn handle_dst_texture_init(
     // clear first since we don't track subrects. This means that in rare cases
     // even a *destination* texture of a transfer may need an immediate texture
     // init.
-    let dst_init_kind = if has_copy_partial_init_tracker_coverage(
-        copy_size,
-        destination.mip_level,
-        &texture.desc,
-    ) {
-        MemoryInitKind::NeedsInitializedMemory
-    } else {
-        MemoryInitKind::ImplicitlyInitialized
-    };
+    let dst_init_kind =
+        if has_copy_partial_init_tracker_coverage(copy_size, destination, &texture.desc) {
+            MemoryInitKind::NeedsInitializedMemory
+        } else {
+            MemoryInitKind::ImplicitlyInitialized
+        };
 
     handle_texture_init(state, dst_init_kind, destination, copy_size, texture)?;
     Ok(())

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -920,7 +920,7 @@ impl Queue {
             .check(init_layer_range.clone())
             .is_some()
         {
-            if has_copy_partial_init_tracker_coverage(size, destination.mip_level, &dst.desc) {
+            if has_copy_partial_init_tracker_coverage(size, &destination, &dst.desc) {
                 for layer_range in dst_initialization_status.mips[destination.mip_level as usize]
                     .drain(init_layer_range)
                     .collect::<Vec<core::ops::Range<u32>>>()
@@ -1182,7 +1182,7 @@ impl Queue {
             .check(init_layer_range.clone())
             .is_some()
         {
-            if has_copy_partial_init_tracker_coverage(&size, destination.mip_level, &dst.desc) {
+            if has_copy_partial_init_tracker_coverage(&size, &destination, &dst.desc) {
                 for layer_range in dst_initialization_status.mips[destination.mip_level as usize]
                     .drain(init_layer_range)
                     .collect::<Vec<core::ops::Range<u32>>>()

--- a/wgpu-core/src/init_tracker/texture.rs
+++ b/wgpu-core/src/init_tracker/texture.rs
@@ -15,16 +15,17 @@ pub(crate) struct TextureInitRange {
 // Returns true if a copy operation doesn't fully cover the texture init
 // tracking granularity. I.e. if this function returns true for a pending copy
 // operation, the target texture needs to be ensured to be initialized first!
-pub(crate) fn has_copy_partial_init_tracker_coverage(
+pub(crate) fn has_copy_partial_init_tracker_coverage<T>(
     copy_size: &wgt::Extent3d,
-    mip_level: u32,
+    copy_info: &wgt::TexelCopyTextureInfo<T>,
     desc: &wgt::TextureDescriptor<(), Vec<wgt::TextureFormat>>,
 ) -> bool {
-    let target_size = desc.mip_level_size(mip_level).unwrap();
+    let target_size = desc.mip_level_size(copy_info.mip_level).unwrap();
     copy_size.width != target_size.width
         || copy_size.height != target_size.height
         || (desc.dimension == wgt::TextureDimension::D3
             && copy_size.depth_or_array_layers != target_size.depth_or_array_layers)
+        || copy_info.aspect != wgt::TextureAspect::All
 }
 
 impl From<TextureSelector> for TextureInitRange {


### PR DESCRIPTION
The init tracker does not track per-aspect initialization status, so we need to initialize the texture before writing to a single aspect of a multi-aspect texture.

**Testing**
Adds directed GPU tests.

**Squash or Rebase?** Rebase (after squashing fixups)

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
