### PR TITLE
[core] Move `begin_*_pass` to `CommandEncoder` and do only ID resolve in global

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -33,7 +33,7 @@ use crate::{
     init_tracker::MemoryInitKind,
     pipeline::ComputePipeline,
     resource::{
-        self, Buffer, DestroyedResourceError, InvalidResourceError, Labeled,
+        self, Buffer, DestroyedResourceError, Fallible, InvalidResourceError, Labeled,
         MissingBufferUsageError, ParentDevice, RawResourceAccess, TextureView, Trackable,
     },
     track::{ResourceUsageCompatibilityError, TextureViewBindGroupState, Tracker},
@@ -455,6 +455,96 @@ fn transition_resources(
     Ok(())
 }
 
+impl CommandEncoder {
+    fn begin_compute_pass(
+        self: &Arc<Self>,
+        desc: &ComputePassDescriptor<'_, PassTimestampWrites<Fallible<resource::QuerySet>>>,
+    ) -> (ComputePass, Option<CommandEncoderError>) {
+        use EncoderStateError as SErr;
+
+        let scope = PassErrorScope::Pass;
+
+        let label = desc.label.as_deref().map(Cow::Borrowed);
+
+        let mut cmd_buf_data = self.data.lock();
+
+        match cmd_buf_data.lock_encoder() {
+            Ok(()) => {
+                drop(cmd_buf_data);
+                if let Err(err) = self.device.check_is_valid() {
+                    return (
+                        ComputePass::new_invalid(Arc::clone(self), &label, err.map_pass_err(scope)),
+                        None,
+                    );
+                }
+
+                match desc
+                    .timestamp_writes
+                    .as_ref()
+                    .map(|tw| {
+                        Self::validate_pass_timestamp_writes::<ComputePassErrorInner>(
+                            &self.device,
+                            tw,
+                        )
+                    })
+                    .transpose()
+                {
+                    Ok(timestamp_writes) => {
+                        let arc_desc = ArcComputePassDescriptor {
+                            label,
+                            timestamp_writes,
+                        };
+                        (ComputePass::new(Arc::clone(self), arc_desc), None)
+                    }
+                    Err(err) => (
+                        ComputePass::new_invalid(Arc::clone(self), &label, err.map_pass_err(scope)),
+                        None,
+                    ),
+                }
+            }
+            Err(err @ SErr::Locked) => {
+                // Attempting to open a new pass while the encoder is locked
+                // invalidates the encoder, but does not generate a validation
+                // error.
+                cmd_buf_data.invalidate(err.clone());
+                drop(cmd_buf_data);
+                (
+                    ComputePass::new_invalid(Arc::clone(self), &label, err.map_pass_err(scope)),
+                    None,
+                )
+            }
+            Err(err @ (SErr::Ended | SErr::Submitted)) => {
+                // Attempting to open a new pass after the encode has ended
+                // generates an immediate validation error.
+                drop(cmd_buf_data);
+                (
+                    ComputePass::new_invalid(
+                        Arc::clone(self),
+                        &label,
+                        err.clone().map_pass_err(scope),
+                    ),
+                    Some(err.into()),
+                )
+            }
+            Err(err @ SErr::Invalid) => {
+                // Passes can be opened even on an invalid encoder. Such passes
+                // are even valid, but since there's no visible side-effect of
+                // the pass being valid and there's no point in storing recorded
+                // commands that will ultimately be discarded, we open an
+                // invalid pass to save that work.
+                drop(cmd_buf_data);
+                (
+                    ComputePass::new_invalid(Arc::clone(self), &label, err.map_pass_err(scope)),
+                    None,
+                )
+            }
+            Err(SErr::Unlocked) => {
+                unreachable!("lock_encoder cannot fail due to the encoder being unlocked")
+            }
+        }
+    }
+}
+
 // Running the compute pass.
 
 impl Global {
@@ -473,87 +563,23 @@ impl Global {
         encoder_id: id::CommandEncoderId,
         desc: &ComputePassDescriptor<'_>,
     ) -> (ComputePass, Option<CommandEncoderError>) {
-        use EncoderStateError as SErr;
-
-        let scope = PassErrorScope::Pass;
         let hub = &self.hub;
 
-        let label = desc.label.as_deref().map(Cow::Borrowed);
-
         let cmd_enc = hub.command_encoders.get(encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
 
-        match cmd_buf_data.lock_encoder() {
-            Ok(()) => {
-                drop(cmd_buf_data);
-                if let Err(err) = cmd_enc.device.check_is_valid() {
-                    return (
-                        ComputePass::new_invalid(cmd_enc, &label, err.map_pass_err(scope)),
-                        None,
-                    );
-                }
+        let desc = ComputePassDescriptor {
+            label: desc.label.as_deref().map(Cow::Borrowed),
+            timestamp_writes: desc
+                .timestamp_writes
+                .as_ref()
+                .map(|tw| PassTimestampWrites {
+                    query_set: hub.query_sets.get(tw.query_set),
+                    beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
+                    end_of_pass_write_index: tw.end_of_pass_write_index,
+                }),
+        };
 
-                match desc
-                    .timestamp_writes
-                    .as_ref()
-                    .map(|tw| {
-                        Self::validate_pass_timestamp_writes::<ComputePassErrorInner>(
-                            &cmd_enc.device,
-                            &hub.query_sets.read(),
-                            tw,
-                        )
-                    })
-                    .transpose()
-                {
-                    Ok(timestamp_writes) => {
-                        let arc_desc = ArcComputePassDescriptor {
-                            label,
-                            timestamp_writes,
-                        };
-                        (ComputePass::new(cmd_enc, arc_desc), None)
-                    }
-                    Err(err) => (
-                        ComputePass::new_invalid(cmd_enc, &label, err.map_pass_err(scope)),
-                        None,
-                    ),
-                }
-            }
-            Err(err @ SErr::Locked) => {
-                // Attempting to open a new pass while the encoder is locked
-                // invalidates the encoder, but does not generate a validation
-                // error.
-                cmd_buf_data.invalidate(err.clone());
-                drop(cmd_buf_data);
-                (
-                    ComputePass::new_invalid(cmd_enc, &label, err.map_pass_err(scope)),
-                    None,
-                )
-            }
-            Err(err @ (SErr::Ended | SErr::Submitted)) => {
-                // Attempting to open a new pass after the encode has ended
-                // generates an immediate validation error.
-                drop(cmd_buf_data);
-                (
-                    ComputePass::new_invalid(cmd_enc, &label, err.clone().map_pass_err(scope)),
-                    Some(err.into()),
-                )
-            }
-            Err(err @ SErr::Invalid) => {
-                // Passes can be opened even on an invalid encoder. Such passes
-                // are even valid, but since there's no visible side-effect of
-                // the pass being valid and there's no point in storing recorded
-                // commands that will ultimately be discarded, we open an
-                // invalid pass to save that work.
-                drop(cmd_buf_data);
-                (
-                    ComputePass::new_invalid(cmd_enc, &label, err.map_pass_err(scope)),
-                    None,
-                )
-            }
-            Err(SErr::Unlocked) => {
-                unreachable!("lock_encoder cannot fail due to the encoder being unlocked")
-            }
-        }
+        cmd_enc.begin_compute_pass(&desc)
     }
 
     pub fn command_encoder_begin_compute_pass_with_id(

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -99,7 +99,6 @@ use crate::resource::{
     DestroyedResourceError, Fallible, InvalidOrDestroyedResourceError, InvalidResourceError,
     Labeled, ParentDevice as _, QuerySet,
 };
-use crate::storage::Storage;
 use crate::track::{DeviceTracker, ResourceUsageCompatibilityError, Tracker, UsageScope};
 use crate::{api_log, global::Global, id, resource_log, Label};
 use crate::{hal_label, LabelHelpers};
@@ -965,6 +964,56 @@ impl CommandEncoder {
         }
     }
 
+    pub(crate) fn validate_pass_timestamp_writes<E>(
+        device: &Device,
+        timestamp_writes: &PassTimestampWrites<Fallible<QuerySet>>,
+    ) -> Result<ArcPassTimestampWrites, E>
+    where
+        E: From<TimestampWritesError>
+            + From<QueryUseError>
+            + From<DeviceError>
+            + From<MissingFeatures>
+            + From<InvalidResourceError>,
+    {
+        let &PassTimestampWrites {
+            ref query_set,
+            beginning_of_pass_write_index,
+            end_of_pass_write_index,
+        } = timestamp_writes;
+
+        device.require_features(wgt::Features::TIMESTAMP_QUERY)?;
+
+        let query_set = query_set.clone().get()?;
+
+        query_set.same_device(device)?;
+
+        for idx in [beginning_of_pass_write_index, end_of_pass_write_index]
+            .into_iter()
+            .flatten()
+        {
+            query_set.validate_query(SimplifiedQueryType::Timestamp, idx, None)?;
+        }
+
+        if let Some((begin, end)) = beginning_of_pass_write_index.zip(end_of_pass_write_index) {
+            if begin == end {
+                return Err(TimestampWritesError::IndicesEqual { idx: begin }.into());
+            }
+        }
+
+        if beginning_of_pass_write_index
+            .or(end_of_pass_write_index)
+            .is_none()
+        {
+            return Err(TimestampWritesError::IndicesMissing.into());
+        }
+
+        Ok(ArcPassTimestampWrites {
+            query_set,
+            beginning_of_pass_write_index,
+            end_of_pass_write_index,
+        })
+    }
+
     pub(crate) fn insert_barriers_from_tracker(
         raw: &mut dyn hal::DynCommandEncoder,
         base: &mut Tracker,
@@ -1814,57 +1863,6 @@ impl Global {
 
         cmd_buf_data
             .push_with(|| -> Result<_, CommandEncoderError> { Ok(ArcCommand::PopDebugGroup) })
-    }
-
-    fn validate_pass_timestamp_writes<E>(
-        device: &Device,
-        query_sets: &Storage<Fallible<QuerySet>>,
-        timestamp_writes: &PassTimestampWrites,
-    ) -> Result<ArcPassTimestampWrites, E>
-    where
-        E: From<TimestampWritesError>
-            + From<QueryUseError>
-            + From<DeviceError>
-            + From<MissingFeatures>
-            + From<InvalidResourceError>,
-    {
-        let &PassTimestampWrites {
-            query_set,
-            beginning_of_pass_write_index,
-            end_of_pass_write_index,
-        } = timestamp_writes;
-
-        device.require_features(wgt::Features::TIMESTAMP_QUERY)?;
-
-        let query_set = query_sets.get(query_set).get()?;
-
-        query_set.same_device(device)?;
-
-        for idx in [beginning_of_pass_write_index, end_of_pass_write_index]
-            .into_iter()
-            .flatten()
-        {
-            query_set.validate_query(SimplifiedQueryType::Timestamp, idx, None)?;
-        }
-
-        if let Some((begin, end)) = beginning_of_pass_write_index.zip(end_of_pass_write_index) {
-            if begin == end {
-                return Err(TimestampWritesError::IndicesEqual { idx: begin }.into());
-            }
-        }
-
-        if beginning_of_pass_write_index
-            .or(end_of_pass_write_index)
-            .is_none()
-        {
-            return Err(TimestampWritesError::IndicesMissing.into());
-        }
-
-        Ok(ArcPassTimestampWrites {
-            query_set,
-            beginning_of_pass_write_index,
-            end_of_pass_write_index,
-        })
     }
 }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -40,9 +40,10 @@ use crate::{
     init_tracker::{MemoryInitKind, TextureInitRange, TextureInitTrackerAction},
     pipeline::{PipelineFlags, RenderPipeline, VertexStep},
     resource::{
-        Buffer, DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
-        MissingTextureUsageError, ParentDevice, QuerySet, RawResourceAccess, ResourceErrorIdent,
-        Texture, TextureView, TextureViewNotRenderableReason,
+        Buffer, DestroyedResourceError, Fallible, InvalidResourceError, Labeled,
+        MissingBufferUsageError, MissingTextureUsageError, ParentDevice, QuerySet,
+        RawResourceAccess, ResourceErrorIdent, Texture, TextureView,
+        TextureViewNotRenderableReason,
     },
     snatch::SnatchGuard,
     track::{ResourceUsageCompatibilityError, Tracker, UsageScope},
@@ -268,6 +269,22 @@ pub struct RenderPassDescriptor<'a> {
     pub timestamp_writes: Option<PassTimestampWrites>,
     /// Defines where the occlusion query results will be stored for this pass.
     pub occlusion_query_set: Option<id::QuerySetId>,
+    /// The multiview array layers that will be used
+    pub multiview_mask: Option<NonZeroU32>,
+}
+
+/// Describes the attachments of a render pass.
+#[derive(Clone, Default)]
+pub struct ResolvedRenderPassDescriptor<'a> {
+    pub label: Label<'a>,
+    /// The color attachments of the render pass.
+    pub color_attachments: Cow<'a, [Option<RenderPassColorAttachment<Fallible<TextureView>>>]>,
+    /// The depth and stencil attachment of the render pass, if any.
+    pub depth_stencil_attachment: Option<RenderPassDepthStencilAttachment<Fallible<TextureView>>>,
+    /// Defines where and when timestamp values will be written for this pass.
+    pub timestamp_writes: Option<PassTimestampWrites<Fallible<QuerySet>>>,
+    /// Defines where the occlusion query results will be stored for this pass.
+    pub occlusion_query_set: Option<Fallible<QuerySet>>,
     /// The multiview array layers that will be used
     pub multiview_mask: Option<NonZeroU32>,
 }
@@ -1809,34 +1826,19 @@ fn check_transient_attachment_ops<V>(load_op: LoadOp<V>, store_op: StoreOp) -> b
     )
 }
 
