### PR TITLE
naga: support parsing and writing SPIR-V's OpGroupNonUniformBallotFindLSB/MSB and GLSL's subgroupBallotFindLSB/MSB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - `wgpu::WriteOnly<[_]>` now implements `Send`. By @kpreid in [#10163](https://github.com/gfx-rs/wgpu/pull/10163).
 - Added `Texture::mark_externally_initialized()` to stop a texture from being lazily cleared if it was written to externally (e.g. via `as_hal`). By @R-Cramer4 in [#10075](https://github.com/gfx-rs/wgpu/pull/10075).
 
+#### naga
+
+- Support SPIR-V's `OpGroupNonUniformBallotFindLSB`/`OpGroupNonUniformBallotFindMSB` and GLSL's `subgroupBallotFindLSB`/`subgroupBallotFindMSB` via a new `Statement::SubgroupBallotFindBit` IR node: native `OpGroupNonUniformBallotFindLSB`/`MSB` and `subgroupBallotFindLSB`/`MSB` on SPIR-V and GLSL output, formula-based polyfills on HLSL, MSL, and WGSL. By @nazar-pc in [#9966](https://github.com/gfx-rs/wgpu/pull/9966)
+
 #### Hal
 
 - Add `BufferBinding::buffer`, a public read accessor for the bound buffer, which was previously inaccessible to out-of-tree `wgpu_hal::Api` implementations. By @danlehmann in [#9820](https://github.com/gfx-rs/wgpu/pull/9820).

--- a/naga/src/back/dot/mod.rs
+++ b/naga/src/back/dot/mod.rs
@@ -404,6 +404,18 @@ impl StatementGraph {
                         },
                     }
                 }
+                S::SubgroupBallotFindBit {
+                    order,
+                    argument,
+                    result,
+                } => {
+                    self.dependencies.push((id, argument, "arg"));
+                    self.emits.push((id, result));
+                    match order {
+                        crate::BallotFindBitOrder::Lsb => "SubgroupBallotFindLSB",
+                        crate::BallotFindBitOrder::Msb => "SubgroupBallotFindMSB",
+                    }
+                }
                 S::CooperativeStore { target, data } => {
                     self.dependencies.push((id, target, "target"));
                     self.dependencies.push((id, data.pointer, "pointer"));

--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -2285,6 +2285,29 @@ impl<'a, W: Write> Writer<'a, W> {
                 }
                 writeln!(self.out, ");")?;
             }
+            Statement::SubgroupBallotFindBit {
+                order,
+                argument,
+                result,
+            } => {
+                write!(self.out, "{level}")?;
+                let res_name = Baked(result).to_string();
+                let res_ty = ctx.info[result].ty.inner_with(&self.module.types);
+                self.write_value_type(res_ty)?;
+                write!(self.out, " {res_name} = ")?;
+                self.named_expressions.insert(result, res_name);
+
+                match order {
+                    crate::BallotFindBitOrder::Lsb => {
+                        write!(self.out, "subgroupBallotFindLSB(")?;
+                    }
+                    crate::BallotFindBitOrder::Msb => {
+                        write!(self.out, "subgroupBallotFindMSB(")?;
+                    }
+                }
+                self.write_expr(argument, ctx)?;
+                writeln!(self.out, ");")?;
+            }
             Statement::CooperativeStore { .. } => unimplemented!(),
             Statement::RayPipelineFunction(_) => unimplemented!(),
         }

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -3071,6 +3071,20 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 argument,
                 result,
             } => {
+                // Evaluate each ballot word once into a local, rather than
+                // repeatedly writing `argument.x`/`.y`/`.z`/`.w` in the
+                // ternary chain below.
+                const COMPONENTS: [char; 4] = ['x', 'y', 'z', 'w'];
+                let mut words: [String; 4] = core::array::from_fn(|_| String::new());
+                for (word, &component) in words.iter_mut().zip(&COMPONENTS) {
+                    write!(self.out, "{level}const uint ")?;
+                    let name = self.namer.call("");
+                    write!(self.out, "{name} = ")?;
+                    self.write_expr(module, argument, func_ctx)?;
+                    writeln!(self.out, ".{component};")?;
+                    *word = name;
+                }
+
                 write!(self.out, "{level}")?;
                 write!(self.out, "const ")?;
                 let name = Baked(result).to_string();
@@ -3083,7 +3097,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 write!(self.out, " {name} = ")?;
                 self.named_expressions.insert(result, name);
 
-                self.write_ballot_find_bit(module, argument, func_ctx, order, 3)?;
+                self.write_ballot_find_bit(&words, order, 3)?;
                 writeln!(self.out, ";")?;
             }
             Statement::CooperativeStore { .. } => unimplemented!(),
@@ -3742,7 +3756,8 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
     }
 
     /// Write a polyfill for [`Statement::SubgroupBallotFindBit`], since HLSL has no
-    /// built-in for it: a chain of ternaries. `priority` counts up from 0 (the
+    /// built-in for it: a chain of ternaries over the already-evaluated ballot
+    /// `words` (`words[0..4]` is `x, y, z, w`). `priority` counts up from 0 (the
     /// lowest-priority word, used as the fallback base case) to 3 (the
     /// highest-priority word, checked first: `x` for LSB, `w` for MSB), each
     /// overriding the lower-priority result when that word has any bit set.
@@ -3750,57 +3765,49 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
     /// [`Statement::SubgroupBallotFindBit`]: crate::Statement::SubgroupBallotFindBit
     fn write_ballot_find_bit(
         &mut self,
-        module: &Module,
-        argument: Handle<crate::Expression>,
-        func_ctx: &back::FunctionCtx<'_>,
+        words: &[String; 4],
         order: crate::BallotFindBitOrder,
         priority: u32,
     ) -> BackendResult {
-        let (component, base) = match (order, priority) {
-            (crate::BallotFindBitOrder::Lsb, 0) => ('w', 96),
-            (crate::BallotFindBitOrder::Lsb, 1) => ('z', 64),
-            (crate::BallotFindBitOrder::Lsb, 2) => ('y', 32),
-            (crate::BallotFindBitOrder::Lsb, 3) => ('x', 0),
-            (crate::BallotFindBitOrder::Msb, 0) => ('x', 0),
-            (crate::BallotFindBitOrder::Msb, 1) => ('y', 32),
-            (crate::BallotFindBitOrder::Msb, 2) => ('z', 64),
-            (crate::BallotFindBitOrder::Msb, 3) => ('w', 96),
+        let (word_index, base) = match (order, priority) {
+            (crate::BallotFindBitOrder::Lsb, 0) => (3, 96),
+            (crate::BallotFindBitOrder::Lsb, 1) => (2, 64),
+            (crate::BallotFindBitOrder::Lsb, 2) => (1, 32),
+            (crate::BallotFindBitOrder::Lsb, 3) => (0, 0),
+            (crate::BallotFindBitOrder::Msb, 0) => (0, 0),
+            (crate::BallotFindBitOrder::Msb, 1) => (1, 32),
+            (crate::BallotFindBitOrder::Msb, 2) => (2, 64),
+            (crate::BallotFindBitOrder::Msb, 3) => (3, 96),
             (_, _) => unreachable!(),
         };
+        let word = &words[word_index];
 
         if priority == 0 {
-            self.write_ballot_find_bit_value(module, argument, func_ctx, order, component, base)?;
+            self.write_ballot_find_bit_value(order, word, base)?;
         } else {
-            write!(self.out, "(")?;
-            self.write_expr(module, argument, func_ctx)?;
-            write!(self.out, ".{component} != 0u ? ")?;
-            self.write_ballot_find_bit_value(module, argument, func_ctx, order, component, base)?;
+            write!(self.out, "({word} != 0u ? ")?;
+            self.write_ballot_find_bit_value(order, word, base)?;
             write!(self.out, " : ")?;
-            self.write_ballot_find_bit(module, argument, func_ctx, order, priority - 1)?;
+            self.write_ballot_find_bit(words, order, priority - 1)?;
             write!(self.out, ")")?;
         }
         Ok(())
     }
 
-    /// Write `firstbitlow`/`firstbithigh` applied to one component of the ballot,
-    /// offset by that component's base invocation index. Used by
+    /// Write `firstbitlow`/`firstbithigh` applied to an already-evaluated ballot
+    /// word, offset by that word's base invocation index. Used by
     /// [`Self::write_ballot_find_bit`].
     fn write_ballot_find_bit_value(
         &mut self,
-        module: &Module,
-        argument: Handle<crate::Expression>,
-        func_ctx: &back::FunctionCtx<'_>,
         order: crate::BallotFindBitOrder,
-        component: char,
+        word: &str,
         base: u32,
     ) -> BackendResult {
         let math_fn = match order {
             crate::BallotFindBitOrder::Lsb => "firstbitlow",
             crate::BallotFindBitOrder::Msb => "firstbithigh",
         };
-        write!(self.out, "{math_fn}(")?;
-        self.write_expr(module, argument, func_ctx)?;
-        write!(self.out, ".{component})")?;
+        write!(self.out, "{math_fn}({word})")?;
         if base != 0 {
             write!(self.out, " + {base}u")?;
         }

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -3066,6 +3066,26 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 }
                 writeln!(self.out, ");")?;
             }
+            Statement::SubgroupBallotFindBit {
+                order,
+                argument,
+                result,
+            } => {
+                write!(self.out, "{level}")?;
+                write!(self.out, "const ")?;
+                let name = Baked(result).to_string();
+                match func_ctx.info[result].ty {
+                    proc::TypeResolution::Handle(handle) => self.write_type(module, handle)?,
+                    proc::TypeResolution::Value(ref value) => {
+                        self.write_value_type(module, value)?
+                    }
+                };
+                write!(self.out, " {name} = ")?;
+                self.named_expressions.insert(result, name);
+
+                self.write_ballot_find_bit(module, argument, func_ctx, order, 3)?;
+                writeln!(self.out, ";")?;
+            }
             Statement::CooperativeStore { .. } => unimplemented!(),
             Statement::RayPipelineFunction(_) => unreachable!(),
         }
@@ -3718,6 +3738,72 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
             }
         }
 
+        Ok(())
+    }
+
+    /// Write a polyfill for [`Statement::SubgroupBallotFindBit`], since HLSL has no
+    /// built-in for it: a chain of ternaries. `priority` counts up from 0 (the
+    /// lowest-priority word, used as the fallback base case) to 3 (the
+    /// highest-priority word, checked first: `x` for LSB, `w` for MSB), each
+    /// overriding the lower-priority result when that word has any bit set.
+    ///
+    /// [`Statement::SubgroupBallotFindBit`]: crate::Statement::SubgroupBallotFindBit
+    fn write_ballot_find_bit(
+        &mut self,
+        module: &Module,
+        argument: Handle<crate::Expression>,
+        func_ctx: &back::FunctionCtx<'_>,
+        order: crate::BallotFindBitOrder,
+        priority: u32,
+    ) -> BackendResult {
+        let (component, base) = match (order, priority) {
+            (crate::BallotFindBitOrder::Lsb, 0) => ('w', 96),
+            (crate::BallotFindBitOrder::Lsb, 1) => ('z', 64),
+            (crate::BallotFindBitOrder::Lsb, 2) => ('y', 32),
+            (crate::BallotFindBitOrder::Lsb, 3) => ('x', 0),
+            (crate::BallotFindBitOrder::Msb, 0) => ('x', 0),
+            (crate::BallotFindBitOrder::Msb, 1) => ('y', 32),
+            (crate::BallotFindBitOrder::Msb, 2) => ('z', 64),
+            (crate::BallotFindBitOrder::Msb, 3) => ('w', 96),
+            (_, _) => unreachable!(),
+        };
+
+        if priority == 0 {
+            self.write_ballot_find_bit_value(module, argument, func_ctx, order, component, base)?;
+        } else {
+            write!(self.out, "(")?;
+            self.write_expr(module, argument, func_ctx)?;
+            write!(self.out, ".{component} != 0u ? ")?;
+            self.write_ballot_find_bit_value(module, argument, func_ctx, order, component, base)?;
+            write!(self.out, " : ")?;
+            self.write_ballot_find_bit(module, argument, func_ctx, order, priority - 1)?;
+            write!(self.out, ")")?;
+        }
+        Ok(())
+    }
+
+    /// Write `firstbitlow`/`firstbithigh` applied to one component of the ballot,
+    /// offset by that component's base invocation index. Used by
+    /// [`Self::write_ballot_find_bit`].
+    fn write_ballot_find_bit_value(
+        &mut self,
+        module: &Module,
+        argument: Handle<crate::Expression>,
+        func_ctx: &back::FunctionCtx<'_>,
+        order: crate::BallotFindBitOrder,
+        component: char,
+        base: u32,
+    ) -> BackendResult {
+        let math_fn = match order {
+            crate::BallotFindBitOrder::Lsb => "firstbitlow",
+            crate::BallotFindBitOrder::Msb => "firstbithigh",
+        };
+        write!(self.out, "{math_fn}(")?;
+        self.write_expr(module, argument, func_ctx)?;
+        write!(self.out, ".{component})")?;
+        if base != 0 {
+            write!(self.out, " + {base}u")?;
+        }
         Ok(())
     }
 

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -2120,6 +2120,78 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
+    /// Write a polyfill for [`Statement::SubgroupBallotFindBit`], since MSL has no
+    /// built-in for it: a chain of ternaries. `priority` counts up from 0 (the
+    /// lowest-priority word, used as the fallback base case) to 3 (the
+    /// highest-priority word, checked first: `x` for LSB, `w` for MSB), each
+    /// overriding the lower-priority result when that word has any bit set.
+    ///
+    /// [`Statement::SubgroupBallotFindBit`]: crate::Statement::SubgroupBallotFindBit
+    fn put_ballot_find_bit(
+        &mut self,
+        argument: Handle<crate::Expression>,
+        context: &ExpressionContext,
+        order: crate::BallotFindBitOrder,
+        priority: u32,
+    ) -> BackendResult {
+        let (component, base) = match (order, priority) {
+            (crate::BallotFindBitOrder::Lsb, 0) => ('w', 96),
+            (crate::BallotFindBitOrder::Lsb, 1) => ('z', 64),
+            (crate::BallotFindBitOrder::Lsb, 2) => ('y', 32),
+            (crate::BallotFindBitOrder::Lsb, 3) => ('x', 0),
+            (crate::BallotFindBitOrder::Msb, 0) => ('x', 0),
+            (crate::BallotFindBitOrder::Msb, 1) => ('y', 32),
+            (crate::BallotFindBitOrder::Msb, 2) => ('z', 64),
+            (crate::BallotFindBitOrder::Msb, 3) => ('w', 96),
+            (_, _) => unreachable!(),
+        };
+
+        if priority == 0 {
+            self.put_ballot_find_bit_value(argument, context, order, component, base)?;
+        } else {
+            write!(self.out, "(")?;
+            self.put_expression(argument, context, true)?;
+            write!(self.out, ".{component} != 0u ? ")?;
+            self.put_ballot_find_bit_value(argument, context, order, component, base)?;
+            write!(self.out, " : ")?;
+            self.put_ballot_find_bit(argument, context, order, priority - 1)?;
+            write!(self.out, ")")?;
+        }
+        Ok(())
+    }
+
+    /// Write the least/most significant set bit of one `u32` component of the
+    /// ballot, offset by that component's base invocation index. Mirrors the
+    /// `Mf::FirstTrailingBit`/`Mf::FirstLeadingBit` formulas above, specialized
+    /// for a known-unsigned 32-bit scalar. Used by [`Self::put_ballot_find_bit`].
+    fn put_ballot_find_bit_value(
+        &mut self,
+        argument: Handle<crate::Expression>,
+        context: &ExpressionContext,
+        order: crate::BallotFindBitOrder,
+        component: char,
+        base: u32,
+    ) -> BackendResult {
+        match order {
+            crate::BallotFindBitOrder::Lsb => {
+                write!(self.out, "((({NAMESPACE}::ctz(")?;
+                self.put_expression(argument, context, true)?;
+                write!(self.out, ".{component}) + 1) % 33) - 1)")?;
+            }
+            crate::BallotFindBitOrder::Msb => {
+                write!(self.out, "{NAMESPACE}::select(31 - {NAMESPACE}::clz(")?;
+                self.put_expression(argument, context, true)?;
+                write!(self.out, ".{component}), uint(-1), ")?;
+                self.put_expression(argument, context, true)?;
+                write!(self.out, ".{component} == 0)")?;
+            }
+        }
+        if base != 0 {
+            write!(self.out, " + {base}u")?;
+        }
+        Ok(())
+    }
+
     /// Emit code for the expression `expr_handle`.
     ///
     /// The `is_scoped` argument is true if the surrounding operators have the
