### PR TITLE
test: Annotate expected failures on Metal and MoltenVK

### DIFF
--- a/benches/benches/wgpu-benchmark/computepass.rs
+++ b/benches/benches/wgpu-benchmark/computepass.rs
@@ -77,7 +77,9 @@ impl ComputepassState {
                 | wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
         )
         // TODO: as of writing llvmpipe segfaults the bindless benchmark on ci
-        && device_state.adapter_info.driver != "llvmpipe";
+        && device_state.adapter_info.driver != "llvmpipe"
+        // TODO(https://github.com/gfx-rs/wgpu/issues/9849): Currently broken on Metal
+        && device_state.adapter_info.backend != wgpu::Backend::Metal;
 
         // Performance gets considerably worse if the resources are shuffled.
         //

--- a/examples/features/src/big_compute_buffers/tests.rs
+++ b/examples/features/src/big_compute_buffers/tests.rs
@@ -17,11 +17,13 @@ pub static TWO_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
                 max_binding_array_elements_per_shader_stage: 8,
                 ..Default::default()
             })
-            // https://github.com/gfx-rs/wgpu/issues/9184
             .expect_fail(
                 wgpu_test::FailureCase::molten_vk()
+                    // https://github.com/gfx-rs/wgpu/issues/9184
                     .validation_error("Shader library compile failed")
-                    .validation_error("could not be compiled into pipeline"),
+                    .validation_error("could not be compiled into pipeline")
+                    // https://github.com/gfx-rs/wgpu/issues/9849
+                    .panic("assertion failed: produced"),
             ),
     )
     .run_async(|ctx| {

--- a/tests/tests/wgpu-gpu/binding_array/buffers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/buffers.rs
@@ -67,8 +67,16 @@ static BINDING_ARRAY_STORAGE_BUFFERS: GpuTestConfiguration = GpuTestConfiguratio
             max_binding_array_elements_per_shader_stage: 17,
             ..Limits::default()
         },
-        // See https://github.com/gfx-rs/wgpu/issues/6745.
-        failures: FailureCase::mac_vulkan(|case| case.panic("bad SPIR-V wrapper struct inference")),
+        // Metal: https://github.com/gfx-rs/wgpu/issues/9849
+        // MoltenVK: #9849 and also https://github.com/gfx-rs/wgpu/issues/6745
+        // With #6745 only, the expected failure was `case.panic("bad SPIR-V wrapper struct inference")`
+        failures: FailureCase::mac_vulkan(|case| {
+            case.validation_error("Shader library compile failed")
+                .validation_error("could not be compiled into pipeline")
+        })
+        .into_iter()
+        .chain([FailureCase::backend(Backends::METAL)])
+        .collect(),
         ..Default::default()
     })
     .run_async(|ctx| async move { binding_array_buffers(ctx, BufferType::Storage, false).await });
@@ -85,8 +93,16 @@ static PARTIAL_BINDING_ARRAY_STORAGE_BUFFERS: GpuTestConfiguration = GpuTestConf
             max_binding_array_elements_per_shader_stage: 33,
             ..Limits::default()
         },
-        // See https://github.com/gfx-rs/wgpu/issues/6745.
-        failures: FailureCase::mac_vulkan(|case| case.panic("bad SPIR-V wrapper struct inference")),
+        // Metal: https://github.com/gfx-rs/wgpu/issues/9849
+        // MoltenVK: #9849 and also https://github.com/gfx-rs/wgpu/issues/6745
+        // With #6745 only, the expected failure was `case.panic("bad SPIR-V wrapper struct inference")`
+        failures: FailureCase::mac_vulkan(|case| {
+            case.validation_error("Shader library compile failed")
+                .validation_error("could not be compiled into pipeline")
+        })
+        .into_iter()
+        .chain([FailureCase::backend(Backends::METAL)])
+        .collect(),
         ..Default::default()
     })
     .run_async(|ctx| async move { binding_array_buffers(ctx, BufferType::Storage, true).await });

--- a/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/sampled_textures.rs
@@ -273,7 +273,13 @@ static PARTIAL_BINDING_ARRAY_FOLLOWED_BY_STORAGE_BUFFER: GpuTestConfiguration =
                 .limits(Limits {
                     max_binding_array_elements_per_shader_stage: 32,
                     ..Limits::default()
-                }),
+                })
+                // https://github.com/gfx-rs/wgpu/issues/9184
+                .expect_fail(
+                    wgpu_test::FailureCase::molten_vk()
+                        .validation_error("Shader library compile failed")
+                        .validation_error("could not be compiled into pipeline"),
+                ),
         )
         .run_async(
             |ctx| async move { partial_binding_array_followed_by_storage_buffer(ctx).await },

--- a/tests/tests/wgpu-gpu/naga_capabilities.rs
+++ b/tests/tests/wgpu-gpu/naga_capabilities.rs
@@ -14,11 +14,9 @@ pub fn validate_capabilities(ctx: TestingContext) {
     );
     let max_caps = match ctx.adapter.get_info().backend {
         wgpu::Backend::Vulkan => naga::back::spv::supported_capabilities(),
-        // TODO: when mesh shaders land, change this
-        wgpu::Backend::Dx12 => naga::back::hlsl::supported_capabilities() | Caps::MESH_SHADER,
+        wgpu::Backend::Dx12 => naga::back::hlsl::supported_capabilities(),
         wgpu::Backend::Metal => {
             naga::back::msl::supported_capabilities()
-                | Caps::MESH_SHADER
                 // TODO(https://github.com/gfx-rs/wgpu/issues/9849): mask off
                 // BUFFER_BINDING_ARRAY because it is not currently reported by
                 // naga's MSL backend.

--- a/tests/tests/wgpu-gpu/naga_capabilities.rs
+++ b/tests/tests/wgpu-gpu/naga_capabilities.rs
@@ -16,7 +16,14 @@ pub fn validate_capabilities(ctx: TestingContext) {
         wgpu::Backend::Vulkan => naga::back::spv::supported_capabilities(),
         // TODO: when mesh shaders land, change this
         wgpu::Backend::Dx12 => naga::back::hlsl::supported_capabilities() | Caps::MESH_SHADER,
-        wgpu::Backend::Metal => naga::back::msl::supported_capabilities() | Caps::MESH_SHADER,
+        wgpu::Backend::Metal => {
+            naga::back::msl::supported_capabilities()
+                | Caps::MESH_SHADER
+                // TODO(https://github.com/gfx-rs/wgpu/issues/9849): mask off
+                // BUFFER_BINDING_ARRAY because it is not currently reported by
+                // naga's MSL backend.
+                | Caps::BUFFER_BINDING_ARRAY
+        }
         wgpu::Backend::Gl => naga::back::glsl::supported_capabilities(),
         wgpu::Backend::BrowserWebGpu => naga::back::wgsl::supported_capabilities(),
         wgpu::Backend::Noop => Caps::all(),


### PR DESCRIPTION
Mostly from #9849, but there is one that seems like a newly added test matching a pre-existing failure symptom associated with #9184.

I believe CI does not cover these due to limitations of the paravirtualized GPU device.

**Testing**
Together with #9838, fixes failures locally. CI will check if any of the expect-fails are overly broad.

**Squash or Rebase?** Squash

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
