### PR TITLE
fix(naga): disable libfuzzer on OpenBSD

### DIFF
--- a/naga/fuzz/Cargo.toml
+++ b/naga/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 [package.metadata]
 cargo-fuzz = true
 
-[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios")))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "openbsd")))'.dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
 libfuzzer-sys.workspace = true
 

--- a/naga/fuzz/build.rs
+++ b/naga/fuzz/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
-        fuzzable_platform: { not(any(target_arch = "wasm32", target_os = "ios", all(windows, target_arch = "aarch64"))) },
+        fuzzable_platform: { not(any(target_arch = "wasm32", target_os = "ios", target_os = "openbsd", all(windows, target_arch = "aarch64"))) },
     }
     // This cfg provided by cargo-fuzz
     println!("cargo::rustc-check-cfg=cfg(fuzzing)");


### PR DESCRIPTION
libfuzzer is not supported on OpenBSD OS, see
https://llvm.googlesource.com/libfuzzer/+/refs/heads/main/FuzzerPlatform.h

**Connections**
Fix #9857 

**Description**
Disable build of `libfuzzer` on OpenBSD OS in `naga/fuzz/`

**Testing**
Build on OpenBSD/amd64 with Rust 1.96.0 succeeds with this fix
```sh
$ cargo build -v
(...)
   Compiling wgpu-core-deps-wasm v30.0.0 (/home/fox/tmp/wgpu.git/wgpu-core/platform-deps/wasm)
     Running `rustc --crate-name wgpu_core_deps_wasm --edition=2021 wgpu-core/platform-deps/wasm/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=273 --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 '--warn=clippy::ref_as_ptr' --warn=missing_debug_implementations --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("webgl"))' -C metadata=ee1ecf26eb5edfc4 -C extra-filename=-5e090552674a93f6 --out-dir /home/fox/tmp/wgpu.git/target/debug/deps -C incremental=/home/fox/tmp/wgpu.git/target/debug/incremental -L dependency=/home/fox/tmp/wgpu.git/target/debug/deps`
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 52s
```

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
