### PR TITLE
[core] Use two staged validity in Texture.

### DIFF
--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -152,7 +152,7 @@ impl Global {
 
         cmd_buf_data.push_with(|| -> Result<_, ClearError> {
             let texture = self.resolve_texture_id(dst);
-            texture.check_valid(&cmd_enc.device.snatchable_lock.read())?;
+            texture.check_valid()?;
             Ok(ArcCommand::ClearTexture {
                 dst: texture,
                 subresource_range: *subresource_range,

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -876,7 +876,7 @@ impl Global {
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
             let texture = self.resolve_texture_id(destination.texture);
-            texture.check_valid(&cmd_enc.device.snatchable_lock.read())?;
+            texture.check_valid()?;
             Ok(ArcCommand::CopyBufferToTexture {
                 src: wgt::TexelCopyBufferInfo::<Arc<Buffer>> {
                     buffer: self.resolve_buffer_id(source.buffer)?,
@@ -913,7 +913,7 @@ impl Global {
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
             let texture = self.resolve_texture_id(source.texture);
-            texture.check_valid(&cmd_enc.device.snatchable_lock.read())?;
+            texture.check_valid()?;
             Ok(ArcCommand::CopyTextureToBuffer {
                 src: wgt::TexelCopyTextureInfo::<Arc<Texture>> {
                     texture,
@@ -951,11 +951,8 @@ impl Global {
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
             let src_texture = self.resolve_texture_id(source.texture);
             let dst_texture = self.resolve_texture_id(destination.texture);
-            {
-                let snatch_guard = cmd_enc.device.snatchable_lock.read();
-                src_texture.check_valid(&snatch_guard)?;
-                dst_texture.check_valid(&snatch_guard)?;
-            }
+            src_texture.check_valid()?;
+            dst_texture.check_valid()?;
             Ok(ArcCommand::CopyTextureToTexture {
                 src: wgt::TexelCopyTextureInfo {
                     texture: src_texture,

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -26,7 +26,6 @@ impl Global {
         // Lock command encoder for recording
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
         let mut cmd_buf_data = cmd_enc.data.lock();
-        let snatch_guard = cmd_enc.device.snatchable_lock.read();
         cmd_buf_data.push_with(|| -> Result<_, TransitionResourcesError> {
             Ok(ArcCommand::TransitionResources {
                 buffer_transitions: buffer_transitions
@@ -40,7 +39,7 @@ impl Global {
                 texture_transitions: texture_transitions
                     .map(|t| {
                         let texture = self.resolve_texture_id(t.texture);
-                        texture.check_valid(&snatch_guard)?;
+                        texture.check_valid()?;
                         Ok(wgt::TextureTransition {
                             texture,
                             selector: t.selector,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1702,7 +1702,7 @@ impl Queue {
             let mut submit_surface_textures =
                 SmallVec::<[&dyn hal::DynSurfaceTexture; 2]>::with_capacity(surface_textures.len());
             for texture in surface_textures.values() {
-                let raw = match texture.inner.get(&snatch_guard).maybe_valid() {
+                let raw = match texture.try_inner(&snatch_guard).ok() {
                     Some(TextureInner::Surface { raw, .. }) => raw.as_ref(),
                     _ => unreachable!(),
                 };

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -339,9 +339,9 @@ impl Queue {
 
         let mut exclusive_snatch_guard = device.snatchable_lock.write();
         let inner = texture
-            .inner
-            .snatch(&mut exclusive_snatch_guard)
-            .maybe_valid();
+            .state()
+            .ok()
+            .and_then(|state| state.inner.snatch(&mut exclusive_snatch_guard));
         drop(exclusive_snatch_guard);
 
         let result = match inner {
@@ -398,9 +398,9 @@ impl Surface {
 
         let mut exclusive_snatch_guard = device.snatchable_lock.write();
         let inner = texture
-            .inner
-            .snatch(&mut exclusive_snatch_guard)
-            .maybe_valid();
+            .state()
+            .ok()
+            .and_then(|state| state.inner.snatch(&mut exclusive_snatch_guard));
         drop(exclusive_snatch_guard);
 
         match inner {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -27,7 +27,7 @@ use crate::{
     lock::{rank, Mutex, RwLock},
     ray_tracing::{BlasCompactReadyPendingClosure, BlasPrepareCompactError},
     resource_log,
-    snatch::{SnatchGuard, Snatchable, Snatchable2},
+    snatch::{SnatchGuard, Snatchable},
     timestamp_normalization::TimestampNormalizationBindGroup,
     track::{SharedTrackerIndexAllocator, TrackerIndex},
     weak_vec::WeakVec,
@@ -113,42 +113,12 @@ impl<T> ResourceState<T> {
     }
 }
 
-pub enum DestructibleResourceState<T> {
-    Valid(T),
-    Invalid,
-    Destroyed,
-}
-
-impl<T> DestructibleResourceState<T> {
-    pub fn as_ref(&self) -> DestructibleResourceState<&T> {
-        match self {
-            DestructibleResourceState::Valid(v) => DestructibleResourceState::Valid(v),
-            DestructibleResourceState::Invalid => DestructibleResourceState::Invalid,
-            DestructibleResourceState::Destroyed => DestructibleResourceState::Destroyed,
-        }
-    }
-
-    pub fn take(&mut self) -> DestructibleResourceState<T> {
-        mem::replace(self, DestructibleResourceState::Destroyed)
-    }
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum InvalidOrDestroyedResourceError {
     #[error(transparent)]
     InvalidResource(#[from] InvalidResourceError),
     #[error(transparent)]
     DestroyedResource(#[from] DestroyedResourceError),
-}
-
-impl<T> DestructibleResourceState<T> {
-    pub fn maybe_valid(self) -> Option<T> {
-        match self {
-            DestructibleResourceState::Valid(t) => Some(t),
-            DestructibleResourceState::Invalid => None,
-            DestructibleResourceState::Destroyed => None,
-        }
-    }
 }
 
 pub trait ParentDevice: Labeled {
@@ -1414,8 +1384,13 @@ pub enum TextureClearMode {
 }
 
 #[derive(Debug)]
+pub struct TextureState {
+    pub(crate) inner: Snatchable<TextureInner>,
+}
+
+#[derive(Debug)]
 pub struct Texture {
-    pub(crate) inner: Snatchable2<TextureInner>,
+    pub(crate) state: ResourceState<TextureState>,
     pub(crate) device: Arc<Device>,
     pub(crate) desc: wgt::TextureDescriptor<String, Vec<wgt::TextureFormat>>,
     pub(crate) _hal_usage: wgt::TextureUses,
@@ -1440,7 +1415,9 @@ impl Texture {
         init: bool,
     ) -> Self {
         Texture {
-            inner: Snatchable2::new(inner),
+            state: ResourceState::Valid(TextureState {
+                inner: Snatchable::new(inner),
+            }),
             device: device.clone(),
             desc: desc.map_label(|label| label.to_string()),
             _hal_usage: hal_usage,
@@ -1466,7 +1443,7 @@ impl Texture {
 
     pub(crate) fn invalid(device: &Arc<Device>, desc: &TextureDescriptor) -> Self {
         Texture {
-            inner: Snatchable2::invalid(),
+            state: ResourceState::Invalid,
             device: device.clone(),
             desc: desc.map_label(|label| label.to_string()),
             _hal_usage: wgt::TextureUses::empty(),
@@ -1544,7 +1521,10 @@ impl Drop for Texture {
             _ => {}
         };
 
-        if let Some(TextureInner::Native { raw }) = self.inner.take().maybe_valid() {
+        let ResourceState::Valid(state) = &mut self.state else {
+            return;
+        };
+        if let Some(TextureInner::Native { raw }) = state.inner.take() {
             resource_log!("Destroy raw {}", self.error_ident());
             unsafe {
                 self.device.raw().destroy_texture(raw);
@@ -1557,27 +1537,18 @@ impl RawResourceAccess for Texture {
     type DynResource = dyn hal::DynTexture;
 
     fn raw<'a>(&'a self, guard: &'a SnatchGuard) -> Option<&'a Self::DynResource> {
-        self.inner.get(guard).maybe_valid().map(|t| t.raw())
+        self.state
+            .as_ref()
+            .valid()
+            .and_then(|t| t.inner.get(guard).map(|t| t.raw()))
     }
 }
 
 impl Texture {
-    pub(crate) fn try_inner<'a>(
-        &'a self,
-        guard: &'a SnatchGuard,
-    ) -> Result<&'a TextureInner, InvalidOrDestroyedResourceError> {
-        match self.inner.get(guard) {
-            DestructibleResourceState::Valid(t) => Ok(t),
-            DestructibleResourceState::Invalid => {
-                Err(InvalidOrDestroyedResourceError::InvalidResource(
-                    InvalidResourceError(self.error_ident()),
-                ))
-            }
-            DestructibleResourceState::Destroyed => {
-                Err(InvalidOrDestroyedResourceError::DestroyedResource(
-                    DestroyedResourceError(self.error_ident()),
-                ))
-            }
+    pub(crate) fn state(&self) -> Result<&TextureState, InvalidResourceError> {
+        match &self.state {
+            ResourceState::Valid(state) => Ok(state),
+            ResourceState::Invalid => Err(InvalidResourceError(self.error_ident())),
         }
     }
 
@@ -1585,19 +1556,28 @@ impl Texture {
         &self,
         guard: &SnatchGuard,
     ) -> Result<(), DestroyedResourceError> {
-        match self.inner.get(guard) {
-            DestructibleResourceState::Valid(_) => Ok(()),
-            DestructibleResourceState::Invalid => Ok(()),
-            DestructibleResourceState::Destroyed => Err(DestroyedResourceError(self.error_ident())),
-        }
+        let Ok(state) = self.state() else {
+            return Ok(());
+        };
+        state
+            .inner
+            .get(guard)
+            .map(|_| ())
+            .ok_or_else(|| DestroyedResourceError(self.error_ident()))
     }
 
-    pub(crate) fn check_valid(&self, guard: &SnatchGuard) -> Result<(), InvalidResourceError> {
-        match self.inner.get(guard) {
-            DestructibleResourceState::Valid(_) => Ok(()),
-            DestructibleResourceState::Invalid => Err(InvalidResourceError(self.error_ident())),
-            DestructibleResourceState::Destroyed => Ok(()),
-        }
+    pub(crate) fn check_valid(&self) -> Result<(), InvalidResourceError> {
+        self.state().map(|_| ())
+    }
+
+    pub(crate) fn try_inner<'a>(
+        &'a self,
+        guard: &'a SnatchGuard,
+    ) -> Result<&'a TextureInner, InvalidOrDestroyedResourceError> {
+        self.state()?
+            .inner
+            .get(guard)
+            .ok_or_else(|| DestroyedResourceError(self.error_ident()).into())
     }
 
     pub(crate) fn get_clear_view<'a>(
@@ -1632,12 +1612,12 @@ impl Texture {
     pub fn destroy(self: &Arc<Self>) {
         let device = &self.device;
 
+        let ResourceState::Valid(state) = &self.state else {
+            return;
+        };
+
         let temp = {
-            let raw = match self
-                .inner
-                .snatch(&mut device.snatchable_lock.write())
-                .maybe_valid()
-            {
+            let raw = match state.inner.snatch(&mut device.snatchable_lock.write()) {
                 Some(TextureInner::Native { raw }) => raw,
                 Some(TextureInner::Surface { .. }) => {
                     return;

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -1,7 +1,6 @@
 use core::{cell::UnsafeCell, fmt, mem::ManuallyDrop};
 
 use crate::lock::{rank, RankData, RwLock, RwLockReadGuard, RwLockWriteGuard};
-use crate::resource::DestructibleResourceState;
 
 /// A guard that provides read access to snatchable data.
 pub struct SnatchGuard<'a>(RwLockReadGuard<'a, ()>);
@@ -62,46 +61,6 @@ impl<T> fmt::Debug for SnatchableInner<T> {
 }
 
 unsafe impl<T> Sync for SnatchableInner<T> {}
-
-/// A value that is mostly immutable but can be "snatched" if we need to destroy
-/// it early.
-///
-/// In order to safely access the underlying data, the device's global snatchable
-/// lock must be taken. To guarantee it, methods take a read or write guard of that
-/// special lock.
-pub type Snatchable2<T> = SnatchableInner<DestructibleResourceState<T>>;
-
-impl<T> Snatchable2<T> {
-    pub fn new(val: T) -> Self {
-        SnatchableInner {
-            value: UnsafeCell::new(DestructibleResourceState::Valid(val)),
-        }
-    }
-
-    pub fn invalid() -> Self {
-        SnatchableInner {
-            value: UnsafeCell::new(DestructibleResourceState::Invalid),
-        }
-    }
-
-    /// Get read access to the value. Requires a the snatchable lock's read guard.
-    pub fn get<'a>(&'a self, _guard: &'a SnatchGuard) -> DestructibleResourceState<&'a T> {
-        unsafe { (*self.value.get()).as_ref() }
-    }
-
-    /// Take the value. Requires a the snatchable lock's write guard.
-    pub fn snatch(&self, _guard: &mut ExclusiveSnatchGuard) -> DestructibleResourceState<T> {
-        unsafe { (*self.value.get()).take() }
-    }
-
-    /// Take the value without a guard. This can only be used with exclusive access
-    /// to self, so it does not require locking.
-    ///
-    /// Typically useful in a drop implementation.
-    pub fn take(&mut self) -> DestructibleResourceState<T> {
-        self.value.get_mut().take()
-    }
-}
 
 use trace::LockTrace;
 #[cfg(all(debug_assertions, feature = "std"))]

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -489,7 +489,7 @@ impl TextureTracker {
             .drain(..)
             .inspect(|pending| {
                 let tex = unsafe { self.metadata.get_resource_unchecked(pending.id as _) };
-                textures.push(tex.inner.get(snatch_guard).maybe_valid());
+                textures.push(tex.try_inner(snatch_guard).ok());
             })
             .collect();
         (transitions, textures)


### PR DESCRIPTION
**Description**
As announced in #9787 we want to avoid requiring snatch_guard for check_valid as it turns out this is very painful otherwise. In some parts this PR reverts #9718.

**Testing**
Refactor, should be covered by existing tests.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