@@ -4445,6 +4517,18 @@ impl<W: Write> Writer<W> {
                         }
                     }
                     writeln!(self.out, ");")?;
+                }
+                crate::Statement::SubgroupBallotFindBit {
+                    order,
+                    argument,
+                    result,
+                } => {
+                    write!(self.out, "{level}")?;
+                    let name = self.namer.call("");
+                    self.start_baking_expression(result, &context.expression, &name)?;
+                    self.named_expressions.insert(result, name);
+                    self.put_ballot_find_bit(argument, &context.expression, order, 3)?;
+                    writeln!(self.out, ";")?;
                 }
                 crate::Statement::CooperativeStore { target, ref data } => {
                     write!(self.out, "{level}simdgroup_store(")?;

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -2121,7 +2121,8 @@ impl<W: Write> Writer<W> {
     }
 
     /// Write a polyfill for [`Statement::SubgroupBallotFindBit`], since MSL has no
-    /// built-in for it: a chain of ternaries. `priority` counts up from 0 (the
+    /// built-in for it: a chain of ternaries over the already-evaluated ballot
+    /// `words` (`words[0..4]` is `x, y, z, w`). `priority` counts up from 0 (the
     /// lowest-priority word, used as the fallback base case) to 3 (the
     /// highest-priority word, checked first: `x` for LSB, `w` for MSB), each
     /// overriding the lower-priority result when that word has any bit set.
@@ -2129,61 +2130,54 @@ impl<W: Write> Writer<W> {
     /// [`Statement::SubgroupBallotFindBit`]: crate::Statement::SubgroupBallotFindBit
     fn put_ballot_find_bit(
         &mut self,
-        argument: Handle<crate::Expression>,
-        context: &ExpressionContext,
+        words: &[String; 4],
         order: crate::BallotFindBitOrder,
         priority: u32,
     ) -> BackendResult {
-        let (component, base) = match (order, priority) {
-            (crate::BallotFindBitOrder::Lsb, 0) => ('w', 96),
-            (crate::BallotFindBitOrder::Lsb, 1) => ('z', 64),
-            (crate::BallotFindBitOrder::Lsb, 2) => ('y', 32),
-            (crate::BallotFindBitOrder::Lsb, 3) => ('x', 0),
-            (crate::BallotFindBitOrder::Msb, 0) => ('x', 0),
-            (crate::BallotFindBitOrder::Msb, 1) => ('y', 32),
-            (crate::BallotFindBitOrder::Msb, 2) => ('z', 64),
-            (crate::BallotFindBitOrder::Msb, 3) => ('w', 96),
+        let (word_index, base) = match (order, priority) {
+            (crate::BallotFindBitOrder::Lsb, 0) => (3, 96),
+            (crate::BallotFindBitOrder::Lsb, 1) => (2, 64),
+            (crate::BallotFindBitOrder::Lsb, 2) => (1, 32),
+            (crate::BallotFindBitOrder::Lsb, 3) => (0, 0),
+            (crate::BallotFindBitOrder::Msb, 0) => (0, 0),
+            (crate::BallotFindBitOrder::Msb, 1) => (1, 32),
+            (crate::BallotFindBitOrder::Msb, 2) => (2, 64),
+            (crate::BallotFindBitOrder::Msb, 3) => (3, 96),
             (_, _) => unreachable!(),
         };
+        let word = &words[word_index];
 
         if priority == 0 {
-            self.put_ballot_find_bit_value(argument, context, order, component, base)?;
+            self.put_ballot_find_bit_value(order, word, base)?;
         } else {
-            write!(self.out, "(")?;
-            self.put_expression(argument, context, true)?;
-            write!(self.out, ".{component} != 0u ? ")?;
-            self.put_ballot_find_bit_value(argument, context, order, component, base)?;
+            write!(self.out, "({word} != 0u ? ")?;
+            self.put_ballot_find_bit_value(order, word, base)?;
             write!(self.out, " : ")?;
-            self.put_ballot_find_bit(argument, context, order, priority - 1)?;
+            self.put_ballot_find_bit(words, order, priority - 1)?;
             write!(self.out, ")")?;
         }
         Ok(())
     }
 
-    /// Write the least/most significant set bit of one `u32` component of the
-    /// ballot, offset by that component's base invocation index. Mirrors the
+    /// Write the least/most significant set bit of an already-evaluated `u32`
+    /// ballot word, offset by that word's base invocation index. Mirrors the
     /// `Mf::FirstTrailingBit`/`Mf::FirstLeadingBit` formulas above, specialized
     /// for a known-unsigned 32-bit scalar. Used by [`Self::put_ballot_find_bit`].
     fn put_ballot_find_bit_value(
         &mut self,
-        argument: Handle<crate::Expression>,
-        context: &ExpressionContext,
         order: crate::BallotFindBitOrder,
-        component: char,
+        word: &str,
         base: u32,
     ) -> BackendResult {
         match order {
             crate::BallotFindBitOrder::Lsb => {
-                write!(self.out, "((({NAMESPACE}::ctz(")?;
-                self.put_expression(argument, context, true)?;
-                write!(self.out, ".{component}) + 1) % 33) - 1)")?;
+                write!(self.out, "((({NAMESPACE}::ctz({word}) + 1) % 33) - 1)")?;
             }
             crate::BallotFindBitOrder::Msb => {
-                write!(self.out, "{NAMESPACE}::select(31 - {NAMESPACE}::clz(")?;
-                self.put_expression(argument, context, true)?;
-                write!(self.out, ".{component}), uint(-1), ")?;
-                self.put_expression(argument, context, true)?;
-                write!(self.out, ".{component} == 0)")?;
+                write!(
+                    self.out,
+                    "{NAMESPACE}::select(31 - {NAMESPACE}::clz({word}), uint(-1), {word} == 0)"
+                )?;
             }
         }
         if base != 0 {
@@ -4523,11 +4517,25 @@ impl<W: Write> Writer<W> {
                     argument,
                     result,
                 } => {
+                    // Evaluate each ballot word once into a local, rather
+                    // than repeatedly writing `argument.x`/`.y`/`.z`/`.w` in
+                    // the ternary chain below.
+                    const COMPONENTS: [char; 4] = ['x', 'y', 'z', 'w'];
+                    let mut words: [String; 4] = core::array::from_fn(|_| String::new());
+                    for (word, &component) in words.iter_mut().zip(&COMPONENTS) {
+                        write!(self.out, "{level}uint ")?;
+                        let name = self.namer.call("");
+                        write!(self.out, "{name} = ")?;
+                        self.put_expression(argument, &context.expression, true)?;
+                        writeln!(self.out, ".{component};")?;
+                        *word = name;
+                    }
+
                     write!(self.out, "{level}")?;
                     let name = self.namer.call("");
                     self.start_baking_expression(result, &context.expression, &name)?;
                     self.named_expressions.insert(result, name);
-                    self.put_ballot_find_bit(argument, &context.expression, order, 3)?;
+                    self.put_ballot_find_bit(&words, order, 3)?;
                     writeln!(self.out, ";")?;
                 }
                 crate::Statement::CooperativeStore { target, ref data } => {

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -872,6 +872,14 @@ fn adjust_stmt(new_pos: &HandleVec<Expression, Handle<Expression>>, stmt: &mut S
             adjust(argument);
             adjust(result)
         }
+        Statement::SubgroupBallotFindBit {
+            order: _,
+            ref mut argument,
+            ref mut result,
+        } => {
+            adjust(argument);
+            adjust(result);
+        }
         Statement::Call {
             ref mut arguments,
             ref mut result,

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -4240,6 +4240,13 @@ impl BlockContext<'_> {
                 } => {
                     self.write_subgroup_gather(mode, argument, result, &mut block)?;
                 }
+                Statement::SubgroupBallotFindBit {
+                    order,
+                    argument,
+                    result,
+                } => {
+                    self.write_subgroup_ballot_find_bit(order, argument, result, &mut block)?;
+                }
                 Statement::CooperativeStore { target, ref data } => {
                     let target_id = self.cached[target];
                     let layout = if data.row_major {

--- a/naga/src/back/spv/instructions.rs
+++ b/naga/src/back/spv/instructions.rs
@@ -1249,6 +1249,21 @@ impl super::Instruction {
 
         instruction
     }
+    pub(super) fn group_non_uniform_ballot_find_bit(
+        op: Op,
+        result_type_id: Word,
+        id: Word,
+        exec_scope_id: Word,
+        value: Word,
+    ) -> Self {
+        let mut instruction = Self::new(op);
+        instruction.set_type(result_type_id);
+        instruction.set_result(id);
+        instruction.add_operand(exec_scope_id);
+        instruction.add_operand(value);
+
+        instruction
+    }
     pub(super) fn group_non_uniform_gather(
         op: Op,
         result_type_id: Word,

--- a/naga/src/back/spv/subgroup.rs
+++ b/naga/src/back/spv/subgroup.rs
@@ -220,4 +220,39 @@ impl BlockContext<'_> {
         self.cached[result] = id;
         Ok(())
     }
+    pub(super) fn write_subgroup_ballot_find_bit(
+        &mut self,
+        order: crate::BallotFindBitOrder,
+        argument: Handle<crate::Expression>,
+        result: Handle<crate::Expression>,
+        block: &mut Block,
+    ) -> Result<(), Error> {
+        self.writer.require_any(
+            "GroupNonUniformBallot",
+            &[spirv::Capability::GroupNonUniformBallot],
+        )?;
+
+        let id = self.gen_id();
+        let result_ty = &self.fun_info[result].ty;
+        let result_type_id = self.get_expression_type_id(result_ty);
+
+        let exec_scope_id = self.get_index_constant(spirv::Scope::Subgroup as u32);
+        let op = match order {
+            crate::BallotFindBitOrder::Lsb => spirv::Op::GroupNonUniformBallotFindLSB,
+            crate::BallotFindBitOrder::Msb => spirv::Op::GroupNonUniformBallotFindMSB,
+        };
+
+        let arg_id = self.cached[argument];
+        block
+            .body
+            .push(Instruction::group_non_uniform_ballot_find_bit(
+                op,
+                result_type_id,
+                id,
+                exec_scope_id,
+                arg_id,
+            ));
+        self.cached[result] = id;
+        Ok(())
+    }
 }

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -1213,12 +1213,26 @@ impl<W: Write> Writer<W> {
                 argument,
                 result,
             } => {
+                // Evaluate each ballot word once into a local, rather than
+                // repeatedly writing `argument.x`/`.y`/`.z`/`.w` in the select
+                // chain below.
+                const COMPONENTS: [char; 4] = ['x', 'y', 'z', 'w'];
+                let mut words: [String; 4] = core::array::from_fn(|_| String::new());
+                for (word, &component) in words.iter_mut().zip(&COMPONENTS) {
+                    write!(self.out, "{level}")?;
+                    let name = self.namer.call("");
+                    write!(self.out, "let {name} = ")?;
+                    self.write_expr(module, argument, func_ctx)?;
+                    writeln!(self.out, ".{component};")?;
+                    *word = name;
+                }
+
                 write!(self.out, "{level}")?;
                 let res_name = Baked(result).to_string();
                 self.start_named_expr(module, result, func_ctx, &res_name)?;
                 self.named_expressions.insert(result, res_name);
 
-                self.write_ballot_find_bit(module, argument, func_ctx, order, 3)?;
+                self.write_ballot_find_bit(&words, order, 3)?;
                 writeln!(self.out, ";")?;
             }
             Statement::CooperativeStore { target, ref data } => {
@@ -1330,7 +1344,8 @@ impl<W: Write> Writer<W> {
     }
 
     /// Write a polyfill for [`Statement::SubgroupBallotFindBit`], since WGSL has no
-    /// built-in for it: a chain of `select`s. `priority` counts up from 0 (the
+    /// built-in for it: a chain of `select`s over the already-evaluated ballot
+    /// `words` (`words[0..4]` is `x, y, z, w`). `priority` counts up from 0 (the
     /// lowest-priority word, used as the fallback base case) to 3 (the
     /// highest-priority word, checked first: `x` for LSB, `w` for MSB), each
     /// overriding the lower-priority result when that word has any bit set.
@@ -1338,57 +1353,49 @@ impl<W: Write> Writer<W> {
     /// [`Statement::SubgroupBallotFindBit`]: crate::Statement::SubgroupBallotFindBit
     fn write_ballot_find_bit(
         &mut self,
-        module: &Module,
-        argument: Handle<crate::Expression>,
-        func_ctx: &back::FunctionCtx<'_>,
+        words: &[String; 4],
         order: crate::BallotFindBitOrder,
         priority: u32,
     ) -> BackendResult {
-        let (component, base) = match (order, priority) {
-            (crate::BallotFindBitOrder::Lsb, 0) => ('w', 96),
-            (crate::BallotFindBitOrder::Lsb, 1) => ('z', 64),
-            (crate::BallotFindBitOrder::Lsb, 2) => ('y', 32),
-            (crate::BallotFindBitOrder::Lsb, 3) => ('x', 0),
-            (crate::BallotFindBitOrder::Msb, 0) => ('x', 0),
-            (crate::BallotFindBitOrder::Msb, 1) => ('y', 32),
-            (crate::BallotFindBitOrder::Msb, 2) => ('z', 64),
-            (crate::BallotFindBitOrder::Msb, 3) => ('w', 96),
+        let (word_index, base) = match (order, priority) {
+            (crate::BallotFindBitOrder::Lsb, 0) => (3, 96),
+            (crate::BallotFindBitOrder::Lsb, 1) => (2, 64),
+            (crate::BallotFindBitOrder::Lsb, 2) => (1, 32),
+            (crate::BallotFindBitOrder::Lsb, 3) => (0, 0),
+            (crate::BallotFindBitOrder::Msb, 0) => (0, 0),
+            (crate::BallotFindBitOrder::Msb, 1) => (1, 32),
+            (crate::BallotFindBitOrder::Msb, 2) => (2, 64),
+            (crate::BallotFindBitOrder::Msb, 3) => (3, 96),
             (_, _) => unreachable!(),
         };
+        let word = &words[word_index];
 
         if priority == 0 {
-            self.write_ballot_find_bit_value(module, argument, func_ctx, order, component, base)?;
+            self.write_ballot_find_bit_value(order, word, base)?;
         } else {
             write!(self.out, "select(")?;
-            self.write_ballot_find_bit(module, argument, func_ctx, order, priority - 1)?;
+            self.write_ballot_find_bit(words, order, priority - 1)?;
             write!(self.out, ", ")?;
-            self.write_ballot_find_bit_value(module, argument, func_ctx, order, component, base)?;
-            write!(self.out, ", ")?;
-            self.write_expr(module, argument, func_ctx)?;
-            write!(self.out, ".{component} != 0u)")?;
+            self.write_ballot_find_bit_value(order, word, base)?;
+            write!(self.out, ", {word} != 0u)")?;
         }
         Ok(())
     }
 
-    /// Write `firstTrailingBit`/`firstLeadingBit` applied to one component of the
-    /// ballot, offset by that component's base invocation index. Used by
+    /// Write `firstTrailingBit`/`firstLeadingBit` applied to an already-evaluated
+    /// ballot word, offset by that word's base invocation index. Used by
     /// [`Self::write_ballot_find_bit`].
     fn write_ballot_find_bit_value(
         &mut self,
-        module: &Module,
-        argument: Handle<crate::Expression>,
-        func_ctx: &back::FunctionCtx<'_>,
         order: crate::BallotFindBitOrder,
-        component: char,
+        word: &str,
         base: u32,
     ) -> BackendResult {
         let math_fn = match order {
             crate::BallotFindBitOrder::Lsb => "firstTrailingBit",
             crate::BallotFindBitOrder::Msb => "firstLeadingBit",
         };
-        write!(self.out, "{math_fn}(")?;
-        self.write_expr(module, argument, func_ctx)?;
-        write!(self.out, ".{component})")?;
+        write!(self.out, "{math_fn}({word})")?;
         if base != 0 {
             write!(self.out, " + {base}u")?;
         }

--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -1208,6 +1208,19 @@ impl<W: Write> Writer<W> {
                 }
                 writeln!(self.out, ");")?;
             }
+            Statement::SubgroupBallotFindBit {
+                order,
+                argument,
+                result,
+            } => {
+                write!(self.out, "{level}")?;
+                let res_name = Baked(result).to_string();
+                self.start_named_expr(module, result, func_ctx, &res_name)?;
+                self.named_expressions.insert(result, res_name);
+
+                self.write_ballot_find_bit(module, argument, func_ctx, order, 3)?;
+                writeln!(self.out, ";")?;
+            }
             Statement::CooperativeStore { target, ref data } => {
                 let suffix = if data.row_major { "T" } else { "" };
                 write!(self.out, "{level}coopStore{suffix}(")?;
@@ -1313,6 +1326,72 @@ impl<W: Write> Writer<W> {
         }
 
         write!(self.out, " = ")?;
+        Ok(())
+    }
+
+    /// Write a polyfill for [`Statement::SubgroupBallotFindBit`], since WGSL has no
+    /// built-in for it: a chain of `select`s. `priority` counts up from 0 (the
+    /// lowest-priority word, used as the fallback base case) to 3 (the
+    /// highest-priority word, checked first: `x` for LSB, `w` for MSB), each
+    /// overriding the lower-priority result when that word has any bit set.
+    ///
+    /// [`Statement::SubgroupBallotFindBit`]: crate::Statement::SubgroupBallotFindBit
+    fn write_ballot_find_bit(
+        &mut self,
+        module: &Module,
+        argument: Handle<crate::Expression>,
+        func_ctx: &back::FunctionCtx<'_>,
+        order: crate::BallotFindBitOrder,
+        priority: u32,
+    ) -> BackendResult {
+        let (component, base) = match (order, priority) {
+            (crate::BallotFindBitOrder::Lsb, 0) => ('w', 96),
+            (crate::BallotFindBitOrder::Lsb, 1) => ('z', 64),
+            (crate::BallotFindBitOrder::Lsb, 2) => ('y', 32),
+            (crate::BallotFindBitOrder::Lsb, 3) => ('x', 0),
+            (crate::BallotFindBitOrder::Msb, 0) => ('x', 0),
+            (crate::BallotFindBitOrder::Msb, 1) => ('y', 32),
+            (crate::BallotFindBitOrder::Msb, 2) => ('z', 64),
+            (crate::BallotFindBitOrder::Msb, 3) => ('w', 96),
+            (_, _) => unreachable!(),
+        };
+
+        if priority == 0 {
+            self.write_ballot_find_bit_value(module, argument, func_ctx, order, component, base)?;
+        } else {
+            write!(self.out, "select(")?;
+            self.write_ballot_find_bit(module, argument, func_ctx, order, priority - 1)?;
+            write!(self.out, ", ")?;
+            self.write_ballot_find_bit_value(module, argument, func_ctx, order, component, base)?;
+            write!(self.out, ", ")?;
+            self.write_expr(module, argument, func_ctx)?;
+            write!(self.out, ".{component} != 0u)")?;
+        }
+        Ok(())
+    }
+
+    /// Write `firstTrailingBit`/`firstLeadingBit` applied to one component of the
+    /// ballot, offset by that component's base invocation index. Used by
+    /// [`Self::write_ballot_find_bit`].
+    fn write_ballot_find_bit_value(
+        &mut self,
+        module: &Module,
+        argument: Handle<crate::Expression>,
+        func_ctx: &back::FunctionCtx<'_>,
+        order: crate::BallotFindBitOrder,
+        component: char,
+        base: u32,
+    ) -> BackendResult {
+        let math_fn = match order {
+            crate::BallotFindBitOrder::Lsb => "firstTrailingBit",
+            crate::BallotFindBitOrder::Msb => "firstLeadingBit",
+        };
+        write!(self.out, "{math_fn}(")?;
+        self.write_expr(module, argument, func_ctx)?;
+        write!(self.out, ".{component})")?;
+        if base != 0 {
+            write!(self.out, " + {base}u")?;
+        }
         Ok(())
     }
 

--- a/naga/src/compact/statements.rs
+++ b/naga/src/compact/statements.rs
@@ -152,6 +152,14 @@ impl FunctionTracer<'_> {
                         self.expressions_used.insert(argument);
                         self.expressions_used.insert(result);
                     }
+                    St::SubgroupBallotFindBit {
+                        order: _,
+                        argument,
+                        result,
+                    } => {
+                        self.expressions_used.insert(argument);
+                        self.expressions_used.insert(result);
+                    }
                     St::CooperativeStore { target, ref data } => {
                         self.expressions_used.insert(target);
                         self.expressions_used.insert(data.pointer);
@@ -385,6 +393,14 @@ impl FunctionMap {
                             | crate::GatherMode::QuadBroadcast(ref mut index) => adjust(index),
                             crate::GatherMode::QuadSwap(_) => {}
                         }
+                        adjust(argument);
+                        adjust(result);
+                    }
+                    St::SubgroupBallotFindBit {
+                        order: _,
+                        ref mut argument,
+                        ref mut result,
+                    } => {
                         adjust(argument);
                         adjust(result);
                     }

--- a/naga/src/front/glsl/builtins.rs
+++ b/naga/src/front/glsl/builtins.rs
@@ -749,6 +749,21 @@ fn inject_standard_builtins(
                 declaration.overloads.push(module.add_builtin(args, mc))
             }
         }
+        "subgroupBallotFindLSB" | "subgroupBallotFindMSB" => {
+            let mc = match name {
+                "subgroupBallotFindLSB" => MacroCall::SubgroupBallotFindLsb,
+                "subgroupBallotFindMSB" => MacroCall::SubgroupBallotFindMsb,
+                _ => unreachable!(),
+            };
+
+            declaration.overloads.push(module.add_builtin(
+                vec![TypeInner::Vector {
+                    size: VectorSize::Quad,
+                    scalar: Scalar::U32,
+                }],
+                mc,
+            ))
+        }
         "packSnorm4x8" | "packUnorm4x8" | "packSnorm2x16" | "packUnorm2x16" | "packHalf2x16" => {
             let fun = match name {
                 "packSnorm4x8" => MathFunction::Pack4x8snorm,
@@ -1562,6 +1577,8 @@ pub enum MacroCall {
     MathFunction(MathFunction),
     FindLsbUint,
     FindMsbUint,
+    SubgroupBallotFindLsb,
+    SubgroupBallotFindMsb,
     BitfieldExtract,
     BitfieldInsert,
     Relational(RelationalFunction),
@@ -1865,6 +1882,36 @@ impl MacroCall {
                     },
                     Span::default(),
                 )?
+            }
+            mc @ (MacroCall::SubgroupBallotFindLsb | MacroCall::SubgroupBallotFindMsb) => {
+                let order = match mc {
+                    MacroCall::SubgroupBallotFindLsb => crate::BallotFindBitOrder::Lsb,
+                    MacroCall::SubgroupBallotFindMsb => crate::BallotFindBitOrder::Msb,
+                    _ => unreachable!(),
+                };
+                // `SubgroupOperationResult` must not be part of an `Emit` range, so
+                // the pending range has to be flushed before creating it and
+                // restarted afterwards.
+                ctx.emit_end();
+                let ty = ctx.module.types.insert(
+                    Type {
+                        name: None,
+                        inner: TypeInner::Scalar(Scalar::U32),
+                    },
+                    Span::default(),
+                );
+                let result =
+                    ctx.add_expression(Expression::SubgroupOperationResult { ty }, meta)?;
+                ctx.body.push(
+                    crate::Statement::SubgroupBallotFindBit {
+                        order,
+                        argument: args[0],
+                        result,
+                    },
+                    meta,
+                );
+                ctx.emit_start();
+                result
             }
             MacroCall::BitfieldInsert => {
                 let conv_arg_2 = ctx.add_expression(

--- a/naga/src/front/glsl/variables.rs
+++ b/naga/src/front/glsl/variables.rs
@@ -208,6 +208,8 @@ impl Frontend {
                     "gl_SampleID" => BuiltIn::SampleIndex,
                     "gl_LocalInvocationIndex" => BuiltIn::LocalInvocationIndex,
                     "gl_DrawID" => BuiltIn::DrawIndex,
+                    "gl_SubgroupSize" => BuiltIn::SubgroupSize,
+                    "gl_SubgroupInvocationID" => BuiltIn::SubgroupInvocationId,
                     _ => return Ok(None),
                 };
 

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -1633,6 +1633,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                 | S::SubgroupBallot { .. }
                 | S::SubgroupCollectiveOperation { .. }
                 | S::SubgroupGather { .. }
+                | S::SubgroupBallotFindBit { .. }
                 | S::RayPipelineFunction(..) => {}
                 S::Call {
                     function: ref mut callee,

--- a/naga/src/front/spv/next_block.rs
+++ b/naga/src/front/spv/next_block.rs
@@ -2835,6 +2835,55 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                     );
                     emitter.start(ctx.expressions);
                 }
+                Op::GroupNonUniformBallotFindLSB | Op::GroupNonUniformBallotFindMSB => {
+                    inst.expect(5)?;
+                    block.extend(emitter.finish(ctx.expressions));
+                    let result_type_id = self.next()?;
+                    let result_id = self.next()?;
+                    let exec_scope_id = self.next()?;
+                    let argument_id = self.next()?;
+
+                    let argument_lookup = self.lookup_expression.lookup(argument_id)?;
+                    let argument_handle = get_expr_handle!(argument_id, argument_lookup);
+
+                    let exec_scope_const = self.lookup_constant.lookup(exec_scope_id)?;
+                    let _exec_scope = resolve_constant(ctx.gctx(), &exec_scope_const.inner)
+                        .filter(|exec_scope| *exec_scope == spirv::Scope::Subgroup as u32)
+                        .ok_or(Error::InvalidBarrierScope(exec_scope_id))?;
+
+                    let order = if inst.op == Op::GroupNonUniformBallotFindLSB {
+                        crate::BallotFindBitOrder::Lsb
+                    } else {
+                        crate::BallotFindBitOrder::Msb
+                    };
+
+                    let result_type = self.lookup_type.lookup(result_type_id)?;
+
+                    let result_handle = ctx.expressions.append(
+                        crate::Expression::SubgroupOperationResult {
+                            ty: result_type.handle,
+                        },
+                        span,
+                    );
+                    self.lookup_expression.insert(
+                        result_id,
+                        LookupExpression {
+                            handle: result_handle,
+                            type_id: result_type_id,
+                            block_id,
+                        },
+                    );
+
+                    block.push(
+                        crate::Statement::SubgroupBallotFindBit {
+                            order,
+                            argument: argument_handle,
+                            result: result_handle,
+                        },
+                        span,
+                    );
+                    emitter.start(ctx.expressions);
+                }
                 Op::AtomicLoad => {
                     inst.expect(6)?;
                     let start = self.data_offset;

--- a/naga/src/ir/mod.rs
+++ b/naga/src/ir/mod.rs
@@ -1540,6 +1540,20 @@ pub enum CollectiveOperation {
     ExclusiveScan = 2,
 }
 
+/// The specific bit a [`SubgroupBallotFindBit`] statement is looking for.
+///
+/// [`SubgroupBallotFindBit`]: Statement::SubgroupBallotFindBit
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub enum BallotFindBitOrder {
+    /// Find the least significant set bit (the lowest invocation index).
+    Lsb = 0,
+    /// Find the most significant set bit (the highest invocation index).
+    Msb = 1,
+}
+
 bitflags::bitflags! {
     /// Memory barrier flags.
     #[cfg_attr(feature = "serialize", derive(Serialize))]
@@ -2371,6 +2385,19 @@ pub enum Statement {
         /// How to combine the results
         collective_op: CollectiveOperation,
         /// The value to compute over
+        argument: Handle<Expression>,
+        /// The [`SubgroupOperationResult`] expression representing this load's result.
+        ///
+        /// [`SubgroupOperationResult`]: Expression::SubgroupOperationResult
+        result: Handle<Expression>,
+    },
+    /// Find the invocation index of a set bit in a subgroup ballot.
+    SubgroupBallotFindBit {
+        /// Which set bit to find.
+        order: BallotFindBitOrder,
+        /// The ballot to search, a `vec4<u32>`, usually a [`SubgroupBallotResult`] expression.
+        ///
+        /// [`SubgroupBallotResult`]: Expression::SubgroupBallotResult
         argument: Handle<Expression>,
         /// The [`SubgroupOperationResult`] expression representing this load's result.
         ///

--- a/naga/src/proc/terminator.rs
+++ b/naga/src/proc/terminator.rs
@@ -42,6 +42,7 @@ pub fn ensure_block_returns(block: &mut crate::Block) {
             | S::SubgroupBallot { .. }
             | S::SubgroupCollectiveOperation { .. }
             | S::SubgroupGather { .. }
+            | S::SubgroupBallotFindBit { .. }
             | S::ControlBarrier(_)
             | S::MemoryBarrier(_)
             | S::CooperativeStore { .. }

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -1184,6 +1184,14 @@ impl FunctionInfo {
                     }
                     FunctionUniformity::new()
                 }
+                S::SubgroupBallotFindBit {
+                    order: _,
+                    argument,
+                    result: _,
+                } => {
+                    let _ = self.add_ref(argument);
+                    FunctionUniformity::new()
+                }
                 S::CooperativeStore { target, ref data } => FunctionUniformity {
                     result: Uniformity {
                         non_uniform_result: self

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -782,6 +782,43 @@ impl super::Validator {
         }
         Ok(())
     }
+    fn validate_subgroup_ballot_find_bit(
+        &mut self,
+        argument: Handle<crate::Expression>,
+        result: Handle<crate::Expression>,
+        context: &BlockContext,
+    ) -> Result<(), WithSpan<FunctionError>> {
+        let argument_inner = context.resolve_type_inner(argument, &self.valid_expression_set)?;
+        if !matches!(
+            *argument_inner,
+            crate::TypeInner::Vector {
+                size: crate::VectorSize::Quad,
+                scalar: crate::Scalar {
+                    kind: crate::ScalarKind::Uint,
+                    width: 4,
+                },
+            }
+        ) {
+            log::error!(
+                "Subgroup ballot find-bit operand type {argument_inner:?}, expected vec4<u32>"
+            );
+            return Err(SubgroupError::InvalidOperand(argument)
+                .with_span_handle(argument, context.expressions)
+                .into_other());
+        }
+
+        self.emit_expression(result, context)?;
+        match context.expressions[result] {
+            crate::Expression::SubgroupOperationResult { ty }
+                if context.types[ty].inner == crate::TypeInner::Scalar(crate::Scalar::U32) => {}
+            _ => {
+                return Err(SubgroupError::ResultTypeMismatch(result)
+                    .with_span_handle(result, context.expressions)
+                    .into_other())
+            }
+        }
+        Ok(())
+    }
 
     #[allow(clippy::large_stack_frames)] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
     fn validate_block_impl(
@@ -1669,6 +1706,31 @@ impl super::Validator {
                         .with_span_static(span, "support for this operation is not present"));
                     }
                     self.validate_subgroup_gather(mode, argument, result, context)?;
+                }
+                S::SubgroupBallotFindBit {
+                    order: _,
+                    argument,
+                    result,
+                } => {
+                    stages &= self.subgroup_stages;
+                    if !self.capabilities.contains(super::Capabilities::SUBGROUP) {
+                        return Err(FunctionError::MissingCapability(
+                            super::Capabilities::SUBGROUP,
+                        )
+                        .with_span_static(span, "missing capability for this operation"));
+                    }
+                    if !self
+                        .subgroup_operations
+                        .contains(super::SubgroupOperationSet::BALLOT)
+                    {
+                        return Err(FunctionError::InvalidSubgroup(
+                            SubgroupError::UnsupportedOperation(
+                                super::SubgroupOperationSet::BALLOT,
+                            ),
+                        )
+                        .with_span_static(span, "support for this operation is not present"));
+                    }
+                    self.validate_subgroup_ballot_find_bit(argument, result, context)?;
                 }
                 S::CooperativeStore { target, ref data } => {
                     stages &= super::ShaderStages::COMPUTE;

--- a/naga/src/valid/handles.rs
+++ b/naga/src/valid/handles.rs
@@ -862,6 +862,15 @@ impl super::Validator {
                 validate_expr(result)?;
                 Ok(())
             }
+            crate::Statement::SubgroupBallotFindBit {
+                order: _,
+                argument,
+                result,
+            } => {
+                validate_expr(argument)?;
+                validate_expr(result)?;
+                Ok(())
+            }
             crate::Statement::CooperativeStore { target, ref data } => {
                 validate_expr(target)?;
                 validate_expr(data.pointer)?;

--- a/naga/tests/in/glsl/subgroup-ballot-find-bit.comp
+++ b/naga/tests/in/glsl/subgroup-ballot-find-bit.comp
@@ -1,0 +1,15 @@
+#version 450
+#extension GL_KHR_shader_subgroup_ballot : require
+
+layout(local_size_x = 1) in;
+
+layout(std430, binding = 0) buffer Output {
+    uint result;
+};
+
+void main() {
+    uvec4 mask = uvec4(gl_GlobalInvocationID.x, 2u, 3u, 4u);
+    uint lsb = subgroupBallotFindLSB(mask);
+    uint msb = subgroupBallotFindMSB(mask);
+    result = lsb + msb;
+}

--- a/naga/tests/in/glsl/subgroup-ballot-find-bit.comp
+++ b/naga/tests/in/glsl/subgroup-ballot-find-bit.comp
@@ -1,4 +1,5 @@
 #version 450
+#extension GL_KHR_shader_subgroup_basic : require
 #extension GL_KHR_shader_subgroup_ballot : require
 
 layout(local_size_x = 1) in;
@@ -8,7 +9,7 @@ layout(std430, binding = 0) buffer Output {
 };
 
 void main() {
-    uvec4 mask = uvec4(gl_GlobalInvocationID.x, 2u, 3u, 4u);
+    uvec4 mask = uvec4(gl_SubgroupInvocationID, gl_SubgroupSize, 3u, 4u);
     uint lsb = subgroupBallotFindLSB(mask);
     uint msb = subgroupBallotFindMSB(mask);
     result = lsb + msb;

--- a/naga/tests/in/glsl/subgroup-ballot-find-bit.toml
+++ b/naga/tests/in/glsl/subgroup-ballot-find-bit.toml
@@ -1,0 +1,21 @@
+capabilities = "SUBGROUP"
+targets = "METAL | GLSL | HLSL | WGSL | SPIRV"
+
+[msl]
+fake_missing_bindings = true
+lang_version = [2, 4]
+spirv_cross_compatibility = false
+zero_initialize_workgroup_memory = true
+
+[hlsl]
+shader_model = "V6_0"
+fake_missing_bindings = true
+restrict_indexing = true
+zero_initialize_workgroup_memory = true
+
+[glsl]
+version.Desktop = 430
+zero_initialize_workgroup_memory = true
+
+[spv]
+version = [1, 3]

--- a/naga/tests/in/spv/subgroup-ballot-find-bit.spvasm
+++ b/naga/tests/in/spv/subgroup-ballot-find-bit.spvasm
@@ -1,0 +1,37 @@
+OpCapability Shader
+OpCapability GroupNonUniform
+OpCapability GroupNonUniformBallot
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main" %invocation_id
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %invocation_id BuiltIn SubgroupLocalInvocationId
+OpDecorate %output_block BufferBlock
+OpMemberDecorate %output_block 0 Offset 0
+OpDecorate %output_var DescriptorSet 0
+OpDecorate %output_var Binding 0
+%void = OpTypeVoid
+%uint = OpTypeInt 32 0
+%bool = OpTypeBool
+%uint4 = OpTypeVector %uint 4
+%ptr_uint_input = OpTypePointer Input %uint
+%invocation_id = OpVariable %ptr_uint_input Input
+%output_block = OpTypeStruct %uint
+%ptr_output_block = OpTypePointer Uniform %output_block
+%output_var = OpVariable %ptr_output_block Uniform
+%ptr_uint_uniform = OpTypePointer Uniform %uint
+%fn_void = OpTypeFunction %void
+%uint_0 = OpConstant %uint 0
+%scope_subgroup = OpConstant %uint 3
+%main = OpFunction %void None %fn_void
+%entry = OpLabel
+%inv_id = OpLoad %uint %invocation_id
+%cond = OpINotEqual %bool %inv_id %uint_0
+%ballot = OpGroupNonUniformBallot %uint4 %scope_subgroup %cond
+%lsb = OpGroupNonUniformBallotFindLSB %uint %scope_subgroup %ballot
+%msb = OpGroupNonUniformBallotFindMSB %uint %scope_subgroup %ballot
+%sum = OpIAdd %uint %lsb %msb
+%dst = OpAccessChain %ptr_uint_uniform %output_var %uint_0
+OpStore %dst %sum
+OpReturn
+OpFunctionEnd

--- a/naga/tests/in/spv/subgroup-ballot-find-bit.toml
+++ b/naga/tests/in/spv/subgroup-ballot-find-bit.toml
@@ -1,0 +1,21 @@
+capabilities = "SUBGROUP"
+targets = "METAL | GLSL | HLSL | WGSL | SPIRV"
+
+[msl]
+fake_missing_bindings = true
+lang_version = [2, 4]
+spirv_cross_compatibility = false
+zero_initialize_workgroup_memory = true
+
+[hlsl]
+shader_model = "V6_0"
+fake_missing_bindings = true
+restrict_indexing = true
+zero_initialize_workgroup_memory = true
+
+[glsl]
+version.Desktop = 430
+zero_initialize_workgroup_memory = true
+
+[spv]
+version = [1, 3]

--- a/naga/tests/out/glsl/glsl-subgroup-ballot-find-bit.comp.main.Compute.glsl
+++ b/naga/tests/out/glsl/glsl-subgroup-ballot-find-bit.comp.main.Compute.glsl
@@ -1,0 +1,45 @@
+#version 430 core
+#extension GL_ARB_compute_shader : require
+#extension GL_ARB_shader_storage_buffer_object : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_vote : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+#extension GL_KHR_shader_subgroup_ballot : require
+#extension GL_KHR_shader_subgroup_shuffle : require
+#extension GL_KHR_shader_subgroup_shuffle_relative : require
+#extension GL_KHR_shader_subgroup_quad : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct Output {
+    uint result;
+};
+layout(std430) buffer Output_block_0Compute { Output _group_0_binding_0_cs; };
+
+uvec3 gen_gl_GlobalInvocationID_1 = uvec3(0u);
+
+
+void main_1() {
+    uvec4 mask = uvec4(0u);
+    uint lsb = 0u;
+    uint msb = 0u;
+    uvec3 _e3 = gen_gl_GlobalInvocationID_1;
+    mask = uvec4(_e3.x, 2u, 3u, 4u);
+    uvec4 _e10 = mask;
+    uint _e11 = subgroupBallotFindLSB(_e10);
+    lsb = _e11;
+    uvec4 _e13 = mask;
+    uint _e14 = subgroupBallotFindMSB(_e13);
+    msb = _e14;
+    uint _e16 = lsb;
+    uint _e17 = msb;
+    _group_0_binding_0_cs.result = (_e16 + _e17);
+    return;
+}
+
+void main() {
+    uvec3 gen_gl_GlobalInvocationID = gl_GlobalInvocationID;
+    gen_gl_GlobalInvocationID_1 = gen_gl_GlobalInvocationID;
+    main_1();
+    return;
+}
+

--- a/naga/tests/out/glsl/glsl-subgroup-ballot-find-bit.comp.main.Compute.glsl
+++ b/naga/tests/out/glsl/glsl-subgroup-ballot-find-bit.comp.main.Compute.glsl
@@ -15,15 +15,18 @@ struct Output {
 };
 layout(std430) buffer Output_block_0Compute { Output _group_0_binding_0_cs; };
 
-uvec3 gen_gl_GlobalInvocationID_1 = uvec3(0u);
+uint gen_gl_SubgroupInvocationID_1 = 0u;
+
+uint gen_gl_SubgroupSize_1 = 0u;
 
 
 void main_1() {
     uvec4 mask = uvec4(0u);
     uint lsb = 0u;
     uint msb = 0u;
-    uvec3 _e3 = gen_gl_GlobalInvocationID_1;
-    mask = uvec4(_e3.x, 2u, 3u, 4u);
+    uint _e4 = gen_gl_SubgroupInvocationID_1;
+    uint _e5 = gen_gl_SubgroupSize_1;
+    mask = uvec4(_e4, _e5, 3u, 4u);
     uvec4 _e10 = mask;
     uint _e11 = subgroupBallotFindLSB(_e10);
     lsb = _e11;
@@ -37,8 +40,10 @@ void main_1() {
 }
 
 void main() {
-    uvec3 gen_gl_GlobalInvocationID = gl_GlobalInvocationID;
-    gen_gl_GlobalInvocationID_1 = gen_gl_GlobalInvocationID;
+    uint gen_gl_SubgroupInvocationID = gl_SubgroupInvocationID;
+    uint gen_gl_SubgroupSize = gl_SubgroupSize;
+    gen_gl_SubgroupInvocationID_1 = gen_gl_SubgroupInvocationID;
+    gen_gl_SubgroupSize_1 = gen_gl_SubgroupSize;
     main_1();
     return;
 }

--- a/naga/tests/out/glsl/spv-subgroup-ballot-find-bit.main.Compute.glsl
+++ b/naga/tests/out/glsl/spv-subgroup-ballot-find-bit.main.Compute.glsl
@@ -1,0 +1,35 @@
+#version 430 core
+#extension GL_ARB_compute_shader : require
+#extension GL_ARB_shader_storage_buffer_object : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_vote : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+#extension GL_KHR_shader_subgroup_ballot : require
+#extension GL_KHR_shader_subgroup_shuffle : require
+#extension GL_KHR_shader_subgroup_shuffle_relative : require
+#extension GL_KHR_shader_subgroup_quad : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct type_1 {
+    uint member;
+};
+uint global = 0u;
+
+layout(std430) buffer type_1_block_0Compute { type_1 _group_0_binding_0_cs; };
+
+
+void function() {
+    uint _e3 = global;
+    uvec4 _e5 = subgroupBallot((_e3 != 0u));
+    uint _e6 = subgroupBallotFindLSB(_e5);
+    uint _e7 = subgroupBallotFindMSB(_e5);
+    _group_0_binding_0_cs.member = (_e6 + _e7);
+    return;
+}
+
+void main() {
+    uint param = gl_SubgroupInvocationID;
+    global = param;
+    function();
+}
+

--- a/naga/tests/out/hlsl/glsl-subgroup-ballot-find-bit.comp.hlsl
+++ b/naga/tests/out/hlsl/glsl-subgroup-ballot-find-bit.comp.hlsl
@@ -1,0 +1,34 @@
+struct Output {
+    uint result;
+};
+
+RWByteAddressBuffer global : register(u0);
+static uint3 gl_GlobalInvocationID_1 = (uint3)0;
+
+void main_1()
+{
+    uint4 mask = (uint4)0;
+    uint lsb = (uint)0;
+    uint msb = (uint)0;
+
+    uint3 _e3 = gl_GlobalInvocationID_1;
+    mask = uint4(_e3.x, 2u, 3u, 4u);
+    uint4 _e10 = mask;
+    const uint _e11 = (_e10.x != 0u ? firstbitlow(_e10.x) : (_e10.y != 0u ? firstbitlow(_e10.y) + 32u : (_e10.z != 0u ? firstbitlow(_e10.z) + 64u : firstbitlow(_e10.w) + 96u)));
+    lsb = _e11;
+    uint4 _e13 = mask;
+    const uint _e14 = (_e13.w != 0u ? firstbithigh(_e13.w) + 96u : (_e13.z != 0u ? firstbithigh(_e13.z) + 64u : (_e13.y != 0u ? firstbithigh(_e13.y) + 32u : firstbithigh(_e13.x))));
+    msb = _e14;
+    uint _e16 = lsb;
+    uint _e17 = msb;
+    global.Store(0, asuint((_e16 + _e17)));
+    return;
+}
+
+[numthreads(1, 1, 1)]
+void main(uint3 gl_GlobalInvocationID : SV_DispatchThreadID)
+{
+    gl_GlobalInvocationID_1 = gl_GlobalInvocationID;
+    main_1();
+    return;
+}

--- a/naga/tests/out/hlsl/glsl-subgroup-ballot-find-bit.comp.hlsl
+++ b/naga/tests/out/hlsl/glsl-subgroup-ballot-find-bit.comp.hlsl
@@ -3,7 +3,11 @@ struct Output {
 };
 
 RWByteAddressBuffer global : register(u0);
-static uint3 gl_GlobalInvocationID_1 = (uint3)0;
+static uint gl_SubgroupInvocationID_1 = (uint)0;
+static uint gl_SubgroupSize_1 = (uint)0;
+
+struct ComputeInput_main {
+};
 
 void main_1()
 {
@@ -11,13 +15,22 @@ void main_1()
     uint lsb = (uint)0;
     uint msb = (uint)0;
 
-    uint3 _e3 = gl_GlobalInvocationID_1;
-    mask = uint4(_e3.x, 2u, 3u, 4u);
+    uint _e4 = gl_SubgroupInvocationID_1;
+    uint _e5 = gl_SubgroupSize_1;
+    mask = uint4(_e4, _e5, 3u, 4u);
     uint4 _e10 = mask;
-    const uint _e11 = (_e10.x != 0u ? firstbitlow(_e10.x) : (_e10.y != 0u ? firstbitlow(_e10.y) + 32u : (_e10.z != 0u ? firstbitlow(_e10.z) + 64u : firstbitlow(_e10.w) + 96u)));
+    const uint unnamed = _e10.x;
+    const uint unnamed_1 = _e10.y;
+    const uint unnamed_2 = _e10.z;
+    const uint unnamed_3 = _e10.w;
+    const uint _e11 = (unnamed != 0u ? firstbitlow(unnamed) : (unnamed_1 != 0u ? firstbitlow(unnamed_1) + 32u : (unnamed_2 != 0u ? firstbitlow(unnamed_2) + 64u : firstbitlow(unnamed_3) + 96u)));
     lsb = _e11;
     uint4 _e13 = mask;
-    const uint _e14 = (_e13.w != 0u ? firstbithigh(_e13.w) + 96u : (_e13.z != 0u ? firstbithigh(_e13.z) + 64u : (_e13.y != 0u ? firstbithigh(_e13.y) + 32u : firstbithigh(_e13.x))));
+    const uint unnamed_4 = _e13.x;
+    const uint unnamed_5 = _e13.y;
+    const uint unnamed_6 = _e13.z;
+    const uint unnamed_7 = _e13.w;
+    const uint _e14 = (unnamed_7 != 0u ? firstbithigh(unnamed_7) + 96u : (unnamed_6 != 0u ? firstbithigh(unnamed_6) + 64u : (unnamed_5 != 0u ? firstbithigh(unnamed_5) + 32u : firstbithigh(unnamed_4))));
     msb = _e14;
     uint _e16 = lsb;
     uint _e17 = msb;
@@ -26,9 +39,12 @@ void main_1()
 }
 
 [numthreads(1, 1, 1)]
-void main(uint3 gl_GlobalInvocationID : SV_DispatchThreadID)
+void main(ComputeInput_main computeinput_main)
 {
-    gl_GlobalInvocationID_1 = gl_GlobalInvocationID;
+    uint gl_SubgroupInvocationID = WaveGetLaneIndex();
+    uint gl_SubgroupSize = WaveGetLaneCount();
+    gl_SubgroupInvocationID_1 = gl_SubgroupInvocationID;
+    gl_SubgroupSize_1 = gl_SubgroupSize;
     main_1();
     return;
 }

--- a/naga/tests/out/hlsl/glsl-subgroup-ballot-find-bit.comp.ron
+++ b/naga/tests/out/hlsl/glsl-subgroup-ballot-find-bit.comp.ron
@@ -1,0 +1,16 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"main",
+            target_profile:"cs_6_0",
+        ),
+    ],
+    task:[
+    ],
+    mesh:[
+    ],
+)

--- a/naga/tests/out/hlsl/spv-subgroup-ballot-find-bit.hlsl
+++ b/naga/tests/out/hlsl/spv-subgroup-ballot-find-bit.hlsl
@@ -1,0 +1,27 @@
+struct type_1 {
+    uint member;
+};
+
+static uint global = (uint)0;
+RWByteAddressBuffer global_1 : register(u0);
+
+struct ComputeInput_main {
+};
+
+void function()
+{
+    uint _e3 = global;
+    const uint4 _e5 = WaveActiveBallot((_e3 != 0u));
+    const uint _e6 = (_e5.x != 0u ? firstbitlow(_e5.x) : (_e5.y != 0u ? firstbitlow(_e5.y) + 32u : (_e5.z != 0u ? firstbitlow(_e5.z) + 64u : firstbitlow(_e5.w) + 96u)));
+    const uint _e7 = (_e5.w != 0u ? firstbithigh(_e5.w) + 96u : (_e5.z != 0u ? firstbithigh(_e5.z) + 64u : (_e5.y != 0u ? firstbithigh(_e5.y) + 32u : firstbithigh(_e5.x))));
+    global_1.Store(0, asuint((_e6 + _e7)));
+    return;
+}
+
+[numthreads(1, 1, 1)]
+void main(ComputeInput_main computeinput_main)
+{
+    uint param = WaveGetLaneIndex();
+    global = param;
+    function();
+}

--- a/naga/tests/out/hlsl/spv-subgroup-ballot-find-bit.hlsl
+++ b/naga/tests/out/hlsl/spv-subgroup-ballot-find-bit.hlsl
@@ -12,8 +12,16 @@ void function()
 {
     uint _e3 = global;
     const uint4 _e5 = WaveActiveBallot((_e3 != 0u));
-    const uint _e6 = (_e5.x != 0u ? firstbitlow(_e5.x) : (_e5.y != 0u ? firstbitlow(_e5.y) + 32u : (_e5.z != 0u ? firstbitlow(_e5.z) + 64u : firstbitlow(_e5.w) + 96u)));
-    const uint _e7 = (_e5.w != 0u ? firstbithigh(_e5.w) + 96u : (_e5.z != 0u ? firstbithigh(_e5.z) + 64u : (_e5.y != 0u ? firstbithigh(_e5.y) + 32u : firstbithigh(_e5.x))));
+    const uint unnamed = _e5.x;
+    const uint unnamed_1 = _e5.y;
+    const uint unnamed_2 = _e5.z;
+    const uint unnamed_3 = _e5.w;
+    const uint _e6 = (unnamed != 0u ? firstbitlow(unnamed) : (unnamed_1 != 0u ? firstbitlow(unnamed_1) + 32u : (unnamed_2 != 0u ? firstbitlow(unnamed_2) + 64u : firstbitlow(unnamed_3) + 96u)));
+    const uint unnamed_4 = _e5.x;
+    const uint unnamed_5 = _e5.y;
+    const uint unnamed_6 = _e5.z;
+    const uint unnamed_7 = _e5.w;
+    const uint _e7 = (unnamed_7 != 0u ? firstbithigh(unnamed_7) + 96u : (unnamed_6 != 0u ? firstbithigh(unnamed_6) + 64u : (unnamed_5 != 0u ? firstbithigh(unnamed_5) + 32u : firstbithigh(unnamed_4))));
     global_1.Store(0, asuint((_e6 + _e7)));
     return;
 }

--- a/naga/tests/out/hlsl/spv-subgroup-ballot-find-bit.ron
+++ b/naga/tests/out/hlsl/spv-subgroup-ballot-find-bit.ron
@@ -1,0 +1,16 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"main",
+            target_profile:"cs_6_0",
+        ),
+    ],
+    task:[
+    ],
+    mesh:[
+    ],
+)

--- a/naga/tests/out/msl/glsl-subgroup-ballot-find-bit.comp.metal
+++ b/naga/tests/out/msl/glsl-subgroup-ballot-find-bit.comp.metal
@@ -1,0 +1,42 @@
+// language: metal2.4
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+struct Output {
+    uint result;
+};
+
+void main_1(
+    device Output& global,
+    thread metal::uint3& gl_GlobalInvocationID_1
+) {
+    metal::uint4 mask = {};
+    uint lsb = {};
+    uint msb = {};
+    metal::uint3 _e3 = gl_GlobalInvocationID_1;
+    mask = metal::uint4(_e3.x, 2u, 3u, 4u);
+    metal::uint4 _e10 = mask;
+    uint unnamed = (_e10.x != 0u ? (((metal::ctz(_e10.x) + 1) % 33) - 1) : (_e10.y != 0u ? (((metal::ctz(_e10.y) + 1) % 33) - 1) + 32u : (_e10.z != 0u ? (((metal::ctz(_e10.z) + 1) % 33) - 1) + 64u : (((metal::ctz(_e10.w) + 1) % 33) - 1) + 96u)));
+    lsb = unnamed;
+    metal::uint4 _e13 = mask;
+    uint unnamed_1 = (_e13.w != 0u ? metal::select(31 - metal::clz(_e13.w), uint(-1), _e13.w == 0) + 96u : (_e13.z != 0u ? metal::select(31 - metal::clz(_e13.z), uint(-1), _e13.z == 0) + 64u : (_e13.y != 0u ? metal::select(31 - metal::clz(_e13.y), uint(-1), _e13.y == 0) + 32u : metal::select(31 - metal::clz(_e13.x), uint(-1), _e13.x == 0))));
+    msb = unnamed_1;
+    uint _e16 = lsb;
+    uint _e17 = msb;
+    global.result = _e16 + _e17;
+    return;
+}
+
+struct main_Input {
+};
+[[max_total_threads_per_threadgroup(1)]] kernel void main_(
+  metal::uint3 gl_GlobalInvocationID [[thread_position_in_grid]]
+, device Output& global [[user(fake0)]]
+) {
+    metal::uint3 gl_GlobalInvocationID_1 = {};
+    gl_GlobalInvocationID_1 = gl_GlobalInvocationID;
+    main_1(global, gl_GlobalInvocationID_1);
+    return;
+}

--- a/naga/tests/out/msl/glsl-subgroup-ballot-find-bit.comp.metal
+++ b/naga/tests/out/msl/glsl-subgroup-ballot-find-bit.comp.metal
@@ -10,19 +10,29 @@ struct Output {
 
 void main_1(
     device Output& global,
-    thread metal::uint3& gl_GlobalInvocationID_1
+    thread uint& gl_SubgroupInvocationID_1,
+    thread uint& gl_SubgroupSize_1
 ) {
     metal::uint4 mask = {};
     uint lsb = {};
     uint msb = {};
-    metal::uint3 _e3 = gl_GlobalInvocationID_1;
-    mask = metal::uint4(_e3.x, 2u, 3u, 4u);
+    uint _e4 = gl_SubgroupInvocationID_1;
+    uint _e5 = gl_SubgroupSize_1;
+    mask = metal::uint4(_e4, _e5, 3u, 4u);
     metal::uint4 _e10 = mask;
-    uint unnamed = (_e10.x != 0u ? (((metal::ctz(_e10.x) + 1) % 33) - 1) : (_e10.y != 0u ? (((metal::ctz(_e10.y) + 1) % 33) - 1) + 32u : (_e10.z != 0u ? (((metal::ctz(_e10.z) + 1) % 33) - 1) + 64u : (((metal::ctz(_e10.w) + 1) % 33) - 1) + 96u)));
-    lsb = unnamed;
+    uint unnamed = _e10.x;
+    uint unnamed_1 = _e10.y;
+    uint unnamed_2 = _e10.z;
+    uint unnamed_3 = _e10.w;
+    uint unnamed_4 = (unnamed != 0u ? (((metal::ctz(unnamed) + 1) % 33) - 1) : (unnamed_1 != 0u ? (((metal::ctz(unnamed_1) + 1) % 33) - 1) + 32u : (unnamed_2 != 0u ? (((metal::ctz(unnamed_2) + 1) % 33) - 1) + 64u : (((metal::ctz(unnamed_3) + 1) % 33) - 1) + 96u)));
+    lsb = unnamed_4;
     metal::uint4 _e13 = mask;
-    uint unnamed_1 = (_e13.w != 0u ? metal::select(31 - metal::clz(_e13.w), uint(-1), _e13.w == 0) + 96u : (_e13.z != 0u ? metal::select(31 - metal::clz(_e13.z), uint(-1), _e13.z == 0) + 64u : (_e13.y != 0u ? metal::select(31 - metal::clz(_e13.y), uint(-1), _e13.y == 0) + 32u : metal::select(31 - metal::clz(_e13.x), uint(-1), _e13.x == 0))));
-    msb = unnamed_1;
+    uint unnamed_5 = _e13.x;
+    uint unnamed_6 = _e13.y;
+    uint unnamed_7 = _e13.z;
+    uint unnamed_8 = _e13.w;
+    uint unnamed_9 = (unnamed_8 != 0u ? metal::select(31 - metal::clz(unnamed_8), uint(-1), unnamed_8 == 0) + 96u : (unnamed_7 != 0u ? metal::select(31 - metal::clz(unnamed_7), uint(-1), unnamed_7 == 0) + 64u : (unnamed_6 != 0u ? metal::select(31 - metal::clz(unnamed_6), uint(-1), unnamed_6 == 0) + 32u : metal::select(31 - metal::clz(unnamed_5), uint(-1), unnamed_5 == 0))));
+    msb = unnamed_9;
     uint _e16 = lsb;
     uint _e17 = msb;
     global.result = _e16 + _e17;
@@ -32,11 +42,14 @@ void main_1(
 struct main_Input {
 };
 [[max_total_threads_per_threadgroup(1)]] kernel void main_(
-  metal::uint3 gl_GlobalInvocationID [[thread_position_in_grid]]
+  uint gl_SubgroupInvocationID [[thread_index_in_simdgroup]]
+, uint gl_SubgroupSize [[threads_per_simdgroup]]
 , device Output& global [[user(fake0)]]
 ) {
-    metal::uint3 gl_GlobalInvocationID_1 = {};
-    gl_GlobalInvocationID_1 = gl_GlobalInvocationID;
-    main_1(global, gl_GlobalInvocationID_1);
+    uint gl_SubgroupInvocationID_1 = {};
+    uint gl_SubgroupSize_1 = {};
+    gl_SubgroupInvocationID_1 = gl_SubgroupInvocationID;
+    gl_SubgroupSize_1 = gl_SubgroupSize;
+    main_1(global, gl_SubgroupInvocationID_1, gl_SubgroupSize_1);
     return;
 }

--- a/naga/tests/out/msl/spv-subgroup-ballot-find-bit.metal
+++ b/naga/tests/out/msl/spv-subgroup-ballot-find-bit.metal
@@ -1,0 +1,32 @@
+// language: metal2.4
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+struct type_1 {
+    uint member;
+};
+
+void function(
+    thread uint& global,
+    device type_1& global_1
+) {
+    uint _e3 = global;
+    metal::uint4 unnamed = metal::uint4((uint64_t)metal::simd_ballot(_e3 != 0u), 0, 0, 0);
+    uint unnamed_1 = (unnamed.x != 0u ? (((metal::ctz(unnamed.x) + 1) % 33) - 1) : (unnamed.y != 0u ? (((metal::ctz(unnamed.y) + 1) % 33) - 1) + 32u : (unnamed.z != 0u ? (((metal::ctz(unnamed.z) + 1) % 33) - 1) + 64u : (((metal::ctz(unnamed.w) + 1) % 33) - 1) + 96u)));
+    uint unnamed_2 = (unnamed.w != 0u ? metal::select(31 - metal::clz(unnamed.w), uint(-1), unnamed.w == 0) + 96u : (unnamed.z != 0u ? metal::select(31 - metal::clz(unnamed.z), uint(-1), unnamed.z == 0) + 64u : (unnamed.y != 0u ? metal::select(31 - metal::clz(unnamed.y), uint(-1), unnamed.y == 0) + 32u : metal::select(31 - metal::clz(unnamed.x), uint(-1), unnamed.x == 0))));
+    global_1.member = unnamed_1 + unnamed_2;
+    return;
+}
+
+struct main_Input {
+};
+[[max_total_threads_per_threadgroup(1)]] kernel void main_(
+  uint param [[thread_index_in_simdgroup]]
+, device type_1& global_1 [[user(fake0)]]
+) {
+    uint global = {};
+    global = param;
+    function(global, global_1);
+}

--- a/naga/tests/out/msl/spv-subgroup-ballot-find-bit.metal
+++ b/naga/tests/out/msl/spv-subgroup-ballot-find-bit.metal
@@ -14,9 +14,17 @@ void function(
 ) {
     uint _e3 = global;
     metal::uint4 unnamed = metal::uint4((uint64_t)metal::simd_ballot(_e3 != 0u), 0, 0, 0);
-    uint unnamed_1 = (unnamed.x != 0u ? (((metal::ctz(unnamed.x) + 1) % 33) - 1) : (unnamed.y != 0u ? (((metal::ctz(unnamed.y) + 1) % 33) - 1) + 32u : (unnamed.z != 0u ? (((metal::ctz(unnamed.z) + 1) % 33) - 1) + 64u : (((metal::ctz(unnamed.w) + 1) % 33) - 1) + 96u)));
-    uint unnamed_2 = (unnamed.w != 0u ? metal::select(31 - metal::clz(unnamed.w), uint(-1), unnamed.w == 0) + 96u : (unnamed.z != 0u ? metal::select(31 - metal::clz(unnamed.z), uint(-1), unnamed.z == 0) + 64u : (unnamed.y != 0u ? metal::select(31 - metal::clz(unnamed.y), uint(-1), unnamed.y == 0) + 32u : metal::select(31 - metal::clz(unnamed.x), uint(-1), unnamed.x == 0))));
-    global_1.member = unnamed_1 + unnamed_2;
+    uint unnamed_1 = unnamed.x;
+    uint unnamed_2 = unnamed.y;
+    uint unnamed_3 = unnamed.z;
+    uint unnamed_4 = unnamed.w;
+    uint unnamed_5 = (unnamed_1 != 0u ? (((metal::ctz(unnamed_1) + 1) % 33) - 1) : (unnamed_2 != 0u ? (((metal::ctz(unnamed_2) + 1) % 33) - 1) + 32u : (unnamed_3 != 0u ? (((metal::ctz(unnamed_3) + 1) % 33) - 1) + 64u : (((metal::ctz(unnamed_4) + 1) % 33) - 1) + 96u)));
+    uint unnamed_6 = unnamed.x;
+    uint unnamed_7 = unnamed.y;
+    uint unnamed_8 = unnamed.z;
+    uint unnamed_9 = unnamed.w;
+    uint unnamed_10 = (unnamed_9 != 0u ? metal::select(31 - metal::clz(unnamed_9), uint(-1), unnamed_9 == 0) + 96u : (unnamed_8 != 0u ? metal::select(31 - metal::clz(unnamed_8), uint(-1), unnamed_8 == 0) + 64u : (unnamed_7 != 0u ? metal::select(31 - metal::clz(unnamed_7), uint(-1), unnamed_7 == 0) + 32u : metal::select(31 - metal::clz(unnamed_6), uint(-1), unnamed_6 == 0))));
+    global_1.member = unnamed_5 + unnamed_10;
     return;
 }
 

--- a/naga/tests/out/spv/glsl-subgroup-ballot-find-bit.comp.spvasm
+++ b/naga/tests/out/spv/glsl-subgroup-ballot-find-bit.comp.spvasm
@@ -1,0 +1,76 @@
+; SPIR-V
+; Version: 1.3
+; Generator: rspirv
+; Bound: 51
+OpCapability Shader
+OpCapability GroupNonUniformBallot
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %47 "main" %44
+OpExecutionMode %47 LocalSize 1 1 1
+OpMemberDecorate %4 0 Offset 0
+OpDecorate %7 DescriptorSet 0
+OpDecorate %7 Binding 0
+OpDecorate %8 Block
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %44 BuiltIn GlobalInvocationId
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%4 = OpTypeStruct %3
+%5 = OpTypeVector %3 4
+%6 = OpTypeVector %3 3
+%8 = OpTypeStruct %4
+%9 = OpTypePointer StorageBuffer %8
+%7 = OpVariable  %9  StorageBuffer
+%11 = OpTypePointer Private %6
+%12 = OpConstantNull  %6
+%10 = OpVariable  %11  Private %12
+%15 = OpTypeFunction %2
+%16 = OpTypePointer StorageBuffer %4
+%17 = OpConstant  %3  0
+%19 = OpConstant  %3  2
+%20 = OpConstant  %3  3
+%21 = OpConstant  %3  4
+%23 = OpTypePointer Function %5
+%24 = OpConstantNull  %5
+%26 = OpTypePointer Function %3
+%27 = OpConstantNull  %3
+%29 = OpConstantNull  %3
+%31 = OpTypePointer StorageBuffer %3
+%45 = OpTypePointer Input %6
+%44 = OpVariable  %45  Input
+%14 = OpFunction  %2  None %15
+%13 = OpLabel
+%22 = OpVariable  %23  Function %24
+%25 = OpVariable  %26  Function %27
+%28 = OpVariable  %26  Function %29
+%18 = OpAccessChain  %16  %7 %17
+OpBranch %30
+%30 = OpLabel
+%32 = OpLoad  %6  %10
+%33 = OpCompositeExtract  %3  %32 0
+%34 = OpCompositeConstruct  %5  %33 %19 %20 %21
+OpStore %22 %34
+%35 = OpLoad  %5  %22
+%36 = OpGroupNonUniformBallotFindLSB  %3  %20 %35
+OpStore %25 %36
+%37 = OpLoad  %5  %22
+%38 = OpGroupNonUniformBallotFindMSB  %3  %20 %37
+OpStore %28 %38
+%39 = OpLoad  %3  %25
+%40 = OpLoad  %3  %28
+%41 = OpIAdd  %3  %39 %40
+%42 = OpAccessChain  %31  %18 %17
+OpStore %42 %41
+OpReturn
+OpFunctionEnd
+%47 = OpFunction  %2  None %15
+%43 = OpLabel
+%46 = OpLoad  %6  %44
+%48 = OpAccessChain  %16  %7 %17
+OpBranch %49
+%49 = OpLabel
+OpStore %10 %46
+%50 = OpFunctionCall  %2  %14
+OpReturn
+OpFunctionEnd

--- a/naga/tests/out/spv/glsl-subgroup-ballot-find-bit.comp.spvasm
+++ b/naga/tests/out/spv/glsl-subgroup-ballot-find-bit.comp.spvasm
@@ -1,76 +1,80 @@
 ; SPIR-V
 ; Version: 1.3
 ; Generator: rspirv
-; Bound: 51
+; Bound: 52
 OpCapability Shader
 OpCapability GroupNonUniformBallot
+OpCapability GroupNonUniform
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %47 "main" %44
-OpExecutionMode %47 LocalSize 1 1 1
+OpEntryPoint GLCompute %48 "main" %43 %46
+OpExecutionMode %48 LocalSize 1 1 1
 OpMemberDecorate %4 0 Offset 0
-OpDecorate %7 DescriptorSet 0
-OpDecorate %7 Binding 0
-OpDecorate %8 Block
-OpMemberDecorate %8 0 Offset 0
-OpDecorate %44 BuiltIn GlobalInvocationId
+OpDecorate %6 DescriptorSet 0
+OpDecorate %6 Binding 0
+OpDecorate %7 Block
+OpMemberDecorate %7 0 Offset 0
+OpDecorate %43 BuiltIn SubgroupLocalInvocationId
+OpDecorate %46 BuiltIn SubgroupSize
 %2 = OpTypeVoid
 %3 = OpTypeInt 32 0
 %4 = OpTypeStruct %3
 %5 = OpTypeVector %3 4
-%6 = OpTypeVector %3 3
-%8 = OpTypeStruct %4
-%9 = OpTypePointer StorageBuffer %8
-%7 = OpVariable  %9  StorageBuffer
-%11 = OpTypePointer Private %6
-%12 = OpConstantNull  %6
-%10 = OpVariable  %11  Private %12
+%7 = OpTypeStruct %4
+%8 = OpTypePointer StorageBuffer %7
+%6 = OpVariable  %8  StorageBuffer
+%10 = OpTypePointer Private %3
+%11 = OpConstantNull  %3
+%9 = OpVariable  %10  Private %11
+%12 = OpVariable  %10  Private %11
 %15 = OpTypeFunction %2
 %16 = OpTypePointer StorageBuffer %4
 %17 = OpConstant  %3  0
-%19 = OpConstant  %3  2
-%20 = OpConstant  %3  3
-%21 = OpConstant  %3  4
-%23 = OpTypePointer Function %5
-%24 = OpConstantNull  %5
-%26 = OpTypePointer Function %3
-%27 = OpConstantNull  %3
-%29 = OpConstantNull  %3
-%31 = OpTypePointer StorageBuffer %3
-%45 = OpTypePointer Input %6
-%44 = OpVariable  %45  Input
+%19 = OpConstant  %3  3
+%20 = OpConstant  %3  4
+%22 = OpTypePointer Function %5
+%23 = OpConstantNull  %5
+%25 = OpTypePointer Function %3
+%26 = OpConstantNull  %3
+%28 = OpConstantNull  %3
+%30 = OpTypePointer StorageBuffer %3
+%44 = OpTypePointer Input %3
+%43 = OpVariable  %44  Input
+%46 = OpVariable  %44  Input
 %14 = OpFunction  %2  None %15
 %13 = OpLabel
-%22 = OpVariable  %23  Function %24
-%25 = OpVariable  %26  Function %27
-%28 = OpVariable  %26  Function %29
-%18 = OpAccessChain  %16  %7 %17
-OpBranch %30
-%30 = OpLabel
-%32 = OpLoad  %6  %10
-%33 = OpCompositeExtract  %3  %32 0
-%34 = OpCompositeConstruct  %5  %33 %19 %20 %21
-OpStore %22 %34
-%35 = OpLoad  %5  %22
-%36 = OpGroupNonUniformBallotFindLSB  %3  %20 %35
-OpStore %25 %36
-%37 = OpLoad  %5  %22
-%38 = OpGroupNonUniformBallotFindMSB  %3  %20 %37
-OpStore %28 %38
-%39 = OpLoad  %3  %25
-%40 = OpLoad  %3  %28
-%41 = OpIAdd  %3  %39 %40
-%42 = OpAccessChain  %31  %18 %17
-OpStore %42 %41
+%21 = OpVariable  %22  Function %23
+%24 = OpVariable  %25  Function %26
+%27 = OpVariable  %25  Function %28
+%18 = OpAccessChain  %16  %6 %17
+OpBranch %29
+%29 = OpLabel
+%31 = OpLoad  %3  %9
+%32 = OpLoad  %3  %12
+%33 = OpCompositeConstruct  %5  %31 %32 %19 %20
+OpStore %21 %33
+%34 = OpLoad  %5  %21
+%35 = OpGroupNonUniformBallotFindLSB  %3  %19 %34
+OpStore %24 %35
+%36 = OpLoad  %5  %21
+%37 = OpGroupNonUniformBallotFindMSB  %3  %19 %36
+OpStore %27 %37
+%38 = OpLoad  %3  %24
+%39 = OpLoad  %3  %27
+%40 = OpIAdd  %3  %38 %39
+%41 = OpAccessChain  %30  %18 %17
+OpStore %41 %40
 OpReturn
 OpFunctionEnd
-%47 = OpFunction  %2  None %15
-%43 = OpLabel
-%46 = OpLoad  %6  %44
-%48 = OpAccessChain  %16  %7 %17
-OpBranch %49
-%49 = OpLabel
-OpStore %10 %46
-%50 = OpFunctionCall  %2  %14
+%48 = OpFunction  %2  None %15
+%42 = OpLabel
+%45 = OpLoad  %3  %43
+%47 = OpLoad  %3  %46
+%49 = OpAccessChain  %16  %6 %17
+OpBranch %50
+%50 = OpLabel
+OpStore %9 %45
+OpStore %12 %47
+%51 = OpFunctionCall  %2  %14
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/glsl-subgroup-ballot-find-bit.comp.spvasm.glsl
+++ b/naga/tests/out/spv/glsl-subgroup-ballot-find-bit.comp.spvasm.glsl
@@ -1,0 +1,33 @@
+#version 460
+#extension GL_KHR_shader_subgroup_ballot : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct _4
+{
+    uint _m0;
+};
+
+layout(set = 0, binding = 0, std430) buffer _8_7
+{
+    _4 _m0;
+} _7;
+
+uvec3 _10 = uvec3(0u);
+
+void _14()
+{
+    uvec4 _22 = uvec4(0u);
+    uint _25 = 0u;
+    uint _28 = 0u;
+    _22 = uvec4(_10.x, 2u, 3u, 4u);
+    _25 = subgroupBallotFindLSB(_22);
+    _28 = subgroupBallotFindMSB(_22);
+    _7._m0._m0 = _25 + _28;
+}
+
+void main()
+{
+    _10 = gl_GlobalInvocationID;
+    _14();
+}
+

--- a/naga/tests/out/spv/glsl-subgroup-ballot-find-bit.comp.spvasm.glsl
+++ b/naga/tests/out/spv/glsl-subgroup-ballot-find-bit.comp.spvasm.glsl
@@ -1,5 +1,6 @@
 #version 460
 #extension GL_KHR_shader_subgroup_ballot : require
+#extension GL_KHR_shader_subgroup_basic : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 struct _4
@@ -7,27 +8,29 @@ struct _4
     uint _m0;
 };
 
-layout(set = 0, binding = 0, std430) buffer _8_7
+layout(set = 0, binding = 0, std430) buffer _7_6
 {
     _4 _m0;
-} _7;
+} _6;
 
-uvec3 _10 = uvec3(0u);
+uint _9 = 0u;
+uint _12 = 0u;
 
 void _14()
 {
-    uvec4 _22 = uvec4(0u);
-    uint _25 = 0u;
-    uint _28 = 0u;
-    _22 = uvec4(_10.x, 2u, 3u, 4u);
-    _25 = subgroupBallotFindLSB(_22);
-    _28 = subgroupBallotFindMSB(_22);
-    _7._m0._m0 = _25 + _28;
+    uvec4 _21 = uvec4(0u);
+    uint _24 = 0u;
+    uint _27 = 0u;
+    _21 = uvec4(_9, _12, 3u, 4u);
+    _24 = subgroupBallotFindLSB(_21);
+    _27 = subgroupBallotFindMSB(_21);
+    _6._m0._m0 = _24 + _27;
 }
 
 void main()
 {
-    _10 = gl_GlobalInvocationID;
+    _9 = gl_SubgroupInvocationID;
+    _12 = gl_SubgroupSize;
     _14();
 }
 

--- a/naga/tests/out/spv/spv-subgroup-ballot-find-bit.spvasm
+++ b/naga/tests/out/spv/spv-subgroup-ballot-find-bit.spvasm
@@ -1,0 +1,60 @@
+; SPIR-V
+; Version: 1.3
+; Generator: rspirv
+; Bound: 37
+OpCapability Shader
+OpCapability GroupNonUniformBallot
+OpCapability GroupNonUniform
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %33 "main" %30
+OpExecutionMode %33 LocalSize 1 1 1
+OpMemberDecorate %4 0 Offset 0
+OpDecorate %9 DescriptorSet 0
+OpDecorate %9 Binding 0
+OpDecorate %10 Block
+OpMemberDecorate %10 0 Offset 0
+OpDecorate %30 BuiltIn SubgroupLocalInvocationId
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%4 = OpTypeStruct %3
+%5 = OpConstant  %3  0
+%7 = OpTypePointer Private %3
+%8 = OpConstantNull  %3
+%6 = OpVariable  %7  Private %8
+%10 = OpTypeStruct %4
+%11 = OpTypePointer StorageBuffer %10
+%9 = OpVariable  %11  StorageBuffer
+%14 = OpTypeFunction %2
+%15 = OpTypePointer StorageBuffer %4
+%19 = OpTypeBool
+%21 = OpTypeVector %3 4
+%22 = OpConstant  %3  3
+%27 = OpTypePointer StorageBuffer %3
+%31 = OpTypePointer Input %3
+%30 = OpVariable  %31  Input
+%13 = OpFunction  %2  None %14
+%12 = OpLabel
+%16 = OpAccessChain  %15  %9 %5
+OpBranch %17
+%17 = OpLabel
+%18 = OpLoad  %3  %6
+%20 = OpINotEqual  %19  %18 %5
+%23 = OpGroupNonUniformBallot  %21  %22 %20
+%24 = OpGroupNonUniformBallotFindLSB  %3  %22 %23
+%25 = OpGroupNonUniformBallotFindMSB  %3  %22 %23
+%26 = OpIAdd  %3  %24 %25
+%28 = OpAccessChain  %27  %16 %5
+OpStore %28 %26
+OpReturn
+OpFunctionEnd
+%33 = OpFunction  %2  None %14
+%29 = OpLabel
+%32 = OpLoad  %3  %30
+%34 = OpAccessChain  %15  %9 %5
+OpBranch %35
+%35 = OpLabel
+OpStore %6 %32
+%36 = OpFunctionCall  %2  %13
+OpReturn
+OpFunctionEnd

--- a/naga/tests/out/spv/spv-subgroup-ballot-find-bit.spvasm.glsl
+++ b/naga/tests/out/spv/spv-subgroup-ballot-find-bit.spvasm.glsl
@@ -1,0 +1,29 @@
+#version 460
+#extension GL_KHR_shader_subgroup_ballot : require
+#extension GL_KHR_shader_subgroup_basic : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct _4
+{
+    uint _m0;
+};
+
+layout(set = 0, binding = 0, std430) buffer _10_9
+{
+    _4 _m0;
+} _9;
+
+uint _6 = 0u;
+
+void _13()
+{
+    uvec4 _23 = subgroupBallot(_6 != 0u);
+    _9._m0._m0 = subgroupBallotFindLSB(_23) + subgroupBallotFindMSB(_23);
+}
+
+void main()
+{
+    _6 = gl_SubgroupInvocationID;
+    _13();
+}
+

--- a/naga/tests/out/wgsl/glsl-subgroup-ballot-find-bit.comp.wgsl
+++ b/naga/tests/out/wgsl/glsl-subgroup-ballot-find-bit.comp.wgsl
@@ -1,0 +1,33 @@
+struct Output {
+    result: u32,
+}
+
+@group(0) @binding(0)
+var<storage, read_write> global: Output;
+var<private> gl_GlobalInvocationID_1: vec3<u32>;
+
+fn main_1() {
+    var mask: vec4<u32>;
+    var lsb: u32;
+    var msb: u32;
+
+    let _e3 = gl_GlobalInvocationID_1;
+    mask = vec4<u32>(_e3.x, 2u, 3u, 4u);
+    let _e10 = mask;
+    let _e11 = select(select(select(firstTrailingBit(_e10.w) + 96u, firstTrailingBit(_e10.z) + 64u, _e10.z != 0u), firstTrailingBit(_e10.y) + 32u, _e10.y != 0u), firstTrailingBit(_e10.x), _e10.x != 0u);
+    lsb = _e11;
+    let _e13 = mask;
+    let _e14 = select(select(select(firstLeadingBit(_e13.x), firstLeadingBit(_e13.y) + 32u, _e13.y != 0u), firstLeadingBit(_e13.z) + 64u, _e13.z != 0u), firstLeadingBit(_e13.w) + 96u, _e13.w != 0u);
+    msb = _e14;
+    let _e16 = lsb;
+    let _e17 = msb;
+    global.result = (_e16 + _e17);
+    return;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn main(@builtin(global_invocation_id) gl_GlobalInvocationID: vec3<u32>) {
+    gl_GlobalInvocationID_1 = gl_GlobalInvocationID;
+    main_1();
+    return;
+}

--- a/naga/tests/out/wgsl/glsl-subgroup-ballot-find-bit.comp.wgsl
+++ b/naga/tests/out/wgsl/glsl-subgroup-ballot-find-bit.comp.wgsl
@@ -4,20 +4,30 @@ struct Output {
 
 @group(0) @binding(0)
 var<storage, read_write> global: Output;
-var<private> gl_GlobalInvocationID_1: vec3<u32>;
+var<private> gl_SubgroupInvocationID_1: u32;
+var<private> gl_SubgroupSize_1: u32;
 
 fn main_1() {
     var mask: vec4<u32>;
     var lsb: u32;
     var msb: u32;
 
-    let _e3 = gl_GlobalInvocationID_1;
-    mask = vec4<u32>(_e3.x, 2u, 3u, 4u);
+    let _e4 = gl_SubgroupInvocationID_1;
+    let _e5 = gl_SubgroupSize_1;
+    mask = vec4<u32>(_e4, _e5, 3u, 4u);
     let _e10 = mask;
-    let _e11 = select(select(select(firstTrailingBit(_e10.w) + 96u, firstTrailingBit(_e10.z) + 64u, _e10.z != 0u), firstTrailingBit(_e10.y) + 32u, _e10.y != 0u), firstTrailingBit(_e10.x), _e10.x != 0u);
+    let unnamed = _e10.x;
+    let unnamed_1 = _e10.y;
+    let unnamed_2 = _e10.z;
+    let unnamed_3 = _e10.w;
+    let _e11 = select(select(select(firstTrailingBit(unnamed_3) + 96u, firstTrailingBit(unnamed_2) + 64u, unnamed_2 != 0u), firstTrailingBit(unnamed_1) + 32u, unnamed_1 != 0u), firstTrailingBit(unnamed), unnamed != 0u);
     lsb = _e11;
     let _e13 = mask;
-    let _e14 = select(select(select(firstLeadingBit(_e13.x), firstLeadingBit(_e13.y) + 32u, _e13.y != 0u), firstLeadingBit(_e13.z) + 64u, _e13.z != 0u), firstLeadingBit(_e13.w) + 96u, _e13.w != 0u);
+    let unnamed_4 = _e13.x;
+    let unnamed_5 = _e13.y;
+    let unnamed_6 = _e13.z;
+    let unnamed_7 = _e13.w;
+    let _e14 = select(select(select(firstLeadingBit(unnamed_4), firstLeadingBit(unnamed_5) + 32u, unnamed_5 != 0u), firstLeadingBit(unnamed_6) + 64u, unnamed_6 != 0u), firstLeadingBit(unnamed_7) + 96u, unnamed_7 != 0u);
     msb = _e14;
     let _e16 = lsb;
     let _e17 = msb;
@@ -26,8 +36,9 @@ fn main_1() {
 }
 
 @compute @workgroup_size(1, 1, 1)
-fn main(@builtin(global_invocation_id) gl_GlobalInvocationID: vec3<u32>) {
-    gl_GlobalInvocationID_1 = gl_GlobalInvocationID;
+fn main(@builtin(subgroup_invocation_id) gl_SubgroupInvocationID: u32, @builtin(subgroup_size) gl_SubgroupSize: u32) {
+    gl_SubgroupInvocationID_1 = gl_SubgroupInvocationID;
+    gl_SubgroupSize_1 = gl_SubgroupSize;
     main_1();
     return;
 }

--- a/naga/tests/out/wgsl/spv-subgroup-ballot-find-bit.wgsl
+++ b/naga/tests/out/wgsl/spv-subgroup-ballot-find-bit.wgsl
@@ -1,0 +1,22 @@
+struct type_1 {
+    member: u32,
+}
+
+var<private> global: u32;
+@group(0) @binding(0)
+var<storage, read_write> global_1: type_1;
+
+fn function_() {
+    let _e3 = global;
+    let _e5 = subgroupBallot((_e3 != 0u));
+    let _e6 = select(select(select(firstTrailingBit(_e5.w) + 96u, firstTrailingBit(_e5.z) + 64u, _e5.z != 0u), firstTrailingBit(_e5.y) + 32u, _e5.y != 0u), firstTrailingBit(_e5.x), _e5.x != 0u);
+    let _e7 = select(select(select(firstLeadingBit(_e5.x), firstLeadingBit(_e5.y) + 32u, _e5.y != 0u), firstLeadingBit(_e5.z) + 64u, _e5.z != 0u), firstLeadingBit(_e5.w) + 96u, _e5.w != 0u);
+    global_1.member = (_e6 + _e7);
+    return;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn main(@builtin(subgroup_invocation_id) param: u32) {
+    global = param;
+    function_();
+}

--- a/naga/tests/out/wgsl/spv-subgroup-ballot-find-bit.wgsl
+++ b/naga/tests/out/wgsl/spv-subgroup-ballot-find-bit.wgsl
@@ -9,8 +9,16 @@ var<storage, read_write> global_1: type_1;
 fn function_() {
     let _e3 = global;
     let _e5 = subgroupBallot((_e3 != 0u));
-    let _e6 = select(select(select(firstTrailingBit(_e5.w) + 96u, firstTrailingBit(_e5.z) + 64u, _e5.z != 0u), firstTrailingBit(_e5.y) + 32u, _e5.y != 0u), firstTrailingBit(_e5.x), _e5.x != 0u);
-    let _e7 = select(select(select(firstLeadingBit(_e5.x), firstLeadingBit(_e5.y) + 32u, _e5.y != 0u), firstLeadingBit(_e5.z) + 64u, _e5.z != 0u), firstLeadingBit(_e5.w) + 96u, _e5.w != 0u);
+    let unnamed = _e5.x;
+    let unnamed_1 = _e5.y;
+    let unnamed_2 = _e5.z;
+    let unnamed_3 = _e5.w;
+    let _e6 = select(select(select(firstTrailingBit(unnamed_3) + 96u, firstTrailingBit(unnamed_2) + 64u, unnamed_2 != 0u), firstTrailingBit(unnamed_1) + 32u, unnamed_1 != 0u), firstTrailingBit(unnamed), unnamed != 0u);
+    let unnamed_4 = _e5.x;
+    let unnamed_5 = _e5.y;
+    let unnamed_6 = _e5.z;
+    let unnamed_7 = _e5.w;
+    let _e7 = select(select(select(firstLeadingBit(unnamed_4), firstLeadingBit(unnamed_5) + 32u, unnamed_5 != 0u), firstLeadingBit(unnamed_6) + 64u, unnamed_6 != 0u), firstLeadingBit(unnamed_7) + 96u, unnamed_7 != 0u);
     global_1.member = (_e6 + _e7);
     return;
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -44,7 +44,7 @@ test-build-with-profiling = ["profiling/type-check"]
 [dependencies]
 # Passthrough backend uses as_hal for the GLES backend, and there's not a great way to cfg-gate that.
 # These are all enabled for any testing on CI anyway, and won't do anything if no devices are detected.
-wgpu = { workspace = true, features = ["noop", "gles", "webgl", "angle", "counters"] }
+wgpu = { workspace = true, features = ["noop", "gles", "webgl", "angle", "counters", "glsl"] }
 wgpu-core = { workspace = true, default-features = true, features = ["trace"] }
 wgpu-hal = { workspace = true, default-features = true, features = ["validation_canary"] }
 wgpu-sync.workspace = true

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -71,6 +71,7 @@ mod shader;
 mod shader_barycentric;
 mod shader_primitive_index;
 mod shader_view_format;
+mod subgroup_ballot_find_bit;
 mod subgroup_operations;
 mod texture_binding;
 mod texture_blit;
@@ -159,6 +160,7 @@ fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     shader_barycentric::all_tests(&mut tests);
     shader_view_format::all_tests(&mut tests);
     shader::all_tests(&mut tests);
+    subgroup_ballot_find_bit::all_tests(&mut tests);
     subgroup_operations::all_tests(&mut tests);
     texture_binding::all_tests(&mut tests);
     texture_blit::all_tests(&mut tests);

--- a/tests/tests/wgpu-gpu/subgroup_ballot_find_bit/mod.rs
+++ b/tests/tests/wgpu-gpu/subgroup_ballot_find_bit/mod.rs
@@ -1,0 +1,122 @@
+use std::{borrow::Cow, num::NonZeroU64};
+
+use wgpu_test::{apply, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(SUBGROUP_BALLOT_FIND_BIT);
+}
+
+const THREAD_COUNT: u64 = 64;
+
+// This shader can only be authored in GLSL (or SPIR-V): WGSL has no
+// `subgroupBallotFindLSB`/`subgroupBallotFindMSB` built-in, so
+// `naga::Statement::SubgroupBallotFindBit` is unreachable from WGSL source.
+// Loading it through `ShaderSource::Glsl` exercises naga's GLSL front-end and
+// then whichever backend the active adapter actually uses: the native
+// `OpGroupNonUniformBallotFindLSB`/`MSB` on Vulkan, native
+// `subgroupBallotFindLSB`/`MSB` again on GL, and the formula-based polyfills
+// on D3D12 (HLSL) and Metal (MSL).
+#[apply(gpu_test!)]
+static SUBGROUP_BALLOT_FIND_BIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(wgpu::Features::SUBGROUP)
+            .limits(wgpu::Limits::downlevel_defaults()),
+    )
+    .run_sync(|ctx| {
+        let device = &ctx.device;
+
+        let storage_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: THREAD_COUNT * size_of::<u32>() as u64,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("bind group layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(THREAD_COUNT * size_of::<u32>() as u64),
+                },
+                count: None,
+            }],
+        });
+
+        let cs_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("subgroup_ballot_find_bit"),
+            source: wgpu::ShaderSource::Glsl {
+                shader: Cow::Borrowed(include_str!("shader.comp")),
+                stage: naga::ShaderStage::Compute,
+                defines: &[],
+            },
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("main"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+        let compute_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: Some(&pipeline_layout),
+            module: &cs_module,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: storage_buffer.as_entire_binding(),
+            }],
+            layout: &bind_group_layout,
+            label: Some("bind group"),
+        });
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        {
+            let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: None,
+                timestamp_writes: None,
+            });
+            cpass.set_pipeline(&compute_pipeline);
+            cpass.set_bind_group(0, &bind_group, &[]);
+            cpass.dispatch_workgroups(1, 1, 1);
+        }
+        ctx.queue.submit(Some(encoder.finish()));
+
+        wgpu::util::DownloadBuffer::read_buffer(
+            device,
+            &ctx.queue,
+            &storage_buffer.slice(..),
+            |mapping_buffer_view| {
+                let mapping_buffer_view = mapping_buffer_view.unwrap();
+                let result: &[u32; THREAD_COUNT as usize] =
+                    bytemuck::from_bytes(&mapping_buffer_view);
+                let expected = [1u32; THREAD_COUNT as usize];
+                if result != &expected {
+                    let failed: Vec<u32> = result
+                        .iter()
+                        .enumerate()
+                        .filter(|&(_, &v)| v != 1)
+                        .map(|(i, _)| i as u32)
+                        .collect();
+                    panic!(
+                        "subgroupBallotFindLSB/MSB mismatch on invocations: {failed:?}\n\
+                        got:      {result:?}\n\
+                        expected: {expected:?}"
+                    );
+                }
+            },
+        );
+    });

--- a/tests/tests/wgpu-gpu/subgroup_ballot_find_bit/shader.comp
+++ b/tests/tests/wgpu-gpu/subgroup_ballot_find_bit/shader.comp
@@ -1,0 +1,62 @@
+#version 450
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_ballot : require
+
+layout(local_size_x = 64) in;
+
+layout(std430, binding = 0) buffer Output {
+    uint pass_mask[64];
+};
+
+void main() {
+    uint id = gl_LocalInvocationID.x;
+
+    // `subgroupBallotFindLSB`/`subgroupBallotFindMSB` only have to consider
+    // bits that correspond to a real invocation, i.e. bits `0..gl_SubgroupSize`
+    // (see the GL_KHR_shader_subgroup_ballot spec); bits beyond that are
+    // undefined, so every bit this test sets must stay within that range. The
+    // two bit positions below therefore cycle through `0..gl_SubgroupSize`
+    // (not a fixed range), so that every branch of the
+    // `subgroupBallotFindLSB`/`subgroupBallotFindMSB` lowering (both native
+    // and polyfilled) gets exercised as far as the actual subgroup size
+    // allows.
+    uint size = clamp(gl_SubgroupSize, 1u, 128u);
+    uint pos_a = id % size;
+    uint pos_b = (id / size) % size;
+
+    uint word_a = pos_a / 32u;
+    uint word_b = pos_b / 32u;
+    uint bit_a = 1u << (pos_a % 32u);
+    uint bit_b = 1u << (pos_b % 32u);
+
+    uvec4 mask = uvec4(0u);
+    mask.x = (word_a == 0u ? bit_a : 0u) | (word_b == 0u ? bit_b : 0u);
+    mask.y = (word_a == 1u ? bit_a : 0u) | (word_b == 1u ? bit_b : 0u);
+    mask.z = (word_a == 2u ? bit_a : 0u) | (word_b == 2u ? bit_b : 0u);
+    mask.w = (word_a == 3u ? bit_a : 0u) | (word_b == 3u ? bit_b : 0u);
+
+    uint actual_lsb = subgroupBallotFindLSB(mask);
+    uint actual_msb = subgroupBallotFindMSB(mask);
+
+    // Independent oracle: a plain scalar bit scan, using no subgroup
+    // operations at all, so it can't share a bug with the code under test.
+    uint expected_lsb = 0xFFFFFFFFu;
+    uint expected_msb = 0xFFFFFFFFu;
+    for (uint word = 0u; word < 4u; word++) {
+        uint value = mask[word];
+        if (value != 0u) {
+            for (uint bit = 0u; bit < 32u; bit++) {
+                if ((value & (1u << bit)) != 0u) {
+                    uint global_bit = word * 32u + bit;
+                    if (expected_lsb == 0xFFFFFFFFu) {
+                        expected_lsb = global_bit;
+                    }
+                    expected_msb = global_bit;
+                }
+            }
+        }
+    }
+
+    bool ok = (actual_lsb == expected_lsb) && (actual_msb == expected_msb);
+    pass_mask[id] = ok ? 1u : 0u;
+}


### PR DESCRIPTION
**Connections**

Fixes https://github.com/gfx-rs/wgpu/issues/8403.

**Description**

Both SPIR-V and GLSL support these operations and can now be losslessly converted in either direction. Other targets have lower-level primitives from which polyfills are built. `Statement::SubgroupBallotFindBit` was introduced to represent this new operation and wired through everything.

The first commit removes the pain point of IDE removing trailing whitespaces in GLSL output that caused tests failures, I hope it is acceptable to include it here.

**Testing**

CI passes, including newly added tests. My project where I was not able to use those operations in the past works correctly as well.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed this PR.
- [ ] I fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
