### PR TITLE
chore(deps): Update `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"


### PR DESCRIPTION
To resolve audit warning for https://rustsec.org/advisories/RUSTSEC-2026-0190, although we only use `anyhow` in tests and utilities.

**Squash or Rebase?** Squash
