### PR TITLE
Add MVP `no_std` Support to `wgpu` & `wgpu-core`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,7 @@ jobs:
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-sync --no-default-features
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p naga --no-default-features
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-hal --no-default-features
+          cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-core --no-default-features
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu --no-default-features
 
           # Check with all compatible features
@@ -335,6 +336,7 @@ jobs:
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-sync --no-default-features --features alloc
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p naga --no-default-features --features dot-out,spv-in,spv-out,glsl-out,msl-out,serialize,deserialize,wgsl-in,wgsl-out,hlsl-out
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-hal --no-default-features --features fragile-send-sync-non-atomic-wasm
+          cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-core --no-default-features --features api_log_info,resource_log_info,strict_asserts,serde,wgsl,spirv,counters,noop
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu --no-default-features --features serde
 
       # Building for native platforms with standard tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p naga --no-default-features --features dot-out,spv-in,spv-out,glsl-out,msl-out,serialize,deserialize,wgsl-in,wgsl-out,hlsl-out
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-hal --no-default-features --features fragile-send-sync-non-atomic-wasm
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-core --no-default-features --features api_log_info,resource_log_info,strict_asserts,serde,wgsl,spirv,counters,noop
-          cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu --no-default-features --features serde
+          cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu --no-default-features --features webgpu,drm,wgsl,strict_asserts,serde,counters
 
       # Building for native platforms with standard tests.
       - name: Check native

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4794,6 +4794,7 @@ dependencies = [
  "macro_rules_attribute",
  "naga",
  "naga-types",
+ "num-traits",
  "once_cell",
  "portable-atomic",
  "profiling",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -111,7 +111,7 @@ fragile-send-sync-non-atomic-wasm = [
 
 ## Enable certain items to be `Send` and `Sync` when they would not otherwise be.
 ## Also enables backtraces in some error cases when also under cfg(debug_assertions).
-std = ["wgpu-sync/std"]
+std = ["wgpu-sync/std", "once_cell/std"]
 
 #! ### External libraries
 # --------------------------------------------------------------------
@@ -199,12 +199,13 @@ hashbrown.workspace = true
 indexmap.workspace = true
 log.workspace = true
 macro_rules_attribute = { workspace = true, optional = true }
-once_cell = { workspace = true, features = ["std"] }
+num-traits = { workspace = true }
+once_cell = { workspace = true, default-features = false }
 profiling = { workspace = true, default-features = false }
 raw-window-handle.workspace = true
 ron = { workspace = true, optional = true }
 rustc-hash.workspace = true
-serde = { workspace = true, features = ["default", "derive"], optional = true }
+serde = { workspace = true, features = ["derive"], default-features = false, optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
 

--- a/wgpu-core/src/pool.rs
+++ b/wgpu-core/src/pool.rs
@@ -2,10 +2,14 @@ use alloc::sync::{Arc, Weak};
 use core::hash::Hash;
 
 use hashbrown::{hash_map::Entry, HashMap};
-use once_cell::sync::OnceCell;
 
 use crate::lock::{rank, Mutex};
 use crate::FastHashMap;
+
+#[cfg(feature = "std")]
+use once_cell::sync::OnceCell;
+#[cfg(not(feature = "std"))]
+use once_cell::unsync::OnceCell;
 
 type SlotInner<V> = Weak<V>;
 type ResourcePoolSlot<V> = Arc<OnceCell<SlotInner<V>>>;

--- a/wgpu-core/src/timestamp_normalization/mod.rs
+++ b/wgpu-core/src/timestamp_normalization/mod.rs
@@ -391,6 +391,9 @@ impl TimestampNormalizationBindGroup {
 }
 
 fn compute_timestamp_period(input: f32) -> (u32, u32) {
+    #[cfg(not(feature = "std"))]
+    use num_traits::float::Float as _;
+
     let pow2 = input.log2().ceil() as i32;
     let clamped_pow2 = pow2.clamp(-32, 32).unsigned_abs();
     let shift = 32 - clamped_pow2;


### PR DESCRIPTION
**Connections**

- Fixes #6826
- Supersedes #7746
- Acts on [this](https://github.com/gfx-rs/wgpu/pull/7746#issuecomment-3028251247) & [this](https://github.com/gfx-rs/wgpu/pull/7746#discussion_r2229699647) feedback
- ~~Blocked on #9780~~

**Description**

Adds `no_std` support to `wgpu-core`, which unblocks further `no_std` support for various `wgpu` features. This required several relatively minor changes:

1. Use floating point methods only provided by `std` (`ilog2`, `round`) from `num_traits` in `not(feature = "std")` configuration.
2. Use `once_cell::unsync::OnceCell` when in `not(feature = "std")` configuration instead of `once_cell::sync::OnceCell`.
3. Disabled `default` feature on `serde` (appears to have been unused anyway)
4. Only enable `once_cell/std` in `wgpu-core/std`.
5. ~~Remove `send_sync` predicate from `wgpu`'s `std`configuration alias now that #9780 provides an appropriate `Mutex` implementation.~~ This has been deferred to a future PR based on [this feedback](https://github.com/gfx-rs/wgpu/pull/9780#issuecomment-5133662462) from the last meeting.
6. Updated CI to test `wgpu-core` in `no_std` and also test newly available features on `wgpu`.

Unlike previous efforts, this PR adds no new feature gates to `wgpu-core`, avoiding one of the larger concerns.

**Testing**

- Expanded CI
- `cargo check` for both `wasm32v1-none` and `x86_64-unknown-none`

**Squash or Rebase?**

Rebase; all commits are atomic.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [X] Validation and feature gates are in place to confine behavioral changes.
- [X] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
  - Note that this PR is based on #9780 and thus includes its commits. Please only review the top two commits and refer to that PR for any other changes.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
