### PR TITLE
[core] Handle ended in RenderBundleEncoder

### DIFF
--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -688,7 +688,7 @@ impl GPUDevice {
     GPURenderBundleEncoder {
       instance: self.instance.clone(),
       error_handler: self.error_handler.clone(),
-      encoder: RefCell::new(Some(encoder)),
+      encoder: RefCell::new(encoder),
       label: descriptor.label,
     }
   }

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -64,7 +64,6 @@ impl GPURenderBundleEncoder {
       label: crate::transform_label(descriptor.label.clone()),
     };
 
-    // TODO: keep the encoder when validation is working in wgpu-core
     let (id, err) = self.instance.render_bundle_encoder_finish(
       &mut self.encoder.borrow_mut(),
       &wgpu_descriptor,

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -64,8 +64,9 @@ impl GPURenderBundleEncoder {
       label: crate::transform_label(descriptor.label.clone()),
     };
 
+    // TODO: keep the encoder when validation is working in wgpu-core
     let (id, err) = self.instance.render_bundle_encoder_finish(
-      self.encoder.borrow_mut().take().unwrap(),
+      &mut self.encoder.borrow_mut().take().unwrap(),
       &wgpu_descriptor,
       None,
     );

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -26,7 +26,7 @@ pub struct GPURenderBundleEncoder {
   pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
-  pub encoder: RefCell<Option<Box<wgpu_core::command::RenderBundleEncoder>>>,
+  pub encoder: RefCell<Box<wgpu_core::command::RenderBundleEncoder>>,
   pub label: String,
 }
 
@@ -66,7 +66,7 @@ impl GPURenderBundleEncoder {
 
     // TODO: keep the encoder when validation is working in wgpu-core
     let (id, err) = self.instance.render_bundle_encoder_finish(
-      &mut self.encoder.borrow_mut().take().unwrap(),
+      &mut self.encoder.borrow_mut(),
       &wgpu_descriptor,
       None,
     );
@@ -86,13 +86,14 @@ impl GPURenderBundleEncoder {
     #[webidl] group_label: String,
   ) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
-    self
+    let err = self
       .instance
-      .render_bundle_encoder_push_debug_group(encoder, &group_label);
+      .render_bundle_encoder_push_debug_group(encoder, &group_label)
+      .err();
+
+    self.error_handler.push_error(err);
 
     Ok(())
   }
@@ -101,10 +102,15 @@ impl GPURenderBundleEncoder {
   #[undefined]
   fn pop_debug_group(&self) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
-    self.instance.render_bundle_encoder_pop_debug_group(encoder);
+    let encoder = encoder.as_mut();
+
+    let err = self
+      .instance
+      .render_bundle_encoder_pop_debug_group(encoder)
+      .err();
+
+    self.error_handler.push_error(err);
+
     Ok(())
   }
 
@@ -114,13 +120,14 @@ impl GPURenderBundleEncoder {
     #[webidl] marker_label: String,
   ) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
-    self
+    let err = self
       .instance
-      .render_bundle_encoder_insert_debug_marker(encoder, &marker_label);
+      .render_bundle_encoder_insert_debug_marker(encoder, &marker_label)
+      .err();
+
+    self.error_handler.push_error(err);
     Ok(())
   }
 
@@ -135,9 +142,7 @@ impl GPURenderBundleEncoder {
     dynamic_offsets_data_length: v8::Local<'a, v8::Value>,
   ) -> Result<(), SetBindGroupError> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
     const PREFIX: &str =
       "Failed to execute 'setBindGroup' on 'GPUComputePassEncoder'";
@@ -173,12 +178,17 @@ impl GPURenderBundleEncoder {
 
       let offsets = &data[start..(start + len)];
 
-      self.instance.render_bundle_encoder_set_bind_group(
-        encoder,
-        index,
-        bind_group.into_option().map(|bind_group| bind_group.id),
-        offsets,
-      );
+      let err = self
+        .instance
+        .render_bundle_encoder_set_bind_group(
+          encoder,
+          index,
+          bind_group.into_option().map(|bind_group| bind_group.id),
+          offsets,
+        )
+        .err();
+
+      self.error_handler.push_error(err);
     } else {
       let offsets = <Option<Vec<u32>>>::convert(
         scope,
@@ -192,12 +202,17 @@ impl GPURenderBundleEncoder {
       )?
       .unwrap_or_default();
 
-      self.instance.render_bundle_encoder_set_bind_group(
-        encoder,
-        index,
-        bind_group.into_option().map(|bind_group| bind_group.id),
-        &offsets,
-      );
+      let err = self
+        .instance
+        .render_bundle_encoder_set_bind_group(
+          encoder,
+          index,
+          bind_group.into_option().map(|bind_group| bind_group.id),
+          &offsets,
+        )
+        .err();
+
+      self.error_handler.push_error(err);
     }
 
     Ok(())
@@ -209,13 +224,14 @@ impl GPURenderBundleEncoder {
     #[webidl] pipeline: Ptr<crate::render_pipeline::GPURenderPipeline>,
   ) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
-    self
+    let err = self
       .instance
-      .render_bundle_encoder_set_pipeline(encoder, pipeline.id);
+      .render_bundle_encoder_set_pipeline(encoder, pipeline.id)
+      .err();
+
+    self.error_handler.push_error(err);
     Ok(())
   }
 
