### PR TITLE
Document why no `Copy` impl on `wgt::Limits`

### DIFF
--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -132,6 +132,8 @@ macro_rules! with_limits {
 ///
 /// [`downlevel_defaults()`]: Limits::downlevel_defaults
 #[repr(C)]
+// Even though this type is simple, it is not copy because it is large.
+// https://rust-lang.github.io/rust-clippy/master/#large_types_passed_by_value
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase", default))]


### PR DESCRIPTION
**Description**
`size_of<wgt::Limits>() == 248` so copies of this struct would be expansive, hence there is no `Copy` impl on `wgt::Limit`. Clippy's ["maybe don't do pass by value"](https://rust-lang.github.io/rust-clippy/master/?search=clippy%3A%3Alarge_types_passed_by_value+) limit starts at 256 bytes.

**Testing**
Just comment

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
