### PR TITLE
[core] Move validity into `Arc<Sampler>`

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -171,7 +171,7 @@ impl Player {
                     .expect("invalid external texture");
             }
             Action::CreateSampler(id, desc) => {
-                let sampler = device.create_sampler(&desc).expect("create_sampler error");
+                let (sampler, _error) = device.create_sampler(&desc);
                 self.samplers.insert(id, sampler);
             }
             Action::DropSampler(id) => {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -583,51 +583,22 @@ impl Global {
         desc: &resource::SamplerDescriptor,
         id_in: Option<id::SamplerId>,
     ) -> (id::SamplerId, Option<resource::CreateSamplerError>) {
-        profiling::scope!("Device::create_sampler");
-
         let hub = &self.hub;
         let fid = hub.samplers.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
-            let sampler = match device.create_sampler(desc) {
-                Ok(sampler) => sampler,
-                Err(e) => break 'error e,
-            };
+        let (sampler, error) = device.create_sampler(desc);
 
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                trace.add(trace::Action::CreateSampler(
-                    sampler.to_trace(),
-                    desc.clone(),
-                ));
-            }
+        let id = fid.assign(sampler);
 
-            let id = fid.assign(Fallible::Valid(sampler));
-            api_log!("Device::create_sampler -> {id:?}");
-
-            return (id, None);
-        };
-
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
-        (id, Some(error))
+        (id, error)
     }
 
     pub fn sampler_drop(&self, sampler_id: id::SamplerId) {
-        profiling::scope!("Sampler::drop");
-        api_log!("Sampler::drop {sampler_id:?}");
-
         let hub = &self.hub;
 
         let _sampler = hub.samplers.remove(sampler_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(sampler) = _sampler.get() {
-            if let Some(t) = sampler.device.trace.lock().as_mut() {
-                t.add(trace::Action::DropSampler(sampler.to_trace()));
-            }
-        }
     }
 
     pub fn device_create_bind_group_layout(
@@ -731,7 +702,7 @@ impl Global {
             fn resolve_entry<'a>(
                 e: &BindGroupEntry<'a>,
                 buffer_storage: &Storage<Fallible<resource::Buffer>>,
-                sampler_storage: &Storage<Fallible<resource::Sampler>>,
+                sampler_storage: &Storage<Arc<resource::Sampler>>,
                 texture_view_storage: &Storage<Arc<resource::TextureView>>,
                 tlas_storage: &Storage<Fallible<resource::Tlas>>,
                 external_texture_storage: &Storage<Fallible<resource::ExternalTexture>>,
@@ -748,12 +719,7 @@ impl Global {
                         })
                         .map_err(binding_model::CreateBindGroupError::from)
                 };
-                let resolve_sampler = |id: &id::SamplerId| {
-                    sampler_storage
-                        .get(*id)
-                        .get()
-                        .map_err(binding_model::CreateBindGroupError::from)
-                };
+                let resolve_sampler = |id: &id::SamplerId| sampler_storage.get(*id);
                 let resolve_view = |id: &id::TextureViewId| texture_view_storage.get(*id);
                 let resolve_tlas = |id: &id::TlasId| {
                     tlas_storage
@@ -779,13 +745,10 @@ impl Global {
                         ResolvedBindingResource::BufferArray(Cow::Owned(buffers))
                     }
                     BindingResource::Sampler(ref sampler) => {
-                        ResolvedBindingResource::Sampler(resolve_sampler(sampler)?)
+                        ResolvedBindingResource::Sampler(resolve_sampler(sampler))
                     }
                     BindingResource::SamplerArray(ref samplers) => {
-                        let samplers = samplers
-                            .iter()
-                            .map(resolve_sampler)
-                            .collect::<Result<Vec<_>, _>>()?;
+                        let samplers = samplers.iter().map(resolve_sampler).collect::<Vec<_>>();
                         ResolvedBindingResource::SamplerArray(Cow::Owned(samplers))
                     }
                     BindingResource::TextureView(ref view) => {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2288,6 +2288,28 @@ impl Device {
     pub fn create_sampler(
         self: &Arc<Self>,
         desc: &resource::SamplerDescriptor,
+    ) -> (Arc<Sampler>, Option<resource::CreateSamplerError>) {
+        profiling::scope!("Device::create_sampler");
+
+        let (sampler, error) = match self.create_sampler_inner(desc) {
+            Ok(sampler) => (sampler, None),
+            Err(e) => (Sampler::invalid(Arc::clone(self), desc), Some(e)),
+        };
+
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use crate::device::trace::{Action, IntoTrace as _};
+            trace.add(Action::CreateSampler(sampler.to_trace(), desc.clone()));
+        }
+
+        api_log!("Device::create_sampler -> {:?}", Arc::as_ptr(&sampler));
+
+        (sampler, error)
+    }
+
+    pub(crate) fn create_sampler_inner(
+        self: &Arc<Self>,
+        desc: &resource::SamplerDescriptor,
     ) -> Result<Arc<Sampler>, resource::CreateSamplerError> {
         self.check_is_valid()?;
 
@@ -2381,7 +2403,7 @@ impl Device {
             .map_err(|e| self.handle_hal_error_with_nonfatal_oom(e))?;
 
         let sampler = Sampler {
-            raw: ManuallyDrop::new(raw),
+            raw: ResourceState::Valid(raw),
             device: self.clone(),
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.samplers.clone()),
@@ -3209,7 +3231,7 @@ impl Device {
             }
         }
 
-        Ok(sampler.raw())
+        Ok(sampler.raw()?)
     }
 
     fn create_texture_binding<'a>(

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -210,7 +210,7 @@ pub struct Hub {
     pub(crate) textures: Registry<Arc<Texture>>,
     pub(crate) texture_views: Registry<Arc<TextureView>>,
     pub(crate) external_textures: Registry<Fallible<ExternalTexture>>,
-    pub(crate) samplers: Registry<Fallible<Sampler>>,
+    pub(crate) samplers: Registry<Arc<Sampler>>,
     pub(crate) blas_s: Registry<Fallible<Blas>>,
     pub(crate) tlas_s: Registry<Fallible<Tlas>>,
     pub(crate) render_passes: Registry<Arc<Mutex<RenderPass>>>,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2307,7 +2307,7 @@ pub struct SamplerDescriptor<'a> {
 
 #[derive(Debug)]
 pub struct Sampler {
-    pub(crate) raw: ManuallyDrop<Box<dyn hal::DynSampler>>,
+    pub(crate) raw: ResourceState<Box<dyn hal::DynSampler>>,
     pub(crate) device: Arc<Device>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
@@ -2319,19 +2319,43 @@ pub struct Sampler {
 }
 
 impl Drop for Sampler {
+    #[allow(trivial_casts)]
     fn drop(&mut self) {
+        profiling::scope!("Sampler::drop");
+        api_log!("Sampler::drop {:?}", self as *const _);
+        #[cfg(feature = "trace")]
+        if let Some(t) = self.device.trace.lock().as_mut() {
+            t.add(trace::Action::DropSampler(unsafe { trace::to_trace(self) }));
+        }
         resource_log!("Destroy raw {}", self.error_ident());
-        // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
-        let raw = unsafe { ManuallyDrop::take(&mut self.raw) };
-        unsafe {
-            self.device.raw().destroy_sampler(raw);
+        if let ResourceState::Valid(raw) = mem::replace(&mut self.raw, ResourceState::Invalid) {
+            unsafe {
+                self.device.raw().destroy_sampler(raw);
+            }
         }
     }
 }
 
 impl Sampler {
-    pub(crate) fn raw(&self) -> &dyn hal::DynSampler {
-        self.raw.as_ref()
+    pub(crate) fn raw(&self) -> Result<&dyn hal::DynSampler, InvalidResourceError> {
+        self.raw
+            .as_ref()
+            .valid()
+            .map(|raw| raw.as_ref())
+            .ok_or_else(|| InvalidResourceError(self.error_ident()))
+    }
+
+    pub(crate) fn invalid(device: Arc<Device>, desc: &SamplerDescriptor) -> Arc<Self> {
+        Arc::new(Sampler {
+            raw: ResourceState::Invalid,
+            label: desc.label.to_string(),
+            tracking_data: TrackingData::new(device.tracker_indices.samplers.clone()),
+            device,
+            comparison: desc.compare.is_some(),
+            filtering: desc.mag_filter == wgt::FilterMode::Linear
+                || desc.min_filter == wgt::FilterMode::Linear
+                || desc.mipmap_filter == wgt::MipmapFilterMode::Linear,
+        })
     }
 }
 


### PR DESCRIPTION
**Connections**
Towards #5121

**Description**
As always we move validity into Sampler by wrapping raw with ResourceState. Tracing and logging is also moved inside PipelineCache.

**Testing**
Just refactor.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
