### PR TITLE
[d3d12] initialize padding of intermediary buffers used for texture to buffer copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,10 @@ Bottom level categories:
 - Replace embedded NUL characters with `?` when writing debug strings to SPIR-V. By @andyleiserson in [#9904](https://github.com/gfx-rs/wgpu/pull/9904).
 - Fix invalid HLSL generated for `textureSampleLevel` with non-2D textures. By @mvanhorn in [#9717](https://github.com/gfx-rs/wgpu/issues/9717).
 
+#### DX12
+
+- Make sure padding bytes are 0 in the destination buffer after a `copy_texture_to_buffer` when `UnrestrictedBufferTextureCopyPitchSupported` is not available. By @teoxoy in [#10005](https://github.com/gfx-rs/wgpu/pull/10005).
+
 #### Vulkan
 
 - Add OpenHarmony surface support via `VK_OHOS_surface`. Previously the Vulkan backend could not create a surface on OpenHarmony, leaving GLES as the only usable backend. By @ozongzi in [#9908](https://github.com/gfx-rs/wgpu/pull/9908).

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -71,6 +71,8 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         VERTEX_BUFFER_TAIL_INIT_MAP_WRITE,
         VERTEX_BUFFER_TAIL_INIT_MAPPED_AT_CREATION,
         VERTEX_BUFFER_TAIL_INIT_MAP_WRITE_MAPPED_AT_CREATION,
+        COPY_TEXTURE_TO_BUFFER_UNALIGNED_OFFSET_ROW_PADDING_INIT,
+        COPY_TEXTURE_TO_BUFFER_UNALIGNED_OFFSET_IMAGE_PADDING_INIT,
     ]);
 }
 
@@ -1561,5 +1563,152 @@ async fn check_vertex_buffer_tail_init(
     assert_eq!(
         tail, 0,
         "did not read expected zero data in padding area (case: {case_desc}): got 0x{tail:08x}",
+    );
+}
+
+// Tests that the padding of a `copy_texture_to_buffer()` destination is not filled
+// with the leftovers of previously freed memory.
+//
+// The test is effective mainly on DX12, where a destination offset that is not a
+// multiple of `D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT` (512) forces the copy to go
+// through a backend-private intermediate buffer. The texture copy only writes the
+// texel bytes of each row of that buffer, but the whole buffer is then copied into
+// the destination, so the padding of the intermediate buffer has to be zeroed first.
+
+// A single pixel wide texture, so that each row of the copy is 4 bytes of texel data
+// followed by 252 bytes of padding.
+#[apply(gpu_test!)]
+static COPY_TEXTURE_TO_BUFFER_UNALIGNED_OFFSET_ROW_PADDING_INIT: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(TestParameters::default().limits(Limits::downlevel_defaults()))
+        .run_async(|ctx| async move {
+            test_copy_texture_to_buffer_padding_init(
+                &ctx,
+                TextureFormat::Rgba8Unorm,
+                Extent3d {
+                    width: 1,
+                    height: 512,
+                    depth_or_array_layers: 1,
+                },
+                256,
+                512,
+            )
+            .await;
+        });
+
+// Padding that neither starts nor ends at a four byte boundary, plus padding
+// between the array layers.
+#[apply(gpu_test!)]
+static COPY_TEXTURE_TO_BUFFER_UNALIGNED_OFFSET_IMAGE_PADDING_INIT: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(TestParameters::default().limits(Limits::downlevel_defaults()))
+        .run_async(|ctx| async move {
+            test_copy_texture_to_buffer_padding_init(
+                &ctx,
+                TextureFormat::R8Unorm,
+                Extent3d {
+                    width: 3,
+                    height: 8,
+                    depth_or_array_layers: 3,
+                },
+                256,
+                12,
+            )
+            .await;
+        });
+
+async fn test_copy_texture_to_buffer_padding_init(
+    ctx: &TestingContext,
+    format: TextureFormat,
+    size: Extent3d,
+    bytes_per_row: u32,
+    rows_per_image: u32,
+) {
+    /// A legal `copy_texture_to_buffer()` destination offset that is not a multiple of
+    /// D3D12's 512 byte texture data placement alignment.
+    const T2B_PAD_OFFSET: u64 = 4;
+    /// How many copies to perform, to give the allocator several chances to hand out
+    /// the memory of the freed seed buffers.
+    const T2B_PAD_COPIES: u64 = 8;
+
+    let texel_bytes = format.block_copy_size(None).unwrap();
+    let row_bytes = size.width * texel_bytes;
+    let image_stride = u64::from(bytes_per_row) * u64::from(rows_per_image);
+    let image_bytes = u64::from(bytes_per_row) * u64::from(size.height - 1) + u64::from(row_bytes);
+    // The copy footprint does not include the padding after its very last row.
+    let footprint = u64::from(size.depth_or_array_layers - 1) * image_stride + image_bytes;
+    // Round up so that every copy's destination offset is congruent to
+    // `T2B_PAD_OFFSET` modulo 512, and thus unaligned for DX12.
+    let stride = footprint.next_multiple_of(512);
+
+    // Dirty some device memory with a recognizable pattern and release it again, so
+    // that the buffers the backend allocates for the copies below are likely to be
+    // suballocated on top of it.
+    let markers: Vec<u32> = (0..footprint.next_multiple_of(4) as usize / 4)
+        .map(|word_index| 0xA73C_0001 + word_index as u32)
+        .collect();
+    let seed_buffers: Vec<Buffer> = (0..T2B_PAD_COPIES)
+        .map(|i| {
+            ctx.device.create_buffer_init(&util::BufferInitDescriptor {
+                label: Some(&format!("copy padding seed {i}")),
+                contents: bytemuck::cast_slice(&markers),
+                usage: BufferUsages::COPY_SRC,
+            })
+        })
+        .collect();
+    ctx.queue.submit(None);
+    ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
+    for seed_buffer in &seed_buffers {
+        seed_buffer.destroy();
+    }
+    drop(seed_buffers);
+    ctx.queue.submit(None);
+    ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
+
+    let texture = ctx.device.create_texture(&TextureDescriptor {
+        label: Some("copy padding source"),
+        size,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: TextureDimension::D2,
+        format,
+        usage: TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+
+    let readback = ctx.device.create_buffer(&BufferDescriptor {
+        label: Some("copy padding readback"),
+        size: T2B_PAD_OFFSET + stride * T2B_PAD_COPIES,
+        usage: BufferUsages::COPY_DST | BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&CommandEncoderDescriptor { label: None });
+    for i in 0..T2B_PAD_COPIES {
+        encoder.copy_texture_to_buffer(
+            texture.as_image_copy(),
+            TexelCopyBufferInfo {
+                buffer: &readback,
+                layout: TexelCopyBufferLayout {
+                    offset: T2B_PAD_OFFSET + stride * i,
+                    bytes_per_row: Some(bytes_per_row),
+                    rows_per_image: Some(rows_per_image),
+                },
+            },
+            size,
+        );
+    }
+    ctx.queue.submit([encoder.finish()]);
+
+    // Neither the source texture nor the destination buffer was ever written by the
+    // application, so the whole buffer must read back as zero. The interesting part is
+    // the footprint of each copy, texel data and padding alike: the copies mark it
+    // initialized, so mapping the buffer will not zero it for us.
+    let data = map_and_read(ctx, &readback).await;
+    assert!(
+        data.iter().all(|&byte| byte == 0),
+        "the destination buffer of copies from a never-written texture is not all zero",
     );
 }

--- a/wgpu-hal/src/dx12/command.rs
+++ b/wgpu-hal/src/dx12/command.rs
@@ -312,6 +312,57 @@ impl super::CommandEncoder {
         }
     }
 
+    /// Zero the padding of `buffer`, which holds the linear footprint of `region`
+    /// starting at offset zero.
+    unsafe fn clear_buf_tex_padding(
+        &mut self,
+        buffer: &super::Buffer,
+        region: &crate::BufferTextureCopy,
+        tex_fmt: wgt::TextureFormat,
+    ) {
+        let info = region
+            .buffer_layout
+            .get_buffer_texture_copy_info(
+                tex_fmt,
+                region.texture_base.aspect.map(),
+                &region.size.into(),
+            )
+            .unwrap();
+
+        let has_row_padding = info.row_stride_bytes > info.row_bytes_dense;
+        for image in 0..info.depth_or_array_layers {
+            let image_base = info.offset + image * info.image_stride_bytes;
+
+            if has_row_padding {
+                for row in 0..info.image_rows_dense - 1 {
+                    let row_base = image_base + row * info.row_stride_bytes;
+                    let start = row_base + info.row_bytes_dense;
+                    let end = row_base + info.row_stride_bytes;
+                    unsafe { self.clear_buffer(buffer, start..end) };
+                }
+            }
+
+            // Everything between the end of the last row of the image and the start
+            // of the next image is padding.
+            if image < info.depth_or_array_layers - 1 {
+                let start = image_base + info.image_bytes_dense;
+                let end = image_base + info.image_stride_bytes;
+                unsafe { self.clear_buffer(buffer, start..end) };
+            }
+        }
+    }
+
+    /// Allocate a scratch buffer holding the linear footprint of `region` at offset
+    /// zero, and run `copy_op` with it while it is in the [`BufferUses::COPY_DST`]
+    /// state. On return, the buffer has been transitioned to [`BufferUses::COPY_SRC`].
+    ///
+    /// The contents of the buffer are *not* initialized, so `copy_op` must write
+    /// every byte that is subsequently read out of it. In particular, if the whole
+    /// footprint is copied somewhere the application can observe, `copy_op` has to
+    /// call [`Self::clear_buf_tex_padding`].
+    ///
+    /// [`BufferUses::COPY_DST`]: wgt::BufferUses::COPY_DST
+    /// [`BufferUses::COPY_SRC`]: wgt::BufferUses::COPY_SRC
     unsafe fn buf_tex_intermediate<T>(
         &mut self,
         region: crate::BufferTextureCopy,
@@ -796,6 +847,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
                         r,
                         src.format,
                         |this, buf, size, intermediate_region| {
+                            this.clear_buf_tex_padding(buf, &intermediate_region, src.format);
                             copy_aligned(this, src, buf, intermediate_region);
                             crate::BufferCopy {
                                 src_offset: 0,


### PR DESCRIPTION
**Connections**
\-

**Description**
Initialize padding of intermediary buffers used for texture to buffer copies.

**Testing**
Added new test.

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
