### PR TITLE
Fix crash in lock validation due to TLS destructor call order

### DIFF
--- a/wgpu-core/src/lock/observing.rs
+++ b/wgpu-core/src/lock/observing.rs
@@ -29,7 +29,7 @@
 //! [`lock/rank.rs`]: ../../../src/wgpu_core/lock/rank.rs.html
 
 use alloc::{format, string::String};
-use core::{cell::RefCell, panic::Location};
+use core::{cell::RefCell, mem::ManuallyDrop, panic::Location};
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -249,11 +249,11 @@ impl Drop for LockStateGuard {
 /// Return the `Option<HeldLock>` state that must be restored when this lock is
 /// released.
 fn acquire(new_rank: LockRank, location: &'static Location<'static>) -> Option<HeldLock> {
-    LOCK_STATE.with_borrow_mut(|state| match *state {
+    LOCK_STATE.with_borrow_mut(|state| match **state {
         ThreadState::Disabled => None,
         ThreadState::Initial => {
             let Ok(dir) = std::env::var("WGPU_CORE_LOCK_OBSERVE_DIR") else {
-                *state = ThreadState::Disabled;
+                **state = ThreadState::Disabled;
                 return None;
             };
 
@@ -269,7 +269,7 @@ fn acquire(new_rank: LockRank, location: &'static Location<'static>) -> Option<H
 
             // Update our state to reflect that we are logging acquisitions, and
             // that we have acquired this lock.
-            *state = ThreadState::Enabled {
+            **state = ThreadState::Enabled {
                 held_lock: Some(HeldLock {
                     rank: new_rank,
                     location,
@@ -302,7 +302,7 @@ fn release(saved: Option<HeldLock>) {
     LOCK_STATE.with_borrow_mut(|state| {
         if let ThreadState::Enabled {
             ref mut held_lock, ..
-        } = *state
+        } = **state
         {
             *held_lock = saved;
         }
@@ -310,7 +310,12 @@ fn release(saved: Option<HeldLock>) {
 }
 
 std::thread_local! {
-    static LOCK_STATE: RefCell<ThreadState> = const { RefCell::new(ThreadState::Initial) };
+    // In order to allow the user to have thread locals which contain WGPU primitives, we leak the
+    // lock state on thread exit. This ensures the destructors of user objects may continue to be
+    // instrumented and will not cause a panic of they run after this thread_local is dropped.
+    // Also see: snatch.rs
+    static LOCK_STATE: RefCell<ManuallyDrop<ThreadState>> =
+        const { RefCell::new(ManuallyDrop::new(ThreadState::Initial)) };
 }
 
 /// Thread-local state for lock observation.

--- a/wgpu-core/src/lock/ranked.rs
+++ b/wgpu-core/src/lock/ranked.rs
@@ -88,6 +88,13 @@ std::thread_local! {
     static LOCK_STATE: Cell<LockState> = const { Cell::new(LockState::INITIAL) };
 }
 
+// If this ever fails, see observing.rs and snatch.rs for cases where thread_locals used for
+// instrumentation must be put into a ManuallyDrop
+const _: () = assert!(
+    !core::mem::needs_drop::<Cell<LockState>>(),
+    "LOCK_STATE must not require Dropping, otherwise locks may be destroyed before user code accesses them, during TLS destruction"
+);
+
 /// Per-thread state for the deadlock checker.
 #[derive(Debug, Copy, Clone)]
 pub struct LockState {

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -65,7 +65,7 @@ unsafe impl<T> Sync for SnatchableInner<T> {}
 use trace::LockTrace;
 #[cfg(all(debug_assertions, feature = "std"))]
 mod trace {
-    use core::{cell::Cell, fmt, panic::Location};
+    use core::{cell::Cell, fmt, mem::ManuallyDrop, panic::Location};
     use std::{backtrace::Backtrace, thread};
 
     pub(super) struct LockTrace {
@@ -94,6 +94,8 @@ mod trace {
             };
 
             if let Some(prev) = SNATCH_LOCK_TRACE.take() {
+                // explicitly drop previous trace, see SNATCH_LOCK_TRACE for reasoning
+                let prev = ManuallyDrop::into_inner(prev);
                 let current = thread::current();
                 let name = current.name().unwrap_or("<unnamed>");
                 panic!(
@@ -102,17 +104,23 @@ mod trace {
                  - Previously acquired {prev}",
                 );
             } else {
-                SNATCH_LOCK_TRACE.set(Some(new));
+                SNATCH_LOCK_TRACE.set(Some(ManuallyDrop::new(new)));
             }
         }
 
         pub(super) fn exit() {
-            SNATCH_LOCK_TRACE.take();
+            if let Some(trace) = SNATCH_LOCK_TRACE.take() {
+                drop(ManuallyDrop::into_inner(trace));
+            }
         }
     }
 
     std::thread_local! {
-        static SNATCH_LOCK_TRACE: Cell<Option<LockTrace>> = const { Cell::new(None) };
+        // In order to allow the user to have thread locals which contain WGPU primitives, we leak the
+        // lock state on thread exit. This ensures the destructors of user objects may continue to be
+        // instrumented and will not cause a panic of they run after this thread_local is dropped
+        // Also see: observing.rs
+        static SNATCH_LOCK_TRACE: Cell<Option<ManuallyDrop<LockTrace>>> = const { Cell::new(None) };
     }
 }
 #[cfg(not(all(debug_assertions, feature = "std")))]
@@ -198,5 +206,42 @@ impl Drop for SnatchGuard<'_> {
 impl Drop for ExclusiveSnatchGuard<'_> {
     fn drop(&mut self) {
         LockTrace::exit();
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::SnatchLock;
+    use crate::lock::rank;
+    use core::cell::Cell;
+
+    /// A thing that reads a snatchlock during drop, to test destruction call order problems
+    struct LockOnDrop(SnatchLock);
+    impl Drop for LockOnDrop {
+        fn drop(&mut self) {
+            drop(self.0.read());
+        }
+    }
+
+    std::thread_local! {
+        static HOLDER: Cell<Option<LockOnDrop>> = const { Cell::new(None) };
+    }
+
+    #[test]
+    fn read_during_tls_destruction() {
+        std::thread::spawn(|| {
+            // our thread local is touched first, so its destructor will be called last
+            HOLDER.set(Some(LockOnDrop(unsafe {
+                SnatchLock::new(rank::DEVICE_SNATCHABLE_LOCK)
+            })));
+
+            // take the lock which causes SNATCH_LOCK_TRACE to be created. it
+            // will be destroyed first
+            let lock = unsafe { SnatchLock::new(rank::DEVICE_SNATCHABLE_LOCK) };
+            drop(lock.read());
+        })
+        .join()
+        .unwrap();
+        // just testing that the thread exited successfully
     }
 }


### PR DESCRIPTION
This can be observed in some cases if you store a graphics primitive in a TLS variable, and the primitive is destroyed after SNATCH_LOCK_TRACE is.

**Connections**

I personally observed this issue while [moving slint's skia surface creation code to use wgpu](https://github.com/slint-ui/slint/pull/12819) and also discovered this boa issue that seems it may be another instance of this happening in the wild: https://github.com/boa-dev/boa/issues/4370

**Description**

It seems that users who allow WGPU primitives (in my case, a `Queue`) to be stored and dropped in TLS storage may find that the debugging / deadlock checker TLS variables `SNATCH_LOCK_TRACE` or `LOCK_STATE`  are already destroyed when their handle is dropped and it tries to access that variable when unlocking the snatch lock.

To fix this, I just do `try_with` so that lock validation is basically disabled after destruction. So this sort of reduces the scope of cases where validation can successfully detect problems compared to the perfect solution which would be to guarantee that the trace variables are initialized first, always. Not sure of a good way to do that that, though. This change at least does not shrink the scope of cases where validation can occur :)

**Testing**

I made a pretty simple test that just replicates the crash, it doesn't contain any explicit asserts. It does crash if any of the `try_with`s are removed.

**Squash or Rebase?**

Rebase.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
(sort of, but only in debug mode)
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
