### PR TITLE
[core] Move Fallible into Arc<Texture>

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -142,7 +142,8 @@ impl Player {
                 let _ = buffer.unmap();
             }
             Action::CreateTexture(id, desc) => {
-                let texture = device.create_texture(&desc).expect("create_texture error");
+                let (texture, _) = device.create_texture(&desc);
+
                 self.textures.insert(id, texture);
             }
             Action::DestroyTexture(id) => {

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -146,6 +146,11 @@ impl Player {
 
                 self.textures.insert(id, texture);
             }
+            Action::CreateTextureError(id, desc) => {
+                let texture = device.create_texture_error(&desc);
+
+                self.textures.insert(id, texture);
+            }
             Action::DestroyTexture(id) => {
                 let texture = self.textures.get(&id).expect("invalid texture");
                 texture.destroy();

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -187,3 +187,86 @@ fn trace_failed_commands() {
 fn trace_failed_submit() {
     trace_test(TestType::FailedSubmit);
 }
+
+#[test]
+fn trace_texture_test() {
+    let global = wgc::global::Global::new(
+        "test",
+        wgt::instance::InstanceDescriptor {
+            backends: wgt::Backends::NOOP,
+            backend_options: wgt::BackendOptions {
+                noop: wgt::NoopBackendOptions::enabled(),
+                ..Default::default()
+            },
+            ..wgt::instance::InstanceDescriptor::new_without_display_handle()
+        },
+        None,
+    );
+    let adapter_id = global
+        .request_adapter(
+            &wgt::RequestAdapterOptions::default(),
+            wgt::Backends::NOOP,
+            None,
+        )
+        .unwrap();
+    let (device_id, _) = global
+        .adapter_request_device(
+            adapter_id,
+            &wgt::DeviceDescriptor {
+                trace: wgt::Trace::Memory,
+                ..Default::default()
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    let desc = wgt::TextureDescriptor {
+        label: None,
+        size: wgt::Extent3d {
+            width: 1024,
+            height: 1024,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgt::TextureDimension::D2,
+        format: wgt::TextureFormat::Rgba8Unorm,
+        usage: wgt::TextureUsages::COPY_DST | wgt::TextureUsages::TEXTURE_BINDING,
+        view_formats: Vec::new(),
+    };
+
+    let (texture_id, error) = global.device_create_texture(device_id, &desc, None);
+
+    assert!(error.is_none());
+
+    let texture_error_id = global.create_texture_error(device_id, None, &desc);
+
+    global.texture_drop(texture_id);
+    global.texture_drop(texture_error_id);
+
+    let trace = global.device_take_trace(device_id).unwrap();
+    let trace = (trace.as_ref() as &dyn Any)
+        .downcast_ref::<wgc::device::trace::MemoryTrace>()
+        .unwrap();
+    let actions = trace.actions();
+    // first one is init
+    let actions = &actions[1..];
+
+    assert_eq!(actions.len(), 4);
+
+    let Action::CreateTexture(texture, ..) = actions[0] else {
+        panic!("expected first action to be CreateTexture");
+    };
+    let Action::CreateTextureError(texture_error, ..) = actions[1] else {
+        panic!("expected second action to be CreateTextureError");
+    };
+    let Action::DropTexture(texture_drop) = actions[2] else {
+        panic!("expected third action to be DropTexture");
+    };
+    assert_eq!(texture, texture_drop);
+    let Action::DropTexture(texture_error_drop) = actions[3] else {
+        panic!("expected fourth action to be DropTexture");
+    };
+    assert_eq!(texture_error, texture_error_drop);
+}

--- a/wgpu-core/src/as_hal.rs
+++ b/wgpu-core/src/as_hal.rs
@@ -181,7 +181,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let texture = hub.textures.get(id).get().ok()?;
+        let texture = hub.textures.get(id);
 
         SnatchableResourceGuard::new(texture)
     }

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -14,7 +14,7 @@ use crate::{
         Buffer, DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
         ParentDevice, RawResourceAccess, ResourceErrorIdent, Texture, TextureClearMode,
     },
-    snatch::SnatchGuard,
+    snatch::{InvalidOrDestroyedResourceError, SnatchGuard},
     track::TextureTrackerSetSingle,
 };
 
@@ -77,6 +77,15 @@ whereas subesource range specified start {subresource_base_array_layer} and coun
     EncoderState(#[from] EncoderStateError),
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
+}
+
+impl From<InvalidOrDestroyedResourceError> for ClearError {
+    fn from(value: InvalidOrDestroyedResourceError) -> Self {
+        match value {
+            InvalidOrDestroyedResourceError::InvalidResource(e) => Self::InvalidResource(e),
+            InvalidOrDestroyedResourceError::DestroyedResource(e) => Self::DestroyedResource(e),
+        }
+    }
 }
 
 impl WebGpuError for ClearError {
@@ -300,7 +309,7 @@ pub(crate) fn clear_texture<T: TextureTrackerSetSingle>(
     snatch_guard: &SnatchGuard<'_>,
     instance_flags: wgt::InstanceFlags,
 ) -> Result<(), ClearError> {
-    let dst_raw = dst_texture.try_raw(snatch_guard)?;
+    let dst_raw = dst_texture.try_inner(snatch_guard)?.raw();
 
     // Issue the right barrier.
     let clear_usage = match *dst_texture.clear_mode.read() {

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -11,10 +11,11 @@ use crate::{
     id::{BufferId, CommandEncoderId, TextureId},
     init_tracker::{MemoryInitKind, TextureInitRange},
     resource::{
-        Buffer, DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
-        ParentDevice, RawResourceAccess, ResourceErrorIdent, Texture, TextureClearMode,
+        Buffer, DestroyedResourceError, InvalidOrDestroyedResourceError, InvalidResourceError,
+        Labeled, MissingBufferUsageError, ParentDevice, RawResourceAccess, ResourceErrorIdent,
+        Texture, TextureClearMode,
     },
-    snatch::{InvalidOrDestroyedResourceError, SnatchGuard},
+    snatch::SnatchGuard,
     track::TextureTrackerSetSingle,
 };
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -138,17 +138,11 @@ impl Global {
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
 
-        let texture = self.resolve_texture_id(dst);
-        {
-            let snatch_guard = cmd_enc.device.snatchable_lock.read();
-            texture
-                .check_valid(&snatch_guard)
-                .map_err(|_| EncoderStateError::Invalid)?;
-        }
-
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, ClearError> {
+            let texture = self.resolve_texture_id(dst);
+            texture.check_valid(&cmd_enc.device.snatchable_lock.read())?;
             Ok(ArcCommand::ClearTexture {
                 dst: texture,
                 subresource_range: *subresource_range,

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -141,7 +141,7 @@ impl Global {
 
         cmd_buf_data.push_with(|| -> Result<_, ClearError> {
             Ok(ArcCommand::ClearTexture {
-                dst: self.resolve_texture_id(dst)?,
+                dst: self.resolve_texture_id(dst),
                 subresource_range: *subresource_range,
             })
         })

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -137,11 +137,20 @@ impl Global {
         let hub = &self.hub;
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
+
+        let texture = self.resolve_texture_id(dst);
+        {
+            let snatch_guard = cmd_enc.device.snatchable_lock.read();
+            texture
+                .check_valid(&snatch_guard)
+                .map_err(|_| EncoderStateError::Invalid)?;
+        }
+
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, ClearError> {
             Ok(ArcCommand::ClearTexture {
-                dst: self.resolve_texture_id(dst),
+                dst: texture,
                 subresource_range: *subresource_range,
             })
         })

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -91,12 +91,13 @@ use crate::device::queue::TempResource;
 use crate::device::{Device, DeviceError, MissingFeatures};
 use crate::id::Id;
 use crate::lock::{rank, Mutex};
-use crate::snatch::{InvalidOrDestroyedResourceError, SnatchGuard};
+use crate::snatch::SnatchGuard;
 
 use crate::init_tracker::BufferInitTrackerAction;
 use crate::ray_tracing::{AsAction, BuildAccelerationStructureError};
 use crate::resource::{
-    DestroyedResourceError, Fallible, InvalidResourceError, Labeled, ParentDevice as _, QuerySet,
+    DestroyedResourceError, Fallible, InvalidOrDestroyedResourceError, InvalidResourceError,
+    Labeled, ParentDevice as _, QuerySet,
 };
 use crate::storage::Storage;
 use crate::track::{DeviceTracker, ResourceUsageCompatibilityError, Tracker, UsageScope};

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -1716,8 +1716,8 @@ impl Global {
     fn resolve_texture_id(
         &self,
         texture_id: Id<id::markers::Texture>,
-    ) -> Result<Arc<crate::resource::Texture>, InvalidResourceError> {
-        self.hub.textures.get(texture_id).get()
+    ) -> Arc<crate::resource::Texture> {
+        self.hub.textures.get(texture_id)
     }
 
     fn resolve_query_set(

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -91,7 +91,7 @@ use crate::device::queue::TempResource;
 use crate::device::{Device, DeviceError, MissingFeatures};
 use crate::id::Id;
 use crate::lock::{rank, Mutex};
-use crate::snatch::SnatchGuard;
+use crate::snatch::{InvalidOrDestroyedResourceError, SnatchGuard};
 
 use crate::init_tracker::BufferInitTrackerAction;
 use crate::ray_tracing::{AsAction, BuildAccelerationStructureError};
@@ -1615,6 +1615,15 @@ pub enum CommandEncoderError {
     ComputePass(#[from] ComputePassError),
     #[error(transparent)]
     RenderPass(#[from] RenderPassError),
+}
+
+impl From<InvalidOrDestroyedResourceError> for CommandEncoderError {
+    fn from(err: InvalidOrDestroyedResourceError) -> Self {
+        match err {
+            InvalidOrDestroyedResourceError::InvalidResource(e) => Self::InvalidResource(e),
+            InvalidOrDestroyedResourceError::DestroyedResource(e) => Self::DestroyedResource(e),
+        }
+    }
 }
 
 impl CommandEncoderError {

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -902,10 +902,15 @@ impl Global {
         let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
         let mut cmd_buf_data = cmd_enc.data.lock();
 
+        let texture = self.resolve_texture_id(source.texture);
+        texture
+            .check_valid(&cmd_enc.device.snatchable_lock.read())
+            .map_err(|_| EncoderStateError::Invalid)?;
+
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
             Ok(ArcCommand::CopyTextureToBuffer {
                 src: wgt::TexelCopyTextureInfo::<Arc<Texture>> {
-                    texture: self.resolve_texture_id(source.texture),
+                    texture,
                     mip_level: source.mip_level,
                     origin: source.origin,
                     aspect: source.aspect,

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -1154,7 +1154,7 @@ pub(super) fn copy_buffer_to_texture(
         .check_usage(BufferUsages::COPY_SRC)
         .map_err(TransferError::MissingBufferUsage)?;
 
-    let dst_raw = dst_texture.try_raw(state.snatch_guard)?;
+    let dst_raw = dst_texture.try_inner(state.snatch_guard)?.raw();
     dst_texture
         .check_usage(TextureUsages::COPY_DST)
         .map_err(TransferError::MissingTextureUsage)?;
@@ -1263,7 +1263,7 @@ pub(super) fn copy_texture_to_buffer(
 
     let (src_range, src_base) = extract_texture_selector(source, copy_size, src_texture)?;
 
-    let src_raw = src_texture.try_raw(state.snatch_guard)?;
+    let src_raw = src_texture.try_inner(state.snatch_guard)?.raw();
     src_texture
         .check_usage(TextureUsages::COPY_SRC)
         .map_err(TransferError::MissingTextureUsage)?;
@@ -1485,11 +1485,11 @@ pub(super) fn copy_texture_to_texture(
         .into());
     }
 
-    let src_raw = src_texture.try_raw(state.snatch_guard)?;
+    let src_raw = src_texture.try_inner(state.snatch_guard)?.raw();
     src_texture
         .check_usage(TextureUsages::COPY_SRC)
         .map_err(TransferError::MissingTextureUsage)?;
-    let dst_raw = dst_texture.try_raw(state.snatch_guard)?;
+    let dst_raw = dst_texture.try_inner(state.snatch_guard)?.raw();
     dst_texture
         .check_usage(TextureUsages::COPY_DST)
         .map_err(TransferError::MissingTextureUsage)?;

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -866,6 +866,12 @@ impl Global {
         );
 
         let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
+
+        let texture = self.resolve_texture_id(destination.texture);
+        texture
+            .check_valid(&cmd_enc.device.snatchable_lock.read())
+            .map_err(|_| EncoderStateError::Invalid)?;
+
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
@@ -875,7 +881,7 @@ impl Global {
                     layout: source.layout,
                 },
                 dst: wgt::TexelCopyTextureInfo::<Arc<Texture>> {
-                    texture: self.resolve_texture_id(destination.texture),
+                    texture,
                     mip_level: destination.mip_level,
                     origin: destination.origin,
                     aspect: destination.aspect,
@@ -900,12 +906,13 @@ impl Global {
         );
 
         let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
 
         let texture = self.resolve_texture_id(source.texture);
         texture
             .check_valid(&cmd_enc.device.snatchable_lock.read())
             .map_err(|_| EncoderStateError::Invalid)?;
+
+        let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
             Ok(ArcCommand::CopyTextureToBuffer {
@@ -939,18 +946,31 @@ impl Global {
         );
 
         let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
+
+        let src_texture = self.resolve_texture_id(source.texture);
+        let dst_texture = self.resolve_texture_id(destination.texture);
+        {
+            let snatch_guard = cmd_enc.device.snatchable_lock.read();
+            src_texture
+                .check_valid(&snatch_guard)
+                .map_err(|_| EncoderStateError::Invalid)?;
+            dst_texture
+                .check_valid(&snatch_guard)
+                .map_err(|_| EncoderStateError::Invalid)?;
+        }
+
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
             Ok(ArcCommand::CopyTextureToTexture {
                 src: wgt::TexelCopyTextureInfo {
-                    texture: self.resolve_texture_id(source.texture),
+                    texture: src_texture,
                     mip_level: source.mip_level,
                     origin: source.origin,
                     aspect: source.aspect,
                 },
                 dst: wgt::TexelCopyTextureInfo {
-                    texture: self.resolve_texture_id(destination.texture),
+                    texture: dst_texture,
                     mip_level: destination.mip_level,
                     origin: destination.origin,
                     aspect: destination.aspect,

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -875,7 +875,7 @@ impl Global {
                     layout: source.layout,
                 },
                 dst: wgt::TexelCopyTextureInfo::<Arc<Texture>> {
-                    texture: self.resolve_texture_id(destination.texture)?,
+                    texture: self.resolve_texture_id(destination.texture),
                     mip_level: destination.mip_level,
                     origin: destination.origin,
                     aspect: destination.aspect,
@@ -905,7 +905,7 @@ impl Global {
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
             Ok(ArcCommand::CopyTextureToBuffer {
                 src: wgt::TexelCopyTextureInfo::<Arc<Texture>> {
-                    texture: self.resolve_texture_id(source.texture)?,
+                    texture: self.resolve_texture_id(source.texture),
                     mip_level: source.mip_level,
                     origin: source.origin,
                     aspect: source.aspect,
@@ -939,13 +939,13 @@ impl Global {
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
             Ok(ArcCommand::CopyTextureToTexture {
                 src: wgt::TexelCopyTextureInfo {
-                    texture: self.resolve_texture_id(source.texture)?,
+                    texture: self.resolve_texture_id(source.texture),
                     mip_level: source.mip_level,
                     origin: source.origin,
                     aspect: source.aspect,
                 },
                 dst: wgt::TexelCopyTextureInfo {
-                    texture: self.resolve_texture_id(destination.texture)?,
+                    texture: self.resolve_texture_id(destination.texture),
                     mip_level: destination.mip_level,
                     origin: destination.origin,
                     aspect: destination.aspect,

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -867,14 +867,11 @@ impl Global {
 
         let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
 
-        let texture = self.resolve_texture_id(destination.texture);
-        texture
-            .check_valid(&cmd_enc.device.snatchable_lock.read())
-            .map_err(|_| EncoderStateError::Invalid)?;
-
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
+            let texture = self.resolve_texture_id(destination.texture);
+            texture.check_valid(&cmd_enc.device.snatchable_lock.read())?;
             Ok(ArcCommand::CopyBufferToTexture {
                 src: wgt::TexelCopyBufferInfo::<Arc<Buffer>> {
                     buffer: self.resolve_buffer_id(source.buffer)?,
@@ -907,14 +904,11 @@ impl Global {
 
         let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
 
-        let texture = self.resolve_texture_id(source.texture);
-        texture
-            .check_valid(&cmd_enc.device.snatchable_lock.read())
-            .map_err(|_| EncoderStateError::Invalid)?;
-
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
+            let texture = self.resolve_texture_id(source.texture);
+            texture.check_valid(&cmd_enc.device.snatchable_lock.read())?;
             Ok(ArcCommand::CopyTextureToBuffer {
                 src: wgt::TexelCopyTextureInfo::<Arc<Texture>> {
                     texture,
@@ -947,21 +941,16 @@ impl Global {
 
         let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
 
-        let src_texture = self.resolve_texture_id(source.texture);
-        let dst_texture = self.resolve_texture_id(destination.texture);
-        {
-            let snatch_guard = cmd_enc.device.snatchable_lock.read();
-            src_texture
-                .check_valid(&snatch_guard)
-                .map_err(|_| EncoderStateError::Invalid)?;
-            dst_texture
-                .check_valid(&snatch_guard)
-                .map_err(|_| EncoderStateError::Invalid)?;
-        }
-
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
+            let src_texture = self.resolve_texture_id(source.texture);
+            let dst_texture = self.resolve_texture_id(destination.texture);
+            {
+                let snatch_guard = cmd_enc.device.snatchable_lock.read();
+                src_texture.check_valid(&snatch_guard)?;
+                dst_texture.check_valid(&snatch_guard)?;
+            }
             Ok(ArcCommand::CopyTextureToTexture {
                 src: wgt::TexelCopyTextureInfo {
                     texture: src_texture,

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -26,6 +26,7 @@ impl Global {
         // Lock command encoder for recording
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
         let mut cmd_buf_data = cmd_enc.data.lock();
+        let snatch_guard = cmd_enc.device.snatchable_lock.read();
         cmd_buf_data.push_with(|| -> Result<_, TransitionResourcesError> {
             Ok(ArcCommand::TransitionResources {
                 buffer_transitions: buffer_transitions
@@ -38,8 +39,12 @@ impl Global {
                     .collect::<Result<_, TransitionResourcesError>>()?,
                 texture_transitions: texture_transitions
                     .map(|t| {
+                        let texture = self.resolve_texture_id(t.texture);
+                        texture
+                            .check_valid(&snatch_guard)
+                            .map_err(|_| EncoderStateError::Invalid)?;
                         Ok(wgt::TextureTransition {
-                            texture: self.resolve_texture_id(t.texture),
+                            texture,
                             selector: t.selector,
                             state: t.state,
                         })

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -39,7 +39,7 @@ impl Global {
                 texture_transitions: texture_transitions
                     .map(|t| {
                         Ok(wgt::TextureTransition {
-                            texture: self.resolve_texture_id(t.texture)?,
+                            texture: self.resolve_texture_id(t.texture),
                             selector: t.selector,
                             state: t.state,
                         })

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -40,9 +40,7 @@ impl Global {
                 texture_transitions: texture_transitions
                     .map(|t| {
                         let texture = self.resolve_texture_id(t.texture);
-                        texture
-                            .check_valid(&snatch_guard)
-                            .map_err(|_| EncoderStateError::Invalid)?;
+                        texture.check_valid(&snatch_guard)?;
                         Ok(wgt::TextureTransition {
                             texture,
                             selector: t.selector,

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -414,14 +414,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _texture = hub.textures.remove(texture_id);
-        #[cfg(feature = "trace")]
-        {
-            let mut t = _texture.device.trace.lock();
-            if let Some(t) = t.as_mut() {
-                t.add(trace::Action::DropTexture(_texture.to_trace()));
-            }
-        }
+        hub.textures.remove(texture_id);
     }
 
     pub fn texture_create_view(

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -207,16 +207,7 @@ impl Global {
     ) {
         let fid = self.hub.textures.prepare(id_in);
         let device = self.hub.devices.get(device_id);
-        let texture = Arc::new(resource::Texture::invalid(&device, desc));
-        #[cfg(feature = "trace")]
-        if let Some(ref mut trace) = *device.trace.lock() {
-            use crate::device::trace::IntoTrace as _;
-
-            trace.add(trace::Action::CreateTexture(
-                texture.to_trace(),
-                desc.clone(),
-            ));
-        }
+        let texture = device.create_texture_error(desc);
         fid.assign(texture);
     }
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -201,11 +201,13 @@ impl Global {
     /// See [`Self::create_buffer_error`] for more context and explanation.
     pub fn create_texture_error(
         &self,
+        device_id: DeviceId,
         id_in: Option<id::TextureId>,
         desc: &resource::TextureDescriptor,
     ) {
         let fid = self.hub.textures.prepare(id_in);
-        fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
+        let device = self.hub.devices.get(device_id);
+        fid.assign(Arc::new(resource::Texture::dummy(&device, desc)));
     }
 
     /// Assign `id_in` an error with the given `label`.
@@ -291,30 +293,26 @@ impl Global {
 
         let fid = hub.textures.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
-            let texture = match device.create_texture(desc) {
-                Ok(texture) => texture,
-                Err(error) => break 'error error,
-            };
+        let (texture, error) = device.create_texture(desc);
 
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                trace.add(trace::Action::CreateTexture(
-                    texture.to_trace(),
-                    desc.clone(),
-                ));
-            }
+        // TODO: we should probably move this inside the function
+        // also we are now tracing also invalid textures
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *device.trace.lock() {
+            use crate::device::trace::IntoTrace as _;
 
-            let id = fid.assign(Fallible::Valid(texture));
-            api_log!("Device::create_texture({desc:?}) -> {id:?}");
+            trace.add(trace::Action::CreateTexture(
+                texture.to_trace(),
+                desc.clone(),
+            ));
+        }
 
-            return (id, None);
-        };
+        let id = fid.assign(texture);
+        api_log!("Device::create_texture({desc:?}) -> {id:?}");
 
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
-        (id, Some(error))
+        (id, error)
     }
 
     /// # Safety
@@ -338,9 +336,9 @@ impl Global {
 
         let fid = hub.textures.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
+        let error = 'error: {
             let texture = match device.create_texture_from_hal(hal_texture, desc, initial_state) {
                 Ok(texture) => texture,
                 Err(error) => break 'error error,
@@ -356,13 +354,13 @@ impl Global {
                 ));
             }
 
-            let id = fid.assign(Fallible::Valid(texture));
+            let id = fid.assign(texture);
             api_log!("Device::create_texture({desc:?}) -> {id:?}");
 
             return (id, None);
         };
 
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
+        let id = fid.assign(Arc::new(resource::Texture::dummy(&device, desc)));
         (id, Some(error))
     }
 
@@ -412,10 +410,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let Ok(texture) = hub.textures.get(texture_id).get() else {
-            // If the texture is already invalid, there's nothing to do.
-            return;
-        };
+        let texture = hub.textures.get(texture_id);
 
         #[cfg(feature = "trace")]
         if let Some(trace) = texture.device.trace.lock().as_mut() {
@@ -431,10 +426,11 @@ impl Global {
 
         let hub = &self.hub;
 
-        let _texture = hub.textures.remove(texture_id);
+        let texture = hub.textures.remove(texture_id);
         #[cfg(feature = "trace")]
-        if let Ok(texture) = _texture.get() {
-            if let Some(t) = texture.device.trace.lock().as_mut() {
+        {
+            let mut t = texture.device.trace.lock();
+            if let Some(t) = t.as_mut() {
                 t.add(trace::Action::DropTexture(texture.to_trace()));
             }
         }
@@ -453,10 +449,7 @@ impl Global {
         let fid = hub.texture_views.prepare(id_in);
 
         let error = 'error: {
-            let texture = match hub.textures.get(texture_id).get() {
-                Ok(texture) => texture,
-                Err(e) => break 'error e.into(),
-            };
+            let texture = hub.textures.get(texture_id);
             let device = &texture.device;
 
             let view = match device.create_texture_view(&texture, desc) {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -204,11 +204,11 @@ impl Global {
         device_id: DeviceId,
         id_in: Option<id::TextureId>,
         desc: &resource::TextureDescriptor,
-    ) {
+    ) -> id::TextureId {
         let fid = self.hub.textures.prepare(id_in);
         let device = self.hub.devices.get(device_id);
         let texture = device.create_texture_error(desc);
-        fid.assign(texture);
+        fid.assign(texture)
     }
 
     /// Assign `id_in` an error with the given `label`.

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -207,7 +207,17 @@ impl Global {
     ) {
         let fid = self.hub.textures.prepare(id_in);
         let device = self.hub.devices.get(device_id);
-        fid.assign(Arc::new(resource::Texture::dummy(&device, desc)));
+        let texture = Arc::new(resource::Texture::invalid(&device, desc));
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *device.trace.lock() {
+            use crate::device::trace::IntoTrace as _;
+
+            trace.add(trace::Action::CreateTexture(
+                texture.to_trace(),
+                desc.clone(),
+            ));
+        }
+        fid.assign(texture);
     }
 
     /// Assign `id_in` an error with the given `label`.
@@ -297,18 +307,6 @@ impl Global {
 
         let (texture, error) = device.create_texture(desc);
 
-        // TODO: we should probably move this inside the function
-        // also we are now tracing also invalid textures
-        #[cfg(feature = "trace")]
-        if let Some(ref mut trace) = *device.trace.lock() {
-            use crate::device::trace::IntoTrace as _;
-
-            trace.add(trace::Action::CreateTexture(
-                texture.to_trace(),
-                desc.clone(),
-            ));
-        }
-
         let id = fid.assign(texture);
         api_log!("Device::create_texture({desc:?}) -> {id:?}");
 
@@ -360,7 +358,7 @@ impl Global {
             return (id, None);
         };
 
-        let id = fid.assign(Arc::new(resource::Texture::dummy(&device, desc)));
+        let id = fid.assign(Arc::new(resource::Texture::invalid(&device, desc)));
         (id, Some(error))
     }
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -426,12 +426,12 @@ impl Global {
 
         let hub = &self.hub;
 
-        let texture = hub.textures.remove(texture_id);
+        let _texture = hub.textures.remove(texture_id);
         #[cfg(feature = "trace")]
         {
-            let mut t = texture.device.trace.lock();
+            let mut t = _texture.device.trace.lock();
             if let Some(t) = t.as_mut() {
-                t.add(trace::Action::DropTexture(texture.to_trace()));
+                t.add(trace::Action::DropTexture(_texture.to_trace()));
             }
         }
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -299,7 +299,6 @@ impl Global {
         let (texture, error) = device.create_texture(desc);
 
         let id = fid.assign(texture);
-        api_log!("Device::create_texture({desc:?}) -> {id:?}");
 
         (id, error)
     }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -40,7 +40,7 @@ use crate::{
     },
     resource_log,
     scratch::ScratchBuffer,
-    snatch::{SnatchGuard, Snatchable},
+    snatch::{InvalidOrDestroyedResourceError, SnatchGuard, Snatchable},
     track::{self, Tracker, TrackerIndex},
     FastHashMap, SubmissionIndex,
 };
@@ -559,6 +559,15 @@ pub enum QueueSubmitError {
     CommandEncoder(#[from] CommandEncoderError),
     #[error(transparent)]
     ValidateAsActionsError(#[from] crate::ray_tracing::ValidateAsActionsError),
+}
+
+impl From<InvalidOrDestroyedResourceError> for QueueSubmitError {
+    fn from(e: InvalidOrDestroyedResourceError) -> Self {
+        match e {
+            InvalidOrDestroyedResourceError::InvalidResource(e) => Self::InvalidResource(e),
+            InvalidOrDestroyedResourceError::DestroyedResource(e) => Self::DestroyedResource(e),
+        }
+    }
 }
 
 impl WebGpuError for QueueSubmitError {
@@ -1644,7 +1653,10 @@ impl Queue {
                 // encoded. If it was destroyed after that, then it was transferred
                 // to `pending_writes.temp_resources` at the time of destruction, so
                 // we are still okay to use it.
-                Err(DestroyedResourceError(_)) => {}
+                Err(InvalidOrDestroyedResourceError::DestroyedResource(_)) => {}
+                Err(InvalidOrDestroyedResourceError::InvalidResource(_)) => {
+                    unreachable!()
+                }
             }
         }
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1678,7 +1678,7 @@ impl Queue {
             let mut submit_surface_textures =
                 SmallVec::<[&dyn hal::DynSurfaceTexture; 2]>::with_capacity(surface_textures.len());
             for texture in surface_textures.values() {
-                let raw = match texture.inner.get(&snatch_guard) {
+                let raw = match texture.inner.get(&snatch_guard).maybe_valid() {
                     Some(TextureInner::Surface { raw, .. }) => raw.as_ref(),
                     _ => unreachable!(),
                 };

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1065,7 +1065,7 @@ impl Queue {
     pub fn copy_external_image_to_texture(
         &self,
         source: &wgt::CopyExternalImageSourceInfo,
-        destination: wgt::CopyExternalImageDestInfo<Fallible<Texture>>,
+        destination: wgt::CopyExternalImageDestInfo<Arc<Texture>>,
         size: wgt::Extent3d,
     ) -> Result<(), QueueWriteError> {
         use crate::conv;
@@ -1093,7 +1093,7 @@ impl Queue {
         let src_width = source.source.width();
         let src_height = source.source.height();
 
-        let dst = destination.texture.get()?;
+        let dst = destination.texture;
         let premultiplied_alpha = destination.premultiplied_alpha;
         let destination = wgt::TexelCopyTextureInfo {
             texture: (),

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1896,7 +1896,7 @@ impl Global {
         size: &wgt::Extent3d,
     ) -> Result<(), QueueWriteError> {
         let queue = self.hub.queues.get(queue_id);
-        let texture = self.hub.textures.get(destination.texture).get()?;
+        let texture = self.hub.textures.get(destination.texture);
         let destination = wgt::TexelCopyTextureInfo {
             texture,
             mip_level: destination.mip_level,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -198,8 +198,8 @@ impl Queue {
         // Emit the transition barriers to PRESENT.
         {
             let raw_texture = texture
-                .try_raw(&submission.snatch_guard)
-                .map_err(|_| DeviceError::Lost)?;
+                .raw(&submission.snatch_guard)
+                .ok_or(DeviceError::Lost)?;
             let barriers: Vec<hal::TextureBarrier<'_, dyn hal::DynTexture>> = pending
                 .into_iter()
                 .map(|pt| pt.into_hal(raw_texture))
@@ -530,6 +530,15 @@ pub enum QueueWriteError {
     DestroyedResource(#[from] DestroyedResourceError),
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
+}
+
+impl From<InvalidOrDestroyedResourceError> for QueueWriteError {
+    fn from(e: InvalidOrDestroyedResourceError) -> Self {
+        match e {
+            InvalidOrDestroyedResourceError::InvalidResource(e) => Self::InvalidResource(e),
+            InvalidOrDestroyedResourceError::DestroyedResource(e) => Self::DestroyedResource(e),
+        }
+    }
 }
 
 impl WebGpuError for QueueWriteError {
@@ -902,7 +911,7 @@ impl Queue {
 
         let snatch_guard = self.device.snatchable_lock.read();
 
-        let dst_raw = dst.try_raw(&snatch_guard)?;
+        let dst_raw = dst.try_inner(&snatch_guard)?.raw();
 
         // This must happen after parameter validation (so that errors are reported
         // as required by the spec), but before any side effects.

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -35,12 +35,13 @@ use crate::{
     resource::{
         Blas, BlasCompactState, Buffer, BufferAccessError, BufferMapState, DestroyedBuffer,
         DestroyedQuerySet, DestroyedResourceError, DestroyedTexture, Fallible,
-        FlushedStagingBuffer, InvalidResourceError, Labeled, ParentDevice, ResourceErrorIdent,
-        StagingBuffer, Texture, TextureInner, Trackable, TrackingData,
+        FlushedStagingBuffer, InvalidOrDestroyedResourceError, InvalidResourceError, Labeled,
+        ParentDevice, ResourceErrorIdent, StagingBuffer, Texture, TextureInner, Trackable,
+        TrackingData,
     },
     resource_log,
     scratch::ScratchBuffer,
-    snatch::{InvalidOrDestroyedResourceError, SnatchGuard, Snatchable},
+    snatch::{SnatchGuard, Snatchable},
     track::{self, Tracker, TrackerIndex},
     FastHashMap, SubmissionIndex,
 };

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1373,398 +1373,386 @@ impl Device {
         }
     }
 
-    pub fn create_texture(
+    fn create_texture_inner(
         self: &Arc<Self>,
         desc: &resource::TextureDescriptor,
-    ) -> (Arc<Texture>, Option<resource::CreateTextureError>) {
-        fn create(
-            device: &Arc<Device>,
-            desc: &resource::TextureDescriptor,
-        ) -> Result<Arc<Texture>, resource::CreateTextureError> {
-            use resource::{CreateTextureError, TextureDimensionError};
+    ) -> Result<Arc<Texture>, resource::CreateTextureError> {
+        use resource::{CreateTextureError, TextureDimensionError};
 
-            device.check_is_valid()?;
+        self.check_is_valid()?;
 
-            if desc.usage.is_empty() || desc.usage.contains_unknown_bits() {
-                return Err(CreateTextureError::InvalidUsage(desc.usage));
+        if desc.usage.is_empty() || desc.usage.contains_unknown_bits() {
+            return Err(CreateTextureError::InvalidUsage(desc.usage));
+        }
+
+        conv::check_texture_dimension_size(
+            desc.dimension,
+            desc.size,
+            desc.sample_count,
+            &self.limits,
+        )?;
+
+        if desc.dimension != wgt::TextureDimension::D2 {
+            // Depth textures can only be 2D
+            if desc.format.is_depth_stencil_format() {
+                return Err(CreateTextureError::InvalidDepthDimension(
+                    desc.dimension,
+                    desc.format,
+                ));
             }
-
-            conv::check_texture_dimension_size(
-                desc.dimension,
-                desc.size,
-                desc.sample_count,
-                &device.limits,
-            )?;
-
-            if desc.dimension != wgt::TextureDimension::D2 {
-                // Depth textures can only be 2D
-                if desc.format.is_depth_stencil_format() {
-                    return Err(CreateTextureError::InvalidDepthDimension(
-                        desc.dimension,
-                        desc.format,
-                    ));
-                }
-                // Transient textures can only be 2D
-                if desc
-                    .usage
-                    .contains(wgt::TextureUsages::TRANSIENT_ATTACHMENT)
-                {
-                    return Err(CreateTextureError::InvalidDimensionUsages(
-                        wgt::TextureUsages::TRANSIENT_ATTACHMENT,
-                        desc.dimension,
-                    ));
-                }
-            }
-
-            if desc.dimension != wgt::TextureDimension::D2
-                && desc.dimension != wgt::TextureDimension::D3
+            // Transient textures can only be 2D
+            if desc
+                .usage
+                .contains(wgt::TextureUsages::TRANSIENT_ATTACHMENT)
             {
-                // Compressed textures can only be 2D or 3D
-                if desc.format.is_compressed() {
+                return Err(CreateTextureError::InvalidDimensionUsages(
+                    wgt::TextureUsages::TRANSIENT_ATTACHMENT,
+                    desc.dimension,
+                ));
+            }
+        }
+
+        if desc.dimension != wgt::TextureDimension::D2
+            && desc.dimension != wgt::TextureDimension::D3
+        {
+            // Compressed textures can only be 2D or 3D
+            if desc.format.is_compressed() {
+                return Err(CreateTextureError::InvalidCompressedDimension(
+                    desc.dimension,
+                    desc.format,
+                ));
+            }
+
+            // Renderable textures can only be 2D or 3D
+            if desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
+                return Err(CreateTextureError::InvalidDimensionUsages(
+                    wgt::TextureUsages::RENDER_ATTACHMENT,
+                    desc.dimension,
+                ));
+            }
+        }
+
+        if desc.format.is_compressed() {
+            let (block_width, block_height) = desc.format.block_dimensions();
+
+            if !desc.size.width.is_multiple_of(block_width) {
+                return Err(CreateTextureError::InvalidDimension(
+                    TextureDimensionError::NotMultipleOfBlockWidth {
+                        width: desc.size.width,
+                        block_width,
+                        format: desc.format,
+                    },
+                ));
+            }
+
+            if !desc.size.height.is_multiple_of(block_height) {
+                return Err(CreateTextureError::InvalidDimension(
+                    TextureDimensionError::NotMultipleOfBlockHeight {
+                        height: desc.size.height,
+                        block_height,
+                        format: desc.format,
+                    },
+                ));
+            }
+
+            if desc.dimension == wgt::TextureDimension::D3 {
+                // Only BCn formats with Sliced 3D feature can be used for 3D textures
+                if desc.format.is_bcn() {
+                    self.require_features(wgt::Features::TEXTURE_COMPRESSION_BC_SLICED_3D)
+                        .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
+                } else if desc.format.is_astc() {
+                    self.require_features(wgt::Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D)
+                        .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
+                } else {
                     return Err(CreateTextureError::InvalidCompressedDimension(
                         desc.dimension,
                         desc.format,
                     ));
                 }
+            }
+        }
 
-                // Renderable textures can only be 2D or 3D
-                if desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
-                    return Err(CreateTextureError::InvalidDimensionUsages(
-                        wgt::TextureUsages::RENDER_ATTACHMENT,
-                        desc.dimension,
-                    ));
-                }
+        let mips = desc.mip_level_count;
+        let max_levels_allowed = desc.size.max_mips(desc.dimension).min(hal::MAX_MIP_LEVELS);
+        if mips == 0 || mips > max_levels_allowed {
+            return Err(CreateTextureError::InvalidMipLevelCount {
+                requested: mips,
+                maximum: max_levels_allowed,
+            });
+        }
+
+        {
+            let (mut width_multiple, mut height_multiple) = desc.format.size_multiple_requirement();
+
+            if desc.format.is_multi_planar_format() {
+                // TODO(https://github.com/gfx-rs/wgpu/issues/8491): fix
+                // `mip_level_size` calculation for these formats and relax this
+                // restriction.
+                width_multiple <<= desc.mip_level_count.saturating_sub(1);
+                height_multiple <<= desc.mip_level_count.saturating_sub(1);
             }
 
-            if desc.format.is_compressed() {
-                let (block_width, block_height) = desc.format.block_dimensions();
-
-                if !desc.size.width.is_multiple_of(block_width) {
-                    return Err(CreateTextureError::InvalidDimension(
-                        TextureDimensionError::NotMultipleOfBlockWidth {
-                            width: desc.size.width,
-                            block_width,
-                            format: desc.format,
-                        },
-                    ));
-                }
-
-                if !desc.size.height.is_multiple_of(block_height) {
-                    return Err(CreateTextureError::InvalidDimension(
-                        TextureDimensionError::NotMultipleOfBlockHeight {
-                            height: desc.size.height,
-                            block_height,
-                            format: desc.format,
-                        },
-                    ));
-                }
-
-                if desc.dimension == wgt::TextureDimension::D3 {
-                    // Only BCn formats with Sliced 3D feature can be used for 3D textures
-                    if desc.format.is_bcn() {
-                        device
-                            .require_features(wgt::Features::TEXTURE_COMPRESSION_BC_SLICED_3D)
-                            .map_err(|error| {
-                                CreateTextureError::MissingFeatures(desc.format, error)
-                            })?;
-                    } else if desc.format.is_astc() {
-                        device
-                            .require_features(wgt::Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D)
-                            .map_err(|error| {
-                                CreateTextureError::MissingFeatures(desc.format, error)
-                            })?;
-                    } else {
-                        return Err(CreateTextureError::InvalidCompressedDimension(
-                            desc.dimension,
-                            desc.format,
-                        ));
-                    }
-                }
-            }
-
-            let mips = desc.mip_level_count;
-            let max_levels_allowed = desc.size.max_mips(desc.dimension).min(hal::MAX_MIP_LEVELS);
-            if mips == 0 || mips > max_levels_allowed {
-                return Err(CreateTextureError::InvalidMipLevelCount {
-                    requested: mips,
-                    maximum: max_levels_allowed,
-                });
-            }
-
-            {
-                let (mut width_multiple, mut height_multiple) =
-                    desc.format.size_multiple_requirement();
-
-                if desc.format.is_multi_planar_format() {
-                    // TODO(https://github.com/gfx-rs/wgpu/issues/8491): fix
-                    // `mip_level_size` calculation for these formats and relax this
-                    // restriction.
-                    width_multiple <<= desc.mip_level_count.saturating_sub(1);
-                    height_multiple <<= desc.mip_level_count.saturating_sub(1);
-                }
-
-                if !desc.size.width.is_multiple_of(width_multiple) {
-                    return Err(CreateTextureError::InvalidDimension(
-                        TextureDimensionError::WidthNotMultipleOf {
-                            width: desc.size.width,
-                            multiple: width_multiple,
-                            format: desc.format,
-                        },
-                    ));
-                }
-
-                if !desc.size.height.is_multiple_of(height_multiple) {
-                    return Err(CreateTextureError::InvalidDimension(
-                        TextureDimensionError::HeightNotMultipleOf {
-                            height: desc.size.height,
-                            multiple: height_multiple,
-                            format: desc.format,
-                        },
-                    ));
-                }
-            }
-
-            if desc
-                .usage
-                .contains(wgt::TextureUsages::TRANSIENT_ATTACHMENT)
-            {
-                if desc.usage
-                    != (wgt::TextureUsages::TRANSIENT_ATTACHMENT
-                        | wgt::TextureUsages::RENDER_ATTACHMENT)
-                {
-                    return Err(CreateTextureError::InvalidTransientTextureUsage(desc.usage));
-                }
-
-                if desc.mip_level_count != 1 {
-                    return Err(CreateTextureError::InvalidTransientTextureMipLevelCount(
-                        desc.mip_level_count,
-                    ));
-                }
-
-                if desc.size.depth_or_array_layers != 1 {
-                    return Err(CreateTextureError::InvalidTransientTextureLayerCount(
-                        desc.size.depth_or_array_layers,
-                    ));
-                }
-
-                if !desc.view_formats.is_empty() {
-                    return Err(CreateTextureError::InvalidTransientTextureViewFormats);
-                }
-            }
-
-            let format_features = device
-                .describe_format_features(desc.format)
-                .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
-
-            if desc.sample_count > 1 {
-                // <https://www.w3.org/TR/2025/CRD-webgpu-20251120/#:~:text=If%20descriptor%2EsampleCount%20%3E%201>
-                //
-                // Note that there are also some checks related to the sample count
-                // in [`conv::check_texture_dimension_size`].
-
-                if desc.mip_level_count != 1 {
-                    return Err(CreateTextureError::InvalidMipLevelCount {
-                        requested: desc.mip_level_count,
-                        maximum: 1,
-                    });
-                }
-
-                if desc.size.depth_or_array_layers != 1
-                    && !device.features.contains(wgt::Features::MULTISAMPLE_ARRAY)
-                {
-                    return Err(CreateTextureError::InvalidDimension(
-                        TextureDimensionError::MultisampledDepthOrArrayLayer(
-                            desc.size.depth_or_array_layers,
-                        ),
-                    ));
-                }
-
-                if desc.usage.contains(wgt::TextureUsages::STORAGE_BINDING) {
-                    return Err(CreateTextureError::InvalidMultisampledStorageBinding);
-                }
-
-                if !desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
-                    return Err(CreateTextureError::MultisampledNotRenderAttachment);
-                }
-
-                if !format_features.flags.intersects(
-                    wgt::TextureFormatFeatureFlags::MULTISAMPLE_X4
-                        | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X2
-                        | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X8
-                        | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X16,
-                ) {
-                    return Err(CreateTextureError::InvalidMultisampledFormat(desc.format));
-                }
-
-                if !format_features
-                    .flags
-                    .sample_count_supported(desc.sample_count)
-                {
-                    return Err(CreateTextureError::InvalidSampleCount(
-                        desc.sample_count,
-                        desc.format,
-                        desc.format
-                            .guaranteed_format_features(device.features)
-                            .flags
-                            .supported_sample_counts(),
-                        device
-                            .adapter
-                            .get_texture_format_features(desc.format)
-                            .flags
-                            .supported_sample_counts(),
-                    ));
-                };
-            }
-
-            let missing_allowed_usages = match desc.format.planes() {
-                Some(planes) => {
-                    let mut planes_usages = wgt::TextureUsages::all();
-                    for plane in 0..planes {
-                        let aspect = wgt::TextureAspect::from_plane(plane).unwrap();
-                        let format = desc.format.aspect_specific_format(aspect).unwrap();
-                        let format_features =
-                            device.describe_format_features(format).map_err(|error| {
-                                CreateTextureError::MissingFeatures(desc.format, error)
-                            })?;
-
-                        planes_usages &= format_features.allowed_usages;
-                    }
-
-                    desc.usage - planes_usages
-                }
-                None => desc.usage - format_features.allowed_usages,
-            };
-
-            if !missing_allowed_usages.is_empty() {
-                // detect downlevel incompatibilities
-                let wgpu_allowed_usages = desc
-                    .format
-                    .guaranteed_format_features(device.features)
-                    .allowed_usages;
-                let wgpu_missing_usages = desc.usage - wgpu_allowed_usages;
-                return Err(CreateTextureError::InvalidFormatUsages(
-                    missing_allowed_usages,
-                    desc.format,
-                    wgpu_missing_usages.is_empty(),
+            if !desc.size.width.is_multiple_of(width_multiple) {
+                return Err(CreateTextureError::InvalidDimension(
+                    TextureDimensionError::WidthNotMultipleOf {
+                        width: desc.size.width,
+                        multiple: width_multiple,
+                        format: desc.format,
+                    },
                 ));
             }
 
-            let mut hal_view_formats = Vec::new();
-            for format in desc.view_formats.iter() {
-                if desc.format == *format {
-                    continue;
-                }
-                if desc.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
-                    return Err(CreateTextureError::InvalidViewFormat(*format, desc.format));
-                }
-                hal_view_formats.push(*format);
+            if !desc.size.height.is_multiple_of(height_multiple) {
+                return Err(CreateTextureError::InvalidDimension(
+                    TextureDimensionError::HeightNotMultipleOf {
+                        height: desc.size.height,
+                        multiple: height_multiple,
+                        format: desc.format,
+                    },
+                ));
             }
-            if !hal_view_formats.is_empty() {
-                device.require_downlevel_flags(wgt::DownlevelFlags::VIEW_FORMATS)?;
-            }
-
-            let hal_usage = conv::map_texture_usage_for_texture(desc, &format_features);
-
-            let hal_desc = hal::TextureDescriptor {
-                label: desc.label.to_hal(device.instance_flags),
-                size: desc.size,
-                mip_level_count: desc.mip_level_count,
-                sample_count: desc.sample_count,
-                dimension: desc.dimension,
-                format: desc.format,
-                usage: hal_usage,
-                memory_flags: hal::MemoryFlags::empty(),
-                view_formats: hal_view_formats,
-            };
-
-            let raw_texture = unsafe { device.raw().create_texture(&hal_desc) }
-                .map_err(|e| device.handle_hal_error_with_nonfatal_oom(e))?;
-
-            let clear_mode = if hal_usage
-                .intersects(wgt::TextureUses::DEPTH_STENCIL_WRITE | wgt::TextureUses::COLOR_TARGET)
-                && desc.dimension == wgt::TextureDimension::D2
-            {
-                let (is_color, usage) = if desc.format.is_depth_stencil_format() {
-                    (false, wgt::TextureUses::DEPTH_STENCIL_WRITE)
-                } else {
-                    (true, wgt::TextureUses::COLOR_TARGET)
-                };
-
-                let clear_label = hal_label(
-                    Some("(wgpu internal) clear texture view"),
-                    device.instance_flags,
-                );
-
-                let mut clear_views = SmallVec::new();
-                for mip_level in 0..desc.mip_level_count {
-                    for array_layer in 0..desc.size.depth_or_array_layers {
-                        macro_rules! push_clear_view {
-                            ($format:expr, $aspect:expr) => {
-                                let desc = hal::TextureViewDescriptor {
-                                    label: clear_label,
-                                    format: $format,
-                                    dimension: TextureViewDimension::D2,
-                                    usage,
-                                    range: wgt::ImageSubresourceRange {
-                                        aspect: $aspect,
-                                        base_mip_level: mip_level,
-                                        mip_level_count: Some(1),
-                                        base_array_layer: array_layer,
-                                        array_layer_count: Some(1),
-                                    },
-                                };
-                                clear_views.push(ManuallyDrop::new(
-                                    unsafe {
-                                        device
-                                            .raw()
-                                            .create_texture_view(raw_texture.as_ref(), &desc)
-                                    }
-                                    .map_err(|e| device.handle_hal_error(e))?,
-                                ));
-                            };
-                        }
-
-                        if let Some(planes) = desc.format.planes() {
-                            for plane in 0..planes {
-                                let aspect = wgt::TextureAspect::from_plane(plane).unwrap();
-                                let format = desc.format.aspect_specific_format(aspect).unwrap();
-                                push_clear_view!(format, aspect);
-                            }
-                        } else {
-                            push_clear_view!(desc.format, wgt::TextureAspect::All);
-                        }
-                    }
-                }
-                resource::TextureClearMode::RenderPass {
-                    clear_views,
-                    is_color,
-                }
-            } else {
-                resource::TextureClearMode::BufferCopy
-            };
-
-            let texture = Texture::new(
-                device,
-                resource::TextureInner::Native { raw: raw_texture },
-                hal_usage,
-                desc,
-                format_features,
-                clear_mode,
-                true,
-            );
-
-            let texture = Arc::new(texture);
-
-            device
-                .trackers
-                .lock()
-                .textures
-                .insert_single(&texture, wgt::TextureUses::UNINITIALIZED);
-
-            Ok(texture)
         }
 
-        let (texture, error) = match create(self, desc) {
+        if desc
+            .usage
+            .contains(wgt::TextureUsages::TRANSIENT_ATTACHMENT)
+        {
+            if desc.usage
+                != (wgt::TextureUsages::TRANSIENT_ATTACHMENT
+                    | wgt::TextureUsages::RENDER_ATTACHMENT)
+            {
+                return Err(CreateTextureError::InvalidTransientTextureUsage(desc.usage));
+            }
+
+            if desc.mip_level_count != 1 {
+                return Err(CreateTextureError::InvalidTransientTextureMipLevelCount(
+                    desc.mip_level_count,
+                ));
+            }
+
+            if desc.size.depth_or_array_layers != 1 {
+                return Err(CreateTextureError::InvalidTransientTextureLayerCount(
+                    desc.size.depth_or_array_layers,
+                ));
+            }
+
+            if !desc.view_formats.is_empty() {
+                return Err(CreateTextureError::InvalidTransientTextureViewFormats);
+            }
+        }
+
+        let format_features = self
+            .describe_format_features(desc.format)
+            .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
+
+        if desc.sample_count > 1 {
+            // <https://www.w3.org/TR/2025/CRD-webgpu-20251120/#:~:text=If%20descriptor%2EsampleCount%20%3E%201>
+            //
+            // Note that there are also some checks related to the sample count
+            // in [`conv::check_texture_dimension_size`].
+
+            if desc.mip_level_count != 1 {
+                return Err(CreateTextureError::InvalidMipLevelCount {
+                    requested: desc.mip_level_count,
+                    maximum: 1,
+                });
+            }
+
+            if desc.size.depth_or_array_layers != 1
+                && !self.features.contains(wgt::Features::MULTISAMPLE_ARRAY)
+            {
+                return Err(CreateTextureError::InvalidDimension(
+                    TextureDimensionError::MultisampledDepthOrArrayLayer(
+                        desc.size.depth_or_array_layers,
+                    ),
+                ));
+            }
+
+            if desc.usage.contains(wgt::TextureUsages::STORAGE_BINDING) {
+                return Err(CreateTextureError::InvalidMultisampledStorageBinding);
+            }
+
+            if !desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
+                return Err(CreateTextureError::MultisampledNotRenderAttachment);
+            }
+
+            if !format_features.flags.intersects(
+                wgt::TextureFormatFeatureFlags::MULTISAMPLE_X4
+                    | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X2
+                    | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X8
+                    | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X16,
+            ) {
+                return Err(CreateTextureError::InvalidMultisampledFormat(desc.format));
+            }
+
+            if !format_features
+                .flags
+                .sample_count_supported(desc.sample_count)
+            {
+                return Err(CreateTextureError::InvalidSampleCount(
+                    desc.sample_count,
+                    desc.format,
+                    desc.format
+                        .guaranteed_format_features(self.features)
+                        .flags
+                        .supported_sample_counts(),
+                    self.adapter
+                        .get_texture_format_features(desc.format)
+                        .flags
+                        .supported_sample_counts(),
+                ));
+            };
+        }
+
+        let missing_allowed_usages = match desc.format.planes() {
+            Some(planes) => {
+                let mut planes_usages = wgt::TextureUsages::all();
+                for plane in 0..planes {
+                    let aspect = wgt::TextureAspect::from_plane(plane).unwrap();
+                    let format = desc.format.aspect_specific_format(aspect).unwrap();
+                    let format_features = self
+                        .describe_format_features(format)
+                        .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
+
+                    planes_usages &= format_features.allowed_usages;
+                }
+
+                desc.usage - planes_usages
+            }
+            None => desc.usage - format_features.allowed_usages,
+        };
+
+        if !missing_allowed_usages.is_empty() {
+            // detect downlevel incompatibilities
+            let wgpu_allowed_usages = desc
+                .format
+                .guaranteed_format_features(self.features)
+                .allowed_usages;
+            let wgpu_missing_usages = desc.usage - wgpu_allowed_usages;
+            return Err(CreateTextureError::InvalidFormatUsages(
+                missing_allowed_usages,
+                desc.format,
+                wgpu_missing_usages.is_empty(),
+            ));
+        }
+
+        let mut hal_view_formats = Vec::new();
+        for format in desc.view_formats.iter() {
+            if desc.format == *format {
+                continue;
+            }
+            if desc.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
+                return Err(CreateTextureError::InvalidViewFormat(*format, desc.format));
+            }
+            hal_view_formats.push(*format);
+        }
+        if !hal_view_formats.is_empty() {
+            self.require_downlevel_flags(wgt::DownlevelFlags::VIEW_FORMATS)?;
+        }
+
+        let hal_usage = conv::map_texture_usage_for_texture(desc, &format_features);
+
+        let hal_desc = hal::TextureDescriptor {
+            label: desc.label.to_hal(self.instance_flags),
+            size: desc.size,
+            mip_level_count: desc.mip_level_count,
+            sample_count: desc.sample_count,
+            dimension: desc.dimension,
+            format: desc.format,
+            usage: hal_usage,
+            memory_flags: hal::MemoryFlags::empty(),
+            view_formats: hal_view_formats,
+        };
+
+        let raw_texture = unsafe { self.raw().create_texture(&hal_desc) }
+            .map_err(|e| self.handle_hal_error_with_nonfatal_oom(e))?;
+
+        let clear_mode = if hal_usage
+            .intersects(wgt::TextureUses::DEPTH_STENCIL_WRITE | wgt::TextureUses::COLOR_TARGET)
+            && desc.dimension == wgt::TextureDimension::D2
+        {
+            let (is_color, usage) = if desc.format.is_depth_stencil_format() {
+                (false, wgt::TextureUses::DEPTH_STENCIL_WRITE)
+            } else {
+                (true, wgt::TextureUses::COLOR_TARGET)
+            };
+
+            let clear_label = hal_label(
+                Some("(wgpu internal) clear texture view"),
+                self.instance_flags,
+            );
+
+            let mut clear_views = SmallVec::new();
+            for mip_level in 0..desc.mip_level_count {
+                for array_layer in 0..desc.size.depth_or_array_layers {
+                    macro_rules! push_clear_view {
+                        ($format:expr, $aspect:expr) => {
+                            let desc = hal::TextureViewDescriptor {
+                                label: clear_label,
+                                format: $format,
+                                dimension: TextureViewDimension::D2,
+                                usage,
+                                range: wgt::ImageSubresourceRange {
+                                    aspect: $aspect,
+                                    base_mip_level: mip_level,
+                                    mip_level_count: Some(1),
+                                    base_array_layer: array_layer,
+                                    array_layer_count: Some(1),
+                                },
+                            };
+                            clear_views.push(ManuallyDrop::new(
+                                unsafe {
+                                    self.raw().create_texture_view(raw_texture.as_ref(), &desc)
+                                }
+                                .map_err(|e| self.handle_hal_error(e))?,
+                            ));
+                        };
+                    }
+
+                    if let Some(planes) = desc.format.planes() {
+                        for plane in 0..planes {
+                            let aspect = wgt::TextureAspect::from_plane(plane).unwrap();
+                            let format = desc.format.aspect_specific_format(aspect).unwrap();
+                            push_clear_view!(format, aspect);
+                        }
+                    } else {
+                        push_clear_view!(desc.format, wgt::TextureAspect::All);
+                    }
+                }
+            }
+            resource::TextureClearMode::RenderPass {
+                clear_views,
+                is_color,
+            }
+        } else {
+            resource::TextureClearMode::BufferCopy
+        };
+
+        let texture = Texture::new(
+            self,
+            resource::TextureInner::Native { raw: raw_texture },
+            hal_usage,
+            desc,
+            format_features,
+            clear_mode,
+            true,
+        );
+
+        let texture = Arc::new(texture);
+
+        self.trackers
+            .lock()
+            .textures
+            .insert_single(&texture, wgt::TextureUses::UNINITIALIZED);
+
+        Ok(texture)
+    }
+
+    pub fn create_texture(
+        self: &Arc<Self>,
+        desc: &resource::TextureDescriptor,
+    ) -> (Arc<Texture>, Option<resource::CreateTextureError>) {
+        let (texture, error) = match self.create_texture_inner(desc) {
             Ok(texture) => (texture, None),
             Err(e) => {
                 let texture = Texture::invalid(self, desc);

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1770,7 +1770,7 @@ impl Device {
 
         let snatch_guard = texture.device.snatchable_lock.read();
 
-        let texture_raw = texture.try_raw(&snatch_guard)?;
+        let texture_raw = texture.try_inner(&snatch_guard)?.raw();
 
         // resolve TextureViewDescriptor defaults
         // https://gpuweb.github.io/gpuweb/#abstract-opdef-resolving-gputextureviewdescriptor-defaults

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1373,386 +1373,398 @@ impl Device {
         }
     }
 
-    fn create_texture_inner(
+    pub fn create_texture(
         self: &Arc<Self>,
         desc: &resource::TextureDescriptor,
-    ) -> Result<Arc<Texture>, resource::CreateTextureError> {
-        use resource::{CreateTextureError, TextureDimensionError};
+    ) -> (Arc<Texture>, Option<resource::CreateTextureError>) {
+        fn create(
+            device: &Arc<Device>,
+            desc: &resource::TextureDescriptor,
+        ) -> Result<Arc<Texture>, resource::CreateTextureError> {
+            use resource::{CreateTextureError, TextureDimensionError};
 
-        self.check_is_valid()?;
+            device.check_is_valid()?;
 
-        if desc.usage.is_empty() || desc.usage.contains_unknown_bits() {
-            return Err(CreateTextureError::InvalidUsage(desc.usage));
-        }
-
-        conv::check_texture_dimension_size(
-            desc.dimension,
-            desc.size,
-            desc.sample_count,
-            &self.limits,
-        )?;
-
-        if desc.dimension != wgt::TextureDimension::D2 {
-            // Depth textures can only be 2D
-            if desc.format.is_depth_stencil_format() {
-                return Err(CreateTextureError::InvalidDepthDimension(
-                    desc.dimension,
-                    desc.format,
-                ));
+            if desc.usage.is_empty() || desc.usage.contains_unknown_bits() {
+                return Err(CreateTextureError::InvalidUsage(desc.usage));
             }
-            // Transient textures can only be 2D
-            if desc
-                .usage
-                .contains(wgt::TextureUsages::TRANSIENT_ATTACHMENT)
+
+            conv::check_texture_dimension_size(
+                desc.dimension,
+                desc.size,
+                desc.sample_count,
+                &device.limits,
+            )?;
+
+            if desc.dimension != wgt::TextureDimension::D2 {
+                // Depth textures can only be 2D
+                if desc.format.is_depth_stencil_format() {
+                    return Err(CreateTextureError::InvalidDepthDimension(
+                        desc.dimension,
+                        desc.format,
+                    ));
+                }
+                // Transient textures can only be 2D
+                if desc
+                    .usage
+                    .contains(wgt::TextureUsages::TRANSIENT_ATTACHMENT)
+                {
+                    return Err(CreateTextureError::InvalidDimensionUsages(
+                        wgt::TextureUsages::TRANSIENT_ATTACHMENT,
+                        desc.dimension,
+                    ));
+                }
+            }
+
+            if desc.dimension != wgt::TextureDimension::D2
+                && desc.dimension != wgt::TextureDimension::D3
             {
-                return Err(CreateTextureError::InvalidDimensionUsages(
-                    wgt::TextureUsages::TRANSIENT_ATTACHMENT,
-                    desc.dimension,
-                ));
-            }
-        }
-
-        if desc.dimension != wgt::TextureDimension::D2
-            && desc.dimension != wgt::TextureDimension::D3
-        {
-            // Compressed textures can only be 2D or 3D
-            if desc.format.is_compressed() {
-                return Err(CreateTextureError::InvalidCompressedDimension(
-                    desc.dimension,
-                    desc.format,
-                ));
-            }
-
-            // Renderable textures can only be 2D or 3D
-            if desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
-                return Err(CreateTextureError::InvalidDimensionUsages(
-                    wgt::TextureUsages::RENDER_ATTACHMENT,
-                    desc.dimension,
-                ));
-            }
-        }
-
-        if desc.format.is_compressed() {
-            let (block_width, block_height) = desc.format.block_dimensions();
-
-            if !desc.size.width.is_multiple_of(block_width) {
-                return Err(CreateTextureError::InvalidDimension(
-                    TextureDimensionError::NotMultipleOfBlockWidth {
-                        width: desc.size.width,
-                        block_width,
-                        format: desc.format,
-                    },
-                ));
-            }
-
-            if !desc.size.height.is_multiple_of(block_height) {
-                return Err(CreateTextureError::InvalidDimension(
-                    TextureDimensionError::NotMultipleOfBlockHeight {
-                        height: desc.size.height,
-                        block_height,
-                        format: desc.format,
-                    },
-                ));
-            }
-
-            if desc.dimension == wgt::TextureDimension::D3 {
-                // Only BCn formats with Sliced 3D feature can be used for 3D textures
-                if desc.format.is_bcn() {
-                    self.require_features(wgt::Features::TEXTURE_COMPRESSION_BC_SLICED_3D)
-                        .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
-                } else if desc.format.is_astc() {
-                    self.require_features(wgt::Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D)
-                        .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
-                } else {
+                // Compressed textures can only be 2D or 3D
+                if desc.format.is_compressed() {
                     return Err(CreateTextureError::InvalidCompressedDimension(
                         desc.dimension,
                         desc.format,
                     ));
                 }
-            }
-        }
 
-        let mips = desc.mip_level_count;
-        let max_levels_allowed = desc.size.max_mips(desc.dimension).min(hal::MAX_MIP_LEVELS);
-        if mips == 0 || mips > max_levels_allowed {
-            return Err(CreateTextureError::InvalidMipLevelCount {
-                requested: mips,
-                maximum: max_levels_allowed,
-            });
-        }
-
-        {
-            let (mut width_multiple, mut height_multiple) = desc.format.size_multiple_requirement();
-
-            if desc.format.is_multi_planar_format() {
-                // TODO(https://github.com/gfx-rs/wgpu/issues/8491): fix
-                // `mip_level_size` calculation for these formats and relax this
-                // restriction.
-                width_multiple <<= desc.mip_level_count.saturating_sub(1);
-                height_multiple <<= desc.mip_level_count.saturating_sub(1);
+                // Renderable textures can only be 2D or 3D
+                if desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
+                    return Err(CreateTextureError::InvalidDimensionUsages(
+                        wgt::TextureUsages::RENDER_ATTACHMENT,
+                        desc.dimension,
+                    ));
+                }
             }
 
-            if !desc.size.width.is_multiple_of(width_multiple) {
-                return Err(CreateTextureError::InvalidDimension(
-                    TextureDimensionError::WidthNotMultipleOf {
-                        width: desc.size.width,
-                        multiple: width_multiple,
-                        format: desc.format,
-                    },
-                ));
+            if desc.format.is_compressed() {
+                let (block_width, block_height) = desc.format.block_dimensions();
+
+                if !desc.size.width.is_multiple_of(block_width) {
+                    return Err(CreateTextureError::InvalidDimension(
+                        TextureDimensionError::NotMultipleOfBlockWidth {
+                            width: desc.size.width,
+                            block_width,
+                            format: desc.format,
+                        },
+                    ));
+                }
+
+                if !desc.size.height.is_multiple_of(block_height) {
+                    return Err(CreateTextureError::InvalidDimension(
+                        TextureDimensionError::NotMultipleOfBlockHeight {
+                            height: desc.size.height,
+                            block_height,
+                            format: desc.format,
+                        },
+                    ));
+                }
+
+                if desc.dimension == wgt::TextureDimension::D3 {
+                    // Only BCn formats with Sliced 3D feature can be used for 3D textures
+                    if desc.format.is_bcn() {
+                        device
+                            .require_features(wgt::Features::TEXTURE_COMPRESSION_BC_SLICED_3D)
+                            .map_err(|error| {
+                                CreateTextureError::MissingFeatures(desc.format, error)
+                            })?;
+                    } else if desc.format.is_astc() {
+                        device
+                            .require_features(wgt::Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D)
+                            .map_err(|error| {
+                                CreateTextureError::MissingFeatures(desc.format, error)
+                            })?;
+                    } else {
+                        return Err(CreateTextureError::InvalidCompressedDimension(
+                            desc.dimension,
+                            desc.format,
+                        ));
+                    }
+                }
             }
 
-            if !desc.size.height.is_multiple_of(height_multiple) {
-                return Err(CreateTextureError::InvalidDimension(
-                    TextureDimensionError::HeightNotMultipleOf {
-                        height: desc.size.height,
-                        multiple: height_multiple,
-                        format: desc.format,
-                    },
-                ));
-            }
-        }
-
-        if desc
-            .usage
-            .contains(wgt::TextureUsages::TRANSIENT_ATTACHMENT)
-        {
-            if desc.usage
-                != (wgt::TextureUsages::TRANSIENT_ATTACHMENT
-                    | wgt::TextureUsages::RENDER_ATTACHMENT)
-            {
-                return Err(CreateTextureError::InvalidTransientTextureUsage(desc.usage));
-            }
-
-            if desc.mip_level_count != 1 {
-                return Err(CreateTextureError::InvalidTransientTextureMipLevelCount(
-                    desc.mip_level_count,
-                ));
-            }
-
-            if desc.size.depth_or_array_layers != 1 {
-                return Err(CreateTextureError::InvalidTransientTextureLayerCount(
-                    desc.size.depth_or_array_layers,
-                ));
-            }
-
-            if !desc.view_formats.is_empty() {
-                return Err(CreateTextureError::InvalidTransientTextureViewFormats);
-            }
-        }
-
-        let format_features = self
-            .describe_format_features(desc.format)
-            .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
-
-        if desc.sample_count > 1 {
-            // <https://www.w3.org/TR/2025/CRD-webgpu-20251120/#:~:text=If%20descriptor%2EsampleCount%20%3E%201>
-            //
-            // Note that there are also some checks related to the sample count
-            // in [`conv::check_texture_dimension_size`].
-
-            if desc.mip_level_count != 1 {
+            let mips = desc.mip_level_count;
+            let max_levels_allowed = desc.size.max_mips(desc.dimension).min(hal::MAX_MIP_LEVELS);
+            if mips == 0 || mips > max_levels_allowed {
                 return Err(CreateTextureError::InvalidMipLevelCount {
-                    requested: desc.mip_level_count,
-                    maximum: 1,
+                    requested: mips,
+                    maximum: max_levels_allowed,
                 });
             }
 
-            if desc.size.depth_or_array_layers != 1
-                && !self.features.contains(wgt::Features::MULTISAMPLE_ARRAY)
             {
-                return Err(CreateTextureError::InvalidDimension(
-                    TextureDimensionError::MultisampledDepthOrArrayLayer(
-                        desc.size.depth_or_array_layers,
-                    ),
-                ));
-            }
+                let (mut width_multiple, mut height_multiple) =
+                    desc.format.size_multiple_requirement();
 
-            if desc.usage.contains(wgt::TextureUsages::STORAGE_BINDING) {
-                return Err(CreateTextureError::InvalidMultisampledStorageBinding);
-            }
-
-            if !desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
-                return Err(CreateTextureError::MultisampledNotRenderAttachment);
-            }
-
-            if !format_features.flags.intersects(
-                wgt::TextureFormatFeatureFlags::MULTISAMPLE_X4
-                    | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X2
-                    | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X8
-                    | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X16,
-            ) {
-                return Err(CreateTextureError::InvalidMultisampledFormat(desc.format));
-            }
-
-            if !format_features
-                .flags
-                .sample_count_supported(desc.sample_count)
-            {
-                return Err(CreateTextureError::InvalidSampleCount(
-                    desc.sample_count,
-                    desc.format,
-                    desc.format
-                        .guaranteed_format_features(self.features)
-                        .flags
-                        .supported_sample_counts(),
-                    self.adapter
-                        .get_texture_format_features(desc.format)
-                        .flags
-                        .supported_sample_counts(),
-                ));
-            };
-        }
-
-        let missing_allowed_usages = match desc.format.planes() {
-            Some(planes) => {
-                let mut planes_usages = wgt::TextureUsages::all();
-                for plane in 0..planes {
-                    let aspect = wgt::TextureAspect::from_plane(plane).unwrap();
-                    let format = desc.format.aspect_specific_format(aspect).unwrap();
-                    let format_features = self
-                        .describe_format_features(format)
-                        .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
-
-                    planes_usages &= format_features.allowed_usages;
+                if desc.format.is_multi_planar_format() {
+                    // TODO(https://github.com/gfx-rs/wgpu/issues/8491): fix
+                    // `mip_level_size` calculation for these formats and relax this
+                    // restriction.
+                    width_multiple <<= desc.mip_level_count.saturating_sub(1);
+                    height_multiple <<= desc.mip_level_count.saturating_sub(1);
                 }
 
-                desc.usage - planes_usages
+                if !desc.size.width.is_multiple_of(width_multiple) {
+                    return Err(CreateTextureError::InvalidDimension(
+                        TextureDimensionError::WidthNotMultipleOf {
+                            width: desc.size.width,
+                            multiple: width_multiple,
+                            format: desc.format,
+                        },
+                    ));
+                }
+
+                if !desc.size.height.is_multiple_of(height_multiple) {
+                    return Err(CreateTextureError::InvalidDimension(
+                        TextureDimensionError::HeightNotMultipleOf {
+                            height: desc.size.height,
+                            multiple: height_multiple,
+                            format: desc.format,
+                        },
+                    ));
+                }
             }
-            None => desc.usage - format_features.allowed_usages,
-        };
 
-        if !missing_allowed_usages.is_empty() {
-            // detect downlevel incompatibilities
-            let wgpu_allowed_usages = desc
-                .format
-                .guaranteed_format_features(self.features)
-                .allowed_usages;
-            let wgpu_missing_usages = desc.usage - wgpu_allowed_usages;
-            return Err(CreateTextureError::InvalidFormatUsages(
-                missing_allowed_usages,
-                desc.format,
-                wgpu_missing_usages.is_empty(),
-            ));
-        }
+            if desc
+                .usage
+                .contains(wgt::TextureUsages::TRANSIENT_ATTACHMENT)
+            {
+                if desc.usage
+                    != (wgt::TextureUsages::TRANSIENT_ATTACHMENT
+                        | wgt::TextureUsages::RENDER_ATTACHMENT)
+                {
+                    return Err(CreateTextureError::InvalidTransientTextureUsage(desc.usage));
+                }
 
-        let mut hal_view_formats = Vec::new();
-        for format in desc.view_formats.iter() {
-            if desc.format == *format {
-                continue;
+                if desc.mip_level_count != 1 {
+                    return Err(CreateTextureError::InvalidTransientTextureMipLevelCount(
+                        desc.mip_level_count,
+                    ));
+                }
+
+                if desc.size.depth_or_array_layers != 1 {
+                    return Err(CreateTextureError::InvalidTransientTextureLayerCount(
+                        desc.size.depth_or_array_layers,
+                    ));
+                }
+
+                if !desc.view_formats.is_empty() {
+                    return Err(CreateTextureError::InvalidTransientTextureViewFormats);
+                }
             }
-            if desc.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
-                return Err(CreateTextureError::InvalidViewFormat(*format, desc.format));
+
+            let format_features = device
+                .describe_format_features(desc.format)
+                .map_err(|error| CreateTextureError::MissingFeatures(desc.format, error))?;
+
+            if desc.sample_count > 1 {
+                // <https://www.w3.org/TR/2025/CRD-webgpu-20251120/#:~:text=If%20descriptor%2EsampleCount%20%3E%201>
+                //
+                // Note that there are also some checks related to the sample count
+                // in [`conv::check_texture_dimension_size`].
+
+                if desc.mip_level_count != 1 {
+                    return Err(CreateTextureError::InvalidMipLevelCount {
+                        requested: desc.mip_level_count,
+                        maximum: 1,
+                    });
+                }
+
+                if desc.size.depth_or_array_layers != 1
+                    && !device.features.contains(wgt::Features::MULTISAMPLE_ARRAY)
+                {
+                    return Err(CreateTextureError::InvalidDimension(
+                        TextureDimensionError::MultisampledDepthOrArrayLayer(
+                            desc.size.depth_or_array_layers,
+                        ),
+                    ));
+                }
+
+                if desc.usage.contains(wgt::TextureUsages::STORAGE_BINDING) {
+                    return Err(CreateTextureError::InvalidMultisampledStorageBinding);
+                }
+
+                if !desc.usage.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
+                    return Err(CreateTextureError::MultisampledNotRenderAttachment);
+                }
+
+                if !format_features.flags.intersects(
+                    wgt::TextureFormatFeatureFlags::MULTISAMPLE_X4
+                        | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X2
+                        | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X8
+                        | wgt::TextureFormatFeatureFlags::MULTISAMPLE_X16,
+                ) {
+                    return Err(CreateTextureError::InvalidMultisampledFormat(desc.format));
+                }
+
+                if !format_features
+                    .flags
+                    .sample_count_supported(desc.sample_count)
+                {
+                    return Err(CreateTextureError::InvalidSampleCount(
+                        desc.sample_count,
+                        desc.format,
+                        desc.format
+                            .guaranteed_format_features(device.features)
+                            .flags
+                            .supported_sample_counts(),
+                        device
+                            .adapter
+                            .get_texture_format_features(desc.format)
+                            .flags
+                            .supported_sample_counts(),
+                    ));
+                };
             }
-            hal_view_formats.push(*format);
-        }
-        if !hal_view_formats.is_empty() {
-            self.require_downlevel_flags(wgt::DownlevelFlags::VIEW_FORMATS)?;
-        }
 
-        let hal_usage = conv::map_texture_usage_for_texture(desc, &format_features);
+            let missing_allowed_usages = match desc.format.planes() {
+                Some(planes) => {
+                    let mut planes_usages = wgt::TextureUsages::all();
+                    for plane in 0..planes {
+                        let aspect = wgt::TextureAspect::from_plane(plane).unwrap();
+                        let format = desc.format.aspect_specific_format(aspect).unwrap();
+                        let format_features =
+                            device.describe_format_features(format).map_err(|error| {
+                                CreateTextureError::MissingFeatures(desc.format, error)
+                            })?;
 
-        let hal_desc = hal::TextureDescriptor {
-            label: desc.label.to_hal(self.instance_flags),
-            size: desc.size,
-            mip_level_count: desc.mip_level_count,
-            sample_count: desc.sample_count,
-            dimension: desc.dimension,
-            format: desc.format,
-            usage: hal_usage,
-            memory_flags: hal::MemoryFlags::empty(),
-            view_formats: hal_view_formats,
-        };
+                        planes_usages &= format_features.allowed_usages;
+                    }
 
-        let raw_texture = unsafe { self.raw().create_texture(&hal_desc) }
-            .map_err(|e| self.handle_hal_error_with_nonfatal_oom(e))?;
-
-        let clear_mode = if hal_usage
-            .intersects(wgt::TextureUses::DEPTH_STENCIL_WRITE | wgt::TextureUses::COLOR_TARGET)
-            && desc.dimension == wgt::TextureDimension::D2
-        {
-            let (is_color, usage) = if desc.format.is_depth_stencil_format() {
-                (false, wgt::TextureUses::DEPTH_STENCIL_WRITE)
-            } else {
-                (true, wgt::TextureUses::COLOR_TARGET)
+                    desc.usage - planes_usages
+                }
+                None => desc.usage - format_features.allowed_usages,
             };
 
-            let clear_label = hal_label(
-                Some("(wgpu internal) clear texture view"),
-                self.instance_flags,
+            if !missing_allowed_usages.is_empty() {
+                // detect downlevel incompatibilities
+                let wgpu_allowed_usages = desc
+                    .format
+                    .guaranteed_format_features(device.features)
+                    .allowed_usages;
+                let wgpu_missing_usages = desc.usage - wgpu_allowed_usages;
+                return Err(CreateTextureError::InvalidFormatUsages(
+                    missing_allowed_usages,
+                    desc.format,
+                    wgpu_missing_usages.is_empty(),
+                ));
+            }
+
+            let mut hal_view_formats = Vec::new();
+            for format in desc.view_formats.iter() {
+                if desc.format == *format {
+                    continue;
+                }
+                if desc.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
+                    return Err(CreateTextureError::InvalidViewFormat(*format, desc.format));
+                }
+                hal_view_formats.push(*format);
+            }
+            if !hal_view_formats.is_empty() {
+                device.require_downlevel_flags(wgt::DownlevelFlags::VIEW_FORMATS)?;
+            }
+
+            let hal_usage = conv::map_texture_usage_for_texture(desc, &format_features);
+
+            let hal_desc = hal::TextureDescriptor {
+                label: desc.label.to_hal(device.instance_flags),
+                size: desc.size,
+                mip_level_count: desc.mip_level_count,
+                sample_count: desc.sample_count,
+                dimension: desc.dimension,
+                format: desc.format,
+                usage: hal_usage,
+                memory_flags: hal::MemoryFlags::empty(),
+                view_formats: hal_view_formats,
+            };
+
+            let raw_texture = unsafe { device.raw().create_texture(&hal_desc) }
+                .map_err(|e| device.handle_hal_error_with_nonfatal_oom(e))?;
+
+            let clear_mode = if hal_usage
+                .intersects(wgt::TextureUses::DEPTH_STENCIL_WRITE | wgt::TextureUses::COLOR_TARGET)
+                && desc.dimension == wgt::TextureDimension::D2
+            {
+                let (is_color, usage) = if desc.format.is_depth_stencil_format() {
+                    (false, wgt::TextureUses::DEPTH_STENCIL_WRITE)
+                } else {
+                    (true, wgt::TextureUses::COLOR_TARGET)
+                };
+
+                let clear_label = hal_label(
+                    Some("(wgpu internal) clear texture view"),
+                    device.instance_flags,
+                );
+
+                let mut clear_views = SmallVec::new();
+                for mip_level in 0..desc.mip_level_count {
+                    for array_layer in 0..desc.size.depth_or_array_layers {
+                        macro_rules! push_clear_view {
+                            ($format:expr, $aspect:expr) => {
+                                let desc = hal::TextureViewDescriptor {
+                                    label: clear_label,
+                                    format: $format,
+                                    dimension: TextureViewDimension::D2,
+                                    usage,
+                                    range: wgt::ImageSubresourceRange {
+                                        aspect: $aspect,
+                                        base_mip_level: mip_level,
+                                        mip_level_count: Some(1),
+                                        base_array_layer: array_layer,
+                                        array_layer_count: Some(1),
+                                    },
+                                };
+                                clear_views.push(ManuallyDrop::new(
+                                    unsafe {
+                                        device
+                                            .raw()
+                                            .create_texture_view(raw_texture.as_ref(), &desc)
+                                    }
+                                    .map_err(|e| device.handle_hal_error(e))?,
+                                ));
+                            };
+                        }
+
+                        if let Some(planes) = desc.format.planes() {
+                            for plane in 0..planes {
+                                let aspect = wgt::TextureAspect::from_plane(plane).unwrap();
+                                let format = desc.format.aspect_specific_format(aspect).unwrap();
+                                push_clear_view!(format, aspect);
+                            }
+                        } else {
+                            push_clear_view!(desc.format, wgt::TextureAspect::All);
+                        }
+                    }
+                }
+                resource::TextureClearMode::RenderPass {
+                    clear_views,
+                    is_color,
+                }
+            } else {
+                resource::TextureClearMode::BufferCopy
+            };
+
+            let texture = Texture::new(
+                device,
+                resource::TextureInner::Native { raw: raw_texture },
+                hal_usage,
+                desc,
+                format_features,
+                clear_mode,
+                true,
             );
 
-            let mut clear_views = SmallVec::new();
-            for mip_level in 0..desc.mip_level_count {
-                for array_layer in 0..desc.size.depth_or_array_layers {
-                    macro_rules! push_clear_view {
-                        ($format:expr, $aspect:expr) => {
-                            let desc = hal::TextureViewDescriptor {
-                                label: clear_label,
-                                format: $format,
-                                dimension: TextureViewDimension::D2,
-                                usage,
-                                range: wgt::ImageSubresourceRange {
-                                    aspect: $aspect,
-                                    base_mip_level: mip_level,
-                                    mip_level_count: Some(1),
-                                    base_array_layer: array_layer,
-                                    array_layer_count: Some(1),
-                                },
-                            };
-                            clear_views.push(ManuallyDrop::new(
-                                unsafe {
-                                    self.raw().create_texture_view(raw_texture.as_ref(), &desc)
-                                }
-                                .map_err(|e| self.handle_hal_error(e))?,
-                            ));
-                        };
-                    }
+            let texture = Arc::new(texture);
 
-                    if let Some(planes) = desc.format.planes() {
-                        for plane in 0..planes {
-                            let aspect = wgt::TextureAspect::from_plane(plane).unwrap();
-                            let format = desc.format.aspect_specific_format(aspect).unwrap();
-                            push_clear_view!(format, aspect);
-                        }
-                    } else {
-                        push_clear_view!(desc.format, wgt::TextureAspect::All);
-                    }
-                }
-            }
-            resource::TextureClearMode::RenderPass {
-                clear_views,
-                is_color,
-            }
-        } else {
-            resource::TextureClearMode::BufferCopy
-        };
+            device
+                .trackers
+                .lock()
+                .textures
+                .insert_single(&texture, wgt::TextureUses::UNINITIALIZED);
 
-        let texture = Texture::new(
-            self,
-            resource::TextureInner::Native { raw: raw_texture },
-            hal_usage,
-            desc,
-            format_features,
-            clear_mode,
-            true,
-        );
+            Ok(texture)
+        }
 
-        let texture = Arc::new(texture);
-
-        self.trackers
-            .lock()
-            .textures
-            .insert_single(&texture, wgt::TextureUses::UNINITIALIZED);
-
-        Ok(texture)
-    }
-
-    pub fn create_texture(
-        self: &Arc<Self>,
-        desc: &resource::TextureDescriptor,
-    ) -> (Arc<Texture>, Option<resource::CreateTextureError>) {
-        let (texture, error) = match self.create_texture_inner(desc) {
+        let (texture, error) = match create(self, desc) {
             Ok(texture) => (texture, None),
             Err(e) => {
                 let texture = Texture::invalid(self, desc);
@@ -1769,6 +1781,24 @@ impl Device {
             ));
         }
         (texture, error)
+    }
+
+    /// Creates a texture that is guaranteed to be invalid
+    pub fn create_texture_error(
+        self: &Arc<Self>,
+        desc: &resource::TextureDescriptor,
+    ) -> Arc<Texture> {
+        let texture = Arc::new(Texture::invalid(self, desc));
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use crate::device::trace::IntoTrace as _;
+
+            trace.add(trace::Action::CreateTexture(
+                texture.to_trace(),
+                desc.clone(),
+            ));
+        }
+        texture
     }
 
     pub fn create_texture_view(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1771,6 +1771,11 @@ impl Device {
                 (Arc::new(texture), Some(e))
             }
         };
+        api_log!(
+            "Device::create_texture({desc:?}) -> {:?}",
+            Arc::as_ptr(&texture)
+        );
+
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *self.trace.lock() {
             use crate::device::trace::IntoTrace as _;
@@ -1793,7 +1798,7 @@ impl Device {
         if let Some(ref mut trace) = *self.trace.lock() {
             use crate::device::trace::IntoTrace as _;
 
-            trace.add(trace::Action::CreateTexture(
+            trace.add(trace::Action::CreateTextureError(
                 texture.to_trace(),
                 desc.clone(),
             ));

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1373,7 +1373,7 @@ impl Device {
         }
     }
 
-    pub fn create_texture_inner(
+    fn create_texture_inner(
         self: &Arc<Self>,
         desc: &resource::TextureDescriptor,
     ) -> Result<Arc<Texture>, resource::CreateTextureError> {
@@ -1752,13 +1752,23 @@ impl Device {
         self: &Arc<Self>,
         desc: &resource::TextureDescriptor,
     ) -> (Arc<Texture>, Option<resource::CreateTextureError>) {
-        match self.create_texture_inner(desc) {
+        let (texture, error) = match self.create_texture_inner(desc) {
             Ok(texture) => (texture, None),
             Err(e) => {
-                let texture = Texture::dummy(self, desc);
+                let texture = Texture::invalid(self, desc);
                 (Arc::new(texture), Some(e))
             }
+        };
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use crate::device::trace::IntoTrace as _;
+
+            trace.add(trace::Action::CreateTexture(
+                texture.to_trace(),
+                desc.clone(),
+            ));
         }
+        (texture, error)
     }
 
     pub fn create_texture_view(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1373,7 +1373,7 @@ impl Device {
         }
     }
 
-    pub fn create_texture(
+    pub fn create_texture_inner(
         self: &Arc<Self>,
         desc: &resource::TextureDescriptor,
     ) -> Result<Arc<Texture>, resource::CreateTextureError> {
@@ -1746,6 +1746,19 @@ impl Device {
             .insert_single(&texture, wgt::TextureUses::UNINITIALIZED);
 
         Ok(texture)
+    }
+
+    pub fn create_texture(
+        self: &Arc<Self>,
+        desc: &resource::TextureDescriptor,
+    ) -> (Arc<Texture>, Option<resource::CreateTextureError>) {
+        match self.create_texture_inner(desc) {
+            Ok(texture) => (texture, None),
+            Err(e) => {
+                let texture = Texture::dummy(self, desc);
+                (Arc::new(texture), Some(e))
+            }
+        }
     }
 
     pub fn create_texture_view(

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -128,6 +128,7 @@ pub enum Action<'a, R: ReferenceType> {
     DestroyBuffer(R::Buffer),
     DropBuffer(R::Buffer),
     CreateTexture(R::Texture, crate::resource::TextureDescriptor<'a>),
+    CreateTextureError(R::Texture, crate::resource::TextureDescriptor<'a>),
     DestroyTexture(R::Texture),
     DropTexture(R::Texture),
     CreateTextureView {

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -979,9 +979,9 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DropBlas(blas) => A::DropBlas(blas),
         A::DropTlas(tlas) => A::DropTlas(tlas),
 
-        A::CreateTexture(..)
-        | A::CreateTextureError(..)
-        | A::CreateTextureView { .. }
+        A::CreateTexture(id, desc) => A::CreateTexture(id, desc.map_label(owned_label)),
+        A::CreateTextureError(id, desc) => A::CreateTextureError(id, desc.map_label(owned_label)),
+        A::CreateTextureView { .. }
         | A::CreateExternalTexture { .. }
         | A::CreateSampler(..)
         | A::CreateBindGroupLayout(..)
@@ -997,4 +997,8 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         | A::CreateBlas { .. }
         | A::CreateTlas { .. } => panic!("Unsupported action for tracing: {action:?}"),
     }
+}
+
+fn owned_label(l: &Option<Cow<'_, str>>) -> Option<Cow<'static, str>> {
+    l.as_ref().map(|l| Cow::Owned(l.to_string()))
 }

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -1,5 +1,5 @@
 use alloc::{borrow::Cow, string::ToString, sync::Arc, vec::Vec};
-use core::{any::Any, convert::Infallible};
+use core::{any::Any, convert::Infallible, marker::PhantomData};
 use std::io::Write as _;
 
 use crate::{
@@ -173,6 +173,15 @@ impl<T: StorageItem> IntoTrace for Arc<T> {
     fn to_trace(&self) -> Self::Output {
         PointerId::from(self)
     }
+}
+
+/// This will work as expected on heap-allocated types that are not moved around.
+pub(crate) unsafe fn to_trace<T: StorageItem>(t: &T) -> PointerId<T::Marker> {
+    PointerId::PointerId(
+        #[expect(trivial_casts)]
+        core::num::NonZeroUsize::new(t as *const T as usize).unwrap(),
+        PhantomData,
+    )
 }
 
 impl IntoTrace for ArcCommand {

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -971,6 +971,7 @@ fn action_to_owned(action: Action<'_, PointerReferences>) -> Action<'static, Poi
         A::DropTlas(tlas) => A::DropTlas(tlas),
 
         A::CreateTexture(..)
+        | A::CreateTextureError(..)
         | A::CreateTextureView { .. }
         | A::CreateExternalTexture { .. }
         | A::CreateSampler(..)

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -200,7 +200,7 @@ pub struct Hub {
     pub(crate) query_sets: Registry<Fallible<QuerySet>>,
     pub(crate) buffers: Registry<Fallible<Buffer>>,
     pub(crate) staging_buffers: Registry<StagingBuffer>,
-    pub(crate) textures: Registry<Fallible<Texture>>,
+    pub(crate) textures: Registry<Arc<Texture>>,
     pub(crate) texture_views: Registry<Fallible<TextureView>>,
     pub(crate) external_textures: Registry<Fallible<ExternalTexture>>,
     pub(crate) samplers: Registry<Fallible<Sampler>>,

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -331,7 +331,10 @@ impl Queue {
         let device = &self.device;
 
         let mut exclusive_snatch_guard = device.snatchable_lock.write();
-        let inner = texture.inner.snatch(&mut exclusive_snatch_guard);
+        let inner = texture
+            .inner
+            .snatch(&mut exclusive_snatch_guard)
+            .maybe_valid();
         drop(exclusive_snatch_guard);
 
         let result = match inner {
@@ -387,7 +390,10 @@ impl Surface {
             .ok_or(SurfaceError::NothingToPresent)?;
 
         let mut exclusive_snatch_guard = device.snatchable_lock.write();
-        let inner = texture.inner.snatch(&mut exclusive_snatch_guard);
+        let inner = texture
+            .inner
+            .snatch(&mut exclusive_snatch_guard)
+            .maybe_valid();
         drop(exclusive_snatch_guard);
 
         match inner {

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -434,9 +434,7 @@ impl Global {
         }
 
         let status = output.status;
-        let texture_id = output
-            .texture
-            .map(|texture| fid.assign(resource::Fallible::Valid(texture)));
+        let texture_id = output.texture.map(|texture| fid.assign(texture));
 
         Ok(SurfaceOutput {
             status,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -27,10 +27,7 @@ use crate::{
     lock::{rank, Mutex, RwLock},
     ray_tracing::{BlasCompactReadyPendingClosure, BlasPrepareCompactError},
     resource_log,
-    snatch::{
-        DestructibleResourceState, InvalidOrDestroyedResourceError, SnatchGuard, Snatchable,
-        Snatchable2,
-    },
+    snatch::{SnatchGuard, Snatchable, Snatchable2},
     timestamp_normalization::TimestampNormalizationBindGroup,
     track::{SharedTrackerIndexAllocator, TrackerIndex},
     weak_vec::WeakVec,
@@ -91,6 +88,44 @@ pub struct ResourceErrorIdent {
 impl fmt::Display for ResourceErrorIdent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{} with '{}' label", self.r#type, self.label)
+    }
+}
+
+pub enum DestructibleResourceState<T> {
+    Valid(T),
+    Invalid,
+    Destroyed,
+}
+
+impl<T> DestructibleResourceState<T> {
+    pub fn as_ref(&self) -> DestructibleResourceState<&T> {
+        match self {
+            DestructibleResourceState::Valid(v) => DestructibleResourceState::Valid(v),
+            DestructibleResourceState::Invalid => DestructibleResourceState::Invalid,
+            DestructibleResourceState::Destroyed => DestructibleResourceState::Destroyed,
+        }
+    }
+
+    pub fn take(&mut self) -> DestructibleResourceState<T> {
+        mem::replace(self, DestructibleResourceState::Destroyed)
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum InvalidOrDestroyedResourceError {
+    #[error(transparent)]
+    InvalidResource(#[from] InvalidResourceError),
+    #[error(transparent)]
+    DestroyedResource(#[from] DestroyedResourceError),
+}
+
+impl<T> DestructibleResourceState<T> {
+    pub fn maybe_valid(self) -> Option<T> {
+        match self {
+            DestructibleResourceState::Valid(t) => Some(t),
+            DestructibleResourceState::Invalid => None,
+            DestructibleResourceState::Destroyed => None,
+        }
     }
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1489,7 +1489,6 @@ impl Drop for Texture {
 impl RawResourceAccess for Texture {
     type DynResource = dyn hal::DynTexture;
 
-    // TODO: this one is bad
     fn raw<'a>(&'a self, guard: &'a SnatchGuard) -> Option<&'a Self::DynResource> {
         self.inner.get(guard).maybe_valid().map(|t| t.raw())
     }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -27,7 +27,10 @@ use crate::{
     lock::{rank, Mutex, RwLock},
     ray_tracing::{BlasCompactReadyPendingClosure, BlasPrepareCompactError},
     resource_log,
-    snatch::{SnatchGuard, Snatchable, Snatchable2},
+    snatch::{
+        DestructibleResourceState, InvalidOrDestroyedResourceError, SnatchGuard, Snatchable,
+        Snatchable2,
+    },
     timestamp_normalization::TimestampNormalizationBindGroup,
     track::{SharedTrackerIndexAllocator, TrackerIndex},
     weak_vec::WeakVec,
@@ -1495,22 +1498,39 @@ impl Texture {
     pub(crate) fn try_inner<'a>(
         &'a self,
         guard: &'a SnatchGuard,
-    ) -> Result<&'a TextureInner, DestroyedResourceError> {
-        self.inner
-            .get(guard)
-            .maybe_valid()
-            .ok_or_else(|| DestroyedResourceError(self.error_ident()))
+    ) -> Result<&'a TextureInner, InvalidOrDestroyedResourceError> {
+        match self.inner.get(guard) {
+            DestructibleResourceState::Valid(t) => Ok(t),
+            DestructibleResourceState::Invalid => {
+                Err(InvalidOrDestroyedResourceError::InvalidResource(
+                    InvalidResourceError(self.error_ident()),
+                ))
+            }
+            DestructibleResourceState::Destroyed => {
+                Err(InvalidOrDestroyedResourceError::DestroyedResource(
+                    DestroyedResourceError(self.error_ident()),
+                ))
+            }
+        }
     }
 
     pub(crate) fn check_destroyed(
         &self,
         guard: &SnatchGuard,
     ) -> Result<(), DestroyedResourceError> {
-        self.inner
-            .get(guard)
-            .maybe_valid()
-            .map(|_| ())
-            .ok_or_else(|| DestroyedResourceError(self.error_ident()))
+        match self.inner.get(guard) {
+            DestructibleResourceState::Valid(_) => Ok(()),
+            DestructibleResourceState::Invalid => Ok(()),
+            DestructibleResourceState::Destroyed => Err(DestroyedResourceError(self.error_ident())),
+        }
+    }
+
+    pub(crate) fn check_valid(&self, guard: &SnatchGuard) -> Result<(), InvalidResourceError> {
+        match self.inner.get(guard) {
+            DestructibleResourceState::Valid(_) => Ok(()),
+            DestructibleResourceState::Invalid => Err(InvalidResourceError(self.error_ident())),
+            DestructibleResourceState::Destroyed => Ok(()),
+        }
     }
 
     pub(crate) fn get_clear_view<'a>(

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1404,6 +1404,31 @@ impl Texture {
         }
     }
 
+    pub(crate) fn dummy(device: &Arc<Device>, desc: &TextureDescriptor) -> Self {
+        Texture {
+            inner: Snatchable2::invalid(),
+            device: device.clone(),
+            desc: desc.map_label(|label| label.to_string()),
+            _hal_usage: wgt::TextureUses::empty(),
+            format_features: wgt::TextureFormatFeatures {
+                allowed_usages: wgt::TextureUsages::empty(),
+                flags: wgt::TextureFormatFeatureFlags::empty(),
+            },
+            initialization_status: RwLock::new(
+                rank::TEXTURE_INITIALIZATION_STATUS,
+                TextureInitTracker::new(0, 0),
+            ),
+            full_range: TextureSelector {
+                mips: 0..desc.mip_level_count,
+                layers: 0..desc.array_layer_count(),
+            },
+            tracking_data: TrackingData::new(device.tracker_indices.textures.clone()),
+            clear_mode: RwLock::new(rank::TEXTURE_CLEAR_MODE, TextureClearMode::None),
+            views: Mutex::new(rank::TEXTURE_VIEWS, WeakVec::new()),
+            bind_groups: Mutex::new(rank::TEXTURE_BIND_GROUPS, WeakVec::new()),
+        }
+    }
+
     /// Checks that the given texture usage contains the required texture usage,
     /// returns an error otherwise.
     pub(crate) fn check_usage(

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1489,6 +1489,7 @@ impl Drop for Texture {
 impl RawResourceAccess for Texture {
     type DynResource = dyn hal::DynTexture;
 
+    // TODO: this one is bad
     fn raw<'a>(&'a self, guard: &'a SnatchGuard) -> Option<&'a Self::DynResource> {
         self.inner.get(guard).maybe_valid().map(|t| t.raw())
     }
@@ -2028,6 +2029,15 @@ pub enum CreateTextureViewError {
     InvalidResource(#[from] InvalidResourceError),
     #[error(transparent)]
     MissingFeatures(#[from] MissingFeatures),
+}
+
+impl From<InvalidOrDestroyedResourceError> for CreateTextureViewError {
+    fn from(value: InvalidOrDestroyedResourceError) -> Self {
+        match value {
+            InvalidOrDestroyedResourceError::InvalidResource(e) => Self::InvalidResource(e),
+            InvalidOrDestroyedResourceError::DestroyedResource(e) => Self::DestroyedResource(e),
+        }
+    }
 }
 
 impl WebGpuError for CreateTextureViewError {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1407,7 +1407,7 @@ impl Texture {
         }
     }
 
-    pub(crate) fn dummy(device: &Arc<Device>, desc: &TextureDescriptor) -> Self {
+    pub(crate) fn invalid(device: &Arc<Device>, desc: &TextureDescriptor) -> Self {
         Texture {
             inner: Snatchable2::invalid(),
             device: device.clone(),

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -27,7 +27,7 @@ use crate::{
     lock::{rank, Mutex, RwLock},
     ray_tracing::{BlasCompactReadyPendingClosure, BlasPrepareCompactError},
     resource_log,
-    snatch::{SnatchGuard, Snatchable},
+    snatch::{SnatchGuard, Snatchable, Snatchable2},
     timestamp_normalization::TimestampNormalizationBindGroup,
     track::{SharedTrackerIndexAllocator, TrackerIndex},
     weak_vec::WeakVec,
@@ -1355,7 +1355,7 @@ pub enum TextureClearMode {
 
 #[derive(Debug)]
 pub struct Texture {
-    pub(crate) inner: Snatchable<TextureInner>,
+    pub(crate) inner: Snatchable2<TextureInner>,
     pub(crate) device: Arc<Device>,
     pub(crate) desc: wgt::TextureDescriptor<String, Vec<wgt::TextureFormat>>,
     pub(crate) _hal_usage: wgt::TextureUses,
@@ -1380,7 +1380,7 @@ impl Texture {
         init: bool,
     ) -> Self {
         Texture {
-            inner: Snatchable::new(inner),
+            inner: Snatchable2::new(inner),
             device: device.clone(),
             desc: desc.map_label(|label| label.to_string()),
             _hal_usage: hal_usage,
@@ -1449,7 +1449,7 @@ impl Drop for Texture {
             _ => {}
         };
 
-        if let Some(TextureInner::Native { raw }) = self.inner.take() {
+        if let Some(TextureInner::Native { raw }) = self.inner.take().maybe_valid() {
             resource_log!("Destroy raw {}", self.error_ident());
             unsafe {
                 self.device.raw().destroy_texture(raw);
@@ -1462,7 +1462,7 @@ impl RawResourceAccess for Texture {
     type DynResource = dyn hal::DynTexture;
 
     fn raw<'a>(&'a self, guard: &'a SnatchGuard) -> Option<&'a Self::DynResource> {
-        self.inner.get(guard).map(|t| t.raw())
+        self.inner.get(guard).maybe_valid().map(|t| t.raw())
     }
 }
 
@@ -1473,6 +1473,7 @@ impl Texture {
     ) -> Result<&'a TextureInner, DestroyedResourceError> {
         self.inner
             .get(guard)
+            .maybe_valid()
             .ok_or_else(|| DestroyedResourceError(self.error_ident()))
     }
 
@@ -1482,6 +1483,7 @@ impl Texture {
     ) -> Result<(), DestroyedResourceError> {
         self.inner
             .get(guard)
+            .maybe_valid()
             .map(|_| ())
             .ok_or_else(|| DestroyedResourceError(self.error_ident()))
     }
@@ -1519,7 +1521,11 @@ impl Texture {
         let device = &self.device;
 
         let temp = {
-            let raw = match self.inner.snatch(&mut device.snatchable_lock.write()) {
+            let raw = match self
+                .inner
+                .snatch(&mut device.snatchable_lock.write())
+                .maybe_valid()
+            {
                 Some(TextureInner::Native { raw }) => raw,
                 Some(TextureInner::Surface { .. }) => {
                     return;

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1487,6 +1487,16 @@ impl Texture {
 
 impl Drop for Texture {
     fn drop(&mut self) {
+        #[cfg(feature = "trace")]
+        {
+            let mut t = self.device.trace.lock();
+            if let Some(t) = t.as_mut() {
+                use crate::device::trace::to_trace;
+
+                // SAFETY: All textures are constructed in Arc => are heap allocated
+                t.add(trace::Action::DropTexture(unsafe { to_trace(self) }));
+            }
+        }
         match *self.clear_mode.write() {
             TextureClearMode::Surface {
                 ref mut clear_view, ..

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -83,15 +83,13 @@ impl<T> DestructibleResourceState<T> {
     }
 }
 
-/*
 #[derive(thiserror::Error, Debug)]
-pub enum InvalidOrDestroyedError {
+pub enum InvalidOrDestroyedResourceError {
     #[error(transparent)]
     InvalidResource(#[from] crate::resource::InvalidResourceError),
     #[error(transparent)]
     DestroyedResource(#[from] crate::resource::DestroyedResourceError),
 }
-*/
 
 impl<T> DestructibleResourceState<T> {
     pub fn maybe_valid(self) -> Option<T> {

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,7 +1,7 @@
-use core::mem::replace;
 use core::{cell::UnsafeCell, fmt, mem::ManuallyDrop};
 
 use crate::lock::{rank, RankData, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use crate::resource::DestructibleResourceState;
 
 /// A guard that provides read access to snatchable data.
 pub struct SnatchGuard<'a>(RwLockReadGuard<'a, ()>);
@@ -62,44 +62,6 @@ impl<T> fmt::Debug for SnatchableInner<T> {
 }
 
 unsafe impl<T> Sync for SnatchableInner<T> {}
-
-pub enum DestructibleResourceState<T> {
-    Valid(T),
-    Invalid,
-    Destroyed,
-}
-
-impl<T> DestructibleResourceState<T> {
-    pub fn as_ref(&self) -> DestructibleResourceState<&T> {
-        match self {
-            DestructibleResourceState::Valid(v) => DestructibleResourceState::Valid(v),
-            DestructibleResourceState::Invalid => DestructibleResourceState::Invalid,
-            DestructibleResourceState::Destroyed => DestructibleResourceState::Destroyed,
-        }
-    }
-
-    pub fn take(&mut self) -> DestructibleResourceState<T> {
-        replace(self, DestructibleResourceState::Destroyed)
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum InvalidOrDestroyedResourceError {
-    #[error(transparent)]
-    InvalidResource(#[from] crate::resource::InvalidResourceError),
-    #[error(transparent)]
-    DestroyedResource(#[from] crate::resource::DestroyedResourceError),
-}
-
-impl<T> DestructibleResourceState<T> {
-    pub fn maybe_valid(self) -> Option<T> {
-        match self {
-            DestructibleResourceState::Valid(t) => Some(t),
-            DestructibleResourceState::Invalid => None,
-            DestructibleResourceState::Destroyed => None,
-        }
-    }
-}
 
 /// A value that is mostly immutable but can be "snatched" if we need to destroy
 /// it early.

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -122,13 +122,6 @@ impl<T> Snatchable2<T> {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn empty() -> Self {
-        SnatchableInner {
-            value: UnsafeCell::new(DestructibleResourceState::Destroyed),
-        }
-    }
-
     /// Get read access to the value. Requires a the snatchable lock's read guard.
     pub fn get<'a>(&'a self, _guard: &'a SnatchGuard) -> DestructibleResourceState<&'a T> {
         unsafe { (*self.value.get()).as_ref() }

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -83,8 +83,18 @@ impl<T> DestructibleResourceState<T> {
     }
 }
 
+/*
+#[derive(thiserror::Error, Debug)]
+pub enum InvalidOrDestroyedError {
+    #[error(transparent)]
+    InvalidResource(#[from] crate::resource::InvalidResourceError),
+    #[error(transparent)]
+    DestroyedResource(#[from] crate::resource::DestroyedResourceError),
+}
+*/
+
 impl<T> DestructibleResourceState<T> {
-    pub fn get_valid(self) -> Option<T> {
+    pub fn maybe_valid(self) -> Option<T> {
         match self {
             DestructibleResourceState::Valid(t) => Some(t),
             DestructibleResourceState::Invalid => None,

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,3 +1,4 @@
+use core::mem::replace;
 use core::{cell::UnsafeCell, fmt, mem::ManuallyDrop};
 
 use crate::lock::{rank, RankData, RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -13,20 +14,22 @@ pub struct ExclusiveSnatchGuard<'a>(#[expect(dead_code)] RwLockWriteGuard<'a, ()
 /// In order to safely access the underlying data, the device's global snatchable
 /// lock must be taken. To guarantee it, methods take a read or write guard of that
 /// special lock.
-pub struct Snatchable<T> {
-    value: UnsafeCell<Option<T>>,
+pub struct SnatchableInner<T> {
+    value: UnsafeCell<T>,
 }
+
+pub type Snatchable<T> = SnatchableInner<Option<T>>;
 
 impl<T> Snatchable<T> {
     pub fn new(val: T) -> Self {
-        Snatchable {
+        SnatchableInner {
             value: UnsafeCell::new(Some(val)),
         }
     }
 
     #[allow(dead_code)]
     pub fn empty() -> Self {
-        Snatchable {
+        SnatchableInner {
             value: UnsafeCell::new(None),
         }
     }
@@ -52,13 +55,90 @@ impl<T> Snatchable<T> {
 
 // Can't safely print the contents of a snatchable object without holding
 // the lock.
-impl<T> fmt::Debug for Snatchable<T> {
+impl<T> fmt::Debug for SnatchableInner<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<snatchable>")
     }
 }
 
-unsafe impl<T> Sync for Snatchable<T> {}
+unsafe impl<T> Sync for SnatchableInner<T> {}
+
+pub enum DestructibleResourceState<T> {
+    Valid(T),
+    Invalid,
+    Destroyed,
+}
+
+impl<T> DestructibleResourceState<T> {
+    pub fn as_ref(&self) -> DestructibleResourceState<&T> {
+        match self {
+            DestructibleResourceState::Valid(v) => DestructibleResourceState::Valid(v),
+            DestructibleResourceState::Invalid => DestructibleResourceState::Invalid,
+            DestructibleResourceState::Destroyed => DestructibleResourceState::Destroyed,
+        }
+    }
+
+    pub fn take(&mut self) -> DestructibleResourceState<T> {
+        replace(self, DestructibleResourceState::Destroyed)
+    }
+}
+
+impl<T> DestructibleResourceState<T> {
+    pub fn get_valid(self) -> Option<T> {
+        match self {
+            DestructibleResourceState::Valid(t) => Some(t),
+            DestructibleResourceState::Invalid => None,
+            DestructibleResourceState::Destroyed => None,
+        }
+    }
+}
+
+/// A value that is mostly immutable but can be "snatched" if we need to destroy
+/// it early.
+///
+/// In order to safely access the underlying data, the device's global snatchable
+/// lock must be taken. To guarantee it, methods take a read or write guard of that
+/// special lock.
+pub type Snatchable2<T> = SnatchableInner<DestructibleResourceState<T>>;
+
+impl<T> Snatchable2<T> {
+    pub fn new(val: T) -> Self {
+        SnatchableInner {
+            value: UnsafeCell::new(DestructibleResourceState::Valid(val)),
+        }
+    }
+
+    pub fn invalid() -> Self {
+        SnatchableInner {
+            value: UnsafeCell::new(DestructibleResourceState::Invalid),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn empty() -> Self {
+        SnatchableInner {
+            value: UnsafeCell::new(DestructibleResourceState::Destroyed),
+        }
+    }
+
+    /// Get read access to the value. Requires a the snatchable lock's read guard.
+    pub fn get<'a>(&'a self, _guard: &'a SnatchGuard) -> DestructibleResourceState<&'a T> {
+        unsafe { (*self.value.get()).as_ref() }
+    }
+
+    /// Take the value. Requires a the snatchable lock's write guard.
+    pub fn snatch(&self, _guard: &mut ExclusiveSnatchGuard) -> DestructibleResourceState<T> {
+        unsafe { (*self.value.get()).take() }
+    }
+
+    /// Take the value without a guard. This can only be used with exclusive access
+    /// to self, so it does not require locking.
+    ///
+    /// Typically useful in a drop implementation.
+    pub fn take(&mut self) -> DestructibleResourceState<T> {
+        self.value.get_mut().take()
+    }
+}
 
 use trace::LockTrace;
 #[cfg(all(debug_assertions, feature = "std"))]

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -489,7 +489,7 @@ impl TextureTracker {
             .drain(..)
             .inspect(|pending| {
                 let tex = unsafe { self.metadata.get_resource_unchecked(pending.id as _) };
-                textures.push(tex.inner.get(snatch_guard));
+                textures.push(tex.inner.get(snatch_guard).maybe_valid());
             })
             .collect();
         (transitions, textures)


### PR DESCRIPTION
**Connections**
Work towards #5121

**Description**
Ass announced in https://github.com/gfx-rs/wgpu/issues/5121#issuecomment-4761550506 we move `Fallible` into `Arc<Texture>`. More specifically we now have:
```rust
pub enum DestructibleResourceState<T> {
    Valid(T),
    Invalid,
    Destroyed,
}
```
in somekind of snatchable. We now have `create_texture_inner(
        device: &Arc<Device>,
        desc: &resource::TextureDescriptor,
    ) -> Result<Arc<Texture>, resource::CreateTextureError>`
which is called by
`pub fn create_texture(
        self: &Arc<Device>,
        desc: &resource::TextureDescriptor,
    ) -> (Arc<Texture>, Option<resource::CreateTextureError>)`
this will also make sense when we do https://github.com/gfx-rs/wgpu/issues/8911.
We also move tracing into the device methods and we now trace all textures (even invalid ones). THis will help with liberating wgpu from IDs.

**Testing**
Refactor, but should be covered by existing tests.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
