### PR TITLE
[core] Wrap `Instance` in Arc and store it in `Adapter`

### DIFF
--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -193,7 +193,7 @@ impl GPU {
       if strict_compliance {
         flags |= wgpu_types::InstanceFlags::STRICT_WEBGPU_COMPLIANCE;
       }
-      state.put(Arc::new(wgpu_core::instance::Instance::new(
+      state.put(wgpu_core::instance::Instance::new(
         "webgpu",
         wgpu_types::InstanceDescriptor {
           backends,
@@ -214,7 +214,7 @@ impl GPU {
           display: None,
         },
         None,
-      )));
+      ));
       state.borrow::<Instance>()
     };
 

--- a/wgpu-core/src/global.rs
+++ b/wgpu-core/src/global.rs
@@ -37,7 +37,7 @@ pub struct Global {
     pub(crate) surfaces: Registry<Arc<Surface>>,
     pub(crate) hub: Hub,
     // the instance must be dropped last
-    pub instance: Instance,
+    pub instance: Arc<Instance>,
 }
 
 impl Global {
@@ -77,7 +77,7 @@ impl Global {
     /// # Safety
     ///
     /// - The raw handles obtained from the Instance must not be manually destroyed
-    pub unsafe fn from_instance(instance: Instance) -> Self {
+    pub unsafe fn from_instance(instance: Arc<Instance>) -> Self {
         profiling::scope!("Global::new");
         Self {
             instance,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -128,7 +128,7 @@ impl Instance {
         name: &str,
         mut instance_desc: wgt::InstanceDescriptor,
         telemetry: Option<hal::Telemetry>,
-    ) -> Self {
+    ) -> Arc<Self> {
         let mut this = Self {
             _name: name.to_owned(),
             instance_per_backend: Vec::new(),
@@ -153,7 +153,7 @@ impl Instance {
         #[cfg(feature = "noop")]
         this.try_add_hal(hal::api::Noop, &instance_desc, telemetry);
 
-        this
+        Arc::new(this)
     }
 
     /// Helper for `Instance::new()`; attempts to add a single `wgpu-hal` backend to this instance.
@@ -210,8 +210,8 @@ impl Instance {
     pub(crate) fn from_hal_instance<A: hal::Api>(
         name: String,
         hal_instance: <A as hal::Api>::Instance,
-    ) -> Self {
-        Self {
+    ) -> Arc<Self> {
+        Arc::new(Self {
             _name: name,
             instance_per_backend: vec![(A::VARIANT, Box::new(hal_instance))],
             requested_backends: A::VARIANT.into(),
@@ -219,7 +219,7 @@ impl Instance {
             flags: InstanceFlags::default(),
             display: None, // TODO: Extract display from HAL instance if available?
             devices: InstanceDevices::new(),
-        }
+        })
     }
 
     pub fn raw(&self, backend: Backend) -> Option<&dyn hal::DynInstance> {
@@ -488,7 +488,7 @@ impl Instance {
     }
 
     pub fn enumerate_adapters(
-        &self,
+        self: &Arc<Self>,
         backends: Backends,
         apply_limit_buckets: bool,
     ) -> Vec<Arc<Adapter>> {
@@ -531,7 +531,7 @@ impl Instance {
                         }
                     })
                     .map(|raw| {
-                        let adapter = Adapter::new(raw, self.devices.clone(), self.flags);
+                        let adapter = Adapter::new(raw, self.clone());
                         api_log_debug!("Adapter {:?}", adapter.raw.info);
                         adapter
                     }),
@@ -541,7 +541,7 @@ impl Instance {
     }
 
     pub fn request_adapter(
-        &self,
+        self: &Arc<Self>,
         desc: &wgt::RequestAdapterOptions<&Surface>,
         backends: Backends,
     ) -> Result<Arc<Adapter>, wgt::RequestAdapterError> {
@@ -681,7 +681,7 @@ impl Instance {
 
         if let Some(adapter) = adapters.into_iter().next() {
             api_log_debug!("Request adapter result {:?}", adapter.info);
-            let adapter = Adapter::new(adapter, self.devices.clone(), self.flags);
+            let adapter = Adapter::new(adapter, self.clone());
             Ok(adapter)
         } else {
             Err(wgt::RequestAdapterError::NotFound {
@@ -731,12 +731,12 @@ impl Instance {
     ///
     /// [lt]: crate::limits#Limit-bucketing
     pub unsafe fn create_adapter_from_hal(
-        &self,
+        self: &Arc<Self>,
         hal_adapter: hal::DynExposedAdapter,
     ) -> Arc<Adapter> {
         profiling::scope!("Instance::create_adapter_from_hal");
 
-        let adapter = Adapter::new(hal_adapter, self.devices.clone(), self.flags);
+        let adapter = Adapter::new(hal_adapter, self.clone());
 
         resource_log!("Created Adapter {:?}", Arc::as_ptr(&adapter));
         adapter
@@ -1043,21 +1043,12 @@ impl Drop for Surface {
 
 pub struct Adapter {
     pub(crate) raw: hal::DynExposedAdapter,
-    pub(crate) devices: InstanceDevices,
-    pub(crate) instance_flags: InstanceFlags,
+    pub(crate) instance: Arc<Instance>,
 }
 
 impl Adapter {
-    pub(crate) fn new(
-        raw: hal::DynExposedAdapter,
-        devices: InstanceDevices,
-        flags: InstanceFlags,
-    ) -> Arc<Self> {
-        Arc::new(Self {
-            raw,
-            devices,
-            instance_flags: flags,
-        })
+    pub(crate) fn new(raw: hal::DynExposedAdapter, instance: Arc<Instance>) -> Arc<Self> {
+        Arc::new(Self { raw, instance })
     }
 
     /// Returns the backend this adapter is using.
@@ -1199,10 +1190,10 @@ impl Adapter {
         profiling::scope!("Adapter::create_device_and_queue_from_hal");
         api_log!("Adapter::create_device_and_queue_from_hal");
 
-        let device = Device::new(hal_device.device, self, desc, self.instance_flags)?;
+        let device = Device::new(hal_device.device, self, desc, self.instance.flags)?;
         let device = Arc::new(device);
 
-        let queue = Queue::new(device.clone(), hal_device.queue, self.instance_flags)?;
+        let queue = Queue::new(device.clone(), hal_device.queue, self.instance.flags)?;
         let queue = Arc::new(queue);
 
         device.set_queue(&queue);
@@ -1211,7 +1202,7 @@ impl Adapter {
         resource_log!("Created Device {:?}", Arc::as_ptr(&device));
         resource_log!("Created Queue {:?}", Arc::as_ptr(&queue));
 
-        self.devices.push(&device);
+        self.instance.devices.push(&device);
 
         Ok((device, queue))
     }
@@ -1224,7 +1215,7 @@ impl Adapter {
         api_log!("Adapter::request_device");
         let mut desc = desc.clone();
         filter_features_and_limits(
-            self.instance_flags,
+            self.instance.flags,
             &mut desc.required_features,
             &mut desc.required_limits,
         );

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -34,8 +34,8 @@ fn downlevel_default_limits_less_than_default_limits() {
     )
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct InstanceDevices(Arc<Mutex<WeakVec<Device>>>);
+#[derive(Debug)]
+pub(crate) struct InstanceDevices(Mutex<WeakVec<Device>>);
 
 impl Default for InstanceDevices {
     fn default() -> Self {
@@ -45,7 +45,7 @@ impl Default for InstanceDevices {
 
 impl InstanceDevices {
     pub(crate) fn new() -> Self {
-        Self(Arc::new(Mutex::new(rank::HUB_OTHER, WeakVec::new())))
+        Self(Mutex::new(rank::HUB_OTHER, WeakVec::new()))
     }
 
     pub(crate) fn push(&self, device: &Arc<Device>) {

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -1,3 +1,5 @@
+#[cfg(wgpu_core)]
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::future::Future;
 
@@ -418,7 +420,7 @@ impl Instance {
     /// # Safety
     ///
     /// Refer to the creation of wgpu-core Instance.
-    pub unsafe fn from_core(core_instance: wgc::instance::Instance) -> Self {
+    pub unsafe fn from_core(core_instance: Arc<wgc::instance::Instance>) -> Self {
         Self {
             inner: unsafe {
                 crate::backend::ContextWgpuCore::from_core_instance(core_instance).into()

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -74,7 +74,7 @@ impl ContextWgpuCore {
         unsafe { self.0.instance_as_hal::<A>() }
     }
 
-    pub unsafe fn from_core_instance(core_instance: wgc::instance::Instance) -> Self {
+    pub unsafe fn from_core_instance(core_instance: Arc<wgc::instance::Instance>) -> Self {
         Self(unsafe { Arc::new(wgc::global::Global::from_instance(core_instance)) })
     }
 


### PR DESCRIPTION
**Connections**
Needed for #9950

**Description**
Currently global enforces drop order so that instance is dropped last: https://github.com/gfx-rs/wgpu/blob/4fe6176a653026ccbce52e6275ff162cbdb1a882/wgpu-core/src/global.rs#L39

But when global is avoided we need to enforce this manually. We already need some of it's data in Adapter so this allows us to remove it. The new ownership chain that fixes the issue in #9950 is `Queue -> Device -> Adapter -> Instance`.

**Testing**
Should be covered by existing tests and new ownership chain fixes the problem in #9950.

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
