### PR TITLE
Add `Debug` implementations and `missing_debug_implementations` lint.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,11 @@ default-members = [
     "xtask",
 ]
 
+# NOTE: many packages have non-inherited [lints] sections (Cargo does not support combining
+# workspace inheritance with customization) and must be updated separately.
+[workspace.lints.rust]
+missing_debug_implementations = "warn"
+
 [workspace.lints.clippy]
 ref_as_ptr = "warn"
 # NOTE: clippy configuration values (disallowed-types and

--- a/cts_runner/Cargo.toml
+++ b/cts_runner/Cargo.toml
@@ -27,3 +27,6 @@ termcolor.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -50,3 +50,6 @@ env_logger.workspace = true
 argh.workspace = true
 anyhow = { workspace = true, features = ["std"] }
 log.workspace = true
+
+[lints]
+workspace = true

--- a/naga-test/Cargo.toml
+++ b/naga-test/Cargo.toml
@@ -34,3 +34,6 @@ toml.workspace = true
 bitflags.workspace = true
 serde_json.workspace = true
 serde.workspace = true
+
+[lints]
+workspace = true

--- a/naga-test/src/lib.rs
+++ b/naga-test/src/lib.rs
@@ -48,7 +48,7 @@ impl Targets {
     }
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct SpvOutVersion(pub u8, pub u8);
 impl Default for SpvOutVersion {
     fn default() -> Self {
@@ -56,7 +56,7 @@ impl Default for SpvOutVersion {
     }
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct BindingMapSerialization {
     pub resource_binding: naga::ResourceBinding,
     pub bind_target: naga::back::spv::BindingInfo,
@@ -78,7 +78,7 @@ where
     Ok(map)
 }
 
-#[derive(Default, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize)]
 #[serde(default)]
 pub struct WriterSharedOptions {
     pub mesh_output_validation: bool,
@@ -86,7 +86,7 @@ pub struct WriterSharedOptions {
     pub bounds_checks_policies: naga::proc::BoundsCheckPolicies,
 }
 
-#[derive(Default, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize)]
 #[serde(default)]
 pub struct WgslInParameters {
     pub parse_doc_comments: bool,
@@ -100,7 +100,7 @@ impl From<&WgslInParameters> for naga::front::wgsl::Options {
     }
 }
 
-#[derive(Default, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize)]
 #[serde(default)]
 pub struct SpirvInParameters {
     pub adjust_coordinate_space: bool,
@@ -114,7 +114,7 @@ impl From<&SpirvInParameters> for naga::front::spv::Options {
     }
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[serde(default)]
 pub struct SpirvOutParameters {
     pub version: SpvOutVersion,
@@ -186,7 +186,7 @@ impl SpirvOutParameters {
     }
 }
 
-#[derive(Default, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize)]
 #[serde(default)]
 pub struct WgslOutParameters {
     pub explicit_types: bool,
@@ -199,13 +199,13 @@ impl From<&WgslOutParameters> for naga::back::wgsl::WriterFlags {
     }
 }
 
-#[derive(Default, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize)]
 pub struct FragmentModule {
     pub path: String,
     pub entry_point: String,
 }
 
-#[derive(Default, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize)]
 #[serde(default)]
 pub struct Parameters {
     // -- validation options --

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -129,6 +129,9 @@ serde = { workspace = true, features = ["default", "derive"] }
 strum = { workspace = true }
 walkdir.workspace = true
 
+[lints.rust]
+missing_debug_implementations = "warn"
+
 [lints.clippy]
 std_instead_of_alloc = "warn"
 std_instead_of_core = "warn"

--- a/naga/hlsl-snapshots/Cargo.toml
+++ b/naga/hlsl-snapshots/Cargo.toml
@@ -13,3 +13,6 @@ test = false
 [dependencies]
 anyhow.workspace = true
 nanoserde.workspace = true
+
+[lints]
+workspace = true

--- a/naga/src/back/dot/mod.rs
+++ b/naga/src/back/dot/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// Configuration options for the dot backend
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Options {
     /// Only emit function bodies
     pub cfg_only: bool,

--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 /// Writer responsible for all code generation.
+#[expect(missing_debug_implementations, reason = "would be way too verbose?")]
 pub struct Writer<'a, W> {
     // Inputs
     /// The module being written.

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -629,7 +629,7 @@ impl Options {
 }
 
 /// Reflection info for entry point names.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ReflectionInfo {
     /// Mapping of the entry point names.
     ///
@@ -720,6 +720,7 @@ impl Wrapped {
 /// If this is provided, vertex outputs will be removed if they are not inputs of this fragment
 /// entry point. This is necessary for generating correct HLSL when some of the vertex shader
 /// outputs are not consumed by the fragment shader.
+#[derive(Debug)]
 pub struct FragmentEntryPoint<'a> {
     module: &'a crate::Module,
     func: &'a crate::Function,
@@ -741,6 +742,7 @@ impl<'a> FragmentEntryPoint<'a> {
     }
 }
 
+#[expect(missing_debug_implementations, reason = "would be way too verbose?")]
 pub struct Writer<'a, W> {
     out: W,
     names: crate::FastHashMap<proc::NameKey, String>,

--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -93,7 +93,7 @@ bitflags::bitflags! {
 pub type PipelineConstants = hashbrown::HashMap<String, f64>;
 
 /// Indentation level.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Level(pub usize);
 
 impl Level {
@@ -174,6 +174,7 @@ impl FunctionType {
 }
 
 /// Helper structure that stores data needed when writing the function
+#[derive(Debug)]
 pub struct FunctionCtx<'a> {
     /// The current function being written
     pub ty: FunctionType,
@@ -389,6 +390,7 @@ bitflags::bitflags! {
 }
 
 /// The intersection test to use for ray queries.
+#[derive(Debug)]
 #[repr(u32)]
 pub enum RayIntersectionType {
     Triangle = 1,

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -774,6 +774,7 @@ const WRAPPED_ARRAY_FIELD: &str = "inner";
 
 /// Information about a translated module that is required
 /// for the use of the result.
+#[derive(Debug)]
 pub struct TranslationInfo {
     /// Mapping of the entry point names. Each item in the array
     /// corresponds to an entry point index.

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -521,6 +521,7 @@ pub(super) enum WrappedFunction {
     },
 }
 
+#[expect(missing_debug_implementations, reason = "would be way too verbose?")]
 pub struct Writer<W> {
     pub(super) out: W,
     pub(super) names: FastHashMap<NameKey, String>,

--- a/naga/src/back/spv/helpers.rs
+++ b/naga/src/back/spv/helpers.rs
@@ -200,6 +200,7 @@ impl StrUnstable for str {
     }
 }
 
+#[derive(Debug)]
 pub enum BindingDecorations {
     BuiltIn(spirv::BuiltIn, ArrayVec<spirv::Decoration, 2>),
     Location {

--- a/naga/src/back/spv/mesh_shader.rs
+++ b/naga/src/back/spv/mesh_shader.rs
@@ -10,12 +10,13 @@ use crate::{
     Handle,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MeshReturnMember {
     pub ty_id: u32,
     pub binding: crate::Binding,
 }
 
+#[derive(Debug)]
 struct PerOutputTypeMeshReturnInfo {
     max_length_constant: Word,
     array_type_id: Word,
@@ -30,6 +31,7 @@ struct PerOutputTypeMeshReturnInfo {
     bindings: Vec<Word>,
 }
 
+#[derive(Debug)]
 pub struct MeshReturnInfo {
     /// Id of the workgroup variable containing the data to be output
     out_variable_id: Word,

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -908,6 +908,7 @@ impl BlockContext<'_> {
 /// type `type_id`, and the result of any `Load` will be immediately converted
 /// to the base type. This is used for matrices with 2 rows, as well as any
 /// arrays or structs containing such matrices.
+#[derive(Debug)]
 pub struct Std140CompatTypeInfo {
     /// ID of the std140 compatible type declaration.
     type_id: Word,
@@ -916,6 +917,7 @@ pub struct Std140CompatTypeInfo {
     member_indices: Vec<u32>,
 }
 
+#[expect(missing_debug_implementations, reason = "would be way too verbose?")]
 pub struct Writer {
     physical_layout: PhysicalLayout,
     logical_layout: LogicalLayout,

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -78,6 +78,7 @@ bitflags::bitflags! {
     }
 }
 
+#[expect(missing_debug_implementations, reason = "would be way too verbose?")]
 pub struct Writer<W> {
     out: W,
     flags: WriterFlags,

--- a/naga/src/common/diagnostic_display.rs
+++ b/naga/src/common/diagnostic_display.rs
@@ -50,6 +50,10 @@ use core::fmt;
 /// definition is expanded to include some indication of the right
 /// source language to use, any use site that does not supply this
 /// indication will provoke a compile-time error.
+#[expect(
+    missing_debug_implementations,
+    reason = "use this type with `Display`, not `Debug`"
+)]
 pub struct DiagnosticDisplay<T>(pub T);
 
 impl fmt::Display for DiagnosticDisplay<(&TypeResolution, GlobalCtx<'_>)> {

--- a/naga/src/common/wgsl/diagnostics.rs
+++ b/naga/src/common/wgsl/diagnostics.rs
@@ -24,6 +24,10 @@ impl Severity {
     }
 }
 
+#[expect(
+    missing_debug_implementations,
+    reason = "use this type with `Display`, not `Debug`"
+)]
 pub struct DisplayFilterableTriggeringRule<'a>(&'a FilterableTriggeringRule);
 
 impl Display for DisplayFilterableTriggeringRule<'_> {

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -100,7 +100,7 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "SPV_KHR_fragment_shader_barycentric",
 ];
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Instruction {
     op: spirv::Op,
     wc: u16,
@@ -608,6 +608,7 @@ enum SignAnchor {
     Operand,
 }
 
+#[expect(missing_debug_implementations, reason = "would be way too verbose?")]
 pub struct Frontend<I> {
     data: I,
     data_offset: usize,

--- a/naga/src/front/wgsl/mod.rs
+++ b/naga/src/front/wgsl/mod.rs
@@ -34,6 +34,7 @@ use std::println;
 
 pub(crate) type Result<'a, T> = core::result::Result<T, Box<Error<'a>>>;
 
+#[derive(Debug)]
 pub struct Frontend {
     parser: Parser,
     options: Options,

--- a/naga/src/front/wgsl/parse/mod.rs
+++ b/naga/src/front/wgsl/parse/mod.rs
@@ -279,6 +279,7 @@ impl<'a> BindingParser<'a> {
 }
 
 /// Configuration for the whole parser run.
+#[derive(Debug)]
 pub struct Options {
     /// Controls whether the parser should parse doc comments.
     pub parse_doc_comments: bool,
@@ -296,6 +297,7 @@ impl Options {
     }
 }
 
+#[derive(Debug)]
 pub struct Parser {
     rules: Vec<(Rule, usize)>,
     recursion_depth: u32,

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -489,7 +489,7 @@ impl From<core::convert::Infallible> for ConstValueError {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct GlobalCtx<'a> {
     pub types: &'a crate::UniqueArena<crate::Type>,
     pub constants: &'a crate::Arena<crate::Constant>,
@@ -986,7 +986,7 @@ impl crate::Module {
     }
 }
 
-#[derive(Default, Copy, Clone)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct RayTracingUses {
     pub pipelines: bool,
     pub queries: bool,

--- a/naga/src/proc/namer.rs
+++ b/naga/src/proc/namer.rs
@@ -86,7 +86,7 @@ pub enum NameKey {
 
 /// This processor assigns names to all the things in a module
 /// that may need identifiers in a textual backend.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Namer {
     /// The last numeric suffix used for each base name. Zero means "no suffix".
     unique: FastHashMap<String, u32>,

--- a/naga/src/proc/overloads/constructor_set.rs
+++ b/naga/src/proc/overloads/constructor_set.rs
@@ -125,7 +125,7 @@ impl ConstructorSet {
 }
 
 /// The sizes a member of [`ConstructorSet`] might have.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum ConstructorSize {
     /// The constructor is [`SCALAR`].
     ///

--- a/naga/src/proc/overloads/rule.rs
+++ b/naga/src/proc/overloads/rule.rs
@@ -23,7 +23,7 @@ use core::fmt;
 use core::result::Result;
 
 /// A single type rule.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Rule {
     pub arguments: Vec<TypeResolution>,
     pub conclusion: Conclusion,

--- a/naga/src/proc/typifier.rs
+++ b/naga/src/proc/typifier.rs
@@ -216,6 +216,7 @@ impl From<crate::proc::MissingSpecialType> for ResolveError {
     }
 }
 
+#[expect(missing_debug_implementations, reason = "would be way too verbose?")]
 pub struct ResolveContext<'a> {
     pub constants: &'a Arena<crate::Constant>,
     pub overrides: &'a Arena<crate::Override>,

--- a/naga/src/racy_lock.rs
+++ b/naga/src/racy_lock.rs
@@ -14,6 +14,7 @@ type Inner<T> = OnceBox<T>;
 ///
 /// [`LazyLock`]: https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html
 /// [`OnceBox`]: https://docs.rs/once_cell/latest/once_cell/race/struct.OnceBox.html
+#[derive(Debug)]
 pub struct RacyLock<T: 'static> {
     inner: Inner<T>,
     #[cfg(no_std)]

--- a/naga/xtask/Cargo.toml
+++ b/naga/xtask/Cargo.toml
@@ -17,3 +17,6 @@ num_cpus.workspace = true
 pico-args.workspace = true
 shell-words.workspace = true
 which.workspace = true
+
+[lints]
+workspace = true

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -46,3 +46,6 @@ features = [
 
 [dev-dependencies]
 serde.workspace = true
+
+[lints]
+workspace = true

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -17,6 +17,7 @@ use wgc::{
     id::{Marker, PointerId},
 };
 
+#[derive(Debug)]
 pub struct Player {
     pipeline_layouts: HashMap<
         wgc::id::PointerId<wgc::id::markers::PipelineLayout>,

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -30,6 +30,7 @@ targets = [
 ignored = ["cfg_aliases"]
 
 [lints.rust]
+missing_debug_implementations = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wgpu_validate_locks)'] }
 
 [lib]

--- a/wgpu-core/platform-deps/apple/Cargo.toml
+++ b/wgpu-core/platform-deps/apple/Cargo.toml
@@ -24,3 +24,6 @@ vulkan-portability = ["wgpu-hal/vulkan", "wgpu-hal/renderdoc"]
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
 [target.'cfg(target_vendor = "apple")'.dependencies]
 wgpu-hal.workspace = true
+
+[lints]
+workspace = true

--- a/wgpu-core/platform-deps/emscripten/Cargo.toml
+++ b/wgpu-core/platform-deps/emscripten/Cargo.toml
@@ -22,3 +22,6 @@ gles = ["wgpu-hal/gles"]
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
 [target.'cfg(target_os = "emscripten")'.dependencies]
 wgpu-hal.workspace = true
+
+[lints]
+workspace = true

--- a/wgpu-core/platform-deps/wasm/Cargo.toml
+++ b/wgpu-core/platform-deps/wasm/Cargo.toml
@@ -22,3 +22,6 @@ webgl = ["wgpu-hal/gles"]
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 wgpu-hal.workspace = true
+
+[lints]
+workspace = true

--- a/wgpu-core/platform-deps/windows-linux-android/Cargo.toml
+++ b/wgpu-core/platform-deps/windows-linux-android/Cargo.toml
@@ -28,3 +28,6 @@ drm = ["wgpu-hal/drm"]
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
 [target.'cfg(any(windows, target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 wgpu-hal.workspace = true
+
+[lints]
+workspace = true

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -40,6 +40,7 @@
     // `wgpu-core` isn't entirely user-facing, so it's useful to document internal items.
     rustdoc::private_intra_doc_links,
 )]
+#![expect(missing_debug_implementations, reason = "TODO")]
 #![warn(
     clippy::alloc_instead_of_core,
     clippy::ptr_as_ptr,

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -34,6 +34,7 @@ targets = [
 ignored = ["cfg_aliases"]
 
 [lints.rust]
+missing_debug_implementations = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(feature, values("cargo-clippy"))', # objc's `msg_send` macro injects this in our code https://github.com/SSheldon/rust-objc/issues/125
     'cfg(web_sys_unstable_apis)', # web-sys uses this

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -72,6 +72,11 @@ Otherwise, we pass a range corresponding only to the current bind group.
 
 !*/
 
+#![expect(
+    missing_debug_implementations,
+    reason = "TODO: someone developing on Windows add Debug impls where possible"
+)]
+
 mod adapter;
 mod command;
 mod conv;
@@ -150,7 +155,7 @@ struct D3D12Lib {
     lib: DynLib,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum CreateDeviceError {
     GetProcAddress,
     D3D12CreateDevice(windows_core::HRESULT),
@@ -1828,7 +1833,7 @@ pub enum ShaderModuleSource {
     HlslPassthrough(HlslPassthroughShader),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FeatureLevel {
     V11_0,
     V11_1,
@@ -1837,7 +1842,7 @@ pub enum FeatureLevel {
     V12_2,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ShaderModel {
     V5_1,
     V6_0,

--- a/wgpu-hal/src/dynamic/adapter.rs
+++ b/wgpu-hal/src/dynamic/adapter.rs
@@ -6,6 +6,7 @@ use crate::{
 
 use super::{DynDevice, DynQueue, DynResource, DynResourceExt, DynSurface};
 
+#[expect(missing_debug_implementations, reason = "dyn")]
 pub struct DynOpenDevice {
     pub device: Box<dyn DynDevice>,
     pub queue: Box<dyn DynQueue>,

--- a/wgpu-hal/src/dynamic/instance.rs
+++ b/wgpu-hal/src/dynamic/instance.rs
@@ -4,6 +4,7 @@ use crate::{Api, Capabilities, ExposedAdapter, Instance, InstanceError};
 
 use super::{DynAdapter, DynResource, DynResourceExt as _, DynSurface};
 
+#[expect(missing_debug_implementations, reason = "dyn")]
 pub struct DynExposedAdapter {
     pub adapter: Box<dyn DynAdapter>,
     pub info: wgt::AdapterInfo,

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -193,6 +193,7 @@ impl EglContext {
 
 /// A wrapper around a [`glow::Context`] and the required EGL context that uses locking to guarantee
 /// exclusive access when shared with multiple threads.
+#[derive(Debug)]
 pub struct AdapterContext {
     glow: Mutex<ManuallyDrop<glow::Context>>,
     egl: Option<EglContext>,
@@ -266,6 +267,7 @@ struct EglContextLock<'a> {
 }
 
 /// A guard containing a lock to an [`AdapterContext`], while the GL context is kept current.
+#[expect(missing_debug_implementations)]
 pub struct AdapterContextLock<'a> {
     glow: MutexGuard<'a, ManuallyDrop<glow::Context>>,
     egl: Option<EglContextLock<'a>>,
@@ -680,6 +682,7 @@ struct WindowSystemInterface {
     kind: WindowKind,
 }
 
+#[derive(Debug)]
 pub struct Instance {
     wsi: WindowSystemInterface,
     flags: wgt::InstanceFlags,

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -301,10 +301,41 @@ struct AdapterShared {
     max_msaa_samples: i32,
 }
 
+impl fmt::Debug for AdapterShared {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            context: _, // may or may not implement Debug depending on platform
+            private_caps,
+            features,
+            limits,
+            workarounds,
+            options,
+            shading_language_version,
+            next_shader_id,
+            program_cache: _,
+            es,
+            max_msaa_samples,
+        } = self;
+        f.debug_struct("AdapterShared")
+            .field("private_caps", private_caps)
+            .field("features", features)
+            .field("limits", limits)
+            .field("workarounds", workarounds)
+            .field("options", options)
+            .field("shading_language_version", shading_language_version)
+            .field("next_shader_id", next_shader_id)
+            .field("es", es)
+            .field("max_msaa_samples", max_msaa_samples)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
 pub struct Adapter {
     shared: Arc<AdapterShared>,
 }
 
+#[derive(Debug)]
 pub struct Device {
     shared: Arc<AdapterShared>,
     main_vao: glow::VertexArray,
@@ -320,11 +351,13 @@ impl Drop for Device {
     }
 }
 
+#[derive(Debug)]
 pub struct ShaderClearProgram {
     pub program: glow::Program,
     pub color_uniform_location: glow::UniformLocation,
 }
 
+#[derive(Debug)]
 pub struct Queue {
     shared: Arc<AdapterShared>,
     features: wgt::Features,
@@ -741,7 +774,7 @@ struct ColorTargetDesc {
     blend: Option<BlendDesc>,
 }
 
-#[derive(PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 struct ProgramStage {
     naga_stage: naga::ShaderStage,
     shader_id: ShaderId,
@@ -750,7 +783,7 @@ struct ProgramStage {
     constant_hash: Vec<u8>,
 }
 
-#[derive(PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 struct ProgramCacheKey {
     stages: ArrayVec<ProgramStage, 3>,
     group_to_binding_to_slot: Box<[Option<Box<[u8]>>]>,

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -8,6 +8,7 @@ use super::TextureFormatDesc;
 
 /// A wrapper around a [`glow::Context`] to provide a fake `lock()` api that makes it compatible
 /// with the `AdapterContext` API from the EGL implementation.
+#[derive(Debug)]
 pub struct AdapterContext {
     pub glow_context: glow::Context,
     pub webgl2_context: web_sys::WebGl2RenderingContext,

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -1,3 +1,8 @@
+#![expect(
+    missing_debug_implementations,
+    reason = "TODO: someone developing on Windows add Debug impls where possible"
+)]
+
 use alloc::{borrow::ToOwned as _, ffi::CString, string::String, sync::Arc, vec::Vec};
 use core::{
     ffi::{c_int, c_void, CStr},

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2422,6 +2422,23 @@ pub enum ShaderInput<'a> {
     },
 }
 
+impl fmt::Debug for ShaderInput<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            // Don't include the entire shader source, especially for binary formats, because it
+            // would be spammy.
+            Self::Naga { .. } => f.debug_tuple("Naga").finish_non_exhaustive(),
+            Self::MetalLib { .. } => f.debug_tuple("MetalLib").finish_non_exhaustive(),
+            Self::Msl { .. } => f.debug_tuple("Msl").finish_non_exhaustive(),
+            Self::SpirV { .. } => f.debug_tuple("SpirV").finish_non_exhaustive(),
+            Self::Dxil { .. } => f.debug_tuple("Dxil").finish_non_exhaustive(),
+            Self::Hlsl { .. } => f.debug_tuple("Hlsl").finish_non_exhaustive(),
+            Self::Glsl { .. } => f.debug_tuple("Glsl").finish_non_exhaustive(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct ShaderModuleDescriptor<'a> {
     pub label: Label<'a>,
 
@@ -2484,6 +2501,7 @@ pub struct ComputePipelineDescriptor<
     pub cache: Option<&'a Pc>,
 }
 
+#[derive(Debug)]
 pub struct PipelineCacheDescriptor<'a> {
     pub label: Label<'a>,
     pub data: Option<&'a [u8]>,
@@ -2808,6 +2826,7 @@ pub struct AccelerationStructureAABBs<'a, B: DynBuffer + ?Sized> {
     pub flags: AccelerationStructureGeometryFlags,
 }
 
+#[derive(Clone, Debug)]
 pub struct AccelerationStructureCopy {
     pub copy_flags: wgt::AccelerationStructureCopy,
     pub type_flags: wgt::AccelerationStructureType,
@@ -2872,6 +2891,7 @@ pub struct TlasInstance {
 }
 
 #[cfg(dx12)]
+#[derive(Debug)]
 pub enum D3D12ExposeAdapterResult {
     CreateDeviceError(dx12::CreateDeviceError),
     UnknownFeatureLevel(i32),

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -134,6 +134,7 @@ impl OsFeatures {
     }
 }
 
+#[derive(Debug)]
 pub struct Instance {}
 
 impl Instance {
@@ -384,6 +385,7 @@ impl Default for Settings {
     }
 }
 
+#[derive(Debug)]
 struct AdapterShared {
     device: Retained<ProtocolObject<dyn MTLDevice>>,
     disabilities: PrivateDisabilities,
@@ -443,6 +445,7 @@ impl AdapterShared {
     }
 }
 
+#[derive(Debug)]
 pub struct Adapter {
     shared: Arc<AdapterShared>,
 }
@@ -450,6 +453,7 @@ pub struct Adapter {
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Adapter: Send, Sync);
 
+#[derive(Debug)]
 pub struct Queue {
     shared: Arc<QueueShared>,
     timestamp_period: f32,
@@ -617,6 +621,7 @@ pub struct QueueShared {
     relay: OnceLock<Relay>,
 }
 
+#[derive(Debug)]
 pub struct Device {
     shared: Arc<AdapterShared>,
     features: wgt::Features,
@@ -624,6 +629,7 @@ pub struct Device {
     limits: wgt::Limits,
 }
 
+#[derive(Debug)]
 pub struct Surface {
     render_layer: Mutex<Retained<CAMetalLayer>>,
     swapchain_format: RwLock<Option<wgt::TextureFormat>>,

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -18,6 +18,7 @@ pub use command::CommandBuffer;
 #[derive(Clone, Debug)]
 pub struct Api;
 
+#[derive(Debug)]
 pub struct Context {
     options: Arc<wgt::NoopBackendOptions>,
 }

--- a/wgpu-hal/src/validation_canary.rs
+++ b/wgpu-hal/src/validation_canary.rs
@@ -21,6 +21,7 @@ pub static VALIDATION_CANARY: ValidationCanary = ValidationCanary {
 };
 
 /// Flag for internal testing.
+#[derive(Debug)]
 pub struct ValidationCanary {
     inner: Mutex<Vec<String>>,
 }

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -126,6 +126,7 @@ struct DebugUtils {
     callback_data: Box<DebugUtilsMessengerUserData>,
 }
 
+#[derive(Debug)]
 pub struct DebugUtilsCreateInfo {
     severity: vk::DebugUtilsMessageSeverityFlagsEXT,
     message_type: vk::DebugUtilsMessageTypeFlagsEXT,
@@ -180,10 +181,38 @@ pub struct InstanceShared {
     drop_guard: Option<crate::DropGuard>,
 }
 
+impl fmt::Debug for InstanceShared {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            raw: _,
+            extensions,
+            flags,
+            memory_budget_thresholds,
+            debug_utils: _,
+            get_physical_device_properties: _,
+            entry: _,
+            has_nv_optimus,
+            android_sdk_version,
+            instance_api_version,
+            drop_guard: _,
+        } = self;
+        f.debug_struct("InstanceShared")
+            .field("extensions", extensions)
+            .field("flags", flags)
+            .field("memory_budget_thresholds", memory_budget_thresholds)
+            .field("has_nv_optimus", has_nv_optimus)
+            .field("android_sdk_version", android_sdk_version)
+            .field("instance_api_version", instance_api_version)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
 pub struct Instance {
     shared: Arc<InstanceShared>,
 }
 
+#[expect(missing_debug_implementations, reason = "TODO?")]
 pub struct Surface {
     swapchain: RwLock<Option<Box<dyn swapchain::Swapchain>>>,
     inner: Box<dyn swapchain::Surface>,
@@ -267,6 +296,7 @@ impl Borrow<dyn crate::DynTexture> for SurfaceTexture {
     }
 }
 
+#[derive(Debug)]
 pub struct Adapter {
     raw: vk::PhysicalDevice,
     instance: Arc<InstanceShared>,
@@ -513,6 +543,10 @@ impl Drop for DeviceShared {
     }
 }
 
+#[expect(
+    missing_debug_implementations,
+    reason = "needs work to not be disastrously verbose"
+)]
 pub struct Device {
     mem_allocator: Mutex<gpu_allocator::vulkan::Allocator>,
     desc_allocator: Mutex<descriptor::DescriptorAllocator>,
@@ -612,6 +646,22 @@ pub struct Queue {
     relay_semaphores: Mutex<RelaySemaphores>,
     signal_semaphores: Mutex<SemaphoreList>,
     wait_semaphores: Mutex<SemaphoreList>,
+}
+
+impl fmt::Debug for Queue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            raw: _,
+            device: _,
+            family_index,
+            relay_semaphores: _,
+            signal_semaphores: _,
+            wait_semaphores: _,
+        } = self;
+        f.debug_struct("Queue")
+            .field("family_index", family_index)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Queue {
@@ -1632,6 +1682,7 @@ struct RawTlasInstance {
 }
 
 /// Arguments to the [`CreateDeviceCallback`].
+#[derive(Debug)]
 pub struct CreateDeviceCallbackArgs<'arg, 'pnext, 'this>
 where
     'this: 'pnext,
@@ -1664,6 +1715,7 @@ pub type CreateDeviceCallback<'this> =
     dyn for<'arg, 'pnext> FnOnce(CreateDeviceCallbackArgs<'arg, 'pnext, 'this>) + 'this;
 
 /// Arguments to the [`CreateInstanceCallback`].
+#[expect(missing_debug_implementations, reason = "TODO?")]
 pub struct CreateInstanceCallbackArgs<'arg, 'pnext, 'this>
 where
     'this: 'pnext,

--- a/wgpu-macros/Cargo.toml
+++ b/wgpu-macros/Cargo.toml
@@ -19,3 +19,6 @@ proc-macro = true
 heck.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["full"] }
+
+[lints]
+workspace = true

--- a/wgpu-naga-bridge/Cargo.toml
+++ b/wgpu-naga-bridge/Cargo.toml
@@ -15,3 +15,6 @@ rust-version = "1.87"
 [dependencies]
 naga = { workspace = true }
 wgpu-types = { workspace = true }
+
+[lints]
+workspace = true

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -26,6 +26,7 @@ targets = [
 ]
 
 [lints.rust]
+missing_debug_implementations = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
 
 [lints.clippy]

--- a/wgpu-types/src/counters.rs
+++ b/wgpu-types/src/counters.rs
@@ -104,7 +104,7 @@ impl fmt::Debug for InternalCounter {
 
 /// `wgpu-hal`'s part of [`InternalCounters`].
 #[allow(missing_docs)]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct HalCounters {
     // API objects
     pub buffers: InternalCounter,
@@ -133,7 +133,7 @@ pub struct HalCounters {
 }
 
 /// `wgpu-core`'s part of [`InternalCounters`].
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CoreCounters {
     // TODO    #[cfg(features=)]
 }
@@ -142,7 +142,7 @@ pub struct CoreCounters {
 ///
 /// Obtain this from
 /// [`Device::get_internal_counters()`](../wgpu/struct.Device.html#method.get_internal_counters).
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct InternalCounters {
     /// `wgpu-core` counters.
     pub core: CoreCounters,
@@ -162,7 +162,7 @@ pub struct AllocationReport {
 }
 
 /// Describes a memory block in the [`AllocatorReport`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MemoryBlockReport {
     /// The size in bytes of this memory block.
     pub size: u64,

--- a/wgpu-types/src/write_only.rs
+++ b/wgpu-types/src/write_only.rs
@@ -767,6 +767,17 @@ pub struct WriteOnlyIter<'a, T> {
     slice: WriteOnly<'a, [T]>,
 }
 
+impl<T> fmt::Debug for WriteOnlyIter<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "WriteOnlyIter([{ty}], len = {len})",
+            ty = core::any::type_name::<T>(),
+            len = self.len(),
+        )
+    }
+}
+
 impl<'a, T> Iterator for WriteOnlyIter<'a, T> {
     type Item = WriteOnly<'a, T>;
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -279,3 +279,6 @@ bytemuck.workspace = true
 
 [build-dependencies]
 cfg_aliases.workspace = true
+
+[lints]
+workspace = true

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -134,6 +134,7 @@ static_assertions::assert_impl_all!(BlasTriangleGeometry<'_>: WasmNotSendSync);
 ///
 /// Buffer data must contain `size.primitive_count` primitives at `primitive_offset`, each `size.stride` bytes,
 /// with `stride` at least [`AABB_GEOMETRY_MIN_STRIDE`] and a multiple of 8.
+#[derive(Debug)]
 pub struct BlasAabbGeometry<'a> {
     /// Sub descriptor for the size defining attributes of this geometry.
     pub size: &'a BlasAABBGeometrySizeDescriptor,
@@ -148,6 +149,7 @@ pub struct BlasAabbGeometry<'a> {
 static_assertions::assert_impl_all!(BlasAabbGeometry<'_>: WasmNotSendSync);
 
 /// Contains the sets of geometry that go into a [Blas].
+#[derive(Debug)]
 pub enum BlasGeometries<'a> {
     /// Triangle geometry variant.
     TriangleGeometries(Vec<BlasTriangleGeometry<'a>>),
@@ -157,6 +159,7 @@ pub enum BlasGeometries<'a> {
 static_assertions::assert_impl_all!(BlasGeometries<'_>: WasmNotSendSync);
 
 /// Builds the given sets of geometry into the given [Blas].
+#[derive(Debug)]
 pub struct BlasBuildEntry<'a> {
     /// Reference to the acceleration structure.
     pub blas: &'a Blas,
@@ -165,7 +168,6 @@ pub struct BlasBuildEntry<'a> {
 }
 static_assertions::assert_impl_all!(BlasBuildEntry<'_>: WasmNotSendSync);
 
-#[derive(Debug, Clone)]
 /// Bottom Level Acceleration Structure (BLAS).
 ///
 /// A BLAS is a device-specific raytracing acceleration structure that contains geometry data.
@@ -173,6 +175,7 @@ static_assertions::assert_impl_all!(BlasBuildEntry<'_>: WasmNotSendSync);
 /// These BLASes are combined with transform in a [TlasInstance] to create a [Tlas].
 ///
 /// [Tlas]: crate::Tlas
+#[derive(Debug, Clone)]
 pub struct Blas {
     pub(crate) handle: Option<u64>,
     pub(crate) inner: dispatch::DispatchBlas,
@@ -240,6 +243,7 @@ impl Blas {
 }
 
 /// Context version of [BlasTriangleGeometry].
+#[expect(missing_debug_implementations)]
 pub struct ContextBlasTriangleGeometry<'a> {
     #[expect(dead_code)]
     pub(crate) size: &'a BlasTriangleGeometrySizeDescriptor,
@@ -260,6 +264,7 @@ pub struct ContextBlasTriangleGeometry<'a> {
 }
 
 /// Context version of [BlasGeometries].
+#[expect(missing_debug_implementations)]
 pub enum ContextBlasGeometries<'a> {
     /// Triangle geometries.
     TriangleGeometries(Box<dyn Iterator<Item = ContextBlasTriangleGeometry<'a>> + 'a>),
@@ -268,6 +273,7 @@ pub enum ContextBlasGeometries<'a> {
 }
 
 /// Context version of [BlasAabbGeometry].
+#[expect(missing_debug_implementations)]
 pub struct ContextBlasAabbGeometry<'a> {
     #[expect(dead_code)]
     pub(crate) size: &'a BlasAABBGeometrySizeDescriptor,
@@ -280,6 +286,7 @@ pub struct ContextBlasAabbGeometry<'a> {
 }
 
 /// Context version see [BlasBuildEntry].
+#[expect(missing_debug_implementations)]
 pub struct ContextBlasBuildEntry<'a> {
     #[expect(dead_code)]
     pub(crate) blas: &'a dispatch::DispatchBlas,

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -916,3 +916,19 @@ impl Drop for ErrorScopeGuard {
         }
     }
 }
+
+impl fmt::Debug for ErrorScopeGuard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ErrorScopeGuard {
+            device,
+            index,
+            popped,
+            _phantom: _,
+        } = self;
+        f.debug_struct("ErrorScopeGuard")
+            .field("device", device)
+            .field("index", index)
+            .field("popped", popped)
+            .finish()
+    }
+}

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use core::fmt;
 use core::ops::RangeBounds;
 
 use crate::{api::DeferredCommandBufferActions, *};
@@ -70,6 +71,15 @@ impl QueueWriteBufferView {
     /// Returns custom implementation of QueueWriteBufferView (if custom backend and is internally T)
     pub fn as_custom<T: custom::QueueWriteBufferInterface>(&self) -> Option<&T> {
         self.inner.as_custom()
+    }
+}
+
+impl fmt::Debug for QueueWriteBufferView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QueueWriteBufferView")
+            .field("buffer", &self.buffer)
+            .field("offset", &self.offset)
+            .finish_non_exhaustive()
     }
 }
 

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -311,6 +311,21 @@ pub enum SurfaceTarget<'window> {
     OffscreenCanvas(web_sys::OffscreenCanvas),
 }
 
+impl fmt::Debug for SurfaceTarget<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DisplayAndWindow(_) => f.debug_tuple("DisplayAndWindow").finish_non_exhaustive(),
+            Self::Window(_) => f.debug_tuple("Window").finish_non_exhaustive(),
+            #[cfg(web)]
+            Self::Canvas(canvas) => f.debug_tuple("Canvas").field(canvas).finish(),
+            #[cfg(web)]
+            Self::OffscreenCanvas(canvas) => {
+                f.debug_tuple("OffscreenCanvas").field(canvas).finish()
+            }
+        }
+    }
+}
+
 impl<'a> SurfaceTarget<'a> {
     /// Constructor for [`Self::Window`] without consuming a display handle
     pub fn from_window_without_display(window: impl WindowHandle + 'a) -> Self {
@@ -335,6 +350,7 @@ where
 ///
 /// See also [`SurfaceTarget`] for safe variants.
 #[non_exhaustive]
+#[derive(Debug)]
 pub enum SurfaceTargetUnsafe {
     /// Raw window & display handle.
     ///

--- a/wgpu/src/util/mod.rs
+++ b/wgpu/src/util/mod.rs
@@ -35,6 +35,7 @@ pub(crate) use panicking::is_panicking;
 use crate::dispatch;
 
 /// CPU accessible buffer used to download data back from the GPU.
+#[derive(Debug)]
 pub struct DownloadBuffer {
     _gpu_buffer: super::Buffer,
     mapped_range: dispatch::DispatchBufferMappedRange,


### PR DESCRIPTION
**Connections**
Inspired by https://github.com/gfx-rs/wgpu/pull/9730#pullrequestreview-4564748014 — let's just do it.

**Description**

* Adds `warn(missing_debug_implementations)` to all packages that are not for development use.

* Adds `Debug` implementations to many public types.

  The added implementations (or lack thereof) are often pretty haphazard; I figure that we can improve them as issues come up. I tried to add manual implementations in obviously valuable cases, like not printing SPIR-V bytecode as a list of integers (or at all).

**Testing**
Nah. We could add tests of `Debug` formatting of specific types, but it’s not clear what would be valuable.

**Squash or Rebase?**
Rebase.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
