### PR TITLE
hal/vulkan: With `internal_error_panic`, panic on Vulkan validation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "tokio",
+ "wgpu-hal",
 ]
 
 [[package]]

--- a/cts_runner/Cargo.toml
+++ b/cts_runner/Cargo.toml
@@ -24,6 +24,7 @@ log.workspace = true
 pico-args.workspace = true
 tokio = { workspace = true, features = ["full"] }
 termcolor.workspace = true
+wgpu-hal = { workspace = true, features = ["internal_error_panic"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -186,10 +186,11 @@ portable-atomic = ["dep:portable-atomic", "dep:portable-atomic-util"]
 # Panic when running into a device lost error (for debugging purposes).
 # Only affects the d3d12 and vulkan backends.
 device_lost_panic = []
-# Panic when running into an internal error other than out-of-memory and device lost
-# (for debugging purposes).
-#
-# Only affects the d3d12 and vulkan backends.
+# Panic on unexpected errors (does _not_ include out-of-memory errors or device
+# loss) from platform APIs, for debugging purposes. Such errors likely indicate
+# bug(s) in wgpu, platform components, or drivers. Despite the name, this is not
+# related to the spec's `GPUInternalError`. Only affects the d3d12 and vulkan
+# backends.
 internal_error_panic = []
 # Tracks validation errors in a `VALIDATION_CANARY` static.
 validation_canary = ["dep:parking_lot"]

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -158,7 +158,61 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         crate::VALIDATION_CANARY.add(message.to_string());
     }
 
+    #[cfg(feature = "internal_error_panic")]
+    if level == log::Level::Error && !cts_error_is_waived(cd.message_id_number) {
+        use alloc::string::ToString as _;
+        panic!("{}", message.to_string());
+    }
+
     vk::FALSE
+}
+
+/// Validation errors known to fire when running the CTS.
+///
+/// These waivers are keyed off the `WGPU_CTS_XTASK` environment variable, which
+/// is set by in `xtask/src/cts.rs`.
+#[cfg(feature = "internal_error_panic")]
+fn cts_error_is_waived(message_id_number: i32) -> bool {
+    use std::sync::LazyLock;
+
+    static WGPU_CTS_XTASK: LazyLock<bool> =
+        LazyLock::new(|| std::env::var_os("WGPU_CTS_XTASK").is_some());
+
+    if !*WGPU_CTS_XTASK {
+        return false;
+    }
+
+    const WAIVED_MESSAGE_IDS: &[i32] = &[
+        // VUID-vkCmdPushConstants-offset-01795
+        // e.g. webgpu:api,operation,command_buffer,programmable,immediate:*
+        0x27bc88c6_u32 as i32,
+        // VUID-SampleMask-SampleMask-04359
+        // e.g. webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,*
+        0x34d444b2_u32 as i32,
+        // SYNC-HAZARD-WRITE-AFTER-WRITE
+        // e.g. webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:*
+        0x5c0ec5d6_u32 as i32,
+        // VUID-vkCmdCopyImage-srcImage-01728
+        // e.g. webgpu:api,validation,encoding,cmds,copyTextureToTexture:*
+        0x6b654496_u32 as i32,
+        // VUID-StandaloneSpirv-OpImageQuerySizeLod-04659
+        // e.g. webgpu:shader,execution,expression,call,builtin,textureNumLayers:*
+        0x82396078_u32 as i32,
+        // VUID-RuntimeSpirv-Location-06272
+        // e.g. webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,*
+        0xa3614f8b_u32 as i32,
+        // VUID-VkViewport-width-01770
+        // e.g. webgpu:api,validation,encoding,cmds,render,dynamic_state:*
+        0xa4164ba5_u32 as i32,
+        // VUID-VkImageViewCreateInfo-image-04441
+        // e.g. webgpu:api,validation,createView:texture_view_usage:*
+        0xb75da543_u32 as i32,
+        // VUID-VkBufferCreateInfo-None-09500
+        // e.g. webgpu:api,validation,buffer,create:usage,*
+        0xf6d454db_u32 as i32,
+    ];
+
+    WAIVED_MESSAGE_IDS.contains(&message_id_number)
 }
 
 impl super::DebugUtilsCreateInfo {

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -159,12 +159,31 @@ unsafe extern "system" fn debug_utils_messenger_callback(
     }
 
     #[cfg(feature = "internal_error_panic")]
-    if level == log::Level::Error && !cts_error_is_waived(cd.message_id_number) {
+    if level == log::Level::Error
+        && !error_is_waived(cd.message_id_number)
+        && !cts_error_is_waived(cd.message_id_number)
+    {
         use alloc::string::ToString as _;
         panic!("{}", message.to_string());
     }
 
     vk::FALSE
+}
+
+/// Validation errors known to fire, not just in the CTS.
+///
+/// These never panic.
+#[cfg(feature = "internal_error_panic")]
+fn error_is_waived(message_id_number: i32) -> bool {
+    const WAIVED_MESSAGE_IDS: &[i32] = &[
+        // SYNC-HAZARD-WRITE-AFTER-WRITE
+        // e.g. webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:*
+        // https://github.com/gfx-rs/wgpu/issues/5231
+        // https://github.com/gfx-rs/wgpu/issues/8705
+        0x5c0ec5d6_u32 as i32,
+    ];
+
+    WAIVED_MESSAGE_IDS.contains(&message_id_number)
 }
 
 /// Validation errors known to fire when running the CTS.
@@ -189,9 +208,6 @@ fn cts_error_is_waived(message_id_number: i32) -> bool {
         // VUID-SampleMask-SampleMask-04359
         // e.g. webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,*
         0x34d444b2_u32 as i32,
-        // SYNC-HAZARD-WRITE-AFTER-WRITE
-        // e.g. webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:*
-        0x5c0ec5d6_u32 as i32,
         // VUID-vkCmdCopyImage-srcImage-01728
         // e.g. webgpu:api,validation,encoding,cmds,copyTextureToTexture:*
         0x6b654496_u32 as i32,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -160,6 +160,7 @@ unsafe extern "system" fn debug_utils_messenger_callback(
 
     #[cfg(feature = "internal_error_panic")]
     if level == log::Level::Error
+        && message_type.contains(vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION)
         && !error_is_waived(cd.message_id_number)
         && !cts_error_is_waived(cd.message_id_number)
     {

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -158,7 +158,7 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         crate::VALIDATION_CANARY.add(message.to_string());
     }
 
-    #[cfg(feature = "internal_error_panic")]
+    #[cfg(all(debug_assertions, feature = "internal_error_panic"))]
     if level == log::Level::Error
         && message_type.contains(vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION)
         && !error_is_waived(cd.message_id_number)
@@ -190,7 +190,7 @@ fn error_is_waived(message_id_number: i32) -> bool {
 /// Validation errors known to fire when running the CTS.
 ///
 /// These waivers are keyed off the `WGPU_CTS_XTASK` environment variable, which
-/// is set by in `xtask/src/cts.rs`.
+/// is set in `xtask/src/cts.rs`.
 #[cfg(feature = "internal_error_panic")]
 fn cts_error_is_waived(message_id_number: i32) -> bool {
     use std::sync::LazyLock;

--- a/xtask/src/cts.rs
+++ b/xtask/src/cts.rs
@@ -72,6 +72,10 @@ pub fn run_cts(
     let llvm_cov = args.contains("--llvm-cov");
     let release = args.contains("--release");
 
+    // This is used in the Vulkan hal to waive pre-existing validation
+    // errors in the CTS, until they can be fixed.
+    shell.set_var("WGPU_CTS_XTASK", "1");
+
     let output_filter = args
         .opt_value_from_str::<_, String>("--print-output-when")?
         .map(|f| {


### PR DESCRIPTION
We discussed in #8094 that we can't unconditionally panic on validation errors in `debug_assertions` builds, because it is too likely to interfere with development of applications using `wgpu`.

However it occurred to me that `internal_error_panic` may be a suitable control for this.

I've also changed `cts_runner` to enable the `internal_error_panic` feature, so that we panic on validation errors running the CTS. There are some existing failures which are waived.

**Testing**
CTS confirms panic is working :(

**Squash or Rebase?** Squash

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
  - Needs a changelog entry. 
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
