### PR TITLE
 [core] Move validity into `Arc<PipelineLayout>`

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -223,9 +223,7 @@ impl Player {
                     immediate_size: desc.immediate_size,
                 };
 
-                let pipeline_layout = device
-                    .create_pipeline_layout(&resolved_desc)
-                    .expect("create_pipeline_layout error");
+                let (pipeline_layout, _error) = device.create_pipeline_layout(&resolved_desc);
                 self.pipeline_layouts.insert(id, pipeline_layout);
             }
             Action::DropPipelineLayout(id) => {

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -999,7 +999,7 @@ pub type ResolvedPipelineLayoutDescriptor<'a, BGL = Arc<BindGroupLayout>> =
 
 #[derive(Debug)]
 pub struct PipelineLayout {
-    pub(crate) raw: ResourceState<ManuallyDrop<Box<dyn hal::DynPipelineLayout>>>,
+    pub(crate) raw: ResourceState<Box<dyn hal::DynPipelineLayout>>,
     pub(crate) device: Arc<Device>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
@@ -1010,9 +1010,8 @@ pub struct PipelineLayout {
 impl Drop for PipelineLayout {
     fn drop(&mut self) {
         resource_log!("Destroy raw {}", self.error_ident());
-        if let ResourceState::Valid(raw) = &mut self.raw {
-            // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
-            let raw = unsafe { ManuallyDrop::take(raw) };
+        if let ResourceState::Valid(raw) = core::mem::replace(&mut self.raw, ResourceState::Invalid)
+        {
             unsafe {
                 self.device.raw().destroy_pipeline_layout(raw);
             }

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -999,7 +999,7 @@ pub type ResolvedPipelineLayoutDescriptor<'a, BGL = Arc<BindGroupLayout>> =
 
 #[derive(Debug)]
 pub struct PipelineLayout {
-    pub(crate) raw: ManuallyDrop<Box<dyn hal::DynPipelineLayout>>,
+    pub(crate) raw: ResourceState<ManuallyDrop<Box<dyn hal::DynPipelineLayout>>>,
     pub(crate) device: Arc<Device>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
@@ -1010,17 +1010,39 @@ pub struct PipelineLayout {
 impl Drop for PipelineLayout {
     fn drop(&mut self) {
         resource_log!("Destroy raw {}", self.error_ident());
-        // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
-        let raw = unsafe { ManuallyDrop::take(&mut self.raw) };
-        unsafe {
-            self.device.raw().destroy_pipeline_layout(raw);
+        if let ResourceState::Valid(raw) = &mut self.raw {
+            // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
+            let raw = unsafe { ManuallyDrop::take(raw) };
+            unsafe {
+                self.device.raw().destroy_pipeline_layout(raw);
+            }
+        }
+        #[cfg(feature = "trace")]
+        {
+            if let Some(t) = self.device.trace.lock().as_mut() {
+                t.add(crate::device::trace::Action::DropPipelineLayout(unsafe {
+                    crate::device::trace::to_trace(self)
+                }));
+            }
         }
     }
 }
 
 impl PipelineLayout {
-    pub(crate) fn raw(&self) -> &dyn hal::DynPipelineLayout {
-        self.raw.as_ref()
+    pub(crate) fn raw(&self) -> Result<&dyn hal::DynPipelineLayout, InvalidResourceError> {
+        self.raw
+            .as_ref()
+            .valid()
+            .map(|r| r.as_ref())
+            .ok_or_else(|| InvalidResourceError(self.error_ident()))
+    }
+
+    pub(crate) fn check_valid(&self) -> Result<(), InvalidResourceError> {
+        self.raw
+            .as_ref()
+            .valid()
+            .map(|_| ())
+            .ok_or_else(|| InvalidResourceError(self.error_ident()))
     }
 
     pub(crate) fn get_bind_group_layout(
@@ -1081,6 +1103,16 @@ impl PipelineLayout {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn invalid(device: Arc<Device>, label: String) -> Arc<Self> {
+        Arc::new(Self {
+            raw: ResourceState::Invalid,
+            device,
+            label,
+            bind_group_layouts: ArrayVec::new(),
+            immediate_size: 0,
+        })
     }
 }
 

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1250,7 +1250,11 @@ impl RenderBundle {
                     let raw_bg = bind_group.as_ref().unwrap().try_raw(snatch_guard)?;
                     unsafe {
                         raw.set_bind_group(
-                            pipeline_layout.as_ref().unwrap().raw(),
+                            pipeline_layout
+                                .as_ref()
+                                .unwrap()
+                                .raw()
+                                .expect("PipelineLayout should be valid at this point"),
                             *index,
                             raw_bg,
                             &offsets[..*num_dynamic_offsets],
@@ -1311,7 +1315,15 @@ impl RenderBundle {
                         let data_slice =
                             &self.base.immediates_data[(values_offset as usize)..values_end_offset];
 
-                        unsafe { raw.set_immediates(pipeline_layout.raw(), *offset, data_slice) }
+                        unsafe {
+                            raw.set_immediates(
+                                pipeline_layout
+                                    .raw()
+                                    .expect("PipelineLayout should be valid at this point"),
+                                *offset,
+                                data_slice,
+                            )
+                        }
                     } else {
                         super::immediates_clear(
                             *offset,
@@ -1319,7 +1331,9 @@ impl RenderBundle {
                             |clear_offset, clear_data| {
                                 unsafe {
                                     raw.set_immediates(
-                                        pipeline_layout.raw(),
+                                        pipeline_layout
+                                            .raw()
+                                            .expect("PipelineLayout should be valid at this point"),
                                         clear_offset,
                                         clear_data,
                                     )

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1106,7 +1106,7 @@ fn dispatch_workgroups_indirect(
             if !state.immediates.is_empty() {
                 unsafe {
                     state.pass.base.raw_encoder.set_immediates(
-                        pipeline_layout.raw(),
+                        pipeline_layout.raw()?,
                         0,
                         &state.immediates,
                     );
@@ -1117,7 +1117,7 @@ fn dispatch_workgroups_indirect(
                 let raw_bg = group.try_raw(state.pass.base.snatch_guard)?;
                 unsafe {
                     state.pass.base.raw_encoder.set_bind_group(
-                        pipeline_layout.raw(),
+                        pipeline_layout.raw()?,
                         i as u32,
                         raw_bg,
                         dynamic_offsets,

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -176,7 +176,9 @@ pub(super) fn flush_bindings_helper(state: &mut PassState) -> Result<(), Destroy
         let raw_bg = bind_group.try_raw(state.base.snatch_guard)?;
         unsafe {
             state.base.raw_encoder.set_bind_group(
-                pipeline_layout.raw(),
+                pipeline_layout
+                    .raw()
+                    .expect("Pipeline layout should be valid at this point"),
                 i as u32,
                 raw_bg,
                 dynamic_offsets,
@@ -207,7 +209,9 @@ where
             pipeline_layout.immediate_size,
             |clear_offset, clear_data| unsafe {
                 state.base.raw_encoder.set_immediates(
-                    pipeline_layout.raw(),
+                    pipeline_layout
+                        .raw()
+                        .expect("Pipeline layout should be valid at this point"),
                     clear_offset,
                     clear_data,
                 );
@@ -288,10 +292,13 @@ where
     f(data_slice);
 
     unsafe {
-        state
-            .base
-            .raw_encoder
-            .set_immediates(pipeline_layout.raw(), offset, data_slice)
+        state.base.raw_encoder.set_immediates(
+            pipeline_layout
+                .raw()
+                .expect("Pipeline layout should be valid at this point"),
+            offset,
+            data_slice,
+        )
     }
     Ok(())
 }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -711,47 +711,25 @@ impl Global {
         let hub = &self.hub;
         let fid = hub.pipeline_layouts.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
-            if let Err(e) = device.check_is_valid() {
-                break 'error e.into();
-            }
-
-            let bind_group_layouts = {
-                let bind_group_layouts_guard = hub.bind_group_layouts.read();
-                desc.bind_group_layouts
-                    .iter()
-                    .map(|bgl_id| bgl_id.map(|bgl_id| bind_group_layouts_guard.get(bgl_id)))
-                    .collect::<Vec<_>>()
-            };
-
-            let desc = binding_model::ResolvedPipelineLayoutDescriptor {
-                label: desc.label.clone(),
-                bind_group_layouts: Cow::Owned(bind_group_layouts),
-                immediate_size: desc.immediate_size,
-            };
-
-            let layout = match device.create_pipeline_layout(&desc) {
-                Ok(layout) => layout,
-                Err(e) => break 'error e,
-            };
-
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                trace.add(trace::Action::CreatePipelineLayout(
-                    layout.to_trace(),
-                    desc.to_trace(),
-                ));
-            }
-
-            let id = fid.assign(Fallible::Valid(layout));
-            api_log!("Device::create_pipeline_layout -> {id:?}");
-            return (id, None);
+        let bind_group_layouts = {
+            let bind_group_layouts_guard = hub.bind_group_layouts.read();
+            desc.bind_group_layouts
+                .iter()
+                .map(|bgl_id| bgl_id.map(|bgl_id| bind_group_layouts_guard.get(bgl_id)))
+                .collect::<Vec<_>>()
         };
 
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
-        (id, Some(error))
+        let desc = binding_model::ResolvedPipelineLayoutDescriptor {
+            label: desc.label.clone(),
+            bind_group_layouts: Cow::Owned(bind_group_layouts),
+            immediate_size: desc.immediate_size,
+        };
+
+        let (layout, error) = device.create_pipeline_layout(&desc);
+        let id = fid.assign(layout);
+        (id, error)
     }
 
     pub fn pipeline_layout_drop(&self, pipeline_layout_id: id::PipelineLayoutId) {
@@ -761,13 +739,6 @@ impl Global {
         let hub = &self.hub;
 
         let _layout = hub.pipeline_layouts.remove(pipeline_layout_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(layout) = _layout.get() {
-            if let Some(t) = layout.device.trace.lock().as_mut() {
-                t.add(trace::Action::DropPipelineLayout(layout.to_trace()));
-            }
-        }
     }
 
     pub fn device_create_bind_group(
@@ -1385,14 +1356,7 @@ impl Global {
                 break 'error e.into();
             }
 
-            let layout = desc
-                .layout
-                .map(|layout| hub.pipeline_layouts.get(layout).get())
-                .transpose();
-            let layout = match layout {
-                Ok(layout) => layout,
-                Err(e) => break 'error e.into(),
-            };
+            let layout = desc.layout.map(|layout| hub.pipeline_layouts.get(layout));
 
             let cache = desc
                 .cache
@@ -1614,14 +1578,7 @@ impl Global {
                 break 'error e.into();
             }
 
-            let layout = desc
-                .layout
-                .map(|layout| hub.pipeline_layouts.get(layout).get())
-                .transpose();
-            let layout = match layout {
-                Ok(layout) => layout,
-                Err(e) => break 'error e.into(),
-            };
+            let layout = desc.layout.map(|layout| hub.pipeline_layouts.get(layout));
 
             let cache = desc
                 .cache

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3940,7 +3940,7 @@ impl Device {
         drop(raw_bind_group_layouts);
 
         let layout = binding_model::PipelineLayout {
-            raw: ResourceState::Valid(ManuallyDrop::new(raw)),
+            raw: ResourceState::Valid(raw),
             device: self.clone(),
             label: desc.label.to_string(),
             bind_group_layouts,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3817,8 +3817,30 @@ impl Device {
     pub fn create_pipeline_layout(
         self: &Arc<Self>,
         desc: &binding_model::ResolvedPipelineLayoutDescriptor,
-    ) -> Result<Arc<binding_model::PipelineLayout>, binding_model::CreatePipelineLayoutError> {
-        self.create_pipeline_layout_impl(desc, false)
+    ) -> (
+        Arc<binding_model::PipelineLayout>,
+        Option<binding_model::CreatePipelineLayoutError>,
+    ) {
+        let (layout, error) = match self.create_pipeline_layout_impl(desc, false) {
+            Ok(layout) => (layout, None),
+            Err(e) => (
+                binding_model::PipelineLayout::invalid(Arc::clone(self), desc.label.to_string()),
+                Some(e),
+            ),
+        };
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use crate::device::trace::IntoTrace;
+            trace.add(trace::Action::CreatePipelineLayout(
+                layout.to_trace(),
+                desc.to_trace(),
+            ));
+        }
+        api_log!(
+            "Device::create_pipeline_layout -> {:?}",
+            Arc::as_ptr(&layout)
+        );
+        (layout, error)
     }
 
     fn create_pipeline_layout_impl(
@@ -3918,7 +3940,7 @@ impl Device {
         drop(raw_bind_group_layouts);
 
         let layout = binding_model::PipelineLayout {
-            raw: ManuallyDrop::new(raw),
+            raw: ResourceState::Valid(ManuallyDrop::new(raw)),
             device: self.clone(),
             label: desc.label.to_string(),
             bind_group_layouts,
@@ -4025,6 +4047,7 @@ impl Device {
         let pipeline_layout = match desc.layout {
             Some(pipeline_layout) => {
                 pipeline_layout.same_device(self)?;
+                pipeline_layout.check_valid()?;
                 Some(pipeline_layout)
             }
             None => None,
@@ -4083,7 +4106,7 @@ impl Device {
 
         let pipeline_desc = hal::ComputePipelineDescriptor {
             label: desc.label.to_hal(self.instance_flags),
-            layout: pipeline_layout.raw(),
+            layout: pipeline_layout.raw()?,
             stage: hal::ProgrammableStage {
                 module: shader_module.raw(),
                 entry_point: final_entry_point_name.as_ref(),
@@ -4580,6 +4603,7 @@ impl Device {
         let pipeline_layout = match desc.layout {
             Some(pipeline_layout) => {
                 pipeline_layout.same_device(self)?;
+                pipeline_layout.check_valid()?;
                 Some(pipeline_layout)
             }
             None => None,
@@ -4918,7 +4942,7 @@ impl Device {
         let raw = {
             let pipeline_desc = hal::RenderPipelineDescriptor {
                 label: desc.label.to_hal(self.instance_flags),
-                layout: pipeline_layout.raw(),
+                layout: pipeline_layout.raw()?,
                 vertex_processor: match vertex_stage {
                     Some(vertex_stage) => hal::VertexProcessor::Standard {
                         vertex_buffers: &hal_vertex_buffer_layouts,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -187,7 +187,7 @@ pub struct Hub {
     pub(crate) adapters: Registry<Arc<Adapter>>,
     pub(crate) devices: Registry<Arc<Device>>,
     pub(crate) queues: Registry<Arc<Queue>>,
-    pub(crate) pipeline_layouts: Registry<Fallible<PipelineLayout>>,
+    pub(crate) pipeline_layouts: Registry<Arc<PipelineLayout>>,
     pub(crate) shader_modules: Registry<Fallible<ShaderModule>>,
     pub(crate) bind_group_layouts: Registry<Arc<BindGroupLayout>>,
     pub(crate) bind_groups: Registry<Fallible<BindGroup>>,


### PR DESCRIPTION
**Connections**

Builds on top of #9764 and #9762 towards #5121.

**Description**

We move `Fallible` into `PipelineLayout` using `ResourceState`. We also move tracing into the device methods and we now trace all pipelinelayouts (even invalid ones).

**Testing**

Covered by existing tests, but it's mainly just refactor.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.