### PR TITLE
[naga msl-out] Evaluate loop `break_if` conditions at their definition point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Bottom level categories:
 
 ### Bug Fixes
 
+#### Metal
+
+- Fixed the MSL backend re-evaluating a loop's `break if` condition after the hoisted `continuing` block had already updated the variables it reads. Loops with a conditional backedge computed in the loop body (`OpBranchConditional` in SPIR-V, e.g. rust-gpu `while` loops) exited one iteration early or looped forever. Such conditions are now captured into a `bool` where they are computed; conditions reading state written by the `continuing` block keep the previous behavior. By @haixuanTao in [#9815](https://github.com/gfx-rs/wgpu/pull/9815).
+
 #### GLES
 
 - Fixed signed integer `%` (and `%=`) returning the wrong result for negative operands in the GLSL (OpenGL/GLES) backend, e.g. `-1 % 768` yielding `255` instead of `-1`. GLSL's `%` is undefined when either operand is negative, so signed remainder is now lowered as `a - b * (a / b)`, matching the SPIR-V, HLSL, and Metal backends. By @mstampfli in [#9687](https://github.com/gfx-rs/wgpu/pull/9687).

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -555,6 +555,35 @@ pub struct Writer<W> {
     /// padding inserted **before** them (i.e. between fields at index - 1 and index)
     struct_member_pads: FastHashSet<(Handle<crate::Type>, u32)>,
     needs_object_memory_barriers: bool,
+    /// Stack of `break_if` condition snapshot variables for enclosing
+    /// [`Statement::Loop`]s, innermost last; `None` for loops without a
+    /// `break_if` or whose condition must be evaluated in the continuing
+    /// block itself.
+    ///
+    /// Since the continuing block is rendered at the top of the next `while`
+    /// iteration, a `break_if` condition computed in the loop body must be
+    /// captured before the continuing statements update the variables it
+    /// reads (see gfx-rs/wgpu#4558):
+    ///
+    /// ```ignore
+    /// bool loop_break = false;
+    /// while(true) {
+    ///   if (!loop_init) {
+    ///     // continuing statements...
+    ///     if (loop_break) { break; }
+    ///   }
+    ///   // body statements...
+    ///   loop_break = <condition>; // also emitted before each `continue;`
+    /// }
+    /// ```
+    ///
+    /// Conditions that read state written by the continuing block (WGSL's
+    /// `continuing { ...; break if c; }` form) are instead rendered in
+    /// place, after the continuing statements; see
+    /// [`break_if_depends_on_continuing`].
+    ///
+    /// [`Statement::Loop`]: crate::Statement::Loop
+    loop_break_snapshots: Vec<Option<(String, Handle<crate::Expression>)>>,
 }
 
 impl crate::Scalar {
@@ -943,6 +972,104 @@ pub(super) struct StatementContext<'a> {
     pub(super) result_struct: Option<&'a str>,
 }
 
