### PR TITLE
fix(hal): derive Debug for PipelineGroupData

### DIFF
--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -3044,6 +3044,7 @@ pub struct Telemetry {
     ),
 }
 
+#[derive(Debug)]
 pub struct PipelineGroupData<'a, B: DynBuffer + ?Sized> {
     pub buffer: &'a B,
     pub offset: wgt::BufferAddress,


### PR DESCRIPTION
**Connections**

Fixes `trunk` CI breakage.

**Description**

#9464 added `PipelineGroupData` without a `Debug` impl and #9744 enabled the `missing_debug_implementations` lint — they collided, so `trunk` HEAD fails the lint. Adds `#[derive(Debug)]` (the `B: DynBuffer` bound already requires `Debug`, like sibling `BufferBinding`).

**Testing**

`cargo clippy -p wgpu-hal` passes with `-D warnings`.

**Squash or Rebase?**

Rebase (single commit).
