### PR TITLE
`TextureDescriptor::theoretical_memory_footprint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Bottom level categories:
 - Support the `wasm64-unknown-unknown` target for the web backend. Building for wasm64 requires a nightly toolchain with `-Z build-std=std,panic_abort`. By @nickbabcock in [#9836](https://github.com/gfx-rs/wgpu/pull/9836).
 - Many types now offer `pub const fn default()` in addition to implementing the `Default` trait, allowing constants to make use of default values. By @kpreid in [#9929](https://github.com/gfx-rs/wgpu/pull/9929).
 - `wgpu-core` now exposes `validate_device_descriptor` and `validate_texture_descriptor` functions that perform the same descriptor validation the corresponding resource creation APIs would, without actually creating a resource. This may be useful in conjunction with hal raw APIs. By @andyleiserson in [#9967](https://github.com/gfx-rs/wgpu/pull/9967) and [#9979](https://github.com/gfx-rs/wgpu/pull/9979).
+- Added `TextureDescriptor::theoretical_memory_footprint` to estimate memory footprint of a texture. By @sagudev in [#10032](https://github.com/gfx-rs/wgpu/pull/10032).
 
 #### Hal
 

--- a/wgpu-types/src/texture.rs
+++ b/wgpu-types/src/texture.rs
@@ -647,6 +647,21 @@ impl<L, V> TextureDescriptor<L, V> {
             TextureDimension::D2 => self.size.depth_or_array_layers,
         }
     }
+
+    /// Returns the theoretical memory footprint of a texture.
+    ///
+    /// Actual memory usage may greatly exceed this value due to alignment and padding.
+    #[must_use]
+    pub fn theoretical_memory_footprint(&self) -> u64 {
+        (0..self.mip_level_count).fold(0, |acc, level| {
+            acc.saturating_add(
+                self.format.theoretical_memory_footprint(
+                    self.mip_level_size(level)
+                        .expect("mipmap level should be inbounds"),
+                ),
+            )
+        })
+    }
 }
 
 /// Describes a `Sampler`.


### PR DESCRIPTION
**Connections**
Inspired by https://bugzilla.mozilla.org/show_bug.cgi?id=2061941

**Description**
Add `TextureDescriptor::theoretical_memory_footprint` that estimates memory footprint of a texture. This will be also useful in servo.

**Testing**
None

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
