### PR TITLE
[hal] Add `BufferBinding::buffer` read accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Bottom level categories:
 
 ## Unreleased
 
+### Added/New Features
+
+#### Hal
+
+- Add `BufferBinding::buffer`, a public read accessor for the bound buffer, which was previously inaccessible to out-of-tree `wgpu_hal::Api` implementations. By @danlehmann in [#9820](https://github.com/gfx-rs/wgpu/pull/9820).
+
 ### Bug Fixes
 
 #### GLES

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -2344,7 +2344,8 @@ pub struct BufferBinding<'a, B: DynBuffer + ?Sized> {
     ///
     /// This is not fully `pub` to prevent direct construction of
     /// `BufferBinding`s, while still allowing public read access to the `offset`
-    /// and `size` properties.
+    /// and `size` properties. Read access to the buffer is available via
+    /// [`Self::buffer`].
     pub(crate) buffer: &'a B,
 
     /// The offset at which the bound region starts.
@@ -2426,6 +2427,11 @@ impl<'a, B: DynBuffer + ?Sized> BufferBinding<'a, B> {
             offset,
             size: size.into(),
         }
+    }
+
+    /// The buffer being bound.
+    pub fn buffer(&self) -> &'a B {
+        self.buffer
     }
 }
 


### PR DESCRIPTION
Out-of-tree implementations receive `BufferBinding`s in `create_bind_group`, `set_index_buffer`, and `set_vertex_buffer`, but had no way to read the bound buffer: the `buffer` field is `pub(crate)`, so only in-tree backends could access it. The field's own doc notes that the privacy exists solely to prevent direct (unvalidated) construction.

Add a `pub fn buffer(&self) -> &'a B` read accessor next to `new_unchecked`, giving out-of-tree backends the same read access in-tree backends already have, while keeping unvalidated construction gated behind `new_unchecked`.

**Connections**

**Description**
I wasn't able to build an out-of-tree driver without this.

**Testing**
Tested locally vs my own driver, which talks to hardware on an unreleased OS.

This is adding a new function, so I don't think this has the ability to break existing code.

**Squash or Rebase?**

Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
