### PR TITLE
Rename `TextureFormat::is_srgb()` to `has_srgb_suffix()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Bottom level categories:
 - Allow `set_immediates` before `set_pipeline` by deferring actual setting of immediates to draw/dispatch call time. By @beicause in [#9597](https://github.com/gfx-rs/wgpu/pull/9597).
 - Validate pipeline layout `immediate_size` and fix its calculation when there are multiple immediate variables. Now it must be >= required size of the shader entry point. By @beicause in [#9711](https://github.com/gfx-rs/wgpu/pull/9711).
 - [`immediate_address_space`](https://www.w3.org/TR/WGSL/#language_extension-immediate_address_space) WGSL language extension is implemented. By @beicause in [#9711](https://github.com/gfx-rs/wgpu/pull/9711).
+- `TextureFormat::is_srgb()` has been renamed to `TextureFormat::has_srgb_suffix()` to clarify its function. By @kpreid in [#9758](https://github.com/gfx-rs/wgpu/pull/9758).
 
 #### naga
 

--- a/examples/standalone/03_hdr_surface/src/main.rs
+++ b/examples/standalone/03_hdr_surface/src/main.rs
@@ -320,7 +320,7 @@ impl State {
         // mode, encode_srgb
         let params: [u32; 2] = [
             choice.shader_mode,
-            u32::from(choice.shader_mode == 0 && !choice.format.is_srgb()),
+            u32::from(choice.shader_mode == 0 && !choice.format.has_srgb_suffix()),
         ];
         let params_buffer = wgpu::util::DeviceExt::create_buffer_init(
             &device,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -779,7 +779,9 @@ impl Surface {
         profiling::scope!("Surface::get_capabilities");
         let mut hal_caps = self.get_hal_capabilities(adapter)?;
 
-        hal_caps.formats.sort_by_key(|fc| !fc.format.is_srgb());
+        hal_caps
+            .formats
+            .sort_by_key(|fc| !fc.format.has_srgb_suffix());
 
         let usages = crate::conv::map_texture_usage_from_hal(hal_caps.usage);
 

--- a/wgpu-hal/src/gles/command.rs
+++ b/wgpu-hal/src/gles/command.rs
@@ -659,7 +659,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                         wgt::TextureSampleType::Float { .. } => C::ClearColorF {
                             draw_buffer: i as u32,
                             color: [c.r as f32, c.g as f32, c.b as f32, c.a as f32],
-                            is_srgb: cat.target.view.format.is_srgb(),
+                            is_srgb: cat.target.view.format.has_srgb_suffix(),
                         },
                         wgt::TextureSampleType::Uint => C::ClearColorU(
                             i as u32,

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1335,7 +1335,7 @@ impl crate::Surface for Surface {
                         khronos_egl::SINGLE_BUFFER
                     },
                 ];
-                if config.format.is_srgb() {
+                if config.format.has_srgb_suffix() {
                     match self.srgb_kind {
                         SrgbFrameBufferKind::None => {}
                         SrgbFrameBufferKind::Core => {

--- a/wgpu-hal/src/gles/web.rs
+++ b/wgpu-hal/src/gles/web.rs
@@ -271,7 +271,7 @@ impl Surface {
             "need to configure surface before presenting",
         ))?;
 
-        if swapchain.format.is_srgb() {
+        if swapchain.format.has_srgb_suffix() {
             // Important to set the viewport since we don't know in what state the user left it.
             unsafe {
                 gl.viewport(
@@ -374,7 +374,7 @@ impl crate::Surface for Surface {
         }
         {
             let mut srgb_present_program = self.srgb_present_program.lock();
-            if srgb_present_program.is_none() && config.format.is_srgb() {
+            if srgb_present_program.is_none() && config.format.has_srgb_suffix() {
                 *srgb_present_program = Some(unsafe { Self::create_srgb_present_program(gl) });
             }
         }

--- a/wgpu-types/src/texture/format.rs
+++ b/wgpu-types/src/texture/format.rs
@@ -1568,7 +1568,12 @@ impl TextureFormat {
         }
     }
 
-    /// Strips the `Srgb` suffix from the given texture format.
+    /// Changes `*UnormSrgb` texture formats to `*Unorm`.
+    ///
+    /// Given a texture format which implicitly performs sRGB decoding when read in shaders and
+    /// encoding when written to as a render target, this returns the corresponding `Unorm` format
+    /// which performs only linear scaling.
+    /// All other formats are returned unchanged.
     #[must_use]
     pub fn remove_srgb_suffix(&self) -> TextureFormat {
         match *self {
@@ -1592,7 +1597,11 @@ impl TextureFormat {
         }
     }
 
-    /// Adds an `Srgb` suffix to the given texture format, if the format supports it.
+    /// Changes `*Unorm` texture formats to `*UnormSrgb`.
+    ///
+    /// Given a `Unorm` texture format, this returns a texture format which implicitly performs sRGB
+    /// decoding when read in shaders and encoding when written to as a render target.
+    /// All other formats are returned unchanged.
     #[must_use]
     pub fn add_srgb_suffix(&self) -> TextureFormat {
         match *self {
@@ -1616,9 +1625,14 @@ impl TextureFormat {
         }
     }
 
-    /// Returns `true` for srgb formats.
+    /// Returns `true` for `*Srgb` formats: those which, when read by a shader, automatically apply
+    /// sRGB decoding, and when written to as a render target, automatically apply sRGB encoding.
+    ///
+    /// This does not relate to whether or not the contents of the texture are expected to be in
+    /// the sRGB color space; that is determined by how it is used (in the case of surface
+    /// textures, by the [`SurfaceColorSpace`][crate::SurfaceColorSpace]).
     #[must_use]
-    pub fn is_srgb(&self) -> bool {
+    pub fn has_srgb_suffix(&self) -> bool {
         *self != self.remove_srgb_suffix()
     }
 


### PR DESCRIPTION
**Description**

* Renamed `TextureFormat::is_srgb()` to `has_srgb_suffix()`.
* Expanded its documentation.
* Rewrote the documentation of `add_srgb_suffix()` and `remove_srgb_suffix()`.

This is intended to clarify the correct use of `is_srgb()`. Ideally, the new name would communicate that it does *not* mean “this (surface) texture format stores sRGB data”, which may be true or false independently; but `has_srgb_suffix` at least makes its relationship to the other operations clearer.

**Testing**
Ran `cargo doc` and reviewed the changed documentation.

**Squash or Rebase?**
Rebase

**Checklist**

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [X] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
