### PR TITLE
Improve error message for transient attachment without `RENDER_ATTACHMENT`

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1505,7 +1505,8 @@ impl Device {
 
         if desc.usage.contains(wgt::TextureUsages::TRANSIENT) {
             if !desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
-                return Err(CreateTextureError::InvalidUsage(
+                return Err(CreateTextureError::MissingRequiredUsage(
+                    wgt::TextureUsages::RENDER_ATTACHMENT,
                     wgt::TextureUsages::TRANSIENT,
                 ));
             }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1689,6 +1689,8 @@ pub enum CreateTextureError {
     CreateTextureView(#[from] CreateTextureViewError),
     #[error("Invalid usage flags {0:?}")]
     InvalidUsage(wgt::TextureUsages),
+    #[error("Missing texture usage {0:?}, which is required by texture usage {1:?}")]
+    MissingRequiredUsage(wgt::TextureUsages, wgt::TextureUsages),
     #[error("Texture usage {0:?} is not compatible with texture usage {1:?}")]
     IncompatibleUsage(wgt::TextureUsages, wgt::TextureUsages),
     #[error(transparent)]
@@ -1746,6 +1748,7 @@ impl WebGpuError for CreateTextureError {
             Self::MissingDownlevelFlags(e) => e.webgpu_error_type(),
 
             Self::InvalidUsage(_)
+            | Self::MissingRequiredUsage(_, _)
             | Self::IncompatibleUsage(_, _)
             | Self::InvalidDepthDimension(_, _)
             | Self::InvalidCompressedDimension(_, _)


### PR DESCRIPTION
**Connections**
Closes #9655

**Description**
Improves the error message for when you try to create a texture with `TextureUsages::TRANSIENT` but no `TextureUsages::RENDER_ATTACHMENT`. It introduces a new enum variant `CreateTextureError::MissingRequiredUsage(A, B)`, which signals that usage A is disabled, but must be enabled as it is required by usage B.

The new error message now reads: `Missing texture usage TextureUsages(RENDER_ATTACHMENT), which is required by texture usage TextureUsages(TRANSIENT)`

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
