### PR TITLE
test(cts): assume all `maxInterStageShaderVariables` tests pass

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -82,9 +82,7 @@ webgpu:api,validation,capability_checks,limits,maxComputeWorkgroupSizeZ:validate
 webgpu:api,validation,capability_checks,limits,maxComputeWorkgroupsPerDimension:validate,*
 //FAIL: other `maxInterStageShaderVariables` cases w/ limitTest ∈ [underDefault, overMaximum]
 // https://github.com/gfx-rs/wgpu/issues/8945
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atDefault";*
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="atMaximum";*
-webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";*
+webgpu:api,validation,capability_checks,limits,maxInterStageShaderVariables:*
 webgpu:api,validation,capability_checks,limits,maxStorageBufferBindingSize:validate,*
 webgpu:api,validation,capability_checks,limits,maxUniformBufferBindingSize:validate,*
 webgpu:api,validation,capability_checks,limits,maxVertexBufferArrayStride:validate,*


### PR DESCRIPTION
https://github.com/gfx-rs/wgpu/issues/8945 was resolved, so let's clean this up!