### PR TITLE
Refactor `check_workgroup_sizes` into a new `struct WorkgroupSizeCheck`

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -121,8 +121,8 @@ use crate::{
     snatch::SnatchGuard,
     track::RenderBundleScope,
     validation::{
-        check_color_attachment_count, check_workgroup_sizes,
-        validate_color_attachment_bytes_per_sample,
+        check_color_attachment_count, validate_color_attachment_bytes_per_sample,
+        WorkgroupSizeCheck,
     },
     Label, LabelHelpers,
 };
@@ -912,13 +912,15 @@ fn draw_mesh_tasks(
         )
     };
 
-    let total_count = check_workgroup_sizes(
-        &[group_count_x, group_count_y, group_count_z],
-        &[groups_size_limit, groups_size_limit, groups_size_limit],
-        "max_task_mesh_workgroups_per_dimension",
-        max_groups,
-        "max_task_mesh_workgroup_total_count",
-    )
+    let total_count = WorkgroupSizeCheck {
+        sizes: &[group_count_x, group_count_y, group_count_z],
+        per_dimension_limits: &[groups_size_limit, groups_size_limit, groups_size_limit],
+        per_dimension_limits_desc: "max_task_mesh_workgroups_per_dimension",
+
+        total_limit: max_groups,
+        total_limit_desc: "max_task_mesh_workgroup_total_count",
+    }
+    .check_and_compute_total_invocations()
     .map_err(|err| RenderBundleErrorInner::Draw(err.into()))?;
 
     if total_count > 0 {

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -913,7 +913,7 @@ fn draw_mesh_tasks(
     };
 
     let total_count = WorkgroupSizeCheck {
-        sizes: &[group_count_x, group_count_y, group_count_z],
+        dimensions: &[group_count_x, group_count_y, group_count_z],
         per_dimension_limits: &[groups_size_limit, groups_size_limit, groups_size_limit],
         per_dimension_limits_desc: "max_task_mesh_workgroups_per_dimension",
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -45,7 +45,7 @@ use crate::{
     },
     snatch::SnatchGuard,
     track::{ResourceUsageCompatibilityError, Tracker, UsageScope},
-    validation::{self, check_workgroup_sizes},
+    validation::{self, WorkgroupSizeCheck},
     Label,
 };
 
@@ -3099,13 +3099,15 @@ fn draw_mesh_tasks(
         )
     };
 
