### PR TITLE
fix(core): Deferred query set destruction

### DIFF
--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -9,9 +9,12 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         BUFFER_DESTROY,
         TEXTURE_DESTROY,
         BUFFER_DESTROY_BEFORE_SUBMIT,
+        BUFFER_DESTROY_AFTER_SUBMIT,
         TEXTURE_DESTROY_BEFORE_SUBMIT,
+        TEXTURE_DESTROY_AFTER_SUBMIT,
         EXTERNAL_TEXTURE_DESTROY_BEFORE_SUBMIT,
         QUERY_SET_DESTROY_BEFORE_SUBMIT,
+        QUERY_SET_DESTROY_AFTER_SUBMIT,
         REPLACED_BIND_GROUP,
     ]);
 }
@@ -397,6 +400,76 @@ static BUFFER_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguration
         test_buffer_destroy_before_submit(&ctx, UsageKind::RenderBundle);
     });
 
+fn test_buffer_destroy_after_submit(ctx: &TestingContext, usage: UsageKind) {
+    if matches!(usage, UsageKind::Direct) {
+        let buffer_source = ctx
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: None,
+                contents: &[0u8; 4],
+                usage: wgpu::BufferUsages::COPY_SRC,
+            });
+        let buffer_dest = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 4,
+            usage: wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        encoder.copy_buffer_to_buffer(&buffer_source, 0, &buffer_dest, 0, 4);
+        ctx.queue.submit([encoder.finish()]);
+
+        buffer_source.destroy();
+        buffer_dest.destroy();
+
+        ctx.device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .unwrap();
+        return;
+    }
+
+    let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 16,
+        usage: wgpu::BufferUsages::UNIFORM,
+        mapped_at_creation: false,
+    });
+
+    let encoder = record_encoder_with_resource(
+        ctx,
+        usage,
+        buffer.as_entire_binding(),
+        BUFFER_RENDER_SHADER,
+        BUFFER_COMPUTE_SHADER,
+    );
+
+    ctx.queue.submit([encoder.finish()]);
+
+    buffer.destroy();
+
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
+}
+
+// Test that destroying a buffer between submission and GPU completion is handled correctly.
+#[gpu_test]
+static BUFFER_DESTROY_AFTER_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop(),
+    )
+    .run_sync(|ctx| {
+        test_buffer_destroy_after_submit(&ctx, UsageKind::Direct);
+        test_buffer_destroy_after_submit(&ctx, UsageKind::RenderPass);
+        test_buffer_destroy_after_submit(&ctx, UsageKind::ComputePass);
+        test_buffer_destroy_after_submit(&ctx, UsageKind::RenderBundle);
+    });
+
 fn test_texture_destroy_before_submit(ctx: &TestingContext, usage: UsageKind) {
     if matches!(usage, UsageKind::Direct) {
         let descriptor = wgpu::TextureDescriptor {
@@ -498,6 +571,108 @@ static TEXTURE_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfiguratio
         test_texture_destroy_before_submit(&ctx, UsageKind::RenderPass);
         test_texture_destroy_before_submit(&ctx, UsageKind::ComputePass);
         test_texture_destroy_before_submit(&ctx, UsageKind::RenderBundle);
+    });
+
+fn test_texture_destroy_after_submit(ctx: &TestingContext, usage: UsageKind) {
+    if matches!(usage, UsageKind::Direct) {
+        let descriptor = wgpu::TextureDescriptor {
+            label: None,
+            size: wgpu::Extent3d {
+                width: 128,
+                height: 128,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Snorm,
+            usage: wgpu::TextureUsages::COPY_SRC | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        };
+
+        let texture_1 = ctx.device.create_texture(&descriptor);
+        let texture_2 = ctx.device.create_texture(&descriptor);
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        encoder.copy_texture_to_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture_1,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture_2,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::Extent3d {
+                width: 128,
+                height: 128,
+                depth_or_array_layers: 1,
+            },
+        );
+        ctx.queue.submit([encoder.finish()]);
+
+        texture_1.destroy();
+        texture_2.destroy();
+
+        ctx.device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .unwrap();
+        return;
+    }
+
+    let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: None,
+        size: wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let encoder = record_encoder_with_resource(
+        ctx,
+        usage,
+        wgpu::BindingResource::TextureView(&view),
+        TEXTURE_RENDER_SHADER,
+        TEXTURE_COMPUTE_SHADER,
+    );
+
+    ctx.queue.submit([encoder.finish()]);
+
+    texture.destroy();
+
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
+}
+
+// Test that destroying a texture between submission and GPU completion is handled correctly.
+#[gpu_test]
+static TEXTURE_DESTROY_AFTER_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop()
+            .features(wgpu::Features::CLEAR_TEXTURE),
+    )
+    .run_sync(|ctx| {
+        test_texture_destroy_after_submit(&ctx, UsageKind::Direct);
+        test_texture_destroy_after_submit(&ctx, UsageKind::RenderPass);
+        test_texture_destroy_after_submit(&ctx, UsageKind::ComputePass);
+        test_texture_destroy_after_submit(&ctx, UsageKind::RenderBundle);
     });
 
 fn test_external_texture_destroy_before_submit(ctx: &TestingContext, usage: UsageKind) {
@@ -659,6 +834,97 @@ static QUERY_SET_DESTROY_BEFORE_SUBMIT: GpuTestConfiguration = GpuTestConfigurat
         test_query_set_destroy_before_submit(&ctx, QueryType::Occlusion, UsageKind::RenderPass);
         test_query_set_destroy_before_submit(&ctx, QueryType::Timestamp, UsageKind::RenderPass);
         test_query_set_destroy_before_submit(&ctx, QueryType::Timestamp, UsageKind::ComputePass);
+    });
+
+fn test_query_set_destroy_after_submit(ctx: &TestingContext, ty: QueryType, usage: UsageKind) {
+    let query_set = ctx.device.create_query_set(&wgpu::QuerySetDescriptor {
+        label: None,
+        count: 2,
+        ty,
+    });
+
+    let (_render_target, rt_view) = create_render_target(&ctx.device);
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+
+    match usage {
+        UsageKind::RenderPass => {
+            let pipeline = create_render_pipeline(&ctx.device, EMPTY_RENDER_SHADER);
+            let color_attachment = [Some(wgpu::RenderPassColorAttachment {
+                view: &rt_view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })];
+            let (occlusion_query_set, timestamp_writes) = match ty {
+                QueryType::Occlusion => (Some(&query_set), None),
+                QueryType::Timestamp => (
+                    None,
+                    Some(RenderPassTimestampWrites {
+                        query_set: &query_set,
+                        beginning_of_pass_write_index: Some(0),
+                        end_of_pass_write_index: Some(1),
+                    }),
+                ),
+                QueryType::PipelineStatistics(_) => unreachable!(),
+            };
+
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                color_attachments: &color_attachment,
+                occlusion_query_set,
+                timestamp_writes,
+                ..Default::default()
+            });
+            pass.set_pipeline(&pipeline);
+            pass.draw(0..0, 0..0);
+        }
+        UsageKind::ComputePass => {
+            let pipeline = create_compute_pipeline(&ctx.device, EMPTY_COMPUTE_SHADER);
+            let timestamp_writes = match ty {
+                QueryType::Timestamp => Some(ComputePassTimestampWrites {
+                    query_set: &query_set,
+                    beginning_of_pass_write_index: Some(0),
+                    end_of_pass_write_index: Some(1),
+                }),
+                _ => unreachable!(),
+            };
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                timestamp_writes,
+                ..Default::default()
+            });
+            pass.set_pipeline(&pipeline);
+            pass.dispatch_workgroups(0, 0, 0);
+        }
+        UsageKind::RenderBundle => unreachable!(),
+        UsageKind::Direct => unreachable!(),
+    }
+
+    ctx.queue.submit([encoder.finish()]);
+
+    query_set.destroy();
+
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .unwrap();
+}
+
+// Test that destroying a query set between submission and GPU completion is handled correctly.
+#[gpu_test]
+static QUERY_SET_DESTROY_AFTER_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .enable_noop()
+            .features(wgpu::Features::TIMESTAMP_QUERY),
+    )
+    .run_sync(|ctx| {
+        test_query_set_destroy_after_submit(&ctx, QueryType::Occlusion, UsageKind::RenderPass);
+        test_query_set_destroy_after_submit(&ctx, QueryType::Timestamp, UsageKind::RenderPass);
+        test_query_set_destroy_after_submit(&ctx, QueryType::Timestamp, UsageKind::ComputePass);
     });
 
 fn test_replaced_bind_group(ctx: &TestingContext, usage: UsageKind) {

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -9,7 +9,7 @@ use crate::{
         DeviceError,
     },
     ray_tracing::BlasCompactReadyPendingClosure,
-    resource::{Blas, Buffer, Texture, Trackable},
+    resource::{Blas, Buffer, DestroyedQuerySet, Texture, Trackable},
     snatch::SnatchGuard,
     SubmissionIndex,
 };
