### PR TITLE
[core] Add support IDed ComputePasses in Global

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1,3 +1,4 @@
+use parking_lot::Mutex;
 use thiserror::Error;
 use wgt::{
     error::{ErrorType, WebGpuError},
@@ -28,7 +29,7 @@ use crate::{
     },
     device::{Device, DeviceError, MissingDownlevelFlags, MissingFeatures},
     global::Global,
-    hal_label, id,
+    hal_label, id, impl_resource_type,
     init_tracker::MemoryInitKind,
     pipeline::ComputePipeline,
     resource::{
@@ -64,6 +65,12 @@ pub struct ComputePass {
     // Resource binding dedupe state.
     current_bind_groups: BindGroupStateChange,
     current_pipeline: StateChange<id::ComputePipelineId>,
+}
+
+impl_resource_type!(ComputePass);
+
+impl crate::storage::StorageItem for ComputePass {
+    type Marker = id::markers::ComputePassEncoder;
 }
 
 impl ComputePass {
@@ -549,6 +556,24 @@ impl Global {
         }
     }
 
+    pub fn command_encoder_begin_compute_pass_with_id(
+        &self,
+        encoder_id: id::CommandEncoderId,
+        desc: &ComputePassDescriptor<'_>,
+        id_in: Option<id::ComputePassEncoderId>,
+    ) -> (id::ComputePassEncoderId, Option<CommandEncoderError>) {
+        let fid = self.hub.compute_passes.prepare(id_in);
+
+        let (pass, err) = self.command_encoder_begin_compute_pass(encoder_id, desc);
+
+        // no lock rank here because only one thread should be using compute pass
+        // and it's only used by id variants of compute pass methods on global
+        // so no deadlock (or concurrent lock) should happen in practise
+        let id = fid.assign(Arc::new(Mutex::new(pass)));
+
+        (id, err)
+    }
+
     pub fn compute_pass_end(&self, pass: &mut ComputePass) -> Result<(), EncoderStateError> {
         profiling::scope!(
             "CommandEncoder::run_compute_pass {}",
@@ -585,6 +610,17 @@ impl Global {
                 timestamp_writes: pass.timestamp_writes.take(),
             })
         })
+    }
+
+    pub fn compute_pass_end_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+    ) -> Result<(), EncoderStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_end(&mut pass)
     }
 }
 
@@ -1219,6 +1255,20 @@ impl Global {
         Ok(())
     }
 
+    pub fn compute_pass_set_bindgroup_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        index: u32,
+        bind_group_id: Option<id::BindGroupId>,
+        offsets: &[DynamicOffset],
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_set_bind_group(&mut pass, index, bind_group_id, offsets)
+    }
+
     pub fn compute_pass_set_pipeline(
         &self,
         pass: &mut ComputePass,
@@ -1244,6 +1294,18 @@ impl Global {
             .push(ArcComputeCommand::SetPipeline(compute_pipeline));
 
         Ok(())
+    }
+
+    pub fn compute_pass_set_pipeline_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        pipeline_id: id::ComputePipelineId,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_set_pipeline(&mut pass, pipeline_id)
     }
 
     pub fn compute_pass_set_immediates(
@@ -1282,6 +1344,19 @@ impl Global {
         Ok(())
     }
 
+    pub fn compute_pass_set_immediates_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        offset: u32,
+        data: &[u8],
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_set_immediates(&mut pass, offset, data)
+    }
+
     pub fn compute_pass_dispatch_workgroups(
         &self,
         pass: &mut ComputePass,
@@ -1300,6 +1375,20 @@ impl Global {
         Ok(())
     }
 
+    pub fn compute_pass_dispatch_workgroups_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        groups_x: u32,
+        groups_y: u32,
+        groups_z: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_dispatch_workgroups(&mut pass, groups_x, groups_y, groups_z)
+    }
+
     pub fn compute_pass_dispatch_workgroups_indirect(
         &self,
         pass: &mut ComputePass,
@@ -1316,6 +1405,19 @@ impl Global {
             .push(ArcComputeCommand::DispatchWorkgroupsIndirect { buffer, offset });
 
         Ok(())
+    }
+
+    pub fn compute_pass_dispatch_workgroups_indirect_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        buffer_id: id::BufferId,
+        offset: BufferAddress,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_dispatch_workgroups_indirect(&mut pass, buffer_id, offset)
     }
 
     pub fn compute_pass_push_debug_group(
@@ -1337,6 +1439,19 @@ impl Global {
         Ok(())
     }
 
+    pub fn compute_pass_push_debug_group_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        label: &str,
+        color: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_push_debug_group(&mut pass, label, color)
+    }
+
     pub fn compute_pass_pop_debug_group(
         &self,
         pass: &mut ComputePass,
@@ -1346,6 +1461,17 @@ impl Global {
         base.commands.push(ArcComputeCommand::PopDebugGroup);
 
         Ok(())
+    }
+
+    pub fn compute_pass_pop_debug_group_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_pop_debug_group(&mut pass)
     }
 
     pub fn compute_pass_insert_debug_marker(
@@ -1367,6 +1493,19 @@ impl Global {
         Ok(())
     }
 
+    pub fn compute_pass_insert_debug_marker_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        label: &str,
+        color: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_insert_debug_marker(&mut pass, label, color)
+    }
+
     pub fn compute_pass_write_timestamp(
         &self,
         pass: &mut ComputePass,
@@ -1385,6 +1524,19 @@ impl Global {
         });
 
         Ok(())
