### PR TITLE
[core] Do simple unmap on Buffer::drop

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -272,9 +272,7 @@ impl Global {
 
         let hub = &self.hub;
 
-        let buffer = hub.buffers.remove(buffer_id);
-
-        let _ = buffer.unmap();
+        let _buffer = hub.buffers.remove(buffer_id);
     }
 
     pub fn device_create_texture(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -273,7 +273,11 @@ pub struct Device {
     pub(crate) instance_flags: wgt::InstanceFlags,
     pub(crate) deferred_destroy: Mutex<Vec<DeferredDestroy>>,
     /// This closures were created in [`Buffer::drop`] where we do not run them to prevent locking problems.
-    pub(crate) deferred_buffer_map_pending_closures: Mutex<Vec<BufferMapPendingClosure>>,
+    ///
+    /// Because all operations are push/swap (no longlived lock),
+    /// we can have mutex without lock rank
+    pub(crate) deferred_buffer_map_pending_closures:
+        parking_lot::Mutex<Vec<BufferMapPendingClosure>>,
     pub(crate) usage_scopes: UsageScopePool,
     pub(crate) indirect_validation: Option<crate::indirect_validation::IndirectValidation>,
     // Optional so that we can late-initialize this after the queue is created.
@@ -562,10 +566,7 @@ impl Device {
             usage_scopes: Mutex::new(rank::DEVICE_USAGE_SCOPES, Default::default()),
             timestamp_normalizer: OnceCellOrLock::new(),
             indirect_validation,
-            deferred_buffer_map_pending_closures: Mutex::new(
-                rank::DEVICE_DEFERRED_BUFFER_MAP_PENDING_CLOSURES,
-                Vec::new(),
-            ),
+            deferred_buffer_map_pending_closures: parking_lot::Mutex::new(Vec::new()),
         })
     }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -204,6 +204,26 @@ impl ExternalTextureParams {
     }
 }
 
+/// Because all operations are push/swap (no longlived lock),
+/// we can have mutex without lock rank
+pub(crate) struct DeferredBufferMapPendingClosures(
+    parking_lot::Mutex<Vec<BufferMapPendingClosure>>,
+);
+
+impl DeferredBufferMapPendingClosures {
+    pub(crate) fn new() -> Self {
+        Self(parking_lot::Mutex::new(Vec::new()))
+    }
+
+    pub(crate) fn push(&self, closure: BufferMapPendingClosure) {
+        self.0.lock().push(closure);
+    }
+
+    pub(crate) fn swap(&self, other: &mut Vec<BufferMapPendingClosure>) {
+        mem::swap(&mut *self.0.lock(), other)
+    }
+}
+
 /// Structure describing a logical device. Some members are internally mutable,
 /// stored behind mutexes.
 pub struct Device {
@@ -273,11 +293,7 @@ pub struct Device {
     pub(crate) instance_flags: wgt::InstanceFlags,
     pub(crate) deferred_destroy: Mutex<Vec<DeferredDestroy>>,
     /// This closures were created in [`Buffer::drop`] where we do not run them to prevent locking problems.
-    ///
-    /// Because all operations are push/swap (no longlived lock),
-    /// we can have mutex without lock rank
-    pub(crate) deferred_buffer_map_pending_closures:
-        parking_lot::Mutex<Vec<BufferMapPendingClosure>>,
+    pub(crate) deferred_buffer_map_pending_closures: DeferredBufferMapPendingClosures,
     pub(crate) usage_scopes: UsageScopePool,
     pub(crate) indirect_validation: Option<crate::indirect_validation::IndirectValidation>,
     // Optional so that we can late-initialize this after the queue is created.
@@ -566,7 +582,7 @@ impl Device {
             usage_scopes: Mutex::new(rank::DEVICE_USAGE_SCOPES, Default::default()),
             timestamp_normalizer: OnceCellOrLock::new(),
             indirect_validation,
-            deferred_buffer_map_pending_closures: parking_lot::Mutex::new(Vec::new()),
+            deferred_buffer_map_pending_closures: DeferredBufferMapPendingClosures::new(),
         })
     }
 
