### PR TITLE
[metal] fix bindgroup resources being bound incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,10 @@ Bottom level categories:
 - Add OpenHarmony surface support via `VK_OHOS_surface`. Previously the Vulkan backend could not create a surface on OpenHarmony, leaving GLES as the only usable backend. By @ozongzi in [#9908](https://github.com/gfx-rs/wgpu/pull/9908).
 - Stop passing an un-waited fence to `vkAcquireNextImageKHR` on non-Windows platforms, which triggered `VUID-vkAcquireNextImageKHR-fence-10066` validation errors every frame since v30.0.0. By @ErichDonGubler in [#9855](https://github.com/gfx-rs/wgpu/issues/9855).
 
+#### Metal
+
+- Fix bind group resources for the task, mesh, fragment, and compute shader stages being bound from the wrong offsets whenever a bind group contained resources visible to the task or mesh stages, which could bind the wrong buffer, texture, or sampler to a shader slot. By @teoxoy in [#10043](https://github.com/gfx-rs/wgpu/issues/10043).
+
 #### GLES
 
 - Fixed signed integer `%` (and `%=`) returning the wrong result for negative operands in the GLSL (OpenGL/GLES) backend, e.g. `-1 % 768` yielding `255` instead of `-1`. GLSL's `%` is undefined when either operand is negative, so signed remainder is now lowered as `a - b * (a / b)`, matching the SPIR-V, HLSL, and Metal backends. By @mstampfli in [#9687](https://github.com/gfx-rs/wgpu/pull/9687).

--- a/tests/tests/wgpu-gpu/bind_groups.rs
+++ b/tests/tests/wgpu-gpu/bind_groups.rs
@@ -14,6 +14,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         BIND_GROUP_NONFILTERING_LAYOUT_MAG_SAMPLER,
         BIND_GROUP_NONFILTERING_LAYOUT_MIPMAP_SAMPLER,
         BIND_GROUP_WITH_MAX_BINDING_INDEX,
+        BIND_GROUP_STAGE_ORDER,
     ]);
 }
 
@@ -387,3 +388,159 @@ static BIND_GROUP_WITH_MAX_BINDING_INDEX: GpuTestConfiguration = GpuTestConfigur
             &test_value.to_le_bytes()
         );
     });
