### PR TITLE
hal/vulkan: add OpenHarmony surface support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Bottom level categories:
 
 #### Vulkan
 
+- Add OpenHarmony surface support via `VK_OHOS_surface`. Previously the Vulkan backend could not create a surface on OpenHarmony, leaving GLES as the only usable backend. By @ozongzi in [#9908](https://github.com/gfx-rs/wgpu/pull/9908).
 - Stop passing an un-waited fence to `vkAcquireNextImageKHR` on non-Windows platforms, which triggered `VUID-vkAcquireNextImageKHR-fence-10066` validation errors every frame since v30.0.0. By @ErichDonGubler in [#9855](https://github.com/gfx-rs/wgpu/issues/9855).
 
 #### GLES

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -11,10 +11,7 @@ use arrayvec::ArrayVec;
 use ash::{ext, khr, vk};
 use parking_lot::RwLock;
 
-/// Name of the `VK_OHOS_surface` extension.
-///
-/// `ash` does not generate OpenHarmony bindings, so this mirrors
-/// `VK_OHOS_SURFACE_EXTENSION_NAME` from the OpenHarmony SDK's `vulkan_ohos.h`.
+/// Name of the `VK_OHOS_surface` extension. Used with [`create_surface_ohos`].
 #[cfg(target_env = "ohos")]
 const OHOS_SURFACE_EXTENSION_NAME: &CStr = c"VK_OHOS_surface";
 
@@ -587,12 +584,12 @@ impl super::Instance {
         Ok(self.create_surface_from_vk_surface_khr(surface, None))
     }
 
-    /// OpenHarmony window-system integration.
+    /// OpenHarmony window-system integration, using the `VK_OHOS_surface` extension.
     ///
-    /// `ash` has no `VK_OHOS_surface` bindings, so the `vkCreateSurfaceOHOS` entry point is
-    /// resolved manually and `VkSurfaceCreateInfoOHOS` is declared here, matching the
-    /// OpenHarmony SDK's `vulkan_ohos.h` (`VK_STRUCTURE_TYPE_SURFACE_CREATE_INFO_OHOS`
-    /// is 1000685000).
+    /// `ash` has no bindings for this, so we create bindings ad-hoc as needed. See also:
+    ///
+    /// - <https://docs.vulkan.org/refpages/latest/refpages/source/VK_OHOS_surface.html>
+    /// - [`vulkan_ohos.h`](https://github.com/KhronosGroup/Vulkan-Headers/blob/e3b1eec08173d6b825cd3ac88c885a63b621504a/include/vulkan/vulkan_ohos.h)
     ///
     /// `window` is the `OHNativeWindow*` handed out by an XComponent.
     #[cfg(target_env = "ohos")]
@@ -600,6 +597,8 @@ impl super::Instance {
         &self,
         window: *mut c_void,
     ) -> Result<super::Surface, crate::InstanceError> {
+        // - Upstream docs:
+        // <https://docs.vulkan.org/refpages/latest/refpages/source/VkSurfaceCreateInfoOHOS.html>
         #[repr(C)]
         struct VkSurfaceCreateInfoOHOS {
             s_type: vk::StructureType,
@@ -607,8 +606,14 @@ impl super::Instance {
             flags: vk::Flags,
             window: *mut c_void,
         }
+
+        // - Upstream docs: Search for term `VK_STRUCTURE_TYPE_SURFACE_CREATE_INFO_OHOS` in
+        // <https://docs.vulkan.org/refpages/latest/refpages/source/VkStructureType.html>.
         const S_TYPE_SURFACE_CREATE_INFO_OHOS: vk::StructureType =
             vk::StructureType::from_raw(1000685000);
+
+        // - Upstream docs:
+        // <https://docs.vulkan.org/refpages/latest/refpages/source/vkCreateSurfaceOHOS.html>
         type PfnCreateSurfaceOHOS = unsafe extern "system" fn(
             vk::Instance,
             *const VkSurfaceCreateInfoOHOS,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -11,7 +11,7 @@ use arrayvec::ArrayVec;
 use ash::{ext, khr, vk};
 use parking_lot::RwLock;
 
-/// Name of the `VK_OHOS_surface` extension. Used with [`create_surface_ohos`].
+/// Name of the `VK_OHOS_surface` extension. Used with [`super::Instance::create_surface_ohos`].
 #[cfg(target_env = "ohos")]
 const OHOS_SURFACE_EXTENSION_NAME: &CStr = c"VK_OHOS_surface";
 

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -11,6 +11,13 @@ use arrayvec::ArrayVec;
 use ash::{ext, khr, vk};
 use parking_lot::RwLock;
 
+/// Name of the `VK_OHOS_surface` extension.
+///
+/// `ash` does not generate OpenHarmony bindings, so this mirrors
+/// `VK_OHOS_SURFACE_EXTENSION_NAME` from the OpenHarmony SDK's `vulkan_ohos.h`.
+#[cfg(target_env = "ohos")]
+const OHOS_SURFACE_EXTENSION_NAME: &CStr = c"VK_OHOS_surface";
+
 unsafe extern "system" fn debug_utils_messenger_callback(
     message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
     message_type: vk::DebugUtilsMessageTypeFlagsEXT,
@@ -309,10 +316,15 @@ impl super::Instance {
         extensions.push(khr::surface::NAME);
 
         // Platform-specific WSI extensions
+        //
+        // Note: OpenHarmony (`target_env = "ohos"`) reports `target_os = "linux"` and is
+        // unix, but has neither X11 nor Wayland. It must be excluded here and uses
+        // `VK_OHOS_surface` instead (see below).
         if cfg!(all(
             unix,
             not(target_os = "android"),
-            not(target_os = "macos")
+            not(target_os = "macos"),
+            not(target_env = "ohos")
         )) {
             // VK_KHR_xlib_surface
             extensions.push(khr::xlib_surface::NAME);
@@ -324,6 +336,11 @@ impl super::Instance {
         if cfg!(target_os = "android") {
             // VK_KHR_android_surface
             extensions.push(khr::android_surface::NAME);
+        }
+        #[cfg(target_env = "ohos")]
+        {
+            // VK_OHOS_surface: surfaces are created from an XComponent's `OHNativeWindow`.
+            extensions.push(OHOS_SURFACE_EXTENSION_NAME);
         }
         if cfg!(target_os = "windows") {
             // VK_KHR_win32_surface
@@ -566,6 +583,74 @@ impl super::Instance {
         .map_err(|err| {
             crate::InstanceError::with_source(String::from("AndroidSurface failed"), err)
         })?;
+
+        Ok(self.create_surface_from_vk_surface_khr(surface, None))
+    }
+
+    /// OpenHarmony window-system integration.
+    ///
+    /// `ash` has no `VK_OHOS_surface` bindings, so the `vkCreateSurfaceOHOS` entry point is
+    /// resolved manually and `VkSurfaceCreateInfoOHOS` is declared here, matching the
+    /// OpenHarmony SDK's `vulkan_ohos.h` (`VK_STRUCTURE_TYPE_SURFACE_CREATE_INFO_OHOS`
+    /// is 1000685000).
+    ///
+    /// `window` is the `OHNativeWindow*` handed out by an XComponent.
+    #[cfg(target_env = "ohos")]
+    fn create_surface_ohos(
+        &self,
+        window: *mut c_void,
+    ) -> Result<super::Surface, crate::InstanceError> {
+        if !self
+            .shared
+            .extensions
+            .contains(&OHOS_SURFACE_EXTENSION_NAME)
+        {
+            return Err(crate::InstanceError::new(String::from(
+                "Vulkan driver does not support VK_OHOS_surface",
+            )));
+        }
+
+        #[repr(C)]
+        struct VkSurfaceCreateInfoOHOS {
+            s_type: vk::StructureType,
+            p_next: *const c_void,
+            flags: vk::Flags,
+            window: *mut c_void,
+        }
+        const S_TYPE_SURFACE_CREATE_INFO_OHOS: vk::StructureType =
+            vk::StructureType::from_raw(1000685000);
+        type PfnCreateSurfaceOHOS = unsafe extern "system" fn(
+            vk::Instance,
+            *const VkSurfaceCreateInfoOHOS,
+            *const vk::AllocationCallbacks,
+            *mut vk::SurfaceKHR,
+        ) -> vk::Result;
+
+        let raw_instance = self.shared.raw.handle();
+        let Some(pfn) = (unsafe {
+            self.shared
+                .entry
+                .get_instance_proc_addr(raw_instance, c"vkCreateSurfaceOHOS".as_ptr())
+        }) else {
+            return Err(crate::InstanceError::new(String::from(
+                "vkCreateSurfaceOHOS not exposed by Vulkan driver",
+            )));
+        };
+        let create: PfnCreateSurfaceOHOS = unsafe { core::mem::transmute(pfn) };
+
+        let info = VkSurfaceCreateInfoOHOS {
+            s_type: S_TYPE_SURFACE_CREATE_INFO_OHOS,
+            p_next: core::ptr::null(),
+            flags: 0,
+            window,
+        };
+        let mut surface = vk::SurfaceKHR::null();
+        let result = unsafe { create(raw_instance, &info, core::ptr::null(), &mut surface) };
+        if result != vk::Result::SUCCESS {
+            return Err(crate::InstanceError::new(format!(
+                "vkCreateSurfaceOHOS failed: {result:?}"
+            )));
+        }
 
         Ok(self.create_surface_from_vk_surface_khr(surface, None))
     }
@@ -995,6 +1080,8 @@ impl crate::Instance for super::Instance {
             (Rwh::AndroidNdk(handle), _) => {
                 self.create_surface_android(handle.a_native_window.as_ptr())
             }
+            #[cfg(target_env = "ohos")]
+            (Rwh::OhosNdk(handle), _) => self.create_surface_ohos(handle.native_window.as_ptr()),
             (Rwh::Win32(handle), _) => {
                 let hinstance = handle.hinstance.ok_or_else(|| {
                     crate::InstanceError::new(String::from(

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -600,16 +600,6 @@ impl super::Instance {
         &self,
         window: *mut c_void,
     ) -> Result<super::Surface, crate::InstanceError> {
-        if !self
-            .shared
-            .extensions
-            .contains(&OHOS_SURFACE_EXTENSION_NAME)
-        {
-            return Err(crate::InstanceError::new(String::from(
-                "Vulkan driver does not support VK_OHOS_surface",
-            )));
-        }
-
         #[repr(C)]
         struct VkSurfaceCreateInfoOHOS {
             s_type: vk::StructureType,
@@ -625,6 +615,16 @@ impl super::Instance {
             *const vk::AllocationCallbacks,
             *mut vk::SurfaceKHR,
         ) -> vk::Result;
+
+        if !self
+            .shared
+            .extensions
+            .contains(&OHOS_SURFACE_EXTENSION_NAME)
+        {
+            return Err(crate::InstanceError::new(String::from(
+                "Vulkan driver does not support VK_OHOS_surface",
+            )));
+        }
 
         let raw_instance = self.shared.raw.handle();
 

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -313,14 +313,12 @@ impl super::Instance {
         extensions.push(khr::surface::NAME);
 
         // Platform-specific WSI extensions
-        //
-        // Note: OpenHarmony (`target_env = "ohos"`) reports `target_os = "linux"` and is
-        // unix, but has neither X11 nor Wayland. It must be excluded here and uses
-        // `VK_OHOS_surface` instead (see below).
         if cfg!(all(
             unix,
             not(target_os = "android"),
             not(target_os = "macos"),
+            // NOTE: OpenHarmony (`target_env = "ohos"`) reports `target_os = "linux"` and is
+            // unix, but has neither X11 nor Wayland.
             not(target_env = "ohos")
         )) {
             // VK_KHR_xlib_surface

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -627,16 +627,25 @@ impl super::Instance {
         ) -> vk::Result;
 
         let raw_instance = self.shared.raw.handle();
-        let Some(pfn) = (unsafe {
+
+        // SAFETY: This is safe because:
+        //
+        // - `raw_instance` is a valid Vulkan instance, and the string we're asking for is
+        //   properly encoded and NUL-terminated.
+        let create = unsafe {
             self.shared
                 .entry
                 .get_instance_proc_addr(raw_instance, c"vkCreateSurfaceOHOS".as_ptr())
-        }) else {
+        };
+        let create =
+            // SAFETY: This function is safe, because we `transmute` between two function pointers
+            // with the same ABI, with the same validity, size, and alignment before and after.
+            unsafe { core::mem::transmute::<vk::PFN_vkVoidFunction, Option<PfnCreateSurfaceOHOS>>(create) };
+        let Some(create) = create else {
             return Err(crate::InstanceError::new(String::from(
                 "vkCreateSurfaceOHOS not exposed by Vulkan driver",
             )));
         };
-        let create: PfnCreateSurfaceOHOS = unsafe { core::mem::transmute(pfn) };
 
         let info = VkSurfaceCreateInfoOHOS {
             s_type: S_TYPE_SURFACE_CREATE_INFO_OHOS,
@@ -645,6 +654,11 @@ impl super::Instance {
             window,
         };
         let mut surface = vk::SurfaceKHR::null();
+        // SAFETY: This is safe because:
+        //
+        // - This function signature is specced to match the signature we casted it to.
+        // - During the previous `transmute` operation, we took care to keep the same ABI (see also
+        // <https://doc.rust-lang.org/nightly/std/primitive.fn.html#abi-compatibility>).
         let result = unsafe { create(raw_instance, &info, core::ptr::null(), &mut surface) };
         if result != vk::Result::SUCCESS {
             return Err(crate::InstanceError::new(format!(


### PR DESCRIPTION
**Connections**

Related to #9158 (GLES sRGB issues, mainly on OpenHarmony). This does not fix that
issue, but it gives OpenHarmony users a Vulkan path instead of leaving them stuck on
the GLES backend.

**Description**

The Vulkan backend has no OpenHarmony window-system integration, so `create_surface`
fails there and GLES is the only backend that works. That rules out anything needing
`VERTEX_STORAGE` or compute, even though OpenHarmony devices ship a working Vulkan
driver and the platform provides `VK_OHOS_surface`.

Three changes:

- `desired_extensions` now asks for `VK_OHOS_surface` on `target_env = "ohos"`. That
  list already gets filtered against the available instance extensions, so a driver
  without the extension just drops it and surface creation fails later with a clear
  message, rather than breaking instance creation.
- `create_surface_ohos` builds the surface from the `OHNativeWindow` that an
  XComponent hands out. `raw-window-handle` already exposes it as
  `RawWindowHandle::OhosNdk`, and the GLES backend already consumes it.
- OpenHarmony no longer picks up the X11/Wayland extensions. It is unix and reports
  `target_os = "linux"`, but has neither.

`ash` has no OpenHarmony bindings, so this resolves `vkCreateSurfaceOHOS` through
`get_instance_proc_addr` and declares `VkSurfaceCreateInfoOHOS` locally, copied from
the OpenHarmony SDK's `vulkan_ohos.h`. Same situation as the existing
`Entry::load_from("libvulkan.so")` call on ohos. Once `ash` ships bindings, both can
go away.

**Testing**

Nothing automated. CI has no OpenHarmony runner, and creating a surface needs a real
XComponent, so none of the existing test suites can reach this path.

I tested it by hand on a HUAWEI MatePad Air (Maleoon 920, HarmonyOS 6.1), running a
renderer that uses storage buffers and compute. Before the patch, Vulkan surface
creation fails, the adapter comes back as `backend: Gl` (`OpenGL ES 3.2`), and any
bind group layout with a storage buffer in the vertex stage dies with
`DownlevelFlags(VERTEX_STORAGE) are required but not supported`. After it, the Vulkan
adapter gets picked and those pipelines build and render.

I have not tried the ohos emulator or any non-Huawei OpenHarmony device.

**Squash or Rebase?**

Single commit, ready to rebase onto `trunk` as it stands.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
      (Only on OpenHarmony, where Vulkan becomes usable instead of GLES-only.)
- [x] Validation and feature gates are in place to confine behavioral changes.
      (All of it sits behind `cfg(target_env = "ohos")`. Extension availability is
      checked at runtime and reported as a normal `InstanceError`.)
- [ ] Tests demonstrate the validation and altered logic works.
      Not done, for the reasons under Testing. If there is a pattern for covering
      platform WSI code that I have missed, I am happy to add it.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
