### PR TITLE
[gles] Avoid duplicate EGL surface type attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Bottom level categories:
 
 #### GLES
 
+- Avoid duplicate `EGL_SURFACE_TYPE` attributes when selecting an EGL framebuffer configuration, which caused Mesa to return no matching configurations. By @BlueJayLouche and @scroix in [#10048](https://github.com/gfx-rs/wgpu/pull/10048).
 - Fixed signed integer `%` (and `%=`) returning the wrong result for negative operands in the GLSL (OpenGL/GLES) backend, e.g. `-1 % 768` yielding `255` instead of `-1`. GLSL's `%` is undefined when either operand is negative, so signed remainder is now lowered as `a - b * (a / b)`, matching the SPIR-V, HLSL, and Metal backends. By @mstampfli in [#9687](https://github.com/gfx-rs/wgpu/pull/9687).
 - Fix negative argument for `atomicSub` yielding incorrect GLSL. By @ErichDonGubler in [#9924](https://github.com/gfx-rs/wgpu/pull/9924).
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -124,9 +124,18 @@ fn choose_config(
         log::debug!("\tTrying {name}");
 
         attributes.clear();
+        let mut surface_type = 0;
         for &(_, tier_attr) in tiers[..=tier_max].iter() {
-            attributes.extend_from_slice(tier_attr);
+            for attribute in tier_attr.chunks_exact(2) {
+                if attribute[0] == khronos_egl::SURFACE_TYPE {
+                    surface_type |= attribute[1];
+                } else {
+                    attributes.extend_from_slice(attribute);
+                }
+            }
         }
+        // Duplicate EGL attribute keys are undefined and make Mesa return no configs.
+        attributes.extend_from_slice(&[khronos_egl::SURFACE_TYPE, surface_type]);
         // make sure the Alpha is enough to support sRGB
         match srgb_kind {
             SrgbFrameBufferKind::None => {}


### PR DESCRIPTION
**Connections**

No existing issue tracks this. #8794 (closed unmerged) rewrote the same code as part of a broader change; #8686 is a nearby Mesa EGL config failure with a different mechanism.

**Description**

`choose_config` builds each EGL attribute list by concatenating the active configuration tiers. Both the off-screen and presentation tiers contain `EGL_SURFACE_TYPE`, so attempts that include both tiers pass the same attribute key twice to `eglChooseConfig`. Duplicate keys in an EGL attribute list are undefined behaviour, and Mesa responds by returning no matching configurations, which prevents surface creation.

This change collects the `EGL_SURFACE_TYPE` values while folding the tiers, combines their bits with OR, and emits a single key/value pair. Other attributes keep their existing values and tier fallback behaviour.

The fix comes from rustjay-engine, which hit the failure in production on a Raspberry Pi (Mesa, Wayland) and has shipped it as a vendored patch to wgpu-hal 29.0.3 since May. The duplicate-key pattern is still present on trunk. Original fix by @BlueJayLouche.

**Testing**

`cargo fmt --all`, `cargo check -p wgpu-hal --features gles`, and `cargo clippy -p wgpu-hal --features gles --tests` all pass on the pinned Rust 1.93.1. `cargo xtask test` and CTS were not run here (no suitable GPU); the equivalent change is field-tested on the Raspberry Pi deployment.

**Squash or Rebase?**

Squash.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes. Not applicable: this only canonicalizes an internal EGL attribute list.
- [ ] Tests demonstrate the validation and altered logic works. No driver-independent regression test is included in this minimal patch.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.