### PR TITLE
[core] Move validity into `Arc<ComputePipeline>`

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -14,7 +14,7 @@ use wgc::{
     binding_model::BindingResource,
     command::{ArcCommand, ArcReferences, BasePass, Command, PointerReferences},
     device::trace::{self, DataKind, DataLoader},
-    id::{Marker, PointerId},
+    id::PointerId,
 };
 
 #[derive(Debug)]
@@ -85,28 +85,6 @@ impl Default for Player {
             samplers: HashMap::new(),
             blas_s: HashMap::new(),
             tlas_s: HashMap::new(),
-        }
-    }
-}
-
-fn process_result<T: Marker, U>(
-    op: &str,
-    map: &mut HashMap<PointerId<T>, U>,
-    id: Option<PointerId<T>>,
-    value: Result<U, impl std::error::Error>,
-) {
-    match (id, value) {
-        (Some(id), Ok(value)) => {
-            map.insert(id, value);
-        }
-        (Some(_), Err(err)) => {
-            panic!("{op} succeeded when recording, but failed on playback: {err}");
-        }
-        (None, Ok(_)) => {
-            panic!("{op} failed when recording, but succeeded on playback");
-        }
-        (None, Err(err)) => {
-            panic!("{op} failed when recording, and failed on playback: {err}");
         }
     }
 }
