### PR TITLE
[core] make `wgc::RenderBundleEncoder` like Passes (with methods on self and global)

### DIFF
--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -22,15 +22,6 @@ use crate::get_data_slice;
 use crate::texture::GPUTextureFormat;
 use crate::Instance;
 
-fn c_string_truncated_at_first_nul<T: Into<Vec<u8>>>(
-  src: T,
-) -> std::ffi::CString {
-  std::ffi::CString::new(src).unwrap_or_else(|err| {
-    let nul_pos = err.nul_position();
-    std::ffi::CString::new(err.into_vec().split_at(nul_pos).0).unwrap()
-  })
-}
-
 pub struct GPURenderBundleEncoder {
   pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
@@ -98,15 +89,9 @@ impl GPURenderBundleEncoder {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
 
-    let label = c_string_truncated_at_first_nul(group_label);
-    // SAFETY: the string the raw pointer points to lives longer than the below
-    // function invocation.
-    unsafe {
-      wgpu_core::command::bundle_ffi::wgpu_render_bundle_push_debug_group(
-        encoder,
-        label.as_ptr(),
-      );
-    }
+    self
+      .instance
+      .render_bundle_encoder_push_debug_group(encoder, &group_label);
 
     Ok(())
   }
@@ -118,7 +103,7 @@ impl GPURenderBundleEncoder {
     let encoder = encoder.as_mut().ok_or_else(|| {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
-    wgpu_core::command::bundle_ffi::wgpu_render_bundle_pop_debug_group(encoder);
+    self.instance.render_bundle_encoder_pop_debug_group(encoder);
     Ok(())
   }
 
@@ -132,15 +117,9 @@ impl GPURenderBundleEncoder {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
 
-    let label = c_string_truncated_at_first_nul(marker_label);
-    // SAFETY: the string the raw pointer points to lives longer than the below
-    // function invocation.
-    unsafe {
-      wgpu_core::command::bundle_ffi::wgpu_render_bundle_insert_debug_marker(
-        encoder,
-        label.as_ptr(),
-      );
-    }
+    self
+      .instance
+      .render_bundle_encoder_insert_debug_marker(encoder, &marker_label);
     Ok(())
   }
 
@@ -193,16 +172,12 @@ impl GPURenderBundleEncoder {
 
       let offsets = &data[start..(start + len)];
 
-      // SAFETY: wgpu FFI call
-      unsafe {
-        wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_bind_group(
-          encoder,
-          index,
-          bind_group.into_option().map(|bind_group| bind_group.id),
-          offsets.as_ptr(),
-          offsets.len(),
-        );
-      }
+      self.instance.render_bundle_encoder_set_bind_group(
+        encoder,
+        index,
+        bind_group.into_option().map(|bind_group| bind_group.id),
+        offsets,
+      );
     } else {
       let offsets = <Option<Vec<u32>>>::convert(
         scope,
@@ -216,16 +191,12 @@ impl GPURenderBundleEncoder {
       )?
       .unwrap_or_default();
 
-      // SAFETY: wgpu FFI call
-      unsafe {
-        wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_bind_group(
-          encoder,
-          index,
-          bind_group.into_option().map(|bind_group| bind_group.id),
-          offsets.as_ptr(),
-          offsets.len(),
-        );
-      }
+      self.instance.render_bundle_encoder_set_bind_group(
+        encoder,
+        index,
+        bind_group.into_option().map(|bind_group| bind_group.id),
+        &offsets,
+      );
     }
 
     Ok(())
@@ -241,10 +212,9 @@ impl GPURenderBundleEncoder {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
 
-    wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_pipeline(
-      encoder,
-      pipeline.id,
-    );
+    self
+      .instance
+      .render_bundle_encoder_set_pipeline(encoder, pipeline.id);
     Ok(())
   }
 
@@ -262,7 +232,8 @@ impl GPURenderBundleEncoder {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
 
-    encoder.set_index_buffer(
+    self.instance.render_bundle_encoder_set_index_buffer(
+      encoder,
       buffer.id,
       index_format.into(),
       offset,
@@ -285,7 +256,7 @@ impl GPURenderBundleEncoder {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
 
-    wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_vertex_buffer(
+    self.instance.render_bundle_encoder_set_vertex_buffer(
       encoder,
       slot,
       buffer.into_option().map(|buffer| buffer.id),
@@ -309,7 +280,7 @@ impl GPURenderBundleEncoder {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
 
-    wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw(
+    self.instance.render_bundle_encoder_draw(
       encoder,
       vertex_count,
       instance_count,
@@ -334,7 +305,7 @@ impl GPURenderBundleEncoder {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
 
-    wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indexed(
+    self.instance.render_bundle_encoder_draw_indexed(
       encoder,
       index_count,
       instance_count,
@@ -357,7 +328,7 @@ impl GPURenderBundleEncoder {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
 
-    wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indirect(
+    self.instance.render_bundle_encoder_draw_indirect(
       encoder,
       indirect_buffer.id,
       indirect_offset,
@@ -377,7 +348,7 @@ impl GPURenderBundleEncoder {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
 
-    wgpu_core::command::bundle_ffi::wgpu_render_bundle_draw_indexed_indirect(
+    self.instance.render_bundle_encoder_draw_indexed_indirect(
       encoder,
       indirect_buffer.id,
       indirect_offset,
@@ -402,14 +373,9 @@ impl GPURenderBundleEncoder {
       JsErrorBox::generic("Encoder has already been finished")
     })?;
 
-    unsafe {
-      wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_immediates(
-        encoder,
-        offset,
-        data.len().try_into().unwrap(),
-        data.as_ptr(),
-      );
-    }
+    self
+      .instance
+      .render_bundle_encoder_set_immediates(encoder, offset, data);
     Ok(())
   }
 }

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -585,6 +585,137 @@ impl RenderBundleEncoder {
             size,
         });
     }
+
+    pub fn set_bind_group(
+        &mut self,
+        index: u32,
+        bind_group_id: Option<id::BindGroupId>,
+        offsets: &[wgt::DynamicOffset],
+    ) {
+        let redundant = self.current_bind_groups.set_and_check_redundant(
+            bind_group_id,
+            index,
+            &mut self.base.dynamic_offsets,
+            offsets,
+        );
+
+        if redundant {
+            return;
+        }
+
+        self.base.commands.push(RenderCommand::SetBindGroup {
+            index,
+            num_dynamic_offsets: offsets.len(),
+            bind_group: bind_group_id,
+        });
+    }
+
+    pub fn set_pipeline(&mut self, pipeline_id: id::RenderPipelineId) {
+        if self.current_pipeline.set_and_check_redundant(pipeline_id) {
+            return;
+        }
+
+        self.base
+            .commands
+            .push(RenderCommand::SetPipeline(pipeline_id));
+    }
+
+    pub fn set_vertex_buffer(
+        &mut self,
+        slot: u32,
+        buffer_id: Option<id::BufferId>,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) {
+        self.base.commands.push(RenderCommand::SetVertexBuffer {
+            slot,
+            buffer: buffer_id,
+            offset,
+            size,
+        });
+    }
+
+    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) {
+        let value_offset = self.base.immediates_data.len().try_into().expect(
+            "Ran out of immediate data space. Don't set 4gb of immediates per RenderBundle.",
+        );
+        self.base.immediates_data.extend(
+            data.chunks_exact(wgt::IMMEDIATE_DATA_ALIGNMENT as usize)
+                .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
+        );
+
+        self.base.commands.push(RenderCommand::SetImmediate {
+            offset,
+            size_bytes: data.len() as u32,
+            values_offset: Some(value_offset),
+        });
+    }
+
+    pub fn draw(
+        &mut self,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) {
+        self.base.commands.push(RenderCommand::Draw {
+            vertex_count,
+            instance_count,
+            first_vertex,
+            first_instance,
+        });
+    }
+
+    pub fn draw_indexed(
+        &mut self,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        first_instance: u32,
+    ) {
+        self.base.commands.push(RenderCommand::DrawIndexed {
+            index_count,
+            instance_count,
+            first_index,
+            base_vertex,
+            first_instance,
+        });
+    }
+
+    pub fn draw_indirect(&mut self, buffer_id: id::BufferId, offset: wgt::BufferAddress) {
+        self.base.commands.push(RenderCommand::DrawIndirect {
+            buffer: buffer_id,
+            offset,
+            count: 1,
+            family: DrawCommandFamily::Draw,
+            vertex_or_index_limit: None,
+            instance_limit: None,
+        });
+    }
+
+    pub fn draw_indexed_indirect(&mut self, buffer_id: id::BufferId, offset: wgt::BufferAddress) {
+        self.base.commands.push(RenderCommand::DrawIndirect {
+            buffer: buffer_id,
+            offset,
+            count: 1,
+            family: DrawCommandFamily::DrawIndexed,
+            vertex_or_index_limit: None,
+            instance_limit: None,
+        });
+    }
+
+    pub fn push_debug_group(&mut self, _label: &str) {
+        //TODO
+    }
+
+    pub fn pop_debug_group(&mut self) {
+        //TODO
+    }
+
+    pub fn insert_debug_marker(&mut self, _label: &str) {
+        //TODO
+    }
 }
 
 fn set_bind_group(
@@ -1594,12 +1725,131 @@ where
     }
 }
 
+impl crate::global::Global {
+    pub fn render_bundle_encoder_set_bind_group(
+        &self,
+        bundle: &mut RenderBundleEncoder,
+        index: u32,
+        bind_group_id: Option<id::BindGroupId>,
+        offsets: &[wgt::DynamicOffset],
+    ) {
+        bundle.set_bind_group(index, bind_group_id, offsets);
+    }
+
+    pub fn render_bundle_encoder_set_pipeline(
+        &self,
+        bundle: &mut RenderBundleEncoder,
+        pipeline_id: id::RenderPipelineId,
+    ) {
+        bundle.set_pipeline(pipeline_id);
+    }
+
+    pub fn render_bundle_encoder_set_vertex_buffer(
+        &self,
+        bundle: &mut RenderBundleEncoder,
+        slot: u32,
+        buffer_id: Option<id::BufferId>,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) {
+        bundle.set_vertex_buffer(slot, buffer_id, offset, size);
+    }
+
+    pub fn render_bundle_encoder_set_index_buffer(
+        &self,
+        encoder: &mut RenderBundleEncoder,
+        buffer: id::BufferId,
+        index_format: wgt::IndexFormat,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) {
+        encoder.set_index_buffer(buffer, index_format, offset, size);
+    }
+
+    pub fn render_bundle_encoder_set_immediates(
+        &self,
+        pass: &mut RenderBundleEncoder,
+        offset: u32,
+        data: &[u8],
+    ) {
+        pass.set_immediates(offset, data);
+    }
+
+    pub fn render_bundle_encoder_draw(
+        &self,
+        bundle: &mut RenderBundleEncoder,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) {
+        bundle.draw(vertex_count, instance_count, first_vertex, first_instance);
+    }
+
+    pub fn render_bundle_encoder_draw_indexed(
+        &self,
+        bundle: &mut RenderBundleEncoder,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        first_instance: u32,
+    ) {
+        bundle.draw_indexed(
+            index_count,
+            instance_count,
+            first_index,
+            base_vertex,
+            first_instance,
+        );
+    }
+
+    pub fn render_bundle_encoder_draw_indirect(
+        &self,
+        bundle: &mut RenderBundleEncoder,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+    ) {
+        bundle.draw_indirect(buffer_id, offset);
+    }
+
+    pub fn render_bundle_encoder_draw_indexed_indirect(
+        &self,
+        bundle: &mut RenderBundleEncoder,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+    ) {
+        bundle.draw_indexed_indirect(buffer_id, offset);
+    }
+
+    pub fn render_bundle_encoder_push_debug_group(
+        &self,
+        bundle: &mut RenderBundleEncoder,
+        label: &str,
+    ) {
+        bundle.push_debug_group(label);
+    }
+
+    pub fn render_bundle_encoder_pop_debug_group(&self, bundle: &mut RenderBundleEncoder) {
+        bundle.pop_debug_group();
+    }
+
+    pub fn render_bundle_encoder_insert_debug_marker(
+        &self,
+        bundle: &mut RenderBundleEncoder,
+        label: &str,
+    ) {
+        bundle.insert_debug_marker(label);
+    }
+}
+
 pub mod bundle_ffi {
-    use super::{RenderBundleEncoder, RenderCommand};
-    use crate::{command::DrawCommandFamily, id, RawString};
+    use super::RenderBundleEncoder;
+    use crate::{id, RawString};
     use core::slice;
     use wgt::{BufferAddress, BufferSize, DynamicOffset, IndexFormat};
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_set_bind_group` instead.")]
     /// # Safety
     ///
     /// This function is unsafe as there is no guarantee that the given pointer is
@@ -1613,38 +1863,18 @@ pub mod bundle_ffi {
     ) {
         let offsets = unsafe { slice::from_raw_parts(offsets, offset_length) };
 
-        let redundant = bundle.current_bind_groups.set_and_check_redundant(
-            bind_group_id,
-            index,
-            &mut bundle.base.dynamic_offsets,
-            offsets,
-        );
-
-        if redundant {
-            return;
-        }
-
-        bundle.base.commands.push(RenderCommand::SetBindGroup {
-            index,
-            num_dynamic_offsets: offset_length,
-            bind_group: bind_group_id,
-        });
+        bundle.set_bind_group(index, bind_group_id, offsets);
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_set_pipeline` instead.")]
     pub fn wgpu_render_bundle_set_pipeline(
         bundle: &mut RenderBundleEncoder,
         pipeline_id: id::RenderPipelineId,
     ) {
-        if bundle.current_pipeline.set_and_check_redundant(pipeline_id) {
-            return;
-        }
-
-        bundle
-            .base
-            .commands
-            .push(RenderCommand::SetPipeline(pipeline_id));
+        bundle.set_pipeline(pipeline_id);
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_set_vertex_buffer` instead.")]
     pub fn wgpu_render_bundle_set_vertex_buffer(
         bundle: &mut RenderBundleEncoder,
         slot: u32,
@@ -1652,14 +1882,10 @@ pub mod bundle_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        bundle.base.commands.push(RenderCommand::SetVertexBuffer {
-            slot,
-            buffer: buffer_id,
-            offset,
-            size,
-        });
+        bundle.set_vertex_buffer(slot, buffer_id, offset, size);
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_set_index_buffer` instead.")]
     pub fn wgpu_render_bundle_set_index_buffer(
         encoder: &mut RenderBundleEncoder,
         buffer: id::BufferId,
@@ -1670,6 +1896,7 @@ pub mod bundle_ffi {
         encoder.set_index_buffer(buffer, index_format, offset, size);
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_set_immediates` instead.")]
     /// # Safety
     ///
     /// This function is unsafe as there is no guarantee that the given pointer is
@@ -1681,22 +1908,10 @@ pub mod bundle_ffi {
         data: *const u8,
     ) {
         let data_slice = unsafe { slice::from_raw_parts(data, size_bytes as usize) };
-        let value_offset = pass.base.immediates_data.len().try_into().expect(
-            "Ran out of immediate data space. Don't set 4gb of immediates per RenderBundle.",
-        );
-        pass.base.immediates_data.extend(
-            data_slice
-                .chunks_exact(wgt::IMMEDIATE_DATA_ALIGNMENT as usize)
-                .map(|arr| u32::from_ne_bytes([arr[0], arr[1], arr[2], arr[3]])),
-        );
-
-        pass.base.commands.push(RenderCommand::SetImmediate {
-            offset,
-            size_bytes,
-            values_offset: Some(value_offset),
-        });
+        pass.set_immediates(offset, data_slice);
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_draw` instead.")]
     pub fn wgpu_render_bundle_draw(
         bundle: &mut RenderBundleEncoder,
         vertex_count: u32,
@@ -1704,14 +1919,10 @@ pub mod bundle_ffi {
         first_vertex: u32,
         first_instance: u32,
     ) {
-        bundle.base.commands.push(RenderCommand::Draw {
-            vertex_count,
-            instance_count,
-            first_vertex,
-            first_instance,
-        });
+        bundle.draw(vertex_count, instance_count, first_vertex, first_instance);
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_draw_indexed` instead.")]
     pub fn wgpu_render_bundle_draw_indexed(
         bundle: &mut RenderBundleEncoder,
         index_count: u32,
@@ -1720,45 +1931,34 @@ pub mod bundle_ffi {
         base_vertex: i32,
         first_instance: u32,
     ) {
-        bundle.base.commands.push(RenderCommand::DrawIndexed {
+        bundle.draw_indexed(
             index_count,
             instance_count,
             first_index,
             base_vertex,
             first_instance,
-        });
+        );
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_draw_indirect` instead.")]
     pub fn wgpu_render_bundle_draw_indirect(
         bundle: &mut RenderBundleEncoder,
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        bundle.base.commands.push(RenderCommand::DrawIndirect {
-            buffer: buffer_id,
-            offset,
-            count: 1,
-            family: DrawCommandFamily::Draw,
-            vertex_or_index_limit: None,
-            instance_limit: None,
-        });
+        bundle.draw_indirect(buffer_id, offset);
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_draw_indexed_indirect` instead.")]
     pub fn wgpu_render_bundle_draw_indexed_indirect(
         bundle: &mut RenderBundleEncoder,
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        bundle.base.commands.push(RenderCommand::DrawIndirect {
-            buffer: buffer_id,
-            offset,
-            count: 1,
-            family: DrawCommandFamily::DrawIndexed,
-            vertex_or_index_limit: None,
-            instance_limit: None,
-        });
+        bundle.draw_indexed_indirect(buffer_id, offset);
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_push_debug_group` instead.")]
     /// # Safety
     ///
     /// This function is unsafe as there is no guarantee that the given `label`
@@ -1770,10 +1970,12 @@ pub mod bundle_ffi {
         //TODO
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_pop_debug_group` instead.")]
     pub fn wgpu_render_bundle_pop_debug_group(_bundle: &mut RenderBundleEncoder) {
         //TODO
     }
 
+    #[deprecated(note = "Use `Global::render_bundle_encoder_insert_debug_marker` instead.")]
     /// # Safety
     ///
     /// This function is unsafe as there is no guarantee that the given `label`

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -21,7 +21,7 @@ use hashbrown::HashMap;
 use arrayvec::ArrayVec;
 use smallvec::SmallVec;
 use wgc::{
-    command::bundle_ffi::*, error::ContextErrorSource, pipeline::CreateShaderModuleError,
+    error::ContextErrorSource, pipeline::CreateShaderModuleError,
     resource::BlasPrepareCompactResult,
 };
 use wgt::{
@@ -3795,7 +3795,9 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     fn set_pipeline(&mut self, pipeline: &dispatch::DispatchRenderPipeline) {
         let pipeline = pipeline.as_core();
 
-        wgpu_render_bundle_set_pipeline(&mut self.encoder, pipeline.id)
+        self.context
+            .0
+            .render_bundle_encoder_set_pipeline(&mut self.encoder, pipeline.id);
     }
 
     fn set_bind_group(
@@ -3806,15 +3808,9 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let bg = bind_group.map(|bg| bg.as_core().id);
 
-        unsafe {
-            wgpu_render_bundle_set_bind_group(
-                &mut self.encoder,
-                index,
-                bg,
-                offsets.as_ptr(),
-                offsets.len(),
-            )
-        }
+        self.context
+            .0
+            .render_bundle_encoder_set_bind_group(&mut self.encoder, index, bg, offsets)
     }
 
     fn set_index_buffer(
@@ -3826,8 +3822,13 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let buffer = buffer.as_core();
 
-        self.encoder
-            .set_index_buffer(buffer.id, index_format, offset, size)
+        self.context.0.render_bundle_encoder_set_index_buffer(
+            &mut self.encoder,
+            buffer.id,
+            index_format,
+            offset,
+            size,
+        );
     }
 
     fn set_vertex_buffer(
@@ -3839,39 +3840,40 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let buffer = buffer.map(|buffer| buffer.as_core().id);
 
-        wgpu_render_bundle_set_vertex_buffer(&mut self.encoder, slot, buffer, offset, size)
+        self.context.0.render_bundle_encoder_set_vertex_buffer(
+            &mut self.encoder,
+            slot,
+            buffer,
+            offset,
+            size,
+        );
     }
 
     fn set_immediates(&mut self, offset: u32, data: &[u8]) {
-        unsafe {
-            wgpu_core::command::bundle_ffi::wgpu_render_bundle_set_immediates(
-                &mut self.encoder,
-                offset,
-                data.len().try_into().unwrap(),
-                data.as_ptr(),
-            );
-        }
+        self.context
+            .0
+            .render_bundle_encoder_set_immediates(&mut self.encoder, offset, data);
     }
 
     fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
-        wgpu_render_bundle_draw(
+        self.context.0.render_bundle_encoder_draw(
             &mut self.encoder,
             vertices.end - vertices.start,
             instances.end - instances.start,
             vertices.start,
             instances.start,
-        )
+        );
     }
 
     fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
-        wgpu_render_bundle_draw_indexed(
+        self.context.0.render_bundle_encoder_draw_indexed(
             &mut self.encoder,
             indices.end - indices.start,
             instances.end - instances.start,
             indices.start,
             base_vertex,
             instances.start,
-        )
+        );
     }
 
     fn draw_indirect(
@@ -3881,7 +3883,11 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        wgpu_render_bundle_draw_indirect(&mut self.encoder, indirect_buffer.id, indirect_offset)
+        self.context.0.render_bundle_encoder_draw_indirect(
+            &mut self.encoder,
+            indirect_buffer.id,
+            indirect_offset,
+        )
     }
 
     fn draw_indexed_indirect(
@@ -3891,7 +3897,7 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        wgpu_render_bundle_draw_indexed_indirect(
+        self.context.0.render_bundle_encoder_draw_indexed_indirect(
             &mut self.encoder,
             indirect_buffer.id,
             indirect_offset,


### PR DESCRIPTION
**Connections**
As announced in https://github.com/gfx-rs/wgpu/issues/5121#issuecomment-4749255875

**Description**

Recording in content process must go and so does current form of RenderBundleEncoder, but before we start doing internal changes to the encoder itself let's make it's outside interface (that is from wgc, normal wgpu wraps it so there is no changes on the outside) same as of other passes with methods on both `&mut self` and `Global` (taking `&mut RenderBundleEncoder` as in passes, tho this might change in the follow ups). We still keep bundle_ffi for now (so there is less rush for changes in FF) but we do not use them in deno nor in wgpu anymore (less unsafe 🎉).

**Testing**

Mainly just refactor.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
