### PR TITLE
[tests] mark timestamps_passes as flaky on GL llvmpipe

### DIFF
--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -430,7 +430,8 @@ pub fn main() {
 
 #[cfg(test)]
 pub mod tests {
-    use wgpu_test::{gpu_test, GpuTestConfiguration};
+    use wgpu::Backends;
+    use wgpu_test::{gpu_test, FailureCase, GpuTestConfiguration};
 
     use super::{submit_render_and_compute_pass_with_queries, QueryResults};
 
@@ -464,6 +465,11 @@ pub mod tests {
                     wgpu::Features::TIMESTAMP_QUERY
                         | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS
                         | wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES,
+                )
+                .expect_fail(
+                    FailureCase::backend_adapter(Backends::GL, "llvmpipe")
+                        .panic("unexpected: inner timestamp before compute pass start timestamp")
+                        .flaky(),
                 ),
         )
         .run_sync(|ctx| test_timestamps(ctx, true, true));
@@ -504,7 +510,10 @@ pub mod tests {
             assert!(render_inside_timestamp <= render_start_end_timestamps[1]);
         }
         if let Some(compute_inside_timestamp) = compute_inside_timestamp {
-            assert!(compute_inside_timestamp >= compute_start_end_timestamps[0]);
+            assert!(
+                compute_inside_timestamp >= compute_start_end_timestamps[0],
+                "unexpected: inner timestamp before compute pass start timestamp"
+            );
             assert!(compute_inside_timestamp <= compute_start_end_timestamps[1]);
         }
     }

--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -475,13 +475,17 @@ pub mod tests {
     ) {
         let queries = submit_render_and_compute_pass_with_queries(&ctx.device, &ctx.queue);
         let raw_results = queries.wait_for_results(&ctx.device);
+        println!("Raw timestamp buffer contents: {raw_results:?}");
+        let query_results = QueryResults::from_raw_results(raw_results, timestamps_inside_passes);
+        query_results.print(&ctx.queue);
+
         let QueryResults {
             encoder_timestamps,
             render_start_end_timestamps,
             render_inside_timestamp,
             compute_start_end_timestamps,
             compute_inside_timestamp,
-        } = QueryResults::from_raw_results(raw_results, timestamps_inside_passes);
+        } = query_results;
 
         // Timestamps may wrap around, so can't really only reason about deltas!
         // Making things worse, deltas are allowed to be zero.


### PR DESCRIPTION
**Connections**
Fixes https://github.com/gfx-rs/wgpu/issues/9706.

**Description**
Marks test as flaky due to driver bug.

**Testing**
n/a

**Squash or Rebase?**
Rebase.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
