### PR TITLE
[core] Move validity into `Arc<QuerySet>`

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -360,9 +360,7 @@ impl Player {
                     .expect("invalid render bundle");
             }
             Action::CreateQuerySet { id, desc } => {
-                let query_set = device
-                    .create_query_set(&desc)
-                    .expect("create_query_set error");
+                let (query_set, _error) = device.create_query_set(&desc);
                 self.query_sets.insert(id, query_set);
             }
             Action::DestroyQuerySet(id) => {

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -33,7 +33,7 @@ use crate::{
     init_tracker::MemoryInitKind,
     pipeline::ComputePipeline,
     resource::{
-        self, Buffer, DestroyedResourceError, Fallible, InvalidResourceError, Labeled,
+        self, Buffer, DestroyedResourceError, InvalidResourceError, Labeled,
         MissingBufferUsageError, ParentDevice, RawResourceAccess, TextureView, Trackable,
     },
     track::{ResourceUsageCompatibilityError, TextureViewBindGroupState, Tracker},
@@ -458,7 +458,7 @@ fn transition_resources(
 impl CommandEncoder {
     fn begin_compute_pass(
         self: &Arc<Self>,
-        desc: &ComputePassDescriptor<'_, PassTimestampWrites<Fallible<resource::QuerySet>>>,
+        desc: &ComputePassDescriptor<'_, PassTimestampWrites<Arc<resource::QuerySet>>>,
     ) -> (ComputePass, Option<CommandEncoderError>) {
         use EncoderStateError as SErr;
 
@@ -1546,7 +1546,8 @@ impl Global {
         let base = pass_base!(pass, scope);
 
         let hub = &self.hub;
-        let query_set = pass_try!(base, scope, hub.query_sets.get(query_set_id).get());
+        let query_set = hub.query_sets.get(query_set_id);
+        pass_try!(base, scope, query_set.check_is_valid());
 
         base.commands.push(ArcComputeCommand::WriteTimestamp {
             query_set,
@@ -1579,7 +1580,8 @@ impl Global {
         let base = pass_base!(pass, scope);
 
         let hub = &self.hub;
-        let query_set = pass_try!(base, scope, hub.query_sets.get(query_set_id).get());
+        let query_set = hub.query_sets.get(query_set_id);
+        pass_try!(base, scope, query_set.check_is_valid());
 
         base.commands
             .push(ArcComputeCommand::BeginPipelineStatisticsQuery {

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -96,8 +96,8 @@ use crate::snatch::SnatchGuard;
 use crate::init_tracker::BufferInitTrackerAction;
 use crate::ray_tracing::{AsAction, BuildAccelerationStructureError};
 use crate::resource::{
-    DestroyedResourceError, Fallible, InvalidOrDestroyedResourceError, InvalidResourceError,
-    Labeled, ParentDevice as _, QuerySet,
+    DestroyedResourceError, InvalidOrDestroyedResourceError, InvalidResourceError, Labeled,
+    ParentDevice as _, QuerySet,
 };
 use crate::track::{DeviceTracker, ResourceUsageCompatibilityError, Tracker, UsageScope};
 use crate::{api_log, global::Global, id, resource_log, Label};
@@ -966,7 +966,7 @@ impl CommandEncoder {
 
     pub(crate) fn validate_pass_timestamp_writes<E>(
         device: &Device,
-        timestamp_writes: &PassTimestampWrites<Fallible<QuerySet>>,
+        timestamp_writes: &PassTimestampWrites<Arc<QuerySet>>,
     ) -> Result<ArcPassTimestampWrites, E>
     where
         E: From<TimestampWritesError>
@@ -983,8 +983,7 @@ impl CommandEncoder {
 
         device.require_features(wgt::Features::TIMESTAMP_QUERY)?;
 
-        let query_set = query_set.clone().get()?;
-
+        query_set.check_is_valid()?;
         query_set.same_device(device)?;
 
         for idx in [beginning_of_pass_write_index, end_of_pass_write_index]
@@ -1008,7 +1007,7 @@ impl CommandEncoder {
         }
 
         Ok(ArcPassTimestampWrites {
-            query_set,
+            query_set: query_set.clone(),
             beginning_of_pass_write_index,
             end_of_pass_write_index,
         })
@@ -1770,13 +1769,6 @@ impl Global {
         buffer_id: Id<id::markers::Buffer>,
     ) -> Result<Arc<crate::resource::Buffer>, InvalidResourceError> {
         self.hub.buffers.get(buffer_id).get()
-    }
-
-    fn resolve_query_set(
-        &self,
-        query_set_id: Id<id::markers::QuerySet>,
-    ) -> Result<Arc<QuerySet>, InvalidResourceError> {
-        self.hub.query_sets.get(query_set_id).get()
     }
 
     /// Finishes a command encoder, creating a command buffer and returning errors that were

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -440,8 +440,10 @@ impl Global {
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, QueryError> {
+            let query_set = self.resolve_query_set_id(query_set_id);
+            query_set.check_is_valid()?;
             Ok(ArcCommand::WriteTimestamp {
-                query_set: self.resolve_query_set(query_set_id)?,
+                query_set,
                 query_index,
             })
         })
@@ -462,8 +464,10 @@ impl Global {
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, QueryError> {
+            let query_set = self.resolve_query_set_id(query_set_id);
+            query_set.check_is_valid()?;
             Ok(ArcCommand::ResolveQuerySet {
-                query_set: self.resolve_query_set(query_set_id)?,
+                query_set,
                 start_query,
                 query_count,
                 destination: self.resolve_buffer_id(destination)?,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -40,10 +40,9 @@ use crate::{
     init_tracker::{MemoryInitKind, TextureInitRange, TextureInitTrackerAction},
     pipeline::{PipelineFlags, RenderPipeline, VertexStep},
     resource::{
-        Buffer, DestroyedResourceError, Fallible, InvalidResourceError, Labeled,
-        MissingBufferUsageError, MissingTextureUsageError, ParentDevice, QuerySet,
-        RawResourceAccess, ResourceErrorIdent, Texture, TextureView,
-        TextureViewNotRenderableReason,
+        Buffer, DestroyedResourceError, InvalidResourceError, Labeled, MissingBufferUsageError,
+        MissingTextureUsageError, ParentDevice, QuerySet, RawResourceAccess, ResourceErrorIdent,
+        Texture, TextureView, TextureViewNotRenderableReason,
     },
     snatch::SnatchGuard,
     track::{ResourceUsageCompatibilityError, Tracker, UsageScope},
@@ -282,9 +281,9 @@ pub struct ResolvedRenderPassDescriptor<'a> {
     /// The depth and stencil attachment of the render pass, if any.
     pub depth_stencil_attachment: Option<RenderPassDepthStencilAttachment<Arc<TextureView>>>,
     /// Defines where and when timestamp values will be written for this pass.
-    pub timestamp_writes: Option<PassTimestampWrites<Fallible<QuerySet>>>,
+    pub timestamp_writes: Option<PassTimestampWrites<Arc<QuerySet>>>,
     /// Defines where the occlusion query results will be stored for this pass.
-    pub occlusion_query_set: Option<Fallible<QuerySet>>,
+    pub occlusion_query_set: Option<Arc<QuerySet>>,
     /// The multiview array layers that will be used
     pub multiview_mask: Option<NonZeroU32>,
 }
@@ -2059,18 +2058,18 @@ impl CommandEncoder {
 
             arc_desc.occlusion_query_set =
                 if let Some(occlusion_query_set) = desc.occlusion_query_set {
-                    let query_set = occlusion_query_set.get()?;
-                    query_set.same_device(device)?;
+                    occlusion_query_set.check_is_valid()?;
+                    occlusion_query_set.same_device(device)?;
 
-                    if !matches!(query_set.desc.ty, wgt::QueryType::Occlusion) {
+                    if !matches!(occlusion_query_set.desc.ty, wgt::QueryType::Occlusion) {
                         return Err(QueryUseError::IncompatibleType {
-                            set_type: query_set.desc.ty.into(),
+                            set_type: occlusion_query_set.desc.ty.into(),
                             query_type: super::SimplifiedQueryType::Occlusion,
                         }
                         .into());
                     }
 
-                    Some(query_set)
+                    Some(occlusion_query_set)
                 } else {
                     None
                 };
@@ -4463,8 +4462,10 @@ impl Global {
         let scope = PassErrorScope::WriteTimestamp;
         let base = pass_base!(pass, scope);
 
+        let query_set = self.resolve_query_set_id(query_set_id);
+        pass_try!(base, scope, query_set.check_is_valid());
         base.commands.push(ArcRenderCommand::WriteTimestamp {
-            query_set: pass_try!(base, scope, self.resolve_query_set(query_set_id)),
+            query_set,
             query_index,
         });
 
@@ -4542,9 +4543,11 @@ impl Global {
         let scope = PassErrorScope::BeginPipelineStatisticsQuery;
         let base = pass_base!(pass, scope);
 
+        let query_set = self.resolve_query_set_id(query_set_id);
+        pass_try!(base, scope, query_set.check_is_valid());
         base.commands
             .push(ArcRenderCommand::BeginPipelineStatisticsQuery {
-                query_set: pass_try!(base, scope, self.resolve_query_set(query_set_id)),
+                query_set,
                 query_index,
             });
 

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1245,49 +1245,21 @@ impl Global {
         let hub = &self.hub;
         let fid = hub.query_sets.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
-            let query_set = match device.create_query_set(desc) {
-                Ok(query_set) => query_set,
-                Err(err) => break 'error err,
-            };
+        let (query_set, error) = device.create_query_set(desc);
 
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                trace.add(trace::Action::CreateQuerySet {
-                    id: query_set.to_trace(),
-                    desc: desc.clone(),
-                });
-            }
+        let id = fid.assign(query_set);
 
-            let id = fid.assign(Fallible::Valid(query_set));
-            api_log!("Device::create_query_set -> {id:?}");
-
-            return (id, None);
-        };
-
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
-        (id, Some(error))
+        (id, error)
     }
 
     pub fn query_set_destroy(&self, query_set_id: id::QuerySetId) {
-        profiling::scope!("QuerySet::destroy");
-        api_log!("QuerySet::destroy {query_set_id:?}");
-
         let hub = &self.hub;
 
-        let Ok(query_set) = hub.query_sets.get(query_set_id).get() else {
-            // If the query set is already invalid, there's nothing to do.
-            return;
-        };
+        let query_set = hub.query_sets.get(query_set_id);
 
         query_set.destroy();
-
-        #[cfg(feature = "trace")]
-        if let Some(trace) = query_set.device.trace.lock().as_mut() {
-            trace.add(trace::Action::DestroyQuerySet(query_set.to_trace()));
-        };
     }
 
     pub fn query_set_drop(&self, query_set_id: id::QuerySetId) {
@@ -1297,13 +1269,6 @@ impl Global {
         let hub = &self.hub;
 
         let _query_set = hub.query_sets.remove(query_set_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(query_set) = _query_set.get() {
-            if let Some(trace) = query_set.device.trace.lock().as_mut() {
-                trace.add(trace::Action::DropQuerySet(query_set.to_trace()));
-            }
-        }
     }
 
     pub fn device_create_render_pipeline(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -47,7 +47,7 @@ use crate::{
     pool::ResourcePool,
     present,
     resource::{
-        self, Buffer, ExternalTexture, Fallible, Labeled, ParentDevice, QuerySet,
+        self, Buffer, ExternalTexture, Fallible, Labeled, ParentDevice, QuerySet, QuerySetState,
         RawResourceAccess, ResourceState, Sampler, StagingBuffer, Texture, TextureView,
         TextureViewNotRenderableReason, TextureViewState, Tlas, TrackingData,
     },
@@ -5243,6 +5243,26 @@ impl Device {
     pub fn create_query_set(
         self: &Arc<Self>,
         desc: &resource::QuerySetDescriptor,
+    ) -> (Arc<QuerySet>, Option<resource::CreateQuerySetError>) {
+        let (query_set, error) = match self.create_query_set_inner(desc) {
+            Ok(query_set) => (query_set, None),
+            Err(e) => (QuerySet::invalid(Arc::clone(self), desc), Some(e)),
+        };
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use trace::IntoTrace;
+            trace.add(trace::Action::CreateQuerySet {
+                id: query_set.to_trace(),
+                desc: desc.clone(),
+            });
+        }
+        api_log!("Device::create_query_set -> {:?}", Arc::as_ptr(&query_set));
+        (query_set, error)
+    }
+
+    pub(crate) fn create_query_set_inner(
+        self: &Arc<Self>,
+        desc: &resource::QuerySetDescriptor,
     ) -> Result<Arc<QuerySet>, resource::CreateQuerySetError> {
         use resource::CreateQuerySetError as Error;
 
@@ -5275,7 +5295,9 @@ impl Device {
             .map_err(|e| self.handle_hal_error_with_nonfatal_oom(e))?;
 
         let query_set = QuerySet {
-            raw: Snatchable::new(raw),
+            state: ResourceState::Valid(QuerySetState {
+                raw: Snatchable::new(raw),
+            }),
             device: self.clone(),
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.query_sets.clone()),

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -8,12 +8,12 @@ use crate::{
     hub::{Hub, HubReport},
     id::{
         AdapterId, BindGroupLayoutId, CommandBufferId, CommandEncoderId, ComputePipelineId,
-        DeviceId, PipelineLayoutId, QueueId, RenderPipelineId, TextureId,
+        DeviceId, PipelineLayoutId, QuerySetId, QueueId, RenderPipelineId, TextureId,
     },
     instance::{Adapter, Instance, Surface},
     pipeline::{ComputePipeline, RenderPipeline},
     registry::{Registry, RegistryReport},
-    resource::Texture,
+    resource::{QuerySet, Texture},
     resource_log,
 };
 
@@ -243,6 +243,22 @@ impl Global {
         compute_pipeline_id: ComputePipelineId,
     ) -> Arc<ComputePipeline> {
         self.hub.compute_pipelines.get(compute_pipeline_id)
+    }
+
+    /// Import [`Arc<QuerySet>`] into the global hub,
+    /// returning a [`QuerySetId`] under which the query set is stored.
+    pub fn import_query_set(
+        &self,
+        query_set: Arc<QuerySet>,
+        id_in: Option<QuerySetId>,
+    ) -> QuerySetId {
+        let fid = self.hub.query_sets.prepare(id_in);
+        fid.assign(query_set)
+    }
+
+    /// Resolve a [`QuerySetId`] to the corresponding [`Arc<QuerySet>`] in the global hub.
+    pub fn resolve_query_set_id(&self, query_set_id: QuerySetId) -> Arc<QuerySet> {
+        self.hub.query_sets.get(query_set_id)
     }
 
     /// Import [`Arc<Texture>`] into the global hub,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -204,7 +204,7 @@ pub struct Hub {
     pub(crate) render_pipelines: Registry<Arc<RenderPipeline>>,
     pub(crate) compute_pipelines: Registry<Arc<ComputePipeline>>,
     pub(crate) pipeline_caches: Registry<Fallible<PipelineCache>>,
-    pub(crate) query_sets: Registry<Fallible<QuerySet>>,
+    pub(crate) query_sets: Registry<Arc<QuerySet>>,
     pub(crate) buffers: Registry<Fallible<Buffer>>,
     pub(crate) staging_buffers: Registry<StagingBuffer>,
     pub(crate) textures: Registry<Arc<Texture>>,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2430,8 +2430,13 @@ impl WebGpuError for CreateQuerySetError {
 pub type QuerySetDescriptor<'a> = wgt::QuerySetDescriptor<Label<'a>>;
 
 #[derive(Debug)]
-pub struct QuerySet {
+pub(crate) struct QuerySetState {
     pub(crate) raw: Snatchable<Box<dyn hal::DynQuerySet>>,
+}
+
+#[derive(Debug)]
+pub struct QuerySet {
+    pub(crate) state: ResourceState<QuerySetState>,
     pub(crate) device: Arc<Device>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
@@ -2444,18 +2449,57 @@ impl RawResourceAccess for QuerySet {
     type DynResource = dyn hal::DynQuerySet;
 
     fn raw<'a>(&'a self, guard: &'a SnatchGuard) -> Option<&'a Self::DynResource> {
-        self.raw.get(guard).map(|b| b.as_ref())
+        self.state().ok()?.raw.get(guard).map(|b| b.as_ref())
     }
 }
 
 impl QuerySet {
+    pub(crate) fn state(&self) -> Result<&QuerySetState, InvalidResourceError> {
+        match &self.state {
+            ResourceState::Valid(state) => Ok(state),
+            ResourceState::Invalid => Err(InvalidResourceError(self.error_ident())),
+        }
+    }
+
+    pub(crate) fn check_is_valid(&self) -> Result<(), InvalidResourceError> {
+        self.state().map(|_| ())
+    }
+
+    pub fn invalid(device: Arc<Device>, desc: &QuerySetDescriptor) -> Arc<Self> {
+        Arc::new(QuerySet {
+            state: ResourceState::Invalid,
+            label: desc.label.to_string(),
+            tracking_data: TrackingData::new(device.tracker_indices.query_sets.clone()),
+            desc: desc.clone().map_label(|_| ()),
+            initialized_slots: Mutex::new(
+                rank::QUERY_SET_INITIALIZED_SLOTS,
+                bit_vec::BitVec::from_elem(desc.count as usize, false),
+            ),
+            device,
+        })
+    }
+
     pub fn destroy(self: &Arc<Self>) {
         let device = &self.device;
+
+        profiling::scope!("QuerySet::destroy");
+        api_log!("QuerySet::destroy {:?}", Arc::as_ptr(self));
+
+        #[cfg(feature = "trace")]
+        if let Some(trace) = device.trace.lock().as_mut() {
+            use crate::device::trace::IntoTrace as _;
+
+            trace.add(trace::Action::DestroyQuerySet(self.to_trace()));
+        };
+
+        let ResourceState::Valid(state) = &self.state else {
+            return;
+        };
 
         let temp = {
             let mut snatch_guard = self.device.snatchable_lock.write();
 
-            let raw = match self.raw.snatch(&mut snatch_guard) {
+            let raw = match state.raw.snatch(&mut snatch_guard) {
                 Some(raw) => raw,
                 None => {
                     // Per spec, it is valid to call `destroy` multiple times.
@@ -2487,7 +2531,16 @@ impl QuerySet {
 impl Drop for QuerySet {
     fn drop(&mut self) {
         resource_log!("Destroy raw {}", self.error_ident());
-        if let Some(raw) = self.raw.take() {
+        #[cfg(feature = "trace")]
+        if let Some(trace) = self.device.trace.lock().as_mut() {
+            use crate::device::trace::to_trace;
+
+            trace.add(trace::Action::DropQuerySet(unsafe { to_trace(self) }));
+        }
+        let ResourceState::Valid(state) = &mut self.state else {
+            return;
+        };
+        if let Some(raw) = state.raw.take() {
             // SAFETY: We are in the Drop impl and we don't use raw anymore after this point.
             unsafe {
                 self.device.raw().destroy_query_set(raw);


### PR DESCRIPTION
**Connections**
Towards https://github.com/gfx-rs/wgpu/issues/5121

**Description**
As done in #9787 we move validity into `QuerySet` by wrapping internal state with `ResourceState`. Tracing is also moved inside `QuerySet`

**Testing**
Refactor, should be covered by existing tests

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
