### PR TITLE
Implement `QuerySet::destroy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Add `as_custom` to many new API types, which increases the capabilities of custom backends. Also fixed render bundles on custom backends. By @inner-daemons in [#9605](https://github.com/gfx-rs/wgpu/pull/9605).
 - Extend `copy_texture_to_texture` to allow copying a single plane of a multi-planar source (NV12, P010) into a single-plane destination of the matching format (e.g. NV12 `Plane0` → `R8Unorm`, NV12 `Plane1` → `Rg8Unorm`). `copy_size` is interpreted in plane texels, not luma texels. By @AdrianEddy in [#9551](https://github.com/gfx-rs/wgpu/pull/9551).
 - Added `InstanceFlags::STRICT_WEBGPU_COMPLIANCE` flag, which restricts the available feature set to the one defined by the WebGPU specification. By @teoxoy in [#9586](https://github.com/gfx-rs/wgpu/pull/9586).
+- Implemented `QuerySet::destroy` by @sagudev in [#9671](https://github.com/gfx-rs/wgpu/pull/9671)
 
 #### Metal
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -234,6 +234,7 @@ webgpu:api,validation,image_copy,texture_related:*
 fails-if(dx12) webgpu:api,validation,layout_shader_compat:pipeline_layout_shader_exact_match:*
 webgpu:api,validation,query_set,destroy:*
 webgpu:api,validation,queue,buffer_mapped:*
+webgpu:api,validation,queue,destroyed,query_set:*
 webgpu:api,validation,queue,submit:command_buffer,*
 webgpu:api,validation,queue,writeBuffer:buffer_state:*
 webgpu:api,validation,queue,writeBuffer:buffer,device_mismatch:*

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -55,9 +55,7 @@ impl GPUQuerySet {
   #[fast]
   #[undefined]
   fn destroy(&self) -> Result<(), JsErrorBox> {
-    // TODO(https://github.com/gfx-rs/wgpu/issues/6495): Destroy the query
-    // set. Until that is supported, it is okay to do nothing here, the
-    // query set will be garbage collected and dropped eventually.
+    self.instance.query_set_destroy(self.id);
     Ok(())
   }
 

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -405,6 +405,12 @@ impl Player {
                     .expect("create_query_set error");
                 self.query_sets.insert(id, query_set);
             }
+            Action::FreeQuerySet(id) => {
+                // Note: query set remains in the HashMap. "Free" and "Destroy"
+                // mean the opposite from WebGPU.
+                let query_set = self.query_sets.get(&id).expect("invalid query set");
+                query_set.destroy();
+            }
             Action::DestroyQuerySet(id) => {
                 self.query_sets.remove(&id).expect("invalid query set");
             }

--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -1,4 +1,5 @@
 use wgpu::util::DeviceExt;
+use wgpu::{ComputePassTimestampWrites, QueryType, RenderPassTimestampWrites};
 use wgpu_test::{
     fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
 };
@@ -10,6 +11,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         BUFFER_DESTROY_BEFORE_SUBMIT,
         TEXTURE_DESTROY_BEFORE_SUBMIT,
         EXTERNAL_TEXTURE_DESTROY_BEFORE_SUBMIT,
+        QUERY_SET_DESTROY_BEFORE_SUBMIT,
         REPLACED_BIND_GROUP,
     ]);
 }
@@ -164,6 +166,13 @@ const EXTERNAL_TEXTURE_RENDER_SHADER: &str = "\
 const EXTERNAL_TEXTURE_COMPUTE_SHADER: &str = "\
 @group(0) @binding(0) var tex: texture_external;
 @compute @workgroup_size(1) fn main() { _ = textureLoad(tex, vec2(0)); }";
+
+const EMPTY_COMPUTE_SHADER: &str = "\
+@compute @workgroup_size(1) fn main() {}";
+
+const EMPTY_RENDER_SHADER: &str = "\
+@vertex fn vs() -> @builtin(position) vec4<f32> { return vec4<f32>(0); }
+@fragment fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0); }";
 
 fn create_render_target(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureView) {
     let texture = device.create_texture(&wgpu::TextureDescriptor {
@@ -558,6 +567,98 @@ static EXTERNAL_TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestCon
         test_external_texture_destroy_before_submit(&ctx, UsageKind::RenderPass);
         test_external_texture_destroy_before_submit(&ctx, UsageKind::ComputePass);
         test_external_texture_destroy_before_submit(&ctx, UsageKind::RenderBundle);
+    });
+
+fn test_query_set_destroy_before_submit(ctx: &TestingContext, ty: QueryType, usage: UsageKind) {
+    let query_set = ctx.device.create_query_set(&wgpu::QuerySetDescriptor {
+        label: None,
+        count: 2,
+        ty,
+    });
+
+    let (_render_target, rt_view) = create_render_target(&ctx.device);
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+
+    match usage {
+        UsageKind::RenderPass => {
+            let pipeline = create_render_pipeline(&ctx.device, EMPTY_RENDER_SHADER);
+            let color_attachment = [Some(wgpu::RenderPassColorAttachment {
+                view: &rt_view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })];
+            let (occlusion_query_set, timestamp_writes) = match ty {
+                QueryType::Occlusion => (Some(&query_set), None),
+                QueryType::Timestamp => (
+                    None,
+                    Some(RenderPassTimestampWrites {
+                        query_set: &query_set,
+                        beginning_of_pass_write_index: Some(0),
+                        end_of_pass_write_index: Some(1),
+                    }),
+                ),
+                QueryType::PipelineStatistics(_) => unreachable!(),
+            };
+
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                color_attachments: &color_attachment,
+                occlusion_query_set,
+                timestamp_writes,
+                ..Default::default()
+            });
+            pass.set_pipeline(&pipeline);
+            pass.draw(0..0, 0..0);
+        }
+        UsageKind::ComputePass => {
+            let pipeline = create_compute_pipeline(&ctx.device, EMPTY_COMPUTE_SHADER);
+            let timestamp_writes = match ty {
+                QueryType::Timestamp => Some(ComputePassTimestampWrites {
+                    query_set: &query_set,
+                    beginning_of_pass_write_index: Some(0),
+                    end_of_pass_write_index: Some(1),
+                }),
+                _ => unreachable!(),
+            };
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                timestamp_writes,
+                ..Default::default()
+            });
+            pass.set_pipeline(&pipeline);
+            pass.dispatch_workgroups(0, 0, 0);
+        }
+        UsageKind::RenderBundle => unreachable!(),
+        UsageKind::Direct => unreachable!(),
+    }
+
+    query_set.destroy();
+
+    fail(
+        &ctx.device,
+        || ctx.queue.submit([encoder.finish()]),
+        Some("QuerySet with '' label has been destroyed"),
+    );
+}
+
+// Test that destroying a query set between command encoding and submission fails
+// gracefully.
+#[gpu_test]
+static QUERY_SET_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop()
+            .features(wgpu::Features::TIMESTAMP_QUERY),
+    )
+    .run_sync(|ctx| {
+        test_query_set_destroy_before_submit(&ctx, QueryType::Occlusion, UsageKind::RenderPass);
+        test_query_set_destroy_before_submit(&ctx, QueryType::Timestamp, UsageKind::RenderPass);
+        test_query_set_destroy_before_submit(&ctx, QueryType::Timestamp, UsageKind::ComputePass);
     });
 
 fn test_replaced_bind_group(ctx: &TestingContext, usage: UsageKind) {

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -688,6 +688,9 @@ pub(super) fn encode_compute_pass(
                     .or(tw.end_of_pass_write_index)
                     .map(|i| i..i + 1)
             };
+            let raw_query_set = query_set
+                .try_raw(parent_state.snatch_guard)
+                .map_pass_err(pass_scope)?;
             // Range should always be Some, both values being None should lead to a validation error.
             // But no point in erroring over that nuance here!
             if let Some(range) = range {
@@ -696,12 +699,12 @@ pub(super) fn encode_compute_pass(
                         .pass
                         .base
                         .raw_encoder
-                        .reset_queries(query_set.raw(), range);
+                        .reset_queries(raw_query_set, range);
                 }
             }
 
             Some(hal::PassTimestampWrites {
-                query_set: query_set.raw(),
+                query_set: raw_query_set,
                 beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
                 end_of_pass_write_index: tw.end_of_pass_write_index,
             })
@@ -812,13 +815,18 @@ pub(super) fn encode_compute_pass(
                     query_index,
                     None,
                     &mut state.active_query,
+                    state.pass.base.snatch_guard,
                 )
                 .map_pass_err(scope)?;
             }
             ArcComputeCommand::EndPipelineStatisticsQuery => {
                 let scope = PassErrorScope::EndPipelineStatisticsQuery;
-                end_pipeline_statistics_query(state.pass.base.raw_encoder, &mut state.active_query)
-                    .map_pass_err(scope)?;
+                end_pipeline_statistics_query(
+                    state.pass.base.raw_encoder,
+                    &mut state.active_query,
+                    state.pass.base.snatch_guard,
+                )
+                .map_pass_err(scope)?;
             }
             ArcComputeCommand::TransitionResources {
                 buffer_transitions,

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -306,6 +306,7 @@ where
         state.base.raw_encoder,
         query_index,
         pending_query_resets,
+        state.base.snatch_guard,
     )?;
     Ok(())
 }

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -11,6 +11,7 @@ use crate::{
         Buffer, DestroyedResourceError, InvalidResourceError, MissingBufferUsageError,
         ParentDevice, QuerySet, RawResourceAccess, Trackable,
     },
+    snatch::SnatchGuard,
     track::{StatelessTracker, TrackerIndex},
     FastHashMap,
 };
@@ -45,7 +46,11 @@ impl QueryResetMap {
         mem::replace(&mut vec_pair.0[query as usize], true)
     }
 
-    pub fn reset_queries(&mut self, raw_encoder: &mut dyn hal::DynCommandEncoder) {
+    pub fn reset_queries(
+        &mut self,
+        raw_encoder: &mut dyn hal::DynCommandEncoder,
+        snatch_guard: &SnatchGuard<'_>,
+    ) -> Result<(), DestroyedResourceError> {
         for (_, (state, query_set)) in self.map.drain() {
             debug_assert_eq!(state.len(), query_set.desc.count as usize);
 
@@ -60,7 +65,10 @@ impl QueryResetMap {
                     // We've hit the end of a run, dispatch a reset
                     (Some(start), false) => {
                         run_start = None;
-                        unsafe { raw_encoder.reset_queries(query_set.raw(), start..idx as u32) };
+                        unsafe {
+                            raw_encoder
+                                .reset_queries(query_set.try_raw(snatch_guard)?, start..idx as u32)
+                        };
                     }
                     // We're starting a run
                     (None, true) => {
@@ -71,6 +79,7 @@ impl QueryResetMap {
                 }
             }
         }
+        Ok(())
     }
 }
 
@@ -151,12 +160,15 @@ pub enum QueryUseError {
     },
     #[error("A query of type {query_type:?} was not ended before the encoder was finished")]
     MissingEnd { query_type: SimplifiedQueryType },
+    #[error(transparent)]
+    DestroyedResource(#[from] DestroyedResourceError),
 }
 
 impl WebGpuError for QueryUseError {
     fn webgpu_error_type(&self) -> ErrorType {
         match self {
             Self::Device(e) => e.webgpu_error_type(),
+            Self::DestroyedResource(e) => e.webgpu_error_type(),
             Self::OutOfBounds { .. }
             | Self::UsedTwiceInsideRenderpass { .. }
             | Self::AlreadyStarted { .. }
@@ -243,6 +255,7 @@ impl QuerySet {
         raw_encoder: &mut dyn hal::DynCommandEncoder,
         query_index: u32,
         reset_state: Option<&mut QueryResetMap>,
+        snatch_guard: &SnatchGuard<'_>,
     ) -> Result<(), QueryUseError> {
         let needs_reset = reset_state.is_none();
         self.validate_query(SimplifiedQueryType::Timestamp, query_index, reset_state)?;
@@ -250,9 +263,10 @@ impl QuerySet {
         unsafe {
             // If we don't have a reset state tracker which can defer resets, we must reset now.
             if needs_reset {
-                raw_encoder.reset_queries(self.raw(), query_index..(query_index + 1));
+                raw_encoder
+                    .reset_queries(self.try_raw(snatch_guard)?, query_index..(query_index + 1));
             }
-            raw_encoder.write_timestamp(self.raw(), query_index);
+            raw_encoder.write_timestamp(self.try_raw(snatch_guard)?, query_index);
         }
 
         Ok(())
@@ -266,6 +280,7 @@ pub(super) fn validate_and_begin_occlusion_query(
     query_index: u32,
     reset_state: Option<&mut QueryResetMap>,
     active_query: &mut Option<(Arc<QuerySet>, u32)>,
+    snatch_guard: &SnatchGuard<'_>,
 ) -> Result<(), QueryUseError> {
     let needs_reset = reset_state.is_none();
     query_set.validate_query(SimplifiedQueryType::Occlusion, query_index, reset_state)?;
@@ -283,9 +298,12 @@ pub(super) fn validate_and_begin_occlusion_query(
     unsafe {
         // If we don't have a reset state tracker which can defer resets, we must reset now.
         if needs_reset {
-            raw_encoder.reset_queries(query_set.raw(), query_index..(query_index + 1));
+            raw_encoder.reset_queries(
+                query_set.try_raw(snatch_guard)?,
+                query_index..(query_index + 1),
+            );
         }
-        raw_encoder.begin_query(query_set.raw(), query_index);
+        raw_encoder.begin_query(query_set.try_raw(snatch_guard)?, query_index);
     }
 
     Ok(())
@@ -294,9 +312,10 @@ pub(super) fn validate_and_begin_occlusion_query(
 pub(super) fn end_occlusion_query(
     raw_encoder: &mut dyn hal::DynCommandEncoder,
     active_query: &mut Option<(Arc<QuerySet>, u32)>,
+    snatch_guard: &SnatchGuard<'_>,
 ) -> Result<(), QueryUseError> {
     if let Some((query_set, query_index)) = active_query.take() {
-        unsafe { raw_encoder.end_query(query_set.raw(), query_index) };
+        unsafe { raw_encoder.end_query(query_set.try_raw(snatch_guard)?, query_index) };
         Ok(())
     } else {
         Err(QueryUseError::AlreadyStopped)
@@ -311,6 +330,7 @@ pub(super) fn validate_and_begin_pipeline_statistics_query(
     query_index: u32,
     reset_state: Option<&mut QueryResetMap>,
     active_query: &mut Option<(Arc<QuerySet>, u32)>,
+    snatch_guard: &SnatchGuard<'_>,
 ) -> Result<(), QueryUseError> {
     query_set.same_device(device)?;
 
@@ -334,9 +354,12 @@ pub(super) fn validate_and_begin_pipeline_statistics_query(
     unsafe {
         // If we don't have a reset state tracker which can defer resets, we must reset now.
         if needs_reset {
-            raw_encoder.reset_queries(query_set.raw(), query_index..(query_index + 1));
+            raw_encoder.reset_queries(
+                query_set.try_raw(snatch_guard)?,
+                query_index..(query_index + 1),
+            );
         }
-        raw_encoder.begin_query(query_set.raw(), query_index);
+        raw_encoder.begin_query(query_set.try_raw(snatch_guard)?, query_index);
     }
 
     Ok(())
@@ -345,9 +368,10 @@ pub(super) fn validate_and_begin_pipeline_statistics_query(
 pub(super) fn end_pipeline_statistics_query(
     raw_encoder: &mut dyn hal::DynCommandEncoder,
     active_query: &mut Option<(Arc<QuerySet>, u32)>,
+    snatch_guard: &SnatchGuard<'_>,
 ) -> Result<(), QueryUseError> {
     if let Some((query_set, query_index)) = active_query.take() {
-        unsafe { raw_encoder.end_query(query_set.raw(), query_index) };
+        unsafe { raw_encoder.end_query(query_set.try_raw(snatch_guard)?, query_index) };
         Ok(())
     } else {
         Err(QueryUseError::AlreadyStopped)
@@ -411,7 +435,12 @@ pub(super) fn write_timestamp(
 
     query_set.same_device(state.device)?;
 
-    query_set.validate_and_write_timestamp(state.raw_encoder, query_index, None)?;
+    query_set.validate_and_write_timestamp(
+        state.raw_encoder,
+        query_index,
+        None,
+        state.snatch_guard,
+    )?;
 
     state.tracker.query_sets.insert_single(query_set);
 
@@ -495,7 +524,7 @@ pub(super) fn resolve_query_set(
     unsafe {
         state.raw_encoder.transition_buffers(dst_barrier.as_slice());
         state.raw_encoder.copy_query_results(
-            query_set.raw(),
+            query_set.try_raw(state.snatch_guard)?,
             start_query..end_query,
             raw_dst_buffer,
             destination_offset,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1633,7 +1633,7 @@ impl RenderPassInfo {
             }
 
             Some(hal::PassTimestampWrites {
-                query_set: query_set.raw(),
+                query_set: query_set.try_raw(snatch_guard)?,
                 beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
                 end_of_pass_write_index: tw.end_of_pass_write_index,
             })
@@ -1643,7 +1643,7 @@ impl RenderPassInfo {
 
         let occlusion_query_set_hal = if let Some(query_set) = occlusion_query_set.as_ref() {
             query_set.same_device(device)?;
-            Some(query_set.raw())
+            Some(query_set.try_raw(snatch_guard)?)
         } else {
             None
         };
@@ -2389,6 +2389,7 @@ pub(super) fn encode_render_pass(
                         query_index,
                         Some(&mut pending_query_resets),
                         &mut state.active_occlusion_query,
+                        state.pass.base.snatch_guard,
                     )
                     .map_pass_err(scope)?;
                 }
@@ -2399,6 +2400,7 @@ pub(super) fn encode_render_pass(
                     end_occlusion_query(
                         state.pass.base.raw_encoder,
                         &mut state.active_occlusion_query,
+                        state.pass.base.snatch_guard,
                     )
                     .map_pass_err(scope)?;
                 }
@@ -2420,6 +2422,7 @@ pub(super) fn encode_render_pass(
                         query_index,
                         Some(&mut pending_query_resets),
                         &mut state.active_pipeline_statistics_query,
+                        state.pass.base.snatch_guard,
                     )
                     .map_pass_err(scope)?;
                 }
@@ -2430,6 +2433,7 @@ pub(super) fn encode_render_pass(
                     end_pipeline_statistics_query(
                         state.pass.base.raw_encoder,
                         &mut state.active_pipeline_statistics_query,
+                        state.pass.base.snatch_guard,
                     )
                     .map_pass_err(scope)?;
                 }
@@ -2503,7 +2507,9 @@ pub(super) fn encode_render_pass(
             parent_state.snatch_guard,
         );
 
-        pending_query_resets.reset_queries(transit);
+        pending_query_resets
+            .reset_queries(transit, parent_state.snatch_guard)
+            .map_pass_err(pass_scope)?;
 
         CommandEncoder::insert_barriers_from_scope(
             transit,

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1313,6 +1313,25 @@ impl Global {
         (id, Some(error))
     }
 
+    pub fn query_set_destroy(&self, query_set_id: id::QuerySetId) {
+        profiling::scope!("QuerySet::destroy");
+        api_log!("QuerySet::destroy {query_set_id:?}");
+
+        let hub = &self.hub;
+
+        let Ok(query_set) = hub.query_sets.get(query_set_id).get() else {
+            // If the query set is already invalid, there's nothing to do.
+            return;
+        };
+
+        query_set.destroy();
+
+        #[cfg(feature = "trace")]
+        if let Some(trace) = query_set.device.trace.lock().as_mut() {
+            trace.add(trace::Action::FreeQuerySet(query_set.to_trace()));
+        };
+    }
+
     pub fn query_set_drop(&self, query_set_id: id::QuerySetId) {
         profiling::scope!("QuerySet::drop");
         api_log!("QuerySet::drop {query_set_id:?}");

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -2064,6 +2064,12 @@ fn validate_command_buffer(
                 }
             }
         }
+        {
+            profiling::scope!("query sets");
+            for query_set in &cmd_buf_data.trackers.query_sets {
+                query_set.try_raw(snatch_guard)?;
+            }
+        }
         // WebGPU requires that we check every bind group referenced during
         // encoding, even ones that may have been replaced before being used.
         // TODO(<https://github.com/gfx-rs/wgpu/issues/8510>): Optimize this.

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -5025,7 +5025,7 @@ impl Device {
             .map_err(|e| self.handle_hal_error_with_nonfatal_oom(e))?;
 
         let query_set = QuerySet {
-            raw: Snatchable::new(ManuallyDrop::new(raw)),
+            raw: Snatchable::new(raw),
             device: self.clone(),
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.query_sets.clone()),

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -5025,7 +5025,7 @@ impl Device {
             .map_err(|e| self.handle_hal_error_with_nonfatal_oom(e))?;
 
         let query_set = QuerySet {
-            raw: ManuallyDrop::new(raw),
+            raw: Snatchable::new(ManuallyDrop::new(raw)),
             device: self.clone(),
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.query_sets.clone()),

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -218,6 +218,7 @@ pub enum Action<'a, R: ReferenceType> {
         desc: crate::resource::QuerySetDescriptor<'a>,
     },
     DestroyQuerySet(PointerId<markers::QuerySet>),
+    FreeQuerySet(PointerId<markers::QuerySet>),
     WriteBuffer {
         id: R::Buffer,
         data: Data,

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -931,6 +931,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DestroyRenderPipeline(pipeline) => A::DestroyRenderPipeline(pipeline),
         A::DestroyPipelineCache(cache) => A::DestroyPipelineCache(cache),
         A::DestroyRenderBundle(render_bundle) => A::DestroyRenderBundle(render_bundle),
+        A::FreeQuerySet(query_set) => A::FreeQuerySet(query_set),
         A::DestroyQuerySet(query_set) => A::DestroyQuerySet(query_set),
         A::WriteBuffer {
             id,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2240,7 +2240,7 @@ pub type QuerySetDescriptor<'a> = wgt::QuerySetDescriptor<Label<'a>>;
 
 #[derive(Debug)]
 pub struct QuerySet {
-    pub(crate) raw: ManuallyDrop<Box<dyn hal::DynQuerySet>>,
+    pub(crate) raw: Snatchable<ManuallyDrop<Box<dyn hal::DynQuerySet>>>,
     pub(crate) device: Arc<Device>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
@@ -2248,13 +2248,43 @@ pub struct QuerySet {
     pub(crate) desc: wgt::QuerySetDescriptor<()>,
 }
 
+impl RawResourceAccess for QuerySet {
+    type DynResource = dyn hal::DynQuerySet;
+
+    fn raw<'a>(&'a self, guard: &'a SnatchGuard) -> Option<&'a Self::DynResource> {
+        self.raw.get(guard).map(|b| b.as_ref())
+    }
+}
+
+impl QuerySet {
+    pub fn destroy(self: &Arc<Self>) {
+        let mut snatch_guard = self.device.snatchable_lock.write();
+
+        let mut raw = match self.raw.snatch(&mut snatch_guard) {
+            Some(raw) => raw,
+            None => {
+                // Per spec, it is valid to call `destroy` multiple times.
+                return;
+            }
+        };
+
+        // SAFETY: We are in the destroy method and we don't use self.raw anymore after this point.
+        let raw = unsafe { ManuallyDrop::take(&mut raw) };
+        unsafe {
+            self.device.raw().destroy_query_set(raw);
+        }
+    }
+}
+
 impl Drop for QuerySet {
     fn drop(&mut self) {
         resource_log!("Destroy raw {}", self.error_ident());
-        // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
-        let raw = unsafe { ManuallyDrop::take(&mut self.raw) };
-        unsafe {
-            self.device.raw().destroy_query_set(raw);
+        if let Some(mut raw) = self.raw.take() {
+            // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
+            let raw = unsafe { ManuallyDrop::take(&mut raw) };
+            unsafe {
+                self.device.raw().destroy_query_set(raw);
+            }
         }
     }
 }
@@ -2264,12 +2294,6 @@ crate::impl_labeled!(QuerySet);
 crate::impl_parent_device!(QuerySet);
 crate::impl_storage_item!(QuerySet);
 crate::impl_trackable!(QuerySet);
-
-impl QuerySet {
-    pub(crate) fn raw(&self) -> &dyn hal::DynQuerySet {
-        self.raw.as_ref()
-    }
-}
 
 pub type BlasDescriptor<'a> = wgt::CreateBlasDescriptor<Label<'a>>;
 pub type TlasDescriptor<'a> = wgt::CreateTlasDescriptor<Label<'a>>;

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2240,7 +2240,7 @@ pub type QuerySetDescriptor<'a> = wgt::QuerySetDescriptor<Label<'a>>;
 
 #[derive(Debug)]
 pub struct QuerySet {
-    pub(crate) raw: Snatchable<ManuallyDrop<Box<dyn hal::DynQuerySet>>>,
+    pub(crate) raw: Snatchable<Box<dyn hal::DynQuerySet>>,
     pub(crate) device: Arc<Device>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
@@ -2260,7 +2260,7 @@ impl QuerySet {
     pub fn destroy(self: &Arc<Self>) {
         let mut snatch_guard = self.device.snatchable_lock.write();
 
-        let mut raw = match self.raw.snatch(&mut snatch_guard) {
+        let raw = match self.raw.snatch(&mut snatch_guard) {
             Some(raw) => raw,
             None => {
                 // Per spec, it is valid to call `destroy` multiple times.
@@ -2268,8 +2268,7 @@ impl QuerySet {
             }
         };
 
-        // SAFETY: We are in the destroy method and we don't use self.raw anymore after this point.
-        let raw = unsafe { ManuallyDrop::take(&mut raw) };
+        // SAFETY: We are in the destroy method and we don't use raw anymore after this point.
         unsafe {
             self.device.raw().destroy_query_set(raw);
         }
@@ -2279,9 +2278,8 @@ impl QuerySet {
 impl Drop for QuerySet {
     fn drop(&mut self) {
         resource_log!("Destroy raw {}", self.error_ident());
-        if let Some(mut raw) = self.raw.take() {
-            // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
-            let raw = unsafe { ManuallyDrop::take(&mut raw) };
+        if let Some(raw) = self.raw.take() {
+            // SAFETY: We are in the Drop impl and we don't use raw anymore after this point.
             unsafe {
                 self.device.raw().destroy_query_set(raw);
             }

--- a/wgpu/src/api/query_set.rs
+++ b/wgpu/src/api/query_set.rs
@@ -41,6 +41,11 @@ impl QuerySet {
         self.inner.as_custom()
     }
 
+    /// Destroys the [`QuerySet`], releasing its resources.
+    pub fn destroy(&self) {
+        self.inner.destroy();
+    }
+
     /// Returns the type of queries stored.
     pub fn ty(&self) -> QueryType {
         self.ty

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2964,7 +2964,12 @@ impl Drop for WebTlas {
     }
 }
 
-impl dispatch::QuerySetInterface for WebQuerySet {}
+impl dispatch::QuerySetInterface for WebQuerySet {
+    fn destroy(&self) {
+        self.inner.destroy();
+    }
+}
+
 impl Drop for WebQuerySet {
     fn drop(&mut self) {
         // no-op

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2388,7 +2388,11 @@ impl Drop for CoreTlas {
     }
 }
 
-impl dispatch::QuerySetInterface for CoreQuerySet {}
+impl dispatch::QuerySetInterface for CoreQuerySet {
+    fn destroy(&self) {
+        self.context.0.query_set_destroy(self.id);
+    }
+}
 
 impl Drop for CoreQuerySet {
     fn drop(&mut self) {

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -301,7 +301,9 @@ pub trait BlasInterface: CommonTraits {
     fn ready_for_compaction(&self) -> bool;
 }
 pub trait TlasInterface: CommonTraits {}
-pub trait QuerySetInterface: CommonTraits {}
+pub trait QuerySetInterface: CommonTraits {
+    fn destroy(&self);
+}
 pub trait PipelineLayoutInterface: CommonTraits {}
 pub trait RenderPipelineInterface: CommonTraits {
     fn get_bind_group_layout(&self, index: u32) -> DispatchBindGroupLayout;


### PR DESCRIPTION
**Connections**
Fixes #6495

**Description**
I followed the pattern of buffer, where we store hal type in snatchable and then destroy it. First commit makes that and deals with passing snatch_guard to other places (my first time working with snatches). Second commit implements proper destroy in deno/wgpu and player.

**Testing**
`webgpu:api,validation,queue,destroyed,query_set:*` tests pass now.

**Squash or Rebase?**

Squash; but reviewable per commit.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
