### PR TITLE
fix(hal/vulkan): count textures created by create_texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
 #### Vulkan
 
+- Fix `HalCounters::textures` drifting negative: `create_texture` never incremented it while `destroy_texture` always decremented it. By @dustyleary in [#10022](https://github.com/gfx-rs/wgpu/pull/10022).
 - Add OpenHarmony surface support via `VK_OHOS_surface`. Previously the Vulkan backend could not create a surface on OpenHarmony, leaving GLES as the only usable backend. By @ozongzi in [#9908](https://github.com/gfx-rs/wgpu/pull/9908).
 
 #### Metal

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -44,7 +44,7 @@ test-build-with-profiling = ["profiling/type-check"]
 [dependencies]
 # Passthrough backend uses as_hal for the GLES backend, and there's not a great way to cfg-gate that.
 # These are all enabled for any testing on CI anyway, and won't do anything if no devices are detected.
-wgpu = { workspace = true, features = ["noop", "gles", "webgl", "angle"] }
+wgpu = { workspace = true, features = ["noop", "gles", "webgl", "angle", "counters"] }
 wgpu-core = { workspace = true, default-features = true, features = ["trace"] }
 wgpu-hal = { workspace = true, default-features = true, features = ["validation_canary"] }
 wgpu-sync.workspace = true

--- a/tests/tests/wgpu-gpu/internal_counters.rs
+++ b/tests/tests/wgpu-gpu/internal_counters.rs
@@ -1,0 +1,63 @@
+//! Tests that the hal internal counters stay balanced across resource
+//! creation and destruction.
+
+use wgpu_test::{
+    apply, gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters,
+};
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(TEXTURE_COUNTERS_BALANCED);
+}
+
+/// Regression test for the Vulkan backend never incrementing
+/// `HalCounters::textures` in `create_texture` while still decrementing it in
+/// `destroy_texture`, which made the reported texture count drift negative.
+#[apply(gpu_test!)]
+static TEXTURE_COUNTERS_BALANCED: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            // The webgpu backend does not implement internal counters.
+            .skip(FailureCase::backend(wgpu::Backends::BROWSER_WEBGPU)),
+    )
+    .run_async(|ctx| async move {
+        let before = ctx.device.get_internal_counters().hal;
+
+        let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("internal counters test"),
+            size: wgpu::Extent3d {
+                width: 256,
+                height: 256,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+
+        let alive = ctx.device.get_internal_counters().hal;
+        assert_eq!(
+            alive.textures.read(),
+            before.textures.read() + 1,
+            "hal.textures should count the live texture",
+        );
+
+        drop(texture);
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
+
+        let after = ctx.device.get_internal_counters().hal;
+        assert_eq!(
+            after.textures.read(),
+            before.textures.read(),
+            "hal.textures should return to its baseline once the texture is destroyed",
+        );
+        assert_eq!(
+            after.texture_memory.read(),
+            before.texture_memory.read(),
+            "hal.texture_memory should return to its baseline once the texture is destroyed",
+        );
+    });

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -11,6 +11,8 @@ mod regression {
     pub mod issue_6467;
     pub mod issue_6827;
     pub mod issue_9115;
+
+    pub mod issue_10038;
 }
 
 mod adapter;
@@ -40,7 +42,6 @@ mod float32_filterable;
 mod image_atomics;
 mod immediates;
 mod instance;
-mod internal_counters;
 mod life_cycle;
 mod mesh_shader;
 mod multiview;
@@ -116,7 +117,6 @@ fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     float32_filterable::all_tests(&mut tests);
     image_atomics::all_tests(&mut tests);
     instance::all_tests(&mut tests);
-    internal_counters::all_tests(&mut tests);
     life_cycle::all_tests(&mut tests);
     mesh_shader::all_tests(&mut tests);
     multiview::all_tests(&mut tests);
@@ -148,6 +148,7 @@ fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     regression::issue_6467::all_tests(&mut tests);
     regression::issue_6827::all_tests(&mut tests);
     regression::issue_9115::all_tests(&mut tests);
+    regression::issue_10038::all_tests(&mut tests);
     render_pass_ownership::all_tests(&mut tests);
     render_target::all_tests(&mut tests);
     resource_descriptor_accessor::all_tests(&mut tests);

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -40,6 +40,7 @@ mod float32_filterable;
 mod image_atomics;
 mod immediates;
 mod instance;
+mod internal_counters;
 mod life_cycle;
 mod mesh_shader;
 mod multiview;
@@ -115,6 +116,7 @@ fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     float32_filterable::all_tests(&mut tests);
     image_atomics::all_tests(&mut tests);
     instance::all_tests(&mut tests);
+    internal_counters::all_tests(&mut tests);
     life_cycle::all_tests(&mut tests);
     mesh_shader::all_tests(&mut tests);
     multiview::all_tests(&mut tests);

--- a/tests/tests/wgpu-gpu/regression/issue_10038.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_10038.rs
@@ -1,6 +1,3 @@
-//! Tests that the hal internal counters stay balanced across resource
-//! creation and destruction.
-
 use wgpu_test::{
     apply, gpu_test, FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters,
 };
@@ -9,14 +6,11 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.push(TEXTURE_COUNTERS_BALANCED);
 }
 
