### PR TITLE
wgpu-core: enable is_sorted_by_key debug assert in triage_submissions

### DIFF
--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -304,8 +304,7 @@ impl LifetimeTracker {
     ) -> SmallVec<[SubmittedWorkDoneClosure; 1]> {
         profiling::scope!("triage_submissions");
 
-        //TODO: enable when `is_sorted_by_key` is stable
-        //debug_assert!(self.active.is_sorted_by_key(|a| a.index));
+        debug_assert!(self.active.is_sorted_by_key(|a| a.index));
         let done_count = self
             .active
             .iter()


### PR DESCRIPTION
## Summary

`triage_submissions` has had this dead code since before Rust 1.82:

```rust
//TODO: enable when `is_sorted_by_key` is stable
//debug_assert!(self.active.is_sorted_by_key(|a| a.index));
```

`is_sorted_by_key` stabilized in Rust 1.82 ([tracking issue](https://github.com/rust-lang/rust/issues/53485)). The MSRV in `rust-toolchain.toml` is now 1.93, so the TODO is resolved — remove the comment and uncomment the assert.

## Change

- `wgpu-core/src/device/life.rs`: remove 2-line comment block, enable 1 `debug_assert!`

The assert fires only in debug builds. It validates the invariant that `LifetimeTracker::active` is maintained in submission-index order, which `triage_submissions` already relies on (it calls `drain(..done_count)` assuming older entries come first).

## Testing

No behavior change in release builds. The assert is exercised by any test that submits work to a device.