### PR TITLE
chore(deps): Update some git dependencies to released versions

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -49,10 +49,6 @@ allow = [
 private = { ignore = true }
 
 [sources]
-allow-git = [
-    # Pending a release for https://github.com/rust-cli/env_logger/commit/143fa647ab33ed3acc9f160dfa3cb075cc62b5a3
-    "https://github.com/rust-cli/env_logger",
-]
 unknown-registry = "deny"
 unknown-git = "deny"
 required-git-spec = "rev"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,8 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
-source = "git+https://github.com/rust-cli/env_logger.git?rev=d550741#d550741cdcd1d64f8a564158d9d0b2554f5d900d"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1245,8 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
-source = "git+https://github.com/rust-cli/env_logger.git?rev=d550741#d550741cdcd1d64f8a564158d9d0b2554f5d900d"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2179,8 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "libtest-mimic"
-version = "0.8.1"
-source = "git+https://github.com/cwfitzgerald/libtest-mimic.git?rev=9979b3c#9979b3c1aa932bd210505029e4639aafa6e3d4f3"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ba06f0ade6e504aff834d7c34298e5155c6baca353cc6a4aaff2f9fd7f33"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -331,9 +331,6 @@ ndk-sys = "0.6"
 [patch.crates-io]
 wgpu = { path = "./wgpu" }
 
-env_logger = { version = "0.11", git = "https://github.com/rust-cli/env_logger.git", rev = "d550741" }
-libtest-mimic = { version = "0.8", git = "https://github.com/cwfitzgerald/libtest-mimic.git", rev = "9979b3c" }
-
 [profile.release]
 lto = "thin"
 debug = true

--- a/examples/bug-repro/01_texture_atomic_bug/Cargo.toml
+++ b/examples/bug-repro/01_texture_atomic_bug/Cargo.toml
@@ -5,7 +5,7 @@ rust-version = "1.87"
 publish = false
 
 [dependencies]
-env_logger = "0.11"
-pollster = "0.4"
-wgpu = { path = "../../../wgpu" }
-winit = "0.30.8"
+env_logger.workspace = true
+pollster.workspace = true
+wgpu.workspace = true
+winit.workspace = true

--- a/examples/bug-repro/02_present_bugs/Cargo.toml
+++ b/examples/bug-repro/02_present_bugs/Cargo.toml
@@ -5,7 +5,7 @@ rust-version = "1.87"
 publish = false
 
 [dependencies]
-env_logger = "0.11"
-pollster = "0.4"
+env_logger.workspace = true
+pollster.workspace = true
 wgpu.workspace = true
-winit = "0.30.8"
+winit.workspace = true


### PR DESCRIPTION
Attempting to resolve intermittent CI errors cloning libtest-mimic.

My impression is the only reason we need newer releases of these crates is dependency compatibility, not any functional difference, so we don't need to explicitly specify a minimum patch version.

I have also changed the `bug-repro` `Cargo.toml` files to use workspace dependencies. I assume they did not originally because they were based on the standalone examples.