### PR TITLE
Improve registry storage assertions

### DIFF
--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -261,14 +261,18 @@ where
 ///
 /// For example, `Device<A>` will have the same type of identifier as
 /// `Device<B>` because `Device<T>` for any `T` defines the same maker type.
-pub trait Marker: 'static + WasmNotSendSync {}
+pub trait Marker: 'static + WasmNotSendSync {
+    const TYPE: &'static str;
+}
 
 // This allows `()` to be used as a marker type for tests.
 //
 // We don't want these in production code, since they essentially remove type
 // safety, like how identifiers across different types can be compared.
 #[cfg(test)]
-impl Marker for () {}
+impl Marker for () {
+    const TYPE: &'static str = "Untyped";
+}
 
 /// Define identifiers for each resource.
 macro_rules! ids {
@@ -281,7 +285,9 @@ macro_rules! ids {
             $(
                 #[derive(Debug)]
                 pub enum $marker {}
-                impl super::Marker for $marker {}
+                impl super::Marker for $marker {
+                    const TYPE: &'static str = stringify!($marker);
+                }
             )*
         }
 

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -210,7 +210,7 @@ where
 {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let (index, epoch) = self.unzip();
-        write!(formatter, "Id({index},{epoch})")?;
+        write!(formatter, "{}Id({index},{epoch})", T::TYPE)?;
         Ok(())
     }
 }

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -60,27 +60,8 @@ impl RawId {
 ///
 /// An `Id<T>` value identifies a value stored in a [`Global`]'s [`Hub`].
 ///
-/// ## Note on `Id` typing
-///
-/// You might assume that an `Id<T>` can only be used to retrieve a resource of
-/// type `T`, but that is not quite the case. The id types in `wgpu-core`'s
-/// public API ([`TextureId`], for example) can refer to resources belonging to
-/// any backend, but the corresponding resource types ([`Texture<A>`], for
-/// example) are always parameterized by a specific backend `A`.
-///
-/// So the `T` in `Id<T>` is usually a resource type like `Texture<Noop>`,
-/// where [`Noop`] is the `wgpu_hal` dummy back end. These empty types are
-/// never actually used, beyond just making sure you access each `Storage` with
-/// the right kind of identifier. The members of [`Hub<A>`] pair up each
-/// `X<Noop>` type with the resource type `X<A>`, for some specific backend
-/// `A`.
-///
 /// [`Global`]: crate::global::Global
 /// [`Hub`]: crate::hub::Hub
-/// [`Hub<A>`]: crate::hub::Hub
-/// [`Texture<A>`]: crate::resource::Texture
-/// [`Registry`]: crate::registry::Registry
-/// [`Noop`]: hal::api::Noop
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -124,7 +124,9 @@ mod tests {
 
     struct TestData;
     struct TestDataId;
-    impl Marker for TestDataId {}
+    impl Marker for TestDataId {
+        const TYPE: &'static str = "TestData";
+    }
 
     impl ResourceType for TestData {
         const TYPE: &'static str = "TestData";

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -56,7 +56,6 @@ where
     T: StorageItem,
 {
     pub(crate) map: Vec<Element<T>>,
-    kind: &'static str,
 }
 
 impl<T> Storage<T>
@@ -64,10 +63,7 @@ where
     T: StorageItem,
 {
     pub(crate) fn new() -> Self {
-        Self {
-            map: Vec::new(),
-            kind: T::TYPE,
-        }
+        Self { map: Vec::new() }
     }
 }
 
@@ -84,11 +80,9 @@ where
         match mem::replace(&mut self.map[index], Element::Occupied(value, epoch)) {
             Element::Vacant => {}
             Element::Occupied(_, storage_epoch) => {
-                assert_ne!(
-                    epoch,
-                    storage_epoch,
-                    "Index {index:?} of {} is already occupied",
-                    T::TYPE
+                panic!(
+                    "Cannot insert {id:?}, found existing resource {other:?}",
+                    other = Id::<T::Marker>::zip(index as Index, storage_epoch),
                 );
             }
         }
@@ -96,16 +90,20 @@ where
 
     pub(crate) fn remove(&mut self, id: Id<T::Marker>) -> T {
         let (index, epoch) = id.unzip();
-        let stored = self
-            .map
-            .get_mut(index as usize)
-            .unwrap_or_else(|| panic!("{}[{:?}] does not exist", self.kind, id));
-        match mem::replace(stored, Element::Vacant) {
-            Element::Occupied(value, storage_epoch) => {
-                assert_eq!(epoch, storage_epoch, "id epoch mismatch");
+        let stored = self.map.get_mut(index as usize);
+        match stored.map(|stored| mem::replace(stored, Element::Vacant)) {
+            Some(Element::Occupied(value, storage_epoch)) => {
+                assert_eq!(
+                    epoch,
+                    storage_epoch,
+                    "Cannot remove {id:?}, found other resource {other:?}",
+                    other = Id::<T::Marker>::zip(index, storage_epoch),
+                );
                 value
             }
-            Element::Vacant => panic!("Cannot remove a vacant resource"),
+            None | Some(Element::Vacant) => {
+                panic!("Cannot remove non-existent resource {id:?}");
+            }
         }
     }
 
@@ -132,13 +130,86 @@ where
         let (index, epoch) = id.unzip();
         let (result, storage_epoch) = match self.map.get(index as usize) {
             Some(&Element::Occupied(ref v, epoch)) => (v.clone(), epoch),
-            None | Some(&Element::Vacant) => panic!("{}[{:?}] does not exist", self.kind, id),
+            None | Some(&Element::Vacant) => {
+                panic!("Cannot get non-existent resource {id:?}");
+            }
         };
         assert_eq!(
-            epoch, storage_epoch,
-            "{}[{:?}] is no longer alive",
-            self.kind, id
+            epoch,
+            storage_epoch,
+            "Cannot get {id:?}, found other resource {other:?}",
+            other = Id::<T::Marker>::zip(index, storage_epoch),
         );
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct TestItem;
+
+    impl ResourceType for TestItem {
+        const TYPE: &'static str = "TestItem";
+    }
+
+    impl StorageItem for TestItem {
+        type Marker = ();
+    }
+
+    fn id(index: Index, epoch: Epoch) -> Id<()> {
+        Id::zip(index, epoch)
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Cannot insert UntypedId(0,1), found existing resource UntypedId(0,1)"
+    )]
+    fn insert_occupied_same_epoch() {
+        let mut storage = Storage::new();
+        storage.insert(id(0, 1), TestItem);
+        storage.insert(id(0, 1), TestItem);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Cannot insert UntypedId(0,2), found existing resource UntypedId(0,1)"
+    )]
+    fn insert_occupied_different_epoch() {
+        let mut storage = Storage::new();
+        storage.insert(id(0, 1), TestItem);
+        storage.insert(id(0, 2), TestItem);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot remove UntypedId(0,2), found other resource UntypedId(0,1)")]
+    fn remove_epoch_mismatch() {
+        let mut storage = Storage::new();
+        storage.insert(id(0, 1), TestItem);
+        storage.remove(id(0, 2));
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot remove non-existent resource UntypedId(0,1)")]
+    fn remove_vacant() {
+        let mut storage = Storage::<TestItem>::new();
+        storage.remove(id(0, 1));
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot get non-existent resource UntypedId(0,1)")]
+    fn get_vacant() {
+        let storage = Storage::<TestItem>::new();
+        storage.get(id(0, 1));
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot get UntypedId(0,2), found other resource UntypedId(0,1)")]
+    fn get_epoch_mismatch() {
+        let mut storage = Storage::new();
+        storage.insert(id(0, 1), TestItem);
+        storage.get(id(0, 2));
     }
 }


### PR DESCRIPTION
In debugging a Firefox bug, I noticed that `Storage::insert` rejects attempts to insert the same resource ID twice, but silently drops `(index, epoch1)` if asked to insert `(index, epoch2)`. This PR disallows that, and logs more information about expected / found IDs in several of the assertions.

Fixes #9685.

**Testing**
Claude wrote me some tests to sanity-check what the messages looked like, which I've included. They seem a little silly as permanent tests, on the other hand, I did add one for the "silently replace object in different epoch" case that was missed before.

**Squash or Rebase?** Rebase