### PR TITLE
fix(vulkan): Remove extra restriction in OOM check

### DIFF
--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -911,10 +911,6 @@ impl super::Device {
             return Ok(());
         };
 
-        // memory types not used by gpu-allocator
-        let invalid_flags =
-            vk::MemoryPropertyFlags::LAZILY_ALLOCATED | vk::MemoryPropertyFlags::PROTECTED;
-
         let preferred_flags = match location {
             MemoryLocation::GpuOnly => vk::MemoryPropertyFlags::DEVICE_LOCAL,
             MemoryLocation::CpuToGpu => {
@@ -937,7 +933,6 @@ impl super::Device {
             .find(|(i, ty)| {
                 (1 << i) & requirements.memory_type_bits != 0
                     && ty.property_flags.contains(preferred_flags)
-                    && !ty.property_flags.intersects(invalid_flags)
             });
 
         if selected_heap.is_none() {
@@ -955,7 +950,6 @@ impl super::Device {
                 .find(|(i, ty)| {
                     (1 << i) & requirements.memory_type_bits != 0
                         && ty.property_flags.contains(required_flags)
-                        && !ty.property_flags.intersects(invalid_flags)
                 });
         }
 


### PR DESCRIPTION
The wgpu Vulkan OOM check excluded all memory types with flags `LAZILY_ALLOCATED` or `PROTECTED`. Before #9643, the check was "declare OOM if any applicable heaps are out of memory". In the case of `LAZILY_ALLOCATED` (transient attachments), it found no applicable heaps, so the OOM check trivially passed.

After #9643, the OOM check is looking for available memory on a particular first compatible heap, and reports OOM if no compatible heap is found. This caused regressions in several tests (skybox, resolve_with_transient, and a few other examples) running on MoltenVK. This change removes the extra condition, which makes our OOM check more closely match gpu-allocator, to fix the regressions. Similar failures might show up in other contexts depending on the set of available memory types. Possibly this fix should be backported to v30.

I confess that I don't totally understand what the intent/purpose was of excluding these memory types. The comment said "memory types not used by gpu-allocator", which seems to be incorrect, since we have a case here where `LAZILY_ALLOCATED` memory type does get used. It's possible that the OOM check predated the transient attachment support and the comment was correct when written. I'm not sure if there might be some circumstance in which the check is still useful, or if it was just a convenient way to quickly exclude a bunch of stuff that didn't matter at the time, but later started to matter.

**Testing**
Fixes tests on a particular configuration that CI does not cover.

**Squash or Rebase?** Squash

**Checklist**

- [ ] I self-reviewed and fully understand this PR.
  - See above.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
  - If they use transient attachments.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works.
  - Our tests catch the problem, but weren't run with the right config in CI. 
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
  - Changelog entry is probably warranted. 
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
