### PR TITLE
Fix `flush_immediates` out of range

### DIFF
--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -302,19 +302,11 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
     }
 
     fn flush_immediates(&mut self) {
-        // SAFETY: The range of immediates written was validated in `is_ready`.
-        unsafe {
-            self.pass.immediate_state.flush_immediates(
-                self.pipeline
-                    .as_ref()
-                    .unwrap()
-                    .layout()
-                    .unwrap()
-                    .raw()
-                    .unwrap(),
-                self.pass.base.raw_encoder,
-            );
-        }
+        let pipeline = self.pipeline.as_ref().unwrap();
+        let layout = pipeline.layout().unwrap();
+        self.pass
+            .immediate_state
+            .flush_immediates(layout, self.pass.base.raw_encoder);
     }
 
     /// Flush binding state in preparation for a dispatch.

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -82,14 +82,22 @@ impl ImmediateState {
         Ok(())
     }
 
-    pub(crate) unsafe fn flush_immediates(
+    pub(crate) fn flush_immediates(
         &mut self,
-        raw_layout: &dyn hal::DynPipelineLayout,
+        layout: &Arc<binding_model::PipelineLayout>,
         raw_encoder: &mut dyn hal::DynCommandEncoder,
     ) {
         if !self.immediates.is_empty() && self.immediates_dirty {
+            // SAFETY: The range of immediates written is within layout immediate size.
             unsafe {
-                raw_encoder.set_immediates(raw_layout, 0, &self.immediates);
+                raw_encoder.set_immediates(
+                    layout.raw().unwrap(),
+                    0,
+                    &self.immediates[..(self
+                        .immediates
+                        .len()
+                        .min(layout.immediate_size as usize / size_of::<u32>()))],
+                );
             }
             self.immediates_dirty = false;
         }

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -739,19 +739,11 @@ impl<'scope, 'snatch_guard, 'cmd_enc> State<'scope, 'snatch_guard, 'cmd_enc> {
     }
 
     fn flush_immediates(&mut self) {
-        // SAFETY: The range of immediates written was validated in `is_ready`.
-        unsafe {
-            self.pass.immediate_state.flush_immediates(
-                self.pipeline
-                    .as_ref()
-                    .unwrap()
-                    .layout()
-                    .unwrap()
-                    .raw()
-                    .unwrap(),
-                self.pass.base.raw_encoder,
-            );
-        }
+        let pipeline = self.pipeline.as_ref().unwrap();
+        let layout = pipeline.layout().unwrap();
+        self.pass
+            .immediate_state
+            .flush_immediates(layout, self.pass.base.raw_encoder);
     }
 
     /// Flush binding state in preparation for a draw call.

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -203,9 +203,6 @@ fn cts_error_is_waived(message_id_number: i32) -> bool {
     }
 
     const WAIVED_MESSAGE_IDS: &[i32] = &[
-        // VUID-vkCmdPushConstants-offset-01795
-        // e.g. webgpu:api,operation,command_buffer,programmable,immediate:*
-        0x27bc88c6_u32 as i32,
         // VUID-SampleMask-SampleMask-04359
         // e.g. webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,*
         0x34d444b2_u32 as i32,


### PR DESCRIPTION
**Connections**
#9880

**Description**
Setting immediates out of the range of pipeline layout immediate size causes `VUID-vkCmdPushConstants-offset-01795`, which is a bug since #9597.
This PR changes `flush_immediates` to consider layout immediate size so that it's within range.

**Testing**
`cargo xtask cts 'webgpu:api,operation,command_buffer,programmable,immediate:*'`

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
