### PR TITLE
[core] Move validity into `Arc<Buffer>`

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -110,7 +110,7 @@ impl Player {
                 panic!("Unexpected Surface action: winit feature is not enabled")
             }
             Action::CreateBuffer(id, desc) => {
-                let buffer = device.create_buffer(&desc).expect("create_buffer error");
+                let (buffer, _error) = device.create_buffer(&desc);
                 self.buffers.insert(id, buffer);
             }
             Action::DestroyBuffer(id) => {

--- a/wgpu-core/src/as_hal.rs
+++ b/wgpu-core/src/as_hal.rs
@@ -165,7 +165,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let buffer = hub.buffers.get(id).get().ok()?;
+        let buffer = hub.buffers.get(id);
 
         SnatchableResourceGuard::new(buffer)
     }

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -935,13 +935,14 @@ fn set_pipeline(
 // This function is duplicative of `render::set_index_buffer`.
 fn set_index_buffer(
     state: &mut State,
-    buffer_guard: &crate::storage::Storage<Fallible<Buffer>>,
+    buffer_guard: &crate::storage::Storage<Arc<Buffer>>,
     buffer_id: id::Id<id::markers::Buffer>,
     index_format: wgt::IndexFormat,
     offset: u64,
     size: Option<NonZeroU64>,
 ) -> Result<(), RenderBundleErrorInner> {
-    let buffer = buffer_guard.get(buffer_id).get()?;
+    let buffer = buffer_guard.get(buffer_id);
+    buffer.check_is_valid()?;
 
     state
         .trackers
@@ -974,7 +975,7 @@ fn set_index_buffer(
 // This function is duplicative of `render::set_vertex_buffer`.
 fn set_vertex_buffer(
     state: &mut State,
-    buffer_guard: &crate::storage::Storage<Fallible<Buffer>>,
+    buffer_guard: &crate::storage::Storage<Arc<Buffer>>,
     slot: u32,
     buffer_id: Option<id::Id<id::markers::Buffer>>,
     offset: u64,
@@ -990,7 +991,8 @@ fn set_vertex_buffer(
     }
 
     if let Some(buffer_id) = buffer_id {
-        let buffer = buffer_guard.get(buffer_id).get()?;
+        let buffer = buffer_guard.get(buffer_id);
+        buffer.check_is_valid()?;
 
         state
             .trackers
@@ -1189,7 +1191,7 @@ fn draw_mesh_tasks(
 
 fn multi_draw_indirect(
     state: &mut State,
-    buffer_guard: &crate::storage::Storage<Fallible<Buffer>>,
+    buffer_guard: &crate::storage::Storage<Arc<Buffer>>,
     buffer_id: id::Id<id::markers::Buffer>,
     offset: u64,
     family: DrawCommandFamily,
@@ -1199,8 +1201,9 @@ fn multi_draw_indirect(
         .device
         .require_downlevel_flags(wgt::DownlevelFlags::INDIRECT_EXECUTION)?;
 
-    let buffer = buffer_guard.get(buffer_id).get()?;
+    let buffer = buffer_guard.get(buffer_id);
 
+    buffer.check_is_valid()?;
     buffer.same_device(&state.device)?;
     buffer.check_usage(wgt::BufferUsages::INDIRECT)?;
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -127,8 +127,10 @@ impl Global {
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, ClearError> {
+            let buffer = self.resolve_buffer_id(dst);
+            buffer.check_is_valid()?;
             Ok(ArcCommand::ClearBuffer {
-                dst: self.resolve_buffer_id(dst)?,
+                dst: buffer,
                 offset,
                 size,
             })

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1429,7 +1429,9 @@ impl Global {
         let scope = PassErrorScope::Dispatch { indirect: true };
         let base = pass_base!(pass, scope);
 
-        let buffer = pass_try!(base, scope, hub.buffers.get(buffer_id).get());
+        let buffer = hub.buffers.get(buffer_id);
+
+        pass_try!(base, scope, buffer.check_is_valid());
 
         base.commands
             .push(ArcComputeCommand::DispatchWorkgroupsIndirect { buffer, offset });
@@ -1643,8 +1645,10 @@ impl Global {
             scope,
             buffer_transitions
                 .map(|buffer_transition| -> Result<_, InvalidResourceError> {
+                    let buffer = hub.buffers.get(buffer_transition.buffer);
+                    buffer.check_is_valid()?;
                     Ok(wgt::BufferTransition {
-                        buffer: hub.buffers.get(buffer_transition.buffer).get()?,
+                        buffer,
                         state: buffer_transition.state,
                     })
                 })

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -89,7 +89,6 @@ pub use timestamp_writes::PassTimestampWrites;
 use crate::binding_model::BindingError;
 use crate::device::queue::TempResource;
 use crate::device::{Device, DeviceError, MissingFeatures};
-use crate::id::Id;
 use crate::lock::{rank, Mutex};
 use crate::snatch::SnatchGuard;
 
@@ -1764,13 +1763,6 @@ impl WebGpuError for TimestampWritesError {
 }
 
 impl Global {
-    fn resolve_buffer_id(
-        &self,
-        buffer_id: Id<id::markers::Buffer>,
-    ) -> Result<Arc<crate::resource::Buffer>, InvalidResourceError> {
-        self.hub.buffers.get(buffer_id).get()
-    }
-
     /// Finishes a command encoder, creating a command buffer and returning errors that were
     /// deferred until now.
     ///

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -466,11 +466,13 @@ impl Global {
         cmd_buf_data.push_with(|| -> Result<_, QueryError> {
             let query_set = self.resolve_query_set_id(query_set_id);
             query_set.check_is_valid()?;
+            let buffer = self.resolve_buffer_id(destination);
+            buffer.check_is_valid()?;
             Ok(ArcCommand::ResolveQuerySet {
                 query_set,
                 start_query,
                 query_count,
-                destination: self.resolve_buffer_id(destination)?,
+                destination: buffer,
                 destination_offset,
             })
         })

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -10,6 +10,7 @@ use wgt::{math::align_to, BufferUsages, BufferUses, Features};
 use crate::{
     command::encoder::EncodingState,
     ray_tracing::{AsAction, AsBuild, TlasBuild, ValidateAsActionsError},
+    resource::InvalidResourceError,
 };
 use crate::{command::EncoderStateError, device::resource::CommandIndices};
 use crate::{
@@ -112,16 +113,26 @@ impl Global {
                         BlasGeometries::TriangleGeometries(triangle_geometries) => {
                             let tri_geo = triangle_geometries
                                 .map(|tg| {
+                                    let vertex_buffer = self.resolve_buffer_id(tg.vertex_buffer);
+                                    vertex_buffer.check_is_valid()?;
                                     Ok(ArcBlasTriangleGeometry {
                                         size: tg.size.clone(),
-                                        vertex_buffer: self.resolve_buffer_id(tg.vertex_buffer)?,
+                                        vertex_buffer,
                                         index_buffer: tg
                                             .index_buffer
-                                            .map(|id| self.resolve_buffer_id(id))
+                                            .map(|id| -> Result<_, InvalidResourceError> {
+                                                let index_buffer = self.resolve_buffer_id(id);
+                                                index_buffer.check_is_valid()?;
+                                                Ok(index_buffer)
+                                            })
                                             .transpose()?,
                                         transform_buffer: tg
                                             .transform_buffer
-                                            .map(|id| self.resolve_buffer_id(id))
+                                            .map(|id| -> Result<_, InvalidResourceError> {
+                                                let transform_buffer = self.resolve_buffer_id(id);
+                                                transform_buffer.check_is_valid()?;
+                                                Ok(transform_buffer)
+                                            })
                                             .transpose()?,
                                         first_vertex: tg.first_vertex,
                                         vertex_stride: tg.vertex_stride,
@@ -135,10 +146,12 @@ impl Global {
                         BlasGeometries::AabbGeometries(aabb_geometries) => {
                             let aabb_geo = aabb_geometries
                                 .map(|ag| {
+                                    let aabb_buffer = self.resolve_buffer_id(ag.aabb_buffer);
+                                    aabb_buffer.check_is_valid()?;
                                     Ok(ArcBlasAabbGeometry {
                                         size: ag.size.clone(),
                                         stride: ag.stride,
-                                        aabb_buffer: self.resolve_buffer_id(ag.aabb_buffer)?,
+                                        aabb_buffer,
                                         primitive_offset: ag.primitive_offset,
                                     })
                                 })

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -3749,8 +3749,11 @@ impl Global {
         let scope = PassErrorScope::SetIndexBuffer;
         let base = pass_base!(pass, scope);
 
+        let buffer = self.resolve_buffer_id(buffer_id);
+        pass_try!(base, scope, buffer.check_is_valid());
+
         base.commands.push(ArcRenderCommand::SetIndexBuffer {
-            buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+            buffer,
             index_format,
             offset,
             size,
@@ -3786,7 +3789,9 @@ impl Global {
         let base = pass_base!(pass, scope);
 
         let buffer = if let Some(buffer_id) = buffer_id {
-            Some(pass_try!(base, scope, self.resolve_buffer_id(buffer_id)))
+            let buffer = self.resolve_buffer_id(buffer_id);
+            pass_try!(base, scope, buffer.check_is_valid());
+            Some(buffer)
         } else {
             None
         };
@@ -4120,8 +4125,11 @@ impl Global {
         };
         let base = pass_base!(pass, scope);
 
+        let buffer = self.resolve_buffer_id(buffer_id);
+        pass_try!(base, scope, buffer.check_is_valid());
+
         base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+            buffer,
             offset,
             count: 1,
             family: DrawCommandFamily::Draw,
@@ -4158,8 +4166,11 @@ impl Global {
         };
         let base = pass_base!(pass, scope);
 
+        let buffer = self.resolve_buffer_id(buffer_id);
+        pass_try!(base, scope, buffer.check_is_valid());
+
         base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+            buffer,
             offset,
             count: 1,
             family: DrawCommandFamily::DrawIndexed,
@@ -4196,8 +4207,11 @@ impl Global {
         };
         let base = pass_base!(pass, scope);
 
+        let buffer = self.resolve_buffer_id(buffer_id);
+        pass_try!(base, scope, buffer.check_is_valid());
+
         base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+            buffer,
             offset,
             count: 1,
             family: DrawCommandFamily::DrawMeshTasks,
@@ -4222,8 +4236,11 @@ impl Global {
         };
         let base = pass_base!(pass, scope);
 
+        let buffer = self.resolve_buffer_id(buffer_id);
+        pass_try!(base, scope, buffer.check_is_valid());
+
         base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+            buffer,
             offset,
             count,
             family: DrawCommandFamily::Draw,
@@ -4248,8 +4265,11 @@ impl Global {
         };
         let base = pass_base!(pass, scope);
 
+        let buffer = self.resolve_buffer_id(buffer_id);
+        pass_try!(base, scope, buffer.check_is_valid());
+
         base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+            buffer,
             offset,
             count,
             family: DrawCommandFamily::DrawIndexed,
@@ -4274,8 +4294,11 @@ impl Global {
         };
         let base = pass_base!(pass, scope);
 
+        let buffer = self.resolve_buffer_id(buffer_id);
+        pass_try!(base, scope, buffer.check_is_valid());
+
         base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+            buffer,
             offset,
             count,
             family: DrawCommandFamily::DrawMeshTasks,
@@ -4302,11 +4325,16 @@ impl Global {
         };
         let base = pass_base!(pass, scope);
 
+        let buffer = self.resolve_buffer_id(buffer_id);
+        pass_try!(base, scope, buffer.check_is_valid());
+        let count_buffer = self.resolve_buffer_id(count_buffer_id);
+        pass_try!(base, scope, count_buffer.check_is_valid());
+
         base.commands
             .push(ArcRenderCommand::MultiDrawIndirectCount {
-                buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+                buffer,
                 offset,
-                count_buffer: pass_try!(base, scope, self.resolve_buffer_id(count_buffer_id)),
+                count_buffer,
                 count_buffer_offset,
                 max_count,
                 family: DrawCommandFamily::Draw,
@@ -4330,11 +4358,16 @@ impl Global {
         };
         let base = pass_base!(pass, scope);
 
+        let buffer = self.resolve_buffer_id(buffer_id);
+        pass_try!(base, scope, buffer.check_is_valid());
+        let count_buffer = self.resolve_buffer_id(count_buffer_id);
+        pass_try!(base, scope, count_buffer.check_is_valid());
+
         base.commands
             .push(ArcRenderCommand::MultiDrawIndirectCount {
-                buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+                buffer,
                 offset,
-                count_buffer: pass_try!(base, scope, self.resolve_buffer_id(count_buffer_id)),
+                count_buffer,
                 count_buffer_offset,
                 max_count,
                 family: DrawCommandFamily::DrawIndexed,
@@ -4358,11 +4391,16 @@ impl Global {
         };
         let base = pass_base!(pass, scope);
 
+        let buffer = self.resolve_buffer_id(buffer_id);
+        pass_try!(base, scope, buffer.check_is_valid());
+        let count_buffer = self.resolve_buffer_id(count_buffer_id);
+        pass_try!(base, scope, count_buffer.check_is_valid());
+
         base.commands
             .push(ArcRenderCommand::MultiDrawIndirectCount {
-                buffer: pass_try!(base, scope, self.resolve_buffer_id(buffer_id)),
+                buffer,
                 offset,
-                count_buffer: pass_try!(base, scope, self.resolve_buffer_id(count_buffer_id)),
+                count_buffer,
                 count_buffer_offset,
                 max_count,
                 family: DrawCommandFamily::DrawMeshTasks,

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -846,10 +846,14 @@ impl Global {
         let mut cmd_buf_data = cmd_enc.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
+            let source_buffer = self.resolve_buffer_id(source);
+            source_buffer.check_is_valid()?;
+            let destination_buffer = self.resolve_buffer_id(destination);
+            destination_buffer.check_is_valid()?;
             Ok(ArcCommand::CopyBufferToBuffer {
-                src: self.resolve_buffer_id(source)?,
+                src: source_buffer,
                 src_offset: source_offset,
-                dst: self.resolve_buffer_id(destination)?,
+                dst: destination_buffer,
                 dst_offset: destination_offset,
                 size,
             })
@@ -877,9 +881,11 @@ impl Global {
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
             let texture = self.resolve_texture_id(destination.texture);
             texture.check_valid()?;
+            let source_buffer = self.resolve_buffer_id(source.buffer);
+            source_buffer.check_is_valid()?;
             Ok(ArcCommand::CopyBufferToTexture {
                 src: wgt::TexelCopyBufferInfo::<Arc<Buffer>> {
-                    buffer: self.resolve_buffer_id(source.buffer)?,
+                    buffer: source_buffer,
                     layout: source.layout,
                 },
                 dst: wgt::TexelCopyTextureInfo::<Arc<Texture>> {
@@ -914,6 +920,8 @@ impl Global {
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
             let texture = self.resolve_texture_id(source.texture);
             texture.check_valid()?;
+            let destination_buffer = self.resolve_buffer_id(destination.buffer);
+            destination_buffer.check_is_valid()?;
             Ok(ArcCommand::CopyTextureToBuffer {
                 src: wgt::TexelCopyTextureInfo::<Arc<Texture>> {
                     texture,
@@ -922,7 +930,7 @@ impl Global {
                     aspect: source.aspect,
                 },
                 dst: wgt::TexelCopyBufferInfo::<Arc<Buffer>> {
-                    buffer: self.resolve_buffer_id(destination.buffer)?,
+                    buffer: destination_buffer,
                     layout: destination.layout,
                 },
                 size: *copy_size,

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -30,8 +30,10 @@ impl Global {
             Ok(ArcCommand::TransitionResources {
                 buffer_transitions: buffer_transitions
                     .map(|t| {
+                        let buffer = self.resolve_buffer_id(t.buffer);
+                        buffer.check_is_valid()?;
                         Ok(wgt::BufferTransition {
-                            buffer: self.resolve_buffer_id(t.buffer)?,
+                            buffer,
                             state: t.state,
                         })
                     })

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -142,43 +142,13 @@ impl Global {
         let hub = &self.hub;
         let fid = hub.buffers.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
-            let buffer = match device.create_buffer(desc) {
-                Ok(buffer) => buffer,
-                Err(e) => {
-                    break 'error e;
-                }
-            };
+        let (buffer, error) = device.create_buffer(desc);
 
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                let mut desc = desc.clone();
-                let mapped_at_creation = core::mem::replace(&mut desc.mapped_at_creation, false);
-                if mapped_at_creation && !desc.usage.contains(wgt::BufferUsages::MAP_WRITE) {
-                    desc.usage |= wgt::BufferUsages::COPY_DST;
-                }
-                trace.add(trace::Action::CreateBuffer(buffer.to_trace(), desc));
-            }
+        let id = fid.assign(buffer);
 
-            let id = fid.assign(Fallible::Valid(buffer));
-
-            api_log!(
-                "Device::create_buffer({:?}{}) -> {id:?}",
-                desc.label.as_deref().unwrap_or(""),
-                if desc.mapped_at_creation {
-                    ", mapped_at_creation"
-                } else {
-                    ""
-                }
-            );
-
-            return (id, None);
-        };
-
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
-        (id, Some(error))
+        (id, error)
     }
 
     /// Assign `id_in` an error with the given `label`.
@@ -211,11 +181,13 @@ impl Global {
     /// [`wgpu_types::BufferUsages`]: wgt::BufferUsages
     pub fn create_buffer_error(
         &self,
+        device_id: DeviceId,
         id_in: Option<id::BufferId>,
         desc: &resource::BufferDescriptor,
     ) {
         let fid = self.hub.buffers.prepare(id_in);
-        fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
+        let device = self.hub.devices.get(device_id);
+        fid.assign(resource::Buffer::invalid(device, desc));
     }
 
     /// Assign `id_in` an error with the given `label`.
@@ -289,17 +261,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let Ok(buffer) = hub.buffers.get(buffer_id).get() else {
-            // If the buffer is already invalid, there's nothing to do.
-            return;
-        };
-
-        #[cfg(feature = "trace")]
-        if let Some(trace) = buffer.device.trace.lock().as_mut() {
-            trace.add(trace::Action::DestroyBuffer(buffer.to_trace()));
-        }
-
-        let _ = buffer.unmap();
+        let buffer = hub.buffers.get(buffer_id);
 
         buffer.destroy();
     }
@@ -310,17 +272,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let buffer = match hub.buffers.remove(buffer_id).get() {
-            Ok(buffer) => buffer,
-            Err(_) => {
-                return;
-            }
-        };
-
-        #[cfg(feature = "trace")]
-        if let Some(t) = buffer.device.trace.lock().as_mut() {
-            t.add(trace::Action::DropBuffer(buffer.to_trace()));
-        }
+        let buffer = hub.buffers.remove(buffer_id);
 
         let _ = buffer.unmap();
     }
@@ -417,20 +369,7 @@ impl Global {
 
         let (buffer, err) = unsafe { device.create_buffer_from_hal(Box::new(hal_buffer), desc) };
 
-        // NB: Any change done through the raw buffer handle will not be
-        // recorded in the replay
-        #[cfg(feature = "trace")]
-        if let Some(trace) = device.trace.lock().as_mut() {
-            match &buffer {
-                Fallible::Valid(arc) => {
-                    trace.add(trace::Action::CreateBuffer(arc.to_trace(), desc.clone()))
-                }
-                Fallible::Invalid(_) => {}
-            }
-        }
-
         let id = fid.assign(buffer);
-        api_log!("Device::create_buffer -> {id:?}");
 
         (id, err)
     }
@@ -662,24 +601,23 @@ impl Global {
 
             fn resolve_entry<'a>(
                 e: &BindGroupEntry<'a>,
-                buffer_storage: &Storage<Fallible<resource::Buffer>>,
+                buffer_storage: &Storage<Arc<resource::Buffer>>,
                 sampler_storage: &Storage<Arc<resource::Sampler>>,
                 texture_view_storage: &Storage<Arc<resource::TextureView>>,
                 tlas_storage: &Storage<Arc<resource::Tlas>>,
                 external_texture_storage: &Storage<Arc<resource::ExternalTexture>>,
             ) -> Result<ResolvedBindGroupEntry<'a>, binding_model::CreateBindGroupError>
             {
-                let resolve_buffer = |bb: &BufferBinding| {
-                    buffer_storage
-                        .get(bb.buffer)
-                        .get()
-                        .map(|buffer| ResolvedBufferBinding {
+                let resolve_buffer =
+                    |bb: &BufferBinding| -> Result<_, binding_model::CreateBindGroupError> {
+                        let buffer = buffer_storage.get(bb.buffer);
+                        buffer.check_is_valid()?;
+                        Ok(ResolvedBufferBinding {
                             buffer,
                             offset: bb.offset,
                             size: bb.size,
                         })
-                        .map_err(binding_model::CreateBindGroupError::from)
-                };
+                    };
                 let resolve_sampler = |id: &id::SamplerId| sampler_storage.get(*id);
                 let resolve_view = |id: &id::TextureViewId| texture_view_storage.get(*id);
                 let resolve_tlas = |id: &id::TlasId| tlas_storage.get(*id);
@@ -1577,15 +1515,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let buffer = match hub.buffers.get(buffer_id).get() {
-            Ok(buffer) => buffer,
-            Err(err) => {
-                if let Some(callback) = op.callback {
-                    callback(Err(err.clone().into()));
-                }
-                return Err(err.into());
-            }
-        };
+        let buffer = hub.buffers.get(buffer_id);
 
         buffer.map_async(offset, size, op)
     }
@@ -1596,12 +1526,9 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferAddress>,
     ) -> Result<(NonNull<u8>, u64), BufferAccessError> {
-        profiling::scope!("Buffer::get_mapped_range");
-        api_log!("Buffer::get_mapped_range {buffer_id:?} offset {offset:?} size {size:?}");
-
         let hub = &self.hub;
 
-        let buffer = hub.buffers.get(buffer_id).get()?;
+        let buffer = hub.buffers.get(buffer_id);
 
         buffer.get_mapped_range(offset, size)
     }
@@ -1612,13 +1539,8 @@ impl Global {
 
         let hub = &self.hub;
 
-        let buffer = hub.buffers.get(buffer_id).get()?;
+        let buffer = hub.buffers.get(buffer_id);
 
-        let snatch_guard = buffer.device.snatchable_lock.read();
-        buffer.check_destroyed(&snatch_guard)?;
-        drop(snatch_guard);
-
-        buffer.device.check_is_valid()?;
         buffer.unmap()
     }
 }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -37,7 +37,7 @@ use crate::{
     resource::{
         Blas, BlasCompactState, BlasDescriptor, BlasState, Buffer, BufferAccessError,
         BufferMapState, DestroyedBuffer, DestroyedQuerySet, DestroyedResourceError,
-        DestroyedTexture, Fallible, FlushedStagingBuffer, InvalidOrDestroyedResourceError,
+        DestroyedTexture, FlushedStagingBuffer, InvalidOrDestroyedResourceError,
         InvalidResourceError, Labeled, ParentDevice, ResourceErrorIdent, ResourceState,
         StagingBuffer, Texture, TextureInner, Trackable, TrackingData,
     },
@@ -639,6 +639,21 @@ impl Queue {
         profiling::scope!("Queue::write_buffer");
         api_log!("Queue::write_buffer");
 
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.device.trace.lock() {
+            use crate::device::trace::DataKind;
+            let size = data.len() as u64;
+            let data = trace.make_binary(DataKind::Bin, data);
+            trace.add(Action::WriteBuffer {
+                id: buffer.to_trace(),
+                data,
+                offset: buffer_offset,
+                size,
+                queued: true,
+            });
+        }
+
+        buffer.check_is_valid()?;
         self.device.check_is_valid()?;
 
         let data_size = data.len() as wgt::BufferAddress;
@@ -706,15 +721,14 @@ impl Queue {
 
     pub fn write_staging_buffer(
         &self,
-        buffer: Fallible<Buffer>,
+        buffer: Arc<Buffer>,
         buffer_offset: wgt::BufferAddress,
         staging_buffer: StagingBuffer,
     ) -> Result<(), QueueWriteError> {
         profiling::scope!("Queue::write_staging_buffer");
 
+        buffer.check_is_valid()?;
         self.device.check_is_valid()?;
-
-        let buffer = buffer.get()?;
 
         // At this point, we have taken ownership of the staging_buffer from the
         // user. Platform validation requires that the staging buffer always
@@ -744,15 +758,14 @@ impl Queue {
 
     pub fn validate_write_buffer(
         &self,
-        buffer: Fallible<Buffer>,
+        buffer: Arc<Buffer>,
         buffer_offset: u64,
         buffer_size: wgt::BufferSize,
     ) -> Result<(), QueueWriteError> {
         profiling::scope!("Queue::validate_write_buffer");
 
         self.device.check_is_valid()?;
-
-        let buffer = buffer.get()?;
+        buffer.check_is_valid()?;
 
         self.validate_write_buffer_impl(&buffer, buffer_offset, buffer_size.into())?;
 
@@ -1901,21 +1914,7 @@ impl Global {
         data: &[u8],
     ) -> Result<(), QueueWriteError> {
         let queue = self.hub.queues.get(queue_id);
-        let buffer = self.hub.buffers.get(buffer_id).get()?;
-
-        #[cfg(feature = "trace")]
-        if let Some(ref mut trace) = *queue.device.trace.lock() {
-            use crate::device::trace::DataKind;
-            let size = data.len() as u64;
-            let data = trace.make_binary(DataKind::Bin, data);
-            trace.add(Action::WriteBuffer {
-                id: buffer.to_trace(),
-                data,
-                offset: buffer_offset,
-                size,
-                queued: true,
-            });
-        }
+        let buffer = self.hub.buffers.get(buffer_id);
 
         queue.write_buffer(buffer, buffer_offset, data)
     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -47,7 +47,7 @@ use crate::{
     pool::ResourcePool,
     present,
     resource::{
-        self, Buffer, ExternalTexture, ExternalTextureState, Fallible, Labeled, ParentDevice,
+        self, Buffer, BufferState, ExternalTexture, ExternalTextureState, Labeled, ParentDevice,
         QuerySet, QuerySetState, RawResourceAccess, ResourceState, Sampler, StagingBuffer, Texture,
         TextureView, TextureViewNotRenderableReason, TextureViewState, Tlas, TrackingData,
     },
@@ -1006,7 +1006,7 @@ impl Device {
         (user_closures, result)
     }
 
-    pub fn create_buffer(
+    pub fn create_buffer_inner(
         self: &Arc<Self>,
         desc: &resource::BufferDescriptor,
     ) -> Result<Arc<Buffer>, resource::CreateBufferError> {
@@ -1125,7 +1125,9 @@ impl Device {
             self.create_indirect_validation_bind_groups(buffer.as_ref(), desc.size, desc.usage)?;
 
         let buffer = Buffer {
-            raw: Snatchable::new(buffer),
+            state: ResourceState::Valid(BufferState {
+                raw: Snatchable::new(buffer),
+            }),
             device: self.clone(),
             usage: desc.usage,
             size: desc.size,
@@ -1182,6 +1184,37 @@ impl Device {
             .insert_single(&buffer, buffer_use);
 
         Ok(buffer)
+    }
+
+    pub fn create_buffer(
+        self: &Arc<Self>,
+        desc: &resource::BufferDescriptor,
+    ) -> (Arc<Buffer>, Option<resource::CreateBufferError>) {
+        let (buffer, error) = match self.create_buffer_inner(desc) {
+            Ok(buffer) => (buffer, None),
+            Err(e) => (Buffer::invalid(Arc::clone(self), desc), Some(e)),
+        };
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use trace::IntoTrace;
+            let mut desc = desc.clone();
+            let mapped_at_creation = mem::replace(&mut desc.mapped_at_creation, false);
+            if mapped_at_creation && !desc.usage.contains(wgt::BufferUsages::MAP_WRITE) {
+                desc.usage |= wgt::BufferUsages::COPY_DST;
+            }
+            trace.add(trace::Action::CreateBuffer(buffer.to_trace(), desc));
+        }
+        api_log!(
+            "Device::create_buffer({:?}{}) -> {:?}",
+            desc.label.as_deref().unwrap_or(""),
+            if desc.mapped_at_creation {
+                ", mapped_at_creation"
+            } else {
+                ""
+            },
+            Arc::as_ptr(&buffer)
+        );
+        (buffer, error)
     }
 
     #[cfg(feature = "replay")]
@@ -1283,14 +1316,40 @@ impl Device {
     /// - `hal_buffer` must have been created respecting `desc` (in particular, the size).
     /// - `hal_buffer` must be initialized.
     /// - `hal_buffer` must not have zero size.
-    pub(crate) unsafe fn create_buffer_from_hal(
+    pub unsafe fn create_buffer_from_hal(
         self: &Arc<Self>,
         hal_buffer: Box<dyn hal::DynBuffer>,
         desc: &resource::BufferDescriptor,
-    ) -> (Fallible<Buffer>, Option<resource::CreateBufferError>) {
-        let timestamp_normalization_bind_group = unsafe {
-            match self
-                .timestamp_normalizer
+    ) -> (Arc<Buffer>, Option<resource::CreateBufferError>) {
+        let (buffer, error) = match unsafe { self.create_buffer_from_hal_inner(hal_buffer, desc) } {
+            Ok(buffer) => (buffer, None),
+            Err(e) => (Buffer::invalid(Arc::clone(self), desc), Some(e)),
+        };
+
+        // NB: Any change done through the raw buffer handle will not be
+        // recorded in the replay
+        #[cfg(feature = "trace")]
+        if let Some(trace) = self.trace.lock().as_mut() {
+            use trace::IntoTrace;
+            trace.add(trace::Action::CreateBuffer(buffer.to_trace(), desc.clone()));
+        }
+        api_log!("Device::create_buffer -> {:?}", Arc::as_ptr(&buffer));
+        (buffer, error)
+    }
+
+    /// # Safety
+    ///
+    /// - `hal_buffer` must have been created on this device.
+    /// - `hal_buffer` must have been created respecting `desc` (in particular, the size).
+    /// - `hal_buffer` must be initialized.
+    /// - `hal_buffer` must not have zero size.
+    pub(crate) unsafe fn create_buffer_from_hal_inner(
+        self: &Arc<Self>,
+        hal_buffer: Box<dyn hal::DynBuffer>,
+        desc: &resource::BufferDescriptor,
+    ) -> Result<Arc<Buffer>, resource::CreateBufferError> {
+        let timestamp_normalization_bind_group = Snatchable::new(unsafe {
+            self.timestamp_normalizer
                 .get()
                 .unwrap()
                 .create_normalization_bind_group(
@@ -1299,30 +1358,21 @@ impl Device {
                     desc.label.as_deref(),
                     wgt::BufferSize::new(desc.size).unwrap(),
                     desc.usage,
-                ) {
-                Ok(bg) => Snatchable::new(bg),
-                Err(e) => {
-                    return (
-                        Fallible::Invalid(Arc::new(desc.label.to_string())),
-                        Some(e.into()),
-                    )
-                }
-            }
-        };
+                )?
+        });
 
-        let indirect_validation_bind_groups = match self.create_indirect_validation_bind_groups(
+        let indirect_validation_bind_groups = self.create_indirect_validation_bind_groups(
             hal_buffer.as_ref(),
             desc.size,
             desc.usage,
-        ) {
-            Ok(ok) => ok,
-            Err(e) => return (Fallible::Invalid(Arc::new(desc.label.to_string())), Some(e)),
-        };
+        )?;
 
         unsafe { self.raw().add_raw_buffer(&*hal_buffer) };
 
         let buffer = Buffer {
-            raw: Snatchable::new(hal_buffer),
+            state: ResourceState::Valid(BufferState {
+                raw: Snatchable::new(hal_buffer),
+            }),
             device: self.clone(),
             usage: desc.usage,
             size: desc.size,
@@ -1345,7 +1395,7 @@ impl Device {
             .buffers
             .insert_single(&buffer, wgt::BufferUses::empty());
 
-        (Fallible::Valid(buffer), None)
+        Ok(buffer)
     }
 
     fn create_indirect_validation_bind_groups(
@@ -2305,7 +2355,7 @@ impl Device {
             usage: wgt::BufferUsages::UNIFORM | wgt::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         };
-        let params = self.create_buffer(&params_desc)?;
+        let params = self.create_buffer_inner(&params_desc)?;
         self.get_queue().unwrap().write_buffer(
             params.clone(),
             0,

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -7,13 +7,14 @@ use crate::{
     device::{queue::Queue, Device},
     hub::{Hub, HubReport},
     id::{
-        AdapterId, BindGroupLayoutId, CommandBufferId, CommandEncoderId, ComputePipelineId,
-        DeviceId, PipelineLayoutId, QuerySetId, QueueId, RenderPipelineId, TextureId,
+        AdapterId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId,
+        ComputePipelineId, DeviceId, PipelineLayoutId, QuerySetId, QueueId, RenderPipelineId,
+        TextureId,
     },
     instance::{Adapter, Instance, Surface},
     pipeline::{ComputePipeline, RenderPipeline},
     registry::{Registry, RegistryReport},
-    resource::{QuerySet, Texture},
+    resource::{Buffer, QuerySet, Texture},
     resource_log,
 };
 
@@ -259,6 +260,18 @@ impl Global {
     /// Resolve a [`QuerySetId`] to the corresponding [`Arc<QuerySet>`] in the global hub.
     pub fn resolve_query_set_id(&self, query_set_id: QuerySetId) -> Arc<QuerySet> {
         self.hub.query_sets.get(query_set_id)
+    }
+
+    /// Import [`Arc<Buffer>`] into the global hub,
+    /// returning a [`BufferId`] under which the buffer is stored.
+    pub fn import_buffer(&self, buffer: Arc<Buffer>, id_in: Option<BufferId>) -> BufferId {
+        let fid = self.hub.buffers.prepare(id_in);
+        fid.assign(buffer)
+    }
+
+    /// Resolve a [`BufferId`] to the corresponding [`Arc<Buffer>`] in the global hub.
+    pub fn resolve_buffer_id(&self, buffer_id: BufferId) -> Arc<Buffer> {
+        self.hub.buffers.get(buffer_id)
     }
 
     /// Import [`Arc<Texture>`] into the global hub,

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -205,7 +205,7 @@ pub struct Hub {
     pub(crate) compute_pipelines: Registry<Arc<ComputePipeline>>,
     pub(crate) pipeline_caches: Registry<Arc<PipelineCache>>,
     pub(crate) query_sets: Registry<Arc<QuerySet>>,
-    pub(crate) buffers: Registry<Fallible<Buffer>>,
+    pub(crate) buffers: Registry<Arc<Buffer>>,
     pub(crate) staging_buffers: Registry<StagingBuffer>,
     pub(crate) textures: Registry<Arc<Texture>>,
     pub(crate) texture_views: Registry<Arc<TextureView>>,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -476,8 +476,13 @@ pub(crate) struct BufferPendingMapping {
 pub type BufferDescriptor<'a> = wgt::BufferDescriptor<Label<'a>>;
 
 #[derive(Debug)]
-pub struct Buffer {
+pub(crate) struct BufferState {
     pub(crate) raw: Snatchable<Box<dyn hal::DynBuffer>>,
+}
+
+#[derive(Debug)]
+pub struct Buffer {
+    pub(crate) state: ResourceState<BufferState>,
     pub(crate) device: Arc<Device>,
     pub(crate) usage: wgt::BufferUsages,
     pub(crate) size: wgt::BufferAddress,
@@ -494,6 +499,11 @@ pub struct Buffer {
 
 impl Drop for Buffer {
     fn drop(&mut self) {
+        #[cfg(feature = "trace")]
+        if let Some(t) = self.device.trace.lock().as_mut() {
+            t.add(trace::Action::DropBuffer(unsafe { trace::to_trace(self) }));
+        }
+
         if let Some(raw) = self.timestamp_normalization_bind_group.take() {
             raw.dispose(self.device.raw());
         }
@@ -502,7 +512,11 @@ impl Drop for Buffer {
             raw.dispose(self.device.raw());
         }
 
-        if let Some(raw) = self.raw.take() {
+        let ResourceState::Valid(state) = &mut self.state else {
+            return;
+        };
+
+        if let Some(raw) = state.raw.take() {
             resource_log!("Destroy raw {}", self.error_ident());
             unsafe {
                 self.device.raw().destroy_buffer(raw);
@@ -515,7 +529,9 @@ impl RawResourceAccess for Buffer {
     type DynResource = dyn hal::DynBuffer;
 
     fn raw<'a>(&'a self, guard: &'a SnatchGuard) -> Option<&'a Self::DynResource> {
-        self.raw.get(guard).map(|b| b.as_ref())
+        self.state()
+            .ok()
+            .and_then(|state| state.raw.get(guard).map(|b| b.as_ref()))
     }
 }
 
@@ -524,7 +540,11 @@ impl Buffer {
         &self,
         guard: &SnatchGuard,
     ) -> Result<(), DestroyedResourceError> {
-        self.raw
+        let ResourceState::Valid(state) = &self.state else {
+            return Ok(());
+        };
+        state
+            .raw
             .get(guard)
             .map(|_| ())
             .ok_or_else(|| DestroyedResourceError(self.error_ident()))
@@ -545,6 +565,36 @@ impl Buffer {
                 expected,
             })
         }
+    }
+
+    pub(crate) fn state(&self) -> Result<&BufferState, InvalidResourceError> {
+        match &self.state {
+            ResourceState::Valid(state) => Ok(state),
+            ResourceState::Invalid => Err(InvalidResourceError(self.error_ident())),
+        }
+    }
+
+    pub(crate) fn check_is_valid(&self) -> Result<(), InvalidResourceError> {
+        self.state().map(|_| ())
+    }
+
+    pub(crate) fn invalid(device: Arc<Device>, desc: &BufferDescriptor) -> Arc<Self> {
+        Arc::new(Buffer {
+            state: ResourceState::Invalid,
+            usage: desc.usage,
+            size: desc.size,
+            initialization_status: RwLock::new(
+                rank::BUFFER_INITIALIZATION_STATUS,
+                BufferInitTracker::new(0),
+            ),
+            map_state: Mutex::new(rank::BUFFER_MAP_STATE, BufferMapState::Idle),
+            label: desc.label.to_string(),
+            tracking_data: TrackingData::new(device.tracker_indices.buffers.clone()),
+            bind_groups: Mutex::new(rank::BUFFER_BIND_GROUPS, WeakVec::new()),
+            timestamp_normalization_bind_group: Snatchable::empty(),
+            indirect_validation_bind_groups: Snatchable::empty(),
+            device,
+        })
     }
 
     /// Resolve the size of a binding for buffer with `offset` and `size`.
@@ -675,6 +725,10 @@ impl Buffer {
             self.size.saturating_sub(offset)
         };
 
+        if let Err(e) = self.check_is_valid() {
+            return Err((op, e.into()));
+        }
+
         if !offset.is_multiple_of(wgt::MAP_ALIGNMENT) {
             return Err((op, BufferAccessError::UnalignedOffset { offset }));
         }
@@ -804,6 +858,13 @@ impl Buffer {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferAddress>,
     ) -> Result<(NonNull<u8>, u64), BufferAccessError> {
+        profiling::scope!("Buffer::get_mapped_range");
+        api_log!(
+            "Buffer::get_mapped_range {:?} offset {offset:?} size {size:?}",
+            Arc::as_ptr(self)
+        );
+
+        self.check_is_valid()?;
         {
             let snatch_guard = self.device.snatchable_lock.read();
             self.check_destroyed(&snatch_guard)?;
@@ -946,7 +1007,10 @@ impl Buffer {
 
     fn unmap_inner(self: &Arc<Self>) -> Result<Option<BufferMapPendingClosure>, BufferAccessError> {
         let device = &self.device;
+        self.check_is_valid()?;
+        self.device.check_is_valid()?;
         let snatch_guard = device.snatchable_lock.read();
+        self.check_destroyed(&snatch_guard)?;
         let raw_buf = self.try_raw(&snatch_guard)?;
         let map_state = mem::replace(&mut *self.map_state.lock(), BufferMapState::Idle);
         match map_state {
@@ -1045,10 +1109,22 @@ impl Buffer {
     pub fn destroy(self: &Arc<Self>) {
         let device = &self.device;
 
+        #[cfg(feature = "trace")]
+        if let Some(trace) = device.trace.lock().as_mut() {
+            use crate::device::trace::IntoTrace;
+            trace.add(trace::Action::DestroyBuffer(self.to_trace()));
+        }
+
+        let ResourceState::Valid(state) = &self.state else {
+            return;
+        };
+
+        let _ = self.unmap();
+
         let temp = {
             let mut snatch_guard = device.snatchable_lock.write();
 
-            let raw = match self.raw.snatch(&mut snatch_guard) {
+            let raw = match state.raw.snatch(&mut snatch_guard) {
                 Some(raw) => raw,
                 None => {
                     // Per spec, it is valid to call `destroy` multiple times.


### PR DESCRIPTION
**Connections**
Towards #5121

**Description**
As always we move validity into Buffer by wrapping raw with ResourceState. Tracing and logging is also moved inside Buffer.

As noted in https://github.com/gfx-rs/wgpu/issues/5121#issuecomment-4866737677 this got complication named unmap in buffer_drop, but I decided to postpone this problem for later. More info here: https://github.com/gfx-rs/wgpu/pull/9803#discussion_r3523388899

**Testing**
Just refactor.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
