### PR TITLE
fix(metal): Gate ExtendedDisplayP3 color space to macOS 11.0+

### DIFF
--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -411,8 +411,12 @@ impl crate::Adapter for super::Adapter {
                 // linear (scRGB) and encoded (extended nonlinear sRGB) form,
                 // for the BT.709 and Display-P3 gamuts.
                 color_spaces |= wgt::SurfaceColorSpaces::EXTENDED_SRGB_LINEAR
-                    | wgt::SurfaceColorSpaces::EXTENDED_SRGB
-                    | wgt::SurfaceColorSpaces::EXTENDED_DISPLAY_P3;
+                    | wgt::SurfaceColorSpaces::EXTENDED_SRGB;
+                // `kCGColorSpaceExtendedDisplayP3` only exists on macOS 11.0+/
+                // iOS 14.0+, so gate it like the BT.2100 spaces below.
+                if available!(macos = 11.0, ios = 14.0, tvos = 14.0, visionos = 1.0) {
+                    color_spaces |= wgt::SurfaceColorSpaces::EXTENDED_DISPLAY_P3;
+                }
             }
             // PQ/HLG only on the >=10-bit formats: 8-bit PQ would result in unusable
             // banding. The ITUR_2100 color space constants require

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -226,15 +226,15 @@ static COLOR_SPACES: LazyLock<Result<ColorSpaces, crate::SurfaceError>> = LazyLo
     };
     fn lookup(
         lib: &libloading::Library,
-        name: &[u8],
+        name: &core::ffi::CStr,
     ) -> Result<&'static CFString, crate::SurfaceError> {
-        let sym = unsafe { lib.get(name) }
+        let sym = unsafe { lib.get(name.to_bytes_with_nul()) }
             .map_err(|_| crate::SurfaceError::Other("error resolving symbol in CoreGraphics"))?;
         Ok(*sym)
     }
-    let extended_display_p3 = lookup(&lib, b"kCGColorSpaceExtendedDisplayP3\0")?;
-    let itur_bt2100_pq = lookup(&lib, b"kCGColorSpaceITUR_2100_PQ\0")?;
-    let itur_bt2100_hlg = lookup(&lib, b"kCGColorSpaceITUR_2100_HLG\0")?;
+    let extended_display_p3 = lookup(&lib, c"kCGColorSpaceExtendedDisplayP3")?;
+    let itur_bt2100_pq = lookup(&lib, c"kCGColorSpaceITUR_2100_PQ")?;
+    let itur_bt2100_hlg = lookup(&lib, c"kCGColorSpaceITUR_2100_HLG")?;
     Ok(ColorSpaces {
         extended_display_p3,
         itur_bt2100_pq,
@@ -296,7 +296,10 @@ impl crate::Surface for super::Surface {
                 Some(unsafe { objc2_core_graphics::kCGColorSpaceExtendedSRGB })
             }
             wgt::SurfaceColorSpace::ExtendedDisplayP3 => {
-                // TODO: This needs protection in `surface_capabilities` like the BT.2100 cases.
+                // Only reported by `surface_capabilities` on macOS 11.0+/iOS 14.0+.
+                if !available!(macos = 11.0, ios = 14.0, tvos = 14.0, visionos = 1.0) {
+                    unreachable!("ExtendedDisplayP3 color space is only reported on macOS 11.0+/iOS 14.0+/tvOS 14.0+");
+                }
                 Some(
                     COLOR_SPACES
                         .as_ref()


### PR DESCRIPTION
**Connections**

Follow-up to #9819, which resolved the CoreGraphics color-space constants dynamically to fix loader errors on old macOS. That PR left a `TODO` to give `ExtendedDisplayP3` the same conditional reporting the BT.2100 spaces already have; this addresses it.

**Description**

`surface_capabilities` advertised `EXTENDED_DISPLAY_P3` for every `Rgba16Float` surface with no OS-version gate, unlike the BT.2100 (PQ/HLG) spaces, which are gated on `available!(macos = 11.0, …)`. But `kCGColorSpaceExtendedDisplayP3` is only present in CoreGraphics on macOS 11.0+/iOS 14.0+.

A note on the version: Apple's headers back-annotate `kCGColorSpaceExtendedDisplayP3` to macOS 10.14.3 / iOS 12.3, but the symbol was not actually shipped in CoreGraphics until 11.0 — it appears only in the 10.15.6 → 11.0 SDK diff, and it is the source of the loader errors #9819 fixed on older macOS. The dynamic lookup added in #9819 also fails as a unit below 11.0, because the same `LazyLock` resolves the 11.0-only `kCGColorSpaceITUR_2100_PQ`/`HLG` symbols, so the effective floor is 11.0 regardless. Gating `ExtendedDisplayP3` identically to BT.2100 is therefore both correct and keeps the two paths consistent.

With reporting gated, wgpu-core's surface validation rejects a request for `ExtendedDisplayP3` on older macOS with a clean `UnsupportedColorSpace` error before it reaches the HAL, instead of the configure-time `SurfaceError` it produced before. The `configure()` arm gets the matching `available!` guard, mirroring the BT.2100 arm and the `unreachable!` convention the DX12 and Vulkan backends use for color spaces that surface capabilities never report.

Also addresses a review nit from #9819 by switching the CoreGraphics symbol lookups from `b"…\0"` byte strings to `c"…"` `CStr` literals.

**Testing**

- `cargo test -p wgpu-core surface_config` passes; the existing surface-configuration validation tests (including `explicit_unsupported_color_space_errors`) exercise the "unreported color space ⇒ `UnsupportedColorSpace`" path this relies on.
- `cargo check` and `cargo clippy -p wgpu-hal --features metal --target aarch64-apple-darwin` are clean.

**Squash or Rebase?**

Squash.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- OS-version-gated reporting can't be unit-tested cross-platform; covered by existing wgpu-core validation tests and the macOS CI build. -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- Omitted, consistent with #9819. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
