### PR TITLE
fix(core): Deferred query set destruction

### DIFF
--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -396,7 +396,7 @@ impl BakedCommands {
         }
 
         // Update query set initialization state.
-        for query_set in &self.trackers.query_sets {
+        for query_set in self.trackers.query_sets.used_resources() {
             if let Some(slots) = self.query_set_writes.get(&query_set.tracker_index()) {
                 let mut initialized = query_set.initialized_slots.lock();
                 initialized.or(slots);

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -13,7 +13,7 @@ use crate::{
         ParentDevice, QuerySet, RawResourceAccess, Trackable,
     },
     snatch::SnatchGuard,
-    track::{StatelessTracker, TrackerIndex},
+    track::{QuerySetTracker, TrackerIndex},
     FastHashMap,
 };
 use thiserror::Error;
@@ -321,7 +321,7 @@ impl QuerySet {
 pub(super) fn validate_and_begin_occlusion_query(
     query_set: Arc<QuerySet>,
     raw_encoder: &mut dyn hal::DynCommandEncoder,
-    tracker: &mut StatelessTracker<QuerySet>,
+    tracker: &mut QuerySetTracker,
     query_index: u32,
     reset_state: Option<&mut QueryResetMap>,
     active_query: &mut Option<(Arc<QuerySet>, u32)>,
@@ -372,7 +372,7 @@ pub(super) fn end_occlusion_query(
 pub(super) fn validate_and_begin_pipeline_statistics_query(
     query_set: Arc<QuerySet>,
     raw_encoder: &mut dyn hal::DynCommandEncoder,
-    tracker: &mut StatelessTracker<QuerySet>,
+    tracker: &mut QuerySetTracker,
     device: &Arc<Device>,
     query_index: u32,
     reset_state: Option<&mut QueryResetMap>,

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -9,7 +9,7 @@ use crate::{
         DeviceError,
     },
     ray_tracing::BlasCompactReadyPendingClosure,
-    resource::{Blas, Buffer, DestroyedQuerySet, Texture, Trackable},
+    resource::{Blas, Buffer, QuerySet, Texture, Trackable},
     snatch::SnatchGuard,
     SubmissionIndex,
 };
@@ -52,9 +52,6 @@ struct ActiveSubmission {
     /// List of queue "on_submitted_work_done" closures to be called once this
     /// submission has completed.
     work_done_closures: SmallVec<[SubmittedWorkDoneClosure; 1]>,
-
-    /// Query sets to be destroyed when this submission has completed.
-    destroy_query_sets: Vec<DestroyedQuerySet>,
 }
 
 impl ActiveSubmission {
@@ -118,6 +115,16 @@ impl ActiveSubmission {
             }
 
             if encoder.pending_blas_s.contains_key(&blas.tracker_index()) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub fn contains_query_set(&self, query_set: &QuerySet) -> bool {
+        for encoder in &self.encoders {
+            if encoder.trackers.query_sets.contains(query_set) {
                 return true;
             }
         }
@@ -219,7 +226,6 @@ impl LifetimeTracker {
             compact_read_back: Vec::new(),
             encoders,
             work_done_closures: SmallVec::new(),
-            destroy_query_sets: Vec::new(),
         });
     }
 
@@ -287,6 +293,23 @@ impl LifetimeTracker {
         })
     }
 
+    /// Returns the submission index of the most recent submission that uses the
+    /// given query set.
+    pub fn get_query_set_latest_submission_index(
+        &self,
+        query_set: &QuerySet,
+    ) -> Option<SubmissionIndex> {
+        // We iterate in reverse order, so that we can bail out early as soon
+        // as we find a hit.
+        self.active.iter().rev().find_map(|submission| {
+            if submission.contains_query_set(query_set) {
+                Some(submission.index)
+            } else {
+                None
+            }
+        })
+    }
+
     /// Sort out the consequences of completed submissions.
     ///
     /// Assume that all submissions up through `last_done` have completed.
@@ -343,26 +366,6 @@ impl LifetimeTracker {
             });
         if let Some(resources) = resources {
             resources.push(temp_resource);
-        }
-    }
-
-    /// Schedule a query set for destruction.
-    ///
-    /// Similar to `schedule_resource_destruction`, but unlike textures and buffers, we
-    /// don't track query set usage information in a way that supports fast lookup, so we
-    /// pessimistically schedule them for destruction after all current submissions are
-    /// completed.
-    ///
-    /// If there are active submissions, then the `DestroyedQuerySet` is taken from the
-    /// `Option` and scheduled for destruction when all those submissions have completed.
-    ///
-    /// If there are no active submissions, then the `DestroyedQuerySet` remains in the
-    /// `Option`, and may be safely dropped by the caller (after locks are released).
-    pub fn schedule_query_set_destruction(&mut self, query_set: &mut Option<DestroyedQuerySet>) {
-        if let Some(submission) = self.active.last_mut() {
-            if let Some(query_set) = query_set.take() {
-                submission.destroy_query_sets.push(query_set);
-            }
         }
     }
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -34,9 +34,9 @@ use crate::{
     ray_tracing::{BlasCompactReadyPendingClosure, CompactBlasError},
     resource::{
         Blas, BlasCompactState, Buffer, BufferAccessError, BufferMapState, DestroyedBuffer,
-        DestroyedResourceError, DestroyedTexture, Fallible, FlushedStagingBuffer,
-        InvalidResourceError, Labeled, ParentDevice, ResourceErrorIdent, StagingBuffer, Texture,
-        TextureInner, Trackable, TrackingData,
+        DestroyedQuerySet, DestroyedResourceError, DestroyedTexture, Fallible,
+        FlushedStagingBuffer, InvalidResourceError, Labeled, ParentDevice, ResourceErrorIdent,
+        StagingBuffer, Texture, TextureInner, Trackable, TrackingData,
     },
     resource_log,
     scratch::ScratchBuffer,
@@ -331,6 +331,7 @@ pub enum TempResource {
     ScratchBuffer(ScratchBuffer),
     DestroyedBuffer(DestroyedBuffer),
     DestroyedTexture(DestroyedTexture),
+    DestroyedQuerySet(DestroyedQuerySet),
 }
 
 /// A series of raw [`CommandBuffer`]s that have been submitted to a
@@ -2073,7 +2074,7 @@ fn validate_command_buffer(
         }
         {
             profiling::scope!("query sets");
-            for query_set in &cmd_buf_data.trackers.query_sets {
+            for query_set in cmd_buf_data.trackers.query_sets.used_resources() {
                 query_set.try_raw(snatch_guard)?;
             }
         }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2261,7 +2261,7 @@ impl QuerySet {
     pub fn destroy(self: &Arc<Self>) {
         let device = &self.device;
 
-        let mut temp = {
+        let temp = {
             let mut snatch_guard = self.device.snatchable_lock.write();
 
             let raw = match self.raw.snatch(&mut snatch_guard) {
@@ -2274,7 +2274,7 @@ impl QuerySet {
 
             drop(snatch_guard);
 
-            Some(DestroyedQuerySet {
+            queue::TempResource::DestroyedQuerySet(DestroyedQuerySet {
                 raw: ManuallyDrop::new(raw),
                 device: Arc::clone(&self.device),
                 label: self.label().to_owned(),
@@ -2285,7 +2285,11 @@ impl QuerySet {
             return;
         };
 
-        queue.lock_life().schedule_query_set_destruction(&mut temp);
+        let mut life_lock = queue.lock_life();
+        let last_submit_index = life_lock.get_query_set_latest_submission_index(self);
+        if let Some(last_submit_index) = last_submit_index {
+            life_lock.schedule_resource_destruction(temp, last_submit_index);
+        }
     }
 }
 

--- a/wgpu-core/src/track/mod.rs
+++ b/wgpu-core/src/track/mod.rs
@@ -98,6 +98,7 @@ Device <- CommandBuffer = insert(device.start, device.end, buffer.start, buffer.
 mod blas;
 mod buffer;
 mod metadata;
+mod query_set;
 mod range;
 mod stateless;
 mod texture;
@@ -117,6 +118,7 @@ use core::{fmt, mem, ops};
 
 use thiserror::Error;
 
+pub(crate) use crate::track::query_set::QuerySetTracker;
 pub(crate) use buffer::{
     BufferBindGroupState, BufferTracker, BufferUsageScope, DeviceBufferTracker,
 };
@@ -647,7 +649,7 @@ pub(crate) struct Tracker {
     pub compute_pipelines: StatelessTracker<pipeline::ComputePipeline>,
     pub render_pipelines: StatelessTracker<pipeline::RenderPipeline>,
     pub bundles: StatelessTracker<command::RenderBundle>,
-    pub query_sets: StatelessTracker<resource::QuerySet>,
+    pub query_sets: QuerySetTracker,
 }
 
 impl Tracker {
@@ -665,7 +667,7 @@ impl Tracker {
             compute_pipelines: StatelessTracker::new(),
             render_pipelines: StatelessTracker::new(),
             bundles: StatelessTracker::new(),
-            query_sets: StatelessTracker::new(),
+            query_sets: QuerySetTracker::new(),
         }
     }
 

--- a/wgpu-core/src/track/query_set.rs
+++ b/wgpu-core/src/track/query_set.rs
@@ -1,0 +1,63 @@
+use crate::{
+    resource::{QuerySet, Trackable},
+    track::metadata::ResourceMetadata,
+};
+use alloc::sync::Arc;
+
+/// A tracker that holds tracks QuerySets.
+///
+/// This is mostly a safe shell around [`ResourceMetadata`]
+#[derive(Debug)]
+pub(crate) struct QuerySetTracker {
+    metadata: ResourceMetadata<Arc<QuerySet>>,
+    size: usize,
+}
+
+impl QuerySetTracker {
+    pub fn new() -> Self {
+        Self {
+            metadata: ResourceMetadata::new(),
+            size: 0,
+        }
+    }
+
+    /// Inserts a single resource into the resource tracker.
+    ///
+    /// Returns a reference to the newly inserted resource.
+    /// (This allows avoiding a clone/reference count increase in many cases.)
+    pub fn insert_single(&mut self, resource: Arc<QuerySet>) -> &Arc<QuerySet> {
+        let index = resource.tracker_index().as_usize();
+        self.allow_index(index);
+
+        unsafe {
+            // # SAFETY: we just allowed this resource, which makes the metadata object larger if
+            // it's not in bounds
+            self.metadata.insert(index, resource)
+        }
+    }
+
+    /// Sets the size of all the vectors inside the tracker.
+    ///
+    /// Must be called with the highest possible Texture ID before
+    /// all unsafe functions are called.
+    pub fn set_size(&mut self, size: usize) {
+        self.size = size;
+        self.metadata.set_size(size)
+    }
+
+    /// Extend the vectors to let the given index be valid.
+    fn allow_index(&mut self, index: usize) {
+        if index >= self.size {
+            self.set_size(index + 1);
+        }
+    }
+
+    /// Returns true if the tracker owns the given query set.
+    pub fn contains(&self, query_set: &QuerySet) -> bool {
+        self.metadata.contains(query_set.tracker_index().as_usize())
+    }
+
+    pub fn used_resources(&self) -> impl Iterator<Item = &Arc<QuerySet>> {
+        self.metadata.owned_resources()
+    }
+}


### PR DESCRIPTION
**Connections**
Improves https://github.com/gfx-rs/wgpu/pull/9697

**Description**
As outlined in https://github.com/gfx-rs/wgpu/pull/9697#issuecomment-4738013102 we created new `QuerySetTracker` (based on `TextureTracker`) that gives us `O(1)` lookup, then use similar architecture for deferred destruction as already used by Texture and Buffer (`get_query_set_latest_submission_index` and `TempResource::DestroyedQuerySet` for `schedule_resource_destruction`)

**Testing**
Covered by existing tests.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
