### PR TITLE
Fix error messages with texture view aspect validation on multiplanar formats

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1896,16 +1896,33 @@ impl Texture {
             ));
         }
 
-        let format_is_good = if desc.range.aspect == wgt::TextureAspect::All {
-            resolved_format == self.desc.format || self.desc.view_formats.contains(&resolved_format)
+        if desc.range.aspect == wgt::TextureAspect::All {
+            if resolved_format != self.desc.format
+                && !self.desc.view_formats.contains(&resolved_format)
+            {
+                return Err(CreateTextureViewError::FormatReinterpretation {
+                    texture: self.desc.format,
+                    view: resolved_format,
+                });
+            }
         } else {
-            Some(resolved_format) == self.desc.format.aspect_specific_format(desc.range.aspect)
-        };
-        if !format_is_good {
-            return Err(CreateTextureViewError::FormatReinterpretation {
-                texture: self.desc.format,
-                view: resolved_format,
-            });
+            let aspect_format = self.desc.format.aspect_specific_format(desc.range.aspect);
+            match aspect_format {
+                Some(aspect_format) if aspect_format == resolved_format => (),
+                Some(aspect_format) => {
+                    return Err(CreateTextureViewError::WrongAspectReinterpretation {
+                        texture: self.desc.format,
+                        aspect: desc.range.aspect,
+                        aspect_format,
+                        requested_format: resolved_format,
+                    })
+                }
+                None => {
+                    // User requested a sub-aspect (not TextureAspect::All) that is not on the texture.
+                    // This should've already returned with the InvalidAspect check above.
+                    unreachable!()
+                }
+            }
         }
 
         // check if multisampled texture is seen as anything but 2D
@@ -2641,6 +2658,17 @@ pub enum CreateTextureViewError {
     InvalidResource(#[from] InvalidResourceError),
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
+
+    #[error(
+        "Trying to create a view of format {requested_format:?} on aspect {aspect:?} of format {texture:?}, \
+         but the actual format of this aspect is {aspect_format:?}"
+    )]
+    WrongAspectReinterpretation {
+        texture: wgt::TextureFormat,
+        aspect: wgt::TextureAspect,
+        aspect_format: wgt::TextureFormat,
+        requested_format: wgt::TextureFormat,
+    },
     #[error("TextureAspect::All cannot be used in texture views on multi-planar formats")]
     MultiplanarFullTexture(wgt::TextureFormat),
 }
@@ -2678,6 +2706,7 @@ impl WebGpuError for CreateTextureViewError {
             | Self::InvalidTextureViewUsage { .. }
             | Self::InvalidTransientTextureViewUsage { .. }
             | Self::MissingFeatures(_)
+            | Self::WrongAspectReinterpretation { .. }
             | Self::MultiplanarFullTexture(_) => ErrorType::Validation,
         }
     }


### PR DESCRIPTION
**Connections**
Closes #9345

**Description**
Currently wgpu can give errors like this
> Trying to create a view of format NV12 of a texture with format NV12, but this view format is not present in the texture's viewFormat array

Which are very unhelpful.

**Testing**
Not tested

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
