### PR TITLE
[core] Move validity into Arc<RenderPipeline>

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -371,13 +371,8 @@ impl Player {
                 // pipeline descriptor that can represent either a conventional
                 // pipeline or a mesh shading pipeline.
                 let resolved_desc = self.resolve_render_pipeline_descriptor(desc);
-                let pipeline = device.create_render_pipeline(resolved_desc);
-                process_result(
-                    "create_render_pipeline",
-                    &mut self.render_pipelines,
-                    id,
-                    pipeline,
-                );
+                let (pipeline, _error) = device.create_render_pipeline(resolved_desc);
+                self.render_pipelines.insert(id, pipeline);
             }
             Action::DropRenderPipeline(id) => {
                 self.render_pipelines

--- a/player/tests/player/data/quad.ron
+++ b/player/tests/player/data/quad.ron
@@ -50,7 +50,7 @@
             immediate_size: 0,
         )),
         CreateGeneralRenderPipeline(
-            id: Some(PointerId(0x10)),
+            id: PointerId(0x10),
             desc: (
                 label: None,
                 layout: Some(PointerId(0x10)),

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -773,13 +773,13 @@ fn set_bind_group(
 
 fn set_pipeline(
     state: &mut State,
-    pipeline_guard: &crate::storage::Storage<Fallible<RenderPipeline>>,
+    pipeline_guard: &crate::storage::Storage<Arc<RenderPipeline>>,
     context: &RenderPassContext,
     is_depth_read_only: bool,
     is_stencil_read_only: bool,
     pipeline_id: id::Id<id::markers::RenderPipeline>,
 ) -> Result<(), RenderBundleErrorInner> {
-    let pipeline = pipeline_guard.get(pipeline_id).get()?;
+    let pipeline = pipeline_guard.get(pipeline_id);
 
     pipeline.same_device(&state.device)?;
 
@@ -802,7 +802,7 @@ fn set_pipeline(
 
     state
         .binder
-        .change_pipeline_layout(&pipeline.layout, &pipeline.late_sized_buffer_groups);
+        .change_pipeline_layout(pipeline.layout()?, &pipeline.late_sized_buffer_groups);
 
     state.vertex.update_limits(&pipeline.vertex_steps);
 
@@ -938,7 +938,7 @@ fn set_immediates(
         .ok_or(DrawError::MissingPipeline(pass::MissingPipeline))?;
 
     pipeline
-        .layout
+        .layout()?
         .validate_immediates_ranges(offset, size_bytes)?;
 
     state.commands.push(ArcRenderCommand::SetImmediate {
@@ -1259,9 +1259,20 @@ impl RenderBundle {
                     offsets = &offsets[*num_dynamic_offsets..];
                 }
                 Cmd::SetPipeline(pipeline) => {
-                    unsafe { raw.set_render_pipeline(pipeline.raw()) };
+                    unsafe {
+                        raw.set_render_pipeline(
+                            pipeline
+                                .raw()
+                                .expect("RenderPipeline should be valid when executing bundle"),
+                        )
+                    };
 
-                    pipeline_layout = Some(pipeline.layout.clone());
+                    pipeline_layout = Some(
+                        pipeline
+                            .layout()
+                            .expect("PipelineLayout should be valid when executing bundle")
+                            .clone(),
+                    );
                 }
                 Cmd::SetIndexBuffer {
                     buffer,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2704,7 +2704,7 @@ fn set_pipeline(
             .pass
             .base
             .raw_encoder
-            .set_render_pipeline(pipeline.raw());
+            .set_render_pipeline(pipeline.raw()?);
     }
 
     if pipeline.flags.contains(PipelineFlags::STENCIL_REFERENCE) {
@@ -2720,7 +2720,7 @@ fn set_pipeline(
     // Rebind resource
     pass::change_pipeline_layout::<RenderPassErrorInner, _>(
         &mut state.pass,
-        &pipeline.layout,
+        pipeline.layout()?,
         &pipeline.late_sized_buffer_groups,
         || {},
     )?;
@@ -3597,7 +3597,8 @@ impl Global {
         }
 
         let hub = &self.hub;
-        let pipeline = pass_try!(base, scope, hub.render_pipelines.get(pipeline_id).get());
+        let pipeline = hub.render_pipelines.get(pipeline_id);
+        pass_try!(base, scope, pipeline.check_valid());
 
         base.commands.push(ArcRenderCommand::SetPipeline(pipeline));
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1377,7 +1377,7 @@ impl Global {
         &self,
         desc: pipeline::GeneralRenderPipelineDescriptor,
         device: Arc<crate::device::resource::Device>,
-        fid: crate::registry::FutureId<Fallible<pipeline::RenderPipeline>>,
+        fid: crate::registry::FutureId<Arc<pipeline::RenderPipeline>>,
     ) -> (
         id::RenderPipelineId,
         Option<pipeline::CreateRenderPipelineError>,
@@ -1386,7 +1386,9 @@ impl Global {
 
         let hub = &self.hub;
 
+        // eventually there will be no error handling here only id to object mapping
         let error = 'error: {
+            // until then we also need this
             if let Err(e) = device.check_is_valid() {
                 break 'error e.into();
             }
@@ -1547,31 +1549,18 @@ impl Global {
                 cache,
             };
 
-            #[cfg(feature = "trace")]
-            let trace_desc = desc.clone().into_trace();
+            let (pipeline, error) = device.create_render_pipeline(desc);
 
-            let res = device.create_render_pipeline(desc);
-
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                trace.add(trace::Action::CreateGeneralRenderPipeline {
-                    id: res.as_ref().ok().map(IntoTrace::to_trace),
-                    desc: trace_desc,
-                });
-            }
-
-            let pipeline = match res {
-                Ok(pair) => pair,
-                Err(e) => break 'error e,
-            };
-
-            let id = fid.assign(Fallible::Valid(pipeline));
+            let id = fid.assign(pipeline);
             api_log!("Device::create_render_pipeline -> {id:?}");
 
-            return (id, None);
+            return (id, error);
         };
 
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
+        let id = fid.assign(pipeline::RenderPipeline::invalid(
+            device.clone(),
+            desc.label.to_string(),
+        ));
 
         (id, Some(error))
     }
@@ -1592,10 +1581,7 @@ impl Global {
         let fid = hub.bind_group_layouts.prepare(id_in);
 
         let error = 'error: {
-            let pipeline = match hub.render_pipelines.get(pipeline_id).get() {
-                Ok(pipeline) => pipeline,
-                Err(e) => break 'error e.into(),
-            };
+            let pipeline = hub.render_pipelines.get(pipeline_id);
             match pipeline.get_bind_group_layout(index) {
                 Ok(bgl) => {
                     #[cfg(feature = "trace")]
@@ -1625,13 +1611,6 @@ impl Global {
         let hub = &self.hub;
 
         let _pipeline = hub.render_pipelines.remove(render_pipeline_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(pipeline) = _pipeline.get() {
-            if let Some(t) = pipeline.device.trace.lock().as_mut() {
-                t.add(trace::Action::DropRenderPipeline(pipeline.to_trace()));
-            }
-        }
     }
 
     pub fn device_create_compute_pipeline(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4102,6 +4102,31 @@ impl Device {
     pub fn create_render_pipeline(
         self: &Arc<Self>,
         desc: pipeline::ResolvedGeneralRenderPipelineDescriptor,
+    ) -> (
+        Arc<pipeline::RenderPipeline>,
+        Option<pipeline::CreateRenderPipelineError>,
+    ) {
+        let (render_pipeline, error) = match self.create_render_pipeline_inner(desc.clone()) {
+            Ok(pipeline) => (pipeline, None),
+            Err(e) => (
+                pipeline::RenderPipeline::invalid(self.clone(), desc.label.to_string()),
+                Some(e),
+            ),
+        };
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use crate::device::trace::IntoTrace;
+            trace.add(trace::Action::CreateGeneralRenderPipeline {
+                id: render_pipeline.to_trace(),
+                desc: desc.to_trace(),
+            });
+        }
+        (render_pipeline, error)
+    }
+
+    pub fn create_render_pipeline_inner(
+        self: &Arc<Self>,
+        desc: pipeline::ResolvedGeneralRenderPipelineDescriptor,
     ) -> Result<Arc<pipeline::RenderPipeline>, pipeline::CreateRenderPipelineError> {
         use wgt::TextureFormatFeatureFlags as Tfff;
 
@@ -4928,8 +4953,10 @@ impl Device {
         };
 
         let pipeline = pipeline::RenderPipeline {
-            raw: ManuallyDrop::new(raw),
-            layout: pipeline_layout,
+            state: resource::ResourceState::Valid(pipeline::RenderPipelineState {
+                raw: ManuallyDrop::new(raw),
+                layout: pipeline_layout.clone(),
+            }),
             device: self.clone(),
             pass_context,
             _shader_modules: shader_modules,
@@ -4948,7 +4975,7 @@ impl Device {
         let pipeline = Arc::new(pipeline);
 
         if is_auto_layout {
-            for bgl in pipeline.layout.bind_group_layouts.iter() {
+            for bgl in pipeline_layout.bind_group_layouts.iter() {
                 let Some(bgl) = bgl else {
                     continue;
                 };

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -200,7 +200,7 @@ pub enum Action<'a, R: ReferenceType> {
     },
     DropComputePipeline(PointerId<markers::ComputePipeline>),
     CreateGeneralRenderPipeline {
-        id: Option<PointerId<markers::RenderPipeline>>,
+        id: PointerId<markers::RenderPipeline>,
         desc: TraceGeneralRenderPipelineDescriptor<'a>,
     },
     DropRenderPipeline(PointerId<markers::RenderPipeline>),

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -194,7 +194,7 @@ pub struct Hub {
     pub(crate) command_encoders: Registry<Arc<CommandEncoder>>,
     pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,
     pub(crate) render_bundles: Registry<Fallible<RenderBundle>>,
-    pub(crate) render_pipelines: Registry<Fallible<RenderPipeline>>,
+    pub(crate) render_pipelines: Registry<Arc<RenderPipeline>>,
     pub(crate) compute_pipelines: Registry<Fallible<ComputePipeline>>,
     pub(crate) pipeline_caches: Registry<Fallible<PipelineCache>>,
     pub(crate) query_sets: Registry<Fallible<QuerySet>>,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -19,9 +19,12 @@ use crate::{
         GetBindGroupLayoutError, PipelineLayout,
     },
     command::ColorAttachmentError,
-    device::{Device, DeviceError, MissingDownlevelFlags, MissingFeatures, RenderPassContext},
+    device::{
+        AttachmentData, Device, DeviceError, MissingDownlevelFlags, MissingFeatures,
+        RenderPassContext,
+    },
     id::{PipelineCacheId, PipelineLayoutId, ShaderModuleId},
-    resource::{InvalidResourceError, Labeled, TrackingData},
+    resource::{InvalidResourceError, Labeled, ResourceState, TrackingData},
     resource_log,
     validation::{self, ShaderMetaData},
     Label,
@@ -834,10 +837,15 @@ impl Default for VertexStep {
 }
 
 #[derive(Debug)]
-pub struct RenderPipeline {
+pub(crate) struct RenderPipelineState {
     pub(crate) raw: ManuallyDrop<Box<dyn hal::DynRenderPipeline>>,
-    pub(crate) device: Arc<Device>,
     pub(crate) layout: Arc<PipelineLayout>,
+}
+
+#[derive(Debug)]
+pub struct RenderPipeline {
+    pub(crate) state: ResourceState<RenderPipelineState>,
+    pub(crate) device: Arc<Device>,
     pub(crate) _shader_modules: ArrayVec<Arc<ShaderModule>, { hal::MAX_CONCURRENT_SHADER_STAGES }>,
     pub(crate) pass_context: RenderPassContext,
     pub(crate) flags: PipelineFlags,
@@ -857,8 +865,20 @@ pub struct RenderPipeline {
 impl Drop for RenderPipeline {
     fn drop(&mut self) {
         resource_log!("Destroy raw {}", self.error_ident());
+        #[cfg(feature = "trace")]
+        {
+            use crate::device::trace;
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DropRenderPipeline(unsafe {
+                    trace::to_trace(self)
+                }));
+            }
+        }
+        let ResourceState::Valid(state) = &mut self.state else {
+            return;
+        };
         // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
-        let raw = unsafe { ManuallyDrop::take(&mut self.raw) };
+        let raw = unsafe { ManuallyDrop::take(&mut state.raw) };
         unsafe {
             self.device.raw().destroy_render_pipeline(raw);
         }
@@ -872,14 +892,58 @@ crate::impl_storage_item!(RenderPipeline);
 crate::impl_trackable!(RenderPipeline);
 
 impl RenderPipeline {
-    pub(crate) fn raw(&self) -> &dyn hal::DynRenderPipeline {
-        self.raw.as_ref()
+    pub(crate) fn raw(&self) -> Result<&dyn hal::DynRenderPipeline, InvalidResourceError> {
+        let ResourceState::Valid(state) = &self.state else {
+            return Err(InvalidResourceError(self.error_ident()));
+        };
+        Ok(state.raw.as_ref())
+    }
+
+    pub(crate) fn layout(&self) -> Result<&Arc<PipelineLayout>, InvalidResourceError> {
+        let ResourceState::Valid(state) = &self.state else {
+            return Err(InvalidResourceError(self.error_ident()));
+        };
+        Ok(&state.layout)
+    }
+
+    pub(crate) fn check_valid(&self) -> Result<(), InvalidResourceError> {
+        let ResourceState::Valid(_) = &self.state else {
+            return Err(InvalidResourceError(self.error_ident()));
+        };
+        Ok(())
+    }
+
+    pub(crate) fn invalid(device: Arc<Device>, label: String) -> Arc<Self> {
+        Arc::new(Self {
+            tracking_data: TrackingData::new(device.tracker_indices.render_pipelines.clone()),
+            state: ResourceState::Invalid,
+            device,
+            _shader_modules: ArrayVec::new(),
+            pass_context: RenderPassContext {
+                attachments: AttachmentData {
+                    colors: ArrayVec::new(),
+                    resolves: ArrayVec::new(),
+                    depth_stencil: None,
+                },
+                sample_count: 0,
+                multiview_mask: None,
+            },
+            flags: PipelineFlags::empty(),
+            topology: wgt::PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            vertex_steps: Vec::new(),
+            late_sized_buffer_groups: ArrayVec::new(),
+            immediate_slots_required: naga::valid::ImmediateSlots::default(),
+            label,
+            is_mesh: false,
+            has_task_shader: false,
+        })
     }
 
     pub fn get_bind_group_layout(
         self: &Arc<Self>,
         index: u32,
     ) -> Result<Arc<BindGroupLayout>, GetBindGroupLayoutError> {
-        self.layout.get_bind_group_layout(index, self.into())
+        self.layout()?.get_bind_group_layout(index, self.into())
     }
 }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -91,6 +91,28 @@ impl fmt::Display for ResourceErrorIdent {
     }
 }
 
+#[derive(Debug)]
+pub enum ResourceState<T> {
+    Valid(T),
+    Invalid,
+}
+
+impl<T> ResourceState<T> {
+    pub fn as_ref(&self) -> ResourceState<&T> {
+        match self {
+            ResourceState::Valid(v) => ResourceState::Valid(v),
+            ResourceState::Invalid => ResourceState::Invalid,
+        }
+    }
+
+    pub fn valid(self) -> Option<T> {
+        match self {
+            ResourceState::Valid(v) => Some(v),
+            ResourceState::Invalid => None,
+        }
+    }
+}
+
 pub enum DestructibleResourceState<T> {
     Valid(T),
     Invalid,


### PR DESCRIPTION
**Connections**
Continuation of https://github.com/gfx-rs/wgpu/pull/9718 as outlined in https://github.com/gfx-rs/wgpu/issues/5121#issuecomment-4761550506

**Description**
Here we move Fallible into RenderPipeline, by introducing:
```rust
struct ResourceState<T> {
    Valid(T),
    Invalid,
}
```
and having some `T = RenderPipelineState`, but more fields could be moved into it in the future. We also move tracing into the device methods and we now trace all renderpipelines (even invalid).

**Testing**
Covered by existing tests.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
