### PR TITLE
Always `extern crate std` when `cfg(test)`.

### DIFF
--- a/naga-types/src/lib.rs
+++ b/naga-types/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 extern crate alloc;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", test))]
 extern crate std;
 
 pub mod glsl;

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -64,7 +64,7 @@
 
 extern crate alloc;
 extern crate naga_types as nt;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", test))]
 extern crate std;
 extern crate wgpu_hal as hal;
 extern crate wgpu_types as wgt;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -243,7 +243,7 @@ extern crate alloc;
 extern crate naga_types as nt;
 extern crate wgpu_types as wgt;
 // Each of these backends needs `std` in some fashion; usually `std::thread` functions.
-#[cfg(any(dx12, gles_with_std, metal, vulkan))]
+#[cfg(any(dx12, gles_with_std, metal, vulkan, test))]
 #[macro_use]
 extern crate std;
 

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -14,7 +14,7 @@
 )]
 #![no_std]
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", test))]
 extern crate std;
 
 extern crate alloc;


### PR DESCRIPTION
**Connections**
Fixes #9783 (but does not regression test).

**Description**
This change fixes failures to build tests in `wgpu-types` and `wgpu-core` when all features are disabled. I have applied it to all crates because it is plausible that references to `std` from tests might be added in the future.

The test harness depends on `std`, so when testing, it is impossible for `std` not to be available.

Note: In the case of `naga`, `build.rs` establishes a cfg alias that includes `test`. I am not sure if this works as intended, but there does not seem to be any problem building `naga`, so I have left it as is.

**Testing**
Tested each affected package with `cargo test --no-default-features -p <name>`

**Squash or Rebase?**
Rebase

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
