### PR TITLE
Update CI to Mesa 26.1.3.

### DIFF
--- a/.github/actions/install-mesa/action.yml
+++ b/.github/actions/install-mesa/action.yml
@@ -4,10 +4,10 @@ inputs:
   # Sourced from https://archive.mesa3d.org/. Bumping this requires
   # updating the mesa build in https://github.com/gfx-rs/ci-build and creating a new release.
   version:
-    default: "25.2.7"
+    default: "26.1.3"
   # Corresponds to https://github.com/gfx-rs/ci-build/releases
   ci-binary-build:
-    default: "build26"
+    default: "build29"
   target-dir:
     description: "The directory into which to install the Mesa libraries."
     default: "target/llvm-cov-target/debug"
@@ -33,10 +33,11 @@ runs:
         cat <<- EOF > icd.json
         {
           "ICD": {
-              "api_version": "1.1.255",
+              "api_version": "1.4.348",
+              "library_arch": "64",
               "library_path": "$PWD/mesa/lib/x86_64-linux-gnu/libvulkan_lvp.so"
           },
-          "file_format_version": "1.0.0"
+          "file_format_version": "1.0.1"
         }
         EOF
 


### PR DESCRIPTION
Update `.github/actions/install-mesa/action.yml` to refer to <del>`build27`</del> <del>`build28`</del> `build29`, which is Mesa <del>26.1.5</del> <del>26.0.3</del> 26.1.3. Update the generated ICD file's API version, and add a `library_arch` field; update `file_format_version` accordingly.

This should not be merged until after #9892.
