### PR TITLE
Replace usage of global with instance and resource methods in tests

### DIFF
--- a/tests/tests/wgpu-validation/limit_buckets.rs
+++ b/tests/tests/wgpu-validation/limit_buckets.rs
@@ -2,6 +2,8 @@
 //!
 //! See [`wgpu_core::limits`].
 
+use std::sync::Arc;
+
 use wgpu_core as wgc;
 use wgpu_types as wgt;
 
@@ -23,8 +25,8 @@ const UPLEVEL_FEATURES: wgt::Features = {
         .union(Features::IMMEDIATES)
 };
 
-fn create_noop_global(options: wgt::NoopBackendOptions) -> wgc::global::Global {
-    wgc::global::Global::new(
+fn create_noop_instance(options: wgt::NoopBackendOptions) -> Arc<wgc::instance::Instance> {
+    wgc::instance::Instance::new(
         "test",
         wgt::instance::InstanceDescriptor {
             backends: wgt::Backends::NOOP,
@@ -40,7 +42,7 @@ fn create_noop_global(options: wgt::NoopBackendOptions) -> wgc::global::Global {
 
 #[test]
 fn enabled() {
-    let global = create_noop_global(wgt::NoopBackendOptions {
+    let instance = create_noop_instance(wgt::NoopBackendOptions {
         enable: true,
         device_type: Some(wgt::DeviceType::DiscreteGpu),
         features: Some(wgt::Features::empty()),
@@ -49,20 +51,19 @@ fn enabled() {
         ..Default::default() // noop defaults to max limits
     });
 
-    let adapter_id = global
+    let adapter = instance
         .request_adapter(
             &wgt::RequestAdapterOptions {
                 apply_limit_buckets: true,
                 ..Default::default()
             },
             wgt::Backends::NOOP,
-            None,
         )
         .unwrap();
 
-    let limits = global.adapter_limits(adapter_id);
-    let features = global.adapter_features(adapter_id);
-    let info = global.adapter_get_info(adapter_id);
+    let limits = adapter.limits();
+    let features = adapter.features();
+    let info = adapter.get_info();
 
     // Max limits should be replaced with "default"
     assert_eq!(limits, wgt::Limits::defaults());
@@ -78,7 +79,7 @@ fn exempt_features() {
         .union(wgt::Features::TEXTURE_FORMAT_P010)
         .union(wgt::Features::TEXTURE_FORMAT_16BIT_NORM);
 
-    let global = create_noop_global(wgt::NoopBackendOptions {
+    let instance = create_noop_instance(wgt::NoopBackendOptions {
         enable: true,
         device_type: Some(wgt::DeviceType::DiscreteGpu),
         features: Some(EXEMPT_FEATURES.union(wgt::Features::SUBGROUP)),
@@ -87,20 +88,19 @@ fn exempt_features() {
         ..Default::default() // noop defaults to max limits
     });
 
-    let adapter_id = global
+    let adapter = instance
         .request_adapter(
             &wgt::RequestAdapterOptions {
                 apply_limit_buckets: true,
                 ..Default::default()
             },
             wgt::Backends::NOOP,
-            None,
         )
         .unwrap();
 
-    let limits = global.adapter_limits(adapter_id);
-    let features = global.adapter_features(adapter_id);
-    let info = global.adapter_get_info(adapter_id);
+    let limits = adapter.limits();
+    let features = adapter.features();
+    let info = adapter.get_info();
 
     // Max limits should be replaced with "default" bucket
     assert_eq!(limits, wgt::Limits::defaults());
@@ -111,7 +111,7 @@ fn exempt_features() {
 
 #[test]
 fn limits_below_minimums_returns_no_adapter() {
-    let global = create_noop_global(wgt::NoopBackendOptions {
+    let instance = create_noop_instance(wgt::NoopBackendOptions {
         enable: true,
         limits: Some(wgt::Limits {
             max_texture_dimension_2d: 1024,
@@ -122,13 +122,12 @@ fn limits_below_minimums_returns_no_adapter() {
         ..Default::default()
     });
 
-    let result = global.request_adapter(
+    let result = instance.request_adapter(
         &wgt::RequestAdapterOptions {
             apply_limit_buckets: true,
             ..Default::default()
         },
         wgt::Backends::NOOP,
-        None,
     );
 
     // Device is below WebGPU minimums, so no bucket matches
@@ -137,44 +136,38 @@ fn limits_below_minimums_returns_no_adapter() {
 
 #[test]
 fn device_creation_exceeding_bucket_fails() {
-    let global = create_noop_global(wgt::NoopBackendOptions {
+    let instance = create_noop_instance(wgt::NoopBackendOptions {
         enable: true,
         device_type: Some(wgt::DeviceType::DiscreteGpu),
         features: Some(wgt::Features::empty()),
         ..Default::default()
     });
 
-    let adapter_id = global
+    let adapter = instance
         .request_adapter(
             &wgt::RequestAdapterOptions {
                 apply_limit_buckets: true,
                 ..Default::default()
             },
             wgt::Backends::NOOP,
-            None,
         )
         .unwrap();
 
     // The "default" bucket has max_bind_groups = 4
-    let result = global.adapter_request_device(
-        adapter_id,
-        &wgt::DeviceDescriptor {
-            required_limits: wgt::Limits {
-                max_bind_groups: 8,
-                ..wgt::Limits::default()
-            },
-            ..Default::default()
+    let result = adapter.request_device(&wgt::DeviceDescriptor {
+        required_limits: wgt::Limits {
+            max_bind_groups: 8,
+            ..wgt::Limits::default()
         },
-        None,
-        None,
-    );
+        ..Default::default()
+    });
 
     assert!(result.is_err());
 }
 
 #[test]
 fn subgroup_sizes_fixed_when_unsupported() {
-    let global = create_noop_global(wgt::NoopBackendOptions {
+    let instance = create_noop_instance(wgt::NoopBackendOptions {
         enable: true,
         device_type: Some(wgt::DeviceType::DiscreteGpu),
         features: Some(wgt::Features::empty()),
@@ -183,19 +176,18 @@ fn subgroup_sizes_fixed_when_unsupported() {
         ..Default::default()
     });
 
-    let adapter_id = global
+    let adapter = instance
         .request_adapter(
             &wgt::RequestAdapterOptions {
                 apply_limit_buckets: true,
                 ..Default::default()
             },
             wgt::Backends::NOOP,
-            None,
         )
         .unwrap();
 
-    let info = global.adapter_get_info(adapter_id);
-    let features = global.adapter_features(adapter_id);
+    let info = adapter.get_info();
+    let features = adapter.features();
 
     // Since the "default" bucket doesn't have the `subgroups` feature:
     //  - bucket match should succeed despite subgroup size range being narrower than bucket,
@@ -208,25 +200,24 @@ fn subgroup_sizes_fixed_when_unsupported() {
 #[test]
 fn fallback_adapter() {
     // DeviceType::Cpu with empty features should match "fallback" bucket
-    let global = create_noop_global(wgt::NoopBackendOptions {
+    let instance = create_noop_instance(wgt::NoopBackendOptions {
         enable: true,
         device_type: Some(wgt::DeviceType::Cpu),
         features: Some(wgt::Features::empty()),
         ..Default::default()
     });
 
-    let adapter_id = global
+    let adapter = instance
         .request_adapter(
             &wgt::RequestAdapterOptions {
                 apply_limit_buckets: true,
                 ..Default::default()
             },
             wgt::Backends::NOOP,
-            None,
         )
         .unwrap();
 
-    let info = global.adapter_get_info(adapter_id);
+    let info = adapter.get_info();
 
     // Should match fallback bucket which is a CPU/fallback adapter
     assert_eq!(info.device_type, wgt::DeviceType::Cpu);
@@ -244,7 +235,7 @@ fn subgroup_max_above_bucket() {
     // This device is disqualified from all tiers besides NO_F16 due to not
     // having f16 support, and disqualified from NO_F16 due to the subgroup max
     // size.
-    let global = create_noop_global(wgt::NoopBackendOptions {
+    let instance = create_noop_instance(wgt::NoopBackendOptions {
         enable: true,
         device_type: Some(wgt::DeviceType::DiscreteGpu),
         subgroup_min_size: Some(32),
@@ -253,18 +244,17 @@ fn subgroup_max_above_bucket() {
         ..Default::default()
     });
 
-    let adapter_id = global
+    let adapter = instance
         .request_adapter(
             &wgt::RequestAdapterOptions {
                 apply_limit_buckets: true,
                 ..Default::default()
             },
             wgt::Backends::NOOP,
-            None,
         )
         .unwrap();
 
-    let features = global.adapter_features(adapter_id);
+    let features = adapter.features();
 
     assert!(!features.contains(wgt::Features::SUBGROUP));
 }
@@ -274,7 +264,7 @@ fn subgroup_min_below_bucket() {
     // The uplevel buckets with smallest subgroup_min_size are M1 (4) and I1/I2 (8). We
     // construct a device that has subgroup_min_size = 7 and max_vertex_attributes = 29, so
     // that it will not qualify for any UPLEVEL bucket (which means it won't get subgroups).
-    let global = create_noop_global(wgt::NoopBackendOptions {
+    let instance = create_noop_instance(wgt::NoopBackendOptions {
         enable: true,
         device_type: Some(wgt::DeviceType::DiscreteGpu),
         subgroup_min_size: Some(7),
@@ -286,36 +276,35 @@ fn subgroup_min_below_bucket() {
         ..Default::default()
     });
 
-    let adapter_id = global
+    let adapter = instance
         .request_adapter(
             &wgt::RequestAdapterOptions {
                 apply_limit_buckets: true,
                 ..Default::default()
             },
             wgt::Backends::NOOP,
-            None,
         )
         .unwrap();
 
-    let features = global.adapter_features(adapter_id);
+    let features = adapter.features();
 
     assert!(!features.contains(wgt::Features::SUBGROUP));
 }
 
 #[test]
 fn enumerate_adapters_bucketing_enabled() {
-    let global = create_noop_global(wgt::NoopBackendOptions {
+    let instance = create_noop_instance(wgt::NoopBackendOptions {
         enable: true,
         device_type: Some(wgt::DeviceType::DiscreteGpu),
         features: Some(wgt::Features::SUBGROUP),
         ..Default::default()
     });
 
-    let adapters = global.enumerate_adapters(wgt::Backends::NOOP, true);
+    let adapters = instance.enumerate_adapters(wgt::Backends::NOOP, true);
     assert_eq!(adapters.len(), 1);
 
-    let adapter_id = adapters[0];
-    let limits = global.adapter_limits(adapter_id);
+    let adapter = &adapters[0];
+    let limits = adapter.limits();
 
     // With bucketing, should have bucketed limits
     assert_eq!(limits, wgt::Limits::defaults());
@@ -328,17 +317,17 @@ fn enumerate_adapters_bucketing_disabled() {
         ..wgt::Limits::default()
     };
 
-    let global = create_noop_global(wgt::NoopBackendOptions {
+    let instance = create_noop_instance(wgt::NoopBackendOptions {
         enable: true,
         limits: Some(custom_limits),
         ..Default::default()
     });
 
-    let adapters = global.enumerate_adapters(wgt::Backends::NOOP, false);
+    let adapters = instance.enumerate_adapters(wgt::Backends::NOOP, false);
     assert_eq!(adapters.len(), 1);
 
-    let adapter_id = adapters[0];
-    let limits = global.adapter_limits(adapter_id);
+    let adapter = &adapters[0];
+    let limits = adapter.limits();
 
     // Without bucketing, should have raw limits
     assert_eq!(limits.max_bind_groups, 99);

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -76,10 +76,11 @@ fn trace_test(test_type: TestType) {
         .downcast_ref::<wgc::device::trace::MemoryTrace>()
         .unwrap();
     let actions = trace.actions();
+    dbg!(actions);
 
     match test_type {
         TestType::Normal => {
-            let Some(Action::Submit(_, commands)) = actions.last() else {
+            let [.., Action::Submit(_, commands), Action::DropBuffer(_)] = actions else {
                 panic!("expected last action to be Submit");
             };
             assert_eq!(commands.len(), 1);

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -15,7 +15,7 @@ enum TestType {
 }
 
 fn trace_test(test_type: TestType) {
-    let global = wgc::global::Global::new(
+    let instance = wgc::instance::Instance::new(
         "test",
         wgt::instance::InstanceDescriptor {
             backends: wgt::Backends::NOOP,
@@ -27,86 +27,51 @@ fn trace_test(test_type: TestType) {
         },
         None,
     );
-    let adapter_id = global
-        .request_adapter(
-            &wgt::RequestAdapterOptions::default(),
-            wgt::Backends::NOOP,
-            None,
-        )
+    let adapter = instance
+        .request_adapter(&wgt::RequestAdapterOptions::default(), wgt::Backends::NOOP)
         .unwrap();
-    let (device_id, queue_id) = global
-        .adapter_request_device(
-            adapter_id,
-            &wgt::DeviceDescriptor {
-                trace: wgt::Trace::Memory,
-                ..Default::default()
-            },
-            None,
-            None,
-        )
+    let (device, queue) = adapter
+        .request_device(&wgt::DeviceDescriptor {
+            trace: wgt::Trace::Memory,
+            ..Default::default()
+        })
         .unwrap();
 
-    let (buffer_id, error) = global.device_create_buffer(
-        device_id,
-        &wgt::BufferDescriptor {
-            label: None,
-            size: 1024,
-            usage: wgt::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        },
-        None,
-    );
+    let (buffer, error) = device.create_buffer(&wgt::BufferDescriptor {
+        label: None,
+        size: 1024,
+        usage: wgt::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
     assert!(error.is_none());
 
-    let (encoder_id, error) = global.device_create_command_encoder(
-        device_id,
-        &wgt::CommandEncoderDescriptor::default(),
-        None,
-    );
+    let (encoder, error) = device.create_command_encoder(&wgt::CommandEncoderDescriptor::default());
     assert!(error.is_none());
 
     match test_type {
         TestType::Normal => {
-            global
-                .command_encoder_clear_buffer(encoder_id, buffer_id, 0, None)
-                .unwrap();
-            let (cmdbuf_id, error) = global.command_encoder_finish(
-                encoder_id,
-                &wgt::CommandBufferDescriptor::default(),
-                None,
-            );
+            encoder.clear_buffer(buffer, 0, None).unwrap();
+            let (cmdbuf, error) = encoder.finish(&wgt::CommandBufferDescriptor::default());
             assert!(error.is_none());
-            global.queue_submit(queue_id, &[cmdbuf_id]).unwrap();
+            queue.submit(&[cmdbuf]).unwrap();
         }
         TestType::FailedCommands => {
             // Try to clear past the end of the buffer.
-            global
-                .command_encoder_clear_buffer(encoder_id, buffer_id, 0, Some(2048))
-                .unwrap();
-            let (_cmdbuf_id, error) = global.command_encoder_finish(
-                encoder_id,
-                &wgt::CommandBufferDescriptor::default(),
-                None,
-            );
+            encoder.clear_buffer(buffer, 0, Some(2048)).unwrap();
+            let (_cmdbuf, error) = encoder.finish(&wgt::CommandBufferDescriptor::default());
             assert!(error.is_some());
         }
         TestType::FailedSubmit => {
             // Destroy the buffer after encoding the clear command, before submitting it.
-            global
-                .command_encoder_clear_buffer(encoder_id, buffer_id, 0, None)
-                .unwrap();
-            let (cmdbuf_id, error) = global.command_encoder_finish(
-                encoder_id,
-                &wgt::CommandBufferDescriptor::default(),
-                None,
-            );
+            encoder.clear_buffer(buffer.clone(), 0, None).unwrap();
+            let (cmdbuf, error) = encoder.finish(&wgt::CommandBufferDescriptor::default());
             assert!(error.is_none());
-            global.buffer_destroy(buffer_id);
-            global.queue_submit(queue_id, &[cmdbuf_id]).unwrap_err();
+            buffer.destroy();
+            queue.submit(&[cmdbuf]).unwrap_err();
         }
     }
 
-    let trace = global.device_take_trace(device_id).unwrap();
+    let trace = device.take_trace().unwrap();
     let trace = (trace.as_ref() as &dyn Any)
         .downcast_ref::<wgc::device::trace::MemoryTrace>()
         .unwrap();
@@ -190,7 +155,7 @@ fn trace_failed_submit() {
 
 #[test]
 fn trace_texture_test() {
-    let global = wgc::global::Global::new(
+    let instance = wgc::instance::Instance::new(
         "test",
         wgt::instance::InstanceDescriptor {
             backends: wgt::Backends::NOOP,
@@ -202,23 +167,14 @@ fn trace_texture_test() {
         },
         None,
     );
-    let adapter_id = global
-        .request_adapter(
-            &wgt::RequestAdapterOptions::default(),
-            wgt::Backends::NOOP,
-            None,
-        )
+    let adapter = instance
+        .request_adapter(&wgt::RequestAdapterOptions::default(), wgt::Backends::NOOP)
         .unwrap();
-    let (device_id, _) = global
-        .adapter_request_device(
-            adapter_id,
-            &wgt::DeviceDescriptor {
-                trace: wgt::Trace::Memory,
-                ..Default::default()
-            },
-            None,
-            None,
-        )
+    let (device, _) = adapter
+        .request_device(&wgt::DeviceDescriptor {
+            trace: wgt::Trace::Memory,
+            ..Default::default()
+        })
         .unwrap();
 
     let desc = wgt::TextureDescriptor {
@@ -236,16 +192,16 @@ fn trace_texture_test() {
         view_formats: Vec::new(),
     };
 
-    let (texture_id, error) = global.device_create_texture(device_id, &desc, None);
+    let (texture, error) = device.create_texture(&desc);
 
     assert!(error.is_none());
 
-    let texture_error_id = global.create_texture_error(device_id, None, &desc);
+    let texture_error = device.create_texture_error(&desc);
 
-    global.texture_drop(texture_id);
-    global.texture_drop(texture_error_id);
+    drop(texture);
+    drop(texture_error);
 
-    let trace = global.device_take_trace(device_id).unwrap();
+    let trace = device.take_trace().unwrap();
     let trace = (trace.as_ref() as &dyn Any)
         .downcast_ref::<wgc::device::trace::MemoryTrace>()
         .unwrap();


### PR DESCRIPTION
**Connections**
towards #5121 

**Description**
I've discovered this while moving global out of wgc.

**Testing**
Just refactor

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
