### PR TITLE
[types] derive Eq and PartialEq for parameter types

### DIFF
--- a/wgpu-types/src/backend.rs
+++ b/wgpu-types/src/backend.rs
@@ -224,7 +224,7 @@ impl Backends {
 /// Options that are passed to a given backend.
 ///
 /// Part of [`InstanceDescriptor`].
-#[derive(Clone, Debug, ConstDefault!)]
+#[derive(Clone, Debug, Eq, PartialEq, ConstDefault!)]
 pub struct BackendOptions {
     /// Options for the OpenGL/OpenGLES backend, [`Backend::Gl`].
     pub gl: GlBackendOptions,
@@ -263,7 +263,7 @@ impl BackendOptions {
 /// Configuration for the OpenGL/OpenGLES backend.
 ///
 /// Part of [`BackendOptions`].
-#[derive(Clone, Debug, ConstDefault!)]
+#[derive(Clone, Debug, Eq, PartialEq, ConstDefault!)]
 pub struct GlBackendOptions {
     /// Which OpenGL ES 3 minor version to request, if using OpenGL ES.
     pub gles_minor_version: Gles3MinorVersion,
@@ -379,7 +379,7 @@ impl GlDebugFns {
 
 /// Used to force wgpu to expose certain features on passthrough shaders even when
 /// those features aren't present on runtime-compiled shaders
-#[derive(Clone, Debug, ConstDefault!)]
+#[derive(Clone, Debug, Eq, PartialEq, ConstDefault!)]
 pub struct ForceShaderModelToken {
     inner: Option<DxcShaderModel>,
 }
@@ -488,7 +488,7 @@ impl Dx12AgilitySDKLoadFailure {
 /// [win11-21h2]: https://support.microsoft.com/en-us/topic/august-22-2023-kb5029332-os-build-22000-2360-preview-8f8aec64-77b4-4225-9a0f-f0153204ae28
 /// [win10-22h2]: https://support.microsoft.com/en-gb/topic/august-22-2023-kb5029331-os-build-19045-3393-preview-9f6c1dbd-0ee6-469b-af24-f9d0bf35ca18
 /// [server-2022]: https://support.microsoft.com/en-au/topic/september-12-2023-kb5030216-os-build-20348-1970-34d4aff3-fd05-4270-b288-4ab6379c7f81
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Dx12AgilitySDK {
     /// The Agility SDK version number (e.g., 614 for SDK version 1.614.0).
     ///
@@ -550,7 +550,7 @@ impl Dx12AgilitySDK {
 /// Configuration for the DX12 backend.
 ///
 /// Part of [`BackendOptions`].
-#[derive(Clone, Debug, ConstDefault!)]
+#[derive(Clone, Debug, Eq, PartialEq, ConstDefault!)]
 pub struct Dx12BackendOptions {
     /// Which DX12 shader compiler to use.
     pub shader_compiler: Dx12Compiler,
@@ -619,7 +619,7 @@ impl Dx12BackendOptions {
 /// Configuration for the noop backend.
 ///
 /// Part of [`BackendOptions`].
-#[derive(Clone, Debug, ConstDefault!)]
+#[derive(Clone, Debug, Eq, PartialEq, ConstDefault!)]
 pub struct NoopBackendOptions {
     /// Whether to allow the noop backend to be used.
     ///
@@ -740,7 +740,7 @@ impl Dx12SwapchainKind {
 }
 
 /// DXC shader model.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 #[allow(missing_docs)]
 pub enum DxcShaderModel {
     V6_0,
@@ -792,7 +792,7 @@ impl DxcShaderModel {
 }
 
 /// Selects which DX12 shader compiler to use.
-#[derive(Clone, Debug, ConstDefault!)]
+#[derive(Clone, Debug, Eq, PartialEq, ConstDefault!)]
 pub enum Dx12Compiler {
     /// The Fxc compiler (default) is old, slow and unmaintained.
     ///
@@ -877,7 +877,7 @@ impl FromStr for Dx12Compiler {
 }
 
 /// Whether and how to use a waitable handle obtained from `GetFrameLatencyWaitableObject`.
-#[derive(Clone, Debug, ConstDefault!)]
+#[derive(Clone, Debug, Eq, PartialEq, ConstDefault!)]
 pub enum Dx12UseFrameLatencyWaitableObject {
     /// Do not obtain a waitable handle and do not wait for it. The swapchain will
     /// be created without the `DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT` flag.

--- a/wgpu-types/src/device.rs
+++ b/wgpu-types/src/device.rs
@@ -56,7 +56,7 @@ impl<L> DeviceDescriptor<L> {
 /// Hints to the device about the memory allocation strategy.
 ///
 /// Some backends may ignore these hints.
-#[derive(Clone, Debug, ConstDefault!)]
+#[derive(Clone, Debug, Eq, PartialEq, ConstDefault!)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MemoryHints {
     /// Favor performance over memory usage (the default value).

--- a/wgpu-types/src/instance.rs
+++ b/wgpu-types/src/instance.rs
@@ -337,7 +337,7 @@ impl InstanceFlags {
 /// Memory budget thresholds used by backends to try to avoid high memory pressure situations.
 ///
 /// Currently only the D3D12 and (optionally) Vulkan backends support these options.
-#[derive(ConstDefault!, Clone, Debug, Copy)]
+#[derive(ConstDefault!, Clone, Debug, Copy, Eq, PartialEq)]
 pub struct MemoryBudgetThresholds {
     /// Threshold at which texture, buffer, query set and acceleration structure creation will start to return OOM errors.
     /// This is a percent of the memory budget reported by native APIs.

--- a/wgpu-types/src/tokens.rs
+++ b/wgpu-types/src/tokens.rs
@@ -3,7 +3,7 @@ use macro_rules_attribute::derive;
 use crate::{link_to_wgpu_item, ConstDefault};
 
 /// Token of the user agreeing to access experimental features.
-#[derive(Debug, ConstDefault!, Copy, Clone)]
+#[derive(Debug, ConstDefault!, Copy, Clone, Eq, PartialEq)]
 pub struct ExperimentalFeatures {
     enabled: bool,
 }


### PR DESCRIPTION
**Connections**

https://github.com/slint-ui/slint/pull/12819

**Description**

While migrating some slint native surface handling code to use wgpu instead (the above PR) I wanted to be able to compare a bunch of parameters for instance/adapter/device/queue creation, in order to share some of these between surfaces if both request these with the same parameters.

**Testing**

This change is not tested- I hope it is not necessary to test autogenerated code like this.

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
