### PR TITLE
Add large stack frames lint

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -8,3 +8,10 @@ disallowed-types = [
 # The default large-error-threshold is 128. We have a bunch of complex error
 # types that are slightly larger than that.
 large-error-threshold = 192
+
+# This relatively small stack frame limit is set to avoid problems in several deeply
+# recursive functions in naga. If your function has a genuine need for a larger stack frame,
+# and is not at risk of deep recursion based on shader structure, it is okay to waive the
+# associated `clippy::large_stack_frames` lint.
+# TODO(https://github.com/gfx-rs/wgpu/issues/9456): Consider reducing this further
+stack-size-threshold = 40_960

--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -2405,6 +2405,7 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// # Notes
     /// Doesn't add any newlines or leading/trailing spaces
+    #[allow(clippy::large_stack_frames)] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
     fn write_expr(
         &mut self,
         expr: Handle<crate::Expression>,

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -33,9 +33,6 @@ use crate::{
     valid, FastHashMap, FastHashSet,
 };
 
-#[cfg(test)]
-use core::ptr;
-
 // This is a hack: we need to pass a pointer to an atomic,
 // but generally the backend isn't putting "&" in front of every pointer.
 // Some more general handling of pointers is needed to be implemented here.
@@ -533,10 +530,6 @@ pub struct Writer<W> {
     pub(super) namer: proc::Namer,
     pub(super) wrapped_functions: FastHashSet<WrappedFunction>,
     emit_int_div_checks: bool,
-    #[cfg(test)]
-    put_expression_stack_pointers: FastHashSet<*const ()>,
-    #[cfg(test)]
-    put_block_stack_pointers: FastHashSet<*const ()>,
     /// Set of (struct type, struct field index) denoting which fields require
     /// padding inserted **before** them (i.e. between fields at index - 1 and index)
     struct_member_pads: FastHashSet<(Handle<crate::Type>, u32)>,
@@ -896,10 +889,6 @@ impl<W: Write> Writer<W> {
             namer: proc::Namer::default(),
             wrapped_functions: FastHashSet::default(),
             emit_int_div_checks: true,
-            #[cfg(test)]
-            put_expression_stack_pointers: Default::default(),
-            #[cfg(test)]
-            put_block_stack_pointers: Default::default(),
             struct_member_pads: FastHashSet::default(),
             needs_object_memory_barriers: false,
         }
@@ -1984,11 +1973,6 @@ impl<W: Write> Writer<W> {
         context: &ExpressionContext,
         is_scoped: bool,
     ) -> BackendResult {
-        // Add to the set in order to track the stack size.
-        #[cfg(test)]
-        self.put_expression_stack_pointers
-            .insert(ptr::from_ref(&expr_handle).cast());
-
         if let Some(name) = self.named_expressions.get(&expr_handle) {
             write!(self.out, "{name}")?;
             return Ok(());
@@ -3747,11 +3731,6 @@ impl<W: Write> Writer<W> {
         statements: &[crate::Statement],
         context: &StatementContext,
     ) -> BackendResult {
-        // Add to the set in order to track the stack size.
-        #[cfg(test)]
-        self.put_block_stack_pointers
-            .insert(ptr::from_ref(&level).cast());
-
         for statement in statements {
             log::trace!("statement[{}] {:?}", level.0, statement);
             match *statement {

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -540,6 +540,7 @@ impl<'a> Context<'a> {
     }
 
     /// Internal implementation of [`lower`](Self::lower)
+    #[allow(clippy::large_stack_frames)] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
     fn lower_inner(
         &mut self,
         stmt: &StmtContext,

--- a/naga/src/front/spv/next_block.rs
+++ b/naga/src/front/spv/next_block.rs
@@ -18,6 +18,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
     /// Except for the function's entry block, `block_id` should be the label of
     /// a block we've seen mentioned before, with an entry in
     /// `block_ctx.body_for_label` to tell us which `Body` it contributes to.
+    #[allow(clippy::large_stack_frames)] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
     pub(in crate::front::spv) fn next_block(
         &mut self,
         block_id: spirv::Word,

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -525,6 +525,9 @@ pub(crate) struct ConcretizationFailedError {
 impl<'a> Error<'a> {
     #[cold]
     #[inline(never)]
+    // This function is not recursive, so it can exceed our conservatively-set
+    // `stack-frame-limit` without causing problems.
+    #[allow(clippy::large_stack_frames)]
     pub(crate) fn as_parse_error(&self, source: &'a str) -> ParseError {
         match *self {
             Error::Unexpected(unexpected_span, expected) => {

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -82,10 +82,11 @@ void main() {
     trivial_numeric_casts,
     unused_extern_crates,
     unused_qualifications,
+    clippy::large_stack_frames,
     clippy::match_wildcard_for_single_variants,
     clippy::missing_const_for_fn,
     clippy::pattern_type_mismatch,
-    clippy::rest_pat_in_fully_bound_structs,
+    clippy::rest_pat_in_fully_bound_structs
 )]
 #![deny(clippy::exit)]
 #![cfg_attr(

--- a/naga/src/lib.rs
+++ b/naga/src/lib.rs
@@ -82,10 +82,10 @@ void main() {
     trivial_numeric_casts,
     unused_extern_crates,
     unused_qualifications,
-    clippy::pattern_type_mismatch,
+    clippy::match_wildcard_for_single_variants,
     clippy::missing_const_for_fn,
+    clippy::pattern_type_mismatch,
     clippy::rest_pat_in_fully_bound_structs,
-    clippy::match_wildcard_for_single_variants
 )]
 #![deny(clippy::exit)]
 #![cfg_attr(

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -779,6 +779,7 @@ impl super::Validator {
         Ok(())
     }
 
+    #[allow(clippy::large_stack_frames)] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
     fn validate_block_impl(
         &mut self,
         statements: &crate::Block,


### PR DESCRIPTION
**Connections**
Related to #9456 
<del>On top of #9648 (may want to exclude first commit when reviewing)</del> (JB: #9648 merged)

**Description**

* Removes some stale code in the msl backend left over from the stack size test that was removed in #7739.
* Configures clippy `stack-size-limit = 40_960`.
* Enables the `large_stack_frames` lint in naga.
* Waives a few warnings (one that seems genuinely okay, and several others that do not)

**Testing**
Clippy

**Squash or Rebase?** Rebase <del>, after #9648 is merged</del> (JB: #9648 merged)
