### PR TITLE
Query Subgroup Size on Metal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
 - Fix Naga's Metal backend crashing when a storage texture was used as a function argument. By @ErichDonGubler in [#9867](https://github.com/gfx-rs/wgpu/pull/9867).
 - Fix `max_task_workgroup_count` being misreported on pre-Apple7 devices. By @inner-daemons in [#10065](https://github.com/gfx-rs/wgpu/pull/10065).
+- Add querying for the `subgroup_size` on compute pipelines, aka. [threadExecutionWidth](https://developer.apple.com/documentation/metal/mtlcomputepipelinestate/threadexecutionwidth). By @Vollkornaffe in [#9876](https://github.com/gfx-rs/wgpu/pull/9876).
 
 #### GLES
 

--- a/examples/standalone/01_hello_compute/src/main.rs
+++ b/examples/standalone/01_hello_compute/src/main.rs
@@ -182,6 +182,7 @@ fn main() {
         compilation_options: wgpu::PipelineCompilationOptions::default(),
         cache: None,
     });
+    println!("{:?}", pipeline.get_subgroup_size());
 
     // The command encoder allows us to record commands that we will later submit to the GPU.
     let mut encoder =

--- a/examples/standalone/01_hello_compute/src/main.rs
+++ b/examples/standalone/01_hello_compute/src/main.rs
@@ -182,7 +182,6 @@ fn main() {
         compilation_options: wgpu::PipelineCompilationOptions::default(),
         cache: None,
     });
-    println!("{:?}", pipeline.get_subgroup_size());
 
     // The command encoder allows us to record commands that we will later submit to the GPU.
     let mut encoder =

--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -393,4 +393,7 @@ impl ComputePipelineInterface for CustomComputePipeline {
     fn get_bind_group_layout(&self, _index: u32) -> wgpu::custom::DispatchBindGroupLayout {
         unimplemented!()
     }
+    fn get_subgroup_size(&self) -> Option<usize> {
+        unimplemented!()
+    }
 }

--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -393,7 +393,7 @@ impl ComputePipelineInterface for CustomComputePipeline {
     fn get_bind_group_layout(&self, _index: u32) -> wgpu::custom::DispatchBindGroupLayout {
         unimplemented!()
     }
-    fn get_subgroup_size(&self) -> Option<usize> {
+    fn get_subgroup_size(&self) -> Option<u32> {
         unimplemented!()
     }
 }

--- a/tests/tests/wgpu-gpu/pipeline.rs
+++ b/tests/tests/wgpu-gpu/pipeline.rs
@@ -168,14 +168,12 @@ static COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE_VERIFY: GpuTestConfiguration =
                 immediate_size: 0,
             });
 
-            let shader = format!(
-                "
+            let shader = "
             @group(0) @binding(0) var<storage, read_write> out: u32;
             @compute @workgroup_size(1)
-            fn main(@builtin(subgroup_size) subgroup_size: u32) {{
+            fn main(@builtin(subgroup_size) subgroup_size: u32) {
                 out = subgroup_size;
-            }}"
-            );
+            }";
 
             let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: None,

--- a/tests/tests/wgpu-gpu/pipeline.rs
+++ b/tests/tests/wgpu-gpu/pipeline.rs
@@ -137,7 +137,11 @@ static COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE_SIMPLE: GpuTestConfiguration =
 #[apply(gpu_test!)]
 static COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE_VERIFY: GpuTestConfiguration =
     GpuTestConfiguration::new()
