### PR TITLE
Replace `GlobalReport` with per device `wgt::Report` that works via Tracing

### DIFF
--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -526,17 +526,6 @@ impl<E: Example> ApplicationHandler<AppAction> for App<E> {
             | WindowEvent::CloseRequested => {
                 event_loop.exit();
             }
-            #[cfg(not(target_arch = "wasm32"))]
-            WindowEvent::KeyboardInput {
-                event:
-                    KeyEvent {
-                        logical_key: Key::Character(s),
-                        ..
-                    },
-                ..
-            } if s == "r" => {
-                println!("{:#?}", context.instance.generate_report());
-            }
             WindowEvent::RedrawRequested => {
                 // Don't render while occluded, this may leak on apple platforms.
                 if self.occluded {

--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -290,6 +290,10 @@ impl DeviceInterface for CustomDevice {
         unimplemented!()
     }
 
+    fn generate_report(&self) -> Option<wgpu::wgt::Report> {
+        unimplemented!()
+    }
+
     fn destroy(&self) {
         unimplemented!()
     }

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -1,4 +1,4 @@
-use wgpu::{Adapter, Backends, Device, Features, Instance, Limits, Queue};
+use wgpu::{Adapter, Backends, Device, Features, Instance, Limits, Queue, Trace};
 
 use crate::{report::AdapterReport, TestParameters};
 
@@ -196,6 +196,7 @@ pub async fn initialize_device(
     adapter: &Adapter,
     features: Features,
     limits: Limits,
+    trace: Trace,
 ) -> (Device, Queue) {
     let bundle = adapter
         .request_device(&wgpu::DeviceDescriptor {
@@ -204,7 +205,7 @@ pub async fn initialize_device(
             required_limits: limits,
             experimental_features: unsafe { wgpu::ExperimentalFeatures::enabled() },
             memory_hints: wgpu::MemoryHints::MemoryUsage,
-            trace: wgpu::Trace::Off,
+            trace,
         })
         .await;
 

--- a/tests/src/params.rs
+++ b/tests/src/params.rs
@@ -1,5 +1,5 @@
 use arrayvec::ArrayVec;
-use wgpu::{DownlevelCapabilities, DownlevelFlags, Features, InstanceFlags, Limits};
+use wgpu::{DownlevelCapabilities, DownlevelFlags, Features, InstanceFlags, Limits, Trace};
 
 use crate::{
     report::AdapterReport, FailureApplicationReasons, FailureBehavior, FailureCase,
@@ -18,6 +18,8 @@ pub struct TestParameters {
     pub required_features: Features,
     pub required_downlevel_caps: DownlevelCapabilities,
     pub required_limits: Limits,
+
+    pub trace: Trace,
 
     pub required_instance_flags: InstanceFlags,
 
@@ -43,6 +45,7 @@ impl Default for TestParameters {
             required_features: Features::empty(),
             required_downlevel_caps: LOWEST_DOWNLEVEL_PROPERTIES,
             required_limits: Limits::downlevel_webgl2_defaults(),
+            trace: Trace::Off,
             required_instance_flags: InstanceFlags::empty(),
             force_fxc: false,
             // By default we skip the noop backend, and enable it if the test
@@ -109,6 +112,11 @@ impl TestParameters {
     pub fn enable_noop(mut self) -> Self {
         self.skips
             .retain(|case| *case != FailureCase::backend(wgpu::Backends::NOOP));
+        self
+    }
+
+    pub fn set_trace(mut self, trace: Trace) -> Self {
+        self.trace = trace;
         self
     }
 

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -70,6 +70,7 @@ pub async fn execute_test(
         &adapter,
         config.params.required_features,
         config.params.required_limits.clone(),
+        config.params.trace,
     )
     .await;
 

--- a/tests/tests/wgpu-gpu/device.rs
+++ b/tests/tests/wgpu-gpu/device.rs
@@ -18,7 +18,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 
     #[cfg(not(wasm_test))]
     {
-        vec.extend([DEVICE_LIFETIME_CHECK, MULTIPLE_DEVICES]);
+        vec.push(MULTIPLE_DEVICES);
     }
 }
 
@@ -50,33 +50,6 @@ static CROSS_DEVICE_BIND_GROUP_USAGE: GpuTestConfiguration = GpuTestConfiguratio
         }
 
         ctx.async_poll(wgpu::PollType::Poll).await.unwrap();
-    });
-
-#[cfg(not(wasm_test))]
-#[apply(gpu_test!)]
-static DEVICE_LIFETIME_CHECK: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().enable_noop())
-    .run_sync(|ctx| {
-        ctx.instance.poll_all(false);
-
-        let pre_report = ctx.instance.generate_report().unwrap();
-
-        let TestingContext {
-            instance,
-            device,
-            queue,
-            ..
-        } = ctx;
-
-        drop(queue);
-        drop(device);
-
-        let post_report = instance.generate_report().unwrap();
-
-        assert_ne!(
-            pre_report, post_report,
-            "Queue and Device has not been dropped as expected"
-        );
     });
 
 #[cfg(not(wasm_test))]
@@ -701,8 +674,13 @@ static DEVICE_AND_QUEUE_HAVE_DIFFERENT_IDS: GpuTestConfiguration = GpuTestConfig
 
         drop(device);
 
-        let (device2, queue2) =
-            wgpu_test::initialize_device(&adapter, device_features, device_limits).await;
+        let (device2, queue2) = wgpu_test::initialize_device(
+            &adapter,
+            device_features,
+            device_limits,
+            wgpu::Trace::Off,
+        )
+        .await;
 
         drop(queue);
         drop(device2);

--- a/tests/tests/wgpu-gpu/mem_leaks.rs
+++ b/tests/tests/wgpu-gpu/mem_leaks.rs
@@ -26,18 +26,12 @@ async fn draw_test_with_reports(
 
     use wgpu::util::DeviceExt;
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.devices.num_allocated, 1);
-    assert_eq!(report.queues.num_allocated, 1);
-
     let shader = ctx
         .device
         .create_shader_module(wgpu::include_wgsl!("./vertex_indices/draw.vert.wgsl"));
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.shader_modules.num_allocated, 1);
+    let report = ctx.device.generate_report().unwrap();
+    assert_eq!(report.shader_modules.active(), 1);
 
     let bgl = ctx
         .device
@@ -55,11 +49,10 @@ async fn draw_test_with_reports(
             }],
         });
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.buffers.num_allocated, 0);
-    assert_eq!(report.bind_groups.num_allocated, 0);
-    assert_eq!(report.bind_group_layouts.num_allocated, 1);
+    let report = ctx.device.generate_report().unwrap();
+    assert_eq!(report.buffers.active(), 0);
+    assert_eq!(report.bind_groups.active(), 0);
+    assert_eq!(report.bind_group_layouts.active(), 1);
 
     let buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
