### PR TITLE
chore: remove `package.authors` in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ license = "MIT OR Apache-2.0"
 homepage = "https://wgpu.rs/"
 repository = "https://github.com/gfx-rs/wgpu"
 version = "30.0.0"
-authors = ["gfx-rs developers"]
 
 [workspace.dependencies]
 naga = { version = "30.0.0", path = "./naga" }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-benchmark"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "wgpu benchmarking suite"
 homepage.workspace = true

--- a/examples/features/Cargo.toml
+++ b/examples/features/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-examples"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Common example code"
 homepage.workspace = true

--- a/lock-analyzer/Cargo.toml
+++ b/lock-analyzer/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 version.workspace = true
-authors.workspace = true
 publish = false
 
 [dependencies]

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "naga-cli"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "CLI for the naga shader translator and validator. Part of the wgpu project"
 repository.workspace = true

--- a/naga-test/Cargo.toml
+++ b/naga-test/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "naga-test"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "common code for naga tests"
 homepage.workspace = true

--- a/naga-types/Cargo.toml
+++ b/naga-types/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "naga-types"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Common types for naga and wgpu"
 homepage.workspace = true

--- a/naga/Cargo.toml
+++ b/naga/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "naga"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Shader translator and validator. Part of the wgpu project"
 repository.workspace = true

--- a/naga/fuzz/Cargo.toml
+++ b/naga/fuzz/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "naga-fuzz"
 version.workspace = true
-authors.workspace = true
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "player"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "WebGPU trace player"
 homepage.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-test"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "common code for wgpu tests"
 homepage.workspace = true

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-core"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Core implementation logic of wgpu, the cross-platform, safe, pure-rust graphics API"
 homepage.workspace = true

--- a/wgpu-core/platform-deps/apple/Cargo.toml
+++ b/wgpu-core/platform-deps/apple/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-core-deps-apple"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Feature unification helper crate for Apple platforms"
 homepage.workspace = true

--- a/wgpu-core/platform-deps/emscripten/Cargo.toml
+++ b/wgpu-core/platform-deps/emscripten/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-core-deps-emscripten"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Feature unification helper crate for the Emscripten platform"
 homepage.workspace = true

--- a/wgpu-core/platform-deps/linux-android-bsd/Cargo.toml
+++ b/wgpu-core/platform-deps/linux-android-bsd/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-core-deps-linux-android-bsd"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Feature unification helper crate for the Linux/Android/BSD platforms"
 homepage.workspace = true

--- a/wgpu-core/platform-deps/wasm/Cargo.toml
+++ b/wgpu-core/platform-deps/wasm/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-core-deps-wasm"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Feature unification helper crate for the WebAssembly platform"
 homepage.workspace = true

--- a/wgpu-core/platform-deps/windows/Cargo.toml
+++ b/wgpu-core/platform-deps/windows/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-core-deps-windows"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Feature unification helper crate for the Windows/Linux/Android platforms"
 homepage.workspace = true

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-hal"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Hardware abstraction layer for wgpu, the cross-platform, safe, pure-rust graphics API"
 homepage.workspace = true

--- a/wgpu-info/Cargo.toml
+++ b/wgpu-info/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-info"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "A tool to print and process information about available wgpu adapters."
 homepage.workspace = true

--- a/wgpu-macros/Cargo.toml
+++ b/wgpu-macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-macros"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Macros for wgpu"
 homepage.workspace = true

--- a/wgpu-naga-bridge/Cargo.toml
+++ b/wgpu-naga-bridge/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-naga-bridge"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Conversions between naga and wgpu-types. Part of the wgpu project"
 homepage.workspace = true

--- a/wgpu-types/Cargo.toml
+++ b/wgpu-types/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu-types"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Common types and utilities for wgpu, the cross-platform, safe, pure-rust graphics API"
 homepage.workspace = true

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wgpu"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 description = "Cross-platform, safe, pure-rust graphics API"
 homepage.workspace = true


### PR DESCRIPTION
I'm not necessarily expecting this to lead anywhere, but this was prompted by some CLI diagnostics I saw with Cargo (a paper cut we generally prefer to avoid) and reading <https://github.com/rust-lang/cargo/issues/16458>.