### PR TITLE
[core] Inherit `InstanceFlags` in `Device` via `Adapter`

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -68,7 +68,6 @@ fn main() {
     #[cfg(feature = "winit")]
     let instance_desc =
         instance_desc.with_display_handle(Box::new(event_loop.owned_display_handle()));
-    let instance_flags = instance_desc.flags;
     let instance = wgc::instance::Instance::new("player", instance_desc, None);
 
     let (backends, device_desc) =
@@ -96,9 +95,7 @@ fn main() {
     let info = adapter.get_info();
     log::info!("Using '{}'", info.name);
 
-    let (device, queue) = adapter
-        .request_device(&device_desc, instance_flags)
-        .unwrap();
+    let (device, queue) = adapter.request_device(&device_desc).unwrap();
 
     let mut player = Player::default();
 

--- a/player/tests/player/main.rs
+++ b/player/tests/player/main.rs
@@ -74,24 +74,16 @@ impl Test<'_> {
         ron::de::from_str(&string).unwrap_or_else(|e| panic!("{path:?}:{} {}", e.span, e.code))
     }
 
-    fn run(
-        self,
-        dir: &Path,
-        instance_flags: wgt::InstanceFlags,
-        adapter: Arc<wgc::instance::Adapter>,
-    ) {
+    fn run(self, dir: &Path, adapter: Arc<wgc::instance::Adapter>) {
         let (device, queue) = adapter
-            .request_device(
-                &wgt::DeviceDescriptor {
-                    label: None,
-                    required_features: self.features,
-                    required_limits: wgt::Limits::default(),
-                    experimental_features: unsafe { wgt::ExperimentalFeatures::enabled() },
-                    memory_hints: wgt::MemoryHints::default(),
-                    trace: wgt::Trace::Off,
-                },
-                instance_flags,
-            )
+            .request_device(&wgt::DeviceDescriptor {
+                label: None,
+                required_features: self.features,
+                required_limits: wgt::Limits::default(),
+                experimental_features: unsafe { wgt::ExperimentalFeatures::enabled() },
+                memory_hints: wgt::MemoryHints::default(),
+                trace: wgt::Trace::Off,
+            })
             .unwrap();
 
         let mut player = Player::default();
@@ -182,7 +174,6 @@ impl Corpus {
                 println!("\t\tTest '{test_path:?}'");
 
                 let instance_desc = wgt::InstanceDescriptor::new_without_display_handle_from_env();
-                let instance_flags = instance_desc.flags;
                 let instance = wgc::instance::Instance::new("test", instance_desc, None);
                 let adapter = match instance.request_adapter(
                     &wgt::RequestAdapterOptions::default(),
@@ -211,7 +202,7 @@ impl Corpus {
                     println!("\t\tSkipped due to missing compute shader capability");
                     continue;
                 }
-                test.run(dir, instance_flags, adapter);
+                test.run(dir, adapter);
             }
         }
     }

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -531,7 +531,7 @@ impl Instance {
                         }
                     })
                     .map(|raw| {
-                        let adapter = Adapter::new(raw, self.devices.clone());
+                        let adapter = Adapter::new(raw, self.devices.clone(), self.flags);
                         api_log_debug!("Adapter {:?}", adapter.raw.info);
                         adapter
                     }),
