### PR TITLE
fix(vulkan): enable vulkanMemoryModelDeviceScope with the memory model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Fixed vkAcquireNextImage fence being awaited on non-Windows platforms causing frametime spikes on nvidia drivers. By @cohaereo in [#9486](https://github.com/gfx-rs/wgpu/pull/9486).
 - Fixed alignment and `MatrixStride` for mat2x2 in SPIR-V uniform blocks. By @39ali [#9369](https://github.com/gfx-rs/wgpu/pull/9369).
 - Fixed loading of `libvulkan.so` on OpenHarmony (`target_env = "ohos"`). By @jschwe in [#9649](https://github.com/gfx-rs/wgpu/pull/9649).
+- Fixed `VUID-RuntimeSpirv-vulkanMemoryModel-06265` validation errors by enabling `vulkanMemoryModelDeviceScope` whenever the Vulkan memory model is enabled, since the SPIR-V backend emits storage atomics with `Device` scope. By @francisdb in [#9741](https://github.com/gfx-rs/wgpu/pull/9741).
 
 #### DX12
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -614,7 +614,13 @@ impl PhysicalDeviceFeatures {
                     requested_features.contains(wgt::Features::EXPERIMENTAL_COOPERATIVE_MATRIX);
                 Some(
                     vk::PhysicalDeviceVulkanMemoryModelFeaturesKHR::default()
-                        .vulkan_memory_model(needed),
+                        .vulkan_memory_model(needed)
+                        // The SPIR-V backend emits storage atomics with `Device`
+                        // memory scope, so whenever the Vulkan memory model is
+                        // enabled we must also enable device scope, otherwise the
+                        // validation layers report
+                        // `VUID-RuntimeSpirv-vulkanMemoryModel-06265`.
+                        .vulkan_memory_model_device_scope(needed),
                 )
             } else {
                 None
@@ -1061,10 +1067,17 @@ impl PhysicalDeviceFeatures {
                 .map(|p| p.multisample_array_image == vk::TRUE)
                 .unwrap_or(true),
         );
-        // Enable cooperative matrix if any configuration is supported
+        // Enable cooperative matrix if any configuration is supported. The SPIR-V
+        // we emit for it uses `Device`-scope atomics under the Vulkan memory model,
+        // so the device must also support `vulkanMemoryModelDeviceScope`, otherwise
+        // those shaders trip `VUID-RuntimeSpirv-vulkanMemoryModel-06265`.
         features.set(
             F::EXPERIMENTAL_COOPERATIVE_MATRIX,
-            !caps.cooperative_matrix_properties.is_empty(),
+            !caps.cooperative_matrix_properties.is_empty()
+                && self.vulkan_memory_model.is_some_and(|m| {
+                    m.vulkan_memory_model == vk::TRUE
+                        && m.vulkan_memory_model_device_scope == vk::TRUE
+                }),
         );
 
         features.set(
@@ -2092,6 +2105,15 @@ impl super::InstanceShared {
                 let next = features
                     .cooperative_matrix
                     .insert(vk::PhysicalDeviceCooperativeMatrixFeaturesKHR::default());
+                features2 = features2.push_next(next);
+            }
+
+            if capabilities.device_api_version >= vk::API_VERSION_1_2
+                || capabilities.supports_extension(khr::vulkan_memory_model::NAME)
+            {
+                let next = features
+                    .vulkan_memory_model
+                    .insert(vk::PhysicalDeviceVulkanMemoryModelFeaturesKHR::default());
                 features2 = features2.push_next(next);
             }
 


### PR DESCRIPTION
**Connections**

Fixes #9729

**Description**

When the Vulkan memory model is enabled, the SPIR-V backend emits storage atomics using `Device` memory scope. Per the Vulkan spec, if `vulkanMemoryModel` is enabled but `vulkanMemoryModelDeviceScope` is not, `Device` scope must not be used, so the validation layers report `VUID-RuntimeSpirv-vulkanMemoryModel-06265` on every such shader module.

Enable `vulkanMemoryModelDeviceScope` alongside `vulkanMemoryModel` so the device-scope atomics naga emits are valid.

**Testing**

Using bevy 0.19 with this patch applied

**Squash or Rebase?**

Rebase

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
