### PR TITLE
Remove never-constructed CreateBlasError::InvalidAabbStride

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Bottom level categories:
 - Validate pipeline layout `immediate_size` and fix its calculation when there are multiple immediate variables. Now it must be >= required size of the shader entry point. By @beicause in [#9711](https://github.com/gfx-rs/wgpu/pull/9711).
 - [`immediate_address_space`](https://www.w3.org/TR/WGSL/#language_extension-immediate_address_space) WGSL language extension is implemented. By @beicause in [#9711](https://github.com/gfx-rs/wgpu/pull/9711).
 - `TextureFormat::is_srgb()` has been renamed to `TextureFormat::has_srgb_suffix()` to clarify its function. By @kpreid in [#9758](https://github.com/gfx-rs/wgpu/pull/9758).
+- Remove the never-constructed `CreateBlasError::InvalidAabbStride` variant. `create_blas` takes no stride, so it could never be produced; AABB stride is validated at build time as `BuildAccelerationStructureError::InvalidAabbStride`. By @mstampfli in [#9935](https://github.com/gfx-rs/wgpu/pull/9935).
 
 #### naga
 

--- a/wgpu-core/src/ray_tracing.rs
+++ b/wgpu-core/src/ray_tracing.rs
@@ -48,8 +48,6 @@ pub enum CreateBlasError {
         "Limit `max_blas_primitive_count` is {0}, but the BLAS had a maximum of {1} primitives"
     )]
     TooManyPrimitives(u32, u32),
-    #[error("AABB geometry stride {0} is invalid (must be >= {1} and a multiple of 8)")]
-    InvalidAabbStride(BufferAddress, BufferAddress),
 }
 
 impl WebGpuError for CreateBlasError {
@@ -60,8 +58,7 @@ impl WebGpuError for CreateBlasError {
             Self::MissingIndexData
             | Self::InvalidVertexFormat(..)
             | Self::TooManyGeometries(..)
-            | Self::TooManyPrimitives(..)
-            | Self::InvalidAabbStride(..) => ErrorType::Validation,
+            | Self::TooManyPrimitives(..) => ErrorType::Validation,
         }
     }
 }


### PR DESCRIPTION
**Connections**
Sibling cleanup to #9934 (found in the same audit of the BLAS AABB stride path); no dependency between the two.

**Description**
`CreateBlasError::InvalidAabbStride` is declared and handled in the `WebGpuError` impl but is never constructed. `create_blas` has no stride input, so a stride error cannot originate there; AABB stride is validated only at build time as `BuildAccelerationStructureError::InvalidAabbStride`. This drops the dead variant and its match arm. It is a (technically breaking) removal from an experimental API - happy to instead keep it as a reserved/`#[doc(hidden)]` variant if you would rather not narrow the enum; let me know your preference.

**Testing**
`cargo check -p wgpu-core` passes; the only remaining `InvalidAabbStride` references are the build-time variant on `BuildAccelerationStructureError`.

**Squash or Rebase?**
Squash.