-        .parameters(TestParameters::default().limits(wgpu::Limits::downlevel_defaults()))
+        .parameters(
+            TestParameters::default()
+                .limits(wgpu::Limits::downlevel_defaults())
+                .features(wgpu::Features::SUBGROUP),
+        )
         .run_async(|ctx| async move {
             if ctx.adapter.get_info().backend != wgpu::Backend::Metal {
                 return; // only works on metal

--- a/tests/tests/wgpu-gpu/pipeline.rs
+++ b/tests/tests/wgpu-gpu/pipeline.rs
@@ -149,7 +149,10 @@ static COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE_VERIFY: GpuTestConfiguration =
 
             let (device, queue) = ctx
                 .adapter
-                .request_device(&Default::default())
+                .request_device(&wgpu::DeviceDescriptor {
+                    required_features: wgpu::Features::SUBGROUP,
+                    ..Default::default()
+                })
                 .await
                 .unwrap();
             let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {

--- a/tests/tests/wgpu-gpu/pipeline.rs
+++ b/tests/tests/wgpu-gpu/pipeline.rs
@@ -6,7 +6,8 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
         COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE,
         COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX,
-        COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE,
+        COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE_SIMPLE,
+        COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE_VERIFY,
         RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE,
         RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX,
         NO_TARGETLESS_RENDER,
@@ -101,31 +102,140 @@ static COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX: GpuTestConfiguration =
             );
         });
 
+// Simply test that `ComputePipeline::get_subgroup_size` returns `Some(..)` on Metal and `None` otherwise.
+// For that we need a basic compute pipeline which makes up most of the code below.
 #[apply(gpu_test!)]
-static COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().test_features_limits())
-    .run_sync(|ctx| {
-        valid(&ctx.device, || {
-            let module = ctx.device.create_shader_module(TRIVIAL_COMPUTE_SHADER_DESC);
+static COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE_SIMPLE: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(TestParameters::default().test_features_limits())
+        .run_sync(|ctx| {
+            valid(&ctx.device, || {
+                let module = ctx.device.create_shader_module(TRIVIAL_COMPUTE_SHADER_DESC);
 
-            let pipeline = ctx
-                .device
-                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-                    label: Some("compute pipeline"),
-                    layout: None,
-                    module: &module,
-                    entry_point: Some("main"),
-                    compilation_options: Default::default(),
-                    cache: None,
-                });
+                let pipeline =
+                    ctx.device
+                        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                            label: Some("compute pipeline"),
+                            layout: None,
+                            module: &module,
+                            entry_point: Some("main"),
+                            compilation_options: Default::default(),
+                            cache: None,
+                        });
 
-            if ctx.adapter.get_info().backend == wgpu::Backend::Metal {
-                assert!(pipeline.get_subgroup_size().is_some())
-            } else {
-                assert!(pipeline.get_subgroup_size().is_none())
-            }
+                if ctx.adapter.get_info().backend == wgpu::Backend::Metal {
+                    assert!(pipeline.get_subgroup_size().is_some())
+                } else {
+                    assert!(pipeline.get_subgroup_size().is_none())
+                }
+            });
         });
-    });
+
+// Verify that `ComputePipeline::get_subgroup_size` returns the same value we get from the builtin `subgroup_size`.
+// For this we need "the whole thing":
+// setup and run a compute pass where we write the value of the builtin to a buffer, copy, readback, and compare.
+#[apply(gpu_test!)]
+static COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE_VERIFY: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(TestParameters::default().limits(wgpu::Limits::downlevel_defaults()))
+        .run_async(|ctx| async move {
+            if ctx.adapter.get_info().backend != wgpu::Backend::Metal {
+                return; // only works on metal
+            }
+
+            let (device, queue) = ctx
+                .adapter
+                .request_device(&Default::default())
+                .await
+                .unwrap();
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: None,
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+            let pl = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: None,
+                bind_group_layouts: &[Some(&bgl)],
+                immediate_size: 0,
+            });
+
+            let shader = format!(
+                "
+            @group(0) @binding(0) var<storage, read_write> out: u32;
+            @compute @workgroup_size(1)
+            fn main(@builtin(subgroup_size) subgroup_size: u32) {{
+                out = subgroup_size;
+            }}"
+            );
+
+            let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: None,
+                source: wgpu::ShaderSource::Wgsl(shader.into()),
+            });
+
+            let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: None,
+                layout: Some(&pl),
+                entry_point: Some("main"),
+                compilation_options: Default::default(),
+                module: &module,
+                cache: None,
+            });
+
+            let subgroup_size = pipeline
+                .get_subgroup_size()
+                .expect("We should get something on Metal");
+
+            let out = device.create_buffer(&wgpu::BufferDescriptor {
+                label: None,
+                size: 4,
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+                mapped_at_creation: false,
+            });
+            let readback = device.create_buffer(&wgpu::BufferDescriptor {
+                label: None,
+                size: 4,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            });
+
+            let bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &bgl,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(out.as_entire_buffer_binding()),
+                }],
+            });
+
+            let mut encoder =
+                device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+                pass.set_bind_group(0, &bg, &[]);
+                pass.set_pipeline(&pipeline);
+                pass.dispatch_workgroups(1, 1, 1);
+            }
+            encoder.copy_buffer_to_buffer(&out, 0, &readback, 0, 4);
+            queue.submit(Some(encoder.finish()));
+
+            readback.slice(..).map_async(wgpu::MapMode::Read, |_| ());
+            device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+
+            assert_eq!(
+                &*readback.slice(..).get_mapped_range().unwrap(),
+                &subgroup_size.to_le_bytes()
+            );
+        });
 
 #[apply(gpu_test!)]
 static RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE: GpuTestConfiguration =