@@ -681,7 +681,7 @@ impl Instance {
 
         if let Some(adapter) = adapters.into_iter().next() {
             api_log_debug!("Request adapter result {:?}", adapter.info);
-            let adapter = Adapter::new(adapter, self.devices.clone());
+            let adapter = Adapter::new(adapter, self.devices.clone(), self.flags);
             Ok(adapter)
         } else {
             Err(wgt::RequestAdapterError::NotFound {
@@ -736,7 +736,7 @@ impl Instance {
     ) -> Arc<Adapter> {
         profiling::scope!("Instance::create_adapter_from_hal");
 
-        let adapter = Adapter::new(hal_adapter, self.devices.clone());
+        let adapter = Adapter::new(hal_adapter, self.devices.clone(), self.flags);
 
         resource_log!("Created Adapter {:?}", Arc::as_ptr(&adapter));
         adapter
@@ -1044,11 +1044,20 @@ impl Drop for Surface {
 pub struct Adapter {
     pub(crate) raw: hal::DynExposedAdapter,
     pub(crate) devices: InstanceDevices,
+    pub(crate) instance_flags: InstanceFlags,
 }
 
 impl Adapter {
-    pub(crate) fn new(raw: hal::DynExposedAdapter, devices: InstanceDevices) -> Arc<Self> {
-        Arc::new(Self { raw, devices })
+    pub(crate) fn new(
+        raw: hal::DynExposedAdapter,
+        devices: InstanceDevices,
+        flags: InstanceFlags,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            raw,
+            devices,
+            instance_flags: flags,
+        })
     }
 
     /// Returns the backend this adapter is using.
@@ -1186,15 +1195,14 @@ impl Adapter {
         self: &Arc<Self>,
         hal_device: hal::DynOpenDevice,
         desc: &DeviceDescriptor,
-        instance_flags: InstanceFlags,
     ) -> Result<(Arc<Device>, Arc<Queue>), RequestDeviceError> {
         profiling::scope!("Adapter::create_device_and_queue_from_hal");
         api_log!("Adapter::create_device_and_queue_from_hal");
 
-        let device = Device::new(hal_device.device, self, desc, instance_flags)?;
+        let device = Device::new(hal_device.device, self, desc, self.instance_flags)?;
         let device = Arc::new(device);
 
-        let queue = Queue::new(device.clone(), hal_device.queue, instance_flags)?;
+        let queue = Queue::new(device.clone(), hal_device.queue, self.instance_flags)?;
         let queue = Arc::new(queue);
 
         device.set_queue(&queue);
@@ -1211,13 +1219,12 @@ impl Adapter {
     pub fn request_device(
         self: &Arc<Self>,
         desc: &DeviceDescriptor,
-        instance_flags: InstanceFlags,
     ) -> Result<(Arc<Device>, Arc<Queue>), RequestDeviceError> {
         profiling::scope!("Adapter::request_device");
         api_log!("Adapter::request_device");
         let mut desc = desc.clone();
         filter_features_and_limits(
-            instance_flags,
+            self.instance_flags,
             &mut desc.required_features,
             &mut desc.required_limits,
         );
@@ -1275,7 +1282,7 @@ impl Adapter {
         }
         .map_err(DeviceError::from_hal)?;
 
-        unsafe { self.create_device_and_queue_from_hal(open, &desc, instance_flags) }
+        unsafe { self.create_device_and_queue_from_hal(open, &desc) }
     }
 }
 
@@ -1587,7 +1594,7 @@ impl Global {
         let queue_fid = self.hub.queues.prepare(queue_id_in);
 
         let adapter = self.hub.adapters.get(adapter_id);
-        let (device, queue) = adapter.request_device(desc, self.instance.flags)?;
+        let (device, queue) = adapter.request_device(desc)?;
 
         let device_id = device_fid.assign(device);
         resource_log!("Created Device {:?}", device_id);
@@ -1614,9 +1621,8 @@ impl Global {
         let queues_fid = self.hub.queues.prepare(queue_id_in);
 
         let adapter = self.hub.adapters.get(adapter_id);
-        let (device, queue) = unsafe {
-            adapter.create_device_and_queue_from_hal(hal_device, desc, self.instance.flags)
-        }?;
+        let (device, queue) =
+            unsafe { adapter.create_device_and_queue_from_hal(hal_device, desc) }?;
 
         let device_id = devices_fid.assign(device);
 


### PR DESCRIPTION
**Connections**
As noted in https://github.com/gfx-rs/wgpu/pull/9901#discussion_r3603187927

**Description**
Before wgc users needed to manually pass instance flags to `request_device`/`create_device_and_queue_from_hal`. We do not override them anywhere so we should just make them inheritable through `Instance -> Adapter -> Device`.

**Testing**
Just refactor

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
