### PR TITLE
Implement query set initialization tracking 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Extend `copy_texture_to_texture` to allow copying a single plane of a multi-planar source (NV12, P010) into a single-plane destination of the matching format (e.g. NV12 `Plane0` → `R8Unorm`, NV12 `Plane1` → `Rg8Unorm`). `copy_size` is interpreted in plane texels, not luma texels. By @AdrianEddy in [#9551](https://github.com/gfx-rs/wgpu/pull/9551).
 - Added `InstanceFlags::STRICT_WEBGPU_COMPLIANCE` flag, which restricts the available feature set to the one defined by the WebGPU specification. By @teoxoy in [#9586](https://github.com/gfx-rs/wgpu/pull/9586).
 - Implemented `QuerySet::destroy` by @sagudev in [#9671](https://github.com/gfx-rs/wgpu/pull/9671)
+- Implemented query set initialization tracking, ensuring unwritten query slots resolve to 0; avoiding UB. By @teoxoy in [#9664](https://github.com/gfx-rs/wgpu/pull/9664).
 
 #### Metal
 

--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -143,7 +143,6 @@ impl Queries {
     fn resolve(&self, encoder: &mut wgpu::CommandEncoder) {
         encoder.resolve_query_set(
             &self.set,
-            // TODO(https://github.com/gfx-rs/wgpu/issues/3993): Musn't be larger than the number valid queries in the set.
             0..self.next_unused_query,
             &self.resolve_buffer,
             0,

--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -430,7 +430,7 @@ pub fn main() {
 
 #[cfg(test)]
 pub mod tests {
-    use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration};
+    use wgpu_test::{gpu_test, GpuTestConfiguration};
 
     use super::{submit_render_and_compute_pass_with_queries, QueryResults};
 
@@ -451,9 +451,7 @@ pub mod tests {
                 .features(
                     wgpu::Features::TIMESTAMP_QUERY
                         | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS,
-                )
-                // see https://github.com/gfx-rs/wgpu/issues/2521
-                .expect_fail(FailureCase::always().panic("unexpected timestamp").flaky()),
+                ),
         )
         .run_sync(|ctx| test_timestamps(ctx, true, false));
 
@@ -466,9 +464,7 @@ pub mod tests {
                     wgpu::Features::TIMESTAMP_QUERY
                         | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS
                         | wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES,
-                )
-                // see https://github.com/gfx-rs/wgpu/issues/2521
-                .expect_fail(FailureCase::always().panic("unexpected timestamp").flaky()),
+                ),
         )
         .run_sync(|ctx| test_timestamps(ctx, true, true));
 
@@ -496,31 +492,16 @@ pub mod tests {
         let encoder_delta = encoder_timestamps[1].wrapping_sub(encoder_timestamps[0]);
 
         if timestamps_on_encoder {
-            assert!(encoder_delta > 0, "unexpected timestamp");
-            assert!(
-                encoder_delta >= render_delta + compute_delta,
-                "unexpected timestamp"
-            );
+            assert!(encoder_delta > 0);
+            assert!(encoder_delta >= render_delta + compute_delta);
         }
         if let Some(render_inside_timestamp) = render_inside_timestamp {
-            assert!(
-                render_inside_timestamp >= render_start_end_timestamps[0],
-                "unexpected timestamp"
-            );
-            assert!(
-                render_inside_timestamp <= render_start_end_timestamps[1],
-                "unexpected timestamp"
-            );
+            assert!(render_inside_timestamp >= render_start_end_timestamps[0]);
+            assert!(render_inside_timestamp <= render_start_end_timestamps[1]);
         }
         if let Some(compute_inside_timestamp) = compute_inside_timestamp {
-            assert!(
-                compute_inside_timestamp >= compute_start_end_timestamps[0],
-                "unexpected timestamp"
-            );
-            assert!(
-                compute_inside_timestamp <= compute_start_end_timestamps[1],
-                "unexpected timestamp"
-            );
+            assert!(compute_inside_timestamp >= compute_start_end_timestamps[0]);
+            assert!(compute_inside_timestamp <= compute_start_end_timestamps[1]);
         }
     }
 }

--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -156,25 +156,11 @@ impl Queries {
         );
     }
 
-    fn wait_for_results(&self, device: &wgpu::Device, is_test_on_metal: bool) -> Vec<u64> {
+    fn wait_for_results(&self, device: &wgpu::Device) -> Vec<u64> {
         self.destination_buffer
             .slice(..)
             .map_async(wgpu::MapMode::Read, |_| ());
-        let poll_type = if is_test_on_metal {
-            // Use a short timeout because the `timestamps_encoder` test (which
-            // is also marked as flaky) has been observed to hang on Metal.
-            //
-            // Note that a timeout here is *not* considered an error. In this
-            // particular case that is what we want, but in general, waits in
-            // tests should probably treat a timeout as an error.
-            wgpu::PollType::Wait {
-                submission_index: None,
-                timeout: Some(std::time::Duration::from_secs(5)),
-            }
-        } else {
-            wgpu::PollType::wait_indefinitely()
-        };
-        device.poll(poll_type).unwrap();
+        device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
 
         let timestamps = {
             let timestamp_view = self
@@ -233,7 +219,7 @@ async fn run() {
         .unwrap();
 
     let queries = submit_render_and_compute_pass_with_queries(&device, &queue);
-    let raw_results = queries.wait_for_results(&device, false);
+    let raw_results = queries.wait_for_results(&device);
     println!("Raw timestamp buffer contents: {raw_results:?}");
     QueryResults::from_raw_results(raw_results, timestamps_inside_passes).print(&queue);
 }
@@ -467,8 +453,6 @@ pub mod tests {
                         | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS,
                 )
                 // see https://github.com/gfx-rs/wgpu/issues/2521
-                // If marking this test non-flaky, also consider removing the silent
-                // timeout in `wait_for_results`.
                 .expect_fail(FailureCase::always().panic("unexpected timestamp").flaky()),
         )
         .run_sync(|ctx| test_timestamps(ctx, true, false));
@@ -484,8 +468,6 @@ pub mod tests {
                         | wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES,
                 )
                 // see https://github.com/gfx-rs/wgpu/issues/2521
-                // If marking this test non-flaky, also consider removing the silent
-                // timeout in `wait_for_results`.
                 .expect_fail(FailureCase::always().panic("unexpected timestamp").flaky()),
         )
         .run_sync(|ctx| test_timestamps(ctx, true, true));
@@ -495,9 +477,8 @@ pub mod tests {
         timestamps_on_encoder: bool,
         timestamps_inside_passes: bool,
     ) {
-        let is_metal = ctx.adapter.get_info().backend == wgpu::Backend::Metal;
         let queries = submit_render_and_compute_pass_with_queries(&ctx.device, &ctx.queue);
-        let raw_results = queries.wait_for_results(&ctx.device, is_metal);
+        let raw_results = queries.wait_for_results(&ctx.device);
         let QueryResults {
             encoder_timestamps,
             render_start_end_timestamps,

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -60,6 +60,7 @@ mod queue_transfer;
 mod ray_tracing;
 mod render_pass_ownership;
 mod render_target;
+mod resolve_query_set_init;
 mod resource_descriptor_accessor;
 mod resource_error;
 mod samplers;
@@ -126,6 +127,7 @@ fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     primitive_index::all_tests(&mut tests);
     immediates::all_tests(&mut tests);
     query_set::all_tests(&mut tests);
+    resolve_query_set_init::all_tests(&mut tests);
     queue_transfer::all_tests(&mut tests);
     ray_tracing::all_tests(&mut tests);
     regression::issue_3349::all_tests(&mut tests);

--- a/tests/tests/wgpu-gpu/resolve_query_set_init.rs
+++ b/tests/tests/wgpu-gpu/resolve_query_set_init.rs
@@ -1,0 +1,593 @@
+//! Tests for query set initialization tracking.
+//!
+//! Unwritten query slots must resolve to zero.
+//! Written slots must not be affected.
+
+use wgpu::*;
+use wgpu_test::{
+    gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.extend([
+        // Occlusion — no features required.
+        UNWRITTEN_OCCLUSION_RESOLVES_TO_ZERO,
+        USED_EMPTY_OCCLUSION_RESOLVES_TO_ZERO,
+        SAME_ENCODER_RESOLVES_CORRECTLY,
+        WRITTEN_IN_PRIOR_SUBMIT_RESOLVES_CORRECTLY,
+        WRITTEN_IN_PRIOR_SUBMIT_AND_SAME_ENCODER_RESOLVES_CORRECTLY,
+        // Timestamp — requires TIMESTAMP_QUERY.
+        UNWRITTEN_TIMESTAMP_RESOLVES_TO_ZERO,
+        WRITTEN_TIMESTAMP_RESOLVES_TO_NONZERO,
+        // Inside-pass timestamp — requires TIMESTAMP_QUERY_INSIDE_PASSES.
+        INSIDE_PASS_WRITTEN_TIMESTAMP_RESOLVES_TO_NONZERO,
+        // Encoder timestamp — requires TIMESTAMP_QUERY_INSIDE_ENCODERS.
+        ENCODER_WRITTEN_TIMESTAMP_RESOLVES_TO_NONZERO,
+        // Pipeline statistics — requires PIPELINE_STATISTICS_QUERY.
+        UNWRITTEN_PIPELINE_STATISTICS_RESOLVES_TO_ZERO,
+        WRITTEN_PIPELINE_STATISTICS_RESOLVES_TO_NONZERO,
+    ]);
+}
+
+#[gpu_test]
+static UNWRITTEN_OCCLUSION_RESOLVES_TO_ZERO: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default())
+    .run_async(|ctx| async move {
+        const COUNT: u32 = 4;
+        let (qs, dst, size) = create_resolve_resources(&ctx, QueryType::Occlusion, COUNT);
+
+        let mut enc = ctx
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor::default());
+        enc.resolve_query_set(&qs, 0..COUNT, &dst, 0);
+        ctx.queue.submit(Some(enc.finish()));
+
+        let result = read_resolve_buffer(&ctx, &dst, size).await;
+        assert!(
+            result.iter().all(|&v| v == 0),
+            "unwritten occlusion slots must resolve to zero, got {:?}",
+            result
+        );
+    });
+
+/// A query that was properly begun and ended (but with no actual draws, so the
+/// result is 0) should also resolve to zero.
+#[gpu_test]
+static USED_EMPTY_OCCLUSION_RESOLVES_TO_ZERO: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default())
+    .run_async(|ctx| async move {
+        let view = ctx
+            .device
+            .create_texture(&TextureDescriptor {
+                label: None,
+                size: Extent3d {
+                    width: 1,
+                    height: 1,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: TextureDimension::D2,
+                format: TextureFormat::Rgba8Unorm,
+                usage: TextureUsages::RENDER_ATTACHMENT,
+                view_formats: &[],
+            })
+            .create_view(&TextureViewDescriptor::default());
+
+        let (qs, dst, size) = create_resolve_resources(&ctx, QueryType::Occlusion, 1);
+
+        let mut enc = ctx
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor::default());
+        {
+            let mut pass = enc.begin_render_pass(&RenderPassDescriptor {
+                label: None,
+                color_attachments: &[Some(RenderPassColorAttachment {
+                    view: &view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: Operations {
+                        load: LoadOp::Clear(Color::BLACK),
+                        store: StoreOp::Discard,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: Some(&qs),
+                multiview_mask: None,
+            });
+            pass.begin_occlusion_query(0);
+            pass.end_occlusion_query();
+        }
+        enc.resolve_query_set(&qs, 0..1, &dst, 0);
+        ctx.queue.submit(Some(enc.finish()));
+
+        let result = read_resolve_buffer(&ctx, &dst, size).await;
+        assert_eq!(
+            result[0], 0,
+            "used-empty occlusion query must resolve to 0, got {}",
+            result[0]
+        );
+    });
+
+/// Slots 0 and 3 are written before the resolve.
+/// Slot 1 is written after the resolve.
+/// Slot 2 is never written.
+#[gpu_test]
+static SAME_ENCODER_RESOLVES_CORRECTLY: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            // See https://github.com/gfx-rs/wgpu/issues/9665.
+            .expect_fail(FailureCase::webgl2()),
+    )
+    .run_async(|ctx| async move {
+        const COUNT: u32 = 4;
+        let (qs, dst, size) = create_resolve_resources(&ctx, QueryType::Occlusion, COUNT);
+        let (view, pipeline) = create_occlusion_render_resources(&ctx);
+
+        let mut enc = ctx
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor::default());
+
+        write_occlusion_query(&mut enc, &view, &pipeline, &qs, 0);
+        write_occlusion_query(&mut enc, &view, &pipeline, &qs, 3);
+        enc.resolve_query_set(&qs, 0..COUNT, &dst, 0);
+        write_occlusion_query(&mut enc, &view, &pipeline, &qs, 1);
+
+        ctx.queue.submit(Some(enc.finish()));
+
+        let result = read_resolve_buffer(&ctx, &dst, size).await;
+        assert_ne!(
+            result[0], 0,
+            "slot 0 (written before resolve) must be non-zero"
+        );
+        assert_eq!(result[1], 0, "slot 1 (written after resolve) must be zero");
+        assert_eq!(result[2], 0, "slot 2 (never written) must be zero");
+        assert_ne!(
+            result[3], 0,
+            "slot 3 (written before resolve) must be non-zero"
+        );
+    });
+
+/// Write queries in submit 1, resolve them in submit 2.
+#[gpu_test]
+static WRITTEN_IN_PRIOR_SUBMIT_RESOLVES_CORRECTLY: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                // See https://github.com/gfx-rs/wgpu/issues/9665.
+                .expect_fail(FailureCase::webgl2()),
+        )
+        .run_async(|ctx| async move {
+            const COUNT: u32 = 2;
+            let (qs, dst, size) = create_resolve_resources(&ctx, QueryType::Occlusion, COUNT);
+            let (view, pipeline) = create_occlusion_render_resources(&ctx);
+
+            // Submit 1: write both slots.
+            let mut enc1 = ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor::default());
+            write_occlusion_query(&mut enc1, &view, &pipeline, &qs, 0);
+            write_occlusion_query(&mut enc1, &view, &pipeline, &qs, 1);
+            ctx.queue.submit(Some(enc1.finish()));
+            ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
+
+            // Submit 2: resolve only.
+            let mut enc2 = ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor::default());
+            enc2.resolve_query_set(&qs, 0..COUNT, &dst, 0);
+            ctx.queue.submit(Some(enc2.finish()));
+
+            let result = read_resolve_buffer(&ctx, &dst, size).await;
+            assert!(
+                result.iter().all(|&v| v != 0),
+                "slots written in a prior submit must resolve to non-zero, got {:?}",
+                result
+            );
+        });
+
+/// Slot 0 written in submit 1.
+/// Slot 1 written in submit 2 before the resolve.
+/// Slot 2 is never written.
+#[gpu_test]
+static WRITTEN_IN_PRIOR_SUBMIT_AND_SAME_ENCODER_RESOLVES_CORRECTLY: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                // See https://github.com/gfx-rs/wgpu/issues/9665.
+                .expect_fail(FailureCase::webgl2()),
+        )
+        .run_async(|ctx| async move {
+            const COUNT: u32 = 3;
+            let (qs, dst, size) = create_resolve_resources(&ctx, QueryType::Occlusion, COUNT);
+            let (view, pipeline) = create_occlusion_render_resources(&ctx);
+
+            // Submit 1: write slot 0.
+            let mut enc1 = ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor::default());
+            write_occlusion_query(&mut enc1, &view, &pipeline, &qs, 0);
+            ctx.queue.submit(Some(enc1.finish()));
+            ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
+
+            // Submit 2: write slot 1, then resolve.
+            let mut enc2 = ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor::default());
+            write_occlusion_query(&mut enc2, &view, &pipeline, &qs, 1);
+            enc2.resolve_query_set(&qs, 0..COUNT, &dst, 0);
+            ctx.queue.submit(Some(enc2.finish()));
+
+            let result = read_resolve_buffer(&ctx, &dst, size).await;
+            assert_ne!(
+                result[0], 0,
+                "slot 0 (written in prior submit) must be non-zero"
+            );
+            assert_ne!(
+                result[1], 0,
+                "slot 1 (written in current encoder before resolve) must be non-zero"
+            );
+            assert_eq!(result[2], 0, "slot 2 (unwritten) must be zero");
+        });
+
+#[gpu_test]
+static UNWRITTEN_TIMESTAMP_RESOLVES_TO_ZERO: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().features(Features::TIMESTAMP_QUERY))
+    .run_async(|ctx| async move {
+        let (qs, dst, size) = create_resolve_resources(&ctx, QueryType::Timestamp, 1);
+
+        let mut enc = ctx
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor::default());
+        enc.resolve_query_set(&qs, 0..1, &dst, 0);
+        ctx.queue.submit(Some(enc.finish()));
+
+        let result = read_resolve_buffer(&ctx, &dst, size).await;
+        assert_eq!(
+            result[0], 0,
+            "unwritten timestamp slot must resolve to zero, got {}",
+            result[0]
+        );
+    });
+
+#[gpu_test]
+static WRITTEN_TIMESTAMP_RESOLVES_TO_NONZERO: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .features(Features::TIMESTAMP_QUERY),
+    )
+    .run_async(|ctx| async move {
+        let shader = ctx.device.create_shader_module(ShaderModuleDescriptor {
+            label: None,
+            source: ShaderSource::Wgsl("@compute @workgroup_size(1) fn cs_main() {}".into()),
+        });
+        let pipeline = ctx
+            .device
+            .create_compute_pipeline(&ComputePipelineDescriptor {
+                label: None,
+                layout: None,
+                module: &shader,
+                entry_point: Some("cs_main"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+        const COUNT: u32 = 2;
+        let (qs, dst, size) = create_resolve_resources(&ctx, QueryType::Timestamp, COUNT);
+
+        let mut enc = ctx
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor::default());
+        {
+            let mut pass = enc.begin_compute_pass(&ComputePassDescriptor {
+                label: None,
+                timestamp_writes: Some(ComputePassTimestampWrites {
+                    query_set: &qs,
+                    beginning_of_pass_write_index: Some(0),
+                    end_of_pass_write_index: Some(1),
+                }),
+            });
+            pass.set_pipeline(&pipeline);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        enc.resolve_query_set(&qs, 0..COUNT, &dst, 0);
+        ctx.queue.submit(Some(enc.finish()));
+
+        let result = read_resolve_buffer(&ctx, &dst, size).await;
+        assert!(
+            result.iter().all(|&v| v != 0),
+            "written timestamp slots must be non-zero, got {:?}",
+            result
+        );
+    });
+
+#[gpu_test]
+static INSIDE_PASS_WRITTEN_TIMESTAMP_RESOLVES_TO_NONZERO: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .features(Features::TIMESTAMP_QUERY | Features::TIMESTAMP_QUERY_INSIDE_PASSES),
+        )
+        .run_async(|ctx| async move {
+            let shader = ctx.device.create_shader_module(ShaderModuleDescriptor {
+                label: None,
+                source: ShaderSource::Wgsl("@compute @workgroup_size(1) fn cs_main() {}".into()),
+            });
+            let pipeline = ctx
+                .device
+                .create_compute_pipeline(&ComputePipelineDescriptor {
+                    label: None,
+                    layout: None,
+                    module: &shader,
+                    entry_point: Some("cs_main"),
+                    compilation_options: Default::default(),
+                    cache: None,
+                });
+
+            const COUNT: u32 = 2;
+            let (qs, dst, size) = create_resolve_resources(&ctx, QueryType::Timestamp, COUNT);
+
+            let mut enc = ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor::default());
+            {
+                let mut pass = enc.begin_compute_pass(&ComputePassDescriptor {
+                    label: None,
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&pipeline);
+                pass.write_timestamp(&qs, 0);
+                pass.dispatch_workgroups(1, 1, 1);
+            }
+            enc.resolve_query_set(&qs, 0..COUNT, &dst, 0);
+            ctx.queue.submit(Some(enc.finish()));
+
+            let result = read_resolve_buffer(&ctx, &dst, size).await;
+            assert_ne!(
+                result[0], 0,
+                "slot 0 (written inside pass) must be non-zero"
+            );
+            assert_eq!(result[1], 0, "slot 1 (unwritten) must be zero");
+        });
+
+#[gpu_test]
+static ENCODER_WRITTEN_TIMESTAMP_RESOLVES_TO_NONZERO: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .features(Features::TIMESTAMP_QUERY | Features::TIMESTAMP_QUERY_INSIDE_ENCODERS),
+        )
+        .run_async(|ctx| async move {
+            const COUNT: u32 = 2;
+            let (qs, dst, size) = create_resolve_resources(&ctx, QueryType::Timestamp, COUNT);
+
+            let mut enc = ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor::default());
+            enc.write_timestamp(&qs, 0);
+            enc.resolve_query_set(&qs, 0..COUNT, &dst, 0);
+            ctx.queue.submit(Some(enc.finish()));
+
+            let result = read_resolve_buffer(&ctx, &dst, size).await;
+            assert_ne!(result[0], 0, "slot 0 (written) must be non-zero");
+            assert_eq!(result[1], 0, "slot 1 (unwritten) must be zero");
+        });
+
+#[gpu_test]
+static UNWRITTEN_PIPELINE_STATISTICS_RESOLVES_TO_ZERO: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .features(Features::PIPELINE_STATISTICS_QUERY),
+        )
+        .run_async(|ctx| async move {
+            let (qs, dst, size) = create_resolve_resources(
+                &ctx,
+                QueryType::PipelineStatistics(PipelineStatisticsTypes::COMPUTE_SHADER_INVOCATIONS),
+                1,
+            );
+
+            let mut enc = ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor::default());
+            enc.resolve_query_set(&qs, 0..1, &dst, 0);
+            ctx.queue.submit(Some(enc.finish()));
+
+            let result = read_resolve_buffer(&ctx, &dst, size).await;
+            assert_eq!(
+                result[0], 0,
+                "unwritten pipeline-statistics slot must be zero, got {}",
+                result[0]
+            );
+        });
+
+#[gpu_test]
+static WRITTEN_PIPELINE_STATISTICS_RESOLVES_TO_NONZERO: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .features(Features::PIPELINE_STATISTICS_QUERY),
+        )
+        .run_async(|ctx| async move {
+            let shader = ctx.device.create_shader_module(ShaderModuleDescriptor {
+                label: None,
+                source: ShaderSource::Wgsl("@compute @workgroup_size(1) fn cs_main() {}".into()),
+            });
+            let pipeline = ctx
+                .device
+                .create_compute_pipeline(&ComputePipelineDescriptor {
+                    label: None,
+                    layout: None,
+                    module: &shader,
+                    entry_point: Some("cs_main"),
+                    compilation_options: Default::default(),
+                    cache: None,
+                });
+
+            let (qs, dst, size) = create_resolve_resources(
+                &ctx,
+                QueryType::PipelineStatistics(PipelineStatisticsTypes::COMPUTE_SHADER_INVOCATIONS),
+                1,
+            );
+
+            let mut enc = ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor::default());
+            {
+                let mut pass = enc.begin_compute_pass(&ComputePassDescriptor {
+                    label: None,
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&pipeline);
+                pass.begin_pipeline_statistics_query(&qs, 0);
+                pass.dispatch_workgroups(4, 1, 1);
+                pass.end_pipeline_statistics_query();
+            }
+            enc.resolve_query_set(&qs, 0..1, &dst, 0);
+            ctx.queue.submit(Some(enc.finish()));
+
+            let result = read_resolve_buffer(&ctx, &dst, size).await;
+            assert_eq!(
+                result[0], 4,
+                "written pipeline-statistics slot must be 4, got {}",
+                result[0]
+            );
+        });
+
+fn create_occlusion_render_resources(ctx: &TestingContext) -> (TextureView, RenderPipeline) {
+    let view = ctx
+        .device
+        .create_texture(&TextureDescriptor {
+            label: None,
+            size: Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: TextureDimension::D2,
+            format: TextureFormat::Rgba8Unorm,
+            usage: TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        })
+        .create_view(&TextureViewDescriptor::default());
+    let shader = ctx.device.create_shader_module(ShaderModuleDescriptor {
+        label: None,
+        source: ShaderSource::Wgsl(
+            "
+            @vertex fn vs(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4<f32> {
+                var pos = array<vec2<f32>, 3>(vec2(-1.0, -1.0), vec2(3.0, -1.0), vec2(-1.0, 3.0));
+                return vec4(pos[vi], 0.0, 1.0);
+            }
+            @fragment fn fs() -> @location(0) vec4<f32> {
+                return vec4(1.0);
+            }
+            "
+            .into(),
+        ),
+    });
+    let pipeline = ctx
+        .device
+        .create_render_pipeline(&RenderPipelineDescriptor {
+            label: None,
+            layout: None,
+            vertex: VertexState {
+                module: &shader,
+                entry_point: Some("vs"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(FragmentState {
+                module: &shader,
+                entry_point: Some("fs"),
+                compilation_options: Default::default(),
+                targets: &[Some(ColorTargetState {
+                    format: TextureFormat::Rgba8Unorm,
+                    blend: None,
+                    write_mask: ColorWrites::ALL,
+                })],
+            }),
+            primitive: PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+    (view, pipeline)
+}
+
+fn write_occlusion_query(
+    enc: &mut CommandEncoder,
+    view: &TextureView,
+    pipeline: &RenderPipeline,
+    qs: &QuerySet,
+    slot: u32,
+) {
+    let mut pass = enc.begin_render_pass(&RenderPassDescriptor {
+        label: None,
+        color_attachments: &[Some(RenderPassColorAttachment {
+            view,
+            depth_slice: None,
+            resolve_target: None,
+            ops: Operations {
+                load: LoadOp::Clear(Color::BLACK),
+                store: StoreOp::Discard,
+            },
+        })],
+        depth_stencil_attachment: None,
+        timestamp_writes: None,
+        occlusion_query_set: Some(qs),
+        multiview_mask: None,
+    });
+    pass.set_pipeline(pipeline);
+    pass.begin_occlusion_query(slot);
+    pass.draw(0..3, 0..1);
+    pass.end_occlusion_query();
+}
+
+fn create_resolve_resources(
+    ctx: &TestingContext,
+    ty: QueryType,
+    count: u32,
+) -> (QuerySet, Buffer, u64) {
+    let qs = ctx.device.create_query_set(&QuerySetDescriptor {
+        label: None,
+        ty,
+        count,
+    });
+    let size = count as u64 * QUERY_SIZE as u64;
+    let dst = ctx.device.create_buffer(&BufferDescriptor {
+        label: Some("resolve"),
+        size,
+        usage: BufferUsages::QUERY_RESOLVE | BufferUsages::COPY_SRC | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    ctx.queue
+        .write_buffer(&dst, 0, &vec![0xAAu8; size as usize]);
+    (qs, dst, size)
+}
+
+async fn read_resolve_buffer(ctx: &TestingContext, src: &Buffer, size: u64) -> Vec<u64> {
+    let readback = ctx.device.create_buffer(&BufferDescriptor {
+        label: Some("readback"),
+        size,
+        usage: BufferUsages::COPY_DST | BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut enc = ctx
+        .device
+        .create_command_encoder(&CommandEncoderDescriptor::default());
+    enc.copy_buffer_to_buffer(src, 0, &readback, 0, size);
+    ctx.queue.submit(Some(enc.finish()));
+    readback.slice(..).map_async(MapMode::Read, |_| ());
+    ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
+    let view = readback.slice(..).get_mapped_range().unwrap();
+    bytemuck::cast_slice::<u8, u64>(&view).to_vec()
+}

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -17,7 +17,10 @@ use crate::{
         memory_init::{fixup_discarded_surfaces, SurfacesInDiscardState},
         pass::{self, flush_bindings_helper},
         pass_base, pass_try,
-        query::{end_pipeline_statistics_query, validate_and_begin_pipeline_statistics_query},
+        query::{
+            end_pipeline_statistics_query, record_pass_timestamp_writes,
+            validate_and_begin_pipeline_statistics_query,
+        },
         ArcCommand, ArcPassTimestampWrites, BasePass, BindGroupStateChange, CommandEncoder,
         CommandEncoderError, DebugGroupError, EncoderStateError, InnerCommandEncoder, MapPassErr,
         PassErrorScope, PassStateError, PassTimestampWrites, QueryUseError, StateChange,
@@ -632,6 +635,8 @@ pub(super) fn encode_compute_pass(
                 indirect_draw_validation_resources: parent_state.indirect_draw_validation_resources,
                 snatch_guard: parent_state.snatch_guard,
                 debug_scope_depth: &mut debug_scope_depth,
+                query_set_writes: parent_state.query_set_writes,
+                deferred_query_set_resolves: parent_state.deferred_query_set_resolves,
             },
             binder: Binder::new(),
             temp_offsets: Vec::new(),
@@ -669,6 +674,8 @@ pub(super) fn encode_compute_pass(
     let timestamp_writes: Option<hal::PassTimestampWrites<'_, dyn hal::DynQuerySet>> =
         if let Some(tw) = timestamp_writes.take() {
             tw.query_set.same_device(device).map_pass_err(pass_scope)?;
+
+            record_pass_timestamp_writes(&tw, state.pass.base.query_set_writes);
 
             let query_set = state
                 .pass
@@ -825,6 +832,7 @@ pub(super) fn encode_compute_pass(
                     state.pass.base.raw_encoder,
                     &mut state.active_query,
                     state.pass.base.snatch_guard,
+                    state.pass.base.query_set_writes,
                 )
                 .map_pass_err(scope)?;
             }

--- a/wgpu-core/src/command/encoder.rs
+++ b/wgpu-core/src/command/encoder.rs
@@ -1,7 +1,10 @@
 use alloc::{sync::Arc, vec::Vec};
 
 use crate::{
-    command::memory_init::CommandBufferTextureMemoryActions,
+    command::{
+        memory_init::CommandBufferTextureMemoryActions,
+        query::{DeferredQuerySetResolve, QuerySetWrites},
+    },
     device::{queue::TempResource, Device},
     init_tracker::BufferInitTrackerAction,
     ray_tracing::AsAction,
@@ -50,4 +53,7 @@ pub(crate) struct EncodingState<'snatch_guard, 'cmd_enc, E: ?Sized = dyn hal::Dy
     /// When encoding a compute or render pass, this is the depth of debug
     /// scopes in the pass, not the depth of debug scopes in the parent encoder.
     pub(crate) debug_scope_depth: &'cmd_enc mut u32,
+
+    pub(crate) query_set_writes: &'cmd_enc mut QuerySetWrites,
+    pub(crate) deferred_query_set_resolves: &'cmd_enc mut Vec<DeferredQuerySetResolve>,
 }

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -7,7 +7,7 @@ use core::ops::Range;
 use hashbrown::hash_map::Entry;
 
 use crate::{
-    device::Device,
+    device::{Device, DeviceError},
     init_tracker::*,
     resource::{DestroyedResourceError, ParentDevice, RawResourceAccess, Texture, Trackable},
     snatch::SnatchGuard,
@@ -331,6 +331,76 @@ impl BakedCommands {
                 .initialization_status
                 .write()
                 .discard(surface_discard.mip_level, surface_discard.layer);
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn process_deferred_query_set_resolves(
+        &mut self,
+        device: &Device,
+        snatch_guard: &SnatchGuard<'_>,
+    ) -> Result<(), DeviceError> {
+        profiling::scope!("process_deferred_query_set_resolves");
+
+        for mut resolve in self.deferred_query_set_resolves.drain(..).rev() {
+            let raw_dst = resolve.dst_buffer.try_raw(snatch_guard).unwrap();
+            let raw_query_set = resolve.query_set.try_raw(snatch_guard).unwrap();
+
+            let raw_encoder = self.encoder.open_pass(crate::hal_label(
+                Some("(wgpu internal) Deferred query set resolve"),
+                device.instance_flags,
+            ))?;
+
+            let initialized_slots_guard = resolve.query_set.initialized_slots.lock();
+            let initialized_slots =
+                if let Some(query_set_writes) = resolve.query_set_writes.as_mut() {
+                    query_set_writes.or(&initialized_slots_guard);
+                    &*query_set_writes
+                } else {
+                    &*initialized_slots_guard
+                };
+
+            let mut start = resolve.start_query;
+            while start < resolve.end_query {
+                let is_initialized = initialized_slots[start as usize];
+                let end = (start + 1..resolve.end_query)
+                    .find(|&i| initialized_slots[i as usize] != is_initialized)
+                    .unwrap_or(resolve.end_query);
+
+                let byte_offset = resolve.destination_offset
+                    + (start - resolve.start_query) as u64 * resolve.stride;
+                let byte_len = (end - start) as u64 * resolve.stride;
+
+                if is_initialized {
+                    unsafe {
+                        raw_encoder.copy_query_results(
+                            raw_query_set,
+                            start..end,
+                            raw_dst,
+                            byte_offset,
+                            wgt::BufferSize::new_unchecked(resolve.stride),
+                        );
+                    }
+                } else {
+                    unsafe {
+                        raw_encoder.clear_buffer(raw_dst, byte_offset..byte_offset + byte_len);
+                    }
+                }
+
+                start = end;
+            }
+            drop(initialized_slots_guard);
+
+            self.encoder.close_and_insert_at(resolve.insertion_point)?;
+        }
+
+        // Update query set initialization state.
+        for query_set in &self.trackers.query_sets {
+            if let Some(slots) = self.query_set_writes.get(&query_set.tracker_index()) {
+                let mut initialized = query_set.initialized_slots.lock();
+                initialized.or(slots);
+            }
         }
 
         Ok(())

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -657,14 +657,7 @@ impl InnerCommandEncoder {
     /// [`transition_buffers`]: hal::CommandEncoder::transition_buffers
     /// [`transition_textures`]: hal::CommandEncoder::transition_textures
     fn close_and_swap(&mut self) -> Result<(), DeviceError> {
-        assert!(self.is_open);
-        self.is_open = false;
-
-        let new =
-            unsafe { self.raw.end_encoding() }.map_err(|e| self.device.handle_hal_error(e))?;
-        self.list.insert(self.list.len() - 1, new);
-
-        Ok(())
+        self.close_and_insert_at(self.list.len() - 1)
     }
 
     /// Finish the current command buffer and insert it at the beginning
@@ -678,12 +671,26 @@ impl InnerCommandEncoder {
     ///
     /// [l]: InnerCommandEncoder::list
     pub(crate) fn close_and_push_front(&mut self) -> Result<(), DeviceError> {
+        self.close_and_insert_at(0)
+    }
+
+    /// Finish the current command buffer and insert it at the given index
+    /// in [`self.list`][l].
+    ///
+    /// On return, the underlying hal encoder is closed.
+    ///
+    /// # Panics
+    ///
+    /// - If the encoder is not open.
+    ///
+    /// [l]: InnerCommandEncoder::list
+    pub(crate) fn close_and_insert_at(&mut self, index: usize) -> Result<(), DeviceError> {
         assert!(self.is_open);
         self.is_open = false;
 
-        let new =
+        let cmd_buf =
             unsafe { self.raw.end_encoding() }.map_err(|e| self.device.handle_hal_error(e))?;
-        self.list.insert(0, new);
+        self.list.insert(index, cmd_buf);
 
         Ok(())
     }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -653,9 +653,15 @@ impl InnerCommandEncoder {
     ///
     /// - If the encoder is not open.
     ///
+    /// # Warning
+    ///
+    /// Any [`DeferredQuerySetResolve::insertion_point`] pointing to the
+    /// last element will be invalidated.
+    ///
     /// [l]: InnerCommandEncoder::list
     /// [`transition_buffers`]: hal::CommandEncoder::transition_buffers
     /// [`transition_textures`]: hal::CommandEncoder::transition_textures
+    /// [`DeferredQuerySetResolve::insertion_point`]: query::DeferredQuerySetResolve::insertion_point
     fn close_and_swap(&mut self) -> Result<(), DeviceError> {
         self.close_and_insert_at(self.list.len() - 1)
     }
@@ -669,7 +675,13 @@ impl InnerCommandEncoder {
     ///
     /// - If the encoder is not open.
     ///
+    /// # Warning
+    ///
+    /// All existing [`DeferredQuerySetResolve::insertion_point`] values
+    /// will be invalidated.
+    ///
     /// [l]: InnerCommandEncoder::list
+    /// [`DeferredQuerySetResolve::insertion_point`]: query::DeferredQuerySetResolve::insertion_point
     pub(crate) fn close_and_push_front(&mut self) -> Result<(), DeviceError> {
         self.close_and_insert_at(0)
     }
@@ -683,7 +695,13 @@ impl InnerCommandEncoder {
     ///
     /// - If the encoder is not open.
     ///
+    /// # Warning
+    ///
+    /// Any [`DeferredQuerySetResolve::insertion_point`] value that is
+    /// >= `index` will be invalidated.
+    ///
     /// [l]: InnerCommandEncoder::list
+    /// [`DeferredQuerySetResolve::insertion_point`]: query::DeferredQuerySetResolve::insertion_point
     pub(crate) fn close_and_insert_at(&mut self, index: usize) -> Result<(), DeviceError> {
         assert!(self.is_open);
         self.is_open = false;
@@ -813,6 +831,8 @@ pub(crate) struct BakedCommands {
     pub(crate) indirect_draw_validation_resources: crate::indirect_validation::DrawResources,
     buffer_memory_init_actions: Vec<BufferInitTrackerAction>,
     texture_memory_actions: CommandBufferTextureMemoryActions,
+    pub(crate) query_set_writes: query::QuerySetWrites,
+    pub(crate) deferred_query_set_resolves: Vec<query::DeferredQuerySetResolve>,
 }
 
 /// The mutable state of a [`CommandBuffer`].
@@ -846,6 +866,11 @@ pub struct CommandBufferMutable {
     /// with integer pointers, and moves them into `trace_commands`.
     #[cfg(feature = "trace")]
     pub(crate) trace_commands: Option<Vec<Command<PointerReferences>>>,
+
+    /// Tracks which query slots have been written by commands in this encoder.
+    pub(crate) query_set_writes: query::QuerySetWrites,
+    /// Query set resolves that had to be deferred to submit time.
+    pub(crate) deferred_query_set_resolves: Vec<query::DeferredQuerySetResolve>,
 }
 
 impl CommandBufferMutable {
@@ -857,6 +882,8 @@ impl CommandBufferMutable {
             indirect_draw_validation_resources: self.indirect_draw_validation_resources,
             buffer_memory_init_actions: self.buffer_memory_init_actions,
             texture_memory_actions: self.texture_memory_actions,
+            query_set_writes: self.query_set_writes,
+            deferred_query_set_resolves: self.deferred_query_set_resolves,
         }
     }
 }
@@ -912,6 +939,8 @@ impl CommandEncoder {
                     indirect_draw_validation_resources:
                         crate::indirect_validation::DrawResources::new(device.clone()),
                     commands: Vec::new(),
+                    query_set_writes: Default::default(),
+                    deferred_query_set_resolves: Default::default(),
                     #[cfg(feature = "trace")]
                     trace_commands: if device.trace.lock().is_some() {
                         Some(Vec::new())
@@ -1040,12 +1069,15 @@ impl CommandEncoder {
         for command in commands {
             if matches!(
                 command,
-                ArcCommand::RunRenderPass { .. } | ArcCommand::RunComputePass { .. }
+                ArcCommand::RunRenderPass { .. }
+                    | ArcCommand::RunComputePass { .. }
+                    | ArcCommand::ResolveQuerySet { .. }
             ) {
                 // Compute passes and render passes can accept either an
-                // open or closed encoder. This state object holds an
-                // `InnerCommandEncoder`. See the documentation of
-                // [`EncodingState`].
+                // open or closed encoder. Resolving query sets needs to
+                // potentially close and open the encoder. This state
+                // object holds an `InnerCommandEncoder`. See the
+                // documentation of [`EncodingState`].
                 let mut state = EncodingState {
                     device,
                     raw_encoder: &mut cmd_buf_data.encoder,
@@ -1058,6 +1090,8 @@ impl CommandEncoder {
                         .indirect_draw_validation_resources,
                     snatch_guard: &snatch_guard,
                     debug_scope_depth: &mut debug_scope_depth,
+                    query_set_writes: &mut cmd_buf_data.query_set_writes,
+                    deferred_query_set_resolves: &mut cmd_buf_data.deferred_query_set_resolves,
                 };
 
                 match command {
@@ -1111,6 +1145,22 @@ impl CommandEncoder {
                         }
                         res?;
                     }
+                    ArcCommand::ResolveQuerySet {
+                        query_set,
+                        start_query,
+                        query_count,
+                        destination,
+                        destination_offset,
+                    } => {
+                        query::resolve_query_set(
+                            &mut state,
+                            query_set,
+                            start_query,
+                            query_count,
+                            destination,
+                            destination_offset,
+                        )?;
+                    }
                     _ => unreachable!(),
                 }
             } else {
@@ -1132,6 +1182,8 @@ impl CommandEncoder {
                         .indirect_draw_validation_resources,
                     snatch_guard: &snatch_guard,
                     debug_scope_depth: &mut debug_scope_depth,
+                    query_set_writes: &mut cmd_buf_data.query_set_writes,
+                    deferred_query_set_resolves: &mut cmd_buf_data.deferred_query_set_resolves,
                 };
                 match command {
                     ArcCommand::CopyBufferToBuffer {
@@ -1169,22 +1221,6 @@ impl CommandEncoder {
                     } => {
                         query::write_timestamp(&mut state, query_set, query_index)?;
                     }
-                    ArcCommand::ResolveQuerySet {
-                        query_set,
-                        start_query,
-                        query_count,
-                        destination,
-                        destination_offset,
-                    } => {
-                        query::resolve_query_set(
-                            &mut state,
-                            query_set,
-                            start_query,
-                            query_count,
-                            destination,
-                            destination_offset,
-                        )?;
-                    }
                     ArcCommand::PushDebugGroup(label) => {
                         push_debug_group(&mut state, &label)?;
                     }
@@ -1207,7 +1243,9 @@ impl CommandEncoder {
                             texture_transitions,
                         )?;
                     }
-                    ArcCommand::RunComputePass { .. } | ArcCommand::RunRenderPass { .. } => {
+                    ArcCommand::RunComputePass { .. }
+                    | ArcCommand::RunRenderPass { .. }
+                    | ArcCommand::ResolveQuerySet { .. } => {
                         unreachable!()
                     }
                 }

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -307,6 +307,7 @@ where
         query_index,
         pending_query_resets,
         state.base.snatch_guard,
+        state.base.query_set_writes,
     )?;
     Ok(())
 }

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -1,8 +1,9 @@
 use alloc::{sync::Arc, vec, vec::Vec};
+use bit_vec::BitVec;
 use core::{iter, mem};
 
 use crate::{
-    command::{encoder::EncodingState, ArcCommand, EncoderStateError},
+    command::{encoder::EncodingState, ArcCommand, EncoderStateError, InnerCommandEncoder},
     device::{Device, DeviceError, MissingFeatures},
     global::Global,
     id,
@@ -20,6 +21,48 @@ use wgt::{
     error::{ErrorType, WebGpuError},
     BufferAddress,
 };
+
+pub(crate) struct DeferredQuerySetResolve {
+    pub(crate) query_set: Arc<QuerySet>,
+    pub(crate) query_set_writes: Option<BitVec>,
+    pub(crate) start_query: u32,
+    pub(crate) end_query: u32,
+    pub(crate) dst_buffer: Arc<Buffer>,
+    pub(crate) destination_offset: BufferAddress,
+    /// Bytes per query slot in the destination buffer
+    /// (accounts for pipeline-statistics element count * `QUERY_SIZE`).
+    pub(crate) stride: u64,
+    /// Index into [`InnerCommandEncoder::list`] at which a new command buffer
+    /// for the resolve operation must be inserted at submit time so that it
+    /// executes at exactly the position it was recorded.
+    pub(crate) insertion_point: usize,
+}
+
+pub(crate) type QuerySetWrites = FastHashMap<TrackerIndex, BitVec>;
+
+pub(super) fn record_pass_timestamp_writes(
+    tw: &crate::command::ArcPassTimestampWrites,
+    query_set_writes: &mut QuerySetWrites,
+) {
+    for index in tw
+        .beginning_of_pass_write_index
+        .into_iter()
+        .chain(tw.end_of_pass_write_index)
+    {
+        record_query_write(query_set_writes, &tw.query_set, index);
+    }
+}
+
+pub(crate) fn record_query_write(
+    query_set_writes: &mut QuerySetWrites,
+    query_set: &Arc<QuerySet>,
+    slot_index: u32,
+) {
+    query_set_writes
+        .entry(query_set.tracker_index())
+        .or_insert_with(|| BitVec::from_elem(query_set.desc.count as usize, false))
+        .set(slot_index as usize, true);
+}
 
 #[derive(Debug)]
 pub(crate) struct QueryResetMap {
@@ -256,6 +299,7 @@ impl QuerySet {
         query_index: u32,
         reset_state: Option<&mut QueryResetMap>,
         snatch_guard: &SnatchGuard<'_>,
+        query_set_writes: &mut QuerySetWrites,
     ) -> Result<(), QueryUseError> {
         let needs_reset = reset_state.is_none();
         self.validate_query(SimplifiedQueryType::Timestamp, query_index, reset_state)?;
@@ -269,6 +313,7 @@ impl QuerySet {
             raw_encoder.write_timestamp(self.try_raw(snatch_guard)?, query_index);
         }
 
+        record_query_write(query_set_writes, self, query_index);
         Ok(())
     }
 }
@@ -313,9 +358,11 @@ pub(super) fn end_occlusion_query(
     raw_encoder: &mut dyn hal::DynCommandEncoder,
     active_query: &mut Option<(Arc<QuerySet>, u32)>,
     snatch_guard: &SnatchGuard<'_>,
+    query_set_writes: &mut QuerySetWrites,
 ) -> Result<(), QueryUseError> {
     if let Some((query_set, query_index)) = active_query.take() {
         unsafe { raw_encoder.end_query(query_set.try_raw(snatch_guard)?, query_index) };
+        record_query_write(query_set_writes, &query_set, query_index);
         Ok(())
     } else {
         Err(QueryUseError::AlreadyStopped)
@@ -369,9 +416,11 @@ pub(super) fn end_pipeline_statistics_query(
     raw_encoder: &mut dyn hal::DynCommandEncoder,
     active_query: &mut Option<(Arc<QuerySet>, u32)>,
     snatch_guard: &SnatchGuard<'_>,
+    query_set_writes: &mut QuerySetWrites,
 ) -> Result<(), QueryUseError> {
     if let Some((query_set, query_index)) = active_query.take() {
         unsafe { raw_encoder.end_query(query_set.try_raw(snatch_guard)?, query_index) };
+        record_query_write(query_set_writes, &query_set, query_index);
         Ok(())
     } else {
         Err(QueryUseError::AlreadyStopped)
@@ -440,6 +489,7 @@ pub(super) fn write_timestamp(
         query_index,
         None,
         state.snatch_guard,
+        state.query_set_writes,
     )?;
 
     state.tracker.query_sets.insert_single(query_set);
@@ -448,7 +498,7 @@ pub(super) fn write_timestamp(
 }
 
 pub(super) fn resolve_query_set(
-    state: &mut EncodingState,
+    state: &mut EncodingState<'_, '_, InnerCommandEncoder>,
     query_set: Arc<QuerySet>,
     start_query: u32,
     query_count: u32,
@@ -511,7 +561,8 @@ pub(super) fn resolve_query_set(
             bytes_used,
         })?;
 
-    // TODO(https://github.com/gfx-rs/wgpu/issues/3993): Need to track initialization state.
+    let query_set = state.tracker.query_sets.insert_single(query_set);
+
     state
         .buffer_memory_init_actions
         .extend(dst_buffer.initialization_status.read().create_action(
@@ -520,23 +571,55 @@ pub(super) fn resolve_query_set(
             MemoryInitKind::ImplicitlyInitialized,
         ));
 
+    let raw_encoder = state.raw_encoder.open_if_closed()?;
     let raw_dst_buffer = dst_buffer.try_raw(state.snatch_guard)?;
     unsafe {
-        state.raw_encoder.transition_buffers(dst_barrier.as_slice());
-        state.raw_encoder.copy_query_results(
-            query_set.try_raw(state.snatch_guard)?,
-            start_query..end_query,
-            raw_dst_buffer,
-            destination_offset,
-            wgt::BufferSize::new_unchecked(stride as u64),
-        );
+        raw_encoder.transition_buffers(dst_barrier.as_slice());
+    }
+
+    // Check if all slots in the range have been written within this encoder.
+    // If so we can emit `copy_query_results` directly.
+    // Otherwise defer to submit time where we have knowledge of
+    // the query set initialization state.
+    let query_set_writes = state.query_set_writes.get(&query_set.tracker_index());
+    let all_written =
+        query_set_writes.is_some_and(|slots| (start_query..end_query).all(|i| slots[i as usize]));
+
+    if all_written {
+        unsafe {
+            raw_encoder.copy_query_results(
+                query_set.try_raw(state.snatch_guard)?,
+                start_query..end_query,
+                raw_dst_buffer,
+                destination_offset,
+                wgt::BufferSize::new_unchecked(stride as u64),
+            );
+        }
+    } else {
+        state.raw_encoder.close_if_open()?;
+        let insertion_point = state.raw_encoder.list.len();
+
+        state
+            .deferred_query_set_resolves
+            .push(DeferredQuerySetResolve {
+                query_set: query_set.clone(),
+                query_set_writes: query_set_writes.cloned(),
+                start_query,
+                end_query,
+                dst_buffer: dst_buffer.clone(),
+                destination_offset,
+                stride: stride as u64,
+                insertion_point,
+            });
     }
 
     if matches!(query_set.desc.ty, wgt::QueryType::Timestamp) {
+        let raw_encoder = state.raw_encoder.open_if_closed()?;
+
         // Timestamp normalization is only needed for timestamps.
         state.device.timestamp_normalizer.get().unwrap().normalize(
             state.snatch_guard,
-            state.raw_encoder,
+            raw_encoder,
             &mut state.tracker.buffers,
             dst_buffer
                 .timestamp_normalization_bind_group
@@ -547,8 +630,6 @@ pub(super) fn resolve_query_set(
             query_count,
         );
     }
-
-    state.tracker.query_sets.insert_single(query_set);
 
     Ok(())
 }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -19,8 +19,9 @@ use crate::{
         pass::{self, flush_bindings_helper},
         pass_base, pass_try,
         query::{
-            end_occlusion_query, end_pipeline_statistics_query, validate_and_begin_occlusion_query,
-            validate_and_begin_pipeline_statistics_query, QueryResetMap,
+            end_occlusion_query, end_pipeline_statistics_query, record_pass_timestamp_writes,
+            validate_and_begin_occlusion_query, validate_and_begin_pipeline_statistics_query,
+            QueryResetMap, QuerySetWrites,
         },
         render_command::ArcRenderCommand,
         ArcCommand, ArcPassTimestampWrites, BasePass, BindGroupStateChange,
@@ -1166,6 +1167,7 @@ impl RenderPassInfo {
         pending_query_resets: &mut QueryResetMap,
         pending_discard_init_fixups: &mut SurfacesInDiscardState,
         snatch_guard: &SnatchGuard<'_>,
+        query_set_writes: &mut QuerySetWrites,
         multiview_mask: Option<NonZeroU32>,
     ) -> Result<Self, RenderPassErrorInner> {
         profiling::scope!("RenderPassInfo::start");
@@ -1631,6 +1633,8 @@ impl RenderPassInfo {
             if let Some(index) = tw.end_of_pass_write_index {
                 pending_query_resets.use_query_set(query_set, index);
             }
+
+            record_pass_timestamp_writes(tw, query_set_writes);
 
             Some(hal::PassTimestampWrites {
                 query_set: query_set.try_raw(snatch_guard)?,
@@ -2109,6 +2113,7 @@ pub(super) fn encode_render_pass(
             &mut pending_query_resets,
             &mut pending_discard_init_fixups,
             parent_state.snatch_guard,
+            parent_state.query_set_writes,
             multiview_mask,
         )
         .map_pass_err(pass_scope)?;
@@ -2148,6 +2153,8 @@ pub(super) fn encode_render_pass(
                         .indirect_draw_validation_resources,
                     snatch_guard: parent_state.snatch_guard,
                     debug_scope_depth: &mut debug_scope_depth,
+                    query_set_writes: parent_state.query_set_writes,
+                    deferred_query_set_resolves: parent_state.deferred_query_set_resolves,
                 },
                 pending_discard_init_fixups,
                 scope: device.new_usage_scope(),
@@ -2401,6 +2408,7 @@ pub(super) fn encode_render_pass(
                         state.pass.base.raw_encoder,
                         &mut state.active_occlusion_query,
                         state.pass.base.snatch_guard,
+                        state.pass.base.query_set_writes,
                     )
                     .map_pass_err(scope)?;
                 }
@@ -2434,6 +2442,7 @@ pub(super) fn encode_render_pass(
                         state.pass.base.raw_encoder,
                         &mut state.active_pipeline_statistics_query,
                         state.pass.base.snatch_guard,
+                        state.pass.base.query_set_writes,
                     )
                     .map_pass_err(scope)?;
                 }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1416,6 +1416,13 @@ impl Queue {
                             }
                         };
 
+                        if let Err(e) = baked.process_deferred_query_set_resolves(
+                            &self.device,
+                            &submission.snatch_guard,
+                        ) {
+                            break 'error Err(e.into());
+                        }
+
                         // execute resource transitions
                         if let Err(e) = baked.encoder.open_pass(hal_label(
                             Some("(wgpu internal) Transit"),

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -5030,6 +5030,10 @@ impl Device {
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.query_sets.clone()),
             desc: desc.map_label(|_| ()),
+            initialized_slots: Mutex::new(
+                rank::QUERY_SET_INITIALIZED_SLOTS,
+                bit_vec::BitVec::from_elem(desc.count as usize, false),
+            ),
         };
 
         let query_set = Arc::new(query_set);

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -133,6 +133,7 @@ define_lock_ranks! {
         TEXTURE_BIND_GROUPS,
         TEXTURE_CLEAR_MODE,
         TEXTURE_VIEWS,
+        QUERY_SET_INITIALIZED_SLOTS,
         // Uncomment this to see an interesting cycle.
         // COMMAND_BUFFER_DATA,
     }
@@ -185,6 +186,7 @@ define_lock_ranks! {
     rank DEVICE_USAGE_SCOPES "Device::usage_scopes" followed by { }
     rank REGISTRY_STORAGE "Registry::storage" followed by { }
     rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }
+    rank QUERY_SET_INITIALIZED_SLOTS "QuerySet::initialized_slots" followed by { }
     rank TEXTURE_BIND_GROUPS "Texture::bind_groups" followed by { }
     rank TEXTURE_CLEAR_MODE "Texture::clear_mode" followed by { }
     rank TEXTURE_VIEWS "Texture::views" followed by { }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2246,6 +2246,7 @@ pub struct QuerySet {
     pub(crate) label: String,
     pub(crate) tracking_data: TrackingData,
     pub(crate) desc: wgt::QuerySetDescriptor<()>,
+    pub(crate) initialized_slots: Mutex<bit_vec::BitVec>,
 }
 
 impl RawResourceAccess for QuerySet {

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1174,9 +1174,14 @@ impl super::CapabilitiesQuery {
         features.set(F::FLOAT32_BLENDABLE, true);
         features.set(F::INDIRECT_FIRST_INSTANCE, self.indirect_draw_dispatch);
         features.set(
-            F::TIMESTAMP_QUERY | F::TIMESTAMP_QUERY_INSIDE_ENCODERS,
+            F::TIMESTAMP_QUERY,
             self.timestamp_query_support
                 .contains(TimestampQuerySupport::STAGE_BOUNDARIES),
+        );
+        features.set(
+            F::TIMESTAMP_QUERY_INSIDE_ENCODERS,
+            self.timestamp_query_support
+                .contains(TimestampQuerySupport::ON_BLIT_ENCODER),
         );
         features.set(
             F::TIMESTAMP_QUERY_INSIDE_PASSES,

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -163,6 +163,9 @@ impl super::CommandEncoder {
             debug_assert!(self.state.render.is_none() && self.state.compute.is_none());
             let cmd_buf = self.raw_cmd_buf.as_ref().unwrap();
 
+            // This code path is currently unused since the written timestamp is always 0.
+            // We should see if we can get it working again, if not remove the code.
+            //
             // Take care of pending timer queries.
             // If we can't use `sample_counters_in_buffer` we have to create a dummy blit encoder!
             //

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -753,14 +753,17 @@ impl crate::CommandEncoder for super::CommandEncoder {
             _ => {}
         }
     }
-    unsafe fn end_query(&mut self, set: &super::QuerySet, _index: u32) {
+    unsafe fn end_query(&mut self, set: &super::QuerySet, index: u32) {
         match set.ty {
             wgt::QueryType::Occlusion => {
                 self.state
                     .render
                     .as_ref()
                     .unwrap()
-                    .setVisibilityResultMode_offset(MTLVisibilityResultMode::Disabled, 0);
+                    .setVisibilityResultMode_offset(
+                        MTLVisibilityResultMode::Disabled,
+                        index as usize * crate::QUERY_SIZE as usize,
+                    );
             }
             _ => {}
         }

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -822,14 +822,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         };
     }
 
-    unsafe fn reset_queries(&mut self, set: &super::QuerySet, range: Range<u32>) {
-        let encoder = self.enter_blit();
-        let raw_range = NSRange {
-            location: range.start as usize * crate::QUERY_SIZE as usize,
-            length: (range.end - range.start) as usize * crate::QUERY_SIZE as usize,
-        };
-        encoder.fillBuffer_range_value(&set.raw_buffer, raw_range, 0);
-    }
+    unsafe fn reset_queries(&mut self, _set: &super::QuerySet, _range: Range<u32>) {}
 
     unsafe fn copy_query_results(
         &mut self,

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -711,7 +711,7 @@ bitflags_array! {
         /// Supported platforms:
         /// - Vulkan
         /// - DX12
-        /// - Metal
+        /// - Metal (AMD & Intel, not Apple GPUs)
         /// - OpenGL (with GL_ARB_timer_query)
         ///
         /// This is a native only feature.


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/3993.
Fixes https://github.com/gfx-rs/wgpu/issues/7238.
Fixes https://github.com/gfx-rs/wgpu/issues/3612.
Reverts https://github.com/gfx-rs/wgpu/pull/8487.
Reverts https://github.com/gfx-rs/wgpu/pull/5838.

**Description**
This PR adds the needed machinery that:
- tracks query set slot initialization per command encoder, propagating it to the query sets themselves on submit;
- on calls to `resolveQuerySet` it checks if all slots have been written so far in the encoder:
  - if so, it emits a direct call to HAL's `resolveQuerySet`
  - if not, we defer the call to submit where we have full knowledge of the initialization state. This requires breaking up the command buffer to be able to insert a new command buffer at submit time with the deferred command.

An alternative to this implementation would be to create a proxy buffer at query set creation. When encoding, we would only resolve the slots written to by other commands that have been encoded and issue a copy buffer to buffer from the proxy buffer to the destination buffer. This would work because the proxy buffer would already contain previous results of resolve commands. It effectively acts as GPU side tracking and would avoid having to break up command buffers. It however costs more GPU memory and I imagined the deferred path in the current implementation to not be hit too much in practice, but I could be wrong and this alternative would be better. The answer to "Will I hit the deferred path?" is the same as "Do you resolve query set slots that haven't been written by any prior command part of the same command encoder?".

While working on this I noticed that `write_timestamp` on command encoders doesn't work (the timestamp is always 0) on my M1 mac. I suspect the strategy implemented in https://github.com/gfx-rs/wgpu/pull/4008 to no longer be working. I gated `TIMESTAMP_QUERY_INSIDE_ENCODERS` behind `TimestampQuerySupport::ON_BLIT_ENCODER` as that should still work for Intel/AMD macs. cc @Wumpf 

Backend requirements: At least Vulkan and D3D12 require query set slots to have been written to prior to resolving them.

> VUID-vkCmdCopyQueryPoolResults-None-09402
> All queries used by the command must not be uninitialized when the command is executed

> VUID-vkCmdCopyQueryPoolResults-None-08752
> All queries used by the command must have been made available by prior executed commands

_from https://docs.vulkan.org/refpages/latest/refpages/source/vkCmdCopyQueryPoolResults.html_

> Resolving queries within a heap that have not been completed (so have had ID3D12GraphicsCommandList::BeginQuery called for them, but not ID3D12GraphicsCommandList::EndQuery), or that have been uninitialized, results in undefined behavior and might cause device hangs or removal.

_from https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-resolvequerydata#remarks_

**Testing**
Added tests.

**Squash or Rebase?**
Rebase.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
