### PR TITLE
Deduplicate TLAS build dependencies by unique BLAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ Bottom level categories:
 
 - Fixed signed integer `%` (and `%=`) returning the wrong result for negative operands in the GLSL (OpenGL/GLES) backend, e.g. `-1 % 768` yielding `255` instead of `-1`. GLSL's `%` is undefined when either operand is negative, so signed remainder is now lowered as `a - b * (a / b)`, matching the SPIR-V, HLSL, and Metal backends. By @mstampfli in [#9687](https://github.com/gfx-rs/wgpu/pull/9687).
 
+### Performance
+
+#### General
+
+- `Queue::submit` no longer scales with TLAS instance count: a built TLAS now records one dependency per unique BLAS instead of one per instance, so acceleration-structure validation and residency tracking are `O(unique BLASes)` rather than `O(instances)`. Heavilty instanced scenes, e.g. forests previously spent tens to hundreds of ms per frame in `Queue::submit`. By @AntonWagnerCAU in [#9835](https://github.com/gfx-rs/wgpu/pull/9835).
+
 ## v30.0.0 (2026-07-01)
 
 ### Major changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,12 +68,6 @@ Bottom level categories:
 
 - Fixed signed integer `%` (and `%=`) returning the wrong result for negative operands in the GLSL (OpenGL/GLES) backend, e.g. `-1 % 768` yielding `255` instead of `-1`. GLSL's `%` is undefined when either operand is negative, so signed remainder is now lowered as `a - b * (a / b)`, matching the SPIR-V, HLSL, and Metal backends. By @mstampfli in [#9687](https://github.com/gfx-rs/wgpu/pull/9687).
 
-### Performance
-
-#### General
-
-- `Queue::submit` no longer scales with TLAS instance count: a built TLAS now records one dependency per unique BLAS instead of one per instance, so acceleration-structure validation and residency tracking are `O(unique BLASes)` rather than `O(instances)`. Heavilty instanced scenes, e.g. forests previously spent tens to hundreds of ms per frame in `Queue::submit`. By @AntonWagnerCAU in [#9835](https://github.com/gfx-rs/wgpu/pull/9835).
-
 ## v30.0.0 (2026-07-01)
 
 ### Major changes

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -27,9 +27,11 @@ use crate::{
         ArcTlasInstance, ArcTlasPackage, BlasBuildEntry, BlasGeometries,
         BuildAccelerationStructureError, OwnedBlasBuildEntry, OwnedTlasPackage, TlasPackage,
     },
-    resource::{Blas, BlasCompactState, Labeled, StagingBuffer, Tlas},
+    resource::{Blas, BlasCompactState, Labeled, StagingBuffer, Tlas, Trackable},
     scratch::ScratchBuffer,
     snatch::SnatchGuard,
+    track::TrackerIndex,
+    FastHashSet,
 };
 use crate::{lock::RwLockWriteGuard, resource::RawResourceAccess};
 
@@ -308,6 +310,7 @@ pub(crate) fn build_acceleration_structures(
         let first_byte_index = instance_buffer_staging_source.len();
 
         let mut dependencies = Vec::new();
+        let mut seen_dependencies = FastHashSet::<TrackerIndex>::default();
 
         let mut instance_count = 0;
         for instance in package.instances.iter().flatten() {
@@ -346,7 +349,9 @@ pub(crate) fn build_acceleration_structures(
 
             instance_count += 1;
 
-            dependencies.push(blas.clone());
+            if seen_dependencies.insert(blas.tracker_index()) {
+                dependencies.push(blas.clone());
+            }
         }
 
         build_command.tlas_s_built.push(TlasBuild {

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -320,7 +320,11 @@ pub(crate) fn build_acceleration_structures(
                 ));
             }
             let blas = &instance.blas;
-            state.tracker.blas_s.insert_single(blas.clone());
+            let is_new_dependency = seen_dependencies.insert(blas.tracker_index());
+
+            if is_new_dependency {
+                state.tracker.blas_s.insert_single(blas.clone());
+            }
 
             instance_buffer_staging_source.extend(state.device.raw().tlas_instance_to_bytes(
                 hal::TlasInstance {
@@ -349,7 +353,7 @@ pub(crate) fn build_acceleration_structures(
 
             instance_count += 1;
 
-            if seen_dependencies.insert(blas.tracker_index()) {
+            if is_new_dependency {
                 dependencies.push(blas.clone());
             }
         }


### PR DESCRIPTION
**Connections**
Relates to Issue #6762 

**Description**
A built TLAS recorded one dependency entry per instance, making Queue::submit's acceleration-structure validation and residency tracking O(instance count). Collapse to unique BLASes via a FastHashSet<TrackerIndex> so it is O(unique BLASes) instead.

**Testing**
Raytracing the landscape scene from https://github.com/mmp/pbrt-v4-scenes/tree/master#landscape had a ~50ms stall on queue submit every frame. After applying my changes the measurable queue submit time dropped to 0.1ms. All scenes render the same as before. 
cargo xtask test --test wgpu-gpu ray_tracing passes 222/222.


Some tests in the full test suite fail on my environment independent of the changes:

```
────────────
     Summary [ 170.936s] 3293 tests run: 3289 passed, 4 failed, 42 skipped
       ABORT [   0.103s] naga::naga wgsl_errors::recursion_depth_template
           - with code 0xc00000fd: Recursion too deep; the stack overflowed. (os error 1001)
        FAIL [   2.076s] wgpu-examples [Executed] [Vulkan/NVIDIA GeForce RTX 4090/0] wgpu_examples::cooperative_matrix::tests::cooperative_matrix
        FAIL [   2.386s] wgpu-test::wgpu-gpu [Executed] [Dx12/Intel(R) UHD Graphics 770/3] wgpu_gpu::multiview::draw_multiview_noncontiguous
        FAIL [   0.527s] wgpu-test::wgpu-gpu [Executed] [Vulkan/Intel(R) UHD Graphics 770/1] wgpu_gpu::multiview::draw_multiview_multisample
error: test run failed
Error: Tests failed
```


**Squash or Rebase?**

Rebase.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
