### PR TITLE
test: Run with LVP_POISON_MEMORY=true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ env:
   # Runtime configuration
   #
 
-  LVP_POISON_MEMORY: true
+  LVP_POISON_MEMORY: true # to test memory init; see docs/testing.md
   WGPU_DX12_COMPILER: dxc
 
 # Every time a PR is pushed to, cancel any previous jobs. This

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
 
 env:
   #
+  # Keep in sync with cts.yml
+  #
+
+  #
   # Dependency versioning
   #
 
@@ -27,12 +31,11 @@ env:
   CORE_MSRV: "1.87"
 
   #
-  # Environment variables
+  # Build and test configuration
   #
 
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
-  WGPU_DX12_COMPILER: dxc
   RUST_LOG: debug,wasm_bindgen_wasm_interpreter=warn,wasm_bindgen_cli_support=warn,walrus=warn,naga=info
   RUST_BACKTRACE: full
   PKG_CONFIG_ALLOW_CROSS: 1 # allow android to work
@@ -41,6 +44,13 @@ env:
   WASM_BINDGEN_TEST_TIMEOUT: 300 # 5 minutes
   CACHE_SUFFIX: e # cache busting
   WGPU_CI: true
+
+  #
+  # Runtime configuration
+  #
+
+  LVP_POISON_MEMORY: true
+  WGPU_DX12_COMPILER: dxc
 
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -14,12 +14,23 @@ on:
   merge_group:
 
 env:
+  #
+  # Keep in sync with ci.yml
+  #
+
   REPO_MSRV: "1.93"
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
+
+  #
+  # Runtime configuration
+  #
+
+  LVP_POISON_MEMORY: true
+  # cts_runner uses dxc by default
 
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -29,7 +29,7 @@ env:
   # Runtime configuration
   #
 
-  LVP_POISON_MEMORY: true
+  LVP_POISON_MEMORY: true # to test memory init; see docs/testing.md
   # cts_runner uses dxc by default
 
 # Every time a PR is pushed to, cancel any previous jobs. This

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -388,7 +388,7 @@ webgpu:shader,execution,expression,unary,bool_conversion:*
 webgpu:shader,execution,flow_control,return:*
 // Many other vertex_buffer_access subtests also passing, but there are too many to enumerate.
 // Fails on Metal in CI only, not when running locally.
-// Fails on Vulkan with LVP_POISON_MEMORY=true due to https://github.com/gfx-rs/wgpu/issues/8034
+// Fails on Vulkan with LVP_POISON_MEMORY=true possibly due to https://github.com/gfx-rs/wgpu/issues/8034
 fails-if(metal,vulkan) webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true
 webgpu:shader,execution,shader_io,fragment_builtins:inputs,front_facing:*
 webgpu:shader,execution,shader_io,fragment_builtins:inputs,interStage,centroid:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -388,7 +388,8 @@ webgpu:shader,execution,expression,unary,bool_conversion:*
 webgpu:shader,execution,flow_control,return:*
 // Many other vertex_buffer_access subtests also passing, but there are too many to enumerate.
 // Fails on Metal in CI only, not when running locally.
-fails-if(metal) webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true
+// Fails on Vulkan with LVP_POISON_MEMORY=true due to https://github.com/gfx-rs/wgpu/issues/8034
+fails-if(metal,vulkan) webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true
 webgpu:shader,execution,shader_io,fragment_builtins:inputs,front_facing:*
 webgpu:shader,execution,shader_io,fragment_builtins:inputs,interStage,centroid:*
 fails-if(vulkan) webgpu:shader,execution,shader_io,fragment_builtins:inputs,interStage:*

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -272,3 +272,13 @@ To find the full list of tests, go to the
 
 The version of the CTS used by `cargo xtask cts` is specified in
 [`cts_runner/revision.txt`](../cts_runner/revision.txt).
+
+## Memory Initialization Testing
+
+Simple tests can fail to detect when necessary memory initialization is omitted because
+allocations that happen to be satisfied by fresh kernel-provided pages are zero, even though
+the actual allocator being invoked does not guarantee that.
+
+To improve our coverage of memory initialization, we set `LVP_POISON_MEMORY=true` in Linux
+(Vulkan) CI. This instructs llvmpipe to fill all newly initialized memory with a non-zero
+value, so tests will reliably fail if the memory is not properly initialized.

--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -171,6 +171,19 @@ impl FailureCase {
         vec![f(FailureCase::molten_vk()), f(FailureCase::kosmic_krisp())]
     }
 
