### PR TITLE
Expect pass: `wgpu_gpu::clear_texture::clear_texture_uncompressed`

### DIFF
--- a/tests/tests/wgpu-gpu/clear_texture.rs
+++ b/tests/tests/wgpu-gpu/clear_texture.rs
@@ -348,17 +348,7 @@ static CLEAR_TEXTURE_UNCOMPRESSED_GLES: GpuTestConfiguration = GpuTestConfigurat
 
 #[gpu_test]
 static CLEAR_TEXTURE_UNCOMPRESSED: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .expect_fail(
-                FailureCase::backend(wgpu::Backends::GL)
-                    .panic("texture with format Rg8Snorm was not fully cleared")
-                    .panic("texture with format Rgb9e5Ufloat was not fully cleared")
-                    .validation_error("GL_INVALID_FRAMEBUFFER_OPERATION")
-                    .validation_error("GL_INVALID_OPERATION"),
-            )
-            .features(wgpu::Features::CLEAR_TEXTURE),
-    )
+    .parameters(TestParameters::default().features(wgpu::Features::CLEAR_TEXTURE))
     .run_async(|ctx| clear_texture_tests(ctx, TEXTURE_FORMATS_UNCOMPRESSED));
 
 #[gpu_test]


### PR DESCRIPTION
On `wgpu_gpu::clear_texture::clear_texture_uncompressed`, remove the `expect_fail` for GL. This passes on current Mesa, and the `expect_fail` dates from 2023-11-23.

If this test still fails on other GL implementations, let's find out what they are and refine the `expect_fail`.

This should be merged after #9903.
