### PR TITLE
fix(deno): Mark some methods reentrant

### DIFF
--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -118,6 +118,7 @@ impl GPUAdapter {
   }
 
   #[async_method(fake)]
+  #[reentrant]
   #[global]
   fn request_device(
     &self,

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -60,6 +60,7 @@ impl GPUCommandEncoder {
     // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn begin_render_pass(
@@ -139,6 +140,7 @@ impl GPUCommandEncoder {
     })
   }
 
+  #[reentrant]
   #[cppgc]
   fn begin_compute_pass(
     &self,
@@ -253,6 +255,7 @@ impl GPUCommandEncoder {
     Ok(())
   }
 
+  #[reentrant]
   #[required(3)]
   #[undefined]
   fn copy_buffer_to_texture(
@@ -283,6 +286,7 @@ impl GPUCommandEncoder {
     );
   }
 
+  #[reentrant]
   #[required(3)]
   #[undefined]
   fn copy_texture_to_buffer(
@@ -313,6 +317,7 @@ impl GPUCommandEncoder {
     );
   }
 
+  #[reentrant]
   #[required(3)]
   #[undefined]
   fn copy_texture_to_texture(
@@ -375,6 +380,7 @@ impl GPUCommandEncoder {
     );
   }
 
+  #[reentrant]
   #[cppgc]
   fn finish(
     &self,

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -136,6 +136,7 @@ impl GPUDevice {
     self.wgpu_device.destroy();
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn create_buffer(
@@ -196,6 +197,7 @@ impl GPUDevice {
     })
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn create_texture(
@@ -241,6 +243,7 @@ impl GPUDevice {
     })
   }
 
+  #[reentrant]
   #[cppgc]
   fn create_sampler(
     &self,
@@ -271,6 +274,7 @@ impl GPUDevice {
     })
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn create_bind_group_layout(
@@ -348,6 +352,7 @@ impl GPUDevice {
     })
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn create_pipeline_layout(
@@ -379,6 +384,7 @@ impl GPUDevice {
     }
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn create_bind_group(
@@ -437,6 +443,7 @@ impl GPUDevice {
     }
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn create_shader_module(
@@ -469,6 +476,7 @@ impl GPUDevice {
     }
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn create_compute_pipeline(
@@ -485,6 +493,7 @@ impl GPUDevice {
     }
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn create_render_pipeline(
@@ -497,6 +506,7 @@ impl GPUDevice {
   }
 
   #[async_method(fake)]
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   #[global]
@@ -536,6 +546,7 @@ impl GPUDevice {
   }
 
   #[async_method(fake)]
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   #[global]
@@ -622,6 +633,7 @@ impl GPUDevice {
     obj
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn create_render_bundle_encoder(
@@ -663,6 +675,7 @@ impl GPUDevice {
     })
   }
 
+  #[reentrant]
   #[required(1)]
   #[cppgc]
   fn create_query_set(

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -175,6 +175,7 @@ impl GPU {
   }
 
   #[async_method]
+  #[reentrant]
   #[cppgc]
   async fn request_adapter(
     &self,

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -54,6 +54,7 @@ impl GPUQueue {
     // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
   }
 
+  #[reentrant]
   #[required(1)]
   #[undefined]
   fn submit(
@@ -134,6 +135,7 @@ impl GPUQueue {
     Ok(())
   }
 
+  #[reentrant]
   #[required(4)]
   #[undefined]
   fn write_texture(

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -52,6 +52,7 @@ impl GPURenderBundleEncoder {
     // TODO(@crowlKats): no-op, needs wpgu to implement changing the label
   }
 
+  #[reentrant]
   #[cppgc]
   fn finish(
     &self,

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -90,6 +90,7 @@ impl GPURenderPassEncoder {
       .set_scissor_rect(x, y, width, height);
   }
 
+  #[reentrant]
   #[required(1)]
   #[undefined]
   fn set_blend_constant(&self, #[webidl] color: GPUColor) {
@@ -129,6 +130,7 @@ impl GPURenderPassEncoder {
     self.render_pass.borrow_mut().end_occlusion_query();
   }
 
+  #[reentrant]
   #[required(1)]
   #[undefined]
   fn execute_bundles(&self, #[webidl] bundles: Vec<Ptr<GPURenderBundle>>) {

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -70,6 +70,7 @@ impl GPUCanvasContext {
     self.canvas.clone()
   }
 
+  #[reentrant]
   #[undefined]
   fn configure(
     &self,

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -150,6 +150,7 @@ impl GPUTexture {
     self.wgpu_texture.destroy();
   }
 
+  #[reentrant]
   #[cppgc]
   fn create_view(
     &self,


### PR DESCRIPTION
Deno has a debug assertion that ops do not reentrantly call other ops unless they are marked with `#[reentrant]`.

https://github.com/denoland/deno/blob/8c80e98c40b2afa9eb853a32b3bb4c4a6c76b6e8/libs/core/ops.rs#L43-L60

The reentrancy check does not exempt argument auto-conversion based on `#[webidl]` annotations.

Because JS, it is possible to do things like pass a `GPUTexture` argument (which has `width`, `height`, and `depthOrArrayLayers` properties) for an argument that is expecting `GPUExtent3DDict`, and the CTS does this. Calling the Rust `#[getter]` method for one of those properties on the `GPUTexture` is a disallowed reentrant call.

So, add the `#[reentrant]` attribute on a bunch of functions in the deno bindings.

**Testing**
Fixes some CTS failures, but I have more sorting to do before they're ready to add to the test lists.

**Squash or Rebase?** Squash
