### PR TITLE
test(cts): Improve diagnostics

### DIFF
--- a/cts_runner/src/main.rs
+++ b/cts_runner/src/main.rs
@@ -174,8 +174,73 @@ impl deno_web::TimersPermission for Permissions {
     }
 }
 
+/// On Windows, install an SEH filter that logs the exception code, so
+/// unhandled-exception crashes from native code (driver bugs, WARP, D3D12) are
+/// more visible in CI. (See <https://github.com/gfx-rs/wgpu/issues/9693> for an
+/// example.)
+#[cfg(windows)]
+fn install_unhandled_exception_filter() {
+    use core::ffi::c_void;
+
+    #[repr(C)]
+    struct ExceptionRecord {
+        exception_code: u32,
+        exception_flags: u32,
+        exception_record: *mut ExceptionRecord,
+        exception_address: *mut c_void,
+        number_parameters: u32,
+        exception_information: [usize; 15],
+    }
+
+    #[repr(C)]
+    struct ExceptionPointers {
+        exception_record: *mut ExceptionRecord,
+        context_record: *mut c_void,
+    }
+
+    type FilterFn = unsafe extern "system" fn(*mut ExceptionPointers) -> i32;
+
+    unsafe extern "system" {
+        fn SetUnhandledExceptionFilter(filter: Option<FilterFn>) -> Option<FilterFn>;
+    }
+
+    unsafe extern "system" fn filter(info: *mut ExceptionPointers) -> i32 {
+        let (code, addr) = unsafe {
+            if info.is_null() || (*info).exception_record.is_null() {
+                (0u32, core::ptr::null_mut::<c_void>())
+            } else {
+                let r = &*(*info).exception_record;
+                (r.exception_code, r.exception_address)
+            }
+        };
+        let name = match code {
+            0x80000003 => "STATUS_BREAKPOINT",
+            0xC0000005 => "STATUS_ACCESS_VIOLATION",
+            0xC0000094 => "STATUS_INTEGER_DIVIDE_BY_ZERO",
+            0xC00000FD => "STATUS_STACK_OVERFLOW",
+            0xC0000374 => "STATUS_HEAP_CORRUPTION",
+            0xC0000409 => "STATUS_STACK_BUFFER_OVERRUN",
+            0xC0000602 => "STATUS_FAIL_FAST_EXCEPTION",
+            _ => "<unknown>",
+        };
+        eprintln!("cts_runner: unhandled SEH exception 0x{code:08x} ({name}) at {addr:p}");
+        // EXCEPTION_CONTINUE_SEARCH: let the OS proceed with its default
+        // termination so the process exit code still reflects the fault.
+        0
+    }
+
+    // SAFETY: passing a valid `extern "system"` function pointer.
+    unsafe {
+        SetUnhandledExceptionFilter(Some(filter));
+    }
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
+    #[cfg(windows)]
+    {
+        install_unhandled_exception_filter();
+    }
     env_logger::init();
     unwrap_or_exit(run().await)
 }

--- a/typos.toml
+++ b/typos.toml
@@ -24,6 +24,9 @@ metalness = "metalness"
 # A DXC command line argument
 Fo = "Fo"
 
+# Abbreviation of Structured Exception Handling
+SEH = "SEH"
+
 # Usernames
 Healthire = "Healthire"
 REASY = "REASY"

--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -442,10 +442,12 @@ pub fn run_cts(
                         println!("\n== Summary for {} ==", test.selector.to_string_lossy());
                         println!("{}", summary.trim());
                     } else {
+                        log::info!("Running {}", test.selector.to_string_lossy());
                         print!("{}", stdout);
                         eprint!("{}", stderr);
                     }
                 } else {
+                    log::info!("Running {}", test.selector.to_string_lossy());
                     print!("{}", stdout);
                     eprint!("{}", stderr);
                     bail!("CTS failed ({})", output.status);

--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -448,7 +448,7 @@ pub fn run_cts(
                 } else {
                     print!("{}", stdout);
                     eprint!("{}", stderr);
-                    bail!("CTS failed");
+                    bail!("CTS failed ({})", output.status);
                 }
             }
             PrintOutputWhen::Always => {


### PR DESCRIPTION
Improve diagnostics so failures like #9693 aren't silent:

* Print the `cts_runner` exit code
* Install a Windows exception handler in `cts_runner` that prints detail of unhandled exceptions 

**Testing**
See e.g. https://github.com/gfx-rs/wgpu/actions/runs/27715428965/job/81987002917:
```
== Summary for webgpu:api,validation,encoding,queries,begin_end:nesting:* ==
Passed  w/o warnings = 0 / 1 =   0.00%
Passed with warnings = 0 / 1 =   0.00%
cts_runner: unhandled SEH exception 0x0000087d (<unknown>) at 0x7ffa8b2aef2c
Skipped              = 1 / 1 = 100.00%
Failed               = 0 / 1 =   0.00%
Error: CTS failed (exit code: 2173)
error: process didn't exit successfully: `target\debug\wgpu-xtask.exe cts --llvm-cov --backend dx12 --filter '^webgpu:api,validation,'` (exit code: 1)
Error: Process completed with exit code 1.
```

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
