### PR TITLE
[core] Add IDed `RenderBundleEncoder` methods on `Global`

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -111,7 +111,7 @@ use crate::{
         RenderPassContext,
     },
     hub::Hub,
-    id,
+    id, impl_resource_type, impl_storage_item,
     init_tracker::{BufferInitTrackerAction, MemoryInitKind, TextureInitTrackerAction},
     pipeline::{PipelineFlags, RenderPipeline},
     resource::{
@@ -180,6 +180,9 @@ pub struct RenderBundleEncoder {
     #[cfg_attr(feature = "serde", serde(skip))]
     current_pipeline: StateChange<id::RenderPipelineId>,
 }
+
+impl_resource_type!(RenderBundleEncoder);
+impl_storage_item!(RenderBundleEncoder);
 
 /// Validate a render bundle descriptor.
 ///
@@ -1834,12 +1837,42 @@ impl crate::global::Global {
         bundle.set_bind_group(index, bind_group_id, offsets)
     }
 
+    pub fn render_bundle_encoder_set_bind_group_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        index: u32,
+        bind_group_id: Option<id::BindGroupId>,
+        offsets: &[wgt::DynamicOffset],
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.set_bind_group(index, bind_group_id, offsets)
+    }
+
     pub fn render_bundle_encoder_set_pipeline(
         &self,
         bundle: &mut RenderBundleEncoder,
         pipeline_id: id::RenderPipelineId,
     ) -> Result<(), PassStateError> {
         bundle.set_pipeline(pipeline_id)
+    }
+
+    pub fn render_bundle_encoder_set_pipeline_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        pipeline_id: id::RenderPipelineId,
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.set_pipeline(pipeline_id)
     }
 
     pub fn render_bundle_encoder_set_vertex_buffer(
@@ -1853,6 +1886,23 @@ impl crate::global::Global {
         bundle.set_vertex_buffer(slot, buffer_id, offset, size)
     }
 
+    pub fn render_bundle_encoder_set_vertex_buffer_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        slot: u32,
+        buffer_id: Option<id::BufferId>,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.set_vertex_buffer(slot, buffer_id, offset, size)
+    }
+
     pub fn render_bundle_encoder_set_index_buffer(
         &self,
         encoder: &mut RenderBundleEncoder,
@@ -1864,6 +1914,23 @@ impl crate::global::Global {
         encoder.set_index_buffer(buffer, index_format, offset, size)
     }
 
+    pub fn render_bundle_encoder_set_index_buffer_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        buffer: id::BufferId,
+        index_format: wgt::IndexFormat,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.set_index_buffer(buffer, index_format, offset, size)
+    }
+
     pub fn render_bundle_encoder_set_immediates(
         &self,
         pass: &mut RenderBundleEncoder,
@@ -1871,6 +1938,21 @@ impl crate::global::Global {
         data: &[u8],
     ) -> Result<(), PassStateError> {
         pass.set_immediates(offset, data)
+    }
+
+    pub fn render_bundle_encoder_set_immediates_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        offset: u32,
+        data: &[u8],
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.set_immediates(offset, data)
     }
 
     pub fn render_bundle_encoder_draw(
@@ -1882,6 +1964,23 @@ impl crate::global::Global {
         first_instance: u32,
     ) -> Result<(), PassStateError> {
         bundle.draw(vertex_count, instance_count, first_vertex, first_instance)
+    }
+
+    pub fn render_bundle_encoder_draw_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.draw(vertex_count, instance_count, first_vertex, first_instance)
     }
 
     pub fn render_bundle_encoder_draw_indexed(
@@ -1902,6 +2001,30 @@ impl crate::global::Global {
         )
     }
 
