### PR TITLE
Fix signed `%` wrong for negative operands in GLSL (OpenGL/GLES)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Bug Fixes
+
+#### GLES
+
+- Fixed signed integer `%` (and `%=`) returning the wrong result for negative operands in the GLSL (OpenGL/GLES) backend, e.g. `-1 % 768` yielding `255` instead of `-1`. GLSL's `%` is undefined when either operand is negative, so signed remainder is now lowered as `a - b * (a / b)`, matching the SPIR-V, HLSL, and Metal backends. By @mstampfli in [#9687](https://github.com/gfx-rs/wgpu/pull/9687).
+
 ## v30.0.0 (2026-07-01)
 
 ### Major changes

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -457,6 +457,10 @@ enum BinaryOperation {
     VectorComponentWise,
     /// GLSL `%` is SPIR-V `OpUMod/OpSMod` and `mod()` is `OpFMod`, but [`BinaryOperator::Modulo`](crate::BinaryOperator::Modulo) is `OpFRem`.
     Modulo,
+    /// Integer modulo. GLSL's `%` operator is undefined when either operand is
+    /// negative, so it is reconstructed as `a - b * (a / b)` (integer division
+    /// truncates toward zero, which is well defined), matching WGSL's truncated `%`.
+    ModuloInt,
     /// Any plain operation. No additional logic required.
     Other,
 }

--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -930,6 +930,22 @@ impl<'a, W: Write> Writer<'a, W> {
                     _ => {}
                 }
             }