@@ -52,6 +52,9 @@ struct ActiveSubmission {
     /// List of queue "on_submitted_work_done" closures to be called once this
     /// submission has completed.
     work_done_closures: SmallVec<[SubmittedWorkDoneClosure; 1]>,
+
+    /// Query sets to be destroyed when this submission has completed.
+    destroy_query_sets: Vec<DestroyedQuerySet>,
 }
 
 impl ActiveSubmission {
@@ -216,6 +219,7 @@ impl LifetimeTracker {
             compact_read_back: Vec::new(),
             encoders,
             work_done_closures: SmallVec::new(),
+            destroy_query_sets: Vec::new(),
         });
     }
 
@@ -339,6 +343,26 @@ impl LifetimeTracker {
             });
         if let Some(resources) = resources {
             resources.push(temp_resource);
+        }
+    }
+
+    /// Schedule a query set for destruction.
+    ///
+    /// Similar to `schedule_resource_destruction`, but unlike textures and buffers, we
+    /// don't track query set usage information in a way that supports fast lookup, so we
+    /// pessimistically schedule them for destruction after all current submissions are
+    /// completed.
+    ///
+    /// If there are active submissions, then the `DestroyedQuerySet` is taken from the
+    /// `Option` and scheduled for destruction when all those submissions have completed.
+    ///
+    /// If there are no active submissions, then the `DestroyedQuerySet` remains in the
+    /// `Option`, and may be safely dropped by the caller (after locks are released).
+    pub fn schedule_query_set_destruction(&mut self, query_set: &mut Option<DestroyedQuerySet>) {
+        if let Some(submission) = self.active.last_mut() {
+            if let Some(query_set) = query_set.take() {
+                submission.destroy_query_sets.push(query_set);
+            }
         }
     }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2259,20 +2259,33 @@ impl RawResourceAccess for QuerySet {
 
 impl QuerySet {
     pub fn destroy(self: &Arc<Self>) {
-        let mut snatch_guard = self.device.snatchable_lock.write();
+        let device = &self.device;
 
-        let raw = match self.raw.snatch(&mut snatch_guard) {
-            Some(raw) => raw,
-            None => {
-                // Per spec, it is valid to call `destroy` multiple times.
-                return;
-            }
+        let mut temp = {
+            let mut snatch_guard = self.device.snatchable_lock.write();
+
+            let raw = match self.raw.snatch(&mut snatch_guard) {
+                Some(raw) => raw,
+                None => {
+                    // Per spec, it is valid to call `destroy` multiple times.
+                    return;
+                }
+            };
+
+            drop(snatch_guard);
+
+            Some(DestroyedQuerySet {
+                raw: ManuallyDrop::new(raw),
+                device: Arc::clone(&self.device),
+                label: self.label().to_owned(),
+            })
         };
 
-        // SAFETY: We are in the destroy method and we don't use raw anymore after this point.
-        unsafe {
-            self.device.raw().destroy_query_set(raw);
-        }
+        let Some(queue) = device.get_queue() else {
+            return;
+        };
+
+        queue.lock_life().schedule_query_set_destruction(&mut temp);
     }
 }
 
@@ -2293,6 +2306,31 @@ crate::impl_labeled!(QuerySet);
 crate::impl_parent_device!(QuerySet);
 crate::impl_storage_item!(QuerySet);
 crate::impl_trackable!(QuerySet);
+
+/// A query set that has been marked as destroyed and is staged for actual deletion soon
+#[derive(Debug)]
+pub struct DestroyedQuerySet {
+    raw: ManuallyDrop<Box<dyn hal::DynQuerySet>>,
+    device: Arc<Device>,
+    label: String,
+}
+
+impl DestroyedQuerySet {
+    pub fn label(&self) -> &dyn fmt::Debug {
+        &self.label
+    }
+}
+
+impl Drop for DestroyedQuerySet {
+    fn drop(&mut self) {
+        resource_log!("Destroy raw QuerySet (destroyed) {:?}", self.label());
+        // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
+        let raw = unsafe { ManuallyDrop::take(&mut self.raw) };
+        unsafe {
+            hal::DynDevice::destroy_query_set(self.device.raw(), raw);
+        }
+    }
+}
 
 pub type BlasDescriptor<'a> = wgt::CreateBlasDescriptor<Label<'a>>;
 pub type TlasDescriptor<'a> = wgt::CreateTlasDescriptor<Label<'a>>;


### PR DESCRIPTION
Follow-up to #9671
Fixes #9693

If a query set is destroyed after submission but before completion of a command buffer that uses the query set, destruction must be deferred until the submission has finished.

For buffers and textures, the trackers can do an `O(1)` lookup to see if the resource is used by a submission. That is not possible with the `StatelessTracker` used by query sets. Using a different tracker for query sets is not that hard, but is not trivial. Instead, this PR schedules query set destruction after completion of the most recent submission prior to being `destroy()`ed.
  
**Testing**
Adds directed tests, which fail on MoltenVK with Vulkan validation errors prior to the fix (however, not tested on Windows where #9693 was observed).

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
