### PR TITLE
Workaround xcode misreporting ray tracing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 #### Metal
 
 - Removed the `size` argument to `wgpu_hal::metal::Device::buffer_from_raw`. The passed size value was previously used only to resolve vertex buffer bindings without an explicit size, possibly incorrectly. Binding sizes are now resolved in `wgpu-core`. By @andyleiserson in [#9848](https://github.com/gfx-rs/wgpu/pull/9848).
+- When `cfg(debug_assertions)` is active and the Metal capture device is detected (e.g. if running the application under Xcode), print a warning that feature detection may be degraded. Without `cfg(debug_assertions)`, remove the feature detection workaround in question entirely. By @andyleiserson in [#9757](https://github.com/gfx-rs/wgpu/pull/9757). Also see <https://github.com/gfx-rs/wgpu/issues/10028>.
 
 ### Bug Fixes
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -622,6 +622,11 @@ impl super::CapabilitiesQuery {
             .any(|x| raw.supportsFeatureSet(x))
     }
 
+    fn is_capture_mtl_device(device: &ProtocolObject<dyn MTLDevice>) -> bool {
+        let obj: &AnyObject = device.as_ref();
+        obj.class().name().to_string_lossy() == "CaptureMTLDevice"
+    }
+
     /// Query the capabilities of the device.
     pub fn new(device: &ProtocolObject<dyn MTLDevice>) -> Self {
         // There are four different OSes we can target: macOS, iOS, tvOS and
@@ -1164,10 +1169,15 @@ impl super::CapabilitiesQuery {
                 tvos = 18.0,
                 visionos = 2.0,
             ) {
-                device_class_responds_to(device, sel!(supportsRaytracing))
-                    && device.supportsRaytracing()
-                    && device_class_responds_to(device, sel!(supportsRaytracingFromRender))
-                    && device.supportsRaytracingFromRender()
+                // Special case for Xcode Capture, which misreports ray tracing support.
+                if Self::is_capture_mtl_device(device) {
+                    metal4 || (family_check && device.supportsFamily(MTLGPUFamily::Apple6))
+                } else {
+                    device_class_responds_to(device, sel!(supportsRaytracing))
+                        && device.supportsRaytracing()
+                        && device_class_responds_to(device, sel!(supportsRaytracingFromRender))
+                        && device.supportsRaytracingFromRender()
+                }
             } else {
                 false
             },

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1156,6 +1156,8 @@ impl super::CapabilitiesQuery {
             supports_cooperative_matrix: family_check
                 && (device.supportsFamily(MTLGPUFamily::Apple7)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
+            // This `available!` condition is for residency sets, which are used by
+            // wgpu's ray tracing support, and not for ray tracing itself.
             // https://developer.apple.com/documentation/metal/mtlresidencyset
             supports_raytracing: if available!(
                 macos = 15.0,
@@ -1163,10 +1165,14 @@ impl super::CapabilitiesQuery {
                 tvos = 18.0,
                 visionos = 2.0,
             ) {
-                device_class_responds_to(device, sel!(supportsRaytracing))
-                    && device.supportsRaytracing()
-                    && device_class_responds_to(device, sel!(supportsRaytracingFromRender))
-                    && device.supportsRaytracingFromRender()
+                // This is the actual ray tracing feature detection. Runtime detection with
+                // `supportsRayTracing{,FromRender}` picks up a few devices before Apple6,
+                // but requires the capture device workaround.
+                (family_check && device.supportsFamily(MTLGPUFamily::Apple6))
+                    || (device_class_responds_to(device, sel!(supportsRaytracing))
+                        && device.supportsRaytracing()
+                        && device_class_responds_to(device, sel!(supportsRaytracingFromRender))
+                        && device.supportsRaytracingFromRender())
             } else {
                 false
             },

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1,5 +1,5 @@
 use objc2::rc::autoreleasepool;
-use objc2::runtime::{AnyObject, ProtocolObject, Sel};
+use objc2::runtime::{ProtocolObject, Sel};
 use objc2::{available, sel};
 use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};
 use objc2_metal::{
@@ -21,9 +21,15 @@ use super::{OsFeatures, TimestampQuerySupport};
 /// This mirrors the check that `objc2` performs internally (in debug builds)
 /// before sending a message. We use it to skip method calls that would panic
 /// on proxy objects like Apple's `CaptureMTLDevice`, which forwards messages
-/// at runtime but doesn't declare the methods in its class.
-fn device_class_responds_to(device: &ProtocolObject<dyn MTLDevice>, sel: Sel) -> bool {
-    AnyObject::class(device.as_ref()).responds_to(sel)
+/// at runtime but doesn't declare the methods in its class. See
+/// <https://github.com/gfx-rs/wgpu/issues/10028>.
+#[cfg(debug_assertions)]
+fn is_valid_objc_call(device: &ProtocolObject<dyn MTLDevice>, sel: Sel) -> bool {
+    objc2::runtime::AnyObject::class(device.as_ref()).responds_to(sel)
+}
+#[cfg(not(debug_assertions))]
+fn is_valid_objc_call(_device: &ProtocolObject<dyn MTLDevice>, _sel: Sel) -> bool {
+    true
 }
 
 /// Maximum number of command buffers for `MTLCommandQueue`s that we create.
@@ -70,6 +76,31 @@ impl crate::Adapter for super::Adapter {
         _memory_hints: &wgt::MemoryHints,
     ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
         autoreleasepool(|_| {
+            #[cfg(debug_assertions)]
+            {
+                // Detect and warn if our feature detection may be degraded due to
+                // the Metal capture device. See `is_valid_objc_call` and
+                // <https://github.com/gfx-rs/wgpu/issues/10028>.
+                use core::sync::atomic::{AtomicBool, Ordering};
+                static MTL_DEBUG_DEVICES: &[&str] = &[
+                    "CaptureMTLDevice",
+                    // others...?
+                ];
+                static WARN_ONCE: AtomicBool = AtomicBool::new(false);
+                let class = objc2::runtime::AnyObject::class(self.shared.device.as_ref())
+                    .name()
+                    .to_string_lossy();
+                if let Some(class) = MTL_DEBUG_DEVICES.iter().find(|&&c| class == c) {
+                    if !WARN_ONCE.fetch_or(true, Ordering::SeqCst) {
+                        log::warn!(
+                            "Metal debug device ({class}) detected. Some Metal features may \
+                            be incorrectly detected as not supported. \
+                            See <https://github.com/gfx-rs/wgpu/issues/10028>."
+                        );
+                    }
+                }
+            }
+
             let queue = self
                 .shared
                 .device
@@ -763,7 +794,7 @@ impl super::CapabilitiesQuery {
             texture_cube_array: Self::supports_any(device, TEXTURE_CUBE_ARRAY_SUPPORT),
             supports_float_filtering: os_type == super::OsType::Macos
                 || (available!(macos = 11.0, ios = 14.0, tvos = 16.0, visionos = 1.0)
-                    && device_class_responds_to(device, sel!(supports32BitFloatFiltering))
+                    && is_valid_objc_call(device, sel!(supports32BitFloatFiltering))
                     && device.supports32BitFloatFiltering()),
             format_depth24_stencil8: os_type == super::OsType::Macos
                 && device.isDepth24Stencil8PixelFormatSupported(),
@@ -777,7 +808,7 @@ impl super::CapabilitiesQuery {
             format_b5: os_type != super::OsType::Macos,
             format_bc: os_type == super::OsType::Macos
                 || (available!(macos = 11.0, ios = 16.4, tvos = 16.4, visionos = 1.0)
-                    && device_class_responds_to(device, sel!(supportsBCTextureCompression))
+                    && is_valid_objc_call(device, sel!(supportsBCTextureCompression))
                     && device.supportsBCTextureCompression()),
             format_eac_etc: os_type != super::OsType::Macos
                 // M1 in macOS supports EAC/ETC2
@@ -1066,7 +1097,7 @@ impl super::CapabilitiesQuery {
                 ios = 13.0,
                 tvos = 13.0,
                 visionos = 1.0
-            ) && device_class_responds_to(device, sel!(hasUnifiedMemory))
+            ) && is_valid_objc_call(device, sel!(hasUnifiedMemory))
             {
                 Some(device.hasUnifiedMemory())
             } else {
@@ -1100,10 +1131,7 @@ impl super::CapabilitiesQuery {
                     && (device.supportsFamily(MTLGPUFamily::Apple7)
                         || device.supportsFamily(MTLGPUFamily::Mac2)))
                 || (available!(macos = 10.15, ios = 14.0, tvos = 16.0, visionos = 1.0)
-                    && device_class_responds_to(
-                        device,
-                        sel!(supportsShaderBarycentricCoordinates),
-                    )
+                    && is_valid_objc_call(device, sel!(supportsShaderBarycentricCoordinates))
                     && device.supportsShaderBarycentricCoordinates()),
             // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf#page=3
             // See https://github.com/gfx-rs/wgpu/pull/8725 for more details
@@ -1169,9 +1197,9 @@ impl super::CapabilitiesQuery {
                 // `supportsRayTracing{,FromRender}` picks up a few devices before Apple6,
                 // but requires the capture device workaround.
                 (family_check && device.supportsFamily(MTLGPUFamily::Apple6))
-                    || (device_class_responds_to(device, sel!(supportsRaytracing))
+                    || (is_valid_objc_call(device, sel!(supportsRaytracing))
                         && device.supportsRaytracing()
-                        && device_class_responds_to(device, sel!(supportsRaytracingFromRender))
+                        && is_valid_objc_call(device, sel!(supportsRaytracingFromRender))
                         && device.supportsRaytracingFromRender())
             } else {
                 false


### PR DESCRIPTION
**Connections**
Fixes #9756 

Related originating PR (no hard dependency): #9081

**Description**

On a CaptureMTLDevice calling supportsRayTracing causes a fault. same problem as hasUnifiedMemory. For Solari or more generally RT apps we still want to use xCode capture.

Since this is a boolean defaulting to false would effectively disable RT frame capture capability on metal devices running Xcode debugger.

So when the API path isn't safe, we fall back to the same source as elsewhere in the file, that is the Metal GPU features table.

Apple documents "Ray tracing in compute/render pipelines" from MTLGPUFamilyApple6 in Metal Feature Set Tables, "Metal feature availability by GPU family," with footnotes 9 and 10. A13 is the first Apple6 GPU in the Apple silicon mapping table.

**Testing**

Tested with repro steps in the linked issue.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
