### PR TITLE
fix(deps): Enable CI on pushes to renovate branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ name: CI
 on:
   push:
     branches-ignore: [
-        # Renovate branches are always PRs, so they will be covered
-        # by the pull_request event.
-        "renovate/**",
         # Branches with the `gh-readonly-queue` prefix are used by the
         # merge queue, so they are already covered by the `merge_group` event.
         "gh-readonly-queue/**",

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -3,9 +3,6 @@ name: CTS
 on:
   push:
     branches-ignore: [
-        # Renovate branches are always PRs, so they will be covered
-        # by the pull_request event.
-        "renovate/**",
         # Branches with the `gh-readonly-queue` prefix are used by the
         # merge queue, so they are already covered by the `merge_group` event.
         "gh-readonly-queue/**",

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,6 @@ name: Docs
 on:
   push:
     branches-ignore: [
-        # Renovate branches are always PRs, so they will be covered
-        # by the pull_request event.
-        "renovate/**",
         # Branches with the `gh-readonly-queue` prefix are used by the
         # merge queue, so they are already covered by the `merge_group` event.
         "gh-readonly-queue/**",

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -3,9 +3,6 @@ name: cargo-generate
 on:
   push:
     branches-ignore: [
-        # Renovate branches are always PRs, so they will be covered
-        # by the pull_request event.
-        "renovate/**",
         # Branches with the `gh-readonly-queue` prefix are used by the
         # merge queue, so they are already covered by the `merge_group` event.
         "gh-readonly-queue/**",

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -4,9 +4,6 @@ name: Lazy
 on:
   push:
     branches-ignore: [
-        # Renovate branches are always PRs, so they will be covered
-        # by the pull_request event.
-        "renovate/**",
         # Branches with the `gh-readonly-queue` prefix are used by the
         # merge queue, so they are already covered by the `merge_group` event.
         "gh-readonly-queue/**",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ name: Publish
 on:
   push:
     branches-ignore: [
-        # Renovate branches are always PRs, so they will be covered
-        # by the pull_request event.
-        "renovate/**",
         # Branches with the `gh-readonly-queue` prefix are used by the
         # merge queue, so they are already covered by the `merge_group` event.
         "gh-readonly-queue/**",

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -3,9 +3,6 @@ name: Shaders
 on:
   push:
     branches-ignore: [
-        # Renovate branches are always PRs, so they will be covered
-        # by the pull_request event.
-        "renovate/**",
         # Branches with the `gh-readonly-queue` prefix are used by the
         # merge queue, so they are already covered by the `merge_group` event.
         "gh-readonly-queue/**",


### PR DESCRIPTION
**Connections**

Next (and final?) chapter in a saga of issues from my misguided attempt to enable `minimumReleaseAge` 😞 (#9546, #9598, #9603, #9622, #9864, #9927).

**Description**

Running CI jobs on pushes to renovate branches was disabled when it was set up, on the rationale that they would trigger CI as pull requests anyways. My theory is that with `prCreation: "not-pending"`, this isn't actually true: renovate pushes a branch, and is waiting to see CI green on the branch before creating a PR, but since we don't trigger CI, that never happens.

I was initially going to remove `prCreation` and `internalChecksFilter` from the config, since we're mostly not using `minimumReleaseAge` anyways, but then I remembered that we do still have `minimumReleaseAge` set for the rust compiler.

On the other hand, I'm not sure that "branch sits around silently and indefinitely" is really the behavior we want for dependency updates that fail CI -- opening the PR anyways, or at least opening an issue, seems better.

Maybe it would be better to entirely give up on `minimumReleaseAge`, remove everything related to it and also `rust-toolchain` from the renovate config, and fall back to updating the Rust version manually.

**Testing**
Not sure how to test other than merging and seeing if it fixes anything.

**Squash or Rebase?** Squash