### PR TITLE
chore(deps): Disable renovate `minimumReleaseAge`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
   "dependencyDashboard": true,
   "prConcurrentLimit": 20,
   "prHourlyLimit": 200,
-  "minimumReleaseAge": "1 week",
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",
   "labels": ["dependencies"],
@@ -83,8 +82,7 @@
       "description": "CTS revision is pinned to a Git SHA.",
       "matchPackageNames": ["https://github.com/gpuweb/cts"],
       "changelogUrl": "https://github.com/gpuweb/cts/commits/main",
-      "versioning": "git",
-      "minimumReleaseAge": "0"
+      "versioning": "git"
     },
     {
       "description": "Rust toolchain should be stable - 3 in accordance with maximum-MSRV policy.",


### PR DESCRIPTION
Disables `minimumReleaseAge` in the renovate config, except for the Rust toolchain. It apparently does not work with `lockFileMaintenance` for cargo. We could try to keep it active for non-patch-release updates, but if enforcement is skipped  for any kind of release, the value is substantially reduced.

See https://github.com/gfx-rs/wgpu/issues/9864#issuecomment-5048744139 for more background.

Fixes #9864 (hopefully)

**Testing**
Hard to test other than by monitoring renovate behavior.

**Squash or Rebase?** Squash