### PR TITLE
build: consume `cfg_aliases` 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,9 +571,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cgl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ bytemuck = { version = "1.22", features = [
     "min_const_generics",
 ] }
 cargo_metadata = "0.23"
-cfg_aliases = "0.2.1"
+cfg_aliases = "0.2.2"
 cfg-if = "1"
 codespan-reporting = { version = "0.13", default-features = false }
 diff = "0.1"

--- a/naga/build.rs
+++ b/naga/build.rs
@@ -1,8 +1,3 @@
-#![allow(
-    semicolon_in_expressions_from_macros,
-    reason = "work around <https://github.com/katharostech/cfg_aliases/issues/16>"
-)]
-
 fn main() {
     cfg_aliases::cfg_aliases! {
         dot_out: { feature = "dot-out" },

--- a/naga/fuzz/build.rs
+++ b/naga/fuzz/build.rs
@@ -1,8 +1,3 @@
-#![allow(
-    semicolon_in_expressions_from_macros,
-    reason = "work around <https://github.com/katharostech/cfg_aliases/issues/16>"
-)]
-
 fn main() {
     cfg_aliases::cfg_aliases! {
         fuzzable_platform: { not(any(target_arch = "wasm32", target_os = "ios", target_os = "openbsd", all(windows, target_arch = "aarch64"))) },

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -1,8 +1,3 @@
-#![allow(
-    semicolon_in_expressions_from_macros,
-    reason = "work around <https://github.com/katharostech/cfg_aliases/issues/16>"
-)]
-
 fn main() {
     cfg_aliases::cfg_aliases! {
         windows_linux_android: { any(windows, target_os = "linux", target_os = "android", target_os = "freebsd") },

--- a/wgpu-hal/build.rs
+++ b/wgpu-hal/build.rs
@@ -1,8 +1,3 @@
-#![allow(
-    semicolon_in_expressions_from_macros,
-    reason = "work around <https://github.com/katharostech/cfg_aliases/issues/16>"
-)]
-
 fn main() {
     cfg_aliases::cfg_aliases! {
         native: { not(target_family = "wasm") },

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -1,8 +1,3 @@
-#![allow(
-    semicolon_in_expressions_from_macros,
-    reason = "work around <https://github.com/katharostech/cfg_aliases/issues/16>"
-)]
-
 fn main() {
     cfg_aliases::cfg_aliases! {
         native: { not(target_family = "wasm") },


### PR DESCRIPTION
This reverts commit 15d817e404b3c37cde06a5100bac98a2f926d140/<https://github.com/gfx-rs/wgpu/pull/9884> and uses a "proper" fix instead.