### PR TITLE
[core] Make command encoder `Global` methods thin

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -1315,10 +1315,19 @@ impl CommandEncoder {
         Ok(())
     }
 
-    fn finish(
+    /// Finishes a command encoder, creating a command buffer and returning errors that were
+    /// deferred until now.
+    ///
+    /// The returned `String` is the label of the command encoder, supplied so that `wgpu` can
+    /// include the label when printing deferred errors without having its own copy of the label.
+    /// This is a kludge and should be replaced if we think of a better solution to propagating
+    /// labels.
+    pub fn finish(
         self: &Arc<Self>,
         desc: &wgt::CommandBufferDescriptor<Label>,
-    ) -> (Arc<CommandBuffer>, Option<CommandEncoderError>) {
+    ) -> (Arc<CommandBuffer>, Option<(String, CommandEncoderError)>) {
+        profiling::scope!("CommandEncoder::finish");
+
         let status = self.data.lock().finish();
 
         let res = match status {
@@ -1374,7 +1383,7 @@ impl CommandEncoder {
             data: Mutex::new(rank::COMMAND_BUFFER_DATA, data),
         });
 
-        (cmd_buf, error)
+        (cmd_buf, error.map(|e| (self.label.clone(), e)))
     }
 }
 
@@ -1392,7 +1401,7 @@ impl CommandBuffer {
         drop(cmd_enc_status);
 
         let (cmd_buf, error) = encoder.finish(&wgt::CommandBufferDescriptor { label: None });
-        if let Some(err) = error {
+        if let Some((_, err)) = error {
             panic!("CommandEncoder::finish failed: {err}");
         }
 
@@ -1762,6 +1771,40 @@ impl WebGpuError for TimestampWritesError {
     }
 }
 
+impl CommandEncoder {
+    pub fn push_debug_group(self: &Arc<Self>, label: &str) -> Result<(), EncoderStateError> {
+        profiling::scope!("CommandEncoder::push_debug_group");
+        api_log!("CommandEncoder::push_debug_group {label}");
+
+        let mut cmd_buf_data = self.data.lock();
+
+        cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
+            Ok(ArcCommand::PushDebugGroup(label.to_owned()))
+        })
+    }
+
+    pub fn insert_debug_marker(self: &Arc<Self>, label: &str) -> Result<(), EncoderStateError> {
+        profiling::scope!("CommandEncoder::insert_debug_marker");
+        api_log!("CommandEncoder::insert_debug_marker {label}");
+
+        let mut cmd_buf_data = self.data.lock();
+
+        cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
+            Ok(ArcCommand::InsertDebugMarker(label.to_owned()))
+        })
+    }
+
+    pub fn pop_debug_group(self: &Arc<Self>) -> Result<(), EncoderStateError> {
+        profiling::scope!("CommandEncoder::pop_debug_marker");
+        api_log!("CommandEncoder::pop_debug_group");
+
+        let mut cmd_buf_data = self.data.lock();
+
+        cmd_buf_data
+            .push_with(|| -> Result<_, CommandEncoderError> { Ok(ArcCommand::PopDebugGroup) })
+    }
+}
+
 impl Global {
     /// Finishes a command encoder, creating a command buffer and returning errors that were
     /// deferred until now.
@@ -1776,18 +1819,13 @@ impl Global {
         desc: &wgt::CommandBufferDescriptor<Label>,
         id_in: Option<id::CommandBufferId>,
     ) -> (id::CommandBufferId, Option<(String, CommandEncoderError)>) {
-        profiling::scope!("CommandEncoder::finish");
-
         let hub = &self.hub;
         let cmd_enc = hub.command_encoders.get(encoder_id);
 
         let (cmd_buf, opt_error) = cmd_enc.finish(desc);
         let cmd_buf_id = hub.command_buffers.prepare(id_in).assign(cmd_buf);
 
-        (
-            cmd_buf_id,
-            opt_error.map(|error| (cmd_enc.label.clone(), error)),
-        )
+        (cmd_buf_id, opt_error)
     }
 
     pub fn command_encoder_push_debug_group(
@@ -1795,17 +1833,10 @@ impl Global {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) -> Result<(), EncoderStateError> {
-        profiling::scope!("CommandEncoder::push_debug_group");
-        api_log!("CommandEncoder::push_debug_group {label}");
-
         let hub = &self.hub;
 
         let cmd_enc = hub.command_encoders.get(encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
-
-        cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
-            Ok(ArcCommand::PushDebugGroup(label.to_owned()))
-        })
+        cmd_enc.push_debug_group(label)
     }
 
     pub fn command_encoder_insert_debug_marker(
@@ -1813,33 +1844,20 @@ impl Global {
         encoder_id: id::CommandEncoderId,
         label: &str,
     ) -> Result<(), EncoderStateError> {
-        profiling::scope!("CommandEncoder::insert_debug_marker");
-        api_log!("CommandEncoder::insert_debug_marker {label}");
-
         let hub = &self.hub;
 
         let cmd_enc = hub.command_encoders.get(encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
-
-        cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
-            Ok(ArcCommand::InsertDebugMarker(label.to_owned()))
-        })
+        cmd_enc.insert_debug_marker(label)
     }
 
     pub fn command_encoder_pop_debug_group(
         &self,
         encoder_id: id::CommandEncoderId,
     ) -> Result<(), EncoderStateError> {
-        profiling::scope!("CommandEncoder::pop_debug_marker");
-        api_log!("CommandEncoder::pop_debug_group");
-
         let hub = &self.hub;
 
         let cmd_enc = hub.command_encoders.get(encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
-
-        cmd_buf_data
-            .push_with(|| -> Result<_, CommandEncoderError> { Ok(ArcCommand::PopDebugGroup) })
+        cmd_enc.pop_debug_group()
     }
 }
 

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -427,6 +427,47 @@ pub(super) fn end_pipeline_statistics_query(
     }
 }
 
