### PR TITLE
Validate unary ops in WGSL lowerer

### DIFF
--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -9,7 +9,7 @@ use crate::common::wgsl::TryToWgsl;
 use crate::diagnostic_filter::ConflictingDiagnosticRuleError;
 use crate::error::replace_control_chars;
 use crate::proc::{Alignment, ConstantEvaluatorError, ResolveError};
-use crate::{Scalar, SourceLocation, Span};
+use crate::{Scalar, SourceLocation, Span, UnaryOperator};
 
 use super::parse::directive::enable_extension::{EnableExtension, UnimplementedEnableExtension};
 use super::parse::directive::language_extension::{
@@ -385,6 +385,12 @@ pub(crate) enum Error<'a> {
     },
     DeclMissingTypeAndInit(Span),
     MissingAttribute(&'static str, Span),
+    InvalidUnaryOperandType {
+        span: Span,
+        op: UnaryOperator,
+        operand_type: String,
+    },
+
     InvalidAddrOfOperand(Span),
     InvalidAtomicPointer(Span),
     InvalidAtomicOperandType(Span),
@@ -964,6 +970,7 @@ impl<'a> Error<'a> {
                 | Error::WrongArgumentCount { span, .. }
                 | Error::ConstantEvaluatorError(_, span)
                 | Error::EnableExtensionNotSupported { span, .. }
+                | Error::InvalidUnaryOperandType { span, .. }
                 | Error::MissingTemplateArg { span, .. } => {
                 let (message, label) = match self {
                     Error::BadMatrixScalarKind(_, scalar) => (
@@ -1023,6 +1030,20 @@ impl<'a> Error<'a> {
                         ),
                         "is missing a template argument"
                     ),
+                    Error::InvalidUnaryOperandType { op, operand_type, .. } => {
+                        let operator = match op {
+                            UnaryOperator::Negate => "-",
+                            UnaryOperator::LogicalNot => "!",
+                            UnaryOperator::BitwiseNot => "~",
+                        };
+                        (
+                            format!(
+                                "unary operator `{operator}` is not defined for operand type `{}`",
+                                operand_type
+                            ),
+                            "invalid operand type for this operator"
+                        )
+                    },
                     _ => unreachable!()
                 };
 
@@ -1660,7 +1681,7 @@ impl<'a> Error<'a> {
                 )],
                 message: "unterminated block comment".into(),
                 notes: vec![],
-            }
+            },
         }
     }
 }

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2921,15 +2921,15 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
         let expr = self.expression_for_abstract(expr, ctx)?;
         ctx.grow_types(expr)?;
-        let expr_resolution = resolve!(ctx, expr);
+        let expr_ty_resolution = resolve!(ctx, expr);
 
         // All unary operators are only defined for scalars and vectors of scalars.
-        let Some(kind) = expr_resolution
+        let Some(kind) = expr_ty_resolution
             .inner_with(&ctx.module.types)
             .vector_size_and_scalar()
             .map(|(_, scalar)| scalar.kind)
         else {
-            let operand_type = ctx.type_resolution_to_string(expr_resolution);
+            let operand_type = ctx.type_resolution_to_string(expr_ty_resolution);
             return Err(Box::new(make_error(operand_type)));
         };
         // validate preconditions
@@ -2938,7 +2938,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             ir::UnaryOperator::LogicalNot => {
                 let valid = matches!(kind, ir::ScalarKind::Bool);
                 if !valid {
-                    let operand_type = ctx.type_resolution_to_string(expr_resolution);
+                    let operand_type = ctx.type_resolution_to_string(expr_ty_resolution);
                     return Err(Box::new(make_error(operand_type)));
                 }
             }
@@ -2954,7 +2954,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                         | ir::ScalarKind::Float
                 );
                 if !valid {
-                    let operand_type = ctx.type_resolution_to_string(expr_resolution);
+                    let operand_type = ctx.type_resolution_to_string(expr_ty_resolution);
                     return Err(Box::new(make_error(operand_type)));
                 }
             }
@@ -2967,7 +2967,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     ir::ScalarKind::Sint | ir::ScalarKind::Uint | ir::ScalarKind::AbstractInt,
                 );
                 if !valid {
-                    let operand_type = ctx.type_resolution_to_string(expr_resolution);
+                    let operand_type = ctx.type_resolution_to_string(expr_ty_resolution);
                     return Err(Box::new(make_error(operand_type)));
                 }
             }

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2921,8 +2921,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
         let expr = self.expression_for_abstract(expr, ctx)?;
         ctx.grow_types(expr)?;
-
         let expr_resolution = resolve!(ctx, expr);
+
         // All unary operators are only defined for scalars and vectors of scalars.
         let Some(kind) = expr_resolution
             .inner_with(&ctx.module.types)

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -5,7 +5,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::num::NonZeroU32;
+use core::{matches, num::NonZeroU32};
 
 use crate::front::wgsl::error::{Error, ExpectedToken, InvalidAssignmentType};
 use crate::front::wgsl::index::Index;
