### PR TITLE
[core] Move validity into `Arc<BindGroupLayout>`

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -183,9 +183,7 @@ impl Player {
                 unimplemented!()
             }
             Action::CreateBindGroupLayout(id, desc) => {
-                let bind_group_layout = device
-                    .create_bind_group_layout(&desc)
-                    .expect("create_bind_group_layout error");
+                let (bind_group_layout, _error) = device.create_bind_group_layout(&desc);
                 self.bind_group_layouts.insert(id, bind_group_layout);
             }
             Action::GetRenderPipelineBindGroupLayout {
@@ -194,9 +192,7 @@ impl Player {
                 index,
             } => {
                 let pipeline = self.resolve_render_pipeline_id(pipeline);
-                let bgl = pipeline
-                    .get_bind_group_layout(index)
-                    .expect("invalid render pipeline");
+                let (bgl, _error) = pipeline.get_bind_group_layout(index);
                 self.bind_group_layouts.insert(id, bgl);
             }
             Action::GetComputePipelineBindGroupLayout {
@@ -205,9 +201,7 @@ impl Player {
                 index,
             } => {
                 let pipeline = self.resolve_compute_pipeline_id(pipeline);
-                let bgl = pipeline
-                    .get_bind_group_layout(index)
-                    .expect("invalid compute pipeline");
+                let (bgl, _error) = pipeline.get_bind_group_layout(index);
                 self.bind_group_layouts.insert(id, bgl);
             }
             Action::DropBindGroupLayout(id) => {

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -25,7 +25,7 @@ use crate::{
     resource::{
         Buffer, DestroyedResourceError, ExternalTexture, InvalidResourceError, Labeled,
         MissingBufferUsageError, MissingTextureUsageError, RawResourceAccess, ResourceErrorIdent,
-        Sampler, TextureView, Tlas, TrackingData,
+        ResourceState, Sampler, TextureView, Tlas, TrackingData,
     },
     resource_log,
     snatch::{SnatchGuard, Snatchable},
@@ -763,15 +763,11 @@ pub enum RawBindGroupLayout {
     Owning(ManuallyDrop<Box<dyn hal::DynBindGroupLayout>>),
     /// The empty BGL was created by the device and will be destroyed by the device.
     RefDeviceEmptyBGL,
-    Invalid,
 }
 
-/// Bind group layout.
 #[derive(Debug)]
-pub struct BindGroupLayout {
+pub(crate) struct BindGroupLayoutState {
     pub(crate) raw: RawBindGroupLayout,
-    pub(crate) device: Arc<Device>,
-    pub(crate) entries: bgl::EntryMap,
     /// It is very important that we know if the bind group comes from the BGL pool.
     ///
     /// If it does, then we need to remove it from the pool when we drop it.
@@ -779,8 +775,16 @@ pub struct BindGroupLayout {
     /// We cannot unconditionally remove from the pool, as BGLs that don't come from the pool
     /// (derived BGLs) must not be removed.
     pub(crate) origin: bgl::Origin,
-    pub(crate) exclusive_pipeline: crate::OnceCellOrLock<ExclusivePipeline>,
     pub(crate) binding_count_validator: BindingTypeMaxCountValidator,
+}
+
+/// Bind group layout.
+#[derive(Debug)]
+pub struct BindGroupLayout {
+    pub(crate) state: ResourceState<BindGroupLayoutState>,
+    pub(crate) device: Arc<Device>,
+    pub(crate) entries: bgl::EntryMap,
+    pub(crate) exclusive_pipeline: crate::OnceCellOrLock<ExclusivePipeline>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
 }
@@ -800,19 +804,21 @@ impl Drop for BindGroupLayout {
             }
         }
         resource_log!("Destroy raw {}", self.error_ident());
-        if matches!(self.origin, bgl::Origin::Pool) {
+        let ResourceState::Valid(state) = &mut self.state else {
+            return;
+        };
+        if matches!(state.origin, bgl::Origin::Pool) {
             self.device.bgl_pool.remove(&self.entries);
         }
-        match self.raw {
+        match state.raw {
             RawBindGroupLayout::Owning(ref mut raw) => {
-                // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
+                // SAFETY: We are in the Drop impl and we don't use state.raw anymore after this point.
                 let raw = unsafe { ManuallyDrop::take(raw) };
                 unsafe {
                     self.device.raw().destroy_bind_group_layout(raw);
                 }
             }
             RawBindGroupLayout::RefDeviceEmptyBGL => {}
-            RawBindGroupLayout::Invalid => {}
         }
     }
 }
@@ -824,41 +830,49 @@ crate::impl_storage_item!(BindGroupLayout);
 
 impl BindGroupLayout {
     pub(crate) fn try_raw(&self) -> Result<&dyn hal::DynBindGroupLayout, InvalidResourceError> {
-        match &self.raw {
+        let ResourceState::Valid(state) = &self.state else {
+            return Err(InvalidResourceError(self.error_ident()));
+        };
+        match &state.raw {
             RawBindGroupLayout::Owning(raw) => Ok(raw.as_ref()),
             RawBindGroupLayout::RefDeviceEmptyBGL => Ok(self.device.empty_bgl.as_ref()),
-            RawBindGroupLayout::Invalid => Err(InvalidResourceError(self.error_ident())),
         }
     }
 
+    pub(crate) fn state(&self) -> Result<&BindGroupLayoutState, InvalidResourceError> {
+        let ResourceState::Valid(state) = &self.state else {
+            return Err(InvalidResourceError(self.error_ident()));
+        };
+        Ok(state)
+    }
+
     pub(crate) fn check_is_valid(self: &Arc<Self>) -> Result<(), InvalidResourceError> {
-        match &self.raw {
-            RawBindGroupLayout::Owning(_) => Ok(()),
-            RawBindGroupLayout::RefDeviceEmptyBGL => Ok(()),
-            RawBindGroupLayout::Invalid => Err(InvalidResourceError(self.error_ident())),
-        }
+        let ResourceState::Valid(_) = &self.state else {
+            return Err(InvalidResourceError(self.error_ident()));
+        };
+        Ok(())
     }
 
     fn empty(device: &Arc<Device>, exclusive_pipeline: ExclusivePipeline) -> Arc<Self> {
         Arc::new(Self {
-            raw: RawBindGroupLayout::RefDeviceEmptyBGL,
+            state: ResourceState::Valid(BindGroupLayoutState {
+                raw: RawBindGroupLayout::RefDeviceEmptyBGL,
+                origin: bgl::Origin::Derived,
+                binding_count_validator: BindingTypeMaxCountValidator::default(),
+            }),
             device: device.clone(),
             entries: bgl::EntryMap::default(),
-            origin: bgl::Origin::Derived,
             exclusive_pipeline: crate::OnceCellOrLock::from(exclusive_pipeline),
-            binding_count_validator: BindingTypeMaxCountValidator::default(),
             label: String::new(),
         })
     }
 
     pub(crate) fn invalid(device: &Arc<Device>, label: String) -> Arc<Self> {
         Arc::new(Self {
-            raw: RawBindGroupLayout::Invalid,
+            state: ResourceState::Invalid,
             device: device.clone(),
             entries: bgl::EntryMap::default(),
-            origin: bgl::Origin::Derived,
             exclusive_pipeline: crate::OnceCellOrLock::from(ExclusivePipeline::None),
-            binding_count_validator: BindingTypeMaxCountValidator::default(),
             label,
         })
     }

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -763,6 +763,7 @@ pub enum RawBindGroupLayout {
     Owning(ManuallyDrop<Box<dyn hal::DynBindGroupLayout>>),
     /// The empty BGL was created by the device and will be destroyed by the device.
     RefDeviceEmptyBGL,
+    Invalid,
 }
 
 /// Bind group layout.
@@ -786,6 +787,18 @@ pub struct BindGroupLayout {
 
 impl Drop for BindGroupLayout {
     fn drop(&mut self) {
+        #[cfg(feature = "trace")]
+        {
+            let mut t = self.device.trace.lock();
+            if let Some(t) = t.as_mut() {
+                use crate::device::trace;
+
+                // SAFETY: All bind group layouts are constructed in Arc => are heap allocated
+                t.add(trace::Action::DropBindGroupLayout(unsafe {
+                    trace::to_trace(self)
+                }));
+            }
+        }
         resource_log!("Destroy raw {}", self.error_ident());
         if matches!(self.origin, bgl::Origin::Pool) {
             self.device.bgl_pool.remove(&self.entries);
@@ -799,6 +812,7 @@ impl Drop for BindGroupLayout {
                 }
             }
             RawBindGroupLayout::RefDeviceEmptyBGL => {}
+            RawBindGroupLayout::Invalid => {}
         }
     }
 }
@@ -809,10 +823,19 @@ crate::impl_parent_device!(BindGroupLayout);
 crate::impl_storage_item!(BindGroupLayout);
 
 impl BindGroupLayout {
-    pub(crate) fn raw(&self) -> &dyn hal::DynBindGroupLayout {
+    pub(crate) fn try_raw(&self) -> Result<&dyn hal::DynBindGroupLayout, InvalidResourceError> {
         match &self.raw {
-            RawBindGroupLayout::Owning(raw) => raw.as_ref(),
-            RawBindGroupLayout::RefDeviceEmptyBGL => self.device.empty_bgl.as_ref(),
+            RawBindGroupLayout::Owning(raw) => Ok(raw.as_ref()),
+            RawBindGroupLayout::RefDeviceEmptyBGL => Ok(self.device.empty_bgl.as_ref()),
+            RawBindGroupLayout::Invalid => Err(InvalidResourceError(self.error_ident())),
+        }
+    }
+
+    pub(crate) fn check_is_valid(self: &Arc<Self>) -> Result<(), InvalidResourceError> {
+        match &self.raw {
+            RawBindGroupLayout::Owning(_) => Ok(()),
+            RawBindGroupLayout::RefDeviceEmptyBGL => Ok(()),
+            RawBindGroupLayout::Invalid => Err(InvalidResourceError(self.error_ident())),
         }
     }
 
@@ -825,6 +848,18 @@ impl BindGroupLayout {
             exclusive_pipeline: crate::OnceCellOrLock::from(exclusive_pipeline),
             binding_count_validator: BindingTypeMaxCountValidator::default(),
             label: String::new(),
+        })
+    }
+
+    pub(crate) fn invalid(device: &Arc<Device>, label: String) -> Arc<Self> {
+        Arc::new(Self {
+            raw: RawBindGroupLayout::Invalid,
+            device: device.clone(),
+            entries: bgl::EntryMap::default(),
+            origin: bgl::Origin::Derived,
+            exclusive_pipeline: crate::OnceCellOrLock::from(ExclusivePipeline::None),
+            binding_count_validator: BindingTypeMaxCountValidator::default(),
+            label,
         })
     }
 }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use core::{ptr::NonNull, sync::atomic::Ordering};
 
 #[cfg(feature = "trace")]
@@ -267,11 +267,16 @@ impl Global {
     /// See [`Self::create_buffer_error`] for additional context and explanation.
     pub fn create_bind_group_layout_error(
         &self,
+        device_id: DeviceId,
         id_in: Option<id::BindGroupLayoutId>,
         label: Option<Cow<'_, str>>,
     ) {
         let fid = self.hub.bind_group_layouts.prepare(id_in);
-        fid.assign(Fallible::Invalid(Arc::new(label.to_string())));
+        let device = self.hub.devices.get(device_id);
+        fid.assign(binding_model::BindGroupLayout::invalid(
+            &device,
+            label.to_string(),
+        ));
     }
 
     pub fn buffer_destroy(&self, buffer_id: id::BufferId) {
@@ -672,30 +677,15 @@ impl Global {
         let hub = &self.hub;
         let fid = hub.bind_group_layouts.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
-            let layout = match device.create_bind_group_layout(desc) {
-                Ok(layout) => layout,
-                Err(e) => break 'error e,
-            };
+        let (bgl, error) = device.create_bind_group_layout(desc);
 
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                trace.add(trace::Action::CreateBindGroupLayout(
-                    layout.to_trace(),
-                    desc.clone(),
-                ));
-            }
+        let id = fid.assign(bgl);
 
-            let id = fid.assign(Fallible::Valid(layout.clone()));
+        api_log!("Device::create_bind_group_layout -> {id:?}");
 
-            api_log!("Device::create_bind_group_layout -> {id:?}");
-            return (id, None);
-        };
-
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
-        (id, Some(error))
+        (id, error)
     }
 
     pub fn bind_group_layout_drop(&self, bind_group_layout_id: id::BindGroupLayoutId) {
@@ -705,13 +695,6 @@ impl Global {
         let hub = &self.hub;
 
         let _layout = hub.bind_group_layouts.remove(bind_group_layout_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(layout) = _layout.get() {
-            if let Some(t) = layout.device.trace.lock().as_mut() {
-                t.add(trace::Action::DropBindGroupLayout(layout.to_trace()));
-            }
-        }
     }
 
     pub fn device_create_pipeline_layout(
@@ -739,16 +722,8 @@ impl Global {
                 let bind_group_layouts_guard = hub.bind_group_layouts.read();
                 desc.bind_group_layouts
                     .iter()
-                    .map(|bgl_id| match bgl_id {
-                        Some(bgl_id) => bind_group_layouts_guard.get(*bgl_id).get().map(Some),
-                        None => Ok(None),
-                    })
-                    .collect::<Result<Vec<_>, _>>()
-            };
-
-            let bind_group_layouts = match bind_group_layouts {
-                Ok(bind_group_layouts) => bind_group_layouts,
-                Err(e) => break 'error e.into(),
+                    .map(|bgl_id| bgl_id.map(|bgl_id| bind_group_layouts_guard.get(bgl_id)))
+                    .collect::<Vec<_>>()
             };
 
             let desc = binding_model::ResolvedPipelineLayoutDescriptor {
@@ -813,10 +788,7 @@ impl Global {
                 break 'error e.into();
             }
 
-            let layout = match hub.bind_group_layouts.get(desc.layout).get() {
-                Ok(layout) => layout,
-                Err(e) => break 'error e.into(),
-            };
+            let layout = hub.bind_group_layouts.get(desc.layout);
 
             fn resolve_entry<'a>(
                 e: &BindGroupEntry<'a>,
@@ -1600,28 +1572,13 @@ impl Global {
 
         let fid = hub.bind_group_layouts.prepare(id_in);
 
-        let error = 'error: {
-            let pipeline = hub.render_pipelines.get(pipeline_id);
-            match pipeline.get_bind_group_layout(index) {
-                Ok(bgl) => {
-                    #[cfg(feature = "trace")]
-                    if let Some(ref mut trace) = *pipeline.device.trace.lock() {
-                        trace.add(trace::Action::GetRenderPipelineBindGroupLayout {
-                            id: bgl.to_trace(),
-                            pipeline: pipeline.to_trace(),
-                            index,
-                        });
-                    }
+        let pipeline = hub.render_pipelines.get(pipeline_id);
 
-                    let id = fid.assign(Fallible::Valid(bgl.clone()));
-                    return (id, None);
-                }
-                Err(err) => break 'error err,
-            };
-        };
+        let (bgl, error) = pipeline.get_bind_group_layout(index);
 
-        let id = fid.assign(Fallible::Invalid(Arc::new(String::new())));
-        (id, Some(error))
+        let id = fid.assign(bgl);
+
+        (id, error)
     }
 
     pub fn render_pipeline_drop(&self, render_pipeline_id: id::RenderPipelineId) {
@@ -1732,27 +1689,11 @@ impl Global {
 
         let pipeline = hub.compute_pipelines.get(pipeline_id);
 
-        let error = 'error: {
-            match pipeline.get_bind_group_layout(index) {
-                Ok(bgl) => {
-                    #[cfg(feature = "trace")]
-                    if let Some(ref mut trace) = *pipeline.device.trace.lock() {
-                        trace.add(trace::Action::GetComputePipelineBindGroupLayout {
-                            id: bgl.to_trace(),
-                            pipeline: pipeline.to_trace(),
-                            index,
-                        });
-                    }
+        let (bgl, error) = pipeline.get_bind_group_layout(index);
 
-                    let id = fid.assign(Fallible::Valid(bgl.clone()));
-                    return (id, None);
-                }
-                Err(err) => break 'error err,
-            };
-        };
+        let id = fid.assign(bgl);
 
-        let id = fid.assign(Fallible::Invalid(Arc::new(String::new())));
-        (id, Some(error))
+        (id, error)
     }
 
     pub fn compute_pipeline_drop(&self, compute_pipeline_id: id::ComputePipelineId) {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -27,7 +27,8 @@ use crate::{
     api_log,
     binding_model::{
         self, BindGroup, BindGroupLateBufferBindingInfo, BindGroupLayout,
-        BindGroupLayoutEntryError, CreateBindGroupError, CreateBindGroupLayoutError,
+        BindGroupLayoutEntryError, BindGroupLayoutState, CreateBindGroupError,
+        CreateBindGroupLayoutError,
     },
     command, conv,
     device::{
@@ -2961,12 +2962,14 @@ impl Device {
             .map_err(|e| self.handle_hal_error(e))?;
 
         let bgl = BindGroupLayout {
-            raw: binding_model::RawBindGroupLayout::Owning(ManuallyDrop::new(raw)),
+            state: ResourceState::Valid(BindGroupLayoutState {
+                raw: binding_model::RawBindGroupLayout::Owning(ManuallyDrop::new(raw)),
+                origin,
+                binding_count_validator: count_validator,
+            }),
             device: self.clone(),
             entries: entry_map,
-            origin,
             exclusive_pipeline: OnceCellOrLock::new(),
-            binding_count_validator: count_validator,
             label: label.to_string(),
         };
 
@@ -3873,7 +3876,7 @@ impl Device {
                 }
             }
 
-            count_validator.merge(&bgl.binding_count_validator);
+            count_validator.merge(&bgl.state()?.binding_count_validator);
         }
 
         count_validator

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2661,6 +2661,29 @@ impl Device {
     pub fn create_bind_group_layout(
         self: &Arc<Self>,
         desc: &binding_model::BindGroupLayoutDescriptor,
+    ) -> (Arc<BindGroupLayout>, Option<CreateBindGroupLayoutError>) {
+        let (bgl, error) = match self.create_bind_group_layout_inner(desc) {
+            Ok(layout) => (layout, None),
+            Err(e) => (
+                BindGroupLayout::invalid(self, desc.label.to_string()),
+                Some(e),
+            ),
+        };
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use crate::device::trace::IntoTrace;
+
+            trace.add(trace::Action::CreateBindGroupLayout(
+                bgl.to_trace(),
+                desc.clone(),
+            ));
+        }
+        (bgl, error)
+    }
+
+    fn create_bind_group_layout_inner(
+        self: &Arc<Device>,
+        desc: &binding_model::BindGroupLayoutDescriptor,
     ) -> Result<Arc<BindGroupLayout>, CreateBindGroupLayoutError> {
         self.check_is_valid()?;
 
@@ -2668,7 +2691,7 @@ impl Device {
 
         let bgl_result = self.bgl_pool.get_or_init(entry_map, |entry_map| {
             let bgl =
-                self.create_bind_group_layout_internal(&desc.label, entry_map, bgl::Origin::Pool)?;
+                self.create_bind_group_layout_impl(&desc.label, entry_map, bgl::Origin::Pool)?;
             bgl.exclusive_pipeline
                 .set(binding_model::ExclusivePipeline::None)
                 .unwrap();
@@ -2681,7 +2704,7 @@ impl Device {
         }
     }
 
-    fn create_bind_group_layout_internal(
+    fn create_bind_group_layout_impl(
         self: &Arc<Self>,
         label: &crate::Label,
         entry_map: bgl::EntryMap,
@@ -3349,6 +3372,7 @@ impl Device {
 
         self.check_is_valid()?;
         layout.same_device(self)?;
+        layout.check_is_valid()?;
 
         {
             // Check that the number of entries in the descriptor matches
@@ -3552,7 +3576,7 @@ impl Device {
 
         let hal_desc = hal::BindGroupDescriptor {
             label: desc.label.to_hal(self.instance_flags),
-            layout: layout.raw(),
+            layout: layout.try_raw()?,
             entries: &hal_entries,
             buffers: &hal_buffers,
             samplers: &hal_samplers,
@@ -3867,8 +3891,8 @@ impl Device {
             .collect::<ArrayVec<_, { hal::MAX_BIND_GROUPS }>>();
 
         let raw_bind_group_layouts = get_bgl_iter()
-            .map(|bgl| bgl.map(|bgl| bgl.raw()))
-            .collect::<ArrayVec<_, { hal::MAX_BIND_GROUPS }>>();
+            .map(|bgl| bgl.map(|bgl| bgl.try_raw()).transpose())
+            .collect::<Result<ArrayVec<_, { hal::MAX_BIND_GROUPS }>, _>>()?;
 
         let additional_flags = if self.indirect_validation.is_some() {
             hal::PipelineLayoutFlags::INDIRECT_BUILTIN_UPDATE
@@ -3928,7 +3952,7 @@ impl Device {
                 match unique_bind_group_layouts.entry(bgl_entry_map) {
                     hashbrown::hash_map::Entry::Occupied(v) => Ok(Some(Arc::clone(v.get()))),
                     hashbrown::hash_map::Entry::Vacant(e) => {
-                        match self.create_bind_group_layout_internal(
+                        match self.create_bind_group_layout_impl(
                             &None,
                             e.key().clone(),
                             bgl::Origin::Derived,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -189,7 +189,7 @@ pub struct Hub {
     pub(crate) queues: Registry<Arc<Queue>>,
     pub(crate) pipeline_layouts: Registry<Fallible<PipelineLayout>>,
     pub(crate) shader_modules: Registry<Fallible<ShaderModule>>,
-    pub(crate) bind_group_layouts: Registry<Fallible<BindGroupLayout>>,
+    pub(crate) bind_group_layouts: Registry<Arc<BindGroupLayout>>,
     pub(crate) bind_groups: Registry<Fallible<BindGroup>>,
     pub(crate) command_encoders: Registry<Arc<CommandEncoder>>,
     pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -380,11 +380,35 @@ impl ComputePipeline {
         })
     }
 
-    pub fn get_bind_group_layout(
+    pub fn get_bind_group_layout_inner(
         self: &Arc<Self>,
         index: u32,
     ) -> Result<Arc<BindGroupLayout>, GetBindGroupLayoutError> {
         self.layout()?.get_bind_group_layout(index, self.into())
+    }
+
+    pub fn get_bind_group_layout(
+        self: &Arc<Self>,
+        index: u32,
+    ) -> (Arc<BindGroupLayout>, Option<GetBindGroupLayoutError>) {
+        let (bgl, error) = match self.get_bind_group_layout_inner(index) {
+            Ok(bgl) => (bgl, None),
+            Err(e) => (
+                BindGroupLayout::invalid(&self.device, String::new()),
+                Some(e),
+            ),
+        };
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.device.trace.lock() {
+            use crate::device::trace;
+            use trace::IntoTrace;
+            trace.add(trace::Action::GetComputePipelineBindGroupLayout {
+                id: bgl.to_trace(),
+                pipeline: self.to_trace(),
+                index,
+            });
+        };
+        (bgl, error)
     }
 }
 
@@ -985,10 +1009,34 @@ impl RenderPipeline {
         })
     }
 
-    pub fn get_bind_group_layout(
+    pub fn get_bind_group_layout_inner(
         self: &Arc<Self>,
         index: u32,
     ) -> Result<Arc<BindGroupLayout>, GetBindGroupLayoutError> {
         self.layout()?.get_bind_group_layout(index, self.into())
+    }
+
+    pub fn get_bind_group_layout(
+        self: &Arc<Self>,
+        index: u32,
+    ) -> (Arc<BindGroupLayout>, Option<GetBindGroupLayoutError>) {
+        let (bgl, error) = match self.get_bind_group_layout_inner(index) {
+            Ok(bgl) => (bgl, None),
+            Err(e) => (
+                BindGroupLayout::invalid(&self.device, String::new()),
+                Some(e),
+            ),
+        };
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.device.trace.lock() {
+            use crate::device::trace;
+            use trace::IntoTrace;
+            trace.add(trace::Action::GetRenderPipelineBindGroupLayout {
+                id: bgl.to_trace(),
+                pipeline: self.to_trace(),
+                index,
+            });
+        };
+        (bgl, error)
     }
 }


### PR DESCRIPTION
**Connections**

Builds on top of #9762 and #9752 towards #5121.

**Description**

We move `Fallible` into `BindGroupLayout` using `ResourceState`. We also move tracing into the device methods and we now trace all bgls (even invalid ones).

**Testing**

Covered by existing tests, but it's mainly just refactor.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
