### PR TITLE
wgpu-core: implement 2-pass isolate() in RangedStates (O(n·k) → O(n+k))

### DIFF
--- a/wgpu-core/src/track/range.rs
+++ b/wgpu-core/src/track/range.rs
@@ -103,10 +103,9 @@ impl<I: Copy + Ord, T: Copy + PartialEq> RangedStates<I, T> {
         // doing this before any mutation lets us reserve exactly once and avoid
         // repeated O(n) shifts from incremental SmallVec::insert calls.
         let mut extra = 0usize;
-        let mut end_pos = start_pos;
         let mut has_prefix_split = false;
         let mut has_suffix_split = false;
-        {
+        let end_pos = {
             let mut scan_cursor = index.start;
             let mut i = start_pos;
             loop {
@@ -114,8 +113,7 @@ impl<I: Copy + Ord, T: Copy + PartialEq> RangedStates<I, T> {
                     if scan_cursor < index.end {
                         extra += 1;
                     }
-                    end_pos = i.min(self.ranges.len());
-                    break;
+                    break i.min(self.ranges.len());
                 }
                 let (ref range, _) = self.ranges[i];
                 if i == start_pos && range.start < index.start {
@@ -129,13 +127,12 @@ impl<I: Copy + Ord, T: Copy + PartialEq> RangedStates<I, T> {
                         extra += 1;
                         has_suffix_split = true;
                     }
-                    end_pos = i + 1;
-                    break;
+                    break i + 1;
                 }
                 scan_cursor = range.end;
                 i += 1;
             }
-        }
+        };
 
         if extra == 0 {
             return &mut self.ranges[start_pos..end_pos];
@@ -174,7 +171,6 @@ impl<I: Copy + Ord, T: Copy + PartialEq> RangedStates<I, T> {
             if effective_end < fill_cursor_end {
                 self.ranges[write_pos as usize] = (effective_end..fill_cursor_end, default);
                 write_pos -= 1;
-                fill_cursor_end = effective_end;
             }
 
             if has_prefix_split && read_index == start_pos {

--- a/wgpu-core/src/track/range.rs
+++ b/wgpu-core/src/track/range.rs
@@ -90,11 +90,7 @@ impl<I: Copy + Ord, T: Copy + PartialEq> RangedStates<I, T> {
     ///
     /// Gaps in the ranges are filled with `default` value.
     pub fn isolate(&mut self, index: &Range<I>, default: T) -> &mut [(Range<I>, T)] {
-        //TODO: implement this in 2 passes:
-        // 1. scan the ranges to figure out how many extra ones need to be inserted
-        // 2. go through the ranges by moving them them to the right and inserting the missing ones
-
-        let mut start_pos = match self.ranges.iter().position(|pair| pair.0.end > index.start) {
+        let start_pos = match self.ranges.iter().position(|pair| pair.0.end > index.start) {
             Some(pos) => pos,
             None => {
                 let pos = self.ranges.len();
@@ -103,47 +99,106 @@ impl<I: Copy + Ord, T: Copy + PartialEq> RangedStates<I, T> {
             }
         };
 
+        // pass 1: count how many extra slots are needed and find end_pos.
+        // doing this before any mutation lets us reserve exactly once and avoid
+        // repeated O(n) shifts from incremental SmallVec::insert calls.
+        let mut extra = 0usize;
+        let mut end_pos = start_pos;
+        let mut has_prefix_split = false;
+        let mut has_suffix_split = false;
         {
-            let (range, value) = self.ranges[start_pos].clone();
-            if range.start < index.start {
-                self.ranges[start_pos].0.start = index.start;
-                self.ranges
-                    .insert(start_pos, (range.start..index.start, value));
-                start_pos += 1;
-            }
-        }
-        let mut pos = start_pos;
-        let mut range_pos = index.start;
-        loop {
-            let (range, value) = self.ranges[pos].clone();
-            if range.start >= index.end {
-                self.ranges.insert(pos, (range_pos..index.end, default));
-                pos += 1;
-                break;
-            }
-            if range.start > range_pos {
-                self.ranges.insert(pos, (range_pos..range.start, default));
-                pos += 1;
-                range_pos = range.start;
-            }
-            if range.end >= index.end {
-                if range.end != index.end {
-                    self.ranges[pos].0.start = index.end;
-                    self.ranges.insert(pos, (range_pos..index.end, value));
+            let mut scan_cursor = index.start;
+            let mut i = start_pos;
+            loop {
+                if i >= self.ranges.len() || self.ranges[i].0.start >= index.end {
+                    if scan_cursor < index.end {
+                        extra += 1;
+                    }
+                    end_pos = i.min(self.ranges.len());
+                    break;
                 }
-                pos += 1;
-                break;
-            }
-            pos += 1;
-            range_pos = range.end;
-            if pos == self.ranges.len() {
-                self.ranges.push((range_pos..index.end, default));
-                pos += 1;
-                break;
+                let (ref range, _) = self.ranges[i];
+                if i == start_pos && range.start < index.start {
+                    extra += 1;
+                    has_prefix_split = true;
+                } else if range.start > scan_cursor {
+                    extra += 1;
+                }
+                if range.end >= index.end {
+                    if range.end > index.end {
+                        extra += 1;
+                        has_suffix_split = true;
+                    }
+                    end_pos = i + 1;
+                    break;
+                }
+                scan_cursor = range.end;
+                i += 1;
             }
         }
 
-        &mut self.ranges[start_pos..pos]
+        if extra == 0 {
+            return &mut self.ranges[start_pos..end_pos];
+        }
+
+        // pass 2: extend once, shift the tail right by `extra`, then fill the
+        // affected window backwards. write_pos always leads read_pos, so reads
+        // are never clobbered before use.
+        let original_length = self.ranges.len();
+        let filler = self.ranges[start_pos].clone();
+        for _ in 0..extra {
+            self.ranges.push(filler.clone());
+        }
+        for i in (end_pos..original_length).rev() {
+            let val = self.ranges[i].clone();
+            self.ranges[i + extra] = val;
+        }
+
+        let mut write_pos = (end_pos + extra) as isize - 1;
+        let mut fill_cursor_end = index.end;
+
+        let mut read_pos = end_pos as isize - 1;
+        while read_pos >= start_pos as isize {
+            let read_index = read_pos as usize;
+            let (range, value) = self.ranges[read_index].clone();
+            let range_start = range.start;
+            let range_end = range.end;
+
+            if has_suffix_split && read_index == end_pos - 1 {
+                self.ranges[write_pos as usize] = (index.end..range_end, value);
+                write_pos -= 1;
+                fill_cursor_end = index.end;
+            }
+
+            let effective_end = range_end.min(index.end);
+            if effective_end < fill_cursor_end {
+                self.ranges[write_pos as usize] = (effective_end..fill_cursor_end, default);
+                write_pos -= 1;
+                fill_cursor_end = effective_end;
+            }
+
+            if has_prefix_split && read_index == start_pos {
+                self.ranges[write_pos as usize] = (index.start..effective_end, value);
+                write_pos -= 1;
+                fill_cursor_end = index.start;
+                self.ranges[write_pos as usize] = (range_start..index.start, value);
+                write_pos -= 1;
+            } else {
+                self.ranges[write_pos as usize] = (range_start..effective_end, value);
+                write_pos -= 1;
+                fill_cursor_end = range_start;
+            }
+
+            read_pos -= 1;
+        }
+
+        if fill_cursor_end > index.start {
+            self.ranges[write_pos as usize] = (index.start..fill_cursor_end, default);
+        }
+
+        let out_start = start_pos + has_prefix_split as usize;
+        let out_end = end_pos + extra - has_suffix_split as usize;
+        &mut self.ranges[out_start..out_end]
     }
 
     /// Helper method for isolation that checks the sanity of the results.


### PR DESCRIPTION
## Summary

`RangedStates::isolate` has a documented TODO asking for a 2-pass implementation:

```rust
//TODO: implement this in 2 passes:
// 1. scan the ranges to figure out how many extra ones need to be inserted
// 2. go through the ranges by moving them to the right and inserting the missing ones
```

The current single-pass implementation calls `SmallVec::insert` incrementally as it discovers gaps and splits. Each `insert` is O(n) (it shifts the tail right). For k insertions into n elements, the total cost is O(n·k).

This PR implements the documented 2-pass approach:

**Pass 1** (read-only scan): traverse the affected window to count how many extra slots are needed (`extra`) and find `end_pos`. No mutation.

**Pass 2**: `push` exactly `extra` filler slots once (a single allocation), right-shift the tail in reverse (one pass, O(n)), then backward-fill the window. The backward fill reads at `read_pos` and writes at `write_pos`; since `write_pos` always leads `read_pos` by at least 1 (extra ≥ 1), no read is clobbered before use.

Total cost: O(n + k).

## Change

`wgpu-core/src/track/range.rs` — `RangedStates::isolate` only. No changes to public API, struct layout, or surrounding code.

### Key details

- `has_prefix_split` / `has_suffix_split` flags track whether the boundary range needs to be split, so the backward fill can handle it correctly in-place.
- `out_start` / `out_end` exclude the prefix and suffix pieces (outside `index`) from the returned slice.
- `Range<I>` does not implement `Copy` (it implements `Iterator`), so all moves use `.clone()`.
- The fast path (`extra == 0`, no insertions needed) returns immediately without any allocation.

## Testing

All 5 existing tests in `track::range::test` pass:
- `sane_good`, `sane_empty`, `sane_intersect` — sanity checks
- `coalesce` — exercises the neighbor-merge path
- `isolate` — exercises all four structural cases: exact match, prefix gap + suffix split, trailing extension, and interior gap with prefix split

```
test track::range::test::coalesce ... ok
test track::range::test::isolate ... ok
test track::range::test::sane_empty - should panic ... ok
test track::range::test::sane_good ... ok
test track::range::test::sane_intersect - should panic ... ok
```