### PR TITLE
wgpu_core::track::range::RangedStates: Remove stale TODO.

### DIFF
--- a/wgpu-core/src/track/range.rs
+++ b/wgpu-core/src/track/range.rs
@@ -90,10 +90,6 @@ impl<I: Copy + Ord, T: Copy + PartialEq> RangedStates<I, T> {
     ///
     /// Gaps in the ranges are filled with `default` value.
     pub fn isolate(&mut self, index: &Range<I>, default: T) -> &mut [(Range<I>, T)] {
-        //TODO: implement this in 2 passes:
-        // 1. scan the ranges to figure out how many extra ones need to be inserted
-        // 2. go through the ranges by moving them them to the right and inserting the missing ones
-
         let mut start_pos = match self.ranges.iter().position(|pair| pair.0.end > index.start) {
             Some(pos) => pos,
             None => {


### PR DESCRIPTION
Delete a stale TODO note which unfortunately led @5unekku to spend time on #9633, which I don't think we should merge.