-impl Global {
-    /// Creates a render pass.
-    ///
-    /// If creation fails, an invalid pass is returned. Attempting to record
-    /// commands into an invalid pass is permitted, but a validation error will
-    /// ultimately be generated when the parent encoder is finished, and it is
-    /// not possible to run any commands from the invalid pass.
-    ///
-    /// If successful, puts the encoder into the [`Locked`] state.
-    ///
-    /// [`Locked`]: crate::command::CommandEncoderStatus::Locked
-    pub fn command_encoder_begin_render_pass(
-        &self,
-        encoder_id: id::CommandEncoderId,
-        desc: &RenderPassDescriptor<'_>,
+impl CommandEncoder {
+    fn begin_render_pass(
+        self: Arc<Self>,
+        desc: &ResolvedRenderPassDescriptor<'_>,
     ) -> (RenderPass, Option<CommandEncoderError>) {
         use EncoderStateError as SErr;
 
         fn fill_arc_desc(
-            hub: &crate::hub::Hub,
-            desc: &RenderPassDescriptor<'_>,
+            desc: &ResolvedRenderPassDescriptor<'_>,
             arc_desc: &mut ArcRenderPassDescriptor,
             device: &Device,
         ) -> Result<(), RenderPassErrorInner> {
             device.check_is_valid()?;
-
-            let query_sets = hub.query_sets.read();
-            let texture_views = hub.texture_views.read();
 
             let max_color_attachments = device.limits.max_color_attachments as usize;
             if desc.color_attachments.len() > max_color_attachments {
@@ -1850,14 +1852,14 @@ impl Global {
 
             for color_attachment in desc.color_attachments.iter() {
                 if let Some(RenderPassColorAttachment {
-                    view: view_id,
+                    view,
                     depth_slice,
                     resolve_target,
                     load_op,
                     store_op,
                 }) = color_attachment
                 {
-                    let view = texture_views.get(*view_id).get()?;
+                    let view = view.clone().get()?;
                     view.same_device(device)?;
                     if matches!(*load_op, LoadOp::DontCare(..))
                         && device
@@ -1882,8 +1884,8 @@ impl Global {
                         ));
                     }
 
-                    let resolve_target = if let Some(resolve_target_id) = resolve_target {
-                        let rt_arc = texture_views.get(*resolve_target_id).get()?;
+                    let resolve_target = if let Some(resolve_target) = resolve_target {
+                        let rt_arc = resolve_target.clone().get()?;
                         rt_arc.same_device(device)?;
 
                         Some(rt_arc)
@@ -1909,7 +1911,7 @@ impl Global {
             arc_desc.depth_stencil_attachment = if let Some(depth_stencil_attachment) =
                 desc.depth_stencil_attachment.as_ref()
             {
-                let view = texture_views.get(depth_stencil_attachment.view).get()?;
+                let view = depth_stencil_attachment.view.clone().get()?;
                 view.same_device(device)?;
 
                 let format = view.desc.format;
@@ -2049,17 +2051,15 @@ impl Global {
                 .timestamp_writes
                 .as_ref()
                 .map(|tw| {
-                    Global::validate_pass_timestamp_writes::<RenderPassErrorInner>(
-                        device,
-                        &query_sets,
-                        tw,
+                    CommandEncoder::validate_pass_timestamp_writes::<RenderPassErrorInner>(
+                        device, tw,
                     )
                 })
                 .transpose()?;
 
             arc_desc.occlusion_query_set =
-                if let Some(occlusion_query_set) = desc.occlusion_query_set {
-                    let query_set = query_sets.get(occlusion_query_set).get()?;
+                if let Some(occlusion_query_set) = &desc.occlusion_query_set {
+                    let query_set = occlusion_query_set.clone().get()?;
                     query_set.same_device(device)?;
 
                     if !matches!(query_set.desc.ty, wgt::QueryType::Occlusion) {
@@ -2081,10 +2081,7 @@ impl Global {
         }
 
         let scope = PassErrorScope::Pass;
-        let hub = &self.hub;
-
-        let cmd_enc = hub.command_encoders.get(encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
+        let mut cmd_buf_data = self.data.lock();
 
         match cmd_buf_data.lock_encoder() {
             Ok(()) => {
@@ -2097,10 +2094,10 @@ impl Global {
                     occlusion_query_set: None,
                     multiview_mask: None,
                 };
-                match fill_arc_desc(hub, desc, &mut arc_desc, &cmd_enc.device) {
-                    Ok(()) => (RenderPass::new(cmd_enc, arc_desc), None),
+                match fill_arc_desc(desc, &mut arc_desc, &self.device) {
+                    Ok(()) => (RenderPass::new(self, arc_desc), None),
                     Err(err) => (
-                        RenderPass::new_invalid(cmd_enc, &desc.label, err.map_pass_err(scope)),
+                        RenderPass::new_invalid(self, &desc.label, err.map_pass_err(scope)),
                         None,
                     ),
                 }
@@ -2112,7 +2109,7 @@ impl Global {
                 cmd_buf_data.invalidate(err.clone());
                 drop(cmd_buf_data);
                 (
-                    RenderPass::new_invalid(cmd_enc, &desc.label, err.map_pass_err(scope)),
+                    RenderPass::new_invalid(self, &desc.label, err.map_pass_err(scope)),
                     None,
                 )
             }
@@ -2121,7 +2118,7 @@ impl Global {
                 // generates an immediate validation error.
                 drop(cmd_buf_data);
                 (
-                    RenderPass::new_invalid(cmd_enc, &desc.label, err.clone().map_pass_err(scope)),
+                    RenderPass::new_invalid(self, &desc.label, err.clone().map_pass_err(scope)),
                     Some(err.into()),
                 )
             }
@@ -2133,7 +2130,7 @@ impl Global {
                 // invalid pass to save that work.
                 drop(cmd_buf_data);
                 (
-                    RenderPass::new_invalid(cmd_enc, &desc.label, err.map_pass_err(scope)),
+                    RenderPass::new_invalid(self, &desc.label, err.map_pass_err(scope)),
                     None,
                 )
             }
@@ -2141,6 +2138,77 @@ impl Global {
                 unreachable!("lock_encoder cannot fail due to the encoder being unlocked")
             }
         }
+    }
+}
+
+impl Global {
+    /// Creates a render pass.
+    ///
+    /// If creation fails, an invalid pass is returned. Attempting to record
+    /// commands into an invalid pass is permitted, but a validation error will
+    /// ultimately be generated when the parent encoder is finished, and it is
+    /// not possible to run any commands from the invalid pass.
+    ///
+    /// If successful, puts the encoder into the [`Locked`] state.
+    ///
+    /// [`Locked`]: crate::command::CommandEncoderStatus::Locked
+    pub fn command_encoder_begin_render_pass(
+        &self,
+        encoder_id: id::CommandEncoderId,
+        desc: &RenderPassDescriptor<'_>,
+    ) -> (RenderPass, Option<CommandEncoderError>) {
+        let hub = &self.hub;
+
+        let cmd_enc = hub.command_encoders.get(encoder_id);
+
+        let texture_views = hub.texture_views.read();
+        let query_sets = hub.query_sets.read();
+
+        let desc = ResolvedRenderPassDescriptor {
+            label: desc.label.as_deref().map(Cow::Borrowed),
+            color_attachments: Cow::Owned(
+                desc.color_attachments
+                    .iter()
+                    .map(|at| {
+                        at.as_ref().map(|at| RenderPassColorAttachment {
+                            view: texture_views.get(at.view),
+                            depth_slice: at.depth_slice,
+                            resolve_target: at
+                                .resolve_target
+                                .as_ref()
+                                .map(|rt| texture_views.get(*rt)),
+                            load_op: at.load_op,
+                            store_op: at.store_op,
+                        })
+                    })
+                    .collect(),
+            ),
+            depth_stencil_attachment: desc.depth_stencil_attachment.as_ref().map(|at| {
+                RenderPassDepthStencilAttachment {
+                    view: texture_views.get(at.view),
+                    depth: at.depth.clone(),
+                    stencil: at.stencil.clone(),
+                }
+            }),
+            timestamp_writes: desc
+                .timestamp_writes
+                .as_ref()
+                .map(|tw| PassTimestampWrites {
+                    query_set: query_sets.get(tw.query_set),
+                    beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
+                    end_of_pass_write_index: tw.end_of_pass_write_index,
+                }),
+            occlusion_query_set: desc
+                .occlusion_query_set
+                .as_ref()
+                .map(|query_set| query_sets.get(*query_set)),
+            multiview_mask: desc.multiview_mask,
+        };
+
+        drop(texture_views);
+        drop(query_sets);
+
+        cmd_enc.begin_render_pass(&desc)
     }
 
     pub fn command_encoder_begin_render_pass_with_id(

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1829,12 +1829,12 @@ fn check_transient_attachment_ops<V>(load_op: LoadOp<V>, store_op: StoreOp) -> b
 impl CommandEncoder {
     fn begin_render_pass(
         self: Arc<Self>,
-        desc: &ResolvedRenderPassDescriptor<'_>,
+        desc: ResolvedRenderPassDescriptor<'_>,
     ) -> (RenderPass, Option<CommandEncoderError>) {
         use EncoderStateError as SErr;
 
         fn fill_arc_desc(
-            desc: &ResolvedRenderPassDescriptor<'_>,
+            desc: ResolvedRenderPassDescriptor<'_>,
             arc_desc: &mut ArcRenderPassDescriptor,
             device: &Device,
         ) -> Result<(), RenderPassErrorInner> {
@@ -1909,9 +1909,9 @@ impl CommandEncoder {
 
             // https://gpuweb.github.io/gpuweb/#abstract-opdef-gpurenderpassdepthstencilattachment-gpurenderpassdepthstencilattachment-valid-usage
             arc_desc.depth_stencil_attachment = if let Some(depth_stencil_attachment) =
-                desc.depth_stencil_attachment.as_ref()
+                desc.depth_stencil_attachment
             {
-                let view = depth_stencil_attachment.view.clone().get()?;
+                let view = depth_stencil_attachment.view.get()?;
                 view.same_device(device)?;
 
                 let format = view.desc.format;
@@ -2049,17 +2049,16 @@ impl CommandEncoder {
 
             arc_desc.timestamp_writes = desc
                 .timestamp_writes
-                .as_ref()
                 .map(|tw| {
                     CommandEncoder::validate_pass_timestamp_writes::<RenderPassErrorInner>(
-                        device, tw,
+                        device, &tw,
                     )
                 })
                 .transpose()?;
 
             arc_desc.occlusion_query_set =
-                if let Some(occlusion_query_set) = &desc.occlusion_query_set {
-                    let query_set = occlusion_query_set.clone().get()?;
+                if let Some(occlusion_query_set) = desc.occlusion_query_set {
+                    let query_set = occlusion_query_set.get()?;
                     query_set.same_device(device)?;
 
                     if !matches!(query_set.desc.ty, wgt::QueryType::Occlusion) {
@@ -2086,8 +2085,9 @@ impl CommandEncoder {
         match cmd_buf_data.lock_encoder() {
             Ok(()) => {
                 drop(cmd_buf_data);
+                let label = desc.label.clone();
                 let mut arc_desc = ArcRenderPassDescriptor {
-                    label: &desc.label,
+                    label: &label,
                     timestamp_writes: None,
                     color_attachments: ArrayVec::new(),
                     depth_stencil_attachment: None,
@@ -2097,7 +2097,7 @@ impl CommandEncoder {
                 match fill_arc_desc(desc, &mut arc_desc, &self.device) {
                     Ok(()) => (RenderPass::new(self, arc_desc), None),
                     Err(err) => (
-                        RenderPass::new_invalid(self, &desc.label, err.map_pass_err(scope)),
+                        RenderPass::new_invalid(self, &label, err.map_pass_err(scope)),
                         None,
                     ),
                 }
@@ -2208,7 +2208,7 @@ impl Global {
         drop(texture_views);
         drop(query_sets);
 
-        cmd_enc.begin_render_pass(&desc)
+        cmd_enc.begin_render_pass(desc)
     }
 
     pub fn command_encoder_begin_render_pass_with_id(


### PR DESCRIPTION
**Connections**
Work towards #5121

**Description**
Global should only resolve id's. Actual work should happen on appropriate methods on `CommandEncoder`.

**Testing**
Just refactor

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
