### PR TITLE
Fix some Mac Vulkan test failures

### DIFF
--- a/examples/features/src/big_compute_buffers/tests.rs
+++ b/examples/features/src/big_compute_buffers/tests.rs
@@ -24,6 +24,10 @@ pub static TWO_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
                     .validation_error("could not be compiled into pipeline")
                     // https://github.com/gfx-rs/wgpu/issues/9849
                     .panic("assertion failed: produced"),
+            )
+            .expect_fail(
+                // https://github.com/gfx-rs/wgpu/issues/9849
+                wgpu_test::FailureCase::kosmic_krisp().panic("assertion failed: produced"),
             ),
     )
     .run_async(|ctx| {

--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -167,17 +167,15 @@ impl FailureCase {
     }
 
     /// Tests running on either Vulkan driver on macOS.
-    pub fn mac_vulkan(f: impl Fn(FailureCase) -> FailureCase) -> Vec<Self> {
-        vec![f(FailureCase::molten_vk()), f(FailureCase::kosmic_krisp())]
+    pub fn mac_vulkan() -> Vec<Self> {
+        vec![FailureCase::molten_vk(), FailureCase::kosmic_krisp()]
     }
 
     /// Tests running on macOS (both Vulkan and Metal).
-    pub fn mac(f: impl Fn(FailureCase) -> FailureCase) -> Vec<Self> {
-        vec![
-            f(FailureCase::molten_vk()),
-            f(FailureCase::kosmic_krisp()),
-            f(FailureCase::backend(wgpu::Backends::METAL)),
-        ]
+    pub fn mac() -> Vec<Self> {
+        let mut cases = Self::mac_vulkan();
+        cases.push(FailureCase::backend(wgpu::Backends::METAL));
+        cases
     }
 
     pub fn lvp_poison_memory(message: &'static str) -> Self {

--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -171,6 +171,15 @@ impl FailureCase {
         vec![f(FailureCase::molten_vk()), f(FailureCase::kosmic_krisp())]
     }
 
+    /// Tests running on macOS (both Vulkan and Metal).
+    pub fn mac(f: impl Fn(FailureCase) -> FailureCase) -> Vec<Self> {
+        vec![
+            f(FailureCase::molten_vk()),
+            f(FailureCase::kosmic_krisp()),
+            f(FailureCase::backend(wgpu::Backends::METAL)),
+        ]
+    }
+
     pub fn lvp_poison_memory(message: &'static str) -> Self {
         if let Ok("true") = std::env::var("LVP_POISON_MEMORY").as_deref() {
             FailureCase {

--- a/tests/tests/wgpu-gpu/bind_groups.rs
+++ b/tests/tests/wgpu-gpu/bind_groups.rs
@@ -2,8 +2,7 @@ use std::num::NonZeroU64;
 
 use wgpu::{util::DeviceExt, BufferUsages, PollType};
 use wgpu_test::{
-    apply, gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters,
-    TestingContext,
+    apply, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
 };
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
@@ -256,11 +255,7 @@ static BIND_GROUP_NONFILTERING_LAYOUT_MIPMAP_SAMPLER: GpuTestConfiguration =
 
 #[apply(gpu_test!)]
 static BIND_GROUP_WITH_MAX_BINDING_INDEX: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .limits(wgpu::Limits::downlevel_defaults())
-            .expect_fail(FailureCase::kosmic_krisp()), // https://github.com/gfx-rs/wgpu/issues/9187
-    )
+    .parameters(TestParameters::default().limits(wgpu::Limits::downlevel_defaults()))
     .run_async(|ctx| async move {
         let (device, queue) = ctx
             .adapter

--- a/tests/tests/wgpu-gpu/binding_array/buffers.rs
+++ b/tests/tests/wgpu-gpu/binding_array/buffers.rs
@@ -68,16 +68,15 @@ static BINDING_ARRAY_STORAGE_BUFFERS: GpuTestConfiguration = GpuTestConfiguratio
             max_binding_array_elements_per_shader_stage: 17,
             ..Limits::default()
         },
-        // Metal: https://github.com/gfx-rs/wgpu/issues/9849
-        // MoltenVK: #9849 and also https://github.com/gfx-rs/wgpu/issues/6745
-        // With #6745 only, the expected failure was `case.panic("bad SPIR-V wrapper struct inference")`
-        failures: FailureCase::mac_vulkan(|case| {
-            case.validation_error("Shader library compile failed")
-                .validation_error("could not be compiled into pipeline")
-        })
-        .into_iter()
-        .chain([FailureCase::backend(Backends::METAL)])
-        .collect(),
+        failures: vec![
+            // https://github.com/gfx-rs/wgpu/issues/9849 and https://github.com/gfx-rs/wgpu/issues/6745
+            // Before #9849, the expected failure with #6745 only was `case.panic("bad SPIR-V wrapper struct inference")`
+            FailureCase::molten_vk()
+                .validation_error("Shader library compile failed")
+                .validation_error("could not be compiled into pipeline"),
+            // https://github.com/gfx-rs/wgpu/issues/9849
+            FailureCase::backend(Backends::METAL),
+        ],
         ..Default::default()
     })
     .run_async(|ctx| async move { binding_array_buffers(ctx, BufferType::Storage, false).await });
@@ -94,16 +93,15 @@ static PARTIAL_BINDING_ARRAY_STORAGE_BUFFERS: GpuTestConfiguration = GpuTestConf
             max_binding_array_elements_per_shader_stage: 33,
             ..Limits::default()
         },
-        // Metal: https://github.com/gfx-rs/wgpu/issues/9849
-        // MoltenVK: #9849 and also https://github.com/gfx-rs/wgpu/issues/6745
-        // With #6745 only, the expected failure was `case.panic("bad SPIR-V wrapper struct inference")`
-        failures: FailureCase::mac_vulkan(|case| {
-            case.validation_error("Shader library compile failed")
-                .validation_error("could not be compiled into pipeline")
-        })
-        .into_iter()
-        .chain([FailureCase::backend(Backends::METAL)])
-        .collect(),
+        failures: vec![
+            // https://github.com/gfx-rs/wgpu/issues/9849 and https://github.com/gfx-rs/wgpu/issues/6745
+            // Before #9849, the expected failure with #6745 only was `case.panic("bad SPIR-V wrapper struct inference")`
+            FailureCase::molten_vk()
+                .validation_error("Shader library compile failed")
+                .validation_error("could not be compiled into pipeline"),
+            // https://github.com/gfx-rs/wgpu/issues/9849
+            FailureCase::backend(Backends::METAL),
+        ],
         ..Default::default()
     })
     .run_async(|ctx| async move { binding_array_buffers(ctx, BufferType::Storage, true).await });

--- a/tests/tests/wgpu-gpu/multiview/mod.rs
+++ b/tests/tests/wgpu-gpu/multiview/mod.rs
@@ -54,7 +54,7 @@ static DRAW_MULTIVIEW_NONCONTIGUOUS: GpuTestConfiguration = GpuTestConfiguration
                  right: None",
             ));
             // https://github.com/gfx-rs/wgpu/issues/9184 and https://github.com/gfx-rs/wgpu/issues/9187
-            failures.append(&mut FailureCase::mac_vulkan(|case| {
+            failures.extend(FailureCase::mac_vulkan().into_iter().map(|case| {
                 case.panic(
                     "assertion `left == right` failed: Expected 0\n  left: Some(255)\n right: None",
                 )

--- a/tests/tests/wgpu-gpu/subgroup_operations/mod.rs
+++ b/tests/tests/wgpu-gpu/subgroup_operations/mod.rs
@@ -15,6 +15,7 @@ static SUBGROUP_OPERATIONS: GpuTestConfiguration = GpuTestConfiguration::new()
         required_features: wgpu::Features::SUBGROUP,
         required_limits: wgpu::Limits::downlevel_defaults(),
         // Expect metal to fail on tests involving operations in divergent control flow
+        // <https://github.com/gfx-rs/wgpu/issues/10019>
         //
         // Newlines are included in the panic message to ensure that _additional_ failures
         // are not matched against.

--- a/tests/tests/wgpu-gpu/subgroup_operations/mod.rs
+++ b/tests/tests/wgpu-gpu/subgroup_operations/mod.rs
@@ -18,15 +18,18 @@ static SUBGROUP_OPERATIONS: GpuTestConfiguration = GpuTestConfiguration::new()
         //
         // Newlines are included in the panic message to ensure that _additional_ failures
         // are not matched against.
-        failures: wgpu_test::FailureCase::mac(|case| {
-            case
-                // 26.0 fails only test 28, and not on thread 0
-                .panic("thread 1 failed tests: 28,\n")
-                // 14.3 fails 27 and 28
-                .panic("thread 0 failed tests: 27,\nthread 1 failed tests: 27, 28,\n")
-                // Prior versions fail 27, 28, and 29
-                .panic("thread 0 failed tests: 27, 29,\nthread 1 failed tests: 27, 28, 29,\n")
-        }),
+        failures: wgpu_test::FailureCase::mac()
+            .into_iter()
+            .map(|case| {
+                case
+                    // 26.0 fails only test 28, and not on thread 0
+                    .panic("thread 1 failed tests: 28,\n")
+                    // 14.3 fails 27 and 28
+                    .panic("thread 0 failed tests: 27,\nthread 1 failed tests: 27, 28,\n")
+                    // Prior versions fail 27, 28, and 29
+                    .panic("thread 0 failed tests: 27, 29,\nthread 1 failed tests: 27, 28, 29,\n")
+            })
+            .collect(),
         ..Default::default()
     })
     .run_sync(|ctx| {

--- a/tests/tests/wgpu-gpu/subgroup_operations/mod.rs
+++ b/tests/tests/wgpu-gpu/subgroup_operations/mod.rs
@@ -11,33 +11,24 @@ const TEST_COUNT: u32 = 37;
 
 #[apply(gpu_test!)]
 static SUBGROUP_OPERATIONS: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .features(wgpu::Features::SUBGROUP)
-            .limits(wgpu::Limits::downlevel_defaults())
-            // Expect metal to fail on tests involving operations in divergent control flow
-            //
-            // Newlines are included in the panic message to ensure that _additional_ failures
-            // are not matched against.
-            .expect_fail(
-                wgpu_test::FailureCase::molten_vk()
-                    // 26.0 fails only test 28, and not on thread 0
-                    .panic("thread 1 failed tests: 28,\n")
-                    // 14.3 fails 27 and 28
-                    .panic("thread 0 failed tests: 27,\nthread 1 failed tests: 27, 28,\n")
-                    // Prior versions fail 27, 28, and 29
-                    .panic("thread 0 failed tests: 27, 29,\nthread 1 failed tests: 27, 28, 29,\n"),
-            )
-            .expect_fail(
-                wgpu_test::FailureCase::backend(wgpu::Backends::METAL)
-                    // 26.0 fails only test 28, and not on thread 0
-                    .panic("thread 1 failed tests: 28,\n")
-                    // 14.3 fails 27 and 28
-                    .panic("thread 0 failed tests: 27,\nthread 1 failed tests: 27, 28,\n")
-                    // Prior versions fail 27, 28, and 29
-                    .panic("thread 0 failed tests: 27, 29,\nthread 1 failed tests: 27, 28, 29,\n"),
-            ),
-    )
+    .parameters(TestParameters {
+        required_features: wgpu::Features::SUBGROUP,
+        required_limits: wgpu::Limits::downlevel_defaults(),
+        // Expect metal to fail on tests involving operations in divergent control flow
+        //
+        // Newlines are included in the panic message to ensure that _additional_ failures
+        // are not matched against.
+        failures: wgpu_test::FailureCase::mac(|case| {
+            case
+                // 26.0 fails only test 28, and not on thread 0
+                .panic("thread 1 failed tests: 28,\n")
+                // 14.3 fails 27 and 28
+                .panic("thread 0 failed tests: 27,\nthread 1 failed tests: 27, 28,\n")
+                // Prior versions fail 27, 28, and 29
+                .panic("thread 0 failed tests: 27, 29,\nthread 1 failed tests: 27, 28, 29,\n")
+        }),
+        ..Default::default()
+    })
     .run_sync(|ctx| {
         let device = &ctx.device;
 

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -911,10 +911,6 @@ impl super::Device {
             return Ok(());
         };
 
-        // memory types not used by gpu-allocator
-        let invalid_flags =
-            vk::MemoryPropertyFlags::LAZILY_ALLOCATED | vk::MemoryPropertyFlags::PROTECTED;
-
         let preferred_flags = match location {
             MemoryLocation::GpuOnly => vk::MemoryPropertyFlags::DEVICE_LOCAL,
             MemoryLocation::CpuToGpu => {
@@ -937,7 +933,6 @@ impl super::Device {
             .find(|(i, ty)| {
                 (1 << i) & requirements.memory_type_bits != 0
                     && ty.property_flags.contains(preferred_flags)
-                    && !ty.property_flags.intersects(invalid_flags)
             });
 
         if selected_heap.is_none() {
@@ -955,7 +950,6 @@ impl super::Device {
                 .find(|(i, ty)| {
                     (1 << i) & requirements.memory_type_bits != 0
                         && ty.property_flags.contains(required_flags)
-                        && !ty.property_flags.intersects(invalid_flags)
                 });
         }
 

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -162,7 +162,15 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         crate::VALIDATION_CANARY.add(message.to_string());
     }
 
-    #[cfg(all(debug_assertions, feature = "internal_error_panic"))]
+    // We disable this on Apple because there are numerous issues, some of
+    // which raise generic errors that we can't match by VUID. See
+    // <https://github.com/gfx-rs/wgpu/issues/9184> and
+    // <https://github.com/gfx-rs/wgpu/issues/9187>.
+    #[cfg(all(
+        debug_assertions,
+        feature = "internal_error_panic",
+        not(target_vendor = "apple")
+    ))]
     if level == log::Level::Error
         && message_type.contains(vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION)
         && !error_is_waived(cd.message_id_number)
@@ -178,7 +186,11 @@ unsafe extern "system" fn debug_utils_messenger_callback(
 /// Validation errors known to fire, not just in the CTS.
 ///
 /// These never panic.
-#[cfg(feature = "internal_error_panic")]
+#[cfg(all(
+    debug_assertions,
+    feature = "internal_error_panic",
+    not(target_vendor = "apple")
+))]
 fn error_is_waived(message_id_number: i32) -> bool {
     const WAIVED_MESSAGE_IDS: &[i32] = &[
         // SYNC-HAZARD-WRITE-AFTER-WRITE
@@ -195,7 +207,11 @@ fn error_is_waived(message_id_number: i32) -> bool {
 ///
 /// These waivers are keyed off the `WGPU_CTS_XTASK` environment variable, which
 /// is set in `xtask/src/cts.rs`.
-#[cfg(feature = "internal_error_panic")]
+#[cfg(all(
+    debug_assertions,
+    feature = "internal_error_panic",
+    not(target_vendor = "apple")
+))]
 fn cts_error_is_waived(message_id_number: i32) -> bool {
     use std::sync::LazyLock;
 


### PR DESCRIPTION
#9879 added a panic on Vulkan validation errors when the `internal_error_panic` feature is active. This disables
that on Mac, because it's too noisy (and some of the errors can't be matched by VUID). 

I've also updated KosmicKrisp expectations, which I assume have shifted due to changes in the driver.

This PR is on top of #9838, since that also affects test expectations for Mac Vulkan.

**Testing**
Is tests

**Squash or Rebase?** Rebase (after #9838 is merged)

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
