### PR TITLE
Revert "Expect failures on dx12 due to #9627"

### DIFF
--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -451,12 +451,7 @@ static WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
-                .limits(Limits::downlevel_defaults())
-                .expect_fail(
-                    // https://github.com/gfx-rs/wgpu/issues/9627
-                    FailureCase::backend(wgpu::Backends::DX12)
-                        .panic("called `Option::unwrap()` on a `None` value"),
-                ),
+                .limits(Limits::downlevel_defaults()),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -476,12 +471,7 @@ static WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_NV12: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
-                .limits(Limits::downlevel_defaults())
-                .expect_fail(
-                    // https://github.com/gfx-rs/wgpu/issues/9627
-                    FailureCase::backend(wgpu::Backends::DX12)
-                        .panic("called `Option::unwrap()` on a `None` value"),
-                ),
+                .limits(Limits::downlevel_defaults()),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -501,12 +491,7 @@ static WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_P010: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_P010 | Features::TEXTURE_FORMAT_16BIT_NORM)
-                .limits(Limits::downlevel_defaults())
-                .expect_fail(
-                    // https://github.com/gfx-rs/wgpu/issues/9627
-                    FailureCase::backend(wgpu::Backends::DX12)
-                        .panic("called `Option::unwrap()` on a `None` value"),
-                ),
+                .limits(Limits::downlevel_defaults()),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -526,12 +511,7 @@ static WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_P010: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_P010 | Features::TEXTURE_FORMAT_16BIT_NORM)
-                .limits(Limits::downlevel_defaults())
-                .expect_fail(
-                    // https://github.com/gfx-rs/wgpu/issues/9627
-                    FailureCase::backend(wgpu::Backends::DX12)
-                        .panic("called `Option::unwrap()` on a `None` value"),
-                ),
+                .limits(Limits::downlevel_defaults()),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -574,12 +554,7 @@ static COPY_BUFFER_TO_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12: GpuTestConfigura
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
-                .limits(Limits::downlevel_defaults())
-                .expect_fail(
-                    // https://github.com/gfx-rs/wgpu/issues/9627
-                    FailureCase::backend(wgpu::Backends::DX12)
-                        .panic("called `Option::unwrap()` on a `None` value"),
-                ),
+                .limits(Limits::downlevel_defaults()),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(


### PR DESCRIPTION
This reverts commit 9f78f6f4dd0db6e2d5104e28ced588d3fec24416.
Closes https://github.com/gfx-rs/wgpu/issues/9627.
Fixes CI on trunk since the functionality was fixed by https://github.com/gfx-rs/wgpu/pull/9551 and I landed it and https://github.com/gfx-rs/wgpu/pull/9626 at the same time...