@@ -68,9 +61,8 @@ async fn draw_test_with_reports(
         mapped_at_creation: false,
     });
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.buffers.num_allocated, 1);
+    let report = ctx.device.generate_report().unwrap();
+    assert_eq!(report.buffers.active(), 1);
 
     let bg = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: None,
@@ -81,11 +73,10 @@ async fn draw_test_with_reports(
         }],
     });
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.buffers.num_allocated, 1);
-    assert_eq!(report.bind_groups.num_allocated, 1);
-    assert_eq!(report.bind_group_layouts.num_allocated, 1);
+    let report = ctx.device.generate_report().unwrap();
+    assert_eq!(report.buffers.active(), 1);
+    assert_eq!(report.bind_groups.active(), 1);
+    assert_eq!(report.bind_group_layouts.active(), 1);
 
     let ppl = ctx
         .device
@@ -95,12 +86,11 @@ async fn draw_test_with_reports(
             immediate_size: 0,
         });
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.buffers.num_allocated, 1);
-    assert_eq!(report.pipeline_layouts.num_allocated, 1);
-    assert_eq!(report.render_pipelines.num_allocated, 0);
-    assert_eq!(report.compute_pipelines.num_allocated, 0);
+    let report = ctx.device.generate_report().unwrap();
+    assert_eq!(report.buffers.active(), 1);
+    assert_eq!(report.pipeline_layouts.active(), 1);
+    assert_eq!(report.render_pipelines.active(), 0);
+    assert_eq!(report.compute_pipelines.active(), 0);
 
     let pipeline = ctx
         .device
@@ -130,24 +120,22 @@ async fn draw_test_with_reports(
             cache: None,
         });
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.buffers.num_allocated, 1);
-    assert_eq!(report.bind_groups.num_allocated, 1);
-    assert_eq!(report.bind_group_layouts.num_allocated, 1);
-    assert_eq!(report.shader_modules.num_allocated, 1);
-    assert_eq!(report.pipeline_layouts.num_allocated, 1);
-    assert_eq!(report.render_pipelines.num_allocated, 1);
-    assert_eq!(report.compute_pipelines.num_allocated, 0);
+    let report = ctx.device.generate_report().unwrap();
+    assert_eq!(report.buffers.active(), 1);
+    assert_eq!(report.bind_groups.active(), 1);
+    assert_eq!(report.bind_group_layouts.active(), 1);
+    assert_eq!(report.shader_modules.active(), 1);
+    assert_eq!(report.pipeline_layouts.active(), 1);
+    assert_eq!(report.render_pipelines.active(), 1);
+    assert_eq!(report.compute_pipelines.active(), 0);
 
     drop(shader);
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.shader_modules.num_allocated, 0);
-    assert_eq!(report.shader_modules.num_kept_from_user, 0);
-    assert_eq!(report.textures.num_allocated, 0);
-    assert_eq!(report.texture_views.num_allocated, 0);
+    let report = ctx.device.generate_report().unwrap();
+    // is kept alive by render pipeline
+    assert_eq!(report.shader_modules.active(), 1);
+    assert_eq!(report.textures.active(), 0);
+    assert_eq!(report.texture_views.active(), 0);
 
     let texture = ctx.device.create_texture_with_data(
         &ctx.queue,
@@ -170,31 +158,26 @@ async fn draw_test_with_reports(
     );
     let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.buffers.num_allocated, 1);
