### PR TITLE
Fixed partially-bound texture and storage-texture binding arrays (PAR…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,7 +241,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Fixed stencil values read with `textureLoad` appearing in G instead of R. By @andyleiserson in [#9520](https://github.com/gfx-rs/wgpu/pull/9520).
 - Fixed some cases where the `textureNum{Layers,Levels,Samples}` functions returned incorrect results. By @andyleiserson in [#9542](https://github.com/gfx-rs/wgpu/pull/9542).
 - Fixed `map_texture_format_for_copy` panicking on `(planar_format, single_plane_aspect)` during buffer<->texture transfers, and `TextureView::subresource_index` previously being hard-coded to plane 0. By @AdrianEddy in [#9551](https://github.com/gfx-rs/wgpu/pull/9551).
-- Fixed partially-bound texture and storage-texture binding arrays (`PARTIALLY_BOUND_BINDING_ARRAY`) reading garbage in `create_bind_group`. By @holg in [#NNNN](https://github.com/gfx-rs/wgpu/pull/NNNN).
+- Fixed partially-bound texture and storage-texture binding arrays (`PARTIALLY_BOUND_BINDING_ARRAY`) reading garbage in `create_bind_group`. By @holg in [#9653](https://github.com/gfx-rs/wgpu/pull/9653).
 
 #### Metal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Fixed stencil values read with `textureLoad` appearing in G instead of R. By @andyleiserson in [#9520](https://github.com/gfx-rs/wgpu/pull/9520).
 - Fixed some cases where the `textureNum{Layers,Levels,Samples}` functions returned incorrect results. By @andyleiserson in [#9542](https://github.com/gfx-rs/wgpu/pull/9542).
 - Fixed `map_texture_format_for_copy` panicking on `(planar_format, single_plane_aspect)` during buffer<->texture transfers, and `TextureView::subresource_index` previously being hard-coded to plane 0. By @AdrianEddy in [#9551](https://github.com/gfx-rs/wgpu/pull/9551).
+- Fixed partially-bound texture and storage-texture binding arrays (`PARTIALLY_BOUND_BINDING_ARRAY`) reading garbage in `create_bind_group`. By @holg in [#NNNN](https://github.com/gfx-rs/wgpu/pull/NNNN).
 
 #### Metal
 

--- a/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
@@ -10,7 +10,7 @@ pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
     tests.extend([
         BINDING_ARRAY_SAMPLED_TEXTURES,
         PARTIAL_BINDING_ARRAY_SAMPLED_TEXTURES,
-        PARTIAL_BINDING_ARRAY_FOLLOWED_BY_UNIFORM,
+        PARTIAL_BINDING_ARRAY_FOLLOWED_BY_STORAGE_BUFFER,
     ]);
 }
 
@@ -260,7 +260,7 @@ async fn binding_array_sampled_textures(ctx: TestingContext, partially_bound: bo
 }
 
 #[gpu_test]
-static PARTIAL_BINDING_ARRAY_FOLLOWED_BY_UNIFORM: GpuTestConfiguration =
+static PARTIAL_BINDING_ARRAY_FOLLOWED_BY_STORAGE_BUFFER: GpuTestConfiguration =
     GpuTestConfiguration::new()
         .parameters(
             TestParameters::default()
@@ -275,17 +275,19 @@ static PARTIAL_BINDING_ARRAY_FOLLOWED_BY_UNIFORM: GpuTestConfiguration =
                     ..Limits::default()
                 }),
         )
-        .run_async(|ctx| async move { partial_binding_array_followed_by_uniform(ctx).await });
+        .run_async(
+            |ctx| async move { partial_binding_array_followed_by_storage_buffer(ctx).await },
+        );
 
 /// Regression test for a DX12 descriptor-table bug. A *partially-bound* binding
-/// array (binding 0) is followed by another binding (binding 1, a uniform) in the
-/// same bind group. On DX12 the root-signature range reserves the array's full
-/// declared size and naga assigns binding 1's shader register *after* the whole
-/// array, but the backend used to stage only the bound array views — shifting
-/// binding 1's descriptor so the uniform was read from the wrong heap slot
-/// (garbage). The shader output here depends only on the trailing uniform, so a
+/// array (binding 0) is followed by another binding (binding 1, a storage buffer)
+/// in the same bind group. On DX12 the root-signature range reserves the array's
+/// full declared size and naga assigns binding 1's shader register *after* the
+/// whole array, but the backend used to stage only the bound array views —
+/// shifting binding 1's descriptor so the buffer was read from the wrong heap slot
+/// (garbage). The shader output here depends only on the trailing buffer, so a
 /// misaligned descriptor makes the readback differ from the marker color.
-async fn partial_binding_array_followed_by_uniform(ctx: TestingContext) {
+async fn partial_binding_array_followed_by_storage_buffer(ctx: TestingContext) {
     let shader = r#"
         enable wgpu_binding_array;
         @group(0) @binding(0)
@@ -306,7 +308,7 @@ async fn partial_binding_array_followed_by_uniform(ctx: TestingContext) {
         @fragment
         fn fragMain(@builtin(position) pos: vec4f) -> @location(0) vec4f {
             // Keep the binding array live (so it stays in the layout before the
-            // uniform), but make the output depend only on the trailing uniform.
+            // buffer), but make the output depend only on the trailing buffer.
             let keep = textureLoad(textures[0], vec2u(0), 0).x * 0.0;
             return marker + vec4f(keep);
         }
@@ -315,7 +317,7 @@ async fn partial_binding_array_followed_by_uniform(ctx: TestingContext) {
     let module = ctx
         .device
         .create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Partial Array + Uniform"),
+            label: Some("Partial Array + Storage Buffer"),
             source: wgpu::ShaderSource::Wgsl(shader.into()),
         });
 
@@ -336,7 +338,7 @@ async fn partial_binding_array_followed_by_uniform(ctx: TestingContext) {
     });
     let input_view = input_texture.create_view(&TextureViewDescriptor::default());
 
-    // The uniform the shader must echo. [0, 1, 0, 1] -> Rgba8Unorm [0, 255, 0, 255].
+    // The marker the shader must echo. [0, 1, 0, 1] -> Rgba8Unorm [0, 255, 0, 255].
     let marker = [0.0f32, 1.0, 0.0, 1.0];
     let marker_bytes: Vec<u8> = marker.iter().flat_map(|f| f.to_le_bytes()).collect();
     let marker_buffer = ctx.device.create_buffer(&BufferDescriptor {
@@ -363,35 +365,35 @@ async fn partial_binding_array_followed_by_uniform(ctx: TestingContext) {
     });
     let output_view = output_texture.create_view(&TextureViewDescriptor::default());
 
-    let bind_group_layout =
-        ctx.device
-            .create_bind_group_layout(&BindGroupLayoutDescriptor {
-                label: Some("Bind Group Layout"),
-                entries: &[
-                    BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: ShaderStages::FRAGMENT,
-                        ty: BindingType::Texture {
-                            sample_type: TextureSampleType::Float { filterable: false },
-                            view_dimension: TextureViewDimension::D2,
-                            multisampled: false,
-                        },
-                        count: Some(NonZeroU32::new(32).unwrap()),
+    let bind_group_layout = ctx
+        .device
+        .create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("Bind Group Layout"),
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Texture {
+                        sample_type: TextureSampleType::Float { filterable: false },
+                        view_dimension: TextureViewDimension::D2,
+                        multisampled: false,
                     },
-                    BindGroupLayoutEntry {
-                        binding: 1,
-                        visibility: ShaderStages::FRAGMENT,
-                        ty: BindingType::Buffer {
-                            ty: BufferBindingType::Storage { read_only: true },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
-                        },
-                        count: None,
+                    count: Some(NonZeroU32::new(32).unwrap()),
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
                     },
-                ],
-            });
+                    count: None,
+                },
+            ],
+        });
 
-    // Bind only 1 view into the 32-slot array (partial), plus the uniform after it.
+    // Bind only 1 view into the 32-slot array (partial), plus the buffer after it.
     let views = [&input_view];
     let bind_group = ctx.device.create_bind_group(&BindGroupDescriptor {
         label: Some("Bind Group"),
@@ -473,8 +475,8 @@ async fn partial_binding_array_followed_by_uniform(ctx: TestingContext) {
     readback_buffers.copy_from(&ctx.device, &mut encoder, &output_texture);
     ctx.queue.submit(Some(encoder.finish()));
 
-    // The output must equal the uniform marker. Before the fix, the uniform's
-    // descriptor was misaligned on DX12 and this read garbage.
+    // The output must equal the marker. Before the fix, the buffer's descriptor
+    // was misaligned on DX12 and this read garbage.
     let expected: [u8; 4] = [0, 255, 0, 255];
     readback_buffers
         .assert_buffer_contents(&ctx, &expected)

--- a/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
@@ -10,6 +10,7 @@ pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
     tests.extend([
         BINDING_ARRAY_SAMPLED_TEXTURES,
         PARTIAL_BINDING_ARRAY_SAMPLED_TEXTURES,
+        PARTIAL_BINDING_ARRAY_FOLLOWED_BY_UNIFORM,
     ]);
 }
 
@@ -256,4 +257,226 @@ async fn binding_array_sampled_textures(ctx: TestingContext, partially_bound: bo
     ctx.queue.submit(Some(encoder.finish()));
 
     readback_buffers.assert_buffer_contents(&ctx, &image).await;
+}
+
+#[gpu_test]
+static PARTIAL_BINDING_ARRAY_FOLLOWED_BY_UNIFORM: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
+                .features(
+                    Features::TEXTURE_BINDING_ARRAY
+                        | Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
+                        | Features::PARTIALLY_BOUND_BINDING_ARRAY,
+                )
+                .limits(Limits {
+                    max_binding_array_elements_per_shader_stage: 32,
+                    ..Limits::default()
+                }),
+        )
+        .run_async(|ctx| async move { partial_binding_array_followed_by_uniform(ctx).await });
+
+/// Regression test for a DX12 descriptor-table bug. A *partially-bound* binding
+/// array (binding 0) is followed by another binding (binding 1, a uniform) in the
+/// same bind group. On DX12 the root-signature range reserves the array's full
+/// declared size and naga assigns binding 1's shader register *after* the whole
+/// array, but the backend used to stage only the bound array views — shifting
+/// binding 1's descriptor so the uniform was read from the wrong heap slot
+/// (garbage). The shader output here depends only on the trailing uniform, so a
+/// misaligned descriptor makes the readback differ from the marker color.
+async fn partial_binding_array_followed_by_uniform(ctx: TestingContext) {
+    let shader = r#"
+        enable wgpu_binding_array;
+        @group(0) @binding(0)
+        var textures: binding_array<texture_2d<f32>>;
+        @group(0) @binding(1)
+        var<storage, read> marker: vec4<f32>;
+
+        @vertex
+        fn vertMain(@builtin(vertex_index) id: u32) -> @builtin(position) vec4f {
+            var positions = array<vec2f, 3>(
+                vec2f(-1.0, -1.0),
+                vec2f(3.0, -1.0),
+                vec2f(-1.0, 3.0)
+            );
+            return vec4f(positions[id], 0.0, 1.0);
+        }
+
+        @fragment
+        fn fragMain(@builtin(position) pos: vec4f) -> @location(0) vec4f {
+            // Keep the binding array live (so it stays in the layout before the
+            // uniform), but make the output depend only on the trailing uniform.
+            let keep = textureLoad(textures[0], vec2u(0), 0).x * 0.0;
+            return marker + vec4f(keep);
+        }
+    "#;
+
+    let module = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Partial Array + Uniform"),
+            source: wgpu::ShaderSource::Wgsl(shader.into()),
+        });
+
+    // A single input texture for the partially-bound array (1 of 32 slots).
+    let input_texture = ctx.device.create_texture(&TextureDescriptor {
+        label: None,
+        size: Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: TextureDimension::D2,
+        format: TextureFormat::Rgba8Unorm,
+        usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+    let input_view = input_texture.create_view(&TextureViewDescriptor::default());
+
+    // The uniform the shader must echo. [0, 1, 0, 1] -> Rgba8Unorm [0, 255, 0, 255].
+    let marker = [0.0f32, 1.0, 0.0, 1.0];
+    let marker_bytes: Vec<u8> = marker.iter().flat_map(|f| f.to_le_bytes()).collect();
+    let marker_buffer = ctx.device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: marker_bytes.len() as u64,
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    ctx.queue.write_buffer(&marker_buffer, 0, &marker_bytes);
+
+    let output_texture = ctx.device.create_texture(&TextureDescriptor {
+        label: Some("Output Texture"),
+        size: Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: TextureDimension::D2,
+        format: TextureFormat::Rgba8Unorm,
+        usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let output_view = output_texture.create_view(&TextureViewDescriptor::default());
+
+    let bind_group_layout =
+        ctx.device
+            .create_bind_group_layout(&BindGroupLayoutDescriptor {
+                label: Some("Bind Group Layout"),
+                entries: &[
+                    BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: ShaderStages::FRAGMENT,
+                        ty: BindingType::Texture {
+                            sample_type: TextureSampleType::Float { filterable: false },
+                            view_dimension: TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: Some(NonZeroU32::new(32).unwrap()),
+                    },
+                    BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: ShaderStages::FRAGMENT,
+                        ty: BindingType::Buffer {
+                            ty: BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                ],
+            });
+
+    // Bind only 1 view into the 32-slot array (partial), plus the uniform after it.
+    let views = [&input_view];
+    let bind_group = ctx.device.create_bind_group(&BindGroupDescriptor {
+        label: Some("Bind Group"),
+        layout: &bind_group_layout,
+        entries: &[
+            BindGroupEntry {
+                binding: 0,
+                resource: BindingResource::TextureViewArray(&views),
+            },
+            BindGroupEntry {
+                binding: 1,
+                resource: marker_buffer.as_entire_binding(),
+            },
+        ],
+    });
+
+    let pipeline_layout = ctx
+        .device
+        .create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("Pipeline Layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+    let pipeline = ctx
+        .device
+        .create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some("Render Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: VertexState {
+                module: &module,
+                entry_point: Some("vertMain"),
+                buffers: &[],
+                compilation_options: PipelineCompilationOptions::default(),
+            },
+            fragment: Some(FragmentState {
+                module: &module,
+                entry_point: Some("fragMain"),
+                targets: &[Some(ColorTargetState {
+                    format: TextureFormat::Rgba8Unorm,
+                    blend: None,
+                    write_mask: ColorWrites::ALL,
+                })],
+                compilation_options: PipelineCompilationOptions::default(),
+            }),
+            primitive: PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+            cache: None,
+            multiview_mask: None,
+        });
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&CommandEncoderDescriptor { label: None });
+    {
+        let mut render_pass = encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some("Render Pass"),
+            color_attachments: &[Some(RenderPassColorAttachment {
+                view: &output_view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: Operations {
+                    load: LoadOp::Clear(Color::RED),
+                    store: StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        render_pass.set_pipeline(&pipeline);
+        render_pass.set_bind_group(0, &bind_group, &[]);
+        render_pass.draw(0..3, 0..1);
+    }
+
+    let readback_buffers = ReadbackBuffers::new(&ctx.device, &output_texture);
+    readback_buffers.copy_from(&ctx.device, &mut encoder, &output_texture);
+    ctx.queue.submit(Some(encoder.finish()));
+
+    // The output must equal the uniform marker. Before the fix, the uniform's
+    // descriptor was misaligned on DX12 and this read garbage.
+    let expected: [u8; 4] = [0, 255, 0, 255];
+    readback_buffers
+        .assert_buffer_contents(&ctx, &expected)
+        .await;
 }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1687,12 +1687,8 @@ impl crate::Device for super::Device {
                             },
                         };
                         unsafe {
-                            self.raw.CreateUnorderedAccessView(
-                                None,
-                                None,
-                                Some(&raw_desc),
-                                handle,
-                            )
+                            self.raw
+                                .CreateUnorderedAccessView(None, None, Some(&raw_desc), handle)
                         };
                         inner.stage.push(handle);
                     }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1634,6 +1634,33 @@ impl crate::Device for super::Device {
                         let handle = data.view.handle_srv.unwrap();
                         cpu_views.as_mut().unwrap().stage.push(handle.raw);
                     }
+                    // The table range reserves the full `layout.count`, so pad a
+                    // partially-bound array with null SRVs to keep later bindings aligned.
+                    let array_size = layout.count.map_or(1, NonZeroU32::get);
+                    for _ in entry.count..array_size {
+                        let inner = cpu_views.as_mut().unwrap();
+                        let cpu_index = inner.stage.len() as u32;
+                        let handle = desc.layout.cpu_heap_views.as_ref().unwrap().at(cpu_index);
+                        let raw_desc = Direct3D12::D3D12_SHADER_RESOURCE_VIEW_DESC {
+                            Format: Dxgi::Common::DXGI_FORMAT_R8G8B8A8_UNORM,
+                            ViewDimension: Direct3D12::D3D12_SRV_DIMENSION_TEXTURE2D,
+                            Shader4ComponentMapping:
+                                Direct3D12::D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
+                            Anonymous: Direct3D12::D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
+                                Texture2D: Direct3D12::D3D12_TEX2D_SRV {
+                                    MostDetailedMip: 0,
+                                    MipLevels: 1,
+                                    PlaneSlice: 0,
+                                    ResourceMinLODClamp: 0.0,
+                                },
+                            },
+                        };
+                        unsafe {
+                            self.raw
+                                .CreateShaderResourceView(None, Some(&raw_desc), handle)
+                        };
+                        inner.stage.push(handle);
+                    }
                 }
                 wgt::BindingType::StorageTexture { .. } => {
                     let start = entry.resource_index as usize;
@@ -1641,6 +1668,33 @@ impl crate::Device for super::Device {
                     for data in &desc.textures[start..end] {
                         let handle = data.view.handle_uav.unwrap();
                         cpu_views.as_mut().unwrap().stage.push(handle.raw);
+                    }
+                    // Same partial-binding-array padding as the `Texture` branch above, but
+                    // with null UAVs so that bindings following the array keep their offsets.
+                    let array_size = layout.count.map_or(1, NonZeroU32::get);
+                    for _ in entry.count..array_size {
+                        let inner = cpu_views.as_mut().unwrap();
+                        let cpu_index = inner.stage.len() as u32;
+                        let handle = desc.layout.cpu_heap_views.as_ref().unwrap().at(cpu_index);
+                        let raw_desc = Direct3D12::D3D12_UNORDERED_ACCESS_VIEW_DESC {
+                            Format: Dxgi::Common::DXGI_FORMAT_R8G8B8A8_UNORM,
+                            ViewDimension: Direct3D12::D3D12_UAV_DIMENSION_TEXTURE2D,
+                            Anonymous: Direct3D12::D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
+                                Texture2D: Direct3D12::D3D12_TEX2D_UAV {
+                                    MipSlice: 0,
+                                    PlaneSlice: 0,
+                                },
+                            },
+                        };
+                        unsafe {
+                            self.raw.CreateUnorderedAccessView(
+                                None,
+                                None,
+                                Some(&raw_desc),
+                                handle,
+                            )
+                        };
+                        inner.stage.push(handle);
                     }
                 }
                 wgt::BindingType::Sampler { .. } => {


### PR DESCRIPTION
Fixed partially-bound texture and storage-texture binding arrays (`PARTIALLY_BOUND_BINDING_ARRAY`) reading garbage in `create_bind_group`.

**Connections**
Related to #3637 (bindless tracking)

_When one pull request builds on another, please put "Depends on
#NNNN" towards the top of its description. This helps maintainers
notice that they shouldn't merge it until its ancestor has been
approved. Don't use draft PR status to indicate this._

**Description**
Fixed partially-bound texture and storage-texture binding arrays (`PARTIALLY_BOUND_BINDING_ARRAY`) reading garbage in `create_bind_group`
**Testing**
Added test case in tests/tests/wgpu-gpu/binding_array/sampled_textures.rs

**Squash or Rebase?**

_If your pull request contains multiple commits, please indicate whether
they need to be squashed into a single commit before they're merged,
or if they're ready to rebase onto `trunk` as they stand. In the
latter case, please ensure that each commit passes all CI tests, so
that we can continue to bisect along `trunk` to isolate bugs._

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
