### PR TITLE
[core] Make `Global` methods thin in render/compute

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -659,7 +659,7 @@ impl RenderBundleEncoder {
     ) -> Result<(), PassStateError> {
         pass_base!(self, PassErrorScope::SetBindGroup);
         let redundant = self.current_bind_groups.set_and_check_redundant(
-            bind_group_id,
+            &bind_group_id,
             index,
             &mut self.base.dynamic_offsets,
             offsets,
@@ -682,7 +682,7 @@ impl RenderBundleEncoder {
         pipeline_id: id::RenderPipelineId,
     ) -> Result<(), PassStateError> {
         pass_base!(self, PassErrorScope::SetPipelineRender);
-        if self.current_pipeline.set_and_check_redundant(pipeline_id) {
+        if self.current_pipeline.set_and_check_redundant(&pipeline_id) {
             return Ok(());
         }
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -1268,7 +1268,7 @@ impl Global {
         let base = pass_base!(pass, scope);
 
         if pass.current_bind_groups.set_and_check_redundant(
-            bind_group_id,
+            &bind_group_id,
             index,
             &mut base.dynamic_offsets,
             offsets,
@@ -1312,7 +1312,7 @@ impl Global {
         pass: &mut ComputePass,
         pipeline_id: id::ComputePipelineId,
     ) -> Result<(), PassStateError> {
-        let redundant = pass.current_pipeline.set_and_check_redundant(pipeline_id);
+        let redundant = pass.current_pipeline.set_and_check_redundant(&pipeline_id);
 
         let scope = PassErrorScope::SetPipelineCompute;
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -10,7 +10,7 @@ use core::{convert::Infallible, fmt, str};
 
 use crate::{
     api_log,
-    binding_model::{BindError, ImmediateUploadError, LateMinBufferBindingSizeMismatch},
+    binding_model::{BindError, BindGroup, ImmediateUploadError, LateMinBufferBindingSizeMismatch},
     command::{
         bind::{Binder, BinderError},
         compute_command::ArcComputeCommand,
@@ -33,9 +33,9 @@ use crate::{
     init_tracker::MemoryInitKind,
     pipeline::ComputePipeline,
     resource::{
-        self, Buffer, DestroyedResourceError, InvalidOrDestroyedResourceError,
-        InvalidResourceError, Labeled, MissingBufferUsageError, ParentDevice, RawResourceAccess,
-        TextureView, Trackable,
+        Buffer, DestroyedResourceError, InvalidOrDestroyedResourceError, InvalidResourceError,
+        Labeled, MissingBufferUsageError, ParentDevice, QuerySet, RawResourceAccess, TextureView,
+        Trackable,
     },
     track::{ResourceUsageCompatibilityError, TextureViewBindGroupState, Tracker},
     Label,
@@ -64,8 +64,8 @@ pub struct ComputePass {
     timestamp_writes: Option<ArcPassTimestampWrites>,
 
     // Resource binding dedupe state.
-    current_bind_groups: BindGroupStateChange,
-    current_pipeline: StateChange<id::ComputePipelineId>,
+    current_bind_groups: BindGroupStateChange<Arc<BindGroup>>,
+    current_pipeline: StateChange<Arc<ComputePipeline>>,
 }
 
 impl_resource_type!(ComputePass);
@@ -277,7 +277,7 @@ struct State<'scope, 'snatch_guard, 'cmd_enc> {
 
     pass: pass::PassState<'scope, 'snatch_guard, 'cmd_enc>,
 
-    active_query: Option<(Arc<resource::QuerySet>, u32)>,
+    active_query: Option<(Arc<QuerySet>, u32)>,
 
     immediates: Vec<u32>,
 
@@ -468,7 +468,7 @@ fn transition_resources(
 impl CommandEncoder {
     fn begin_compute_pass(
         self: &Arc<Self>,
-        desc: &ComputePassDescriptor<'_, PassTimestampWrites<Arc<resource::QuerySet>>>,
+        desc: &ComputePassDescriptor<'_, PassTimestampWrites<Arc<QuerySet>>>,
     ) -> (ComputePass, Option<CommandEncoderError>) {
         use EncoderStateError as SErr;
 
@@ -556,6 +556,45 @@ impl CommandEncoder {
 }
 
 // Running the compute pass.
+impl ComputePass {
+    fn end(&mut self) -> Result<(), EncoderStateError> {
+        profiling::scope!(
+            "CommandEncoder::run_compute_pass {}",
+            self.base.label.as_deref().unwrap_or("")
+        );
+
+        let cmd_enc = self.parent.take().ok_or(EncoderStateError::Ended)?;
+        let mut cmd_buf_data = cmd_enc.data.lock();
+
+        cmd_buf_data.unlock_encoder()?;
+
+        let base = self.base.take();
+
+        if let Err(ComputePassError {
+            inner:
+                ComputePassErrorInner::EncoderState(
+                    err @ (EncoderStateError::Locked | EncoderStateError::Ended),
+                ),
+            scope: _,
+        }) = base
+        {
+            // Most encoding errors are detected and raised within `finish()`.
+            //
+            // However, we raise a validation error here if the pass was opened
+            // within another pass, or on a finished encoder. The latter is
+            // particularly important, because in that case reporting errors via
+            // `CommandEncoder::finish` is not possible.
+            return Err(err.clone());
+        }
+
+        cmd_buf_data.push_with(|| -> Result<_, ComputePassError> {
+            Ok(ArcCommand::RunComputePass {
+                pass: base?,
+                timestamp_writes: self.timestamp_writes.take(),
+            })
+        })
+    }
+}
 
 impl Global {
     /// Creates a compute pass.
@@ -611,41 +650,7 @@ impl Global {
     }
 
     pub fn compute_pass_end(&self, pass: &mut ComputePass) -> Result<(), EncoderStateError> {
-        profiling::scope!(
-            "CommandEncoder::run_compute_pass {}",
-            pass.base.label.as_deref().unwrap_or("")
-        );
-
-        let cmd_enc = pass.parent.take().ok_or(EncoderStateError::Ended)?;
-        let mut cmd_buf_data = cmd_enc.data.lock();
-
-        cmd_buf_data.unlock_encoder()?;
-
-        let base = pass.base.take();
-
-        if let Err(ComputePassError {
-            inner:
-                ComputePassErrorInner::EncoderState(
-                    err @ (EncoderStateError::Locked | EncoderStateError::Ended),
-                ),
-            scope: _,
-        }) = base
-        {
-            // Most encoding errors are detected and raised within `finish()`.
-            //
-            // However, we raise a validation error here if the pass was opened
-            // within another pass, or on a finished encoder. The latter is
-            // particularly important, because in that case reporting errors via
-            // `CommandEncoder::finish` is not possible.
-            return Err(err.clone());
-        }
-
-        cmd_buf_data.push_with(|| -> Result<_, ComputePassError> {
-            Ok(ArcCommand::RunComputePass {
-                pass: base?,
-                timestamp_writes: pass.timestamp_writes.take(),
-            })
-        })
+        pass.end()
     }
 
     pub fn compute_pass_end_with_id(
@@ -1252,12 +1257,11 @@ fn dispatch_workgroups_indirect(
 // The `pass_try!` macro should be used to handle errors appropriately. Note
 // that the `pass_try!` and `pass_base!` macros may return early from the
 // function that invokes them, like the `?` operator.
-impl Global {
-    pub fn compute_pass_set_bind_group(
-        &self,
-        pass: &mut ComputePass,
+impl ComputePass {
+    pub fn set_bind_group(
+        &mut self,
         index: u32,
-        bind_group_id: Option<id::BindGroupId>,
+        bind_group: Option<Arc<BindGroup>>,
         offsets: &[DynamicOffset],
     ) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetBindGroup;
@@ -1265,10 +1269,10 @@ impl Global {
         // This statement will return an error if the pass is ended. It's
         // important the error check comes before the early-out for
         // `set_and_check_redundant`.
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
-        if pass.current_bind_groups.set_and_check_redundant(
-            &bind_group_id,
+        if self.current_bind_groups.set_and_check_redundant(
+            &bind_group,
             index,
             &mut base.dynamic_offsets,
             offsets,
@@ -1276,13 +1280,12 @@ impl Global {
             return Ok(());
         }
 
-        let mut bind_group = None;
-        if let Some(bind_group_id) = bind_group_id {
-            let hub = &self.hub;
-            let bg = hub.bind_groups.get(bind_group_id);
-            pass_try!(base, scope, bg.check_is_valid());
-            bind_group = Some(bg);
-        }
+        let bind_group = if let Some(bind_group) = bind_group {
+            pass_try!(base, scope, bind_group.check_is_valid());
+            Some(bind_group)
+        } else {
+            None
+        };
 
         base.commands.push(ArcComputeCommand::SetBindGroup {
             index,
@@ -1293,39 +1296,24 @@ impl Global {
         Ok(())
     }
 
-    pub fn compute_pass_set_bind_group_with_id(
-        &self,
-        pass_id: id::ComputePassEncoderId,
-        index: u32,
-        bind_group_id: Option<id::BindGroupId>,
-        offsets: &[DynamicOffset],
+    pub fn set_pipeline(
+        &mut self,
+        compute_pipeline: Arc<ComputePipeline>,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
-        self.compute_pass_set_bind_group(&mut pass, index, bind_group_id, offsets)
-    }
-
-    pub fn compute_pass_set_pipeline(
-        &self,
-        pass: &mut ComputePass,
-        pipeline_id: id::ComputePipelineId,
-    ) -> Result<(), PassStateError> {
-        let redundant = pass.current_pipeline.set_and_check_redundant(&pipeline_id);
+        let redundant = self
+            .current_pipeline
+            .set_and_check_redundant(&compute_pipeline);
 
         let scope = PassErrorScope::SetPipelineCompute;
 
         // This statement will return an error if the pass is ended.
         // Its important the error check comes before the early-out for `redundant`.
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
         if redundant {
             return Ok(());
         }
 
-        let hub = &self.hub;
-        let compute_pipeline = hub.compute_pipelines.get(pipeline_id);
         pass_try!(base, scope, compute_pipeline.check_valid());
 
         base.commands
@@ -1334,26 +1322,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn compute_pass_set_pipeline_with_id(
-        &self,
-        pass_id: id::ComputePassEncoderId,
-        pipeline_id: id::ComputePipelineId,
-    ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
-        self.compute_pass_set_pipeline(&mut pass, pipeline_id)
-    }
-
-    pub fn compute_pass_set_immediates(
-        &self,
-        pass: &mut ComputePass,
-        offset: u32,
-        data: &[u8],
-    ) -> Result<(), PassStateError> {
+    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetImmediate;
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
         let size_bytes = pass_try!(
             base,
@@ -1382,6 +1353,239 @@ impl Global {
         Ok(())
     }
 
+    pub fn dispatch_workgroups(
+        &mut self,
+        groups_x: u32,
+        groups_y: u32,
+        groups_z: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Dispatch { indirect: false };
+
+        pass_base!(self, scope)
+            .commands
+            .push(ArcComputeCommand::DispatchWorkgroups([
+                groups_x, groups_y, groups_z,
+            ]));
+
+        Ok(())
+    }
+
+    pub fn dispatch_workgroups_indirect(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Dispatch { indirect: true };
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, buffer.check_is_valid());
+
+        base.commands
+            .push(ArcComputeCommand::DispatchWorkgroupsIndirect { buffer, offset });
+
+        Ok(())
+    }
+
+    pub fn push_debug_group(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
+        let base = pass_base!(self, PassErrorScope::PushDebugGroup);
+
+        let bytes = label.as_bytes();
+        base.string_data.extend_from_slice(bytes);
+
+        base.commands.push(ArcComputeCommand::PushDebugGroup {
+            color,
+            len: bytes.len(),
+        });
+
+        Ok(())
+    }
+
+    pub fn pop_debug_group(&mut self) -> Result<(), PassStateError> {
+        let base = pass_base!(self, PassErrorScope::PopDebugGroup);
+
+        base.commands.push(ArcComputeCommand::PopDebugGroup);
+
+        Ok(())
+    }
+
+    pub fn insert_debug_marker(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
+        let base = pass_base!(self, PassErrorScope::InsertDebugMarker);
+
+        let bytes = label.as_bytes();
+        base.string_data.extend_from_slice(bytes);
+
+        base.commands.push(ArcComputeCommand::InsertDebugMarker {
+            color,
+            len: bytes.len(),
+        });
+
+        Ok(())
+    }
+
+    pub fn write_timestamp(
+        &mut self,
+        query_set: Arc<QuerySet>,
+        query_index: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::WriteTimestamp;
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, query_set.check_is_valid());
+
+        base.commands.push(ArcComputeCommand::WriteTimestamp {
+            query_set,
+            query_index,
+        });
+
+        Ok(())
+    }
+
+    pub fn begin_pipeline_statistics_query(
+        &mut self,
+        query_set: Arc<QuerySet>,
+        query_index: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::BeginPipelineStatisticsQuery;
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, query_set.check_is_valid());
+
+        base.commands
+            .push(ArcComputeCommand::BeginPipelineStatisticsQuery {
+                query_set,
+                query_index,
+            });
+
+        Ok(())
+    }
+
+    pub fn end_pipeline_statistics_query(&mut self) -> Result<(), PassStateError> {
+        pass_base!(self, PassErrorScope::EndPipelineStatisticsQuery)
+            .commands
+            .push(ArcComputeCommand::EndPipelineStatisticsQuery);
+
+        Ok(())
+    }
+
+    pub fn transition_resources(
+        &mut self,
+        buffer_transitions: impl Iterator<Item = wgt::BufferTransition<Arc<Buffer>>>,
+        texture_transitions: impl Iterator<Item = wgt::TextureTransition<Arc<TextureView>>>,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::TransitionResources;
+        let base = pass_base!(self, scope);
+
+        let buffer_transitions = pass_try!(
+            base,
+            scope,
+            buffer_transitions
+                .map(|buffer_transition| -> Result<_, InvalidResourceError> {
+                    let buffer = buffer_transition.buffer;
+                    buffer.check_is_valid()?;
+                    Ok(wgt::BufferTransition {
+                        buffer,
+                        state: buffer_transition.state,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()
+        );
+
+        let texture_transitions = pass_try!(
+            base,
+            scope,
+            texture_transitions
+                .map(|texture_transition| -> Result<_, InvalidResourceError> {
+                    let texture_view = texture_transition.texture;
+                    texture_view.check_valid()?;
+                    Ok(wgt::TextureTransition {
+                        texture: texture_view,
+                        selector: texture_transition.selector,
+                        state: texture_transition.state,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()
+        );
+
+        base.commands.push(ArcComputeCommand::TransitionResources {
+            buffer_transitions,
+            texture_transitions,
+        });
+
+        Ok(())
+    }
+}
+
+// Recording a compute pass.
+//
+// The only error that should be returned from these methods is
+// `EncoderStateError::Ended`, when the pass has already ended and an immediate
+// validation error is raised.
+//
+// All other errors should be stored in the pass for later reporting when
+// `CommandEncoder.finish()` is called.
+//
+// The `pass_try!` macro should be used to handle errors appropriately. Note
+// that the `pass_try!` and `pass_base!` macros may return early from the
+// function that invokes them, like the `?` operator.
+impl Global {
+    pub fn compute_pass_set_bind_group(
+        &self,
+        pass: &mut ComputePass,
+        index: u32,
+        bind_group_id: Option<id::BindGroupId>,
+        offsets: &[DynamicOffset],
+    ) -> Result<(), PassStateError> {
+        pass.set_bind_group(
+            index,
+            bind_group_id.map(|bind_group_id| self.hub.bind_groups.get(bind_group_id)),
+            offsets,
+        )
+    }
+
+    pub fn compute_pass_set_bind_group_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        index: u32,
+        bind_group_id: Option<id::BindGroupId>,
+        offsets: &[DynamicOffset],
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_set_bind_group(&mut pass, index, bind_group_id, offsets)
+    }
+
+    pub fn compute_pass_set_pipeline(
+        &self,
+        pass: &mut ComputePass,
+        pipeline_id: id::ComputePipelineId,
+    ) -> Result<(), PassStateError> {
+        let pipeline = self.hub.compute_pipelines.get(pipeline_id);
+        pass.set_pipeline(pipeline)
+    }
+
+    pub fn compute_pass_set_pipeline_with_id(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        pipeline_id: id::ComputePipelineId,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.compute_passes.get(pass_id);
+        let mut pass = pass
+            .try_lock()
+            .expect("ComputePasses should not be accessed concurrently");
+        self.compute_pass_set_pipeline(&mut pass, pipeline_id)
+    }
+
+    pub fn compute_pass_set_immediates(
+        &self,
+        pass: &mut ComputePass,
+        offset: u32,
+        data: &[u8],
+    ) -> Result<(), PassStateError> {
+        pass.set_immediates(offset, data)
+    }
+
     pub fn compute_pass_set_immediates_with_id(
         &self,
         pass_id: id::ComputePassEncoderId,
@@ -1402,15 +1606,7 @@ impl Global {
         groups_y: u32,
         groups_z: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::Dispatch { indirect: false };
-
-        pass_base!(pass, scope)
-            .commands
-            .push(ArcComputeCommand::DispatchWorkgroups([
-                groups_x, groups_y, groups_z,
-            ]));
-
-        Ok(())
+        pass.dispatch_workgroups(groups_x, groups_y, groups_z)
     }
 
     pub fn compute_pass_dispatch_workgroups_with_id(
@@ -1433,18 +1629,7 @@ impl Global {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), PassStateError> {
-        let hub = &self.hub;
-        let scope = PassErrorScope::Dispatch { indirect: true };
-        let base = pass_base!(pass, scope);
-
-        let buffer = hub.buffers.get(buffer_id);
-
-        pass_try!(base, scope, buffer.check_is_valid());
-
-        base.commands
-            .push(ArcComputeCommand::DispatchWorkgroupsIndirect { buffer, offset });
-
-        Ok(())
+        pass.dispatch_workgroups_indirect(self.hub.buffers.get(buffer_id), offset)
     }
 
     pub fn compute_pass_dispatch_workgroups_indirect_with_id(
@@ -1466,17 +1651,7 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let base = pass_base!(pass, PassErrorScope::PushDebugGroup);
-
-        let bytes = label.as_bytes();
-        base.string_data.extend_from_slice(bytes);
-
-        base.commands.push(ArcComputeCommand::PushDebugGroup {
-            color,
-            len: bytes.len(),
-        });
-
-        Ok(())
+        pass.push_debug_group(label, color)
     }
 
     pub fn compute_pass_push_debug_group_with_id(
@@ -1496,11 +1671,7 @@ impl Global {
         &self,
         pass: &mut ComputePass,
     ) -> Result<(), PassStateError> {
-        let base = pass_base!(pass, PassErrorScope::PopDebugGroup);
-
-        base.commands.push(ArcComputeCommand::PopDebugGroup);
-
-        Ok(())
+        pass.pop_debug_group()
     }
 
     pub fn compute_pass_pop_debug_group_with_id(
@@ -1520,17 +1691,7 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let base = pass_base!(pass, PassErrorScope::InsertDebugMarker);
-
-        let bytes = label.as_bytes();
-        base.string_data.extend_from_slice(bytes);
-
-        base.commands.push(ArcComputeCommand::InsertDebugMarker {
-            color,
-            len: bytes.len(),
-        });
-
-        Ok(())
+        pass.insert_debug_marker(label, color)
     }
 
     pub fn compute_pass_insert_debug_marker_with_id(
@@ -1552,19 +1713,8 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::WriteTimestamp;
-        let base = pass_base!(pass, scope);
-
-        let hub = &self.hub;
-        let query_set = hub.query_sets.get(query_set_id);
-        pass_try!(base, scope, query_set.check_is_valid());
-
-        base.commands.push(ArcComputeCommand::WriteTimestamp {
-            query_set,
-            query_index,
-        });
-
-        Ok(())
+        let query_set = self.hub.query_sets.get(query_set_id);
+        pass.write_timestamp(query_set, query_index)
     }
 
     pub fn compute_pass_write_timestamp_with_id(
@@ -1586,20 +1736,8 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::BeginPipelineStatisticsQuery;
-        let base = pass_base!(pass, scope);
-
-        let hub = &self.hub;
-        let query_set = hub.query_sets.get(query_set_id);
-        pass_try!(base, scope, query_set.check_is_valid());
-
-        base.commands
-            .push(ArcComputeCommand::BeginPipelineStatisticsQuery {
-                query_set,
-                query_index,
-            });
-
-        Ok(())
+        let query_set = self.hub.query_sets.get(query_set_id);
+        pass.begin_pipeline_statistics_query(query_set, query_index)
     }
 
     pub fn compute_pass_begin_pipeline_statistics_query_with_id(
@@ -1619,11 +1757,7 @@ impl Global {
         &self,
         pass: &mut ComputePass,
     ) -> Result<(), PassStateError> {
-        pass_base!(pass, PassErrorScope::EndPipelineStatisticsQuery)
-            .commands
-            .push(ArcComputeCommand::EndPipelineStatisticsQuery);
-
-        Ok(())
+        pass.end_pipeline_statistics_query()
     }
 
     pub fn compute_pass_end_pipeline_statistics_query_with_id(
@@ -1643,47 +1777,16 @@ impl Global {
         buffer_transitions: impl Iterator<Item = wgt::BufferTransition<id::BufferId>>,
         texture_transitions: impl Iterator<Item = wgt::TextureTransition<id::TextureViewId>>,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::TransitionResources;
-        let base = pass_base!(pass, scope);
-
-        let hub = &self.hub;
-
-        let buffer_transitions = pass_try!(
-            base,
-            scope,
-            buffer_transitions
-                .map(|buffer_transition| -> Result<_, InvalidResourceError> {
-                    let buffer = hub.buffers.get(buffer_transition.buffer);
-                    buffer.check_is_valid()?;
-                    Ok(wgt::BufferTransition {
-                        buffer,
-                        state: buffer_transition.state,
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()
-        );
-
-        let texture_transitions = pass_try!(
-            base,
-            scope,
-            texture_transitions
-                .map(|texture_transition| -> Result<_, InvalidResourceError> {
-                    let texture_view = hub.texture_views.get(texture_transition.texture);
-                    texture_view.check_valid()?;
-                    Ok(wgt::TextureTransition {
-                        texture: texture_view,
-                        selector: texture_transition.selector,
-                        state: texture_transition.state,
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()
-        );
-
-        base.commands.push(ArcComputeCommand::TransitionResources {
-            buffer_transitions,
-            texture_transitions,
-        });
-
-        Ok(())
+        pass.transition_resources(
+            buffer_transitions.map(|bt| wgt::BufferTransition {
+                buffer: self.hub.buffers.get(bt.buffer),
+                state: bt.state,
+            }),
+            texture_transitions.map(|tt| wgt::TextureTransition {
+                texture: self.hub.texture_views.get(tt.texture),
+                selector: tt.selector,
+                state: tt.state,
+            }),
+        )
     }
 }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -1912,46 +1912,76 @@ where
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 struct StateChange<T> {
     last_state: Option<T>,
 }
 
-impl<T: Copy + PartialEq> StateChange<T> {
-    fn new() -> Self {
+impl<T: Clone + PartialEq_> StateChange<T> {
+    const fn new() -> Self {
         Self { last_state: None }
     }
-    fn set_and_check_redundant(&mut self, new_state: T) -> bool {
-        let already_set = self.last_state == Some(new_state);
-        self.last_state = Some(new_state);
+
+    fn set_and_check_redundant(&mut self, new_state: &T) -> bool {
+        let already_set = self.last_state.as_ref().is_some_and(|s| s.eq(new_state));
+        if !already_set {
+            self.last_state = Some(new_state.clone());
+        }
         already_set
     }
+
     fn reset(&mut self) {
         self.last_state = None;
     }
 }
 
-impl<T: Copy + PartialEq> Default for StateChange<T> {
+impl<T: Clone + PartialEq_> Default for StateChange<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[derive(Debug)]
-struct BindGroupStateChange {
-    last_states: [StateChange<Option<id::BindGroupId>>; hal::MAX_BIND_GROUPS],
+trait PartialEq_ {
+    fn eq(&self, other: &Self) -> bool;
 }
 
-impl BindGroupStateChange {
+impl<T: id::Marker> PartialEq_ for id::Id<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl<T> PartialEq_ for Arc<T> {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(self, other)
+    }
+}
+
+impl<T: PartialEq_> PartialEq_ for Option<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Some(a), Some(b)) => a.eq(b),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BindGroupStateChange<BG = id::BindGroupId> {
+    last_states: [StateChange<Option<BG>>; hal::MAX_BIND_GROUPS],
+}
+
+impl<BG: Clone + PartialEq_> BindGroupStateChange<BG> {
     fn new() -> Self {
         Self {
-            last_states: [StateChange::new(); hal::MAX_BIND_GROUPS],
+            last_states: [const { StateChange::new() }; hal::MAX_BIND_GROUPS],
         }
     }
 
     fn set_and_check_redundant(
         &mut self,
-        bind_group_id: Option<id::BindGroupId>,
+        bind_group: &Option<BG>,
         index: u32,
         dynamic_offsets: &mut Vec<u32>,
         offsets: &[wgt::DynamicOffset],
@@ -1962,7 +1992,7 @@ impl BindGroupStateChange {
             // so let the call through to get a proper error
             if let Some(current_bind_group) = self.last_states.get_mut(index as usize) {
                 // Bail out if we're binding the same bind group.
-                if current_bind_group.set_and_check_redundant(bind_group_id) {
+                if current_bind_group.set_and_check_redundant(bind_group) {
                     return true;
                 }
             }
@@ -1978,11 +2008,11 @@ impl BindGroupStateChange {
         false
     }
     fn reset(&mut self) {
-        self.last_states = [StateChange::new(); hal::MAX_BIND_GROUPS];
+        self.last_states = [const { StateChange::new() }; hal::MAX_BIND_GROUPS];
     }
 }
 
-impl Default for BindGroupStateChange {
+impl<BG: Clone + PartialEq_> Default for BindGroupStateChange<BG> {
     fn default() -> Self {
         Self::new()
     }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -3672,7 +3672,7 @@ impl Global {
         let base = pass_base!(pass, scope);
 
         if pass.current_bind_groups.set_and_check_redundant(
-            bind_group_id,
+            &bind_group_id,
             index,
             &mut base.dynamic_offsets,
             offsets,
@@ -3718,7 +3718,7 @@ impl Global {
     ) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetPipelineRender;
 
-        let redundant = pass.current_pipeline.set_and_check_redundant(pipeline_id);
+        let redundant = pass.current_pipeline.set_and_check_redundant(&pipeline_id);
 
         // This statement will return an error if the pass is ended.
         // Its important the error check comes before the early-out for `redundant`.

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -13,7 +13,7 @@ use wgt::{
 
 use crate::{
     api_log,
-    binding_model::{BindError, ImmediateUploadError},
+    binding_model::{BindError, BindGroup, ImmediateUploadError},
     command::{
         bind::Binder,
         memory_init::{fixup_discarded_surfaces, SurfacesInDiscardState, TextureSurfaceDiscard},
@@ -29,7 +29,7 @@ use crate::{
         CommandBufferTextureMemoryActions, CommandEncoder, CommandEncoderError, DebugGroupError,
         DrawCommandFamily, DrawError, DrawKind, EncoderStateError, EncodingState, ExecutionError,
         InnerCommandEncoder, MapPassErr, PassErrorScope, PassStateError, PassTimestampWrites,
-        QueryUseError, Rect, RenderCommandError, StateChange, TimestampWritesError,
+        QueryUseError, Rect, RenderBundle, RenderCommandError, StateChange, TimestampWritesError,
     },
     device::{
         AttachmentData, Device, DeviceError, MissingDownlevelFlags, MissingFeatures,
@@ -334,8 +334,8 @@ pub struct RenderPass {
     multiview_mask: Option<NonZeroU32>,
 
     // Resource binding dedupe state.
-    current_bind_groups: BindGroupStateChange,
-    current_pipeline: StateChange<id::RenderPipelineId>,
+    current_bind_groups: BindGroupStateChange<Arc<BindGroup>>,
+    current_pipeline: StateChange<Arc<RenderPipeline>>,
 }
 
 impl_resource_type!(RenderPass);
@@ -2151,6 +2151,50 @@ impl CommandEncoder {
     }
 }
 
+impl RenderPass {
+    pub fn end(&mut self) -> Result<(), EncoderStateError> {
+        profiling::scope!(
+            "CommandEncoder::run_render_pass {}",
+            self.base.label.as_deref().unwrap_or("")
+        );
+
+        let cmd_enc = self.parent.take().ok_or(EncoderStateError::Ended)?;
+        let mut cmd_buf_data = cmd_enc.data.lock();
+
+        cmd_buf_data.unlock_encoder()?;
+
+        let base = self.base.take();
+
+        if let Err(RenderPassError {
+            inner:
+                RenderPassErrorInner::EncoderState(
+                    err @ (EncoderStateError::Locked | EncoderStateError::Ended),
+                ),
+            scope: _,
+        }) = base
+        {
+            // Most encoding errors are detected and raised within `finish()`.
+            //
+            // However, we raise a validation error here if the pass was opened
+            // within another pass, or on a finished encoder. The latter is
+            // particularly important, because in that case reporting errors via
+            // `CommandEncoder::finish` is not possible.
+            return Err(err.clone());
+        }
+
+        cmd_buf_data.push_with(|| -> Result<_, RenderPassError> {
+            Ok(ArcCommand::RunRenderPass {
+                pass: base?,
+                color_attachments: SmallVec::from(self.color_attachments.as_slice()),
+                depth_stencil_attachment: self.depth_stencil_attachment.take(),
+                timestamp_writes: self.timestamp_writes.take(),
+                occlusion_query_set: self.occlusion_query_set.take(),
+                multiview_mask: self.multiview_mask,
+            })
+        })
+    }
+}
+
 impl Global {
     /// Creates a render pass.
     ///
@@ -3566,7 +3610,7 @@ fn execute_bundle(
     state: &mut State,
     indirect_draw_validation_batcher: &mut crate::indirect_validation::DrawBatcher,
     device: &Arc<Device>,
-    bundle: Arc<super::RenderBundle>,
+    bundle: Arc<RenderBundle>,
 ) -> Result<(), RenderPassErrorInner> {
     api_log!("RenderPass::execute_bundle {}", bundle.error_ident());
 
@@ -3656,12 +3700,11 @@ fn execute_bundle(
 // The `pass_try!` macro should be used to handle errors appropriately. Note
 // that the `pass_try!` and `pass_base!` macros may return early from the
 // function that invokes them, like the `?` operator.
-impl Global {
-    pub fn render_pass_set_bind_group(
-        &self,
-        pass: &mut RenderPass,
+impl RenderPass {
+    pub fn set_bind_group(
+        &mut self,
         index: u32,
-        bind_group_id: Option<id::BindGroupId>,
+        bind_group: Option<Arc<BindGroup>>,
         offsets: &[DynamicOffset],
     ) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetBindGroup;
@@ -3669,10 +3712,10 @@ impl Global {
         // This statement will return an error if the pass is ended. It's
         // important the error check comes before the early-out for
         // `set_and_check_redundant`.
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
-        if pass.current_bind_groups.set_and_check_redundant(
-            &bind_group_id,
+        if self.current_bind_groups.set_and_check_redundant(
+            &bind_group,
             index,
             &mut base.dynamic_offsets,
             offsets,
@@ -3680,13 +3723,12 @@ impl Global {
             return Ok(());
         }
 
-        let mut bind_group = None;
-        if let Some(bind_group_id) = bind_group_id {
-            let hub = &self.hub;
-            let bg = hub.bind_groups.get(bind_group_id);
-            pass_try!(base, scope, bg.check_is_valid());
-            bind_group = Some(bg);
-        }
+        let bind_group = if let Some(bind_group) = bind_group {
+            pass_try!(base, scope, bind_group.check_is_valid());
+            Some(bind_group)
+        } else {
+            None
+        };
 
         base.commands.push(ArcRenderCommand::SetBindGroup {
             index,
@@ -3697,39 +3739,19 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_bind_group_with_id(
-        &self,
-        pass: id::RenderPassEncoderId,
-        index: u32,
-        bind_group_id: Option<id::BindGroupId>,
-        offsets: &[DynamicOffset],
-    ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
-        self.render_pass_set_bind_group(&mut pass, index, bind_group_id, offsets)
-    }
-
-    pub fn render_pass_set_pipeline(
-        &self,
-        pass: &mut RenderPass,
-        pipeline_id: id::RenderPipelineId,
-    ) -> Result<(), PassStateError> {
+    pub fn set_pipeline(&mut self, pipeline: Arc<RenderPipeline>) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetPipelineRender;
 
-        let redundant = pass.current_pipeline.set_and_check_redundant(&pipeline_id);
+        let redundant = self.current_pipeline.set_and_check_redundant(&pipeline);
 
         // This statement will return an error if the pass is ended.
         // Its important the error check comes before the early-out for `redundant`.
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
         if redundant {
             return Ok(());
         }
 
-        let hub = &self.hub;
-        let pipeline = hub.render_pipelines.get(pipeline_id);
         pass_try!(base, scope, pipeline.check_valid());
 
         base.commands.push(ArcRenderCommand::SetPipeline(pipeline));
@@ -3737,30 +3759,16 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_pipeline_with_id(
-        &self,
-        pass: id::RenderPassEncoderId,
-        pipeline_id: id::RenderPipelineId,
-    ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
-        self.render_pass_set_pipeline(&mut pass, pipeline_id)
-    }
-
-    pub fn render_pass_set_index_buffer(
-        &self,
-        pass: &mut RenderPass,
-        buffer_id: id::BufferId,
+    pub fn set_index_buffer(
+        &mut self,
+        buffer: Arc<Buffer>,
         index_format: IndexFormat,
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetIndexBuffer;
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
-        let buffer = self.resolve_buffer_id(buffer_id);
         pass_try!(base, scope, buffer.check_is_valid());
 
         base.commands.push(ArcRenderCommand::SetIndexBuffer {
@@ -3773,34 +3781,17 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_index_buffer_with_id(
-        &self,
-        pass: id::RenderPassEncoderId,
-        buffer_id: id::BufferId,
-        index_format: IndexFormat,
-        offset: BufferAddress,
-        size: Option<BufferSize>,
-    ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
-        self.render_pass_set_index_buffer(&mut pass, buffer_id, index_format, offset, size)
-    }
-
-    pub fn render_pass_set_vertex_buffer(
-        &self,
-        pass: &mut RenderPass,
+    pub fn set_vertex_buffer(
+        &mut self,
         slot: u32,
-        buffer_id: Option<id::BufferId>,
+        buffer: Option<Arc<Buffer>>,
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetVertexBuffer;
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
-        let buffer = if let Some(buffer_id) = buffer_id {
-            let buffer = self.resolve_buffer_id(buffer_id);
+        let buffer = if let Some(buffer) = buffer {
             pass_try!(base, scope, buffer.check_is_valid());
             Some(buffer)
         } else {
@@ -3817,28 +3808,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_vertex_buffer_with_id(
-        &self,
-        pass: id::RenderPassEncoderId,
-        slot: u32,
-        buffer_id: Option<id::BufferId>,
-        offset: BufferAddress,
-        size: Option<BufferSize>,
-    ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
-        self.render_pass_set_vertex_buffer(&mut pass, slot, buffer_id, offset, size)
-    }
-
-    pub fn render_pass_set_blend_constant(
-        &self,
-        pass: &mut RenderPass,
-        color: Color,
-    ) -> Result<(), PassStateError> {
+    pub fn set_blend_constant(&mut self, color: Color) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetBlendConstant;
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
         base.commands
             .push(ArcRenderCommand::SetBlendConstant(color));
@@ -3846,28 +3818,12 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_blend_constant_with_id(
-        &self,
-        pass: id::RenderPassEncoderId,
-        color: Color,
-    ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
-        self.render_pass_set_blend_constant(&mut pass, color)
-    }
-
-    pub fn render_pass_set_stencil_reference(
-        &self,
-        pass: &mut RenderPass,
-        value: u32,
-    ) -> Result<(), PassStateError> {
+    pub fn set_stencil_reference(&mut self, value: u32) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetStencilReference;
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
         let value = convert_stencil_value(
             value,
-            pass.depth_stencil_attachment
+            self.depth_stencil_attachment
                 .as_ref()
                 .map(|at| at.view.desc.format),
         );
@@ -3877,21 +3833,8 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_stencil_reference_with_id(
-        &self,
-        pass: id::RenderPassEncoderId,
-        value: u32,
-    ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
-        self.render_pass_set_stencil_reference(&mut pass, value)
-    }
-
-    pub fn render_pass_set_viewport(
-        &self,
-        pass: &mut RenderPass,
+    pub fn set_viewport(
+        &mut self,
         x: f32,
         y: f32,
         w: f32,
@@ -3900,7 +3843,7 @@ impl Global {
         depth_max: f32,
     ) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetViewport;
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
         base.commands.push(ArcRenderCommand::SetViewport {
             rect: Rect { x, y, w, h },
@@ -3911,33 +3854,15 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_viewport_with_id(
-        &self,
-        pass: id::RenderPassEncoderId,
-        x: f32,
-        y: f32,
-        w: f32,
-        h: f32,
-        depth_min: f32,
-        depth_max: f32,
-    ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
-        self.render_pass_set_viewport(&mut pass, x, y, w, h, depth_min, depth_max)
-    }
-
-    pub fn render_pass_set_scissor_rect(
-        &self,
-        pass: &mut RenderPass,
+    pub fn set_scissor_rect(
+        &mut self,
         x: u32,
         y: u32,
         w: u32,
         h: u32,
     ) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetScissorRect;
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
         base.commands
             .push(ArcRenderCommand::SetScissor(Rect { x, y, w, h }));
@@ -3945,29 +3870,9 @@ impl Global {
         Ok(())
     }
 
-    pub fn render_pass_set_scissor_rect_with_id(
-        &self,
-        pass: id::RenderPassEncoderId,
-        x: u32,
-        y: u32,
-        w: u32,
-        h: u32,
-    ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
-        self.render_pass_set_scissor_rect(&mut pass, x, y, w, h)
-    }
-
-    pub fn render_pass_set_immediates(
-        &self,
-        pass: &mut RenderPass,
-        offset: u32,
-        data: &[u8],
-    ) -> Result<(), PassStateError> {
+    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetImmediate;
-        let base = pass_base!(pass, scope);
+        let base = pass_base!(self, scope);
 
         let size_bytes = pass_try!(
             base,
@@ -3996,6 +3901,692 @@ impl Global {
         Ok(())
     }
 
+    pub fn draw(
+        &mut self,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::Draw,
+            family: DrawCommandFamily::Draw,
+        };
+        let base = pass_base!(self, scope);
+
+        base.commands.push(ArcRenderCommand::Draw {
+            vertex_count,
+            instance_count,
+            first_vertex,
+            first_instance,
+        });
+
+        Ok(())
+    }
+
+    pub fn draw_indexed(
+        &mut self,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        first_instance: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::Draw,
+            family: DrawCommandFamily::DrawIndexed,
+        };
+        let base = pass_base!(self, scope);
+
+        base.commands.push(ArcRenderCommand::DrawIndexed {
+            index_count,
+            instance_count,
+            first_index,
+            base_vertex,
+            first_instance,
+        });
+
+        Ok(())
+    }
+
+    pub fn draw_mesh_tasks(
+        &mut self,
+        group_count_x: u32,
+        group_count_y: u32,
+        group_count_z: u32,
+    ) -> Result<(), RenderPassError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::Draw,
+            family: DrawCommandFamily::DrawMeshTasks,
+        };
+        let base = pass_base!(self, scope);
+
+        base.commands.push(ArcRenderCommand::DrawMeshTasks {
+            group_count_x,
+            group_count_y,
+            group_count_z,
+        });
+        Ok(())
+    }
+
+    pub fn draw_indirect(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::DrawIndirect,
+            family: DrawCommandFamily::Draw,
+        };
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, buffer.check_is_valid());
+
+        base.commands.push(ArcRenderCommand::DrawIndirect {
+            buffer,
+            offset,
+            count: 1,
+            family: DrawCommandFamily::Draw,
+
+            vertex_or_index_limit: None,
+            instance_limit: None,
+        });
+
+        Ok(())
+    }
+
+    pub fn draw_indexed_indirect(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::DrawIndirect,
+            family: DrawCommandFamily::DrawIndexed,
+        };
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, buffer.check_is_valid());
+
+        base.commands.push(ArcRenderCommand::DrawIndirect {
+            buffer,
+            offset,
+            count: 1,
+            family: DrawCommandFamily::DrawIndexed,
+
+            vertex_or_index_limit: None,
+            instance_limit: None,
+        });
+
+        Ok(())
+    }
+
+    pub fn draw_mesh_tasks_indirect(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+    ) -> Result<(), RenderPassError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::DrawIndirect,
+            family: DrawCommandFamily::DrawMeshTasks,
+        };
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, buffer.check_is_valid());
+
+        base.commands.push(ArcRenderCommand::DrawIndirect {
+            buffer,
+            offset,
+            count: 1,
+            family: DrawCommandFamily::DrawMeshTasks,
+
+            vertex_or_index_limit: None,
+            instance_limit: None,
+        });
+
+        Ok(())
+    }
+
+    pub fn multi_draw_indirect(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::MultiDrawIndirect,
+            family: DrawCommandFamily::Draw,
+        };
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, buffer.check_is_valid());
+
+        base.commands.push(ArcRenderCommand::DrawIndirect {
+            buffer,
+            offset,
+            count,
+            family: DrawCommandFamily::Draw,
+
+            vertex_or_index_limit: None,
+            instance_limit: None,
+        });
+
+        Ok(())
+    }
+
+    pub fn multi_draw_indexed_indirect(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::MultiDrawIndirect,
+            family: DrawCommandFamily::DrawIndexed,
+        };
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, buffer.check_is_valid());
+
+        base.commands.push(ArcRenderCommand::DrawIndirect {
+            buffer,
+            offset,
+            count,
+            family: DrawCommandFamily::DrawIndexed,
+
+            vertex_or_index_limit: None,
+            instance_limit: None,
+        });
+
+        Ok(())
+    }
+
+    pub fn multi_draw_mesh_tasks_indirect(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count: u32,
+    ) -> Result<(), RenderPassError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::MultiDrawIndirect,
+            family: DrawCommandFamily::DrawMeshTasks,
+        };
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, buffer.check_is_valid());
+
+        base.commands.push(ArcRenderCommand::DrawIndirect {
+            buffer,
+            offset,
+            count,
+            family: DrawCommandFamily::DrawMeshTasks,
+
+            vertex_or_index_limit: None,
+            instance_limit: None,
+        });
+
+        Ok(())
+    }
+
+    pub fn multi_draw_indirect_count(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count_buffer: Arc<Buffer>,
+        count_buffer_offset: BufferAddress,
+        max_count: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::MultiDrawIndirectCount,
+            family: DrawCommandFamily::Draw,
+        };
+        let base = pass_base!(self, scope);
+        pass_try!(base, scope, buffer.check_is_valid());
+        pass_try!(base, scope, count_buffer.check_is_valid());
+
+        base.commands
+            .push(ArcRenderCommand::MultiDrawIndirectCount {
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_count,
+                family: DrawCommandFamily::Draw,
+            });
+
+        Ok(())
+    }
+
+    pub fn multi_draw_indexed_indirect_count(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count_buffer: Arc<Buffer>,
+        count_buffer_offset: BufferAddress,
+        max_count: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::MultiDrawIndirectCount,
+            family: DrawCommandFamily::DrawIndexed,
+        };
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, buffer.check_is_valid());
+        pass_try!(base, scope, count_buffer.check_is_valid());
+
+        base.commands
+            .push(ArcRenderCommand::MultiDrawIndirectCount {
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_count,
+                family: DrawCommandFamily::DrawIndexed,
+            });
+
+        Ok(())
+    }
+
+    pub fn multi_draw_mesh_tasks_indirect_count(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count_buffer: Arc<Buffer>,
+        count_buffer_offset: BufferAddress,
+        max_count: u32,
+    ) -> Result<(), RenderPassError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::MultiDrawIndirectCount,
+            family: DrawCommandFamily::DrawMeshTasks,
+        };
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, buffer.check_is_valid());
+        pass_try!(base, scope, count_buffer.check_is_valid());
+
+        base.commands
+            .push(ArcRenderCommand::MultiDrawIndirectCount {
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_count,
+                family: DrawCommandFamily::DrawMeshTasks,
+            });
+
+        Ok(())
+    }
+
+    pub fn push_debug_group(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
+        let base = pass_base!(self, PassErrorScope::PushDebugGroup);
+
+        let bytes = label.as_bytes();
+        base.string_data.extend_from_slice(bytes);
+
+        base.commands.push(ArcRenderCommand::PushDebugGroup {
+            color,
+            len: bytes.len(),
+        });
+
+        Ok(())
+    }
+
+    pub fn pop_debug_group(&mut self) -> Result<(), PassStateError> {
+        let base = pass_base!(self, PassErrorScope::PopDebugGroup);
+
+        base.commands.push(ArcRenderCommand::PopDebugGroup);
+
+        Ok(())
+    }
+
+    pub fn insert_debug_marker(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
+        let base = pass_base!(self, PassErrorScope::InsertDebugMarker);
+
+        let bytes = label.as_bytes();
+        base.string_data.extend_from_slice(bytes);
+
+        base.commands.push(ArcRenderCommand::InsertDebugMarker {
+            color,
+            len: bytes.len(),
+        });
+
+        Ok(())
+    }
+
+    pub fn write_timestamp(
+        &mut self,
+        query_set: Arc<QuerySet>,
+        query_index: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::WriteTimestamp;
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, query_set.check_is_valid());
+        base.commands.push(ArcRenderCommand::WriteTimestamp {
+            query_set,
+            query_index,
+        });
+
+        Ok(())
+    }
+
+    pub fn begin_occlusion_query(&mut self, query_index: u32) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::BeginOcclusionQuery;
+        let base = pass_base!(self, scope);
+
+        base.commands
+            .push(ArcRenderCommand::BeginOcclusionQuery { query_index });
+
+        Ok(())
+    }
+
+    pub fn end_occlusion_query(&mut self) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::EndOcclusionQuery;
+        let base = pass_base!(self, scope);
+
+        base.commands.push(ArcRenderCommand::EndOcclusionQuery);
+
+        Ok(())
+    }
+
+    pub fn begin_pipeline_statistics_query(
+        &mut self,
+        query_set: Arc<QuerySet>,
+        query_index: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::BeginPipelineStatisticsQuery;
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, query_set.check_is_valid());
+        base.commands
+            .push(ArcRenderCommand::BeginPipelineStatisticsQuery {
+                query_set,
+                query_index,
+            });
+
+        Ok(())
+    }
+
+    pub fn end_pipeline_statistics_query(&mut self) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::EndPipelineStatisticsQuery;
+        let base = pass_base!(self, scope);
+
+        base.commands
+            .push(ArcRenderCommand::EndPipelineStatisticsQuery);
+
+        Ok(())
+    }
+
+    pub fn execute_bundles(
+        &mut self,
+        render_bundles: &[Arc<RenderBundle>],
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::ExecuteBundle;
+        let base = pass_base!(self, scope);
+
+        for bundle in render_bundles {
+            pass_try!(base, scope, bundle.check_is_valid());
+
+            base.commands
+                .push(ArcRenderCommand::ExecuteBundle(bundle.clone()));
+        }
+        self.current_pipeline.reset();
+        self.current_bind_groups.reset();
+
+        Ok(())
+    }
+}
+
+pub(crate) const fn get_src_stride_of_indirect_args(family: DrawCommandFamily) -> u64 {
+    match family {
+        DrawCommandFamily::Draw => size_of::<wgt::DrawIndirectArgs>() as u64,
+        DrawCommandFamily::DrawIndexed => size_of::<wgt::DrawIndexedIndirectArgs>() as u64,
+        DrawCommandFamily::DrawMeshTasks => size_of::<wgt::DispatchIndirectArgs>() as u64,
+    }
+}
+
+pub(crate) const fn get_dst_stride_of_indirect_args(
+    backend: wgt::Backend,
+    family: DrawCommandFamily,
+) -> u64 {
+    // space for D3D12 special constants
+    let extra = if matches!(backend, wgt::Backend::Dx12) {
+        3 * size_of::<u32>() as u64
+    } else {
+        0
+    };
+    extra + get_src_stride_of_indirect_args(family)
+}
+
+// Recording a render pass.
+//
+// The only error that should be returned from these methods is
+// `EncoderStateError::Ended`, when the pass has already ended and an immediate
+// validation error is raised.
+//
+// All other errors should be stored in the pass for later reporting when
+// `CommandEncoder.finish()` is called.
+//
+// The `pass_try!` macro should be used to handle errors appropriately. Note
+// that the `pass_try!` and `pass_base!` macros may return early from the
+// function that invokes them, like the `?` operator.
+impl Global {
+    pub fn render_pass_set_bind_group(
+        &self,
+        pass: &mut RenderPass,
+        index: u32,
+        bind_group_id: Option<id::BindGroupId>,
+        offsets: &[DynamicOffset],
+    ) -> Result<(), PassStateError> {
+        pass.set_bind_group(
+            index,
+            bind_group_id.map(|id| self.hub.bind_groups.get(id)),
+            offsets,
+        )
+    }
+
+    pub fn render_pass_set_bind_group_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        index: u32,
+        bind_group_id: Option<id::BindGroupId>,
+        offsets: &[DynamicOffset],
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_bind_group(&mut pass, index, bind_group_id, offsets)
+    }
+
+    pub fn render_pass_set_pipeline(
+        &self,
+        pass: &mut RenderPass,
+        pipeline_id: id::RenderPipelineId,
+    ) -> Result<(), PassStateError> {
+        let pipeline = self.resolve_render_pipeline_id(pipeline_id);
+        pass.set_pipeline(pipeline)
+    }
+
+    pub fn render_pass_set_pipeline_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        pipeline_id: id::RenderPipelineId,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_pipeline(&mut pass, pipeline_id)
+    }
+
+    pub fn render_pass_set_index_buffer(
+        &self,
+        pass: &mut RenderPass,
+        buffer_id: id::BufferId,
+        index_format: IndexFormat,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) -> Result<(), PassStateError> {
+        pass.set_index_buffer(
+            self.resolve_buffer_id(buffer_id),
+            index_format,
+            offset,
+            size,
+        )
+    }
+
+    pub fn render_pass_set_index_buffer_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        buffer_id: id::BufferId,
+        index_format: IndexFormat,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_index_buffer(&mut pass, buffer_id, index_format, offset, size)
+    }
+
+    pub fn render_pass_set_vertex_buffer(
+        &self,
+        pass: &mut RenderPass,
+        slot: u32,
+        buffer_id: Option<id::BufferId>,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) -> Result<(), PassStateError> {
+        pass.set_vertex_buffer(
+            slot,
+            buffer_id.map(|id| self.resolve_buffer_id(id)),
+            offset,
+            size,
+        )
+    }
+
+    pub fn render_pass_set_vertex_buffer_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        slot: u32,
+        buffer_id: Option<id::BufferId>,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_vertex_buffer(&mut pass, slot, buffer_id, offset, size)
+    }
+
+    pub fn render_pass_set_blend_constant(
+        &self,
+        pass: &mut RenderPass,
+        color: Color,
+    ) -> Result<(), PassStateError> {
+        pass.set_blend_constant(color)
+    }
+
+    pub fn render_pass_set_blend_constant_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        color: Color,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_blend_constant(&mut pass, color)
+    }
+
+    pub fn render_pass_set_stencil_reference(
+        &self,
+        pass: &mut RenderPass,
+        value: u32,
+    ) -> Result<(), PassStateError> {
+        pass.set_stencil_reference(value)
+    }
+
+    pub fn render_pass_set_stencil_reference_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        value: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_stencil_reference(&mut pass, value)
+    }
+
+    pub fn render_pass_set_viewport(
+        &self,
+        pass: &mut RenderPass,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        depth_min: f32,
+        depth_max: f32,
+    ) -> Result<(), PassStateError> {
+        pass.set_viewport(x, y, w, h, depth_min, depth_max)
+    }
+
+    pub fn render_pass_set_viewport_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        depth_min: f32,
+        depth_max: f32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_viewport(&mut pass, x, y, w, h, depth_min, depth_max)
+    }
+
+    pub fn render_pass_set_scissor_rect(
+        &self,
+        pass: &mut RenderPass,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> Result<(), PassStateError> {
+        pass.set_scissor_rect(x, y, w, h)
+    }
+
+    pub fn render_pass_set_scissor_rect_with_id(
+        &self,
+        pass: id::RenderPassEncoderId,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> Result<(), PassStateError> {
+        let pass = self.hub.render_passes.get(pass);
+        let mut pass = pass
+            .try_lock()
+            .expect("RenderPasses should not be used concurrently");
+        self.render_pass_set_scissor_rect(&mut pass, x, y, w, h)
+    }
+
+    pub fn render_pass_set_immediates(
+        &self,
+        pass: &mut RenderPass,
+        offset: u32,
+        data: &[u8],
+    ) -> Result<(), PassStateError> {
+        pass.set_immediates(offset, data)
+    }
+
     pub fn render_pass_set_immediates_with_id(
         &self,
         pass: id::RenderPassEncoderId,
@@ -4017,20 +4608,7 @@ impl Global {
         first_vertex: u32,
         first_instance: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::Draw,
-            family: DrawCommandFamily::Draw,
-        };
-        let base = pass_base!(pass, scope);
-
-        base.commands.push(ArcRenderCommand::Draw {
-            vertex_count,
-            instance_count,
-            first_vertex,
-            first_instance,
-        });
-
-        Ok(())
+        pass.draw(vertex_count, instance_count, first_vertex, first_instance)
     }
 
     pub fn render_pass_draw_with_id(
@@ -4063,21 +4641,13 @@ impl Global {
         base_vertex: i32,
         first_instance: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::Draw,
-            family: DrawCommandFamily::DrawIndexed,
-        };
-        let base = pass_base!(pass, scope);
-
-        base.commands.push(ArcRenderCommand::DrawIndexed {
+        pass.draw_indexed(
             index_count,
             instance_count,
             first_index,
             base_vertex,
             first_instance,
-        });
-
-        Ok(())
+        )
     }
 
     pub fn render_pass_draw_indexed_with_id(
@@ -4110,18 +4680,7 @@ impl Global {
         group_count_y: u32,
         group_count_z: u32,
     ) -> Result<(), RenderPassError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::Draw,
-            family: DrawCommandFamily::DrawMeshTasks,
-        };
-        let base = pass_base!(pass, scope);
-
-        base.commands.push(ArcRenderCommand::DrawMeshTasks {
-            group_count_x,
-            group_count_y,
-            group_count_z,
-        });
-        Ok(())
+        pass.draw_mesh_tasks(group_count_x, group_count_y, group_count_z)
     }
 
     pub fn render_pass_draw_indirect(
@@ -4130,26 +4689,7 @@ impl Global {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::DrawIndirect,
-            family: DrawCommandFamily::Draw,
-        };
-        let base = pass_base!(pass, scope);
-
-        let buffer = self.resolve_buffer_id(buffer_id);
-        pass_try!(base, scope, buffer.check_is_valid());
-
-        base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer,
-            offset,
-            count: 1,
-            family: DrawCommandFamily::Draw,
-
-            vertex_or_index_limit: None,
-            instance_limit: None,
-        });
-
-        Ok(())
+        pass.draw_indirect(self.resolve_buffer_id(buffer_id), offset)
     }
 
     pub fn render_pass_draw_indirect_with_id(
@@ -4171,26 +4711,7 @@ impl Global {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::DrawIndirect,
-            family: DrawCommandFamily::DrawIndexed,
-        };
-        let base = pass_base!(pass, scope);
-
-        let buffer = self.resolve_buffer_id(buffer_id);
-        pass_try!(base, scope, buffer.check_is_valid());
-
-        base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer,
-            offset,
-            count: 1,
-            family: DrawCommandFamily::DrawIndexed,
-
-            vertex_or_index_limit: None,
-            instance_limit: None,
-        });
-
-        Ok(())
+        pass.draw_indexed_indirect(self.resolve_buffer_id(buffer_id), offset)
     }
 
     pub fn render_pass_draw_indexed_indirect_with_id(
@@ -4212,26 +4733,7 @@ impl Global {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), RenderPassError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::DrawIndirect,
-            family: DrawCommandFamily::DrawMeshTasks,
-        };
-        let base = pass_base!(pass, scope);
-
-        let buffer = self.resolve_buffer_id(buffer_id);
-        pass_try!(base, scope, buffer.check_is_valid());
-
-        base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer,
-            offset,
-            count: 1,
-            family: DrawCommandFamily::DrawMeshTasks,
-
-            vertex_or_index_limit: None,
-            instance_limit: None,
-        });
-
-        Ok(())
+        pass.draw_mesh_tasks_indirect(self.resolve_buffer_id(buffer_id), offset)
     }
 
     pub fn render_pass_multi_draw_indirect(
@@ -4241,26 +4743,7 @@ impl Global {
         offset: BufferAddress,
         count: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::MultiDrawIndirect,
-            family: DrawCommandFamily::Draw,
-        };
-        let base = pass_base!(pass, scope);
-
-        let buffer = self.resolve_buffer_id(buffer_id);
-        pass_try!(base, scope, buffer.check_is_valid());
-
-        base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer,
-            offset,
-            count,
-            family: DrawCommandFamily::Draw,
-
-            vertex_or_index_limit: None,
-            instance_limit: None,
-        });
-
-        Ok(())
+        pass.multi_draw_indirect(self.resolve_buffer_id(buffer_id), offset, count)
     }
 
     pub fn render_pass_multi_draw_indexed_indirect(
@@ -4270,26 +4753,7 @@ impl Global {
         offset: BufferAddress,
         count: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::MultiDrawIndirect,
-            family: DrawCommandFamily::DrawIndexed,
-        };
-        let base = pass_base!(pass, scope);
-
-        let buffer = self.resolve_buffer_id(buffer_id);
-        pass_try!(base, scope, buffer.check_is_valid());
-
-        base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer,
-            offset,
-            count,
-            family: DrawCommandFamily::DrawIndexed,
-
-            vertex_or_index_limit: None,
-            instance_limit: None,
-        });
-
-        Ok(())
+        pass.multi_draw_indexed_indirect(self.resolve_buffer_id(buffer_id), offset, count)
     }
 
     pub fn render_pass_multi_draw_mesh_tasks_indirect(
@@ -4299,26 +4763,7 @@ impl Global {
         offset: BufferAddress,
         count: u32,
     ) -> Result<(), RenderPassError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::MultiDrawIndirect,
-            family: DrawCommandFamily::DrawMeshTasks,
-        };
-        let base = pass_base!(pass, scope);
-
-        let buffer = self.resolve_buffer_id(buffer_id);
-        pass_try!(base, scope, buffer.check_is_valid());
-
-        base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer,
-            offset,
-            count,
-            family: DrawCommandFamily::DrawMeshTasks,
-
-            vertex_or_index_limit: None,
-            instance_limit: None,
-        });
-
-        Ok(())
+        pass.multi_draw_mesh_tasks_indirect(self.resolve_buffer_id(buffer_id), offset, count)
     }
 
     pub fn render_pass_multi_draw_indirect_count(
@@ -4330,28 +4775,13 @@ impl Global {
         count_buffer_offset: BufferAddress,
         max_count: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::MultiDrawIndirectCount,
-            family: DrawCommandFamily::Draw,
-        };
-        let base = pass_base!(pass, scope);
-
-        let buffer = self.resolve_buffer_id(buffer_id);
-        pass_try!(base, scope, buffer.check_is_valid());
-        let count_buffer = self.resolve_buffer_id(count_buffer_id);
-        pass_try!(base, scope, count_buffer.check_is_valid());
-
-        base.commands
-            .push(ArcRenderCommand::MultiDrawIndirectCount {
-                buffer,
-                offset,
-                count_buffer,
-                count_buffer_offset,
-                max_count,
-                family: DrawCommandFamily::Draw,
-            });
-
-        Ok(())
+        pass.multi_draw_indirect_count(
+            self.resolve_buffer_id(buffer_id),
+            offset,
+            self.resolve_buffer_id(count_buffer_id),
+            count_buffer_offset,
+            max_count,
+        )
     }
 
     pub fn render_pass_multi_draw_indexed_indirect_count(
@@ -4363,28 +4793,13 @@ impl Global {
         count_buffer_offset: BufferAddress,
         max_count: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::MultiDrawIndirectCount,
-            family: DrawCommandFamily::DrawIndexed,
-        };
-        let base = pass_base!(pass, scope);
-
-        let buffer = self.resolve_buffer_id(buffer_id);
-        pass_try!(base, scope, buffer.check_is_valid());
-        let count_buffer = self.resolve_buffer_id(count_buffer_id);
-        pass_try!(base, scope, count_buffer.check_is_valid());
-
-        base.commands
-            .push(ArcRenderCommand::MultiDrawIndirectCount {
-                buffer,
-                offset,
-                count_buffer,
-                count_buffer_offset,
-                max_count,
-                family: DrawCommandFamily::DrawIndexed,
-            });
-
-        Ok(())
+        pass.multi_draw_indexed_indirect_count(
+            self.resolve_buffer_id(buffer_id),
+            offset,
+            self.resolve_buffer_id(count_buffer_id),
+            count_buffer_offset,
+            max_count,
+        )
     }
 
     pub fn render_pass_multi_draw_mesh_tasks_indirect_count(
@@ -4396,28 +4811,13 @@ impl Global {
         count_buffer_offset: BufferAddress,
         max_count: u32,
     ) -> Result<(), RenderPassError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::MultiDrawIndirectCount,
-            family: DrawCommandFamily::DrawMeshTasks,
-        };
-        let base = pass_base!(pass, scope);
-
-        let buffer = self.resolve_buffer_id(buffer_id);
-        pass_try!(base, scope, buffer.check_is_valid());
-        let count_buffer = self.resolve_buffer_id(count_buffer_id);
-        pass_try!(base, scope, count_buffer.check_is_valid());
-
-        base.commands
-            .push(ArcRenderCommand::MultiDrawIndirectCount {
-                buffer,
-                offset,
-                count_buffer,
-                count_buffer_offset,
-                max_count,
-                family: DrawCommandFamily::DrawMeshTasks,
-            });
-
-        Ok(())
+        pass.multi_draw_mesh_tasks_indirect_count(
+            self.resolve_buffer_id(buffer_id),
+            offset,
+            self.resolve_buffer_id(count_buffer_id),
+            count_buffer_offset,
+            max_count,
+        )
     }
 
     pub fn render_pass_push_debug_group(
@@ -4426,17 +4826,7 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let base = pass_base!(pass, PassErrorScope::PushDebugGroup);
-
-        let bytes = label.as_bytes();
-        base.string_data.extend_from_slice(bytes);
-
-        base.commands.push(ArcRenderCommand::PushDebugGroup {
-            color,
-            len: bytes.len(),
-        });
-
-        Ok(())
+        pass.push_debug_group(label, color)
     }
 
     pub fn render_pass_push_debug_group_with_id(
@@ -4453,11 +4843,7 @@ impl Global {
     }
 
     pub fn render_pass_pop_debug_group(&self, pass: &mut RenderPass) -> Result<(), PassStateError> {
-        let base = pass_base!(pass, PassErrorScope::PopDebugGroup);
-
-        base.commands.push(ArcRenderCommand::PopDebugGroup);
-
-        Ok(())
+        pass.pop_debug_group()
     }
 
     pub fn render_pass_pop_debug_group_with_id(
@@ -4477,17 +4863,7 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let base = pass_base!(pass, PassErrorScope::InsertDebugMarker);
-
-        let bytes = label.as_bytes();
-        base.string_data.extend_from_slice(bytes);
-
-        base.commands.push(ArcRenderCommand::InsertDebugMarker {
-            color,
-            len: bytes.len(),
-        });
-
-        Ok(())
+        pass.insert_debug_marker(label, color)
     }
 
     pub fn render_pass_insert_debug_marker_with_id(
@@ -4509,17 +4885,7 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::WriteTimestamp;
-        let base = pass_base!(pass, scope);
-
-        let query_set = self.resolve_query_set_id(query_set_id);
-        pass_try!(base, scope, query_set.check_is_valid());
-        base.commands.push(ArcRenderCommand::WriteTimestamp {
-            query_set,
-            query_index,
-        });
-
-        Ok(())
+        pass.write_timestamp(self.resolve_query_set_id(query_set_id), query_index)
     }
 
     pub fn render_pass_write_timestamp_with_id(
@@ -4540,13 +4906,7 @@ impl Global {
         pass: &mut RenderPass,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::BeginOcclusionQuery;
-        let base = pass_base!(pass, scope);
-
-        base.commands
-            .push(ArcRenderCommand::BeginOcclusionQuery { query_index });
-
-        Ok(())
+        pass.begin_occlusion_query(query_index)
     }
 
     pub fn render_pass_begin_occlusion_query_with_id(
@@ -4565,12 +4925,7 @@ impl Global {
         &self,
         pass: &mut RenderPass,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::EndOcclusionQuery;
-        let base = pass_base!(pass, scope);
-
-        base.commands.push(ArcRenderCommand::EndOcclusionQuery);
-
-        Ok(())
+        pass.end_occlusion_query()
     }
 
     pub fn render_pass_end_occlusion_query_with_id(
@@ -4590,18 +4945,7 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::BeginPipelineStatisticsQuery;
-        let base = pass_base!(pass, scope);
-
-        let query_set = self.resolve_query_set_id(query_set_id);
-        pass_try!(base, scope, query_set.check_is_valid());
-        base.commands
-            .push(ArcRenderCommand::BeginPipelineStatisticsQuery {
-                query_set,
-                query_index,
-            });
-
-        Ok(())
+        pass.begin_pipeline_statistics_query(self.resolve_query_set_id(query_set_id), query_index)
     }
 
     pub fn render_pass_begin_pipeline_statistics_query_with_id(
@@ -4621,13 +4965,7 @@ impl Global {
         &self,
         pass: &mut RenderPass,
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::EndPipelineStatisticsQuery;
-        let base = pass_base!(pass, scope);
-
-        base.commands
-            .push(ArcRenderCommand::EndPipelineStatisticsQuery);
-
-        Ok(())
+        pass.end_pipeline_statistics_query()
     }
 
     pub fn render_pass_end_pipeline_statistics_query_with_id(
@@ -4646,22 +4984,14 @@ impl Global {
         pass: &mut RenderPass,
         render_bundle_ids: &[id::RenderBundleId],
     ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::ExecuteBundle;
-        let base = pass_base!(pass, scope);
-
         let hub = &self.hub;
         let bundles = hub.render_bundles.read();
+        let render_bundles = render_bundle_ids
+            .iter()
+            .map(|&id| bundles.get(id))
+            .collect::<Vec<_>>();
 
-        for &bundle_id in render_bundle_ids {
-            let bundle = bundles.get(bundle_id);
-            pass_try!(base, scope, bundle.check_is_valid());
-
-            base.commands.push(ArcRenderCommand::ExecuteBundle(bundle));
-        }
-        pass.current_pipeline.reset();
-        pass.current_bind_groups.reset();
-
-        Ok(())
+        pass.execute_bundles(&render_bundles)
     }
 
     pub fn render_pass_execute_bundles_with_id(
@@ -4675,25 +5005,4 @@ impl Global {
             .expect("RenderPasses should not be used concurrently");
         self.render_pass_execute_bundles(&mut pass, render_bundle_ids)
     }
-}
-
-pub(crate) const fn get_src_stride_of_indirect_args(family: DrawCommandFamily) -> u64 {
-    match family {
-        DrawCommandFamily::Draw => size_of::<wgt::DrawIndirectArgs>() as u64,
-        DrawCommandFamily::DrawIndexed => size_of::<wgt::DrawIndexedIndirectArgs>() as u64,
-        DrawCommandFamily::DrawMeshTasks => size_of::<wgt::DispatchIndirectArgs>() as u64,
-    }
-}
-
-pub(crate) const fn get_dst_stride_of_indirect_args(
-    backend: wgt::Backend,
-    family: DrawCommandFamily,
-) -> u64 {
-    // space for D3D12 special constants
-    let extra = if matches!(backend, wgt::Backend::Dx12) {
-        3 * size_of::<u32>() as u64
-    } else {
-        0
-    };
-    extra + get_src_stride_of_indirect_args(family)
 }


### PR DESCRIPTION
**Connections**
Towards #5121 

**Description**
Firstly we need to have generic `StateChange` and `BindGroupStateChange` so we can use both ID or Arced. This got complicated because arc are not copy and do not implement PartialEq so we rolled our own trait.

Then we can move logic from global methods into new methods on resources (ComputePass/RenderPass) and make Global methods only resolve ids and call them (we say we make global methods thin).

**Testing**
Just refactor

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