+    pub fn render_bundle_encoder_draw_indexed_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        first_instance: u32,
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.draw_indexed(
+            index_count,
+            instance_count,
+            first_index,
+            base_vertex,
+            first_instance,
+        )
+    }
+
     pub fn render_bundle_encoder_draw_indirect(
         &self,
         bundle: &mut RenderBundleEncoder,
@@ -1909,6 +2032,21 @@ impl crate::global::Global {
         offset: wgt::BufferAddress,
     ) -> Result<(), PassStateError> {
         bundle.draw_indirect(buffer_id, offset)
+    }
+
+    pub fn render_bundle_encoder_draw_indirect_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.draw_indirect(buffer_id, offset)
     }
 
     pub fn render_bundle_encoder_draw_indexed_indirect(
@@ -1920,12 +2058,41 @@ impl crate::global::Global {
         bundle.draw_indexed_indirect(buffer_id, offset)
     }
 
+    pub fn render_bundle_encoder_draw_indexed_indirect_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        buffer_id: id::BufferId,
+        offset: wgt::BufferAddress,
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.draw_indexed_indirect(buffer_id, offset)
+    }
+
     pub fn render_bundle_encoder_push_debug_group(
         &self,
         bundle: &mut RenderBundleEncoder,
         label: &str,
     ) -> Result<(), PassStateError> {
         bundle.push_debug_group(label)
+    }
+
+    pub fn render_bundle_encoder_push_debug_group_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        label: &str,
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.push_debug_group(label)
     }
 
     pub fn render_bundle_encoder_pop_debug_group(
@@ -1935,12 +2102,39 @@ impl crate::global::Global {
         bundle.pop_debug_group()
     }
 
+    pub fn render_bundle_encoder_pop_debug_group_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.pop_debug_group()
+    }
+
     pub fn render_bundle_encoder_insert_debug_marker(
         &self,
         bundle: &mut RenderBundleEncoder,
         label: &str,
     ) -> Result<(), PassStateError> {
         bundle.insert_debug_marker(label)
+    }
+
+    pub fn render_bundle_encoder_insert_debug_marker_with_id(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        label: &str,
+    ) -> Result<(), PassStateError> {
+        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        bundle_encoder.insert_debug_marker(label)
     }
 }
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1164,6 +1164,28 @@ impl Global {
         (Box::new(encoder), error)
     }
 
