### PR TITLE
Cherry pick "fix(metal): Restore the `Queue::as_raw` method" to v29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Bottom level categories:
 
 ### Bug Fixes
 
+#### Metal
+
+- Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).
+
 #### Vulkan
 
 - Fixed `VUID-RuntimeSpirv-vulkanMemoryModel-06265` validation errors by enabling `vulkanMemoryModelDeviceScope` whenever the Vulkan memory model is enabled, since the SPIR-V backend emits storage atomics with `Device` scope. By @francisdb in [#9741](https://github.com/gfx-rs/wgpu/pull/9741).

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -477,6 +477,10 @@ impl Queue {
             timestamp_period,
         }
     }
+
+    pub fn as_raw(&self) -> &ProtocolObject<dyn MTLCommandQueue> {
+        &self.shared.raw
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
**Connections**
Cherry-pick of #9560. This method was removed incidental to another change in #9217, and should not have been.

**Testing**
Untested

**Squash or Rebase?** Squash