### PR TITLE
Add wasm64 backend support for the web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,13 @@ jobs:
             tier: 2
             kind: web
 
+          - name: WebAssembly 64-bit
+            os: ubuntu-24.04
+            target: wasm64-unknown-unknown
+            kind: wgpu-only
+            tier: 3
+            extra-flags: -Zbuild-std=std,panic_abort
+
           - name: Emscripten
             os: ubuntu-24.04
             target: wasm32-unknown-emscripten

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Bottom level categories:
 
 ### Added/New Features
 
+#### General
+
+- Support the `wasm64-unknown-unknown` target for the web backend. Building for wasm64 requires a nightly toolchain with `-Z build-std=std,panic_abort`. By @nickbabcock in [#9836](https://github.com/gfx-rs/wgpu/pull/9836).
+
 #### Hal
 
 - Add `BufferBinding::buffer`, a public read accessor for the bound buffer, which was previously inaccessible to out-of-tree `wgpu_hal::Api` implementations. By @danlehmann in [#9820](https://github.com/gfx-rs/wgpu/pull/9820).
@@ -77,6 +81,16 @@ Bottom level categories:
 #### GLES
 
 - Fixed signed integer `%` (and `%=`) returning the wrong result for negative operands in the GLSL (OpenGL/GLES) backend, e.g. `-1 % 768` yielding `255` instead of `-1`. GLSL's `%` is undefined when either operand is negative, so signed remainder is now lowered as `a - b * (a / b)`, matching the SPIR-V, HLSL, and Metal backends. By @mstampfli in [#9687](https://github.com/gfx-rs/wgpu/pull/9687).
+
+### Dependency Updates
+
+#### General
+
+- Raise the minimum version of the `wasm-bindgen` family to the earliest releases that support wasm64. By @nickbabcock in [#9836](https://github.com/gfx-rs/wgpu/pull/9836).
+
+#### GLES
+
+- Update `glow` to 0.18 for wasm64 support. By @nickbabcock in [#9836](https://github.com/gfx-rs/wgpu/pull/9836).
 
 ## v30.0.0 (2026-07-01)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,9 +1624,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+checksum = "263218b0ba2b0715c3370fb04674f5f8aa331594b521c94ff0a8e4a8472d1386"
 dependencies = [
  "js-sys",
  "slotmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,7 @@ gpu-allocator = { version = "0.28", default-features = false, features = [
 
 # Gles dependencies
 khronos-egl = "6"
-glow = "0.17"
+glow = "0.18"
 glutin = { version = "0.32", default-features = false }
 glutin-winit = { version = "0.5", default-features = false }
 glutin_wgl_sys = "0.6"
@@ -302,13 +302,13 @@ glutin_wgl_sys = "0.6"
 # DX12 and GLES dependencies
 windows = { version = "0.62", default-features = false }
 
-# wasm32 dependencies
+# wasm dependencies
 console_error_panic_hook = "0.1.5"
 console_log = "1"
-js-sys = { version = "0.3.85", default-features = false }
-wasm-bindgen = { version = "0.2.108", default-features = false }
-wasm-bindgen-futures = { version = "0.4.58", default-features = false }
-web-sys = { version = "0.3.85", default-features = false }
+js-sys = { version = "0.3.100", default-features = false }
+wasm-bindgen = { version = "0.2.123", default-features = false }
+wasm-bindgen-futures = { version = "0.4.73", default-features = false }
+web-sys = { version = "0.3.100", default-features = false }
 web-time = "1.1.0"
 
 # deno dependencies

--- a/examples/standalone/03_hdr_surface/Cargo.toml
+++ b/examples/standalone/03_hdr_surface/Cargo.toml
@@ -24,9 +24,9 @@ block2 = "0.6.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.5"
-wasm-bindgen = "0.2.108"
-wasm-bindgen-futures = "0.4.58"
-web-sys = { version = "0.3.85", features = [
+wasm-bindgen = "0.2.123"
+wasm-bindgen-futures = "0.4.73"
+web-sys = { version = "0.3.100", features = [
     "console",
     "Document",
     "Element",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -172,7 +172,7 @@ wgpu-core-deps-apple = { workspace = true, optional = true }
 [target.'cfg(target_os = "emscripten")'.dependencies]
 wgpu-core-deps-emscripten = { workspace = true, optional = true }
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+[target.'cfg(all(target_family = "wasm", not(target_os = "emscripten")))'.dependencies]
 wgpu-core-deps-wasm = { workspace = true, optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -4,12 +4,12 @@ fn main() {
         send_sync: { all(
             feature = "std",
             any(
-                not(target_arch = "wasm32"),
+                not(target_family = "wasm"),
                 all(feature = "fragile-send-sync-non-atomic-wasm", not(target_feature = "atomics"))
             )
         ) },
         dx12: { all(target_os = "windows", feature = "dx12") },
-        webgl: { all(target_arch = "wasm32", not(target_os = "emscripten"), feature = "webgl") },
+        webgl: { all(target_family = "wasm", not(target_os = "emscripten"), feature = "webgl") },
         gles: { any(
             all(windows_linux_android, feature = "gles"), // Regular GLES
             all(webgl), // WebGL

--- a/wgpu-core/platform-deps/wasm/Cargo.toml
+++ b/wgpu-core/platform-deps/wasm/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.76"
 webgl = ["wgpu-hal/gles"]
 
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+[target.'cfg(all(target_family = "wasm", not(target_os = "emscripten")))'.dependencies]
 wgpu-hal.workspace = true
 
 [lints]

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -5938,7 +5938,7 @@ impl Device {
                     Ok(wgt::PollStatus::Poll) => {
                         unreachable!("Cannot get a Poll result from a Wait action.")
                     }
-                    Err(WaitIdleError::Timeout) if cfg!(target_arch = "wasm32") => {
+                    Err(WaitIdleError::Timeout) if cfg!(target_family = "wasm") => {
                         // On wasm, you cannot actually successfully wait for the surface.
                         // However WebGL does not actually require you do this, so ignoring
                         // the failure is totally fine. See

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -12,7 +12,7 @@
 // When we have no backends, we end up with a lot of dead or otherwise unreachable code.
 #![cfg_attr(
     all(
-        not(all(feature = "vulkan", not(target_arch = "wasm32"))),
+        not(all(feature = "vulkan", not(target_family = "wasm"))),
         not(all(feature = "metal", any(target_vendor = "apple"))),
         not(all(feature = "dx12", windows)),
         not(feature = "gles"),

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -234,7 +234,7 @@ glow = { workspace = true, optional = true }
 ### Platform: Native ###
 ########################
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 # Backend: Vulkan and Dx12
 gpu-allocator = { workspace = true, optional = true }
 # Backend: Vulkan
@@ -317,7 +317,7 @@ ndk-sys = { workspace = true, optional = true }
 ### Platform: Webassembly ###
 #############################
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+[target.'cfg(all(target_family = "wasm", not(target_os = "emscripten")))'.dependencies]
 # Backend: GLES
 wasm-bindgen = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true, features = [
@@ -361,6 +361,6 @@ naga = { workspace = true, features = ["wgsl-in", "termcolor"] }
 winit.workspace = true # for "halmark" example
 
 ### Platform: Windows + MacOS + Linux for "raw-gles" example ###
-[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos", target_env = "ohos")))'.dev-dependencies]
+[target.'cfg(not(any(target_family = "wasm", target_os = "ios", target_os = "visionos", target_env = "ohos")))'.dev-dependencies]
 glutin-winit = { workspace = true, features = ["egl", "wgl", "wayland", "x11"] }
 glutin = { workspace = true, features = ["egl", "wgl", "wayland", "x11"] }

--- a/wgpu-hal/build.rs
+++ b/wgpu-hal/build.rs
@@ -1,11 +1,11 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
-        native: { not(target_arch = "wasm32") },
+        native: { not(target_family = "wasm") },
         send_sync: { any(
-            not(target_arch = "wasm32"),
+            not(target_family = "wasm"),
             all(feature = "fragile-send-sync-non-atomic-wasm", not(target_feature = "atomics"))
         ) },
-        webgl: { all(target_arch = "wasm32", not(target_os = "emscripten"), gles) },
+        webgl: { all(target_family = "wasm", not(target_os = "emscripten"), gles) },
         Emscripten: { all(target_os = "emscripten", gles) },
         dx12: { all(target_os = "windows", feature = "dx12") },
         gles: { all(feature = "gles") },
@@ -14,7 +14,7 @@ fn main() {
         gles_with_std: { all(
             feature = "gles",
             any(
-                not(target_arch = "wasm32"),
+                not(target_family = "wasm"),
                 // Accept wasm32-unknown-unknown, which uniquely has a stub `std`
                 all(target_vendor = "unknown", target_os = "unknown"),
                 // Accept wasm32-unknown-emscripten and similar, which has a real `std`
@@ -22,7 +22,7 @@ fn main() {
             )
         ) },
         metal: { all(target_vendor = "apple", feature = "metal") },
-        vulkan: { all(not(target_arch = "wasm32"), feature = "vulkan") },
+        vulkan: { all(not(target_family = "wasm"), feature = "vulkan") },
         drm: { all(
             feature = "drm",
             any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -941,7 +941,7 @@ impl super::Adapter {
         // Drop the GL guard so we can move the context into AdapterShared
         // ( on Wasm the gl handle is just a ref so we tell clippy to allow
         // dropping the ref )
-        #[cfg_attr(target_arch = "wasm32", allow(dropping_references))]
+        #[cfg_attr(target_family = "wasm", allow(dropping_references))]
         drop(gl);
 
         Some(crate::ExposedAdapter {

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -246,7 +246,7 @@ impl super::Device {
         gl: &glow::Context,
         shader: &str,
         naga_stage: naga::ShaderStage,
-        #[cfg_attr(target_arch = "wasm32", allow(unused))] label: Option<&str>,
+        #[cfg_attr(target_family = "wasm", allow(unused))] label: Option<&str>,
     ) -> Result<glow::Shader, crate::PipelineError> {
         let target = match naga_stage {
             naga::ShaderStage::Vertex => glow::VERTEX_SHADER,
@@ -400,7 +400,7 @@ impl super::Device {
         gl: &glow::Context,
         shaders: ArrayVec<ShaderStage<'a>, { crate::MAX_CONCURRENT_SHADER_STAGES }>,
         layout: &super::PipelineLayout,
-        #[cfg_attr(target_arch = "wasm32", allow(unused))] label: Option<&str>,
+        #[cfg_attr(target_family = "wasm", allow(unused))] label: Option<&str>,
         multiview_mask: Option<NonZeroU32>,
     ) -> Result<Arc<super::PipelineInner>, crate::PipelineError> {
         let mut program_stages = ArrayVec::new();
@@ -462,7 +462,7 @@ impl super::Device {
         gl: &glow::Context,
         shaders: ArrayVec<ShaderStage<'a>, { crate::MAX_CONCURRENT_SHADER_STAGES }>,
         layout: &super::PipelineLayout,
-        #[cfg_attr(target_arch = "wasm32", allow(unused))] label: Option<&str>,
+        #[cfg_attr(target_family = "wasm", allow(unused))] label: Option<&str>,
         multiview_mask: Option<NonZeroU32>,
         glsl_version: naga::back::glsl::Version,
         private_caps: PrivateCapabilities,
@@ -1680,7 +1680,7 @@ impl crate::Device for super::Device {
     }
     unsafe fn destroy_pipeline_cache(&self, _: super::PipelineCache) {}
 
-    #[cfg_attr(target_arch = "wasm32", allow(unused))]
+    #[cfg_attr(target_family = "wasm", allow(unused))]
     unsafe fn create_query_set(
         &self,
         desc: &wgt::QuerySetDescriptor<crate::Label>,
@@ -1736,7 +1736,7 @@ impl crate::Device for super::Device {
         &self,
         fence: &super::Fence,
     ) -> Result<crate::FenceValue, crate::DeviceError> {
-        #[cfg_attr(target_arch = "wasm32", allow(clippy::needless_borrow))]
+        #[cfg_attr(target_family = "wasm", allow(clippy::needless_borrow))]
         Ok(fence.get_latest(&self.shared.context.lock()))
     }
     unsafe fn wait(

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -193,7 +193,7 @@ impl super::Queue {
         &self,
         gl: &glow::Context,
         command: &C,
-        #[cfg_attr(target_arch = "wasm32", allow(unused))] data_bytes: &[u8],
+        #[cfg_attr(target_family = "wasm", allow(unused))] data_bytes: &[u8],
         queries: &[glow::Query],
     ) {
         match *command {

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -68,7 +68,7 @@ serde = { workspace = true, default-features = false, features = [
 ], optional = true }
 static_assertions.workspace = true
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = { workspace = true, optional = true, default-features = false }
 web-sys = { workspace = true, optional = true, default-features = false, features = [
     "ImageBitmap",

--- a/wgpu-types/src/send_sync.rs
+++ b/wgpu-types/src/send_sync.rs
@@ -1,7 +1,7 @@
 pub trait WasmNotSendSync: WasmNotSend + WasmNotSync {}
 impl<T: WasmNotSend + WasmNotSync> WasmNotSendSync for T {}
 #[cfg(any(
-    not(target_arch = "wasm32"),
+    not(target_family = "wasm"),
     all(
         feature = "fragile-send-sync-non-atomic-wasm",
         not(target_feature = "atomics")
@@ -9,7 +9,7 @@ impl<T: WasmNotSend + WasmNotSync> WasmNotSendSync for T {}
 ))]
 pub trait WasmNotSend: Send {}
 #[cfg(any(
-    not(target_arch = "wasm32"),
+    not(target_family = "wasm"),
     all(
         feature = "fragile-send-sync-non-atomic-wasm",
         not(target_feature = "atomics")
@@ -17,7 +17,7 @@ pub trait WasmNotSend: Send {}
 ))]
 impl<T: Send> WasmNotSend for T {}
 #[cfg(not(any(
-    not(target_arch = "wasm32"),
+    not(target_family = "wasm"),
     all(
         feature = "fragile-send-sync-non-atomic-wasm",
         not(target_feature = "atomics")
@@ -25,7 +25,7 @@ impl<T: Send> WasmNotSend for T {}
 )))]
 pub trait WasmNotSend {}
 #[cfg(not(any(
-    not(target_arch = "wasm32"),
+    not(target_family = "wasm"),
     all(
         feature = "fragile-send-sync-non-atomic-wasm",
         not(target_feature = "atomics")
@@ -34,7 +34,7 @@ pub trait WasmNotSend {}
 impl<T> WasmNotSend for T {}
 
 #[cfg(any(
-    not(target_arch = "wasm32"),
+    not(target_family = "wasm"),
     all(
         feature = "fragile-send-sync-non-atomic-wasm",
         not(target_feature = "atomics")
@@ -42,7 +42,7 @@ impl<T> WasmNotSend for T {}
 ))]
 pub trait WasmNotSync: Sync {}
 #[cfg(any(
-    not(target_arch = "wasm32"),
+    not(target_family = "wasm"),
     all(
         feature = "fragile-send-sync-non-atomic-wasm",
         not(target_feature = "atomics")
@@ -50,7 +50,7 @@ pub trait WasmNotSync: Sync {}
 ))]
 impl<T: Sync> WasmNotSync for T {}
 #[cfg(not(any(
-    not(target_arch = "wasm32"),
+    not(target_family = "wasm"),
     all(
         feature = "fragile-send-sync-non-atomic-wasm",
         not(target_feature = "atomics")
@@ -58,7 +58,7 @@ impl<T: Sync> WasmNotSync for T {}
 )))]
 pub trait WasmNotSync {}
 #[cfg(not(any(
-    not(target_arch = "wasm32"),
+    not(target_family = "wasm"),
     all(
         feature = "fragile-send-sync-non-atomic-wasm",
         not(target_feature = "atomics")

--- a/wgpu-types/src/texture/external_image.rs
+++ b/wgpu-types/src/texture/external_image.rs
@@ -5,7 +5,7 @@ use crate::{DownlevelFlags, Origin2d};
 ///
 /// Corresponds to [WebGPU `GPUCopyExternalImageSourceInfo`](
 /// https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopyexternalimage).
-#[cfg(all(target_arch = "wasm32", feature = "web"))]
+#[cfg(all(target_family = "wasm", feature = "web"))]
 #[derive(Clone, Debug)]
 pub struct CopyExternalImageSourceInfo {
     /// The texture to be copied from. The copy source data is captured at the moment
@@ -28,7 +28,7 @@ pub struct CopyExternalImageSourceInfo {
 ///
 /// Corresponds to the [implicit union type on WebGPU `GPUCopyExternalImageSourceInfo.source`](
 /// https://gpuweb.github.io/gpuweb/#dom-gpuimagecopyexternalimage-source).
-#[cfg(all(target_arch = "wasm32", feature = "web"))]
+#[cfg(all(target_family = "wasm", feature = "web"))]
 #[derive(Clone, Debug)]
 pub enum ExternalImageSource {
     /// Copy from a previously-decoded image bitmap.
@@ -49,7 +49,7 @@ pub enum ExternalImageSource {
     VideoFrame(web_sys::VideoFrame),
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "web"))]
+#[cfg(all(target_family = "wasm", feature = "web"))]
 impl ExternalImageSource {
     /// Gets the pixel, not css, width of the source.
     pub fn width(&self) -> u32 {
@@ -78,7 +78,7 @@ impl ExternalImageSource {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "web"))]
+#[cfg(all(target_family = "wasm", feature = "web"))]
 impl core::ops::Deref for ExternalImageSource {
     type Target = js_sys::Object;
 
@@ -96,14 +96,14 @@ impl core::ops::Deref for ExternalImageSource {
 }
 
 #[cfg(all(
-    target_arch = "wasm32",
+    target_family = "wasm",
     feature = "web",
     feature = "fragile-send-sync-non-atomic-wasm",
     not(target_feature = "atomics")
 ))]
 unsafe impl Send for ExternalImageSource {}
 #[cfg(all(
-    target_arch = "wasm32",
+    target_family = "wasm",
     feature = "web",
     feature = "fragile-send-sync-non-atomic-wasm",
     not(target_feature = "atomics")

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -229,7 +229,7 @@ static_assertions.workspace = true
 ###################
 # Not Webassembly #
 ###################
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 # Needed for only wgpu-core backend. Not optional as only wgpu-core backend exists on native platforms.
 wgpu-core = { workspace = true, features = [
     "renderdoc",
@@ -243,7 +243,7 @@ smallvec.workspace = true
 ###############
 # Webassembly #
 ###############
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+[target.'cfg(all(target_family = "wasm", not(target_os = "emscripten")))'.dependencies]
 # Needed for all backends
 js-sys = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -1,8 +1,8 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
-        native: { not(target_arch = "wasm32") },
-        Emscripten: { all(target_arch = "wasm32", target_os = "emscripten") },
-        web: { all(target_arch = "wasm32", not(Emscripten), feature = "web") },
+        native: { not(target_family = "wasm") },
+        Emscripten: { all(target_family = "wasm", target_os = "emscripten") },
+        web: { all(target_family = "wasm", not(Emscripten), feature = "web") },
 
         send_sync: { any(
             native,


### PR DESCRIPTION
**Description**

- Bumps glow to 0.18 which gains support for wasm64
- Update cfg gates from `target_arch = "wasm32"` to `target_family = "wasm"`

This commit, unfortunately, does not touch upon example code as that brings in getrandom 0.3 (0.4 supports wasm64) through flume and futures-lite. How would you like to handle these dev-dependencies issues? Wait for upstream or forge on ahead?

**Testing**
This was tested manually, but I can commit something like this if desired 😅 

<details><summary>lib.rs (hello triangle-ish)</summary>

```rust
use wasm_bindgen::prelude::*;

// Renders a colored triangle to the given canvas using wgpu's WebGPU backend,
// compiled to wasm64 (memory64).
#[wasm_bindgen]
pub async fn render(canvas: web_sys::HtmlCanvasElement) -> Result<(), JsValue> {
    console_error_panic_hook::set_once();
    let _ = console_log::init_with_level(log::Level::Info);

    let instance = wgpu::Instance::default();
    let surface = instance
        .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
        .map_err(err)?;

    let adapter = instance
        .request_adapter(&wgpu::RequestAdapterOptions {
            compatible_surface: Some(&surface),
            ..Default::default()
        })
        .await
        .map_err(err)?;
    log::info!("wasm64 adapter: {:?}", adapter.get_info());

    let (device, queue) = adapter
        .request_device(&wgpu::DeviceDescriptor::default())
        .await
        .map_err(err)?;

    let (w, h) = (canvas.width().max(1), canvas.height().max(1));
    let config = surface
        .get_default_config(&adapter, w, h)
        .ok_or_else(|| JsValue::from_str("surface not supported by adapter"))?;
    let format = config.format;
    surface.configure(&device, &config);

    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
        label: None,
        source: wgpu::ShaderSource::Wgsl(SHADER.into()),
    });
    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
        label: None,
        layout: None,
        vertex: wgpu::VertexState {
            module: &shader,
            entry_point: Some("vs"),
            compilation_options: Default::default(),
            buffers: &[],
        },
        fragment: Some(wgpu::FragmentState {
            module: &shader,
            entry_point: Some("fs"),
            compilation_options: Default::default(),
            targets: &[Some(format.into())],
        }),
        primitive: Default::default(),
        depth_stencil: None,
        multisample: Default::default(),
        multiview_mask: None,
        cache: None,
    });

    let frame = match surface.get_current_texture() {
        wgpu::CurrentSurfaceTexture::Success(t) | wgpu::CurrentSurfaceTexture::Suboptimal(t) => t,
        other => return Err(JsValue::from_str(&format!("no frame: {other:?}"))),
    };
    let view = frame.texture.create_view(&Default::default());
    let mut enc = device.create_command_encoder(&Default::default());
    {
        let mut rp = enc.begin_render_pass(&wgpu::RenderPassDescriptor {
            label: None,
            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                view: &view,
                depth_slice: None,
                resolve_target: None,
                ops: wgpu::Operations {
                    load: wgpu::LoadOp::Clear(wgpu::Color {
                        r: 0.05,
                        g: 0.05,
                        b: 0.08,
                        a: 1.0,
                    }),
                    store: wgpu::StoreOp::Store,
                },
            })],
            depth_stencil_attachment: None,
            timestamp_writes: None,
            occlusion_query_set: None,
            multiview_mask: None,
        });
        rp.set_pipeline(&pipeline);
        rp.draw(0..3, 0..1);
    }
    queue.submit(Some(enc.finish()));
    queue.present(frame);
    log::info!("wasm64 triangle presented");
    Ok(())
}

fn err<E: std::fmt::Debug>(e: E) -> JsValue {
    JsValue::from_str(&format!("{e:?}"))
}

const SHADER: &str = r#"
@vertex
fn vs(@builtin(vertex_index) i: u32) -> @builtin(position) vec4<f32> {
    var p = array<vec2<f32>, 3>(vec2(0.0, 0.6), vec2(-0.6, -0.6), vec2(0.6, -0.6));
    return vec4<f32>(p[i], 0.0, 1.0);
}
@fragment
fn fs(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
    return vec4<f32>(pos.x / 640.0, pos.y / 480.0, 0.8, 1.0);
}
"#;
```

</details> 

```bash
cargo +nightly build --release --target wasm64-unknown-unknown -Z build-std=std,panic_abort

wasm-bindgen --target web --out-dir web target/wasm64-unknown-unknown/release/wasm64_demo.wasm
```

sprinkle in some html:

```html
  <canvas id="c" width="640" height="480"></canvas>
  <script type="module">
    import init, { render } from "./wasm64_demo.js";
    try {
      await init();
      await render(document.getElementById("c"));
    } catch (e) {
      console.error(e);
    }
  </script>
```

<img width="720" height="560" alt="image" src="https://github.com/user-attachments/assets/4e8dfaf5-88a1-4f4a-98c5-eba4c5cc0131" />


<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
