### PR TITLE
fix(core): Fixes for initialization tracking of render targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Fix required immediate slots calculation and remove `naga::valid::FunctionInfo::immediate_slots_used`. By @beicause in [#9725](https://github.com/gfx-rs/wgpu/pull/9725).
 - Fix a spurious assertion failure in `Device::maintain` when multiple threads race polling the same device. By @AdrianEddy in [#9958](https://github.com/gfx-rs/wgpu/pull/9958).
 - Fix `PendingSubmission` releasing its lock guards out of stacking order, which tripped `--cfg wgpu_validate_locks` on any submission. By @AdrianEddy in [#9960](https://github.com/gfx-rs/wgpu/pull/9960).
-- Fixed some cases where initialization tracking was not correct. By @andyleiserson in [#10002](https://github.com/gfx-rs/wgpu/pull/10002).
+- Fix initialization tracking for some cases of array textures, 3d textures, and depth/stencil textures with divergent usage in a render pass. By @andyleiserson in [#10002](https://github.com/gfx-rs/wgpu/pull/10002) and [#10060](https://github.com/gfx-rs/wgpu/pull/10060).
 
 #### naga
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -16,7 +16,6 @@ webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_t
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth24plus-stencil8";depthReadOnly=true;stencilReadOnly=false // https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=false;stencilReadOnly=true // https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=true;stencilReadOnly=false // https://github.com/gfx-rs/wgpu/issues/8705
-webgpu:api,operation,rendering,3d_texture_slices:* // https://github.com/gfx-rs/wgpu/issues/9455
 
 webgpu:api,validation,buffer,create:new_usages,* // 0%, deno_webgpu declares the GPU*Usage constants as static getters, which are non-enumerable, so the test sees no legal usage bits, https://github.com/denoland/deno/issues/33846
 webgpu:api,validation,buffer,mapping:* // crash

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -55,6 +55,7 @@ webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_t
 webgpu:api,operation,render_pass,*
 webgpu:api,operation,render_pipeline,overrides:*
 webgpu:api,operation,render_pipeline,pipeline_output_targets:color,component_count,blend:*
+webgpu:api,operation,rendering,3d_texture_slices:*
 webgpu:api,operation,rendering,basic:clear:*
 webgpu:api,operation,rendering,basic:fullscreen_quad:*
 //FAIL: webgpu:api,operation,rendering,basic:large_draw:*

--- a/tests/src/copy_texture_to_buffer.wgsl
+++ b/tests/src/copy_texture_to_buffer.wgsl
@@ -6,12 +6,12 @@ var<storage, read_write> output: array<{{type}}>;
 
 @compute @workgroup_size(1)
 fn copy_texture_to_buffer() {
-    let layers = i32(textureNumLayers(texture));
+    let layers = textureNumLayers(texture);
     let dim = textureDimensions(texture);
-    for (var l = 0; l < layers; l++) {
+    for (var l = 0u; l < layers; l++) {
         for (var y = 0u; y < dim.y; y++) {
             for (var x = 0u; x < dim.x; x++) {
-                output[x + y * dim.x] = textureLoad(texture, vec2(x, y), l, 0).x;
+                output[(l * dim.y + y) * dim.x + x] = textureLoad(texture, vec2(x, y), l, 0).x;
             }
         }
     }

--- a/tests/src/image.rs
+++ b/tests/src/image.rs
@@ -275,13 +275,131 @@ fn sanitize_for_path(s: &str) -> String {
         .collect()
 }
 
+/// Value that readback buffers are filled with before use, so that a copy that fails to
+/// happen is not mistaken for zeroed memory.
+const POISON: u8 = 255;
+
+/// Layout of one mip level of one aspect of a texture within a readback buffer.
+///
+/// The array layers (for `D2` textures) or depth slices (for `D3`) of a mip level are laid
+/// out consecutively within its region, each `bytes_per_row * rows_per_image` bytes long.
+#[derive(Clone, Copy, Debug)]
+struct MipLayout {
+    /// Byte offset of this mip level's region within the buffer. A multiple of
+    /// [`COPY_BYTES_PER_ROW_ALIGNMENT`], which satisfies every alignment requirement that
+    /// applies: copy offsets, storage binding offsets, and buffer mapping.
+    offset: u64,
+    /// Row stride within the buffer. Aligned to [`COPY_BYTES_PER_ROW_ALIGNMENT`], which
+    /// `copy_texture_to_buffer` requires, except on the compute shader path, whose shader
+    /// writes tightly packed rows.
+    bytes_per_row: u32,
+    /// Bytes of texel data in each row, without the padding included in `bytes_per_row`.
+    unpadded_bytes_per_row: u32,
+    /// Number of block rows in each array layer or depth slice.
+    rows_per_image: u32,
+    /// Physical (block aligned) extent of this mip level.
+    size: Extent3d,
+    /// Bytes reserved for this mip level, including the padding that keeps the offset of
+    /// the next mip level aligned.
+    region_size: u64,
+}
+
+impl MipLayout {
+    /// Bytes of texel data in one array layer or depth slice, excluding row padding.
+    fn unpadded_subresource_size(&self) -> usize {
+        self.unpadded_bytes_per_row as usize * self.rows_per_image as usize
+    }
+
+    /// Bytes of texel data in this mip level, excluding all padding.
+    fn unpadded_size(&self) -> usize {
+        self.unpadded_subresource_size() * self.size.depth_or_array_layers as usize
+    }
+}
+
+/// Whether the readable aspect of `format` has to be read with a compute shader because it
+/// cannot be the source of a `copy_texture_to_buffer`.
+fn needs_compute_readback(format: TextureFormat) -> bool {
+    matches!(
+        format,
+        TextureFormat::Depth24Plus | TextureFormat::Depth24PlusStencil8
+    )
+}
+
+/// Compute the layout of every mip level of one aspect of `texture`.
+///
+/// When `dense_rows` is `true`, computes a layout with tightly packed rows for
+/// the compute shader path. When false, computes a layout with padding to
+/// `COPY_BYTES_PER_ROW_ALIGNMENT` for `copy_texture_to_buffer`.
+fn mip_layouts(
+    texture: &Texture,
+    aspect: Option<TextureAspect>,
+    dense_rows: bool,
+) -> Vec<MipLayout> {
+    let format = texture.format();
+    let (block_width, block_height) = format.block_dimensions();
+    // `block_copy_size` returns `None` for the aspects that are read with a compute
+    // shader, which writes one `f32` or `u32` per texel.
+    let block_size = format.block_copy_size(aspect).unwrap_or(4);
+
+    let mut offset = 0;
+    (0..texture.mip_level_count())
+        .map(|mip_level| {
+            // The physical size is what a copy of a whole mip level must use, and it is
+            // what the buffer has to hold: for a compressed format, the last row or
+            // column of blocks extends past the logical size.
+            let size = texture
+                .size()
+                .mip_level_size(mip_level, texture.dimension())
+                .physical_size(format);
+            let unpadded_bytes_per_row = (size.width / block_width) * block_size;
+            let bytes_per_row = if dense_rows {
+                unpadded_bytes_per_row
+            } else {
+                align_to(unpadded_bytes_per_row, COPY_BYTES_PER_ROW_ALIGNMENT)
+            };
+            let rows_per_image = size.height / block_height;
+            let layout = MipLayout {
+                offset,
+                bytes_per_row,
+                unpadded_bytes_per_row,
+                rows_per_image,
+                size,
+                region_size: align_to(
+                    u64::from(bytes_per_row)
+                        * u64::from(rows_per_image)
+                        * u64::from(size.depth_or_array_layers),
+                    u64::from(COPY_BYTES_PER_ROW_ALIGNMENT),
+                ),
+            };
+            offset += layout.region_size;
+            layout
+        })
+        .collect()
+}
+
+fn create_readback_buffer(device: &Device, label: &str, layouts: &[MipLayout]) -> Buffer {
+    let size = layouts.last().map_or(0, |l| l.offset + l.region_size);
+    device.create_buffer_init(&util::BufferInitDescriptor {
+        label: Some(label),
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        contents: &vec![POISON; size as usize],
+    })
+}
+
 fn copy_via_compute(
     device: &Device,
     encoder: &mut CommandEncoder,
     texture: &Texture,
     buffer: &Buffer,
+    layouts: &[MipLayout],
     aspect: TextureAspect,
 ) {
+    assert_eq!(
+        texture.dimension(),
+        TextureDimension::D2,
+        "the compute shader readback path binds the texture as `D2Array`"
+    );
+
     let bgl = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         label: None,
         entries: &[
@@ -312,37 +430,47 @@ fn copy_via_compute(
         ],
     });
 
-    let view = texture.create_view(&TextureViewDescriptor {
-        aspect,
-        dimension: Some(TextureViewDimension::D2Array),
-        ..Default::default()
-    });
-
-    let output_buffer = device.create_buffer(&BufferDescriptor {
+    // The shader writes one texel at a time, so anything it fails to cover keeps the
+    // poison value rather than reading back as zero.
+    let output_buffer = device.create_buffer_init(&util::BufferInitDescriptor {
         label: Some("output buffer"),
-        size: buffer.size(),
         usage: BufferUsages::COPY_SRC | BufferUsages::STORAGE,
-        mapped_at_creation: false,
+        contents: &vec![POISON; buffer.size() as usize],
     });
 
-    let bg = device.create_bind_group(&BindGroupDescriptor {
-        label: None,
-        layout: &bgl,
-        entries: &[
-            BindGroupEntry {
-                binding: 0,
-                resource: BindingResource::TextureView(&view),
-            },
-            BindGroupEntry {
-                binding: 1,
-                resource: BindingResource::Buffer(BufferBinding {
-                    buffer: &output_buffer,
-                    offset: 0,
-                    size: None,
-                }),
-            },
-        ],
-    });
+    // A view of a single mip level rebases mip level 0 onto it, so the shader reads the
+    // right level without knowing which one it is.
+    let bind_groups: Vec<BindGroup> = layouts
+        .iter()
+        .enumerate()
+        .map(|(mip_level, layout)| {
+            let view = texture.create_view(&TextureViewDescriptor {
+                aspect,
+                dimension: Some(TextureViewDimension::D2Array),
+                base_mip_level: mip_level as u32,
+                mip_level_count: Some(1),
+                ..Default::default()
+            });
+            device.create_bind_group(&BindGroupDescriptor {
+                label: None,
+                layout: &bgl,
+                entries: &[
+                    BindGroupEntry {
+                        binding: 0,
+                        resource: BindingResource::TextureView(&view),
+                    },
+                    BindGroupEntry {
+                        binding: 1,
+                        resource: BindingResource::Buffer(BufferBinding {
+                            buffer: &output_buffer,
+                            offset: layout.offset,
+                            size: BufferSize::new(layout.region_size),
+                        }),
+                    },
+                ],
+            })
+        })
+        .collect();
 
     let pll = device.create_pipeline_layout(&PipelineLayoutDescriptor {
         label: None,
@@ -379,241 +507,180 @@ fn copy_via_compute(
         let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor::default());
 
         pass.set_pipeline(&pipeline_copy);
-        pass.set_bind_group(0, &bg, &[]);
-        pass.dispatch_workgroups(1, 1, 1);
+        for bind_group in &bind_groups {
+            pass.set_bind_group(0, bind_group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
     }
 
-    encoder.copy_buffer_to_buffer(&output_buffer, 0, buffer, 0, buffer.size());
+    encoder.copy_buffer_to_buffer(&output_buffer, 0, buffer, 0, output_buffer.size());
 }
 
 fn copy_texture_to_buffer_with_aspect(
     encoder: &mut CommandEncoder,
     texture: &Texture,
     buffer: &Buffer,
-    buffer_stencil: &Option<Buffer>,
+    layouts: &[MipLayout],
     aspect: TextureAspect,
 ) {
-    let (block_width, block_height) = texture.format().block_dimensions();
-    let block_size = texture.format().block_copy_size(Some(aspect)).unwrap();
-    let bytes_per_row = align_to(
-        (texture.width() / block_width) * block_size,
-        COPY_BYTES_PER_ROW_ALIGNMENT,
-    );
-    let mip_level = 0;
-    encoder.copy_texture_to_buffer(
-        TexelCopyTextureInfo {
-            texture,
-            mip_level,
-            origin: Origin3d::ZERO,
-            aspect,
-        },
-        TexelCopyBufferInfo {
-            buffer: match aspect {
-                TextureAspect::StencilOnly => buffer_stencil.as_ref().unwrap(),
-                _ => buffer,
+    for (mip_level, layout) in layouts.iter().enumerate() {
+        encoder.copy_texture_to_buffer(
+            TexelCopyTextureInfo {
+                texture,
+                mip_level: mip_level as u32,
+                origin: Origin3d::ZERO,
+                aspect,
             },
-            layout: TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(bytes_per_row),
-                rows_per_image: Some(texture.height() / block_height),
+            TexelCopyBufferInfo {
+                buffer,
+                layout: TexelCopyBufferLayout {
+                    offset: layout.offset,
+                    bytes_per_row: Some(layout.bytes_per_row),
+                    rows_per_image: Some(layout.rows_per_image),
+                },
             },
-        },
-        texture
-            .size()
-            .mip_level_size(mip_level, texture.dimension()),
-    );
-}
-
-fn copy_texture_to_buffer(
-    device: &Device,
-    encoder: &mut CommandEncoder,
-    texture: &Texture,
-    buffer: &Buffer,
-    buffer_stencil: &Option<Buffer>,
-) {
-    match texture.format() {
-        TextureFormat::Depth24Plus => {
-            copy_via_compute(device, encoder, texture, buffer, TextureAspect::DepthOnly);
-        }
-        TextureFormat::Depth24PlusStencil8 => {
-            copy_via_compute(device, encoder, texture, buffer, TextureAspect::DepthOnly);
-            copy_texture_to_buffer_with_aspect(
-                encoder,
-                texture,
-                buffer,
-                buffer_stencil,
-                TextureAspect::StencilOnly,
-            );
-        }
-        TextureFormat::Depth32FloatStencil8 => {
-            copy_texture_to_buffer_with_aspect(
-                encoder,
-                texture,
-                buffer,
-                buffer_stencil,
-                TextureAspect::DepthOnly,
-            );
-            copy_texture_to_buffer_with_aspect(
-                encoder,
-                texture,
-                buffer,
-                buffer_stencil,
-                TextureAspect::StencilOnly,
-            );
-        }
-        _ => {
-            copy_texture_to_buffer_with_aspect(
-                encoder,
-                texture,
-                buffer,
-                buffer_stencil,
-                TextureAspect::All,
-            );
-        }
+            layout.size,
+        );
     }
 }
 
+/// Buffers holding a readback of every mip level and every array layer or depth slice of a
+/// texture.
 pub struct ReadbackBuffers {
-    /// texture format
+    /// format of the texture this was created for
     texture_format: TextureFormat,
-    /// texture width
-    texture_width: u32,
-    /// texture height
-    texture_height: u32,
-    /// texture depth or array layer count
-    texture_depth_or_array_layers: u32,
     /// buffer for color or depth aspects
     buffer: Buffer,
+    /// layout of `buffer`, one entry per mip level
+    layouts: Vec<MipLayout>,
     /// buffer for stencil aspect
     buffer_stencil: Option<Buffer>,
+    /// layout of `buffer_stencil`, empty if there is none
+    stencil_layouts: Vec<MipLayout>,
 }
 
 impl ReadbackBuffers {
     pub fn new(device: &Device, texture: &Texture) -> Self {
-        let (block_width, block_height) = texture.format().block_dimensions();
-        const SKIP_ALIGNMENT_FORMATS: [TextureFormat; 2] = [
-            TextureFormat::Depth24Plus,
-            TextureFormat::Depth24PlusStencil8,
-        ];
-        let should_align_buffer_size = !SKIP_ALIGNMENT_FORMATS.contains(&texture.format());
-        if texture.format().is_combined_depth_stencil_format() {
-            let mut buffer_depth_bytes_per_row = (texture.width() / block_width)
-                * texture
-                    .format()
-                    .block_copy_size(Some(TextureAspect::DepthOnly))
-                    .unwrap_or(4);
-            if should_align_buffer_size {
-                buffer_depth_bytes_per_row =
-                    align_to(buffer_depth_bytes_per_row, COPY_BYTES_PER_ROW_ALIGNMENT);
-            }
-            let buffer_size = buffer_depth_bytes_per_row
-                * (texture.height() / block_height)
-                * texture.depth_or_array_layers();
+        let texture_format = texture.format();
+        let combined = texture_format.is_combined_depth_stencil_format();
 
-            let buffer_stencil_bytes_per_row = align_to(
-                (texture.width() / block_width)
-                    * texture
-                        .format()
-                        .block_copy_size(Some(TextureAspect::StencilOnly))
-                        .unwrap_or(4),
-                COPY_BYTES_PER_ROW_ALIGNMENT,
-            );
-            let buffer_stencil_size = buffer_stencil_bytes_per_row
-                * (texture.height() / block_height)
-                * texture.depth_or_array_layers();
+        // When using the compute shader path (`depth24plus` and
+        // `depth24plus-stencil8`), rows are packed tightly instead of padded to
+        // `COPY_BYTES_PER_ROW_ALIGNMENT`.
+        let layouts = mip_layouts(
+            texture,
+            combined.then_some(TextureAspect::DepthOnly),
+            needs_compute_readback(texture_format),
+        );
+        let buffer = create_readback_buffer(device, "Texture Readback", &layouts);
 
-            let buffer = device.create_buffer_init(&util::BufferInitDescriptor {
-                label: Some("Texture Readback"),
-                usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
-                contents: &vec![255; buffer_size as usize],
-            });
-            let buffer_stencil = device.create_buffer_init(&util::BufferInitDescriptor {
-                label: Some("Texture Stencil-Aspect Readback"),
-                usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
-                contents: &vec![255; buffer_stencil_size as usize],
-            });
-            ReadbackBuffers {
-                texture_format: texture.format(),
-                texture_width: texture.width(),
-                texture_height: texture.height(),
-                texture_depth_or_array_layers: texture.depth_or_array_layers(),
-                buffer,
-                buffer_stencil: Some(buffer_stencil),
-            }
+        let (buffer_stencil, stencil_layouts) = if combined {
+            let layouts = mip_layouts(texture, Some(TextureAspect::StencilOnly), false);
+            let buffer =
+                create_readback_buffer(device, "Texture Stencil-Aspect Readback", &layouts);
+            (Some(buffer), layouts)
         } else {
-            let mut bytes_per_row = (texture.width() / block_width)
-                * texture.format().block_copy_size(None).unwrap_or(4);
-            if should_align_buffer_size {
-                bytes_per_row = align_to(bytes_per_row, COPY_BYTES_PER_ROW_ALIGNMENT);
-            }
-            let buffer_size =
-                bytes_per_row * (texture.height() / block_height) * texture.depth_or_array_layers();
-            let buffer = device.create_buffer_init(&util::BufferInitDescriptor {
-                label: Some("Texture Readback"),
-                usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
-                contents: &vec![255; buffer_size as usize],
-            });
-            ReadbackBuffers {
-                texture_format: texture.format(),
-                texture_width: texture.width(),
-                texture_height: texture.height(),
-                texture_depth_or_array_layers: texture.depth_or_array_layers(),
-                buffer,
-                buffer_stencil: None,
-            }
+            (None, Vec::new())
+        };
+
+        ReadbackBuffers {
+            texture_format,
+            buffer,
+            layouts,
+            buffer_stencil,
+            stencil_layouts,
         }
     }
 
-    // TODO: also copy and check mips
     pub fn copy_from(&self, device: &Device, encoder: &mut CommandEncoder, texture: &Texture) {
-        copy_texture_to_buffer(device, encoder, texture, &self.buffer, &self.buffer_stencil);
+        assert_eq!(
+            (texture.format(), texture.mip_level_count() as usize),
+            (self.texture_format, self.layouts.len()),
+            "texture does not match the one this `ReadbackBuffers` was created for"
+        );
+
+        if needs_compute_readback(self.texture_format) {
+            copy_via_compute(
+                device,
+                encoder,
+                texture,
+                &self.buffer,
+                &self.layouts,
+                TextureAspect::DepthOnly,
+            );
+        } else {
+            let aspect = if self.buffer_stencil.is_some() {
+                TextureAspect::DepthOnly
+            } else {
+                TextureAspect::All
+            };
+            copy_texture_to_buffer_with_aspect(
+                encoder,
+                texture,
+                &self.buffer,
+                &self.layouts,
+                aspect,
+            );
+        }
+
+        if let Some(buffer_stencil) = &self.buffer_stencil {
+            copy_texture_to_buffer_with_aspect(
+                encoder,
+                texture,
+                buffer_stencil,
+                &self.stencil_layouts,
+                TextureAspect::StencilOnly,
+            );
+        }
     }
 
+    /// Map `buffer` and return its texel data, tightly packed, with the row padding that
+    /// `layouts` describes removed. Mip level 0 comes first.
+    ///
+    /// The caller is responsible for unmapping `buffer`.
     async fn retrieve_buffer(
         &self,
         ctx: &TestingContext,
         buffer: &Buffer,
-        aspect: Option<TextureAspect>,
+        layouts: &[MipLayout],
     ) -> Vec<u8> {
         let buffer_slice = buffer.slice(..);
         buffer_slice.map_async(MapMode::Read, |_| ());
         ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
-        let (block_width, block_height) = self.texture_format.block_dimensions();
-        let expected_bytes_per_row = (self.texture_width / block_width)
-            * self.texture_format.block_copy_size(aspect).unwrap_or(4);
-        let expected_buffer_size = expected_bytes_per_row
-            * (self.texture_height / block_height)
-            * self.texture_depth_or_array_layers;
         let data: BufferView = buffer_slice.get_mapped_range().unwrap();
-        if expected_buffer_size as usize == data.len() {
-            data.to_vec()
-        } else {
-            bytemuck::cast_slice(&data)
-                .chunks_exact(
-                    align_to(expected_bytes_per_row, COPY_BYTES_PER_ROW_ALIGNMENT) as usize,
-                )
-                .flat_map(|x| x.iter().take(expected_bytes_per_row as usize))
-                .copied()
-                .collect()
+
+        let mut result = Vec::with_capacity(layouts.iter().map(MipLayout::unpadded_size).sum());
+        for layout in layouts {
+            let start = layout.offset as usize;
+            let rows = layout.rows_per_image as usize * layout.size.depth_or_array_layers as usize;
+            let region = &data[start..start + layout.bytes_per_row as usize * rows];
+            for row in region.chunks_exact(layout.bytes_per_row as usize) {
+                result.extend_from_slice(&row[..layout.unpadded_bytes_per_row as usize]);
+            }
+        }
+        result
+    }
+
+    /// Read back one aspect of the texture.
+    ///
+    /// Reads the stencil buffer if `aspect` is [`TextureAspect::StencilOnly`] and the
+    /// texture has a separate stencil aspect, and the color or depth buffer otherwise.
+    pub async fn retrieve(&self, ctx: &TestingContext, aspect: TextureAspect) -> ReadbackData {
+        let (buffer, layouts) = match (aspect, &self.buffer_stencil) {
+            (TextureAspect::StencilOnly, Some(buffer)) => (buffer, &self.stencil_layouts),
+            _ => (&self.buffer, &self.layouts),
+        };
+        let data = self.retrieve_buffer(ctx, buffer, layouts).await;
+        buffer.unmap();
+        ReadbackData {
+            data,
+            layouts: layouts.clone(),
         }
     }
 
-    fn buffer_aspect(&self) -> Option<TextureAspect> {
-        if self.texture_format.is_combined_depth_stencil_format() {
-            Some(TextureAspect::DepthOnly)
-        } else {
-            None
-        }
-    }
-
-    async fn is_zero(
-        &self,
-        ctx: &TestingContext,
-        buffer: &Buffer,
-        aspect: Option<TextureAspect>,
-    ) -> bool {
+    async fn is_zero(&self, ctx: &TestingContext, buffer: &Buffer, layouts: &[MipLayout]) -> bool {
         let is_zero = self
-            .retrieve_buffer(ctx, buffer, aspect)
+            .retrieve_buffer(ctx, buffer, layouts)
             .await
             .iter()
             .all(|b| *b == 0);
@@ -622,16 +689,18 @@ impl ReadbackBuffers {
     }
 
     pub async fn are_zero(&self, ctx: &TestingContext) -> bool {
-        let buffer_zero = self.is_zero(ctx, &self.buffer, self.buffer_aspect()).await;
+        let buffer_zero = self.is_zero(ctx, &self.buffer, &self.layouts).await;
         let mut stencil_buffer_zero = true;
         if let Some(buffer) = &self.buffer_stencil {
-            stencil_buffer_zero = self
-                .is_zero(ctx, buffer, Some(TextureAspect::StencilOnly))
-                .await;
+            stencil_buffer_zero = self.is_zero(ctx, buffer, &self.stencil_layouts).await;
         };
         buffer_zero && stencil_buffer_zero
     }
 
+    /// Assert that the color or depth aspect starts with `expected_data`.
+    ///
+    /// Only a prefix of the readback is checked, so for a texture with more than one mip
+    /// level this covers mip level 0 alone unless `expected_data` holds every mip level.
     pub async fn assert_buffer_contents(&self, ctx: &TestingContext, expected_data: &[u8]) {
         self.assert_buffer_contents_imprecise(ctx, expected_data, 0)
             .await;
@@ -643,9 +712,7 @@ impl ReadbackBuffers {
         expected_data: &[u8],
         max_diff: u8,
     ) {
-        let result_buffer = self
-            .retrieve_buffer(ctx, &self.buffer, self.buffer_aspect())
-            .await;
+        let result_buffer = self.retrieve_buffer(ctx, &self.buffer, &self.layouts).await;
         assert!(
             result_buffer.len() >= expected_data.len(),
             "Result buffer ({}) smaller than expected buffer ({})",
@@ -658,5 +725,38 @@ impl ReadbackBuffers {
             .zip(expected_data)
             .all(|(a, b)| a.abs_diff(*b) <= max_diff));
         self.buffer.unmap();
+    }
+}
+
+/// Tightly packed contents of one aspect of a texture, as read back by
+/// [`ReadbackBuffers::retrieve`].
+pub struct ReadbackData {
+    data: Vec<u8>,
+    layouts: Vec<MipLayout>,
+}
+
+impl ReadbackData {
+    /// Every mip level, tightly packed, mip level 0 first.
+    pub fn all(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Contents of one array layer (for a `D2` texture) or depth slice (for `D3`) of one
+    /// mip level, tightly packed.
+    pub fn subresource(&self, mip_level: u32, index: u32) -> &[u8] {
+        let layouts = &self.layouts[..mip_level as usize + 1];
+        let (layout, preceding) = layouts.split_last().unwrap();
+        assert!(
+            index < layout.size.depth_or_array_layers,
+            "mip level {mip_level} has {} array layers or depth slices, asked for {index}",
+            layout.size.depth_or_array_layers,
+        );
+        let size = layout.unpadded_subresource_size();
+        let start = preceding
+            .iter()
+            .map(MipLayout::unpadded_size)
+            .sum::<usize>()
+            + index as usize * size;
+        &self.data[start..start + size]
     }
 }

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -9,8 +9,9 @@ use core::num::NonZeroU64;
 use wgpu::util::DeviceExt as _;
 use wgpu::*;
 use wgpu_test::{
-    apply, gpu_test, image::ReadbackBuffers, FailureCase, GpuTestConfiguration, GpuTestInitializer,
-    TestParameters, TestingContext,
+    apply, gpu_test,
+    image::{ReadbackBuffers, ReadbackData},
+    FailureCase, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
 };
 
 /// A way to write data into a texture.
@@ -52,10 +53,22 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
         COPY_BUFFER_TO_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12,
         COPY_BUFFER_TO_TEXTURE_STENCIL_LEAVES_DEPTH_UNINIT_DEPTH32FLOAT_STENCIL8,
-        DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_AFTER_SUBMIT,
-        DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_IN_SAME_ENCODER,
-        DISCARDING_DEPTH_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_IN_SAME_ENCODER,
+        DISCARDING_3D_DEPTH_SLICE_PRESERVES_OTHER_SLICES,
+        DISCARDING_BOTH_DEPTH_AND_STENCIL_WITH_DIVERGING_LOAD_OPS,
+        DISCARDING_COLOR_TARGET_AT_NONZERO_MIP_AND_LAYER,
+        DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE,
+        DISCARDING_COLOR_TARGET_THEN_LOADING_IT_IN_SAME_ENCODER,
+        DISCARDING_DEPTH_TARGET_AT_NONZERO_MIP_AND_LAYER,
+        DISCARDING_DEPTH_TARGET_AT_NONZERO_MIP_AND_LAYER_DEPTH32FLOAT_STENCIL8,
+        DISCARDING_DEPTH_TARGET_RESETS_TEXTURE_INIT_STATE,
+        DISCARDING_DEPTH_TARGET_RESETS_TEXTURE_INIT_STATE_DEPTH32FLOAT_STENCIL8,
+        DISCARDING_EITHER_DEPTH_OR_STENCIL_ASPECT_AT_NONZERO_MIP_AND_LAYER,
         DISCARDING_EITHER_DEPTH_OR_STENCIL_ASPECT_TEST,
+        RENDER_PASS_LOAD_INITS_WHOLE_3D_MIP,
+        RENDER_PASS_STORE_INITS_ONLY_TARGET_3D_MIP,
+        RENDER_PASS_STORE_INITS_ONLY_TARGET_COLOR_SUBRESOURCE,
+        RENDER_PASS_STORE_INITS_ONLY_TARGET_DEPTH_STENCIL_SUBRESOURCE,
+        RENDER_PASS_STORE_TO_3D_DEPTH_SLICE_INITS_OTHER_SLICES,
         WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12,
         WRITE_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_P010,
         WRITE_TEXTURE_PLANE1_LEAVES_PLANE0_UNINIT_NV12,
@@ -76,64 +89,47 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     ]);
 }
 
-// Checks if discarding a color target resets its init state, causing a zero read of this texture when copied in after submit of the encoder.
+// Checks if discarding a color target resets its init state, causing a zero read of this texture
+// when copied in the same encoder as the discarding pass, or in a later one.
 #[apply(gpu_test!)]
-static DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_AFTER_SUBMIT:
-    GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().expect_fail(FailureCase::webgl2()))
-    .run_async(|mut ctx| async move {
-        let mut case = DiscardTestCase::new(&mut ctx, TextureFormat::Rgba8UnormSrgb);
-        case.create_command_encoder();
-        case.discard();
-        case.submit_command_encoder();
+static DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        // https://github.com/gfx-rs/wgpu/issues/10162
+        .parameters(TestParameters::default().expect_fail(FailureCase::webgl2()))
+        .run_async(|ctx| async move {
+            check_discard_resets_whole_texture(&ctx, TextureFormat::Rgba8UnormSrgb).await;
+        });
 
-        case.create_command_encoder();
-        case.copy_texture_to_buffer();
-        case.submit_command_encoder();
-
-        case.assert_buffers_are_zero().await;
-    });
-
+// As above, for depth/stencil targets.
 #[apply(gpu_test!)]
-static DISCARDING_COLOR_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_IN_SAME_ENCODER:
-    GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(TestParameters::default().expect_fail(FailureCase::webgl2()))
-    .run_async(|mut ctx| async move {
-        let mut case = DiscardTestCase::new(&mut ctx, TextureFormat::Rgba8UnormSrgb);
-        case.create_command_encoder();
-        case.discard();
-        case.copy_texture_to_buffer();
-        case.submit_command_encoder();
+static DISCARDING_DEPTH_TARGET_RESETS_TEXTURE_INIT_STATE: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .downlevel_flags(
+                    DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES
+                        | DownlevelFlags::COMPUTE_SHADERS,
+                )
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            for &format in CORE_DEPTH_STENCIL_FORMATS {
+                check_discard_resets_whole_texture(&ctx, format).await;
+            }
+        });
 
-        case.assert_buffers_are_zero().await;
-    });
-
+// As above, for the depth/stencil format that is behind an optional feature.
 #[apply(gpu_test!)]
-static DISCARDING_DEPTH_TARGET_RESETS_TEXTURE_INIT_STATE_CHECK_VISIBLE_ON_COPY_IN_SAME_ENCODER:
+static DISCARDING_DEPTH_TARGET_RESETS_TEXTURE_INIT_STATE_DEPTH32FLOAT_STENCIL8:
     GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .downlevel_flags(
-                DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES | DownlevelFlags::COMPUTE_SHADERS,
-            )
+            .features(Features::DEPTH32FLOAT_STENCIL8)
+            .downlevel_flags(DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES)
             .limits(Limits::downlevel_defaults()),
     )
-    .run_async(|mut ctx| async move {
-        for format in [
-            TextureFormat::Stencil8,
-            TextureFormat::Depth16Unorm,
-            TextureFormat::Depth24Plus,
-            TextureFormat::Depth24PlusStencil8,
-            TextureFormat::Depth32Float,
-        ] {
-            let mut case = DiscardTestCase::new(&mut ctx, format);
-            case.create_command_encoder();
-            case.discard();
-            case.copy_texture_to_buffer();
-            case.submit_command_encoder();
-
-            case.assert_buffers_are_zero().await;
-        }
+    .run_async(|ctx| async move {
+        check_discard_resets_whole_texture(&ctx, TextureFormat::Depth32FloatStencil8).await;
     });
 
 #[apply(gpu_test!)]
@@ -147,21 +143,21 @@ static DISCARDING_EITHER_DEPTH_OR_STENCIL_ASPECT_TEST: GpuTestConfiguration =
                 )
                 .limits(Limits::downlevel_defaults()),
         )
-        .run_async(|mut ctx| async move {
-            for format in [
-                TextureFormat::Stencil8,
-                TextureFormat::Depth16Unorm,
-                TextureFormat::Depth24Plus,
-                TextureFormat::Depth24PlusStencil8,
-                TextureFormat::Depth32Float,
-            ] {
-                let mut case = DiscardTestCase::new(&mut ctx, format);
+        .run_async(|ctx| async move {
+            for &format in CORE_DEPTH_STENCIL_FORMATS {
+                let mut case = discard_case(&ctx, format, false);
                 case.create_command_encoder();
-                case.discard_depth();
+                case.pass(
+                    RenderTarget::Array { mip: 0, layer: 0 },
+                    PassOps::discard_depth_keep_stencil(),
+                );
                 case.submit_command_encoder();
 
                 case.create_command_encoder();
-                case.discard_stencil();
+                case.pass(
+                    RenderTarget::Array { mip: 0, layer: 0 },
+                    PassOps::discard_stencil_keep_depth(),
+                );
                 case.submit_command_encoder();
 
                 case.create_command_encoder();
@@ -172,115 +168,514 @@ static DISCARDING_EITHER_DEPTH_OR_STENCIL_ASPECT_TEST: GpuTestConfiguration =
             }
         });
 
-struct DiscardTestCase<'ctx> {
-    ctx: &'ctx mut TestingContext,
+/// A single-mip, single-layer render target, as used by the
+/// `DISCARDING_*_RESETS_TEXTURE_INIT_STATE_*` tests.
+fn discard_case(
+    ctx: &TestingContext,
     format: TextureFormat,
-    texture: Texture,
-    readback_buffers: ReadbackBuffers,
-    encoder: Option<CommandEncoder>,
+    readback_in_same_encoder: bool,
+) -> RenderTargetInitCase<'_> {
+    RenderTargetInitCase::new(
+        ctx,
+        TextureSpec {
+            format,
+            dimension: TextureDimension::D2,
+            size: Extent3d {
+                width: SUBRESOURCE_WIDTH,
+                height: SUBRESOURCE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+        },
+        TextureViewDimension::D2,
+        PreInit::Sentinel,
+        format!(
+            "{format:?} target discard{}",
+            if readback_in_same_encoder {
+                ", read back in the same encoder"
+            } else {
+                ""
+            }
+        ),
+    )
 }
 
-impl<'ctx> DiscardTestCase<'ctx> {
-    pub fn new(ctx: &'ctx mut TestingContext, format: TextureFormat) -> Self {
-        let extra_usages = match format {
+/// Discards the only subresource of a `format` texture and checks that the whole texture
+/// reads back as zero, both when the readback copy is in the same encoder as the discarding
+/// pass and when it is in a later one.
+async fn check_discard_resets_whole_texture(ctx: &TestingContext, format: TextureFormat) {
+    for readback_in_same_encoder in [false, true] {
+        let mut case = discard_case(ctx, format, readback_in_same_encoder);
+        case.create_command_encoder();
+        case.pass(
+            RenderTarget::Array { mip: 0, layer: 0 },
+            PassOps::load_discard(),
+        );
+        if !readback_in_same_encoder {
+            case.submit_command_encoder();
+            case.create_command_encoder();
+        }
+        case.copy_texture_to_buffer();
+        case.submit_command_encoder();
+
+        case.assert_buffers_are_zero().await;
+    }
+}
+
+/// The texture used by a render-target initialization test case.
+#[derive(Clone, Copy)]
+struct TextureSpec {
+    format: TextureFormat,
+    /// Either `D2` or `D3`.
+    dimension: TextureDimension,
+    size: Extent3d,
+    mip_level_count: u32,
+}
+
+impl TextureSpec {
+    fn mip_size(&self, mip_level: u32) -> Extent3d {
+        self.size.mip_level_size(mip_level, self.dimension)
+    }
+
+    /// Number of array layers (`D2`) or depth slices (`D3`) at `mip_level`.
+    fn subresources_at(&self, mip_level: u32) -> u32 {
+        self.mip_size(mip_level).depth_or_array_layers
+    }
+
+    /// The aspects whose exact contents are checked. [`ReadbackBuffers`] reads a combined
+    /// depth/stencil format into one buffer per aspect, and both of them are checked.
+    fn readback_aspects(&self) -> &'static [TextureAspect] {
+        match self.format {
+            TextureFormat::Depth24PlusStencil8 | TextureFormat::Depth32FloatStencil8 => {
+                &[TextureAspect::DepthOnly, TextureAspect::StencilOnly]
+            }
+            TextureFormat::Depth24Plus => &[TextureAspect::DepthOnly],
+            _ => &[TextureAspect::All],
+        }
+    }
+
+    fn texel_size(&self, aspect: TextureAspect) -> u32 {
+        match (self.format, aspect) {
+            // Read back by a compute shader, which writes one `f32` per texel.
+            (
+                TextureFormat::Depth24Plus | TextureFormat::Depth24PlusStencil8,
+                TextureAspect::DepthOnly,
+            ) => 4,
+            _ => self
+                .format
+                .block_copy_size(Some(aspect))
+                .expect("aspect is not directly readable"),
+        }
+    }
+
+    /// Row stride of a tightly packed image of `mip_level`, for `write_texture`, which
+    /// imposes no row alignment requirement. Only used for the single-aspect color formats.
+    fn bytes_per_row(&self, mip_level: u32) -> u32 {
+        self.mip_size(mip_level).width * self.texel_size(TextureAspect::All)
+    }
+
+    fn create(&self, ctx: &TestingContext) -> Texture {
+        // `ReadbackBuffers` reads the depth aspect of these formats with a compute shader.
+        let extra_usages = match self.format {
             TextureFormat::Depth24Plus | TextureFormat::Depth24PlusStencil8 => {
                 TextureUsages::TEXTURE_BINDING
             }
             _ => TextureUsages::empty(),
         };
 
-        let texture = ctx.device.create_texture(&TextureDescriptor {
+        assert!(!self.format.is_compressed());
+
+        ctx.device.create_texture(&TextureDescriptor {
             label: Some("RenderTarget"),
-            // Non-square so a width/height swap in the row-stride math is caught.
-            // `width` is a multiple of `COPY_BYTES_PER_ROW_ALIGNMENT` so
-            // `bytes_per_row` stays aligned for every tested format.
-            size: Extent3d {
-                width: COPY_BYTES_PER_ROW_ALIGNMENT,
-                height: COPY_BYTES_PER_ROW_ALIGNMENT / 2,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
+            size: self.size,
+            mip_level_count: self.mip_level_count,
             sample_count: 1,
-            dimension: TextureDimension::D2,
-            format,
+            dimension: self.dimension,
+            format: self.format,
             usage: TextureUsages::COPY_DST
                 | TextureUsages::COPY_SRC
                 | TextureUsages::RENDER_ATTACHMENT
                 | extra_usages,
             view_formats: &[],
-        });
+        })
+    }
+}
 
-        // Clear using a write_texture operation. We could also clear using a render_pass clear.
-        // However, when making this test intentionally fail (by breaking wgpu impl), it shows that at least on the tested Vulkan driver,
-        // the later following discard pass in the test (i.e. internally vk::AttachmentStoreOp::DONT_CARE) will yield different depending on the operation we take here:
-        // * clearing white -> discard will cause it to become black!
-        // * clearing red -> discard will keep it red
-        // * write_texture -> discard will keep buffer
-        // This behavior is curious, but does not violate any spec - it is wgpu's job to pass this test no matter what a render target discard does.
+/// The single subresource that the render pass under test targets.
+#[derive(Clone, Copy)]
+enum RenderTarget {
+    /// A (mip level, array layer) of a 2D texture.
+    Array { mip: u32, layer: u32 },
+    /// A (mip level, depth slice) of a 3D texture.
+    Volume { mip: u32, depth_slice: u32 },
+}
 
-        // ... but that said, for depth/stencil textures we need to do a clear.
-        if format.is_depth_stencil_format() {
-            let mut encoder = ctx
-                .device
-                .create_command_encoder(&CommandEncoderDescriptor::default());
-            encoder.begin_render_pass(&RenderPassDescriptor {
-                label: Some("Depth/Stencil setup"),
-                color_attachments: &[],
-                depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
-                    view: &texture.create_view(&TextureViewDescriptor::default()),
-                    depth_ops: format.has_depth_aspect().then_some(Operations {
-                        load: LoadOp::Clear(1.0),
-                        store: StoreOp::Store,
-                    }),
-                    stencil_ops: format.has_stencil_aspect().then_some(Operations {
-                        load: LoadOp::Clear(0xFFFFFFFF),
-                        store: StoreOp::Store,
-                    }),
-                }),
-                timestamp_writes: None,
-                occlusion_query_set: None,
-                multiview_mask: None,
-            });
-            ctx.queue.submit([encoder.finish()]);
-        } else {
-            let block_size = format.block_copy_size(None).unwrap();
-            let bytes_per_row = texture.width() * block_size;
-
-            // Size for tests is chosen so that we don't need to care about buffer alignments.
-            assert!(!format.is_compressed());
-            assert_eq!(bytes_per_row % COPY_BYTES_PER_ROW_ALIGNMENT, 0);
-
-            let buffer_size = texture.height() * bytes_per_row;
-            let data = vec![255; buffer_size as usize];
-            ctx.queue.write_texture(
-                TexelCopyTextureInfo {
-                    texture: &texture,
-                    mip_level: 0,
-                    origin: Origin3d { x: 0, y: 0, z: 0 },
-                    aspect: TextureAspect::All,
-                },
-                &data,
-                TexelCopyBufferLayout {
-                    offset: 0,
-                    bytes_per_row: Some(bytes_per_row),
-                    rows_per_image: None,
-                },
-                texture.size(),
-            );
-        }
-
-        let readback_buffers = ReadbackBuffers::new(&ctx.device, &texture);
-
-        Self {
-            ctx,
-            format,
-            texture,
-            readback_buffers,
-            encoder: None,
+impl RenderTarget {
+    fn mip(&self) -> u32 {
+        match *self {
+            Self::Array { mip, .. } | Self::Volume { mip, .. } => mip,
         }
     }
 
-    pub fn create_command_encoder(&mut self) {
+    /// Index of this target within the readback of its mip level.
+    fn subresource_index(&self) -> u32 {
+        match *self {
+            Self::Array { layer, .. } => layer,
+            Self::Volume { depth_slice, .. } => depth_slice,
+        }
+    }
+}
+
+impl core::fmt::Display for RenderTarget {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match *self {
+            Self::Array { mip, layer } => write!(f, "mip {mip}, layer {layer}"),
+            Self::Volume { mip, depth_slice } => write!(f, "mip {mip}, slice {depth_slice}"),
+        }
+    }
+}
+
+/// Operations for the render pass under test. Depth and stencil are kept separate so that
+/// passes with diverging depth/stencil operations can be constructed.
+#[derive(Clone, Copy)]
+struct PassOps {
+    color: Operations<Color>,
+    depth: Operations<f32>,
+    stencil: Operations<u32>,
+}
+
+impl PassOps {
+    /// Write the sentinel value into the target.
+    fn clear_store(sentinel: Sentinel) -> Self {
+        Self {
+            color: Operations {
+                load: LoadOp::Clear(sentinel.color),
+                store: StoreOp::Store,
+            },
+            depth: Operations {
+                load: LoadOp::Clear(sentinel.depth),
+                store: StoreOp::Store,
+            },
+            stencil: Operations {
+                load: LoadOp::Clear(sentinel.stencil),
+                store: StoreOp::Store,
+            },
+        }
+    }
+
+    /// Clear the target to the sentinel value, then discard it.
+    fn clear_discard(sentinel: Sentinel) -> Self {
+        let mut ops = Self::clear_store(sentinel);
+        ops.color.store = StoreOp::Discard;
+        ops.depth.store = StoreOp::Discard;
+        ops.stencil.store = StoreOp::Discard;
+        ops
+    }
+
+    fn load_store() -> Self {
+        Self {
+            color: Operations {
+                load: LoadOp::Load,
+                store: StoreOp::Store,
+            },
+            depth: Operations {
+                load: LoadOp::Load,
+                store: StoreOp::Store,
+            },
+            stencil: Operations {
+                load: LoadOp::Load,
+                store: StoreOp::Store,
+            },
+        }
+    }
+
+    fn load_discard() -> Self {
+        let mut ops = Self::load_store();
+        ops.color.store = StoreOp::Discard;
+        ops.depth.store = StoreOp::Discard;
+        ops.stencil.store = StoreOp::Discard;
+        ops
+    }
+
+    /// Discard the depth aspect while storing a zeroed stencil aspect.
+    fn discard_depth_keep_stencil() -> Self {
+        let mut ops = Self::load_discard();
+        ops.stencil = Operations {
+            load: LoadOp::Clear(0),
+            store: StoreOp::Store,
+        };
+        ops
+    }
+
+    /// Discard the stencil aspect while storing a zeroed depth aspect.
+    fn discard_stencil_keep_depth() -> Self {
+        let mut ops = Self::load_discard();
+        ops.depth = Operations {
+            load: LoadOp::Clear(0.0),
+            store: StoreOp::Store,
+        };
+        ops
+    }
+
+    /// Discard both aspects, loading only one of them and clearing the other to zero, so
+    /// that the load operations diverge while the store operations match.
+    fn discard_both_with_diverging_load(load_depth: bool) -> Self {
+        let mut ops = Self::load_discard();
+        if load_depth {
+            ops.stencil.load = LoadOp::Clear(0);
+        } else {
+            ops.depth.load = LoadOp::Clear(0.0);
+        }
+        ops
+    }
+}
+
+/// A non-zero value written into a render target, and the bytes it must read back as.
+#[derive(Clone, Copy)]
+struct Sentinel {
+    color: Color,
+    depth: f32,
+    stencil: u32,
+    /// Bytes that the color aspect, or the depth aspect of a depth/stencil format, must read
+    /// back as.
+    texel: [u8; 4],
+    texel_size: usize,
+    /// Byte that the stencil aspect must read back as, for a format that has one that is
+    /// read separately.
+    stencil_texel: [u8; 1],
+}
+
+impl Sentinel {
+    /// Bytes that one texel of `aspect` must read back as.
+    fn texel(&self, aspect: TextureAspect) -> &[u8] {
+        match aspect {
+            TextureAspect::StencilOnly => &self.stencil_texel,
+            _ => &self.texel[..self.texel_size],
+        }
+    }
+}
+
+/// Clear values are chosen to be exactly representable in the target format, and non-zero,
+/// so that a zero-filled subresource is distinguishable from the sentinel.
+///
+/// Most are also distinct from the byte that [`ReadbackBuffers`] poisons its buffers with, so
+/// that a readback that never happened is distinguishable too. [`TextureFormat::Rgba8UnormSrgb`]
+/// is the exception: 1.0 is the only non-zero value that the linear to sRGB clear value
+/// conversion is guaranteed to reproduce exactly, and it is all-ones, like the poison byte.
+/// That is harmless, because the tests that use the format only assert that the texture reads
+/// back as zero.
+fn sentinel_for(format: TextureFormat) -> Sentinel {
+    // 0.75 * 65535 = 49151.25 is far enough from a rounding boundary that any
+    // implementation produces 49151 (0xBFFF) for `Depth16Unorm`.
+    let mut depth = 0.75;
+    let stencil = 0xAB;
+
+    let (color, texel, texel_size) = match format {
+        // Integer clear values are not subject to any conversion.
+        TextureFormat::Rgba8Uint => (
+            Color {
+                r: f64::from(0x11_u8),
+                g: f64::from(0x22_u8),
+                b: f64::from(0x33_u8),
+                a: f64::from(0x44_u8),
+            },
+            [0x11, 0x22, 0x33, 0x44],
+            4,
+        ),
+        TextureFormat::Rgba8UnormSrgb => (Color::WHITE, [0xFF; 4], 4),
+        TextureFormat::Stencil8 => (Color::TRANSPARENT, [stencil as u8, 0, 0, 0], 1),
+        TextureFormat::Depth16Unorm => (Color::TRANSPARENT, [0xFF, 0xBF, 0, 0], 2),
+        TextureFormat::Depth32Float | TextureFormat::Depth32FloatStencil8 => {
+            (Color::TRANSPARENT, 0.75_f32.to_le_bytes(), 4)
+        }
+        TextureFormat::Depth24Plus | TextureFormat::Depth24PlusStencil8 => {
+            // The depth aspect of these formats is read back as `f32` by a compute shader,
+            // and a backend may give it either 24 bit unorm or `f32` precision. 1.0 is the
+            // only non-zero value that both of those represent exactly.
+            depth = 1.0;
+            (Color::TRANSPARENT, 1.0_f32.to_le_bytes(), 4)
+        }
+        _ => unimplemented!("no sentinel value defined for {format:?}"),
+    };
+
+    Sentinel {
+        color,
+        depth,
+        stencil,
+        texel,
+        texel_size,
+        stencil_texel: [stencil as u8],
+    }
+}
+
+/// Expected contents of a single mip level / array layer / depth slice.
+#[derive(Clone, Copy, Debug)]
+enum Expected {
+    Zero,
+    Sentinel,
+}
+
+/// Contents of the texture before the render pass under test.
+#[derive(Clone, Copy)]
+enum PreInit {
+    /// Leave the texture untouched, i.e. uninitialized.
+    Fresh,
+    /// Write the sentinel value into every mip level and array layer / depth slice.
+    Sentinel,
+}
+
+struct RenderTargetInitCase<'ctx> {
+    ctx: &'ctx TestingContext,
+    spec: TextureSpec,
+    sentinel: Sentinel,
+    view_dimension: TextureViewDimension,
+    texture: Texture,
+    readback: ReadbackBuffers,
+    encoder: Option<CommandEncoder>,
+    /// Prefix of every assertion message, identifying the case.
+    desc: String,
+}
+
+impl<'ctx> RenderTargetInitCase<'ctx> {
+    fn new(
+        ctx: &'ctx TestingContext,
+        spec: TextureSpec,
+        view_dimension: TextureViewDimension,
+        pre_init: PreInit,
+        desc: String,
+    ) -> Self {
+        let texture = spec.create(ctx);
+        let sentinel = sentinel_for(spec.format);
+        let readback = ReadbackBuffers::new(&ctx.device, &texture);
+
+        let case = Self {
+            ctx,
+            spec,
+            sentinel,
+            view_dimension,
+            texture,
+            readback,
+            encoder: None,
+            desc,
+        };
+        if matches!(pre_init, PreInit::Sentinel) {
+            case.write_sentinel();
+        }
+        case
+    }
+
+    /// Fill every mip level and array layer / depth slice with the sentinel value.
+    fn write_sentinel(&self) {
+        // Color textures are filled with `write_texture` rather than a render pass clear,
+        // to maximize the chance that these tests detect a missing zero-init. On at least
+        // one Vulkan driver, what the discard pass leaves behind depends on how the texture
+        // is filled here:
+        // * clear to white -> the discarded texture reads back as black, which is what the
+        //   test asserts, so a wgpu that never zero-initialized any discarded texture would
+        //   still pass
+        // * clear to red -> the discarded texture stays red
+        // * write_texture -> the discarded texture keeps its contents
+        // None of that violates any spec: it is wgpu's job to zero-fill the texture, no
+        // matter what the discard does or does not do.
+        //
+        // Depth/stencil textures have to use a clear regardless, because their depth aspect
+        // cannot be the destination of a `write_texture`, so they remain exposed to this
+        // possibility of a false-negative.
+        if self.spec.format.is_depth_stencil_format() {
+            let mut encoder = self
+                .ctx
+                .device
+                .create_command_encoder(&CommandEncoderDescriptor {
+                    label: Some("Depth/Stencil setup"),
+                });
+            for mip_level in 0..self.spec.mip_level_count {
+                for layer in 0..self.spec.subresources_at(mip_level) {
+                    self.record_pass(
+                        &mut encoder,
+                        RenderTarget::Array {
+                            mip: mip_level,
+                            layer,
+                        },
+                        PassOps::clear_store(self.sentinel),
+                    );
+                }
+            }
+            self.ctx.queue.submit([encoder.finish()]);
+        } else {
+            for mip_level in 0..self.spec.mip_level_count {
+                let mip_size = self.spec.mip_size(mip_level);
+                let bytes_per_row = self.spec.bytes_per_row(mip_level);
+                let texels = mip_size.height * mip_size.depth_or_array_layers * mip_size.width;
+                let texel = self.sentinel.texel(TextureAspect::All);
+                let data: Vec<u8> = texel
+                    .iter()
+                    .copied()
+                    .cycle()
+                    .take(texels as usize * texel.len())
+                    .collect();
+                self.ctx.queue.write_texture(
+                    TexelCopyTextureInfo {
+                        texture: &self.texture,
+                        mip_level,
+                        origin: Origin3d::ZERO,
+                        aspect: TextureAspect::All,
+                    },
+                    &data,
+                    TexelCopyBufferLayout {
+                        offset: 0,
+                        bytes_per_row: Some(bytes_per_row),
+                        rows_per_image: Some(mip_size.height),
+                    },
+                    mip_size,
+                );
+            }
+            self.ctx.queue.submit(None);
+        }
+    }
+
+    /// Record a render pass whose only attachment is `target`. The pass has no pipeline and
+    /// issues no draws; its load and store operations are the entire point.
+    fn record_pass(&self, encoder: &mut CommandEncoder, target: RenderTarget, ops: PassOps) {
+        let format = self.spec.format;
+        let (base_array_layer, depth_slice) = match target {
+            RenderTarget::Array { layer, .. } => (layer, None),
+            RenderTarget::Volume { depth_slice, .. } => (0, Some(depth_slice)),
+        };
+        let view = self.texture.create_view(&TextureViewDescriptor {
+            label: None,
+            format: Some(format),
+            dimension: Some(self.view_dimension),
+            usage: Some(TextureUsages::RENDER_ATTACHMENT),
+            aspect: TextureAspect::All,
+            base_mip_level: target.mip(),
+            mip_level_count: Some(1),
+            base_array_layer,
+            array_layer_count: Some(1),
+        });
+        encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some("Render target under test"),
+            color_attachments: &[format
+                .has_color_aspect()
+                .then_some(RenderPassColorAttachment {
+                    view: &view,
+                    depth_slice,
+                    resolve_target: None,
+                    ops: ops.color,
+                })],
+            depth_stencil_attachment: format.is_depth_stencil_format().then_some(
+                RenderPassDepthStencilAttachment {
+                    view: &view,
+                    depth_ops: format.has_depth_aspect().then_some(ops.depth),
+                    stencil_ops: format.has_stencil_aspect().then_some(ops.stencil),
+                },
+            ),
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+    }
+
+    fn create_command_encoder(&mut self) {
         self.encoder = Some(
             self.ctx
                 .device
@@ -288,115 +683,693 @@ impl<'ctx> DiscardTestCase<'ctx> {
         )
     }
 
-    pub fn submit_command_encoder(&mut self) {
+    fn submit_command_encoder(&mut self) {
         self.ctx
             .queue
             .submit([self.encoder.take().unwrap().finish()]);
     }
 
-    pub fn discard(&mut self) {
-        self.encoder
-            .as_mut()
-            .unwrap()
-            .begin_render_pass(&RenderPassDescriptor {
-                label: Some("Discard"),
-                color_attachments: &[self.format.has_color_aspect().then_some(
-                    RenderPassColorAttachment {
-                        view: &self.texture.create_view(&TextureViewDescriptor::default()),
-                        depth_slice: None,
-                        resolve_target: None,
-                        ops: Operations {
-                            load: LoadOp::Load,
-                            store: StoreOp::Discard,
-                        },
-                    },
-                )],
-                depth_stencil_attachment: self.format.is_depth_stencil_format().then_some(
-                    RenderPassDepthStencilAttachment {
-                        view: &self.texture.create_view(&TextureViewDescriptor::default()),
-                        depth_ops: self.format.has_depth_aspect().then_some(Operations {
-                            load: LoadOp::Load,
-                            store: StoreOp::Discard,
-                        }),
-                        stencil_ops: self.format.has_stencil_aspect().then_some(Operations {
-                            load: LoadOp::Load,
-                            store: StoreOp::Discard,
-                        }),
-                    },
-                ),
-                timestamp_writes: None,
-                occlusion_query_set: None,
-                multiview_mask: None,
-            });
+    fn pass(&mut self, target: RenderTarget, ops: PassOps) {
+        let mut encoder = self.encoder.take().unwrap();
+        self.record_pass(&mut encoder, target, ops);
+        self.encoder = Some(encoder);
     }
 
-    pub fn discard_depth(&mut self) {
-        self.encoder
-            .as_mut()
-            .unwrap()
-            .begin_render_pass(&RenderPassDescriptor {
-                label: Some("Discard Depth"),
-                color_attachments: &[],
-                depth_stencil_attachment: self.format.is_depth_stencil_format().then_some(
-                    RenderPassDepthStencilAttachment {
-                        view: &self.texture.create_view(&TextureViewDescriptor::default()),
-                        depth_ops: self.format.has_depth_aspect().then_some(Operations {
-                            load: LoadOp::Load,
-                            store: StoreOp::Discard,
-                        }),
-                        stencil_ops: self.format.has_stencil_aspect().then_some(Operations {
-                            load: LoadOp::Clear(0),
-                            store: StoreOp::Store,
-                        }),
-                    },
-                ),
-                timestamp_writes: None,
-                occlusion_query_set: None,
-                multiview_mask: None,
-            });
+    fn copy_texture_to_buffer(&mut self) {
+        let mut encoder = self.encoder.take().unwrap();
+        self.readback
+            .copy_from(&self.ctx.device, &mut encoder, &self.texture);
+        self.encoder = Some(encoder);
     }
 
-    pub fn discard_stencil(&mut self) {
-        self.encoder
-            .as_mut()
-            .unwrap()
-            .begin_render_pass(&RenderPassDescriptor {
-                label: Some("Discard Stencil"),
-                color_attachments: &[],
-                depth_stencil_attachment: self.format.is_depth_stencil_format().then_some(
-                    RenderPassDepthStencilAttachment {
-                        view: &self.texture.create_view(&TextureViewDescriptor::default()),
-                        depth_ops: self.format.has_depth_aspect().then_some(Operations {
-                            load: LoadOp::Clear(0.0),
-                            store: StoreOp::Store,
-                        }),
-                        stencil_ops: self.format.has_stencil_aspect().then_some(Operations {
-                            load: LoadOp::Load,
-                            store: StoreOp::Discard,
-                        }),
-                    },
-                ),
-                timestamp_writes: None,
-                occlusion_query_set: None,
-                multiview_mask: None,
-            });
+    /// Compare every texel of every mip level and array layer / depth slice, of every aspect
+    /// that [`TextureSpec::readback_aspects`] selects, against `expected`, which is called
+    /// with (mip level, array layer or depth slice).
+    async fn assert_contents(&self, expected: impl Fn(u32, u32) -> Expected) {
+        let aspects = self.spec.readback_aspects();
+        let mut failure = None;
+
+        for &aspect in aspects {
+            // Naming the aspect is noise for a format that has only one.
+            let aspect_note = match aspect {
+                _ if aspects.len() == 1 => "",
+                TextureAspect::DepthOnly => ", depth aspect",
+                _ => ", stencil aspect",
+            };
+            let data = self.readback.retrieve(self.ctx, aspect).await;
+            let aspect_failure = self.check_aspect(aspect, aspect_note, &data, &expected);
+            if failure.is_none() {
+                failure = aspect_failure;
+            }
+        }
+
+        if let Some(failure) = failure {
+            panic!("{failure}");
+        }
     }
 
-    pub fn copy_texture_to_buffer(&mut self) {
-        self.readback_buffers.copy_from(
-            &self.ctx.device,
-            self.encoder.as_mut().unwrap(),
-            &self.texture,
-        );
+    /// Check one aspect of a readback, logging the result for every subresource and
+    /// returning a message describing the first mismatch, if there was one.
+    fn check_aspect(
+        &self,
+        aspect: TextureAspect,
+        aspect_note: &str,
+        data: &ReadbackData,
+        expected: &impl Fn(u32, u32) -> Expected,
+    ) -> Option<String> {
+        let texel_size = self.spec.texel_size(aspect) as usize;
+        assert_eq!(texel_size, self.sentinel.texel(aspect).len());
+        let case_desc = &self.desc;
+        let subresource_name = match self.spec.dimension {
+            TextureDimension::D3 => "slice",
+            _ => "layer",
+        };
+        let zero = [0_u8; 4];
+        let mut failure = None;
+
+        for mip_level in 0..self.spec.mip_level_count {
+            let width = self.spec.mip_size(mip_level).width;
+
+            for index in 0..self.spec.subresources_at(mip_level) {
+                let expected = expected(mip_level, index);
+                let want = match expected {
+                    Expected::Zero => &zero[..texel_size],
+                    Expected::Sentinel => self.sentinel.texel(aspect),
+                };
+
+                let texels = data.subresource(mip_level, index).chunks_exact(texel_size);
+                let texel_count = texels.len();
+                let mut wrong = 0;
+                let mut first_wrong = None;
+                for (i, texel) in texels.enumerate() {
+                    if texel != want {
+                        wrong += 1;
+                        if first_wrong.is_none() {
+                            first_wrong = Some((i, texel));
+                        }
+                    }
+                }
+
+                if wrong == 0 {
+                    log::info!(
+                        "{case_desc}: mip {mip_level}, {subresource_name} {index}{aspect_note}: ok"
+                    );
+                    continue;
+                }
+                log::info!(
+                    "{case_desc}: mip {mip_level}, {subresource_name} {index}{aspect_note}: \
+                     {wrong}/{texel_count} texels wrong"
+                );
+
+                let (i, texel) = first_wrong.unwrap();
+                if failure.is_none() {
+                    let problem = match expected {
+                        Expected::Zero => "read back non-zero",
+                        Expected::Sentinel => "lost its contents",
+                    };
+                    failure = Some(format!(
+                        "{case_desc}: mip {mip_level}, {subresource_name} \
+                         {index}{aspect_note} {problem} at x={x} y={y}: \
+                         expected {want:02x?}, got {texel:02x?}",
+                        x = i as u32 % width,
+                        y = i as u32 / width,
+                    ));
+                }
+            }
+        }
+
+        failure
     }
 
-    pub async fn assert_buffers_are_zero(&mut self) {
-        assert!(
-            self.readback_buffers.are_zero(self.ctx).await,
-            "texture was not fully cleared"
-        );
+    /// Assert that `target` holds `target_expected` and every other subresource holds the
+    /// opposite.
+    async fn assert_only_target(&self, target: RenderTarget, target_expected: Expected) {
+        let other = match target_expected {
+            Expected::Zero => Expected::Sentinel,
+            Expected::Sentinel => Expected::Zero,
+        };
+        self.assert_contents(|mip_level, index| {
+            if mip_level == target.mip() && index == target.subresource_index() {
+                target_expected
+            } else {
+                other
+            }
+        })
+        .await
+    }
+
+    async fn assert_buffers_are_zero(&self) {
+        self.assert_contents(|_, _| Expected::Zero).await
     }
 }
+
+// Tests of initialization tracking for textures used as render targets.
+//
+// Init tracking is per (mip level, array layer), and a render pass attachment is always a
+// view of a single mip level and a single array layer. Depth slices of 3D textures are not
+// tracked at all: for a 3D texture, one mip level is a single tracking unit covering all of
+// its slices.
+
+/// Mip level count and array layer count of the textures used by the subresource tests.
+/// Every combination of a mip level and an array layer is a distinct tracking unit.
+const SUBRESOURCE_MIPS: u32 = 3;
+const SUBRESOURCE_LAYERS: u32 = 3;
+/// Size of mip level 0 of the textures used by these tests. Non-square, so a width/height
+/// swap is caught. Deliberately small: the depth aspect of `Depth24Plus` and
+/// `Depth24PlusStencil8` is read back by a single-invocation compute shader in
+/// [`ReadbackBuffers`].
+const SUBRESOURCE_WIDTH: u32 = 256;
+const SUBRESOURCE_HEIGHT: u32 = 4;
+
+fn color_2d_spec() -> TextureSpec {
+    TextureSpec {
+        format: TextureFormat::Rgba8Uint,
+        dimension: TextureDimension::D2,
+        size: Extent3d {
+            width: SUBRESOURCE_WIDTH,
+            height: SUBRESOURCE_HEIGHT,
+            depth_or_array_layers: SUBRESOURCE_LAYERS,
+        },
+        mip_level_count: SUBRESOURCE_MIPS,
+    }
+}
+
+/// Mip level 0 has four depth slices and mip level 1 has two, so a single-slice attachment
+/// covers only part of the tracking unit. Mip level 2 has a single slice, which one
+/// attachment covers completely.
+fn color_3d_spec() -> TextureSpec {
+    TextureSpec {
+        format: TextureFormat::Rgba8Uint,
+        dimension: TextureDimension::D3,
+        size: Extent3d {
+            width: SUBRESOURCE_WIDTH,
+            height: SUBRESOURCE_HEIGHT,
+            depth_or_array_layers: 4,
+        },
+        mip_level_count: SUBRESOURCE_MIPS,
+    }
+}
+
+/// Depth/stencil formats other than [`TextureFormat::Depth32FloatStencil8`],
+/// which requires [`Features::DEPTH32FLOAT_STENCIL8`].
+const CORE_DEPTH_STENCIL_FORMATS: &[TextureFormat] = &[
+    TextureFormat::Stencil8,
+    TextureFormat::Depth16Unorm,
+    TextureFormat::Depth24Plus,
+    TextureFormat::Depth24PlusStencil8,
+    TextureFormat::Depth32Float,
+];
+
+fn depth_stencil_2d_spec(format: TextureFormat) -> TextureSpec {
+    TextureSpec {
+        format,
+        dimension: TextureDimension::D2,
+        size: Extent3d {
+            width: SUBRESOURCE_WIDTH,
+            height: SUBRESOURCE_HEIGHT,
+            depth_or_array_layers: SUBRESOURCE_LAYERS,
+        },
+        mip_level_count: SUBRESOURCE_MIPS,
+    }
+}
+
+/// Renders the sentinel value into `target` with `StoreOp::Store` and checks that only
+/// `target` holds it, and that every other subresource of the texture reads back as zero.
+///
+/// The sentinel check fails deterministically if the store is tracked as initializing too
+/// little; the zero checks only fail if the underlying allocation is not already zero (see
+/// the comment at the top of this file).
+async fn check_store_inits_only_target(
+    ctx: &TestingContext,
+    spec: TextureSpec,
+    view_dimension: TextureViewDimension,
+    target: RenderTarget,
+    readback_in_same_encoder: bool,
+) {
+    let mut case = RenderTargetInitCase::new(
+        ctx,
+        spec,
+        view_dimension,
+        PreInit::Fresh,
+        format!(
+            "{:?} store to {target} of a {view_dimension:?} view{}",
+            spec.format,
+            if readback_in_same_encoder {
+                ", read back in the same encoder"
+            } else {
+                ""
+            }
+        ),
+    );
+
+    let ops = PassOps::clear_store(case.sentinel);
+    case.create_command_encoder();
+    case.pass(target, ops);
+    if !readback_in_same_encoder {
+        case.submit_command_encoder();
+        case.create_command_encoder();
+    }
+    case.copy_texture_to_buffer();
+    case.submit_command_encoder();
+
+    case.assert_only_target(target, Expected::Sentinel).await;
+}
+
+/// Discards `target` and checks that only `target` was reset to zero, and that every other
+/// subresource of the texture kept the sentinel value.
+async fn check_discard_resets_only_target(
+    ctx: &TestingContext,
+    spec: TextureSpec,
+    view_dimension: TextureViewDimension,
+    target: RenderTarget,
+    load: LoadOp<()>,
+    readback_in_same_encoder: bool,
+) {
+    let mut case = RenderTargetInitCase::new(
+        ctx,
+        spec,
+        view_dimension,
+        PreInit::Sentinel,
+        format!(
+            "{:?} {} + discard of {target}{}",
+            spec.format,
+            if matches!(load, LoadOp::Load) {
+                "load"
+            } else {
+                "clear"
+            },
+            if readback_in_same_encoder {
+                ", read back in the same encoder"
+            } else {
+                ""
+            }
+        ),
+    );
+
+    let ops = if matches!(load, LoadOp::Load) {
+        PassOps::load_discard()
+    } else {
+        PassOps::clear_discard(case.sentinel)
+    };
+    case.create_command_encoder();
+    case.pass(target, ops);
+    if !readback_in_same_encoder {
+        case.submit_command_encoder();
+        case.create_command_encoder();
+    }
+    case.copy_texture_to_buffer();
+    case.submit_command_encoder();
+
+    case.assert_only_target(target, Expected::Zero).await;
+}
+
+/// Discards a subresource of a mipmapped, layered `format` texture that is neither the first
+/// mip level nor the first array layer, and checks that no other subresource was affected.
+async fn check_depth_discard_at_nonzero_mip_and_layer(ctx: &TestingContext, format: TextureFormat) {
+    for target in [
+        RenderTarget::Array { mip: 1, layer: 1 },
+        RenderTarget::Array { mip: 2, layer: 2 },
+    ] {
+        for readback_in_same_encoder in [false, true] {
+            check_discard_resets_only_target(
+                ctx,
+                depth_stencil_2d_spec(format),
+                TextureViewDimension::D2,
+                target,
+                LoadOp::Load,
+                readback_in_same_encoder,
+            )
+            .await;
+        }
+    }
+}
+
+// A `StoreOp::Store` pass must mark only the (mip level, array layer) that it targets as
+// initialized.
+#[apply(gpu_test!)]
+static RENDER_PASS_STORE_INITS_ONLY_TARGET_COLOR_SUBRESOURCE: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(TestParameters::default())
+        .run_async(|ctx| async move {
+            for view_dimension in [TextureViewDimension::D2, TextureViewDimension::D2Array] {
+                for target in [
+                    RenderTarget::Array { mip: 0, layer: 0 },
+                    RenderTarget::Array { mip: 1, layer: 1 },
+                    RenderTarget::Array { mip: 2, layer: 2 },
+                    RenderTarget::Array { mip: 2, layer: 0 },
+                ] {
+                    for readback_in_same_encoder in [false, true] {
+                        check_store_inits_only_target(
+                            &ctx,
+                            color_2d_spec(),
+                            view_dimension,
+                            target,
+                            readback_in_same_encoder,
+                        )
+                        .await;
+                    }
+                }
+            }
+        });
+
+#[apply(gpu_test!)]
+static RENDER_PASS_STORE_INITS_ONLY_TARGET_DEPTH_STENCIL_SUBRESOURCE: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                // `ReadbackBuffers` reads the depth aspect of `Depth24PlusStencil8` with a
+                // compute shader.
+                .downlevel_flags(
+                    DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES
+                        | DownlevelFlags::COMPUTE_SHADERS,
+                )
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            for &format in CORE_DEPTH_STENCIL_FORMATS {
+                for target in [
+                    RenderTarget::Array { mip: 0, layer: 0 },
+                    RenderTarget::Array { mip: 1, layer: 1 },
+                    RenderTarget::Array { mip: 2, layer: 2 },
+                ] {
+                    check_store_inits_only_target(
+                        &ctx,
+                        depth_stencil_2d_spec(format),
+                        TextureViewDimension::D2,
+                        target,
+                        false,
+                    )
+                    .await;
+                }
+            }
+        });
+
+// Rendering to the last mip level of the 3D texture, which has a single depth slice, covers
+// its whole tracking unit, so it must behave like any other fully covered render target.
+#[apply(gpu_test!)]
+static RENDER_PASS_STORE_INITS_ONLY_TARGET_3D_MIP: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                // https://github.com/gfx-rs/wgpu/issues/9184
+                .expect_fail(
+                    FailureCase::molten_vk()
+                        .validation_error("VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT"),
+                ),
+        )
+        .run_async(|ctx| async move {
+            check_store_inits_only_target(
+                &ctx,
+                color_3d_spec(),
+                TextureViewDimension::D3,
+                RenderTarget::Volume {
+                    mip: SUBRESOURCE_MIPS - 1,
+                    depth_slice: 0,
+                },
+                false,
+            )
+            .await;
+        });
+
+// `LoadOp::Load` of a single depth slice must initialize the whole mip level, because the
+// slices of a 3D mip level are not tracked separately.
+#[apply(gpu_test!)]
+static RENDER_PASS_LOAD_INITS_WHOLE_3D_MIP: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            // https://github.com/gfx-rs/wgpu/issues/9184
+            .expect_fail(
+                FailureCase::molten_vk()
+                    .validation_error("VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT"),
+            ),
+    )
+    .run_async(|ctx| async move {
+        for pre_init in [PreInit::Fresh, PreInit::Sentinel] {
+            for target in [
+                RenderTarget::Volume {
+                    mip: 0,
+                    depth_slice: 2,
+                },
+                RenderTarget::Volume {
+                    mip: 1,
+                    depth_slice: 1,
+                },
+            ] {
+                // A freshly created texture must read back as zero everywhere. A texture
+                // that was fully written must keep its contents everywhere, including the
+                // slices that the pass did not target.
+                let expected = match pre_init {
+                    PreInit::Fresh => Expected::Zero,
+                    PreInit::Sentinel => Expected::Sentinel,
+                };
+
+                let mut case = RenderTargetInitCase::new(
+                    &ctx,
+                    color_3d_spec(),
+                    TextureViewDimension::D3,
+                    pre_init,
+                    format!("load of {target} of a 3D texture ({expected:?})"),
+                );
+                case.create_command_encoder();
+                case.pass(target, PassOps::load_store());
+                case.submit_command_encoder();
+
+                case.create_command_encoder();
+                case.copy_texture_to_buffer();
+                case.submit_command_encoder();
+
+                case.assert_contents(|_, _| expected).await;
+            }
+        }
+    });
+
+// Discarding a (mip level, array layer) must reset only that subresource, whether the
+// discarded contents are read in the same encoder or after a submit.
+#[apply(gpu_test!)]
+static DISCARDING_COLOR_TARGET_AT_NONZERO_MIP_AND_LAYER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        // https://github.com/gfx-rs/wgpu/issues/10162
+        .parameters(TestParameters::default().expect_fail(FailureCase::webgl2()))
+        .run_async(|ctx| async move {
+            for target in [
+                RenderTarget::Array { mip: 1, layer: 1 },
+                RenderTarget::Array { mip: 2, layer: 2 },
+            ] {
+                for load in [LoadOp::Load, LoadOp::Clear(())] {
+                    for readback_in_same_encoder in [false, true] {
+                        check_discard_resets_only_target(
+                            &ctx,
+                            color_2d_spec(),
+                            TextureViewDimension::D2,
+                            target,
+                            load,
+                            readback_in_same_encoder,
+                        )
+                        .await;
+                    }
+                }
+            }
+        });
+
+#[apply(gpu_test!)]
+static DISCARDING_DEPTH_TARGET_AT_NONZERO_MIP_AND_LAYER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .downlevel_flags(
+                    DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES
+                        | DownlevelFlags::COMPUTE_SHADERS,
+                )
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            for &format in CORE_DEPTH_STENCIL_FORMATS {
+                check_depth_discard_at_nonzero_mip_and_layer(&ctx, format).await;
+            }
+        });
+
+// As above, for the depth/stencil format that is behind an optional feature.
+#[apply(gpu_test!)]
+static DISCARDING_DEPTH_TARGET_AT_NONZERO_MIP_AND_LAYER_DEPTH32FLOAT_STENCIL8:
+    GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(Features::DEPTH32FLOAT_STENCIL8)
+            .downlevel_flags(DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES)
+            .limits(Limits::downlevel_defaults()),
+    )
+    .run_async(|ctx| async move {
+        check_depth_discard_at_nonzero_mip_and_layer(&ctx, TextureFormat::Depth32FloatStencil8)
+            .await;
+    });
+
+// Init state is not tracked per aspect, so discarding one aspect of a combined
+// depth/stencil texture must still leave the discarded aspect of that subresource
+// initialized, and must not affect any other subresource.
+#[apply(gpu_test!)]
+static DISCARDING_EITHER_DEPTH_OR_STENCIL_ASPECT_AT_NONZERO_MIP_AND_LAYER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .downlevel_flags(
+                    DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES
+                        | DownlevelFlags::COMPUTE_SHADERS,
+                )
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            let target = RenderTarget::Array { mip: 1, layer: 1 };
+            let mut case = RenderTargetInitCase::new(
+                &ctx,
+                depth_stencil_2d_spec(TextureFormat::Depth24PlusStencil8),
+                TextureViewDimension::D2,
+                PreInit::Sentinel,
+                format!("diverging depth/stencil discard of {target}"),
+            );
+
+            case.create_command_encoder();
+            case.pass(target, PassOps::discard_depth_keep_stencil());
+            case.submit_command_encoder();
+
+            case.create_command_encoder();
+            case.pass(target, PassOps::discard_stencil_keep_depth());
+            case.submit_command_encoder();
+
+            case.create_command_encoder();
+            case.copy_texture_to_buffer();
+            case.submit_command_encoder();
+
+            case.assert_only_target(target, Expected::Zero).await;
+        });
+
+// Discarding both aspects of a combined depth/stencil texture must reset the whole
+// subresource, even when the load operations of the two aspects diverge. This is a
+// regression test for an error in the handling of divergent depth/stencil usage within a
+// render pass, which takes a dedicated path for handling the store ops, even when they do
+// not differ.
+#[apply(gpu_test!)]
+static DISCARDING_BOTH_DEPTH_AND_STENCIL_WITH_DIVERGING_LOAD_OPS: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .downlevel_flags(
+                    DownlevelFlags::DEPTH_TEXTURE_AND_BUFFER_COPIES
+                        | DownlevelFlags::COMPUTE_SHADERS,
+                )
+                .limits(Limits::downlevel_defaults()),
+        )
+        .run_async(|ctx| async move {
+            let target = RenderTarget::Array { mip: 1, layer: 1 };
+            let mut case = RenderTargetInitCase::new(
+                &ctx,
+                depth_stencil_2d_spec(TextureFormat::Depth24PlusStencil8),
+                TextureViewDimension::D2,
+                PreInit::Sentinel,
+                format!("discard of both aspects of {target}, loading stencil"),
+            );
+
+            case.create_command_encoder();
+            case.pass(
+                target,
+                PassOps::discard_both_with_diverging_load(/* load_depth */ false),
+            );
+            case.submit_command_encoder();
+
+            case.create_command_encoder();
+            case.copy_texture_to_buffer();
+            case.submit_command_encoder();
+
+            case.assert_only_target(target, Expected::Zero).await;
+        });
+
+// A discarded subresource that is loaded by a later render pass in the same encoder must be
+// initialized before that pass runs.
+#[apply(gpu_test!)]
+static DISCARDING_COLOR_TARGET_THEN_LOADING_IT_IN_SAME_ENCODER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        // https://github.com/gfx-rs/wgpu/issues/10162
+        .parameters(TestParameters::default().expect_fail(FailureCase::webgl2()))
+        .run_async(|ctx| async move {
+            let target = RenderTarget::Array { mip: 1, layer: 1 };
+            let mut case = RenderTargetInitCase::new(
+                &ctx,
+                color_2d_spec(),
+                TextureViewDimension::D2,
+                PreInit::Sentinel,
+                format!("discard then load of {target}"),
+            );
+
+            case.create_command_encoder();
+            case.pass(target, PassOps::load_discard());
+            case.pass(target, PassOps::load_store());
+            case.copy_texture_to_buffer();
+            case.submit_command_encoder();
+
+            case.assert_only_target(target, Expected::Zero).await;
+        });
+
+// The slices of a 3D mip level are not tracked separately, so a `StoreOp::Store` pass that
+// covers a single slice of a multi-slice mip level must trigger initialization of the
+// complete texture uninitialized.
+#[apply(gpu_test!)]
+static RENDER_PASS_STORE_TO_3D_DEPTH_SLICE_INITS_OTHER_SLICES: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                // https://github.com/gfx-rs/wgpu/issues/9184
+                .expect_fail(
+                    FailureCase::molten_vk()
+                        .validation_error("VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT"),
+                ),
+        )
+        .run_async(|ctx| async move {
+            check_store_inits_only_target(
+                &ctx,
+                color_3d_spec(),
+                TextureViewDimension::D3,
+                RenderTarget::Volume {
+                    mip: 0,
+                    depth_slice: 2,
+                },
+                false,
+            )
+            .await;
+        });
+
+// Discarding a single slice of a multi-slice 3D mip level must reset only that slice. Since
+// the init tracker cannot represent a discarded slice, the slice has to be reinitialized
+// immediately instead.
+#[apply(gpu_test!)]
+static DISCARDING_3D_DEPTH_SLICE_PRESERVES_OTHER_SLICES: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                // https://github.com/gfx-rs/wgpu/issues/10162
+                .expect_fail(FailureCase::webgl2())
+                // https://github.com/gfx-rs/wgpu/issues/9184
+                .expect_fail(
+                    FailureCase::molten_vk()
+                        .validation_error("VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT"),
+                ),
+        )
+        .run_async(|ctx| async move {
+            for load in [LoadOp::Load, LoadOp::Clear(())] {
+                for readback_in_same_encoder in [false, true] {
+                    check_discard_resets_only_target(
+                        &ctx,
+                        color_3d_spec(),
+                        TextureViewDimension::D3,
+                        RenderTarget::Volume {
+                            mip: 0,
+                            depth_slice: 2,
+                        },
+                        load,
+                        readback_in_same_encoder,
+                    )
+                    .await;
+                }
+            }
+        });
 
 // Tests that a full-extent, single-aspect `write_texture` does not cause
 // *other* aspects of a multi-aspect texture to be considered initialized.

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -53,6 +53,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([
         COPY_BUFFER_TO_TEXTURE_PLANE0_LEAVES_PLANE1_UNINIT_NV12,
         COPY_BUFFER_TO_TEXTURE_STENCIL_LEAVES_DEPTH_UNINIT_DEPTH32FLOAT_STENCIL8,
+        DISCARDING_3D_DEPTH_SLICE_ALONGSIDE_ANOTHER_SLICE_IN_SAME_PASS,
         DISCARDING_3D_DEPTH_SLICE_PRESERVES_OTHER_SLICES,
         DISCARDING_BOTH_DEPTH_AND_STENCIL_WITH_DIVERGING_LOAD_OPS,
         DISCARDING_COLOR_TARGET_AT_NONZERO_MIP_AND_LAYER,
@@ -675,6 +676,51 @@ impl<'ctx> RenderTargetInitCase<'ctx> {
         });
     }
 
+    /// Record a render pass with one color attachment per entry of `targets`, which must all
+    /// be distinct depth slices of the same mip level of a 3D texture.
+    fn record_multi_slice_pass(
+        &self,
+        encoder: &mut CommandEncoder,
+        targets: &[(RenderTarget, PassOps)],
+    ) {
+        let views: Vec<TextureView> = targets
+            .iter()
+            .map(|(target, _)| {
+                self.texture.create_view(&TextureViewDescriptor {
+                    label: None,
+                    format: Some(self.spec.format),
+                    dimension: Some(self.view_dimension),
+                    usage: Some(TextureUsages::RENDER_ATTACHMENT),
+                    aspect: TextureAspect::All,
+                    base_mip_level: target.mip(),
+                    mip_level_count: Some(1),
+                    base_array_layer: 0,
+                    array_layer_count: Some(1),
+                })
+            })
+            .collect();
+        let attachments: Vec<Option<RenderPassColorAttachment<'_>>> = targets
+            .iter()
+            .zip(&views)
+            .map(|((target, ops), view)| {
+                Some(RenderPassColorAttachment {
+                    view,
+                    depth_slice: Some(target.subresource_index()),
+                    resolve_target: None,
+                    ops: ops.color,
+                })
+            })
+            .collect();
+        encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some("Render targets under test"),
+            color_attachments: &attachments,
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+    }
+
     fn create_command_encoder(&mut self) {
         self.encoder = Some(
             self.ctx
@@ -692,6 +738,12 @@ impl<'ctx> RenderTargetInitCase<'ctx> {
     fn pass(&mut self, target: RenderTarget, ops: PassOps) {
         let mut encoder = self.encoder.take().unwrap();
         self.record_pass(&mut encoder, target, ops);
+        self.encoder = Some(encoder);
+    }
+
+    fn multi_slice_pass(&mut self, targets: &[(RenderTarget, PassOps)]) {
+        let mut encoder = self.encoder.take().unwrap();
+        self.record_multi_slice_pass(&mut encoder, targets);
         self.encoder = Some(encoder);
     }
 
@@ -1368,6 +1420,91 @@ static DISCARDING_3D_DEPTH_SLICE_PRESERVES_OTHER_SLICES: GpuTestConfiguration =
                     )
                     .await;
                 }
+            }
+        });
+
+// Distinct depth slices of one 3D mip level do not overlap, so a single render pass may
+// attach several of them at once. Those attachments are processed by successive calls to
+// [`CommandBufferTextureMemoryActions::register_init_action`]. Global init tracking for 3D
+// textures operates per mip level, but pending discards within a single command buffer
+// _are_ tracked per depth slice, and it is important that they be matched that way against
+// init actions, due to the following case.
+//
+// A pending discard of a slice is repaired by clearing it ahead of a subsequent operation in
+// the same command buffer that needs the mip level initialized, or otherwise at the end of
+// the command buffer. Doing that without checking depth slices is correct when the discard
+// came from an earlier pass, but not when it came from another attachment to the same
+// pass:
+//
+// - attachment 0: mip 0, depth_slice 0, `LoadOp::Clear` / `StoreOp::Discard`
+// - attachment 1: mip 0, depth_slice 1, `LoadOp::Load` / `StoreOp::Store`
+//
+// Attachment 1 needs mip 0 initialized, so if depth slices were not considered, it would
+// repair slice 0's discard. But that clear would be emitted ahead of the pass, so slice 0
+// would be left holding the discarded contents with the mip level recorded as initialized.
+// The repair has to be deferred to the end of the command buffer instead. We test both
+// `Load` and `Clear` for attachment 1 (`other`). Either requires that the whole mip level
+// be initialized, because a mip level is the finest granularity the init tracker can record
+// (after the command buffer concludes).
+//
+// Attachment 0 clears to the sentinel value so that slice 0 holds something other than zero
+// when the discard takes effect. Under `LoadOp::Load` the pass would write nothing there,
+// and a misplaced pre-pass clear to zero would coincidentally match the expected result,
+// leaving the test unable to tell whether the discard was correctly tracked.
+#[apply(gpu_test!)]
+static DISCARDING_3D_DEPTH_SLICE_ALONGSIDE_ANOTHER_SLICE_IN_SAME_PASS: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                // https://github.com/gfx-rs/wgpu/issues/10162
+                .expect_fail(FailureCase::webgl2())
+                // https://github.com/gfx-rs/wgpu/issues/9184
+                .expect_fail(
+                    FailureCase::molten_vk()
+                        .validation_error("VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT"),
+                ),
+        )
+        .run_async(|ctx| async move {
+            let discarded = RenderTarget::Volume {
+                mip: 0,
+                depth_slice: 0,
+            };
+            let other = RenderTarget::Volume {
+                mip: 0,
+                depth_slice: 1,
+            };
+
+            for (other_ops, other_desc) in [
+                (
+                    PassOps::clear_store(sentinel_for(color_3d_spec().format)),
+                    "clear + store",
+                ),
+                (PassOps::load_store(), "load + store"),
+            ] {
+                let mut case = RenderTargetInitCase::new(
+                    &ctx,
+                    color_3d_spec(),
+                    TextureViewDimension::D3,
+                    PreInit::Sentinel,
+                    format!("clear + discard of {discarded} alongside {other_desc} of {other}"),
+                );
+
+                let sentinel = case.sentinel;
+                case.create_command_encoder();
+                case.multi_slice_pass(&[
+                    (discarded, PassOps::clear_discard(sentinel)),
+                    (other, other_ops),
+                ]);
+                case.submit_command_encoder();
+
+                case.create_command_encoder();
+                case.copy_texture_to_buffer();
+                case.submit_command_encoder();
+
+                // Every slice the pass did not discard holds the sentinel: the ones it did not
+                // touch keep what `PreInit::Sentinel` wrote, and the other attachment either
+                // cleared its slice to the sentinel or loaded and stored it unchanged.
+                case.assert_only_target(discarded, Expected::Zero).await;
             }
         });
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -289,6 +289,7 @@ pub(super) fn clear_texture_cmd(
             mip_range: subresource_mip_range,
             layer_range: subresource_layer_range,
         },
+        None,
         state.raw_encoder,
         &mut state.tracker.textures,
         &state.device.alignments,
@@ -307,9 +308,15 @@ pub(super) fn clear_texture_cmd(
 /// [`clear_texture_cmd`], which does the validation. This function is also
 /// called directly from various places within wgpu that need to clear a
 /// texture.
+///
+/// For a 3D texture:
+/// - If `depth_slice` is `Some`, clear only that depth slice (in this case,
+///   `range.mip_range` must be a single mip level).
+/// - If `depth_slice` is `None`, clear entire mip level(s).
 pub(crate) fn clear_texture<T: TextureTrackerSetSingle>(
     dst_texture: &Arc<Texture>,
     range: TextureInitRange,
+    depth_slice: Option<u32>,
     encoder: &mut dyn hal::DynCommandEncoder,
     texture_tracker: &mut T,
     alignments: &hal::Alignments,
@@ -369,6 +376,7 @@ pub(crate) fn clear_texture<T: TextureTrackerSetSingle>(
             alignments,
             zero_buffer,
             range,
+            depth_slice,
             encoder,
             dst_raw,
         ),
@@ -394,10 +402,21 @@ fn clear_texture_via_buffer_copies(
     alignments: &hal::Alignments,
     zero_buffer: &dyn hal::DynBuffer, // Buffer of size device::ZERO_BUFFER_SIZE
     range: TextureInitRange,
+    depth_slice: Option<u32>,
     encoder: &mut dyn hal::DynCommandEncoder,
     dst_raw: &dyn hal::DynTexture,
 ) {
+    // These preconditions should apply to `clear_texture` as a whole, but since they're
+    // currently only serving this function, seems clearer to keep them here.
     assert!(!texture_desc.format.is_depth_stencil_format());
+    assert!(
+        depth_slice.is_none() || texture_desc.dimension == wgt::TextureDimension::D3,
+        "depth_slice is only applicable to 3D textures",
+    );
+    assert!(
+        depth_slice.is_none() || range.mip_range.len() == 1,
+        "must target a single depth slice when clearing a mip level",
+    );
 
     if texture_desc.format == wgt::TextureFormat::NV12
         || texture_desc.format == wgt::TextureFormat::P010
@@ -436,11 +455,13 @@ fn clear_texture_via_buffer_copies(
             texture_desc.size
         );
 
-        let z_range = 0..(if texture_desc.dimension == wgt::TextureDimension::D3 {
-            mip_size.depth_or_array_layers
+        let z_range = if let Some(depth_slice) = depth_slice {
+            depth_slice..depth_slice + 1
+        } else if texture_desc.dimension == wgt::TextureDimension::D3 {
+            0..mip_size.depth_or_array_layers
         } else {
-            1
-        });
+            0..1
+        };
 
         for array_layer in range.layer_range.clone() {
             // TODO: Only doing one layer at a time for volume textures right now.

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -887,6 +887,8 @@ pub(super) fn encode_compute_pass(
             device.instance_flags,
         ))
         .map_pass_err(pass_scope)?;
+    // If the compute pass reads any surfaces that were discarded by a previous
+    // render pass in the same command buffer, initialize them.
     fixup_discarded_surfaces(
         pending_discard_init_fixups.into_iter(),
         transit,

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -62,14 +62,29 @@ impl CommandBufferTextureMemoryActions {
         self.discards.push(discard);
     }
 
-    // Registers a TextureInitTrackerAction.
-    // Returns previously discarded surface that need to be initialized *immediately* now.
-    // Only returns a non-empty list if action is MemoryInitKind::NeedsInitializedMemory.
+    /// Registers a [`TextureInitTrackerAction`].
+    ///
+    /// Returns previously discarded surfaces that need to be initialized
+    /// *immediately*. Only returns a non-empty list if `action.kind` is
+    /// [`MemoryInitKind::NeedsInitializedMemory`]. These surfaces are removed
+    /// from the pending discard list, so the caller takes on the obligation to
+    /// clear them (via [`fixup_discarded_surfaces`]).
+    ///
+    /// `depth_slices` is the range of depth slices that `action` physically
+    /// accesses, or `None` if the access is to all slices of a 3D texture or
+    /// to some other texture type. The depth slice information does not flow to
+    /// the global init tracker, whose granularity is a whole mip level, but it
+    /// is important in deciding which pending discards have to be repaired
+    /// ahead of this action, as opposed to at the end of the command buffer.
     #[must_use]
     pub(crate) fn register_init_action(
         &mut self,
         action: &TextureInitTrackerAction,
+        depth_slices: Option<Range<u32>>,
     ) -> SurfacesInDiscardState {
+        let is_3d = action.texture.desc.dimension == wgt::TextureDimension::D3;
+        debug_assert!(depth_slices.is_none() || is_3d);
+
         // Texture subresources from `self.discards` that were discarded earlier in this
         // command buffer and which the present `action` requires be initialized. These
         // require inline initialization, which will be done by `fixup_discarded_surfaces`.
@@ -95,23 +110,41 @@ impl CommandBufferTextureMemoryActions {
         // self.discards is empty!)
         let init_actions = &mut self.init_actions;
         self.discards.retain(|discarded_surface| {
-            if discarded_surface.texture.is_equal(&action.texture)
-                && discarded_surface.texture.desc.dimension != wgt::TextureDimension::D3
-                && action
-                    .range
-                    .layer_range
-                    .contains(&discarded_surface.layer_or_depth_slice)
-                && action
+            if !discarded_surface.texture.is_equal(&action.texture)
+                || !action
                     .range
                     .mip_range
                     .contains(&discarded_surface.mip_level)
             {
-                if let MemoryInitKind::NeedsInitializedMemory = action.kind {
-                    immediately_necessary_clears.push(discarded_surface.clone());
+                return true;
+            }
 
-                    // Mark surface as implicitly initialized (this is relevant
-                    // because it might have been uninitialized prior to
-                    // discarding
+            let overlaps_discard = if is_3d {
+                // The `layer_range` for a `TextureInitTrackerAction` does not identify
+                // depth slices, so the caller passed that information separately.
+                depth_slices
+                    .as_ref()
+                    .is_none_or(|slices| slices.contains(&discarded_surface.layer_or_depth_slice))
+            } else {
+                action
+                    .range
+                    .layer_range
+                    .contains(&discarded_surface.layer_or_depth_slice)
+            };
+            if !overlaps_discard {
+                return true;
+            }
+
+            if let MemoryInitKind::NeedsInitializedMemory = action.kind {
+                immediately_necessary_clears.push(discarded_surface.clone());
+
+                // Mark surface as implicitly initialized. This matters for non-3D textures
+                // where the discarded layer range may differ from the action layer range,
+                // and may have been uninitialized prior to discarding. For 3D textures,
+                // init state does not vary per layer, so we either emitted an init action
+                // above for the whole mip level, or it was already initialized and none
+                // is necessary.
+                if !is_3d {
                     let layer = discarded_surface.layer_or_depth_slice;
                     init_actions.push(TextureInitTrackerAction {
                         texture: discarded_surface.texture.clone(),
@@ -123,31 +156,8 @@ impl CommandBufferTextureMemoryActions {
                         kind: MemoryInitKind::ImplicitlyInitialized,
                     });
                 }
-                false
-            } else if discarded_surface.texture.is_equal(&action.texture)
-                && discarded_surface.texture.desc.dimension == wgt::TextureDimension::D3
-                && action
-                    .range
-                    .mip_range
-                    .contains(&discarded_surface.mip_level)
-            {
-                if let MemoryInitKind::NeedsInitializedMemory = action.kind {
-                    immediately_necessary_clears.push(discarded_surface.clone());
-
-                    // Init tracking of 3D textures is for mip levels only (not depth
-                    // slices). If a mip was uninitialized at the start of the
-                    // command buffer, we recorded an init action above. We don't need
-                    // to additionally record `ImplicitlyInitialized` for it here.
-                    // When the actual initialization commands are prepared in
-                    // [`Queue::submit`], `initialize_texture_memory` collects a list of any
-                    // slices remaining in `self.discards` and returns it, and they will be
-                    // reinitialized before the conclusion of the command buffer by
-                    // `initialize_discarded_depth_slices`.
-                }
-                false
-            } else {
-                true
             }
+            false
         });
 
         immediately_necessary_clears
@@ -160,11 +170,14 @@ impl CommandBufferTextureMemoryActions {
         texture: &Arc<Texture>,
         range: TextureInitRange,
     ) {
-        let must_be_empty = self.register_init_action(&TextureInitTrackerAction {
-            texture: texture.clone(),
-            range,
-            kind: MemoryInitKind::ImplicitlyInitialized,
-        });
+        let must_be_empty = self.register_init_action(
+            &TextureInitTrackerAction {
+                texture: texture.clone(),
+                range,
+                kind: MemoryInitKind::ImplicitlyInitialized,
+            },
+            None,
+        );
         assert!(must_be_empty.is_empty());
     }
 }

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -23,7 +23,11 @@ use super::{clear_texture, BakedCommands, ClearError};
 pub(crate) struct TextureSurfaceDiscard {
     pub texture: Arc<Texture>,
     pub mip_level: u32,
-    pub layer: u32,
+
+    /// For 3D textures, this field is a depth slice, otherwise, it is an array
+    /// layer. Unlike the primary initialization tracker, we _do_ track
+    /// individual discarded depth slices during encoding of a command buffer.
+    pub layer_or_depth_slice: u32,
 }
 
 pub(crate) type SurfacesInDiscardState = Vec<TextureSurfaceDiscard>;
@@ -33,9 +37,19 @@ pub(crate) struct CommandBufferTextureMemoryActions {
     /// The tracker actions that we need to be executed before the command
     /// buffer is executed.
     init_actions: Vec<TextureInitTrackerAction>,
-    /// All the discards that haven't been followed by init again within the
-    /// command buffer i.e. everything in this list resets the texture init
-    /// state *after* the command buffer execution
+    /// Tracks surfaces that were previously discarded within this command buffer.
+    ///
+    /// If a later pass reads from one of these surfaces, we must insert an immediate
+    /// clear operation in the command sequence. (Typically, memory initialization is done
+    /// in a dedicated pass prepended to the entire command buffer, but the discards we are
+    /// tracking here occur after that). Any discarded surfaces that are not reinitialized
+    /// prior to the end of the command buffer, will have their `initialization_status` set
+    /// to uninitialized at that point, except for depth slices, which must be reinitialized
+    /// prior to the end of the command buffer.
+    ///
+    /// We do a linear scan of the discarded surface list for _each_ initialization
+    /// action, i.e., we assume that most of the time there are no discarded surfaces.
+    /// If this list has more than a few items, performance will suffer.
     discards: Vec<TextureSurfaceDiscard>,
 }
 
@@ -56,6 +70,9 @@ impl CommandBufferTextureMemoryActions {
         &mut self,
         action: &TextureInitTrackerAction,
     ) -> SurfacesInDiscardState {
+        // Texture subresources from `self.discards` that were discarded earlier in this
+        // command buffer and which the present `action` requires be initialized. These
+        // require inline initialization, which will be done by `fixup_discarded_surfaces`.
         let mut immediately_necessary_clears = SurfacesInDiscardState::new();
 
         // Note that within a command buffer we may stack arbitrary memory init
@@ -79,7 +96,11 @@ impl CommandBufferTextureMemoryActions {
         let init_actions = &mut self.init_actions;
         self.discards.retain(|discarded_surface| {
             if discarded_surface.texture.is_equal(&action.texture)
-                && action.range.layer_range.contains(&discarded_surface.layer)
+                && discarded_surface.texture.desc.dimension != wgt::TextureDimension::D3
+                && action
+                    .range
+                    .layer_range
+                    .contains(&discarded_surface.layer_or_depth_slice)
                 && action
                     .range
                     .mip_range
@@ -91,15 +112,37 @@ impl CommandBufferTextureMemoryActions {
                     // Mark surface as implicitly initialized (this is relevant
                     // because it might have been uninitialized prior to
                     // discarding
+                    let layer = discarded_surface.layer_or_depth_slice;
                     init_actions.push(TextureInitTrackerAction {
                         texture: discarded_surface.texture.clone(),
                         range: TextureInitRange {
                             mip_range: discarded_surface.mip_level
                                 ..(discarded_surface.mip_level + 1),
-                            layer_range: discarded_surface.layer..(discarded_surface.layer + 1),
+                            layer_range: layer..(layer + 1),
                         },
                         kind: MemoryInitKind::ImplicitlyInitialized,
                     });
+                }
+                false
+            } else if discarded_surface.texture.is_equal(&action.texture)
+                && discarded_surface.texture.desc.dimension == wgt::TextureDimension::D3
+                && action
+                    .range
+                    .mip_range
+                    .contains(&discarded_surface.mip_level)
+            {
+                if let MemoryInitKind::NeedsInitializedMemory = action.kind {
+                    immediately_necessary_clears.push(discarded_surface.clone());
+
+                    // Init tracking of 3D textures is for mip levels only (not depth
+                    // slices). If a mip was uninitialized at the start of the
+                    // command buffer, we recorded an init action above. We don't need
+                    // to additionally record `ImplicitlyInitialized` for it here.
+                    // When the actual initialization commands are prepared in
+                    // [`Queue::submit`], `initialize_texture_memory` collects a list of any
+                    // slices remaining in `self.discards` and returns it, and they will be
+                    // reinitialized before the conclusion of the command buffer by
+                    // `initialize_discarded_depth_slices`.
                 }
                 false
             } else {
@@ -138,12 +181,22 @@ pub(crate) fn fixup_discarded_surfaces<InitIter: Iterator<Item = TextureSurfaceD
     snatch_guard: &SnatchGuard<'_>,
 ) {
     for init in inits {
+        let (layer_range, depth_slice) = if init.texture.desc.dimension == wgt::TextureDimension::D3
+        {
+            (0..1, Some(init.layer_or_depth_slice))
+        } else {
+            (
+                init.layer_or_depth_slice..(init.layer_or_depth_slice + 1),
+                None,
+            )
+        };
         clear_texture(
             &init.texture,
             TextureInitRange {
                 mip_range: init.mip_level..(init.mip_level + 1),
-                layer_range: init.layer..(init.layer + 1),
+                layer_range,
             },
+            depth_slice,
             encoder,
             texture_tracker,
             &device.alignments,
@@ -268,8 +321,9 @@ impl BakedCommands {
     ///
     /// Inserts all texture initializations that are going to be needed for
     /// executing the commands, and updates resource init states accordingly. Any
-    /// textures that are left discarded by this command buffer will be marked as
-    /// uninitialized.
+    /// non-3D textures that are left discarded by this command buffer will be marked as
+    /// uninitialized, and a list of any 3D depth slices is returned, to be reinitialized
+    /// just prior to the end of the command buffer.
     ///
     /// The caller is responsible for checking that any texture this may touch has not been
     /// destroyed, and must have done that check under the same snatch guard that is passed
@@ -285,8 +339,10 @@ impl BakedCommands {
         device_tracker: &mut DeviceTracker,
         device: &Device,
         snatch_guard: &SnatchGuard<'_>,
-    ) -> Result<(), ClearError> {
+    ) -> Result<SurfacesInDiscardState, ClearError> {
         profiling::scope!("initialize_texture_memory");
+
+        let mut depth_slice_discards = SurfacesInDiscardState::new();
 
         let mut ranges: Vec<TextureInitRange> = Vec::new();
         for texture_use in self.texture_memory_actions.drain_init_actions() {
@@ -324,6 +380,7 @@ impl BakedCommands {
                 let clear_result = clear_texture(
                     &texture_use.texture,
                     range,
+                    None,
                     self.encoder.raw.as_mut(),
                     &mut device_tracker.textures,
                     &device.alignments,
@@ -344,15 +401,80 @@ impl BakedCommands {
             }
         }
 
-        // Now that all buffers/textures have the proper init state for before
-        // cmdbuf start, we discard init states for textures it left discarded
-        // after its execution.
-        for surface_discard in self.texture_memory_actions.discards.iter() {
-            surface_discard
-                .texture
-                .initialization_status
-                .write()
-                .discard(surface_discard.mip_level, surface_discard.layer);
+        // Process any surfaces that remain in discarded state after
+        // the command buffer executes.
+        for surface_discard in self.texture_memory_actions.discards.drain(..) {
+            if surface_discard.texture.desc.dimension == wgt::TextureDimension::D3 {
+                // Depth slices are below the resolution of the init tracker, so
+                // collect a list of them to be initialized just prior to the
+                // end of the command buffer.
+                //
+                // We could optimize this by checking whether the entire mip is
+                // uninitialized (command buffer either did Clear+Discard when it was
+                // already uninitialized, or discarded every slice), and if so, ignore the
+                // pending discard, but it's not clear that happens enough for the
+                // optimization to be worth it.
+                depth_slice_discards.push(surface_discard);
+            } else {
+                // Anything else, record the discarded state in the initialization tracker.
+                surface_discard
+                    .texture
+                    .initialization_status
+                    .write()
+                    .discard(
+                        surface_discard.mip_level,
+                        surface_discard.layer_or_depth_slice,
+                    );
+            }
+        }
+
+        Ok(depth_slice_discards)
+    }
+
+    /// Reinitialize any depth slices that were discarded during the command buffer and not
+    /// subsequently reinitialized.
+    ///
+    /// This is necessary because the initialization tracker does not track the status of
+    /// individual depth slices.
+    ///
+    /// We do not optimize the case where _every_ depth slice of a 3D texture is discarded.
+    pub(crate) fn initialize_discarded_depth_slices(
+        &mut self,
+        discards: SurfacesInDiscardState,
+        device_tracker: &mut DeviceTracker,
+        device: &Device,
+        snatch_guard: &SnatchGuard<'_>,
+    ) -> Result<(), ClearError> {
+        for discard in discards {
+            assert!(
+                discard.texture.desc.dimension == wgt::TextureDimension::D3,
+                "unexpected texture dimension {:?} in initialize_discarded_depth_slices",
+                discard.texture.desc.dimension,
+            );
+            let range = TextureInitRange {
+                mip_range: discard.mip_level..(discard.mip_level + 1),
+                layer_range: 0..1,
+            };
+            let clear_result = clear_texture(
+                &discard.texture,
+                range,
+                Some(discard.layer_or_depth_slice),
+                self.encoder.raw.as_mut(),
+                &mut device_tracker.textures,
+                &device.alignments,
+                device.zero_buffer.as_ref(),
+                snatch_guard,
+                device.instance_flags,
+            );
+            // We panic on destroyed textures for symmetry with the main buffer
+            // and initialization pass. It should not happen, but supposing it
+            // did, it would also be fine to return the error and lose the
+            // device in queue submit.
+            if matches!(clear_result, Err(ClearError::DestroyedResource(_))) {
+                panic!("attempt to initialize a destroyed texture");
+            } else {
+                clear_result?;
+            }
         }
 
         Ok(())

--- a/wgpu-core/src/command/pass.rs
+++ b/wgpu-core/src/command/pass.rs
@@ -228,7 +228,7 @@ pub(super) fn flush_bindings_helper(
                 state
                     .base
                     .texture_memory_actions
-                    .register_init_action(action),
+                    .register_init_action(action, None),
             );
         }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1199,7 +1199,6 @@ impl RenderPassInfo {
         let mut is_stencil_read_only = false;
 
         let mut render_attachments = AttachmentDataVec::<RenderAttachment>::new();
-        let mut discarded_surfaces = AttachmentDataVec::new();
         let mut divergent_discarded_depth_stencil_aspect = None;
 
         let mut attachment_location = AttachmentErrorLocation::Color {
@@ -1307,7 +1306,7 @@ impl RenderPassInfo {
                 // This is the only place (anywhere in wgpu) where Stencil &
                 // Depth init state can diverge.
                 //
-                // To safe us the overhead of tracking init state of texture
+                // To save us the overhead of tracking init state of texture
                 // aspects everywhere, we're going to cheat a little bit in
                 // order to keep the init state of both Stencil and Depth
                 // aspects in sync. The expectation is that we hit this path
@@ -1316,7 +1315,8 @@ impl RenderPassInfo {
                 // Diverging LoadOp, i.e. Load + Clear:
                 //
                 // Record MemoryInitKind::NeedsInitializedMemory for the entire
-                // surface, a bit wasteful on unit but no negative effect!
+                // surface, a bit wasteful due to redundancy with Clear, but no
+                // negative effect!
                 //
                 // Rationale: If the loaded channel is uninitialized it needs
                 // clearing, the cleared channel doesn't care. (If everything is
@@ -1362,7 +1362,7 @@ impl RenderPassInfo {
                     ));
                 } else if at.depth.store_op() == StoreOp::Discard {
                     // Both are discarded using the regular path.
-                    discarded_surfaces.push(TextureSurfaceDiscard {
+                    texture_memory_actions.discard(TextureSurfaceDiscard {
                         texture: view.parent.clone(),
                         mip_level: view.selector.mips.start,
                         layer: view.selector.layers.start,
@@ -1751,15 +1751,12 @@ impl RenderPassInfo {
             };
         }
 
-        // If either only stencil or depth was discarded, we put in a special
-        // clear pass to keep the init status of the aspects in sync. We do this
-        // so we don't need to track init state for depth/stencil aspects
-        // individually.
-        //
-        // Note that we don't go the usual route of "brute force" initializing
-        // the texture when need arises here, since this path is actually
-        // something a user may genuinely want (where as the other cases are
-        // more seen along the lines as gracefully handling a user error).
+        // If one aspect of a combined depth/stencil format was discarded, we
+        // clear that aspect immediately to keep the init status of the aspects
+        // in sync. We do this so we don't need to track init state for depth/
+        // stencil aspects individually. We can't initialize the entire texture,
+        // because the user may genuinely want to preserve the data in the
+        // aspect that was not discarded.
         if let Some((aspect, view)) = self.divergent_discarded_depth_stencil_aspect {
             let (depth_ops, stencil_ops) = if aspect == wgt::TextureAspect::DepthOnly {
                 (

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1183,6 +1183,7 @@ impl RenderPassInfo {
                     // Note that this is needed for `Load` even if the target has `StoreOp::Discard`.
                     kind: MemoryInitKind::NeedsInitializedMemory,
                 },
+                depth_slice.map(|slice| slice..slice + 1),
             ));
         } else if store_op == StoreOp::Store {
             if partial_z {
@@ -1193,6 +1194,7 @@ impl RenderPassInfo {
                         range: TextureInitRange::from(view),
                         kind: MemoryInitKind::NeedsInitializedMemory,
                     },
+                    depth_slice.map(|slice| slice..slice + 1),
                 ));
             } else {
                 // Clear + Store
@@ -1377,11 +1379,14 @@ impl RenderPassInfo {
                     at.depth.load_op() == LoadOp::Load || at.stencil.load_op() == LoadOp::Load;
                 if need_init_beforehand {
                     pending_discard_init_fixups.extend(
-                        texture_memory_actions.register_init_action(&TextureInitTrackerAction {
-                            texture: view.parent.clone(),
-                            range: TextureInitRange::from(view.as_ref()),
-                            kind: MemoryInitKind::NeedsInitializedMemory,
-                        }),
+                        texture_memory_actions.register_init_action(
+                            &TextureInitTrackerAction {
+                                texture: view.parent.clone(),
+                                range: TextureInitRange::from(view.as_ref()),
+                                kind: MemoryInitKind::NeedsInitializedMemory,
+                            },
+                            None, // depth/stencil textures are never 3D
+                        ),
                     );
                 }
 
@@ -3557,7 +3562,7 @@ fn execute_bundle(
                 .pass
                 .base
                 .texture_memory_actions
-                .register_init_action(action),
+                .register_init_action(action, None),
         );
     }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1142,32 +1142,78 @@ impl RenderPassInfo {
         store_op: StoreOp,
         texture_memory_actions: &mut CommandBufferTextureMemoryActions,
         view: &TextureView,
+        depth_slice: Option<u32>,
         pending_discard_init_fixups: &mut SurfacesInDiscardState,
     ) {
+        match (
+            depth_slice,
+            view.parent.desc.dimension == wgt::TextureDimension::D3,
+        ) {
+            (Some(_), true) | (None, false) => {}
+            _ => unreachable!("3D textures, but not any other kind, must specify a depth slice"),
+        }
+        // 3D textures with more than one depth slice are a special case,
+        // because we don't track initialization status per slice.
+        let partial_z = view.parent.desc.dimension == wgt::TextureDimension::D3
+            && view
+                .parent
+                .desc
+                .mip_level_size(view.selector.mips.start)
+                .is_some_and(|dim| dim.depth_or_array_layers > 1);
+
         if matches!(load_op, LoadOp::Load) {
+            // Record the initialization action for the texture. Simultaneously, collect a
+            // list of any ranges of the texture that were discarded within the current
+            // command buffer, for initialization by `fixup_discarded_surfaces`.
+            // (The analogous case for texture copies is in `handle_texture_init`.)
+            //
+            // Even when the target is a depth slice of a 3D texture, this is an action
+            // for the entire mip. In most cases that is what we want (if there is any
+            // live data in the mip at the end of a command buffer, we must have the
+            // entire thing initialized). The exception is Load+Discard of one slice in an
+            // uninitialized mip. In that case, we could initialize only one slice, and then
+            // leave the entire mip uninitialized at the end of the command buffer. But we
+            // don't optimize that, because it is a lot of complexity for a case that
+            // doesn't seem very useful (if the render targets are only used transiently,
+            // why is it important that they are volume slices?).
             pending_discard_init_fixups.extend(texture_memory_actions.register_init_action(
                 &TextureInitTrackerAction {
                     texture: view.parent.clone(),
                     range: TextureInitRange::from(view),
-                    // Note that this is needed even if the target is discarded,
+                    // Note that this is needed for `Load` even if the target has `StoreOp::Discard`.
                     kind: MemoryInitKind::NeedsInitializedMemory,
                 },
             ));
         } else if store_op == StoreOp::Store {
-            // Clear + Store
-            texture_memory_actions.register_implicit_init(
-                &view.parent,
-                TextureInitRange::from(view),
-            );
+            if partial_z {
+                // We must initialize the entire mip due to init tracking granularity.
+                pending_discard_init_fixups.extend(texture_memory_actions.register_init_action(
+                    &TextureInitTrackerAction {
+                        texture: view.parent.clone(),
+                        range: TextureInitRange::from(view),
+                        kind: MemoryInitKind::NeedsInitializedMemory,
+                    },
+                ));
+            } else {
+                // Clear + Store
+                texture_memory_actions
+                    .register_implicit_init(&view.parent, TextureInitRange::from(view));
+            }
         }
         if store_op == StoreOp::Discard {
-            // the discard happens at the *end* of a pass, but recording the
-            // discard right away be alright since the texture can't be used
-            // during the pass anyways
+            // The discard happens at the *end* of a pass, but recording the
+            // discard right away is fine, since attachments can't be used
+            // for any other purpose during the pass.
+            //
+            // Discards are usually deferred as long as possible (i.e. until the
+            // next use of the subresource). But discarded depth slices of 3D
+            // textures will be reinitialized at the end of the command buffer
+            // (by [`BakedCommands::initialize_discarded_depth_slices`]),
+            // because the primary init tracker does not track individual slices.
             texture_memory_actions.discard(TextureSurfaceDiscard {
                 texture: view.parent.clone(),
                 mip_level: view.selector.mips.start,
-                layer: view.selector.layers.start,
+                layer_or_depth_slice: depth_slice.unwrap_or(view.selector.layers.start),
             });
         }
     }
@@ -1292,6 +1338,7 @@ impl RenderPassInfo {
                     at.depth.store_op(),
                     texture_memory_actions,
                     view,
+                    None,
                     pending_discard_init_fixups,
                 );
             } else if !ds_aspects.contains(hal::FormatAspects::DEPTH) {
@@ -1300,6 +1347,7 @@ impl RenderPassInfo {
                     at.stencil.store_op(),
                     texture_memory_actions,
                     view,
+                    None,
                     pending_discard_init_fixups,
                 );
             } else {
@@ -1365,7 +1413,7 @@ impl RenderPassInfo {
                     texture_memory_actions.discard(TextureSurfaceDiscard {
                         texture: view.parent.clone(),
                         mip_level: view.selector.mips.start,
-                        layer: view.selector.layers.start,
+                        layer_or_depth_slice: view.selector.layers.start,
                     });
                 }
             }
@@ -1520,6 +1568,7 @@ impl RenderPassInfo {
                 at.store_op,
                 texture_memory_actions,
                 color_view,
+                at.depth_slice,
                 pending_discard_init_fixups,
             );
             render_attachments
@@ -2626,6 +2675,8 @@ pub(super) fn encode_render_pass(
             ))
             .map_pass_err(pass_scope)?;
 
+        // If this pass reads any surfaces that were discarded by a previous
+        // pass in the same command buffer, initialize them.
         fixup_discarded_surfaces(
             pending_discard_init_fixups.into_iter(),
             transit,

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1148,7 +1148,7 @@ impl RenderPassInfo {
             pending_discard_init_fixups.extend(texture_memory_actions.register_init_action(
                 &TextureInitTrackerAction {
                     texture: view.parent.clone(),
-                    range: TextureInitRange::from(view.selector.clone()),
+                    range: TextureInitRange::from(view),
                     // Note that this is needed even if the target is discarded,
                     kind: MemoryInitKind::NeedsInitializedMemory,
                 },
@@ -1157,7 +1157,7 @@ impl RenderPassInfo {
             // Clear + Store
             texture_memory_actions.register_implicit_init(
                 &view.parent,
-                TextureInitRange::from(view.selector.clone()),
+                TextureInitRange::from(view),
             );
         }
         if store_op == StoreOp::Discard {
@@ -1331,7 +1331,7 @@ impl RenderPassInfo {
                     pending_discard_init_fixups.extend(
                         texture_memory_actions.register_init_action(&TextureInitTrackerAction {
                             texture: view.parent.clone(),
-                            range: TextureInitRange::from(view.selector.clone()),
+                            range: TextureInitRange::from(view.as_ref()),
                             kind: MemoryInitKind::NeedsInitializedMemory,
                         }),
                     );
@@ -1349,7 +1349,7 @@ impl RenderPassInfo {
                     if !need_init_beforehand {
                         texture_memory_actions.register_implicit_init(
                             &view.parent,
-                            TextureInitRange::from(view.selector.clone()),
+                            TextureInitRange::from(view.as_ref()),
                         );
                     }
                     divergent_discarded_depth_stencil_aspect = Some((
@@ -1587,7 +1587,7 @@ impl RenderPassInfo {
 
                 texture_memory_actions.register_implicit_init(
                     &resolve_view.parent,
-                    TextureInitRange::from(resolve_view.selector.clone()),
+                    TextureInitRange::from(resolve_view.as_ref()),
                 );
                 render_attachments
                     .push(resolve_view.to_render_attachment(wgt::TextureUses::COLOR_TARGET));

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -666,13 +666,19 @@ fn handle_texture_init(
         kind: init_kind,
     };
 
-    // Record the initialization action. Simultaneously, collect a list of any
-    // ranges of the texture that were discarded within the current command
-    // buffer, for immediate initialization. (The analogous case for passes is
-    // in `fixup_discarded_surfaces`.)
+    // Record the initialization action. Simultaneously, collect a list of any ranges of the
+    // texture that were discarded within the current command buffer, for immediate
+    // initialization. (The analogous case for passes is in `fixup_discarded_surfaces`.)
+    //
+    // Depth slices are only relevant to deciding which pending discards (in a command
+    // buffer with prior render passes) have to be repaired ahead of this copy. Any
+    // initialization that gets generated covers the whole mip level, because that is the
+    // granularity of the init tracker.
+    let accessed_depth_slices = (texture.desc.dimension == wgt::TextureDimension::D3)
+        .then(|| copy_texture.origin.z..copy_texture.origin.z + copy_size.depth_or_array_layers);
     let immediate_inits = state
         .texture_memory_actions
-        .register_init_action(&{ init_action });
+        .register_init_action(&{ init_action }, accessed_depth_slices);
 
     // In rare cases we may need to insert an init operation immediately onto the command buffer.
     if !immediate_inits.is_empty() {

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -666,7 +666,10 @@ fn handle_texture_init(
         kind: init_kind,
     };
 
-    // Register the init action.
+    // Record the initialization action. Simultaneously, collect a list of any
+    // ranges of the texture that were discarded within the current command
+    // buffer, for immediate initialization. (The analogous case for passes is
+    // in `fixup_discarded_surfaces`.)
     let immediate_inits = state
         .texture_memory_actions
         .register_init_action(&{ init_action });
@@ -674,12 +677,20 @@ fn handle_texture_init(
     // In rare cases we may need to insert an init operation immediately onto the command buffer.
     if !immediate_inits.is_empty() {
         for init in immediate_inits {
+            let index = init.layer_or_depth_slice;
+            let (layer_range, depth_slice) = if texture.desc.dimension == wgt::TextureDimension::D3
+            {
+                (0..1, Some(index))
+            } else {
+                (index..(index + 1), None)
+            };
             clear_texture(
                 &init.texture,
                 TextureInitRange {
                     mip_range: init.mip_level..(init.mip_level + 1),
-                    layer_range: init.layer..(init.layer + 1),
+                    layer_range,
                 },
+                depth_slice,
                 state.raw_encoder,
                 &mut state.tracker.textures,
                 &state.device.alignments,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -156,6 +156,7 @@ impl Queue {
                     mip_range: 0..1,
                     layer_range: 0..1,
                 },
+                None,
                 encoder,
                 &mut trackers.textures,
                 &device.alignments,
@@ -1089,6 +1090,7 @@ impl Queue {
                         mip_range: destination.mip_level..(destination.mip_level + 1),
                         layer_range,
                     },
+                    None,
                     encoder,
                     &mut trackers.textures,
                     &self.device.alignments,
@@ -1377,6 +1379,7 @@ impl Queue {
                         mip_range: destination.mip_level..(destination.mip_level + 1),
                         layer_range,
                     },
+                    None,
                     encoder,
                     &mut trackers.textures,
                     &self.device.alignments,
@@ -1620,7 +1623,7 @@ impl Queue {
                 // this stage:
                 //  - `hal` command encoding errors. These produce device loss in
                 //    `handle_hal_error`, independent of what we do here.
-                //  - Errors from `initialize_texture_memory`. The error cases that
+                //  - Errors from texture initialization. The error cases that
                 //    can actually occur should also be encoder errors, but we map
                 //    everything to device loss, just in case.
                 lose_device_on_error = true;
@@ -1641,15 +1644,18 @@ impl Queue {
 
                     baked.initialize_buffer_memory(&mut trackers, &submission.snatch_guard);
 
-                    if let Err(e) = baked.initialize_texture_memory(
+                    let depth_slice_discards = match baked.initialize_texture_memory(
                         &mut trackers,
                         &self.device,
                         &submission.snatch_guard,
                     ) {
-                        break 'error Err(QueueSubmitError::CommandEncoder(
-                            CommandEncoderError::Clear(e),
-                        ));
-                    }
+                        Ok(discards) => discards,
+                        Err(e) => {
+                            break 'error Err(QueueSubmitError::CommandEncoder(
+                                CommandEncoderError::Clear(e),
+                            ));
+                        }
+                    };
 
                     //Note: stateless trackers are not merged:
                     // device already knows these resources exist.
@@ -1664,16 +1670,28 @@ impl Queue {
                         break 'error Err(e.into());
                     }
 
-                    // Transition surface textures into `Present` state.
-                    // Note: we could technically do it after all of the command buffers,
-                    // but here we have a command encoder by hand, so it's easier to use it.
-                    if !used_surface_textures.is_empty() {
+                    if !depth_slice_discards.is_empty() || !used_surface_textures.is_empty() {
                         if let Err(e) = baked.encoder.open_pass(hal_label(
-                            Some("(wgpu internal) Present"),
+                            Some("(wgpu internal) Finalize"),
                             self.device.instance_flags,
                         )) {
                             break 'error Err(e.into());
                         }
+
+                        if let Err(e) = baked.initialize_discarded_depth_slices(
+                            depth_slice_discards,
+                            &mut trackers,
+                            &self.device,
+                            &submission.snatch_guard,
+                        ) {
+                            break 'error Err(QueueSubmitError::CommandEncoder(
+                                CommandEncoderError::Clear(e),
+                            ));
+                        }
+
+                        // Transition surface textures into `Present` state.
+                        // Note: we could technically do it after all of the command buffers,
+                        // but here we have a command encoder by hand, so it's easier to use it.
                         let texture_barriers = trackers
                             .textures
                             .set_from_usage_scope_and_drain_transitions(

--- a/wgpu-core/src/init_tracker/texture.rs
+++ b/wgpu-core/src/init_tracker/texture.rs
@@ -1,9 +1,8 @@
 use super::{InitTracker, MemoryInitKind};
-use crate::resource::Texture;
+use crate::resource::{Texture, TextureView};
 use alloc::{string::String, sync::Arc, vec::Vec};
 use arrayvec::ArrayVec;
 use core::ops::Range;
-use wgt::TextureSelector;
 
 #[derive(Debug, Clone)]
 pub(crate) struct TextureInitRange {
@@ -28,11 +27,17 @@ pub(crate) fn has_copy_partial_init_tracker_coverage<T>(
         || copy_info.aspect != wgt::TextureAspect::All
 }
 
-impl From<TextureSelector> for TextureInitRange {
-    fn from(selector: TextureSelector) -> Self {
+impl From<&'_ TextureView> for TextureInitRange {
+    fn from(view: &'_ TextureView) -> Self {
+        // TextureInitRange is always array layers, never depth slices.
+        let layer_range = if view.parent.desc.dimension == wgt::TextureDimension::D3 {
+            0..1
+        } else {
+            view.selector.layers.clone()
+        };
         TextureInitRange {
-            mip_range: selector.mips,
-            layer_range: selector.layers,
+            mip_range: view.selector.mips.clone(),
+            layer_range,
         }
     }
 }


### PR DESCRIPTION
Fixes initialization tracking when depth slices of 3D textures are used as render targets, and also for div/reconvergent depth/stencil. Comprised of 5 commits plus a bonus commit:

- Extends the `ReadbackBuffers` helper to cover MIP levels, depth slices, and array layers.
- Add directed tests for various relevant cases
- Fix for when depth/stencil load ops differ (mixed clear + load) and store ops are both discard, we recorded the discard in a temporary variable and then lost track of it.
- Fixes `TextureInitRange` to be constructed from a `TextureView` rather than a `TextureSelector`. Knowing the dimension of the texture is necessary to set the layer range properly.
- Fixes the initialization tracking when depth slices of 3D textures are used as render targets. Because we don't track initialization status of individual depth slices:
  - When a depth slice needs to be initialized, we must initialize the entire volume.
  - When a depth slice appears with `StoreOp::Discard`, we must reinitialize that depth slice before the end of the command buffer (including before use in later commands, if applicable, and being careful to leave live data in other slices untouched).
  - This is a simplified summary, there are more details in comments in the code.
- Fix a significant bug in the previous bullet, when multiple depth slices of a single 3D texture are attached to the same render pass. (Maybe not significant from a use case perspective, but exposures of uninitialized memory are not less serious just because they require an esoteric pipeline.)

Fixes #9455.

**Testing**
Enables CTS tests and adds directed tests.

**Squash or Rebase?** Rebase (after squashing any fixups)

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
  - Updated an existing changelog entry for init tracking. 
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
