### PR TITLE
Suppress renovate PRs until dependencies are of age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
   "prConcurrentLimit": 20,
   "prHourlyLimit": 200,
   "minimumReleaseAge": "1 week",
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
   "labels": ["dependencies"],
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
Small one that follows up https://github.com/gfx-rs/wgpu/pull/9598 to suppress PR creation until the age has elapsed. This _wont_ apply to things done with `cargo update` as that's handled by cargo.