+
+/// Regression test for the wgpu-hal Metal backend binding a shader stage's
+/// resources from the wrong offset into its internal per-bind-group
+/// resource arrays.
+///
+/// wgpu-hal's Metal backend builds one flat array per resource kind
+/// (buffers/textures/samplers) for each bind group, containing every
+/// resource visible to any shader stage, laid out stage-by-stage in a fixed
+/// order. When encoding `set_bind_group`, it computes where each stage's own
+/// resources start in that array as the sum of the resource counts of every
+/// stage that comes before it. If the stage order used to lay out the array
+/// and the stage order used to sum up the preceding counts ever disagree,
+/// a stage can end up bound to a completely different resource than the one
+/// it was assigned in the bind group.
+///
+/// This creates a bind group with buffers visible to `TASK`, `MESH`, and
+/// `FRAGMENT` (none of which the compute shader below actually uses) ahead
+/// of a `COMPUTE`-visible buffer, then dispatches a compute shader that
+/// doubles the compute buffer's value. If the compute stage's resources are
+/// read from the wrong offset because of a stage-ordering mismatch, the
+/// shader will double one of the filler buffers' values instead, and the
+/// compute buffer will be left unmodified.
+async fn bind_group_stage_order(ctx: TestingContext) {
+    let device = &ctx.device;
+
+    const FILLER_VALUE: u32 = 0xDEAD_0000;
+    const COMPUTE_VALUE: u32 = 111;
+
+    let make_filler_buffer = |label: &str| {
+        device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some(label),
+            usage: wgpu::BufferUsages::STORAGE,
+            contents: bytemuck::bytes_of(&FILLER_VALUE),
+        })
+    };
+
+    let task_filler = make_filler_buffer("task filler");
+    let mesh_filler = make_filler_buffer("mesh filler");
+    let fragment_filler = make_filler_buffer("fragment filler");
+    let compute_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("compute buffer"),
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        contents: bytemuck::bytes_of(&COMPUTE_VALUE),
+    });
+
+    let filler_entry = |binding: u32, visibility: wgpu::ShaderStages| wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only: false },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    };
+
+    let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("bgl"),
+        entries: &[
+            filler_entry(0, wgpu::ShaderStages::TASK),
+            filler_entry(1, wgpu::ShaderStages::MESH),
+            filler_entry(2, wgpu::ShaderStages::FRAGMENT),
+            filler_entry(3, wgpu::ShaderStages::COMPUTE),
+        ],
+    });
+
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("bg"),
+        layout: &bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: task_filler.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: mesh_filler.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: fragment_filler.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: compute_buffer.as_entire_binding(),
+            },
+        ],
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("pipeline layout"),
+        bind_group_layouts: &[Some(&bind_group_layout)],
+        immediate_size: 0,
+    });
+
+    let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("shader"),
+        source: wgpu::ShaderSource::Wgsl(
+            "
+            @group(0) @binding(3) var<storage, read_write> value: u32;
+
+            @compute @workgroup_size(1)
+            fn main() {
+                value = value * 2u;
+            }
+            "
+            .into(),
+        ),
+    });
+
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("pipeline"),
+        layout: Some(&pipeline_layout),
+        module: &module,
+        entry_point: Some("main"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("readback"),
+        size: 4,
+        usage: BufferUsages::COPY_DST | BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    {
+        let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        cpass.set_pipeline(&pipeline);
+        cpass.set_bind_group(0, &bind_group, &[]);
+        cpass.dispatch_workgroups(1, 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(&compute_buffer, 0, &readback, 0, 4);
+    ctx.queue.submit(Some(encoder.finish()));
+
+    readback.slice(..).map_async(wgpu::MapMode::Read, |_| ());
+    device.poll(PollType::wait_indefinitely()).unwrap();
+
+    let result: u32 = *bytemuck::from_bytes(&readback.slice(..).get_mapped_range().unwrap());
+    assert_eq!(
+        result,
+        COMPUTE_VALUE * 2,
+        "compute stage was bound to the wrong buffer (expected the `COMPUTE`-visible buffer's \
+         value to be doubled, got {result:#x})",
+    );
+}
+
+#[apply(gpu_test!)]
+static BIND_GROUP_STAGE_ORDER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .limits(wgpu::Limits::downlevel_defaults())
+            .features(wgpu::Features::EXPERIMENTAL_MESH_SHADER),
+    )
+    .run_async(bind_group_stage_order);

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -1109,8 +1109,8 @@ impl crate::CommandEncoder for super::CommandEncoder {
             );
             self.update_bind_group_state(
                 Encoder::Task(&encoder),
-                // All zeros, as ts comes first
-                super::ResourceData::default(),
+                // ts's resources come right after vs's
+                group.counters.vs.clone(),
                 bg_info,
                 dynamic_offsets,
                 group_index,
@@ -1118,7 +1118,11 @@ impl crate::CommandEncoder for super::CommandEncoder {
             );
             self.update_bind_group_state(
                 Encoder::Mesh(&encoder),
-                group.counters.ts.clone(),
+                super::ResourceData {
+                    buffers: group.counters.vs.buffers + group.counters.ts.buffers,
+                    textures: group.counters.vs.textures + group.counters.ts.textures,
+                    samplers: group.counters.vs.samplers + group.counters.ts.samplers,
+                },
                 bg_info,
                 dynamic_offsets,
                 group_index,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -942,18 +942,18 @@ struct ResourceData<T> {
 #[derive(Clone, Debug, Default)]
 struct MultiStageData<T> {
     vs: T,
-    fs: T,
-    cs: T,
     ts: T,
     ms: T,
+    fs: T,
+    cs: T,
 }
 
 const NAGA_STAGES: MultiStageData<naga::ShaderStage> = MultiStageData {
     vs: naga::ShaderStage::Vertex,
-    fs: naga::ShaderStage::Fragment,
-    cs: naga::ShaderStage::Compute,
     ts: naga::ShaderStage::Task,
     ms: naga::ShaderStage::Mesh,
+    fs: naga::ShaderStage::Fragment,
+    cs: naga::ShaderStage::Compute,
 };
 
 impl<T> ops::Index<naga::ShaderStage> for MultiStageData<T> {
@@ -977,34 +977,42 @@ impl<T> MultiStageData<T> {
     fn map_ref<Y>(&self, fun: impl Fn(&T) -> Y) -> MultiStageData<Y> {
         MultiStageData {
             vs: fun(&self.vs),
-            fs: fun(&self.fs),
-            cs: fun(&self.cs),
             ts: fun(&self.ts),
             ms: fun(&self.ms),
+            fs: fun(&self.fs),
+            cs: fun(&self.cs),
         }
     }
+
     fn map<Y>(self, fun: impl Fn(T) -> Y) -> MultiStageData<Y> {
         MultiStageData {
             vs: fun(self.vs),
-            fs: fun(self.fs),
-            cs: fun(self.cs),
             ts: fun(self.ts),
             ms: fun(self.ms),
+            fs: fun(self.fs),
+            cs: fun(self.cs),
         }
     }
+
+    /// The iteration order here is load-bearing: `Device::create_bind_group`
+    /// uses it to lay out each bind group's flat per-kind resource arrays,
+    /// and `CommandEncoder::set_bind_group` uses the same order to compute
+    /// each stage's base offset into those arrays.
     fn iter<'a>(&'a self) -> impl Iterator<Item = &'a T> {
         iter::once(&self.vs)
-            .chain(iter::once(&self.fs))
-            .chain(iter::once(&self.cs))
             .chain(iter::once(&self.ts))
             .chain(iter::once(&self.ms))
+            .chain(iter::once(&self.fs))
+            .chain(iter::once(&self.cs))
     }
+
+    /// See [`Self::iter`].
     fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = &'a mut T> {
         iter::once(&mut self.vs)
-            .chain(iter::once(&mut self.fs))
-            .chain(iter::once(&mut self.cs))
             .chain(iter::once(&mut self.ts))
             .chain(iter::once(&mut self.ms))
+            .chain(iter::once(&mut self.fs))
+            .chain(iter::once(&mut self.cs))
     }
 }
 


### PR DESCRIPTION
**Connections**
\-

**Description**
Fixes bind group resources for the task, mesh, fragment, and compute shader stages being bound from the wrong offsets whenever a bind group contained resources visible to the task or mesh stages, which could bind the wrong buffer, texture, or sampler to a shader slot.

**Testing**
Added a test.

**Squash or Rebase?**
Squash.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
