### PR TITLE
Fix required immediate slots calculation and panics when slots overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Bottom level categories:
 #### General
 
 - Zero-initialize padding (if any) at the end of a buffer allocation. This was application-visible in rare cases on Vulkan when a shader read beyond the valid range of a vertex buffer. By @andyleiserson in [#9791](https://github.com/gfx-rs/wgpu/pull/9791).
-- Fix required immediate slots calculation and remove `naga::valid::FunctionInfo::immediate_slots_required`. By @beicause in [#9725](https://github.com/gfx-rs/wgpu/pull/9725).
+- Fix required immediate slots calculation and remove `naga::valid::FunctionInfo::immediate_slots_used`. By @beicause in [#9725](https://github.com/gfx-rs/wgpu/pull/9725).
 
 #### naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ Bottom level categories:
 #### General
 
 - Zero-initialize padding (if any) at the end of a buffer allocation. This was application-visible in rare cases on Vulkan when a shader read beyond the valid range of a vertex buffer. By @andyleiserson in [#9791](https://github.com/gfx-rs/wgpu/pull/9791).
+- Fix required immediate slots calculation and remove `naga::valid::FunctionInfo::immediate_slots_required`. By @beicause in [#9725](https://github.com/gfx-rs/wgpu/pull/9725).
+
+#### naga
+
+- Fix panics when shader `var<immediate>` size is larger than 256 bytes. By @beicause in [#9725](https://github.com/gfx-rs/wgpu/pull/9725).
 
 #### GLES
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -197,10 +197,7 @@ webgpu:api,validation,encoding,encoder_state:*
 webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:*
 // On dx12, Error: Unexpected internal error occurred: undefined
 // https://github.com/gfx-rs/wgpu/issues/8556
-fails-if(dx12) webgpu:api,validation,encoding,programmable,pipeline_immediate:overprovisioned_immediate_data:*
-fails-if(dx12) webgpu:api,validation,encoding,programmable,pipeline_immediate:render_bundle_execution_state_invalidation:*
-webgpu:api,validation,encoding,programmable,pipeline_immediate:required_slots_set:*
-fails-if(dx12) webgpu:api,validation,encoding,programmable,pipeline_immediate:unused_variable:*
+fails-if(dx12) webgpu:api,validation,encoding,programmable,pipeline_immediate:*
 webgpu:api,validation,encoding,queries,begin_end:nesting:*
 webgpu:api,validation,encoding,queries,begin_end:occlusion_query,*
 webgpu:api,validation,encoding,queries,general:occlusion_query,*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -199,9 +199,7 @@ webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:*
 // https://github.com/gfx-rs/wgpu/issues/8556
 fails-if(dx12) webgpu:api,validation,encoding,programmable,pipeline_immediate:overprovisioned_immediate_data:*
 fails-if(dx12) webgpu:api,validation,encoding,programmable,pipeline_immediate:render_bundle_execution_state_invalidation:*
-//FAIL: webgpu:api,validation,encoding,programmable,pipeline_immediate:required_slots_set:*
-// Naga `immediate_slots_required` is not quite correct.
-// https://github.com/gfx-rs/wgpu/issues/9724
+webgpu:api,validation,encoding,programmable,pipeline_immediate:required_slots_set:*
 fails-if(dx12) webgpu:api,validation,encoding,programmable,pipeline_immediate:unused_variable:*
 webgpu:api,validation,encoding,queries,begin_end:nesting:*
 webgpu:api,validation,encoding,queries,begin_end:occlusion_query,*

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -8,9 +8,7 @@
 use alloc::{boxed::Box, vec};
 use core::ops;
 
-use super::{
-    ExpressionError, FunctionError, ImmediateSlots, ModuleInfo, ShaderStages, ValidationFlags,
-};
+use super::{ExpressionError, FunctionError, ModuleInfo, ShaderStages, ValidationFlags};
 use crate::diagnostic_filter::{DiagnosticFilterNode, StandardFilterableTriggeringRule};
 use crate::span::{AddSpan as _, WithSpan};
 use crate::{
@@ -304,10 +302,6 @@ pub struct FunctionInfo {
     /// See [`DiagnosticFilterNode`] for details on how the tree is represented and used in
     /// validation.
     diagnostic_filter_leaf: Option<Handle<DiagnosticFilterNode>>,
-
-    /// A bitmask, tracking which 4-byte slots this function (possibly transitively) reads.
-    /// Used to determine the minimum set of slots that must be written via `set_immediates`.
-    pub immediate_slots_used: ImmediateSlots,
 }
 
 impl FunctionInfo {
@@ -503,7 +497,6 @@ impl FunctionInfo {
         for (mine, other) in self.global_uses.iter_mut().zip(callee.global_uses.iter()) {
             *mine |= *other;
         }
-        self.immediate_slots_used |= callee.immediate_slots_used;
 
         Ok(FunctionUniformity {
             result: callee.uniformity.clone(),
@@ -681,18 +674,6 @@ impl FunctionInfo {
             },
             E::Load { pointer } => {
                 let non_uniform_result = self.add_ref(pointer);
-                // Track which immediate slots this load touches.
-                if let Some(global) = self.expressions[pointer.index()].assignable_global {
-                    if resolve_context.global_vars[global].space == crate::AddressSpace::Immediate {
-                        self.immediate_slots_used |= ImmediateSlots::for_pointer(
-                            pointer,
-                            global,
-                            expression_arena,
-                            resolve_context.global_vars,
-                            resolve_context.types,
-                        );
-                    }
-                }
                 Uniformity {
                     non_uniform_result,
                     requirements: UniformityRequirements::empty(),
@@ -1268,7 +1249,6 @@ impl ModuleInfo {
             sampling: crate::FastHashSet::default(),
             dual_source_blending: false,
             diagnostic_filter_leaf: fun.diagnostic_filter_leaf,
-            immediate_slots_used: ImmediateSlots::default(),
         };
         let resolve_context =
             ResolveContext::with_locals(module, &fun.local_variables, &fun.arguments);
@@ -1404,7 +1384,6 @@ fn uniform_control_flow() {
         sampling: crate::FastHashSet::default(),
         dual_source_blending: false,
         diagnostic_filter_leaf: None,
-        immediate_slots_used: ImmediateSlots::default(),
     };
     let resolve_context = ResolveContext {
         constants: &Arena::new(),

--- a/naga/src/valid/immediates.rs
+++ b/naga/src/valid/immediates.rs
@@ -12,6 +12,59 @@ pub struct ImmediateSlotsOverflowError(pub u64);
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub struct ImmediateSlots(u64);
 
+#[derive(Clone, Copy, Debug)]
+pub enum ImmediateUsage {
+    Valid { slots: ImmediateSlots, size: u32 },
+    // Used when a shader's immediate data type exceeds the maximum of 256 bytes and cannot
+    // be represented in the `ImmediateSlots` bitmask.
+    Invalid { size: u32 },
+}
+
+impl Default for ImmediateUsage {
+    fn default() -> Self {
+        ImmediateUsage::Valid {
+            slots: ImmediateSlots::default(),
+            size: 0,
+        }
+    }
+}
+
+impl ImmediateUsage {
+    pub const fn size(&self) -> u32 {
+        match *self {
+            ImmediateUsage::Valid { size, .. } => size,
+            ImmediateUsage::Invalid { size } => size,
+        }
+    }
+
+    pub fn from_type(
+        ty: &crate::TypeInner,
+        types: &crate::UniqueArena<crate::Type>,
+        gctx: crate::proc::GlobalCtx,
+    ) -> Self {
+        let size = ty.size(gctx);
+        ImmediateSlots::from_type(ty, types, gctx)
+            .map(|slots| Self::Valid { slots, size })
+            .unwrap_or(Self::Invalid { size })
+    }
+
+    pub fn merge(&self, other: &ImmediateUsage) -> Self {
+        let size = self.size().max(other.size());
+        match (*self, *other) {
+            (
+                ImmediateUsage::Valid { slots, .. },
+                ImmediateUsage::Valid {
+                    slots: other_slots, ..
+                },
+            ) => Self::Valid {
+                slots: slots | other_slots,
+                size,
+            },
+            _ => Self::Invalid { size },
+        }
+    }
+}
+
 impl ImmediateSlots {
     pub const fn from_raw(raw: u64) -> Self {
         Self(raw)

--- a/naga/src/valid/immediates.rs
+++ b/naga/src/valid/immediates.rs
@@ -1,10 +1,15 @@
-use core::{fmt, ops};
+use core::{
+    fmt::{self, Debug},
+    ops,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("Immediate size {0} overflows the bitmask")]
+pub struct ImmediateSlotsOverflowError(pub u64);
 
 /// A bitmask, tracking which 4-byte slots have been written via `set_immediates`.
 /// Bit N corresponds to bytes [N*4 .. N*4+4).
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub struct ImmediateSlots(u64);
 
 impl ImmediateSlots {
@@ -13,23 +18,35 @@ impl ImmediateSlots {
     }
 
     /// Compute the bitmask for a byte range [offset .. offset + size_bytes).
-    pub const fn from_range(offset: u32, size_bytes: u32) -> Self {
+    pub const fn from_range(
+        offset: u32,
+        size_bytes: u32,
+    ) -> Result<Self, ImmediateSlotsOverflowError> {
+        let Some(end) = offset.checked_add(size_bytes) else {
+            return Err(ImmediateSlotsOverflowError(
+                offset as u64 + size_bytes as u64,
+            ));
+        };
+        if end > u64::BITS * 4 {
+            return Err(ImmediateSlotsOverflowError(end as u64));
+        }
         if size_bytes == 0 {
-            return Self(0);
+            return Ok(Self(0));
         }
         let lo = offset / 4;
         let hi = (offset + size_bytes).div_ceil(4);
-        Self(u64::MAX << lo & u64::MAX >> (64 - hi))
+        Ok(Self(u64::MAX << lo & u64::MAX >> (64 - hi)))
     }
 
     /// Compute the slots occupied by a type at a given byte offset,
     /// excluding padding between struct members.
+    /// Return `None` if the bitmask overflows.
     pub fn from_type(
         ty: &crate::TypeInner,
         offset: u32,
         types: &crate::UniqueArena<crate::Type>,
         gctx: crate::proc::GlobalCtx,
-    ) -> Self {
+    ) -> Result<Self, ImmediateSlotsOverflowError> {
         // <https://www.w3.org/TR/WGSL/#accessible-bytes>
         match *ty {
             crate::TypeInner::Matrix {
@@ -40,17 +57,17 @@ impl ImmediateSlots {
                 let mut slots = Self::default();
                 let stride = crate::proc::Alignment::from(rows) * scalar.width as u32;
                 for col in 0..u32::from(columns) {
-                    slots |= Self::from_range(col * stride, u32::from(rows) * scalar.width as u32);
+                    slots |= Self::from_range(col * stride, u32::from(rows) * scalar.width as u32)?;
                 }
-                slots
+                Ok(slots)
             }
             crate::TypeInner::Struct { ref members, .. } => {
                 let mut slots = Self::default();
                 for member in members {
                     let member_ty = &types[member.ty].inner;
-                    slots |= Self::from_type(member_ty, offset + member.offset, types, gctx);
+                    slots |= Self::from_type(member_ty, offset + member.offset, types, gctx)?;
                 }
-                slots
+                Ok(slots)
             }
             _ => Self::from_range(offset, ty.size(gctx)),
         }
@@ -64,46 +81,6 @@ impl ImmediateSlots {
     /// Returns the bits in `self` that are not set in `other`.
     pub const fn difference(self, other: Self) -> Self {
         Self(self.0 & !other.0)
-    }
-
-    /// Compute the immediate slot bitmask for a pointer expression that
-    /// refers to (part of) an immediate global variable.
-    ///
-    /// `global` is the handle of the immediate global variable that this
-    /// pointer derives from (obtained from `assignable_global`).
-    pub(crate) fn for_pointer(
-        pointer: crate::arena::Handle<crate::Expression>,
-        global: crate::arena::Handle<crate::GlobalVariable>,
-        expression_arena: &crate::Arena<crate::Expression>,
-        global_vars: &crate::Arena<crate::GlobalVariable>,
-        types: &crate::UniqueArena<crate::Type>,
-    ) -> Self {
-        use crate::Expression as E;
-        use crate::TypeInner;
-
-        let gctx = crate::proc::GlobalCtx {
-            types,
-            constants: &crate::Arena::new(),
-            overrides: &crate::Arena::new(),
-            global_expressions: &crate::Arena::new(),
-        };
-
-        let global_ty = &types[global_vars[global].ty].inner;
-
-        match expression_arena[pointer] {
-            E::GlobalVariable(_) => Self::from_type(global_ty, 0, types, gctx),
-            E::AccessIndex { base, index } => {
-                if let E::GlobalVariable(_) = expression_arena[base] {
-                    if let TypeInner::Struct { ref members, .. } = *global_ty {
-                        let member = &members[index as usize];
-                        let member_ty = &types[member.ty].inner;
-                        return Self::from_type(member_ty, member.offset, types, gctx);
-                    }
-                }
-                Self::from_type(global_ty, 0, types, gctx)
-            }
-            _ => Self::from_type(global_ty, 0, types, gctx),
-        }
     }
 }
 
@@ -147,22 +124,30 @@ impl fmt::Display for ImmediateSlots {
     }
 }
 
+impl Debug for ImmediateSlots {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::valid::ImmediateSlotsOverflowError;
+
     use super::ImmediateSlots;
 
     #[test]
     fn range_single() {
         assert_eq!(
-            ImmediateSlots::from_range(0, 4),
+            ImmediateSlots::from_range(0, 4).unwrap(),
             ImmediateSlots::from_raw(0b1)
         );
         assert_eq!(
-            ImmediateSlots::from_range(4, 4),
+            ImmediateSlots::from_range(4, 4).unwrap(),
             ImmediateSlots::from_raw(0b10)
         );
         assert_eq!(
-            ImmediateSlots::from_range(8, 4),
+            ImmediateSlots::from_range(8, 4).unwrap(),
             ImmediateSlots::from_raw(0b100)
         );
     }
@@ -170,11 +155,11 @@ mod tests {
     #[test]
     fn range_vec4() {
         assert_eq!(
-            ImmediateSlots::from_range(0, 16),
+            ImmediateSlots::from_range(0, 16).unwrap(),
             ImmediateSlots::from_raw(0b1111)
         );
         assert_eq!(
-            ImmediateSlots::from_range(16, 16),
+            ImmediateSlots::from_range(16, 16).unwrap(),
             ImmediateSlots::from_raw(0b1111_0000)
         );
     }
@@ -182,9 +167,36 @@ mod tests {
     #[test]
     fn range_full_256() {
         assert_eq!(
-            ImmediateSlots::from_range(0, 256),
+            ImmediateSlots::from_range(0, 256).unwrap(),
             ImmediateSlots::from_raw(u64::MAX)
         );
+    }
+
+    #[test]
+    fn range_overflow() {
+        assert_eq!(
+            ImmediateSlots::from_range(0, 257),
+            Err(ImmediateSlotsOverflowError(257))
+        );
+    }
+
+    #[test]
+    fn from_type_overflow() {
+        let module = crate::front::wgsl::parse_str(
+            "struct S { \
+            e64: mat4x4<f32>, \
+            e128: mat4x4<f32>, \
+            e192: mat4x4<f32>, \
+            e256: mat4x4<f32>, \
+            e260: f32\
+            }",
+        )
+        .unwrap();
+        let struct_ty = (module.types.iter().map(|ty| ty.1))
+            .find(|ty| ty.name.as_deref() == Some("S"))
+            .unwrap();
+        let slots = ImmediateSlots::from_type(&struct_ty.inner, 0, &module.types, module.to_ctx());
+        assert_eq!(slots, Err(ImmediateSlotsOverflowError(260)));
     }
 
     #[test]
@@ -193,7 +205,8 @@ mod tests {
         let struct_ty = (module.types.iter().map(|ty| ty.1))
             .find(|ty| ty.name.as_deref() == Some("S"))
             .unwrap();
-        let slots = ImmediateSlots::from_type(&struct_ty.inner, 0, &module.types, module.to_ctx());
+        let slots =
+            ImmediateSlots::from_type(&struct_ty.inner, 0, &module.types, module.to_ctx()).unwrap();
         assert_eq!(slots, ImmediateSlots::from_raw(0b1111_0001));
     }
 
@@ -203,18 +216,19 @@ mod tests {
         let struct_ty = (module.types.iter().map(|ty| ty.1))
             .find(|ty| ty.name.as_deref() == Some("S"))
             .unwrap();
-        let slots = ImmediateSlots::from_type(&struct_ty.inner, 0, &module.types, module.to_ctx());
+        let slots =
+            ImmediateSlots::from_type(&struct_ty.inner, 0, &module.types, module.to_ctx()).unwrap();
         assert_eq!(slots, ImmediateSlots::from_raw(0b0111_0111_0111));
     }
 
     #[test]
     fn range_unaligned() {
         assert_eq!(
-            ImmediateSlots::from_range(0, 3),
+            ImmediateSlots::from_range(0, 3).unwrap(),
             ImmediateSlots::from_raw(0b1)
         );
         assert_eq!(
-            ImmediateSlots::from_range(0, 5),
+            ImmediateSlots::from_range(0, 5).unwrap(),
             ImmediateSlots::from_raw(0b11)
         );
     }
@@ -224,16 +238,16 @@ mod tests {
         let required = ImmediateSlots::from_raw(0b1111_0001);
         let mut set = ImmediateSlots::default();
         assert!(!set.contains(required));
-        set |= ImmediateSlots::from_range(0, 4);
+        set |= ImmediateSlots::from_range(0, 4).unwrap();
         assert!(!set.contains(required));
-        set |= ImmediateSlots::from_range(16, 16);
+        set |= ImmediateSlots::from_range(16, 16).unwrap();
         assert!(set.contains(required));
     }
 
     #[test]
     fn difference() {
         let required = ImmediateSlots::from_raw(0b1111_0001);
-        let set = ImmediateSlots::from_range(0, 4);
+        let set = ImmediateSlots::from_range(0, 4).unwrap();
         assert_eq!(
             required.difference(set),
             ImmediateSlots::from_raw(0b1111_0000)

--- a/naga/src/valid/immediates.rs
+++ b/naga/src/valid/immediates.rs
@@ -38,39 +38,49 @@ impl ImmediateSlots {
         Ok(Self(u64::MAX << lo & u64::MAX >> (64 - hi)))
     }
 
-    /// Compute the slots occupied by a type at a given byte offset,
-    /// excluding padding between struct members.
-    /// Return `None` if the bitmask overflows.
+    /// Compute the slots occupied by a type,
+    /// excluding padding between matrix columns or struct members.
     pub fn from_type(
         ty: &crate::TypeInner,
-        offset: u32,
         types: &crate::UniqueArena<crate::Type>,
         gctx: crate::proc::GlobalCtx,
     ) -> Result<Self, ImmediateSlotsOverflowError> {
-        // <https://www.w3.org/TR/WGSL/#accessible-bytes>
-        match *ty {
-            crate::TypeInner::Matrix {
-                columns,
-                rows,
-                scalar,
-            } => {
-                let mut slots = Self::default();
-                let stride = crate::proc::Alignment::from(rows) * scalar.width as u32;
-                for col in 0..u32::from(columns) {
-                    slots |= Self::from_range(col * stride, u32::from(rows) * scalar.width as u32)?;
+        fn from_type_recursive(
+            ty: &crate::TypeInner,
+            offset: u32,
+            types: &crate::UniqueArena<crate::Type>,
+            gctx: crate::proc::GlobalCtx,
+        ) -> Result<ImmediateSlots, ImmediateSlotsOverflowError> {
+            // <https://www.w3.org/TR/WGSL/#accessible-bytes>
+            match *ty {
+                crate::TypeInner::Matrix {
+                    columns,
+                    rows,
+                    scalar,
+                } => {
+                    let mut slots = ImmediateSlots::default();
+                    let stride = crate::proc::Alignment::from(rows) * u32::from(scalar.width);
+                    for col in 0..u32::from(columns) {
+                        slots |= ImmediateSlots::from_range(
+                            offset + col * stride,
+                            u32::from(rows) * u32::from(scalar.width),
+                        )?;
+                    }
+                    Ok(slots)
                 }
-                Ok(slots)
-            }
-            crate::TypeInner::Struct { ref members, .. } => {
-                let mut slots = Self::default();
-                for member in members {
-                    let member_ty = &types[member.ty].inner;
-                    slots |= Self::from_type(member_ty, offset + member.offset, types, gctx)?;
+                crate::TypeInner::Struct { ref members, .. } => {
+                    let mut slots = ImmediateSlots::default();
+                    for member in members {
+                        let member_ty = &types[member.ty].inner;
+                        slots |=
+                            from_type_recursive(member_ty, offset + member.offset, types, gctx)?;
+                    }
+                    Ok(slots)
                 }
-                Ok(slots)
+                _ => ImmediateSlots::from_range(offset, ty.size(gctx)),
             }
-            _ => Self::from_range(offset, ty.size(gctx)),
         }
+        from_type_recursive(ty, 0, types, gctx)
     }
 
     /// Returns true if `self` contains all bits in `other`.
@@ -195,7 +205,7 @@ mod tests {
         let struct_ty = (module.types.iter().map(|ty| ty.1))
             .find(|ty| ty.name.as_deref() == Some("S"))
             .unwrap();
-        let slots = ImmediateSlots::from_type(&struct_ty.inner, 0, &module.types, module.to_ctx());
+        let slots = ImmediateSlots::from_type(&struct_ty.inner, &module.types, module.to_ctx());
         assert_eq!(slots, Err(ImmediateSlotsOverflowError(260)));
     }
 
@@ -206,7 +216,7 @@ mod tests {
             .find(|ty| ty.name.as_deref() == Some("S"))
             .unwrap();
         let slots =
-            ImmediateSlots::from_type(&struct_ty.inner, 0, &module.types, module.to_ctx()).unwrap();
+            ImmediateSlots::from_type(&struct_ty.inner, &module.types, module.to_ctx()).unwrap();
         assert_eq!(slots, ImmediateSlots::from_raw(0b1111_0001));
     }
 
@@ -217,8 +227,17 @@ mod tests {
             .find(|ty| ty.name.as_deref() == Some("S"))
             .unwrap();
         let slots =
-            ImmediateSlots::from_type(&struct_ty.inner, 0, &module.types, module.to_ctx()).unwrap();
+            ImmediateSlots::from_type(&struct_ty.inner, &module.types, module.to_ctx()).unwrap();
         assert_eq!(slots, ImmediateSlots::from_raw(0b0111_0111_0111));
+
+        let module =
+            crate::front::wgsl::parse_str("struct S { f: f32, mat: mat2x2<f32> }").unwrap();
+        let struct_ty = (module.types.iter().map(|ty| ty.1))
+            .find(|ty| ty.name.as_deref() == Some("S"))
+            .unwrap();
+        let slots =
+            ImmediateSlots::from_type(&struct_ty.inner, &module.types, module.to_ctx()).unwrap();
+        assert_eq!(slots, ImmediateSlots::from_raw(0b11_11_01));
     }
 
     #[test]

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -31,7 +31,7 @@ pub use compose::ComposeError;
 pub use expression::{check_literal_value, LiteralError};
 pub use expression::{ConstExpressionError, ExpressionError};
 pub use function::{CallError, FunctionError, LocalVariableError, SubgroupError};
-pub use immediates::{ImmediateSlots, ImmediateSlotsOverflowError};
+pub use immediates::{ImmediateSlots, ImmediateSlotsOverflowError, ImmediateUsage};
 pub use interface::{EntryPointError, GlobalVariableError, VaryingError};
 pub use r#type::{Disalignment, ImmediateError, TypeError, TypeFlags, WidthError};
 

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -31,7 +31,7 @@ pub use compose::ComposeError;
 pub use expression::{check_literal_value, LiteralError};
 pub use expression::{ConstExpressionError, ExpressionError};
 pub use function::{CallError, FunctionError, LocalVariableError, SubgroupError};
-pub use immediates::ImmediateSlots;
+pub use immediates::{ImmediateSlots, ImmediateSlotsOverflowError};
 pub use interface::{EntryPointError, GlobalVariableError, VaryingError};
 pub use r#type::{Disalignment, ImmediateError, TypeError, TypeFlags, WidthError};
 

--- a/naga/tests/out/analysis/spv-shadow.info.ron
+++ b/naga/tests/out/analysis/spv-shadow.info.ron
@@ -413,7 +413,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -1592,7 +1591,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
     ],
     entry_points: [
@@ -1687,7 +1685,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
     ],
     const_expression_types: [

--- a/naga/tests/out/analysis/wgsl-access.info.ron
+++ b/naga/tests/out/analysis/wgsl-access.info.ron
@@ -1197,7 +1197,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2524,7 +2523,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2565,7 +2563,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2615,7 +2612,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2659,7 +2655,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2754,7 +2749,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2876,7 +2870,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2929,7 +2922,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -2985,7 +2977,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -3038,7 +3029,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -3094,7 +3084,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -3159,7 +3148,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -3233,7 +3221,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -3310,7 +3297,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -3411,7 +3397,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -3608,7 +3593,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
     ],
     entry_points: [
@@ -4306,7 +4290,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -4759,7 +4742,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -4830,7 +4812,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
     ],
     const_expression_types: [

--- a/naga/tests/out/analysis/wgsl-collatz.info.ron
+++ b/naga/tests/out/analysis/wgsl-collatz.info.ron
@@ -275,7 +275,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
     ],
     entry_points: [
@@ -431,7 +430,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
     ],
     const_expression_types: [],

--- a/naga/tests/out/analysis/wgsl-overrides.info.ron
+++ b/naga/tests/out/analysis/wgsl-overrides.info.ron
@@ -201,7 +201,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
     ],
     const_expression_types: [

--- a/naga/tests/out/analysis/wgsl-push-constants.info.ron
+++ b/naga/tests/out/analysis/wgsl-push-constants.info.ron
@@ -155,7 +155,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (1),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -235,7 +234,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (240),
         ),
     ],
     const_expression_types: [],

--- a/naga/tests/out/analysis/wgsl-storage-textures.info.ron
+++ b/naga/tests/out/analysis/wgsl-storage-textures.info.ron
@@ -184,7 +184,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
         (
             flags: ("EXPRESSIONS | BLOCKS | CONTROL_FLOW_UNIFORMITY | STRUCT_LAYOUTS | CONSTANTS | BINDINGS"),
@@ -397,7 +396,6 @@
             sampling: [],
             dual_source_blending: false,
             diagnostic_filter_leaf: None,
-            immediate_slots_used: (0),
         ),
     ],
     const_expression_types: [],

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -76,7 +76,7 @@ impl ImmediateState {
             .copy_from_slice(data);
         self.immediate_slots_set |=
             naga::valid::ImmediateSlots::from_range(offset_bytes, size_bytes.try_into().unwrap())
-                .unwrap();
+                .expect("maxImmediateSize should not exceed 256");
         self.immediates_dirty = true;
 
         Ok(())

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -75,7 +75,8 @@ impl ImmediateState {
         self.immediates[offset_bytes_usize / size_per_elem..end_offset_bytes / size_per_elem]
             .copy_from_slice(data);
         self.immediate_slots_set |=
-            naga::valid::ImmediateSlots::from_range(offset_bytes, size_bytes.try_into().unwrap());
+            naga::valid::ImmediateSlots::from_range(offset_bytes, size_bytes.try_into().unwrap())
+                .unwrap();
         self.immediates_dirty = true;
 
         Ok(())

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4610,8 +4610,16 @@ impl Device {
         let pipeline_layout = match binding_layout_source {
             validation::BindingLayoutSource::Provided(pipeline_layout) => pipeline_layout,
             validation::BindingLayoutSource::Derived(entries) => {
-                self.create_derived_pipeline_layout(entries, io.immediate_size_required)?
+                self.create_derived_pipeline_layout(entries, io.immediates.size())?
             }
+        };
+
+        let naga::valid::ImmediateUsage::Valid {
+            slots: immediate_slots_required,
+            size: _,
+        } = io.immediates
+        else {
+            unreachable!("Immediates exceeding maxImmediateSize should have been rejected");
         };
 
         let late_sized_buffer_groups =
@@ -4666,7 +4674,7 @@ impl Device {
             }),
             device: self.clone(),
             late_sized_buffer_groups,
-            immediate_slots_required: io.immediate_slots_required.unwrap(),
+            immediate_slots_required,
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.compute_pipelines.clone()),
         };
@@ -5409,8 +5417,16 @@ impl Device {
         let pipeline_layout = match binding_layout_source {
             validation::BindingLayoutSource::Provided(pipeline_layout) => pipeline_layout,
             validation::BindingLayoutSource::Derived(entries) => {
-                self.create_derived_pipeline_layout(entries, io.immediate_size_required)?
+                self.create_derived_pipeline_layout(entries, io.immediates.size())?
             }
+        };
+
+        let naga::valid::ImmediateUsage::Valid {
+            slots: immediate_slots_required,
+            size: _,
+        } = io.immediates
+        else {
+            unreachable!("Immediates exceeding maxImmediateSize should have been rejected");
         };
 
         if let pipeline::RenderPipelineVertexProcessor::Vertex(ref vertex) = desc.vertex {
@@ -5590,7 +5606,7 @@ impl Device {
             strip_index_format: desc.primitive.strip_index_format,
             vertex_steps,
             late_sized_buffer_groups,
-            immediate_slots_required: io.immediate_slots_required.unwrap(),
+            immediate_slots_required,
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.render_pipelines.clone()),
             is_mesh,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4666,7 +4666,7 @@ impl Device {
             }),
             device: self.clone(),
             late_sized_buffer_groups,
-            immediate_slots_required: io.immediate_slots_required,
+            immediate_slots_required: io.immediate_slots_required.unwrap(),
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.compute_pipelines.clone()),
         };
@@ -5590,7 +5590,7 @@ impl Device {
             strip_index_format: desc.primitive.strip_index_format,
             vertex_steps,
             late_sized_buffer_groups,
-            immediate_slots_required: io.immediate_slots_required,
+            immediate_slots_required: io.immediate_slots_required.unwrap(),
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.render_pipelines.clone()),
             is_mesh,

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -281,7 +281,7 @@ struct EntryPointMeshInfo {
     primitive_topology: wgt::PrimitiveTopology,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct EntryPoint {
     inputs: Vec<Varying>,
     outputs: Vec<Varying>,
@@ -293,26 +293,7 @@ struct EntryPoint {
     dual_source_blending: bool,
     task_payload_size: Option<u32>,
     mesh_info: Option<EntryPointMeshInfo>,
-    immediate_slots: Result<naga::valid::ImmediateSlots, naga::valid::ImmediateSlotsOverflowError>,
-    immediate_size: u32,
-}
-
-impl Default for EntryPoint {
-    fn default() -> Self {
-        Self {
-            inputs: Default::default(),
-            outputs: Default::default(),
-            resources: Default::default(),
-            spec_constants: Default::default(),
-            sampling_pairs: Default::default(),
-            workgroup_size: Default::default(),
-            dual_source_blending: Default::default(),
-            task_payload_size: Default::default(),
-            mesh_info: Default::default(),
-            immediate_slots: Ok(Default::default()),
-            immediate_size: Default::default(),
-        }
-    }
+    immediate_usage: naga::valid::ImmediateUsage,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]
@@ -1088,7 +1069,7 @@ impl BindingLayoutSource {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct StageIo {
     pub varyings: FastHashMap<wgt::ShaderLocation, InterfaceVar>,
     /// This must match between mesh & task shaders
@@ -1099,21 +1080,7 @@ pub struct StageIo {
     ///
     /// This is Some if it was a mesh shader.
     pub primitive_index: Option<bool>,
-    pub immediate_slots_required:
-        Result<naga::valid::ImmediateSlots, naga::valid::ImmediateSlotsOverflowError>,
-    pub immediate_size_required: u32,
-}
-
-impl Default for StageIo {
-    fn default() -> Self {
-        Self {
-            varyings: Default::default(),
-            task_payload_size: Default::default(),
-            primitive_index: Default::default(),
-            immediate_slots_required: Ok(Default::default()),
-            immediate_size_required: Default::default(),
-        }
-    }
+    pub immediates: naga::valid::ImmediateUsage,
 }
 
 impl Interface {
@@ -1343,20 +1310,16 @@ impl Interface {
                 .filter(|&(_, var)| var.space == naga::AddressSpace::Immediate)
                 .map(|(handle, _)| handle)
                 .filter(|&handle| !func_info[handle].is_empty());
-            (ep.immediate_size, ep.immediate_slots) =
-                if let Some(immediate) = used_immediates.next() {
-                    let ty = &module.types[module.global_variables[immediate].ty];
-                    (
-                        ty.inner.size(module.to_ctx()),
-                        naga::valid::ImmediateSlots::from_type(
-                            &ty.inner,
-                            &module.types,
-                            module.to_ctx(),
-                        ),
+            ep.immediate_usage = used_immediates
+                .next()
+                .map(|handle| {
+                    naga::valid::ImmediateUsage::from_type(
+                        &module.types[module.global_variables[handle].ty].inner,
+                        &module.types,
+                        module.to_ctx(),
                     )
-                } else {
-                    (0, Ok(Default::default()))
-                };
+                })
+                .unwrap_or_default();
             assert!(used_immediates.next().is_none());
 
             if let Some(task_payload) = entry_point.task_payload {
@@ -1403,19 +1366,15 @@ impl Interface {
         }
     }
 
-    fn immediate_size_and_slots_required(
+    fn immediate_usage(
         &self,
         stage: naga::ShaderStage,
         entry_point_name: &str,
-    ) -> (
-        u32,
-        Result<naga::valid::ImmediateSlots, naga::valid::ImmediateSlotsOverflowError>,
-    ) {
+    ) -> naga::valid::ImmediateUsage {
         self.entry_points
             .get(&EntryPointKeyRef(stage, entry_point_name))
-            .map_or((0, Ok(Default::default())), |ep| {
-                (ep.immediate_size, ep.immediate_slots)
-            })
+            .map(|ep| ep.immediate_usage)
+            .unwrap_or_default()
     }
 
     pub fn finalize_entry_point_name(
@@ -1957,21 +1916,16 @@ impl Interface {
             })
             .collect();
 
-        let (immediate_size_required, immediate_slots_required) =
-            self.immediate_size_and_slots_required(shader_stage.to_naga(), entry_point_name);
-        let immediate_slots_required = immediate_slots_required.and_then(|slots| {
-            inputs
-                .immediate_slots_required
-                .map(|input_slots| slots | input_slots)
-        });
-        let immediate_size_required = immediate_size_required.max(inputs.immediate_size_required);
+        let immediate_usage = self
+            .immediate_usage(shader_stage.to_naga(), entry_point_name)
+            .merge(&inputs.immediates);
 
         // Check pipeline layout immediate size
         if let BindingLayoutSource::Provided(pipeline_layout) = layouts {
-            if pipeline_layout.immediate_size < immediate_size_required {
+            if pipeline_layout.immediate_size < immediate_usage.size() {
                 return Err(StageError::LayoutImmediateSize {
                     layout: pipeline_layout.immediate_size,
-                    required: immediate_size_required,
+                    required: immediate_usage.size(),
                 });
             }
         }
@@ -1984,8 +1938,7 @@ impl Interface {
             } else {
                 None
             },
-            immediate_slots_required,
-            immediate_size_required,
+            immediates: immediate_usage,
         })
     }
 }

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -281,7 +281,7 @@ struct EntryPointMeshInfo {
     primitive_topology: wgt::PrimitiveTopology,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct EntryPoint {
     inputs: Vec<Varying>,
     outputs: Vec<Varying>,
@@ -293,8 +293,26 @@ struct EntryPoint {
     dual_source_blending: bool,
     task_payload_size: Option<u32>,
     mesh_info: Option<EntryPointMeshInfo>,
-    immediate_slots: naga::valid::ImmediateSlots,
+    immediate_slots: Result<naga::valid::ImmediateSlots, naga::valid::ImmediateSlotsOverflowError>,
     immediate_size: u32,
+}
+
+impl Default for EntryPoint {
+    fn default() -> Self {
+        Self {
+            inputs: Default::default(),
+            outputs: Default::default(),
+            resources: Default::default(),
+            spec_constants: Default::default(),
+            sampling_pairs: Default::default(),
+            workgroup_size: Default::default(),
+            dual_source_blending: Default::default(),
+            task_payload_size: Default::default(),
+            mesh_info: Default::default(),
+            immediate_slots: Ok(Default::default()),
+            immediate_size: Default::default(),
+        }
+    }
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]
@@ -1070,7 +1088,7 @@ impl BindingLayoutSource {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct StageIo {
     pub varyings: FastHashMap<wgt::ShaderLocation, InterfaceVar>,
     /// This must match between mesh & task shaders
@@ -1081,8 +1099,21 @@ pub struct StageIo {
     ///
     /// This is Some if it was a mesh shader.
     pub primitive_index: Option<bool>,
-    pub immediate_slots_required: naga::valid::ImmediateSlots,
+    pub immediate_slots_required:
+        Result<naga::valid::ImmediateSlots, naga::valid::ImmediateSlotsOverflowError>,
     pub immediate_size_required: u32,
+}
+
+impl Default for StageIo {
+    fn default() -> Self {
+        Self {
+            varyings: Default::default(),
+            task_payload_size: Default::default(),
+            primitive_index: Default::default(),
+            immediate_slots_required: Ok(Default::default()),
+            immediate_size_required: Default::default(),
+        }
+    }
 }
 
 impl Interface {
@@ -1303,7 +1334,6 @@ impl Interface {
             }
             ep.dual_source_blending = func_info.dual_source_blending;
             ep.workgroup_size = entry_point.workgroup_size;
-            ep.immediate_slots = func_info.immediate_slots_used;
 
             // Find the used immediates. Naga should have validated that
             // at most one immediate is used by the entry point.
@@ -1313,12 +1343,21 @@ impl Interface {
                 .filter(|&(_, var)| var.space == naga::AddressSpace::Immediate)
                 .map(|(handle, _)| handle)
                 .filter(|&handle| !func_info[handle].is_empty());
-            ep.immediate_size = if let Some(immediate) = used_immediates.next() {
-                let ty = &module.types[module.global_variables[immediate].ty];
-                ty.inner.size(module.to_ctx())
-            } else {
-                0
-            };
+            (ep.immediate_size, ep.immediate_slots) =
+                if let Some(immediate) = used_immediates.next() {
+                    let ty = &module.types[module.global_variables[immediate].ty];
+                    (
+                        ty.inner.size(module.to_ctx()),
+                        naga::valid::ImmediateSlots::from_type(
+                            &ty.inner,
+                            0,
+                            &module.types,
+                            module.to_ctx(),
+                        ),
+                    )
+                } else {
+                    (0, Ok(Default::default()))
+                };
             assert!(used_immediates.next().is_none());
 
             if let Some(task_payload) = entry_point.task_payload {
@@ -1369,10 +1408,13 @@ impl Interface {
         &self,
         stage: naga::ShaderStage,
         entry_point_name: &str,
-    ) -> (u32, naga::valid::ImmediateSlots) {
+    ) -> (
+        u32,
+        Result<naga::valid::ImmediateSlots, naga::valid::ImmediateSlotsOverflowError>,
+    ) {
         self.entry_points
             .get(&EntryPointKeyRef(stage, entry_point_name))
-            .map_or(Default::default(), |ep| {
+            .map_or((0, Ok(Default::default())), |ep| {
                 (ep.immediate_size, ep.immediate_slots)
             })
     }
@@ -1918,7 +1960,11 @@ impl Interface {
 
         let (immediate_size_required, immediate_slots_required) =
             self.immediate_size_and_slots_required(shader_stage.to_naga(), entry_point_name);
-        let immediate_slots_required = immediate_slots_required | inputs.immediate_slots_required;
+        let immediate_slots_required = immediate_slots_required.and_then(|slots| {
+            inputs
+                .immediate_slots_required
+                .map(|input_slots| slots | input_slots)
+        });
         let immediate_size_required = immediate_size_required.max(inputs.immediate_size_required);
 
         // Check pipeline layout immediate size

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1350,7 +1350,6 @@ impl Interface {
                         ty.inner.size(module.to_ctx()),
                         naga::valid::ImmediateSlots::from_type(
                             &ty.inner,
-                            0,
                             &module.types,
                             module.to_ctx(),
                         ),


### PR DESCRIPTION
**Connections**
Immediates issue: https://github.com/gfx-rs/wgpu/issues/8556

**Description**

1. Fixes https://github.com/gfx-rs/wgpu/issues/9724

2. Fixes panic when `var<immediate>` is larger than 256 bytes / the bitmask overflows.

**Testing**

For 1, test with CTS `webgpu:api,validation,encoding,programmable,pipeline_immediate:required_slots_set:*`
For 2, test with CTS `webgpu:api,validation,pipeline,immediates:*`.

**Squash or Rebase?**

Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
