### PR TITLE
cts: Enable strict WebGPU compliance in `cts_runner`

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -24,7 +24,6 @@ env:
   RUST_BACKTRACE: full
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
-  DENO_WEBGPU_STRICT_COMPLIANCE: 1
 
   #
   # Runtime configuration

--- a/cts_runner/src/main.rs
+++ b/cts_runner/src/main.rs
@@ -54,6 +54,23 @@ pub async fn run() -> Result<(), AnyError> {
         }
     }
 
+    if let Some(val) = env::var_os(deno_webgpu::STRICT_COMPLIANCE_ENV_VAR) {
+        log::info!(
+            "Environment variable `{}` is set to `{}`.",
+            deno_webgpu::STRICT_COMPLIANCE_ENV_VAR,
+            &val.to_string_lossy(),
+        );
+    } else {
+        log::info!(
+            "cts_runner enables strict WebGPU compliance by default. Configure with `{}` environment variable.",
+            deno_webgpu::STRICT_COMPLIANCE_ENV_VAR,
+        );
+        unsafe {
+            // SAFETY: We are single-threaded at this point.
+            env::set_var(deno_webgpu::STRICT_COMPLIANCE_ENV_VAR, "1");
+        }
+    }
+
     let options = RuntimeOptions {
         module_loader: Some(Rc::new(deno_core::FsModuleLoader)),
         extensions: vec![

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -46,6 +46,7 @@ mod webidl;
 pub const UNSTABLE_FEATURE_NAME: &str = "webgpu";
 
 pub const DX12_COMPILER_ENV_VAR: &str = "DENO_WEBGPU_DX12_COMPILER";
+pub const STRICT_COMPLIANCE_ENV_VAR: &str = "DENO_WEBGPU_STRICT_COMPLIANCE";
 
 #[allow(clippy::print_stdout)]
 pub fn print_linker_flags(name: &str) {
@@ -185,7 +186,11 @@ impl GPU {
       instance
     } else {
       let mut flags = wgpu_types::InstanceFlags::from_build_config();
-      if std::env::var_os("DENO_WEBGPU_STRICT_COMPLIANCE").is_some() {
+      let strict_compliance = std::env::var(STRICT_COMPLIANCE_ENV_VAR)
+        .is_ok_and(|value| {
+          !matches!(value.to_ascii_lowercase().as_str(), "false" | "no" | "0")
+        });
+      if strict_compliance {
         flags |= wgpu_types::InstanceFlags::STRICT_WEBGPU_COMPLIANCE;
       }
       state.put(Arc::new(wgpu_core::global::Global::new(


### PR DESCRIPTION
Enable strict WebGPU compliance in `cts_runner`, instead of in the CI workflow definition, so that local runs match CI.

**Testing**
Tested locally.

**Squash or Rebase?** Squash