### PR TITLE
[dxgi] lookup `CreateDXGIFactory1` dynamically

### DIFF
--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -102,6 +102,7 @@ vulkan = [
     "dep:raw-window-metal",
     "dep:smallvec",
     "dep:windows",
+    "dep:windows-core",
     "gpu-allocator/vulkan",
     "windows/Win32",
     "windows/Win32_Devices_Display",

--- a/wgpu-hal/src/auxil/dxgi/dxgi_lib.rs
+++ b/wgpu-hal/src/auxil/dxgi/dxgi_lib.rs
@@ -1,0 +1,112 @@
+use super::result::HResult as _;
+use crate::auxil::dyn_lib::DynLib;
+use core::ffi;
+use windows::core::Interface as _;
+use windows::Win32::Graphics::Dxgi;
+
+#[derive(Debug)]
+pub struct DxgiLib {
+    lib: DynLib,
+}
+
+impl DxgiLib {
+    pub fn new() -> Result<Self, libloading::Error> {
+        unsafe { DynLib::new("dxgi.dll").map(|lib| Self { lib }) }
+    }
+
+    /// Will error with crate::DeviceError::Unexpected if DXGI 1.3 is not available.
+    #[cfg_attr(not(dx12), expect(dead_code))]
+    pub fn debug_interface1(&self) -> Result<Option<Dxgi::IDXGIInfoQueue>, crate::DeviceError> {
+        // Calls windows::Win32::Graphics::Dxgi::DXGIGetDebugInterface1 on dxgi.dll
+        type Fun = extern "system" fn(
+            flags: u32,
+            riid: *const windows_core::GUID,
+            pdebug: *mut *mut ffi::c_void,
+        ) -> windows_core::HRESULT;
+        let func: libloading::Symbol<Fun> =
+            unsafe { self.lib.get(c"DXGIGetDebugInterface1".to_bytes()) }?;
+
+        let mut result__ = None;
+
+        let res = (func)(0, &Dxgi::IDXGIInfoQueue::IID, <*mut _>::cast(&mut result__)).ok();
+
+        if let Err(ref err) = res {
+            match err.code() {
+                Dxgi::DXGI_ERROR_SDK_COMPONENT_MISSING => return Ok(None),
+                _ => {}
+            }
+        }
+
+        res.into_device_result("debug_interface1")?;
+
+        result__.ok_or(crate::DeviceError::Unexpected).map(Some)
+    }
+
+    /// Will error with crate::DeviceError::Unexpected if DXGI 1.1 is not available.
+    pub fn create_factory1(&self) -> Result<Dxgi::IDXGIFactory1, crate::DeviceError> {
+        // Calls windows::Win32::Graphics::Dxgi::CreateDXGIFactory1 on dxgi.dll
+        type Fun = extern "system" fn(
+            riid: *const windows_core::GUID,
+            ppfactory: *mut *mut ffi::c_void,
+        ) -> windows_core::HRESULT;
+        let func: libloading::Symbol<Fun> =
+            unsafe { self.lib.get(c"CreateDXGIFactory1".to_bytes()) }?;
+
+        let mut result__ = None;
+
+        (func)(&Dxgi::IDXGIFactory1::IID, <*mut _>::cast(&mut result__))
+            .ok()
+            .into_device_result("create_factory1")?;
+
+        result__.ok_or(crate::DeviceError::Unexpected)
+    }
+
+    /// Will error with crate::DeviceError::Unexpected if DXGI 1.4 is not available.
+    #[cfg_attr(not(dx12), expect(dead_code))]
+    pub fn create_factory4(
+        &self,
+        factory_flags: Dxgi::DXGI_CREATE_FACTORY_FLAGS,
+    ) -> Result<Dxgi::IDXGIFactory4, crate::DeviceError> {
+        // Calls windows::Win32::Graphics::Dxgi::CreateDXGIFactory2 on dxgi.dll
+        type Fun = extern "system" fn(
+            flags: Dxgi::DXGI_CREATE_FACTORY_FLAGS,
+            riid: *const windows_core::GUID,
+            ppfactory: *mut *mut ffi::c_void,
+        ) -> windows_core::HRESULT;
+        let func: libloading::Symbol<Fun> =
+            unsafe { self.lib.get(c"CreateDXGIFactory2".to_bytes()) }?;
+
+        let mut result__ = None;
+
+        (func)(
+            factory_flags,
+            &Dxgi::IDXGIFactory4::IID,
+            <*mut _>::cast(&mut result__),
+        )
+        .ok()
+        .into_device_result("create_factory4")?;
+
+        result__.ok_or(crate::DeviceError::Unexpected)
+    }
+
+    /// Will error with crate::DeviceError::Unexpected if DXGI 1.3 is not available.
+    #[cfg_attr(not(dx12), expect(dead_code))]
+    pub fn create_factory_media(&self) -> Result<Dxgi::IDXGIFactoryMedia, crate::DeviceError> {
+        // Calls windows::Win32::Graphics::Dxgi::CreateDXGIFactory1 on dxgi.dll
+        type Fun = extern "system" fn(
+            riid: *const windows_core::GUID,
+            ppfactory: *mut *mut ffi::c_void,
+        ) -> windows_core::HRESULT;
+        let func: libloading::Symbol<Fun> =
+            unsafe { self.lib.get(c"CreateDXGIFactory1".to_bytes()) }?;
+
+        let mut result__ = None;
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_3/nn-dxgi1_3-idxgifactorymedia
+        (func)(&Dxgi::IDXGIFactoryMedia::IID, <*mut _>::cast(&mut result__))
+            .ok()
+            .into_device_result("create_factory_media")?;
+
+        result__.ok_or(crate::DeviceError::Unexpected)
+    }
+}

--- a/wgpu-hal/src/auxil/dxgi/factory.rs
+++ b/wgpu-hal/src/auxil/dxgi/factory.rs
@@ -3,8 +3,7 @@ use core::ops::Deref;
 
 use windows::{core::Interface as _, Win32::Graphics::Dxgi};
 
-use crate::dx12::DxgiLib;
-
+use super::dxgi_lib::DxgiLib;
 use super::result::HResult as _;
 
 // We can rely on the presence of DXGI 1.4 since D3D12 requires WDDM 2.0, Windows 10 (1507), and so does DXGI 1.4.

--- a/wgpu-hal/src/auxil/dxgi/hdr.rs
+++ b/wgpu-hal/src/auxil/dxgi/hdr.rs
@@ -13,6 +13,8 @@ use windows::{
     },
 };
 
