### PR TITLE
[core] Move validity into `Arc<Tlas>`

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -437,7 +437,7 @@ impl Player {
                 self.blas_s.remove(&id).expect("invalid blas");
             }
             Action::CreateTlas { id, desc } => {
-                let tlas = device.create_tlas(&desc).expect("create_tlas error");
+                let (tlas, _error) = device.create_tlas(&desc);
                 self.tlas_s.insert(id, tlas);
             }
             Action::DropTlas(id) => {

--- a/wgpu-core/src/as_hal.rs
+++ b/wgpu-core/src/as_hal.rs
@@ -338,7 +338,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let tlas = hub.tlas_s.get(id).get().ok()?;
+        let tlas = hub.tlas_s.get(id);
 
         SnatchableResourceGuard::new(tlas)
     }

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -10,7 +10,6 @@ use wgt::{math::align_to, BufferUsages, BufferUses, Features};
 use crate::{
     command::encoder::EncodingState,
     ray_tracing::{AsAction, AsBuild, TlasBuild, ValidateAsActionsError},
-    resource::InvalidResourceError,
 };
 use crate::{command::EncoderStateError, device::resource::CommandIndices};
 use crate::{
@@ -50,10 +49,6 @@ struct TlasStore<'a> {
 }
 
 impl Global {
-    fn resolve_tlas_id(&self, tlas_id: TlasId) -> Result<Arc<Tlas>, InvalidResourceError> {
-        self.hub.tlas_s.get(tlas_id).get()
-    }
-
     pub fn command_encoder_mark_acceleration_structures_built(
         &self,
         command_encoder_id: CommandEncoderId,
@@ -83,7 +78,8 @@ impl Global {
                 }
 
                 for tlas in tlas_ids {
-                    let tlas = hub.tlas_s.get(*tlas).get()?;
+                    let tlas = hub.tlas_s.get(*tlas);
+                    tlas.check_is_valid()?;
                     build_command.tlas_s_built.push(TlasBuild {
                         tlas,
                         dependencies: Vec::new(),
@@ -176,8 +172,10 @@ impl Global {
                                 .transpose()
                         })
                         .collect::<Result<_, BuildAccelerationStructureError>>()?;
+                    let tlas = self.hub.tlas_s.get(tlas_package.tlas_id);
+                    tlas.check_is_valid()?;
                     Ok(ArcTlasPackage {
-                        tlas: self.resolve_tlas_id(tlas_package.tlas_id)?,
+                        tlas,
                         instances,
                         lowest_unmodified: tlas_package.lowest_unmodified,
                     })
@@ -287,7 +285,7 @@ pub(crate) fn build_acceleration_structures(
                 tlas: tlas.clone(),
                 entries: hal::AccelerationStructureEntries::Instances(
                     hal::AccelerationStructureInstances {
-                        buffer: Some(tlas.instance_buffer.as_ref()),
+                        buffer: Some(tlas.state()?.instance_buffer.as_ref()),
                         offset: 0,
                         count: instance_count,
                     },
@@ -407,8 +405,9 @@ pub(crate) fn build_acceleration_structures(
                 None => continue,
                 Some(size) => size,
             };
+            let tlas_state = tlas.state()?;
             instance_buffer_barriers.push(hal::BufferBarrier::<dyn hal::DynBuffer> {
-                buffer: tlas.instance_buffer.as_ref(),
+                buffer: tlas_state.instance_buffer.as_ref(),
                 usage: hal::StateTransition {
                     from: BufferUses::COPY_DST,
                     to: BufferUses::TOP_LEVEL_ACCELERATION_STRUCTURE_INPUT,
@@ -416,7 +415,7 @@ pub(crate) fn build_acceleration_structures(
             });
             unsafe {
                 raw_encoder.transition_buffers(&[hal::BufferBarrier::<dyn hal::DynBuffer> {
-                    buffer: tlas.instance_buffer.as_ref(),
+                    buffer: tlas_state.instance_buffer.as_ref(),
                     usage: hal::StateTransition {
                         from: BufferUses::TOP_LEVEL_ACCELERATION_STRUCTURE_INPUT,
                         to: BufferUses::COPY_DST,
@@ -429,7 +428,7 @@ pub(crate) fn build_acceleration_structures(
                 };
                 raw_encoder.copy_buffer_to_buffer(
                     staging_buffer.as_ref().unwrap().raw(),
-                    tlas.instance_buffer.as_ref(),
+                    tlas_state.instance_buffer.as_ref(),
                     &[temp],
                 );
             }

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -665,7 +665,7 @@ impl Global {
                 buffer_storage: &Storage<Fallible<resource::Buffer>>,
                 sampler_storage: &Storage<Arc<resource::Sampler>>,
                 texture_view_storage: &Storage<Arc<resource::TextureView>>,
-                tlas_storage: &Storage<Fallible<resource::Tlas>>,
+                tlas_storage: &Storage<Arc<resource::Tlas>>,
                 external_texture_storage: &Storage<Arc<resource::ExternalTexture>>,
             ) -> Result<ResolvedBindGroupEntry<'a>, binding_model::CreateBindGroupError>
             {
@@ -682,12 +682,7 @@ impl Global {
                 };
                 let resolve_sampler = |id: &id::SamplerId| sampler_storage.get(*id);
                 let resolve_view = |id: &id::TextureViewId| texture_view_storage.get(*id);
-                let resolve_tlas = |id: &id::TlasId| {
-                    tlas_storage
-                        .get(*id)
-                        .get()
-                        .map_err(binding_model::CreateBindGroupError::from)
-                };
+                let resolve_tlas = |id: &id::TlasId| tlas_storage.get(*id);
                 let resolve_external_texture =
                     |id: &id::ExternalTextureId| external_texture_storage.get(*id);
                 let resource = match e.resource {
@@ -716,13 +711,10 @@ impl Global {
                         ResolvedBindingResource::TextureViewArray(Cow::Owned(views))
                     }
                     BindingResource::AccelerationStructure(ref tlas) => {
-                        ResolvedBindingResource::AccelerationStructure(resolve_tlas(tlas)?)
+                        ResolvedBindingResource::AccelerationStructure(resolve_tlas(tlas))
                     }
                     BindingResource::AccelerationStructureArray(ref tlas_array) => {
-                        let tlas_array = tlas_array
-                            .iter()
-                            .map(resolve_tlas)
-                            .collect::<Result<Vec<_>, _>>()?;
+                        let tlas_array = tlas_array.iter().map(resolve_tlas).collect::<Vec<_>>();
                         ResolvedBindingResource::AccelerationStructureArray(Cow::Owned(tlas_array))
                     }
                     BindingResource::ExternalTexture(ref et) => {

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -1,9 +1,10 @@
-use alloc::{string::ToString as _, sync::Arc, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 use core::mem::{size_of, ManuallyDrop};
 
 #[cfg(feature = "trace")]
 use crate::device::trace::{Action, IntoTrace};
 use crate::device::DeviceError;
+use crate::resource::ResourceState;
 use crate::{
     api_log,
     device::Device,
@@ -15,9 +16,7 @@ use crate::{
     ray_tracing::BlasPrepareCompactError,
     ray_tracing::{CreateBlasError, CreateTlasError},
     resource,
-    resource::{
-        BlasCompactCallback, BlasCompactState, Fallible, InvalidResourceError, TrackingData,
-    },
+    resource::{BlasCompactCallback, BlasCompactState, InvalidResourceError, TrackingData},
     snatch::Snatchable,
     LabelHelpers,
 };
@@ -219,7 +218,7 @@ impl Device {
         };
 
         Ok(Arc::new(resource::Blas {
-            state: resource::ResourceState::Valid(resource::BlasState {
+            state: ResourceState::Valid(resource::BlasState {
                 raw: Snatchable::new(raw),
             }),
             device: self.clone(),
@@ -237,6 +236,27 @@ impl Device {
     }
 
     pub fn create_tlas(
+        self: &Arc<Self>,
+        desc: &resource::TlasDescriptor,
+    ) -> (Arc<resource::Tlas>, Option<CreateTlasError>) {
+        let (tlas, error) = match self.create_tlas_inner(desc) {
+            Ok(tlas) => (tlas, None),
+            Err(e) => (resource::Tlas::invalid(Arc::clone(self), desc), Some(e)),
+        };
+        #[cfg(feature = "trace")]
+        if let Some(trace) = self.trace.lock().as_mut() {
+            trace.add(Action::CreateTlas {
+                id: tlas.to_trace(),
+                desc: desc.clone(),
+            });
+        }
+
+        api_log!("Device::create_tlas -> {:?}", Arc::as_ptr(&tlas));
+
+        (tlas, error)
+    }
+
+    pub(crate) fn create_tlas_inner(
         self: &Arc<Self>,
         desc: &resource::TlasDescriptor,
     ) -> Result<Arc<resource::Tlas>, CreateTlasError> {
@@ -309,14 +329,16 @@ impl Device {
         .map_err(|e| self.handle_hal_error_with_nonfatal_oom(e))?;
 
         Ok(Arc::new(resource::Tlas {
-            raw: Snatchable::new(raw),
+            state: ResourceState::Valid(resource::TlasState {
+                raw: Snatchable::new(raw),
+                instance_buffer,
+            }),
             device: self.clone(),
             size_info,
             flags: desc.flags,
             update_mode: desc.update_mode,
             built_index: RwLock::new(rank::TLAS_BUILT_INDEX, None),
             dependencies: RwLock::new(rank::TLAS_DEPENDENCIES, Vec::new()),
-            instance_buffer: ManuallyDrop::new(instance_buffer),
             label: desc.label.to_string(),
             max_instance_count: desc.max_instances,
             tracking_data: TrackingData::new(self.tracker_indices.tlas_s.clone()),
@@ -357,30 +379,13 @@ impl Global {
 
         let fid = self.hub.tlas_s.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
-            let tlas = match device.create_tlas(desc) {
-                Ok(tlas) => tlas,
-                Err(e) => break 'error e,
-            };
+        let (tlas, error) = device.create_tlas(desc);
 
-            #[cfg(feature = "trace")]
-            if let Some(trace) = device.trace.lock().as_mut() {
-                trace.add(Action::CreateTlas {
-                    id: tlas.to_trace(),
-                    desc: desc.clone(),
-                });
-            }
+        let id = fid.assign(tlas);
 
-            let id = fid.assign(Fallible::Valid(tlas));
-            api_log!("Device::create_tlas -> {id:?}");
-
-            return (id, None);
-        };
-
-        let id = fid.assign(Fallible::Invalid(Arc::new(error.to_string())));
-        (id, Some(error))
+        (id, error)
     }
 
     pub fn blas_drop(&self, blas_id: BlasId) {
@@ -388,17 +393,7 @@ impl Global {
     }
 
     pub fn tlas_drop(&self, tlas_id: TlasId) {
-        profiling::scope!("Tlas::drop");
-        api_log!("Tlas::drop {tlas_id:?}");
-
         let _tlas = self.hub.tlas_s.remove(tlas_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(tlas) = _tlas.get() {
-            if let Some(t) = tlas.device.trace.lock().as_mut() {
-                t.add(Action::DropTlas(tlas.to_trace()));
-            }
-        }
     }
 
     pub fn blas_prepare_compact_async(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3447,6 +3447,7 @@ impl Device {
 
         used.acceleration_structures.insert_single(tlas.clone());
 
+        tlas.check_is_valid()?;
         tlas.same_device(self)?;
 
         match decl.ty {

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -212,7 +212,7 @@ pub struct Hub {
     pub(crate) external_textures: Registry<Arc<ExternalTexture>>,
     pub(crate) samplers: Registry<Arc<Sampler>>,
     pub(crate) blas_s: Registry<Arc<Blas>>,
-    pub(crate) tlas_s: Registry<Fallible<Tlas>>,
+    pub(crate) tlas_s: Registry<Arc<Tlas>>,
     pub(crate) render_passes: Registry<Arc<Mutex<RenderPass>>>,
     pub(crate) compute_passes: Registry<Arc<Mutex<ComputePass>>>,
     pub(crate) render_bundle_encoders: Registry<Arc<Mutex<RenderBundleEncoder>>>,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2918,8 +2918,14 @@ crate::impl_storage_item!(Blas);
 crate::impl_trackable!(Blas);
 
 #[derive(Debug)]
-pub struct Tlas {
+pub(crate) struct TlasState {
     pub(crate) raw: Snatchable<Box<dyn hal::DynAccelerationStructure>>,
+    pub(crate) instance_buffer: Box<dyn hal::DynBuffer>,
+}
+
+#[derive(Debug)]
+pub struct Tlas {
+    pub(crate) state: ResourceState<TlasState>,
     pub(crate) device: Arc<Device>,
     pub(crate) size_info: hal::AccelerationStructureBuildSizes,
     pub(crate) max_instance_count: u32,
@@ -2927,22 +2933,64 @@ pub struct Tlas {
     pub(crate) update_mode: wgt::AccelerationStructureUpdateMode,
     pub(crate) built_index: RwLock<Option<NonZeroU64>>,
     pub(crate) dependencies: RwLock<Vec<Arc<Blas>>>,
-    pub(crate) instance_buffer: ManuallyDrop<Box<dyn hal::DynBuffer>>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
     pub(crate) tracking_data: TrackingData,
 }
 
 impl Drop for Tlas {
+    #[allow(trivial_casts)]
     fn drop(&mut self) {
-        unsafe {
-            resource_log!("Destroy raw {}", self.error_ident());
-            if let Some(structure) = self.raw.take() {
-                self.device.raw().destroy_acceleration_structure(structure);
-            }
-            let buffer = ManuallyDrop::take(&mut self.instance_buffer);
-            self.device.raw().destroy_buffer(buffer);
+        profiling::scope!("Tlas::drop");
+        api_log!("Tlas::drop {:?}", self as *const _);
+
+        #[cfg(feature = "trace")]
+        if let Some(t) = self.device.trace.lock().as_mut() {
+            use crate::device::trace::{to_trace, Action};
+            t.add(Action::DropTlas(unsafe { to_trace(self) }));
         }
+
+        resource_log!("Destroy raw {}", self.error_ident());
+        let ResourceState::Valid(mut state) = mem::replace(&mut self.state, ResourceState::Invalid)
+        else {
+            return;
+        };
+        if let Some(structure) = state.raw.take() {
+            unsafe { self.device.raw().destroy_acceleration_structure(structure) };
+        }
+        unsafe { self.device.raw().destroy_buffer(state.instance_buffer) };
+    }
+}
+
+impl Tlas {
+    pub(crate) fn state(&self) -> Result<&TlasState, InvalidResourceError> {
+        match &self.state {
+            ResourceState::Valid(state) => Ok(state),
+            ResourceState::Invalid => Err(InvalidResourceError(self.error_ident())),
+        }
+    }
+
+    pub(crate) fn check_is_valid(&self) -> Result<(), InvalidResourceError> {
+        self.state().map(|_| ())
+    }
+
+    pub(crate) fn invalid(device: Arc<Device>, desc: &TlasDescriptor) -> Arc<Self> {
+        Arc::new(Self {
+            state: ResourceState::Invalid,
+            label: desc.label.to_string(),
+            tracking_data: TrackingData::new(device.tracker_indices.tlas_s.clone()),
+            size_info: hal::AccelerationStructureBuildSizes {
+                acceleration_structure_size: 0,
+                update_scratch_size: 0,
+                build_scratch_size: 0,
+            },
+            max_instance_count: desc.max_instances,
+            flags: desc.flags,
+            update_mode: desc.update_mode,
+            built_index: RwLock::new(rank::TLAS_BUILT_INDEX, None),
+            dependencies: RwLock::new(rank::TLAS_DEPENDENCIES, Vec::new()),
+            device,
+        })
     }
 }
 
@@ -2950,7 +2998,7 @@ impl RawResourceAccess for Tlas {
     type DynResource = dyn hal::DynAccelerationStructure;
 
     fn raw<'a>(&'a self, guard: &'a SnatchGuard) -> Option<&'a Self::DynResource> {
-        self.raw.get(guard).map(|raw| raw.as_ref())
+        self.state().ok()?.raw.get(guard).map(|raw| raw.as_ref())
     }
 }
 


### PR DESCRIPTION
**Connections**
Towards #5121

**Description**
As always we move validity into Tlas by wrapping raw with ResourceState. Tracing and logging is also moved inside Tlas (where present).

**Testing**
Just refactor.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
