### PR TITLE
[core] Make `Global` methods thin in present

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -118,7 +118,7 @@ fn main() {
     {
         struct App<'a> {
             window: Option<Arc<Window>>,
-            surface: Option<wgc::instance::Surface>,
+            surface: Option<Arc<wgc::instance::Surface>>,
             configured_surface_id: Option<wgc::id::PointerId<wgc::id::markers::Surface>>,
             instance: &'a wgc::instance::Instance,
             device: &'a Arc<wgc::device::Device>,
@@ -151,7 +151,7 @@ fn main() {
                 }
                 .unwrap();
                 self.window = Some(window);
-                self.surface = Some(surface);
+                self.surface = Some(Arc::new(surface));
             }
 
             fn exiting(&mut self, _event_loop: &ActiveEventLoop) {

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -450,7 +450,7 @@ impl Player {
     pub fn get_surface_texture(
         &mut self,
         id: wgc::id::PointerId<wgc::id::markers::Texture>,
-        surface: &wgc::instance::Surface,
+        surface: &Arc<wgc::instance::Surface>,
     ) {
         let frame = surface
             .get_current_texture()

--- a/wgpu-core/src/present.rs
+++ b/wgpu-core/src/present.rs
@@ -162,7 +162,23 @@ pub struct SurfaceOutput<T = id::TextureId> {
 }
 
 impl Surface {
-    pub fn get_current_texture(&self) -> Result<ResolvedSurfaceOutput, SurfaceError> {
+    pub fn get_current_texture(self: &Arc<Self>) -> Result<ResolvedSurfaceOutput, SurfaceError> {
+        let output = self.get_current_texture_inner();
+        #[cfg(feature = "trace")]
+        if let Some(present) = self.presentation.lock().as_ref() {
+            if let Some(ref mut trace) = *present.device.trace.lock() {
+                if let Some(texture) = present.acquired_texture.as_ref() {
+                    trace.add(Action::GetSurfaceTexture {
+                        id: texture.to_trace(),
+                        parent: self.to_trace(),
+                    });
+                }
+            }
+        }
+        output
+    }
+
+    pub(crate) fn get_current_texture_inner(&self) -> Result<ResolvedSurfaceOutput, SurfaceError> {
         profiling::scope!("Surface::get_current_texture");
 
         let (device, config) = if let Some(ref present) = *self.presentation.lock() {
@@ -279,7 +295,17 @@ impl Surface {
         Ok(ResolvedSurfaceOutput { status, texture })
     }
 
-    pub fn present(&self) -> Result<Status, SurfaceError> {
+    pub fn present(self: &Arc<Self>) -> Result<Status, SurfaceError> {
+        #[cfg(feature = "trace")]
+        if let Some(present) = self.presentation.lock().as_ref() {
+            if let Some(ref mut trace) = *present.device.trace.lock() {
+                trace.add(Action::Present(self.to_trace()));
+            }
+        }
+        self.present_inner()
+    }
+
+    pub(crate) fn present_inner(&self) -> Result<Status, SurfaceError> {
         profiling::scope!("Surface::present");
 
         let presentation = self.presentation.lock();
@@ -378,7 +404,17 @@ impl Queue {
 }
 
 impl Surface {
-    pub fn discard(&self) -> Result<(), SurfaceError> {
+    pub fn discard(self: &Arc<Self>) -> Result<(), SurfaceError> {
+        #[cfg(feature = "trace")]
+        if let Some(present) = self.presentation.lock().as_ref() {
+            if let Some(ref mut trace) = *present.device.trace.lock() {
+                trace.add(Action::DiscardSurfaceTexture(self.to_trace()));
+            }
+        }
+        self.discard_inner()
+    }
+
+    pub(crate) fn discard_inner(&self) -> Result<(), SurfaceError> {
         profiling::scope!("Surface::discard");
 
         let mut presentation = self.presentation.lock();
@@ -415,9 +451,19 @@ impl Surface {
         Ok(())
     }
 
+    pub fn release(self: &Arc<Self>) -> Result<(), SurfaceError> {
+        #[cfg(feature = "trace")]
+        if let Some(present) = self.presentation.lock().as_ref() {
+            if let Some(ref mut trace) = *present.device.trace.lock() {
+                trace.add(Action::ReleaseSurfaceTexture(self.to_trace()));
+            }
+        }
+        self.release_inner()
+    }
+
     /// Like `discard`, drops the inner texture reference, but skips the
     /// HAL `discard_texture` call. Safe to call during unwinding
-    pub fn release(&self) -> Result<(), SurfaceError> {
+    pub(crate) fn release_inner(&self) -> Result<(), SurfaceError> {
         profiling::scope!("Surface::release");
 
         let mut presentation = self.presentation.lock();
@@ -450,18 +496,6 @@ impl Global {
 
         let output = surface.get_current_texture()?;
 
-        #[cfg(feature = "trace")]
-        if let Some(present) = surface.presentation.lock().as_ref() {
-            if let Some(ref mut trace) = *present.device.trace.lock() {
-                if let Some(texture) = present.acquired_texture.as_ref() {
-                    trace.add(Action::GetSurfaceTexture {
-                        id: texture.to_trace(),
-                        parent: surface.to_trace(),
-                    });
-                }
-            }
-        }
-
         let status = output.status;
         let texture_id = output.texture.map(|texture| fid.assign(texture));
 
@@ -474,38 +508,17 @@ impl Global {
     pub fn surface_present(&self, surface_id: id::SurfaceId) -> Result<Status, SurfaceError> {
         let surface = self.surfaces.get(surface_id);
 
-        #[cfg(feature = "trace")]
-        if let Some(present) = surface.presentation.lock().as_ref() {
-            if let Some(ref mut trace) = *present.device.trace.lock() {
-                trace.add(Action::Present(surface.to_trace()));
-            }
-        }
-
         surface.present()
     }
 
     pub fn surface_texture_discard(&self, surface_id: id::SurfaceId) -> Result<(), SurfaceError> {
         let surface = self.surfaces.get(surface_id);
 
-        #[cfg(feature = "trace")]
-        if let Some(present) = surface.presentation.lock().as_ref() {
-            if let Some(ref mut trace) = *present.device.trace.lock() {
-                trace.add(Action::DiscardSurfaceTexture(surface.to_trace()));
-            }
-        }
-
         surface.discard()
     }
 
     pub fn surface_texture_release(&self, surface_id: id::SurfaceId) -> Result<(), SurfaceError> {
         let surface = self.surfaces.get(surface_id);
-
-        #[cfg(feature = "trace")]
-        if let Some(present) = surface.presentation.lock().as_ref() {
-            if let Some(ref mut trace) = *present.device.trace.lock() {
-                trace.add(Action::ReleaseSurfaceTexture(surface.to_trace()));
-            }
-        }
 
         surface.release()
     }


### PR DESCRIPTION
**Connections**
Towards #5121 

**Description**
We move logic from global methods into new methods on resources and make Global methods only resolve ids and call them (we make global methods thin).

**Testing**
Just refactor

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
