### PR TITLE
Reject user locations and return types for compute shaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Bottom level categories:
 - Replace embedded NUL characters with `?` when writing debug strings to SPIR-V. By @andyleiserson in [#9904](https://github.com/gfx-rs/wgpu/pull/9904).
 - Fix invalid HLSL generated for `textureSampleLevel` with non-2D textures. By @mvanhorn in [#9717](https://github.com/gfx-rs/wgpu/issues/9717).
 - Reject return types on compute shader entrypoints. By @ErichDonGubler in [#10026](https://github.com/gfx-rs/wgpu/pull/10026).
+- Reject `@location(…)`s in compute shaders. By @ErichDonGubler in [#10026](https://github.com/gfx-rs/wgpu/pull/10026).
 
 #### Vulkan
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Bottom level categories:
 
 - Replace embedded NUL characters with `?` when writing debug strings to SPIR-V. By @andyleiserson in [#9904](https://github.com/gfx-rs/wgpu/pull/9904).
 - Fix invalid HLSL generated for `textureSampleLevel` with non-2D textures. By @mvanhorn in [#9717](https://github.com/gfx-rs/wgpu/issues/9717).
+- Reject return types on compute shader entrypoints. By @ErichDonGubler in [#10026](https://github.com/gfx-rs/wgpu/pull/10026).
 
 #### Vulkan
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -493,13 +493,7 @@ fails-if(vulkan) webgpu:shader,validation,shader_io,group_and_binding:*
 webgpu:shader,validation,shader_io,group:*
 webgpu:shader,validation,shader_io,interpolate:*
 webgpu:shader,validation,shader_io,invariant:*
-webgpu:shader,validation,shader_io,locations:duplicates:*
-webgpu:shader,validation,shader_io,locations:location_fp16:*
-webgpu:shader,validation,shader_io,locations:nesting:*
-webgpu:shader,validation,shader_io,locations:out_of_order:*
-webgpu:shader,validation,shader_io,locations:stage_inout:*
-webgpu:shader,validation,shader_io,locations:type:*
-webgpu:shader,validation,shader_io,locations:validation:*
+webgpu:shader,validation,shader_io,locations:*
 webgpu:shader,validation,shader_io,size:*
 webgpu:shader,validation,statement,break_if:*
 webgpu:shader,validation,statement,break:*

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -497,6 +497,7 @@ webgpu:shader,validation,shader_io,locations:duplicates:*
 webgpu:shader,validation,shader_io,locations:location_fp16:*
 webgpu:shader,validation,shader_io,locations:nesting:*
 webgpu:shader,validation,shader_io,locations:out_of_order:*
+webgpu:shader,validation,shader_io,locations:stage_inout:*
 webgpu:shader,validation,shader_io,locations:type:*
 webgpu:shader,validation,shader_io,locations:validation:*
 webgpu:shader,validation,shader_io,size:*

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -191,6 +191,8 @@ pub enum EntryPointError {
     RayPayloadInInvalidStage(crate::ShaderStage),
     #[error("Only the `closest_hit`, `any_hit`, and `miss` shader stages can access a global variable in the `incoming_ray_payload` address space")]
     IncomingRayPayloadInInvalidStage(crate::ShaderStage),
+    #[error("Compute shader entry point cannot have a return type")]
+    UnexpectedComputeShaderEntryResult,
 }
 
 fn storage_usage(access: crate::StorageAccess) -> GlobalUse {
@@ -1419,8 +1421,10 @@ impl super::Validator {
                         return Err(EntryPointError::WrongTaskShaderEntryResult.with_span());
                     }
                 }
+                nt::ShaderStage::Compute => {
+                    return Err(EntryPointError::UnexpectedComputeShaderEntryResult.with_span())
+                }
                 nt::ShaderStage::Fragment
-                | nt::ShaderStage::Compute
                 | nt::ShaderStage::RayGeneration
                 | nt::ShaderStage::Miss
                 | nt::ShaderStage::AnyHit

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -1400,29 +1400,48 @@ impl super::Validator {
             };
             ctx.validate(ep, fr.ty, fr.binding.as_ref())
                 .map_err_inner(|e| EntryPointError::Result(e).with_span())?;
-            if ep.stage == crate::ShaderStage::Vertex
-                && !result_built_ins.contains(&crate::BuiltIn::Position { invariant: false })
-            {
-                return Err(EntryPointError::MissingVertexOutputPosition.with_span());
-            }
-            if ep.stage == crate::ShaderStage::Mesh {
-                return Err(EntryPointError::UnexpectedMeshShaderEntryResult.with_span());
-            }
-            // Task shaders must have a single `MeshTaskSize` output, and nothing else.
-            if ep.stage == crate::ShaderStage::Task {
-                let ok = module.types[fr.ty].inner
-                    == crate::TypeInner::Vector {
-                        size: crate::VectorSize::Tri,
-                        scalar: crate::Scalar::U32,
-                    };
-                if !ok {
-                    return Err(EntryPointError::WrongTaskShaderEntryResult.with_span());
+            match ep.stage {
+                nt::ShaderStage::Vertex => {
+                    if !result_built_ins.contains(&crate::BuiltIn::Position { invariant: false }) {
+                        return Err(EntryPointError::MissingVertexOutputPosition.with_span());
+                    }
                 }
+                nt::ShaderStage::Mesh => {
+                    return Err(EntryPointError::UnexpectedMeshShaderEntryResult.with_span())
+                }
+                nt::ShaderStage::Task => {
+                    let ok = module.types[fr.ty].inner
+                        == crate::TypeInner::Vector {
+                            size: crate::VectorSize::Tri,
+                            scalar: crate::Scalar::U32,
+                        };
+                    if !ok {
+                        return Err(EntryPointError::WrongTaskShaderEntryResult.with_span());
+                    }
+                }
+                nt::ShaderStage::Fragment
+                | nt::ShaderStage::Compute
+                | nt::ShaderStage::RayGeneration
+                | nt::ShaderStage::Miss
+                | nt::ShaderStage::AnyHit
+                | nt::ShaderStage::ClosestHit => {}
             }
-        } else if ep.stage == crate::ShaderStage::Vertex {
-            return Err(EntryPointError::MissingVertexOutputPosition.with_span());
-        } else if ep.stage == crate::ShaderStage::Task {
-            return Err(EntryPointError::WrongTaskShaderEntryResult.with_span());
+        } else {
+            match ep.stage {
+                nt::ShaderStage::Vertex => {
+                    return Err(EntryPointError::MissingVertexOutputPosition.with_span())
+                }
+                nt::ShaderStage::Task => {
+                    return Err(EntryPointError::WrongTaskShaderEntryResult.with_span())
+                }
+                nt::ShaderStage::Mesh
+                | nt::ShaderStage::Fragment
+                | nt::ShaderStage::Compute
+                | nt::ShaderStage::RayGeneration
+                | nt::ShaderStage::Miss
+                | nt::ShaderStage::AnyHit
+                | nt::ShaderStage::ClosestHit => {}
+            }
         }
 
         {

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -1382,6 +1382,36 @@ impl super::Validator {
             };
             ctx.validate(ep, fa.ty, fa.binding.as_ref())
                 .map_err_inner(|e| EntryPointError::Argument(index as u32, e).with_span())?;
+            match ep.stage {
+                nt::ShaderStage::Compute | nt::ShaderStage::Mesh | nt::ShaderStage::Task => {
+                    let reject_location_binding = |binding| {
+                        if let Some(&crate::ir::Binding::Location { .. }) = binding {
+                            return Err(EntryPointError::Argument(
+                                index as u32,
+                                VaryingError::InvalidAttributeInStage("location", ep.stage),
+                            )
+                            .with_span());
+                        }
+                        Ok(())
+                    };
+                    reject_location_binding(fa.binding.as_ref())?;
+
+                    if let &crate::TypeInner::Struct { ref members, .. } =
+                        &module.types[fa.ty].inner
+                    {
+                        members
+                            .iter()
+                            .map(|m| m.binding.as_ref())
+                            .try_for_each(reject_location_binding)?;
+                    }
+                }
+                nt::ShaderStage::Vertex
+                | nt::ShaderStage::Fragment
+                | nt::ShaderStage::RayGeneration
+                | nt::ShaderStage::Miss
+                | nt::ShaderStage::AnyHit
+                | nt::ShaderStage::ClosestHit => {}
+            }
         }
 
         self.location_mask.make_empty();

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -5671,3 +5671,50 @@ fn compute_shaders_dont_accept_result_types() {
         )
     }
 }
+
+#[test]
+fn user_locations_not_accepted_in_compute_entry_point_arguments() {
+    check_validation! {
+        "
+        @compute @workgroup_size(1)
+        fn main(@location(0) _input: u32) { return; }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Compute,
+                source: naga::valid::EntryPointError::Argument(
+                    0,
+                    naga::valid::VaryingError::InvalidAttributeInStage(
+                        "location",
+                        naga::ShaderStage::Compute,
+                    ),
+                ),
+                ..
+            },
+        )
+    }
+
+    check_validation! {
+        "
+        struct ComputeInput {
+            @location(0) input0: vec4<f32>,
+            @location(1) input1: u32,
+        }
+        @compute @workgroup_size(1)
+        fn main(_input: ComputeInput) { return; }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Compute,
+                source: naga::valid::EntryPointError::Argument(
+                    0,
+                    naga::valid::VaryingError::InvalidAttributeInStage(
+                        "location",
+                        naga::ShaderStage::Compute
+                    ),
+                ),
+                ..
+            },
+        )
+    }
+}

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -5636,3 +5636,38 @@ fn unterminated_block_comment_errors() {
         "unterminated block comment",
     )
 }
+
+#[test]
+fn compute_shaders_dont_accept_result_types() {
+    check_validation! {
+        "
+        @compute @workgroup_size(1)
+        fn main() -> @location(0) u32 { return 0; }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Compute,
+                source: naga::valid::EntryPointError::UnexpectedComputeShaderEntryResult,
+                ..
+            },
+        )
+    }
+
+    check_validation! {
+        "
+        struct ComputeOutput {
+            @location(0) output0: vec4<f32>,
+            @location(1) output1: u32,
+        }
+        @compute @workgroup_size(1)
+        fn main() -> ComputeOutput { return ComputeOutput(vec4(0.0), 1); }
+        ":
+        Err(
+            naga::valid::ValidationError::EntryPoint {
+                stage: naga::ShaderStage::Compute,
+                source: naga::valid::EntryPointError::UnexpectedComputeShaderEntryResult,
+                ..
+            },
+        )
+    }
+}


### PR DESCRIPTION
**Connections**

- Resolves https://github.com/gfx-rs/wgpu/issues/10025
- Resolves https://github.com/gfx-rs/wgpu/issues/10024

**Testing**

Test coverage has been added to the `wgsl_errors` test group.

**Squash or Rebase?**

Rebase, please.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
