### PR TITLE
Process submitted command buffers in two passes

### DIFF
--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -9,7 +9,7 @@ use hashbrown::hash_map::Entry;
 use crate::{
     device::{Device, DeviceError},
     init_tracker::*,
-    resource::{DestroyedResourceError, ParentDevice, RawResourceAccess, Texture, Trackable},
+    resource::{ParentDevice, RawResourceAccess, Texture, Trackable},
     snatch::SnatchGuard,
     track::{DeviceTracker, TextureTracker},
     FastHashMap,
@@ -156,13 +156,22 @@ pub(crate) fn fixup_discarded_surfaces<InitIter: Iterator<Item = TextureSurfaceD
 }
 
 impl BakedCommands {
-    // inserts all buffer initializations that are going to be needed for
-    // executing the commands and updates resource init states accordingly
+    /// Initialize buffers.
+    ///
+    /// Inserts all buffer initializations that are going to be needed for
+    /// executing the commands, and updates resource init states accordingly.
+    ///
+    /// The caller is responsible for checking that any buffer this may touch has not been
+    /// destroyed, and must have done that check under the same snatch guard that is passed
+    /// to this function.
+    ///
+    /// # Panics
+    /// If a destroyed buffer is encountered.
     pub(crate) fn initialize_buffer_memory(
         &mut self,
         device_tracker: &mut DeviceTracker,
         snatch_guard: &SnatchGuard<'_>,
-    ) -> Result<(), DestroyedResourceError> {
+    ) {
         profiling::scope!("initialize_buffer_memory");
 
         // Gather init ranges for each buffer so we can collapse them.
@@ -220,7 +229,9 @@ impl BakedCommands {
                 .buffers
                 .set_single(&buffer, wgt::BufferUses::COPY_DST);
 
-            let raw_buf = buffer.try_raw(snatch_guard)?;
+            let raw_buf = buffer
+                .try_raw(snatch_guard)
+                .expect("attempt to initialize a destroyed buffer");
 
             unsafe {
                 self.encoder.raw.transition_buffers(
@@ -251,19 +262,30 @@ impl BakedCommands {
                 }
             }
         }
-        Ok(())
     }
 
-    // inserts all texture initializations that are going to be needed for
-    // executing the commands and updates resource init states accordingly any
-    // textures that are left discarded by this command buffer will be marked as
-    // uninitialized
+    /// Initialize textures.
+    ///
+    /// Inserts all texture initializations that are going to be needed for
+    /// executing the commands, and updates resource init states accordingly. Any
+    /// textures that are left discarded by this command buffer will be marked as
+    /// uninitialized.
+    ///
+    /// The caller is responsible for checking that any texture this may touch has not been
+    /// destroyed, and must have done that check under the same snatch guard that is passed
+    /// to this function.
+    ///
+    /// Note that any error returned from this function will become device loss in
+    /// [`crate::device::queue::Queue::submit`].
+    ///
+    /// # Panics
+    /// If a destroyed texture is encountered.
     pub(crate) fn initialize_texture_memory(
         &mut self,
         device_tracker: &mut DeviceTracker,
         device: &Device,
         snatch_guard: &SnatchGuard<'_>,
-    ) -> Result<(), DestroyedResourceError> {
+    ) -> Result<(), ClearError> {
         profiling::scope!("initialize_texture_memory");
 
         let mut ranges: Vec<TextureInitRange> = Vec::new();
@@ -308,16 +330,14 @@ impl BakedCommands {
                     device.instance_flags,
                 );
 
-                // A Texture can be destroyed between the command recording
-                // and now, this is out of our control so we have to handle
-                // it gracefully.
-                if let Err(ClearError::DestroyedResource(e)) = clear_result {
-                    return Err(e);
-                }
-
-                // Other errors are unexpected.
-                if let Err(error) = clear_result {
-                    panic!("{error}");
+                // We panic on destroyed textures for symmetry with buffer
+                // initialization. It should not happen, but supposing it did,
+                // it would also be fine to return the error and lose the
+                // device in queue submit.
+                if matches!(clear_result, Err(ClearError::DestroyedResource(_))) {
+                    panic!("attempt to initialize a destroyed texture");
+                } else {
+                    clear_result?;
                 }
             }
         }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1414,6 +1414,11 @@ impl Queue {
             .map_err(|(index, e)| (index, e.into()))?;
         let submit_index = submission.index;
 
+        // If we encounter an error after we have started updating global state and before
+        // successful submission, we must lose the device to avoid continuing with
+        // potentially inaccurate resource state.
+        let mut lose_device_on_error = false;
+
         let res = 'error: {
             let mut used_surface_textures = track::TextureUsageScope::default();
             let mut baked_command_buffers = Vec::with_capacity(command_buffers.len());
@@ -1505,6 +1510,23 @@ impl Queue {
                     break 'error Err(first_error);
                 }
 
+                // At this point we have validated all the command buffers, and we start
+                // making updates to global state. If we fail between here and successful
+                // submission, we must lose the device, or else we could leave that global
+                // state inaccurate or inconsistent.
+                //
+                // At time of writing, there were two kinds of errors that can occur in
+                // this stage:
+                //  - `hal` command encoding errors. These produce device loss in
+                //    `handle_hal_error`, independent of what we do here.
+                //  - Errors from `initialize_texture_memory`. The error cases that
+                //    can actually occur should also be encoder errors, but we map
+                //    everything to device loss, just in case.
+                lose_device_on_error = true;
+
+                // Note: locking the trackers has to be done after the storages
+                let mut trackers = self.device.trackers.lock();
+
                 for mut baked in baked_command_buffers {
                     profiling::scope!("process baked commands");
 
@@ -1516,19 +1538,16 @@ impl Queue {
                         break 'error Err(e.into());
                     }
 
-                    //Note: locking the trackers has to be done after the storages
-                    let mut trackers = self.device.trackers.lock();
-                    if let Err(e) =
-                        baked.initialize_buffer_memory(&mut trackers, &submission.snatch_guard)
-                    {
-                        break 'error Err(e.into());
-                    }
+                    baked.initialize_buffer_memory(&mut trackers, &submission.snatch_guard);
+
                     if let Err(e) = baked.initialize_texture_memory(
                         &mut trackers,
                         &self.device,
                         &submission.snatch_guard,
                     ) {
-                        break 'error Err(e.into());
+                        break 'error Err(QueueSubmitError::CommandEncoder(
+                            CommandEncoderError::Clear(e),
+                        ));
                     }
 
                     //Note: stateless trackers are not merged:
@@ -1617,11 +1636,16 @@ impl Queue {
             };
 
             Ok(closures)
-        };
+        }; // 'error
 
         let callbacks = match res {
             Ok(ok) => ok,
-            Err(e) => return Err((submit_index, e)),
+            Err(e) => {
+                if lose_device_on_error {
+                    self.device.lose("submission failed");
+                }
+                return Err((submit_index, e));
+            }
         };
 
         // the closures should execute with nothing locked!

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1416,169 +1416,171 @@ impl Queue {
 
         let res = 'error: {
             let mut used_surface_textures = track::TextureUsageScope::default();
+            let mut baked_command_buffers = Vec::with_capacity(command_buffers.len());
 
-            {
-                if !command_buffers.is_empty() {
-                    profiling::scope!("prepare");
+            if !command_buffers.is_empty() {
+                profiling::scope!("prepare");
 
-                    let mut first_error = None;
+                let mut first_error = None;
 
-                    //TODO: if multiple command buffers are submitted, we can re-use the last
-                    // native command buffer of the previous chain instead of always creating
-                    // a temporary one, since the chains are not finished.
+                // We are required to invalidate all command buffers in both the success and
+                // failure paths, so we `continue` after errors, and disallow `?`.
+                #[deny(clippy::question_mark_used)]
+                for command_buffer in command_buffers {
+                    profiling::scope!("process command buffer");
 
-                    // finish all the command buffers first
-                    for command_buffer in command_buffers {
-                        profiling::scope!("process command buffer");
+                    // we reset the used surface textures every time we use
+                    // it, so make sure to set_size on it.
+                    used_surface_textures.set_size(self.device.tracker_indices.textures.size());
 
-                        // we reset the used surface textures every time we use
-                        // it, so make sure to set_size on it.
-                        used_surface_textures.set_size(self.device.tracker_indices.textures.size());
+                    // Anything other than our own submission work in the remainder of this
+                    // function that attempts to use the WebGPU command buffer after this
+                    // point, will find it vacant (invalid), and produce an error.
+                    #[cfg_attr(not(feature = "trace"), expect(unused_mut))]
+                    let mut cmd_buf_data = command_buffer.take_finished();
 
-                        // Note that we are required to invalidate all command buffers in both the success and failure paths.
-                        // This is why we `continue` and don't early return via `?`.
-                        #[allow(unused_mut)]
-                        let mut cmd_buf_data = command_buffer.take_finished();
+                    if first_error.is_some() {
+                        continue;
+                    }
 
-                        if first_error.is_some() {
-                            continue;
-                        }
+                    #[cfg(feature = "trace")]
+                    let trace_commands = cmd_buf_data
+                        .as_mut()
+                        .ok()
+                        .and_then(|data| mem::take(&mut data.trace_commands));
 
-                        #[cfg(feature = "trace")]
-                        let trace_commands = cmd_buf_data
-                            .as_mut()
-                            .ok()
-                            .and_then(|data| mem::take(&mut data.trace_commands));
-
-                        let mut baked = match cmd_buf_data {
-                            Ok(cmd_buf_data) => {
-                                let res = validate_command_buffer(
-                                    command_buffer,
-                                    self,
-                                    &cmd_buf_data,
-                                    &submission.snatch_guard,
-                                    &mut submission.surface_textures,
-                                    &mut used_surface_textures,
-                                    &mut submission.command_index_guard,
-                                );
-                                if let Err(err) = res {
-                                    #[cfg(feature = "trace")]
-                                    self.trace_failed_submission(
-                                        submit_index,
-                                        trace_commands,
-                                        err.to_string(),
-                                    );
-                                    first_error.get_or_insert(err);
-                                    continue;
-                                }
-
-                                #[cfg(feature = "trace")]
-                                if let Some(commands) = trace_commands {
-                                    self.trace_submission(submit_index, commands);
-                                }
-
-                                cmd_buf_data.set_acceleration_structure_dependencies(
-                                    &submission.snatch_guard,
-                                );
-                                cmd_buf_data.into_baked_commands()
-                            }
-                            Err(err) => {
+                    let mut baked = match cmd_buf_data {
+                        Ok(cmd_buf_data) => {
+                            let res = validate_command_buffer(
+                                command_buffer,
+                                self,
+                                &cmd_buf_data,
+                                &submission.snatch_guard,
+                                &mut submission.surface_textures,
+                                &mut used_surface_textures,
+                                &mut submission.command_index_guard,
+                            );
+                            if let Err(err) = res {
                                 #[cfg(feature = "trace")]
                                 self.trace_failed_submission(
                                     submit_index,
                                     trace_commands,
                                     err.to_string(),
                                 );
-                                first_error.get_or_insert(err.into());
+                                first_error.get_or_insert(err);
                                 continue;
                             }
-                        };
 
-                        if let Err(e) = baked.process_deferred_query_set_resolves(
-                            &self.device,
-                            &submission.snatch_guard,
-                        ) {
-                            break 'error Err(e.into());
+                            #[cfg(feature = "trace")]
+                            if let Some(commands) = trace_commands {
+                                self.trace_submission(submit_index, commands);
+                            }
+
+                            cmd_buf_data
+                                .set_acceleration_structure_dependencies(&submission.snatch_guard);
+                            cmd_buf_data.into_baked_commands()
                         }
+                        Err(err) => {
+                            #[cfg(feature = "trace")]
+                            self.trace_failed_submission(
+                                submit_index,
+                                trace_commands,
+                                err.to_string(),
+                            );
+                            first_error.get_or_insert(err.into());
+                            continue;
+                        }
+                    };
 
-                        // execute resource transitions
+                    if let Err(e) = baked
+                        .process_deferred_query_set_resolves(&self.device, &submission.snatch_guard)
+                    {
+                        break 'error Err(e.into());
+                    }
+
+                    baked_command_buffers.push(baked);
+                }
+
+                if let Some(first_error) = first_error {
+                    break 'error Err(first_error);
+                }
+
+                for mut baked in baked_command_buffers {
+                    profiling::scope!("process baked commands");
+
+                    // execute resource transitions
+                    if let Err(e) = baked.encoder.open_pass(hal_label(
+                        Some("(wgpu internal) Transit"),
+                        self.device.instance_flags,
+                    )) {
+                        break 'error Err(e.into());
+                    }
+
+                    //Note: locking the trackers has to be done after the storages
+                    let mut trackers = self.device.trackers.lock();
+                    if let Err(e) =
+                        baked.initialize_buffer_memory(&mut trackers, &submission.snatch_guard)
+                    {
+                        break 'error Err(e.into());
+                    }
+                    if let Err(e) = baked.initialize_texture_memory(
+                        &mut trackers,
+                        &self.device,
+                        &submission.snatch_guard,
+                    ) {
+                        break 'error Err(e.into());
+                    }
+
+                    //Note: stateless trackers are not merged:
+                    // device already knows these resources exist.
+                    CommandEncoder::insert_barriers_from_device_tracker(
+                        baked.encoder.raw.as_mut(),
+                        &mut trackers,
+                        &baked.trackers,
+                        &submission.snatch_guard,
+                    );
+
+                    if let Err(e) = baked.encoder.close_and_push_front() {
+                        break 'error Err(e.into());
+                    }
+
+                    // Transition surface textures into `Present` state.
+                    // Note: we could technically do it after all of the command buffers,
+                    // but here we have a command encoder by hand, so it's easier to use it.
+                    if !used_surface_textures.is_empty() {
                         if let Err(e) = baked.encoder.open_pass(hal_label(
-                            Some("(wgpu internal) Transit"),
+                            Some("(wgpu internal) Present"),
                             self.device.instance_flags,
                         )) {
                             break 'error Err(e.into());
                         }
-
-                        //Note: locking the trackers has to be done after the storages
-                        let mut trackers = self.device.trackers.lock();
-                        if let Err(e) =
-                            baked.initialize_buffer_memory(&mut trackers, &submission.snatch_guard)
-                        {
+                        let texture_barriers = trackers
+                            .textures
+                            .set_from_usage_scope_and_drain_transitions(
+                                &used_surface_textures,
+                                &submission.snatch_guard,
+                            )
+                            .collect::<Vec<_>>();
+                        unsafe {
+                            baked.encoder.raw.transition_textures(&texture_barriers);
+                        };
+                        if let Err(e) = baked.encoder.close() {
                             break 'error Err(e.into());
                         }
-                        if let Err(e) = baked.initialize_texture_memory(
-                            &mut trackers,
-                            &self.device,
-                            &submission.snatch_guard,
-                        ) {
-                            break 'error Err(e.into());
-                        }
-
-                        //Note: stateless trackers are not merged:
-                        // device already knows these resources exist.
-                        CommandEncoder::insert_barriers_from_device_tracker(
-                            baked.encoder.raw.as_mut(),
-                            &mut trackers,
-                            &baked.trackers,
-                            &submission.snatch_guard,
-                        );
-
-                        if let Err(e) = baked.encoder.close_and_push_front() {
-                            break 'error Err(e.into());
-                        }
-
-                        // Transition surface textures into `Present` state.
-                        // Note: we could technically do it after all of the command buffers,
-                        // but here we have a command encoder by hand, so it's easier to use it.
-                        if !used_surface_textures.is_empty() {
-                            if let Err(e) = baked.encoder.open_pass(hal_label(
-                                Some("(wgpu internal) Present"),
-                                self.device.instance_flags,
-                            )) {
-                                break 'error Err(e.into());
-                            }
-                            let texture_barriers = trackers
-                                .textures
-                                .set_from_usage_scope_and_drain_transitions(
-                                    &used_surface_textures,
-                                    &submission.snatch_guard,
-                                )
-                                .collect::<Vec<_>>();
-                            unsafe {
-                                baked.encoder.raw.transition_textures(&texture_barriers);
-                            };
-                            if let Err(e) = baked.encoder.close() {
-                                break 'error Err(e.into());
-                            }
-                            used_surface_textures = track::TextureUsageScope::default();
-                        }
-
-                        // done
-                        submission.executions.push(EncoderInFlight {
-                            inner: baked.encoder,
-                            trackers: baked.trackers,
-                            temp_resources: baked.temp_resources,
-                            _indirect_draw_validation_resources: baked
-                                .indirect_draw_validation_resources,
-                            pending_buffers: FastHashMap::default(),
-                            pending_textures: FastHashMap::default(),
-                            pending_blas_s: FastHashMap::default(),
-                        });
+                        used_surface_textures = track::TextureUsageScope::default();
                     }
 
-                    if let Some(first_error) = first_error {
-                        break 'error Err(first_error);
-                    }
+                    // done
+                    submission.executions.push(EncoderInFlight {
+                        inner: baked.encoder,
+                        trackers: baked.trackers,
+                        temp_resources: baked.temp_resources,
+                        _indirect_draw_validation_resources: baked
+                            .indirect_draw_validation_resources,
+                        pending_buffers: FastHashMap::default(),
+                        pending_textures: FastHashMap::default(),
+                        pending_blas_s: FastHashMap::default(),
+                    });
                 }
             }
 
@@ -1590,6 +1592,11 @@ impl Queue {
             };
 
             profiling::scope!("cleanup");
+
+            // Failing in `Device::maintain` won't put resource state at risk, but returning
+            // an error from a successful submission could be confusing, do we really want
+            // to do that?
+            lose_device_on_error = false;
 
             // This will schedule destruction of all resources that are no longer needed
             // by the user but used in the command stream, among other things.

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -5557,7 +5557,7 @@ impl Device {
         Ok(query_set)
     }
 
-    fn lose(&self, message: &str) {
+    pub(crate) fn lose(&self, message: &str) {
         // Follow the steps at https://gpuweb.github.io/gpuweb/#lose-the-device.
 
         // Mark the device explicitly as invalid. This is checked in various


### PR DESCRIPTION
`Queue::submit` previously had a single loop that interleaved validation of each command buffer to be submitted with encoding of transitions and initialization actions for that buffer. When multiple command buffers are submitted, an error after the first could abort the submission without rolling back updates to global state that assume the submission happens.

This splits `Queue::submit` processing into two `for` loops. The first is the validation pass, and the second is the transitions + initialization pass. Errors in the validation pass (which are common and reachable based on application behavior) abort with an error before any global state is updated. Errors in the second pass (which are generally unexpected errors from platform APIs) result in device loss. The device loss behavior was actually the case already; this change even relaxes things slightly by changing non-`DestroyedResource` errors in `clear_texture` from a panic to device loss. But I do think it is valuable to have the explicit device loss, in case error behavior changes in the future. (I considered making a `DeviceLost` token that can wrap something in `Result::Err`, so we could verify a "every error propagating on this path definitely caused the device to be lost" property, but it seemed like it was going to ripple more widely throughout the code than I could justify.)

Suggest suppressing whitespace changes when reviewing.

**Testing**
Tested locally with an application-level test case. It's hard to write a regression test for this that doesn't depend on `wgpu` internals.

**Squash or Rebase?** Rebase (after squashing any fixups)

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
  - _Not yet, but it probably should._ 
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
