### PR TITLE
diag(naga): add missing end backtick to `InvalidInterpolationForInteger` msg.

### DIFF
--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -72,7 +72,7 @@ pub enum VaryingError {
         interpolation: crate::Interpolation,
         sampling: crate::Sampling,
     },
-    #[error("`@interpolate(flat) must be explicitly specified for integer I/O")]
+    #[error("`@interpolate(flat)` must be explicitly specified for integer I/O")]
     InvalidInterpolationForInteger,
     #[error("Interpolation must be specified on vertex shader outputs and fragment shader inputs")]
     MissingInterpolation,


### PR DESCRIPTION
This seems minor enough to not warrant a `CHANGELOG` entry, IMO.