### PR TITLE
[core] Always return surface wrapped in arc

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -151,7 +151,7 @@ fn main() {
                 }
                 .unwrap();
                 self.window = Some(window);
-                self.surface = Some(Arc::new(surface));
+                self.surface = Some(surface);
             }
 
             fn exiting(&mut self, _event_loop: &ActiveEventLoop) {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -262,7 +262,7 @@ impl Instance {
         &self,
         display_handle: Option<raw_window_handle::RawDisplayHandle>,
         window_handle: raw_window_handle::RawWindowHandle,
-    ) -> Result<Surface, CreateSurfaceError> {
+    ) -> Result<Arc<Surface>, CreateSurfaceError> {
         profiling::scope!("Instance::create_surface");
 
         let instance_display_handle = self.display.as_ref().map(|d| {
@@ -308,10 +308,10 @@ impl Instance {
                 errors,
             ))
         } else {
-            let surface = Surface {
+            let surface = Arc::new(Surface {
                 presentation: Mutex::new(rank::SURFACE_PRESENTATION, None),
                 surface_per_backend,
-            };
+            });
 
             Ok(surface)
         }
@@ -338,7 +338,7 @@ impl Instance {
         width: u32,
         height: u32,
         refresh_rate: u32,
-    ) -> Result<Surface, CreateSurfaceError> {
+    ) -> Result<Arc<Surface>, CreateSurfaceError> {
         profiling::scope!("Instance::create_surface_from_drm");
 
         let mut errors = HashMap::default();
@@ -375,10 +375,10 @@ impl Instance {
                 errors,
             ))
         } else {
-            let surface = Surface {
+            let surface = Arc::new(Surface {
                 presentation: Mutex::new(rank::SURFACE_PRESENTATION, None),
                 surface_per_backend,
-            };
+            });
 
             Ok(surface)
         }
@@ -391,7 +391,7 @@ impl Instance {
     pub unsafe fn create_surface_metal(
         &self,
         layer: *mut core::ffi::c_void,
-    ) -> Result<Surface, CreateSurfaceError> {
+    ) -> Result<Arc<Surface>, CreateSurfaceError> {
         profiling::scope!("Instance::create_surface_metal");
 
         let instance = unsafe { self.as_hal::<hal::api::Metal>() }
@@ -413,10 +413,10 @@ impl Instance {
         let raw_surface: Box<dyn hal::DynSurface> =
             Box::new(instance.create_surface_from_layer(layer));
 
-        let surface = Surface {
+        let surface = Arc::new(Surface {
             presentation: Mutex::new(rank::SURFACE_PRESENTATION, None),
             surface_per_backend: core::iter::once((Backend::Metal, raw_surface)).collect(),
-        };
+        });
 
         Ok(surface)
     }
@@ -425,15 +425,15 @@ impl Instance {
     fn create_surface_dx12(
         &self,
         create_surface_func: impl FnOnce(&hal::dx12::Instance) -> hal::dx12::Surface,
-    ) -> Result<Surface, CreateSurfaceError> {
+    ) -> Result<Arc<Surface>, CreateSurfaceError> {
         let instance = unsafe { self.as_hal::<hal::api::Dx12>() }
             .ok_or(CreateSurfaceError::BackendNotEnabled(Backend::Dx12))?;
         let surface: Box<dyn hal::DynSurface> = Box::new(create_surface_func(instance));
 
-        let surface = Surface {
+        let surface = Arc::new(Surface {
             presentation: Mutex::new(rank::SURFACE_PRESENTATION, None),
             surface_per_backend: core::iter::once((Backend::Dx12, surface)).collect(),
-        };
+        });
 
         Ok(surface)
     }
@@ -445,7 +445,7 @@ impl Instance {
     pub unsafe fn create_surface_from_visual(
         &self,
         visual: *mut core::ffi::c_void,
-    ) -> Result<Surface, CreateSurfaceError> {
+    ) -> Result<Arc<Surface>, CreateSurfaceError> {
         profiling::scope!("Instance::instance_create_surface_from_visual");
         self.create_surface_dx12(|inst| unsafe { inst.create_surface_from_visual(visual) })
     }
@@ -457,7 +457,7 @@ impl Instance {
     pub unsafe fn create_surface_from_surface_handle(
         &self,
         surface_handle: *mut core::ffi::c_void,
-    ) -> Result<Surface, CreateSurfaceError> {
+    ) -> Result<Arc<Surface>, CreateSurfaceError> {
         profiling::scope!("Instance::instance_create_surface_from_surface_handle");
         self.create_surface_dx12(|inst| unsafe {
             inst.create_surface_from_surface_handle(surface_handle)
@@ -471,7 +471,7 @@ impl Instance {
     pub unsafe fn create_surface_from_swap_chain_panel(
         &self,
         swap_chain_panel: *mut core::ffi::c_void,
-    ) -> Result<Surface, CreateSurfaceError> {
+    ) -> Result<Arc<Surface>, CreateSurfaceError> {
         profiling::scope!("Instance::instance_create_surface_from_swap_chain_panel");
         self.create_surface_dx12(|inst| unsafe {
             inst.create_surface_from_swap_chain_panel(swap_chain_panel)
@@ -1361,7 +1361,7 @@ impl Global {
         id_in: Option<SurfaceId>,
     ) -> Result<SurfaceId, CreateSurfaceError> {
         let surface = unsafe { self.instance.create_surface(display_handle, window_handle) }?;
-        let id = self.surfaces.prepare(id_in).assign(Arc::new(surface));
+        let id = self.surfaces.prepare(id_in).assign(surface);
         Ok(id)
     }
 
@@ -1397,7 +1397,7 @@ impl Global {
                 refresh_rate,
             )
         }?;
-        let id = self.surfaces.prepare(id_in).assign(Arc::new(surface));
+        let id = self.surfaces.prepare(id_in).assign(surface);
 
         Ok(id)
     }
@@ -1412,7 +1412,7 @@ impl Global {
         id_in: Option<SurfaceId>,
     ) -> Result<SurfaceId, CreateSurfaceError> {
         let surface = unsafe { self.instance.create_surface_metal(layer) }?;
-        let id = self.surfaces.prepare(id_in).assign(Arc::new(surface));
+        let id = self.surfaces.prepare(id_in).assign(surface);
         Ok(id)
     }
 
@@ -1426,7 +1426,7 @@ impl Global {
         id_in: Option<SurfaceId>,
     ) -> Result<SurfaceId, CreateSurfaceError> {
         let surface = unsafe { self.instance.create_surface_from_visual(visual) }?;
-        let id = self.surfaces.prepare(id_in).assign(Arc::new(surface));
+        let id = self.surfaces.prepare(id_in).assign(surface);
         Ok(id)
     }
 
@@ -1443,7 +1443,7 @@ impl Global {
             self.instance
                 .create_surface_from_surface_handle(surface_handle)
         }?;
-        let id = self.surfaces.prepare(id_in).assign(Arc::new(surface));
+        let id = self.surfaces.prepare(id_in).assign(surface);
         Ok(id)
     }
 
@@ -1460,7 +1460,7 @@ impl Global {
             self.instance
                 .create_surface_from_swap_chain_panel(swap_chain_panel)
         }?;
-        let id = self.surfaces.prepare(id_in).assign(Arc::new(surface));
+        let id = self.surfaces.prepare(id_in).assign(surface);
         Ok(id)
     }
 


### PR DESCRIPTION
**Connections**
Noticed in #9901

**Description**
Move arcing from `Global:create_surface*` into `Instance::create_surface*`.

**Testing**
Just refactor.

**Squash or Rebase?**
Squash.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