+/// Whether `block` (or any block nested within it) contains an [`Emit`]
+/// statement whose range covers `handle`.
+///
+/// [`Emit`]: crate::Statement::Emit
+fn block_emits_expression(block: &crate::Block, handle: Handle<crate::Expression>) -> bool {
+    block.iter().any(|stmt| match *stmt {
+        crate::Statement::Emit(ref range) => range.clone().any(|h| h == handle),
+        crate::Statement::Block(ref b) => block_emits_expression(b, handle),
+        crate::Statement::If {
+            ref accept,
+            ref reject,
+            ..
+        } => block_emits_expression(accept, handle) || block_emits_expression(reject, handle),
+        crate::Statement::Switch { ref cases, .. } => cases
+            .iter()
+            .any(|case| block_emits_expression(&case.body, handle)),
+        crate::Statement::Loop {
+            ref body,
+            ref continuing,
+            ..
+        } => block_emits_expression(body, handle) || block_emits_expression(continuing, handle),
+        _ => false,
+    })
+}
+
+/// Whether evaluating `cond` must wait until the loop's `continuing` block
+/// has executed: true iff its expression tree contains a state-reading
+/// sub-expression ([`Load`] or similar) emitted within `continuing`. See
+/// [`Writer::loop_break_snapshots`].
+///
+/// [`Load`]: crate::Expression::Load
+fn break_if_depends_on_continuing(
+    func: &crate::Function,
+    continuing: &crate::Block,
+    cond: Handle<crate::Expression>,
+) -> bool {
+    use crate::Expression as Ex;
+    let mut stack = vec![cond];
+    let mut seen = FastHashSet::default();
+    while let Some(handle) = stack.pop() {
+        if !seen.insert(handle) {
+            continue;
+        }
+        let stateful = matches!(
+            func.expressions[handle],
+            Ex::Load { .. }
+                | Ex::ImageSample { .. }
+                | Ex::ImageLoad { .. }
+                | Ex::RayQueryVertexPositions { .. }
+                | Ex::RayQueryGetIntersection { .. }
+        );
+        if stateful && block_emits_expression(continuing, handle) {
+            return true;
+        }
+        match func.expressions[handle] {
+            Ex::Access { base, index } => {
+                stack.push(base);
+                stack.push(index);
+            }
+            Ex::AccessIndex { base, .. } => stack.push(base),
+            Ex::Splat { value, .. } => stack.push(value),
+            Ex::Swizzle { vector, .. } => stack.push(vector),
+            Ex::Compose { ref components, .. } => stack.extend(components.iter().copied()),
+            Ex::Load { pointer } => stack.push(pointer),
+            Ex::Unary { expr, .. } | Ex::Derivative { expr, .. } | Ex::As { expr, .. } => {
+                stack.push(expr)
+            }
+            Ex::Binary { left, right, .. } => {
+                stack.push(left);
+                stack.push(right);
+            }
+            Ex::Select {
+                condition,
+                accept,
+                reject,
+            } => {
+                stack.push(condition);
+                stack.push(accept);
+                stack.push(reject);
+            }
+            Ex::Relational { argument, .. } => stack.push(argument),
+            Ex::Math {
+                arg,
+                arg1,
+                arg2,
+                arg3,
+                ..
+            } => {
+                stack.push(arg);
+                stack.extend([arg1, arg2, arg3].into_iter().flatten());
+            }
+            Ex::ArrayLength(expr) => stack.push(expr),
+            _ => {}
+        }
+    }
+    false
+}
+
 impl<W: Write> Writer<W> {
     /// Creates a new `Writer` instance.
     pub fn new(out: W) -> Self {
@@ -956,6 +1083,7 @@ impl<W: Write> Writer<W> {
             emit_int_div_checks: true,
             struct_member_pads: FastHashSet::default(),
             needs_object_memory_barriers: false,
+            loop_break_snapshots: Vec::new(),
         }
     }
 
@@ -4085,9 +4213,22 @@ impl<W: Write> Writer<W> {
                         self.gen_force_bounded_loop_statements(level, context);
                     let gate_name = (!continuing.is_empty() || break_if.is_some())
                         .then(|| self.namer.call("loop_init"));
+                    // See `loop_break_snapshots`.
+                    let break_snap = break_if
+                        .filter(|&cond| {
+                            !break_if_depends_on_continuing(
+                                context.expression.function,
+                                continuing,
+                                cond,
+                            )
+                        })
+                        .map(|cond| (self.namer.call("loop_break"), cond));
 
                     if let Some((ref decl, _)) = force_loop_bound_statements {
                         writeln!(self.out, "{decl}")?;
+                    }
+                    if let Some((ref snap, _)) = break_snap {
+                        writeln!(self.out, "{level}bool {snap} = false;")?;
                     }
                     if let Some(ref gate_name) = gate_name {
                         writeln!(self.out, "{level}bool {gate_name} = true;")?;
@@ -4102,7 +4243,11 @@ impl<W: Write> Writer<W> {
                         let lcontinuing = lif.next();
                         writeln!(self.out, "{lif}if (!{gate_name}) {{")?;
                         self.put_block(lcontinuing, continuing, context)?;
-                        if let Some(condition) = break_if {
+                        if let Some((ref snap, _)) = break_snap {
+                            writeln!(self.out, "{lcontinuing}if ({snap}) {{")?;
+                            writeln!(self.out, "{}break;", lcontinuing.next())?;
+                            writeln!(self.out, "{lcontinuing}}}")?;
+                        } else if let Some(condition) = break_if {
                             write!(self.out, "{lcontinuing}if (")?;
                             self.put_expression(condition, &context.expression, true)?;
                             writeln!(self.out, ") {{")?;
@@ -4112,7 +4257,26 @@ impl<W: Write> Writer<W> {
                         writeln!(self.out, "{lif}}}")?;
                         writeln!(self.out, "{lif}{gate_name} = false;")?;
                     }
+                    self.loop_break_snapshots.push(break_snap.clone());
                     self.put_block(level.next(), body, context)?;
+                    self.loop_break_snapshots.pop();
+                    // Body fall-through also reaches the continuing block:
+                    // capture the condition here too, unless this statement
+                    // would be unreachable.
+                    let body_falls_through = !matches!(
+                        body.last(),
+                        Some(
+                            &crate::Statement::Continue
+                                | &crate::Statement::Break
+                                | &crate::Statement::Return { .. }
+                                | &crate::Statement::Kill
+                        )
+                    );
+                    if let Some((ref snap, cond)) = break_snap.filter(|_| body_falls_through) {
+                        write!(self.out, "{}{snap} = ", level.next())?;
+                        self.put_expression(cond, &context.expression, true)?;
+                        writeln!(self.out, ";")?;
+                    }
 
                     writeln!(self.out, "{level}}}")?;
                 }
@@ -4120,6 +4284,12 @@ impl<W: Write> Writer<W> {
                     writeln!(self.out, "{level}break;")?;
                 }
                 crate::Statement::Continue => {
+                    // See `loop_break_snapshots`.
+                    if let Some(Some((snap, cond))) = self.loop_break_snapshots.last().cloned() {
+                        write!(self.out, "{level}{snap} = ")?;
+                        self.put_expression(cond, &context.expression, true)?;
+                        writeln!(self.out, ";")?;
+                    }
                     writeln!(self.out, "{level}continue;")?;
                 }
                 crate::Statement::Return {

--- a/naga/tests/in/spv/break-if-body-condition.spvasm
+++ b/naga/tests/in/spv/break-if-body-condition.spvasm
@@ -1,0 +1,83 @@
+; SPIR-V
+; Version: 1.0
+
+;; Ensure that a conditional backedge whose condition is computed in the loop
+;; BODY — before the continuing block advances the variables the condition
+;; reads — breaks at the right iteration (gfx-rs/wgpu#4558).
+;;
+;; This is the loop shape rust-gpu (and LLVM-derived front ends generally)
+;; emit for `while`/`for` loops: the header computes `i < N` from the
+;; pre-increment counter, the continuing block increments the counter, and the
+;; backedge `OpBranchConditional` consumes the header's comparison. A backend
+;; that re-evaluates the condition after the continuing block sees the
+;; post-increment counter and exits one body-execution early:
+;;
+;;     i = 0; acc = 0;
+;;     do {
+;;         acc += i;
+;;         keep = i < 3;   // pre-increment
+;;         // continuing: i += 1;
+;;     } while(keep);
+;;
+;; must run the body for i = 0, 1, 2, 3 (acc = 6), not stop at i = 2 (acc = 3).
+
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %f_ "f("
+               OpName %i "i"
+               OpName %acc "acc"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %bool = OpTypeBool
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+      %int_3 = OpConstant %int 3
+
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %20 = OpFunctionCall %void %f_
+               OpReturn
+               OpFunctionEnd
+
+         %f_ = OpFunction %void None %3
+         %11 = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+        %acc = OpVariable %_ptr_Function_int Function
+               OpStore %i %int_0
+               OpStore %acc %int_0
+               OpBranch %12
+
+;; Loop header; naga structurizes this into the `Loop`'s body.
+         %12 = OpLabel
+               OpLoopMerge %14 %15 None
+               OpBranch %13
+
+;; Loop body: accumulate, then compute the branch condition from the
+;; PRE-increment counter.
+         %13 = OpLabel
+         %16 = OpLoad %int %i
+         %17 = OpLoad %int %acc
+         %18 = OpIAdd %int %17 %16
+               OpStore %acc %18
+         %19 = OpSLessThan %bool %16 %int_3
+               OpBranch %15
+
+;; Continuing block: advance the counter the condition above already read,
+;; then take the conditional backedge on the body-computed condition.
+         %15 = OpLabel
+         %21 = OpLoad %int %i
+         %22 = OpIAdd %int %21 %int_1
+               OpStore %i %22
+               OpBranchConditional %19 %12 %14
+
+         %14 = OpLabel
+               OpReturn
+
+               OpFunctionEnd

--- a/naga/tests/in/spv/break-if-body-condition.toml
+++ b/naga/tests/in/spv/break-if-body-condition.toml
@@ -1,0 +1,4 @@
+targets = "METAL | WGSL"
+
+[spv-in]
+adjust_coordinate_space = true

--- a/naga/tests/out/msl/spv-break-if-body-condition.metal
+++ b/naga/tests/out/msl/spv-break-if-body-condition.metal
@@ -1,0 +1,46 @@
+// language: metal1.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+
+void f_u0028_(
+) {
+    int i = {};
+    int acc = {};
+    i = 0;
+    acc = 0;
+    uint2 loop_bound = uint2(4294967295u);
+    bool loop_break = false;
+    bool loop_init = true;
+    while(true) {
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
+        if (!loop_init) {
+            int _e9 = i;
+            i = as_type<int>(as_type<uint>(_e9) + as_type<uint>(1));
+            if (loop_break) {
+                break;
+            }
+        }
+        loop_init = false;
+        int _e5 = i;
+        int _e6 = acc;
+        acc = as_type<int>(as_type<uint>(_e6) + as_type<uint>(_e5));
+        loop_break = !((_e5 < 3));
+        continue;
+    }
+    return;
+}
+
+void main_1(
+) {
+    f_u0028_();
+    return;
+}
+
+fragment void main_(
+) {
+    main_1();
+}

--- a/naga/tests/out/msl/wgsl-break-if.metal
+++ b/naga/tests/out/msl/wgsl-break-if.metal
@@ -8,16 +8,18 @@ using metal::uint;
 void breakIfEmpty(
 ) {
     uint2 loop_bound = uint2(4294967295u);
+    bool loop_break = false;
     bool loop_init = true;
     while(true) {
         if (metal::all(loop_bound == uint2(0u))) { break; }
         loop_bound -= uint2(loop_bound.y == 0u, 1u);
         if (!loop_init) {
-            if (true) {
+            if (loop_break) {
                 break;
             }
         }
         loop_init = false;
+        loop_break = true;
     }
     return;
 }

--- a/naga/tests/out/wgsl/spv-break-if-body-condition.wgsl
+++ b/naga/tests/out/wgsl/spv-break-if-body-condition.wgsl
@@ -1,0 +1,29 @@
+fn f_u0028_() {
+    var i: i32;
+    var acc: i32;
+
+    i = 0i;
+    acc = 0i;
+    loop {
+        let _e5 = i;
+        let _e6 = acc;
+        acc = (_e6 + _e5);
+        continue;
+        continuing {
+            let _e9 = i;
+            i = (_e9 + 1i);
+            break if !((_e5 < 3i));
+        }
+    }
+    return;
+}
+
+fn main_1() {
+    f_u0028_();
+    return;
+}
+
+@fragment 
+fn main() {
+    main_1();
+}


### PR DESCRIPTION
# Human Generated

While doing a back-to-back test of wgpu and cuda-oxide, I found a bug of compilation with the exact same shaders.

Letting the AI fix it got me here.

# AI Generated

## Connections
Fixes #4558.

## Description

The MSL backend renders a loop's `continuing` block at the top of the next `while` iteration (guarded by a `loop_init` gate), because `continue` in MSL jumps past anything placed at the bottom of the body. The `break if` check was rendered inside that hoisted block by calling `put_expression` on the condition — i.e. **re-rendering the expression after the continuing statements had already mutated the local variables it reads**.

Per the IR docs (`Statement::Loop`), `break_if` is an *expression*: its value is fixed where it is emitted (normally in the loop body); "evaluated after the continuing block" refers to when the branch decision happens, not to re-computing the value with post-continuing state. The WGSL backend gets this right because it renders the `continuing { ... break if c; }` block at the natural position and references the baked condition value; the MSL backend only happened to be correct when the condition expression got baked into a named temporary for other reasons.

### Observed miscompiles

* #4558: `if (!(((phi_79_ < 8) ? true : false)))` rendered *after* `phi_79_ = ...;` in the hoisted block → infinite loop.
* SPIR-V front end (rust-gpu): loops whose back edge is `OpBranchConditional` translate to a body that computes the condition and a `break_if` on it. Re-rendering the condition after the phi updates makes the loop exit **one body-execution early**, silently dropping stores performed by the final pass. In our case (dimforge nexus physics engine compiled with rust-gpu), per-lane reduction loops of the form `while i < n { acc += ...; i += 32 }` (exactly one iteration per lane) executed zero accumulations on Metal — the contact solver produced zero impulses and rigid bodies fell through the floor, while the same SPIR-V was correct via CUDA and Vulkan (spirv-passthrough). Verified against a CUDA golden reference: with this fix the Metal results match to float noise.

### Fix

Conditions whose expression tree does **not** read state written by the continuing block (checked by walking the tree for `Load`-like sub-expressions emitted within `continuing`) have their value captured into a pre-declared `bool` at every `continue` site and at the body's fall-through (both edges that reach the continuing block), and the hoisted gate tests the captured value. Conditions that **do** read continuing-written state — WGSL's `continuing { ...; break if c; }` form, whose value is only defined after the continuing statements run — keep the existing render-in-place path (which is correct for them, as the existing `wgsl-break-if` snapshots show):

```msl
bool loop_break = false;
bool loop_init = true;
while(true) {
    if (!loop_init) {
        // continuing statements ...
        if (loop_break) { break; }
    }
    loop_init = false;
    // body ...
    loop_break = <condition>;   // also emitted before each `continue;`
}
```

A snapshot-variable stack on the writer handles nested loops. Loops without `break_if` are unchanged, as is the `force_loop_bounding` scaffolding.

## Testing

* `cargo test -p naga --all-features` — snapshot outputs under `naga/tests/out/msl/` regenerated (e.g. `wgsl-break-if.metal`, `spv-do-while.metal`).
* End-to-end on an Apple-silicon Mac: a rust-gpu-compiled physics pipeline (~150 kernels) that previously produced zero contact impulses on Metal now matches a CUDA golden reference of the same SPIR-V to ~1e-4 across multi-step simulations, and an RL training run over it converges identically to the CUDA machine.

## Checklist

- [x] Run `cargo fmt`.
- [x] Run `taplo format`.
- [x] Run `cargo clippy --tests`.
- [x] Run `cargo test`.
- [x] Add change to `CHANGELOG.md`.
