### PR TITLE
[tracing] Rename `Destroy*` -> `Drop*` and `Free*` -> `Destroy*` to match wgc and spec

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -145,9 +145,7 @@ impl Player {
                 let texture = device.create_texture(&desc).expect("create_texture error");
                 self.textures.insert(id, texture);
             }
-            Action::FreeTexture(id) => {
-                // Note: texture remains in the HashMap. "Free" and "Destroy"
-                // mean the opposite from WebGPU.
+            Action::DestroyTexture(id) => {
                 let texture = self.textures.get(&id).expect("invalid texture");
                 texture.destroy();
             }

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -139,7 +139,7 @@ impl Player {
                 let buffer = self.buffers.get(&id).expect("invalid buffer");
                 buffer.destroy();
             }
-            Action::DestroyBuffer(id) => {
+            Action::DropBuffer(id) => {
                 let buffer = self.buffers.remove(&id).expect("invalid buffer");
                 let _ = buffer.unmap();
             }

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -353,7 +353,7 @@ impl Player {
                     pipeline,
                 );
             }
-            Action::DestroyComputePipeline(id) => {
+            Action::DropComputePipeline(id) => {
                 self.compute_pipelines
                     .remove(&id)
                     .expect("invalid compute pipeline");

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -260,7 +260,7 @@ impl Player {
                     .expect("create_bind_group error");
                 self.bind_groups.insert(id, bind_group);
             }
-            Action::DestroyBindGroup(id) => {
+            Action::DropBindGroup(id) => {
                 let _bind_group = self.bind_groups.remove(&id).expect("invalid bind group");
             }
             Action::CreateShaderModule { id, desc, data } => {

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -224,7 +224,7 @@ impl Player {
                     .expect("invalid compute pipeline");
                 self.bind_group_layouts.insert(id, bgl);
             }
-            Action::DestroyBindGroupLayout(id) => {
+            Action::DropBindGroupLayout(id) => {
                 self.bind_group_layouts
                     .remove(&id)
                     .expect("invalid bind group layout");

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -388,7 +388,7 @@ impl Player {
             Action::CreateRenderBundle { .. } => {
                 unimplemented!("traced render bundles are not supported");
             }
-            Action::DestroyRenderBundle(id) => {
+            Action::DropRenderBundle(id) => {
                 self.render_bundles
                     .remove(&id)
                     .expect("invalid render bundle");

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -476,7 +476,7 @@ impl Player {
                 let tlas = device.create_tlas(&desc).expect("create_tlas error");
                 self.tlas_s.insert(id, tlas);
             }
-            Action::DestroyTlas(id) => {
+            Action::DropTlas(id) => {
                 self.tlas_s.remove(&id).expect("invalid tlas");
             }
         }

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -405,9 +405,7 @@ impl Player {
                     .expect("create_query_set error");
                 self.query_sets.insert(id, query_set);
             }
-            Action::FreeQuerySet(id) => {
-                // Note: query set remains in the HashMap. "Free" and "Destroy"
-                // mean the opposite from WebGPU.
+            Action::DestroyQuerySet(id) => {
                 let query_set = self.query_sets.get(&id).expect("invalid query set");
                 query_set.destroy();
             }

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -159,7 +159,7 @@ impl Player {
                     .expect("create_texture_view error");
                 self.texture_views.insert(id, texture_view);
             }
-            Action::DestroyTextureView(id) => {
+            Action::DropTextureView(id) => {
                 self.texture_views
                     .remove(&id)
                     .expect("invalid texture view");

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -190,7 +190,7 @@ impl Player {
                 let sampler = device.create_sampler(&desc).expect("create_sampler error");
                 self.samplers.insert(id, sampler);
             }
-            Action::DestroySampler(id) => {
+            Action::DropSampler(id) => {
                 self.samplers.remove(&id).expect("invalid sampler");
             }
             Action::GetSurfaceTexture { .. } => {

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -338,7 +338,7 @@ impl Player {
                     Err(e) => panic!("shader compilation error:\n{e}"),
                 };
             }
-            Action::DestroyShaderModule(id) => {
+            Action::DropShaderModule(id) => {
                 self.shader_modules
                     .remove(&id)
                     .expect("invalid shader module");

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -411,7 +411,7 @@ impl Player {
                 let query_set = self.query_sets.get(&id).expect("invalid query set");
                 query_set.destroy();
             }
-            Action::DestroyQuerySet(id) => {
+            Action::DropQuerySet(id) => {
                 self.query_sets.remove(&id).expect("invalid query set");
             }
             Action::WriteBuffer {

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -183,7 +183,7 @@ impl Player {
                     .expect("invalid external texture");
                 external_texture.destroy();
             }
-            Action::DestroyExternalTexture(id) => {
+            Action::DropExternalTexture(id) => {
                 self.external_textures
                     .remove(&id)
                     .expect("invalid external texture");

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -469,7 +469,7 @@ impl Player {
                 let blas = device.create_blas(&desc, sizes).expect("create_blas error");
                 self.blas_s.insert(id, blas);
             }
-            Action::DestroyBlas(id) => {
+            Action::DropBlas(id) => {
                 self.blas_s.remove(&id).expect("invalid blas");
             }
             Action::CreateTlas { id, desc } => {

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -174,9 +174,7 @@ impl Player {
                     .expect("create_external_texture error");
                 self.external_textures.insert(id, external_texture);
             }
-            Action::FreeExternalTexture(id) => {
-                // Note: external texture remains in the HashMap. "Free" and "Destroy"
-                // mean the opposite from WebGPU.
+            Action::DestroyExternalTexture(id) => {
                 let external_texture = self
                     .external_textures
                     .get(&id)

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -151,7 +151,7 @@ impl Player {
                 let texture = self.textures.get(&id).expect("invalid texture");
                 texture.destroy();
             }
-            Action::DestroyTexture(id) => {
+            Action::DropTexture(id) => {
                 self.textures.remove(&id).expect("invalid texture");
             }
             Action::CreateTextureView { id, parent, desc } => {

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -248,7 +248,7 @@ impl Player {
                     .expect("create_pipeline_layout error");
                 self.pipeline_layouts.insert(id, pipeline_layout);
             }
-            Action::DestroyPipelineLayout(id) => {
+            Action::DropPipelineLayout(id) => {
                 self.pipeline_layouts
                     .remove(&id)
                     .expect("invalid pipeline layout");

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -133,9 +133,7 @@ impl Player {
                 let buffer = device.create_buffer(&desc).expect("create_buffer error");
                 self.buffers.insert(id, buffer);
             }
-            Action::FreeBuffer(id) => {
-                // Note: buffer remains in the HashMap. "Free" and "Destroy"
-                // mean the opposite from WebGPU.
+            Action::DestroyBuffer(id) => {
                 let buffer = self.buffers.get(&id).expect("invalid buffer");
                 buffer.destroy();
             }

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -380,7 +380,7 @@ impl Player {
                 let cache = unsafe { device.create_pipeline_cache(&desc) }.unwrap();
                 self.pipeline_caches.insert(id, cache);
             }
-            Action::DestroyPipelineCache(id) => {
+            Action::DropPipelineCache(id) => {
                 self.pipeline_caches
                     .remove(&id)
                     .expect("invalid pipeline cache");

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -371,7 +371,7 @@ impl Player {
                     pipeline,
                 );
             }
-            Action::DestroyRenderPipeline(id) => {
+            Action::DropRenderPipeline(id) => {
                 self.render_pipelines
                     .remove(&id)
                     .expect("invalid render pipeline");

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1145,7 +1145,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(shader_module) = _shader_module.get() {
             if let Some(t) = shader_module.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyShaderModule(shader_module.to_trace()));
+                t.add(trace::Action::DropShaderModule(shader_module.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -495,7 +495,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(view) = _view.get() {
             if let Some(t) = view.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyTextureView(view.to_trace()));
+                t.add(trace::Action::DropTextureView(view.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1641,7 +1641,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(pipeline) = _pipeline.get() {
             if let Some(t) = pipeline.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyRenderPipeline(pipeline.to_trace()));
+                t.add(trace::Action::DropRenderPipeline(pipeline.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -973,7 +973,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(bind_group) = _bind_group.get() {
             if let Some(t) = bind_group.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyBindGroup(bind_group.to_trace()));
+                t.add(trace::Action::DropBindGroup(bind_group.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1343,7 +1343,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(query_set) = _query_set.get() {
             if let Some(trace) = query_set.device.trace.lock().as_mut() {
-                trace.add(trace::Action::DestroyQuerySet(query_set.to_trace()));
+                trace.add(trace::Action::DropQuerySet(query_set.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -590,7 +590,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(external_texture) = _external_texture.get() {
             if let Some(t) = external_texture.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyExternalTexture(
+                t.add(trace::Action::DropExternalTexture(
                     external_texture.to_trace(),
                 ));
             }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -273,7 +273,7 @@ impl Global {
 
         #[cfg(feature = "trace")]
         if let Some(t) = buffer.device.trace.lock().as_mut() {
-            t.add(trace::Action::DestroyBuffer(buffer.to_trace()));
+            t.add(trace::Action::DropBuffer(buffer.to_trace()));
         }
 
         let _ = buffer.unmap();

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -250,7 +250,7 @@ impl Global {
 
         #[cfg(feature = "trace")]
         if let Some(trace) = buffer.device.trace.lock().as_mut() {
-            trace.add(trace::Action::FreeBuffer(buffer.to_trace()));
+            trace.add(trace::Action::DestroyBuffer(buffer.to_trace()));
         }
 
         let _ = buffer.unmap();

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1271,7 +1271,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(bundle) = _bundle.get() {
             if let Some(t) = bundle.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyRenderBundle(bundle.to_trace()));
+                t.add(trace::Action::DropRenderBundle(bundle.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -645,7 +645,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(sampler) = _sampler.get() {
             if let Some(t) = sampler.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroySampler(sampler.to_trace()));
+                t.add(trace::Action::DropSampler(sampler.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -435,7 +435,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(texture) = _texture.get() {
             if let Some(t) = texture.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyTexture(texture.to_trace()));
+                t.add(trace::Action::DropTexture(texture.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1328,7 +1328,7 @@ impl Global {
 
         #[cfg(feature = "trace")]
         if let Some(trace) = query_set.device.trace.lock().as_mut() {
-            trace.add(trace::Action::FreeQuerySet(query_set.to_trace()));
+            trace.add(trace::Action::DestroyQuerySet(query_set.to_trace()));
         };
     }
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1853,7 +1853,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(cache) = _cache.get() {
             if let Some(t) = cache.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyPipelineCache(cache.to_trace()));
+                t.add(trace::Action::DropPipelineCache(cache.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -701,7 +701,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(layout) = _layout.get() {
             if let Some(t) = layout.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyBindGroupLayout(layout.to_trace()));
+                t.add(trace::Action::DropBindGroupLayout(layout.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -782,7 +782,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(layout) = _layout.get() {
             if let Some(t) = layout.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyPipelineLayout(layout.to_trace()));
+                t.add(trace::Action::DropPipelineLayout(layout.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -571,7 +571,7 @@ impl Global {
 
         #[cfg(feature = "trace")]
         if let Some(trace) = external_texture.device.trace.lock().as_mut() {
-            trace.add(trace::Action::FreeExternalTexture(
+            trace.add(trace::Action::DestroyExternalTexture(
                 external_texture.to_trace(),
             ));
         }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -419,7 +419,7 @@ impl Global {
 
         #[cfg(feature = "trace")]
         if let Some(trace) = texture.device.trace.lock().as_mut() {
-            trace.add(trace::Action::FreeTexture(texture.to_trace()));
+            trace.add(trace::Action::DestroyTexture(texture.to_trace()));
         }
 
         texture.destroy();

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1793,7 +1793,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(pipeline) = _pipeline.get() {
             if let Some(t) = pipeline.device.trace.lock().as_mut() {
-                t.add(trace::Action::DestroyComputePipeline(pipeline.to_trace()));
+                t.add(trace::Action::DropComputePipeline(pipeline.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -399,7 +399,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(tlas) = _tlas.get() {
             if let Some(t) = tlas.device.trace.lock().as_mut() {
-                t.add(Action::DestroyTlas(tlas.to_trace()));
+                t.add(Action::DropTlas(tlas.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -385,7 +385,7 @@ impl Global {
         #[cfg(feature = "trace")]
         if let Ok(blas) = _blas.get() {
             if let Some(t) = blas.device.trace.lock().as_mut() {
-                t.add(Action::DestroyBlas(blas.to_trace()));
+                t.add(Action::DropBlas(blas.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -128,7 +128,7 @@ pub enum Action<'a, R: ReferenceType> {
     DestroyBuffer(R::Buffer),
     DropBuffer(R::Buffer),
     CreateTexture(R::Texture, crate::resource::TextureDescriptor<'a>),
-    FreeTexture(R::Texture),
+    DestroyTexture(R::Texture),
     DropTexture(R::Texture),
     CreateTextureView {
         id: R::TextureView,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -125,7 +125,7 @@ pub enum Action<'a, R: ReferenceType> {
         wgt::SurfaceConfiguration<Vec<wgt::TextureFormat>>,
     ),
     CreateBuffer(R::Buffer, crate::resource::BufferDescriptor<'a>),
-    FreeBuffer(R::Buffer),
+    DestroyBuffer(R::Buffer),
     DropBuffer(R::Buffer),
     CreateTexture(R::Texture, crate::resource::TextureDescriptor<'a>),
     FreeTexture(R::Texture),

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -147,7 +147,7 @@ pub enum Action<'a, R: ReferenceType> {
         PointerId<markers::Sampler>,
         crate::resource::SamplerDescriptor<'a>,
     ),
-    DestroySampler(PointerId<markers::Sampler>),
+    DropSampler(PointerId<markers::Sampler>),
     GetSurfaceTexture {
         id: R::Texture,
         parent: R::Surface,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -218,7 +218,7 @@ pub enum Action<'a, R: ReferenceType> {
         desc: crate::resource::QuerySetDescriptor<'a>,
     },
     DropQuerySet(PointerId<markers::QuerySet>),
-    FreeQuerySet(PointerId<markers::QuerySet>),
+    DestroyQuerySet(PointerId<markers::QuerySet>),
     WriteBuffer {
         id: R::Buffer,
         data: Data,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -142,7 +142,7 @@ pub enum Action<'a, R: ReferenceType> {
         planes: alloc::boxed::Box<[R::TextureView]>,
     },
     FreeExternalTexture(R::ExternalTexture),
-    DestroyExternalTexture(R::ExternalTexture),
+    DropExternalTexture(R::ExternalTexture),
     CreateSampler(
         PointerId<markers::Sampler>,
         crate::resource::SamplerDescriptor<'a>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -206,7 +206,7 @@ pub enum Action<'a, R: ReferenceType> {
         id: PointerId<markers::PipelineCache>,
         desc: crate::pipeline::PipelineCacheDescriptor<'a>,
     },
-    DestroyPipelineCache(PointerId<markers::PipelineCache>),
+    DropPipelineCache(PointerId<markers::PipelineCache>),
     CreateRenderBundle {
         id: R::RenderBundle,
         desc: crate::command::RenderBundleEncoderDescriptor<'a>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -126,7 +126,7 @@ pub enum Action<'a, R: ReferenceType> {
     ),
     CreateBuffer(R::Buffer, crate::resource::BufferDescriptor<'a>),
     FreeBuffer(R::Buffer),
-    DestroyBuffer(R::Buffer),
+    DropBuffer(R::Buffer),
     CreateTexture(R::Texture, crate::resource::TextureDescriptor<'a>),
     FreeTexture(R::Texture),
     DestroyTexture(R::Texture),

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -246,7 +246,7 @@ pub enum Action<'a, R: ReferenceType> {
         desc: crate::resource::BlasDescriptor<'a>,
         sizes: wgt::BlasGeometrySizeDescriptors,
     },
-    DestroyBlas(R::Blas),
+    DropBlas(R::Blas),
     CreateTlas {
         id: R::Tlas,
         desc: crate::resource::TlasDescriptor<'a>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -191,7 +191,7 @@ pub enum Action<'a, R: ReferenceType> {
         label: crate::Label<'a>,
         entry_points: Cow<'a, [wgt::PassthroughShaderEntryPoint<'a>]>,
     },
-    DestroyShaderModule(PointerId<markers::ShaderModule>),
+    DropShaderModule(PointerId<markers::ShaderModule>),
     CreateComputePipeline {
         id: Option<PointerId<markers::ComputePipeline>>,
         desc: TraceComputePipelineDescriptor<'a>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -141,7 +141,7 @@ pub enum Action<'a, R: ReferenceType> {
         desc: crate::resource::ExternalTextureDescriptor<'a>,
         planes: alloc::boxed::Box<[R::TextureView]>,
     },
-    FreeExternalTexture(R::ExternalTexture),
+    DestroyExternalTexture(R::ExternalTexture),
     DropExternalTexture(R::ExternalTexture),
     CreateSampler(
         PointerId<markers::Sampler>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -217,7 +217,7 @@ pub enum Action<'a, R: ReferenceType> {
         id: PointerId<markers::QuerySet>,
         desc: crate::resource::QuerySetDescriptor<'a>,
     },
-    DestroyQuerySet(PointerId<markers::QuerySet>),
+    DropQuerySet(PointerId<markers::QuerySet>),
     FreeQuerySet(PointerId<markers::QuerySet>),
     WriteBuffer {
         id: R::Buffer,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -168,7 +168,7 @@ pub enum Action<'a, R: ReferenceType> {
         pipeline: PointerId<markers::ComputePipeline>,
         index: u32,
     },
-    DestroyBindGroupLayout(PointerId<markers::BindGroupLayout>),
+    DropBindGroupLayout(PointerId<markers::BindGroupLayout>),
     CreatePipelineLayout(
         PointerId<markers::PipelineLayout>,
         crate::binding_model::ResolvedPipelineLayoutDescriptor<

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -135,7 +135,7 @@ pub enum Action<'a, R: ReferenceType> {
         parent: R::Texture,
         desc: crate::resource::TextureViewDescriptor<'a>,
     },
-    DestroyTextureView(R::TextureView),
+    DropTextureView(R::TextureView),
     CreateExternalTexture {
         id: R::ExternalTexture,
         desc: crate::resource::ExternalTextureDescriptor<'a>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -196,7 +196,7 @@ pub enum Action<'a, R: ReferenceType> {
         id: Option<PointerId<markers::ComputePipeline>>,
         desc: TraceComputePipelineDescriptor<'a>,
     },
-    DestroyComputePipeline(PointerId<markers::ComputePipeline>),
+    DropComputePipeline(PointerId<markers::ComputePipeline>),
     CreateGeneralRenderPipeline {
         id: Option<PointerId<markers::RenderPipeline>>,
         desc: TraceGeneralRenderPipelineDescriptor<'a>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -251,7 +251,7 @@ pub enum Action<'a, R: ReferenceType> {
         id: R::Tlas,
         desc: crate::resource::TlasDescriptor<'a>,
     },
-    DestroyTlas(R::Tlas),
+    DropTlas(R::Tlas),
 }
 
 /// cbindgen:ignore

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -176,7 +176,7 @@ pub enum Action<'a, R: ReferenceType> {
             PointerId<markers::BindGroupLayout>,
         >,
     ),
-    DestroyPipelineLayout(PointerId<markers::PipelineLayout>),
+    DropPipelineLayout(PointerId<markers::PipelineLayout>),
     CreateBindGroup(PointerId<markers::BindGroup>, TraceBindGroupDescriptor<'a>),
     DestroyBindGroup(PointerId<markers::BindGroup>),
     CreateShaderModule {

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -129,7 +129,7 @@ pub enum Action<'a, R: ReferenceType> {
     DropBuffer(R::Buffer),
     CreateTexture(R::Texture, crate::resource::TextureDescriptor<'a>),
     FreeTexture(R::Texture),
-    DestroyTexture(R::Texture),
+    DropTexture(R::Texture),
     CreateTextureView {
         id: R::TextureView,
         parent: R::Texture,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -201,7 +201,7 @@ pub enum Action<'a, R: ReferenceType> {
         id: Option<PointerId<markers::RenderPipeline>>,
         desc: TraceGeneralRenderPipelineDescriptor<'a>,
     },
-    DestroyRenderPipeline(PointerId<markers::RenderPipeline>),
+    DropRenderPipeline(PointerId<markers::RenderPipeline>),
     CreatePipelineCache {
         id: PointerId<markers::PipelineCache>,
         desc: crate::pipeline::PipelineCacheDescriptor<'a>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -212,7 +212,7 @@ pub enum Action<'a, R: ReferenceType> {
         desc: crate::command::RenderBundleEncoderDescriptor<'a>,
         base: BasePass<RenderCommand<R>, Infallible>,
     },
-    DestroyRenderBundle(PointerId<markers::RenderBundle>),
+    DropRenderBundle(PointerId<markers::RenderBundle>),
     CreateQuerySet {
         id: PointerId<markers::QuerySet>,
         desc: crate::resource::QuerySetDescriptor<'a>,

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -178,7 +178,7 @@ pub enum Action<'a, R: ReferenceType> {
     ),
     DropPipelineLayout(PointerId<markers::PipelineLayout>),
     CreateBindGroup(PointerId<markers::BindGroup>, TraceBindGroupDescriptor<'a>),
-    DestroyBindGroup(PointerId<markers::BindGroup>),
+    DropBindGroup(PointerId<markers::BindGroup>),
     CreateShaderModule {
         id: PointerId<markers::ShaderModule>,
         desc: crate::pipeline::ShaderModuleDescriptor<'a>,

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -898,7 +898,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DropBuffer(buffer) => A::DropBuffer(buffer),
         A::DestroyTexture(texture) => A::DestroyTexture(texture),
         A::DropTexture(texture) => A::DropTexture(texture),
-        A::DestroyTextureView(texture_view) => A::DestroyTextureView(texture_view),
+        A::DropTextureView(texture_view) => A::DropTextureView(texture_view),
         A::DestroyExternalTexture(external_texture) => A::DestroyExternalTexture(external_texture),
         A::DropExternalTexture(external_texture) => A::DropExternalTexture(external_texture),
         A::DestroySampler(sampler) => A::DestroySampler(sampler),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -929,7 +929,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DropShaderModule(shader_module) => A::DropShaderModule(shader_module),
         A::DropComputePipeline(pipeline) => A::DropComputePipeline(pipeline),
         A::DropRenderPipeline(pipeline) => A::DropRenderPipeline(pipeline),
-        A::DestroyPipelineCache(cache) => A::DestroyPipelineCache(cache),
+        A::DropPipelineCache(cache) => A::DropPipelineCache(cache),
         A::DestroyRenderBundle(render_bundle) => A::DestroyRenderBundle(render_bundle),
         A::DestroyQuerySet(query_set) => A::DestroyQuerySet(query_set),
         A::DropQuerySet(query_set) => A::DropQuerySet(query_set),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -925,7 +925,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
             index,
         },
         A::DropPipelineLayout(layout) => A::DropPipelineLayout(layout),
-        A::DestroyBindGroup(bind_group) => A::DestroyBindGroup(bind_group),
+        A::DropBindGroup(bind_group) => A::DropBindGroup(bind_group),
         A::DestroyShaderModule(shader_module) => A::DestroyShaderModule(shader_module),
         A::DestroyComputePipeline(pipeline) => A::DestroyComputePipeline(pipeline),
         A::DestroyRenderPipeline(pipeline) => A::DestroyRenderPipeline(pipeline),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -926,7 +926,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         },
         A::DropPipelineLayout(layout) => A::DropPipelineLayout(layout),
         A::DropBindGroup(bind_group) => A::DropBindGroup(bind_group),
-        A::DestroyShaderModule(shader_module) => A::DestroyShaderModule(shader_module),
+        A::DropShaderModule(shader_module) => A::DropShaderModule(shader_module),
         A::DestroyComputePipeline(pipeline) => A::DestroyComputePipeline(pipeline),
         A::DestroyRenderPipeline(pipeline) => A::DestroyRenderPipeline(pipeline),
         A::DestroyPipelineCache(cache) => A::DestroyPipelineCache(cache),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -968,7 +968,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
             error,
         },
         A::DropBlas(blas) => A::DropBlas(blas),
-        A::DestroyTlas(tlas) => A::DestroyTlas(tlas),
+        A::DropTlas(tlas) => A::DropTlas(tlas),
 
         A::CreateTexture(..)
         | A::CreateTextureView { .. }

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -901,7 +901,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DropTextureView(texture_view) => A::DropTextureView(texture_view),
         A::DestroyExternalTexture(external_texture) => A::DestroyExternalTexture(external_texture),
         A::DropExternalTexture(external_texture) => A::DropExternalTexture(external_texture),
-        A::DestroySampler(sampler) => A::DestroySampler(sampler),
+        A::DropSampler(sampler) => A::DropSampler(sampler),
         A::GetSurfaceTexture { id, parent } => A::GetSurfaceTexture { id, parent },
         A::Present(surface) => A::Present(surface),
         A::DiscardSurfaceTexture(surface) => A::DiscardSurfaceTexture(surface),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -896,7 +896,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         ),
         A::DestroyBuffer(buffer) => A::DestroyBuffer(buffer),
         A::DropBuffer(buffer) => A::DropBuffer(buffer),
-        A::FreeTexture(texture) => A::FreeTexture(texture),
+        A::DestroyTexture(texture) => A::DestroyTexture(texture),
         A::DropTexture(texture) => A::DropTexture(texture),
         A::DestroyTextureView(texture_view) => A::DestroyTextureView(texture_view),
         A::FreeExternalTexture(external_texture) => A::FreeExternalTexture(external_texture),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -894,7 +894,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
                 mapped_at_creation: desc.mapped_at_creation,
             },
         ),
-        A::FreeBuffer(buffer) => A::FreeBuffer(buffer),
+        A::DestroyBuffer(buffer) => A::DestroyBuffer(buffer),
         A::DropBuffer(buffer) => A::DropBuffer(buffer),
         A::FreeTexture(texture) => A::FreeTexture(texture),
         A::DestroyTexture(texture) => A::DestroyTexture(texture),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -967,7 +967,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
             failed_at_submit,
             error,
         },
-        A::DestroyBlas(blas) => A::DestroyBlas(blas),
+        A::DropBlas(blas) => A::DropBlas(blas),
         A::DestroyTlas(tlas) => A::DestroyTlas(tlas),
 
         A::CreateTexture(..)

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -895,7 +895,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
             },
         ),
         A::FreeBuffer(buffer) => A::FreeBuffer(buffer),
-        A::DestroyBuffer(buffer) => A::DestroyBuffer(buffer),
+        A::DropBuffer(buffer) => A::DropBuffer(buffer),
         A::FreeTexture(texture) => A::FreeTexture(texture),
         A::DestroyTexture(texture) => A::DestroyTexture(texture),
         A::DestroyTextureView(texture_view) => A::DestroyTextureView(texture_view),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -899,7 +899,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DestroyTexture(texture) => A::DestroyTexture(texture),
         A::DropTexture(texture) => A::DropTexture(texture),
         A::DestroyTextureView(texture_view) => A::DestroyTextureView(texture_view),
-        A::FreeExternalTexture(external_texture) => A::FreeExternalTexture(external_texture),
+        A::DestroyExternalTexture(external_texture) => A::DestroyExternalTexture(external_texture),
         A::DropExternalTexture(external_texture) => A::DropExternalTexture(external_texture),
         A::DestroySampler(sampler) => A::DestroySampler(sampler),
         A::GetSurfaceTexture { id, parent } => A::GetSurfaceTexture { id, parent },

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -932,7 +932,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DestroyPipelineCache(cache) => A::DestroyPipelineCache(cache),
         A::DestroyRenderBundle(render_bundle) => A::DestroyRenderBundle(render_bundle),
         A::FreeQuerySet(query_set) => A::FreeQuerySet(query_set),
-        A::DestroyQuerySet(query_set) => A::DestroyQuerySet(query_set),
+        A::DropQuerySet(query_set) => A::DropQuerySet(query_set),
         A::WriteBuffer {
             id,
             data,

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -924,7 +924,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
             pipeline,
             index,
         },
-        A::DestroyPipelineLayout(layout) => A::DestroyPipelineLayout(layout),
+        A::DropPipelineLayout(layout) => A::DropPipelineLayout(layout),
         A::DestroyBindGroup(bind_group) => A::DestroyBindGroup(bind_group),
         A::DestroyShaderModule(shader_module) => A::DestroyShaderModule(shader_module),
         A::DestroyComputePipeline(pipeline) => A::DestroyComputePipeline(pipeline),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -930,7 +930,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DropComputePipeline(pipeline) => A::DropComputePipeline(pipeline),
         A::DropRenderPipeline(pipeline) => A::DropRenderPipeline(pipeline),
         A::DropPipelineCache(cache) => A::DropPipelineCache(cache),
-        A::DestroyRenderBundle(render_bundle) => A::DestroyRenderBundle(render_bundle),
+        A::DropRenderBundle(render_bundle) => A::DropRenderBundle(render_bundle),
         A::DestroyQuerySet(query_set) => A::DestroyQuerySet(query_set),
         A::DropQuerySet(query_set) => A::DropQuerySet(query_set),
         A::WriteBuffer {

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -897,7 +897,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DestroyBuffer(buffer) => A::DestroyBuffer(buffer),
         A::DropBuffer(buffer) => A::DropBuffer(buffer),
         A::FreeTexture(texture) => A::FreeTexture(texture),
-        A::DestroyTexture(texture) => A::DestroyTexture(texture),
+        A::DropTexture(texture) => A::DropTexture(texture),
         A::DestroyTextureView(texture_view) => A::DestroyTextureView(texture_view),
         A::FreeExternalTexture(external_texture) => A::FreeExternalTexture(external_texture),
         A::DestroyExternalTexture(external_texture) => A::DestroyExternalTexture(external_texture),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -905,7 +905,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::GetSurfaceTexture { id, parent } => A::GetSurfaceTexture { id, parent },
         A::Present(surface) => A::Present(surface),
         A::DiscardSurfaceTexture(surface) => A::DiscardSurfaceTexture(surface),
-        A::DestroyBindGroupLayout(layout) => A::DestroyBindGroupLayout(layout),
+        A::DropBindGroupLayout(layout) => A::DropBindGroupLayout(layout),
         A::GetRenderPipelineBindGroupLayout {
             id,
             pipeline,

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -931,7 +931,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DestroyRenderPipeline(pipeline) => A::DestroyRenderPipeline(pipeline),
         A::DestroyPipelineCache(cache) => A::DestroyPipelineCache(cache),
         A::DestroyRenderBundle(render_bundle) => A::DestroyRenderBundle(render_bundle),
-        A::FreeQuerySet(query_set) => A::FreeQuerySet(query_set),
+        A::DestroyQuerySet(query_set) => A::DestroyQuerySet(query_set),
         A::DropQuerySet(query_set) => A::DropQuerySet(query_set),
         A::WriteBuffer {
             id,

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -900,7 +900,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DropTexture(texture) => A::DropTexture(texture),
         A::DestroyTextureView(texture_view) => A::DestroyTextureView(texture_view),
         A::FreeExternalTexture(external_texture) => A::FreeExternalTexture(external_texture),
-        A::DestroyExternalTexture(external_texture) => A::DestroyExternalTexture(external_texture),
+        A::DropExternalTexture(external_texture) => A::DropExternalTexture(external_texture),
         A::DestroySampler(sampler) => A::DestroySampler(sampler),
         A::GetSurfaceTexture { id, parent } => A::GetSurfaceTexture { id, parent },
         A::Present(surface) => A::Present(surface),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -927,7 +927,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DropPipelineLayout(layout) => A::DropPipelineLayout(layout),
         A::DropBindGroup(bind_group) => A::DropBindGroup(bind_group),
         A::DropShaderModule(shader_module) => A::DropShaderModule(shader_module),
-        A::DestroyComputePipeline(pipeline) => A::DestroyComputePipeline(pipeline),
+        A::DropComputePipeline(pipeline) => A::DropComputePipeline(pipeline),
         A::DestroyRenderPipeline(pipeline) => A::DestroyRenderPipeline(pipeline),
         A::DestroyPipelineCache(cache) => A::DestroyPipelineCache(cache),
         A::DestroyRenderBundle(render_bundle) => A::DestroyRenderBundle(render_bundle),

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -928,7 +928,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DropBindGroup(bind_group) => A::DropBindGroup(bind_group),
         A::DropShaderModule(shader_module) => A::DropShaderModule(shader_module),
         A::DropComputePipeline(pipeline) => A::DropComputePipeline(pipeline),
-        A::DestroyRenderPipeline(pipeline) => A::DestroyRenderPipeline(pipeline),
+        A::DropRenderPipeline(pipeline) => A::DropRenderPipeline(pipeline),
         A::DestroyPipelineCache(cache) => A::DestroyPipelineCache(cache),
         A::DestroyRenderBundle(render_bundle) => A::DestroyRenderBundle(render_bundle),
         A::DestroyQuerySet(query_set) => A::DestroyQuerySet(query_set),


### PR DESCRIPTION
**Connections**
Fixes #9670

**Description**

"Free" and "Destroy" mean the opposite from WebGPU and wgpu-core in tracing so this PR fixes that. Changes are best described with table:

| wgc | tracing (before) | tracing (now) |
|-----|-------------------|---------------|
|`*_destroy`|`Free*`|`Destroy*`|
|`*_drop`|`Destroy*`|`Drop*`|

**Testing**
It compiles

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
