### PR TITLE
fix(core): Add missing shader output vs. color target validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Bottom level categories:
 #### Validation
 
 - Validate that the arguments are within the indirect buffer when encoding an indirect draw to a render bundle. Moves some indirect draw errors from `RenderPassErrorInner` to `RenderCommandError`. By @andyleiserson in [#9871](https://github.com/gfx-rs/wgpu/pull/9871).
+- When creating render pipelines, validate that a corresponding shader output is present for each color attachment with non-zero write mask, and that shader output includes alpha when the blend operation uses source alpha. By @andyleiserson in [#9939](https://github.com/gfx-rs/wgpu/pull/9939).
 
 #### Naga
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -48,8 +48,6 @@ webgpu:api,validation,queue,destroyed,* // 71%, writeBuffer/writeTexture return 
 webgpu:api,validation,queue,writeBuffer:ranges:* // 0%, missing OperationError for invalid ranges
 webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_stencil_read_only_write_state:* // fails on dx12
 webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadOnly:* // 33%, missing validation: depth/stencil load/store ops provided for missing texture format aspects
-webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets,blend:* // 95%, blend factors reading source alpha require vec4
-webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets:* // 3%, color target without shader output requires writeMask=0
 webgpu:api,validation,render_pipeline,inter_stage:* // 15%, inter-stage type validation gaps and interpolation default handling
 webgpu:api,validation,render_pipeline,misc:external_texture:* // 0%, no external texture in deno
 webgpu:api,validation,render_pipeline,multisample_state:* // 60%, https://github.com/gfx-rs/wgpu/issues/8779

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -7,6 +7,11 @@
 //
 // The `cts_runner` integration test `lst_files_are_sorted` verifies that test selectors
 // appear in this file in order -- including ones in comments.
+//
+// Test selector behavior is subtle. If a single test file contains `test`,
+// `test,foo`, and `test,bar`, the selector `test,*` will match all of those,
+// i.e., it is not necessary to list both `test:*` and `test,*`.  The selector
+// `test:*` will only match that single test, however.
 
 unittests:*
 
@@ -131,7 +136,6 @@ webgpu:api,validation,createBindGroupLayout:multisampled_validation:*
 webgpu:api,validation,createBindGroupLayout:storage_texture,formats:*
 webgpu:api,validation,createBindGroupLayout:storage_texture,layout_dimension:*
 webgpu:api,validation,createBindGroupLayout:visibility,*
-webgpu:api,validation,createBindGroupLayout:visibility:*
 webgpu:api,validation,createPipelineLayout:*
 webgpu:api,validation,createSampler:*
 webgpu:api,validation,createTexture:depthOrArrayLayers_and_mipLevelCount_for_transient_attachments:*
@@ -266,6 +270,7 @@ webgpu:api,validation,render_pipeline,float32_blendable:*
 webgpu:api,validation,render_pipeline,fragment_state:color_target_exists:*
 webgpu:api,validation,render_pipeline,fragment_state:dual_source_blending,*
 webgpu:api,validation,render_pipeline,fragment_state:limits,*
+webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets,*
 webgpu:api,validation,render_pipeline,fragment_state:targets_blend:*
 webgpu:api,validation,render_pipeline,fragment_state:targets_format_filterable:*
 webgpu:api,validation,render_pipeline,fragment_state:targets_format_is_color_format:*

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -17,7 +17,8 @@ use arrayvec::ArrayVec;
 use bitflags::Flags;
 use smallvec::SmallVec;
 use wgt::{
-    math::align_to, DeviceLostReason, TextureFormat, TextureSampleType, TextureViewDimension,
+    math::align_to, ColorWrites, DeviceLostReason, TextureFormat, TextureSampleType,
+    TextureViewDimension,
 };
 
 #[cfg(feature = "trace")]
@@ -4631,6 +4632,10 @@ impl Device {
         }
 
         let mut target_specified = false;
+        let mut required_color_outputs = 0u64;
+        const _: () = {
+            assert!(hal::MAX_COLOR_ATTACHMENTS <= 64);
+        };
 
         for (i, cs) in color_targets.iter().enumerate() {
             if let Some(cs) = cs.as_ref() {
@@ -4641,6 +4646,8 @@ impl Device {
                     // on the device timeline.
                     if cs.write_mask.contains_unknown_bits() {
                         break 'error Some(ColorStateError::InvalidWriteMask(cs.write_mask));
+                    } else if cs.write_mask != ColorWrites::NONE {
+                        required_color_outputs |= 1 << i;
                     }
 
                     let format_features = self.describe_format_features(cs.format)?;
@@ -4679,7 +4686,7 @@ impl Device {
                     if let Some(blend_mode) = cs.blend {
                         for component in [&blend_mode.color, &blend_mode.alpha] {
                             for factor in [component.src_factor, component.dst_factor] {
-                                if factor.ref_second_blend_source() {
+                                if factor.uses_second_blend_source() {
                                     self.require_features(wgt::Features::DUAL_SOURCE_BLENDING)?;
                                     if i == 0 {
                                         dual_source_blending = true;
@@ -5079,21 +5086,16 @@ impl Device {
             ));
         }
 
+        let mut active_color_outputs = 0u64;
         if validated_stages.contains(wgt::ShaderStages::FRAGMENT) {
             for (i, output) in io.varyings.iter() {
+                active_color_outputs |= 1 << i;
                 match color_targets.get(*i as usize) {
                     Some(Some(state)) => {
-                        validation::check_texture_format(state.format, &output.ty).map_err(
-                            |pipeline| {
-                                pipeline::CreateRenderPipelineError::ColorState(
-                                    *i as u8,
-                                    ColorStateError::IncompatibleFormat {
-                                        pipeline,
-                                        shader: output.ty,
-                                    },
-                                )
-                            },
-                        )?;
+                        validation::check_color_attachment_compatibility(state, output.ty)
+                            .map_err(|err| {
+                                pipeline::CreateRenderPipelineError::ColorState(*i as u8, err)
+                            })?;
                     }
                     _ => {
                         log::debug!(
@@ -5106,7 +5108,16 @@ impl Device {
                     }
                 }
             }
+
+            let missing_color_outputs = required_color_outputs & !active_color_outputs;
+            if missing_color_outputs != 0 {
+                return Err(pipeline::CreateRenderPipelineError::ColorState(
+                    missing_color_outputs.trailing_zeros() as u8,
+                    ColorStateError::OutputNotPresent,
+                ));
+            }
         }
+
         let last_stage = match desc.fragment {
             Some(_) => wgt::ShaderStages::FRAGMENT,
             None => wgt::ShaderStages::VERTEX,

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -809,6 +809,11 @@ pub enum ColorStateError {
         factor: wgt::BlendFactor,
         target: u32,
     },
+    #[error("The {which} blend factor {factor:?} is not valid because the shader output does have an alpha channel.")]
+    InvalidAlphaBlend {
+        which: &'static str,
+        factor: wgt::BlendFactor,
+    },
     #[error(
         "Blend factor {factor:?} for render target {target} is not valid. Blend factor must be `one` when using min/max blend operations."
     )]
@@ -816,6 +821,8 @@ pub enum ColorStateError {
         factor: wgt::BlendFactor,
         target: u32,
     },
+    #[error("Shader does not produce an output at this index")]
+    OutputNotPresent,
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -16,7 +16,8 @@ use wgt::{
 };
 
 use crate::{
-    command::ColorAttachmentError, device::bgl, resource::InvalidResourceError,
+    command::ColorAttachmentError, device::bgl, pipeline::ColorStateError,
+    resource::InvalidResourceError,
     validation::shader_io_deductions::MaxFragmentShaderInputDeduction, FastHashMap, FastHashSet,
 };
 
@@ -1016,7 +1017,7 @@ impl NumericType {
         }
     }
 
-    fn is_subtype_of(&self, other: &NumericType) -> bool {
+    fn is_subtype_of(self, other: NumericType) -> bool {
         if self.scalar.width > other.scalar.width {
             return false;
         }
@@ -1036,16 +1037,34 @@ impl NumericType {
 }
 
 /// Return true if the fragment `format` is covered by the provided `output`.
-pub fn check_texture_format(
-    format: wgt::TextureFormat,
-    output: &NumericType,
-) -> Result<(), NumericType> {
-    let nt = NumericType::from_texture_format(format);
-    if nt.is_subtype_of(output) {
-        Ok(())
-    } else {
-        Err(nt)
+pub fn check_color_attachment_compatibility(
+    state: &wgt::ColorTargetState,
+    output_ty: NumericType,
+) -> Result<(), ColorStateError> {
+    let pipeline_ty = NumericType::from_texture_format(state.format);
+    if !pipeline_ty.is_subtype_of(output_ty) {
+        return Err(ColorStateError::IncompatibleFormat {
+            pipeline: pipeline_ty,
+            shader: output_ty,
+        });
     }
+    if let Some(blend) = state.blend {
+        for (factor, name) in [
+            (blend.color.src_factor, "source"),
+            (blend.color.dst_factor, "destination"),
+        ] {
+            if factor.uses_source_alpha()
+                && output_ty.dim != NumericDimension::Vector(naga::VectorSize::Quad)
+            {
+                return Err(ColorStateError::InvalidAlphaBlend {
+                    which: name,
+                    factor,
+                });
+            }
+        }
+    }
+
+    Ok(())
 }
 
 pub enum BindingLayoutSource {
@@ -1617,7 +1636,7 @@ impl Interface {
                                         ));
                                     }
                                     (
-                                        iv.ty.is_subtype_of(&provided.ty),
+                                        iv.ty.is_subtype_of(provided.ty),
                                         iv.per_primitive == provided.per_primitive,
                                     )
                                 }

--- a/wgpu-types/src/render.rs
+++ b/wgpu-types/src/render.rs
@@ -65,10 +65,23 @@ impl BlendFactor {
     ///
     /// Note that the usage of those blend factors require [`Features::DUAL_SOURCE_BLENDING`].
     #[must_use]
-    pub fn ref_second_blend_source(&self) -> bool {
+    pub fn uses_second_blend_source(&self) -> bool {
         match self {
             BlendFactor::Src1
             | BlendFactor::OneMinusSrc1
+            | BlendFactor::Src1Alpha
+            | BlendFactor::OneMinusSrc1Alpha => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the blend factor references the source alpha.
+    #[must_use]
+    pub fn uses_source_alpha(&self) -> bool {
+        match self {
+            BlendFactor::SrcAlpha
+            | BlendFactor::OneMinusSrcAlpha
+            | BlendFactor::SrcAlphaSaturated
             | BlendFactor::Src1Alpha
             | BlendFactor::OneMinusSrc1Alpha => true,
             _ => false,
@@ -252,6 +265,8 @@ pub struct ColorWrites(u32);
 
 bitflags::bitflags! {
     impl ColorWrites: u32 {
+        /// Do not write any channels
+        const NONE = 0;
         /// Enable red channel writes
         const RED = 1 << 0;
         /// Enable green channel writes


### PR DESCRIPTION
 - If a color attachment does not have a matching shader output, then the color attachment's `writeMask` must be zero.
 - If either color blend factor uses source alpha, then the shader output must have an alpha channel (i.e. be a `vec4`).

Fixes #9147

**Testing**
Enables CTS tests.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
