### PR TITLE
Integrate `zizmor` into CI

### DIFF
--- a/.github/actions/install-agility-sdk/action.yml
+++ b/.github/actions/install-agility-sdk/action.yml
@@ -4,7 +4,12 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      run: |
+      # NOTE: We ignore the `github-env` lint because we trust:
+      #
+      # - Our `install-agility-sdk` task's output
+      # - Otherwise, `WGPU_DX12_AGILITY_SDK_REQUIRE` is a fixed environment variable that is easy
+      #   to audit.
+      run: | # zizmor: ignore[github-env]
         set -e
 
         cargo xtask install-agility-sdk >> "$GITHUB_ENV"

--- a/.github/actions/install-dxc/action.yml
+++ b/.github/actions/install-dxc/action.yml
@@ -4,7 +4,11 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      run: |
+      # NOTE: We ignore the `github-env` lint because we trust:
+      #
+      # - The `cygpath` tool
+      # - The contents of the DXC release we use.
+      run: | # zizmor: ignore[github-env]
         set -e
 
         export DXC_RELEASE="v1.9.2602.24"

--- a/.github/actions/install-mesa/action.yml
+++ b/.github/actions/install-mesa/action.yml
@@ -56,6 +56,7 @@ runs:
       env:
         MESA_VERSION: ${{ inputs.version }}
         CI_BINARY_BUILD: ${{ inputs.ci-binary-build }}
+        INPUTS_TARGET_DIR: ${{ inputs.target-dir }}
       # NOTE: We ignore `github-env` because we trust:
       #
       # - The `cygpath` tool
@@ -67,8 +68,8 @@ runs:
         curl.exe -L --retry 5 https://github.com/pal1000/mesa-dist-win/releases/download/$MESA_VERSION/mesa3d-$MESA_VERSION-release-msvc.7z -o mesa.7z
         7z.exe e mesa.7z -omesa x64/{opengl32.dll,libgallium_wgl.dll,libglapi.dll,vulkan_lvp.dll,lvp_icd.x86_64.json}
 
