### PR TITLE
metal: detect BC texture support on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 #### Metal
 
+- Detect BC texture support on newer iOS, tvOS, and visionOS devices. By @bmisiak in [#9656](https://github.com/gfx-rs/wgpu/pull/9656).
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
 - Improved command buffer completion handling. By @39ali in [#9328](https://github.com/gfx-rs/wgpu/pull/9328).
   - Wait using a condition variable, instead of polling.

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -745,7 +745,10 @@ impl super::CapabilitiesQuery {
                 1
             },
             format_b5: os_type != super::OsType::Macos,
-            format_bc: os_type == super::OsType::Macos,
+            format_bc: os_type == super::OsType::Macos
+                || (available!(macos = 11.0, ios = 16.4, tvos = 16.4, visionos = 1.0)
+                    && device_class_responds_to(device, sel!(supportsBCTextureCompression))
+                    && device.supportsBCTextureCompression()),
             format_eac_etc: os_type != super::OsType::Macos
                 // M1 in macOS supports EAC/ETC2
                 || (family_check && device.supportsFamily(MTLGPUFamily::Apple7)),


### PR DESCRIPTION
**Description**
`wgpu` is conservative and only allowes BC textures on macOS. On iOS, it panics:
```thread 'Compute Task Pool (0)' (1766837) panicked at /Users/bm/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-27.0.1/src/backend/wgpu_core.rs:1588:26:
wgpu error: Validation Error

Caused by:
  In Device::create_texture
    Texture format Bc1RgbaUnormSrgb can't be used due to missing features
      Features Features { features_wgpu: FeaturesWGPU(0x0), features_webgpu: FeaturesWebGPU(TEXTURE_COMPRESSION_BC) } are required but not enabled on the device
```

Apple Silicon, starting with the "Apple9" family (A17 Pro/A18 and up), actually does support BC textures on all platforms, whereas older ones only supported them on macOS. 

Their [docs](https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf) say:
> Some GPU devices in the Apple7 and Apple8 families support BC texture compression in iPadOS. You can check an individual GPU’s support for this feature by inspecting its [MTLDevice.supportsBCTextureCompression](https://developer.apple.com/documentation/metal/mtldevice/supportsbctexturecompression) property at runtime. **As of Apple9 all GPUs have support.**

The API is present on iOS >=16.4. I simply added the check gated on this version and it seems to be working well.

**Testing**
I manually tested this fork by running my Bevy app with BC textures on an iPhone 15 Pro Max (A17 Pro, Apple9), but I don't have a minimal repro. Let me know if you need more testing!

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.


<img width="672" height="907" alt="image" src="https://github.com/user-attachments/assets/01ef0724-3bc0-485c-83e8-572b39fd76a1" />