### PR TITLE
fix(naga msl-out): Support sampler `lod_clamp` & `max_anisotropy`

### DIFF
--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -4957,6 +4957,7 @@ template <typename A>
         &mut self,
         level: back::Level,
         sampler: &sm::InlineSampler,
+        options: &Options,
     ) -> BackendResult {
         for (&letter, address) in ['s', 't', 'r'].iter().zip(sampler.address.iter()) {
             writeln!(
@@ -5001,17 +5002,26 @@ template <typename A>
                 sampler.border_color.as_str(),
             )?;
         }
-        //TODO: I'm not able to feed this in a way that MSL likes:
-        //>error: use of undeclared identifier 'lod_clamp'
-        //>error: no member named 'max_anisotropy' in namespace 'metal'
-        if false {
+
+        if options.lang_version >= (1, 2) {
             if let Some(ref lod) = sampler.lod_clamp {
-                writeln!(self.out, "{}lod_clamp({},{}),", level, lod.start, lod.end,)?;
+                writeln!(
+                    self.out,
+                    "{}{}::lod_clamp({},{}),",
+                    level, NAMESPACE, lod.start, lod.end,
+                )?;
             }
             if let Some(aniso) = sampler.max_anisotropy {
-                writeln!(self.out, "{}max_anisotropy({}),", level, aniso.get(),)?;
+                writeln!(
+                    self.out,
+                    "{}{}::max_anisotropy({}),",
+                    level,
+                    NAMESPACE,
+                    aniso.get(),
+                )?;
             }
         }
+
         if sampler.compare_func != sm::CompareFunc::Never {
             writeln!(
                 self.out,
@@ -8113,7 +8123,7 @@ template <typename A>
                             NAMESPACE,
                             name
                         )?;
-                        self.put_inline_sampler_properties(back::Level(2), sampler)?;
+                        self.put_inline_sampler_properties(back::Level(2), sampler, options)?;
                         writeln!(self.out, "{});", back::INDENT)?;
                     } else if let crate::TypeInner::Image {
                         class: crate::ImageClass::External,

--- a/naga/tests/out/msl/wgsl-skybox.metal
+++ b/naga/tests/out/msl/wgsl-skybox.metal
@@ -62,6 +62,8 @@ fragment fs_mainOutput fs_main(
         metal::r_address::clamp_to_edge,
         metal::mag_filter::linear,
         metal::min_filter::linear,
+        metal::lod_clamp(0.5,10),
+        metal::max_anisotropy(8),
         metal::coord::normalized
     );
     const VertexOutput in = { position, varyings_1.uv };


### PR DESCRIPTION
**Connections**

Fixes #4322

**Description**

It seems these aren't support on Metal version 1.0 (and 1.1 which is equivalent to 1.0), only on 1.2 onwards. Though [the spec](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf) doesn't technically state this, I was checking the metal config files on my Macbook and it looks like there is a certain define flag that includes the structs required for `max_anisotropy` and `lod_clamp`, and this flag is defined for all versions except 1.1.

**Testing**

Existing tests pass validation.

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
