### PR TITLE
Suppress `semicolon_in_expressions_from_macros` lint in build scripts

### DIFF
--- a/naga/build.rs
+++ b/naga/build.rs
@@ -1,3 +1,8 @@
+#![allow(
+    semicolon_in_expressions_from_macros,
+    reason = "work around <https://github.com/katharostech/cfg_aliases/issues/16>"
+)]
+
 fn main() {
     cfg_aliases::cfg_aliases! {
         dot_out: { feature = "dot-out" },

--- a/naga/fuzz/build.rs
+++ b/naga/fuzz/build.rs
@@ -1,3 +1,8 @@
+#![allow(
+    semicolon_in_expressions_from_macros,
+    reason = "work around <https://github.com/katharostech/cfg_aliases/issues/16>"
+)]
+
 fn main() {
     cfg_aliases::cfg_aliases! {
         fuzzable_platform: { not(any(target_arch = "wasm32", target_os = "ios", target_os = "openbsd", all(windows, target_arch = "aarch64"))) },

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -1,3 +1,8 @@
+#![allow(
+    semicolon_in_expressions_from_macros,
+    reason = "work around <https://github.com/katharostech/cfg_aliases/issues/16>"
+)]
+
 fn main() {
     cfg_aliases::cfg_aliases! {
         windows_linux_android: { any(windows, target_os = "linux", target_os = "android", target_os = "freebsd") },

--- a/wgpu-hal/build.rs
+++ b/wgpu-hal/build.rs
@@ -1,3 +1,8 @@
+#![allow(
+    semicolon_in_expressions_from_macros,
+    reason = "work around <https://github.com/katharostech/cfg_aliases/issues/16>"
+)]
+
 fn main() {
     cfg_aliases::cfg_aliases! {
         native: { not(target_family = "wasm") },

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -1,3 +1,8 @@
+#![allow(
+    semicolon_in_expressions_from_macros,
+    reason = "work around <https://github.com/katharostech/cfg_aliases/issues/16>"
+)]
+
 fn main() {
     cfg_aliases::cfg_aliases! {
         native: { not(target_family = "wasm") },


### PR DESCRIPTION
<https://github.com/katharostech/cfg_aliases/issues/16> is blocking CI suddenly, because Nightly started shipping <https://github.com/rust-lang/rust/issues/79813>.