### PR TITLE
fix(core): Fix validation of shader I/O numeric types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ Bottom level categories:
 - When creating render pipelines, validate that a corresponding shader output is present for each color attachment with non-zero write mask, and that shader output includes alpha when the blend operation uses source alpha. By @andyleiserson in [#9939](https://github.com/gfx-rs/wgpu/pull/9939).
 - Reject bind group layout entries with `TASK` or `MESH` visibility unless `Features::EXPERIMENTAL_MESH_SHADER` is enabled. By @teoxoy in [#10042](https://github.com/gfx-rs/wgpu/issues/10042).
 - Reject bind group layout entries with `RAY_GENERATION`, `ANY_HIT`, `CLOSEST_HIT`, or `MISS` visibility unless `Features::EXPERIMENTAL_RAY_TRACING_PIPELINES` is enabled. By @teoxoy in [#10042](https://github.com/gfx-rs/wgpu/issues/10042).
+- Numeric types must now match exactly on inter-stage interfaces. Previously, the receiving type was only required to be a subtype of the originating type. By @andyleiserson in TBD.
+- Relaxed requirement that the pipeline scalar type for a color output be at least as wide as the shader output type. Now, only the scalar kind must match. By @andyleiserson in TBD.
 
 #### Naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,8 @@ Bottom level categories:
 - When creating render pipelines, validate that a corresponding shader output is present for each color attachment with non-zero write mask, and that shader output includes alpha when the blend operation uses source alpha. By @andyleiserson in [#9939](https://github.com/gfx-rs/wgpu/pull/9939).
 - Reject bind group layout entries with `TASK` or `MESH` visibility unless `Features::EXPERIMENTAL_MESH_SHADER` is enabled. By @teoxoy in [#10042](https://github.com/gfx-rs/wgpu/issues/10042).
 - Reject bind group layout entries with `RAY_GENERATION`, `ANY_HIT`, `CLOSEST_HIT`, or `MISS` visibility unless `Features::EXPERIMENTAL_RAY_TRACING_PIPELINES` is enabled. By @teoxoy in [#10042](https://github.com/gfx-rs/wgpu/issues/10042).
-- Numeric types must now match exactly on inter-stage interfaces. Previously, the receiving type was only required to be a subtype of the originating type. By @andyleiserson in TBD.
-- Relaxed requirement that the pipeline scalar type for a color output be at least as wide as the shader output type. Now, only the scalar kind must match. By @andyleiserson in TBD.
+- Numeric types must now match exactly on inter-stage interfaces. Previously, the receiving type was only required to be a subtype of the originating type. By @andyleiserson in [#9999](https://github.com/gfx-rs/wgpu/pull/9999). 
+- Relaxed requirement that the pipeline scalar type for a color output be at least as wide as the shader output type. Now, only the scalar kind must match. By @andyleiserson in [#9999](https://github.com/gfx-rs/wgpu/pull/9999). 
 
 #### Naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,8 @@ Bottom level categories:
 - When creating render pipelines, validate that a corresponding shader output is present for each color attachment with non-zero write mask, and that shader output includes alpha when the blend operation uses source alpha. By @andyleiserson in [#9939](https://github.com/gfx-rs/wgpu/pull/9939).
 - Reject bind group layout entries with `TASK` or `MESH` visibility unless `Features::EXPERIMENTAL_MESH_SHADER` is enabled. By @teoxoy in [#10042](https://github.com/gfx-rs/wgpu/issues/10042).
 - Reject bind group layout entries with `RAY_GENERATION`, `ANY_HIT`, `CLOSEST_HIT`, or `MISS` visibility unless `Features::EXPERIMENTAL_RAY_TRACING_PIPELINES` is enabled. By @teoxoy in [#10042](https://github.com/gfx-rs/wgpu/issues/10042).
-- Numeric types must now match exactly on inter-stage interfaces. Previously, the receiving type was only required to be a subtype of the originating type. By @andyleiserson in [#9999](https://github.com/gfx-rs/wgpu/pull/9999). 
-- Relaxed requirement that the pipeline scalar type for a color output be at least as wide as the shader output type. Now, only the scalar kind must match. By @andyleiserson in [#9999](https://github.com/gfx-rs/wgpu/pull/9999). 
+- Numeric types must now match exactly on inter-stage interfaces. Previously, the receiving type was only required to be a subtype of the originating type. By @andyleiserson in [#9999](https://github.com/gfx-rs/wgpu/pull/9999).
+- Relaxed requirement that the pipeline scalar type for a color output be at least as wide as the shader output type. Now, only the scalar kind must match. By @andyleiserson in [#9999](https://github.com/gfx-rs/wgpu/pull/9999).
 
 #### Naga
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -277,6 +277,7 @@ webgpu:api,validation,render_pipeline,fragment_state:targets_write_mask:*
 webgpu:api,validation,render_pipeline,inter_stage:location,*
 webgpu:api,validation,render_pipeline,inter_stage:max_shader_variable_location:*
 fails-if(dx12) webgpu:api,validation,render_pipeline,inter_stage:max_variables_count,*
+webgpu:api,validation,render_pipeline,inter_stage:type:*
 webgpu:api,validation,render_pipeline,misc:basic:*
 fails-if(vulkan) webgpu:api,validation,render_pipeline,misc:external_texture:*
 webgpu:api,validation,render_pipeline,misc:no_attachment:*

--- a/tests/tests/wgpu-validation/api/render_pipeline.rs
+++ b/tests/tests/wgpu-validation/api/render_pipeline.rs
@@ -1,6 +1,6 @@
 //! Tests of [`wgpu::RenderPipeline`] and related.
 
-use wgpu_test::fail;
+use wgpu_test::{fail, valid};
 
 #[test]
 fn reject_fragment_shader_output_over_max_color_attachments() {
@@ -67,4 +67,70 @@ fn frag() -> @location({}) vec4f {{
             "with sampling Some(Center)'s index exceeds the `max_color_attachments` limit (8)"
         )),
     );
+}
+
+/// A fragment shader may output an `f16` value to a color target whose sample
+/// type is `float`, even when the format's components are 32-bit. The WebGPU
+/// spec only requires the output's scalar *kind* (floating-point) to match the
+/// format's sample type, not its bit width.
+#[test]
+fn accept_f16_fragment_output_to_f32_target() {
+    let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor {
+        required_features: wgpu::Features::SHADER_F16,
+        ..Default::default()
+    });
+
+    // NOTE: Vertex shader is a boring quad. The fragment shader is the interesting part.
+    let source = "\
+enable f16;
+
+@vertex
+fn vert(@builtin(vertex_index) vertex_index : u32) -> @builtin(position) vec4f {
+    var pos = array<vec2f, 3>(
+        vec2(0.0, 0.5),
+        vec2(-0.5, -0.5),
+        vec2(0.5, -0.5)
+    );
+    return vec4f(pos[vertex_index], 0.0, 1.0);
+}
+
+@fragment
+fn frag() -> @location(0) vec4h {
+    return vec4h(1.0h, 0.0h, 0.0h, 1.0h);
+}
+";
+
+    let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: None,
+        source: wgpu::ShaderSource::Wgsl(source.into()),
+    });
+    let module = &module;
+
+    valid(&device, || {
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            layout: None,
+            label: None,
+            vertex: wgpu::VertexState {
+                module,
+                entry_point: None,
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module,
+                entry_point: None,
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: wgpu::TextureFormat::Rgba8Unorm,
+                    blend: None,
+                    write_mask: Default::default(),
+                })],
+            }),
+            primitive: Default::default(),
+            depth_stencil: None,
+            multisample: Default::default(),
+            multiview_mask: None,
+            cache: None,
+        })
+    });
 }

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1103,14 +1103,11 @@ impl NumericType {
         }
     }
 
-    fn is_subtype_of(self, other: NumericType) -> bool {
-        if self.scalar.width > other.scalar.width {
+    fn compatible_with_shader_output(self, shader: NumericType) -> bool {
+        if self.scalar.kind != shader.scalar.kind {
             return false;
         }
-        if self.scalar.kind != other.scalar.kind {
-            return false;
-        }
-        match (self.dim, other.dim) {
+        match (self.dim, shader.dim) {
             (NumericDimension::Scalar, NumericDimension::Scalar) => true,
             (NumericDimension::Scalar, NumericDimension::Vector(_)) => true,
             (NumericDimension::Vector(s0), NumericDimension::Vector(s1)) => s0 <= s1,
@@ -1128,7 +1125,7 @@ pub fn check_color_attachment_compatibility(
     output_ty: NumericType,
 ) -> Result<(), ColorStateError> {
     let pipeline_ty = NumericType::from_texture_format(state.format);
-    if !pipeline_ty.is_subtype_of(output_ty) {
+    if !pipeline_ty.compatible_with_shader_output(output_ty) {
         return Err(ColorStateError::IncompatibleFormat {
             pipeline: pipeline_ty,
             shader: output_ty,
@@ -1763,7 +1760,7 @@ impl Interface {
                                         ));
                                     }
                                     (
-                                        iv.ty.is_subtype_of(provided.ty),
+                                        iv.ty == provided.ty,
                                         iv.per_primitive == provided.per_primitive,
                                     )
                                 }


### PR DESCRIPTION
For shader I/O:

- Inter-stage types must match exactly
- Fragment outputs only require that scalar kind matches. Scalar width may differ in either direction.

Fixes Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=2013404 and part of #9143.

**Testing**
Enables CTS tests and adds a directed test.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
