### PR TITLE
fix(metal): Resolve some color space constants dynamically

### DIFF
--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -76,6 +76,7 @@ metal = [
     "dep:arrayvec",
     "dep:block2",
     "dep:bytemuck",
+    "dep:libloading",
     "dep:objc2",
     "dep:objc2-core-foundation",
     "dep:objc2-core-graphics",

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use alloc::borrow::ToOwned as _;
 
 use objc2::{
@@ -204,6 +206,42 @@ impl super::Surface {
     }
 }
 
+// objc2 strings are not, in general, thread-safe, but these should be constants.
+unsafe impl Send for ColorSpaces {}
+unsafe impl Sync for ColorSpaces {}
+
+struct ColorSpaces {
+    extended_display_p3: &'static CFString,
+    itur_bt2100_pq: &'static CFString,
+    itur_bt2100_hlg: &'static CFString,
+}
+
+static COLOR_SPACES: LazyLock<Result<ColorSpaces, crate::SurfaceError>> = LazyLock::new(|| {
+    // Stable Rust doesn't support weak linkage, so objc2 doesn't
+    // offer it. To avoid link errors on old OS versions, resolve
+    // these dynamically.
+    let lib = unsafe {
+        libloading::Library::new("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")
+            .map_err(|_| crate::SurfaceError::Other("error loading CoreGraphics"))?
+    };
+    fn lookup(
+        lib: &libloading::Library,
+        name: &[u8],
+    ) -> Result<&'static CFString, crate::SurfaceError> {
+        let sym = unsafe { lib.get(name) }
+            .map_err(|_| crate::SurfaceError::Other("error resolving symbol in CoreGraphics"))?;
+        Ok(*sym)
+    }
+    let extended_display_p3 = lookup(&lib, b"kCGColorSpaceExtendedDisplayP3\0")?;
+    let itur_bt2100_pq = lookup(&lib, b"kCGColorSpaceITUR_2100_PQ\0")?;
+    let itur_bt2100_hlg = lookup(&lib, b"kCGColorSpaceITUR_2100_HLG\0")?;
+    Ok(ColorSpaces {
+        extended_display_p3,
+        itur_bt2100_pq,
+        itur_bt2100_hlg,
+    })
+});
+
 impl crate::Surface for super::Surface {
     type A = super::Api;
 
@@ -258,7 +296,13 @@ impl crate::Surface for super::Surface {
                 Some(unsafe { objc2_core_graphics::kCGColorSpaceExtendedSRGB })
             }
             wgt::SurfaceColorSpace::ExtendedDisplayP3 => {
-                Some(unsafe { objc2_core_graphics::kCGColorSpaceExtendedDisplayP3 })
+                // TODO: This needs protection in `surface_capabilities` like the BT.2100 cases.
+                Some(
+                    COLOR_SPACES
+                        .as_ref()
+                        .map_err(|e| e.clone())?
+                        .extended_display_p3,
+                )
             }
             wgt::SurfaceColorSpace::DisplayP3 => {
                 Some(unsafe { objc2_core_graphics::kCGColorSpaceDisplayP3 })
@@ -270,9 +314,12 @@ impl crate::Surface for super::Surface {
                     unreachable!("BT.2100 PQ/HLG color spaces are only reported on macOS 11.0+/iOS 14.0+/tvOS 14.0+");
                 }
                 Some(if config.color_space == wgt::SurfaceColorSpace::Bt2100Pq {
-                    unsafe { objc2_core_graphics::kCGColorSpaceITUR_2100_PQ }
+                    COLOR_SPACES.as_ref().map_err(|e| e.clone())?.itur_bt2100_pq
                 } else {
-                    unsafe { objc2_core_graphics::kCGColorSpaceITUR_2100_HLG }
+                    COLOR_SPACES
+                        .as_ref()
+                        .map_err(|e| e.clone())?
+                        .itur_bt2100_hlg
                 })
             }
         };


### PR DESCRIPTION
Resolves loader errors seen with Firefox on old MacOS versions.

It appears that Extended Display P3 is also not supported before MacOS 11, and needs to be conditionally reported in `surface_capabilities`.

**Testing**
Relying on existing tests.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
