### PR TITLE
test(cts): List updates for new/changed CTS tests

### DIFF
--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -18,7 +18,7 @@ webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_t
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=true;stencilReadOnly=false // https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,operation,rendering,3d_texture_slices:* // https://github.com/gfx-rs/wgpu/issues/9455
 
-webgpu:api,validation,buffer,create:new_usages,* // https://github.com/denoland/deno/issues/33846; possibly issues with wgpu extensions
+webgpu:api,validation,buffer,create:new_usages,* // 0%, deno_webgpu declares the GPU*Usage constants as static getters, which are non-enumerable, so the test sees no legal usage bits, https://github.com/denoland/deno/issues/33846
 webgpu:api,validation,buffer,mapping:* // crash
 webgpu:api,validation,capability_checks,features,* // 21%, TypeError not thrown for missing features (needs deno_webgpu fix)
 webgpu:api,validation,capability_checks,limits,* // 60%, workgroup storage size validation unimplemented; interstage vars counting; bind group timing on dx12
@@ -28,7 +28,7 @@ webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:* // 0%
 webgpu:api,validation,createBindGroup:buffer,resource_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,createBindGroup:external_texture,* // 0%, no external external texture in deno
 webgpu:api,validation,createBindGroup:texture,resource_state:* // crash, https://github.com/gfx-rs/wgpu/issues/7881
-webgpu:api,validation,createTexture:new_usages,* // https://github.com/denoland/deno/issues/33846; possibly issues with wgpu extensions
+webgpu:api,validation,createTexture:new_usages,* // 0%, deno_webgpu declares the GPU*Usage constants as static getters, which are non-enumerable, so the test sees no legal usage bits, https://github.com/denoland/deno/issues/33846
 webgpu:api,validation,createView:texture_state:* // 0%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,debug:* // 92%, https://github.com/gfx-rs/wgpu/issues/8039
 webgpu:api,validation,encoding,cmds,render,draw:max_draw_count:* // https://github.com/gfx-rs/wgpu/issues/8737
@@ -37,7 +37,6 @@ webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoder
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20bundle";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:encoderType="render%20pass";state="destroyed";* // https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,cmds,setBindGroup:u32array_start_and_length:* // deno unwrap
-webgpu:api,validation,encoding,encoder_open_state:* // https://github.com/gfx-rs/wgpu/issues/7857
 webgpu:api,validation,encoding,queries,resolveQuerySet:* // 93%, https://github.com/gfx-rs/wgpu/issues/7881
 webgpu:api,validation,encoding,render_bundle:* // 81%, readonly flag normalization mismatch
 webgpu:api,validation,image_copy,buffer_texture_copies:* // https://github.com/gfx-rs/wgpu/issues/7946

--- a/cts_runner/skip.lst
+++ b/cts_runner/skip.lst
@@ -4,10 +4,15 @@
 // appear in this file in order -- including ones in comments.
 
 webgpu:api,validation,dispatch:* // linear indexing, https://github.com/gfx-rs/wgpu/issues/9296
+webgpu:api,validation,encoding,cmds,render,draw:last_buffer_setting_take_account:* // unimplemented in CTS
+webgpu:api,validation,encoding,cmds,render,indirect_multi_draw:* // no 'chromium-experimental-multi-draw-indirect' feature
+webgpu:api,validation,encoding,cmds,render,state_tracking:all_needed_index_buffer_should_be_bound:* // unimplemented in CTS
+webgpu:api,validation,encoding,cmds,render,state_tracking:all_needed_vertex_buffer_should_be_bound:* // unimplemented in CTS
 webgpu:api,validation,gpu_external_texture_expiration:* // external texture
 webgpu:api,validation,queue,copyToTexture,CopyExternalImageToTexture:* // external texture
 
 webgpu:shader,validation,decl,immediate:* // WGSL language extension 'immediate_address_space' isn't added, https://github.com/gfx-rs/wgpu/issues/8556
+webgpu:shader,validation,expression,call,builtin,atomicStoreMinMax:* // device feature 'atomic-vec2u-min-max' isn't implemented
 webgpu:shader,validation,expression,call,builtin,quadBroadcast:* // subgroups, https://github.com/gfx-rs/wgpu/issues/8722
 webgpu:shader,validation,expression,call,builtin,quadSwap:* // ibid.
 webgpu:shader,validation,expression,call,builtin,subgroupAdd:* // ibid.
@@ -20,4 +25,5 @@ webgpu:shader,validation,expression,call,builtin,subgroupElect:* // ibid.
 webgpu:shader,validation,expression,call,builtin,subgroupMinMax:* // ibid.
 webgpu:shader,validation,expression,call,builtin,subgroupMul:* // ibid.
 webgpu:shader,validation,expression,call,builtin,subgroupShuffle:* // ibid.
+webgpu:shader,validation,extension,subgroup_size_control:* // device feature 'subgroup-size-control' isn't implemented
 webgpu:shader,validation,statement,swizzle_assignment:* // swizzle assignment, https://github.com/gfx-rs/wgpu/issues/9159

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -172,6 +172,8 @@ webgpu:api,validation,encoding,cmds,debug:debug_group:*
 webgpu:api,validation,encoding,cmds,debug:debug_marker:*
 webgpu:api,validation,encoding,cmds,index_access:*
 webgpu:api,validation,encoding,cmds,render,draw:buffer_binding_overlap:*
+webgpu:api,validation,encoding,cmds,render,draw:index_buffer_format_dirtying:*
+webgpu:api,validation,encoding,cmds,render,draw:index_buffer_format:*
 webgpu:api,validation,encoding,cmds,render,draw:index_buffer_OOB:*
 webgpu:api,validation,encoding,cmds,render,draw:unused_buffer_bound:*
 webgpu:api,validation,encoding,cmds,render,draw:vertex_buffer_OOB:*


### PR DESCRIPTION
Updates the CTS test lists with some new/changed tests from the latest version of the CTS, to restore the property that everything under the `validation` suites appears in one of the list files.

**Testing**
CI will check that the newly-added `test.lst` items pass, and that the list files remain sorted.

**Squash or Rebase?** Squash