-/// Regression test for the Vulkan backend never incrementing
-/// `HalCounters::textures` in `create_texture` while still decrementing it in
-/// `destroy_texture`, which made the reported texture count drift negative.
 #[apply(gpu_test!)]
 static TEXTURE_COUNTERS_BALANCED: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            // The webgpu backend does not implement internal counters.
+            // NOTE: The WebGPU backend does not implement internal counters.
             .skip(FailureCase::backend(wgpu::Backends::BROWSER_WEBGPU)),
     )
     .run_async(|ctx| async move {
@@ -41,7 +35,7 @@ static TEXTURE_COUNTERS_BALANCED: GpuTestConfiguration = GpuTestConfiguration::n
         assert_eq!(
             alive.textures.read(),
             before.textures.read() + 1,
-            "hal.textures should count the live texture",
+            "internal texture counter should increment with new texture",
         );
 
         drop(texture);
@@ -53,11 +47,14 @@ static TEXTURE_COUNTERS_BALANCED: GpuTestConfiguration = GpuTestConfiguration::n
         assert_eq!(
             after.textures.read(),
             before.textures.read(),
-            "hal.textures should return to its baseline once the texture is destroyed",
+            "internal texture counter should return to baseline once texture is destroyed",
         );
         assert_eq!(
             after.texture_memory.read(),
             before.texture_memory.read(),
-            "hal.texture_memory should return to its baseline once the texture is destroyed",
+            concat!(
+                "internal texture memory counter should return to its baseline ",
+                "once the texture is destroyed"
+            ),
         );
     });

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -1217,8 +1217,6 @@ impl crate::Device for super::Device {
                 unsafe { self.shared.raw.destroy_image(image.raw, None) };
             })?;
 
-        self.counters.texture_memory.add(allocation.size() as isize);
-
         unsafe {
             self.shared
                 .raw
@@ -1228,6 +1226,9 @@ impl crate::Device for super::Device {
         .inspect_err(|_| {
             unsafe { self.shared.raw.destroy_image(image.raw, None) };
         })?;
+
+        self.counters.texture_memory.add(allocation.size() as isize);
+        self.counters.textures.add(1);
 
         Ok(unsafe {
             self.texture_from_raw(


### PR DESCRIPTION
**Connections**

- Fixes #10038.

**Description**

On the Vulkan backend, `HalCounters::textures` is only ever decremented for textures created through the ordinary `create_texture` path, so `Device::get_internal_counters()` reports a texture count that drifts negative while `texture_memory` stays correct (e.g. "-37 textures / 1.31 GB of texture memory").

Apply two fixes:

1. Increment `counters.textures` in Vulkan's `create_texture`.
2. Move resource tracking increments to be after the last fallible operation to avoid leaking when `bind_image_memory` fails partway through.

**Testing**

Add `wgpu_gpu::regression::issue_10038::texture_counters_balanced`. Add the `counters` feature to the test crate's `wgpu` dependency. Also confirmed as fixed in a downstream project, with this PR backported to 29.0.3.

**Squash or Rebase?**

Squash.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
