### PR TITLE
Naga HLSL direct samplers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - spirv-out ray tracing pipelines. By @Vecvec in [#9085](https://github.com/gfx-rs/wgpu/pull/9085).
 - Add `spirv-out` ray tracing pipelines. By @Vecvec in [#9085](https://github.com/gfx-rs/wgpu/pull/9085).
 - Add `naga::front::wgsl::ParseError::notes()`. By @kwillemsen in [#9572](https://github.com/gfx-rs/wgpu/pull/9572).
+- Add `hlsl::SamplerBinding` and the `hlsl::Options::sampler_binding` field. Set it to `SamplerBinding::Direct` to make the HLSL backend emit ordinary `SamplerState`/`SamplerComparisonState` declarations bound directly to a register, instead of routing all samplers through the D3D12 sampler heap. By @Inner-Daemons.
 
 ### Changes
 

--- a/docs/superpowers/specs/2026-07-09-hlsl-direct-samplers-design.md
+++ b/docs/superpowers/specs/2026-07-09-hlsl-direct-samplers-design.md
@@ -1,0 +1,157 @@
+# HLSL backend: direct sampler binding (no sampler heap)
+
+## Problem
+
+Naga's HLSL backend always binds samplers through a D3D12 "sampler heap"
+indirection. It declares two global heaps (`nagaSamplerHeap[2048]` and
+`nagaComparisonSamplerHeap[2048]`), a per-bind-group `StructuredBuffer<uint>`
+index buffer, and accesses every sampler as
+`static const SamplerState s = nagaSamplerHeap[indexBuffer[reg]];`.
+
+There is no way to emit an ordinary HLSL sampler bound directly to a register.
+Consumers that manage their own sampler descriptors (i.e. bind samplers the
+"normal" way) cannot use the backend. We want an option to disable the heap
+indirection.
+
+## Scope
+
+- **In scope:** the naga HLSL backend (`naga/src/back/hlsl`) plus a snapshot
+  test exercising the new mode.
+- **Out of scope:** wiring the option through `wgpu-hal`'s dx12 backend or
+  `wgpu-core`. The dx12 HAL owns descriptor-heap allocation and root-signature
+  construction; making it emit direct samplers at runtime is a separate, much
+  larger change. This spec only gives naga the capability.
+
+## Design
+
+### New public API
+
+In `naga/src/back/hlsl/mod.rs`, add an enum describing how samplers are bound:
+
+```rust
+/// How the HLSL backend binds sampler global variables.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+pub enum SamplerBinding {
+    /// Bind the entire D3D12 sampler heap (as both a standard and a comparison
+    /// sampler heap) plus a per-bind-group sampler index buffer, and access
+    /// each sampler through that indirection.
+    ///
+    /// This is required by the `wgpu` dx12 backend. See the module
+    /// documentation's "Sampler Handling" section for details.
+    #[default]
+    Heap,
+    /// Declare each sampler as an ordinary HLSL `SamplerState` /
+    /// `SamplerComparisonState` bound directly to the register given by its
+    /// [`Options::binding_map`] entry, with no heap indirection.
+    Direct,
+}
+```
+
+Add a field to `Options`:
+
+```rust
+/// How sampler global variables are bound. Defaults to [`SamplerBinding::Heap`].
+pub sampler_binding: SamplerBinding,
+```
+
+`Options::default()` sets it to `SamplerBinding::Heap`. Because the field uses
+serde `default` (the `Options` struct already carries `#[serde(default)]`), it
+is optional in deserialized configs and defaults to `Heap`, so existing
+callers and all existing snapshots are unchanged.
+
+### Behavior in `Direct` mode
+
+Only two sites in `writer.rs` branch on the mode; the heap/index-buffer writers
+in `help.rs` are simply never reached because nothing calls them.
+
+**1. `Writer::write_global_sampler` (`writer.rs`, ~line 1224).**
+
+In `Heap` mode: unchanged.
+
+In `Direct` mode: do **not** call `write_wrapped_sampler_buffer`. Resolve the
+sampler's `BindTarget` from `binding_map` (via `resolve_resource_binding`) and
+treat its `register` / `space` as a real HLSL register (symmetric with how
+textures and buffers are already emitted). Emit:
+
+- `TypeInner::Sampler { comparison }`:
+  ```
+  SamplerState <name> : register(s<reg>[, space<space>]);
+  ```
+  using `SamplerComparisonState` when `comparison` is true.
+- `TypeInner::BindingArray { .. }` of a sampler:
+  ```
+  SamplerState <name>[<size>] : register(s<reg>[, space<space>]);
+  ```
+  Array size comes from the existing `write_array_size` / `binding_array_size`
+  logic. `space<space>` is omitted when the space is 0, matching the existing
+  register-writing convention elsewhere in the writer.
+
+The `space` register-suffix is only written when non-zero, consistent with the
+other `register(...)` emitters in `write_global`.
+
+**2. `Writer::sampler_binding_array_info_from_expression` (`writer.rs`, ~line
+4733).**
+
+In `Heap` mode: unchanged (returns `Some(info)`, which drives the
+`heap[indexBuffer[base + i]]` access form).
+
+In `Direct` mode: return `None`. With `None`, `Access` / `AccessIndex`
+expression codegen falls through to plain HLSL array indexing (`<name>[i]`),
+which is correct for a directly-declared sampler array.
+
+### What is intentionally *not* changed
+
+- Heap / index-buffer writers (`write_sampler_heaps`,
+  `write_wrapped_sampler_buffer` in `help.rs`) — unreachable in `Direct` mode,
+  left as-is.
+- `sampler_heap_target` and `sampler_buffer_binding_map` options — unused in
+  `Direct` mode, left as-is (no deprecation).
+- The `SamplerState` / `SamplerComparisonState` type emission in `write_type`
+  already produces the right HLSL type name; reused unchanged.
+
+## Testing
+
+### Snapshot test
+
+Add `naga/tests/in/wgsl/hlsl-sampler-binding-direct.wgsl` containing, at minimum:
+
+- a `texture_2d<f32>` + a `sampler`, used in a `textureSample` — exercises the
+  direct scalar sampler path;
+- a `sampler_comparison`, used in a `textureSampleCompare` — exercises
+  `SamplerComparisonState`;
+- a `binding_array<sampler>` indexed by a value — exercises the direct sampler
+  binding-array path (requires the
+  `TEXTURE_AND_SAMPLER_BINDING_ARRAY` capability).
+
+Add `naga/tests/in/wgsl/hlsl-sampler-binding-direct.toml`:
+
+- `targets = "HLSL"` (HLSL only — this feature is HLSL-specific);
+- required `capabilities` for the binding array;
+- `[hlsl]` section with `sampler_binding = "Direct"`, `fake_missing_bindings`,
+  and a `binding_map` giving every texture and sampler an explicit
+  `{ register, space }` (and `binding_array_size` for the array).
+
+Running the snapshot suite writes `naga/tests/out/hlsl/hlsl-sampler-binding-direct.hlsl`
+and `.ron`. Manually verify the generated HLSL:
+
+- contains `SamplerState ... : register(s...)` and
+  `SamplerComparisonState ... : register(s...)` declarations;
+- contains **no** `nagaSamplerHeap`, `nagaComparisonSamplerHeap`, or
+  `StructuredBuffer<uint>` sampler-index-buffer declarations;
+- indexes the sampler array directly (`name[i]`), not through a heap.
+
+### Regression
+
+The full existing snapshot suite (`cargo test -p naga --test naga`) must still
+pass with **no** changes to any existing `out/hlsl/*` file — proving the
+`Heap` default is byte-for-byte unchanged.
+
+## Risks / notes
+
+- FXC/DXC are not run in the snapshot tests, so correctness of the emitted HLSL
+  is verified by inspection of the snapshot, not by compilation. This matches
+  how the rest of the HLSL snapshot suite works.
+- `binding_array<sampler>` requires the `TEXTURE_AND_SAMPLER_BINDING_ARRAY`
+  capability; the test toml must enable it or validation fails.

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -99,12 +99,17 @@ accessing individual columns by dynamic index.
 
 ## Sampler Handling
 
-Due to limitations in how sampler heaps work in D3D12, we need to access samplers
-through a layer of indirection. Instead of directly binding samplers, we bind the entire
-sampler heap as both a standard and a comparison sampler heap. We then use a sampler
-index buffer for each bind group. This buffer is accessed in the shader to get the actual
-sampler index within the heap. See the wgpu_hal dx12 backend documentation for more
-information.
+By default ([`SamplerBinding::Heap`]), due to limitations in how sampler heaps work in
+D3D12, we access samplers through a layer of indirection. Instead of directly binding
+samplers, we bind the entire sampler heap as both a standard and a comparison sampler
+heap. We then use a sampler index buffer for each bind group. This buffer is accessed in
+the shader to get the actual sampler index within the heap. See the wgpu_hal dx12 backend
+documentation for more information.
+
+Consumers that manage sampler descriptors themselves can instead set
+[`Options::sampler_binding`] to [`SamplerBinding::Direct`], which declares each sampler as
+an ordinary HLSL `SamplerState`/`SamplerComparisonState` bound directly to the register
+given by its [`Options::binding_map`] entry, with no heap indirection.
 
 # External textures
 
@@ -344,6 +349,32 @@ impl Default for SamplerHeapBindTargets {
     }
 }
 
+/// How the HLSL backend binds sampler global variables.
+///
+/// Selected via [`Options::sampler_binding`].
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+pub enum SamplerBinding {
+    /// Bind the entire sampler heap (as both a standard and a comparison
+    /// sampler heap) plus a per-bind-group sampler index buffer, and access
+    /// each sampler through that indirection.
+    ///
+    /// This is the layout the `wgpu` `dx12` backend expects. See the module
+    /// documentation's [Sampler Handling] section for details.
+    ///
+    /// [Sampler Handling]: index.html#sampler-handling
+    #[default]
+    Heap,
+    /// Declare each sampler as an ordinary HLSL `SamplerState` /
+    /// `SamplerComparisonState` bound directly to the register given by its
+    /// [`Options::binding_map`] entry, with no heap indirection.
+    ///
+    /// In this mode the [`Options::sampler_heap_target`] and
+    /// [`Options::sampler_buffer_binding_map`] options are unused.
+    Direct,
+}
+
 #[cfg(feature = "deserialize")]
 #[derive(serde::Deserialize)]
 struct SamplerIndexBufferBindingSerialization {
@@ -513,6 +544,19 @@ pub struct Options {
     /// [`D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS`]: https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_root_parameter_type
     pub immediates_target: Option<BindTarget>,
 
+    /// How sampler global variables are bound.
+    ///
+    /// Defaults to [`SamplerBinding::Heap`], which routes samplers through the
+    /// sampler heap described by [`sampler_heap_target`] and
+    /// [`sampler_buffer_binding_map`]. Set to [`SamplerBinding::Direct`] to
+    /// instead declare each sampler directly on the register given by its
+    /// [`binding_map`] entry.
+    ///
+    /// [`sampler_heap_target`]: Options::sampler_heap_target
+    /// [`sampler_buffer_binding_map`]: Options::sampler_buffer_binding_map
+    /// [`binding_map`]: Options::binding_map
+    pub sampler_binding: SamplerBinding,
+
     /// HLSL binding information for the sampler heap and comparison sampler heap.
     pub sampler_heap_target: SamplerHeapBindTargets,
 
@@ -570,6 +614,7 @@ impl Default for Options {
             binding_map: BindingMap::default(),
             fake_missing_bindings: true,
             special_constants_binding: None,
+            sampler_binding: SamplerBinding::default(),
             sampler_heap_target: SamplerHeapBindTargets::default(),
             sampler_buffer_binding_map: alloc::collections::BTreeMap::default(),
             immediates_target: None,

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -1229,13 +1229,19 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
     ) -> BackendResult {
         let binding = *global.binding.as_ref().unwrap();
 
+        // This was already validated, so we can confidently unwrap it.
+        let bt = self.options.resolve_resource_binding(&binding).unwrap();
+
+        // In `Direct` mode, declare the sampler on its own register instead of
+        // routing it through the sampler heap.
+        if self.options.sampler_binding == super::SamplerBinding::Direct {
+            return self.write_global_sampler_direct(module, handle, global, bt);
+        }
+
         let key = super::SamplerIndexBufferKey {
             group: binding.group,
         };
         self.write_wrapped_sampler_buffer(key)?;
-
-        // This was already validated, so we can confidently unwrap it.
-        let bt = self.options.resolve_resource_binding(&binding).unwrap();
 
         match module.types[global.ty].inner {
             TypeInner::Sampler { comparison } => {
@@ -1277,6 +1283,54 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
             }
             _ => unreachable!(),
         };
+
+        Ok(())
+    }
+
+    /// Write a sampler global for [`SamplerBinding::Direct`] mode: an ordinary
+    /// HLSL `SamplerState`/`SamplerComparisonState` bound directly to a register,
+    /// with no sampler heap indirection.
+    ///
+    /// [`SamplerBinding::Direct`]: super::SamplerBinding::Direct
+    fn write_global_sampler_direct(
+        &mut self,
+        module: &Module,
+        handle: Handle<crate::GlobalVariable>,
+        global: &crate::GlobalVariable,
+        bt: super::BindTarget,
+    ) -> BackendResult {
+        // Determine whether this is a comparison sampler and, for binding
+        // arrays, the element type and declared size.
+        let (comparison, array) = match module.types[global.ty].inner {
+            TypeInner::Sampler { comparison } => (comparison, None),
+            TypeInner::BindingArray { base, size } => match module.types[base].inner {
+                TypeInner::Sampler { comparison } => (comparison, Some((base, size))),
+                _ => unreachable!(),
+            },
+            _ => unreachable!(),
+        };
+
+        let ty_name = if comparison {
+            "SamplerComparisonState"
+        } else {
+            "SamplerState"
+        };
+        let name = &self.names[&NameKey::GlobalVariable(handle)];
+        write!(self.out, "{ty_name} {name}")?;
+
+        if let Some((base, size)) = array {
+            if let Some(overridden_size) = bt.binding_array_size {
+                write!(self.out, "[{overridden_size}]")?;
+            } else {
+                self.write_array_size(module, base, size)?;
+            }
+        }
+
+        write!(self.out, " : register(s{}", bt.register)?;
+        if bt.space != 0 {
+            write!(self.out, ", space{}", bt.space)?;
+        }
+        writeln!(self.out, ");")?;
 
         Ok(())
     }
@@ -3761,17 +3815,23 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 let global_variable = &module.global_variables[handle];
                 let ty = &module.types[global_variable.ty].inner;
 
-                // In the case of binding arrays of samplers, we need to not write anything
-                // as the we are in the wrong position to fully write the expression.
+                // In `Heap` mode, for binding arrays of samplers we need to not
+                // write anything here, as we are in the wrong position to fully
+                // write the expression; the entire writing is done by
+                // Access/AccessIndex via the sampler heap indirection.
                 //
-                // The entire writing is done by AccessIndex.
-                let is_binding_array_of_samplers = match *ty {
-                    TypeInner::BindingArray { base, .. } => {
-                        let base_ty = &module.types[base].inner;
-                        matches!(*base_ty, TypeInner::Sampler { .. })
-                    }
-                    _ => false,
-                };
+                // In `Direct` mode the sampler array is an ordinary HLSL array,
+                // so we write its name here and let Access/AccessIndex append
+                // the index normally.
+                let is_binding_array_of_samplers = self.options.sampler_binding
+                    == super::SamplerBinding::Heap
+                    && match *ty {
+                        TypeInner::BindingArray { base, .. } => {
+                            let base_ty = &module.types[base].inner;
+                            matches!(*base_ty, TypeInner::Sampler { .. })
+                        }
+                        _ => false,
+                    };
 
                 let is_storage_space =
                     matches!(global_variable.space, crate::AddressSpace::Storage { .. });
@@ -4730,6 +4790,12 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         base: Handle<crate::Expression>,
         resolved: &TypeInner,
     ) -> Option<BindingArraySamplerInfo> {
+        // In `Direct` mode samplers are declared as ordinary HLSL sampler
+        // arrays, so they are indexed directly with no heap indirection.
+        if self.options.sampler_binding == super::SamplerBinding::Direct {
+            return None;
+        }
+
         if let TypeInner::BindingArray {
             base: base_ty_handle,
             ..

--- a/naga/tests/in/wgsl/hlsl-sampler-binding-direct.toml
+++ b/naga/tests/in/wgsl/hlsl-sampler-binding-direct.toml
@@ -1,0 +1,35 @@
+capabilities = """
+  TEXTURE_AND_SAMPLER_BINDING_ARRAY
+  | TEXTURE_AND_SAMPLER_BINDING_ARRAY_NON_UNIFORM_INDEXING
+"""
+targets = "HLSL"
+
+[hlsl]
+sampler_binding = "Direct"
+fake_missing_bindings = true
+zero_initialize_workgroup_memory = true
+
+# tex
+[[hlsl.binding_map]]
+bind_target = { register = 0, space = 0 }
+resource_binding = { group = 0, binding = 0 }
+
+# samp
+[[hlsl.binding_map]]
+bind_target = { register = 0, space = 0 }
+resource_binding = { group = 0, binding = 1 }
+
+# depth_tex
+[[hlsl.binding_map]]
+bind_target = { register = 1, space = 0 }
+resource_binding = { group = 0, binding = 2 }
+
+# samp_comp
+[[hlsl.binding_map]]
+bind_target = { register = 1, space = 0 }
+resource_binding = { group = 0, binding = 3 }
+
+# samp_array
+[[hlsl.binding_map]]
+bind_target = { register = 2, space = 0, binding_array_size = 4 }
+resource_binding = { group = 0, binding = 4 }

--- a/naga/tests/in/wgsl/hlsl-sampler-binding-direct.wgsl
+++ b/naga/tests/in/wgsl/hlsl-sampler-binding-direct.wgsl
@@ -1,0 +1,32 @@
+// Exercises the HLSL backend's `SamplerBinding::Direct` option, which declares
+// samplers as ordinary HLSL `SamplerState`/`SamplerComparisonState` bound to a
+// register, rather than routing them through the D3D12 sampler heap.
+enable wgpu_binding_array;
+
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@group(0) @binding(1) var samp: sampler;
+@group(0) @binding(2) var depth_tex: texture_depth_2d;
+@group(0) @binding(3) var samp_comp: sampler_comparison;
+@group(0) @binding(4) var samp_array: binding_array<sampler, 4>;
+
+struct FragmentIn {
+    @location(0) uv: vec2<f32>,
+    @location(1) @interpolate(flat) index: u32,
+};
+
+@fragment
+fn main(in: FragmentIn) -> @location(0) vec4<f32> {
+    var color = vec4<f32>(0.0);
+
+    // A plain sampler: `SamplerState`.
+    color += textureSample(tex, samp, in.uv);
+
+    // A comparison sampler: `SamplerComparisonState`.
+    color.x += textureSampleCompare(depth_tex, samp_comp, in.uv, 0.5);
+
+    // A sampler binding array, indexed by a constant and a (non-uniform) value.
+    color += textureSample(tex, samp_array[0], in.uv);
+    color += textureSample(tex, samp_array[in.index], in.uv);
+
+    return color;
+}

--- a/naga/tests/out/hlsl/wgsl-hlsl-sampler-binding-direct.hlsl
+++ b/naga/tests/out/hlsl/wgsl-hlsl-sampler-binding-direct.hlsl
@@ -1,0 +1,36 @@
+struct FragmentIn {
+    float2 uv : LOC0;
+    nointerpolation uint index : LOC1;
+};
+
+Texture2D<float4> tex : register(t0);
+SamplerState samp : register(s0);
+Texture2D<float> depth_tex : register(t1);
+SamplerComparisonState samp_comp : register(s1);
+SamplerState samp_array[4] : register(s2);
+
+struct FragmentInput_main {
+    float2 uv : LOC0;
+    nointerpolation uint index : LOC1;
+};
+
+float4 main(FragmentInput_main fragmentinput_main) : SV_Target0
+{
+    FragmentIn in_ = { fragmentinput_main.uv, fragmentinput_main.index };
+    float4 color = (0.0).xxxx;
+
+    float4 _e4 = color;
+    float4 _e8 = tex.Sample(samp, in_.uv);
+    color = (_e4 + _e8);
+    float _e11 = color.x;
+    float _e16 = depth_tex.SampleCmp(samp_comp, in_.uv, 0.5);
+    color.x = (_e11 + _e16);
+    float4 _e18 = color;
+    float4 _e23 = tex.Sample(samp_array[0], in_.uv);
+    color = (_e18 + _e23);
+    float4 _e25 = color;
+    float4 _e31 = tex.Sample(samp_array[NonUniformResourceIndex(in_.index)], in_.uv);
+    color = (_e25 + _e31);
+    float4 _e33 = color;
+    return _e33;
+}

--- a/naga/tests/out/hlsl/wgsl-hlsl-sampler-binding-direct.ron
+++ b/naga/tests/out/hlsl/wgsl-hlsl-sampler-binding-direct.ron
@@ -1,0 +1,16 @@
+(
+    vertex:[
+    ],
+    fragment:[
+        (
+            entry_point:"main",
+            target_profile:"ps_5_1",
+        ),
+    ],
+    compute:[
+    ],
+    task:[
+    ],
+    mesh:[
+    ],
+)

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -1502,6 +1502,7 @@ impl crate::Device for super::Device {
                 dynamic_storage_buffer_offsets_targets,
                 zero_initialize_workgroup_memory: true,
                 restrict_indexing: true,
+                sampler_binding: hlsl::SamplerBinding::Heap,
                 sampler_heap_target,
                 sampler_buffer_binding_map,
                 external_texture_binding_map,


### PR DESCRIPTION
**Connections**

**Description**
I can file an issue with more details if needed.

Naga's HLSL writer currently expects a sampler heap with a fixed size of 2048 and all samplers are passed as indices to this. Non-wgpu users of naga might not have a sampler heap and thus cannot use naga-generated HLSL. This PR adds a flag to use direct samplers.

**Testing**
New snapshot

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
