### PR TITLE
[deno] Use Arced resources instead of `Global` (aka `Instance` in deno)

### DIFF
--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -2,6 +2,7 @@
 
 use std::ops::BitOr;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use deno_core::cppgc::SameObject;
 use deno_core::op2;
@@ -16,7 +17,6 @@ use super::device::DEVICE_EXTERNAL_MEMORY_SIZE;
 use super::queue::GPUQueue;
 use crate::error::GPUGenericError;
 use crate::webidl::GPUFeatureName;
-use crate::Instance;
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
@@ -49,18 +49,11 @@ struct GPUDeviceDescriptor {
 }
 
 pub struct GPUAdapter {
-  pub instance: Instance,
-  pub id: wgpu_core::id::AdapterId,
+  pub wgpu_adapter: Arc<wgpu_core::instance::Adapter>,
 
   pub features: SameObject<GPUSupportedFeatures>,
   pub limits: SameObject<GPUSupportedLimits>,
   pub info: Rc<SameObject<GPUAdapterInfo>>,
-}
-
-impl Drop for GPUAdapter {
-  fn drop(&mut self) {
-    self.instance.adapter_drop(self.id);
-  }
 }
 
 impl GarbageCollected for GPUAdapter {
@@ -81,7 +74,7 @@ impl GPUAdapter {
   #[global]
   fn info(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
     self.info.get(scope, |_| {
-      let info = self.instance.adapter_get_info(self.id);
+      let info = self.wgpu_adapter.get_info();
 
       GPUAdapterInfo { info }
     })
@@ -91,7 +84,7 @@ impl GPUAdapter {
   #[global]
   fn features(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
     self.features.get(scope, |scope| {
-      let features = self.instance.adapter_features(self.id);
+      let features = self.wgpu_adapter.features();
       // Only expose WebGPU features, not wgpu native-only features
       let features = features & wgpu_types::Features::all_webgpu_mask();
       GPUSupportedFeatures::new(scope, features)
@@ -102,7 +95,7 @@ impl GPUAdapter {
   #[global]
   fn limits(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
     self.limits.get(scope, |_| {
-      let adapter_limits = self.instance.adapter_limits(self.id);
+      let adapter_limits = self.wgpu_adapter.limits();
       GPUSupportedLimits(adapter_limits)
     })
   }
@@ -115,7 +108,7 @@ impl GPUAdapter {
     scope: &mut v8::HandleScope,
     #[webidl] descriptor: GPUDeviceDescriptor,
   ) -> Result<v8::Global<v8::Value>, CreateDeviceError> {
-    let supported_features = self.instance.adapter_features(self.id);
+    let supported_features = self.wgpu_adapter.features();
     let required_features = descriptor
       .required_features
       .iter()
@@ -161,12 +154,7 @@ impl GPUAdapter {
       trace,
     };
 
-    let (device, queue) = self.instance.adapter_request_device(
-      self.id,
-      &wgpu_descriptor,
-      None,
-      None,
-    )?;
+    let (device, queue) = self.wgpu_adapter.request_device(&wgpu_descriptor)?;
 
     // Associate external memory with the device to encourage V8 to garbage
     // collect devices promptly.
@@ -187,23 +175,21 @@ impl GPUAdapter {
     let queue_obj = deno_core::cppgc::make_cppgc_object(
       scope,
       GPUQueue {
-        instance: self.instance.clone(),
         error_handler: error_handler.clone(),
         label: descriptor.label.clone(),
-        id: queue,
-        device,
+        wgpu_queue: queue,
+        wgpu_device: device.clone(),
       },
     );
     let queue_obj = v8::Global::new(scope, queue_obj);
 
     let device = GPUDevice {
-      instance: self.instance.clone(),
-      id: device,
+      wgpu_device: device,
       label: descriptor.label,
       queue_obj,
       adapter_info: self.info.clone(),
       error_handler,
-      adapter: self.id,
+      wgpu_adapter: self.wgpu_adapter.clone(),
       lost_promise: v8::Global::new(scope, lost_promise),
       limits: SameObject::new(),
       features: SameObject::new(),

--- a/deno_webgpu/bind_group.rs
+++ b/deno_webgpu/bind_group.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use deno_core::cppgc::Ptr;
 use deno_core::op2;
@@ -20,18 +21,10 @@ use crate::sampler::GPUSampler;
 use crate::texture::GPUExternalTexture;
 use crate::texture::GPUTexture;
 use crate::texture::GPUTextureView;
-use crate::Instance;
 
 pub struct GPUBindGroup {
-  pub instance: Instance,
-  pub id: wgpu_core::id::BindGroupId,
+  pub wgpu_bind_group: Arc<wgpu_core::binding_model::BindGroup>,
   pub label: String,
-}
-
-impl Drop for GPUBindGroup {
-  fn drop(&mut self) {
-    self.instance.bind_group_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPUBindGroup {

--- a/deno_webgpu/bind_group_layout.rs
+++ b/deno_webgpu/bind_group_layout.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
+use std::sync::Arc;
+
 use deno_core::op2;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
@@ -7,18 +9,10 @@ use deno_core::WebIDL;
 use crate::error::GPUGenericError;
 use crate::texture::GPUTextureViewDimension;
 use crate::webidl::GPUShaderStageFlags;
-use crate::Instance;
 
 pub struct GPUBindGroupLayout {
-  pub instance: Instance,
-  pub id: wgpu_core::id::BindGroupLayoutId,
+  pub wgpu_bind_group_layout: Arc<wgpu_core::binding_model::BindGroupLayout>,
   pub label: String,
-}
-
-impl Drop for GPUBindGroupLayout {
-  fn drop(&mut self) {
-    self.instance.bind_group_layout_drop(self.id);
-  }
 }
 
 impl deno_core::webidl::WebIdlInterfaceConverter for GPUBindGroupLayout {

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use deno_core::futures::channel::oneshot;
@@ -14,7 +15,6 @@ use deno_error::JsErrorBox;
 use wgpu_core::device::HostMap as MapMode;
 
 use crate::error::GPUGenericError;
-use crate::Instance;
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
@@ -46,11 +46,10 @@ pub enum BufferError {
 }
 
 pub struct GPUBuffer {
-  pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
-  pub id: wgpu_core::id::BufferId,
-  pub device: wgpu_core::id::DeviceId,
+  pub wgpu_buffer: Arc<wgpu_core::resource::Buffer>,
+  pub wgpu_device: Arc<wgpu_core::device::Device>,
 
   pub label: String,
 
@@ -61,12 +60,6 @@ pub struct GPUBuffer {
   pub map_mode: RefCell<Option<MapMode>>,
 
   pub mapped_js_buffers: RefCell<Vec<v8::Global<v8::ArrayBuffer>>>,
-}
-
-impl Drop for GPUBuffer {
-  fn drop(&mut self) {
-    self.instance.buffer_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPUBuffer {
@@ -152,9 +145,8 @@ impl GPUBuffer {
       });
 
       let err = self
-        .instance
-        .buffer_map_async(
-          self.id,
+        .wgpu_buffer
+        .map_async(
           offset,
           size,
           wgpu_core::resource::BufferMapOperation {
@@ -176,8 +168,8 @@ impl GPUBuffer {
       while !*done.borrow() {
         {
           self
-            .instance
-            .device_poll(self.device, wgpu_types::PollType::wait_indefinitely())
+            .wgpu_device
+            .poll(wgpu_types::PollType::wait_indefinitely())
             .unwrap();
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -207,8 +199,8 @@ impl GPUBuffer {
     #[webidl] size: Option<u64>,
   ) -> Result<v8::Local<'s, v8::ArrayBuffer>, BufferError> {
     let (slice_pointer, range_size) = self
-      .instance
-      .buffer_get_mapped_range(self.id, offset, size)
+      .wgpu_buffer
+      .get_mapped_range(offset, size)
       .map_err(BufferError::Access)?;
 
     let mode = self.map_mode.borrow();
@@ -260,10 +252,7 @@ impl GPUBuffer {
       ab.detach(None);
     }
 
-    self
-      .instance
-      .buffer_unmap(self.id)
-      .map_err(BufferError::Access)?;
+    self.wgpu_buffer.unmap().map_err(BufferError::Access)?;
 
     *self.map_state.borrow_mut() = "unmapped";
 
@@ -273,6 +262,6 @@ impl GPUBuffer {
   #[fast]
   #[undefined]
   fn destroy(&self) {
-    self.instance.buffer_destroy(self.id);
+    self.wgpu_buffer.destroy();
   }
 }

--- a/deno_webgpu/byow.rs
+++ b/deno_webgpu/byow.rs
@@ -10,6 +10,7 @@ use std::ffi::c_void;
   target_os = "openbsd"
 ))]
 use std::ptr::NonNull;
+use std::sync::Arc;
 
 use deno_core::cppgc::SameObject;
 use deno_core::op2;
@@ -91,7 +92,7 @@ pub enum ByowError {
 
 // TODO(@littledivy): This will extend `OffscreenCanvas` when we add it.
 pub struct UnsafeWindowSurface {
-  pub id: wgpu_core::id::SurfaceId,
+  pub wgpu_surface: Arc<wgpu_core::instance::Surface>,
   pub width: RefCell<u32>,
   pub height: RefCell<u32>,
 
@@ -140,14 +141,14 @@ impl UnsafeWindowSurface {
     )?;
 
     // SAFETY: see above comment
-    let id = unsafe {
+    let wgpu_surface = unsafe {
       instance
-        .instance_create_surface(display_handle, win_handle, None)
+        .create_surface(display_handle, win_handle)
         .map_err(ByowError::CreateSurface)?
     };
 
     Ok(UnsafeWindowSurface {
-      id,
+      wgpu_surface,
       width: RefCell::new(options.width),
       height: RefCell::new(options.height),
       context: SameObject::new(),
@@ -161,7 +162,7 @@ impl UnsafeWindowSurface {
     scope: &mut v8::HandleScope,
   ) -> v8::Global<v8::Object> {
     self.context.get(scope, |_| GPUCanvasContext {
-      surface_id: self.id,
+      wgpu_surface: self.wgpu_surface.clone(),
       width: self.width.clone(),
       height: self.height.clone(),
       config: RefCell::new(None),

--- a/deno_webgpu/command_buffer.rs
+++ b/deno_webgpu/command_buffer.rs
@@ -1,22 +1,16 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
+use std::sync::Arc;
+
 use deno_core::op2;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 
 use crate::error::GPUGenericError;
-use crate::Instance;
 
 pub struct GPUCommandBuffer {
-  pub instance: Instance,
-  pub id: wgpu_core::id::CommandBufferId,
+  pub wgpu_command_buffer: Arc<wgpu_core::command::CommandBuffer>,
   pub label: String,
-}
-
-impl Drop for GPUCommandBuffer {
-  fn drop(&mut self) {
-    self.instance.command_buffer_drop(self.id);
-  }
 }
 
 impl deno_core::webidl::WebIdlInterfaceConverter for GPUCommandBuffer {

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::num::NonZero;
+use std::sync::Arc;
 #[cfg(target_vendor = "apple")]
 use std::sync::OnceLock;
 
@@ -23,25 +24,17 @@ use crate::error::GPUGenericError;
 use crate::queue::GPUTexelCopyTextureInfo;
 use crate::render_pass::GPURenderPassEncoder;
 use crate::webidl::GPUExtent3D;
-use crate::Instance;
 
 pub struct GPUCommandEncoder {
-  pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
-  pub id: wgpu_core::id::CommandEncoderId,
+  pub wgpu_command_encoder: Arc<wgpu_core::command::CommandEncoder>,
   pub label: String,
 
   // Weak reference to the JS object so we can attach a finalizer.
   // See `GPUDevice::create_command_encoder`.
   #[cfg(target_vendor = "apple")]
   pub(crate) weak: OnceLock<v8::Weak<v8::Object>>,
-}
-
-impl Drop for GPUCommandEncoder {
-  fn drop(&mut self) {
-    self.instance.command_encoder_drop(self.id);
-  }
 }
 
 impl GarbageCollected for GPUCommandEncoder {
@@ -82,11 +75,11 @@ impl GPUCommandEncoder {
         .map(|attachment| {
           attachment.into_option().map(|attachment| {
             wgpu_core::command::RenderPassColorAttachment {
-              view: attachment.view.to_view_id(),
+              view: attachment.view.to_view(),
               depth_slice: attachment.depth_slice,
               resolve_target: attachment
                 .resolve_target
-                .map(|target| target.to_view_id()),
+                .map(|target| target.to_view()),
               load_op: attachment
                 .load_op
                 .with_default_value(attachment.clear_value.map(Into::into)),
@@ -100,7 +93,7 @@ impl GPUCommandEncoder {
     let depth_stencil_attachment =
       descriptor.depth_stencil_attachment.map(|attachment| {
         wgpu_core::command::RenderPassDepthStencilAttachment {
-          view: attachment.view.to_view_id(),
+          view: attachment.view.to_view(),
           depth: PassChannel {
             load_op: attachment
               .depth_load_op
@@ -121,32 +114,30 @@ impl GPUCommandEncoder {
     let timestamp_writes =
       descriptor.timestamp_writes.map(|timestamp_writes| {
         wgpu_core::command::PassTimestampWrites {
-          query_set: timestamp_writes.query_set.id,
+          query_set: timestamp_writes.query_set.wgpu_query_set.clone(),
           beginning_of_pass_write_index: timestamp_writes
             .beginning_of_pass_write_index,
           end_of_pass_write_index: timestamp_writes.end_of_pass_write_index,
         }
       });
 
-    let wgpu_descriptor = wgpu_core::command::RenderPassDescriptor {
+    let wgpu_descriptor = wgpu_core::command::ResolvedRenderPassDescriptor {
       label: crate::transform_label(descriptor.label.clone()),
       color_attachments,
       depth_stencil_attachment,
       timestamp_writes,
       occlusion_query_set: descriptor
         .occlusion_query_set
-        .map(|query_set| query_set.id),
+        .map(|query_set| query_set.wgpu_query_set.clone()),
       multiview_mask: NonZero::new(descriptor.multiview_mask),
     };
 
-    let (render_pass, err) = self
-      .instance
-      .command_encoder_begin_render_pass(self.id, &wgpu_descriptor);
+    let (render_pass, err) =
+      self.wgpu_command_encoder.begin_render_pass(wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     Ok(GPURenderPassEncoder {
-      instance: self.instance.clone(),
       error_handler: self.error_handler.clone(),
       render_pass: RefCell::new(render_pass),
       label: descriptor.label,
@@ -161,7 +152,7 @@ impl GPUCommandEncoder {
     let timestamp_writes =
       descriptor.timestamp_writes.map(|timestamp_writes| {
         wgpu_core::command::PassTimestampWrites {
-          query_set: timestamp_writes.query_set.id,
+          query_set: timestamp_writes.query_set.wgpu_query_set.clone(),
           beginning_of_pass_write_index: timestamp_writes
             .beginning_of_pass_write_index,
           end_of_pass_write_index: timestamp_writes.end_of_pass_write_index,
@@ -174,13 +165,12 @@ impl GPUCommandEncoder {
     };
 
     let (compute_pass, err) = self
-      .instance
-      .command_encoder_begin_compute_pass(self.id, &wgpu_descriptor);
+      .wgpu_command_encoder
+      .begin_compute_pass(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     GPUComputePassEncoder {
-      instance: self.instance.clone(),
       error_handler: self.error_handler.clone(),
       compute_pass: RefCell::new(compute_pass),
       label: descriptor.label,
@@ -261,12 +251,11 @@ impl GPUCommandEncoder {
     }
 
     let err = self
-      .instance
-      .command_encoder_copy_buffer_to_buffer(
-        self.id,
-        source.id,
+      .wgpu_command_encoder
+      .copy_buffer_to_buffer(
+        source.wgpu_buffer.clone(),
         source_offset,
-        destination.id,
+        destination.wgpu_buffer.clone(),
         destination_offset,
         size,
       )
@@ -286,7 +275,7 @@ impl GPUCommandEncoder {
     #[webidl] copy_size: GPUExtent3D,
   ) {
     let source = TexelCopyBufferInfo {
-      buffer: source.buffer.id,
+      buffer: source.buffer.wgpu_buffer.clone(),
       layout: wgpu_types::TexelCopyBufferLayout {
         offset: source.offset,
         bytes_per_row: source.bytes_per_row,
@@ -294,20 +283,15 @@ impl GPUCommandEncoder {
       },
     };
     let destination = wgpu_types::TexelCopyTextureInfo {
-      texture: destination.texture.id,
+      texture: destination.texture.wgpu_texture.clone(),
       mip_level: destination.mip_level,
       origin: destination.origin.into(),
       aspect: destination.aspect.into(),
     };
 
     let err = self
-      .instance
-      .command_encoder_copy_buffer_to_texture(
-        self.id,
-        &source,
-        &destination,
-        &copy_size.into(),
-      )
+      .wgpu_command_encoder
+      .copy_buffer_to_texture(&source, &destination, &copy_size.into())
       .err();
 
     self.error_handler.push_error(err);
@@ -322,13 +306,13 @@ impl GPUCommandEncoder {
     #[webidl] copy_size: GPUExtent3D,
   ) {
     let source = wgpu_types::TexelCopyTextureInfo {
-      texture: source.texture.id,
+      texture: source.texture.wgpu_texture.clone(),
       mip_level: source.mip_level,
       origin: source.origin.into(),
       aspect: source.aspect.into(),
     };
     let destination = TexelCopyBufferInfo {
-      buffer: destination.buffer.id,
+      buffer: destination.buffer.wgpu_buffer.clone(),
       layout: wgpu_types::TexelCopyBufferLayout {
         offset: destination.offset,
         bytes_per_row: destination.bytes_per_row,
@@ -337,13 +321,8 @@ impl GPUCommandEncoder {
     };
 
     let err = self
-      .instance
-      .command_encoder_copy_texture_to_buffer(
-        self.id,
-        &source,
-        &destination,
-        &copy_size.into(),
-      )
+      .wgpu_command_encoder
+      .copy_texture_to_buffer(&source, &destination, &copy_size.into())
       .err();
 
     self.error_handler.push_error(err);
@@ -358,26 +337,21 @@ impl GPUCommandEncoder {
     #[webidl] copy_size: GPUExtent3D,
   ) {
     let source = wgpu_types::TexelCopyTextureInfo {
-      texture: source.texture.id,
+      texture: source.texture.wgpu_texture.clone(),
       mip_level: source.mip_level,
       origin: source.origin.into(),
       aspect: source.aspect.into(),
     };
     let destination = wgpu_types::TexelCopyTextureInfo {
-      texture: destination.texture.id,
+      texture: destination.texture.wgpu_texture.clone(),
       mip_level: destination.mip_level,
       origin: destination.origin.into(),
       aspect: destination.aspect.into(),
     };
 
     let err = self
-      .instance
-      .command_encoder_copy_texture_to_texture(
-        self.id,
-        &source,
-        &destination,
-        &copy_size.into(),
-      )
+      .wgpu_command_encoder
+      .copy_texture_to_texture(&source, &destination, &copy_size.into())
       .err();
 
     self.error_handler.push_error(err);
@@ -392,8 +366,8 @@ impl GPUCommandEncoder {
     #[webidl(options(enforce_range = true))] size: Option<u64>,
   ) {
     let err = self
-      .instance
-      .command_encoder_clear_buffer(self.id, buffer.id, offset, size)
+      .wgpu_command_encoder
+      .clear_buffer(buffer.wgpu_buffer.clone(), offset, size)
       .err();
     self.error_handler.push_error(err);
   }
@@ -409,13 +383,12 @@ impl GPUCommandEncoder {
     #[webidl(options(enforce_range = true))] destination_offset: u64,
   ) {
     let err = self
-      .instance
-      .command_encoder_resolve_query_set(
-        self.id,
-        query_set.id,
+      .wgpu_command_encoder
+      .resolve_query_set(
+        query_set.wgpu_query_set.clone(),
         first_query,
         query_count,
-        destination.id,
+        destination.wgpu_buffer.clone(),
         destination_offset,
       )
       .err();
@@ -432,40 +405,37 @@ impl GPUCommandEncoder {
       label: crate::transform_label(descriptor.label.clone()),
     };
 
-    let (id, opt_label_and_err) =
-      self
-        .instance
-        .command_encoder_finish(self.id, &wgpu_descriptor, None);
+    let (wgpu_command_buffer, opt_label_and_err) =
+      self.wgpu_command_encoder.finish(&wgpu_descriptor);
 
     self
       .error_handler
       .push_error(opt_label_and_err.map(|(_label, err)| err));
 
     GPUCommandBuffer {
-      instance: self.instance.clone(),
-      id,
+      wgpu_command_buffer,
       label: descriptor.label,
     }
   }
 
   fn push_debug_group(&self, #[webidl] group_label: String) {
     let err = self
-      .instance
-      .command_encoder_push_debug_group(self.id, &group_label)
+      .wgpu_command_encoder
+      .push_debug_group(&group_label)
       .err();
     self.error_handler.push_error(err);
   }
 
   #[fast]
   fn pop_debug_group(&self) {
-    let err = self.instance.command_encoder_pop_debug_group(self.id).err();
+    let err = self.wgpu_command_encoder.pop_debug_group().err();
     self.error_handler.push_error(err);
   }
 
   fn insert_debug_marker(&self, #[webidl] marker_label: String) {
     let err = self
-      .instance
-      .command_encoder_insert_debug_marker(self.id, &marker_label)
+      .wgpu_command_encoder
+      .insert_debug_marker(&marker_label)
       .err();
     self.error_handler.push_error(err);
   }

--- a/deno_webgpu/compute_pass.rs
+++ b/deno_webgpu/compute_pass.rs
@@ -16,10 +16,8 @@ use deno_error::JsErrorBox;
 
 use crate::error::GPUGenericError;
 use crate::get_data_slice;
-use crate::Instance;
 
 pub struct GPUComputePassEncoder {
-  pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
   pub compute_pass: RefCell<wgpu_core::command::ComputePass>,
@@ -57,11 +55,9 @@ impl GPUComputePassEncoder {
     #[webidl] pipeline: Ptr<crate::compute_pipeline::GPUComputePipeline>,
   ) {
     let err = self
-      .instance
-      .compute_pass_set_pipeline(
-        &mut self.compute_pass.borrow_mut(),
-        pipeline.id,
-      )
+      .compute_pass
+      .borrow_mut()
+      .set_pipeline(pipeline.wgpu_compute_pipeline.clone())
       .err();
     self.error_handler.push_error(err);
   }
@@ -76,9 +72,9 @@ impl GPUComputePassEncoder {
     work_group_count_z: u32,
   ) {
     let err = self
-      .instance
-      .compute_pass_dispatch_workgroups(
-        &mut self.compute_pass.borrow_mut(),
+      .compute_pass
+      .borrow_mut()
+      .dispatch_workgroups(
         work_group_count_x,
         work_group_count_y,
         work_group_count_z,
@@ -94,10 +90,10 @@ impl GPUComputePassEncoder {
     #[webidl(options(enforce_range = true))] indirect_offset: u64,
   ) {
     let err = self
-      .instance
-      .compute_pass_dispatch_workgroups_indirect(
-        &mut self.compute_pass.borrow_mut(),
-        indirect_buffer.id,
+      .compute_pass
+      .borrow_mut()
+      .dispatch_workgroups_indirect(
+        indirect_buffer.wgpu_buffer.clone(),
         indirect_offset,
       )
       .err();
@@ -107,19 +103,16 @@ impl GPUComputePassEncoder {
   #[fast]
   #[undefined]
   fn end(&self) {
-    let err = self
-      .instance
-      .compute_pass_end(&mut self.compute_pass.borrow_mut())
-      .err();
+    let err = self.compute_pass.borrow_mut().end().err();
     self.error_handler.push_error(err);
   }
 
   #[undefined]
   fn push_debug_group(&self, #[webidl] group_label: String) {
     let err = self
-      .instance
-      .compute_pass_push_debug_group(
-        &mut self.compute_pass.borrow_mut(),
+      .compute_pass
+      .borrow_mut()
+      .push_debug_group(
         &group_label,
         0, // wgpu#975
       )
@@ -130,19 +123,16 @@ impl GPUComputePassEncoder {
   #[fast]
   #[undefined]
   fn pop_debug_group(&self) {
-    let err = self
-      .instance
-      .compute_pass_pop_debug_group(&mut self.compute_pass.borrow_mut())
-      .err();
+    let err = self.compute_pass.borrow_mut().pop_debug_group().err();
     self.error_handler.push_error(err);
   }
 
   #[undefined]
   fn insert_debug_marker(&self, #[webidl] marker_label: String) {
     let err = self
-      .instance
-      .compute_pass_insert_debug_marker(
-        &mut self.compute_pass.borrow_mut(),
+      .compute_pass
+      .borrow_mut()
+      .insert_debug_marker(
         &marker_label,
         0, // wgpu#975
       )
@@ -196,11 +186,13 @@ impl GPUComputePassEncoder {
       let offsets = &data[start..(start + len)];
 
       self
-        .instance
-        .compute_pass_set_bind_group(
-          &mut self.compute_pass.borrow_mut(),
+        .compute_pass
+        .borrow_mut()
+        .set_bind_group(
           index,
-          bind_group.into_option().map(|bind_group| bind_group.id),
+          bind_group
+            .into_option()
+            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
           offsets,
         )
         .err()
@@ -218,11 +210,13 @@ impl GPUComputePassEncoder {
       .unwrap_or_default();
 
       self
-        .instance
-        .compute_pass_set_bind_group(
-          &mut self.compute_pass.borrow_mut(),
+        .compute_pass
+        .borrow_mut()
+        .set_bind_group(
           index,
-          bind_group.into_option().map(|bind_group| bind_group.id),
+          bind_group
+            .into_option()
+            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
           &offsets,
         )
         .err()
@@ -246,12 +240,9 @@ impl GPUComputePassEncoder {
     let data = get_data_slice(scope, data_arg, data_offset, data_size)?;
 
     let err = self
-      .instance
-      .compute_pass_set_immediates(
-        &mut self.compute_pass.borrow_mut(),
-        offset,
-        data,
-      )
+      .compute_pass
+      .borrow_mut()
+      .set_immediates(offset, data)
       .err();
     self.error_handler.push_error(err);
     Ok(())

--- a/deno_webgpu/compute_pipeline.rs
+++ b/deno_webgpu/compute_pipeline.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
+use std::sync::Arc;
+
 use deno_core::cppgc::Ptr;
 use deno_core::op2;
 use deno_core::webidl::WebIdlInterfaceConverter;
@@ -11,20 +13,12 @@ use crate::bind_group_layout::GPUBindGroupLayout;
 use crate::error::GPUGenericError;
 use crate::shader::GPUShaderModule;
 use crate::webidl::GPUPipelineLayoutOrGPUAutoLayoutMode;
-use crate::Instance;
 
 pub struct GPUComputePipeline {
-  pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
-  pub id: wgpu_core::id::ComputePipelineId,
+  pub wgpu_compute_pipeline: Arc<wgpu_core::pipeline::ComputePipeline>,
   pub label: String,
-}
-
-impl Drop for GPUComputePipeline {
-  fn drop(&mut self) {
-    self.instance.compute_pipeline_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPUComputePipeline {
@@ -58,16 +52,14 @@ impl GPUComputePipeline {
 
   #[cppgc]
   fn get_bind_group_layout(&self, #[webidl] index: u32) -> GPUBindGroupLayout {
-    let (id, err) = self
-      .instance
-      .compute_pipeline_get_bind_group_layout(self.id, index, None);
+    let (wgpu_bind_group_layout, err) =
+      self.wgpu_compute_pipeline.get_bind_group_layout(index);
 
     self.error_handler.push_error(err);
 
     // TODO(wgpu): needs to support retrieving the label
     GPUBindGroupLayout {
-      instance: self.instance.clone(),
-      id,
+      wgpu_bind_group_layout,
       label: "".to_string(),
     }
   }

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::num::NonZeroU64;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use deno_core::cppgc::{make_cppgc_object, SameObject};
 use deno_core::op2;
@@ -35,7 +36,6 @@ use crate::render_bundle::GPURenderBundleEncoder;
 use crate::render_pipeline::GPURenderPipeline;
 use crate::shader::GPUCompilationInfo;
 use crate::webidl::GPUTextureUsageFlags;
-use crate::Instance;
 
 /// External memory associated with device and queue, to encourage V8 to garbage
 /// collect devices promptly. This seems to be particularly important when
@@ -44,9 +44,8 @@ use crate::Instance;
 pub(crate) const DEVICE_EXTERNAL_MEMORY_SIZE: i64 = 1 << 24; // 16 MB
 
 pub struct GPUDevice {
-  pub instance: Instance,
-  pub id: wgpu_core::id::DeviceId,
-  pub adapter: wgpu_core::id::AdapterId,
+  pub wgpu_device: Arc<wgpu_core::device::Device>,
+  pub wgpu_adapter: Arc<wgpu_core::instance::Adapter>,
 
   pub label: String,
 
@@ -61,12 +60,6 @@ pub struct GPUDevice {
 
   // Weak reference to the JS object so we can attach a finalizer.
   pub(crate) weak: std::sync::OnceLock<v8::Weak<v8::Object>>,
-}
-
-impl Drop for GPUDevice {
-  fn drop(&mut self) {
-    self.instance.device_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPUDevice {
@@ -103,8 +96,8 @@ impl GPUDevice {
   #[global]
   fn features(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
     self.features.get(scope, |scope| {
-      let features = self.instance.device_features(self.id);
-      GPUSupportedFeatures::new(scope, features)
+      let features = self.wgpu_device.features();
+      GPUSupportedFeatures::new(scope, *features)
     })
   }
 
@@ -112,8 +105,8 @@ impl GPUDevice {
   #[global]
   fn limits(&self, scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
     self.limits.get(scope, |_| {
-      let limits = self.instance.device_limits(self.id);
-      GPUSupportedLimits(limits)
+      let limits = self.wgpu_device.limits();
+      GPUSupportedLimits(limits.clone())
     })
   }
 
@@ -124,7 +117,7 @@ impl GPUDevice {
     scope: &mut v8::HandleScope,
   ) -> v8::Global<v8::Object> {
     self.adapter_info.get(scope, |_| {
-      let info = self.instance.adapter_get_info(self.adapter);
+      let info = self.wgpu_adapter.get_info();
 
       GPUAdapterInfo { info }
     })
@@ -139,7 +132,7 @@ impl GPUDevice {
   #[fast]
   #[undefined]
   fn destroy(&self) {
-    self.instance.device_destroy(self.id);
+    self.wgpu_device.destroy();
     self
       .error_handler
       .push_error(Some(GPUError::Lost(GPUDeviceLostReason::Destroyed)));
@@ -180,18 +173,14 @@ impl GPUDevice {
       mapped_at_creation: descriptor.mapped_at_creation,
     };
 
-    let (id, err) =
-      self
-        .instance
-        .device_create_buffer(self.id, &wgpu_descriptor, None);
+    let (wgpu_buffer, err) = self.wgpu_device.create_buffer(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     Ok(GPUBuffer {
-      instance: self.instance.clone(),
       error_handler: self.error_handler.clone(),
-      id,
-      device: self.id,
+      wgpu_buffer,
+      wgpu_device: self.wgpu_device.clone(),
       label: descriptor.label,
       size: descriptor.size,
       usage: descriptor.usage,
@@ -221,7 +210,7 @@ impl GPUDevice {
     let usage = wgpu_types::TextureUsages::from_bits(descriptor.usage)
       .unwrap_or(wgpu_types::TextureUsages::empty());
 
-    let wgpu_descriptor = wgpu_core::resource::TextureDescriptor {
+    let wgpu_descriptor = wgpu_types::TextureDescriptor {
       label: crate::transform_label(descriptor.label.clone()),
       size: descriptor.size.into(),
       mip_level_count: descriptor.mip_level_count,
@@ -236,18 +225,14 @@ impl GPUDevice {
         .collect(),
     };
 
-    let (id, err) =
-      self
-        .instance
-        .device_create_texture(self.id, &wgpu_descriptor, None);
+    let (wgpu_texture, err) = self.wgpu_device.create_texture(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     Ok(GPUTexture {
-      instance: self.instance.clone(),
       error_handler: self.error_handler.clone(),
-      id,
-      default_view_id: Default::default(),
+      wgpu_texture,
+      default_view: Default::default(),
       label: descriptor.label,
       size: wgpu_descriptor.size,
       mip_level_count: wgpu_descriptor.mip_level_count,
@@ -280,16 +265,12 @@ impl GPUDevice {
       border_color: None,
     };
 
-    let (id, err) =
-      self
-        .instance
-        .device_create_sampler(self.id, &wgpu_descriptor, None);
+    let (wgpu_sampler, err) = self.wgpu_device.create_sampler(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     Ok(GPUSampler {
-      instance: self.instance.clone(),
-      id,
+      wgpu_sampler,
       label: descriptor.label,
     })
   }
@@ -360,17 +341,13 @@ impl GPUDevice {
       entries: Cow::Owned(entries),
     };
 
-    let (id, err) = self.instance.device_create_bind_group_layout(
-      self.id,
-      &wgpu_descriptor,
-      None,
-    );
+    let (wgpu_bind_group_layout, err) =
+      self.wgpu_device.create_bind_group_layout(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     Ok(GPUBindGroupLayout {
-      instance: self.instance.clone(),
-      id,
+      wgpu_bind_group_layout,
       label: descriptor.label,
     })
   }
@@ -385,9 +362,9 @@ impl GPUDevice {
       .bind_group_layouts
       .into_iter()
       .map(|bind_group_layout| {
-        bind_group_layout
-          .into_option()
-          .map(|bind_group_layout| bind_group_layout.id)
+        bind_group_layout.into_option().map(|bind_group_layout| {
+          bind_group_layout.wgpu_bind_group_layout.clone()
+        })
       })
       .collect();
 
@@ -397,17 +374,13 @@ impl GPUDevice {
       immediate_size: descriptor.immediate_size,
     };
 
-    let (id, err) = self.instance.device_create_pipeline_layout(
-      self.id,
-      &wgpu_descriptor,
-      None,
-    );
+    let (wgpu_pipeline_layout, err) =
+      self.wgpu_device.create_pipeline_layout(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     GPUPipelineLayout {
-      instance: self.instance.clone(),
-      id,
+      wgpu_pipeline_layout,
       label: descriptor.label,
     }
   }
@@ -421,55 +394,55 @@ impl GPUDevice {
     let entries = descriptor
       .entries
       .into_iter()
-      .map(|entry| wgpu_core::binding_model::BindGroupEntry {
+      .map(|entry| wgpu_core::binding_model::ResolvedBindGroupEntry {
         binding: entry.binding,
         resource: match entry.resource {
           GPUBindingResource::Sampler(sampler) => {
-            BindingResource::Sampler(sampler.id)
+            BindingResource::Sampler(sampler.wgpu_sampler.clone())
           }
           GPUBindingResource::Texture(texture) => {
-            BindingResource::TextureView(texture.default_view_id())
+            BindingResource::TextureView(texture.default_view())
           }
           GPUBindingResource::TextureView(texture_view) => {
-            BindingResource::TextureView(texture_view.id)
+            BindingResource::TextureView(texture_view.wgpu_texture_view.clone())
           }
           GPUBindingResource::Buffer(buffer) => {
             BindingResource::Buffer(wgpu_core::binding_model::BufferBinding {
-              buffer: buffer.id,
+              buffer: buffer.wgpu_buffer.clone(),
               offset: 0,
               size: Some(buffer.size),
             })
           }
           GPUBindingResource::BufferBinding(buffer_binding) => {
             BindingResource::Buffer(wgpu_core::binding_model::BufferBinding {
-              buffer: buffer_binding.buffer.id,
+              buffer: buffer_binding.buffer.wgpu_buffer.clone(),
               offset: buffer_binding.offset,
               size: buffer_binding.size,
             })
           }
           GPUBindingResource::ExternalTexture(external_texture) => {
-            BindingResource::ExternalTexture(external_texture.id)
+            BindingResource::ExternalTexture(
+              external_texture.wgpu_external_texture.clone(),
+            )
           }
         },
       })
       .collect::<Vec<_>>();
 
-    let wgpu_descriptor = wgpu_core::binding_model::BindGroupDescriptor {
-      label: crate::transform_label(descriptor.label.clone()),
-      layout: descriptor.layout.id,
-      entries: Cow::Owned(entries),
-    };
+    let wgpu_descriptor =
+      wgpu_core::binding_model::ResolvedBindGroupDescriptor {
+        label: crate::transform_label(descriptor.label.clone()),
+        layout: descriptor.layout.wgpu_bind_group_layout.clone(),
+        entries: Cow::Owned(entries),
+      };
 
-    let (id, err) =
-      self
-        .instance
-        .device_create_bind_group(self.id, &wgpu_descriptor, None);
+    let (wgpu_bind_group, err) =
+      self.wgpu_device.create_bind_group(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     GPUBindGroup {
-      instance: self.instance.clone(),
-      id,
+      wgpu_bind_group,
       label: descriptor.label,
     }
   }
@@ -486,13 +459,11 @@ impl GPUDevice {
       runtime_checks: wgpu_types::ShaderRuntimeChecks::default(),
     };
 
-    let (id, err) = self.instance.device_create_shader_module(
-      self.id,
+    let (wgpu_shader_module, err) = self.wgpu_device.create_shader_module(
       &wgpu_descriptor,
       wgpu_core::pipeline::ShaderModuleSource::Wgsl(Cow::Borrowed(
         &descriptor.code,
       )),
-      None,
     );
 
     let compilation_info =
@@ -502,8 +473,7 @@ impl GPUDevice {
     self.error_handler.push_error(err);
 
     GPUShaderModule {
-      instance: self.instance.clone(),
-      id,
+      wgpu_shader_module,
       label: descriptor.label,
       compilation_info,
     }
@@ -609,18 +579,14 @@ impl GPUDevice {
     #[cfg(target_vendor = "apple")]
     scope.adjust_amount_of_external_allocated_memory(EXTERNAL_MEMORY_AMOUNT);
 
-    let (id, err) = self.instance.device_create_command_encoder(
-      self.id,
-      &wgpu_descriptor,
-      None,
-    );
+    let (wgpu_command_encoder, err) =
+      self.wgpu_device.create_command_encoder(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     let encoder = GPUCommandEncoder {
-      instance: self.instance.clone(),
       error_handler: self.error_handler.clone(),
-      id,
+      wgpu_command_encoder,
       label,
       #[cfg(target_vendor = "apple")]
       weak: std::sync::OnceLock::new(),
@@ -680,13 +646,12 @@ impl GPUDevice {
     };
 
     let (encoder, err) = self
-      .instance
-      .device_create_render_bundle_encoder(self.id, &wgpu_descriptor);
+      .wgpu_device
+      .create_render_bundle_encoder(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     GPURenderBundleEncoder {
-      instance: self.instance.clone(),
       error_handler: self.error_handler.clone(),
       encoder: RefCell::new(encoder),
       label: descriptor.label,
@@ -705,16 +670,13 @@ impl GPUDevice {
       count: descriptor.count,
     };
 
-    let (id, err) =
-      self
-        .instance
-        .device_create_query_set(self.id, &wgpu_descriptor, None);
+    let (wgpu_query_set, err) =
+      self.wgpu_device.create_query_set(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     GPUQuerySet {
-      instance: self.instance.clone(),
-      id,
+      wgpu_query_set,
       r#type: descriptor.r#type,
       count: descriptor.count,
       label: descriptor.label,
@@ -768,19 +730,15 @@ impl GPUDevice {
 
   #[fast]
   fn start_capture(&self) {
-    unsafe {
-      self
-        .instance
-        .device_start_graphics_debugger_capture(self.id)
-    };
+    unsafe { self.wgpu_device.start_graphics_debugger_capture() };
   }
   #[fast]
   fn stop_capture(&self) {
     self
-      .instance
-      .device_poll(self.id, wgpu_types::PollType::wait_indefinitely())
+      .wgpu_device
+      .poll(wgpu_types::PollType::wait_indefinitely())
       .unwrap();
-    unsafe { self.instance.device_stop_graphics_debugger_capture(self.id) };
+    unsafe { self.wgpu_device.stop_graphics_debugger_capture() };
   }
 }
 
@@ -792,29 +750,26 @@ impl GPUDevice {
     GPUComputePipeline,
     Option<wgpu_core::pipeline::CreateComputePipelineError>,
   ) {
-    let wgpu_descriptor = wgpu_core::pipeline::ComputePipelineDescriptor {
-      label: crate::transform_label(descriptor.label.clone()),
-      layout: descriptor.layout.into(),
-      stage: ProgrammableStageDescriptor {
-        module: descriptor.compute.module.id,
-        entry_point: descriptor.compute.entry_point.map(Into::into),
-        constants: descriptor.compute.constants.into_iter().collect(),
-        zero_initialize_workgroup_memory: true,
-      },
-      cache: None,
-    };
+    let wgpu_descriptor =
+      wgpu_core::pipeline::ResolvedComputePipelineDescriptor {
+        label: crate::transform_label(descriptor.label.clone()),
+        layout: descriptor.layout.into(),
+        stage: ProgrammableStageDescriptor {
+          module: descriptor.compute.module.wgpu_shader_module.clone(),
+          entry_point: descriptor.compute.entry_point.map(Into::into),
+          constants: descriptor.compute.constants.into_iter().collect(),
+          zero_initialize_workgroup_memory: true,
+        },
+        cache: None,
+      };
 
-    let (id, err) = self.instance.device_create_compute_pipeline(
-      self.id,
-      &wgpu_descriptor,
-      None,
-    );
+    let (wgpu_compute_pipeline, err) =
+      self.wgpu_device.create_compute_pipeline(wgpu_descriptor);
 
     (
       GPUComputePipeline {
-        instance: self.instance.clone(),
         error_handler: self.error_handler.clone(),
-        id,
+        wgpu_compute_pipeline,
         label: descriptor.label.clone(),
       },
       err,
@@ -830,7 +785,7 @@ impl GPUDevice {
   ) {
     let vertex = wgpu_core::pipeline::VertexState {
       stage: ProgrammableStageDescriptor {
-        module: descriptor.vertex.module.id,
+        module: descriptor.vertex.module.wgpu_shader_module.clone(),
         entry_point: descriptor.vertex.entry_point.map(Into::into),
         constants: descriptor.vertex.constants.into_iter().collect(),
         zero_initialize_workgroup_memory: true,
@@ -921,7 +876,7 @@ impl GPUDevice {
         .fragment
         .map(|fragment| wgpu_core::pipeline::FragmentState {
           stage: ProgrammableStageDescriptor {
-            module: fragment.module.id,
+            module: fragment.module.wgpu_shader_module.clone(),
             entry_point: fragment.entry_point.map(Into::into),
             constants: fragment.constants.into_iter().collect(),
             zero_initialize_workgroup_memory: true,
@@ -954,29 +909,28 @@ impl GPUDevice {
           ),
         });
 
-    let wgpu_descriptor = wgpu_core::pipeline::RenderPipelineDescriptor {
-      label: crate::transform_label(descriptor.label.clone()),
-      layout: descriptor.layout.into(),
-      vertex,
-      primitive,
-      depth_stencil,
-      multisample,
-      fragment,
-      cache: None,
-      multiview_mask: None,
-    };
+    let wgpu_descriptor =
+      wgpu_core::pipeline::ResolvedGeneralRenderPipelineDescriptor {
+        label: crate::transform_label(descriptor.label.clone()),
+        layout: descriptor.layout.into(),
+        vertex: wgpu_core::pipeline::RenderPipelineVertexProcessor::Vertex(
+          vertex,
+        ),
+        primitive,
+        depth_stencil,
+        multisample,
+        fragment,
+        cache: None,
+        multiview_mask: None,
+      };
 
-    let (id, err) = self.instance.device_create_render_pipeline(
-      self.id,
-      &wgpu_descriptor,
-      None,
-    );
+    let (wgpu_render_pipeline, err) =
+      self.wgpu_device.create_render_pipeline(wgpu_descriptor);
 
     (
       GPURenderPipeline {
-        instance: self.instance.clone(),
         error_handler: self.error_handler.clone(),
-        id,
+        wgpu_render_pipeline,
         label: descriptor.label,
       },
       err,
@@ -1039,17 +993,13 @@ impl GPUDeviceLostInfo {
 #[op2(fast)]
 pub fn op_webgpu_device_start_capture(#[cppgc] device: &GPUDevice) {
   unsafe {
-    device
-      .instance
-      .device_start_graphics_debugger_capture(device.id);
+    device.wgpu_device.start_graphics_debugger_capture();
   }
 }
 
 #[op2(fast)]
 pub fn op_webgpu_device_stop_capture(#[cppgc] device: &GPUDevice) {
   unsafe {
-    device
-      .instance
-      .device_stop_graphics_debugger_capture(device.id);
+    device.wgpu_device.stop_graphics_debugger_capture();
   }
 }

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -67,7 +67,7 @@ pub fn print_linker_flags(name: &str) {
   }
 }
 
-pub type Instance = Arc<wgpu_core::global::Global>;
+pub type Instance = Arc<wgpu_core::instance::Instance>;
 
 deno_core::extension!(
   deno_webgpu,
@@ -193,7 +193,7 @@ impl GPU {
       if strict_compliance {
         flags |= wgpu_types::InstanceFlags::STRICT_WEBGPU_COMPLIANCE;
       }
-      state.put(Arc::new(wgpu_core::global::Global::new(
+      state.put(Arc::new(wgpu_core::instance::Instance::new(
         "webgpu",
         wgpu_types::InstanceDescriptor {
           backends,
@@ -228,7 +228,7 @@ impl GPU {
     ))
     .ok()?;
 
-    let descriptor = wgpu_core::instance::RequestAdapterOptions {
+    let descriptor = wgpu_types::RequestAdapterOptions {
       power_preference: options
         .power_preference
         .map(|pp| match pp {
@@ -242,14 +242,13 @@ impl GPU {
       compatible_surface: None, // windowless
       apply_limit_buckets: false,
     };
-    let id = instance.request_adapter(&descriptor, backends, None).ok()?;
+    let wgpu_adapter = instance.request_adapter(&descriptor, backends).ok()?;
 
     Some(adapter::GPUAdapter {
-      instance: instance.clone(),
       features: SameObject::new(),
       limits: SameObject::new(),
       info: Rc::new(SameObject::new()),
-      id,
+      wgpu_adapter,
     })
   }
 

--- a/deno_webgpu/pipeline_layout.rs
+++ b/deno_webgpu/pipeline_layout.rs
@@ -6,20 +6,13 @@ use deno_core::webidl::Nullable;
 use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
+use std::sync::Arc;
 
 use crate::error::GPUGenericError;
-use crate::Instance;
 
 pub struct GPUPipelineLayout {
-  pub instance: Instance,
-  pub id: wgpu_core::id::PipelineLayoutId,
+  pub wgpu_pipeline_layout: Arc<wgpu_core::binding_model::PipelineLayout>,
   pub label: String,
-}
-
-impl Drop for GPUPipelineLayout {
-  fn drop(&mut self) {
-    self.instance.pipeline_layout_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPUPipelineLayout {

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
+use std::sync::Arc;
+
 use deno_core::op2;
 use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
@@ -7,20 +9,12 @@ use deno_core::WebIDL;
 use deno_error::JsErrorBox;
 
 use crate::error::GPUGenericError;
-use crate::Instance;
 
 pub struct GPUQuerySet {
-  pub instance: Instance,
-  pub id: wgpu_core::id::QuerySetId,
+  pub wgpu_query_set: Arc<wgpu_core::resource::QuerySet>,
   pub r#type: GPUQueryType,
   pub count: u32,
   pub label: String,
-}
-
-impl Drop for GPUQuerySet {
-  fn drop(&mut self) {
-    self.instance.query_set_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPUQuerySet {
@@ -55,7 +49,7 @@ impl GPUQuerySet {
   #[fast]
   #[undefined]
   fn destroy(&self) -> Result<(), JsErrorBox> {
-    self.instance.query_set_destroy(self.id);
+    self.wgpu_query_set.destroy();
     Ok(())
   }
 

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use deno_core::cppgc::Ptr;
@@ -20,22 +21,14 @@ use crate::texture::GPUTexture;
 use crate::texture::GPUTextureAspect;
 use crate::webidl::GPUExtent3D;
 use crate::webidl::GPUOrigin3D;
-use crate::Instance;
 
 pub struct GPUQueue {
-  pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
   pub label: String,
 
-  pub id: wgpu_core::id::QueueId,
-  pub device: wgpu_core::id::DeviceId,
-}
-
-impl Drop for GPUQueue {
-  fn drop(&mut self) {
-    self.instance.queue_drop(self.id);
-  }
+  pub wgpu_queue: Arc<wgpu_core::device::queue::Queue>,
+  pub wgpu_device: Arc<wgpu_core::device::Device>,
 }
 
 impl GarbageCollected for GPUQueue {
@@ -71,10 +64,10 @@ impl GPUQueue {
   ) -> Result<(), JsErrorBox> {
     let ids = command_buffers
       .into_iter()
-      .map(|cb| cb.id)
+      .map(|cb| cb.wgpu_command_buffer.clone())
       .collect::<Vec<_>>();
 
-    let err = self.instance.queue_submit(self.id, &ids).err();
+    let err = self.wgpu_queue.submit(&ids).err();
 
     if let Some((_, err)) = err {
       self.error_handler.push_error(Some(err));
@@ -94,9 +87,7 @@ impl GPUQueue {
       sender.send(()).unwrap();
     });
 
-    self
-      .instance
-      .queue_on_submitted_work_done(self.id, callback);
+    self.wgpu_queue.on_submitted_work_done(callback);
 
     let done = Rc::new(RefCell::new(false));
     let done_ = done.clone();
@@ -104,8 +95,8 @@ impl GPUQueue {
       while !*done.borrow() {
         {
           self
-            .instance
-            .device_poll(self.device, wgpu_types::PollType::wait_indefinitely())
+            .wgpu_device
+            .poll(wgpu_types::PollType::wait_indefinitely())
             .unwrap();
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -141,8 +132,8 @@ impl GPUQueue {
     let data = get_data_slice(scope, data_arg, data_offset, size)?;
 
     let err = self
-      .instance
-      .queue_write_buffer(self.id, buffer.id, buffer_offset, data)
+      .wgpu_queue
+      .write_buffer(buffer.wgpu_buffer.clone(), buffer_offset, data)
       .err();
 
     self.error_handler.push_error(err);
@@ -160,7 +151,7 @@ impl GPUQueue {
     #[webidl] size: GPUExtent3D,
   ) {
     let destination = wgpu_types::TexelCopyTextureInfo {
-      texture: destination.texture.id,
+      texture: destination.texture.wgpu_texture.clone(),
       mip_level: destination.mip_level,
       origin: destination.origin.into(),
       aspect: destination.aspect.into(),
@@ -173,14 +164,8 @@ impl GPUQueue {
     };
 
     let err = self
-      .instance
-      .queue_write_texture(
-        self.id,
-        &destination,
-        buf,
-        &data_layout,
-        &size.into(),
-      )
+      .wgpu_queue
+      .write_texture(destination, buf, &data_layout, &size.into())
       .err();
 
     self.error_handler.push_error(err);

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::num::NonZeroU64;
+use std::sync::Arc;
 
 use deno_core::cppgc::Ptr;
 use deno_core::op2;
@@ -20,10 +21,8 @@ use crate::buffer::GPUBuffer;
 use crate::error::GPUGenericError;
 use crate::get_data_slice;
 use crate::texture::GPUTextureFormat;
-use crate::Instance;
 
 pub struct GPURenderBundleEncoder {
-  pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
   pub encoder: RefCell<Box<wgpu_core::command::RenderBundleEncoder>>,
@@ -63,18 +62,13 @@ impl GPURenderBundleEncoder {
     let wgpu_descriptor = wgpu_core::command::RenderBundleDescriptor {
       label: crate::transform_label(descriptor.label.clone()),
     };
-
-    let (id, err) = self.instance.render_bundle_encoder_finish(
-      &mut self.encoder.borrow_mut(),
-      &wgpu_descriptor,
-      None,
-    );
+    let (wgpu_render_bundle, err) =
+      self.encoder.borrow_mut().finish(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     GPURenderBundle {
-      instance: self.instance.clone(),
-      id,
+      wgpu_render_bundle,
       label: descriptor.label.clone(),
     }
   }
@@ -87,10 +81,7 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_push_debug_group(encoder, &group_label)
-      .err();
+    let err = encoder.push_debug_group(&group_label).err();
 
     self.error_handler.push_error(err);
 
@@ -103,10 +94,7 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_pop_debug_group(encoder)
-      .err();
+    let err = encoder.pop_debug_group().err();
 
     self.error_handler.push_error(err);
 
@@ -121,10 +109,7 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_insert_debug_marker(encoder, &marker_label)
-      .err();
+    let err = encoder.insert_debug_marker(&marker_label).err();
 
     self.error_handler.push_error(err);
     Ok(())
@@ -177,12 +162,12 @@ impl GPURenderBundleEncoder {
 
       let offsets = &data[start..(start + len)];
 
-      let err = self
-        .instance
-        .render_bundle_encoder_set_bind_group(
-          encoder,
+      let err = encoder
+        .set_bind_group(
           index,
-          bind_group.into_option().map(|bind_group| bind_group.id),
+          bind_group
+            .into_option()
+            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
           offsets,
         )
         .err();
@@ -201,12 +186,12 @@ impl GPURenderBundleEncoder {
       )?
       .unwrap_or_default();
 
-      let err = self
-        .instance
-        .render_bundle_encoder_set_bind_group(
-          encoder,
+      let err = encoder
+        .set_bind_group(
           index,
-          bind_group.into_option().map(|bind_group| bind_group.id),
+          bind_group
+            .into_option()
+            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
           &offsets,
         )
         .err();
@@ -225,9 +210,8 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_set_pipeline(encoder, pipeline.id)
+    let err = encoder
+      .set_pipeline(pipeline.wgpu_render_pipeline.clone())
       .err();
 
     self.error_handler.push_error(err);
@@ -246,11 +230,9 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_set_index_buffer(
-        encoder,
-        buffer.id,
+    let err = encoder
+      .set_index_buffer(
+        buffer.wgpu_buffer.clone(),
         index_format.into(),
         offset,
         size.and_then(NonZeroU64::new),
@@ -274,12 +256,12 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_set_vertex_buffer(
-        encoder,
+    let err = encoder
+      .set_vertex_buffer(
         slot,
-        buffer.into_option().map(|buffer| buffer.id),
+        buffer
+          .into_option()
+          .map(|buffer| buffer.wgpu_buffer.clone()),
         offset,
         size.and_then(NonZeroU64::new),
       )
@@ -300,15 +282,8 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_draw(
-        encoder,
-        vertex_count,
-        instance_count,
-        first_vertex,
-        first_instance,
-      )
+    let err = encoder
+      .draw(vertex_count, instance_count, first_vertex, first_instance)
       .err();
     self.error_handler.push_error(err);
     Ok(())
@@ -327,10 +302,8 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_draw_indexed(
-        encoder,
+    let err = encoder
+      .draw_indexed(
         index_count,
         instance_count,
         first_index,
@@ -352,13 +325,8 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_draw_indirect(
-        encoder,
-        indirect_buffer.id,
-        indirect_offset,
-      )
+    let err = encoder
+      .draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset)
       .err();
     self.error_handler.push_error(err);
     Ok(())
@@ -374,11 +342,9 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_draw_indexed_indirect(
-        encoder,
-        indirect_buffer.id,
+    let err = encoder
+      .draw_indexed_indirect(
+        indirect_buffer.wgpu_buffer.clone(),
         indirect_offset,
       )
       .err();
@@ -401,10 +367,7 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = self
-      .instance
-      .render_bundle_encoder_set_immediates(encoder, offset, data)
-      .err();
+    let err = encoder.set_immediates(offset, data).err();
     self.error_handler.push_error(err);
     Ok(())
   }
@@ -439,15 +402,8 @@ enum SetBindGroupError {
 }
 
 pub struct GPURenderBundle {
-  pub instance: Instance,
-  pub id: wgpu_core::id::RenderBundleId,
+  pub wgpu_render_bundle: Arc<wgpu_core::command::RenderBundle>,
   pub label: String,
-}
-
-impl Drop for GPURenderBundle {
-  fn drop(&mut self) {
-    self.instance.render_bundle_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPURenderBundle {

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::num::NonZeroU64;
+use std::sync::Arc;
 
 use deno_core::cppgc::Ptr;
 use deno_core::op2;
@@ -26,10 +27,8 @@ use crate::render_bundle::GPURenderBundle;
 use crate::texture::GPUTexture;
 use crate::texture::GPUTextureView;
 use crate::webidl::GPUColor;
-use crate::Instance;
 
 pub struct GPURenderPassEncoder {
-  pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
   pub render_pass: RefCell<wgpu_core::command::RenderPass>,
@@ -73,16 +72,9 @@ impl GPURenderPassEncoder {
     #[webidl] max_depth: f32,
   ) {
     let err = self
-      .instance
-      .render_pass_set_viewport(
-        &mut self.render_pass.borrow_mut(),
-        x,
-        y,
-        width,
-        height,
-        min_depth,
-        max_depth,
-      )
+      .render_pass
+      .borrow_mut()
+      .set_viewport(x, y, width, height, min_depth, max_depth)
       .err();
     self.error_handler.push_error(err);
   }
@@ -97,14 +89,9 @@ impl GPURenderPassEncoder {
     #[webidl(options(enforce_range = true))] height: u32,
   ) {
     let err = self
-      .instance
-      .render_pass_set_scissor_rect(
-        &mut self.render_pass.borrow_mut(),
-        x,
-        y,
-        width,
-        height,
-      )
+      .render_pass
+      .borrow_mut()
+      .set_scissor_rect(x, y, width, height)
       .err();
     self.error_handler.push_error(err);
   }
@@ -113,11 +100,9 @@ impl GPURenderPassEncoder {
   #[undefined]
   fn set_blend_constant(&self, #[webidl] color: GPUColor) {
     let err = self
-      .instance
-      .render_pass_set_blend_constant(
-        &mut self.render_pass.borrow_mut(),
-        color.into(),
-      )
+      .render_pass
+      .borrow_mut()
+      .set_blend_constant(color.into())
       .err();
     self.error_handler.push_error(err);
   }
@@ -129,11 +114,9 @@ impl GPURenderPassEncoder {
     #[webidl(options(enforce_range = true))] reference: u32,
   ) {
     let err = self
-      .instance
-      .render_pass_set_stencil_reference(
-        &mut self.render_pass.borrow_mut(),
-        reference,
-      )
+      .render_pass
+      .borrow_mut()
+      .set_stencil_reference(reference)
       .err();
     self.error_handler.push_error(err);
   }
@@ -145,11 +128,9 @@ impl GPURenderPassEncoder {
     #[webidl(options(enforce_range = true))] query_index: u32,
   ) {
     let err = self
-      .instance
-      .render_pass_begin_occlusion_query(
-        &mut self.render_pass.borrow_mut(),
-        query_index,
-      )
+      .render_pass
+      .borrow_mut()
+      .begin_occlusion_query(query_index)
       .err();
     self.error_handler.push_error(err);
   }
@@ -157,10 +138,7 @@ impl GPURenderPassEncoder {
   #[fast]
   #[undefined]
   fn end_occlusion_query(&self) {
-    let err = self
-      .instance
-      .render_pass_end_occlusion_query(&mut self.render_pass.borrow_mut())
-      .err();
+    let err = self.render_pass.borrow_mut().end_occlusion_query().err();
     self.error_handler.push_error(err);
   }
 
@@ -168,12 +146,12 @@ impl GPURenderPassEncoder {
   #[undefined]
   fn execute_bundles(&self, #[webidl] bundles: Vec<Ptr<GPURenderBundle>>) {
     let err = self
-      .instance
-      .render_pass_execute_bundles(
-        &mut self.render_pass.borrow_mut(),
+      .render_pass
+      .borrow_mut()
+      .execute_bundles(
         &bundles
           .into_iter()
-          .map(|bundle| bundle.id)
+          .map(|bundle| bundle.wgpu_render_bundle.clone())
           .collect::<Vec<_>>(),
       )
       .err();
@@ -183,19 +161,16 @@ impl GPURenderPassEncoder {
   #[fast]
   #[undefined]
   fn end(&self) {
-    let err = self
-      .instance
-      .render_pass_end(&mut self.render_pass.borrow_mut())
-      .err();
+    let err = self.render_pass.borrow_mut().end().err();
     self.error_handler.push_error(err);
   }
 
   #[undefined]
   fn push_debug_group(&self, #[webidl] group_label: String) {
     let err = self
-      .instance
-      .render_pass_push_debug_group(
-        &mut self.render_pass.borrow_mut(),
+      .render_pass
+      .borrow_mut()
+      .push_debug_group(
         &group_label,
         0, // wgpu#975
       )
@@ -206,19 +181,16 @@ impl GPURenderPassEncoder {
   #[fast]
   #[undefined]
   fn pop_debug_group(&self) {
-    let err = self
-      .instance
-      .render_pass_pop_debug_group(&mut self.render_pass.borrow_mut())
-      .err();
+    let err = self.render_pass.borrow_mut().pop_debug_group().err();
     self.error_handler.push_error(err);
   }
 
   #[undefined]
   fn insert_debug_marker(&self, #[webidl] marker_label: String) {
     let err = self
-      .instance
-      .render_pass_insert_debug_marker(
-        &mut self.render_pass.borrow_mut(),
+      .render_pass
+      .borrow_mut()
+      .insert_debug_marker(
         &marker_label,
         0, // wgpu#975
       )
@@ -273,11 +245,13 @@ impl GPURenderPassEncoder {
       let offsets = &data[start..(start + len)];
 
       self
-        .instance
-        .render_pass_set_bind_group(
-          &mut self.render_pass.borrow_mut(),
+        .render_pass
+        .borrow_mut()
+        .set_bind_group(
           index,
-          bind_group.into_option().map(|bind_group| bind_group.id),
+          bind_group
+            .into_option()
+            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
           offsets,
         )
         .err()
@@ -295,11 +269,13 @@ impl GPURenderPassEncoder {
       .unwrap_or_default();
 
       self
-        .instance
-        .render_pass_set_bind_group(
-          &mut self.render_pass.borrow_mut(),
+        .render_pass
+        .borrow_mut()
+        .set_bind_group(
           index,
-          bind_group.into_option().map(|bind_group| bind_group.id),
+          bind_group
+            .into_option()
+            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
           &offsets,
         )
         .err()
@@ -316,8 +292,9 @@ impl GPURenderPassEncoder {
     #[webidl] pipeline: Ptr<crate::render_pipeline::GPURenderPipeline>,
   ) {
     let err = self
-      .instance
-      .render_pass_set_pipeline(&mut self.render_pass.borrow_mut(), pipeline.id)
+      .render_pass
+      .borrow_mut()
+      .set_pipeline(pipeline.wgpu_render_pipeline.clone())
       .err();
     self.error_handler.push_error(err);
   }
@@ -332,10 +309,10 @@ impl GPURenderPassEncoder {
     #[webidl(options(enforce_range = true))] size: Option<u64>,
   ) {
     let err = self
-      .instance
-      .render_pass_set_index_buffer(
-        &mut self.render_pass.borrow_mut(),
-        buffer.id,
+      .render_pass
+      .borrow_mut()
+      .set_index_buffer(
+        buffer.wgpu_buffer.clone(),
         index_format.into(),
         offset,
         size.and_then(NonZeroU64::new),
@@ -354,11 +331,13 @@ impl GPURenderPassEncoder {
     #[webidl(options(enforce_range = true))] size: Option<u64>,
   ) {
     let err = self
-      .instance
-      .render_pass_set_vertex_buffer(
-        &mut self.render_pass.borrow_mut(),
+      .render_pass
+      .borrow_mut()
+      .set_vertex_buffer(
         slot,
-        buffer.into_option().map(|buffer| buffer.id),
+        buffer
+          .into_option()
+          .map(|buffer| buffer.wgpu_buffer.clone()),
         offset,
         size.and_then(NonZeroU64::new),
       )
@@ -376,14 +355,9 @@ impl GPURenderPassEncoder {
     #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
   ) {
     let err = self
-      .instance
-      .render_pass_draw(
-        &mut self.render_pass.borrow_mut(),
-        vertex_count,
-        instance_count,
-        first_vertex,
-        first_instance,
-      )
+      .render_pass
+      .borrow_mut()
+      .draw(vertex_count, instance_count, first_vertex, first_instance)
       .err();
     self.error_handler.push_error(err);
   }
@@ -399,9 +373,9 @@ impl GPURenderPassEncoder {
     #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
   ) {
     let err = self
-      .instance
-      .render_pass_draw_indexed(
-        &mut self.render_pass.borrow_mut(),
+      .render_pass
+      .borrow_mut()
+      .draw_indexed(
         index_count,
         instance_count,
         first_index,
@@ -420,12 +394,9 @@ impl GPURenderPassEncoder {
     #[webidl(options(enforce_range = true))] indirect_offset: u64,
   ) {
     let err = self
-      .instance
-      .render_pass_draw_indirect(
-        &mut self.render_pass.borrow_mut(),
-        indirect_buffer.id,
-        indirect_offset,
-      )
+      .render_pass
+      .borrow_mut()
+      .draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset)
       .err();
     self.error_handler.push_error(err);
   }
@@ -438,10 +409,10 @@ impl GPURenderPassEncoder {
     #[webidl(options(enforce_range = true))] indirect_offset: u64,
   ) {
     let err = self
-      .instance
-      .render_pass_draw_indexed_indirect(
-        &mut self.render_pass.borrow_mut(),
-        indirect_buffer.id,
+      .render_pass
+      .borrow_mut()
+      .draw_indexed_indirect(
+        indirect_buffer.wgpu_buffer.clone(),
         indirect_offset,
       )
       .err();
@@ -461,12 +432,9 @@ impl GPURenderPassEncoder {
     let data = get_data_slice(scope, data_arg, data_offset, data_size)?;
 
     let err = self
-      .instance
-      .render_pass_set_immediates(
-        &mut self.render_pass.borrow_mut(),
-        offset,
-        data,
-      )
+      .render_pass
+      .borrow_mut()
+      .set_immediates(offset, data)
       .err();
     self.error_handler.push_error(err);
     Ok(())
@@ -579,10 +547,10 @@ pub(crate) enum GPUTextureOrView {
 }
 
 impl GPUTextureOrView {
-  pub(crate) fn to_view_id(&self) -> wgpu_core::id::TextureViewId {
+  pub(crate) fn to_view(&self) -> Arc<wgpu_core::resource::TextureView> {
     match self {
-      Self::Texture(texture) => texture.default_view_id(),
-      Self::TextureView(texture_view) => texture_view.id,
+      Self::Texture(texture) => texture.default_view(),
+      Self::TextureView(texture_view) => texture_view.wgpu_texture_view.clone(),
     }
   }
 }

--- a/deno_webgpu/render_pipeline.rs
+++ b/deno_webgpu/render_pipeline.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
+use std::sync::Arc;
+
 use deno_core::cppgc::Ptr;
 use deno_core::op2;
 use deno_core::webidl::Nullable;
@@ -15,20 +17,12 @@ use crate::shader::GPUShaderModule;
 use crate::texture::GPUTextureFormat;
 use crate::webidl::GPUColorWriteFlags;
 use crate::webidl::GPUPipelineLayoutOrGPUAutoLayoutMode;
-use crate::Instance;
 
 pub struct GPURenderPipeline {
-  pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
-  pub id: wgpu_core::id::RenderPipelineId,
+  pub wgpu_render_pipeline: Arc<wgpu_core::pipeline::RenderPipeline>,
   pub label: String,
-}
-
-impl Drop for GPURenderPipeline {
-  fn drop(&mut self) {
-    self.instance.render_pipeline_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPURenderPipeline {
@@ -62,16 +56,14 @@ impl GPURenderPipeline {
 
   #[cppgc]
   fn get_bind_group_layout(&self, #[webidl] index: u32) -> GPUBindGroupLayout {
-    let (id, err) = self
-      .instance
-      .render_pipeline_get_bind_group_layout(self.id, index, None);
+    let (wgpu_bind_group_layout, err) =
+      self.wgpu_render_pipeline.get_bind_group_layout(index);
 
     self.error_handler.push_error(err);
 
     // TODO(wgpu): needs to add a way to retrieve the label
     GPUBindGroupLayout {
-      instance: self.instance.clone(),
-      id,
+      wgpu_bind_group_layout,
       label: "".to_string(),
     }
   }

--- a/deno_webgpu/sampler.rs
+++ b/deno_webgpu/sampler.rs
@@ -1,23 +1,17 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
+use std::sync::Arc;
+
 use deno_core::op2;
 use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 
 use crate::error::GPUGenericError;
-use crate::Instance;
 
 pub struct GPUSampler {
-  pub instance: Instance,
-  pub id: wgpu_core::id::SamplerId,
+  pub wgpu_sampler: Arc<wgpu_core::resource::Sampler>,
   pub label: String,
-}
-
-impl Drop for GPUSampler {
-  fn drop(&mut self) {
-    self.instance.sampler_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPUSampler {

--- a/deno_webgpu/shader.rs
+++ b/deno_webgpu/shader.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
+use std::sync::Arc;
+
 use deno_core::cppgc::make_cppgc_object;
 use deno_core::op2;
 use deno_core::v8;
@@ -9,19 +11,11 @@ use deno_core::WebIDL;
 use wgpu_core::pipeline;
 
 use crate::error::GPUGenericError;
-use crate::Instance;
 
 pub struct GPUShaderModule {
-  pub instance: Instance,
-  pub id: wgpu_core::id::ShaderModuleId,
+  pub wgpu_shader_module: Arc<wgpu_core::pipeline::ShaderModule>,
   pub label: String,
   pub compilation_info: v8::Global<v8::Object>,
-}
-
-impl Drop for GPUShaderModule {
-  fn drop(&mut self) {
-    self.instance.shader_module_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPUShaderModule {

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 use std::cell::RefCell;
+use std::sync::Arc;
 
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
@@ -39,7 +40,7 @@ pub struct Configuration {
 }
 
 pub struct GPUCanvasContext {
-  pub surface_id: wgpu_core::id::SurfaceId,
+  pub wgpu_surface: Arc<wgpu_core::instance::Surface>,
   pub width: RefCell<u32>,
   pub height: RefCell<u32>,
 
@@ -105,10 +106,7 @@ impl GPUCanvasContext {
 
     let device = configuration.device;
 
-    let err =
-      device
-        .instance
-        .surface_configure(self.surface_id, device.id, &conf);
+    let err = self.wgpu_surface.configure(&device.wgpu_device, &conf);
 
     device.error_handler.push_error(err);
 
@@ -144,20 +142,14 @@ impl GPUCanvasContext {
       }
     }
 
-    let output = config
-      .device
-      .instance
-      .surface_get_current_texture(self.surface_id, None)?;
+    let output = self.wgpu_surface.get_current_texture()?;
 
     match output.status {
       SurfaceStatus::Good | SurfaceStatus::Suboptimal => {
-        let id = output.texture.unwrap();
-
         let texture = GPUTexture {
-          instance: config.device.instance.clone(),
           error_handler: config.device.error_handler.clone(),
-          id,
-          default_view_id: Default::default(),
+          wgpu_texture: output.texture.unwrap(),
+          default_view: Default::default(),
           label: "".to_string(),
           size: wgpu_types::Extent3d {
             width: *self.width.borrow(),
@@ -184,11 +176,11 @@ impl GPUCanvasContext {
 impl GPUCanvasContext {
   pub fn present(&self) -> Result<(), SurfaceError> {
     let config = self.config.borrow();
-    let Some(config) = config.as_ref() else {
+    if config.is_none() {
       return Err(SurfaceError::UnconfiguredContext);
     };
 
-    config.device.instance.surface_present(self.surface_id)?;
+    self.wgpu_surface.present()?;
 
     // next `get_current_texture` call would get a new texture
     *self.texture.borrow_mut() = None;
@@ -208,11 +200,9 @@ impl GPUCanvasContext {
     config.surface_config.width = width;
     config.surface_config.height = height;
 
-    let err = config.device.instance.surface_configure(
-      self.surface_id,
-      config.device.id,
-      &config.surface_config,
-    );
+    let err = self
+      .wgpu_surface
+      .configure(&config.device.wgpu_device, &config.surface_config);
 
     config.device.error_handler.push_error(err);
   }

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 use deno_core::op2;
@@ -17,7 +18,6 @@ use wgpu_types::TextureViewDimension;
 
 use crate::error::GPUGenericError;
 use crate::webidl::GPUTextureUsageFlags;
-use crate::Instance;
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
@@ -41,11 +41,10 @@ pub(crate) struct GPUTextureDescriptor {
 }
 
 pub struct GPUTexture {
-  pub instance: Instance,
   pub error_handler: super::error::ErrorHandler,
 
-  pub id: wgpu_core::id::TextureId,
-  pub default_view_id: OnceLock<wgpu_core::id::TextureViewId>,
+  pub wgpu_texture: Arc<wgpu_core::resource::Texture>,
+  pub default_view: OnceLock<Arc<wgpu_core::resource::TextureView>>,
 
   pub label: String,
 
@@ -58,35 +57,27 @@ pub struct GPUTexture {
 }
 
 impl GPUTexture {
-  pub(crate) fn default_view_id(&self) -> wgpu_core::id::TextureViewId {
-    *self.default_view_id.get_or_init(|| {
-      let (id, err) =
-        self
-          .instance
-          .texture_create_view(self.id, &Default::default(), None);
-      if let Some(err) = err {
-        use wgpu_types::error::WebGpuError;
-        assert_ne!(
-          err.webgpu_error_type(),
-          wgpu_types::error::ErrorType::Validation,
-          concat!(
-            "getting default view for a texture ",
-            "caused a validation error (!?)"
-          )
-        );
-        self.error_handler.push_error(Some(err));
-      }
-      id
-    })
-  }
-}
-
-impl Drop for GPUTexture {
-  fn drop(&mut self) {
-    if let Some(id) = self.default_view_id.take() {
-      self.instance.texture_view_drop(id);
-    }
-    self.instance.texture_drop(self.id);
+  pub(crate) fn default_view(&self) -> Arc<wgpu_core::resource::TextureView> {
+    self
+      .default_view
+      .get_or_init(|| {
+        let (wgpu_texture_view, err) =
+          self.wgpu_texture.create_view(&Default::default());
+        if let Some(err) = err {
+          use wgpu_types::error::WebGpuError;
+          assert_ne!(
+            err.webgpu_error_type(),
+            wgpu_types::error::ErrorType::Validation,
+            concat!(
+              "getting default view for a texture ",
+              "caused a validation error (!?)"
+            )
+          );
+          self.error_handler.push_error(Some(err));
+        }
+        wgpu_texture_view
+      })
+      .clone()
   }
 }
 
@@ -156,7 +147,7 @@ impl GPUTexture {
   #[fast]
   #[undefined]
   fn destroy(&self) {
-    self.instance.texture_destroy(self.id);
+    self.wgpu_texture.destroy();
   }
 
   #[cppgc]
@@ -178,16 +169,13 @@ impl GPUTexture {
       },
     };
 
-    let (id, err) =
-      self
-        .instance
-        .texture_create_view(self.id, &wgpu_descriptor, None);
+    let (wgpu_texture_view, err) =
+      self.wgpu_texture.create_view(&wgpu_descriptor);
 
     self.error_handler.push_error(err);
 
     Ok(GPUTextureView {
-      instance: self.instance.clone(),
-      id,
+      wgpu_texture_view,
       label: descriptor.label,
     })
   }
@@ -266,15 +254,8 @@ impl From<GPUTextureAspect> for TextureAspect {
 }
 
 pub struct GPUTextureView {
-  pub instance: Instance,
-  pub id: wgpu_core::id::TextureViewId,
+  pub wgpu_texture_view: Arc<wgpu_core::resource::TextureView>,
   pub label: String,
-}
-
-impl Drop for GPUTextureView {
-  fn drop(&mut self) {
-    self.instance.texture_view_drop(self.id);
-  }
 }
 
 impl WebIdlInterfaceConverter for GPUTextureView {
@@ -711,7 +692,7 @@ impl From<GPUTextureFormat> for TextureFormat {
 }
 
 pub struct GPUExternalTexture {
-  pub id: wgpu_core::id::ExternalTextureId,
+  pub wgpu_external_texture: Arc<wgpu_core::resource::ExternalTexture>,
 }
 
 impl WebIdlInterfaceConverter for GPUExternalTexture {

--- a/deno_webgpu/webidl.rs
+++ b/deno_webgpu/webidl.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use deno_core::cppgc::Ptr;
 use deno_core::v8;
@@ -327,12 +328,12 @@ pub(crate) enum GPUPipelineLayoutOrGPUAutoLayoutMode {
 }
 
 impl From<GPUPipelineLayoutOrGPUAutoLayoutMode>
-  for Option<wgpu_core::id::PipelineLayoutId>
+  for Option<Arc<wgpu_core::binding_model::PipelineLayout>>
 {
   fn from(value: GPUPipelineLayoutOrGPUAutoLayoutMode) -> Self {
     match value {
       GPUPipelineLayoutOrGPUAutoLayoutMode::PipelineLayout(layout) => {
-        Some(layout.id)
+        Some(layout.wgpu_pipeline_layout.clone())
       }
       GPUPipelineLayoutOrGPUAutoLayoutMode::AutoLayoutMode(
         GPUAutoLayoutMode::Auto,

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -466,7 +466,7 @@ fn transition_resources(
 }
 
 impl CommandEncoder {
-    fn begin_compute_pass(
+    pub fn begin_compute_pass(
         self: &Arc<Self>,
         desc: &ComputePassDescriptor<'_, PassTimestampWrites<Arc<QuerySet>>>,
     ) -> (ComputePass, Option<CommandEncoderError>) {
@@ -557,7 +557,7 @@ impl CommandEncoder {
 
 // Running the compute pass.
 impl ComputePass {
-    fn end(&mut self) -> Result<(), EncoderStateError> {
+    pub fn end(&mut self) -> Result<(), EncoderStateError> {
         profiling::scope!(
             "CommandEncoder::run_compute_pass {}",
             self.base.label.as_deref().unwrap_or("")

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -61,7 +61,7 @@ pub use self::{
         ColorAttachmentError, ColorAttachments, LoadOp, PassChannel, RenderBasePass, RenderPass,
         RenderPassColorAttachment, RenderPassDepthStencilAttachment, RenderPassDescriptor,
         RenderPassError, RenderPassErrorInner, ResolvedPassChannel,
-        ResolvedRenderPassDepthStencilAttachment, StoreOp,
+        ResolvedRenderPassDepthStencilAttachment, ResolvedRenderPassDescriptor, StoreOp,
     },
     render_command::ArcRenderCommand,
     transfer::{CopySide, TransferError},

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1826,8 +1826,8 @@ fn check_transient_attachment_ops<V>(load_op: LoadOp<V>, store_op: StoreOp) -> b
 }
 
 impl CommandEncoder {
-    fn begin_render_pass(
-        self: Arc<Self>,
+    pub fn begin_render_pass(
+        self: &Arc<Self>,
         desc: ResolvedRenderPassDescriptor<'_>,
     ) -> (RenderPass, Option<CommandEncoderError>) {
         use EncoderStateError as SErr;
@@ -2095,9 +2095,9 @@ impl CommandEncoder {
                     multiview_mask: None,
                 };
                 match fill_arc_desc(desc, &mut arc_desc, &self.device) {
-                    Ok(()) => (RenderPass::new(self, arc_desc), None),
+                    Ok(()) => (RenderPass::new(self.clone(), arc_desc), None),
                     Err(err) => (
-                        RenderPass::new_invalid(self, &label, err.map_pass_err(scope)),
+                        RenderPass::new_invalid(self.clone(), &label, err.map_pass_err(scope)),
                         None,
                     ),
                 }
@@ -2109,7 +2109,7 @@ impl CommandEncoder {
                 cmd_buf_data.invalidate(err.clone());
                 drop(cmd_buf_data);
                 (
-                    RenderPass::new_invalid(self, &desc.label, err.map_pass_err(scope)),
+                    RenderPass::new_invalid(self.clone(), &desc.label, err.map_pass_err(scope)),
                     None,
                 )
             }
@@ -2118,7 +2118,11 @@ impl CommandEncoder {
                 // generates an immediate validation error.
                 drop(cmd_buf_data);
                 (
-                    RenderPass::new_invalid(self, &desc.label, err.clone().map_pass_err(scope)),
+                    RenderPass::new_invalid(
+                        self.clone(),
+                        &desc.label,
+                        err.clone().map_pass_err(scope),
+                    ),
                     Some(err.into()),
                 )
             }
@@ -2130,7 +2134,7 @@ impl CommandEncoder {
                 // invalid pass to save that work.
                 drop(cmd_buf_data);
                 (
-                    RenderPass::new_invalid(self, &desc.label, err.map_pass_err(scope)),
+                    RenderPass::new_invalid(self.clone(), &desc.label, err.map_pass_err(scope)),
                     None,
                 )
             }


### PR DESCRIPTION
**Connections**
Towards #5121

Depends on https://github.com/gfx-rs/wgpu/pull/9895
Depends on https://github.com/gfx-rs/wgpu/pull/9915
Depends on https://github.com/gfx-rs/wgpu/pull/9916

**Description**
No more `Global` and `Id`s in deno. Each `struct GPU*` now has `wgpu_*` field for Arced wgc resources.

**Testing**
Just refactor.

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
