### PR TITLE
[core] IDed encoders needs to be dropped

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -648,6 +648,10 @@ impl Global {
             .expect("ComputePasses should not be accessed concurrently");
         self.compute_pass_end(&mut pass)
     }
+
+    pub fn compute_pass_drop(&self, pass_id: id::ComputePassEncoderId) {
+        self.hub.compute_passes.remove(pass_id);
+    }
 }
 
 pub(super) fn encode_compute_pass(

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1285,7 +1285,7 @@ impl Global {
         Ok(())
     }
 
-    pub fn compute_pass_set_bindgroup_with_id(
+    pub fn compute_pass_set_bind_group_with_id(
         &self,
         pass_id: id::ComputePassEncoderId,
         index: u32,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2279,6 +2279,10 @@ impl Global {
             .expect("RenderPasses should not be accessed concurrently");
         self.render_pass_end(&mut pass)
     }
+
+    pub fn render_pass_drop(&self, pass: id::RenderPassEncoderId) {
+        self.hub.render_passes.remove(pass);
+    }
 }
 
 pub(super) fn encode_render_pass(

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1253,6 +1253,12 @@ impl Global {
         (id, error)
     }
 
+    pub fn render_bundle_encoder_drop(&self, render_bundle_encoder_id: id::RenderBundleEncoderId) {
+        let hub = &self.hub;
+
+        let _bundle_encoder = hub.render_bundle_encoders.remove(render_bundle_encoder_id);
+    }
+
     pub fn render_bundle_drop(&self, render_bundle_id: id::RenderBundleId) {
         profiling::scope!("RenderBundle::drop");
         api_log!("RenderBundle::drop {render_bundle_id:?}");


### PR DESCRIPTION
**Connections**
Fixup https://github.com/gfx-rs/wgpu/pull/9740, https://github.com/gfx-rs/wgpu/pull/9776 and https://github.com/gfx-rs/wgpu/pull/9778

**Description**
I tried to port servo to IDed encoders, but this methods were missing and are obviously needed otherwise we never clear up the storage.

Also `compute_pass_set_bindgroup_with_id` -> `compute_pass_set_bind_group_with_id` to be in line with others.

**Testing**
None

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