@@ -229,17 +245,21 @@ impl GPURenderBundleEncoder {
     #[webidl(options(enforce_range = true))] size: Option<u64>,
   ) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
-    self.instance.render_bundle_encoder_set_index_buffer(
-      encoder,
-      buffer.id,
-      index_format.into(),
-      offset,
-      size.and_then(NonZeroU64::new),
-    );
+    let err = self
+      .instance
+      .render_bundle_encoder_set_index_buffer(
+        encoder,
+        buffer.id,
+        index_format.into(),
+        offset,
+        size.and_then(NonZeroU64::new),
+      )
+      .err();
+
+    self.error_handler.push_error(err);
+
     Ok(())
   }
 
@@ -253,17 +273,19 @@ impl GPURenderBundleEncoder {
     #[webidl(options(enforce_range = true))] size: Option<u64>,
   ) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
-    self.instance.render_bundle_encoder_set_vertex_buffer(
-      encoder,
-      slot,
-      buffer.into_option().map(|buffer| buffer.id),
-      offset,
-      size.and_then(NonZeroU64::new),
-    );
+    let err = self
+      .instance
+      .render_bundle_encoder_set_vertex_buffer(
+        encoder,
+        slot,
+        buffer.into_option().map(|buffer| buffer.id),
+        offset,
+        size.and_then(NonZeroU64::new),
+      )
+      .err();
+    self.error_handler.push_error(err);
     Ok(())
   }
 
@@ -277,17 +299,19 @@ impl GPURenderBundleEncoder {
     #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
   ) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
-    self.instance.render_bundle_encoder_draw(
-      encoder,
-      vertex_count,
-      instance_count,
-      first_vertex,
-      first_instance,
-    );
+    let err = self
+      .instance
+      .render_bundle_encoder_draw(
+        encoder,
+        vertex_count,
+        instance_count,
+        first_vertex,
+        first_instance,
+      )
+      .err();
+    self.error_handler.push_error(err);
     Ok(())
   }
 
@@ -302,18 +326,20 @@ impl GPURenderBundleEncoder {
     #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
   ) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
-    self.instance.render_bundle_encoder_draw_indexed(
-      encoder,
-      index_count,
-      instance_count,
-      first_index,
-      base_vertex,
-      first_instance,
-    );
+    let err = self
+      .instance
+      .render_bundle_encoder_draw_indexed(
+        encoder,
+        index_count,
+        instance_count,
+        first_index,
+        base_vertex,
+        first_instance,
+      )
+      .err();
+    self.error_handler.push_error(err);
     Ok(())
   }
 
@@ -325,15 +351,17 @@ impl GPURenderBundleEncoder {
     #[webidl(options(enforce_range = true))] indirect_offset: u64,
   ) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
-    self.instance.render_bundle_encoder_draw_indirect(
-      encoder,
-      indirect_buffer.id,
-      indirect_offset,
-    );
+    let err = self
+      .instance
+      .render_bundle_encoder_draw_indirect(
+        encoder,
+        indirect_buffer.id,
+        indirect_offset,
+      )
+      .err();
+    self.error_handler.push_error(err);
     Ok(())
   }
 
@@ -345,15 +373,17 @@ impl GPURenderBundleEncoder {
     #[webidl(options(enforce_range = true))] indirect_offset: u64,
   ) -> Result<(), JsErrorBox> {
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
-    self.instance.render_bundle_encoder_draw_indexed_indirect(
-      encoder,
-      indirect_buffer.id,
-      indirect_offset,
-    );
+    let err = self
+      .instance
+      .render_bundle_encoder_draw_indexed_indirect(
+        encoder,
+        indirect_buffer.id,
+        indirect_offset,
+      )
+      .err();
+    self.error_handler.push_error(err);
     Ok(())
   }
 
