### PR TITLE
[core] Move validity into `Arc<ExternalTexture>`

### DIFF
--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -153,9 +153,7 @@ impl Player {
                     .iter()
                     .map(|&id| self.resolve_texture_view_id(id))
                     .collect::<Vec<_>>();
-                let external_texture = device
-                    .create_external_texture(&desc, &planes)
-                    .expect("create_external_texture error");
+                let (external_texture, _error) = device.create_external_texture(&desc, &planes);
                 self.external_textures.insert(id, external_texture);
             }
             Action::DestroyExternalTexture(id) => {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -252,11 +252,13 @@ impl Global {
     /// See [`Self::create_buffer_error`] for more context and explanation.
     pub fn create_external_texture_error(
         &self,
+        device_id: DeviceId,
         id_in: Option<id::ExternalTextureId>,
         desc: &resource::ExternalTextureDescriptor,
     ) {
         let fid = self.hub.external_textures.prepare(id_in);
-        fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
+        let device = self.hub.devices.get(device_id);
+        fid.assign(resource::ExternalTexture::invalid(device, desc));
     }
 
     /// Assign `id_in` an error with the given `label`.
@@ -502,42 +504,18 @@ impl Global {
 
         let fid = hub.external_textures.prepare(id_in);
 
-        let error = 'error: {
-            let device = self.hub.devices.get(device_id);
+        let device = self.hub.devices.get(device_id);
 
-            let planes = planes
-                .iter()
-                .map(|plane_id| self.hub.texture_views.get(*plane_id))
-                .collect::<Vec<_>>();
+        let planes = planes
+            .iter()
+            .map(|plane_id| self.hub.texture_views.get(*plane_id))
+            .collect::<Vec<_>>();
 
-            let external_texture = match device.create_external_texture(desc, &planes) {
-                Ok(external_texture) => external_texture,
-                Err(error) => break 'error error,
-            };
+        let (external_texture, error) = device.create_external_texture(desc, &planes);
 
-            #[cfg(feature = "trace")]
-            if let Some(ref mut trace) = *device.trace.lock() {
-                let planes = Box::from(
-                    planes
-                        .into_iter()
-                        .map(|plane| plane.to_trace())
-                        .collect::<Vec<_>>(),
-                );
-                trace.add(trace::Action::CreateExternalTexture {
-                    id: external_texture.to_trace(),
-                    desc: desc.clone(),
-                    planes,
-                });
-            }
+        let id = fid.assign(external_texture);
 
-            let id = fid.assign(Fallible::Valid(external_texture));
-            api_log!("Device::create_external_texture({desc:?}) -> {id:?}");
-
-            return (id, None);
-        };
-
-        let id = fid.assign(Fallible::Invalid(Arc::new(desc.label.to_string())));
-        (id, Some(error))
+        (id, error)
     }
 
     pub fn external_texture_destroy(&self, external_texture_id: id::ExternalTextureId) {
@@ -546,17 +524,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let Ok(external_texture) = hub.external_textures.get(external_texture_id).get() else {
-            // If the external texture is already invalid, there's nothing to do.
-            return;
-        };
-
-        #[cfg(feature = "trace")]
-        if let Some(trace) = external_texture.device.trace.lock().as_mut() {
-            trace.add(trace::Action::DestroyExternalTexture(
-                external_texture.to_trace(),
-            ));
-        }
+        let external_texture = hub.external_textures.get(external_texture_id);
 
         external_texture.destroy();
     }
@@ -568,15 +536,6 @@ impl Global {
         let hub = &self.hub;
 
         let _external_texture = hub.external_textures.remove(external_texture_id);
-
-        #[cfg(feature = "trace")]
-        if let Ok(external_texture) = _external_texture.get() {
-            if let Some(t) = external_texture.device.trace.lock().as_mut() {
-                t.add(trace::Action::DropExternalTexture(
-                    external_texture.to_trace(),
-                ));
-            }
-        }
     }
 
     pub fn device_create_sampler(
@@ -707,7 +666,7 @@ impl Global {
                 sampler_storage: &Storage<Arc<resource::Sampler>>,
                 texture_view_storage: &Storage<Arc<resource::TextureView>>,
                 tlas_storage: &Storage<Fallible<resource::Tlas>>,
-                external_texture_storage: &Storage<Fallible<resource::ExternalTexture>>,
+                external_texture_storage: &Storage<Arc<resource::ExternalTexture>>,
             ) -> Result<ResolvedBindGroupEntry<'a>, binding_model::CreateBindGroupError>
             {
                 let resolve_buffer = |bb: &BufferBinding| {
@@ -729,12 +688,8 @@ impl Global {
                         .get()
                         .map_err(binding_model::CreateBindGroupError::from)
                 };
-                let resolve_external_texture = |id: &id::ExternalTextureId| {
-                    external_texture_storage
-                        .get(*id)
-                        .get()
-                        .map_err(binding_model::CreateBindGroupError::from)
-                };
+                let resolve_external_texture =
+                    |id: &id::ExternalTextureId| external_texture_storage.get(*id);
                 let resource = match e.resource {
                     BindingResource::Buffer(ref buffer) => {
                         ResolvedBindingResource::Buffer(resolve_buffer(buffer)?)
@@ -771,7 +726,7 @@ impl Global {
                         ResolvedBindingResource::AccelerationStructureArray(Cow::Owned(tlas_array))
                     }
                     BindingResource::ExternalTexture(ref et) => {
-                        ResolvedBindingResource::ExternalTexture(resolve_external_texture(et)?)
+                        ResolvedBindingResource::ExternalTexture(resolve_external_texture(et))
                     }
                 };
                 Ok(ResolvedBindGroupEntry {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -47,9 +47,9 @@ use crate::{
     pool::ResourcePool,
     present,
     resource::{
-        self, Buffer, ExternalTexture, Fallible, Labeled, ParentDevice, QuerySet, QuerySetState,
-        RawResourceAccess, ResourceState, Sampler, StagingBuffer, Texture, TextureView,
-        TextureViewNotRenderableReason, TextureViewState, Tlas, TrackingData,
+        self, Buffer, ExternalTexture, ExternalTextureState, Fallible, Labeled, ParentDevice,
+        QuerySet, QuerySetState, RawResourceAccess, ResourceState, Sampler, StagingBuffer, Texture,
+        TextureView, TextureViewNotRenderableReason, TextureViewState, Tlas, TrackingData,
     },
     resource_log,
     snatch::{SnatchGuard, SnatchLock, Snatchable},
@@ -2194,6 +2194,45 @@ impl Device {
         self: &Arc<Self>,
         desc: &resource::ExternalTextureDescriptor,
         planes: &[Arc<TextureView>],
+    ) -> (
+        Arc<ExternalTexture>,
+        Option<resource::CreateExternalTextureError>,
+    ) {
+        let (external_texture, error) = match self.create_external_texture_inner(desc, planes) {
+            Ok(external_texture) => (external_texture, None),
+            Err(e) => (ExternalTexture::invalid(Arc::clone(self), desc), Some(e)),
+        };
+
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.trace.lock() {
+            use crate::device::trace;
+            use trace::IntoTrace as _;
+
+            let planes = Box::from(
+                planes
+                    .iter()
+                    .map(|plane| plane.to_trace())
+                    .collect::<Vec<_>>(),
+            );
+            trace.add(trace::Action::CreateExternalTexture {
+                id: external_texture.to_trace(),
+                desc: desc.clone(),
+                planes,
+            });
+        }
+
+        api_log!(
+            "Device::create_external_texture({desc:?}) -> {:?}",
+            Arc::as_ptr(&external_texture)
+        );
+
+        (external_texture, error)
+    }
+
+    pub(crate) fn create_external_texture_inner(
+        self: &Arc<Self>,
+        desc: &resource::ExternalTextureDescriptor,
+        planes: &[Arc<TextureView>],
     ) -> Result<Arc<ExternalTexture>, resource::CreateExternalTextureError> {
         use resource::CreateExternalTextureError;
         self.require_features(wgt::Features::EXTERNAL_TEXTURE)?;
@@ -2274,9 +2313,9 @@ impl Device {
         )?;
 
         let external_texture = ExternalTexture {
+            state: ResourceState::Valid(ExternalTextureState { params }),
             device: self.clone(),
             planes,
-            params,
             label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.external_textures.clone()),
         };
@@ -3445,6 +3484,7 @@ impl Device {
     > {
         use crate::binding_model::CreateBindGroupError as Error;
 
+        let external_texture_state = external_texture.state()?;
         external_texture.same_device(self)?;
 
         used.external_textures
@@ -3483,9 +3523,14 @@ impl Device {
             .collect::<Result<Vec<_>, Error>>()?;
         let planes = planes.try_into().unwrap();
 
-        used.buffers
-            .insert_single(external_texture.params.clone(), wgt::BufferUses::UNIFORM);
-        let params = external_texture.params.binding(0, None, snatch_guard)?.0;
+        used.buffers.insert_single(
+            external_texture_state.params.clone(),
+            wgt::BufferUses::UNIFORM,
+        );
+        let params = external_texture_state
+            .params
+            .binding(0, None, snatch_guard)?
+            .0;
 
         Ok(hal::ExternalTextureBinding { planes, params })
     }

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -209,7 +209,7 @@ pub struct Hub {
     pub(crate) staging_buffers: Registry<StagingBuffer>,
     pub(crate) textures: Registry<Arc<Texture>>,
     pub(crate) texture_views: Registry<Arc<TextureView>>,
-    pub(crate) external_textures: Registry<Fallible<ExternalTexture>>,
+    pub(crate) external_textures: Registry<Arc<ExternalTexture>>,
     pub(crate) samplers: Registry<Arc<Sampler>>,
     pub(crate) blas_s: Registry<Fallible<Blas>>,
     pub(crate) tlas_s: Registry<Fallible<Tlas>>,

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2188,13 +2188,18 @@ crate::impl_storage_item!(TextureView);
 pub type ExternalTextureDescriptor<'a> = wgt::ExternalTextureDescriptor<Label<'a>>;
 
 #[derive(Debug)]
-pub struct ExternalTexture {
-    pub(crate) device: Arc<Device>,
-    /// Between 1 and 3 (inclusive) planes of texture data.
-    pub(crate) planes: arrayvec::ArrayVec<Arc<TextureView>, 3>,
+pub(crate) struct ExternalTextureState {
     /// Buffer containing a [`crate::device::resource::ExternalTextureParams`]
     /// describing the external texture.
     pub(crate) params: Arc<Buffer>,
+}
+
+#[derive(Debug)]
+pub struct ExternalTexture {
+    pub(crate) state: ResourceState<ExternalTextureState>,
+    pub(crate) device: Arc<Device>,
+    /// Between 1 and 3 (inclusive) planes of texture data.
+    pub(crate) planes: arrayvec::ArrayVec<Arc<TextureView>, 3>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
     pub(crate) tracking_data: TrackingData,
@@ -2203,12 +2208,43 @@ pub struct ExternalTexture {
 impl Drop for ExternalTexture {
     fn drop(&mut self) {
         resource_log!("Destroy raw {}", self.error_ident());
+        #[cfg(feature = "trace")]
+        if let Some(t) = self.device.trace.lock().as_mut() {
+            t.add(trace::Action::DropExternalTexture(unsafe {
+                trace::to_trace(self)
+            }));
+        }
     }
 }
 
 impl ExternalTexture {
+    pub(crate) fn state(&self) -> Result<&ExternalTextureState, InvalidResourceError> {
+        match &self.state {
+            ResourceState::Valid(state) => Ok(state),
+            ResourceState::Invalid => Err(InvalidResourceError(self.error_ident())),
+        }
+    }
+
     pub fn destroy(self: &Arc<Self>) {
-        self.params.destroy();
+        #[cfg(feature = "trace")]
+        if let Some(trace) = self.device.trace.lock().as_mut() {
+            use crate::device::trace::IntoTrace as _;
+
+            trace.add(trace::Action::DestroyExternalTexture(self.to_trace()));
+        }
+        if let Ok(state) = self.state() {
+            state.params.destroy();
+        }
+    }
+
+    pub fn invalid(device: Arc<Device>, desc: &ExternalTextureDescriptor) -> Arc<Self> {
+        Arc::new(ExternalTexture {
+            state: ResourceState::Invalid,
+            planes: arrayvec::ArrayVec::new(),
+            label: desc.label.to_string(),
+            tracking_data: TrackingData::new(device.tracker_indices.external_textures.clone()),
+            device,
+        })
     }
 }
 


### PR DESCRIPTION
**Connections**
Towards #5121

**Description**
As always we move validity into ExternalTexture by wrapping params buffer with ResourceState. Tracing and logging is also moved inside ExternalTexture.

**Testing**
Just refactor.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
