### PR TITLE
fix: gate on static_dxc not static-dxc

### DIFF
--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -62,7 +62,7 @@ impl crate::Instance for super::Instance {
                 crate::InstanceError::with_source(String::from("Failed to load FXC"), e)
             })?,
             wgt::Dx12Compiler::Auto => {
-                if cfg!(feature = "static-dxc") {
+                if cfg!(static_dxc) {
                     // Prefer static DXC if its compiled in
                     CompilerContainer::new_static_dxc().map_err(|e| {
                         crate::InstanceError::with_source(


### PR DESCRIPTION
gate on static_dxc not static-dxc when Initialize the shader compiler

**Connections**
fixes #9784

**Description**
if you run `cargo run --bin wgpu-examples skybox` on `aarch64-pc-windows-msvc`, it fails

```
thread 'main' (29552) panicked at wgpu-hal\src\dx12\shader_compilation.rs:91:13:
Attempted to create a static DXC shader compiler, but the static-dxc feature was not enabled
```

**Testing**
ran it

**Squash or Rebase?**

it's a single commit

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
