### PR TITLE
fix: emit dimension-correct HLSL texture sample offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ Bottom level categories:
 #### Naga
 
 - Replace embedded NUL characters with `?` when writing debug strings to SPIR-V. By @andyleiserson in [#9904](https://github.com/gfx-rs/wgpu/pull/9904).
-- Fixed invalid HLSL generated for `textureSampleLevel` with an explicit offset on 3D textures. The HLSL backend wrapped every sampling offset in `int2(...)`, producing a nested `int2(int3(...))` that matches no `Texture3D.SampleLevel` overload; the constructor now follows the offset's own dimension. By @mvanhorn in [#9717](https://github.com/gfx-rs/wgpu/issues/9717).
+- Fix invalid HLSL generated for `textureSampleLevel` with non-2D textures. By @mvanhorn in [#9717](https://github.com/gfx-rs/wgpu/issues/9717).
 
 #### Vulkan
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Bottom level categories:
 #### Naga
 
 - Replace embedded NUL characters with `?` when writing debug strings to SPIR-V. By @andyleiserson in [#9904](https://github.com/gfx-rs/wgpu/pull/9904).
+- Fixed invalid HLSL generated for `textureSampleLevel` with an explicit offset on 3D textures. The HLSL backend wrapped every sampling offset in `int2(...)`, producing a nested `int2(int3(...))` that matches no `Texture3D.SampleLevel` overload; the constructor now follows the offset's own dimension. By @mvanhorn in [#9717](https://github.com/gfx-rs/wgpu/issues/9717).
 
 #### Vulkan
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -341,6 +341,8 @@ webgpu:shader,execution,expression,call,builtin,textureNumLevels:*
 fails-if(dx12) webgpu:shader,execution,expression,call,builtin,textureNumSamples:*
 webgpu:shader,execution,expression,call,builtin,textureSample:sampled_1d_coords:*
 webgpu:shader,execution,expression,call,builtin,textureSampleBaseClampToEdge:2d_coords:stage="c";textureType="texture_2d<f32>";*
+webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_1d_coords:*
+webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_3d_coords:*
 // NOTE: This is supposed to be an exhaustive listing underneath
 // `webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:*`, so exceptions can be
 // worked around.

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -341,8 +341,6 @@ webgpu:shader,execution,expression,call,builtin,textureNumLevels:*
 fails-if(dx12) webgpu:shader,execution,expression,call,builtin,textureNumSamples:*
 webgpu:shader,execution,expression,call,builtin,textureSample:sampled_1d_coords:*
 webgpu:shader,execution,expression,call,builtin,textureSampleBaseClampToEdge:2d_coords:stage="c";textureType="texture_2d<f32>";*
-webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_1d_coords:*
-webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_3d_coords:*
 // NOTE: This is supposed to be an exhaustive listing underneath
 // `webgpu:shader,execution,expression,call,builtin,workgroupUniformLoad:*`, so exceptions can be
 // worked around.

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -4239,17 +4239,17 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
 
                 if let Some(offset) = offset {
                     write!(self.out, ", ")?;
-                    let (scalar, size) = match *func_ctx.resolve_type(offset, &module.types) {
-                        TypeInner::Scalar(scalar) => (scalar, None),
-                        TypeInner::Vector { size, scalar } => (scalar, Some(size)),
-                        _ => unreachable!(),
-                    };
-                    debug_assert_eq!(scalar.kind, ScalarKind::Sint);
+                    // Work around https://github.com/microsoft/DirectXShaderCompiler/issues/5082#issuecomment-1540147807
+                    let (size, scalar) = func_ctx
+                        .resolve_type(offset, &module.types)
+                        .vector_size_and_scalar()
+                        .unwrap();
+                    assert_eq!(scalar.kind, ScalarKind::Sint);
                     write!(self.out, "{}", scalar.to_hlsl_str()?)?;
                     if let Some(size) = size {
                         write!(self.out, "{}", common::vector_size_str(size))?;
                     }
-                    write!(self.out, "(")?; // work around https://github.com/microsoft/DirectXShaderCompiler/issues/5082#issuecomment-1540147807
+                    write!(self.out, "(")?;
                     self.write_const_expression(module, offset, func_ctx.expressions)?;
                     write!(self.out, ")")?;
                 }

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -4239,7 +4239,17 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
 
                 if let Some(offset) = offset {
                     write!(self.out, ", ")?;
-                    write!(self.out, "int2(")?; // work around https://github.com/microsoft/DirectXShaderCompiler/issues/5082#issuecomment-1540147807
+                    let (scalar, size) = match *func_ctx.resolve_type(offset, &module.types) {
+                        TypeInner::Scalar(scalar) => (scalar, None),
+                        TypeInner::Vector { size, scalar } => (scalar, Some(size)),
+                        _ => unreachable!(),
+                    };
+                    debug_assert_eq!(scalar.kind, ScalarKind::Sint);
+                    write!(self.out, "{}", scalar.to_hlsl_str()?)?;
+                    if let Some(size) = size {
+                        write!(self.out, "{}", common::vector_size_str(size))?;
+                    }
+                    write!(self.out, "(")?; // work around https://github.com/microsoft/DirectXShaderCompiler/issues/5082#issuecomment-1540147807
                     self.write_const_expression(module, offset, func_ctx.expressions)?;
                     write!(self.out, ")")?;
                 }

--- a/naga/tests/in/wgsl/9717-texture-sample-level-offset.toml
+++ b/naga/tests/in/wgsl/9717-texture-sample-level-offset.toml
@@ -1,0 +1,1 @@
+targets = "HLSL"

--- a/naga/tests/in/wgsl/9717-texture-sample-level-offset.wgsl
+++ b/naga/tests/in/wgsl/9717-texture-sample-level-offset.wgsl
@@ -1,0 +1,31 @@
+@group(0) @binding(0)
+var sampled_texture_1d: texture_1d<f32>;
+
+@group(0) @binding(1)
+var sampled_texture_2d: texture_2d<f32>;
+
+@group(0) @binding(2)
+var sampled_texture_3d: texture_3d<f32>;
+
+@group(0) @binding(3)
+var texture_sampler: sampler;
+
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    let sample_1d = textureSampleLevel(sampled_texture_1d, texture_sampler, 0.5, 0.0, -1);
+    let sample_2d = textureSampleLevel(
+        sampled_texture_2d,
+        texture_sampler,
+        vec2<f32>(0.5),
+        0.0,
+        vec2<i32>(-1, 2),
+    );
+    let sample_3d = textureSampleLevel(
+        sampled_texture_3d,
+        texture_sampler,
+        vec3<f32>(0.5),
+        0.0,
+        vec3<i32>(-1, 2, -3),
+    );
+    return sample_1d + sample_2d + sample_3d;
+}

--- a/naga/tests/out/hlsl/wgsl-9717-texture-sample-level-offset.hlsl
+++ b/naga/tests/out/hlsl/wgsl-9717-texture-sample-level-offset.hlsl
@@ -1,0 +1,15 @@
+Texture1D<float4> sampled_texture_1d : register(t0);
+Texture2D<float4> sampled_texture_2d : register(t1);
+Texture3D<float4> sampled_texture_3d : register(t2);
+SamplerState nagaSamplerHeap[2048]: register(s0, space0);
+SamplerComparisonState nagaComparisonSamplerHeap[2048]: register(s0, space1);
+StructuredBuffer<uint> nagaGroup0SamplerIndexArray : register(t0, space255);
+static const SamplerState texture_sampler = nagaSamplerHeap[nagaGroup0SamplerIndexArray[3]];
+
+float4 main() : SV_Target0
+{
+    float4 sample_1d = sampled_texture_1d.SampleLevel(texture_sampler, 0.5, 0.0, int(int(-1)));
+    float4 sample_2d = sampled_texture_2d.SampleLevel(texture_sampler, (0.5).xx, 0.0, int2(int2(int(-1), int(2))));
+    float4 sample_3d = sampled_texture_3d.SampleLevel(texture_sampler, (0.5).xxx, 0.0, int3(int3(int(-1), int(2), int(-3))));
+    return ((sample_1d + sample_2d) + sample_3d);
+}

--- a/naga/tests/out/hlsl/wgsl-9717-texture-sample-level-offset.ron
+++ b/naga/tests/out/hlsl/wgsl-9717-texture-sample-level-offset.ron
@@ -1,0 +1,16 @@
+(
+    vertex:[
+    ],
+    fragment:[
+        (
+            entry_point:"main",
+            target_profile:"ps_5_1",
+        ),
+    ],
+    compute:[
+    ],
+    task:[
+    ],
+    mesh:[
+    ],
+)


### PR DESCRIPTION
**Connections**

- Fixes <https://github.com/gfx-rs/wgpu/issues/9717>.

**Summary**

The HLSL backend wrapped every image-sampling offset in `int2(...)` as a DXC overload-resolution workaround. For a `textureSampleLevel` call on other-dimensioned sampled textures, that's the wrong type. For example, with 3D textures, the writer emitted a nested `int2(int3(...))` expression, which fails to compile.

This makes the constructor follow the offset expression's own dimension, emitting `int`, `int2`, or `int3` as appropriate, while keeping the explicit-constructor workaround DXC needs.

## Testing

- Added a `wgsl-9717-texture-sample-level-offset.hlsl` snapshot test that emits checks for all dimensions of texture with `textureSampleLevel`.

## Squash or Rebase?

Rebase.

## Checklist

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Tests demonstrate the validation and altered logic works.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
