### PR TITLE
fix(webgl): Add destination of `copy_external_image_to_texture` to `PendingWrites`

### DIFF
--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1259,6 +1259,8 @@ impl Queue {
             );
         }
 
+        pending_writes.insert_texture(&dst);
+
         Ok(())
     }
 


### PR DESCRIPTION
I noticed that `Queue::write_texture` [adds the destination to `PendingWrites`](https://github.com/gfx-rs/wgpu/blob/ed57d2e82ae64f4bdae0bc7f4b9bdd4be6ea2cc8/wgpu-core/src/device/queue.rs#L1059), but `Queue::copy_external_image_to_texture` (which is webgl-only) did not. Adding it to `PendingWrites` ensures it stays alive until the command executes (may not matter for webgl), and that the write is flushed if the buffer is mapped before the write is otherwise submitted. (_Edit: except that matters for buffers, not textures. So maybe this doesn't matter at all. But it still seems better to just record it in `PendingWrites` in case it does matter, now or in the future._)

**Testing**
Untested.

**Squash or Rebase?** Squash

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
