### PR TITLE
[core] Move validity into `Arc<RenderBundle>`

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -81,6 +81,7 @@ index format changes.
 use alloc::{
     borrow::{Cow, ToOwned as _},
     string::String,
+    string::ToString as _,
     sync::Arc,
     vec::Vec,
 };
@@ -100,6 +101,7 @@ use wgt::error::{ErrorType, WebGpuError};
 #[cfg(feature = "trace")]
 use crate::command::ArcReferences;
 use crate::{
+    api_log,
     binding_model::{BindError, BindGroup, PipelineLayout},
     command::{
         bind::Binder, pass::validate_immediates_alignment, pass_base, BasePass,
@@ -116,7 +118,7 @@ use crate::{
     pipeline::{PipelineFlags, RenderPipeline},
     resource::{
         Buffer, DestroyedResourceError, Fallible, InvalidResourceError, Labeled, ParentDevice,
-        RawResourceAccess, TrackingData,
+        RawResourceAccess, ResourceState, TrackingData,
     },
     resource_log,
     snatch::SnatchGuard,
@@ -315,7 +317,54 @@ impl RenderBundleEncoder {
     /// and accumulate buffer and texture initialization actions.
     ///
     /// [`ExecuteBundle`]: RenderCommand::ExecuteBundle
-    pub(crate) fn finish(
+    pub fn finish(
+        &mut self,
+        desc: &RenderBundleDescriptor,
+        device: &Arc<Device>,
+        hub: &Hub,
+    ) -> (Arc<RenderBundle>, Option<RenderBundleError>) {
+        #[cfg(feature = "trace")]
+        let trace_desc = crate::device::trace::new_render_bundle_encoder_descriptor(
+            desc.label.clone(),
+            &self.context,
+            self.is_depth_read_only,
+            self.is_stencil_read_only,
+        );
+
+        let (render_bundle, error) = match self.finish_inner(desc, device, hub) {
+            Ok(render_bundle) => (render_bundle, None),
+            Err(e) => (RenderBundle::invalid(Arc::clone(device), desc), Some(e)),
+        };
+
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *device.trace.lock() {
+            use crate::device::trace::{Action, IntoTrace};
+            trace.add(Action::CreateRenderBundle {
+                id: render_bundle.to_trace(),
+                desc: trace_desc,
+                base: render_bundle.to_base_pass().to_trace(),
+            });
+        }
+
+        api_log!(
+            "RenderBundleEncoder::finish -> {:?}",
+            Arc::as_ptr(&render_bundle)
+        );
+
+        (render_bundle, error)
+    }
+
+    /// Convert this encoder's commands into a [`RenderBundle`].
+    ///
+    /// We want executing a [`RenderBundle`] to be quick, so we take
+    /// this opportunity to clean up the [`RenderBundleEncoder`]'s
+    /// command stream and gather metadata about it that will help
+    /// keep [`ExecuteBundle`] simple and fast. We remove redundant
+    /// commands (along with their side data), note resource usage,
+    /// and accumulate buffer and texture initialization actions.
+    ///
+    /// [`ExecuteBundle`]: RenderCommand::ExecuteBundle
+    pub(crate) fn finish_inner(
         &mut self,
         desc: &RenderBundleDescriptor,
         device: &Arc<Device>,
@@ -558,6 +607,10 @@ impl RenderBundleEncoder {
         let immediates_data = mem::take(&mut self.base.immediates_data);
         let context = mem::take(&mut self.context);
         let render_bundle = RenderBundle {
+            state: ResourceState::Valid(RenderBundleState {
+                context,
+                used: trackers,
+            }),
             base: BasePass {
                 label: desc.label.as_deref().map(str::to_owned),
                 error: None,
@@ -569,10 +622,8 @@ impl RenderBundleEncoder {
             is_depth_read_only: self.is_depth_read_only,
             is_stencil_read_only: self.is_stencil_read_only,
             device: device.clone(),
-            used: trackers,
             buffer_memory_init_actions,
             texture_memory_init_actions,
-            context,
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(tracker_indices),
             discard_hal_labels,
@@ -1247,22 +1298,27 @@ pub enum ExecutionError {
 
 pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
 
+#[derive(Debug)]
+pub(crate) struct RenderBundleState {
+    pub(crate) used: RenderBundleScope,
+    pub(super) context: RenderPassContext,
+}
+
 //Note: here, `RenderBundle` is just wrapping a raw stream of render commands.
 // The plan is to back it by an actual Vulkan secondary buffer, D3D12 Bundle,
 // or Metal indirect command buffer.
 /// cbindgen:ignore
 #[derive(Debug)]
 pub struct RenderBundle {
+    pub(crate) state: ResourceState<RenderBundleState>,
     // Normalized command stream. It can be executed verbatim,
     // without re-binding anything on the pipeline change.
     base: BasePass<ArcRenderCommand, Infallible>,
     pub(super) is_depth_read_only: bool,
     pub(super) is_stencil_read_only: bool,
     pub(crate) device: Arc<Device>,
-    pub(crate) used: RenderBundleScope,
     pub(super) buffer_memory_init_actions: Vec<BufferInitTrackerAction>,
     pub(super) texture_memory_init_actions: Vec<TextureInitTrackerAction>,
-    pub(super) context: RenderPassContext,
     /// The `label` from the descriptor used to create the resource.
     label: String,
     pub(crate) tracking_data: TrackingData,
@@ -1270,8 +1326,17 @@ pub struct RenderBundle {
 }
 
 impl Drop for RenderBundle {
+    #[expect(trivial_casts)]
     fn drop(&mut self) {
+        profiling::scope!("RenderBundle::drop");
+        api_log!("RenderBundle::drop {:?}", self as *const _);
         resource_log!("Drop {}", self.error_ident());
+        #[cfg(feature = "trace")]
+        if let Some(t) = self.device.trace.lock().as_mut() {
+            use crate::device::trace::{to_trace, Action};
+
+            t.add(Action::DropRenderBundle(unsafe { to_trace(self) }));
+        }
     }
 }
 
@@ -1281,6 +1346,39 @@ unsafe impl Send for RenderBundle {}
 unsafe impl Sync for RenderBundle {}
 
 impl RenderBundle {
+    pub(crate) fn state(&self) -> Result<&RenderBundleState, InvalidResourceError> {
+        self.state
+            .as_ref()
+            .valid()
+            .ok_or_else(|| InvalidResourceError(self.error_ident()))
+    }
+
+    pub(crate) fn check_is_valid(&self) -> Result<(), InvalidResourceError> {
+        self.state().map(|_| ())
+    }
+
+    pub(crate) fn invalid(device: Arc<Device>, desc: &RenderBundleDescriptor) -> Arc<Self> {
+        Arc::new(RenderBundle {
+            state: ResourceState::Invalid,
+            base: BasePass {
+                label: desc.label.as_ref().map(|l| l.to_string()),
+                error: None,
+                commands: Vec::new(),
+                dynamic_offsets: Vec::new(),
+                string_data: Vec::new(),
+                immediates_data: Vec::new(),
+            },
+            is_depth_read_only: false,
+            is_stencil_read_only: false,
+            buffer_memory_init_actions: Vec::new(),
+            texture_memory_init_actions: Vec::new(),
+            label: desc.label.to_string(),
+            tracking_data: TrackingData::new(device.tracker_indices.bundles.clone()),
+            discard_hal_labels: false,
+            device,
+        })
+    }
+
     #[cfg(feature = "trace")]
     pub(crate) fn to_base_pass(&self) -> BasePass<RenderCommand<ArcReferences>, Infallible> {
         self.base.clone()
@@ -1603,7 +1701,7 @@ impl IndexState {
 /// [`SetBindGroup`]: RenderCommand::SetBindGroup
 /// [`SetIndexBuffer`]: RenderCommand::SetIndexBuffer
 struct State {
-    /// Resources used by this bundle. This will become [`RenderBundle::used`].
+    /// Resources used by this bundle. This will become [`RenderBundleState::used`].
     trackers: RenderBundleScope,
 
     /// The currently set pipeline, if any.

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -3562,12 +3562,13 @@ fn execute_bundle(
 
     let bundle = state.pass.base.tracker.bundles.insert_single(bundle);
 
+    let bundle_state = bundle.state()?;
     bundle.same_device(device)?;
 
     state
         .info
         .context
-        .check_compatible(&bundle.context, bundle.as_ref())
+        .check_compatible(&bundle_state.context, bundle.as_ref())
         .map_err(RenderPassErrorInner::IncompatibleBundleTargets)?;
 
     if (state.info.is_depth_read_only && !bundle.is_depth_read_only)
@@ -3624,7 +3625,7 @@ fn execute_bundle(
     })?;
 
     unsafe {
-        state.pass.scope.merge_render_bundle(&bundle.used)?;
+        state.pass.scope.merge_render_bundle(&bundle_state.used)?;
     };
     state.reset_bundle();
     Ok(())
@@ -4603,7 +4604,8 @@ impl Global {
         let bundles = hub.render_bundles.read();
 
         for &bundle_id in render_bundle_ids {
-            let bundle = pass_try!(base, scope, bundles.get(bundle_id).get());
+            let bundle = bundles.get(bundle_id);
+            pass_try!(base, scope, bundle.check_is_valid());
 
             base.commands.push(ArcRenderCommand::ExecuteBundle(bundle));
         }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -223,11 +223,13 @@ impl Global {
     /// See [`Self::create_buffer_error`] for more context and explanation.
     pub fn create_render_bundle_error(
         &self,
+        device_id: DeviceId,
         id_in: Option<id::RenderBundleId>,
         desc: &command::RenderBundleDescriptor,
     ) {
+        let device = self.hub.devices.get(device_id);
         let fid = self.hub.render_bundles.prepare(id_in);
-        fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
+        fid.assign(command::RenderBundle::invalid(device, desc));
     }
 
     /// Assign `id_in` an error with the given `label`.
@@ -1157,39 +1159,13 @@ impl Global {
 
         let fid = hub.render_bundles.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(bundle_encoder.parent());
+        let device = self.hub.devices.get(bundle_encoder.parent());
 
-            #[cfg(feature = "trace")]
-            let trace_desc = trace::new_render_bundle_encoder_descriptor(
-                desc.label.clone(),
-                &bundle_encoder.context,
-                bundle_encoder.is_depth_read_only,
-                bundle_encoder.is_stencil_read_only,
-            );
+        let (render_bundle, error) = bundle_encoder.finish(desc, &device, hub);
 
-            let render_bundle = match bundle_encoder.finish(desc, &device, hub) {
-                Ok(bundle) => bundle,
-                Err(e) => break 'error e,
-            };
+        let id = fid.assign(render_bundle);
 
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                trace.add(trace::Action::CreateRenderBundle {
-                    id: render_bundle.to_trace(),
-                    desc: trace_desc,
-                    base: render_bundle.to_base_pass().to_trace(),
-                });
-            }
-
-            let id = fid.assign(Fallible::Valid(render_bundle));
-            api_log!("RenderBundleEncoder::finish -> {id:?}");
-
-            return (id, None);
-        };
-
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
-        (id, Some(error))
+        (id, error)
     }
 
     pub fn render_bundle_encoder_finish_with_id(
@@ -1219,19 +1195,9 @@ impl Global {
     }
 
     pub fn render_bundle_drop(&self, render_bundle_id: id::RenderBundleId) {
-        profiling::scope!("RenderBundle::drop");
-        api_log!("RenderBundle::drop {render_bundle_id:?}");
-
         let hub = &self.hub;
 
         let _bundle = hub.render_bundles.remove(render_bundle_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(bundle) = _bundle.get() {
-            if let Some(t) = bundle.device.trace.lock().as_mut() {
-                t.add(trace::Action::DropRenderBundle(bundle.to_trace()));
-            }
-        }
     }
 
     pub fn device_create_query_set(

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -200,7 +200,7 @@ pub struct Hub {
     pub(crate) bind_groups: Registry<Fallible<BindGroup>>,
     pub(crate) command_encoders: Registry<Arc<CommandEncoder>>,
     pub(crate) command_buffers: Registry<Arc<CommandBuffer>>,
-    pub(crate) render_bundles: Registry<Fallible<RenderBundle>>,
+    pub(crate) render_bundles: Registry<Arc<RenderBundle>>,
     pub(crate) render_pipelines: Registry<Arc<RenderPipeline>>,
     pub(crate) compute_pipelines: Registry<Arc<ComputePipeline>>,
     pub(crate) pipeline_caches: Registry<Fallible<PipelineCache>>,


### PR DESCRIPTION
**Connections**
Towards #5121.

**Description**
As always we move validity into RenderBundle by wrapping some internal state with ResourceState. Tracing and logging is also moved inside RenderBundle.

**Testing**
Just refactor.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