@@ -353,13 +331,8 @@ impl Player {
             }
             Action::CreateComputePipeline { id, desc } => {
                 let resolved_desc = self.resolve_compute_pipeline_descriptor(desc);
-                let pipeline = device.create_compute_pipeline(resolved_desc);
-                process_result(
-                    "create_compute_pipeline",
-                    &mut self.compute_pipelines,
-                    id,
-                    pipeline,
-                );
+                let (pipeline, _error) = device.create_compute_pipeline(resolved_desc);
+                self.compute_pipelines.insert(id, pipeline);
             }
             Action::DropComputePipeline(id) => {
                 self.compute_pipelines

--- a/player/tests/player/data/bind-group.ron
+++ b/player/tests/player/data/bind-group.ron
@@ -50,7 +50,7 @@
             data: File("empty.wgsl"),
         ),
         CreateComputePipeline(
-            id: Some(PointerId(0x10)),
+            id: PointerId(0x10),
             desc: (
                 label: None,
                 layout: Some(PointerId(0x10)),

--- a/player/tests/player/data/pipeline-statistics-query.ron
+++ b/player/tests/player/data/pipeline-statistics-query.ron
@@ -23,7 +23,7 @@
             data: File("empty.wgsl"),
         ),
         CreateComputePipeline(
-            id: Some(PointerId(0x10)),
+            id: PointerId(0x10),
             desc: (
                 label: None,
                 layout: Some(PointerId(0x10)),

--- a/player/tests/player/data/zero-init-buffer.ron
+++ b/player/tests/player/data/zero-init-buffer.ron
@@ -125,7 +125,7 @@
             immediate_size: 0,
         )),
         CreateComputePipeline(
-            id: Some(PointerId(0x10)),
+            id: PointerId(0x10),
             desc: (
                 label: None,
                 layout: Some(PointerId(0x10)),

--- a/player/tests/player/data/zero-init-texture-binding.ron
+++ b/player/tests/player/data/zero-init-texture-binding.ron
@@ -128,7 +128,7 @@
             data: File("zero-init-texture-binding.wgsl"),
         ),
         CreateComputePipeline(
-            id: Some(PointerId(0x10)),
+            id: PointerId(0x10),
             desc: (
                 label: None,
                 layout: Some(PointerId(0x10)),

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -915,22 +915,23 @@ fn set_pipeline(
             .pass
             .base
             .raw_encoder
-            .set_compute_pipeline(pipeline.raw());
+            .set_compute_pipeline(pipeline.raw()?);
     }
 
     // Rebind resources
+    let pipeline_layout = pipeline.layout()?;
     pass::change_pipeline_layout::<ComputePassErrorInner, _>(
         &mut state.pass,
-        &pipeline.layout,
+        pipeline_layout,
         &pipeline.late_sized_buffer_groups,
         || {
             // This only needs to be here for compute pipelines because they use immediates for
             // validating indirect draws.
             state.immediates.clear();
             // Note that can only be one range for each stage. See the `MoreThanOneImmediateRangePerStage` error.
-            if pipeline.layout.immediate_size != 0 {
+            if pipeline_layout.immediate_size != 0 {
                 // Note that non-0 range start doesn't work anyway https://github.com/gfx-rs/wgpu/issues/4502
-                let len = pipeline.layout.immediate_size as usize
+                let len = pipeline_layout.immediate_size as usize
                     / wgt::IMMEDIATE_DATA_ALIGNMENT as usize;
                 state.immediates.extend(core::iter::repeat_n(0, len));
             }
@@ -1097,13 +1098,15 @@ fn dispatch_workgroups_indirect(
                     .pass
                     .base
                     .raw_encoder
-                    .set_compute_pipeline(pipeline.raw());
+                    .set_compute_pipeline(pipeline.raw()?);
             }
+
+            let pipeline_layout = pipeline.layout()?;
 
             if !state.immediates.is_empty() {
                 unsafe {
                     state.pass.base.raw_encoder.set_immediates(
-                        pipeline.layout.raw(),
+                        pipeline_layout.raw(),
                         0,
                         &state.immediates,
                     );
@@ -1114,7 +1117,7 @@ fn dispatch_workgroups_indirect(
                 let raw_bg = group.try_raw(state.pass.base.snatch_guard)?;
                 unsafe {
                     state.pass.base.raw_encoder.set_bind_group(
-                        pipeline.layout.raw(),
+                        pipeline_layout.raw(),
                         i as u32,
                         raw_bg,
                         dynamic_offsets,
@@ -1234,9 +1237,11 @@ impl Global {
         }
 
         let hub = &self.hub;
-        let pipeline = pass_try!(base, scope, hub.compute_pipelines.get(pipeline_id).get());
+        let compute_pipeline = hub.compute_pipelines.get(pipeline_id);
+        pass_try!(base, scope, compute_pipeline.check_valid());
 
-        base.commands.push(ArcComputeCommand::SetPipeline(pipeline));
+        base.commands
+            .push(ArcComputeCommand::SetPipeline(compute_pipeline));
 
         Ok(())
     }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1628,9 +1628,11 @@ impl Global {
 
         let fid = hub.compute_pipelines.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
+        // eventually there will be no error handling here only id to object mapping
+        let error = 'error: {
+            // until then we also need this
             if let Err(e) = device.check_is_valid() {
                 break 'error e.into();
             }
@@ -1677,31 +1679,18 @@ impl Global {
                 cache,
             };
 
-            #[cfg(feature = "trace")]
-            let trace_desc = desc.clone().into_trace();
+            let (pipeline, error) = device.create_compute_pipeline(desc);
 
-            let res = device.create_compute_pipeline(desc);
-
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                trace.add(trace::Action::CreateComputePipeline {
-                    id: res.as_ref().ok().map(IntoTrace::to_trace),
-                    desc: trace_desc,
-                });
-            }
-
-            let pipeline = match res {
-                Ok(pair) => pair,
-                Err(e) => break 'error e,
-            };
-
-            let id = fid.assign(Fallible::Valid(pipeline));
+            let id = fid.assign(pipeline);
             api_log!("Device::create_compute_pipeline -> {id:?}");
 
-            return (id, None);
+            return (id, error);
         };
 
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
+        let id = fid.assign(pipeline::ComputePipeline::invalid(
+            device,
+            desc.label.to_string(),
+        ));
 
         (id, Some(error))
     }
@@ -1721,12 +1710,9 @@ impl Global {
 
         let fid = hub.bind_group_layouts.prepare(id_in);
 
-        let error = 'error: {
-            let pipeline = match hub.compute_pipelines.get(pipeline_id).get() {
-                Ok(pipeline) => pipeline,
-                Err(e) => break 'error e.into(),
-            };
+        let pipeline = hub.compute_pipelines.get(pipeline_id);
 
+        let error = 'error: {
             match pipeline.get_bind_group_layout(index) {
                 Ok(bgl) => {
                     #[cfg(feature = "trace")]
@@ -1756,13 +1742,6 @@ impl Global {
         let hub = &self.hub;
 
         let _pipeline = hub.compute_pipelines.remove(compute_pipeline_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(pipeline) = _pipeline.get() {
-            if let Some(t) = pipeline.device.trace.lock().as_mut() {
-                t.add(trace::Action::DropComputePipeline(pipeline.to_trace()));
-            }
-        }
     }
 
     /// # Safety

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -47,7 +47,7 @@ use crate::{
     present,
     resource::{
         self, Buffer, ExternalTexture, Fallible, Labeled, ParentDevice, QuerySet,
-        RawResourceAccess, Sampler, StagingBuffer, Texture, TextureView,
+        RawResourceAccess, ResourceState, Sampler, StagingBuffer, Texture, TextureView,
         TextureViewNotRenderableReason, Tlas, TrackingData,
     },
     resource_log,
@@ -3957,6 +3957,32 @@ impl Device {
     pub fn create_compute_pipeline(
         self: &Arc<Self>,
         desc: pipeline::ResolvedComputePipelineDescriptor,
+    ) -> (
+        Arc<pipeline::ComputePipeline>,
+        Option<pipeline::CreateComputePipelineError>,
+    ) {
+        let (compute_pipeline, error) = match self.create_compute_pipeline_inner(desc.clone()) {
+            Ok(compute_pipeline) => (compute_pipeline, None),
+            Err(error) => (
+                pipeline::ComputePipeline::invalid(self.clone(), desc.label.to_string()),
+                Some(error),
+            ),
+        };
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use crate::device::trace;
+            use crate::device::trace::IntoTrace;
+            trace.add(trace::Action::CreateComputePipeline {
+                id: compute_pipeline.to_trace(),
+                desc: desc.to_trace(),
+            });
+        }
+        (compute_pipeline, error)
+    }
+
+    pub fn create_compute_pipeline_inner(
+        self: &Arc<Self>,
+        desc: pipeline::ResolvedComputePipelineDescriptor,
     ) -> Result<Arc<pipeline::ComputePipeline>, pipeline::CreateComputePipelineError> {
         self.check_is_valid()?;
 
@@ -4072,10 +4098,12 @@ impl Device {
                 });
 
         let pipeline = pipeline::ComputePipeline {
-            raw: ManuallyDrop::new(raw),
-            layout: pipeline_layout,
+            state: ResourceState::Valid(pipeline::ComputePipelineState {
+                raw: ManuallyDrop::new(raw),
+                layout: pipeline_layout.clone(),
+                _shader_module: shader_module,
+            }),
             device: self.clone(),
-            _shader_module: shader_module,
             late_sized_buffer_groups,
             immediate_slots_required,
             label: desc.label.to_string(),
@@ -4085,7 +4113,7 @@ impl Device {
         let pipeline = Arc::new(pipeline);
 
         if is_auto_layout {
-            for bgl in pipeline.layout.bind_group_layouts.iter() {
+            for bgl in pipeline_layout.bind_group_layouts.iter() {
                 let Some(bgl) = bgl else {
                     continue;
                 };
@@ -4953,7 +4981,7 @@ impl Device {
         };
 
         let pipeline = pipeline::RenderPipeline {
-            state: resource::ResourceState::Valid(pipeline::RenderPipelineState {
+            state: ResourceState::Valid(pipeline::RenderPipelineState {
                 raw: ManuallyDrop::new(raw),
                 layout: pipeline_layout.clone(),
             }),

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -195,7 +195,7 @@ pub enum Action<'a, R: ReferenceType> {
     },
     DropShaderModule(PointerId<markers::ShaderModule>),
     CreateComputePipeline {
-        id: Option<PointerId<markers::ComputePipeline>>,
+        id: PointerId<markers::ComputePipeline>,
         desc: TraceComputePipelineDescriptor<'a>,
     },
     DropComputePipeline(PointerId<markers::ComputePipeline>),

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -195,7 +195,7 @@ pub struct Hub {
     pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,
     pub(crate) render_bundles: Registry<Fallible<RenderBundle>>,
     pub(crate) render_pipelines: Registry<Arc<RenderPipeline>>,
-    pub(crate) compute_pipelines: Registry<Fallible<ComputePipeline>>,
+    pub(crate) compute_pipelines: Registry<Arc<ComputePipeline>>,
     pub(crate) pipeline_caches: Registry<Fallible<PipelineCache>>,
     pub(crate) query_sets: Registry<Fallible<QuerySet>>,
     pub(crate) buffers: Registry<Fallible<Buffer>>,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -301,11 +301,16 @@ impl WebGpuError for CreateComputePipelineError {
 }
 
 #[derive(Debug)]
-pub struct ComputePipeline {
+pub struct ComputePipelineState {
     pub(crate) raw: ManuallyDrop<Box<dyn hal::DynComputePipeline>>,
     pub(crate) layout: Arc<PipelineLayout>,
-    pub(crate) device: Arc<Device>,
     pub(crate) _shader_module: Arc<ShaderModule>,
+}
+
+#[derive(Debug)]
+pub struct ComputePipeline {
+    pub(crate) state: ResourceState<ComputePipelineState>,
+    pub(crate) device: Arc<Device>,
     pub(crate) late_sized_buffer_groups: ArrayVec<LateSizedBufferGroup, { hal::MAX_BIND_GROUPS }>,
     pub(crate) immediate_slots_required: naga::valid::ImmediateSlots,
     /// The `label` from the descriptor used to create the resource.
@@ -316,8 +321,20 @@ pub struct ComputePipeline {
 impl Drop for ComputePipeline {
     fn drop(&mut self) {
         resource_log!("Destroy raw {}", self.error_ident());
+        #[cfg(feature = "trace")]
+        {
+            use crate::device::trace;
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(trace::Action::DropComputePipeline(unsafe {
+                    trace::to_trace(self)
+                }));
+            }
+        }
+        let ResourceState::Valid(state) = &mut self.state else {
+            return;
+        };
         // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
-        let raw = unsafe { ManuallyDrop::take(&mut self.raw) };
+        let raw = unsafe { ManuallyDrop::take(&mut state.raw) };
         unsafe {
             self.device.raw().destroy_compute_pipeline(raw);
         }
@@ -331,15 +348,43 @@ crate::impl_storage_item!(ComputePipeline);
 crate::impl_trackable!(ComputePipeline);
 
 impl ComputePipeline {
-    pub(crate) fn raw(&self) -> &dyn hal::DynComputePipeline {
-        self.raw.as_ref()
+    pub(crate) fn raw(&self) -> Result<&dyn hal::DynComputePipeline, InvalidResourceError> {
+        let ResourceState::Valid(state) = &self.state else {
+            return Err(InvalidResourceError(self.error_ident()));
+        };
+        Ok(state.raw.as_ref())
+    }
+
+    pub(crate) fn layout(&self) -> Result<&Arc<PipelineLayout>, InvalidResourceError> {
+        let ResourceState::Valid(state) = &self.state else {
+            return Err(InvalidResourceError(self.error_ident()));
+        };
+        Ok(&state.layout)
+    }
+
+    pub(crate) fn check_valid(&self) -> Result<(), InvalidResourceError> {
+        let ResourceState::Valid(_) = &self.state else {
+            return Err(InvalidResourceError(self.error_ident()));
+        };
+        Ok(())
+    }
+
+    pub(crate) fn invalid(device: Arc<Device>, label: String) -> Arc<Self> {
+        Arc::new(Self {
+            tracking_data: TrackingData::new(device.tracker_indices.compute_pipelines.clone()),
+            state: ResourceState::Invalid,
+            device,
+            late_sized_buffer_groups: ArrayVec::new(),
+            immediate_slots_required: naga::valid::ImmediateSlots::default(),
+            label,
+        })
     }
 
     pub fn get_bind_group_layout(
         self: &Arc<Self>,
         index: u32,
     ) -> Result<Arc<BindGroupLayout>, GetBindGroupLayoutError> {
-        self.layout.get_bind_group_layout(index, self.into())
+        self.layout()?.get_bind_group_layout(index, self.into())
     }
 }
 


### PR DESCRIPTION
**Connections**
Part of #5121.
Practically same as https://github.com/gfx-rs/wgpu/pull/9752 just different pipeline.

**Description**
We move `Fallible` into `ComputePipeline` using `ResourceState`. We also move tracing into the device methods and we now trace all computepipelines (even invalid).

**Testing**
Covered by existing tests.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.