+impl super::CommandEncoder {
+    pub fn write_timestamp(
+        self: &Arc<Self>,
+        query_set: Arc<QuerySet>,
+        query_index: u32,
+    ) -> Result<(), EncoderStateError> {
+        let mut cmd_buf_data = self.data.lock();
+
+        cmd_buf_data.push_with(|| -> Result<_, QueryError> {
+            query_set.check_is_valid()?;
+            Ok(ArcCommand::WriteTimestamp {
+                query_set,
+                query_index,
+            })
+        })
+    }
+
+    pub fn resolve_query_set(
+        self: &Arc<Self>,
+        query_set: Arc<QuerySet>,
+        start_query: u32,
+        query_count: u32,
+        destination: Arc<Buffer>,
+        destination_offset: BufferAddress,
+    ) -> Result<(), EncoderStateError> {
+        let mut cmd_buf_data = self.data.lock();
+
+        cmd_buf_data.push_with(|| -> Result<_, QueryError> {
+            query_set.check_is_valid()?;
+            destination.check_is_valid()?;
+            Ok(ArcCommand::ResolveQuerySet {
+                query_set,
+                start_query,
+                query_count,
+                destination,
+                destination_offset,
+            })
+        })
+    }
+}
+
 impl Global {
     pub fn command_encoder_write_timestamp(
         &self,
@@ -437,16 +478,7 @@ impl Global {
         let hub = &self.hub;
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
-
-        cmd_buf_data.push_with(|| -> Result<_, QueryError> {
-            let query_set = self.resolve_query_set_id(query_set_id);
-            query_set.check_is_valid()?;
-            Ok(ArcCommand::WriteTimestamp {
-                query_set,
-                query_index,
-            })
-        })
+        cmd_enc.write_timestamp(hub.query_sets.get(query_set_id), query_index)
     }
 
     pub fn command_encoder_resolve_query_set(
@@ -461,21 +493,14 @@ impl Global {
         let hub = &self.hub;
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
 
-        cmd_buf_data.push_with(|| -> Result<_, QueryError> {
-            let query_set = self.resolve_query_set_id(query_set_id);
-            query_set.check_is_valid()?;
-            let buffer = self.resolve_buffer_id(destination);
-            buffer.check_is_valid()?;
-            Ok(ArcCommand::ResolveQuerySet {
-                query_set,
-                start_query,
-                query_count,
-                destination: buffer,
-                destination_offset,
-            })
-        })
+        cmd_enc.resolve_query_set(
+            hub.query_sets.get(query_set_id),
+            start_query,
+            query_count,
+            hub.buffers.get(destination),
+            destination_offset,
+        )
     }
 }
 

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -825,63 +825,56 @@ fn handle_buffer_init(
     }
 }
 
-impl Global {
-    pub fn command_encoder_copy_buffer_to_buffer(
-        &self,
-        command_encoder_id: CommandEncoderId,
-        source: BufferId,
+impl super::CommandEncoder {
+    pub fn copy_buffer_to_buffer(
+        self: &Arc<Self>,
+        source: Arc<Buffer>,
         source_offset: BufferAddress,
-        destination: BufferId,
+        destination: Arc<Buffer>,
         destination_offset: BufferAddress,
         size: Option<BufferAddress>,
     ) -> Result<(), EncoderStateError> {
         profiling::scope!("CommandEncoder::copy_buffer_to_buffer");
         api_log!(
-            "CommandEncoder::copy_buffer_to_buffer {source:?} -> {destination:?} {size:?}bytes"
+            "CommandEncoder::copy_buffer_to_buffer {:?} -> {:?} {size:?}bytes",
+            Arc::as_ptr(&source),
+            Arc::as_ptr(&destination)
         );
 
-        let hub = &self.hub;
-
-        let cmd_enc = hub.command_encoders.get(command_encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
+        let mut cmd_buf_data = self.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
-            let source_buffer = self.resolve_buffer_id(source);
-            source_buffer.check_is_valid()?;
-            let destination_buffer = self.resolve_buffer_id(destination);
-            destination_buffer.check_is_valid()?;
+            source.check_is_valid()?;
+            destination.check_is_valid()?;
             Ok(ArcCommand::CopyBufferToBuffer {
-                src: source_buffer,
+                src: source,
                 src_offset: source_offset,
-                dst: destination_buffer,
+                dst: destination,
                 dst_offset: destination_offset,
                 size,
             })
         })
     }
 
-    pub fn command_encoder_copy_buffer_to_texture(
-        &self,
-        command_encoder_id: CommandEncoderId,
-        source: &TexelCopyBufferInfo,
-        destination: &wgt::TexelCopyTextureInfo<TextureId>,
+    pub fn copy_buffer_to_texture(
+        self: &Arc<Self>,
+        source: &wgt::TexelCopyBufferInfo<Arc<Buffer>>,
+        destination: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
         copy_size: &Extent3d,
     ) -> Result<(), EncoderStateError> {
         profiling::scope!("CommandEncoder::copy_buffer_to_texture");
         api_log!(
             "CommandEncoder::copy_buffer_to_texture {:?} -> {:?} {copy_size:?}",
-            source.buffer,
-            destination.texture
+            Arc::as_ptr(&source.buffer),
+            Arc::as_ptr(&destination.texture)
         );
 
-        let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
-
-        let mut cmd_buf_data = cmd_enc.data.lock();
+        let mut cmd_buf_data = self.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
-            let texture = self.resolve_texture_id(destination.texture);
+            let texture = destination.texture.clone();
             texture.check_valid()?;
-            let source_buffer = self.resolve_buffer_id(source.buffer);
+            let source_buffer = source.buffer.clone();
             source_buffer.check_is_valid()?;
             Ok(ArcCommand::CopyBufferToTexture {
                 src: wgt::TexelCopyBufferInfo::<Arc<Buffer>> {
@@ -899,28 +892,25 @@ impl Global {
         })
     }
 
-    pub fn command_encoder_copy_texture_to_buffer(
-        &self,
-        command_encoder_id: CommandEncoderId,
-        source: &wgt::TexelCopyTextureInfo<TextureId>,
-        destination: &TexelCopyBufferInfo,
+    pub fn copy_texture_to_buffer(
+        self: &Arc<Self>,
+        source: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
+        destination: &wgt::TexelCopyBufferInfo<Arc<Buffer>>,
         copy_size: &Extent3d,
     ) -> Result<(), EncoderStateError> {
         profiling::scope!("CommandEncoder::copy_texture_to_buffer");
         api_log!(
             "CommandEncoder::copy_texture_to_buffer {:?} -> {:?} {copy_size:?}",
-            source.texture,
-            destination.buffer
+            Arc::as_ptr(&source.texture),
+            Arc::as_ptr(&destination.buffer)
         );
 
-        let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
-
-        let mut cmd_buf_data = cmd_enc.data.lock();
+        let mut cmd_buf_data = self.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
-            let texture = self.resolve_texture_id(source.texture);
+            let texture = source.texture.clone();
             texture.check_valid()?;
-            let destination_buffer = self.resolve_buffer_id(destination.buffer);
+            let destination_buffer = destination.buffer.clone();
             destination_buffer.check_is_valid()?;
             Ok(ArcCommand::CopyTextureToBuffer {
                 src: wgt::TexelCopyTextureInfo::<Arc<Texture>> {
@@ -938,27 +928,24 @@ impl Global {
         })
     }
 
-    pub fn command_encoder_copy_texture_to_texture(
-        &self,
-        command_encoder_id: CommandEncoderId,
-        source: &wgt::TexelCopyTextureInfo<TextureId>,
-        destination: &wgt::TexelCopyTextureInfo<TextureId>,
+    pub fn copy_texture_to_texture(
+        self: &Arc<Self>,
+        source: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
+        destination: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
         copy_size: &Extent3d,
     ) -> Result<(), EncoderStateError> {
         profiling::scope!("CommandEncoder::copy_texture_to_texture");
         api_log!(
             "CommandEncoder::copy_texture_to_texture {:?} -> {:?} {copy_size:?}",
-            source.texture,
-            destination.texture
+            Arc::as_ptr(&source.texture),
+            Arc::as_ptr(&destination.texture)
         );
 
-        let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
-
-        let mut cmd_buf_data = cmd_enc.data.lock();
+        let mut cmd_buf_data = self.data.lock();
 
         cmd_buf_data.push_with(|| -> Result<_, CommandEncoderError> {
-            let src_texture = self.resolve_texture_id(source.texture);
-            let dst_texture = self.resolve_texture_id(destination.texture);
+            let src_texture = source.texture.clone();
+            let dst_texture = destination.texture.clone();
             src_texture.check_valid()?;
             dst_texture.check_valid()?;
             Ok(ArcCommand::CopyTextureToTexture {
@@ -977,6 +964,92 @@ impl Global {
                 size: *copy_size,
             })
         })
+    }
+}
+
+impl Global {
+    pub fn command_encoder_copy_buffer_to_buffer(
+        &self,
+        command_encoder_id: CommandEncoderId,
+        source: BufferId,
+        source_offset: BufferAddress,
+        destination: BufferId,
+        destination_offset: BufferAddress,
+        size: Option<BufferAddress>,
+    ) -> Result<(), EncoderStateError> {
+        let hub = &self.hub;
+
+        let cmd_enc = hub.command_encoders.get(command_encoder_id);
+        let source = self.resolve_buffer_id(source);
+        let destination = self.resolve_buffer_id(destination);
+        cmd_enc.copy_buffer_to_buffer(source, source_offset, destination, destination_offset, size)
+    }
+
+    pub fn command_encoder_copy_buffer_to_texture(
+        &self,
+        command_encoder_id: CommandEncoderId,
+        source: &TexelCopyBufferInfo,
+        destination: &wgt::TexelCopyTextureInfo<TextureId>,
+        copy_size: &Extent3d,
+    ) -> Result<(), EncoderStateError> {
+        let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
+        let source = wgt::TexelCopyBufferInfo {
+            buffer: self.resolve_buffer_id(source.buffer),
+            layout: source.layout,
+        };
+        let destination = wgt::TexelCopyTextureInfo {
+            texture: self.resolve_texture_id(destination.texture),
+            mip_level: destination.mip_level,
+            origin: destination.origin,
+            aspect: destination.aspect,
+        };
+        cmd_enc.copy_buffer_to_texture(&source, &destination, copy_size)
+    }
+
+    pub fn command_encoder_copy_texture_to_buffer(
+        &self,
+        command_encoder_id: CommandEncoderId,
+        source: &wgt::TexelCopyTextureInfo<TextureId>,
+        destination: &TexelCopyBufferInfo,
+        copy_size: &Extent3d,
+    ) -> Result<(), EncoderStateError> {
+        let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
+
+        let source = wgt::TexelCopyTextureInfo {
+            texture: self.resolve_texture_id(source.texture),
+            mip_level: source.mip_level,
+            origin: source.origin,
+            aspect: source.aspect,
+        };
+        let destination = wgt::TexelCopyBufferInfo {
+            buffer: self.resolve_buffer_id(destination.buffer),
+            layout: destination.layout,
+        };
+        cmd_enc.copy_texture_to_buffer(&source, &destination, copy_size)
+    }
+
+    pub fn command_encoder_copy_texture_to_texture(
+        &self,
+        command_encoder_id: CommandEncoderId,
+        source: &wgt::TexelCopyTextureInfo<TextureId>,
+        destination: &wgt::TexelCopyTextureInfo<TextureId>,
+        copy_size: &Extent3d,
+    ) -> Result<(), EncoderStateError> {
+        let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
+
+        let source = wgt::TexelCopyTextureInfo {
+            texture: self.resolve_texture_id(source.texture),
+            mip_level: source.mip_level,
+            origin: source.origin,
+            aspect: source.aspect,
+        };
+        let destination = wgt::TexelCopyTextureInfo {
+            texture: self.resolve_texture_id(destination.texture),
+            mip_level: destination.mip_level,
+            origin: destination.origin,
+            aspect: destination.aspect,
+        };
+        cmd_enc.copy_texture_to_texture(&source, &destination, copy_size)
     }
 }
 

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -12,38 +12,32 @@ use crate::{
     track::ResourceUsageCompatibilityError,
 };
 
-impl Global {
-    pub fn command_encoder_transition_resources(
-        &self,
-        command_encoder_id: CommandEncoderId,
-        buffer_transitions: impl Iterator<Item = wgt::BufferTransition<BufferId>>,
-        texture_transitions: impl Iterator<Item = wgt::TextureTransition<TextureId>>,
+impl CommandEncoder {
+    pub fn transition_resources(
+        self: &Arc<Self>,
+        buffer_transitions: impl Iterator<Item = wgt::BufferTransition<Arc<Buffer>>>,
+        texture_transitions: impl Iterator<Item = wgt::TextureTransition<Arc<Texture>>>,
     ) -> Result<(), EncoderStateError> {
         profiling::scope!("CommandEncoder::transition_resources");
 
-        let hub = &self.hub;
-
         // Lock command encoder for recording
-        let cmd_enc = hub.command_encoders.get(command_encoder_id);
-        let mut cmd_buf_data = cmd_enc.data.lock();
+        let mut cmd_buf_data = self.data.lock();
         cmd_buf_data.push_with(|| -> Result<_, TransitionResourcesError> {
             Ok(ArcCommand::TransitionResources {
                 buffer_transitions: buffer_transitions
                     .map(|t| {
-                        let buffer = self.resolve_buffer_id(t.buffer);
-                        buffer.check_is_valid()?;
+                        t.buffer.check_is_valid()?;
                         Ok(wgt::BufferTransition {
-                            buffer,
+                            buffer: t.buffer,
                             state: t.state,
                         })
                     })
                     .collect::<Result<_, TransitionResourcesError>>()?,
                 texture_transitions: texture_transitions
                     .map(|t| {
-                        let texture = self.resolve_texture_id(t.texture);
-                        texture.check_valid()?;
+                        t.texture.check_valid()?;
                         Ok(wgt::TextureTransition {
-                            texture,
+                            texture: t.texture,
                             selector: t.selector,
                             state: t.state,
                         })
@@ -51,6 +45,42 @@ impl Global {
                     .collect::<Result<_, TransitionResourcesError>>()?,
             })
         })
+    }
+}
+
+impl Global {
+    pub fn command_encoder_transition_resources(
+        &self,
+        command_encoder_id: CommandEncoderId,
+        buffer_transitions: impl Iterator<Item = wgt::BufferTransition<BufferId>>,
+        texture_transitions: impl Iterator<Item = wgt::TextureTransition<TextureId>>,
+    ) -> Result<(), EncoderStateError> {
+        let hub = &self.hub;
+
+        let cmd_enc = hub.command_encoders.get(command_encoder_id);
+        let buffer_transitions = buffer_transitions
+            .map(|t| {
+                let buffer = hub.buffers.get(t.buffer);
+                wgt::BufferTransition {
+                    buffer,
+                    state: t.state,
+                }
+            })
+            .collect::<Vec<_>>();
+        let texture_transitions = texture_transitions
+            .map(|t| {
+                let texture = hub.textures.get(t.texture);
+                wgt::TextureTransition {
+                    texture,
+                    selector: t.selector,
+                    state: t.state,
+                }
+            })
+            .collect::<Vec<_>>();
+        cmd_enc.transition_resources(
+            buffer_transitions.into_iter(),
+            texture_transitions.into_iter(),
+        )
     }
 }
 


### PR DESCRIPTION
**Connections**
Towards #5121 

**Description**
We move logic from global methods into new methods on resources and make Global methods only resolve ids and call them (we make global methods thin).

**Testing**
Just refactor

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
