### PR TITLE
impl Debug for TextureBlitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Relaxed locking within `wgpu-core` to enable queue submission processing on one thread to proceed while another thread is blocked in a device poll. To facilitate this, `wgpu-hal` fences are now internally synchronized. By @Vecvec in [#9475](https://github.com/gfx-rs/wgpu/pull/9475).
 - `AdapterInfo::transient_saves_memory` now is `Option<bool>` instead of `bool`. It is `None` on web and `Some` on native platforms. By @beicause in [#9568](https://github.com/gfx-rs/wgpu/pull/9568).
 - BREAKING: `TextureUsages::TRANSIENT` is renamed to `TextureUsages::TRANSIENT_ATTACHMENT` and brought in line with WebGPU spec. Transient textures may now only be used with `LoadOp::Clear` or `LoadOp::DontCare` (if it is available) and `StoreOp::Discard`. By @beicause in [#9568](https://github.com/gfx-rs/wgpu/pull/9568).
+- Implement `Debug` for `TextureBlitter` and its builder. By @euclio in [#9370](https://github.com/gfx-rs/wgpu/pull/9730).
 
 #### Validation
 

--- a/wgpu/src/util/texture_blitter.rs
+++ b/wgpu/src/util/texture_blitter.rs
@@ -14,6 +14,7 @@ use crate::{
 
 /// A builder for the [`TextureBlitter`] utility.
 /// If you want the default [`TextureBlitter`] use [`TextureBlitter::new`] instead.
+#[derive(Debug)]
 pub struct TextureBlitterBuilder<'a> {
     device: &'a Device,
     format: TextureFormat,
@@ -148,6 +149,7 @@ impl<'a> TextureBlitterBuilder<'a> {
 /// - Textures are in incompatible formats.
 /// - Textures are of different sizes.
 /// - Your copy destination is the surface texture and does not have the `COPY_DST` usage.
+#[derive(Debug)]
 pub struct TextureBlitter {
     pipeline: RenderPipeline,
     bind_group_layout: BindGroupLayout,


### PR DESCRIPTION
**Description**

Derives `Debug` for `TextureBlitter` and its builder. This makes it easier for downstream structures to derive `Debug` as well.

It might make sense to enable `warn(missing_debug_implementations`) at the crate level to catch issues like this, but there are some structs that have a non-derivable implementation, and I noticed that there are otherwise no manual `Debug` implementations in the codebase.

**Testing**

N/A.

**Squash or Rebase?**

N/A

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
