### PR TITLE
[core] Do not overflow on user input in `TextureView::Invalid`

### DIFF
--- a/tests/tests/wgpu-validation/api/texture.rs
+++ b/tests/tests/wgpu-validation/api/texture.rs
@@ -1,5 +1,7 @@
 //! Tests of [`wgpu::Texture`] and related.
 
+use std::sync::Arc;
+
 use wgpu_test::{fail, valid};
 
 /// Ensures that submitting a command buffer referencing an already destroyed texture
@@ -686,4 +688,31 @@ fn transient_invalid_storeop() {
         },
       Some("Color attachment with `TRANSIENT_ATTACHMENT` usage can only be used with `LoadOp::Clear` or `LoadOp::DontCare` (if it is available) and  `StoreOp::Discard`. Operations `(Clear(Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }), Store)` were provided")
     );
+}
+
+/// <https://bugzilla.mozilla.org/show_bug.cgi?id=2053860>
+#[test]
+fn no_overflow_in_texture_selector() {
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    // ignore validation errors to not panic before reaching `TextureView::invalid`
+    device.on_uncaptured_error(Arc::new(|_| {}));
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: None,
+        size: wgpu::Extent3d {
+            width: 59,
+            height: 401,
+            depth_or_array_layers: 1948,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::R8Unorm,
+        usage: wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+    let _view = texture.create_view(&wgpu::TextureViewDescriptor {
+        base_array_layer: 3385121660,
+        array_layer_count: Some(3815184380),
+        ..Default::default()
+    });
 }

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2151,11 +2151,8 @@ impl TextureView {
             format_features: texture.format_features,
             samples: texture.desc.sample_count,
             selector: TextureSelector {
-                mips: desc.range.base_mip_level
-                    ..(desc.range.base_mip_level + desc.range.mip_level_count.unwrap_or_default()),
-                layers: desc.range.base_array_layer
-                    ..(desc.range.base_array_layer
-                        + desc.range.array_layer_count.unwrap_or_default()),
+                mips: desc.range.mip_range(texture.desc.mip_level_count),
+                layers: desc.range.layer_range(texture.desc.array_layer_count()),
             },
             label: desc.label.to_string(),
         })


### PR DESCRIPTION
**Connections**
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=2053860 which I caused in #9787

**Description**
Never trust user input! so we use `ImageSubresourceRange::mip_range` and `ImageSubresourceRange::layer_range` for mips&layers range computation, both of which uses `saturating_add` to prevent overflow panics.

**Testing**
Added new test that reproduces https://bugzilla.mozilla.org/show_bug.cgi?id=2053860 to verify the fix.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