-    assert_eq!(report.texture_views.num_allocated, 1);
-    assert_eq!(report.textures.num_allocated, 1);
+    let report = ctx.device.generate_report().unwrap();
+    assert_eq!(report.buffers.active(), 1);
+    assert_eq!(report.texture_views.active(), 1);
+    assert_eq!(report.textures.active(), 1);
 
     drop(texture);
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.buffers.num_allocated, 1);
-    assert_eq!(report.texture_views.num_allocated, 1);
-    assert_eq!(report.texture_views.num_kept_from_user, 1);
+    let report = ctx.device.generate_report().unwrap();
+    assert_eq!(report.buffers.active(), 1);
+    assert_eq!(report.texture_views.active(), 1);
     // TextureViews in `wgpu` have a reference to the texture.
-    assert_eq!(report.textures.num_allocated, 1);
-    assert_eq!(report.textures.num_kept_from_user, 1);
+    assert_eq!(report.textures.active(), 1);
 
     let mut encoder = ctx
         .device
         .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.command_encoders.num_allocated, 1);
-    assert_eq!(report.buffers.num_allocated, 1);
+    let report = ctx.device.generate_report().unwrap();
+    // assert_eq!(report.command_encoders.active(), 1);
+    assert_eq!(report.buffers.active(), 1);
 
     let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
         label: None,
@@ -213,18 +196,17 @@ async fn draw_test_with_reports(
     rpass.set_pipeline(&pipeline);
     rpass.set_bind_group(0, &bg, &[]);
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.buffers.num_allocated, 1);
-    assert_eq!(report.bind_groups.num_allocated, 1);
-    assert_eq!(report.bind_group_layouts.num_allocated, 1);
-    assert_eq!(report.pipeline_layouts.num_allocated, 1);
-    assert_eq!(report.render_pipelines.num_allocated, 1);
-    assert_eq!(report.compute_pipelines.num_allocated, 0);
-    assert_eq!(report.command_encoders.num_allocated, 1);
-    assert_eq!(report.render_bundles.num_allocated, 0);
-    assert_eq!(report.texture_views.num_allocated, 1);
-    assert_eq!(report.textures.num_allocated, 1);
+    let report = ctx.device.generate_report().unwrap();
+    assert_eq!(report.buffers.active(), 1);
+    assert_eq!(report.bind_groups.active(), 1);
+    assert_eq!(report.bind_group_layouts.active(), 1);
+    assert_eq!(report.pipeline_layouts.active(), 1);
+    assert_eq!(report.render_pipelines.active(), 1);
+    assert_eq!(report.compute_pipelines.active(), 0);
+    // assert_eq!(report.command_encoders.active(), 1);
+    assert_eq!(report.render_bundles.active(), 0);
+    assert_eq!(report.texture_views.active(), 1);
+    assert_eq!(report.textures.active(), 1);
 
     function(&mut rpass);
 