+use crate::dx12::DxgiLib;
+
 /// The primary colors of a color space, in CIE 1931 xy:
 /// `[[red_x, red_y], [green_x, green_y], [blue_x, blue_y]]`.
 type Primaries = [[f32; 2]; 3];
@@ -114,6 +116,7 @@ fn display_hdr_info_from_desc1(
 pub struct DxgiHdrSource {
     hwnd: HWND,
     factory: Mutex<Option<Dxgi::IDXGIFactory1>>,
+    dxgi_lib: Option<DxgiLib>,
 }
 
 // SAFETY: `HWND` and `IDXGIFactory1` are `!Send`/`!Sync` in windows-rs. The `HWND`
@@ -131,6 +134,9 @@ impl DxgiHdrSource {
         Self {
             hwnd,
             factory: Mutex::new(None),
+            dxgi_lib: DxgiLib::new()
+                .inspect_err(|e| log::warn!("DxgiLib::new failed: {e}"))
+                .ok(),
         }
     }
 
@@ -161,7 +167,7 @@ impl DxgiHdrSource {
         if need_new {
             // SAFETY: `CreateDXGIFactory1` takes no caller pointers; the `windows`
             // binding fills the interface out-pointer itself.
-            match unsafe { Dxgi::CreateDXGIFactory1() } {
+            match self.dxgi_lib.as_ref()?.create_factory1() {
                 Ok(new) => *factory = Some(new),
                 Err(e) => {
                     log::warn!("CreateDXGIFactory1 failed: {e}");

--- a/wgpu-hal/src/auxil/dxgi/hdr.rs
+++ b/wgpu-hal/src/auxil/dxgi/hdr.rs
@@ -13,7 +13,7 @@ use windows::{
     },
 };
 
-use crate::dx12::DxgiLib;
+use super::dxgi_lib::DxgiLib;
 
 /// The primary colors of a color space, in CIE 1931 xy:
 /// `[[red_x, red_y], [green_x, green_y], [blue_x, blue_y]]`.

--- a/wgpu-hal/src/auxil/dxgi/mod.rs
+++ b/wgpu-hal/src/auxil/dxgi/mod.rs
@@ -3,6 +3,7 @@
 // Vulkan-on-Windows backend also uses.
 #[cfg(dx12)]
 pub mod conv;
+pub mod dxgi_lib;
 #[cfg(dx12)]
 pub mod exception;
 #[cfg(dx12)]
@@ -10,7 +11,6 @@ pub mod factory;
 pub mod hdr;
 #[cfg(dx12)]
 pub mod name;
-#[cfg(dx12)]
 pub mod result;
 #[cfg(dx12)]
 pub mod time;

--- a/wgpu-hal/src/auxil/dyn_lib.rs
+++ b/wgpu-hal/src/auxil/dyn_lib.rs
@@ -1,0 +1,28 @@
+#[derive(Debug)]
+pub struct DynLib {
+    inner: libloading::Library,
+}
+
+impl DynLib {
+    pub unsafe fn new<P>(filename: P) -> Result<Self, libloading::Error>
+    where
+        P: AsRef<std::ffi::OsStr>,
+    {
+        unsafe { libloading::Library::new(filename) }.map(|inner| Self { inner })
+    }
+
+    pub unsafe fn get<T>(
+        &self,
+        symbol: &[u8],
+    ) -> Result<libloading::Symbol<'_, T>, crate::DeviceError> {
+        unsafe { self.inner.get(symbol) }.map_err(|e| match e {
+            libloading::Error::GetProcAddress { .. } | libloading::Error::GetProcAddressUnknown => {
+                crate::DeviceError::Unexpected
+            }
+            libloading::Error::IncompatibleSize
+            | libloading::Error::CreateCString { .. }
+            | libloading::Error::CreateCStringWithTrailing { .. } => crate::hal_internal_error(e),
+            _ => crate::DeviceError::Unexpected, // could be unreachable!() but we prefer to be more robust
+        })
+    }
+}

--- a/wgpu-hal/src/auxil/mod.rs
+++ b/wgpu-hal/src/auxil/mod.rs
@@ -4,6 +4,9 @@
 #[cfg(any(dx12, all(vulkan, windows)))]
 pub(super) mod dxgi;
 
+#[cfg(any(dx12, all(vulkan, windows)))]
+pub(super) mod dyn_lib;
+
 #[cfg(all(native, feature = "renderdoc"))]
 pub(super) mod renderdoc;
 

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -358,6 +358,25 @@ impl DxgiLib {
         result__.ok_or(crate::DeviceError::Unexpected).map(Some)
     }
 
+    /// Will error with crate::DeviceError::Unexpected if DXGI 1.1 is not available.
+    pub fn create_factory1(&self) -> Result<Dxgi::IDXGIFactory1, crate::DeviceError> {
+        // Calls windows::Win32::Graphics::Dxgi::CreateDXGIFactory1 on dxgi.dll
+        type Fun = extern "system" fn(
+            riid: *const windows_core::GUID,
+            ppfactory: *mut *mut ffi::c_void,
+        ) -> windows_core::HRESULT;
+        let func: libloading::Symbol<Fun> =
+            unsafe { self.lib.get(c"CreateDXGIFactory1".to_bytes()) }?;
+
+        let mut result__ = None;
+
+        (func)(&Dxgi::IDXGIFactory1::IID, <*mut _>::cast(&mut result__))
+            .ok()
+            .into_device_result("create_factory1")?;
+
+        result__.ok_or(crate::DeviceError::Unexpected)
+    }
+
     /// Will error with crate::DeviceError::Unexpected if DXGI 1.4 is not available.
     pub fn create_factory4(
         &self,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -116,39 +116,12 @@ use self::dcomp::DCompLib;
 use crate::auxil::{
     self,
     dxgi::{
+        dxgi_lib::DxgiLib,
         factory::{DxgiAdapter, DxgiFactory},
         result::HResult,
     },
+    dyn_lib::DynLib,
 };
-
-#[derive(Debug)]
-struct DynLib {
-    inner: libloading::Library,
-}
-
-impl DynLib {
-    unsafe fn new<P>(filename: P) -> Result<Self, libloading::Error>
-    where
-        P: AsRef<std::ffi::OsStr>,
-    {
-        unsafe { libloading::Library::new(filename) }.map(|inner| Self { inner })
-    }
-
-    unsafe fn get<T>(
-        &self,
-        symbol: &[u8],
-    ) -> Result<libloading::Symbol<'_, T>, crate::DeviceError> {
-        unsafe { self.inner.get(symbol) }.map_err(|e| match e {
-            libloading::Error::GetProcAddress { .. } | libloading::Error::GetProcAddressUnknown => {
-                crate::DeviceError::Unexpected
-            }
-            libloading::Error::IncompatibleSize
-            | libloading::Error::CreateCString { .. }
-            | libloading::Error::CreateCStringWithTrailing { .. } => crate::hal_internal_error(e),
-            _ => crate::DeviceError::Unexpected, // could be unreachable!() but we prefer to be more robust
-        })
-    }
-}
 
 #[derive(Debug)]
 struct D3D12Lib {
@@ -320,110 +293,6 @@ impl fmt::Display for GetInterfaceError {
 }
 
 impl core::error::Error for GetInterfaceError {}
-
-#[derive(Debug)]
-pub(super) struct DxgiLib {
-    lib: DynLib,
-}
-
-impl DxgiLib {
-    pub fn new() -> Result<Self, libloading::Error> {
-        unsafe { DynLib::new("dxgi.dll").map(|lib| Self { lib }) }
-    }
-
-    /// Will error with crate::DeviceError::Unexpected if DXGI 1.3 is not available.
-    pub fn debug_interface1(&self) -> Result<Option<Dxgi::IDXGIInfoQueue>, crate::DeviceError> {
-        // Calls windows::Win32::Graphics::Dxgi::DXGIGetDebugInterface1 on dxgi.dll
-        type Fun = extern "system" fn(
-            flags: u32,
-            riid: *const windows_core::GUID,
-            pdebug: *mut *mut ffi::c_void,
-        ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> =
-            unsafe { self.lib.get(c"DXGIGetDebugInterface1".to_bytes()) }?;
-
-        let mut result__ = None;
-
-        let res = (func)(0, &Dxgi::IDXGIInfoQueue::IID, <*mut _>::cast(&mut result__)).ok();
-
-        if let Err(ref err) = res {
-            match err.code() {
-                Dxgi::DXGI_ERROR_SDK_COMPONENT_MISSING => return Ok(None),
-                _ => {}
-            }
-        }
-
-        res.into_device_result("debug_interface1")?;
-
-        result__.ok_or(crate::DeviceError::Unexpected).map(Some)
-    }
-
-    /// Will error with crate::DeviceError::Unexpected if DXGI 1.1 is not available.
-    pub fn create_factory1(&self) -> Result<Dxgi::IDXGIFactory1, crate::DeviceError> {
-        // Calls windows::Win32::Graphics::Dxgi::CreateDXGIFactory1 on dxgi.dll
-        type Fun = extern "system" fn(
-            riid: *const windows_core::GUID,
-            ppfactory: *mut *mut ffi::c_void,
-        ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> =
-            unsafe { self.lib.get(c"CreateDXGIFactory1".to_bytes()) }?;
-
-        let mut result__ = None;
-
-        (func)(&Dxgi::IDXGIFactory1::IID, <*mut _>::cast(&mut result__))
-            .ok()
-            .into_device_result("create_factory1")?;
-
-        result__.ok_or(crate::DeviceError::Unexpected)
-    }
-
-    /// Will error with crate::DeviceError::Unexpected if DXGI 1.4 is not available.
-    pub fn create_factory4(
-        &self,
-        factory_flags: Dxgi::DXGI_CREATE_FACTORY_FLAGS,
-    ) -> Result<Dxgi::IDXGIFactory4, crate::DeviceError> {
-        // Calls windows::Win32::Graphics::Dxgi::CreateDXGIFactory2 on dxgi.dll
-        type Fun = extern "system" fn(
-            flags: Dxgi::DXGI_CREATE_FACTORY_FLAGS,
-            riid: *const windows_core::GUID,
-            ppfactory: *mut *mut ffi::c_void,
-        ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> =
-            unsafe { self.lib.get(c"CreateDXGIFactory2".to_bytes()) }?;
-
-        let mut result__ = None;
-
-        (func)(
-            factory_flags,
-            &Dxgi::IDXGIFactory4::IID,
-            <*mut _>::cast(&mut result__),
-        )
-        .ok()
-        .into_device_result("create_factory4")?;
-
-        result__.ok_or(crate::DeviceError::Unexpected)
-    }
-
-    /// Will error with crate::DeviceError::Unexpected if DXGI 1.3 is not available.
-    pub fn create_factory_media(&self) -> Result<Dxgi::IDXGIFactoryMedia, crate::DeviceError> {
-        // Calls windows::Win32::Graphics::Dxgi::CreateDXGIFactory1 on dxgi.dll
-        type Fun = extern "system" fn(
-            riid: *const windows_core::GUID,
-            ppfactory: *mut *mut ffi::c_void,
-        ) -> windows_core::HRESULT;
-        let func: libloading::Symbol<Fun> =
-            unsafe { self.lib.get(c"CreateDXGIFactory1".to_bytes()) }?;
-
-        let mut result__ = None;
-
-        // https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_3/nn-dxgi1_3-idxgifactorymedia
-        (func)(&Dxgi::IDXGIFactoryMedia::IID, <*mut _>::cast(&mut result__))
-            .ok()
-            .into_device_result("create_factory_media")?;
-
-        result__.ok_or(crate::DeviceError::Unexpected)
-    }
-}
 
 /// Create a temporary "owned" copy inside a [`mem::ManuallyDrop`] without increasing the refcount or
 /// moving away the source variable.


### PR DESCRIPTION
**Connections**

- Regressed in <https://github.com/gfx-rs/wgpu/pull/9739>.
- Resolves https://bugzilla.mozilla.org/show_bug.cgi?id=2053293.

**Description**
Dynamically link dxgi.dll and lookup `CreateDXGIFactory1`.

**Testing**
Existing tests.

**Squash or Rebase?**
Squash.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
