### PR TITLE
fix(hal): Fence in swapchain does not reset

### DIFF
--- a/wgpu-hal/src/vulkan/swapchain/native.rs
+++ b/wgpu-hal/src/vulkan/swapchain/native.rs
@@ -458,11 +458,15 @@ impl Swapchain for NativeSwapchain {
         // will block if no image is available
         let (index, suboptimal) = match unsafe {
             profiling::scope!("vkAcquireNextImageKHR");
+            #[cfg(target_os = "windows")]
+            let fence = self.fence;
+            #[cfg(not(target_os = "windows"))]
+            let fence = vk::Fence::null();
             self.functor.acquire_next_image(
                 self.raw,
                 timeout_ns,
                 acquire_semaphore_guard.acquire,
-                self.fence,
+                fence
             )
         } {
             // We treat `VK_SUBOPTIMAL_KHR` as `VK_SUCCESS` on Android.


### PR DESCRIPTION
**Connections**

Related issue: #9808 
Related PRs: 
- introduce swapchain fence: #8420
- restrict wait+reset to windows-only: #9486

**Description**

Solve the `anon_inode:sync_file` file descriptor leak on Android Vulkan platform.

This change also includes some other non-Windows platforms:
- The fence was initially introduced only for Windows DXGI swapchain, which should not exist on other platforms.
- Later PR reverts the wait + reset process (for performance?) but does _NOT_ revert the init process.
- This leads to a FD leaks on Android platform. No significant problems on other platforms, though.
- This PR restrict fence to be created only on Windows platform.

**Testing**

For any Android application:
`watch -n 1 "adb shell run-as <package> ls -l /proc/$(adb shell pidof <package>)/fd 2>/dev/null | grep -c sync_file"`

Before the fix the counter will increase.

Tests are performed on Android 14 API Level 34.

**Squash or Rebase?**

Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
