### PR TITLE
[core] Move validity into `Arc<Blas>`

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -432,7 +432,7 @@ impl Player {
                 panic!("Error recorded in trace: {error}");
             }
             Action::CreateBlas { id, desc, sizes } => {
-                let blas = device.create_blas(&desc, sizes).expect("create_blas error");
+                let (blas, _error) = device.create_blas(&desc, sizes);
                 self.blas_s.insert(id, blas);
             }
             Action::DropBlas(id) => {

--- a/wgpu-core/src/as_hal.rs
+++ b/wgpu-core/src/as_hal.rs
@@ -322,7 +322,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let blas = hub.blas_s.get(id).get().ok()?;
+        let blas = hub.blas_s.get(id);
 
         SnatchableResourceGuard::new(blas)
     }

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -50,10 +50,6 @@ struct TlasStore<'a> {
 }
 
 impl Global {
-    fn resolve_blas_id(&self, blas_id: BlasId) -> Result<Arc<Blas>, InvalidResourceError> {
-        self.hub.blas_s.get(blas_id).get()
-    }
-
     fn resolve_tlas_id(&self, tlas_id: TlasId) -> Result<Arc<Tlas>, InvalidResourceError> {
         self.hub.tlas_s.get(tlas_id).get()
     }
@@ -81,7 +77,9 @@ impl Global {
                 let mut build_command = AsBuild::with_capacity(blas_ids.len(), tlas_ids.len());
 
                 for blas in blas_ids {
-                    let blas = hub.blas_s.get(*blas).get()?;
+                    let blas = hub.blas_s.get(*blas);
+                    blas.check_is_valid()?;
+                    // TODO: we should probably do same device check too
                     build_command.blas_s_built.push(blas);
                 }
 
@@ -153,10 +151,9 @@ impl Global {
                             ArcBlasGeometries::AabbGeometries(aabb_geo)
                         }
                     };
-                    Ok(ArcBlasBuildEntry {
-                        blas: self.resolve_blas_id(blas_entry.blas_id)?,
-                        geometries,
-                    })
+                    let blas = hub.blas_s.get(blas_entry.blas_id);
+                    blas.check_is_valid()?;
+                    Ok(ArcBlasBuildEntry { blas, geometries })
                 })
                 .collect::<Result<_, BuildAccelerationStructureError>>()?;
 
