### PR TITLE
fix(hal/vulkan): Use queue family index modified by device open callback

### DIFF
--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -3011,11 +3011,10 @@ impl super::Adapter {
         let mut enabled_extensions = self.required_device_extensions(features);
         let mut enabled_phd_features = self.physical_device_features(&enabled_extensions, features);
 
-        let family_index = 0; //TODO
-        let family_info = vk::DeviceQueueCreateInfo::default()
-            .queue_family_index(family_index)
-            .queue_priorities(&[1.0]);
-        let mut family_infos = Vec::from([family_info]);
+        let default_family_index = 0; //TODO
+        let mut family_infos = Vec::from([vk::DeviceQueueCreateInfo::default()
+            .queue_family_index(default_family_index)
+            .queue_priorities(&[1.0])]);
 
         let mut pre_info = vk::DeviceCreateInfo::default();
 
@@ -3069,7 +3068,7 @@ impl super::Adapter {
                 features,
                 limits,
                 memory_hints,
-                family_info.queue_family_index,
+                family_infos[0].queue_family_index,
                 0,
             )
         }

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -3011,10 +3011,10 @@ impl super::Adapter {
         let mut enabled_extensions = self.required_device_extensions(features);
         let mut enabled_phd_features = self.physical_device_features(&enabled_extensions, features);
 
-        let default_family_index = 0; //TODO
-        let mut family_infos = Vec::from([vk::DeviceQueueCreateInfo::default()
+        let default_family_index = 0;
+        let mut family_infos = vec![vk::DeviceQueueCreateInfo::default()
             .queue_family_index(default_family_index)
-            .queue_priorities(&[1.0])]);
+            .queue_priorities(&[1.0])];
 
         let mut pre_info = vk::DeviceCreateInfo::default();
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -1710,7 +1710,10 @@ where
     pub extensions: &'arg mut Vec<&'static CStr>,
     /// The physical device features to enable. You may enable features, but must not disable any.
     pub device_features: &'arg mut PhysicalDeviceFeatures,
-    /// The queue create infos for the device. You may add or modify queue create infos as needed.
+    /// The queue create infos for the device. You may substitute a different queue, but:
+    /// 1. Any queue you provide must be compatible with `wgpu`'s usage,
+    /// 2. You must not leave the vector empty,
+    /// 3. `wgpu` currently only uses the first entry.
     pub queue_create_infos: &'arg mut Vec<vk::DeviceQueueCreateInfo<'pnext>>,
     /// The create info for the device. You may add or modify things in the pnext chain, but
     /// do not turn features off. Additionally, do not add things to the list of extensions,


### PR DESCRIPTION
Just a small thing I noticed. `family_info` was not routed through the callback, so if the callback did modify `queue_create_infos`, an incorrect index could be used.

Also updates the doc comment for `CreateDeviceCallbackArgs::queue_create_infos`.

**Testing**
Untested

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
