### PR TITLE
[core] Remove unused uses of `IDReferences`

### DIFF
--- a/wgpu-core/src/ray_tracing.rs
+++ b/wgpu-core/src/ray_tracing.rs
@@ -21,7 +21,7 @@ use wgt::{
 #[cfg(feature = "serde")]
 use crate::command::serde_object_reference_struct;
 use crate::{
-    command::{ArcReferences, EncoderStateError, IdReferences, ReferenceType},
+    command::{ArcReferences, EncoderStateError, ReferenceType},
     device::{DeviceError, MissingFeatures},
     resource::{
         self, Blas, BlasCompactCallback, BlasPrepareCompactResult, DestroyedResourceError,
@@ -370,7 +370,6 @@ pub struct OwnedBlasTriangleGeometry<R: ReferenceType> {
 }
 
 pub type ArcBlasTriangleGeometry = OwnedBlasTriangleGeometry<ArcReferences>;
-pub type TraceBlasTriangleGeometry = OwnedBlasTriangleGeometry<IdReferences>;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", apply(serde_object_reference_struct))]
@@ -382,7 +381,6 @@ pub struct OwnedBlasAabbGeometry<R: ReferenceType> {
 }
 
 pub type ArcBlasAabbGeometry = OwnedBlasAabbGeometry<ArcReferences>;
-pub type TraceBlasAabbGeometry = OwnedBlasAabbGeometry<IdReferences>;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", apply(serde_object_reference_struct))]
@@ -392,7 +390,6 @@ pub enum OwnedBlasGeometries<R: ReferenceType> {
 }
 
 pub type ArcBlasGeometries = OwnedBlasGeometries<ArcReferences>;
-pub type TraceBlasGeometries = OwnedBlasGeometries<IdReferences>;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", apply(serde_object_reference_struct))]
@@ -402,7 +399,6 @@ pub struct OwnedBlasBuildEntry<R: ReferenceType> {
 }
 
 pub type ArcBlasBuildEntry = OwnedBlasBuildEntry<ArcReferences>;
-pub type TraceBlasBuildEntry = OwnedBlasBuildEntry<IdReferences>;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", apply(serde_object_reference_struct))]
@@ -414,7 +410,6 @@ pub struct OwnedTlasInstance<R: ReferenceType> {
 }
 
 pub type ArcTlasInstance = OwnedTlasInstance<ArcReferences>;
-pub type TraceTlasInstance = OwnedTlasInstance<IdReferences>;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", apply(serde_object_reference_struct))]
@@ -424,7 +419,6 @@ pub struct OwnedTlasPackage<R: ReferenceType> {
     pub lowest_unmodified: u32,
 }
 
-pub type TraceTlasPackage = OwnedTlasPackage<IdReferences>;
 pub type ArcTlasPackage = OwnedTlasPackage<ArcReferences>;
 
 /// [`BlasTriangleGeometry`], without the resources.


### PR DESCRIPTION
**Connections**
Towards #5121 

**Description**
Those types are unused as tracing uses PointerId types instead of actual ids.

**Testing**
Just refactor

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
