### PR TITLE
[metal] synchronize acceleration structure builds using fences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
 - Fixed structure field names incorrectly ignoring reserved keywords in the Metal (MSL) backend. By @39ali [#9379](https://github.com/gfx-rs/wgpu/pull/9379).
 - Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).
+- Fixed missing synchronization between acceleration structure builds, which could cause TLAS builds to consume BLASes that were still building, producing incorrect intersection results or GPU hangs. By @jtbirdsell in [#9645](https://github.com/gfx-rs/wgpu/pull/9645).
 
 ### Dependency Updates
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,6 +238,7 @@ objc2-metal = { version = "0.3.2", default-features = false, features = [
     "MTLDevice",
     "MTLDrawable",
     "MTLEvent",
+    "MTLFence",
     "MTLLibrary",
     "MTLPipeline",
     "MTLPixelFormat",

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -34,6 +34,9 @@ impl Default for super::CommandState {
         Self {
             blit: None,
             acceleration_structure_builder: None,
+            acceleration_structure_fence: None,
+            pending_acceleration_structure_fence_wait: false,
+            acceleration_structure_builder_has_builds: false,
             render: None,
             compute: None,
             raw_primitive_type: MTLPrimitiveType::Point,
@@ -273,6 +276,14 @@ impl super::CommandEncoder {
                 self.state.acceleration_structure_builder =
                     cmd_buf.accelerationStructureCommandEncoder().to_owned();
             });
+            if self.state.pending_acceleration_structure_fence_wait {
+                self.state.pending_acceleration_structure_fence_wait = false;
+                self.state
+                    .acceleration_structure_builder
+                    .as_ref()
+                    .unwrap()
+                    .waitForFence(self.state.acceleration_structure_fence.as_ref().unwrap());
+            }
         }
         self.state.acceleration_structure_builder.clone().unwrap()
     }
@@ -280,6 +291,27 @@ impl super::CommandEncoder {
     pub(super) fn leave_acceleration_structure_builder(&mut self) {
         if let Some(encoder) = self.state.acceleration_structure_builder.take() {
             encoder.endEncoding();
+            self.state.acceleration_structure_builder_has_builds = false;
+        }
+    }
+
+    /// Ends the current acceleration structure encoder, if any, after
+    /// updating [`super::CommandState::acceleration_structure_fence`], which
+    /// the next acceleration structure encoder then waits on (see
+    /// [`Self::enter_acceleration_structure_builder`]). Metal does not order
+    /// acceleration structure commands encoded on the same encoder, and
+    /// fences are only defined across encoder boundaries, so this is how
+    /// commands later in the command buffer are ordered after prior builds.
+    fn split_acceleration_structure_builder(&mut self) {
+        if let Some(encoder) = self.state.acceleration_structure_builder.take() {
+            let fence = self
+                .state
+                .acceleration_structure_fence
+                .get_or_insert_with(|| self.shared.device.newFence().unwrap());
+            encoder.updateFence(fence);
+            encoder.endEncoding();
+            self.state.pending_acceleration_structure_fence_wait = true;
+            self.state.acceleration_structure_builder_has_builds = false;
         }
     }
 
@@ -498,6 +530,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     unsafe fn discard_encoding(&mut self) {
         self.leave_blit();
         self.leave_acceleration_structure_builder();
+        self.state.pending_acceleration_structure_fence_wait = false;
         // when discarding, we don't have a guarantee that
         // everything is in a good state, so check carefully
         if let Some(encoder) = self.state.render.take() {
@@ -526,6 +559,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
         self.leave_blit();
         self.leave_acceleration_structure_builder();
+        self.state.pending_acceleration_structure_fence_wait = false;
         debug_assert!(self.state.render.is_none());
         debug_assert!(self.state.compute.is_none());
         debug_assert!(self.state.pending_timer_queries.is_empty());
@@ -1816,6 +1850,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         >,
     {
         let command_encoder = self.enter_acceleration_structure_builder();
+        self.state.acceleration_structure_builder_has_builds = true;
         for descriptor in descriptors {
             let acceleration_structure_descriptor =
                 conv::map_acceleration_structure_descriptor(descriptor.entries, descriptor.flags);
@@ -1844,8 +1879,16 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn place_acceleration_structure_barrier(
         &mut self,
-        _barriers: crate::AccelerationStructureBarrier,
+        _barrier: crate::AccelerationStructureBarrier,
     ) {
+        // wgpu-core emits an acceleration structure barrier at every point
+        // where ordering between acceleration structure commands is required,
+        // so rather than interpret the usage flags, split any open encoder
+        // unconditionally. An encoder is only open here if it encoded prior
+        // acceleration structure commands, so this never splits needlessly,
+        // and not relying on the flags keeps this correct if wgpu-core's
+        // barrier emission changes.
+        self.split_acceleration_structure_builder();
     }
 
     unsafe fn read_acceleration_structure_compact_size(
@@ -1853,6 +1896,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
         acceleration_structure: &super::AccelerationStructure,
         buffer: &super::Buffer,
     ) {
+        // wgpu-core encodes this with no barrier after the build of the
+        // acceleration structure being queried, so if the current encoder
+        // contains builds, split it; otherwise the size could be read from a
+        // still-building acceleration structure.
+        if self.state.acceleration_structure_builder_has_builds {
+            self.split_acceleration_structure_builder();
+        }
         let command_encoder = self.enter_acceleration_structure_builder();
         command_encoder.writeCompactedAccelerationStructureSize_toBuffer_offset(
             &acceleration_structure.raw,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -48,7 +48,7 @@ use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLArgumentBuffersTier,
     MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue,
     MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer, MTLCullMode,
-    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLIndexType,
+    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLFence, MTLIndexType,
     MTLLanguageVersion, MTLLibrary, MTLPrimitiveType, MTLReadWriteTextureTier,
     MTLRenderCommandEncoder, MTLRenderPipelineState, MTLRenderStages, MTLResource,
     MTLResourceUsage, MTLSamplerState, MTLSharedEvent, MTLSize, MTLTexture, MTLTextureType,
@@ -1084,6 +1084,20 @@ struct CommandState {
     blit: Option<Retained<ProtocolObject<dyn MTLBlitCommandEncoder>>>,
     acceleration_structure_builder:
         Option<Retained<ProtocolObject<dyn MTLAccelerationStructureCommandEncoder>>>,
+    /// Fence used to order acceleration structure encoders split by
+    /// `CommandEncoder::split_acceleration_structure_builder`. Created lazily
+    /// and kept alive for the lifetime of the encoder. Command buffers
+    /// created with unretained references do not retain this fence, so the
+    /// encoder (which owns it) must be kept alive until its submitted
+    /// command buffers have finished executing.
+    acceleration_structure_fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
+    /// Whether the next acceleration structure encoder must wait on
+    /// [`Self::acceleration_structure_fence`] before encoding any commands.
+    pending_acceleration_structure_fence_wait: bool,
+    /// Whether the current acceleration structure encoder has encoded any
+    /// builds, i.e. whether commands consuming their results must split the
+    /// encoder first.
+    acceleration_structure_builder_has_builds: bool,
     render: Option<Retained<ProtocolObject<dyn MTLRenderCommandEncoder>>>,
     compute: Option<Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>>,
     raw_primitive_type: MTLPrimitiveType,


### PR DESCRIPTION
**Connections**

Fixes #9215. Related to #9100 (results below). This is option 1 from the discussion in #9215.

**Description**

On Metal, `place_acceleration_structure_barrier` was an empty no-op, and Metal does not order acceleration structure commands encoded on the same `MTLAccelerationStructureCommandEncoder`. A TLAS build could end up consuming a BLAS that was still building, which shows up as garbage intersections in the repro and would be a hang in bigger workloads.

Apple's docs rule out fixing this within one encoder ("Don't update a fence and then wait for the same fence within a pass because it can create a GPU deadlock"), so the fix splits the encoder at sync points instead:

- `place_acceleration_structure_barrier` ends any open AS encoder after encoding `updateFence:`, and the next AS encoder starts with `waitForFence:`. It splits unconditionally rather than interpreting the barrier's usage flags. wgpu-core only emits AS barriers where ordering is required, and an encoder is only open when prior AS commands exist, so this never splits needlessly, and it stays correct if core's barrier emission changes later.
- `read_acceleration_structure_compact_size` splits first if the open encoder contains builds. wgpu-core encodes the size query with no barrier after the build of the structure being queried, so without this the compacted size can be read from a still-building BLAS.
- One `MTLFence` is created lazily and reused for the encoder's lifetime, wait first then update within each pass, which is the reuse pattern Apple documents. Creating a fence per split would be a use after free hazard with `commandBufferWithUnretainedReferences`, which doesn't retain the fence past encoding.
- The pending wait flag is cleared at `end_encoding`/`discard_encoding`, so a wait can never land in a different command buffer than its update. That could deadlock if buffers are submitted out of order.

Both fence methods go back to macOS 11 / iOS 14, the same availability as acceleration structures themselves, so Intel Macs are fine (unlike the Metal 26 `barrier(afterQueueStages:beforeStages:)` alternative).

**Testing**

On an M3 MacBook Pro (10 core GPU, hardware RT):

- https://github.com/Vecvec/macos-ray-tracing-test pointed at this branch: 20/20 runs failed before this change, 0/100 after. On this hardware the race isn't even intermittent, and only the cases that build BLAS and TLAS in the same submission fail.
- `cargo xtask test`: same results before and after (945 passed; the 4 failures are naga SPV snapshots and Metal shader passthrough, pre-existing on trunk on my machine and unrelated). The ray_tracing group passes 42/42 including the `blas_compaction` tests, which exercise the compact size path.
- `cargo xtask cts --backend metal`: no regressions. One pre-existing `maxStorageBufferBindingSize:validate` failure, also present on unpatched trunk.
- Re #9100: the ray tracing example tests all pass on this M3 both with and without this change at current trunk, so I couldn't reproduce that one. Noted on the issue.

**Squash or Rebase?**

Squash.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
