### PR TITLE
[core] Add support IDed `RenderPass`es in `Global`

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1,5 +1,6 @@
 use alloc::{borrow::Cow, sync::Arc, vec::Vec};
 use core::{convert::Infallible, fmt, num::NonZeroU32, ops::Range, str};
+use parking_lot::Mutex;
 use smallvec::SmallVec;
 
 use arrayvec::ArrayVec;
@@ -35,7 +36,7 @@ use crate::{
         RenderPassCompatibilityError, RenderPassContext,
     },
     global::Global,
-    hal_label, id,
+    hal_label, id, impl_resource_type,
     init_tracker::{MemoryInitKind, TextureInitRange, TextureInitTrackerAction},
     pipeline::{PipelineFlags, RenderPipeline, VertexStep},
     resource::{
@@ -318,6 +319,12 @@ pub struct RenderPass {
     // Resource binding dedupe state.
     current_bind_groups: BindGroupStateChange,
     current_pipeline: StateChange<id::RenderPipelineId>,
+}
+
+impl_resource_type!(RenderPass);
+
+impl crate::storage::StorageItem for RenderPass {
+    type Marker = id::markers::RenderPassEncoder;
 }
 
 impl RenderPass {
@@ -2136,6 +2143,22 @@ impl Global {
         }
     }
 
+    pub fn command_encoder_begin_render_pass_with_id(
+        &self,
+        encoder_id: id::CommandEncoderId,
+        desc: &RenderPassDescriptor<'_>,
+        id_in: Option<id::RenderPassEncoderId>,
+    ) -> (id::RenderPassEncoderId, Option<CommandEncoderError>) {
+        let hub = &self.hub;
+        let fid = hub.render_passes.prepare(id_in);
+        let (render_pass, error) = self.command_encoder_begin_render_pass(encoder_id, desc);
+        // no lock rank here because only one thread should be using renderpass
+        // and it's only used by id variants of render pass methods on global
+        // so no deadlock (or concurrent lock) should happen in practise
+        let id = fid.assign(Arc::new(Mutex::new(render_pass)));
+        (id, error)
+    }
+
     pub fn render_pass_end(&self, pass: &mut RenderPass) -> Result<(), EncoderStateError> {
         profiling::scope!(
             "CommandEncoder::run_render_pass {}",
@@ -2176,6 +2199,17 @@ impl Global {
                 multiview_mask: pass.multiview_mask,
             })
         })
+    }
+
+    pub fn render_pass_end_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+    ) -> Result<(), EncoderStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be accessed concurrently");
+        self.render_pass_end(&mut pass)
     }
 }
 
@@ -3579,6 +3613,20 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_set_bind_group_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        index: u32,
+        bind_group_id: Option<id::BindGroupId>,
+        offsets: &[DynamicOffset],
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_bind_group(&mut pass, index, bind_group_id, offsets)
+    }
+
     pub fn render_pass_set_pipeline(
         &self,
         pass: &mut RenderPass,
@@ -3605,6 +3653,18 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_set_pipeline_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        pipeline_id: id::RenderPipelineId,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_pipeline(&mut pass, pipeline_id)
+    }
+
     pub fn render_pass_set_index_buffer(
         &self,
         pass: &mut RenderPass,
@@ -3624,6 +3684,21 @@ impl Global {
         });
 
         Ok(())