+    pub fn device_create_render_bundle_encoder_with_id(
+        &self,
+        device_id: DeviceId,
+        desc: &command::RenderBundleEncoderDescriptor,
+        id_in: Option<id::RenderBundleEncoderId>,
+    ) -> (
+        id::RenderBundleEncoderId,
+        Option<command::CreateRenderBundleError>,
+    ) {
+        let fid = self.hub.render_bundle_encoders.prepare(id_in);
+
+        let (render_bundle_encoder, error) =
+            self.device_create_render_bundle_encoder(device_id, desc);
+
+        // no lock rank here because only one thread should be using compute pass
+        // and it's only used by id variants of compute pass methods on global
+        // so no deadlock (or concurrent lock) should happen in practise
+        let id = fid.assign(Arc::new(parking_lot::Mutex::new(render_bundle_encoder)));
+
+        (id, error)
+    }
+
     pub fn render_bundle_encoder_finish(
         &self,
         bundle_encoder: &mut Box<command::RenderBundleEncoder>,
@@ -1209,6 +1231,26 @@ impl Global {
 
         let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
         (id, Some(error))
+    }
+
+    pub fn render_bundle_encoder_finish_with_id(
+        &self,
+        render_bundle_encoder_id: id::RenderBundleEncoderId,
+        desc: &command::RenderBundleDescriptor,
+        id_in: Option<id::RenderBundleId>,
+    ) -> (id::RenderBundleId, Option<command::RenderBundleError>) {
+        let bundle_encoder = self
+            .hub
+            .render_bundle_encoders
+            .get(render_bundle_encoder_id);
+
+        let mut bundle_encoder = bundle_encoder
+            .try_lock()
+            .expect("RenderBundleEncoders should not be accessed concurrently");
+
+        let (id, error) = self.render_bundle_encoder_finish(&mut bundle_encoder, desc, id_in);
+
+        (id, error)
     }
 
     pub fn render_bundle_drop(&self, render_bundle_id: id::RenderBundleId) {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1181,14 +1181,14 @@ impl Global {
         // no lock rank here because only one thread should be using compute pass
         // and it's only used by id variants of compute pass methods on global
         // so no deadlock (or concurrent lock) should happen in practise
-        let id = fid.assign(Arc::new(parking_lot::Mutex::new(render_bundle_encoder)));
+        let id = fid.assign(Arc::new(parking_lot::Mutex::new(*render_bundle_encoder)));
 
         (id, error)
     }
 
     pub fn render_bundle_encoder_finish(
         &self,
-        bundle_encoder: &mut Box<command::RenderBundleEncoder>,
+        bundle_encoder: &mut command::RenderBundleEncoder,
         desc: &command::RenderBundleDescriptor,
         id_in: Option<id::RenderBundleId>,
     ) -> (id::RenderBundleId, Option<command::RenderBundleError>) {

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -116,7 +116,6 @@ when replaying a trace.
 
 */
 
-use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::fmt::Debug;
 
@@ -216,7 +215,7 @@ pub struct Hub {
     pub(crate) tlas_s: Registry<Fallible<Tlas>>,
     pub(crate) render_passes: Registry<Arc<Mutex<RenderPass>>>,
     pub(crate) compute_passes: Registry<Arc<Mutex<ComputePass>>>,
-    pub(crate) render_bundle_encoders: Registry<Arc<Mutex<Box<RenderBundleEncoder>>>>,
+    pub(crate) render_bundle_encoders: Registry<Arc<Mutex<RenderBundleEncoder>>>,
 }
 
 impl Hub {

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -116,12 +116,15 @@ when replaying a trace.
 
 */
 
+use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::fmt::Debug;
 
 use crate::{
     binding_model::{BindGroup, BindGroupLayout, PipelineLayout},
-    command::{CommandBuffer, CommandEncoder, ComputePass, RenderBundle, RenderPass},
+    command::{
+        CommandBuffer, CommandEncoder, ComputePass, RenderBundle, RenderBundleEncoder, RenderPass,
+    },
     device::{queue::Queue, Device},
     instance::Adapter,
     lock::rank,
@@ -158,6 +161,7 @@ pub struct HubReport {
     pub samplers: RegistryReport,
     pub render_passes: RegistryReport,
     pub compute_passes: RegistryReport,
+    pub render_bundle_encoders: RegistryReport,
 }
 
 impl HubReport {
@@ -212,6 +216,7 @@ pub struct Hub {
     pub(crate) tlas_s: Registry<Fallible<Tlas>>,
     pub(crate) render_passes: Registry<Arc<Mutex<RenderPass>>>,
     pub(crate) compute_passes: Registry<Arc<Mutex<ComputePass>>>,
+    pub(crate) render_bundle_encoders: Registry<Arc<Mutex<Box<RenderBundleEncoder>>>>,
 }
 
 impl Hub {
@@ -248,6 +253,7 @@ impl Hub {
             tlas_s: Registry::with_rank(rank::HUB_TLAS),
             render_passes: Registry::new(),
             compute_passes: Registry::new(),
+            render_bundle_encoders: Registry::new(),
         }
     }
 
@@ -274,6 +280,7 @@ impl Hub {
             samplers: self.samplers.generate_report(),
             render_passes: self.render_passes.generate_report(),
             compute_passes: self.compute_passes.generate_report(),
+            render_bundle_encoders: self.render_bundle_encoders.generate_report(),
         }
     }
 }

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 use core::mem;
 
 use crate::id::{Id, Marker};
@@ -39,14 +39,6 @@ impl<T: ResourceType> ResourceType for Mutex<T> {
 }
 
 impl<T: StorageItem> StorageItem for Mutex<T> {
-    type Marker = T::Marker;
-}
-
-impl<T: ResourceType> ResourceType for Box<T> {
-    const TYPE: &'static str = T::TYPE;
-}
-
-impl<T: StorageItem> StorageItem for Box<T> {
     type Marker = T::Marker;
 }
 

--- a/wgpu-core/src/storage.rs
+++ b/wgpu-core/src/storage.rs
@@ -1,4 +1,4 @@
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::mem;
 
 use crate::id::{Id, Marker};
@@ -39,6 +39,14 @@ impl<T: ResourceType> ResourceType for Mutex<T> {
 }
 
 impl<T: StorageItem> StorageItem for Mutex<T> {
+    type Marker = T::Marker;
+}
+
+impl<T: ResourceType> ResourceType for Box<T> {
+    const TYPE: &'static str = T::TYPE;
+}
+
+impl<T: StorageItem> StorageItem for Box<T> {
     type Marker = T::Marker;
 }
 


### PR DESCRIPTION
**Connections**
Depends on #9777
Similar to #9740 and #9776

**Description**

As discussed in https://github.com/gfx-rs/wgpu/pull/9712#issuecomment-4788311141 and in #5121 we need this to remove recording from content process in firefox. Servo will also benefit from this.

In addition to normal methods that take `&mut RenderBundleEncoder` we also add some that take `id::RenderBundleEncoderId` and use the passes from registry (which are made mut using unranked `Mutex`). One could consider this as "second registry" for encoders. This works because passes are not passed to any other resource via descriptor.

This allow for wgpu and deno to keep using the ones without id and avoid another level of indirection. The down side is that these wrapper are not tested anywhere in wgpu repo, but I think they are thin so it should not be that much problematic.

**Testing**
None, as this should only be used by servo/firefox.

**Squash or Rebase?**

Squash.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
