### PR TITLE
[core] Promote unexpected varying types to `log::error`.

### DIFF
--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1160,12 +1160,7 @@ impl Interface {
                 return;
             }
             ref other => {
-                //Note: technically this should be at least `log::error`, but
-                // the reality is - every shader coming from `glslc` outputs an array
-                // of clip distances and hits this path :(
-                // So we lower it to `log::debug` to be less annoying as
-                // there's nothing the user can do about it.
-                log::debug!("Unexpected varying type: {other:?}");
+                log::error!("Unexpected varying type: {other:?}");
                 return;
             }
         };


### PR DESCRIPTION
When `wgpu_core` finds a binding with an unexpected type, log that with `error` severity, not `debug`. This was demoted to `debug` in be6898f166, because, as the comment says:

> every shader coming from `glslc` outputs an array of clip distances
> and hits this path :(

However, #8762 added a match case above this that handles clip distance arrays, so such output should no longer trigger any logging at all.

cc: @ErichDonGubler 