+    }
+
+    pub fn render_pass_set_index_buffer_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        buffer_id: id::BufferId,
+        index_format: IndexFormat,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_index_buffer(&mut pass, buffer_id, index_format, offset, size)
     }
 
     pub fn render_pass_set_vertex_buffer(
@@ -3653,6 +3728,21 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_set_vertex_buffer_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        slot: u32,
+        buffer_id: Option<id::BufferId>,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_vertex_buffer(&mut pass, slot, buffer_id, offset, size)
+    }
+
     pub fn render_pass_set_blend_constant(
         &self,
         pass: &mut RenderPass,
@@ -3665,6 +3755,18 @@ impl Global {
             .push(ArcRenderCommand::SetBlendConstant(color));
 
         Ok(())
+    }
+
+    pub fn render_pass_set_blend_constant_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        color: Color,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_blend_constant(&mut pass, color)
     }
 
     pub fn render_pass_set_stencil_reference(
@@ -3684,6 +3786,18 @@ impl Global {
             .push(ArcRenderCommand::SetStencilReference(value));
 
         Ok(())
+    }
+
+    pub fn render_pass_set_stencil_reference_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        value: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_stencil_reference(&mut pass, value)
     }
 
     pub fn render_pass_set_viewport(
@@ -3708,6 +3822,23 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_set_viewport_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        depth_min: f32,
+        depth_max: f32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_viewport(&mut pass, x, y, w, h, depth_min, depth_max)
+    }
+
     pub fn render_pass_set_scissor_rect(
         &self,
         pass: &mut RenderPass,
@@ -3723,6 +3854,21 @@ impl Global {
             .push(ArcRenderCommand::SetScissor(Rect { x, y, w, h }));
 
         Ok(())
+    }
+
+    pub fn render_pass_set_scissor_rect_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_scissor_rect(&mut pass, x, y, w, h)
     }
 
     pub fn render_pass_set_immediates(
@@ -3761,6 +3907,19 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_set_immediates_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        offset: u32,
+        data: &[u8],
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_immediates(&mut pass, offset, data)
+    }
+
     pub fn render_pass_draw(
         &self,
         pass: &mut RenderPass,
@@ -3783,6 +3942,27 @@ impl Global {
         });
 
         Ok(())
+    }
+
+    pub fn render_pass_draw_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_draw(
+            &mut pass,
+            vertex_count,
+            instance_count,
+            first_vertex,
+            first_instance,
+        )
     }
 
     pub fn render_pass_draw_indexed(
@@ -3809,6 +3989,29 @@ impl Global {
         });
 
         Ok(())
+    }
+
+    pub fn render_pass_draw_indexed_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        first_instance: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_draw_indexed(
+            &mut pass,
+            index_count,
+            instance_count,
+            first_index,
+            base_vertex,
+            first_instance,
+        )
     }
 
     pub fn render_pass_draw_mesh_tasks(
@@ -3857,6 +4060,19 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_draw_indirect_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        buffer_id: id::BufferId,
+        offset: BufferAddress,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_draw_indirect(&mut pass, buffer_id, offset)
+    }
+
     pub fn render_pass_draw_indexed_indirect(
         &self,
         pass: &mut RenderPass,
@@ -3880,6 +4096,19 @@ impl Global {
         });
 
         Ok(())
+    }
+
+    pub fn render_pass_draw_indexed_indirect_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        buffer_id: id::BufferId,
+        offset: BufferAddress,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_draw_indexed_indirect(&mut pass, buffer_id, offset)
     }
 
     pub fn render_pass_draw_mesh_tasks_indirect(
@@ -4088,12 +4317,36 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_push_debug_group_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        label: &str,
+        color: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_push_debug_group(&mut pass, label, color)
+    }
+
     pub fn render_pass_pop_debug_group(&self, pass: &mut RenderPass) -> Result<(), PassStateError> {
         let base = pass_base!(pass, PassErrorScope::PopDebugGroup);
 
         base.commands.push(ArcRenderCommand::PopDebugGroup);
 
         Ok(())
+    }
+
+    pub fn render_pass_pop_debug_group_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_pop_debug_group(&mut pass)
     }
 
     pub fn render_pass_insert_debug_marker(
@@ -4115,6 +4368,19 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_insert_debug_marker_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        label: &str,
+        color: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_insert_debug_marker(&mut pass, label, color)
+    }
+
     pub fn render_pass_write_timestamp(
         &self,
         pass: &mut RenderPass,
@@ -4132,6 +4398,19 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_write_timestamp_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_write_timestamp(&mut pass, query_set_id, query_index)
+    }
+
     pub fn render_pass_begin_occlusion_query(
         &self,
         pass: &mut RenderPass,
@@ -4146,6 +4425,18 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_begin_occlusion_query_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        query_index: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_begin_occlusion_query(&mut pass, query_index)
+    }
+
     pub fn render_pass_end_occlusion_query(
         &self,
         pass: &mut RenderPass,
@@ -4156,6 +4447,17 @@ impl Global {
         base.commands.push(ArcRenderCommand::EndOcclusionQuery);
 
         Ok(())
+    }
+
+    pub fn render_pass_end_occlusion_query_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_end_occlusion_query(&mut pass)
     }
 
     pub fn render_pass_begin_pipeline_statistics_query(
@@ -4176,6 +4478,19 @@ impl Global {
         Ok(())
     }
 
+    pub fn render_pass_begin_pipeline_statistics_query_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_begin_pipeline_statistics_query(&mut pass, query_set_id, query_index)
+    }
+
     pub fn render_pass_end_pipeline_statistics_query(
         &self,
         pass: &mut RenderPass,
@@ -4187,6 +4502,17 @@ impl Global {
             .push(ArcRenderCommand::EndPipelineStatisticsQuery);
 
         Ok(())
+    }
+
+    pub fn render_pass_end_pipeline_statistics_query_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_end_pipeline_statistics_query(&mut pass)
     }
 
     pub fn render_pass_execute_bundles(
@@ -4209,6 +4535,18 @@ impl Global {
         pass.current_bind_groups.reset();
 
         Ok(())
+    }
+
+    pub fn render_pass_execute_bundles_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        render_bundle_ids: &[id::RenderBundleId],
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_execute_bundles(&mut pass, render_bundle_ids)
     }
 }
 

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -121,7 +121,7 @@ use core::fmt::Debug;
 
 use crate::{
     binding_model::{BindGroup, BindGroupLayout, PipelineLayout},
-    command::{CommandBuffer, CommandEncoder, RenderBundle},
+    command::{CommandBuffer, CommandEncoder, RenderBundle, RenderPass},
     device::{queue::Queue, Device},
     instance::Adapter,
     lock::rank,
@@ -132,6 +132,8 @@ use crate::{
         TextureView, Tlas,
     },
 };
