### PR TITLE
Advertise PreMultipled rather than PostMultiplied alpha for metal backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,8 @@ Bottom level categories:
 #### Metal
 
 - Fix bind group resources for the task, mesh, fragment, and compute shader stages being bound from the wrong offsets whenever a bind group contained resources visible to the task or mesh stages, which could bind the wrong buffer, texture, or sampler to a shader slot. By @teoxoy in [#10043](https://github.com/gfx-rs/wgpu/issues/10043).
-- Advertise `CompositeAlphaMode::PreMultiplied` instead of `PostMultiplied`, matching the premultiplied alpha compositing that Core Animation actually performs for a non-opaque `CAMetalLayer`. By @nicoburns in [#9922](https://github.com/gfx-rs/wgpu/pull/9922).
+- BREAKING: Advertise `CompositeAlphaMode::PreMultiplied` instead of `PostMultiplied`, matching the premultiplied alpha compositing that Core Animation actually performs for a non-opaque `CAMetalLayer`. By @nicoburns in [#9922](https://github.com/gfx-rs/wgpu/pull/9922).
+  - If you previously hard-coded `PostMultiplied` to get a transparent macOS window, you will start receiving `UnsupportedAlphaMode` validation errors for this. Those affected should migrate to `PreMultiplied` instead.
 
 #### GLES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Bottom level categories:
 #### Metal
 
 - Fix bind group resources for the task, mesh, fragment, and compute shader stages being bound from the wrong offsets whenever a bind group contained resources visible to the task or mesh stages, which could bind the wrong buffer, texture, or sampler to a shader slot. By @teoxoy in [#10043](https://github.com/gfx-rs/wgpu/issues/10043).
+- Advertise `CompositeAlphaMode::PreMultiplied` instead of `PostMultiplied`, matching the premultiplied alpha compositing that Core Animation actually performs for a non-opaque `CAMetalLayer`. By @nicoburns in [#9922](https://github.com/gfx-rs/wgpu/pull/9922).
 
 #### GLES
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -471,7 +471,7 @@ impl crate::Adapter for super::Adapter {
             },
             composite_alpha_modes: vec![
                 wgt::CompositeAlphaMode::Opaque,
-                wgt::CompositeAlphaMode::PostMultiplied,
+                wgt::CompositeAlphaMode::PreMultiplied,
             ],
 
             current_extent: Some(surface.dimensions()),

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -268,7 +268,7 @@ impl crate::Surface for super::Surface {
 
         match config.composite_alpha_mode {
             wgt::CompositeAlphaMode::Opaque => render_layer.setOpaque(true),
-            wgt::CompositeAlphaMode::PostMultiplied => render_layer.setOpaque(false),
+            wgt::CompositeAlphaMode::PreMultiplied => render_layer.setOpaque(false),
             _ => (),
         }
 


### PR DESCRIPTION

**Connections**
Fixes #9896

**Description**
The Metal backend is advertising the wrong AlphaMode.

- This issues was first noticed in https://github.com/DioxusLabs/anyrender/pull/70#issuecomment-4992911829
- I have been unable to find official documentation confirming this (not entirely unsurprising for Apple)
- However, I had AI create a test case (can be viewed/run here: https://github.com/gfx-rs/wgpu/pull/9897) which tests the output by actually creating a transparent window (with an opaque black window positioned underneath), and I am personally convinced that this demonstrates that compositing on macOS is actually PreMultiplied (although my expertise in graphics is limited). I would encourage wgpu maintainers to review/run this example themselves and convince themselves of the same before merging this PR.

**Testing**
That is the correct alpha mode has been manually tested using the reproduction in https://github.com/gfx-rs/wgpu/pull/9897

**Squash or Rebase?**

Either - there is only one commit.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
