### PR TITLE
fix(core): Align limit when clamping at u32 for indirect validation

### DIFF
--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -625,8 +625,9 @@ impl Instance {
             limits.max_buffer_size = limits.max_buffer_size.min(u32::MAX as u64);
             limits.max_uniform_buffer_binding_size =
                 limits.max_uniform_buffer_binding_size.min(u32::MAX as u64);
-            limits.max_storage_buffer_binding_size =
-                limits.max_storage_buffer_binding_size.min(u32::MAX as u64);
+            limits.max_storage_buffer_binding_size = limits
+                .max_storage_buffer_binding_size
+                .min(u32::MAX as u64 & !(wgt::STORAGE_BINDING_SIZE_ALIGNMENT as u64 - 1));
         }
     }
 


### PR DESCRIPTION
Fixes some CTS failures running on my MacBook.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