+
+use parking_lot::Mutex;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HubReport {
@@ -154,6 +156,7 @@ pub struct HubReport {
     pub texture_views: RegistryReport,
     pub external_textures: RegistryReport,
     pub samplers: RegistryReport,
+    pub render_passes: RegistryReport,
 }
 
 impl HubReport {
@@ -206,6 +209,7 @@ pub struct Hub {
     pub(crate) samplers: Registry<Fallible<Sampler>>,
     pub(crate) blas_s: Registry<Fallible<Blas>>,
     pub(crate) tlas_s: Registry<Fallible<Tlas>>,
+    pub(crate) render_passes: Registry<Arc<Mutex<RenderPass>>>,
 }
 
 impl Hub {
@@ -240,6 +244,7 @@ impl Hub {
             samplers: Registry::with_rank(rank::HUB_SAMPLERS),
             blas_s: Registry::new(),
             tlas_s: Registry::with_rank(rank::HUB_TLAS),
+            render_passes: Registry::new(),
         }
     }
 
@@ -264,6 +269,7 @@ impl Hub {
             texture_views: self.texture_views.generate_report(),
             external_textures: self.external_textures.generate_report(),
             samplers: self.samplers.generate_report(),
+            render_passes: self.render_passes.generate_report(),
         }
     }
 }

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -4,6 +4,7 @@ use core::mem;
 use crate::id::{Id, Marker};
 use crate::resource::ResourceType;
 use crate::{Epoch, Index};
+use parking_lot::Mutex;
 
 /// An entry in a `Storage::map` table.
 #[derive(Debug)]
@@ -30,6 +31,14 @@ impl<T: ResourceType> ResourceType for Arc<T> {
 }
 
 impl<T: StorageItem> StorageItem for Arc<T> {
+    type Marker = T::Marker;
+}
+
+impl<T: ResourceType> ResourceType for Mutex<T> {
+    const TYPE: &'static str = T::TYPE;
+}
+
+impl<T: StorageItem> StorageItem for Mutex<T> {
     type Marker = T::Marker;
 }
 


### PR DESCRIPTION
**Description**

As discussed in https://github.com/gfx-rs/wgpu/pull/9712#issuecomment-4788311141 and in #5121 we need this to remove recording from content process in firefox. Servo will also benefit from this.

In addition to normal methods that take `&mut RenderPass` we also add some that take `id::RenderPassEncoderId` and use the passes from registry (which are made mut using unranked `Mutex`). One could consider this as "second registry" for encoders. This works because passes are not passed to any other resource via descriptor.

This allow for wgpu and deno to keep using the ones without id and avoid another level of indirection. The down side is that these wrapper are not tested anywhere in wgpu repo, but I think they are thin so it should not be that much problematic.

**Testing**
None, as this should only be used by servo/firefox.

**Squash or Rebase?**

Squash.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