@@ -843,10 +859,7 @@ impl Device {
 
         let mut user_closures = UserClosures::default();
 
-        mem::swap(
-            &mut user_closures.mappings,
-            &mut self.deferred_buffer_map_pending_closures.lock(),
-        );
+        self.deferred_buffer_map_pending_closures.swap(&mut user_closures.mappings);
 
         // If a wait was requested, determine which submission index to wait for.
         let wait_submission_index = match poll_type {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -859,7 +859,8 @@ impl Device {
 
         let mut user_closures = UserClosures::default();
 
-        self.deferred_buffer_map_pending_closures.swap(&mut user_closures.mappings);
+        self.deferred_buffer_map_pending_closures
+            .swap(&mut user_closures.mappings);
 
         // If a wait was requested, determine which submission index to wait for.
         let wait_submission_index = match poll_type {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -33,8 +33,8 @@ use crate::{
     command, conv,
     device::{
         bgl, create_validator, features_to_naga_capabilities, life::WaitIdleError, map_buffer,
-        AttachmentData, DeviceLostInvocation, HostMap, MissingDownlevelFlags, MissingFeatures,
-        RenderPassContext,
+        AttachmentData, BufferMapPendingClosure, DeviceLostInvocation, HostMap,
+        MissingDownlevelFlags, MissingFeatures, RenderPassContext,
     },
     hal_label,
     init_tracker::{
@@ -272,6 +272,8 @@ pub struct Device {
     pub(crate) ordered_texture_usages: wgt::TextureUses,
     pub(crate) instance_flags: wgt::InstanceFlags,
     pub(crate) deferred_destroy: Mutex<Vec<DeferredDestroy>>,
+    /// This closures were created in [`Buffer::drop`] where we do not run them to prevent locking problems.
+    pub(crate) deferred_buffer_map_pending_closures: Mutex<Vec<BufferMapPendingClosure>>,
     pub(crate) usage_scopes: UsageScopePool,
     pub(crate) indirect_validation: Option<crate::indirect_validation::IndirectValidation>,
     // Optional so that we can late-initialize this after the queue is created.
@@ -560,6 +562,10 @@ impl Device {
             usage_scopes: Mutex::new(rank::DEVICE_USAGE_SCOPES, Default::default()),
             timestamp_normalizer: OnceCellOrLock::new(),
             indirect_validation,
+            deferred_buffer_map_pending_closures: Mutex::new(
+                rank::DEVICE_DEFERRED_BUFFER_MAP_PENDING_CLOSURES,
+                Vec::new(),
+            ),
         })
     }
 
@@ -835,6 +841,11 @@ impl Device {
         profiling::scope!("Device::maintain");
 
         let mut user_closures = UserClosures::default();
+
+        mem::swap(
+            &mut user_closures.mappings,
+            &mut self.deferred_buffer_map_pending_closures.lock(),
+        );
 
         // If a wait was requested, determine which submission index to wait for.
         let wait_submission_index = match poll_type {

--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -79,6 +79,10 @@ impl<T> Mutex<T> {
         }
     }
 
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
+
     pub fn into_inner(self) -> T {
         self.inner.into_inner()
     }

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -212,7 +212,6 @@ define_lock_ranks! {
 
     // Ranks not connected to the graph, alphabetical.
     rank BLAS_BUILT_INDEX "Blas::built_index" followed by { }
-    rank DEVICE_DEFERRED_BUFFER_MAP_PENDING_CLOSURES "Device::deferred_buffer_map_pending_closures" followed by { }
     rank DEVICE_LOST_CLOSURE "Device::device_lost_closure" followed by { }
     rank IDENTITY_MANAGER_VALUES "IdentityManager::values" followed by { }
     rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -212,6 +212,7 @@ define_lock_ranks! {
 
     // Ranks not connected to the graph, alphabetical.
     rank BLAS_BUILT_INDEX "Blas::built_index" followed by { }
+    rank DEVICE_DEFERRED_BUFFER_MAP_PENDING_CLOSURES "Device::deferred_buffer_map_pending_closures" followed by { }
     rank DEVICE_LOST_CLOSURE "Device::device_lost_closure" followed by { }
     rank IDENTITY_MANAGER_VALUES "IdentityManager::values" followed by { }
     rank RESOURCE_POOL_INNER "ResourcePool::inner" followed by { }

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -230,6 +230,10 @@ impl<T> Mutex<T> {
         }
     }
 
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
+
     pub fn into_inner(self) -> T {
         self.inner.into_inner()
     }

--- a/wgpu-core/src/lock/vanilla.rs
+++ b/wgpu-core/src/lock/vanilla.rs
@@ -35,6 +35,10 @@ impl<T> Mutex<T> {
         MutexGuard(self.0.lock())
     }
 
+    pub fn get_mut(&mut self) -> &mut T {
+        self.0.get_mut()
+    }
+
     pub fn into_inner(self) -> T {
         self.0.into_inner()
     }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -512,11 +512,36 @@ impl Drop for Buffer {
             raw.dispose(self.device.raw());
         }
 
+        let map_state = mem::replace(self.map_state.get_mut(), BufferMapState::Idle);
+        let active_map = match map_state {
+            BufferMapState::Init { staging_buffer } => {
+                staging_buffer.dispose();
+                false
+            }
+            BufferMapState::Waiting(buffer_pending_mapping) => {
+                if buffer_pending_mapping.op.callback.is_some() {
+                    let result = Err(BufferAccessError::DestroyedResource(
+                        DestroyedResourceError(self.error_ident()),
+                    ));
+                    self.device
+                        .deferred_buffer_map_pending_closures
+                        .lock()
+                        .push((buffer_pending_mapping.op, result));
+                }
+                false
+            }
+            BufferMapState::Active { .. } => true,
+            BufferMapState::Idle => false,
+        };
+
         let ResourceState::Valid(state) = &mut self.state else {
             return;
         };
 
         if let Some(raw) = state.raw.take() {
+            if active_map {
+                unsafe { self.device.raw().unmap_buffer(raw.as_ref()) }
+            }
             resource_log!("Destroy raw {}", self.error_ident());
             unsafe {
                 self.device.raw().destroy_buffer(raw);
@@ -1395,6 +1420,12 @@ impl StagingBuffer {
             device,
             size,
         }
+    }
+
+    pub(crate) fn dispose(self) {
+        let device = self.device.raw();
+        unsafe { device.unmap_buffer(self.raw.as_ref()) };
+        unsafe { device.destroy_buffer(self.raw) };
     }
 }
 

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -525,7 +525,6 @@ impl Drop for Buffer {
                     ));
                     self.device
                         .deferred_buffer_map_pending_closures
-                        .lock()
                         .push((buffer_pending_mapping.op, result));
                 }
                 false


### PR DESCRIPTION
**Connections**
Follow up to https://github.com/gfx-rs/wgpu/pull/9803, towards #5121 

**Description**
Instead of doing unmap before drop, we do it as part of drop. We cannot use regular unmap because we do not have access to Arc and we cannot use device locks. More info here: https://github.com/gfx-rs/wgpu/pull/9803#discussion_r3523388899 but the gist is that because of locks we need to defer callbacks from drop until device::maintain.

**Testing**
Passes existing tests, have no idea for better testing.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