+
+            if let Expression::Binary {
+                op: crate::BinaryOperator::Modulo,
+                left,
+                right,
+            } = *expr
+            {
+                // Integer `%` is lowered to `left - right * (left / right)` in
+                // write_expr (`BinaryOperation::ModuloInt`), which references each
+                // operand twice, so bake both to avoid re-evaluating them.
+                if let Some(crate::ScalarKind::Sint | crate::ScalarKind::Uint) = inner.scalar_kind()
+                {
+                    self.need_bake_expressions.insert(left);
+                    self.need_bake_expressions.insert(right);
+                }
+            }
         }
 
         for statement in func.body.iter() {
@@ -2878,6 +2894,9 @@ impl<'a, W: Write> Writer<'a, W> {
                         | Bo::Equal
                         | Bo::NotEqual => BinaryOperation::VectorCompare,
                         Bo::Modulo if scalar.kind == Sk::Float => BinaryOperation::Modulo,
+                        Bo::Modulo if scalar.kind == Sk::Sint || scalar.kind == Sk::Uint => {
+                            BinaryOperation::ModuloInt
+                        }
                         Bo::And if scalar.kind == Sk::Bool => {
                             op = crate::BinaryOperator::LogicalAnd;
                             BinaryOperation::VectorComponentWise
@@ -2893,6 +2912,11 @@ impl<'a, W: Write> Writer<'a, W> {
                             Bo::Modulo => BinaryOperation::Modulo,
                             _ => BinaryOperation::Other,
                         },
+                        (Some(Sk::Sint | Sk::Uint), _) | (_, Some(Sk::Sint | Sk::Uint))
+                            if op == Bo::Modulo =>
+                        {
+                            BinaryOperation::ModuloInt
+                        }
                         (Some(Sk::Bool), Some(Sk::Bool)) => match op {
                             Bo::InclusiveOr => {
                                 op = crate::BinaryOperator::LogicalOr;
@@ -2950,18 +2974,11 @@ impl<'a, W: Write> Writer<'a, W> {
 
                         write!(self.out, ")")?;
                     }
-                    // TODO: handle undefined behavior of BinaryOperator::Modulo
-                    //
-                    // sint:
-                    // if right == 0 return 0
-                    // if left == min(type_of(left)) && right == -1 return 0
-                    // if sign(left) == -1 || sign(right) == -1 return result as defined by WGSL
-                    //
-                    // uint:
-                    // if right == 0 return 0
-                    //
-                    // float:
-                    // if right == 0 return ? see https://github.com/gpuweb/gpuweb/issues/2798
+                    // Signed/unsigned integer `%` with a negative operand is handled by
+                    // `BinaryOperation::ModuloInt` below. Remaining TODO: the degenerate
+                    // div-by-zero / `INT_MIN % -1` cases (this backend also leaves integer
+                    // `/` unguarded), and float `% 0` (see
+                    // https://github.com/gpuweb/gpuweb/issues/2798).
                     BinaryOperation::Modulo => {
                         write!(self.out, "(")?;
 
@@ -2977,6 +2994,23 @@ impl<'a, W: Write> Writer<'a, W> {
                         write!(self.out, ")")?;
 
                         write!(self.out, ")")?;
+                    }
+                    BinaryOperation::ModuloInt => {
+                        // GLSL's `%` is undefined when either operand is negative.
+                        // Integer division truncates toward zero (which is well
+                        // defined), so reconstruct the remainder as `e1 - e2 * (e1 / e2)`.
+                        // This matches WGSL's truncated `%` for all operands; the
+                        // degenerate `x % 0` / `INT_MIN % -1` cases stay consistent
+                        // with this backend's unguarded integer `/`.
+                        write!(self.out, "(")?;
+                        self.write_expr(left, ctx)?;
+                        write!(self.out, " - ")?;
+                        self.write_expr(right, ctx)?;
+                        write!(self.out, " * (")?;
+                        self.write_expr(left, ctx)?;
+                        write!(self.out, " / ")?;
+                        self.write_expr(right, ctx)?;
+                        write!(self.out, "))")?;
                     }
                     BinaryOperation::Other => {
                         write!(self.out, "(")?;

--- a/naga/tests/out/glsl/wgsl-image.main.Compute.glsl
+++ b/naga/tests/out/glsl/wgsl-image.main.Compute.glsl
@@ -20,7 +20,9 @@ layout(r32ui) writeonly uniform uimage1D _group_0_binding_2_cs;
 void main() {
     uvec3 local_id = gl_LocalInvocationID;
     uvec2 dim = uvec2(imageSize(_group_0_binding_1_cs).xy);
-    ivec2 itc = (ivec2((dim * local_id.xy)) % ivec2(10, 20));
+    ivec2 _e5 = ivec2((dim * local_id.xy));
+    ivec2 _e8 = ivec2(10, 20);
+    ivec2 itc = (_e5 - _e8 * (_e5 / _e8));
     uvec4 value1_ = texelFetch(_group_0_binding_0_cs, itc, int(local_id.z));
     uvec4 value1_2_ = texelFetch(_group_0_binding_0_cs, itc, int(uint(local_id.z)));
     uvec4 value2_ = texelFetch(_group_0_binding_3_cs, itc, int(local_id.z));

--- a/naga/tests/out/glsl/wgsl-operators.main.Compute.glsl
+++ b/naga/tests/out/glsl/wgsl-operators.main.Compute.glsl
@@ -31,7 +31,9 @@ vec4 builtins() {
 
 vec4 splat(float m, int n) {
     vec2 a_2 = (((vec2(2.0) + vec2(m)) - vec2(4.0)) / vec2(8.0));
-    ivec4 b = (ivec4(n) % ivec4(2));
+    ivec4 _e12 = ivec4(n);
+    ivec4 _e14 = ivec4(2);
+    ivec4 b = (_e12 - _e14 * (_e12 / _e14));
     return (a_2.xyxy + vec4(b));
 }
 
@@ -163,11 +165,15 @@ void arithmetic() {
     ivec2 div3_ = (ivec2(2) / ivec2(1));
     uvec3 div4_ = (uvec3(2u) / uvec3(1u));
     vec4 div5_ = (vec4(2.0) / vec4(1.0));
-    int rem0_ = (2 % 1);
-    uint rem1_ = (2u % 1u);
+    int rem0_ = (2 - 1 * (2 / 1));
+    uint rem1_ = (2u - 1u * (2u / 1u));
     float rem2_ = (2.0 - 1.0 * trunc(2.0 / 1.0));
-    ivec2 rem3_ = (ivec2(2) % ivec2(1));
-    uvec3 rem4_ = (uvec3(2u) % uvec3(1u));
+    ivec2 _e62 = ivec2(2);
+    ivec2 _e63 = ivec2(1);
+    ivec2 rem3_ = (_e62 - _e63 * (_e62 / _e63));
+    uvec3 _e65 = uvec3(2u);
+    uvec3 _e66 = uvec3(1u);
+    uvec3 rem4_ = (_e65 - _e66 * (_e65 / _e66));
     vec4 rem5_ = (vec4(2.0) - vec4(1.0) * trunc(vec4(2.0) / vec4(1.0)));
     {
         ivec2 add0_1 = (ivec2(2) + ivec2(1));
@@ -194,10 +200,18 @@ void arithmetic() {
         uvec2 div3_1 = (uvec2(2u) / uvec2(1u));
         vec2 div4_1 = (vec2(2.0) / vec2(1.0));
         vec2 div5_1 = (vec2(2.0) / vec2(1.0));
-        ivec2 rem0_1 = (ivec2(2) % ivec2(1));
-        ivec2 rem1_1 = (ivec2(2) % ivec2(1));
-        uvec2 rem2_1 = (uvec2(2u) % uvec2(1u));
-        uvec2 rem3_1 = (uvec2(2u) % uvec2(1u));
+        ivec2 _e137 = ivec2(2);
+        ivec2 _e138 = ivec2(1);
+        ivec2 rem0_1 = (_e137 - _e138 * (_e137 / _e138));
+        ivec2 _e140 = ivec2(1);
+        ivec2 _e141 = ivec2(2);
+        ivec2 rem1_1 = (_e141 - _e140 * (_e141 / _e140));
+        uvec2 _e143 = uvec2(2u);
+        uvec2 _e144 = uvec2(1u);
+        uvec2 rem2_1 = (_e143 - _e144 * (_e143 / _e144));
+        uvec2 _e146 = uvec2(1u);
+        uvec2 _e147 = uvec2(2u);
+        uvec2 rem3_1 = (_e147 - _e146 * (_e147 / _e146));
         vec2 rem4_1 = (vec2(2.0) - vec2(1.0) * trunc(vec2(2.0) / vec2(1.0)));
         vec2 rem5_1 = (vec2(2.0) - vec2(1.0) * trunc(vec2(2.0) / vec2(1.0)));
     }
@@ -296,7 +310,7 @@ void assignment() {
     int _e13 = a_1;
     a_1 = (_e12 / _e13);
     int _e15 = a_1;
-    a_1 = (_e15 % 1);
+    a_1 = (_e15 - 1 * (_e15 / 1));
     int _e17 = a_1;
     a_1 = (_e17 & 0);
     int _e19 = a_1;


### PR DESCRIPTION
Sibling of #9674 and the same class of bug as #8191: signed integer `%` wrong for negative operands, this time in the GLSL (OpenGL/GLES) backend instead of SPIR-V.

### Problem

WGSL defines signed integer `%` for all non-degenerate operands. `-1 % 768` must be `-1` (truncated remainder, sign of the dividend; WGSL 8.7). But rendered through the GLSL backend it returns `255`, i.e. `(-1 as u32) % 768`.

naga's GLSL backend emits a raw `a % b` for integer modulo. GLSL leaves `%` undefined when either operand is negative (GLSL spec 5.9), so the result is implementation defined. HLSL and Metal already reconstruct around this; GLSL did not. Same gap as #8191 on Vulkan, different backend.

### Evidence

WGSL `a % b` run through the GLSL backend on an NVIDIA RTX 5060 OpenGL driver (610.43.02), before this change:

```
a         : -4  -3  -2  -1   0   1   2   3
a % 3 (cpu): -1   0  -2  -1   0   1   2   0
a % 3 (gpu):  2   0   1   2   0   1   2   0    WRONG for negatives

a % 768   : -1 -> 255 (should be -1),  -5 -> 251,  -769 -> 255, ...
```

Every negative dividend was wrong (32 of the 64 tested values), the same unsigned-fold symptom as the Vulkan case.

### Fix

Integer division `/` truncates toward zero and is well defined in GLSL, so signed and unsigned `%` is lowered as `a - b * (a / b)`, exactly mirroring the existing HLSL and Metal backends. Float modulo (already a `trunc`-based reconstruction) is unchanged.

Unlike the Vulkan fix this is unconditional rather than driver gated: GLSL's `%` is undefined for negative operands per spec, so it affects every OpenGL/GLES target, not one vendor.

### Testing

- Regenerated snapshots: only the `operators` and `image` GLSL outputs change (integer `%` becomes the reconstruction). HLSL, MSL, SPIR-V, and WGSL outputs are byte-for-byte unchanged. `operators.wgsl` already covers scalar, vector, and mixed scalar/vector modulo for signed and unsigned ints.
- Re-ran the same shaders on the NVIDIA RTX 5060 OpenGL driver after the fix: all negative dividends match the CPU reference (`-1 % 3 == -1`, `-2 % 3 == -2`, `-1 % 768 == -1`), 0 mismatches across the tested range.

Squash or rebase? Squash.
