### PR TITLE
wgpu-hal: vulkan: Fix compilation for time64 systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ indicatif = "0.18"
 itertools = { version = "0.14" }
 jobserver = "0.1"
 ktx2 = "0.5"
-libc = { version = "0.2.172", default-features = false }
+libc = { version = "0.2.183", default-features = false }
 # See https://github.com/rust-fuzz/libfuzzer/issues/126
 libfuzzer-sys = ">0.4.0,<=0.4.7"
 libloading = "0.8"

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -3094,10 +3094,7 @@ impl crate::Adapter for super::Adapter {
         // on mac, so this is fine.
         #[cfg(unix)]
         {
-            let mut timespec = libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
+            let mut timespec = libc::timespec::default();
             unsafe {
                 libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut timespec);
             }


### PR DESCRIPTION
**Description**

With time64 enabled in the libc crate (for example, via the environment variable `RUST_LIBC_UNSTABLE_MUSL_V1_2_3=1` or `RUST_LIBC_UNSTABLE_GNU_TIME_BITS=64`), the timespec struct has private padding fields, which means struct initialization will fail to compile.

Instead, the struct implements `Default` since 0.2.183, which should be used instead.

**Testing**

```
$ export RUST_LIBC_UNSTABLE_MUSL_V1_2_3=1
$ cargo check --target armv7-unknown-linux-musleabihf -Zbuild-std=core,alloc,std --features vulkan
```

which will fail to compile before this commit and compile fine afterwards.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
