### PR TITLE
fix: remove "static-dxc" from `workspace.dependencies.wgpu`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ wgpu = { version = "29.0.0", path = "./wgpu", default-features = false, features
     "metal",
     "vulkan-portability",
     "angle",
-    "static-dxc",
 ] }
 wgpu-core = { version = "29.0.0", path = "./wgpu-core" }
 wgpu-hal = { version = "29.0.0", path = "./wgpu-hal" }


### PR DESCRIPTION
fix: remove "static-dxc" from `workspace.dependencies.wgpu`
because I am unsure why that is set.

**Connections**
fixes #9784

complements #9785

**Description**
if you run `cargo run --bin wgpu-examples skybox` on `aarch64-pc-windows-msvc`, it fails

```
thread 'main' (29552) panicked at wgpu-hal\src\dx12\shader_compilation.rs:91:13:
Attempted to create a static DXC shader compiler, but the static-dxc feature was not enabled
```

**Testing**
ran it

**Squash or Rebase?**

it's a single commit

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
