### PR TITLE
Make `SurfaceColorSpace` accessors `const fn`

### DIFF
--- a/wgpu-types/src/surface.rs
+++ b/wgpu-types/src/surface.rs
@@ -418,7 +418,7 @@ impl SurfaceColorSpace {
     /// Returns the [`SurfaceColorSpaces`] flag set holding just this color space,
     /// or `None` for [`Auto`](Self::Auto) (which maps to no specific flag).
     #[must_use]
-    pub fn to_color_spaces(self) -> Option<SurfaceColorSpaces> {
+    pub const fn to_color_spaces(self) -> Option<SurfaceColorSpaces> {
         match self {
             Self::Auto => None,
             Self::Srgb => Some(SurfaceColorSpaces::SRGB),
@@ -444,7 +444,7 @@ impl SurfaceColorSpace {
     /// [`SurfaceCapabilities`]: only an HDR result drives highlights above SDR
     /// white (`1.0`).
     #[must_use]
-    pub fn is_hdr(self) -> bool {
+    pub const fn is_hdr(self) -> bool {
         match self {
             Self::ExtendedSrgbLinear
             | Self::ExtendedSrgb


### PR DESCRIPTION
**Description**
Mark `SurfaceColorSpace::is_hdr()` and `SurfaceColorSpace::to_color_spaces` as `const fn` so they can be used in constants.

**Testing**
If CI passes, it's good.

**Squash or Rebase?**
Rebase.

**Checklist**

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
