### PR TITLE
fix(core): Fix corner cases in initialized range tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Bottom level categories:
 - Zero-initialize padding (if any) at the end of a buffer allocation. This was application-visible in rare cases on Vulkan when a shader read beyond the valid range of a vertex buffer. By @andyleiserson in [#9791](https://github.com/gfx-rs/wgpu/pull/9791).
 - Fix required immediate slots calculation and remove `naga::valid::FunctionInfo::immediate_slots_used`. By @beicause in [#9725](https://github.com/gfx-rs/wgpu/pull/9725).
 - Fix `PendingSubmission` releasing its lock guards out of stacking order, which tripped `--cfg wgpu_validate_locks` on any submission. By @AdrianEddy in [#9960](https://github.com/gfx-rs/wgpu/pull/9960).
+- Fixed some cases where initialization tracking was not correct. By @andyleiserson in [#10002](https://github.com/gfx-rs/wgpu/pull/10002).
 
 #### naga
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,6 +1370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1569,17 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -3189,6 +3206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,10 +3278,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -3299,6 +3351,18 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -3307,6 +3371,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -3511,6 +3578,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "same-file"
@@ -4202,6 +4281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4403,6 +4488,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -4713,6 +4807,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "profiling",
+ "proptest",
  "raw-window-handle",
  "ron",
  "rustc-hash 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,8 @@ portable-atomic = "1.10"
 portable-atomic-util = "0.2.4"
 pp-rs = "0.2.1"
 profiling = { version = "1.0.1", default-features = false }
+# Limit to versions that use rand 0.8
+proptest = ">=1, <1.7"
 raw-window-handle = { version = "0.6.2", default-features = false }
 rayon = "1.3"
 regex-lite = "0.1"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -211,5 +211,8 @@ thiserror.workspace = true
 [target.'cfg(not(target_has_atomic = "64"))'.dependencies]
 portable-atomic = { workspace = true, optional = true }
 
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+proptest.workspace = true
+
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/wgpu-core/src/init_tracker/mod.rs
+++ b/wgpu-core/src/init_tracker/mod.rs
@@ -234,14 +234,24 @@ where
 
     // Drains uninitialized ranges in a query range.
     pub(crate) fn drain(&mut self, drain_range: Range<Idx>) -> InitTrackerDrain<'_, Idx> {
-        let index = self
-            .uninitialized_ranges
-            .partition_point(|r| r.end <= drain_range.start);
-        InitTrackerDrain {
-            drain_range,
-            uninitialized_ranges: &mut self.uninitialized_ranges,
-            first_index: index,
-            next_index: index,
+        if drain_range.is_empty() {
+            let len = self.uninitialized_ranges.len();
+            InitTrackerDrain {
+                drain_range,
+                uninitialized_ranges: &mut self.uninitialized_ranges,
+                first_index: len,
+                next_index: len,
+            }
+        } else {
+            let index = self
+                .uninitialized_ranges
+                .partition_point(|r| r.end <= drain_range.start);
+            InitTrackerDrain {
+                drain_range,
+                uninitialized_ranges: &mut self.uninitialized_ranges,
+                first_index: index,
+                next_index: index,
+            }
         }
     }
 }
@@ -269,7 +279,7 @@ impl InitTracker<u32> {
                     self.uninitialized_ranges[r_idx] = pos..r.end;
                 } else {
                     // previous range end must be smaller than idx, therefore no merge possible
-                    self.uninitialized_ranges.push(pos..(pos + 1));
+                    self.uninitialized_ranges.insert(r_idx, pos..(pos + 1));
                 }
             }
         } else {
@@ -378,6 +388,18 @@ mod test {
             tracker.drain(0..1337).collect::<Vec<Range<u32>>>(),
             vec![0..5, 1003..1337]
         );
+
+        // Doesn't split for an empty query
+        let mut tracker = Tracker::new(2);
+        assert_eq!(tracker.drain(1..1).count(), 0, "{tracker:?}");
+        assert_eq!(tracker.uninitialized_ranges.len(), 1, "{tracker:?}");
+        assert_eq!(tracker.uninitialized_ranges[0], 0..2, "{tracker:?}");
+
+        // If the range were split to `[0..1, 1..2]` before, this discard
+        // would result in `[0..2, 1..2]`.
+        tracker.discard(1);
+        assert_eq!(tracker.uninitialized_ranges.len(), 1, "{tracker:?}");
+        assert_eq!(tracker.uninitialized_ranges[0], 0..2, "{tracker:?}");
     }
 
     #[test]
@@ -387,11 +409,22 @@ mod test {
         tracker.discard(0);
         tracker.discard(5);
         tracker.discard(9);
-        assert_eq!(tracker.check(0..1), Some(0..1));
-        assert_eq!(tracker.check(1..5), None);
-        assert_eq!(tracker.check(5..6), Some(5..6));
-        assert_eq!(tracker.check(6..9), None);
-        assert_eq!(tracker.check(9..10), Some(9..10));
+        assert_eq!(tracker.check(0..1), Some(0..1), "{tracker:?}");
+        assert_eq!(tracker.check(1..5), None, "{tracker:?}");
+        assert_eq!(tracker.check(5..6), Some(5..6), "{tracker:?}");
+        assert_eq!(tracker.check(6..9), None, "{tracker:?}");
+        assert_eq!(tracker.check(9..10), Some(9..10), "{tracker:?}");
+
+        let mut tracker = Tracker::new(10);
+        tracker.drain(0..10);
+        tracker.discard(9);
+        tracker.discard(5);
+        tracker.discard(0);
+        assert_eq!(tracker.check(0..1), Some(0..1), "{tracker:?}");
+        assert_eq!(tracker.check(1..5), None, "{tracker:?}");
+        assert_eq!(tracker.check(5..6), Some(5..6), "{tracker:?}");
+        assert_eq!(tracker.check(6..9), None, "{tracker:?}");
+        assert_eq!(tracker.check(9..10), Some(9..10), "{tracker:?}");
     }
 
     #[test]
@@ -422,5 +455,201 @@ mod test {
         tracker.discard(3);
         assert_eq!(tracker.uninitialized_ranges.len(), 1);
         assert_eq!(tracker.uninitialized_ranges[0], 0..10);
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod proptest {
+    use alloc::{vec, vec::Vec};
+    use core::ops::Range;
+
+    use proptest::prelude::*;
+
+    type Tracker = super::InitTracker<u32>;
+
+    /// A simple reference model for [`super::InitTracker`].
+    ///
+    /// `initialized[i]` is true iff position `i` is initialized.
+    #[derive(Debug, Clone)]
+    struct Model {
+        initialized: Vec<bool>,
+    }
+
+    impl Model {
+        fn new(size: u32) -> Self {
+            Model {
+                initialized: vec![false; size as usize],
+            }
+        }
+
+        fn drain(&mut self, range: Range<u32>) {
+            for i in range {
+                self.initialized[i as usize] = true;
+            }
+        }
+
+        fn discard(&mut self, pos: u32) {
+            self.initialized[pos as usize] = false;
+        }
+
+        fn size(&self) -> u32 {
+            self.initialized.len() as u32
+        }
+
+        /// The uninitialized positions within `query`, in ascending order.
+        fn uninitialized_positions(&self, query: Range<u32>) -> Vec<u32> {
+            query.filter(|&i| !self.initialized[i as usize]).collect()
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    enum Op {
+        Drain(Range<u32>),
+        Discard(u32),
+    }
+
+    /// A normalized (`start <= end`) subrange of `0..=size`, possibly empty.
+    fn range_strategy(size: u32) -> impl Strategy<Value = Range<u32>> {
+        (0..=size, 0..=size).prop_map(|(a, b)| if a <= b { a..b } else { b..a })
+    }
+
+    fn op_strategy(size: u32) -> impl Strategy<Value = Op> {
+        prop_oneof![
+            3 => range_strategy(size).prop_map(Op::Drain),
+            // `discard` operates on a single existing position, so it must be
+            // in bounds (`size` is always >= 1 here).
+            1 => (0..size).prop_map(Op::Discard),
+        ]
+    }
+
+    /// The set of positions the tracker treats as uninitialized, reconstructed
+    /// from its internal range list.
+    fn tracker_uninit(tracker: &Tracker, size: u32) -> Vec<bool> {
+        let mut set = vec![false; size as usize];
+        for r in tracker.uninitialized_ranges.iter() {
+            for i in r.clone() {
+                set[i as usize] = true;
+            }
+        }
+        set
+    }
+
+    /// Assert the tracker's internal state matches the model.
+    ///
+    /// The tracked set of uninitialized positions must exactly match the model.
+    ///
+    /// The internal range list must uphold the invariant that it contains non-empty,
+    /// in-bounds ranges, not overlapping or adjacent, and sorted by end. The non-adjacency
+    /// property (alternatively, that ranges must be merged whenever possible) is required
+    /// by `discard`, which could otherwise corrupt an adjacency into an overlap.
+    fn assert_state_matches_model(tracker: &Tracker, model: &Model) {
+        let ranges = &tracker.uninitialized_ranges;
+        let mut prev_end = None;
+        for (i, r) in ranges.iter().enumerate() {
+            assert!(r.start < r.end, "empty range {r:?} at index {i}");
+            assert!(
+                r.end <= model.size(),
+                "out-of-bounds range {r:?} at index {i}"
+            );
+            if let Some(prev_end) = prev_end {
+                assert!(
+                    prev_end < r.start,
+                    "range {r:?} at index {i} is not strictly after the previous range \
+                     (previous end {prev_end}); the list must stay sorted by end and fully \
+                     merged (no overlapping or adjacent ranges)",
+                );
+            }
+            prev_end = Some(r.end);
+        }
+
+        let tracker_uninit = tracker_uninit(tracker, model.size());
+        let model_uninit: Vec<bool> = model.initialized.iter().map(|&i| !i).collect();
+        assert_eq!(
+            tracker_uninit, model_uninit,
+            "tracker's uninitialized set diverged from the model",
+        );
+    }
+
+    /// Verify that `check` and `uninitialized` return results matching the model.
+    fn assert_queries_match_model(tracker: &mut Tracker, model: &Model, query: Range<u32>) {
+        let uninit = model.uninitialized_positions(query.clone());
+
+        // `check` is allowed to be loose: its result is only used to decide whether any
+        // initialization may be needed, not directly as the target of a clear. So a
+        // `Some(r)` from `check` may be larger than necessary, but must stay within the
+        // query and cover every uninitialized position in it; `None` must only be returned
+        // if the entire query range is initialized.
+        match tracker.check(query.clone()) {
+            None => assert!(
+                uninit.is_empty(),
+                "check({query:?}) returned None but positions {uninit:?} are uninitialized",
+            ),
+            Some(r) => {
+                assert!(
+                    r.start >= query.start && r.end <= query.end,
+                    "check({query:?}) returned {r:?} outside the query range",
+                );
+                if let (Some(&first), Some(&last)) = (uninit.first(), uninit.last()) {
+                    assert!(
+                        r.start <= first && r.end > last,
+                        "check({query:?}) = {r:?} does not cover all uninitialized positions \
+                         (first {first}, last {last})",
+                    );
+                }
+            }
+        }
+
+        // The ranges returned by `uninitialized` will be zero-filled, so it must be exact,
+        // otherwise we could clobber valid data.
+        let iter_positions: Vec<u32> = tracker
+            .uninitialized(query.clone())
+            .inspect(|r| {
+                assert!(
+                    r.start >= query.start && r.end <= query.end,
+                    "uninitialized({query:?}) yielded out-of-range subrange {r:?}",
+                );
+            })
+            .flatten()
+            .collect();
+        assert_eq!(
+            iter_positions, uninit,
+            "uninitialized({query:?}) did not enumerate exactly the uninitialized positions",
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn tracker_matches_model(
+            (size, ops, queries) in (1u32..=64).prop_flat_map(|size| {
+                (
+                    Just(size),
+                    proptest::collection::vec(op_strategy(size), 0..64),
+                    proptest::collection::vec(range_strategy(size), 1..16),
+                )
+            })
+        ) {
+            let mut tracker = Tracker::new(size);
+            let mut model = Model::new(size);
+            assert_state_matches_model(&tracker, &model);
+
+            for op in ops {
+                match op {
+                    Op::Drain(range) => {
+                        // Fully consume the drain iterator, as callers do.
+                        tracker.drain(range.clone()).for_each(drop);
+                        model.drain(range);
+                    }
+                    Op::Discard(pos) => {
+                        tracker.discard(pos);
+                        model.discard(pos);
+                    }
+                }
+                assert_state_matches_model(&tracker, &model);
+            }
+
+            for query in queries {
+                assert_queries_match_model(&mut tracker, &model, query);
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a [proptest](https://docs.rs/proptest/latest/proptest/) for the uninitialized range tracker, and fixes a few corner cases.

This does add a new dev-dependency on proptest; I think these are good tests and this probably isn't the only place where we could benefit, but every dependency costs something.

**Testing**
The proptest; also includes directed tests for the fixes.

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
