### PR TITLE
test: use non-square asymmetric textures in coordinate-sensitive tests

### DIFF
--- a/tests/tests/wgpu-gpu/clip_distances.rs
+++ b/tests/tests/wgpu-gpu/clip_distances.rs
@@ -57,12 +57,18 @@ async fn clip_distances(ctx: TestingContext) {
             cache: None,
         });
 
+    // Deliberately non-square so a width/height swap in the copy or the
+    // readback index math is caught. `WIDTH` is a multiple of
+    // `COPY_BYTES_PER_ROW_ALIGNMENT` so `bytes_per_row` stays aligned.
+    const WIDTH: u32 = 256;
+    const HEIGHT: u32 = 192;
+
     // Create render target
     let render_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
         label: Some("Render Texture"),
         size: wgpu::Extent3d {
-            width: 256,
-            height: 256,
+            width: WIDTH,
+            height: HEIGHT,
             depth_or_array_layers: 1,
         },
         mip_level_count: 1,
@@ -106,7 +112,7 @@ async fn clip_distances(ctx: TestingContext) {
     // Read texture data
     let readback_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
-        size: 256 * 256,
+        size: (WIDTH * HEIGHT) as u64,
         usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
         mapped_at_creation: false,
     });
@@ -121,13 +127,13 @@ async fn clip_distances(ctx: TestingContext) {
             buffer: &readback_buffer,
             layout: wgpu::TexelCopyBufferLayout {
                 offset: 0,
-                bytes_per_row: Some(256),
+                bytes_per_row: Some(WIDTH),
                 rows_per_image: None,
             },
         },
         wgpu::Extent3d {
-            width: 256,
-            height: 256,
+            width: WIDTH,
+            height: HEIGHT,
             depth_or_array_layers: 1,
         },
     );
@@ -139,11 +145,23 @@ async fn clip_distances(ctx: TestingContext) {
         .unwrap();
     let data: &[u8] = &slice.get_mapped_range().unwrap();
 
-    // We should have filled the upper sector of the texture. Verify that this is the case.
-    assert_eq!(data[128 + 64 * 256], 0xFF);
-    assert_eq!(data[64 + 128 * 256], 0x00);
-    assert_eq!(data[192 + 128 * 256], 0x00);
-    assert_eq!(data[128 + 192 * 256], 0x00);
+    // The shader fills the upper wedge of the framebuffer (`y_ndc >= |x_ndc|`).
+    // Sample one point inside the wedge and three outside it. The points are
+    // deliberately off-axis and use a non-square stride (`x + y * WIDTH`) so a
+    // width/height confusion would read the wrong texel.
+    let texel = |x: u32, y: u32| data[(x + y * WIDTH) as usize];
+    assert_eq!(
+        texel(144, 48),
+        0xFF,
+        "inside wedge (upper, right of center)"
+    );
+    assert_eq!(texel(32, 96), 0x00, "outside wedge (far left, middle row)");
+    assert_eq!(
+        texel(224, 96),
+        0x00,
+        "outside wedge (far right, middle row)"
+    );
+    assert_eq!(texel(128, 160), 0x00, "outside wedge (bottom center)");
 }
 
 const SHADER_SRC: &str = "