@@ -236,37 +218,26 @@ async fn draw_test_with_reports(
     drop(bg);
     drop(buffer);
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.command_encoders.num_kept_from_user, 1);
-    assert_eq!(report.render_pipelines.num_kept_from_user, 0);
-    assert_eq!(report.pipeline_layouts.num_kept_from_user, 0);
-    assert_eq!(report.bind_group_layouts.num_kept_from_user, 0);
-    assert_eq!(report.bind_groups.num_kept_from_user, 0);
-    assert_eq!(report.buffers.num_kept_from_user, 0);
-    assert_eq!(report.texture_views.num_kept_from_user, 0);
-    assert_eq!(report.textures.num_kept_from_user, 0);
-    assert_eq!(report.command_encoders.num_allocated, 1);
-    assert_eq!(report.render_pipelines.num_allocated, 0);
-    assert_eq!(report.pipeline_layouts.num_allocated, 0);
-    assert_eq!(report.bind_group_layouts.num_allocated, 0);
-    assert_eq!(report.bind_groups.num_allocated, 0);
-    assert_eq!(report.buffers.num_allocated, 0);
-    assert_eq!(report.texture_views.num_allocated, 0);
-    assert_eq!(report.textures.num_allocated, 0);
+    let report = ctx.device.generate_report().unwrap();
+    // assert_eq!(report.command_encoders.active(), 1);
+    assert_eq!(report.render_pipelines.active(), 1);
+    assert_eq!(report.pipeline_layouts.active(), 1);
+    assert_eq!(report.bind_group_layouts.active(), 1);
+    assert_eq!(report.bind_groups.active(), 1);
+    assert_eq!(report.buffers.active(), 1);
+    assert_eq!(report.texture_views.active(), 1);
+    assert_eq!(report.textures.active(), 1);
 
     let command_buffer = encoder.finish();
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.command_encoders.num_allocated, 0);
-    assert_eq!(report.command_buffers.num_allocated, 1);
+    // let report = ctx.device.generate_report().unwrap();
+    // assert_eq!(report.command_encoders.active(), 0);
+    // assert_eq!(report.command_buffers.active(), 1);
 
     let submit_index = ctx.queue.submit(Some(command_buffer));
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-    assert_eq!(report.command_buffers.num_allocated, 0);
+    // let report = ctx.device.generate_report().unwrap();
+    // assert_eq!(report.command_buffers.active(), 0);
 
     ctx.async_poll(wgpu::PollType::Wait {
         submission_index: Some(submit_index),
@@ -275,32 +246,14 @@ async fn draw_test_with_reports(
     .await
     .unwrap();
 
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-
-    assert_eq!(report.render_pipelines.num_allocated, 0);
-    assert_eq!(report.bind_groups.num_allocated, 0);
-    assert_eq!(report.bind_group_layouts.num_allocated, 0);
-    assert_eq!(report.pipeline_layouts.num_allocated, 0);
-    assert_eq!(report.texture_views.num_allocated, 0);
-    assert_eq!(report.textures.num_allocated, 0);
-    assert_eq!(report.buffers.num_allocated, 0);
-
-    drop(ctx.queue);
-    drop(ctx.device);
-    drop(ctx.adapter);
-
-    let global_report = ctx.instance.generate_report().unwrap();
-    let report = global_report.hub_report();
-
-    assert_eq!(report.queues.num_kept_from_user, 0);
-    assert_eq!(report.textures.num_kept_from_user, 0);
-    assert_eq!(report.devices.num_kept_from_user, 0);
-    assert_eq!(report.queues.num_allocated, 0);
-    assert_eq!(report.buffers.num_allocated, 0);
-    assert_eq!(report.textures.num_allocated, 0);
-    assert_eq!(report.texture_views.num_allocated, 0);
-    assert_eq!(report.devices.num_allocated, 0);
+    let report = ctx.device.generate_report().unwrap();
+    assert_eq!(report.render_pipelines.active(), 0);
+    assert_eq!(report.bind_groups.active(), 0);
+    assert_eq!(report.bind_group_layouts.active(), 0);
+    assert_eq!(report.pipeline_layouts.active(), 0);
+    assert_eq!(report.texture_views.active(), 0);
+    assert_eq!(report.textures.active(), 0);
+    assert_eq!(report.buffers.active(), 0);
 }
 
 #[cfg(any(
@@ -315,7 +268,8 @@ static SIMPLE_DRAW_CHECK_MEM_LEAKS: wgpu_test::GpuTestConfiguration =
             wgpu_test::TestParameters::default()
                 .test_features_limits()
                 .features(wgpu::Features::VERTEX_WRITABLE_STORAGE)
-                .enable_noop(),
+                .enable_noop()
+                .set_trace(wgpu::Trace::Memory),
         )
         .run_async(|ctx| {
             draw_test_with_reports(ctx, &[0, 1, 2, 3, 4, 5], |cmb| {

--- a/tests/tests/wgpu-gpu/poll.rs
+++ b/tests/tests/wgpu-gpu/poll.rs
@@ -346,9 +346,13 @@ static WAIT_AFTER_BAD_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::n
     .run_async(wait_after_bad_submission);
 
 async fn wait_after_bad_submission(ctx: TestingContext) {
-    let (device2, queue2) =
-        wgpu_test::initialize_device(&ctx.adapter, ctx.device_features, ctx.device_limits.clone())
-            .await;
+    let (device2, queue2) = wgpu_test::initialize_device(
+        &ctx.adapter,
+        ctx.device_features,
+        ctx.device_limits.clone(),
+        wgpu::Trace::Off,
+    )
+    .await;
 
     let command_buffer1 = ctx
         .device
@@ -392,9 +396,13 @@ static WAIT_ON_FAILED_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::n
 async fn wait_on_failed_submission(ctx: TestingContext) {
     // Create an alternate device; we will produce a failed submission by
     // submitting a command buffer to the wrong device.
-    let (device2, queue2) =
-        wgpu_test::initialize_device(&ctx.adapter, ctx.device_features, ctx.device_limits.clone())
-            .await;
+    let (device2, queue2) = wgpu_test::initialize_device(
+        &ctx.adapter,
+        ctx.device_features,
+        ctx.device_limits.clone(),
+        wgpu::Trace::Off,
+    )
+    .await;
 
     // 1. Successful empty submit. Advances `last_successful_submission_index`.
     let _idx_before = queue2.submit([]);

--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -1171,6 +1171,11 @@ impl Global {
         device.take_trace()
     }
 
+    pub fn device_report(&self, device_id: DeviceId) -> Option<wgt::Report> {
+        let device = self.hub.devices.get(device_id);
+        device.report()
+    }
+
     pub fn queue_drop(&self, queue_id: QueueId) {
         self.hub.queues.remove(queue_id);
     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -798,6 +798,14 @@ impl Device {
         self.trace.lock().take()
     }
 
+    /// Returns a report of the trace object.
+    pub fn report(&self) -> Option<wgt::Report> {
+        #[cfg(feature = "trace")]
+        return self.trace.lock().as_ref().map(|t| t.report());
+        #[cfg(not(feature = "trace"))]
+        return None;
+    }
+
     /// Checks that we are operating within the memory budget reported by the native APIs.
     ///
     /// If we are not, the device gets invalidated.

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -1,6 +1,7 @@
 use alloc::{borrow::Cow, string::ToString, sync::Arc, vec::Vec};
 use core::{any::Any, convert::Infallible, marker::PhantomData};
 use std::io::Write as _;
+use wgt::{Report, ResourceReport};
 
 use crate::{
     command::{
@@ -44,6 +45,8 @@ pub trait Trace: Any + Send + Sync {
 
     fn make_string(&mut self, kind: DataKind, data: &str) -> Data;
 
+    fn report(&self) -> Report;
+
     fn add(&mut self, action: Action<'_, PointerReferences>)
     where
         for<'a> Action<'a, PointerReferences>: serde::Serialize;
@@ -55,6 +58,7 @@ pub struct DiskTrace {
     file: std::fs::File,
     config: ron::ser::PrettyConfig,
     data_id: usize,
+    report: Report,
 }
 
 impl DiskTrace {
@@ -67,6 +71,7 @@ impl DiskTrace {
             file,
             config: ron::ser::PrettyConfig::default(),
             data_id: 0,
+            report: Report::default(),
         })
     }
 }
@@ -91,10 +96,15 @@ impl Trace for DiskTrace {
         self.make_binary(kind, data.as_bytes())
     }
 
+    fn report(&self) -> Report {
+        self.report.clone()
+    }
+
     fn add(&mut self, action: Action<'_, PointerReferences>)
     where
         for<'a> Action<'a, PointerReferences>: serde::Serialize,
     {
+        report_action(&mut self.report, &action);
         match ron::ser::to_string_pretty(&action, self.config.clone()) {
             Ok(string) => {
                 let _ = writeln!(self.file, "{string},");
@@ -109,6 +119,79 @@ impl Trace for DiskTrace {
 impl Drop for DiskTrace {
     fn drop(&mut self) {
         let _ = self.file.write_all(b"]");
+    }
+}
+
+fn report_create(report: &mut ResourceReport) {
+    report.num_allocated += 1;
+}
+
+fn report_drop(report: &mut ResourceReport) {
+    report.num_released += 1;
+}
+
+fn report_action(report: &mut Report, action: &Action<'_, PointerReferences>) {
+    // creation can happen at many places and we want to capture all of them
+    // to have balanced create/drop counts
+    match action {
+        Action::Init { .. } => {}
+        Action::ConfigureSurface(_, _) => {}
+        Action::CreateBuffer(_, _) => report_create(&mut report.buffers),
+        Action::DestroyBuffer(_) => {}
+        Action::DropBuffer(_) => report_drop(&mut report.buffers),
+        Action::CreateTexture(_, _) => report_create(&mut report.textures),
+        Action::CreateTextureError(_, _) => report_create(&mut report.textures),
+        Action::DestroyTexture(_) => {}
+        Action::DropTexture(_) => report_drop(&mut report.textures),
+        Action::CreateTextureView { .. } => report_create(&mut report.texture_views),
+        Action::DropTextureView(_) => report_drop(&mut report.texture_views),
+        Action::CreateExternalTexture { .. } => report_create(&mut report.external_textures),
+        Action::DestroyExternalTexture(_) => {}
+        Action::DropExternalTexture(_) => report_drop(&mut report.external_textures),
+        Action::CreateSampler(_, _) => report_create(&mut report.samplers),
+        Action::DropSampler(_) => report_drop(&mut report.samplers),
+        Action::GetSurfaceTexture { .. } => report_create(&mut report.textures),
+        Action::Present(_) => {}
+        Action::DiscardSurfaceTexture(_) => {}
+        Action::ReleaseSurfaceTexture(_) => {}
+        Action::CreateBindGroupLayout(_, _) => {
+            report_create(&mut report.bind_group_layouts);
+        }
+        Action::GetRenderPipelineBindGroupLayout { .. } => {
+            report_create(&mut report.bind_group_layouts);
+        }
+        Action::GetComputePipelineBindGroupLayout { .. } => {
+            report_create(&mut report.bind_group_layouts);
+        }
+        Action::DropBindGroupLayout(_) => report_drop(&mut report.bind_group_layouts),
+        Action::CreatePipelineLayout(_, _) => {
+            report_create(&mut report.pipeline_layouts);
+        }
+        Action::DropPipelineLayout(_) => report_drop(&mut report.pipeline_layouts),
+        Action::CreateBindGroup(_, _) => report_create(&mut report.bind_groups),
+        Action::DropBindGroup(_) => report_drop(&mut report.bind_groups),
+        Action::CreateShaderModule { .. } => report_create(&mut report.shader_modules),
+        Action::CreateShaderModulePassthrough { .. } => report_create(&mut report.shader_modules),
+        Action::DropShaderModule(_) => report_drop(&mut report.shader_modules),
+        Action::CreateComputePipeline { .. } => report_create(&mut report.compute_pipelines),
+        Action::DropComputePipeline(_) => report_drop(&mut report.compute_pipelines),
+        Action::CreateGeneralRenderPipeline { .. } => report_create(&mut report.render_pipelines),
+        Action::DropRenderPipeline(_) => report_drop(&mut report.render_pipelines),
+        Action::CreatePipelineCache { .. } => report_create(&mut report.pipeline_caches),
+        Action::DropPipelineCache(_) => report_drop(&mut report.pipeline_caches),
+        Action::CreateRenderBundle { .. } => report_create(&mut report.render_bundles),
+        Action::DropRenderBundle(_) => report_drop(&mut report.render_bundles),
+        Action::CreateQuerySet { .. } => report_create(&mut report.query_sets),
+        Action::DropQuerySet(_) => report_drop(&mut report.query_sets),
+        Action::DestroyQuerySet(_) => report_drop(&mut report.query_sets),
+        Action::WriteBuffer { .. } => {}
+        Action::WriteTexture { .. } => {}
+        Action::Submit(_, _) => {}
+        Action::FailedCommands { .. } => {}
+        Action::CreateBlas { .. } => report_create(&mut report.blases),
+        Action::DropBlas(_) => report_drop(&mut report.blases),
+        Action::CreateTlas { .. } => report_create(&mut report.tlases),
+        Action::DropTlas(_) => report_drop(&mut report.tlases),
     }
 }
 
@@ -142,6 +225,14 @@ impl Trace for MemoryTrace {
     /// `make_binary` instead.
     fn make_string(&mut self, kind: DataKind, data: &str) -> Data {
         Data::String(kind, data.to_string())
+    }
+
+    fn report(&self) -> Report {
+        let mut report = Report::default();
+        for action in &self.actions {
+            report_action(&mut report, action);
+        }
+        report
     }
 
     fn add(&mut self, action: Action<'_, PointerReferences>)

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -5,7 +5,7 @@ use crate::{
     binding_model::{BindGroupLayout, PipelineLayout},
     command::{CommandBuffer, CommandEncoder},
     device::{queue::Queue, Device},
-    hub::{Hub, HubReport},
+    hub::Hub,
     id::{
         AdapterId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId,
         ComputePipelineId, DeviceId, PipelineLayoutId, QuerySetId, QueueId, RenderPipelineId,
@@ -13,25 +13,10 @@ use crate::{
     },
     instance::{Adapter, Instance, Surface},
     pipeline::{ComputePipeline, RenderPipeline},
-    registry::{Registry, RegistryReport},
+    registry::Registry,
     resource::{Buffer, QuerySet, Texture},
     resource_log,
 };
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct GlobalReport {
-    pub surfaces: RegistryReport,
-    pub hub: HubReport,
-}
-
-impl GlobalReport {
-    pub fn surfaces(&self) -> &RegistryReport {
-        &self.surfaces
-    }
-    pub fn hub_report(&self) -> &HubReport {
-        &self.hub
-    }
-}
 
 pub struct Global {
     pub(crate) surfaces: Registry<Arc<Surface>>,
@@ -83,13 +68,6 @@ impl Global {
             instance,
             surfaces: Registry::new(),
             hub: Hub::new(),
-        }
-    }
-
-    pub fn generate_report(&self) -> GlobalReport {
-        GlobalReport {
-            surfaces: self.surfaces.generate_report(),
-            hub: self.hub.generate_report(),
         }
     }
 }

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -117,7 +117,6 @@ when replaying a trace.
 */
 
 use alloc::sync::Arc;
-use core::fmt::Debug;
 
 use crate::{
     binding_model::{BindGroup, BindGroupLayout, PipelineLayout},
@@ -128,45 +127,13 @@ use crate::{
     instance::Adapter,
     lock::rank,
     pipeline::{ComputePipeline, PipelineCache, RenderPipeline, ShaderModule},
-    registry::{Registry, RegistryReport},
+    registry::Registry,
     resource::{
         Blas, Buffer, ExternalTexture, QuerySet, Sampler, StagingBuffer, Texture, TextureView, Tlas,
     },
 };
 
 use parking_lot::Mutex;
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct HubReport {
-    pub adapters: RegistryReport,
-    pub devices: RegistryReport,
-    pub queues: RegistryReport,
-    pub pipeline_layouts: RegistryReport,
-    pub shader_modules: RegistryReport,
-    pub bind_group_layouts: RegistryReport,
-    pub bind_groups: RegistryReport,
-    pub command_encoders: RegistryReport,
-    pub command_buffers: RegistryReport,
-    pub render_bundles: RegistryReport,
-    pub render_pipelines: RegistryReport,
-    pub compute_pipelines: RegistryReport,
-    pub pipeline_caches: RegistryReport,
-    pub query_sets: RegistryReport,
-    pub buffers: RegistryReport,
-    pub textures: RegistryReport,
-    pub texture_views: RegistryReport,
-    pub external_textures: RegistryReport,
-    pub samplers: RegistryReport,
-    pub render_passes: RegistryReport,
-    pub compute_passes: RegistryReport,
-    pub render_bundle_encoders: RegistryReport,
-}
-
-impl HubReport {
-    pub fn is_empty(&self) -> bool {
-        self.adapters.is_empty()
-    }
-}
 
 #[allow(rustdoc::private_intra_doc_links)]
 /// All the resources tracked by a [`crate::global::Global`].
@@ -252,33 +219,6 @@ impl Hub {
             render_passes: Registry::new(),
             compute_passes: Registry::new(),
             render_bundle_encoders: Registry::new(),
-        }
-    }
-
-    pub fn generate_report(&self) -> HubReport {
-        HubReport {
-            adapters: self.adapters.generate_report(),
-            devices: self.devices.generate_report(),
-            queues: self.queues.generate_report(),
-            pipeline_layouts: self.pipeline_layouts.generate_report(),
-            shader_modules: self.shader_modules.generate_report(),
-            bind_group_layouts: self.bind_group_layouts.generate_report(),
-            bind_groups: self.bind_groups.generate_report(),
-            command_encoders: self.command_encoders.generate_report(),
-            command_buffers: self.command_buffers.generate_report(),
-            render_bundles: self.render_bundles.generate_report(),
-            render_pipelines: self.render_pipelines.generate_report(),
-            compute_pipelines: self.compute_pipelines.generate_report(),
-            pipeline_caches: self.pipeline_caches.generate_report(),
-            query_sets: self.query_sets.generate_report(),
-            buffers: self.buffers.generate_report(),
-            textures: self.textures.generate_report(),
-            texture_views: self.texture_views.generate_report(),
-            external_textures: self.external_textures.generate_report(),
-            samplers: self.samplers.generate_report(),
-            render_passes: self.render_passes.generate_report(),
-            compute_passes: self.compute_passes.generate_report(),
-            render_bundle_encoders: self.render_bundle_encoders.generate_report(),
         }
     }
 }

--- a/wgpu-core/src/identity.rs
+++ b/wgpu-core/src/identity.rs
@@ -108,10 +108,6 @@ impl IdentityValues {
         }
         self.count -= 1;
     }
-
-    pub fn count(&self) -> usize {
-        self.count
-    }
 }
 
 #[derive(Debug)]

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -7,27 +7,8 @@ use crate::{
         rank::{self, LockRank},
         RwLock, RwLockReadGuard,
     },
-    storage::{Element, Storage, StorageItem},
+    storage::{Storage, StorageItem},
 };
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct RegistryReport {
-    /// Count of IDs allocated by [`IdentityManager`]
-    ///
-    /// This may be inconsistent with other fields of the report if
-    /// IDs are allocated or released concurrently with report
-    /// generation.
-    pub num_allocated: usize,
-    pub num_kept_from_user: usize,
-    pub num_released_from_user: usize,
-    pub element_size: usize,
-}
-
-impl RegistryReport {
-    pub fn is_empty(&self) -> bool {
-        self.num_allocated + self.num_kept_from_user == 0
-    }
-}
 
 /// Registry is the primary holder of each resource type
 /// Every resource is now arcanized so the last arc released
@@ -103,28 +84,6 @@ impl<T: StorageItem> Registry<T> {
         self.identity.free(id);
         //Returning None is legal if it's an error ID
         value
-    }
-
-    pub(crate) fn generate_report(&self) -> RegistryReport {
-        let mut report = RegistryReport {
-            element_size: size_of::<T>(),
-            ..Default::default()
-        };
-
-        // Acquiring the identity values lock while holding the storage lock
-        // would require adding an edge in the lock graph, and would still not
-        // ensure a consistent report, because the storage lock is not otherwise
-        // acquired when managing IDs.
-        report.num_allocated = self.identity.values.lock().count();
-
-        let storage = self.storage.read();
-        for element in storage.map.iter() {
-            match *element {
-                Element::Occupied(..) => report.num_kept_from_user += 1,
-                Element::Vacant => report.num_released_from_user += 1,
-            }
-        }
-        report
     }
 }
 

--- a/wgpu-types/src/counters.rs
+++ b/wgpu-types/src/counters.rs
@@ -238,3 +238,50 @@ impl fmt::Display for FmtBytes {
         }
     }
 }
+
+/// Count of resources created/destroyed as captured by tracing.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct ResourceReport {
+    /// Number of resources created.
+    pub num_allocated: usize,
+    /// Number of resources deallocated.
+    pub num_released: usize,
+}
+
+impl ResourceReport {
+    /// Returns the number of resources that are currently alive.
+    pub fn active(&self) -> usize {
+        self.num_allocated
+            .checked_sub(self.num_released)
+            .expect("Trace should be balanced")
+    }
+}
+
+#[expect(missing_docs)]
+/// Report of all resources created/destroyed as captured by tracing.
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
+pub struct Report {
+    pub pipeline_layouts: ResourceReport,
+    pub shader_modules: ResourceReport,
+    pub bind_group_layouts: ResourceReport,
+    pub bind_groups: ResourceReport,
+    // not impl in tracing yet
+    // pub command_encoders: ResourceReport,
+    // pub command_buffers: ResourceReport,
+    pub render_bundles: ResourceReport,
+    pub render_pipelines: ResourceReport,
+    pub compute_pipelines: ResourceReport,
+    pub pipeline_caches: ResourceReport,
+    pub query_sets: ResourceReport,
+    pub buffers: ResourceReport,
+    pub textures: ResourceReport,
+    pub texture_views: ResourceReport,
+    pub external_textures: ResourceReport,
+    pub samplers: ResourceReport,
+    pub render_passes: ResourceReport,
+    pub compute_passes: ResourceReport,
+    pub render_bundle_encoders: ResourceReport,
+    pub blases: ResourceReport,
+    pub tlases: ResourceReport,
+    pub surfaces: ResourceReport,
+}

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -631,6 +631,14 @@ impl Device {
         self.inner.generate_allocator_report()
     }
 
+    /// Generates memory report.
+    ///
+    /// Returns `None` if the feature is not supported by the backend (webgpu)
+    /// or if tracing is not enabled.
+    pub fn generate_report(&self) -> Option<wgt::Report> {
+        self.inner.generate_report()
+    }
+
     /// Get the [`wgpu_hal`] device from this `Device`.
     ///
     /// Find the Api struct corresponding to the active backend in [`wgpu_hal::api`],

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -302,15 +302,6 @@ impl Instance {
     pub fn poll_all(&self, force_wait: bool) -> bool {
         self.inner.poll_all_devices(force_wait)
     }
-
-    /// Generates memory report.
-    ///
-    /// Returns `None` if the feature is not supported by the backend
-    /// which happens only when WebGPU is pre-selected by the instance creation.
-    #[cfg(wgpu_core)]
-    pub fn generate_report(&self) -> Option<wgc::global::GlobalReport> {
-        self.inner.as_core_opt().map(|ctx| ctx.generate_report())
-    }
 }
 
 /// Interop with wgpu-hal.

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2716,6 +2716,10 @@ impl dispatch::DeviceInterface for WebDevice {
         None
     }
 
+    fn generate_report(&self) -> Option<wgt::Report> {
+        None
+    }
+
     fn destroy(&self) {
         self.inner.destroy();
     }

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -262,10 +262,6 @@ impl ContextWgpuCore {
         unsafe { self.0.tlas_as_hal::<A>(tlas.id) }
     }
 
-    pub fn generate_report(&self) -> wgc::global::GlobalReport {
-        self.0.generate_report()
-    }
-
     #[cold]
     #[track_caller]
     #[inline(never)]
@@ -1937,6 +1933,10 @@ impl dispatch::DeviceInterface for CoreDevice {
 
     fn generate_allocator_report(&self) -> Option<wgt::AllocatorReport> {
         self.context.0.device_generate_allocator_report(self.id)
+    }
+
+    fn generate_report(&self) -> Option<wgt::Report> {
+        self.context.0.device_report(self.id)
     }
 
     fn destroy(&self) {

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -218,6 +218,7 @@ pub trait DeviceInterface: CommonTraits {
 
     fn get_internal_counters(&self) -> crate::InternalCounters;
     fn generate_allocator_report(&self) -> Option<crate::AllocatorReport>;
+    fn generate_report(&self) -> Option<wgt::Report>;
 
     fn destroy(&self);
 }


### PR DESCRIPTION
**Connections**
For #9950 and towards #5121

**Description**
In #9950 I discovered that we need `GlobalReport` for some memory leak tests. One option is to completely remove all such uses and tests (I wonder how useful they are anyway). This PR goes into alternative route by impl reporting as part of tracing (which gives us most of Creates/Drops). Tracing is per device not per instance, so some stuff is unimplementable (so is removed from test), some stuff are not traced yet so they are commented out. Still I think the most important part of mem leak test was kept.

**Testing**
Covered by tests.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