+    pub fn lvp_poison_memory(message: &'static str) -> Self {
+        if let Ok("true") = std::env::var("LVP_POISON_MEMORY").as_deref() {
+            FailureCase {
+                backends: Some(wgpu::Backends::VULKAN),
+                driver: Some("llvmpipe"),
+                reasons: vec![FailureReason::panic().with_message(message)],
+                ..FailureCase::default()
+            }
+        } else {
+            FailureCase::never()
+        }
+    }
+
     /// Return the reasons why this case should fail.
     pub fn reasons(&self) -> &[FailureReason] {
         if self.reasons.is_empty() {

--- a/tests/tests/wgpu-gpu/multiview/mod.rs
+++ b/tests/tests/wgpu-gpu/multiview/mod.rs
@@ -44,14 +44,15 @@ static DRAW_MULTIVIEW_NONCONTIGUOUS: GpuTestConfiguration = GpuTestConfiguration
             max_multiview_view_count: 4,
             ..Limits::defaults()
         },
-        // https://github.com/gfx-rs/wgpu/issues/9184 and https://github.com/gfx-rs/wgpu/issues/9187
         failures: {
             let mut failures = Vec::new();
+            // https://github.com/gfx-rs/wgpu/issues/9620
             failures.push(FailureCase::lvp_poison_memory(
                 "assertion `left == right` failed: Expected 0\n  \
                  left: Some(128)\n \
                  right: None",
             ));
+            // https://github.com/gfx-rs/wgpu/issues/9184 and https://github.com/gfx-rs/wgpu/issues/9187
             failures.append(&mut FailureCase::mac_vulkan(|case| {
                 case.panic(
                     "assertion `left == right` failed: Expected 0\n  left: Some(255)\n right: None",

--- a/tests/tests/wgpu-gpu/multiview/mod.rs
+++ b/tests/tests/wgpu-gpu/multiview/mod.rs
@@ -2,7 +2,7 @@ use std::num::NonZero;
 
 use wgpu::{Features, Limits};
 use wgpu_test::{
-    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+    gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
 };
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
@@ -45,11 +45,20 @@ static DRAW_MULTIVIEW_NONCONTIGUOUS: GpuTestConfiguration = GpuTestConfiguration
             ..Limits::defaults()
         },
         // https://github.com/gfx-rs/wgpu/issues/9184 and https://github.com/gfx-rs/wgpu/issues/9187
-        failures: wgpu_test::FailureCase::mac_vulkan(|case| {
-            case.panic(
-                "assertion `left == right` failed: Expected 0\n  left: Some(255)\n right: None",
-            )
-        }),
+        failures: {
+            let mut failures = Vec::new();
+            failures.push(FailureCase::lvp_poison_memory(
+                "assertion `left == right` failed: Expected 0\n  \
+                 left: Some(128)\n \
+                 right: None",
+            ));
+            failures.append(&mut FailureCase::mac_vulkan(|case| {
+                case.panic(
+                    "assertion `left == right` failed: Expected 0\n  left: Some(255)\n right: None",
+                )
+            }));
+            failures
+        },
         ..Default::default()
     })
     .run_async(|ctx| run_test(ctx, 0b1001, 1));

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -456,6 +456,7 @@ static WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12: GpuTestConfiguration =
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
                 .limits(Limits::downlevel_defaults())
+                // https://github.com/gfx-rs/wgpu/issues/9688
                 .expect_fail(FailureCase::lvp_poison_memory("read back non-zero")),
         )
         .run_async(|ctx| async move {
@@ -477,6 +478,7 @@ static WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_NV12: GpuTestConfiguration =
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
                 .limits(Limits::downlevel_defaults())
+                // https://github.com/gfx-rs/wgpu/issues/9688
                 .expect_fail(FailureCase::lvp_poison_memory("read back non-zero")),
         )
         .run_async(|ctx| async move {
@@ -498,6 +500,7 @@ static WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_P010: GpuTestConfiguration =
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_P010 | Features::TEXTURE_FORMAT_16BIT_NORM)
                 .limits(Limits::downlevel_defaults())
+                // https://github.com/gfx-rs/wgpu/issues/9688
                 .expect_fail(FailureCase::lvp_poison_memory("read back non-zero")),
         )
         .run_async(|ctx| async move {
@@ -519,6 +522,7 @@ static WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_P010: GpuTestConfiguration =
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_P010 | Features::TEXTURE_FORMAT_16BIT_NORM)
                 .limits(Limits::downlevel_defaults())
+                // https://github.com/gfx-rs/wgpu/issues/9688
                 .expect_fail(FailureCase::lvp_poison_memory("read back non-zero")),
         )
         .run_async(|ctx| async move {
@@ -562,7 +566,9 @@ static COPY_BUFFER_TO_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12: GpuTestConfigura
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
-                .limits(Limits::downlevel_defaults()),
+                .limits(Limits::downlevel_defaults())
+                // https://github.com/gfx-rs/wgpu/issues/9688
+                .expect_fail(FailureCase::lvp_poison_memory("read back non-zero")),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -455,7 +455,8 @@ static WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
-                .limits(Limits::downlevel_defaults()),
+                .limits(Limits::downlevel_defaults())
+                .expect_fail(FailureCase::lvp_poison_memory("read back non-zero")),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -475,7 +476,8 @@ static WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_NV12: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_NV12)
-                .limits(Limits::downlevel_defaults()),
+                .limits(Limits::downlevel_defaults())
+                .expect_fail(FailureCase::lvp_poison_memory("read back non-zero")),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -495,7 +497,8 @@ static WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_P010: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_P010 | Features::TEXTURE_FORMAT_16BIT_NORM)
-                .limits(Limits::downlevel_defaults()),
+                .limits(Limits::downlevel_defaults())
+                .expect_fail(FailureCase::lvp_poison_memory("read back non-zero")),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(
@@ -515,7 +518,8 @@ static WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_P010: GpuTestConfiguration =
         .parameters(
             TestParameters::default()
                 .features(Features::TEXTURE_FORMAT_P010 | Features::TEXTURE_FORMAT_16BIT_NORM)
-                .limits(Limits::downlevel_defaults()),
+                .limits(Limits::downlevel_defaults())
+                .expect_fail(FailureCase::lvp_poison_memory("read back non-zero")),
         )
         .run_async(|ctx| async move {
             check_plane_write_leaves_other_plane_uninit(


### PR DESCRIPTION
Run tests with `LVP_POISON_MEMORY=true`, to better detect missing memory initialization.

Fixes #9701
Conflicts with #9700. #9700 resolves several of the expect-fails in this PR.

**Testing**
Yes

**Squash or Rebase?** Squash