### PR TITLE
Add getters for `type` and `count` on `QuerySet`

### DIFF
--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -429,7 +429,11 @@ impl Device {
     #[must_use]
     pub fn create_query_set(&self, desc: &QuerySetDescriptor<'_>) -> QuerySet {
         let query_set = self.inner.create_query_set(desc);
-        QuerySet { inner: query_set }
+        QuerySet {
+            inner: query_set,
+            ty: desc.ty,
+            count: desc.count,
+        }
     }
 
     /// Set a callback which will be called for all errors that are not handled in error scopes.

--- a/wgpu/src/api/query_set.rs
+++ b/wgpu/src/api/query_set.rs
@@ -25,6 +25,8 @@ use crate::*;
 #[derive(Debug, Clone)]
 pub struct QuerySet {
     pub(crate) inner: dispatch::DispatchQuerySet,
+    pub(crate) ty: QueryType,
+    pub(crate) count: u32,
 }
 #[cfg(send_sync)]
 #[cfg(send_sync)]
@@ -37,6 +39,16 @@ impl QuerySet {
     /// Returns custom implementation of QuerySet (if custom backend and is internally T)
     pub fn as_custom<T: custom::QuerySetInterface>(&self) -> Option<&T> {
         self.inner.as_custom()
+    }
+
+    /// Returns the type of queries stored.
+    pub fn ty(&self) -> QueryType {
+        self.ty
+    }
+
+    /// Returns the number of query result slots.
+    pub fn count(&self) -> u32 {
+        self.count
     }
 }
 


### PR DESCRIPTION
**Description**
As usually, we store them on creation into wgpu object and then provide getters for them as required by spec: https://www.w3.org/TR/webgpu/#gpuqueryset

**Testing**
None

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