@@ -168,8 +165,10 @@ impl Global {
                             instance
                                 .as_ref()
                                 .map(|instance| {
+                                    let blas = hub.blas_s.get(instance.blas_id);
+                                    blas.check_is_valid()?;
                                     Ok(ArcTlasInstance {
-                                        blas: self.resolve_blas_id(instance.blas_id)?,
+                                        blas,
                                         transform: *instance.transform,
                                         custom_data: instance.custom_data,
                                         mask: instance.mask,

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -79,7 +79,6 @@ impl Global {
                 for blas in blas_ids {
                     let blas = hub.blas_s.get(*blas);
                     blas.check_is_valid()?;
-                    // TODO: we should probably do same device check too
                     build_command.blas_s_built.push(blas);
                 }
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -33,11 +33,11 @@ use crate::{
     lock::{rank, Mutex, MutexGuard, RwLock, RwLockWriteGuard},
     ray_tracing::{BlasCompactReadyPendingClosure, CompactBlasError},
     resource::{
-        Blas, BlasCompactState, Buffer, BufferAccessError, BufferMapState, DestroyedBuffer,
-        DestroyedQuerySet, DestroyedResourceError, DestroyedTexture, Fallible,
-        FlushedStagingBuffer, InvalidOrDestroyedResourceError, InvalidResourceError, Labeled,
-        ParentDevice, ResourceErrorIdent, StagingBuffer, Texture, TextureInner, Trackable,
-        TrackingData,
+        Blas, BlasCompactState, BlasDescriptor, BlasState, Buffer, BufferAccessError,
+        BufferMapState, DestroyedBuffer, DestroyedQuerySet, DestroyedResourceError,
+        DestroyedTexture, Fallible, FlushedStagingBuffer, InvalidOrDestroyedResourceError,
+        InvalidResourceError, Labeled, ParentDevice, ResourceErrorIdent, ResourceState,
+        StagingBuffer, Texture, TextureInner, Trackable, TrackingData,
     },
     resource_log,
     scratch::ScratchBuffer,
@@ -1761,13 +1761,52 @@ impl Queue {
         self.lock_life().add_work_done_closure(closure)
     }
 
-    pub fn compact_blas(&self, blas: &Arc<Blas>) -> Result<Arc<Blas>, CompactBlasError> {
+    #[allow(trivial_casts)]
+    pub fn compact_blas(&self, blas: &Arc<Blas>) -> (Arc<Blas>, Option<CompactBlasError>) {
+        api_log!(
+            "Queue::compact_blas {:?}, {:?}",
+            self as *const _,
+            Arc::as_ptr(blas)
+        );
+
+        let (blas, error) = match self.compact_blas_inner(blas) {
+            Ok(blas) => (blas, None),
+            Err(err) => {
+                let new_label = blas.label.clone() + " (compacted)";
+                (
+                    Blas::invalid(
+                        self.device.clone(),
+                        &BlasDescriptor {
+                            label: Some(new_label.into()),
+                            flags: blas.flags,
+                            update_mode: blas.update_mode,
+                        },
+                    ),
+                    Some(err),
+                )
+            }
+        };
+
+        // TODO: Tracing
+
+        (blas, error)
+    }
+
+    pub(crate) fn compact_blas_inner(
+        &self,
+        blas: &Arc<Blas>,
+    ) -> Result<Arc<Blas>, CompactBlasError> {
         profiling::scope!("Queue::compact_blas");
         api_log!("Queue::compact_blas");
 
         let new_label = blas.label.clone() + " (compacted)";
 
         self.device.check_is_valid()?;
+
+        self.device
+            .require_features(wgpu_types::Features::EXPERIMENTAL_RAY_QUERY)?;
+
+        blas.check_is_valid()?;
         self.same_device_as(blas.as_ref())?;
 
         let device = blas.device.clone();
@@ -1821,7 +1860,9 @@ impl Queue {
                 .unwrap();
 
         let new_blas = Arc::new(Blas {
-            raw: Snatchable::new(raw),
+            state: ResourceState::Valid(BlasState {
+                raw: Snatchable::new(raw),
+            }),
             device: device.clone(),
             size_info,
             sizes: blas.sizes.clone(),
@@ -1838,6 +1879,12 @@ impl Queue {
 
         pending_writes.insert_blas(blas);
         pending_writes.insert_blas(&new_blas);
+
+        // We should have no more errors after this because we have marked the command encoder as successful.
+        let old_blas_size = blas.size_info.acceleration_structure_size;
+        let new_blas_size = new_blas.size_info.acceleration_structure_size;
+
+        api_log!("CommandEncoder::compact_blas {:?} (size: {old_blas_size}) -> {:?} (size: {new_blas_size})", Arc::as_ptr(blas), Arc::as_ptr(&new_blas));
 
         Ok(new_blas)
     }
@@ -2006,47 +2053,17 @@ impl Global {
         blas_id: BlasId,
         id_in: Option<BlasId>,
     ) -> (BlasId, Option<u64>, Option<CompactBlasError>) {
-        api_log!("Queue::compact_blas {queue_id:?}, {blas_id:?}");
-
         let fid = self.hub.blas_s.prepare(id_in);
 
         let queue = self.hub.queues.get(queue_id);
         let blas = self.hub.blas_s.get(blas_id);
-        let device = &queue.device;
 
-        // TODO: Tracing
+        let (blas, error) = queue.compact_blas(&blas);
 
-        let error = 'error: {
-            match device.require_features(wgpu_types::Features::EXPERIMENTAL_RAY_QUERY) {
-                Ok(_) => {}
-                Err(err) => break 'error err.into(),
-            }
+        let handle = blas.handle();
+        let id = fid.assign(blas);
 
-            let blas = match blas.get() {
-                Ok(blas) => blas,
-                Err(err) => break 'error err.into(),
-            };
-
-            let new_blas = match queue.compact_blas(&blas) {
-                Ok(blas) => blas,
-                Err(err) => break 'error err,
-            };
-
-            // We should have no more errors after this because we have marked the command encoder as successful.
-            let old_blas_size = blas.size_info.acceleration_structure_size;
-            let new_blas_size = new_blas.size_info.acceleration_structure_size;
-            let handle = new_blas.handle;
-
-            let id = fid.assign(Fallible::Valid(new_blas));
-
-            api_log!("CommandEncoder::compact_blas {blas_id:?} (size: {old_blas_size}) -> {id:?} (size: {new_blas_size})");
-
-            return (id, Some(handle), None);
-        };
-
-        let id = fid.assign(Fallible::Invalid(Arc::new(error.to_string())));
-
-        (id, None, Some(error))
+        (id, handle, error)
     }
 }
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1,4 +1,6 @@
-use alloc::{boxed::Box, string::ToString, sync::Arc, vec, vec::Vec};
+#[cfg(feature = "trace")]
+use alloc::string::ToString as _;
+use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 use core::{
     iter,
     mem::{self, ManuallyDrop},

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -29,6 +29,31 @@ impl Device {
         self: &Arc<Self>,
         blas_desc: &resource::BlasDescriptor,
         sizes: wgt::BlasGeometrySizeDescriptors,
+    ) -> (Arc<resource::Blas>, Option<CreateBlasError>) {
+        #[cfg(feature = "trace")]
+        let trace_sizes = sizes.clone();
+
+        let (blas, error) = match self.create_blas_inner(blas_desc, sizes) {
+            Ok(blas) => (blas, None),
+            Err(err) => (resource::Blas::invalid(self.clone(), blas_desc), Some(err)),
+        };
+
+        #[cfg(feature = "trace")]
+        if let Some(trace) = self.trace.lock().as_mut() {
+            trace.add(Action::CreateBlas {
+                id: blas.to_trace(),
+                desc: blas_desc.clone(),
+                sizes: trace_sizes,
+            });
+        }
+
+        api_log!("Device::create_blas -> {:?}", Arc::as_ptr(&blas));
+        (blas, error)
+    }
+    pub(crate) fn create_blas_inner(
+        self: &Arc<Self>,
+        blas_desc: &resource::BlasDescriptor,
+        sizes: wgt::BlasGeometrySizeDescriptors,
     ) -> Result<Arc<resource::Blas>, CreateBlasError> {
         self.check_is_valid()?;
         self.require_features(Features::EXPERIMENTAL_RAY_QUERY)?;
@@ -194,7 +219,9 @@ impl Device {
         };
 
         Ok(Arc::new(resource::Blas {
-            raw: Snatchable::new(raw),
+            state: resource::ResourceState::Valid(resource::BlasState {
+                raw: Snatchable::new(raw),
+            }),
             device: self.clone(),
             size_info,
             sizes,
@@ -309,35 +336,15 @@ impl Global {
 
         let fid = self.hub.blas_s.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
-            #[cfg(feature = "trace")]
-            let trace_sizes = sizes.clone();
+        let (blas, error) = device.create_blas(desc, sizes);
 
-            let blas = match device.create_blas(desc, sizes) {
-                Ok(blas) => blas,
-                Err(e) => break 'error e,
-            };
-            let handle = blas.handle;
+        let handle = blas.handle();
 
-            #[cfg(feature = "trace")]
-            if let Some(trace) = device.trace.lock().as_mut() {
-                trace.add(Action::CreateBlas {
-                    id: blas.to_trace(),
-                    desc: desc.clone(),
-                    sizes: trace_sizes,
-                });
-            }
+        let id = fid.assign(blas);
 
-            let id = fid.assign(Fallible::Valid(blas));
-            api_log!("Device::create_blas -> {id:?}");
-
-            return (id, Some(handle), None);
-        };
-
-        let id = fid.assign(Fallible::Invalid(Arc::new(error.to_string())));
-        (id, None, Some(error))
+        (id, handle, error)
     }
 
     pub fn device_create_tlas(
@@ -377,17 +384,7 @@ impl Global {
     }
 
     pub fn blas_drop(&self, blas_id: BlasId) {
-        profiling::scope!("Blas::drop");
-        api_log!("Blas::drop {blas_id:?}");
-
         let _blas = self.hub.blas_s.remove(blas_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(blas) = _blas.get() {
-            if let Some(t) = blas.device.trace.lock().as_mut() {
-                t.add(Action::DropBlas(blas.to_trace()));
-            }
-        }
     }
 
     pub fn tlas_drop(&self, tlas_id: TlasId) {
@@ -409,37 +406,18 @@ impl Global {
         blas_id: BlasId,
         callback: Option<BlasCompactCallback>,
     ) -> Result<crate::SubmissionIndex, BlasPrepareCompactError> {
-        profiling::scope!("Blas::prepare_compact_async");
-        api_log!("Blas::prepare_compact_async {blas_id:?}");
-
         let hub = &self.hub;
 
-        let compact_result = match hub.blas_s.get(blas_id).get() {
-            Ok(blas) => blas.prepare_compact_async(callback),
-            Err(e) => Err((callback, e.into())),
-        };
+        let blas = hub.blas_s.get(blas_id);
 
-        match compact_result {
-            Ok(submission_index) => Ok(submission_index),
-            Err((mut callback, err)) => {
-                if let Some(callback) = callback.take() {
-                    callback(Err(err.clone()));
-                }
-                Err(err)
-            }
-        }
+        blas.prepare_compact_async(callback)
     }
 
     pub fn ready_for_compaction(&self, blas_id: BlasId) -> Result<bool, InvalidResourceError> {
-        profiling::scope!("Blas::prepare_compact_async");
-        api_log!("Blas::prepare_compact_async {blas_id:?}");
-
         let hub = &self.hub;
 
-        let blas = hub.blas_s.get(blas_id).get()?;
+        let blas = hub.blas_s.get(blas_id);
 
-        let lock = blas.compacted_state.lock();
-
-        Ok(matches!(*lock, BlasCompactState::Ready { .. }))
+        blas.ready_for_compaction()
     }
 }

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -211,7 +211,7 @@ pub struct Hub {
     pub(crate) texture_views: Registry<Arc<TextureView>>,
     pub(crate) external_textures: Registry<Fallible<ExternalTexture>>,
     pub(crate) samplers: Registry<Arc<Sampler>>,
-    pub(crate) blas_s: Registry<Fallible<Blas>>,
+    pub(crate) blas_s: Registry<Arc<Blas>>,
     pub(crate) tlas_s: Registry<Fallible<Tlas>>,
     pub(crate) render_passes: Registry<Arc<Mutex<RenderPass>>>,
     pub(crate) compute_passes: Registry<Arc<Mutex<ComputePass>>>,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2647,8 +2647,13 @@ unsafe impl Send for BlasCompactState {}
 unsafe impl Sync for BlasCompactState {}
 
 #[derive(Debug)]
-pub struct Blas {
+pub(crate) struct BlasState {
     pub(crate) raw: Snatchable<Box<dyn hal::DynAccelerationStructure>>,
+}
+
+#[derive(Debug)]
+pub struct Blas {
+    pub(crate) state: ResourceState<BlasState>,
     pub(crate) device: Arc<Device>,
     pub(crate) size_info: hal::AccelerationStructureBuildSizes,
     pub(crate) sizes: wgt::BlasGeometrySizeDescriptors,
@@ -2664,12 +2669,22 @@ pub struct Blas {
 }
 
 impl Drop for Blas {
+    #[allow(trivial_casts)]
     fn drop(&mut self) {
+        profiling::scope!("Blas::drop");
+        api_log!("Blas::drop {:?}", self as *const _);
+        #[cfg(feature = "trace")]
+        if let Some(t) = self.device.trace.lock().as_mut() {
+            use crate::device::trace::{to_trace, Action};
+            t.add(Action::DropBlas(unsafe { to_trace(self) }));
+        }
         resource_log!("Destroy raw {}", self.error_ident());
         // SAFETY: We are in the Drop impl, and we don't use self.raw or self.compaction_buffer anymore after this point.
-        if let Some(raw) = self.raw.take() {
-            unsafe {
-                self.device.raw().destroy_acceleration_structure(raw);
+        if let ResourceState::Valid(state) = &mut self.state {
+            if let Some(raw) = state.raw.take() {
+                unsafe {
+                    self.device.raw().destroy_acceleration_structure(raw);
+                }
             }
         }
         if let Some(mut raw) = self.compaction_buffer.take() {
@@ -2686,17 +2701,88 @@ impl RawResourceAccess for Blas {
     type DynResource = dyn hal::DynAccelerationStructure;
 
     fn raw<'a>(&'a self, guard: &'a SnatchGuard) -> Option<&'a Self::DynResource> {
-        self.raw.get(guard).map(|it| it.as_ref())
+        self.state().ok()?.raw.get(guard).map(|it| it.as_ref())
     }
 }
 
 impl Blas {
-    pub(crate) fn prepare_compact_async(
+    pub(crate) fn state(&self) -> Result<&BlasState, InvalidResourceError> {
+        match &self.state {
+            ResourceState::Valid(state) => Ok(state),
+            ResourceState::Invalid => Err(InvalidResourceError(self.error_ident())),
+        }
+    }
+
+    pub(crate) fn check_is_valid(&self) -> Result<(), InvalidResourceError> {
+        self.state().map(|_| ())
+    }
+
+    pub(crate) fn invalid(device: Arc<Device>, desc: &BlasDescriptor) -> Arc<Self> {
+        Arc::new(Blas {
+            state: ResourceState::Invalid,
+            size_info: hal::AccelerationStructureBuildSizes {
+                acceleration_structure_size: 0,
+                update_scratch_size: 0,
+                build_scratch_size: 0,
+            },
+            sizes: wgt::BlasGeometrySizeDescriptors::Triangles {
+                descriptors: Vec::new(),
+            },
+            flags: desc.flags,
+            update_mode: desc.update_mode,
+            built_index: RwLock::new(rank::BLAS_BUILT_INDEX, None),
+            handle: 0,
+            label: desc.label.to_string(),
+            tracking_data: TrackingData::new(device.tracker_indices.blas_s.clone()),
+            device,
+            compaction_buffer: None,
+            compacted_state: Mutex::new(rank::BLAS_COMPACTION_STATE, BlasCompactState::Idle),
+        })
+    }
+
+    pub fn handle(&self) -> Option<u64> {
+        Some(self.handle)
+    }
+
+    pub fn ready_for_compaction(self: &Arc<Self>) -> Result<bool, InvalidResourceError> {
+        profiling::scope!("Blas::prepare_compact_async");
+        api_log!("Blas::prepare_compact_async {:?}", Arc::as_ptr(self));
+
+        self.check_is_valid()?;
+        let state = self.compacted_state.lock();
+        Ok(matches!(*state, BlasCompactState::Ready { .. }))
+    }
+
+    pub fn prepare_compact_async(
+        self: &Arc<Self>,
+        callback: Option<BlasCompactCallback>,
+    ) -> Result<SubmissionIndex, BlasPrepareCompactError> {
+        profiling::scope!("Blas::prepare_compact_async");
+        api_log!("Blas::prepare_compact_async {:?}", Arc::as_ptr(self));
+
+        let compact_result = self.prepare_compact_async_inner(callback);
+
+        match compact_result {
+            Ok(submission_index) => Ok(submission_index),
+            Err((mut callback, err)) => {
+                if let Some(callback) = callback.take() {
+                    callback(Err(err.clone()));
+                }
+                Err(err)
+            }
+        }
+    }
+
+    fn prepare_compact_async_inner(
         self: &Arc<Self>,
         op: Option<BlasCompactCallback>,
     ) -> Result<SubmissionIndex, (Option<BlasCompactCallback>, BlasPrepareCompactError)> {
         let device = &self.device;
         if let Err(e) = device.check_is_valid() {
+            return Err((op, e.into()));
+        }
+
+        if let Err(e) = self.check_is_valid() {
             return Err((op, e.into()));
         }
 


### PR DESCRIPTION
**Connections**
Towards #5121

**Description**
As always we move validity into Blas by wrapping raw with ResourceState. Tracing and logging is also moved inside Blas (where present).

**Testing**
Just refactor.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