-        cp -v mesa/* ${{ inputs.target-dir }}/
-        cp -v mesa/* ${{ inputs.target-dir }}/deps
+        cp -v mesa/* ${INPUTS_TARGET_DIR}/
+        cp -v mesa/* ${INPUTS_TARGET_DIR}/deps
 
         # We need to use cygpath to convert PWD to a windows path as we're using bash.
         echo "VK_DRIVER_FILES=`cygpath --windows $PWD/mesa/lvp_icd.x86_64.json`" >> "$GITHUB_ENV"

--- a/.github/actions/install-mesa/action.yml
+++ b/.github/actions/install-mesa/action.yml
@@ -20,7 +20,12 @@ runs:
       env:
         MESA_VERSION: ${{ inputs.version }}
         CI_BINARY_BUILD: ${{ inputs.ci-binary-build }}
-      run: |
+      # NOTE: We ignore `github-env` because we trust:
+      #
+      # - The `cygpath` tool
+      # - The `$PWD` variable
+      # - The contents of the Mesa archive we download here, which we control.
+      run: | # zizmor: ignore[github-env]
         set -e
 
         curl -L --retry 5 https://github.com/gfx-rs/ci-build/releases/download/$CI_BINARY_BUILD/mesa-$MESA_VERSION-linux-x86_64.tar.xz -o mesa.tar.xz
@@ -51,7 +56,12 @@ runs:
       env:
         MESA_VERSION: ${{ inputs.version }}
         CI_BINARY_BUILD: ${{ inputs.ci-binary-build }}
-      run: |
+      # NOTE: We ignore `github-env` because we trust:
+      #
+      # - The `cygpath` tool
+      # - The `$PWD` variable
+      # - The contents of the Mesa archive we download here.
+      run: | # zizmor: ignore[github-env]
         set -e
 
         curl.exe -L --retry 5 https://github.com/pal1000/mesa-dist-win/releases/download/$MESA_VERSION/mesa3d-$MESA_VERSION-release-msvc.7z -o mesa.7z

--- a/.github/actions/install-vulkan-sdk/action.yml
+++ b/.github/actions/install-vulkan-sdk/action.yml
@@ -21,11 +21,11 @@ runs:
       run: | # zizmor: ignore[github-env]
         set -e
 
-        curl -L --retry 5 https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_FULL_SDK_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.VULKAN_FULL_SDK_VERSION }}.tar.xz -o vulkan-sdk.tar.xz
+        curl -L --retry 5 https://sdk.lunarg.com/sdk/download/${VULKAN_FULL_SDK_VERSION}/linux/vulkansdk-linux-x86_64-${VULKAN_FULL_SDK_VERSION}.tar.xz -o vulkan-sdk.tar.xz
         mkdir vulkan-sdk
         tar xpf vulkan-sdk.tar.xz -C vulkan-sdk
 
-        mv ./vulkan-sdk/${{ env.VULKAN_FULL_SDK_VERSION }} $HOME/VulkanSDK
+        mv ./vulkan-sdk/${VULKAN_FULL_SDK_VERSION} $HOME/VulkanSDK
 
         echo "$HOME/VulkanSDK/x86_64/bin" >> "$GITHUB_PATH"
         echo "LD_LIBRARY_PATH=$HOME/VulkanSDK/x86_64/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
@@ -43,11 +43,11 @@ runs:
       run: | # zizmor: ignore[github-env]
         set -e
 
-        curl.exe -L --retry 5 https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_FULL_SDK_VERSION }}/windows/vulkansdk-windows-X64-${{ env.VULKAN_FULL_SDK_VERSION }}.exe -o vulkan-sdk-installer.exe
+        curl.exe -L --retry 5 https://sdk.lunarg.com/sdk/download/${VULKAN_FULL_SDK_VERSION}/windows/vulkansdk-windows-X64-${VULKAN_FULL_SDK_VERSION}.exe -o vulkan-sdk-installer.exe
 
         ./vulkan-sdk-installer.exe --accept-licenses --default-answer --confirm-command install
 
-        echo "C:/VulkanSDK/${{ env.VULKAN_FULL_SDK_VERSION }}/Bin" >> "$GITHUB_PATH"
+        echo "C:/VulkanSDK/${VULKAN_FULL_SDK_VERSION}/Bin" >> "$GITHUB_PATH"
 
     - name: (Mac) Install Vulkan SDK
       if: runner.os == 'macOS'
@@ -61,10 +61,10 @@ runs:
       run: | # zizmor: ignore[github-env]
         set -e
 
-        curl -L --retry 5 https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_FULL_SDK_VERSION }}/mac/vulkansdk-macos-${{ env.VULKAN_FULL_SDK_VERSION }}.zip -o vulkan-sdk.zip
+        curl -L --retry 5 https://sdk.lunarg.com/sdk/download/${VULKAN_FULL_SDK_VERSION}/mac/vulkansdk-macos-${VULKAN_FULL_SDK_VERSION}.zip -o vulkan-sdk.zip
         unzip vulkan-sdk.zip -d vulkan-sdk
 
         ls -l vulkan-sdk
-        sudo ./vulkan-sdk/vulkansdk-macOS-${{ env.VULKAN_FULL_SDK_VERSION }}.app/Contents/MacOS/vulkansdk-macOS-${{ env.VULKAN_FULL_SDK_VERSION }} --root "$HOME/VulkanSDK" --accept-licenses --default-answer --confirm-command install
+        sudo ./vulkan-sdk/vulkansdk-macOS-${VULKAN_FULL_SDK_VERSION}.app/Contents/MacOS/vulkansdk-macOS-${VULKAN_FULL_SDK_VERSION} --root "$HOME/VulkanSDK" --accept-licenses --default-answer --confirm-command install
 
         echo "$HOME/VulkanSDK/macOS/bin" >> "$GITHUB_PATH"

--- a/.github/actions/install-vulkan-sdk/action.yml
+++ b/.github/actions/install-vulkan-sdk/action.yml
@@ -15,7 +15,10 @@ runs:
       env:
         VULKAN_SDK_VERSION: ${{ inputs.version }}
         VULKAN_FULL_SDK_VERSION: ${{ inputs.full-version }}
-      run: |
+      # NOTE: We ignore the `github-env` lint because we trust:
+      #
+      # - The contents of the Vulkan SDK we are downloading.
+      run: | # zizmor: ignore[github-env]
         set -e
 
         curl -L --retry 5 https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_FULL_SDK_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.VULKAN_FULL_SDK_VERSION }}.tar.xz -o vulkan-sdk.tar.xz
@@ -34,7 +37,10 @@ runs:
       env:
         VULKAN_SDK_VERSION: ${{ inputs.version }}
         VULKAN_FULL_SDK_VERSION: ${{ inputs.full-version }}
-      run: |
+      # NOTE: We ignore the `github-env` lint because we trust:
+      #
+      # - The contents of the Vulkan SDK we are downloading.
+      run: | # zizmor: ignore[github-env]
         set -e
 
         curl.exe -L --retry 5 https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_FULL_SDK_VERSION }}/windows/vulkansdk-windows-X64-${{ env.VULKAN_FULL_SDK_VERSION }}.exe -o vulkan-sdk-installer.exe
@@ -49,7 +55,10 @@ runs:
       env:
         VULKAN_SDK_VERSION: ${{ inputs.version }}
         VULKAN_FULL_SDK_VERSION: ${{ inputs.full-version }}
-      run: |
+      # NOTE: We ignore the `github-env` lint because we trust:
+      #
+      # - The contents of the Vulkan SDK we are downloading.
+      run: | # zizmor: ignore[github-env]
         set -e
 
         curl -L --retry 5 https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_FULL_SDK_VERSION }}/mac/vulkansdk-macos-${{ env.VULKAN_FULL_SDK_VERSION }}.zip -o vulkan-sdk.zip

--- a/.github/actions/install-warp/action.yml
+++ b/.github/actions/install-warp/action.yml
@@ -8,7 +8,9 @@ runs:
   using: "composite"
   steps:
     - shell: bash
+      env:
+        INPUTS_TARGET_DIR: ${{ inputs.target-dir }}
       run: |
         set -e
 
-        cargo xtask install-warp --target-dir ${{ inputs.target-dir }}
+        cargo xtask install-warp --target-dir ${INPUTS_TARGET_DIR}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -47,5 +47,7 @@ jobs:
 
       # NOTE: Keep label name(s) in sync. with `xtask`'s implementation.
       - name: Run `cargo xtask changelog …`
+        env:
+          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          cargo xtask changelog "origin/${{ github.event.pull_request.base.ref }}" ${{ contains(github.event.pull_request.labels.*.name, 'changelog: released entry changed') && '--allow-released-changes' || ''  }}
+          cargo xtask changelog "origin/${GITHUB_EVENT_PULL_REQUEST_BASE_REF}" ${{ contains(github.event.pull_request.labels.*.name, 'changelog: released entry changed') && '--allow-released-changes' || ''  }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -38,6 +38,8 @@ jobs:
     name: Check changelog for errors
     runs-on: ubuntu-latest
 
+    permissions: {}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # NOTE: Keep label name(s) in sync. with `xtask`'s implementation.
       - name: Run `cargo xtask changelog …`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -918,7 +918,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run `cargo deny check`
-        uses: EmbarkStudios/cargo-deny-action@v2.1.1
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check advisories
           arguments: --all-features --workspace
@@ -936,7 +936,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run `cargo deny check`
-        uses: EmbarkStudios/cargo-deny-action@v2.1.1
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check bans licenses sources
           arguments: --all-features --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -986,3 +986,16 @@ jobs:
           arguments: --all-features --workspace
           command-arguments: -Dwarnings -Aunmatched-organization
           rust-version: ${{ env.REPO_MSRV }}
+
+  zizmor:
+    name: "Zizmor"
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run `zizmor`
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -865,7 +865,7 @@ jobs:
         run: tombi format --check --diff
 
       - name: Check for typos
-        uses: crate-ci/typos@v1.49.0
+        uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0
 
   check-cts-runner:
     # runtime is normally 2 minutes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
           EOF
 
       - name: Caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: clippy-${{ matrix.target }}-${{ matrix.kind }}-${{ env.CACHE_SUFFIX }}
           env-vars: ImageVersion
@@ -437,7 +437,7 @@ jobs:
           EOF
 
       - name: Caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: wgpu-msrv-check-${{ matrix.target }}-${{ env.CACHE_SUFFIX }}
           env-vars: ImageVersion
@@ -511,7 +511,7 @@ jobs:
           EOF
 
       - name: Caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: core-msrv-check-${{ matrix.target }}-${{ env.CACHE_SUFFIX }}
           env-vars: ImageVersion
@@ -669,7 +669,7 @@ jobs:
         # Cache step must go before warp and mesa install on windows as they write into the
         # target directory, and rust-cache will overwrite the entirety of the target directory.
       - name: Caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: test-${{ matrix.os }}-${{ env.CACHE_SUFFIX }}
           env-vars: ImageVersion
@@ -782,7 +782,7 @@ jobs:
           cargo -V
 
       - name: Caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: doctests-${{ env.CACHE_SUFFIX }}
           env-vars: ImageVersion
@@ -815,7 +815,7 @@ jobs:
           cargo -V
 
       - name: Caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: miri-${{ env.CACHE_SUFFIX }}
           env-vars: ImageVersion
@@ -894,7 +894,7 @@ jobs:
           EOF
 
       - name: Caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: cts-runner-${{ env.CACHE_SUFFIX }}
           env-vars: ImageVersion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,7 +758,7 @@ jobs:
           cargo --locked llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         if: steps.coverage.outcome == 'success'
         with:
           files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,7 +730,7 @@ jobs:
         # git diff doesn't check untracked files, we need to stage those then compare with HEAD.
         run: git add . && git diff --exit-code HEAD naga/tests/out
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         name: Upload comparison images
         if: always() # We want artifacts even if the tests fail.
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install toolchain (repo MSRV - tier 1 or 2)
         if: matrix.tier == 1 || matrix.tier == 2
@@ -418,7 +418,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install core MSRV toolchain
         run: |
@@ -492,7 +492,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install core MSRV toolchain
         run: |
@@ -550,7 +550,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install toolchain
         run: |
@@ -591,7 +591,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install repo MSRV toolchain
         run: |
@@ -644,7 +644,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install repo MSRV toolchain
         run: |
@@ -773,7 +773,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install repo MSRV toolchain
         run: |
@@ -804,7 +804,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Miri is *only* available on nightly.
       - name: Install nightly toolchain
@@ -839,7 +839,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install repo MSRV toolchain
         run: |
@@ -875,7 +875,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install MSRV toolchain
         run: |
@@ -915,7 +915,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run `cargo deny check`
         uses: EmbarkStudios/cargo-deny-action@v2
@@ -933,7 +933,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run `cargo deny check`
         uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,7 +611,7 @@ jobs:
         run: cargo +stable install wasm-bindgen-cli --version=$WASM_BINDGEN_VERSION
 
       - name: Install `cargo-nextest`
-        uses: taiki-e/install-action@v2.83.2
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: cargo-nextest
 
@@ -652,7 +652,7 @@ jobs:
           cargo -V
 
       - name: Install `cargo-nextest` and `cargo-llvm-cov`
-        uses: taiki-e/install-action@v2.83.2
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: cargo-nextest,cargo-llvm-cov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,8 @@ jobs:
     name: Clippy ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
+    permissions: {}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -418,6 +420,8 @@ jobs:
     name: wgpu MSRV Check ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
+    permissions: {}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -494,6 +498,8 @@ jobs:
     name: Core MSRV Check ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
+    permissions: {}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -554,6 +560,8 @@ jobs:
       # Also, allow unexpected_cfgs because it is very common and spammy when using old deps.
       RUSTFLAGS: -A unexpected_cfgs
 
+    permissions: {}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -596,6 +604,8 @@ jobs:
 
     name: Test WebAssembly
     runs-on: ubuntu-latest
+
+    permissions: {}
 
     steps:
       - name: Checkout repo
@@ -651,6 +661,8 @@ jobs:
 
     name: Test ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+
+    permissions: {}
 
     steps:
       - name: Checkout repo
@@ -783,6 +795,8 @@ jobs:
     name: Doctest
     runs-on: ubuntu-latest
 
+    permissions: {}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -815,6 +829,8 @@ jobs:
 
     name: Miri (limited scope)
     runs-on: ubuntu-latest
+
+    permissions: {}
 
     steps:
       - name: Checkout repo
@@ -853,6 +869,7 @@ jobs:
 
     name: Format & Typos
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -891,6 +908,7 @@ jobs:
 
     name: Clippy cts_runner
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -933,6 +951,7 @@ jobs:
 
     name: "cargo-deny advisories"
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -953,6 +972,7 @@ jobs:
 
     name: "cargo-deny"
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,37 +703,37 @@ jobs:
 
       - name: (Windows) Install DXC
         if: matrix.os == 'windows-2022'
-        uses: ./.github/actions/install-dxc
+        uses: $/.github/actions/install-dxc
 
       - name: (Windows) Install WARP
         if: matrix.os == 'windows-2022'
-        uses: ./.github/actions/install-warp
+        uses: $/.github/actions/install-warp
         with:
           target-dir: "target/llvm-cov-target/debug"
 
       - name: (Windows) Install Agility SDK
         if: matrix.os == 'windows-2022'
-        uses: ./.github/actions/install-agility-sdk
+        uses: $/.github/actions/install-agility-sdk
 
       - name: (Windows) Install Mesa
         if: matrix.os == 'windows-2022'
-        uses: ./.github/actions/install-mesa
+        uses: $/.github/actions/install-mesa
 
       - name: (Windows) Install Vulkan SDK
         if: matrix.os == 'windows-2022'
-        uses: ./.github/actions/install-vulkan-sdk
+        uses: $/.github/actions/install-vulkan-sdk
 
       - name: (Mac) Install Vulkan SDK
         if: matrix.os == 'macos-14'
-        uses: ./.github/actions/install-vulkan-sdk
+        uses: $/.github/actions/install-vulkan-sdk
 
       - name: (Linux) Install Vulkan SDK
         if: matrix.os == 'ubuntu-24.04'
-        uses: ./.github/actions/install-vulkan-sdk
+        uses: $/.github/actions/install-vulkan-sdk
 
       - name: (Linux) Install Mesa
         if: matrix.os == 'ubuntu-24.04'
-        uses: ./.github/actions/install-mesa
+        uses: $/.github/actions/install-mesa
 
       - name: Delete Naga snapshots
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,7 +611,7 @@ jobs:
         run: cargo +stable install wasm-bindgen-cli --version=$WASM_BINDGEN_VERSION
 
       - name: Install `cargo-nextest`
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.83.2
         with:
           tool: cargo-nextest
 
@@ -652,7 +652,7 @@ jobs:
           cargo -V
 
       - name: Install `cargo-nextest` and `cargo-llvm-cov`
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.83.2
         with:
           tool: cargo-nextest,cargo-llvm-cov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,7 +730,7 @@ jobs:
         # git diff doesn't check untracked files, we need to stage those then compare with HEAD.
         run: git add . && git diff --exit-code HEAD naga/tests/out
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7.0.1
         name: Upload comparison images
         if: always() # We want artifacts even if the tests fail.
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -918,7 +918,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run `cargo deny check`
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@v2.1.1
         with:
           command: check advisories
           arguments: --all-features --workspace
@@ -936,7 +936,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run `cargo deny check`
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@v2.1.1
         with:
           command: check bans licenses sources
           arguments: --all-features --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,7 +857,7 @@ jobs:
           cargo --locked fmt -- --check
 
       - name: Install Tombi
-        uses: tombi-toml/setup-tombi@v1.2.0
+        uses: tombi-toml/setup-tombi@fa8fb98ef9af2d3b9da565edc15935d523bca7e9 # v1.2.0
         with:
           version: "1.1.3"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install toolchain (repo MSRV - tier 1 or 2)
         if: matrix.tier == 1 || matrix.tier == 2
@@ -419,6 +421,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install core MSRV toolchain
         run: |
@@ -493,6 +497,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install core MSRV toolchain
         run: |
@@ -551,6 +557,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install toolchain
         run: |
@@ -592,6 +600,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install repo MSRV toolchain
         run: |
@@ -645,6 +655,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install repo MSRV toolchain
         run: |
@@ -774,6 +786,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install repo MSRV toolchain
         run: |
@@ -805,6 +819,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Miri is *only* available on nightly.
       - name: Install nightly toolchain
@@ -840,6 +856,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install repo MSRV toolchain
         run: |
@@ -876,6 +894,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install MSRV toolchain
         run: |
@@ -916,6 +936,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run `cargo deny check`
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
@@ -934,6 +956,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run `cargo deny check`
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -145,19 +145,19 @@ jobs:
 
       - name: (Windows) Install DXC
         if: matrix.os == 'windows-2022'
-        uses: ./.github/actions/install-dxc
+        uses: $/.github/actions/install-dxc
 
       # Note: `target-dir` is intentionally different from other jobs.
       # See note above about `llvm-cov show-env`.
       - name: (Windows) Install WARP
         if: matrix.os == 'windows-2022'
-        uses: ./.github/actions/install-warp
+        uses: $/.github/actions/install-warp
         with:
           target-dir: "target/debug"
 
       - name: (Linux) Install Mesa
         if: matrix.os == 'ubuntu-24.04'
-        uses: ./.github/actions/install-mesa
+        uses: $/.github/actions/install-mesa
         with:
           target-dir: "target/debug"
 

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -180,7 +180,7 @@ jobs:
           cargo --locked llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         if: steps.coverage.outcome == 'success'
         with:
           files: lcov.info

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -90,6 +90,8 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Repo MSRV toolchain
         run: |

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -103,7 +103,7 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # The version number can be incremented for cache busting.
           prefix-key: v3-rust-${{ hashFiles('cts_runner/revision.txt') }}

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -87,6 +87,8 @@ jobs:
         # Substitution of ${{ matrix.shell }} appears not to work in per-step configuration
         shell: ${{ matrix.shell }}
 
+    permissions: {}
+
     steps:
       - name: checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -98,7 +98,7 @@ jobs:
           cargo -V
 
       - name: Install `cargo-llvm-cov`
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.83.2
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Repo MSRV toolchain
         run: |

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -98,7 +98,7 @@ jobs:
           cargo -V
 
       - name: Install `cargo-llvm-cov`
-        uses: taiki-e/install-action@v2.83.2
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions: {}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
           EOF
 
       - name: Caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: doc-build
           env-vars: ImageVersion

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,7 +65,7 @@ jobs:
           RUSTC_BOOTSTRAP: 1
 
       - name: Deploy the docs
-        uses: JamesIves/github-pages-deploy-action@v4.9.0
+        uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445 # v4.9.0
         if: github.ref == 'refs/heads/trunk'
         with:
           token: ${{ secrets.WEB_DEPLOY }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -93,7 +93,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Install `cargo-generate`
-        uses: taiki-e/install-action@v2.83.2
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: cargo-generate
 

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -102,13 +102,18 @@ jobs:
           tool: cargo-generate
 
       - name: Run `cargo-generate`
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
+          MATRIX_PATH: ${{ matrix.path }}
         run: |
           cd ..
-          cargo generate --path wgpu --name ${{ matrix.name }} ${{ matrix.path }}
+          cargo generate --path wgpu --name ${MATRIX_NAME} ${MATRIX_PATH}
 
       - name: Check generated files
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
         run: |
-          cd ../${{ matrix.name }}/
+          cd ../${MATRIX_NAME}/
           cat <<EOF >> Cargo.toml
             [patch.crates-io]
             wgpu = { path = "../wgpu/wgpu" }

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -38,7 +38,7 @@ jobs:
       matrix: ${{ steps.discover.outputs.matrix }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Find standalone examples
         id: discover
@@ -66,7 +66,7 @@ jobs:
     name: "${{ matrix.name }}"
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # We can't rely on an override here, as that would only set
       # the toolchain for the current directory, not the newly generated project.

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -28,6 +28,8 @@ concurrency:
 
 jobs:
   discover-standalone-examples:
+    permissions: {}
+
     timeout-minutes: 5
 
     runs-on: ubuntu-latest
@@ -55,6 +57,8 @@ jobs:
           echo "$matrix"
 
   cargo-generate:
+    permissions: {}
+
     timeout-minutes: 5
 
     runs-on: ubuntu-latest

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -93,7 +93,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Install `cargo-generate`
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.83.2
         with:
           tool: cargo-generate
 

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -86,7 +86,7 @@ jobs:
           EOF
 
       - name: Caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: cargo-generate-${{ matrix.name }}
           env-vars: ImageVersion

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -39,6 +39,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Find standalone examples
         id: discover
@@ -67,6 +69,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # We can't rely on an override here, as that would only set
       # the toolchain for the current directory, not the newly generated project.

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - run: mkdir naga/data
 
@@ -55,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download shaders
         run: cd naga && git clone https://github.com/SaschaWillems/Vulkan.git
@@ -90,6 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download shaders
         run: |

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -110,7 +110,7 @@ jobs:
           cargo build --release -p naga-cli
 
       - name: Install Vulkan SDK
-        uses: ./.github/actions/install-vulkan-sdk
+        uses: $/.github/actions/install-vulkan-sdk
 
       - name: Compile `spv` from `spvasm`
         run: |

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -28,7 +28,7 @@ jobs:
     name: "Validate Shaders: Dota2"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - run: mkdir naga/data
 
@@ -54,7 +54,7 @@ jobs:
     name: "Validate Shaders: Sascha Willems Vulkan Tutorial"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download shaders
         run: cd naga && git clone https://github.com/SaschaWillems/Vulkan.git
@@ -89,7 +89,7 @@ jobs:
     name: "Validate Shaders: dneto0 spirv-samples"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download shaders
         run: |

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -27,6 +27,7 @@ jobs:
   parse-dota2:
     name: "Validate Shaders: Dota2"
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -55,6 +56,7 @@ jobs:
   parse-vulkan-tutorial-shaders:
     name: "Validate Shaders: Sascha Willems Vulkan Tutorial"
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -92,6 +94,7 @@ jobs:
   dneto0_spirv-samples:
     name: "Validate Shaders: dneto0 spirv-samples"
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
           EOF
 
       - name: Caching
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: publish-build
           env-vars: ImageVersion

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
         run: cargo xtask run-wasm --no-serve
 
       - name: Deploy WebGPU examples
-        uses: JamesIves/github-pages-deploy-action@v4.9.0
+        uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445 # v4.9.0
         if: github.ref == 'refs/heads/trunk'
         with:
           token: ${{ secrets.WEB_DEPLOY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -21,6 +21,7 @@ jobs:
   naga-validate-windows:
     name: "Validate: HLSL"
     runs-on: windows-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -70,6 +71,7 @@ jobs:
   naga-validate-macos:
     name: "Validate: MSL"
     runs-on: macos-26
+    permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -102,6 +104,7 @@ jobs:
   naga-validate-linux:
     name: "Validate: SPIR-V/GLSL/DOT/WGSL"
     runs-on: ubuntu-24.04
+    permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -55,7 +55,7 @@ jobs:
         shell: powershell
 
       - name: Setup DXC
-        uses: ./.github/actions/install-dxc
+        uses: $/.github/actions/install-dxc
 
       - name: Validate
         shell: bash
@@ -111,7 +111,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Vulkan SDK
-        uses: ./.github/actions/install-vulkan-sdk
+        uses: $/.github/actions/install-vulkan-sdk
 
       - name: Install Graphviz
         run: sudo apt-get install graphviz

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -22,7 +22,7 @@ jobs:
     name: "Validate: HLSL"
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Debug symbols to `line-tables-only`
         shell: bash
@@ -69,7 +69,7 @@ jobs:
     name: "Validate: MSL"
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Debug symbols to line-tables-only
         shell: bash
@@ -99,7 +99,7 @@ jobs:
     name: "Validate: SPIR-V/GLSL/DOT/WGSL"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Vulkan SDK
         uses: ./.github/actions/install-vulkan-sdk

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -34,7 +34,7 @@ jobs:
             debug = "line-tables-only"
           EOF
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
@@ -81,7 +81,7 @@ jobs:
             debug = "line-tables-only"
           EOF
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
@@ -117,7 +117,7 @@ jobs:
             debug = "line-tables-only"
           EOF
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           env-vars: ImageVersion
           save-if: ${{ github.ref == 'refs/heads/trunk' }}

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Debug symbols to `line-tables-only`
         shell: bash
@@ -70,6 +72,8 @@ jobs:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Debug symbols to line-tables-only
         shell: bash
@@ -100,6 +104,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Vulkan SDK
         uses: ./.github/actions/install-vulkan-sdk


### PR DESCRIPTION
[Zizmor](https://github.com/zizmorcore/zizmor) is a neat security tool that focuses on how repositories use GitHub Actions. Mozilla is starting to add it to its standard kit of GitHub Actions for its GH repos (albeit with a different entry point), and I decided to try out integrating it here. It seems workable enough to just fix things up and add it.