### PR TITLE
Expect `wgpu_gpu::immediates::render_pass_test` to fail on RADV.

### DIFF
--- a/tests/tests/wgpu-gpu/immediates.rs
+++ b/tests/tests/wgpu-gpu/immediates.rs
@@ -167,6 +167,14 @@ static RENDER_PASS_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
             .limits(wgpu::Limits {
                 max_immediate_size: 64,
                 ..Default::default()
+            })
+            // https://github.com/gfx-rs/wgpu/issues/8612
+            .expect_fail(wgpu_test::FailureCase {
+                backends: Some(wgpu::Backends::VULKAN),
+                driver: Some("radv"),
+                reasons: vec![wgpu_test::FailureReason::panic()
+                    .with_message("assertion `left == right` failed")],
+                ..Default::default()
             }),
     )
     .run_async(move |ctx| async move {


### PR DESCRIPTION
Add an `expect_fail` clause to `wgpu_gpu::immediates::render_pass_test` blaming it on [wgpu#8612], which looks like a Mesa code generation bug.

[wgpu#8612]: https://github.com/gfx-rs/wgpu/issues/8612