--- a/tests/tests/wgpu-gpu/pipeline.rs
+++ b/tests/tests/wgpu-gpu/pipeline.rs
@@ -1,9 +1,12 @@
-use wgpu_test::{apply, fail, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+use wgpu_test::{
+    apply, fail, gpu_test, valid, GpuTestConfiguration, GpuTestInitializer, TestParameters,
+};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
         COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE,
         COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX,
+        COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE,
         RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE,
         RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX,
         NO_TARGETLESS_RENDER,
@@ -97,6 +100,32 @@ static COMPUTE_PIPELINE_DEFAULT_LAYOUT_BAD_BGL_INDEX: GpuTestConfiguration =
                 Some("Bind group layout index 4294967295 is greater than the device's configured `max_bind_groups` limit"),
             );
         });
+
+#[apply(gpu_test!)]
+static COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().test_features_limits())
+    .run_sync(|ctx| {
+        valid(&ctx.device, || {
+            let module = ctx.device.create_shader_module(TRIVIAL_COMPUTE_SHADER_DESC);
+
+            let pipeline = ctx
+                .device
+                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                    label: Some("compute pipeline"),
+                    layout: None,
+                    module: &module,
+                    entry_point: Some("main"),
+                    compilation_options: Default::default(),
+                    cache: None,
+                });
+
+            if ctx.adapter.get_info().backend == wgpu::Backend::Metal {
+                assert!(pipeline.get_subgroup_size().is_some())
+            } else {
+                assert!(pipeline.get_subgroup_size().is_none())
+            }
+        });
+    });
 
 #[apply(gpu_test!)]
 static RENDER_PIPELINE_DEFAULT_LAYOUT_BAD_MODULE: GpuTestConfiguration =

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -593,7 +593,7 @@ impl ComputePipeline {
     }
 
     // TODO: this probably doesn't need tracing?
-    pub fn get_subgroup_size(self: &Arc<Self>) -> Option<usize> {
+    pub fn get_subgroup_size(self: &Arc<Self>) -> Option<u32> {
         self.raw()
             // TODO:
             // not sure if this is useful

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -601,11 +601,9 @@ impl ComputePipeline {
             .map_err(|err| {
                 self.device
                     .handle_error_nolabel(err, "ComputePipeline::get_subgroup_size");
-                ()
             })
             .ok()
-            .map(hal::DynComputePipeline::get_subgroup_size)
-            .flatten()
+            .and_then(hal::DynComputePipeline::get_subgroup_size)
     }
 }
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -591,6 +591,22 @@ impl ComputePipeline {
         };
         bgl
     }
+
+    // TODO: this probably doesn't need tracing?
+    pub fn get_subgroup_size(self: &Arc<Self>) -> Option<usize> {
+        self.raw()
+            // TODO:
+            // not sure if this is useful
+            // if not useful, `map_err` can just be removed
+            .map_err(|err| {
+                self.device
+                    .handle_error_nolabel(err, "ComputePipeline::get_subgroup_size");
+                ()
+            })
+            .ok()
+            .map(hal::DynComputePipeline::get_subgroup_size)
+            .flatten()
+    }
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -100,7 +100,11 @@ pub trait DynBindGroup: DynResource + fmt::Debug {}
 pub trait DynBindGroupLayout: DynResource + fmt::Debug {}
 pub trait DynBuffer: DynResource + fmt::Debug {}
 pub trait DynCommandBuffer: DynResource + fmt::Debug {}
