### PR TITLE
[core] Make `Global` methods thin in clear

### DIFF
--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -110,6 +110,44 @@ impl WebGpuError for ClearError {
     }
 }
 
+impl super::CommandEncoder {
+    pub fn clear_buffer(
+        self: &Arc<Self>,
+        dst: Arc<Buffer>,
+        offset: BufferAddress,
+        size: Option<BufferAddress>,
+    ) -> Result<(), EncoderStateError> {
+        profiling::scope!("CommandEncoder::clear_buffer");
+        api_log!("CommandEncoder::clear_buffer {:?}", Arc::as_ptr(&dst));
+
+        let mut cmd_buf_data = self.data.lock();
+
+        cmd_buf_data.push_with(|| -> Result<_, ClearError> {
+            dst.check_is_valid()?;
+            Ok(ArcCommand::ClearBuffer { dst, offset, size })
+        })
+    }
+
+    pub fn clear_texture(
+        self: &Arc<Self>,
+        dst: Arc<Texture>,
+        subresource_range: &ImageSubresourceRange,
+    ) -> Result<(), EncoderStateError> {
+        profiling::scope!("CommandEncoder::clear_texture");
+        api_log!("CommandEncoder::clear_texture {:?}", Arc::as_ptr(&dst));
+
+        let mut cmd_buf_data = self.data.lock();
+
+        cmd_buf_data.push_with(|| -> Result<_, ClearError> {
+            dst.check_valid()?;
+            Ok(ArcCommand::ClearTexture {
+                dst,
+                subresource_range: *subresource_range,
+            })
+        })
+    }
+}
+
 impl Global {
     pub fn command_encoder_clear_buffer(
         &self,
@@ -118,23 +156,10 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferAddress>,
     ) -> Result<(), EncoderStateError> {
-        profiling::scope!("CommandEncoder::clear_buffer");
-        api_log!("CommandEncoder::clear_buffer {dst:?}");
-
         let hub = &self.hub;
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
-
-        cmd_buf_data.push_with(|| -> Result<_, ClearError> {
-            let buffer = self.resolve_buffer_id(dst);
-            buffer.check_is_valid()?;
-            Ok(ArcCommand::ClearBuffer {
-                dst: buffer,
-                offset,
-                size,
-            })
-        })
+        cmd_enc.clear_buffer(hub.buffers.get(dst), offset, size)
     }
 
     pub fn command_encoder_clear_texture(
@@ -143,23 +168,11 @@ impl Global {
         dst: TextureId,
         subresource_range: &ImageSubresourceRange,
     ) -> Result<(), EncoderStateError> {
-        profiling::scope!("CommandEncoder::clear_texture");
-        api_log!("CommandEncoder::clear_texture {dst:?}");
-
         let hub = &self.hub;
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
 
-        let mut cmd_buf_data = cmd_enc.data.lock();
-
-        cmd_buf_data.push_with(|| -> Result<_, ClearError> {
-            let texture = self.resolve_texture_id(dst);
-            texture.check_valid()?;
-            Ok(ArcCommand::ClearTexture {
-                dst: texture,
-                subresource_range: *subresource_range,
-            })
-        })
+        cmd_enc.clear_texture(hub.textures.get(dst), subresource_range)
     }
 }
 


### PR DESCRIPTION
**Connections**
Towards #5121 

**Description**
We move logic from global methods into new methods on resources and make Global methods only resolve ids and call them (we make global methods thin).

**Testing**
Just refactor

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
