### PR TITLE
WIP wgpu-hal: Use `wayland-egl` instead of `wayland-sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop",
  "rustix 0.38.44",
- "wayland-backend",
+ "wayland-backend 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client",
 ]
 
@@ -1653,7 +1653,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "once_cell",
  "raw-window-handle",
- "wayland-sys",
+ "wayland-sys 0.31.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "windows-sys 0.52.0",
  "x11-dl",
 ]
@@ -3720,7 +3720,7 @@ dependencies = [
  "memmap2",
  "rustix 0.38.44",
  "thiserror 1.0.69",
- "wayland-backend",
+ "wayland-backend 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
@@ -4504,7 +4504,19 @@ dependencies = [
  "rustix 1.1.4",
  "scoped-tls",
  "smallvec",
- "wayland-sys",
+ "wayland-sys 0.31.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "git+https://github.com/smithay/wayland-rs#249f35c8ce18c8a8000c627ffe04ac235bc0764f"
+dependencies = [
+ "cc",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys 0.31.11 (git+https://github.com/smithay/wayland-rs)",
 ]
 
 [[package]]
@@ -4515,7 +4527,7 @@ checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.13.0",
  "rustix 1.1.4",
- "wayland-backend",
+ "wayland-backend 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-scanner",
 ]
 
@@ -4527,7 +4539,7 @@ checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
  "bitflags 2.13.0",
  "cursor-icon",
- "wayland-backend",
+ "wayland-backend 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4542,13 +4554,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-egl"
+version = "0.32.11"
+source = "git+https://github.com/smithay/wayland-rs#249f35c8ce18c8a8000c627ffe04ac235bc0764f"
+dependencies = [
+ "wayland-backend 0.3.15 (git+https://github.com/smithay/wayland-rs)",
+ "wayland-sys 0.31.11 (git+https://github.com/smithay/wayland-rs)",
+]
+
+[[package]]
 name = "wayland-protocols"
 version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags 2.13.0",
- "wayland-backend",
+ "wayland-backend 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client",
  "wayland-scanner",
 ]
@@ -4560,7 +4581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
  "bitflags 2.13.0",
- "wayland-backend",
+ "wayland-backend 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client",
  "wayland-protocols",
  "wayland-scanner",
@@ -4573,7 +4594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
  "bitflags 2.13.0",
- "wayland-backend",
+ "wayland-backend 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client",
  "wayland-protocols",
  "wayland-scanner",
@@ -4595,6 +4616,17 @@ name = "wayland-sys"
 version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "git+https://github.com/smithay/wayland-rs#249f35c8ce18c8a8000c627ffe04ac235bc0764f"
 dependencies = [
  "dlib",
  "log",
@@ -4889,7 +4921,7 @@ dependencies = [
  "static_assertions",
  "thiserror 2.0.18",
  "wasm-bindgen",
- "wayland-sys",
+ "wayland-egl",
  "web-sys",
  "wgpu-naga-bridge",
  "wgpu-types",
@@ -5303,7 +5335,7 @@ dependencies = [
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wayland-backend",
+ "wayland-backend 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-plasma",

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -125,7 +125,7 @@ gles = [
     "dep:parking_lot",
     "dep:profiling",
     "dep:wasm-bindgen",
-    "dep:wayland-sys",
+    "dep:wayland-egl",
     "dep:web-sys",
     "dep:windows-result",
     "naga/glsl-out",
@@ -254,10 +254,9 @@ renderdoc-sys = { workspace = true, optional = true }
 # Backend: Vulkan
 libc = { workspace = true, optional = true }
 # backend: GLES
-wayland-sys = { version = "0.31.3", features = [
-    "client",
+# XXX Release
+wayland-egl = { git  = "https://github.com/smithay/wayland-rs", default-features = false, features = [
     "dlopen",
-    "egl",
 ], optional = true }
 
 ## Support creating textures from DRM display/window handles.

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1101,7 +1101,7 @@ impl super::Device {
 #[derive(Debug)]
 pub struct Swapchain {
     surface: khronos_egl::Surface,
-    wl_window: Option<*mut ffi::c_void>,
+    wl_window: Option<wayland_egl::WlEglSurface>,
     framebuffer: glow::Framebuffer,
     renderbuffer: glow::Renderbuffer,
     /// Extent because the window lies
@@ -1209,7 +1209,7 @@ impl Surface {
     unsafe fn unconfigure_impl(
         &self,
         device: &super::Device,
-    ) -> Option<(khronos_egl::Surface, Option<*mut ffi::c_void>)> {
+    ) -> Option<(khronos_egl::Surface, Option<wayland_egl::WlEglSurface>)> {
         let gl = &device.shared.context.lock();
         match self.swapchain.write().take() {
             Some(sc) => {
@@ -1242,11 +1242,8 @@ impl crate::Surface for Surface {
         let (surface, wl_window) = match unsafe { self.unconfigure_impl(device) } {
             Some((sc, wl_window)) => {
                 #[cfg(unix)]
-                if let Some(window) = wl_window {
-                    wayland_sys::ffi_dispatch!(
-                        wayland_sys::egl::wayland_egl_handle(),
-                        wl_egl_window_resize,
-                        window.cast(),
+                if let Some(window) = &wl_window {
+                    window.resize(
                         config.extent.width as i32,
                         config.extent.height as i32,
                         0,
@@ -1279,15 +1276,17 @@ impl crate::Surface for Surface {
                     (WindowKind::Unknown, Rwh::OhosNdk(handle)) => handle.native_window.as_ptr(),
                     #[cfg(unix)]
                     (WindowKind::Wayland, Rwh::Wayland(handle)) => {
-                        let window = wayland_sys::ffi_dispatch!(
-                            wayland_sys::egl::wayland_egl_handle(),
-                            wl_egl_window_create,
-                            handle.surface.as_ptr().cast(),
-                            config.extent.width as i32,
-                            config.extent.height as i32,
-                        );
-                        wl_window = Some(window.cast());
-                        window.cast()
+                        let window = unsafe {
+                            wayland_egl::WlEglSurface::new_from_raw(
+                                handle.surface.cast(),
+                                config.extent.width as i32,
+                                config.extent.height as i32,
+                            )
+                            .unwrap()
+                        };
+                        let ptr = window.ptr();
+                        wl_window = Some(window);
+                        ptr.as_ptr()
                     }
                     #[cfg(Emscripten)]
                     (WindowKind::Unknown, Rwh::Web(handle)) => handle.id as *mut ffi::c_void,
@@ -1439,19 +1438,11 @@ impl crate::Surface for Surface {
     }
 
     unsafe fn unconfigure(&self, device: &super::Device) {
-        if let Some((surface, wl_window)) = unsafe { self.unconfigure_impl(device) } {
+        if let Some((surface, _wl_window)) = unsafe { self.unconfigure_impl(device) } {
             self.egl
                 .instance
                 .destroy_surface(self.egl.display, surface)
                 .unwrap();
-            if let Some(_window) = wl_window {
-                #[cfg(unix)]
-                wayland_sys::ffi_dispatch!(
-                    wayland_sys::egl::wayland_egl_handle(),
-                    wl_egl_window_destroy,
-                    _window.cast(),
-                );
-            }
         }
     }
 


### PR DESCRIPTION
**Connections**
Depends on next release of wayland-rs (https://github.com/Smithay/wayland-rs/issues/900). The `wayland-egl` crate could be used before that, but the next release should have a couple improvements.

**Description**
I'm working on the next API-breaking version of wayland-rs, and looking up what updates are needed in crates using wayland-rs (and making sure any API changes are working well). `wgpu` is a pretty simple one.

Currently `wgpu` is using `wayland-sys`, but it's slightly simpler using the `wayland-egl` crate wrapping that. One of the goals of the next release of `wayland-rs` is making `wayland-sys` a private dependency, so it seems best to use the higher-level crate.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