--- a/tests/tests/wgpu-gpu/planar_texture/mod.rs
+++ b/tests/tests/wgpu-gpu/planar_texture/mod.rs
@@ -230,9 +230,11 @@ static NV12_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfigurati
             .enable_noop(),
     )
     .run_sync(|ctx| {
+        // Deliberately non-square so a width/height swap is caught. Both
+        // dimensions stay even, as required by NV12/P010 (chroma is half-res).
         let size = wgpu::Extent3d {
             width: 256,
-            height: 256,
+            height: 128,
             depth_or_array_layers: 1,
         };
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
@@ -271,9 +273,11 @@ static P010_TEXTURE_CREATION_SAMPLING: GpuTestConfiguration = GpuTestConfigurati
             .enable_noop(),
     )
     .run_sync(|ctx| {
+        // Deliberately non-square so a width/height swap is caught. Both
+        // dimensions stay even, as required by NV12/P010 (chroma is half-res).
         let size = wgpu::Extent3d {
             width: 256,
-            height: 256,
+            height: 128,
             depth_or_array_layers: 1,
         };
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
@@ -309,9 +313,11 @@ static NV12_TEXTURE_RENDERING: GpuTestConfiguration = GpuTestConfiguration::new(
             .enable_noop(),
     )
     .run_sync(|ctx| {
+        // Deliberately non-square so a width/height swap is caught. Both
+        // dimensions stay even, as required by NV12/P010 (chroma is half-res).
         let size = wgpu::Extent3d {
             width: 256,
-            height: 256,
+            height: 128,
             depth_or_array_layers: 1,
         };
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
@@ -351,9 +357,11 @@ static NV12_TEXTURE_COPYING: GpuTestConfiguration = GpuTestConfiguration::new()
             .enable_noop(),
     )
     .run_sync(|ctx| {
+        // Deliberately non-square so a width/height swap is caught. Both
+        // dimensions stay even, as required by NV12/P010 (chroma is half-res).
         let size = wgpu::Extent3d {
             width: 256,
-            height: 256,
+            height: 128,
             depth_or_array_layers: 1,
         };
         let input_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
@@ -399,8 +407,9 @@ static NV12_PLANE_TO_SINGLE_PLANE_COPY: GpuTestConfiguration = GpuTestConfigurat
         // Width chosen so that bytes-per-row is 256-aligned for both planes:
         //   luma   R8Unorm:  256 px * 1 byte/px = 256
         //   chroma Rg8Unorm: 128 px * 2 byte/px = 256
+        // Height is deliberately different from width so a swap is caught.
         const WIDTH: u32 = 256;
-        const HEIGHT: u32 = 256;
+        const HEIGHT: u32 = 128;
         let luma_size = wgpu::Extent3d {
             width: WIDTH,
             height: HEIGHT,
@@ -424,10 +433,23 @@ static NV12_PLANE_TO_SINGLE_PLANE_COPY: GpuTestConfiguration = GpuTestConfigurat
         });
 
         // Distinct patterns per plane so a swap or plane-0-fallback would fail
-        // the assertion at the end.
-        let luma_bytes: Vec<u8> = (0..(WIDTH * HEIGHT) as usize).map(|i| i as u8).collect();
-        let chroma_bytes: Vec<u8> = (0..(WIDTH / 2 * HEIGHT / 2 * 2) as usize)
-            .map(|i| (i ^ 0xA5) as u8)
+        // the assertion at the end. Each pattern depends on both `x` and `y`
+        // with different per-axis weights, so it is asymmetric under transpose,
+        // horizontal mirror, and vertical mirror — a row/column mix-up changes
+        // the bytes and fails the comparison.
+        let luma_bytes: Vec<u8> = (0..HEIGHT)
+            .flat_map(|y| {
+                (0..WIDTH).map(move |x| x.wrapping_mul(3).wrapping_add(y.wrapping_mul(101)) as u8)
+            })
+            .collect();
+        let chroma_bytes: Vec<u8> = (0..HEIGHT / 2)
+            .flat_map(|y| {
+                (0..WIDTH / 2).flat_map(move |x| {
+                    let r = x.wrapping_mul(7).wrapping_add(y.wrapping_mul(53)) as u8;
+                    let g = (x.wrapping_mul(29).wrapping_add(y.wrapping_mul(13)) ^ 0xA5) as u8;
+                    [r, g]
+                })
+            })
             .collect();
 
         ctx.queue.write_texture(
@@ -593,9 +615,11 @@ static P010_TEXTURE_COPYING: GpuTestConfiguration = GpuTestConfiguration::new()
             .enable_noop(),
     )
     .run_sync(|ctx| {
+        // Deliberately non-square so a width/height swap is caught. Both
+        // dimensions stay even, as required by NV12/P010 (chroma is half-res).
         let size = wgpu::Extent3d {
             width: 256,
-            height: 256,
+            height: 128,
             depth_or_array_layers: 1,
         };
         let input_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {

--- a/tests/tests/wgpu-gpu/regression/issue_6827.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_6827.rs
@@ -33,10 +33,12 @@ async fn run_test(ctx: TestingContext, use_many_writes: bool) {
     let device = ctx.device;
     let queue = ctx.queue;
 
+    // Deliberately distinct in every dimension so that an axis swap (width vs.
+    // height vs. depth) in the copy or the readback would be caught.
     let size = wgpu::Extent3d {
         width: 4,
-        height: 4,
-        depth_or_array_layers: 4,
+        height: 5,
+        depth_or_array_layers: 6,
     };
     let texture = {
         device.create_texture(&wgpu::TextureDescriptor {

--- a/tests/tests/wgpu-gpu/write_texture.rs
+++ b/tests/tests/wgpu-gpu/write_texture.rs
@@ -15,14 +15,18 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 #[gpu_test]
 static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
     GpuTestConfiguration::new().run_async(|ctx| async move {
-        let size = 256;
+        // Deliberately non-square so a width/height swap is caught. `width` is
+        // a multiple of `COPY_BYTES_PER_ROW_ALIGNMENT` so `bytes_per_row` (one
+        // byte per R8Uint texel) stays aligned for `copy_texture_to_buffer`.
+        let width = 256;
+        let height = 192;
 
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
             dimension: wgpu::TextureDimension::D2,
             size: wgpu::Extent3d {
-                width: size,
-                height: size,
+                width,
+                height,
                 depth_or_array_layers: 1,
             },
             format: wgpu::TextureFormat::R8Uint,
@@ -33,7 +37,7 @@ static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
             sample_count: 1,
             view_formats: &[],
         });
-        let data = vec![1u8; size as usize * 2];
+        let data = vec![1u8; width as usize * 2];
         // Write the first two rows
         ctx.queue.write_texture(
             wgpu::TexelCopyTextureInfo {
@@ -45,11 +49,11 @@ static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
             &data,
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
-                bytes_per_row: Some(size),
-                rows_per_image: Some(size),
+                bytes_per_row: Some(width),
+                rows_per_image: Some(height),
             },
             wgpu::Extent3d {
-                width: size,
+                width,
                 height: 2,
                 depth_or_array_layers: 1,
             },
@@ -59,7 +63,7 @@ static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
 
         let read_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
-            size: (size * size) as u64,
+            size: (width * height) as u64,
             usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -79,13 +83,13 @@ static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
                 buffer: &read_buffer,
                 layout: wgpu::TexelCopyBufferLayout {
                     offset: 0,
-                    bytes_per_row: Some(size),
-                    rows_per_image: Some(size),
+                    bytes_per_row: Some(width),
+                    rows_per_image: Some(height),
                 },
             },
             wgpu::Extent3d {
-                width: size,
-                height: size,
+                width,
+                height,
                 depth_or_array_layers: 1,
             },
         );
@@ -99,10 +103,10 @@ static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
             .unwrap();
         let data: Vec<u8> = slice.get_mapped_range().unwrap().to_vec();
 
-        for byte in &data[..(size as usize * 2)] {
+        for byte in &data[..(width as usize * 2)] {
             assert_eq!(*byte, 1);
         }
-        for byte in &data[(size as usize * 2)..] {
+        for byte in &data[(width as usize * 2)..] {
             assert_eq!(*byte, 0);
         }
     });
@@ -110,14 +114,18 @@ static WRITE_TEXTURE_SUBSET_2D: GpuTestConfiguration =
 #[gpu_test]
 static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
     GpuTestConfiguration::new().run_async(|ctx| async move {
-        let size = 256;
+        // Deliberately non-square (and a depth distinct from both) so any
+        // width/height/depth swap is caught. `width` is a multiple of
+        // `COPY_BYTES_PER_ROW_ALIGNMENT` so `bytes_per_row` stays aligned.
+        let width = 256;
+        let height = 192;
         let depth = 4;
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
             dimension: wgpu::TextureDimension::D3,
             size: wgpu::Extent3d {
-                width: size,
-                height: size,
+                width,
+                height,
                 depth_or_array_layers: depth,
             },
             format: wgpu::TextureFormat::R8Uint,
@@ -128,7 +136,7 @@ static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
             sample_count: 1,
             view_formats: &[],
         });
-        let data = vec![1u8; (size * size) as usize * 2];
+        let data = vec![1u8; (width * height) as usize * 2];
         // Write the first two slices
         ctx.queue.write_texture(
             wgpu::TexelCopyTextureInfo {
@@ -140,12 +148,12 @@ static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
             &data,
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
-                bytes_per_row: Some(size),
-                rows_per_image: Some(size),
+                bytes_per_row: Some(width),
+                rows_per_image: Some(height),
             },
             wgpu::Extent3d {
-                width: size,
-                height: size,
+                width,
+                height,
                 depth_or_array_layers: 2,
             },
         );
@@ -154,7 +162,7 @@ static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
 
         let read_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
-            size: (size * size * depth) as u64,
+            size: (width * height * depth) as u64,
             usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -174,13 +182,13 @@ static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
                 buffer: &read_buffer,
                 layout: wgpu::TexelCopyBufferLayout {
                     offset: 0,
-                    bytes_per_row: Some(size),
-                    rows_per_image: Some(size),
+                    bytes_per_row: Some(width),
+                    rows_per_image: Some(height),
                 },
             },
             wgpu::Extent3d {
-                width: size,
-                height: size,
+                width,
+                height,
                 depth_or_array_layers: depth,
             },
         );
@@ -194,10 +202,10 @@ static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
             .unwrap();
         let data: Vec<u8> = slice.get_mapped_range().unwrap().to_vec();
 
-        for byte in &data[..((size * size) as usize * 2)] {
+        for byte in &data[..((width * height) as usize * 2)] {
             assert_eq!(*byte, 1);
         }
-        for byte in &data[((size * size) as usize * 2)..] {
+        for byte in &data[((width * height) as usize * 2)..] {
             assert_eq!(*byte, 0);
         }
     });
@@ -206,14 +214,16 @@ static WRITE_TEXTURE_SUBSET_3D: GpuTestConfiguration =
 static WRITE_TEXTURE_NO_OOB: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().enable_noop())
     .run_async(|ctx| async move {
-        let size = 256;
+        // Non-square so a width/height swap is caught.
+        let width = 256;
+        let height = 192;
 
         let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: None,
             dimension: wgpu::TextureDimension::D2,
             size: wgpu::Extent3d {
-                width: size,
-                height: size,
+                width,
+                height,
                 depth_or_array_layers: 1,
             },
             format: wgpu::TextureFormat::R8Uint,
@@ -222,7 +232,7 @@ static WRITE_TEXTURE_NO_OOB: GpuTestConfiguration = GpuTestConfiguration::new()
             sample_count: 1,
             view_formats: &[],
         });
-        let data = vec![1u8; size as usize * 2 + 100]; // check that we don't attempt to copy OOB internally by adding 100 bytes here
+        let data = vec![1u8; width as usize * 2 + 100]; // check that we don't attempt to copy OOB internally by adding 100 bytes here
         ctx.queue.write_texture(
             wgpu::TexelCopyTextureInfo {
                 texture: &tex,
@@ -233,11 +243,11 @@ static WRITE_TEXTURE_NO_OOB: GpuTestConfiguration = GpuTestConfiguration::new()
             &data,
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
-                bytes_per_row: Some(size),
-                rows_per_image: Some(size),
+                bytes_per_row: Some(width),
+                rows_per_image: Some(height),
             },
             wgpu::Extent3d {
-                width: size,
+                width,
                 height: 2,
                 depth_or_array_layers: 1,
             },

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -145,9 +145,12 @@ impl<'ctx> DiscardTestCase<'ctx> {
 
         let texture = ctx.device.create_texture(&TextureDescriptor {
             label: Some("RenderTarget"),
+            // Non-square so a width/height swap in the row-stride math is caught.
+            // `width` is a multiple of `COPY_BYTES_PER_ROW_ALIGNMENT` so
+            // `bytes_per_row` stays aligned for every tested format.
             size: Extent3d {
                 width: COPY_BYTES_PER_ROW_ALIGNMENT,
-                height: COPY_BYTES_PER_ROW_ALIGNMENT,
+                height: COPY_BYTES_PER_ROW_ALIGNMENT / 2,
                 depth_or_array_layers: 1,
             },
             mip_level_count: 1,
@@ -387,9 +390,10 @@ static WRITE_TEXTURE_STENCIL_LEAVES_DEPTH_UNINIT_DEPTH24PLUS_STENCIL8: GpuTestCo
                 .limits(Limits::downlevel_defaults()),
         )
         .run_async(|ctx| async move {
+            // Non-square so a width/height swap is caught.
             let size = Extent3d {
                 width: 256,
-                height: 256,
+                height: 192,
                 depth_or_array_layers: 1,
             };
 
@@ -596,9 +600,10 @@ async fn check_depth_stencil_write_leaves_other_uninit(
     write_aspect: TextureAspect,
     method: WriteMethod,
 ) {
+    // Non-square so a width/height swap is caught.
     let size = Extent3d {
         width: 256,
-        height: 256,
+        height: 192,
         depth_or_array_layers: 1,
     };
     let (write_bpp, read_aspect, read_bpp) = match write_aspect {
@@ -633,14 +638,15 @@ async fn check_plane_write_leaves_other_plane_uninit(
     method: WriteMethod,
 ) {
     // Plane 1 of NV12/P010 is half resolution in each dimension.
+    // Non-square so a width/height swap is caught.
     let full_size = Extent3d {
         width: 256,
-        height: 256,
+        height: 192,
         depth_or_array_layers: 1,
     };
     let half_size = Extent3d {
         width: 128,
-        height: 128,
+        height: 96,
         depth_or_array_layers: 1,
     };
     let (write_size, write_bpp, read_aspect, read_size, read_bpp) = match write_plane {
@@ -687,9 +693,10 @@ async fn check_write_aspect_leaves_other_uninit(
 ) {
     let texture = ctx.device.create_texture(&TextureDescriptor {
         label: Some("aspect-init test"),
+        // Must match the full-plane / full-aspect size used by the callers.
         size: Extent3d {
             width: 256,
-            height: 256,
+            height: 192,
             depth_or_array_layers: 1,
         },
         mip_level_count: 1,


### PR DESCRIPTION
**Connections**
* Related to https://github.com/gfx-rs/wgpu/pull/9302

**Summary**
Use non-square asymmetric textures in tests to catch bugs like the one in #9302. No bugs were caught.

**Description**

Many GPU tests allocate square textures (`width == height`). A square texture hides bugs: code that swaps width and height, or that confuses `u`/`v` texture coordinates, still produces a passing test because the two dimensions are interchangeable and the contents are often symmetric.

This PR converts the coordinate-sensitive tests — those that write known data, copy regions, render, or sample and then assert on per-coordinate values — to use non-square textures. Where a test asserts on texel *contents*, the contents are also made asymmetric under transpose, horizontal mirror, and vertical mirror, so a row/column or `u`/`v` mix-up changes the bytes and fails the assertion. The most notable content fix is `planar_texture`'s plane-copy test, whose old `i as u8` pattern aliased every row identically (vertically symmetric); it now depends on both axes.

Tests converted:

- `write_texture`: 256×256 → 256×320 (SUBSET_2D/3D, NO_OOB)
- `regression/issue_6827`: 4×4×4 → 4×5×6 (every axis distinct)
- `clip_distances`: 256×256 → 256×320, per-pixel asserts recomputed
- `planar_texture`: 256×256 → 256×320; plane-copy content now depends on both `x` and `y`
- `zero_init`: 256×256 → 256×320 (and half-res planes 128×160)

Dimensions were chosen to keep all existing alignment requirements satisfied: `width` stays a multiple of `COPY_BYTES_PER_ROW_ALIGNMENT` (256) so `bytes_per_row` remains aligned for `copy_texture_to_buffer`, and NV12/P010 textures keep even dimensions (chroma is half-resolution).

`height > width` is deliberate: a backend that mistakenly sizes a texture's height from its width (the exact bug fixed in #9302, where GLES `create_texture` used `desc.size.width` for the height) then under-allocates, so the full-extent readback or render overruns the real storage and the test fails. With `height < width` such a backend would over-allocate and every in-bounds access would still return correct data, hiding the bug — which is why the square tests never caught #9302.

Tests that are not coordinate-sensitive (lifecycle, OOM, bounds-validation, 1×1, mip-array, sampler-filtering) were intentionally left unchanged.

**Testing**

Test-only change. `cargo check`, `cargo clippy`, and `cargo fmt` pass for the `wgpu-gpu` test target. The converted tests retain their original assertions, recomputed for the new dimensions (e.g. the `clip_distances` per-pixel checks were recomputed from the shader's `y_ndc >= |x_ndc|` fill region). The full GPU test suite should be run on CI across backends — in particular on a GL backend, where the `height > width` choice is what exercises the #9302 regression.

**Squash or Rebase?**

Single commit; ready to rebase onto `trunk` as it stands.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally. <!-- N/A: test-only change -->
- [x] Validation and feature gates are in place to confine behavioral changes. <!-- N/A: no behavioral change -->
- [x] Tests demonstrate the validation and altered logic works.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- N/A: no user-facing effect -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
