### PR TITLE
Replace expect usage on vulkan surface creation with returning an InstanceError

### DIFF
--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -404,8 +404,13 @@ impl super::Instance {
                 .dpy(dpy);
 
             unsafe { xlib_loader.create_xlib_surface(&info, None) }
-                .expect("XlibSurface::create_xlib_surface() failed")
-        };
+        }
+        .map_err(|err| {
+            crate::InstanceError::with_source(
+                String::from("XlibSurface::create_xlib_surface() failed"),
+                err,
+            )
+        })?;
 
         Ok(self.create_surface_from_vk_surface_khr(surface, None))
     }
@@ -429,8 +434,13 @@ impl super::Instance {
                 .connection(connection);
 
             unsafe { xcb_loader.create_xcb_surface(&info, None) }
-                .expect("XcbSurface::create_xcb_surface() failed")
-        };
+        }
+        .map_err(|err| {
+            crate::InstanceError::with_source(
+                String::from("XcbSurface::create_xcb_surface() failed"),
+                err,
+            )
+        })?;
 
         Ok(self.create_surface_from_vk_surface_khr(surface, None))
     }
@@ -454,8 +464,11 @@ impl super::Instance {
                 .display(display)
                 .surface(surface);
 
-            unsafe { w_loader.create_wayland_surface(&info, None) }.expect("WaylandSurface failed")
-        };
+            unsafe { w_loader.create_wayland_surface(&info, None) }
+        }
+        .map_err(|err| {
+            crate::InstanceError::with_source(String::from("WaylandSurface failed"), err)
+        })?;
 
         Ok(self.create_surface_from_vk_surface_khr(surface, None))
     }
@@ -477,8 +490,11 @@ impl super::Instance {
                 .flags(vk::AndroidSurfaceCreateFlagsKHR::empty())
                 .window(window);
 
-            unsafe { a_loader.create_android_surface(&info, None) }.expect("AndroidSurface failed")
-        };
+            unsafe { a_loader.create_android_surface(&info, None) }
+        }
+        .map_err(|err| {
+            crate::InstanceError::with_source(String::from("AndroidSurface failed"), err)
+        })?;
 
         Ok(self.create_surface_from_vk_surface_khr(surface, None))
     }
@@ -501,12 +517,11 @@ impl super::Instance {
                 .hwnd(hwnd);
             let win32_loader =
                 khr::win32_surface::Instance::new(&self.shared.entry, &self.shared.raw);
-            unsafe {
-                win32_loader
-                    .create_win32_surface(&info, None)
-                    .expect("Unable to create Win32 surface")
-            }
-        };
+            unsafe { win32_loader.create_win32_surface(&info, None) }
+        }
+        .map_err(|err| {
+            crate::InstanceError::with_source(String::from("Unable to create Win32 surface"), err)
+        })?;
 
         // Wrap ash's `isize` `HWND` in `WindowHandle`; on Windows the
         // `NativeSurface` builds its DXGI HDR source from it.


### PR DESCRIPTION
**Description**

On android with wrong view management a panic occurs for `create_surface`, because only one swapchain is allowed. (<https://docs.vulkan.org/refpages/latest/refpages/source/vkCreateAndroidSurfaceKHR.html#_description>).
I don't know if the other cases (memory, validation, unknown) for android and other vulkan platforms are always catched by wgpu before the vulkan call.

This changes the `expect` calls to `map_err` for the different `create_surface` vulkan calls. 

I am unsure if this should be in the changelog, if wanted I can add an entry.

**Testing**

Create two surfaces for the same view on android.

I did not find a suitable test to extend and have no android setup at the moment.
If required I can add an example for reproduction.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
      - The behavior changes, but I hope errors are preferred over panics
- [ ] ~~Validation and feature gates are in place to confine behavioral changes.~~
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
