### PR TITLE
printing average frame time in examples/halmark when bunnies are spawned after first 100 frames

### DIFF
--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -885,7 +885,7 @@ impl ApplicationHandler for App {
                     self.accum_time += self.last_frame_inst.elapsed().as_secs_f32();
                     self.last_frame_inst = Instant::now();
                     self.frame_count += 1;
-                    if self.frame_count == 100 && !ex.is_empty() {
+                    if self.frame_count >= 100 && !ex.is_empty() {
                         println!(
                             "Avg frame time {}ms",
                             self.accum_time * 1000.0 / self.frame_count as f32


### PR DESCRIPTION
**Description**
Fixes a bug in `examples/halmark` where the average frame time is **never printed** if no bunnies are spawned during the first 100 rendered frames.

The benchmark prints the average frame time when exactly `frame_count == 100` and at least one bunny exists. If no bunnies have been spawned **by then**, the condition is skipped and `frame_count` continues increasing beyond 100.

| befrore  | after |
|---------|----------------|
| <img width="439" height="223" alt="before" src="https://github.com/user-attachments/assets/9ba2eb4c-aa33-4fef-a851-5e9ad99e3a8b" /> | <img width="525" height="419" alt="after" src="https://github.com/user-attachments/assets/02e96c13-ee25-4551-9851-6f15a58a1fba" />      |


