### PR TITLE
[core] Move validity into `Arc<PipelineCache>`

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -345,7 +345,7 @@ impl Player {
                     .expect("invalid render pipeline");
             }
             Action::CreatePipelineCache { id, desc } => {
-                let cache = unsafe { device.create_pipeline_cache(&desc) }.unwrap();
+                let (cache, _error) = unsafe { device.create_pipeline_cache(&desc) };
                 self.pipeline_caches.insert(id, cache);
             }
             Action::DropPipelineCache(id) => {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1159,14 +1159,7 @@ impl Global {
 
             let layout = desc.layout.map(|layout| hub.pipeline_layouts.get(layout));
 
-            let cache = desc
-                .cache
-                .map(|cache| hub.pipeline_caches.get(cache).get())
-                .transpose();
-            let cache = match cache {
-                Ok(cache) => cache,
-                Err(e) => break 'error e.into(),
-            };
+            let cache = desc.cache.map(|cache| hub.pipeline_caches.get(cache));
 
             let vertex = match desc.vertex {
                 RenderPipelineVertexProcessor::Vertex(ref vertex) => {
@@ -1320,14 +1313,7 @@ impl Global {
 
             let layout = desc.layout.map(|layout| hub.pipeline_layouts.get(layout));
 
-            let cache = desc
-                .cache
-                .map(|cache| hub.pipeline_caches.get(cache).get())
-                .transpose();
-            let cache = match cache {
-                Ok(cache) => cache,
-                Err(e) => break 'error e.into(),
-            };
+            let cache = desc.cache.map(|cache| hub.pipeline_caches.get(cache));
 
             let module = hub.shader_modules.get(desc.stage.module);
 
@@ -1411,47 +1397,19 @@ impl Global {
         let hub = &self.hub;
 
         let fid = hub.pipeline_caches.prepare(id_in);
-        let error: pipeline::CreatePipelineCacheError = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
-            let cache = unsafe { device.create_pipeline_cache(desc) };
-            match cache {
-                Ok(cache) => {
-                    #[cfg(feature = "trace")]
-                    if let Some(ref mut trace) = *device.trace.lock() {
-                        trace.add(trace::Action::CreatePipelineCache {
-                            id: cache.to_trace(),
-                            desc: desc.clone(),
-                        });
-                    }
+        let (cache, error) = unsafe { device.create_pipeline_cache(desc) };
 
-                    let id = fid.assign(Fallible::Valid(cache));
-                    api_log!("Device::create_pipeline_cache -> {id:?}");
-                    return (id, None);
-                }
-                Err(e) => break 'error e,
-            }
-        };
+        let id = fid.assign(cache);
 
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
-
-        (id, Some(error))
+        (id, error)
     }
 
     pub fn pipeline_cache_drop(&self, pipeline_cache_id: id::PipelineCacheId) {
-        profiling::scope!("PipelineCache::drop");
-        api_log!("PipelineCache::drop {pipeline_cache_id:?}");
-
         let hub = &self.hub;
 
         let _cache = hub.pipeline_caches.remove(pipeline_cache_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(cache) = _cache.get() {
-            if let Some(t) = cache.device.trace.lock().as_mut() {
-                t.add(trace::Action::DropPipelineCache(cache.to_trace()));
-            }
-        }
     }
 
     pub fn surface_configure(
@@ -1577,32 +1535,9 @@ impl Global {
     }
 
     pub fn pipeline_cache_get_data(&self, id: id::PipelineCacheId) -> Option<Vec<u8>> {
-        use crate::pipeline_cache;
-        api_log!("PipelineCache::get_data");
         let hub = &self.hub;
 
-        if let Ok(cache) = hub.pipeline_caches.get(id).get() {
-            // TODO: Is this check needed?
-            if !cache.device.is_valid() {
-                return None;
-            }
-            let mut vec = unsafe { cache.device.raw().pipeline_cache_get_data(cache.raw()) }?;
-            let validation_key = cache.device.raw().pipeline_cache_validation_key()?;
-
-            let mut header_contents = [0; pipeline_cache::HEADER_LENGTH];
-            pipeline_cache::add_cache_header(
-                &mut header_contents,
-                &vec,
-                &cache.device.adapter.raw.info,
-                validation_key,
-            );
-
-            let deleted = vec.splice(..0, header_contents).collect::<Vec<_>>();
-            debug_assert!(deleted.is_empty());
-
-            return Some(vec);
-        }
-        None
+        hub.pipeline_caches.get(id).get_data()
     }
 
     pub fn device_drop(&self, device_id: DeviceId) {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4289,6 +4289,7 @@ impl Device {
 
         let cache = match desc.cache {
             Some(cache) => {
+                cache.check_is_valid()?;
                 cache.same_device(self)?;
                 Some(cache)
             }
@@ -4304,7 +4305,7 @@ impl Device {
                 constants: &desc.stage.constants,
                 zero_initialize_workgroup_memory: desc.stage.zero_initialize_workgroup_memory,
             },
-            cache: cache.as_ref().map(|it| it.raw()),
+            cache: cache.as_ref().map(|it| it.raw()).transpose()?,
         };
 
         let raw =
@@ -5183,6 +5184,7 @@ impl Device {
 
         let cache = match desc.cache {
             Some(cache) => {
+                cache.check_is_valid()?;
                 cache.same_device(self)?;
                 Some(cache)
             }
@@ -5211,7 +5213,7 @@ impl Device {
                 fragment_stage,
                 color_targets,
                 multiview_mask: desc.multiview_mask,
-                cache: cache.as_ref().map(|it| it.raw()),
+                cache: cache.as_ref().map(|it| it.raw()).transpose()?,
             };
             unsafe { self.raw().create_render_pipeline(&pipeline_desc) }.map_err(
                 |err| match err {
@@ -5326,6 +5328,35 @@ impl Device {
     pub unsafe fn create_pipeline_cache(
         self: &Arc<Self>,
         desc: &pipeline::PipelineCacheDescriptor,
+    ) -> (
+        Arc<pipeline::PipelineCache>,
+        Option<pipeline::CreatePipelineCacheError>,
+    ) {
+        let (cache, error) = match unsafe { self.create_pipeline_cache_inner(desc) } {
+            Ok(cache) => (cache, None),
+            Err(e) => (
+                pipeline::PipelineCache::invalid(self.clone(), desc),
+                Some(e),
+            ),
+        };
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use trace::IntoTrace;
+            trace.add(trace::Action::CreatePipelineCache {
+                id: cache.to_trace(),
+                desc: desc.clone(),
+            });
+        }
+        api_log!("Device::create_pipeline_cache -> {:?}", Arc::as_ptr(&cache));
+        (cache, error)
+    }
+
+    /// # Safety
+    /// The `data` field on `desc` must have previously been returned from
+    /// [`crate::global::Global::pipeline_cache_get_data`]
+    pub(crate) unsafe fn create_pipeline_cache_inner(
+        self: &Arc<Self>,
+        desc: &pipeline::PipelineCacheDescriptor,
     ) -> Result<Arc<pipeline::PipelineCache>, pipeline::CreatePipelineCacheError> {
         use crate::pipeline_cache;
 
@@ -5365,7 +5396,7 @@ impl Device {
             device: self.clone(),
             label: desc.label.to_string(),
             // This would be none in the error condition, which we don't implement yet
-            raw: ManuallyDrop::new(raw),
+            raw: ResourceState::Valid(raw),
         };
 
         let cache = Arc::new(cache);

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -203,7 +203,7 @@ pub struct Hub {
     pub(crate) render_bundles: Registry<Arc<RenderBundle>>,
     pub(crate) render_pipelines: Registry<Arc<RenderPipeline>>,
     pub(crate) compute_pipelines: Registry<Arc<ComputePipeline>>,
-    pub(crate) pipeline_caches: Registry<Fallible<PipelineCache>>,
+    pub(crate) pipeline_caches: Registry<Arc<PipelineCache>>,
     pub(crate) query_sets: Registry<Arc<QuerySet>>,
     pub(crate) buffers: Registry<Fallible<Buffer>>,
     pub(crate) staging_buffers: Registry<StagingBuffer>,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -14,6 +14,7 @@ use wgt::error::{ErrorType, WebGpuError};
 
 pub use crate::pipeline_cache::PipelineCacheValidationError;
 use crate::{
+    api_log,
     binding_model::{
         BindGroupLayout, CreateBindGroupLayoutError, CreatePipelineLayoutError,
         GetBindGroupLayoutError, PipelineLayout,
@@ -24,10 +25,11 @@ use crate::{
         RenderPassContext,
     },
     id::{PipelineCacheId, PipelineLayoutId, ShaderModuleId},
+    pipeline_cache,
     resource::{InvalidResourceError, Labeled, ResourceState, TrackingData},
     resource_log,
     validation::{self, ShaderMetaData},
-    Label,
+    Label, LabelHelpers as _,
 };
 
 /// Information about buffer bindings, which
@@ -461,19 +463,28 @@ impl WebGpuError for CreatePipelineCacheError {
 
 #[derive(Debug)]
 pub struct PipelineCache {
-    pub(crate) raw: ManuallyDrop<Box<dyn hal::DynPipelineCache>>,
+    pub(crate) raw: ResourceState<Box<dyn hal::DynPipelineCache>>,
     pub(crate) device: Arc<Device>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
 }
 
 impl Drop for PipelineCache {
+    #[allow(trivial_casts)]
     fn drop(&mut self) {
+        profiling::scope!("PipelineCache::drop");
+        api_log!("PipelineCache::drop {:?}", self as *const _);
+        #[cfg(feature = "trace")]
+        if let Some(t) = self.device.trace.lock().as_mut() {
+            use crate::device::trace::{to_trace, Action};
+            t.add(Action::DropPipelineCache(unsafe { to_trace(self) }));
+        }
         resource_log!("Destroy raw {}", self.error_ident());
-        // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
-        let raw = unsafe { ManuallyDrop::take(&mut self.raw) };
-        unsafe {
-            self.device.raw().destroy_pipeline_cache(raw);
+        if let ResourceState::Valid(raw) = core::mem::replace(&mut self.raw, ResourceState::Invalid)
+        {
+            unsafe {
+                self.device.raw().destroy_pipeline_cache(raw);
+            }
         }
     }
 }
@@ -484,8 +495,51 @@ crate::impl_parent_device!(PipelineCache);
 crate::impl_storage_item!(PipelineCache);
 
 impl PipelineCache {
-    pub(crate) fn raw(&self) -> &dyn hal::DynPipelineCache {
-        self.raw.as_ref()
+    pub(crate) fn raw(&self) -> Result<&dyn hal::DynPipelineCache, InvalidResourceError> {
+        self.raw
+            .as_ref()
+            .valid()
+            .map(|raw| raw.as_ref())
+            .ok_or_else(|| InvalidResourceError(self.error_ident()))
+    }
+
+    pub(crate) fn check_is_valid(&self) -> Result<(), InvalidResourceError> {
+        self.raw().map(|_| ())
+    }
+
+    pub(crate) fn invalid(device: Arc<Device>, desc: &PipelineCacheDescriptor) -> Arc<Self> {
+        Arc::new(Self {
+            raw: ResourceState::Invalid,
+            device,
+            label: desc.label.to_string(),
+        })
+    }
+
+    pub fn get_data(self: &Arc<Self>) -> Option<Vec<u8>> {
+        api_log!("PipelineCache::get_data");
+
+        let ResourceState::Valid(raw) = &self.raw else {
+            return None;
+        };
+
+        if !self.device.is_valid() {
+            return None;
+        }
+        let mut vec = unsafe { self.device.raw().pipeline_cache_get_data(raw.as_ref()) }?;
+        let validation_key = self.device.raw().pipeline_cache_validation_key()?;
+
+        let mut header_contents = [0; pipeline_cache::HEADER_LENGTH];
+        pipeline_cache::add_cache_header(
+            &mut header_contents,
+            &vec,
+            &self.device.adapter.raw.info,
+            validation_key,
+        );
+
+        let deleted = vec.splice(..0, header_contents).collect::<Vec<_>>();
+        debug_assert!(deleted.is_empty());
+
+        Some(vec)
     }
 }
 


### PR DESCRIPTION
**Connections**
Towards #5121

**Description**
As always we move validity into PipelineCache by wrapping raw with ResourceState (there is some todo coment above none, but I am not sure to what exactly does it refer to). `pipeline_cache_get_data` is has now main logic in `PipelineCache::GetData`. Tracing and logging is also moved inside PipelineCache.

**Testing**
Just refactor.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
