### PR TITLE
ci: inline prettier check, drop creyD/prettier_action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -816,14 +816,8 @@ jobs:
           rustup override set ${{ env.REPO_MSRV }}
           cargo -V
 
-      # NOTE: Keep this above the others, because this will fail if there are _any_ changes to
-      # files, even ones this step doesn't modify.
       - name: "Format `**/*.{md,js,html,yml}` files"
-        uses: creyD/prettier_action@v4.6
-        with:
-          prettier_version: 3.8.1
-          prettier_options: --check --write .
-          dry: true
+        run: npx --yes prettier@3.8.1 --check .
 
       - name: Run `cargo fmt`
         run: |


### PR DESCRIPTION
**Connections**

Found in #9758 

**Description**

Pinning the version in the npx package spec avoids creyD/prettier_action#154, where the pinned version was ignored and the latest release was used instead.

**Testing**

CI

**Squash or Rebase?**

Yes

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
