### PR TITLE
fix(naga msl-out): Fix identifier collision for multiple fragment `return`s

### DIFF
--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -3445,7 +3445,7 @@ impl<W: Write> Writer<W> {
                 let result_ty = context.function.result.as_ref().unwrap().ty;
                 match context.module.types[result_ty].inner {
                     crate::TypeInner::Struct { ref members, .. } => {
-                        let tmp = "_tmp";
+                        let tmp = self.namer.call("_tmp");
                         write!(self.out, "{level}const auto {tmp} = ")?;
                         self.put_expression(expr_handle, context, true)?;
                         writeln!(self.out, ";")?;

--- a/naga/tests/in/wgsl/msl-9683-multiple-returns.toml
+++ b/naga/tests/in/wgsl/msl-9683-multiple-returns.toml
@@ -1,0 +1,1 @@
+targets = "METAL"

--- a/naga/tests/in/wgsl/msl-9683-multiple-returns.wgsl
+++ b/naga/tests/in/wgsl/msl-9683-multiple-returns.wgsl
@@ -1,0 +1,9 @@
+struct Outputs {
+    @location(0) color : vec4<f32>,
+}
+
+@fragment
+fn main() -> Outputs {
+    return Outputs(vec4f());
+    return Outputs(vec4f());
+}

--- a/naga/tests/out/msl/wgsl-fragment-output.metal
+++ b/naga/tests/out/msl/wgsl-fragment-output.metal
@@ -63,6 +63,6 @@ fragment main_vec2scalarOutput main_vec2scalar(
     output_1.scalari = 0;
     output_1.scalaru = 0u;
     FragmentOutputVec2Scalar _e16 = output_1;
-    const auto _tmp = _e16;
-    return main_vec2scalarOutput { _tmp.vec2f, _tmp.vec2i, _tmp.vec2u, _tmp.scalarf, _tmp.scalari, _tmp.scalaru };
+    const auto _tmp_1 = _e16;
+    return main_vec2scalarOutput { _tmp_1.vec2f, _tmp_1.vec2i, _tmp_1.vec2u, _tmp_1.scalarf, _tmp_1.scalari, _tmp_1.scalaru };
 }

--- a/naga/tests/out/msl/wgsl-interface.metal
+++ b/naga/tests/out/msl/wgsl-interface.metal
@@ -62,8 +62,8 @@ fragment fragment_Output fragment_(
     const VertexOutput in = { position, varyings_1._varying };
     uint mask = sample_mask & (1u << sample_index);
     float color_1 = front_facing ? 1.0 : 0.0;
-    const auto _tmp = FragmentOutput {in._varying, mask, color_1};
-    return fragment_Output { _tmp.depth, _tmp.sample_mask, _tmp.color };
+    const auto _tmp_1 = FragmentOutput {in._varying, mask, color_1};
+    return fragment_Output { _tmp_1.depth, _tmp_1.sample_mask, _tmp_1.color };
 }
 
 

--- a/naga/tests/out/msl/wgsl-msl-9683-multiple-returns.metal
+++ b/naga/tests/out/msl/wgsl-msl-9683-multiple-returns.metal
@@ -1,0 +1,20 @@
+// language: metal1.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+struct Outputs {
+    metal::float4 color;
+};
+
+struct main_Output {
+    metal::float4 color [[color(0)]];
+};
+fragment main_Output main_(
+) {
+    const auto _tmp = Outputs {metal::float4 {}};
+    return main_Output { _tmp.color };
+    const auto _tmp_1 = Outputs {metal::float4 {}};
+    return main_Output { _tmp_1.color };
+}


### PR DESCRIPTION
Fixes #9683 a.k.a. https://bugzilla.mozilla.org/show_bug.cgi?id=2046962 and https://github.com/TUDA-MUST/ITEP/issues/92.

**Description**
Use the namer.

**Testing**
Snapshot test.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
