### PR TITLE
fix packSnorm2x16/packUnorm2x16 swap in naga GLSL frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Added support for `enable wgpu_binding_array;`. By @39ali in [#9298](https://github.com/gfx-rs/wgpu/pull/9298).
 - Ability to disable integer division safety checks on Vulkan and Metal. By @kvark in [#9443](https://github.com/gfx-rs/wgpu/pull/9443).
 - \[hlsl\] more `matCx2` fixes. By @teoxoy in [#9507](https://github.com/gfx-rs/wgpu/pull/9507).
+- Fix `packSnorm2x16` and `packUnorm2x16` swap in the GLSL frontend. By @treylutton in [#9675](https://github.com/gfx-rs/wgpu/pull/9675).
 
 #### Vulkan
 

--- a/naga/src/front/glsl/builtins.rs
+++ b/naga/src/front/glsl/builtins.rs
@@ -753,8 +753,8 @@ fn inject_standard_builtins(
             let fun = match name {
                 "packSnorm4x8" => MathFunction::Pack4x8snorm,
                 "packUnorm4x8" => MathFunction::Pack4x8unorm,
-                "packSnorm2x16" => MathFunction::Pack2x16unorm,
-                "packUnorm2x16" => MathFunction::Pack2x16snorm,
+                "packSnorm2x16" => MathFunction::Pack2x16snorm,
+                "packUnorm2x16" => MathFunction::Pack2x16unorm,
                 "packHalf2x16" => MathFunction::Pack2x16float,
                 _ => unreachable!(),
             };

--- a/naga/tests/out/wgsl/glsl-bits.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-bits.frag.wgsl
@@ -15,9 +15,9 @@ fn main_1() {
     let _e30 = f4_;
     u = pack4x8unorm(_e30);
     let _e32 = f2_;
-    u = pack2x16unorm(_e32);
+    u = pack2x16snorm(_e32);
     let _e34 = f2_;
-    u = pack2x16snorm(_e34);
+    u = pack2x16unorm(_e34);
     let _e36 = f2_;
     u = pack2x16float(_e36);
     let _e38 = u;


### PR DESCRIPTION
**Connections**
Fix for [Issue #9669](https://github.com/gfx-rs/wgpu/issues/9669).

**Description**
Swapped the GLSL front end `MathFunction` mappings for `packSnorm2x16` and `packUnorm2x16`.  

**Testing**
These mappings were already covered in the `naga/tests/in/glsl/bits.frag` snapshot test. The updated `naga/tests/out/wgsl/glsl-bits.frag.wgsl` snapshot shows the corrected mappings.

**Squash or Rebase?**
Single commit. 

**Checklist**
- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