@@ -2414,10 +2414,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
                 return expr.try_map(|handle| ctx.interrupt_emitter(handle, span));
             }
-            ast::Expression::Unary { op, expr } => {
-                let expr = self.expression_for_abstract(expr, ctx)?;
-                Typed::Plain(ir::Expression::Unary { op, expr })
-            }
+            ast::Expression::Unary { op, expr } => self.unary(op, expr, span, ctx)?,
             ast::Expression::AddrOf(expr) => {
                 // The `&` operator simply converts a reference to a pointer. And since a
                 // reference is required, the Load Rule is not applied.
@@ -2907,6 +2904,76 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             }
         };
         Ok(ty)
+    }
+
+    fn unary(
+        &mut self,
+        op: ir::UnaryOperator,
+        expr: Handle<ast::Expression<'source>>,
+        span: Span,
+        ctx: &mut ExpressionContext<'source, '_, '_>,
+    ) -> Result<'source, Typed<ir::Expression>> {
+        let make_error = |operand_type: String| Error::InvalidUnaryOperandType {
+            span,
+            op,
+            operand_type,
+        };
+
+        let expr = self.expression_for_abstract(expr, ctx)?;
+        ctx.grow_types(expr)?;
+
+        let expr_resolution = resolve!(ctx, expr);
+        // All unary operators are only defined for scalars and vectors of scalars.
+        let size_and_scalar = expr_resolution
+            .inner_with(&ctx.module.types)
+            .vector_size_and_scalar();
+
+        let Some(kind) = size_and_scalar.map(|(_, scalar)| scalar.kind) else {
+            let operand_type = ctx.type_resolution_to_string(expr_resolution);
+            return Err(Box::new(make_error(operand_type)));
+        };
+        // validate preconditions
+        match op {
+            // `T` is `bool` or `vecN<bool>`. These types have no automatic conversions.
+            ir::UnaryOperator::LogicalNot => {
+                let valid = matches!(kind, ir::ScalarKind::Bool);
+                if !valid {
+                    let operand_type = ctx.type_resolution_to_string(expr_resolution);
+                    return Err(Box::new(make_error(operand_type)));
+                }
+            }
+
+            // `T` is `AbstractInt`, `AbstractFloat`, `i32`, `f32`, `f16`,
+            // `vecN<AbstractInt>`, `vecN<AbstractFloat>`, `vecN<i32>`, `vecN<f32>`, or `vecN<f16>`.
+            ir::UnaryOperator::Negate => {
+                let valid = matches!(
+                    kind,
+                    ir::ScalarKind::AbstractInt
+                        | ir::ScalarKind::AbstractFloat
+                        | ir::ScalarKind::Sint
+                        | ir::ScalarKind::Float
+                );
+                if !valid {
+                    let operand_type = ctx.type_resolution_to_string(expr_resolution);
+                    return Err(Box::new(make_error(operand_type)));
+                }
+            }
+
+            // `S` is `AbstractInt`, `i32`, or `u32`.
+            // `T` is `S` or `vecN<S>`.
+            ir::UnaryOperator::BitwiseNot => {
+                let valid = matches!(
+                    kind,
+                    ir::ScalarKind::Sint | ir::ScalarKind::Uint | ir::ScalarKind::AbstractInt,
+                );
+                if !valid {
+                    let operand_type = ctx.type_resolution_to_string(expr_resolution);
+                    return Err(Box::new(make_error(operand_type)));
+                }
+            }
+        }
+
+        Ok(Typed::Plain(ir::Expression::Unary { op, expr }))
     }
 
     fn binary(

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2924,11 +2924,11 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
         let expr_resolution = resolve!(ctx, expr);
         // All unary operators are only defined for scalars and vectors of scalars.
-        let size_and_scalar = expr_resolution
+        let Some(kind) = expr_resolution
             .inner_with(&ctx.module.types)
-            .vector_size_and_scalar();
-
-        let Some(kind) = size_and_scalar.map(|(_, scalar)| scalar.kind) else {
+            .vector_size_and_scalar()
+            .map(|(_, scalar)| scalar.kind)
+        else {
             let operand_type = ctx.type_resolution_to_string(expr_resolution);
             return Err(Box::new(make_error(operand_type)));
         };

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -2933,43 +2933,30 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             return Err(Box::new(make_error(operand_type)));
         };
         // validate preconditions
-        match op {
+        match (op, kind) {
             // `T` is `bool` or `vecN<bool>`. These types have no automatic conversions.
-            ir::UnaryOperator::LogicalNot => {
-                let valid = matches!(kind, ir::ScalarKind::Bool);
-                if !valid {
-                    let operand_type = ctx.type_resolution_to_string(expr_ty_resolution);
-                    return Err(Box::new(make_error(operand_type)));
-                }
-            }
+            (ir::UnaryOperator::LogicalNot, ir::ScalarKind::Bool) => {}
 
             // `T` is `AbstractInt`, `AbstractFloat`, `i32`, `f32`, `f16`,
             // `vecN<AbstractInt>`, `vecN<AbstractFloat>`, `vecN<i32>`, `vecN<f32>`, or `vecN<f16>`.
-            ir::UnaryOperator::Negate => {
-                let valid = matches!(
-                    kind,
-                    ir::ScalarKind::AbstractInt
-                        | ir::ScalarKind::AbstractFloat
-                        | ir::ScalarKind::Sint
-                        | ir::ScalarKind::Float
-                );
-                if !valid {
-                    let operand_type = ctx.type_resolution_to_string(expr_ty_resolution);
-                    return Err(Box::new(make_error(operand_type)));
-                }
-            }
+            (
+                ir::UnaryOperator::Negate,
+                ir::ScalarKind::AbstractInt
+                | ir::ScalarKind::AbstractFloat
+                | ir::ScalarKind::Sint
+                | ir::ScalarKind::Float,
+            ) => {}
 
             // `S` is `AbstractInt`, `i32`, or `u32`.
             // `T` is `S` or `vecN<S>`.
-            ir::UnaryOperator::BitwiseNot => {
-                let valid = matches!(
-                    kind,
-                    ir::ScalarKind::Sint | ir::ScalarKind::Uint | ir::ScalarKind::AbstractInt,
-                );
-                if !valid {
-                    let operand_type = ctx.type_resolution_to_string(expr_ty_resolution);
-                    return Err(Box::new(make_error(operand_type)));
-                }
+            (
+                ir::UnaryOperator::BitwiseNot,
+                ir::ScalarKind::Sint | ir::ScalarKind::Uint | ir::ScalarKind::AbstractInt,
+            ) => {}
+
+            _ => {
+                let operand_type = ctx.type_resolution_to_string(expr_ty_resolution);
+                return Err(Box::new(make_error(operand_type)));
             }
         }
 

--- a/naga/src/front/wgsl/tests.rs
+++ b/naga/src/front/wgsl/tests.rs
@@ -783,6 +783,86 @@ mod diagnostic_filter {
     use crate::front::wgsl::assert_parse_err;
 
     #[test]
+    fn invalid_unary_operand_negative_unsigned_integer() {
+        let shader = "
+fn myfunc() {
+    _ = -(2u);
+}
+";
+        assert_parse_err(
+            shader,
+            "\
+error: unary operator `-` is not defined for operand type `u32`
+  ┌─ wgsl:3:9
+  │
+3 │     _ = -(2u);
+  │         ^^^^^ invalid operand type for this operator
+
+",
+        );
+    }
+
+    #[test]
+    fn invalid_unary_operand_negative_neither_scalar_nor_vector() {
+        let shader = "
+fn myfunc() {
+    _ = -mat2x2f();
+}
+";
+        assert_parse_err(
+            shader,
+            "\
+error: unary operator `-` is not defined for operand type `mat2x2<f32>`
+  ┌─ wgsl:3:9
+  │
+3 │     _ = -mat2x2f();
+  │         ^^^^^^^^^^ invalid operand type for this operator
+
+",
+        );
+    }
+
+    #[test]
+    fn invalid_unary_operand_logical_not() {
+        let shader = "
+fn myfunc() {
+    _ = !1;
+}
+";
+        assert_parse_err(
+            shader,
+            "\
+error: unary operator `!` is not defined for operand type `{AbstractInt}`
+  ┌─ wgsl:3:9
+  │
+3 │     _ = !1;
+  │         ^^ invalid operand type for this operator
+
+",
+        );
+    }
+
+    #[test]
+    fn invalid_unary_operand_bitwise_not() {
+        let shader = "
+fn myfunc() {
+    _ = ~(1.0f);
+}
+";
+        assert_parse_err(
+            shader,
+            "\
+error: unary operator `~` is not defined for operand type `f32`
+  ┌─ wgsl:3:9
+  │
+3 │     _ = ~(1.0f);
+  │         ^^^^^^^ invalid operand type for this operator
+
+",
+        );
+    }
+
+    #[test]
     fn intended_global_directive() {
         let shader = "@diagnostic(off, my.lint);";
         assert_parse_err(

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -2725,7 +2725,7 @@ impl<'a> ConstantEvaluator<'a> {
                 components: ref src_components,
             } => {
                 match self.types[ty].inner {
-                    TypeInner::Vector { .. } | TypeInner::Matrix { .. } => (),
+                    TypeInner::Vector { .. } => (),
                     _ => return Err(ConstantEvaluatorError::InvalidUnaryOpArg),
                 }
 


### PR DESCRIPTION
**Connections**
No connections.

**Description**
I noticed that naga accepts invalid WGSL while playing with wesl-rs and wgsl-analyzer. The original issue is that it accepted `-mat2x2f()` (negating a matrix) as a valid expression. However, according to the WGSL specification, that violates the precondition.

**Testing**
Added tests to assert the error messages.

**Squash or Rebase?**

Either.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