-pub trait DynComputePipeline: DynResource + fmt::Debug {}
+pub trait DynComputePipeline: DynResource + fmt::Debug {
+    fn get_subgroup_size(&self) -> Option<usize> {
+        None
+    }
+}
 pub trait DynFence: DynResource + fmt::Debug {}
 pub trait DynPipelineCache: DynResource + fmt::Debug {}
 pub trait DynPipelineLayout: DynResource + fmt::Debug {}

--- a/wgpu-hal/src/dynamic/mod.rs
+++ b/wgpu-hal/src/dynamic/mod.rs
@@ -101,7 +101,7 @@ pub trait DynBindGroupLayout: DynResource + fmt::Debug {}
 pub trait DynBuffer: DynResource + fmt::Debug {}
 pub trait DynCommandBuffer: DynResource + fmt::Debug {}
 pub trait DynComputePipeline: DynResource + fmt::Debug {
-    fn get_subgroup_size(&self) -> Option<usize> {
+    fn get_subgroup_size(&self) -> Option<u32> {
         None
     }
 }

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -1247,7 +1247,11 @@ pub struct ComputePipeline {
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(ComputePipeline: Send, Sync);
 
-impl crate::DynComputePipeline for ComputePipeline {}
+impl crate::DynComputePipeline for ComputePipeline {
+    fn get_subgroup_size(&self) -> Option<usize> {
+        Some(self.raw.threadExecutionWidth())
+    }
+}
 
 #[derive(Debug)]
 pub struct RayTracingPipeline {}

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -1248,8 +1248,8 @@ pub struct ComputePipeline {
 static_assertions::assert_impl_all!(ComputePipeline: Send, Sync);
 
 impl crate::DynComputePipeline for ComputePipeline {
-    fn get_subgroup_size(&self) -> Option<usize> {
-        Some(self.raw.threadExecutionWidth())
+    fn get_subgroup_size(&self) -> Option<u32> {
+        Some(self.raw.threadExecutionWidth() as u32)
     }
 }
 

--- a/wgpu/src/api/compute_pipeline.rs
+++ b/wgpu/src/api/compute_pipeline.rs
@@ -32,7 +32,7 @@ impl ComputePipeline {
     ///
     /// Returns `None` on all platforms except for Metal, where it returns the
     /// [`threadExecutionWidth`](https://developer.apple.com/documentation/metal/mtlcomputepipelinestate/threadexecutionwidth).
-    pub fn get_subgroup_size(&self) -> Option<usize> {
+    pub fn get_subgroup_size(&self) -> Option<u32> {
         self.inner.get_subgroup_size()
     }
 

--- a/wgpu/src/api/compute_pipeline.rs
+++ b/wgpu/src/api/compute_pipeline.rs
@@ -28,6 +28,10 @@ impl ComputePipeline {
         BindGroupLayout { inner: bind_group }
     }
 
+    /// Get the subgroup size of the compute pipeline.
+    ///
+    /// Returns `None` on all platforms except for Metal, where it returns the
+    /// [`threadExecutionWidth`](https://developer.apple.com/documentation/metal/mtlcomputepipelinestate/threadexecutionwidth).
     pub fn get_subgroup_size(&self) -> Option<usize> {
         self.inner.get_subgroup_size()
     }

--- a/wgpu/src/api/compute_pipeline.rs
+++ b/wgpu/src/api/compute_pipeline.rs
@@ -28,6 +28,10 @@ impl ComputePipeline {
         BindGroupLayout { inner: bind_group }
     }
 
+    pub fn get_subgroup_size(&self) -> Option<usize> {
+        self.inner.get_subgroup_size()
+    }
+
     #[cfg(custom)]
     /// Returns custom implementation of ComputePipeline (if custom backend and is internally T)
     pub fn as_custom<T: custom::ComputePipelineInterface>(&self) -> Option<&T> {

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -3313,7 +3313,7 @@ impl dispatch::ComputePipelineInterface for WebComputePipeline {
         }
         .into()
     }
-    fn get_subgroup_size(&self) -> Option<usize> {
+    fn get_subgroup_size(&self) -> Option<u32> {
         None // only available on Metal
     }
 }

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -3313,6 +3313,9 @@ impl dispatch::ComputePipelineInterface for WebComputePipeline {
         }
         .into()
     }
+    fn get_subgroup_size(&self) -> Option<usize> {
+        None // only available on Metal
+    }
 }
 impl Drop for WebComputePipeline {
     fn drop(&mut self) {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1784,6 +1784,10 @@ impl dispatch::ComputePipelineInterface for CoreComputePipeline {
         }
         .into()
     }
+
+    fn get_subgroup_size(&self) -> Option<usize> {
+        self.wgpu_compute_pipeline.get_subgroup_size()
+    }
 }
 
 impl dispatch::PipelineCacheInterface for CorePipelineCache {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1785,7 +1785,7 @@ impl dispatch::ComputePipelineInterface for CoreComputePipeline {
         .into()
     }
 
-    fn get_subgroup_size(&self) -> Option<usize> {
+    fn get_subgroup_size(&self) -> Option<u32> {
         self.wgpu_compute_pipeline.get_subgroup_size()
     }
 }

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -341,6 +341,7 @@ pub trait RenderPipelineInterface: CommonTraits {
 }
 pub trait ComputePipelineInterface: CommonTraits {
     fn get_bind_group_layout(&self, index: u32) -> DispatchBindGroupLayout;
+    fn get_subgroup_size(&self) -> Option<usize>;
 }
 pub trait PipelineCacheInterface: CommonTraits {
     fn get_data(&self) -> Option<Vec<u8>>;

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -341,7 +341,7 @@ pub trait RenderPipelineInterface: CommonTraits {
 }
 pub trait ComputePipelineInterface: CommonTraits {
     fn get_bind_group_layout(&self, index: u32) -> DispatchBindGroupLayout;
-    fn get_subgroup_size(&self) -> Option<usize>;
+    fn get_subgroup_size(&self) -> Option<u32>;
 }
 pub trait PipelineCacheInterface: CommonTraits {
     fn get_data(&self) -> Option<Vec<u8>>;


### PR DESCRIPTION
**Connections**

Related Discord message: https://discord.com/channels/676678179678715904/1438215925391163532/1526577321736142929
Related issue on gpuweb: https://github.com/gpuweb/gpuweb/issues/6278
Seemingly related, but doesn't fix this problem: https://github.com/gfx-rs/wgpu/pull/9523
Related issue on Squishy Volumes: https://github.com/Algebraic-UG/squishy_volumes/issues/206

**Description**

The reported Subgroup size min and max are 4 and 64 on the Metal backend (at least in some cases).
The actual size should be fixed for a single pipeline and can be queried with [`threadExecutionWidth`](https://developer.apple.com/documentation/metal/mtlcomputepipelinestate/threadexecutionwidth).

However, it cannot be controlled with the [`SUBGROUP_SIZE_CONTROL`](https://github.com/gfx-rs/wgpu/pull/9523).

Being able to at least know the size allows for certain implementations of prefix sum and radix sort to be more efficient or work in the first place.

`threadExecutionWidth` is exposed through [`objc2_metal`](https://docs.rs/objc2-metal/0.3.2/objc2_metal/trait.MTLComputePipelineState.html#method.threadExecutionWidth), so we could use it for the Metal backend and return `None` or an error for all other cases.

**Testing**

Two tests make sure the feature works as intended.

1. `COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE_SIMPLE` just checks that we return `Some(..)` on Metal and `None` otherwise.
2. `COMPUTE_PIPELINE_QUERY_SUBGROUP_SIZE_VERIFY` actually compares the value against the one we get from the built-in `subgroup_size`.
The latter is a bit more complicated because we need to set up & run a compute pass.

Both are added to `wgpu_gpu::pipeline`, maybe they could be in a separate file, though.

**Squash or Rebase?**

I'm leaning towards Squashing, but I do not have a strong opinion on this. 

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR. (except for the TODOs I've noted below)
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes. (This doesn't apply, I think)
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