-    let total_count = check_workgroup_sizes(
-        &[group_count_x, group_count_y, group_count_z],
-        &[groups_size_limit, groups_size_limit, groups_size_limit],
-        "max_task_mesh_workgroups_per_dimension",
-        max_groups,
-        "max_task_mesh_workgroup_total_count",
-    )
+    let total_count = WorkgroupSizeCheck {
+        sizes: &[group_count_x, group_count_y, group_count_z],
+        per_dimension_limits: &[groups_size_limit, groups_size_limit, groups_size_limit],
+        per_dimension_limits_desc: "max_task_mesh_workgroups_per_dimension",
+
+        total_limit: max_groups,
+        total_limit_desc: "max_task_mesh_workgroup_total_count",
+    }
+    .check_and_compute_total_invocations()
     .map_err(|err| RenderPassErrorInner::Draw(err.into()))?;
 
     unsafe {

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -3100,7 +3100,7 @@ fn draw_mesh_tasks(
     };
 
     let total_count = WorkgroupSizeCheck {
-        sizes: &[group_count_x, group_count_y, group_count_z],
+        dimensions: &[group_count_x, group_count_y, group_count_z],
         per_dimension_limits: &[groups_size_limit, groups_size_limit, groups_size_limit],
         per_dimension_limits_desc: "max_task_mesh_workgroups_per_dimension",
 

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1506,31 +1506,37 @@ impl Interface {
         // check workgroup size limits
         if shader_stage.to_naga().compute_like() {
             let total = match shader_stage.to_naga() {
-                naga::ShaderStage::Compute => check_workgroup_sizes(
-                    &entry_point.workgroup_size,
-                    &[
+                naga::ShaderStage::Compute => WorkgroupSizeCheck {
+                    sizes: &entry_point.workgroup_size,
+                    per_dimension_limits: &[
                         self.limits.max_compute_workgroup_size_x,
                         self.limits.max_compute_workgroup_size_y,
                         self.limits.max_compute_workgroup_size_z,
                     ],
-                    "max_compute_workgroup_size_*",
-                    self.limits.max_compute_invocations_per_workgroup,
-                    "max_compute_invocations_per_workgroup",
-                )?,
-                naga::ShaderStage::Task => check_workgroup_sizes(
-                    &entry_point.workgroup_size,
-                    &[self.limits.max_task_invocations_per_dimension; 3],
-                    "max_task_invocations_per_dimension",
-                    self.limits.max_task_invocations_per_workgroup,
-                    "max_task_invocations_per_workgroup",
-                )?,
-                naga::ShaderStage::Mesh => check_workgroup_sizes(
-                    &entry_point.workgroup_size,
-                    &[self.limits.max_mesh_invocations_per_dimension; 3],
-                    "max_mesh_invocations_per_dimension",
-                    self.limits.max_mesh_invocations_per_workgroup,
-                    "max_mesh_invocations_per_workgroup",
-                )?,
+                    per_dimension_limits_desc: "max_compute_workgroup_size_*",
+
+                    total_limit: self.limits.max_compute_invocations_per_workgroup,
+                    total_limit_desc: "max_compute_invocations_per_workgroup",
+                }
+                .check_and_compute_total_invocations()?,
+                naga::ShaderStage::Task => WorkgroupSizeCheck {
+                    sizes: &entry_point.workgroup_size,
+                    per_dimension_limits: &[self.limits.max_task_invocations_per_dimension; 3],
+                    per_dimension_limits_desc: "max_task_invocations_per_dimension",
+
+                    total_limit: self.limits.max_task_invocations_per_workgroup,
+                    total_limit_desc: "max_task_invocations_per_workgroup",
+                }
+                .check_and_compute_total_invocations()?,
+                naga::ShaderStage::Mesh => WorkgroupSizeCheck {
+                    sizes: &entry_point.workgroup_size,
+                    per_dimension_limits: &[self.limits.max_mesh_invocations_per_dimension; 3],
+                    per_dimension_limits_desc: "max_mesh_invocations_per_dimension",
+
+                    total_limit: self.limits.max_mesh_invocations_per_workgroup,
+                    total_limit_desc: "max_mesh_invocations_per_workgroup",
+                }
+                .check_and_compute_total_invocations()?,
                 _ => unreachable!(),
             };
             if total == 0 {
@@ -1960,40 +1966,57 @@ pub enum InvalidWorkgroupSizeError {
     Zero { dimensions: [u32; 3] },
 }
 
-/// Check X/Y/Z workgroup sizes against per-dimension and overall limits.
-///
-/// This function does not check that the sizes are non-zero. In a dispatch, it is legal for
-/// the size to be zero. In shader or pipeline creation, it is an error for the size to be
-/// zero, and the caller must check that.
-pub(crate) fn check_workgroup_sizes(
-    sizes: &[u32; 3],
-    per_dimension_limits: &[u32; 3],
-    per_dimension_limits_desc: &'static str,
-    total_limit: u32,
-    total_limit_desc: &'static str,
-) -> Result<u32, InvalidWorkgroupSizeError> {
-    let total = sizes
-        .iter()
-        .fold(1u32, |total, &dim| total.saturating_mul(dim));
+/// A helper type for avoiding argument order mistakes when calling
+/// [`Self::check_and_compute_total_invocations`].
+#[derive(Clone, Debug)]
+pub(crate) struct WorkgroupSizeCheck<'a> {
+    pub sizes: &'a [u32; 3],
+    pub per_dimension_limits: &'a [u32; 3],
+    pub per_dimension_limits_desc: &'static str,
+    pub total_limit: u32,
+    pub total_limit_desc: &'static str,
+}
 
-    let invalid_total_invocations = total > total_limit;
-
-    let dimension_too_large = sizes
-        .iter()
-        .zip(per_dimension_limits.iter())
-        .any(|(dim, limit)| dim > limit);
-
-    if invalid_total_invocations || dimension_too_large {
-        Err(InvalidWorkgroupSizeError::LimitExceeded {
-            dimensions: *sizes,
-            per_dimension_limits: *per_dimension_limits,
+impl WorkgroupSizeCheck<'_> {
+    /// Check X/Y/Z workgroup sizes against per-dimension and overall limits.
+    ///
+    /// This function does not check that the sizes are non-zero. In a dispatch, it is legal for
+    /// the size to be zero. In shader or pipeline creation, it is an error for the size to be
+    /// zero, and the caller must check that.
+    pub(crate) fn check_and_compute_total_invocations(
+        self,
+    ) -> Result<u32, InvalidWorkgroupSizeError> {
+        let Self {
+            sizes,
+            per_dimension_limits,
             per_dimension_limits_desc,
-            total,
             total_limit,
             total_limit_desc,
-        })
-    } else {
-        Ok(total)
+        } = self;
+
+        let total = sizes
+            .iter()
+            .fold(1u32, |total, &dim| total.saturating_mul(dim));
+
+        let invalid_total_invocations = total > total_limit;
+
+        let dimension_too_large = sizes
+            .iter()
+            .zip(per_dimension_limits.iter())
+            .any(|(dim, limit)| dim > limit);
+
+        if invalid_total_invocations || dimension_too_large {
+            Err(InvalidWorkgroupSizeError::LimitExceeded {
+                dimensions: *sizes,
+                per_dimension_limits: *per_dimension_limits,
+                per_dimension_limits_desc,
+                total,
+                total_limit,
+                total_limit_desc,
+            })
+        } else {
+            Ok(total)
+        }
     }
 }
 

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1519,22 +1519,14 @@ impl Interface {
                 )?,
                 naga::ShaderStage::Task => check_workgroup_sizes(
                     &entry_point.workgroup_size,
-                    &[
-                        self.limits.max_task_invocations_per_dimension,
-                        self.limits.max_task_invocations_per_dimension,
-                        self.limits.max_task_invocations_per_dimension,
-                    ],
+                    &[self.limits.max_task_invocations_per_dimension; 3],
                     "max_task_invocations_per_dimension",
                     self.limits.max_task_invocations_per_workgroup,
                     "max_task_invocations_per_workgroup",
                 )?,
                 naga::ShaderStage::Mesh => check_workgroup_sizes(
                     &entry_point.workgroup_size,
-                    &[
-                        self.limits.max_mesh_invocations_per_dimension,
-                        self.limits.max_mesh_invocations_per_dimension,
-                        self.limits.max_mesh_invocations_per_dimension,
-                    ],
+                    &[self.limits.max_mesh_invocations_per_dimension; 3],
                     "max_mesh_invocations_per_dimension",
                     self.limits.max_mesh_invocations_per_workgroup,
                     "max_mesh_invocations_per_workgroup",

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1507,7 +1507,7 @@ impl Interface {
         if shader_stage.to_naga().compute_like() {
             let total = match shader_stage.to_naga() {
                 naga::ShaderStage::Compute => WorkgroupSizeCheck {
-                    sizes: &entry_point.workgroup_size,
+                    dimensions: &entry_point.workgroup_size,
                     per_dimension_limits: &[
                         self.limits.max_compute_workgroup_size_x,
                         self.limits.max_compute_workgroup_size_y,
@@ -1520,7 +1520,7 @@ impl Interface {
                 }
                 .check_and_compute_total_invocations()?,
                 naga::ShaderStage::Task => WorkgroupSizeCheck {
-                    sizes: &entry_point.workgroup_size,
+                    dimensions: &entry_point.workgroup_size,
                     per_dimension_limits: &[self.limits.max_task_invocations_per_dimension; 3],
                     per_dimension_limits_desc: "max_task_invocations_per_dimension",
 
@@ -1529,7 +1529,7 @@ impl Interface {
                 }
                 .check_and_compute_total_invocations()?,
                 naga::ShaderStage::Mesh => WorkgroupSizeCheck {
-                    sizes: &entry_point.workgroup_size,
+                    dimensions: &entry_point.workgroup_size,
                     per_dimension_limits: &[self.limits.max_mesh_invocations_per_dimension; 3],
                     per_dimension_limits_desc: "max_mesh_invocations_per_dimension",
 
@@ -1970,7 +1970,7 @@ pub enum InvalidWorkgroupSizeError {
 /// [`Self::check_and_compute_total_invocations`].
 #[derive(Clone, Debug)]
 pub(crate) struct WorkgroupSizeCheck<'a> {
-    pub sizes: &'a [u32; 3],
+    pub dimensions: &'a [u32; 3],
     pub per_dimension_limits: &'a [u32; 3],
     pub per_dimension_limits_desc: &'static str,
     pub total_limit: u32,
@@ -1987,27 +1987,27 @@ impl WorkgroupSizeCheck<'_> {
         self,
     ) -> Result<u32, InvalidWorkgroupSizeError> {
         let Self {
-            sizes,
+            dimensions,
             per_dimension_limits,
             per_dimension_limits_desc,
             total_limit,
             total_limit_desc,
         } = self;
 
-        let total = sizes
+        let total = dimensions
             .iter()
             .fold(1u32, |total, &dim| total.saturating_mul(dim));
 
         let invalid_total_invocations = total > total_limit;
 
-        let dimension_too_large = sizes
+        let dimension_too_large = dimensions
             .iter()
             .zip(per_dimension_limits.iter())
             .any(|(dim, limit)| dim > limit);
 
         if invalid_total_invocations || dimension_too_large {
             Err(InvalidWorkgroupSizeError::LimitExceeded {
-                dimensions: *sizes,
+                dimensions: *dimensions,
                 per_dimension_limits: *per_dimension_limits,
                 per_dimension_limits_desc,
                 total,

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1505,7 +1505,7 @@ impl Interface {
 
         // check workgroup size limits
         if shader_stage.to_naga().compute_like() {
-            let total = match shader_stage.to_naga() {
+            let workgroup_size_check = match shader_stage.to_naga() {
                 naga::ShaderStage::Compute => WorkgroupSizeCheck {
                     dimensions: &entry_point.workgroup_size,
                     per_dimension_limits: &[
@@ -1517,8 +1517,7 @@ impl Interface {
 
                     total_limit: self.limits.max_compute_invocations_per_workgroup,
                     total_limit_desc: "max_compute_invocations_per_workgroup",
-                }
-                .check_and_compute_total_invocations()?,
+                },
                 naga::ShaderStage::Task => WorkgroupSizeCheck {
                     dimensions: &entry_point.workgroup_size,
                     per_dimension_limits: &[self.limits.max_task_invocations_per_dimension; 3],
@@ -1526,8 +1525,7 @@ impl Interface {
 
                     total_limit: self.limits.max_task_invocations_per_workgroup,
                     total_limit_desc: "max_task_invocations_per_workgroup",
-                }
-                .check_and_compute_total_invocations()?,
+                },
                 naga::ShaderStage::Mesh => WorkgroupSizeCheck {
                     dimensions: &entry_point.workgroup_size,
                     per_dimension_limits: &[self.limits.max_mesh_invocations_per_dimension; 3],
@@ -1535,10 +1533,10 @@ impl Interface {
 
                     total_limit: self.limits.max_mesh_invocations_per_workgroup,
                     total_limit_desc: "max_mesh_invocations_per_workgroup",
-                }
-                .check_and_compute_total_invocations()?,
+                },
                 _ => unreachable!(),
             };
+            let total = workgroup_size_check.check_and_compute_total_invocations()?;
             if total == 0 {
                 return Err(StageError::InvalidWorkgroupSize(
                     InvalidWorkgroupSizeError::Zero {


### PR DESCRIPTION
**Connections**

Done while working on <https://github.com/gfx-rs/wgpu/pull/9732>.

Conflicts with <https://github.com/gfx-rs/wgpu/pull/9732>. I have a resolution ready in <https://github.com/gfx-rs/wgpu/compare/trunk...erichdongubler-mozilla:wgpu:erichdongubler-push-uovkovyvxuzq> to handle this.

**Description**

I think this tidies this bit of code nicely. Recommended review experience is commit-by-commit.

**Testing**

Things still compile, so I think the risk of something breaking is low.

**Squash or Rebase?** rebaseplz

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] ~~`CHANGELOG.md` entries for the user-facing effects of this change are present.~~
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
