### PR TITLE
wgpu-core: deduplicate resources in StatelessTracker by pointer identity

### DIFF
--- a/wgpu-core/src/track/stateless.rs
+++ b/wgpu-core/src/track/stateless.rs
@@ -1,28 +1,44 @@
 use alloc::{sync::Arc, vec::Vec};
 use core::slice::Iter;
 
-/// A tracker that holds strong references to resources.
+use crate::FastHashMap;
+
+/// A tracker that holds strong references to resources, deduplicated by pointer
+/// identity.
 ///
-/// This is only used to keep resources alive.
+/// Deduplication ensures each unique resource is stored and checked at most
+/// once at submit time, avoiding redundant liveness checks when the same
+/// resource is recorded multiple times in a command buffer.
 #[derive(Debug)]
 pub(crate) struct StatelessTracker<T> {
     resources: Vec<Arc<T>>,
+    ptr_to_index: FastHashMap<usize, usize>,
 }
 
 impl<T> StatelessTracker<T> {
     pub fn new() -> Self {
         Self {
             resources: Vec::new(),
+            ptr_to_index: FastHashMap::default(),
         }
     }
 
-    /// Inserts a single resource into the resource tracker.
+    /// Inserts a resource into the tracker.
     ///
-    /// Returns a reference to the newly inserted resource.
-    /// (This allows avoiding a clone/reference count increase in many cases.)
+    /// If an `Arc` pointing to the same allocation is already present, the
+    /// existing entry is reused. Returns a reference to the stored `Arc`.
     pub fn insert_single(&mut self, resource: Arc<T>) -> &Arc<T> {
-        self.resources.push(resource);
-        unsafe { self.resources.last().unwrap_unchecked() }
+        let ptr = Arc::as_ptr(&resource) as usize;
+        let index = match self.ptr_to_index.get(&ptr) {
+            Some(&index) => index,
+            None => {
+                let index = self.resources.len();
+                self.ptr_to_index.insert(ptr, index);
+                self.resources.push(resource);
+                index
+            }
+        };
+        &self.resources[index]
     }
 }
 


### PR DESCRIPTION
## Summary

`StatelessTracker<T>` accumulates `Arc<T>` references during command buffer recording and iterates them at submit time to verify liveness (via `try_raw`). Currently, if the same resource is set multiple times — e.g. the same bind group used across 1000 draw calls in a sprite batch — it is pushed into the `Vec` each time, resulting in 1000 identical liveness checks at submit.

This PR adds a `FastHashMap<usize, usize>` (pointer → vec index) to deduplicate by `Arc` pointer identity. Each unique allocation is stored and checked at most once per command buffer, regardless of how many times it was recorded.

## Change

`wgpu-core/src/track/stateless.rs`:

- Add `ptr_to_index: FastHashMap<usize, usize>` field
- `insert_single` checks the map before pushing; returns a reference to the existing entry if already present
- Removes the `unsafe { self.resources.last().unwrap_unchecked() }` (replaced by safe index lookup)
- Uses `crate::FastHashMap` (hashbrown + FxHasher, already a dependency via `hash_utils`)

```rust
pub fn insert_single(&mut self, resource: Arc<T>) -> &Arc<T> {
    let ptr = Arc::as_ptr(&resource) as usize;
    let index = match self.ptr_to_index.get(&ptr) {
        Some(&index) => index,
        None => {
            let index = self.resources.len();
            self.ptr_to_index.insert(ptr, index);
            self.resources.push(resource);
            index
        }
    };
    &self.resources[index]
}
```

## Correctness

- `Arc::as_ptr` returns a pointer to the `T` allocation. Two `Arc<T>` values cloned from the same source share one allocation, so they produce the same pointer — correctly identified as duplicates.
- Two independently allocated `Arc<T>` values will always have different pointers while both are alive — no false positives.
- The `ptr_to_index` map holds indices into `resources`, which only grows (never reorders), so stored indices remain valid for the lifetime of the tracker.
- The tracker is per-command-encoder and is dropped after submit, so there is no cross-frame pointer reuse concern.

## Impact

Workloads that rebind the same bind group (textures, uniforms) many times per frame — common in 2D renderers and sprite batching — will see reduced submit overhead proportional to the duplication ratio.