### PR TITLE
Metal: expose transaction presentation completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Bottom level categories:
 
 - Add `BufferBinding::buffer`, a public read accessor for the bound buffer, which was previously inaccessible to out-of-tree `wgpu_hal::Api` implementations. By @danlehmann in [#9820](https://github.com/gfx-rs/wgpu/pull/9820).
 
+#### Metal
+
+- Expose transaction-presentation generations and completion callbacks to `wgpu-hal` clients. By @yay in [#9828](https://github.com/gfx-rs/wgpu/pull/9828).
+
 ### Bug Fixes
 
 #### GLES

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -29,6 +29,7 @@ mod surface;
 mod time;
 
 use alloc::{
+    boxed::Box,
     string::{String, ToString as _},
     sync::Arc,
     vec::Vec,
@@ -644,6 +645,107 @@ pub struct Surface {
     render_layer: Mutex<Retained<CAMetalLayer>>,
     swapchain_format: RwLock<Option<wgt::TextureFormat>>,
     extent: RwLock<wgt::Extent3d>,
+    transaction_presentation: Arc<TransactionPresentationState>,
+}
+
+type TransactionPresentationCallback = Box<dyn FnOnce() + Send + Sync>;
+
+#[derive(Default)]
+struct TransactionPresentationState {
+    /// Monotonically increasing identifier assigned to transaction-presented drawables.
+    submitted: atomic::AtomicU64,
+    /// Greatest submitted generation that Metal has reported as presented.
+    completed: atomic::AtomicU64,
+    /// Callbacks waiting for Metal to present at least their target generation.
+    waiters: Mutex<Vec<(u64, TransactionPresentationCallback)>>,
+}
+
+impl TransactionPresentationState {
+    fn record_submission(&self) -> u64 {
+        self.submitted.fetch_add(1, atomic::Ordering::AcqRel) + 1
+    }
+
+    fn submitted(&self) -> u64 {
+        self.submitted.load(atomic::Ordering::Acquire)
+    }
+
+    fn completed(&self) -> u64 {
+        self.completed.load(atomic::Ordering::Acquire)
+    }
+
+    fn register_waiter(
+        &self,
+        generation: u64,
+        callback: TransactionPresentationCallback,
+    ) -> Option<TransactionPresentationCallback> {
+        let mut waiters = self.waiters.lock();
+        if self.completed() >= generation {
+            Some(callback)
+        } else {
+            waiters.push((generation, callback));
+            None
+        }
+    }
+
+    fn complete(&self, generation: u64) -> Vec<TransactionPresentationCallback> {
+        self.completed
+            .fetch_max(generation, atomic::Ordering::Release);
+        let mut waiters = self.waiters.lock();
+        let (ready, pending) = core::mem::take(&mut *waiters)
+            .into_iter()
+            .partition::<Vec<_>, _>(|(target, _)| *target <= generation);
+        *waiters = pending;
+        ready.into_iter().map(|(_, callback)| callback).collect()
+    }
+}
+
+impl fmt::Debug for TransactionPresentationState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TransactionPresentationState")
+            .field("submitted", &self.submitted.load(atomic::Ordering::Relaxed))
+            .field("completed", &self.completed.load(atomic::Ordering::Relaxed))
+            .field("waiters", &self.waiters.lock().len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod transaction_presentation_tests {
+    use super::*;
+
+    #[test]
+    fn waiters_complete_at_their_target_generation() {
+        let state = TransactionPresentationState::default();
+        let calls = Arc::new(atomic::AtomicUsize::new(0));
+
+        for generation in [2, 3] {
+            let calls = Arc::clone(&calls);
+            assert!(state
+                .register_waiter(
+                    generation,
+                    Box::new(move || {
+                        calls.fetch_add(1, atomic::Ordering::Relaxed);
+                    }),
+                )
+                .is_none());
+        }
+
+        for callback in state.complete(2) {
+            callback();
+        }
+        assert_eq!(calls.load(atomic::Ordering::Relaxed), 1);
+
+        for callback in state.complete(3) {
+            callback();
+        }
+        assert_eq!(calls.load(atomic::Ordering::Relaxed), 2);
+
+        let Some(callback) = state.register_waiter(3, Box::new(|| {})) else {
+            panic!("completed generations should run callbacks immediately");
+        };
+        callback();
+    }
 }
 
 unsafe impl Send for Surface {}
@@ -801,7 +903,7 @@ impl crate::Queue for Queue {
     }
     unsafe fn present(
         &self,
-        _surface: &Surface,
+        surface: &Surface,
         texture: SurfaceTexture,
     ) -> Result<(), crate::SurfaceError> {
         autoreleasepool(|_| {
@@ -818,6 +920,18 @@ impl crate::Queue for Queue {
             command_buffer.commit();
 
             if texture.present_with_transaction {
+                let transaction_presentation = Arc::clone(&surface.transaction_presentation);
+                let generation = transaction_presentation.record_submission();
+                let block = block2::RcBlock::new(move |_drawable| {
+                    for callback in transaction_presentation.complete(generation) {
+                        callback();
+                    }
+                });
+                unsafe {
+                    texture
+                        .drawable
+                        .addPresentedHandler(block2::RcBlock::as_ptr(&block));
+                }
                 command_buffer.waitUntilScheduled();
                 texture.drawable.present();
             }

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use alloc::borrow::ToOwned as _;
+use alloc::{borrow::ToOwned as _, boxed::Box};
 
 use objc2::{
     available,
@@ -40,6 +40,7 @@ impl super::Surface {
             render_layer: Mutex::new(layer),
             swapchain_format: RwLock::new(None),
             extent: RwLock::new(wgt::Extent3d::default()),
+            transaction_presentation: Default::default(),
         }
     }
 
@@ -180,6 +181,32 @@ impl super::Surface {
             // TODO: iOS/tvOS/visionOS could report EDR headroom via
             // `UIScreen.currentEDRHeadroom`.
             None
+        }
+    }
+
+    /// Returns the newest generation submitted using transaction presentation.
+    pub fn submitted_transaction_presentation(&self) -> u64 {
+        self.transaction_presentation.submitted()
+    }
+
+    /// Returns the newest transaction-presented generation displayed onscreen.
+    pub fn completed_transaction_presentation(&self) -> u64 {
+        self.transaction_presentation.completed()
+    }
+
+    /// Runs `callback` after `generation` or a newer generation is displayed.
+    ///
+    /// Runs the callback immediately if that presentation has already happened.
+    pub fn notify_transaction_presentation<F>(&self, generation: u64, callback: F)
+    where
+        F: FnOnce() + Send + Sync + 'static,
+    {
+        let callback: super::TransactionPresentationCallback = Box::new(callback);
+        if let Some(callback) = self
+            .transaction_presentation
+            .register_waiter(generation, callback)
+        {
+            callback();
         }
     }
 


### PR DESCRIPTION
## Why

This came out of chasing a particularly slippery macOS live-resize race in egui.

When a `CAMetalLayer` uses transaction presentation, AppKit can report that native live resize has
ended while the final transaction-presented drawable is still in flight. If the client disables
transaction presentation and reconfigures its surface at that point, the window can briefly stop
accepting interaction and then adjust to a slightly different size when the delayed drawable is
finally shown.

A timer or an extra event-loop turn made the problem less frequent, but did not make it reliable.
The useful synchronization point is Metal's own confirmation that the final drawable was
presented. The downstream context is [emilk/egui#8280](https://github.com/emilk/egui/pull/8280).

## What changed

- Assign a monotonically increasing generation to drawables presented through
  `presentsWithTransaction`.
- Use `MTLDrawable::addPresentedHandler` to record the greatest generation Metal has presented.
- Expose the submitted and completed generations on the Metal HAL surface.
- Allow clients to register one-shot callbacks for a target generation. Multiple waiters are
  retained and callbacks registered after completion run immediately.

This is intentionally Metal HAL-specific. It does not change the portable wgpu surface API or
the non-transaction presentation path.

This is a draft because I would appreciate feedback on the HAL API shape before adapting the
downstream egui PR to it.