+    }
+
+    pub fn compute_pass_write_timestamp_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_write_timestamp(&mut pass, query_set_id, query_index)
     }
 
     pub fn compute_pass_begin_pipeline_statistics_query(
@@ -1408,6 +1560,19 @@ impl Global {
         Ok(())
     }
 
+    pub fn compute_pass_begin_pipeline_statistics_query_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        query_set_id: id::QuerySetId,
+        query_index: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_begin_pipeline_statistics_query(&mut pass, query_set_id, query_index)
+    }
+
     pub fn compute_pass_end_pipeline_statistics_query(
         &self,
         pass: &mut ComputePass,
@@ -1417,6 +1582,17 @@ impl Global {
             .push(ArcComputeCommand::EndPipelineStatisticsQuery);
 
         Ok(())
+    }
+
+    pub fn compute_pass_end_pipeline_statistics_query_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_end_pipeline_statistics_query(&mut pass)
     }
 
     pub fn compute_pass_transition_resources(

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -121,7 +121,7 @@ use core::fmt::Debug;
 
 use crate::{
     binding_model::{BindGroup, BindGroupLayout, PipelineLayout},
-    command::{CommandBuffer, CommandEncoder, RenderBundle, RenderPass},
+    command::{CommandBuffer, CommandEncoder, ComputePass, RenderBundle, RenderPass},
     device::{queue::Queue, Device},
     instance::Adapter,
     lock::rank,
@@ -157,6 +157,7 @@ pub struct HubReport {
     pub external_textures: RegistryReport,
     pub samplers: RegistryReport,
     pub render_passes: RegistryReport,
+    pub compute_passes: RegistryReport,
 }
 
 impl HubReport {
@@ -210,6 +211,7 @@ pub struct Hub {
     pub(crate) blas_s: Registry<Fallible<Blas>>,
     pub(crate) tlas_s: Registry<Fallible<Tlas>>,
     pub(crate) render_passes: Registry<Arc<Mutex<RenderPass>>>,
+    pub(crate) compute_passes: Registry<Arc<Mutex<ComputePass>>>,
 }
 
 impl Hub {
@@ -245,6 +247,7 @@ impl Hub {
             blas_s: Registry::new(),
             tlas_s: Registry::with_rank(rank::HUB_TLAS),
             render_passes: Registry::new(),
+            compute_passes: Registry::new(),
         }
     }
 
@@ -270,6 +273,7 @@ impl Hub {
             external_textures: self.external_textures.generate_report(),
             samplers: self.samplers.generate_report(),
             render_passes: self.render_passes.generate_report(),
+            compute_passes: self.compute_passes.generate_report(),
         }
     }
 }


### PR DESCRIPTION
**Connections**

Similar to #9740

**Description**

As discussed in https://github.com/gfx-rs/wgpu/pull/9712#issuecomment-4788311141 and in #5121 we need this to remove recording from content process in firefox. Servo will also benefit from this.

In addition to normal methods that take `&mut ComputePass` we also add some that take `id::ComputePassEncoderId` and use the passes from registry (which are made mut using unranked `Mutex`). One could consider this as "second registry" for encoders. This works because passes are not passed to any other resource via descriptor.

This allow for wgpu and deno to keep using the ones without id and avoid another level of indirection. The down side is that these wrapper are not tested anywhere in wgpu repo, but I think they are thin so it should not be that much problematic.

**Testing**
None, as this should only be used by servo/firefox.

**Squash or Rebase?**

Squash.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