@@ -370,13 +400,13 @@ impl GPURenderBundleEncoder {
     let data = get_data_slice(scope, data_arg, data_offset, data_size)?;
 
     let mut encoder = self.encoder.borrow_mut();
-    let encoder = encoder.as_mut().ok_or_else(|| {
-      JsErrorBox::generic("Encoder has already been finished")
-    })?;
+    let encoder = encoder.as_mut();
 
-    self
+    let err = self
       .instance
-      .render_bundle_encoder_set_immediates(encoder, offset, data);
+      .render_bundle_encoder_set_immediates(encoder, offset, data)
+      .err();
+    self.error_handler.push_error(err);
     Ok(())
   }
 }

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -102,9 +102,9 @@ use crate::command::ArcReferences;
 use crate::{
     binding_model::{BindError, BindGroup, PipelineLayout},
     command::{
-        bind::Binder, pass::validate_immediates_alignment, BasePass, BindGroupStateChange,
-        ColorAttachmentError, DrawError, IdReferences, MapPassErr, PassErrorScope, RenderCommand,
-        RenderCommandError, StateChange,
+        bind::Binder, pass::validate_immediates_alignment, pass_base, BasePass,
+        BindGroupStateChange, ColorAttachmentError, DrawError, EncoderStateError, IdReferences,
+        MapPassErr, PassErrorScope, PassStateError, RenderCommand, RenderCommandError, StateChange,
     },
     device::{
         AttachmentData, Device, DeviceError, MissingDownlevelFlags, MissingFeatures,
@@ -164,6 +164,12 @@ pub struct RenderBundleEncoderDescriptor<'a> {
 pub struct RenderBundleEncoder {
     base: BasePass<RenderCommand<IdReferences>, Infallible>,
     parent_id: id::DeviceId,
+    /// State of the render bundle encoder. Encoded to be compatible with pass macros.
+    ///
+    /// If this is `Some`, then the pass is in WebGPU's "open" state. If it is
+    /// `None`, then the pass is in the "ended" state.
+    /// See <https://www.w3.org/TR/webgpu/#encoder-state>
+    parent: Option<()>,
     pub(crate) context: RenderPassContext,
     pub(crate) is_depth_read_only: bool,
     pub(crate) is_stencil_read_only: bool,
@@ -259,6 +265,7 @@ impl RenderBundleEncoder {
 
         Ok(Self {
             base: BasePass::new(&desc.label),
+            parent: Some(()),
             parent_id,
             context: RenderPassContext {
                 attachments: AttachmentData {
@@ -280,6 +287,7 @@ impl RenderBundleEncoder {
     pub fn dummy(parent_id: id::DeviceId) -> Self {
         Self {
             base: BasePass::new(&None),
+            parent: None,
             parent_id,
             context: RenderPassContext::default(),
             is_depth_read_only: false,
@@ -311,6 +319,11 @@ impl RenderBundleEncoder {
         hub: &Hub,
     ) -> Result<Arc<RenderBundle>, RenderBundleError> {
         let scope = PassErrorScope::Bundle;
+
+        self.parent
+            .take()
+            .ok_or(RenderBundleErrorInner::Ended)
+            .map_pass_err(scope)?;
 
         device.check_is_valid().map_pass_err(scope)?;
 
@@ -573,13 +586,15 @@ impl RenderBundleEncoder {
         index_format: wgt::IndexFormat,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
-    ) {
+    ) -> Result<(), PassStateError> {
+        pass_base!(self, PassErrorScope::SetIndexBuffer);
         self.base.commands.push(RenderCommand::SetIndexBuffer {
             buffer,
             index_format,
             offset,
             size,
         });
+        Ok(())
     }
 
     pub fn set_bind_group(
@@ -587,7 +602,8 @@ impl RenderBundleEncoder {
         index: u32,
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[wgt::DynamicOffset],
-    ) {
+    ) -> Result<(), PassStateError> {
+        pass_base!(self, PassErrorScope::SetBindGroup);
         let redundant = self.current_bind_groups.set_and_check_redundant(
             bind_group_id,
             index,
@@ -596,7 +612,7 @@ impl RenderBundleEncoder {
         );
 
         if redundant {
-            return;
+            return Ok(());
         }
 
         self.base.commands.push(RenderCommand::SetBindGroup {
@@ -604,16 +620,22 @@ impl RenderBundleEncoder {
             num_dynamic_offsets: offsets.len(),
             bind_group: bind_group_id,
         });
+        Ok(())
     }
 
-    pub fn set_pipeline(&mut self, pipeline_id: id::RenderPipelineId) {
+    pub fn set_pipeline(
+        &mut self,
+        pipeline_id: id::RenderPipelineId,
+    ) -> Result<(), PassStateError> {
+        pass_base!(self, PassErrorScope::SetPipelineRender);
         if self.current_pipeline.set_and_check_redundant(pipeline_id) {
-            return;
+            return Ok(());
         }
 
         self.base
             .commands
             .push(RenderCommand::SetPipeline(pipeline_id));
+        Ok(())
     }
 
     pub fn set_vertex_buffer(
@@ -622,16 +644,19 @@ impl RenderBundleEncoder {
         buffer_id: Option<id::BufferId>,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
-    ) {
+    ) -> Result<(), PassStateError> {
+        pass_base!(self, PassErrorScope::SetVertexBuffer);
         self.base.commands.push(RenderCommand::SetVertexBuffer {
             slot,
             buffer: buffer_id,
             offset,
             size,
         });
+        Ok(())
     }
 
-    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) {
+    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) -> Result<(), PassStateError> {
+        pass_base!(self, PassErrorScope::SetImmediate);
         let value_offset = self.base.immediates_data.len().try_into().expect(
             "Ran out of immediate data space. Don't set 4gb of immediates per RenderBundle.",
         );
@@ -645,6 +670,7 @@ impl RenderBundleEncoder {
             size_bytes: data.len() as u32,
             values_offset: Some(value_offset),
         });
+        Ok(())
     }
 
     pub fn draw(
@@ -653,13 +679,21 @@ impl RenderBundleEncoder {
         instance_count: u32,
         first_vertex: u32,
         first_instance: u32,
-    ) {
+    ) -> Result<(), PassStateError> {
+        pass_base!(
+            self,
+            PassErrorScope::Draw {
+                kind: DrawKind::Draw,
+                family: DrawCommandFamily::Draw
+            }
+        );
         self.base.commands.push(RenderCommand::Draw {
             vertex_count,
             instance_count,
             first_vertex,
             first_instance,
         });
+        Ok(())
     }
 
     pub fn draw_indexed(
@@ -669,7 +703,14 @@ impl RenderBundleEncoder {
         first_index: u32,
         base_vertex: i32,
         first_instance: u32,
-    ) {
+    ) -> Result<(), PassStateError> {
+        pass_base!(
+            self,
+            PassErrorScope::Draw {
+                kind: DrawKind::Draw,
+                family: DrawCommandFamily::DrawIndexed
+            }
+        );
         self.base.commands.push(RenderCommand::DrawIndexed {
             index_count,
             instance_count,
@@ -677,9 +718,21 @@ impl RenderBundleEncoder {
             base_vertex,
             first_instance,
         });
+        Ok(())
     }
 
-    pub fn draw_indirect(&mut self, buffer_id: id::BufferId, offset: wgt::BufferAddress) {
+    pub fn draw_indirect(
+        &mut self,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+    ) -> Result<(), PassStateError> {
+        pass_base!(
+            self,
+            PassErrorScope::Draw {
+                kind: DrawKind::DrawIndirect,
+                family: DrawCommandFamily::Draw
+            }
+        );
         self.base.commands.push(RenderCommand::DrawIndirect {
             buffer: buffer_id,
             offset,
@@ -688,9 +741,21 @@ impl RenderBundleEncoder {
             vertex_or_index_limit: None,
             instance_limit: None,
         });
+        Ok(())
     }
 
-    pub fn draw_indexed_indirect(&mut self, buffer_id: id::BufferId, offset: wgt::BufferAddress) {
+    pub fn draw_indexed_indirect(
+        &mut self,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+    ) -> Result<(), PassStateError> {
+        pass_base!(
+            self,
+            PassErrorScope::Draw {
+                kind: DrawKind::DrawIndirect,
+                family: DrawCommandFamily::DrawIndexed
+            }
+        );
         self.base.commands.push(RenderCommand::DrawIndirect {
             buffer: buffer_id,
             offset,
@@ -699,18 +764,25 @@ impl RenderBundleEncoder {
             vertex_or_index_limit: None,
             instance_limit: None,
         });
+        Ok(())
     }
 
-    pub fn push_debug_group(&mut self, _label: &str) {
+    pub fn push_debug_group(&mut self, _label: &str) -> Result<(), PassStateError> {
+        pass_base!(self, PassErrorScope::PushDebugGroup);
         //TODO
+        Ok(())
     }
 
-    pub fn pop_debug_group(&mut self) {
+    pub fn pop_debug_group(&mut self) -> Result<(), PassStateError> {
+        pass_base!(self, PassErrorScope::PopDebugGroup);
         //TODO
+        Ok(())
     }
 
-    pub fn insert_debug_marker(&mut self, _label: &str) {
+    pub fn insert_debug_marker(&mut self, _label: &str) -> Result<(), PassStateError> {
+        pass_base!(self, PassErrorScope::InsertDebugMarker);
         //TODO
+        Ok(())
     }
 }
 
@@ -1692,6 +1764,8 @@ pub enum RenderBundleErrorInner {
     Bind(#[from] BindError),
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
+    #[error("Render bundle encoder has already ended")]
+    Ended,
 }
 
 impl<T> From<T> for RenderBundleErrorInner
@@ -1723,6 +1797,7 @@ impl WebGpuError for RenderBundleError {
             RenderBundleErrorInner::MissingDownlevelFlags(e) => e.webgpu_error_type(),
             RenderBundleErrorInner::Bind(e) => e.webgpu_error_type(),
             RenderBundleErrorInner::InvalidResource(e) => e.webgpu_error_type(),
+            RenderBundleErrorInner::Ended => ErrorType::Validation,
         }
     }
 }
@@ -1755,16 +1830,16 @@ impl crate::global::Global {
         index: u32,
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[wgt::DynamicOffset],
-    ) {
-        bundle.set_bind_group(index, bind_group_id, offsets);
+    ) -> Result<(), PassStateError> {
+        bundle.set_bind_group(index, bind_group_id, offsets)
     }
 
     pub fn render_bundle_encoder_set_pipeline(
         &self,
         bundle: &mut RenderBundleEncoder,
         pipeline_id: id::RenderPipelineId,
-    ) {
-        bundle.set_pipeline(pipeline_id);
+    ) -> Result<(), PassStateError> {
+        bundle.set_pipeline(pipeline_id)
     }
 
     pub fn render_bundle_encoder_set_vertex_buffer(
@@ -1774,8 +1849,8 @@ impl crate::global::Global {
         buffer_id: Option<id::BufferId>,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
-    ) {
-        bundle.set_vertex_buffer(slot, buffer_id, offset, size);
+    ) -> Result<(), PassStateError> {
+        bundle.set_vertex_buffer(slot, buffer_id, offset, size)
     }
 
     pub fn render_bundle_encoder_set_index_buffer(
@@ -1785,8 +1860,8 @@ impl crate::global::Global {
         index_format: wgt::IndexFormat,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
-    ) {
-        encoder.set_index_buffer(buffer, index_format, offset, size);
+    ) -> Result<(), PassStateError> {
+        encoder.set_index_buffer(buffer, index_format, offset, size)
     }
 
     pub fn render_bundle_encoder_set_immediates(
@@ -1794,8 +1869,8 @@ impl crate::global::Global {
         pass: &mut RenderBundleEncoder,
         offset: u32,
         data: &[u8],
-    ) {
-        pass.set_immediates(offset, data);
+    ) -> Result<(), PassStateError> {
+        pass.set_immediates(offset, data)
     }
 
     pub fn render_bundle_encoder_draw(
@@ -1805,8 +1880,8 @@ impl crate::global::Global {
         instance_count: u32,
         first_vertex: u32,
         first_instance: u32,
-    ) {
-        bundle.draw(vertex_count, instance_count, first_vertex, first_instance);
+    ) -> Result<(), PassStateError> {
+        bundle.draw(vertex_count, instance_count, first_vertex, first_instance)
     }
 
     pub fn render_bundle_encoder_draw_indexed(
@@ -1817,14 +1892,14 @@ impl crate::global::Global {
         first_index: u32,
         base_vertex: i32,
         first_instance: u32,
-    ) {
+    ) -> Result<(), PassStateError> {
         bundle.draw_indexed(
             index_count,
             instance_count,
             first_index,
             base_vertex,
             first_instance,
-        );
+        )
     }
 
     pub fn render_bundle_encoder_draw_indirect(
@@ -1832,8 +1907,8 @@ impl crate::global::Global {
         bundle: &mut RenderBundleEncoder,
         buffer_id: id::BufferId,
         offset: wgt::BufferAddress,
-    ) {
-        bundle.draw_indirect(buffer_id, offset);
+    ) -> Result<(), PassStateError> {
+        bundle.draw_indirect(buffer_id, offset)
     }
 
     pub fn render_bundle_encoder_draw_indexed_indirect(
@@ -1841,28 +1916,31 @@ impl crate::global::Global {
         bundle: &mut RenderBundleEncoder,
         buffer_id: id::BufferId,
         offset: wgt::BufferAddress,
-    ) {
-        bundle.draw_indexed_indirect(buffer_id, offset);
+    ) -> Result<(), PassStateError> {
+        bundle.draw_indexed_indirect(buffer_id, offset)
     }
 
     pub fn render_bundle_encoder_push_debug_group(
         &self,
         bundle: &mut RenderBundleEncoder,
         label: &str,
-    ) {
-        bundle.push_debug_group(label);
+    ) -> Result<(), PassStateError> {
+        bundle.push_debug_group(label)
     }
 
-    pub fn render_bundle_encoder_pop_debug_group(&self, bundle: &mut RenderBundleEncoder) {
-        bundle.pop_debug_group();
+    pub fn render_bundle_encoder_pop_debug_group(
+        &self,
+        bundle: &mut RenderBundleEncoder,
+    ) -> Result<(), PassStateError> {
+        bundle.pop_debug_group()
     }
 
     pub fn render_bundle_encoder_insert_debug_marker(
         &self,
         bundle: &mut RenderBundleEncoder,
         label: &str,
-    ) {
-        bundle.insert_debug_marker(label);
+    ) -> Result<(), PassStateError> {
+        bundle.insert_debug_marker(label)
     }
 }
 
@@ -1886,7 +1964,7 @@ pub mod bundle_ffi {
     ) {
         let offsets = unsafe { slice::from_raw_parts(offsets, offset_length) };
 
-        bundle.set_bind_group(index, bind_group_id, offsets);
+        let _ = bundle.set_bind_group(index, bind_group_id, offsets);
     }
 
     #[deprecated(note = "Use `Global::render_bundle_encoder_set_pipeline` instead.")]
@@ -1894,7 +1972,7 @@ pub mod bundle_ffi {
         bundle: &mut RenderBundleEncoder,
         pipeline_id: id::RenderPipelineId,
     ) {
-        bundle.set_pipeline(pipeline_id);
+        let _ = bundle.set_pipeline(pipeline_id);
     }
 
     #[deprecated(note = "Use `Global::render_bundle_encoder_set_vertex_buffer` instead.")]
@@ -1905,7 +1983,7 @@ pub mod bundle_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        bundle.set_vertex_buffer(slot, buffer_id, offset, size);
+        let _ = bundle.set_vertex_buffer(slot, buffer_id, offset, size);
     }
 
     #[deprecated(note = "Use `Global::render_bundle_encoder_set_index_buffer` instead.")]
@@ -1916,7 +1994,7 @@ pub mod bundle_ffi {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) {
-        encoder.set_index_buffer(buffer, index_format, offset, size);
+        let _ = encoder.set_index_buffer(buffer, index_format, offset, size);
     }
 
     #[deprecated(note = "Use `Global::render_bundle_encoder_set_immediates` instead.")]
@@ -1931,7 +2009,7 @@ pub mod bundle_ffi {
         data: *const u8,
     ) {
         let data_slice = unsafe { slice::from_raw_parts(data, size_bytes as usize) };
-        pass.set_immediates(offset, data_slice);
+        let _ = pass.set_immediates(offset, data_slice);
     }
 
     #[deprecated(note = "Use `Global::render_bundle_encoder_draw` instead.")]
@@ -1942,7 +2020,7 @@ pub mod bundle_ffi {
         first_vertex: u32,
         first_instance: u32,
     ) {
-        bundle.draw(vertex_count, instance_count, first_vertex, first_instance);
+        let _ = bundle.draw(vertex_count, instance_count, first_vertex, first_instance);
     }
 
     #[deprecated(note = "Use `Global::render_bundle_encoder_draw_indexed` instead.")]
@@ -1954,7 +2032,7 @@ pub mod bundle_ffi {
         base_vertex: i32,
         first_instance: u32,
     ) {
-        bundle.draw_indexed(
+        let _ = bundle.draw_indexed(
             index_count,
             instance_count,
             first_index,
@@ -1969,7 +2047,7 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        bundle.draw_indirect(buffer_id, offset);
+        let _ = bundle.draw_indirect(buffer_id, offset);
     }
 
     #[deprecated(note = "Use `Global::render_bundle_encoder_draw_indexed_indirect` instead.")]
@@ -1978,7 +2056,7 @@ pub mod bundle_ffi {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) {
-        bundle.draw_indexed_indirect(buffer_id, offset);
+        let _ = bundle.draw_indexed_indirect(buffer_id, offset);
     }
 
     #[deprecated(note = "Use `Global::render_bundle_encoder_push_debug_group` instead.")]

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -86,6 +86,7 @@ use alloc::{
 };
 use core::{
     convert::Infallible,
+    mem,
     num::{NonZeroU32, NonZeroU64},
     ops::Range,
 };
@@ -280,15 +281,7 @@ impl RenderBundleEncoder {
         Self {
             base: BasePass::new(&None),
             parent_id,
-            context: RenderPassContext {
-                attachments: AttachmentData {
-                    colors: ArrayVec::new(),
-                    resolves: ArrayVec::new(),
-                    depth_stencil: None,
-                },
-                sample_count: 0,
-                multiview_mask: None,
-            },
+            context: RenderPassContext::default(),
             is_depth_read_only: false,
             is_stencil_read_only: false,
 
@@ -312,7 +305,7 @@ impl RenderBundleEncoder {
     ///
     /// [`ExecuteBundle`]: RenderCommand::ExecuteBundle
     pub(crate) fn finish(
-        self,
+        &mut self,
         desc: &RenderBundleDescriptor,
         device: &Arc<Device>,
         hub: &Hub,
@@ -545,14 +538,17 @@ impl RenderBundleEncoder {
             .instance_flags
             .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS);
 
+        let string_data = mem::take(&mut self.base.string_data);
+        let immediates_data = mem::take(&mut self.base.immediates_data);
+        let context = mem::take(&mut self.context);
         let render_bundle = RenderBundle {
             base: BasePass {
                 label: desc.label.as_deref().map(str::to_owned),
                 error: None,
                 commands,
                 dynamic_offsets: flat_dynamic_offsets,
-                string_data: self.base.string_data,
-                immediates_data: self.base.immediates_data,
+                string_data,
+                immediates_data,
             },
             is_depth_read_only: self.is_depth_read_only,
             is_stencil_read_only: self.is_stencil_read_only,
@@ -560,7 +556,7 @@ impl RenderBundleEncoder {
             used: trackers,
             buffer_memory_init_actions,
             texture_memory_init_actions,
-            context: self.context,
+            context,
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(tracker_indices),
             discard_hal_labels,

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1166,7 +1166,7 @@ impl Global {
 
     pub fn render_bundle_encoder_finish(
         &self,
-        bundle_encoder: Box<command::RenderBundleEncoder>,
+        bundle_encoder: &mut Box<command::RenderBundleEncoder>,
         desc: &command::RenderBundleDescriptor,
         id_in: Option<id::RenderBundleId>,
     ) -> (id::RenderBundleId, Option<command::RenderBundleError>) {

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -64,6 +64,21 @@ pub(crate) struct RenderPassContext {
     pub sample_count: u32,
     pub multiview_mask: Option<NonZeroU32>,
 }
+
+impl Default for RenderPassContext {
+    fn default() -> Self {
+        Self {
+            attachments: AttachmentData {
+                colors: ArrayVec::new(),
+                resolves: ArrayVec::new(),
+                depth_stencil: None,
+            },
+            sample_count: Default::default(),
+            multiview_mask: Default::default(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum RenderPassCompatibilityError {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -3797,7 +3797,8 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
 
         self.context
             .0
-            .render_bundle_encoder_set_pipeline(&mut self.encoder, pipeline.id);
+            .render_bundle_encoder_set_pipeline(&mut self.encoder, pipeline.id)
+            .expect("RenderBundleEncoder should not have ended")
     }
 
     fn set_bind_group(
@@ -3811,6 +3812,7 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
         self.context
             .0
             .render_bundle_encoder_set_bind_group(&mut self.encoder, index, bg, offsets)
+            .expect("RenderBundleEncoder should not have ended");
     }
 
     fn set_index_buffer(
@@ -3822,13 +3824,16 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let buffer = buffer.as_core();
 
-        self.context.0.render_bundle_encoder_set_index_buffer(
-            &mut self.encoder,
-            buffer.id,
-            index_format,
-            offset,
-            size,
-        );
+        self.context
+            .0
+            .render_bundle_encoder_set_index_buffer(
+                &mut self.encoder,
+                buffer.id,
+                index_format,
+                offset,
+                size,
+            )
+            .expect("RenderBundleEncoder should not have ended");
     }
 
     fn set_vertex_buffer(
@@ -3840,40 +3845,44 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let buffer = buffer.map(|buffer| buffer.as_core().id);
 
-        self.context.0.render_bundle_encoder_set_vertex_buffer(
-            &mut self.encoder,
-            slot,
-            buffer,
-            offset,
-            size,
-        );
+        self.context
+            .0
+            .render_bundle_encoder_set_vertex_buffer(&mut self.encoder, slot, buffer, offset, size)
+            .expect("RenderBundleEncoder should not have ended");
     }
 
     fn set_immediates(&mut self, offset: u32, data: &[u8]) {
         self.context
             .0
-            .render_bundle_encoder_set_immediates(&mut self.encoder, offset, data);
+            .render_bundle_encoder_set_immediates(&mut self.encoder, offset, data)
+            .expect("RenderBundleEncoder should not have ended");
     }
 
     fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
-        self.context.0.render_bundle_encoder_draw(
-            &mut self.encoder,
-            vertices.end - vertices.start,
-            instances.end - instances.start,
-            vertices.start,
-            instances.start,
-        );
+        self.context
+            .0
+            .render_bundle_encoder_draw(
+                &mut self.encoder,
+                vertices.end - vertices.start,
+                instances.end - instances.start,
+                vertices.start,
+                instances.start,
+            )
+            .expect("RenderBundleEncoder should not have ended");
     }
 
     fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
-        self.context.0.render_bundle_encoder_draw_indexed(
-            &mut self.encoder,
-            indices.end - indices.start,
-            instances.end - instances.start,
-            indices.start,
-            base_vertex,
-            instances.start,
-        );
+        self.context
+            .0
+            .render_bundle_encoder_draw_indexed(
+                &mut self.encoder,
+                indices.end - indices.start,
+                instances.end - instances.start,
+                indices.start,
+                base_vertex,
+                instances.start,
+            )
+            .expect("RenderBundleEncoder should not have ended");
     }
 
     fn draw_indirect(
@@ -3883,11 +3892,14 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        self.context.0.render_bundle_encoder_draw_indirect(
-            &mut self.encoder,
-            indirect_buffer.id,
-            indirect_offset,
-        )
+        self.context
+            .0
+            .render_bundle_encoder_draw_indirect(
+                &mut self.encoder,
+                indirect_buffer.id,
+                indirect_offset,
+            )
+            .expect("RenderBundleEncoder should not have ended");
     }
 
     fn draw_indexed_indirect(
@@ -3897,11 +3909,14 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        self.context.0.render_bundle_encoder_draw_indexed_indirect(
-            &mut self.encoder,
-            indirect_buffer.id,
-            indirect_offset,
-        )
+        self.context
+            .0
+            .render_bundle_encoder_draw_indexed_indirect(
+                &mut self.encoder,
+                indirect_buffer.id,
+                indirect_offset,
+            )
+            .expect("RenderBundleEncoder should not have ended");
     }
 
     fn finish(mut self, desc: &crate::RenderBundleDescriptor<'_>) -> dispatch::DispatchRenderBundle

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -3904,12 +3904,12 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
         )
     }
 
-    fn finish(self, desc: &crate::RenderBundleDescriptor<'_>) -> dispatch::DispatchRenderBundle
+    fn finish(mut self, desc: &crate::RenderBundleDescriptor<'_>) -> dispatch::DispatchRenderBundle
     where
         Self: Sized,
     {
         let (id, error) = self.context.0.render_bundle_encoder_finish(
-            self.encoder,
+            &mut self.encoder,
             &desc.map_label(|l| l.map(Borrowed)),
             None,
         );


### PR DESCRIPTION
**Connections**
Fixes #7857.

**Description**
First commit is from https://github.com/gfx-rs/wgpu/pull/9712#issuecomment-4788985969 (we need this to be able to put them behind ids) but now we actually implement handling ending RenderBundleEncoder in second commit. We implement this similarly as in other Passes (using `parent: Option<()>`) so we can reuse `pass_base!` macro.

Wgpu should never get ended RenderBundleEncoder because of rust typesystem (finish consumes it).
ffi functions ignore results to keep same behavior/signature as we will migrate off them soon. 

**Testing**

Relevant CTS test pass now:
```
Running webgpu:api,validation,encoding,encoder_open_state:render_bundle_commands:*
** Summary **
Passed  w/o warnings = 11 / 12 =  91.67%
Passed with warnings =  0 / 12 =   0.00%
Skipped              =  0 / 12 =   0.00%
Failed               =  1 / 12 =   8.33%
Error: CTS failed
```
except for setImmidiates case because CTS is wrong there (waiting for https://github.com/gpuweb/cts/pull/4673 to be in our CTS checkout)

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
