### PR TITLE
Clean up some more Global stuff

### DIFF
--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -40,14 +40,14 @@ therefore immediate data must be set again.
 To create a render bundle:
 
 1) Create a [`RenderBundleEncoder`] by calling
-   [`Global::device_create_render_bundle_encoder`][Gdcrbe].
+   [`Device::create_render_bundle_encoder`][Dcrbe].
 
 2) Record commands in the `RenderBundleEncoder` using methods on [`RenderBundleEncoder`].
 
 3) Call [`RenderBundleEncoder::finish`], which analyzes and cleans up
    the command stream and returns a [`RenderBundle`].
 
-4) Then, any number of times, call [`render_pass_execute_bundles`][wrpeb] to
+4) Then, any number of times, call [`RenderPass::execute_bundles`][rpeb] to
    execute the bundle as part of some render pass.
 
 ## Implementation
@@ -70,8 +70,8 @@ called. It goes through the commands and issues them into the native command
 buffer. Thanks to isolation, it doesn't track any bind group invalidations or
 index format changes.
 
-[Gdcrbe]: crate::global::Global::device_create_render_bundle_encoder
-[wrpeb]: crate::global::Global::render_pass_execute_bundles
+[Dcrbe]: crate::device::Device::create_render_bundle_encoder
+[rpeb]: crate::command::RenderPass::execute_bundles
 !*/
 
 #![allow(clippy::reversed_empty_ranges)]

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -146,15 +146,12 @@ fn make_error_state<E: Into<CommandEncoderError>>(error: E) -> CommandEncoderSta
 pub(crate) enum CommandEncoderStatus {
     /// Ready to record commands. An encoder's initial state.
     ///
-    /// Command building methods like [`command_encoder_clear_buffer`] and
-    /// [`compute_pass_end`] require the encoder to be in this
+    /// Command building methods like [`CommandEncoder::clear_buffer`] and
+    /// [`ComputePass::end`] require the encoder to be in this
     /// state.
     ///
     /// This corresponds to WebGPU's "open" state.
     /// See <https://www.w3.org/TR/webgpu/#encoder-state-open>
-    ///
-    /// [`command_encoder_clear_buffer`]: Global::command_encoder_clear_buffer
-    /// [`compute_pass_end`]: Global::compute_pass_end
     Recording(CommandBufferMutable),
 
     /// Locked by a render or compute pass.
@@ -171,14 +168,16 @@ pub(crate) enum CommandEncoderStatus {
 
     /// Command recording is complete, and the buffer is ready for submission.
     ///
-    /// [`Global::command_encoder_finish`] transitions a
+    /// [`CommandEncoder::finish`] transitions a
     /// `CommandBuffer` from the `Recording` state into this state.
     ///
-    /// [`Global::queue_submit`] requires that command buffers are
+    /// [`Queue::submit`] requires that command buffers are
     /// in this state.
     ///
     /// This corresponds to WebGPU's "ended" state.
     /// See <https://www.w3.org/TR/webgpu/#encoder-state-ended>
+    ///
+    /// [`Queue::submit`]: crate::device::queue::Queue::submit
     Finished(CommandBufferMutable),
 
     /// The command encoder is invalid.

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -126,7 +126,7 @@ pub(crate) fn transition_resources(
     Ok(())
 }
 
-/// Error encountered while attempting to perform [`Global::command_encoder_transition_resources`].
+/// Error encountered while attempting to perform [`CommandEncoder::transition_resources`].
 #[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum TransitionResourcesError {

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -126,14 +126,14 @@ impl Global {
     /// which requires [`GPUBufferDescriptor`] validation to be generated on the
     /// Device timeline and leave the newly created [`GPUBuffer`] invalid.
     ///
-    /// Ideally, we would simply let [`device_create_buffer`] take care of all
+    /// Ideally, we would simply let [`Device::create_buffer`] take care of all
     /// of this, but some errors must be detected before we can even construct a
     /// [`wgpu_types::BufferDescriptor`] to give it. For example, the WebGPU API
     /// allows a `GPUBufferDescriptor`'s [`usage`] property to be any WebIDL
     /// `unsigned long` value, but we can't construct a
     /// [`wgpu_types::BufferUsages`] value from values with unassigned bits
     /// set. This means we must validate `usage` before we can call
-    /// `device_create_buffer`.
+    /// `Device::create_buffer`.
     ///
     /// When that validation fails, we must arrange for the buffer id to be
     /// considered invalid. This method provides the means to do so.
@@ -142,7 +142,7 @@ impl Global {
     /// [`GPUBufferDescriptor`]: https://www.w3.org/TR/webgpu/#dictdef-gpubufferdescriptor
     /// [`GPUBuffer`]: https://www.w3.org/TR/webgpu/#gpubuffer
     /// [`wgpu_types::BufferDescriptor`]: wgt::BufferDescriptor
-    /// [`device_create_buffer`]: Global::device_create_buffer
+    /// [`Device::create_buffer`]: crate::device::Device::create_buffer
     /// [`usage`]: https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-usage
     /// [`wgpu_types::BufferUsages`]: wgt::BufferUsages
     pub fn create_buffer_error(

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -269,8 +269,6 @@ impl Global {
         initial_state: wgt::TextureUses,
         id_in: Option<id::TextureId>,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
-        profiling::scope!("Device::create_texture_from_hal");
-
         let hub = &self.hub;
 
         let fid = hub.textures.prepare(id_in);
@@ -297,8 +295,6 @@ impl Global {
         desc: &resource::BufferDescriptor,
         id_in: Option<id::BufferId>,
     ) -> (id::BufferId, Option<CreateBufferError>) {
-        profiling::scope!("Device::create_buffer");
-
         let hub = &self.hub;
         let fid = hub.buffers.prepare(id_in);
 
@@ -669,8 +665,6 @@ impl Global {
         desc: &wgt::CommandEncoderDescriptor<Label>,
         id_in: Option<id::CommandEncoderId>,
     ) -> (id::CommandEncoderId, Option<DeviceError>) {
-        profiling::scope!("Device::create_command_encoder");
-
         let hub = &self.hub;
         let fid = hub.command_encoders.prepare(id_in);
 

--- a/wgpu-core/src/device/life.rs
+++ b/wgpu-core/src/device/life.rs
@@ -177,7 +177,7 @@ impl WaitIdleError {
 ///     2)  `handle_mapping` drains `self.ready_to_map` and actually maps the
 ///         buffers, collecting a list of notification closures to call.
 ///
-/// Only calling `Global::buffer_map_async` clones a new `Arc` for the
+/// Only calling [`Buffer::map_async`] clones a new `Arc` for the
 /// buffer. This new `Arc` is only dropped by `handle_mapping`.
 pub(crate) struct LifetimeTracker {
     /// Resources used by queue submissions still in flight. One entry per

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -839,9 +839,11 @@ impl Device {
     /// Poll the device, returning any `UserClosures` that need to be executed.
     ///
     /// The caller must invoke the `UserClosures` even if this function returns
-    /// an error. This is an internal helper, used by `Device::poll` and
-    /// `Global::poll_all_devices`, so that `poll_all_devices` can invoke
+    /// an error. This is an internal helper, used by [`Device::poll`] and
+    /// [`Instance::poll_all_devices`], so that `poll_all_devices` can invoke
     /// closures once after all devices have been polled.
+    ///
+    /// [`Instance::poll_all_devices`]: crate::instance::Instance::poll_all_devices
     pub(crate) fn poll_and_return_closures(
         &self,
         poll_type: wgt::PollType<crate::SubmissionIndex>,
@@ -5633,7 +5635,7 @@ impl Device {
 
     /// # Safety
     /// The `data` field on `desc` must have previously been returned from
-    /// [`crate::global::Global::pipeline_cache_get_data`]
+    /// [`pipeline::PipelineCache::get_data`]
     pub unsafe fn create_pipeline_cache(
         self: &Arc<Self>,
         desc: &pipeline::PipelineCacheDescriptor,
@@ -5663,7 +5665,7 @@ impl Device {
 
     /// # Safety
     /// The `data` field on `desc` must have previously been returned from
-    /// [`crate::global::Global::pipeline_cache_get_data`]
+    /// [`pipeline::PipelineCache::get_data`]
     pub(crate) unsafe fn create_pipeline_cache_inner(
         self: &Arc<Self>,
         desc: &pipeline::PipelineCacheDescriptor,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1479,6 +1479,7 @@ impl Device {
         hal_buffer: Box<dyn hal::DynBuffer>,
         desc: &resource::BufferDescriptor,
     ) -> (Arc<Buffer>, Option<resource::CreateBufferError>) {
+        profiling::scope!("Device::create_buffer");
         let (buffer, error) = match unsafe { self.create_buffer_from_hal_inner(hal_buffer, desc) } {
             Ok(buffer) => (buffer, None),
             Err(e) => (Buffer::invalid(Arc::clone(self), desc), Some(e)),

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1285,18 +1285,18 @@ unsafe impl Sync for StagingBuffer {}
 /// is always created mapped, and the command that uses it destroys the buffer
 /// when it is done.
 ///
-/// [`StagingBuffer`]s can be created with [`queue_create_staging_buffer`] and
-/// used with [`queue_write_staging_buffer`]. They are also used internally by
-/// operations like [`queue_write_texture`] that need to upload data to the GPU,
+/// [`StagingBuffer`]s can be created with [`Queue::create_staging_buffer`] and
+/// used with [`Queue::write_staging_buffer`]. They are also used internally by
+/// operations like [`Queue::write_texture`] that need to upload data to the GPU,
 /// but that don't belong to any particular wgpu command buffer.
 ///
 /// Used `StagingBuffer`s are accumulated in [`Device::pending_writes`], to be
 /// freed once their associated operation's queue submission has finished
 /// execution.
 ///
-/// [`queue_create_staging_buffer`]: crate::global::Global::queue_create_staging_buffer
-/// [`queue_write_staging_buffer`]: crate::global::Global::queue_write_staging_buffer
-/// [`queue_write_texture`]: crate::global::Global::queue_write_texture
+/// [`Queue::create_staging_buffer`]: crate::device::queue::Queue::create_staging_buffer
+/// [`Queue::write_staging_buffer`]: crate::device::queue::Queue::write_staging_buffer
+/// [`Queue::write_texture`]: crate::device::queue::Queue::write_texture
 /// [`Device::pending_writes`]: crate::device::Device
 #[derive(Debug)]
 pub struct StagingBuffer {


### PR DESCRIPTION
**Connections**
Towards #5121 

**Description**
In #9830 I discovered some stale `profilling::scope` and many doc comments still referring to `Global` so we replace those with methods on resources.

**Testing**
Just refactor/docs.

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
