### PR TITLE
[core] Move remaining stuff from global into resource methods

### DIFF
--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2271,43 +2271,7 @@ impl Global {
     }
 
     pub fn render_pass_end(&self, pass: &mut RenderPass) -> Result<(), EncoderStateError> {
-        profiling::scope!(
-            "CommandEncoder::run_render_pass {}",
-            pass.base.label.as_deref().unwrap_or("")
-        );
-
-        let cmd_enc = pass.parent.take().ok_or(EncoderStateError::Ended)?;
-        let mut cmd_buf_data = cmd_enc.data.lock();
-
-        cmd_buf_data.unlock_encoder()?;
-
-        let base = pass.base.take();
-
-        if let Err(RenderPassError { inner, scope: _ }) = &base {
-            if let RenderPassErrorInner::EncoderState(
-                err @ (EncoderStateError::Locked | EncoderStateError::Ended),
-            ) = inner.as_ref()
-            {
-                // Most encoding errors are detected and raised within `finish()`.
-                //
-                // However, we raise a validation error here if the pass was opened
-                // within another pass, or on a finished encoder. The latter is
-                // particularly important, because in that case reporting errors via
-                // `CommandEncoder::finish` is not possible.
-                return Err(err.clone());
-            }
-        }
-
-        cmd_buf_data.push_with(|| -> Result<_, RenderPassError> {
-            Ok(ArcCommand::RunRenderPass {
-                pass: base?,
-                color_attachments: SmallVec::from(pass.color_attachments.as_slice()),
-                depth_stencil_attachment: pass.depth_stencil_attachment.take(),
-                timestamp_writes: pass.timestamp_writes.take(),
-                occlusion_query_set: pass.occlusion_query_set.take(),
-                multiview_mask: pass.multiview_mask,
-            })
-        })
+        pass.end()
     }
 
     pub fn render_pass_end_with_id(

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1841,8 +1841,16 @@ impl Queue {
         Ok(SubmissionResult { snatch_guard })
     }
 
-    pub fn get_timestamp_period(&self) -> f32 {
+    pub(crate) fn get_raw_timestamp_period(&self) -> f32 {
         unsafe { self.raw().get_timestamp_period() }
+    }
+
+    pub fn get_timestamp_period(&self) -> f32 {
+        if self.device.timestamp_normalizer.get().unwrap().enabled() {
+            return 1.0;
+        }
+
+        self.get_raw_timestamp_period()
     }
 
     /// `closure` is guaranteed to be called.
@@ -2100,10 +2108,6 @@ impl Global {
 
     pub fn queue_get_timestamp_period(&self, queue_id: QueueId) -> f32 {
         let queue = self.hub.queues.get(queue_id);
-
-        if queue.device.timestamp_normalizer.get().unwrap().enabled() {
-            return 1.0;
-        }
 
         queue.get_timestamp_period()
     }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -912,6 +912,18 @@ impl Queue {
         profiling::scope!("Queue::write_texture");
         api_log!("Queue::write_texture");
 
+        #[cfg(feature = "trace")]
+        if let Some(ref mut trace) = *self.device.trace.lock() {
+            use crate::device::trace::DataKind;
+            let data = trace.make_binary(DataKind::Bin, data);
+            trace.add(Action::WriteTexture {
+                to: destination.to_trace(),
+                data,
+                layout: *data_layout,
+                size: *size,
+            });
+        }
+
         self.device.check_is_valid()?;
 
         let dst = destination.texture;
@@ -2047,18 +2059,6 @@ impl Global {
             origin: destination.origin,
             aspect: destination.aspect,
         };
-
-        #[cfg(feature = "trace")]
-        if let Some(ref mut trace) = *queue.device.trace.lock() {
-            use crate::device::trace::DataKind;
-            let data = trace.make_binary(DataKind::Bin, data);
-            trace.add(Action::WriteTexture {
-                to: destination.to_trace(),
-                data,
-                layout: *data_layout,
-                size: *size,
-            });
-        }
 
         queue.write_texture(destination, data, data_layout, size)
     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -765,7 +765,7 @@ impl Device {
 
         let timestamp_normalizer = crate::timestamp_normalization::TimestampNormalizer::new(
             self,
-            queue.get_timestamp_period(),
+            queue.get_raw_timestamp_period(),
         )?;
 
         self.timestamp_normalizer


### PR DESCRIPTION
**Connections**
Towards #5121 

**Description**
Discovered in #10053 

**Testing**
Just refactor

**Squash or Rebase?**
Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
