### PR TITLE
fix(core): Add some missing validity checks

### DIFF
--- a/tests/tests/wgpu-gpu/resource_error.rs
+++ b/tests/tests/wgpu-gpu/resource_error.rs
@@ -1,11 +1,11 @@
 use wgpu_test::{fail, gpu_test, valid, GpuTestConfiguration, GpuTestInitializer, TestParameters};
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
-    vec.extend([BAD_BUFFER, BAD_TEXTURE]);
+    vec.extend([BAD_BUFFER_MAP, BAD_TEXTURE_CREATE_VIEW, BAD_TEXTURE_WRITE]);
 }
 
 #[gpu_test]
-static BAD_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
+static BAD_BUFFER_MAP: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         // Create a buffer with bad parameters and call a few methods.
@@ -38,7 +38,7 @@ static BAD_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
     });
 
 #[gpu_test]
-static BAD_TEXTURE: GpuTestConfiguration = GpuTestConfiguration::new()
+static BAD_TEXTURE_CREATE_VIEW: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(TestParameters::default().enable_noop())
     .run_sync(|ctx| {
         let texture = fail(
@@ -71,4 +71,52 @@ static BAD_TEXTURE: GpuTestConfiguration = GpuTestConfiguration::new()
         );
         valid(&ctx.device, || texture.destroy());
         valid(&ctx.device, || texture.destroy());
+    });
+
+#[gpu_test]
+static BAD_TEXTURE_WRITE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_sync(|ctx| {
+        let texture = fail(
+            &ctx.device,
+            || {
+                ctx.device.create_texture(&wgpu::TextureDescriptor {
+                    label: None,
+                    size: wgpu::Extent3d {
+                        width: 256,
+                        height: 256,
+                        depth_or_array_layers: 1,
+                    },
+                    mip_level_count: 5888,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: wgpu::TextureFormat::Rgba8Unorm,
+                    usage: wgpu::TextureUsages::COPY_DST,
+                    view_formats: &[],
+                })
+            },
+            Some("mip level count"),
+        );
+
+        fail(
+            &ctx.device,
+            || {
+                ctx.queue.write_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &texture,
+                        mip_level: 255,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    &[0u8; 4],
+                    wgpu::TexelCopyBufferLayout::default(),
+                    wgpu::Extent3d {
+                        width: 1,
+                        height: 1,
+                        depth_or_array_layers: 1,
+                    },
+                );
+            },
+            Some("Texture with '' label is invalid"),
+        );
     });

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -922,6 +922,8 @@ impl Queue {
 
         self.same_device_as(dst.as_ref())?;
 
+        dst.check_valid()?;
+
         dst.check_usage(wgt::TextureUsages::COPY_DST)
             .map_err(TransferError::MissingTextureUsage)?;
 
@@ -1170,6 +1172,8 @@ impl Queue {
             origin: destination.origin,
             aspect: destination.aspect,
         };
+
+        dst.check_valid()?;
 
         if !conv::is_valid_external_image_copy_dst_texture_format(dst.desc.format) {
             return Err(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3816,6 +3816,7 @@ impl Device {
         use crate::binding_model::CreateBindGroupError as Error;
 
         view.same_device(self)?;
+        view.check_valid()?;
 
         let internal_use = self.texture_use_parameters(binding, decl, view, "SampledTexture")?;
         used.views.insert_single(view.clone(), internal_use);

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2645,7 +2645,7 @@ impl QuerySet {
             desc: desc.clone().map_label(|_| ()),
             initialized_slots: Mutex::new(
                 rank::QUERY_SET_INITIALIZED_SLOTS,
-                bit_vec::BitVec::from_elem(desc.count as usize, false),
+                bit_vec::BitVec::new(),
             ),
             device,
         })

--- a/wgpu-types/src/origin_extent.rs
+++ b/wgpu-types/src/origin_extent.rs
@@ -177,15 +177,17 @@ impl Extent3d {
     #[must_use]
     pub fn mip_level_size(&self, level: u32, dim: TextureDimension) -> Self {
         Self {
-            width: u32::max(1, self.width >> level),
+            width: u32::max(1, self.width.unbounded_shr(level)),
             height: match dim {
                 TextureDimension::D1 => 1,
-                _ => u32::max(1, self.height >> level),
+                _ => u32::max(1, self.height.unbounded_shr(level)),
             },
             depth_or_array_layers: match dim {
                 TextureDimension::D1 => 1,
                 TextureDimension::D2 => self.depth_or_array_layers,
-                TextureDimension::D3 => u32::max(1, self.depth_or_array_layers >> level),
+                TextureDimension::D3 => {
+                    u32::max(1, self.depth_or_array_layers.unbounded_shr(level))
+                }
             },
         }
     }


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=2055976, and a few similar cases.

There are some cases where we need to check that an internal-validity object is valid, before proceeding with other checks that examine the resource descriptor (because in the case of an invalid object, the descriptor may contain nonsensical values).

Follow-up to #9788 and related PRs.

**Testing**
Adds a test for the issue found in Firefox, but not the additional ones found through review.

**Squash or Rebase?** Squash