### PR TITLE
[core] Support importing/resolving on global

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -520,7 +520,7 @@ impl<'a> ops::DerefMut for RecordingGuard<'a> {
     }
 }
 
-pub(crate) struct CommandEncoder {
+pub struct CommandEncoder {
     pub(crate) device: Arc<Device>,
 
     pub(crate) label: String,
@@ -1770,13 +1770,6 @@ impl Global {
         buffer_id: Id<id::markers::Buffer>,
     ) -> Result<Arc<crate::resource::Buffer>, InvalidResourceError> {
         self.hub.buffers.get(buffer_id).get()
-    }
-
-    fn resolve_texture_id(
-        &self,
-        texture_id: Id<id::markers::Texture>,
-    ) -> Arc<crate::resource::Texture> {
-        self.hub.textures.get(texture_id)
     }
 
     fn resolve_query_set(

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -2,9 +2,18 @@ use alloc::{borrow::ToOwned as _, sync::Arc};
 use core::fmt;
 
 use crate::{
+    binding_model::{BindGroupLayout, PipelineLayout},
+    command::{CommandBuffer, CommandEncoder},
+    device::{queue::Queue, Device},
     hub::{Hub, HubReport},
-    instance::{Instance, Surface},
+    id::{
+        AdapterId, BindGroupLayoutId, CommandBufferId, CommandEncoderId, ComputePipelineId,
+        DeviceId, PipelineLayoutId, QueueId, RenderPipelineId, TextureId,
+    },
+    instance::{Adapter, Instance, Surface},
+    pipeline::{ComputePipeline, RenderPipeline},
     registry::{Registry, RegistryReport},
+    resource::Texture,
     resource_log,
 };
 
@@ -81,6 +90,171 @@ impl Global {
             surfaces: self.surfaces.generate_report(),
             hub: self.hub.generate_report(),
         }
+    }
+}
+
+// methods to import and resolve resources in the global hub
+impl Global {
+    /// Import [`Arc<Adapter>`] into the global hub,
+    /// returning an [`AdapterId`] under which the adapter is stored.
+    pub fn import_adapter(&self, adapter: Arc<Adapter>, id_in: Option<AdapterId>) -> AdapterId {
+        let fid = self.hub.adapters.prepare(id_in);
+        fid.assign(adapter)
+    }
+
+    /// Resolve an [`AdapterId`] to the corresponding [`Arc<Adapter>`] in the global hub.
+    pub fn resolve_adapter_id(&self, adapter_id: AdapterId) -> Arc<Adapter> {
+        self.hub.adapters.get(adapter_id)
+    }
+
+    /// Import [`Arc<Device>`] into the global hub,
+    /// returning a [`DeviceId`] under which the device is stored.
+    pub fn import_device(&self, device: Arc<Device>, id_in: Option<DeviceId>) -> DeviceId {
+        let fid = self.hub.devices.prepare(id_in);
+        fid.assign(device)
+    }
+
+    /// Resolve a [`DeviceId`] to the corresponding [`Arc<Device>`] in the global hub.
+    pub fn resolve_device_id(&self, device_id: DeviceId) -> Arc<Device> {
+        self.hub.devices.get(device_id)
+    }
+
+    /// Import [`Arc<Queue>`] into the global hub,
+    /// returning a [`QueueId`] under which the queue is stored.
+    pub fn import_queue(&self, queue: Arc<Queue>, id_in: Option<QueueId>) -> QueueId {
+        let fid = self.hub.queues.prepare(id_in);
+        fid.assign(queue)
+    }
+
+    /// Resolve a [`QueueId`] to the corresponding [`Arc<Queue>`] in the global hub.
+    pub fn resolve_queue_id(&self, queue_id: QueueId) -> Arc<Queue> {
+        self.hub.queues.get(queue_id)
+    }
+
+    /// Import [`Arc<PipelineLayout>`] into the global hub,
+    /// returning a [`PipelineLayoutId`] under which the pipeline layout is stored.
+    pub fn import_pipeline_layout(
+        &self,
+        pipeline_layout: Arc<PipelineLayout>,
+        id_in: Option<PipelineLayoutId>,
+    ) -> PipelineLayoutId {
+        let fid = self.hub.pipeline_layouts.prepare(id_in);
+        fid.assign(pipeline_layout)
+    }
+
+    /// Resolve a [`PipelineLayoutId`] to the corresponding [`Arc<PipelineLayout>`] in the global hub.
+    pub fn resolve_pipeline_layout_id(
+        &self,
+        pipeline_layout_id: PipelineLayoutId,
+    ) -> Arc<PipelineLayout> {
+        self.hub.pipeline_layouts.get(pipeline_layout_id)
+    }
+
+    /// Import [`Arc<BindGroupLayout>`] into the global hub,
+    /// returning a [`BindGroupLayoutId`] under which the bind group layout is stored.
+    pub fn import_bind_group_layout(
+        &self,
+        bind_group_layout: Arc<BindGroupLayout>,
+        id_in: Option<BindGroupLayoutId>,
+    ) -> BindGroupLayoutId {
+        let fid = self.hub.bind_group_layouts.prepare(id_in);
+        fid.assign(bind_group_layout)
+    }
+
+    /// Resolve a [`BindGroupLayoutId`] to the corresponding [`Arc<BindGroupLayout>`] in the global hub.
+    pub fn resolve_bind_group_layout_id(
+        &self,
+        bind_group_layout_id: BindGroupLayoutId,
+    ) -> Arc<BindGroupLayout> {
+        self.hub.bind_group_layouts.get(bind_group_layout_id)
+    }
+
+    /// Import [`Arc<CommandEncoder>`] into the global hub,
+    /// returning a [`CommandEncoderId`] under which the command encoder is stored.
+    pub fn import_command_encoder(
+        &self,
+        command_encoder: Arc<CommandEncoder>,
+        id_in: Option<CommandEncoderId>,
+    ) -> CommandEncoderId {
+        let fid = self.hub.command_encoders.prepare(id_in);
+        fid.assign(command_encoder)
+    }
+
+    /// Resolve a [`CommandEncoderId`] to the corresponding [`Arc<CommandEncoder>`] in the global hub.
+    pub fn resolve_command_encoder_id(
+        &self,
+        command_encoder_id: CommandEncoderId,
+    ) -> Arc<CommandEncoder> {
+        self.hub.command_encoders.get(command_encoder_id)
+    }
+
+    /// Import [`Arc<CommandBuffer>`] into the global hub,
+    /// returning a [`CommandBufferId`] under which the command buffer is stored.
+    pub fn import_command_buffer(
+        &self,
+        command_buffer: Arc<CommandBuffer>,
+        id_in: Option<CommandBufferId>,
+    ) -> CommandBufferId {
+        let fid = self.hub.command_buffers.prepare(id_in);
+        fid.assign(command_buffer)
+    }
+
+    /// Resolve a [`CommandBufferId`] to the corresponding [`Arc<CommandBuffer>`] in the global hub.
+    pub fn resolve_command_buffer_id(
+        &self,
+        command_buffer_id: CommandBufferId,
+    ) -> Arc<CommandBuffer> {
+        self.hub.command_buffers.get(command_buffer_id)
+    }
+
+    /// Import [`Arc<RenderPipeline>`] into the global hub,
+    /// returning a [`RenderPipelineId`] under which the render pipeline is stored.
+    pub fn import_render_pipeline(
+        &self,
+        render_pipeline: Arc<RenderPipeline>,
+        id_in: Option<RenderPipelineId>,
+    ) -> RenderPipelineId {
+        let fid = self.hub.render_pipelines.prepare(id_in);
+        fid.assign(render_pipeline)
+    }
+
+    /// Resolve a [`RenderPipelineId`] to the corresponding [`Arc<RenderPipeline>`] in the global hub.
+    pub fn resolve_render_pipeline_id(
+        &self,
+        render_pipeline_id: RenderPipelineId,
+    ) -> Arc<RenderPipeline> {
+        self.hub.render_pipelines.get(render_pipeline_id)
+    }
+
+    /// Import [`Arc<ComputePipeline>`] into the global hub,
+    /// returning a [`ComputePipelineId`] under which the compute pipeline is stored.
+    pub fn import_compute_pipeline(
+        &self,
+        compute_pipeline: Arc<ComputePipeline>,
+        id_in: Option<ComputePipelineId>,
+    ) -> ComputePipelineId {
+        let fid = self.hub.compute_pipelines.prepare(id_in);
+        fid.assign(compute_pipeline)
+    }
+
+    /// Resolve a [`ComputePipelineId`] to the corresponding [`Arc<ComputePipeline>`] in the global hub.
+    pub fn resolve_compute_pipeline_id(
+        &self,
+        compute_pipeline_id: ComputePipelineId,
+    ) -> Arc<ComputePipeline> {
+        self.hub.compute_pipelines.get(compute_pipeline_id)
+    }
+
+    /// Import [`Arc<Texture>`] into the global hub,
+    /// returning a [`TextureId`] under which the texture is stored.
+    pub fn import_texture(&self, texture: Arc<Texture>, id_in: Option<TextureId>) -> TextureId {
+        let fid = self.hub.textures.prepare(id_in);
+        fid.assign(texture)
+    }
+
+    /// Resolve a [`TextureId`] to the corresponding [`Arc<Texture>`] in the global hub.
+    pub fn resolve_texture_id(&self, texture_id: TextureId) -> Arc<Texture> {
+        self.hub.textures.get(texture_id)
     }
 }
 


### PR DESCRIPTION
**Connections**
Towards #5121 

**Description**

We add `import_{resource}(&self: &Global, resource: Arc<{resource}>, id_in: Option<{resource}Id>)` and `resolve_{resource}_id(&self: &Global, id: {resource}Id) -> Arc<{resource}>` for resources with inner validity (will be all soon). This allows importing "external" (outside of global hub) resources into the global hub and allows obtaining (resolving) them out of global hub. Drop functions are already present.

This will be useful for what I plan to do in servo (importing wgpu-core resources into wgpu as abstraction) and will help with incremental migration of wgpu from ids to Arced resources.

I initially planed to wait with this for later stage of work on #5121, but firefox could use this now: https://bugzilla.mozilla.org/show_bug.cgi?id=2051199#c2, https://phabricator.services.mozilla.com/D285435#inline-1556089

**Testing**
In rust we trust.

**Squash or Rebase?**

Squash.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
