### PR TITLE
fix(msl-out): populate `TypeContext::access` when printing storage texture function arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Bottom level categories:
 
 - Add `BufferBinding::buffer`, a public read accessor for the bound buffer, which was previously inaccessible to out-of-tree `wgpu_hal::Api` implementations. By @danlehmann in [#9820](https://github.com/gfx-rs/wgpu/pull/9820).
 
+#### Metal
+
+- Fix Naga's Metal backend crashing when a storage texture was used as a function argument. By @ErichDonGubler in [#9867](https://github.com/gfx-rs/wgpu/pull/9867).
+
 #### GLES
 
 - Add ANGLE as an opt-in OpenGL backend on Windows via `cfg(windows_angle)`, while keeping the `angle` feature for ANGLE on macOS/iOS. By @csmoe in [#9422](https://github.com/gfx-rs/wgpu/pull/9422).

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -58,6 +58,7 @@ webgpu:api,operation,rendering,color_target_state:blending,formats:*
 webgpu:api,operation,rendering,color_target_state:blending,GPUBlendComponent:*
 webgpu:api,operation,rendering,depth:*
 webgpu:api,operation,rendering,draw:*
+fails-if(dx12,vulkan) webgpu:api,operation,sampling,*
 webgpu:api,operation,shader_module,compilation_info:*
 webgpu:api,operation,uncapturederror:iff_uncaptured:*
 //FAIL: webgpu:api,operation,uncapturederror:onuncapturederror_order_wrt_addEventListener

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -6989,7 +6989,13 @@ template <typename A>
                     handle: arg.ty,
                     gctx: module.to_ctx(),
                     names: &self.names,
-                    access: crate::StorageAccess::empty(),
+                    access: match module.types[arg.ty].inner {
+                        crate::TypeInner::Image {
+                            class: crate::ImageClass::Storage { access, .. },
+                            ..
+                        } => access,
+                        _ => crate::StorageAccess::empty(),
+                    },
                     first_time: false,
                 };
                 let separator = separate(


### PR DESCRIPTION
**Connections**

- Fixes <https://github.com/gfx-rs/wgpu/issues/6816>.

**Description**

When handling function arguments, Naga's Metal backend uses a `TypeContext` structure as a helper structure for printing the proper Metal output. This structure's `access` member obviously needs to be populated from the argument's storage access modifier in the case of storage textures, but it wasn't, causing a panic with `module is not valid` when checked in the printing code for `TypeContext` itself.

**Testing**

`webgpu:api,operation,sampling,sampler_texture:sample_texture_combos:*` previously crashed because of this issue. `webgpu:api,operation,sampling:*` has been added to `test.lst`, and fully passes on macOS (🙌🏻).

**Squash or Rebase?** Squash.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
