### PR TITLE
[core-remote] Remove mutexes and other simplifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4854,7 +4854,6 @@ dependencies = [
 name = "wgpu-core-remote"
 version = "30.0.0"
 dependencies = [
- "parking_lot",
  "raw-window-handle",
  "serde",
  "wgpu-core",

--- a/wgpu-core-remote/Cargo.toml
+++ b/wgpu-core-remote/Cargo.toml
@@ -32,6 +32,5 @@ serde = ["dep:serde", "wgpu-types/serde", "wgpu-core/serde"]
 wgpu-core = { workspace = true, default-features = false }
 wgpu-hal = { workspace = true, default-features = false }
 wgpu-types.workspace = true
-parking_lot.workspace = true
 raw-window-handle.workspace = true
 serde = { workspace = true, optional = true }

--- a/wgpu-core-remote/src/global/bundle.rs
+++ b/wgpu-core-remote/src/global/bundle.rs
@@ -9,11 +9,7 @@ impl crate::global::Global {
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[wgt::DynamicOffset],
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.set_bind_group(
             index,
@@ -27,11 +23,7 @@ impl crate::global::Global {
         bundle_encoder: id::RenderBundleEncoderId,
         pipeline_id: id::RenderPipelineId,
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.set_pipeline(self.hub.render_pipelines.get(pipeline_id))
     }
@@ -44,11 +36,7 @@ impl crate::global::Global {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.set_vertex_buffer(
             slot,
@@ -66,11 +54,7 @@ impl crate::global::Global {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.set_index_buffer(self.hub.buffers.get(buffer), index_format, offset, size)
     }
@@ -81,11 +65,7 @@ impl crate::global::Global {
         offset: u32,
         data: &[u8],
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.set_immediates(offset, data)
     }
@@ -98,11 +78,7 @@ impl crate::global::Global {
         first_vertex: u32,
         first_instance: u32,
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.draw(vertex_count, instance_count, first_vertex, first_instance)
     }
@@ -116,11 +92,7 @@ impl crate::global::Global {
         base_vertex: i32,
         first_instance: u32,
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.draw_indexed(
             index_count,
@@ -137,11 +109,7 @@ impl crate::global::Global {
         buffer_id: id::BufferId,
         offset: wgt::BufferAddress,
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.draw_indirect(self.hub.buffers.get(buffer_id), offset)
     }
@@ -152,11 +120,7 @@ impl crate::global::Global {
         buffer_id: id::BufferId,
         offset: wgt::BufferAddress,
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.draw_indexed_indirect(self.hub.buffers.get(buffer_id), offset)
     }
@@ -166,11 +130,7 @@ impl crate::global::Global {
         bundle_encoder: id::RenderBundleEncoderId,
         label: &str,
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.push_debug_group(label)
     }
@@ -179,11 +139,7 @@ impl crate::global::Global {
         &self,
         bundle_encoder: id::RenderBundleEncoderId,
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.pop_debug_group()
     }
@@ -193,11 +149,7 @@ impl crate::global::Global {
         bundle_encoder: id::RenderBundleEncoderId,
         label: &str,
     ) -> Result<(), PassStateError> {
-        let bundle_encoder = self.hub.render_bundle_encoders.get(bundle_encoder);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.insert_debug_marker(label)
     }

--- a/wgpu-core-remote/src/global/command_encoder.rs
+++ b/wgpu-core-remote/src/global/command_encoder.rs
@@ -18,7 +18,7 @@ impl Global {
         &self,
         encoder_id: CommandEncoderId,
         desc: &wgt::CommandBufferDescriptor<Label>,
-        id_in: Option<id::CommandBufferId>,
+        id_in: id::CommandBufferId,
     ) -> (id::CommandBufferId, Option<(String, CommandEncoderError)>) {
         let hub = &self.hub;
         let cmd_enc = hub.command_encoders.get(encoder_id);

--- a/wgpu-core-remote/src/global/compute_pass.rs
+++ b/wgpu-core-remote/src/global/compute_pass.rs
@@ -1,8 +1,5 @@
-use alloc::sync::Arc;
-
 use alloc::borrow::Cow;
 
-use parking_lot::Mutex;
 use wgpu_core::command::{
     CommandEncoderError, ComputePassDescriptor, EncoderStateError, PassStateError,
     PassTimestampWrites,
@@ -47,10 +44,7 @@ impl Global {
 
         let (pass, err) = cmd_enc.begin_compute_pass(&desc);
 
-        // no lock rank here because only one thread should be using compute pass
-        // and it's only used by id variants of compute pass methods on global
-        // so no deadlock (or concurrent lock) should happen in practise
-        let id = fid.assign(Arc::new(Mutex::new(pass)));
+        let id = fid.assign(pass);
 
         (id, err)
     }
@@ -59,10 +53,7 @@ impl Global {
         &self,
         pass_id: id::ComputePassEncoderId,
     ) -> Result<(), EncoderStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         pass.end()
     }
 
@@ -87,10 +78,7 @@ impl Global {
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[DynamicOffset],
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         pass.set_bind_group(
             index,
             bind_group_id.map(|bind_group_id| self.hub.bind_groups.get(bind_group_id)),
@@ -103,10 +91,7 @@ impl Global {
         pass_id: id::ComputePassEncoderId,
         pipeline_id: id::ComputePipelineId,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         let pipeline = self.hub.compute_pipelines.get(pipeline_id);
         pass.set_pipeline(pipeline)
     }
@@ -117,10 +102,7 @@ impl Global {
         offset: u32,
         data: &[u8],
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         pass.set_immediates(offset, data)
     }
 
@@ -131,10 +113,7 @@ impl Global {
         groups_y: u32,
         groups_z: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         pass.dispatch_workgroups(groups_x, groups_y, groups_z)
     }
 
@@ -144,10 +123,7 @@ impl Global {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         pass.dispatch_workgroups_indirect(self.hub.buffers.get(buffer_id), offset)
     }
 
@@ -157,10 +133,7 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         pass.push_debug_group(label, color)
     }
 
@@ -168,10 +141,7 @@ impl Global {
         &self,
         pass_id: id::ComputePassEncoderId,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         pass.pop_debug_group()
     }
 
@@ -181,10 +151,7 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         pass.insert_debug_marker(label, color)
     }
 
@@ -194,10 +161,7 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         let query_set = self.hub.query_sets.get(query_set_id);
         pass.write_timestamp(query_set, query_index)
     }
@@ -208,10 +172,7 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         let query_set = self.hub.query_sets.get(query_set_id);
         pass.begin_pipeline_statistics_query(query_set, query_index)
     }
@@ -220,10 +181,7 @@ impl Global {
         &self,
         pass_id: id::ComputePassEncoderId,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.compute_passes.get(pass_id);
-        let mut pass = pass
-            .try_lock()
-            .expect("ComputePasses should not be accessed concurrently");
+        let mut pass = self.hub.compute_passes.get_mut(pass_id);
         pass.end_pipeline_statistics_query()
     }
 }

--- a/wgpu-core-remote/src/global/compute_pass.rs
+++ b/wgpu-core-remote/src/global/compute_pass.rs
@@ -27,7 +27,7 @@ impl Global {
         &self,
         encoder_id: id::CommandEncoderId,
         desc: &ComputePassDescriptor<'_, PassTimestampWrites<id::QuerySetId>>,
-        id_in: Option<id::ComputePassEncoderId>,
+        id_in: id::ComputePassEncoderId,
     ) -> (id::ComputePassEncoderId, Option<CommandEncoderError>) {
         let fid = self.hub.compute_passes.prepare(id_in);
 

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -693,10 +693,7 @@ impl Global {
         let device = self.hub.devices.get(device_id);
         let (render_bundle_encoder, error) = device.create_render_bundle_encoder(desc);
 
-        // no lock rank here because only one thread should be using compute pass
-        // and it's only used by id variants of compute pass methods on global
-        // so no deadlock (or concurrent lock) should happen in practise
-        let id = fid.assign(Arc::new(parking_lot::Mutex::new(*render_bundle_encoder)));
+        let id = fid.assign(*render_bundle_encoder);
 
         (id, error)
     }
@@ -707,14 +704,10 @@ impl Global {
         desc: &command::RenderBundleDescriptor,
         id_in: id::RenderBundleId,
     ) -> (id::RenderBundleId, Option<command::RenderBundleError>) {
-        let bundle_encoder = self
+        let mut bundle_encoder = self
             .hub
             .render_bundle_encoders
-            .get(render_bundle_encoder_id);
-
-        let mut bundle_encoder = bundle_encoder
-            .try_lock()
-            .expect("RenderBundleEncoders should not be accessed concurrently");
+            .get_mut(render_bundle_encoder_id);
 
         let fid = self.hub.render_bundles.prepare(id_in);
 

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -92,7 +92,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &resource::BufferDescriptor,
-        id_in: Option<id::BufferId>,
+        id_in: id::BufferId,
     ) -> (id::BufferId, Option<CreateBufferError>) {
         let hub = &self.hub;
         let fid = hub.buffers.prepare(id_in);
@@ -137,7 +137,7 @@ impl Global {
     pub fn create_buffer_error(
         &self,
         device_id: DeviceId,
-        id_in: Option<id::BufferId>,
+        id_in: id::BufferId,
         desc: &resource::BufferDescriptor,
     ) {
         let fid = self.hub.buffers.prepare(id_in);
@@ -151,7 +151,7 @@ impl Global {
     pub fn create_render_bundle_error(
         &self,
         device_id: DeviceId,
-        id_in: Option<id::RenderBundleId>,
+        id_in: id::RenderBundleId,
         desc: &command::RenderBundleDescriptor,
     ) {
         let device = self.hub.devices.get(device_id);
@@ -165,7 +165,7 @@ impl Global {
     pub fn create_texture_error(
         &self,
         device_id: DeviceId,
-        id_in: Option<id::TextureId>,
+        id_in: id::TextureId,
         desc: &resource::TextureDescriptor,
     ) -> id::TextureId {
         let fid = self.hub.textures.prepare(id_in);
@@ -180,7 +180,7 @@ impl Global {
     pub fn create_external_texture_error(
         &self,
         device_id: DeviceId,
-        id_in: Option<id::ExternalTextureId>,
+        id_in: id::ExternalTextureId,
         desc: &resource::ExternalTextureDescriptor,
     ) {
         let fid = self.hub.external_textures.prepare(id_in);
@@ -199,7 +199,7 @@ impl Global {
     pub fn create_bind_group_layout_error(
         &self,
         device_id: DeviceId,
-        id_in: Option<id::BindGroupLayoutId>,
+        id_in: id::BindGroupLayoutId,
         label: Option<Cow<'_, str>>,
     ) {
         let fid = self.hub.bind_group_layouts.prepare(id_in);
@@ -228,7 +228,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &resource::TextureDescriptor,
-        id_in: Option<id::TextureId>,
+        id_in: id::TextureId,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
         let hub = &self.hub;
 
@@ -268,7 +268,7 @@ impl Global {
         device_id: DeviceId,
         desc: &resource::TextureDescriptor,
         initial_state: wgt::TextureUses,
-        id_in: Option<id::TextureId>,
+        id_in: id::TextureId,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
         let hub = &self.hub;
 
@@ -294,7 +294,7 @@ impl Global {
         hal_buffer: A::Buffer,
         device_id: DeviceId,
         desc: &resource::BufferDescriptor,
-        id_in: Option<id::BufferId>,
+        id_in: id::BufferId,
     ) -> (id::BufferId, Option<CreateBufferError>) {
         let hub = &self.hub;
         let fid = hub.buffers.prepare(id_in);
@@ -326,7 +326,7 @@ impl Global {
         &self,
         texture_id: id::TextureId,
         desc: &resource::TextureViewDescriptor,
-        id_in: Option<id::TextureViewId>,
+        id_in: id::TextureViewId,
     ) -> (id::TextureViewId, Option<resource::CreateTextureViewError>) {
         let hub = &self.hub;
 
@@ -352,7 +352,7 @@ impl Global {
         device_id: DeviceId,
         desc: &resource::ExternalTextureDescriptor,
         planes: &[id::TextureViewId],
-        id_in: Option<id::ExternalTextureId>,
+        id_in: id::ExternalTextureId,
     ) -> (
         id::ExternalTextureId,
         Option<resource::CreateExternalTextureError>,
@@ -393,7 +393,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &resource::SamplerDescriptor,
-        id_in: Option<id::SamplerId>,
+        id_in: id::SamplerId,
     ) -> (id::SamplerId, Option<resource::CreateSamplerError>) {
         let hub = &self.hub;
         let fid = hub.samplers.prepare(id_in);
@@ -417,7 +417,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &binding_model::BindGroupLayoutDescriptor,
-        id_in: Option<id::BindGroupLayoutId>,
+        id_in: id::BindGroupLayoutId,
     ) -> (
         id::BindGroupLayoutId,
         Option<binding_model::CreateBindGroupLayoutError>,
@@ -444,7 +444,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &binding_model::PipelineLayoutDescriptor<id::BindGroupLayoutId>,
-        id_in: Option<id::PipelineLayoutId>,
+        id_in: id::PipelineLayoutId,
     ) -> (
         id::PipelineLayoutId,
         Option<binding_model::CreatePipelineLayoutError>,
@@ -483,7 +483,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &BindGroupDescriptor,
-        id_in: Option<id::BindGroupId>,
+        id_in: id::BindGroupId,
     ) -> (id::BindGroupId, Option<binding_model::CreateBindGroupError>) {
         let hub = &self.hub;
         let fid = hub.bind_groups.prepare(id_in);
@@ -606,7 +606,7 @@ impl Global {
         device_id: DeviceId,
         desc: &pipeline::ShaderModuleDescriptor,
         source: pipeline::ShaderModuleSource,
-        id_in: Option<id::ShaderModuleId>,
+        id_in: id::ShaderModuleId,
     ) -> (
         id::ShaderModuleId,
         Option<pipeline::CreateShaderModuleError>,
@@ -631,7 +631,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &pipeline::ShaderModuleDescriptorPassthrough<'_>,
-        id_in: Option<id::ShaderModuleId>,
+        id_in: id::ShaderModuleId,
     ) -> (
         id::ShaderModuleId,
         Option<pipeline::CreateShaderModuleError>,
@@ -658,7 +658,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &wgt::CommandEncoderDescriptor<Label>,
-        id_in: Option<id::CommandEncoderId>,
+        id_in: id::CommandEncoderId,
     ) -> (id::CommandEncoderId, Option<DeviceError>) {
         let hub = &self.hub;
         let fid = hub.command_encoders.prepare(id_in);
@@ -683,7 +683,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &command::RenderBundleEncoderDescriptor,
-        id_in: Option<id::RenderBundleEncoderId>,
+        id_in: id::RenderBundleEncoderId,
     ) -> (
         id::RenderBundleEncoderId,
         Option<command::CreateRenderBundleError>,
@@ -705,7 +705,7 @@ impl Global {
         &self,
         render_bundle_encoder_id: id::RenderBundleEncoderId,
         desc: &command::RenderBundleDescriptor,
-        id_in: Option<id::RenderBundleId>,
+        id_in: id::RenderBundleId,
     ) -> (id::RenderBundleId, Option<command::RenderBundleError>) {
         let bundle_encoder = self
             .hub
@@ -741,7 +741,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &resource::QuerySetDescriptor,
-        id_in: Option<id::QuerySetId>,
+        id_in: id::QuerySetId,
     ) -> (id::QuerySetId, Option<resource::CreateQuerySetError>) {
         let hub = &self.hub;
         let fid = hub.query_sets.prepare(id_in);
@@ -773,7 +773,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &RenderPipelineDescriptor,
-        id_in: Option<id::RenderPipelineId>,
+        id_in: id::RenderPipelineId,
     ) -> (
         id::RenderPipelineId,
         Option<pipeline::CreateRenderPipelineError>,
@@ -847,7 +847,7 @@ impl Global {
         &self,
         pipeline_id: id::RenderPipelineId,
         index: u32,
-        id_in: Option<id::BindGroupLayoutId>,
+        id_in: id::BindGroupLayoutId,
     ) -> (
         id::BindGroupLayoutId,
         Option<binding_model::GetBindGroupLayoutError>,
@@ -875,7 +875,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &ComputePipelineDescriptor,
-        id_in: Option<id::ComputePipelineId>,
+        id_in: id::ComputePipelineId,
     ) -> (
         id::ComputePipelineId,
         Option<pipeline::CreateComputePipelineError>,
@@ -919,7 +919,7 @@ impl Global {
         &self,
         pipeline_id: id::ComputePipelineId,
         index: u32,
-        id_in: Option<id::BindGroupLayoutId>,
+        id_in: id::BindGroupLayoutId,
     ) -> (
         id::BindGroupLayoutId,
         Option<binding_model::GetBindGroupLayoutError>,
@@ -950,7 +950,7 @@ impl Global {
         &self,
         device_id: DeviceId,
         desc: &pipeline::PipelineCacheDescriptor<'_>,
-        id_in: Option<id::PipelineCacheId>,
+        id_in: id::PipelineCacheId,
     ) -> (
         id::PipelineCacheId,
         Option<pipeline::CreatePipelineCacheError>,

--- a/wgpu-core-remote/src/global/instance.rs
+++ b/wgpu-core-remote/src/global/instance.rs
@@ -8,25 +8,11 @@ use crate::id::{AdapterId, DeviceId, QueueId};
 pub type RequestAdapterOptions = wgt::RequestAdapterOptions<()>;
 
 impl Global {
-    pub fn enumerate_adapters(
-        &self,
-        backends: Backends,
-        apply_limit_buckets: bool,
-    ) -> Vec<AdapterId> {
-        let adapters = self
-            .instance
-            .enumerate_adapters(backends, apply_limit_buckets);
-        adapters
-            .into_iter()
-            .map(|adapter| self.hub.adapters.prepare(None).assign(adapter))
-            .collect()
-    }
-
     pub fn request_adapter(
         &self,
         desc: &RequestAdapterOptions,
         backends: Backends,
-        id_in: Option<AdapterId>,
+        id_in: AdapterId,
     ) -> Result<AdapterId, wgt::RequestAdapterError> {
         let desc = wgt::RequestAdapterOptions {
             power_preference: desc.power_preference,
@@ -55,9 +41,9 @@ impl Global {
     pub unsafe fn create_adapter_from_hal(
         &self,
         hal_adapter: hal::DynExposedAdapter,
-        input: Option<AdapterId>,
+        id_in: AdapterId,
     ) -> AdapterId {
-        let fid = self.hub.adapters.prepare(input);
+        let fid = self.hub.adapters.prepare(id_in);
         fid.assign(unsafe { self.instance.create_adapter_from_hal(hal_adapter) })
     }
 
@@ -119,8 +105,8 @@ impl Global {
         &self,
         adapter_id: AdapterId,
         desc: &DeviceDescriptor,
-        device_id_in: Option<DeviceId>,
-        queue_id_in: Option<QueueId>,
+        device_id_in: DeviceId,
+        queue_id_in: QueueId,
     ) -> Result<(DeviceId, QueueId), RequestDeviceError> {
         let device_fid = self.hub.devices.prepare(device_id_in);
         let queue_fid = self.hub.queues.prepare(queue_id_in);
@@ -153,8 +139,8 @@ impl Global {
         adapter_id: AdapterId,
         hal_device: hal::DynOpenDevice,
         desc: &DeviceDescriptor,
-        device_id_in: Option<DeviceId>,
-        queue_id_in: Option<QueueId>,
+        device_id_in: DeviceId,
+        queue_id_in: QueueId,
     ) -> Result<(DeviceId, QueueId), RequestDeviceError> {
         let devices_fid = self.hub.devices.prepare(device_id_in);
         let queues_fid = self.hub.queues.prepare(queue_id_in);

--- a/wgpu-core-remote/src/global/mod.rs
+++ b/wgpu-core-remote/src/global/mod.rs
@@ -8,7 +8,7 @@ use wgpu_core::instance::{Adapter, Instance};
 use wgpu_core::pipeline::{ComputePipeline, RenderPipeline};
 use wgpu_core::resource::{Buffer, QuerySet, Texture};
 
-use crate::hub::{Hub, HubReport};
+use crate::hub::Hub;
 use crate::id::{
     AdapterId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId, ComputePipelineId,
     DeviceId, PipelineLayoutId, QuerySetId, QueueId, RenderPipelineId, TextureId,
@@ -22,17 +22,6 @@ mod device;
 mod instance;
 mod queue;
 mod render_pass;
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct GlobalReport {
-    pub hub: HubReport,
-}
-
-impl GlobalReport {
-    pub fn hub_report(&self) -> &HubReport {
-        &self.hub
-    }
-}
 
 pub struct Global {
     pub(crate) hub: Hub,
@@ -78,19 +67,13 @@ impl Global {
             hub: Hub::new(),
         }
     }
-
-    pub fn generate_report(&self) -> GlobalReport {
-        GlobalReport {
-            hub: self.hub.generate_report(),
-        }
-    }
 }
 
 // methods to import and resolve resources in the global hub
 impl Global {
     /// Import [`Arc<Adapter>`] into the global hub,
     /// returning an [`AdapterId`] under which the adapter is stored.
-    pub fn import_adapter(&self, adapter: Arc<Adapter>, id_in: Option<AdapterId>) -> AdapterId {
+    pub fn import_adapter(&self, adapter: Arc<Adapter>, id_in: AdapterId) -> AdapterId {
         let fid = self.hub.adapters.prepare(id_in);
         fid.assign(adapter)
     }
@@ -102,7 +85,7 @@ impl Global {
 
     /// Import [`Arc<Device>`] into the global hub,
     /// returning a [`DeviceId`] under which the device is stored.
-    pub fn import_device(&self, device: Arc<Device>, id_in: Option<DeviceId>) -> DeviceId {
+    pub fn import_device(&self, device: Arc<Device>, id_in: DeviceId) -> DeviceId {
         let fid = self.hub.devices.prepare(id_in);
         fid.assign(device)
     }
@@ -114,7 +97,7 @@ impl Global {
 
     /// Import [`Arc<Queue>`] into the global hub,
     /// returning a [`QueueId`] under which the queue is stored.
-    pub fn import_queue(&self, queue: Arc<Queue>, id_in: Option<QueueId>) -> QueueId {
+    pub fn import_queue(&self, queue: Arc<Queue>, id_in: QueueId) -> QueueId {
         let fid = self.hub.queues.prepare(id_in);
         fid.assign(queue)
     }
@@ -129,7 +112,7 @@ impl Global {
     pub fn import_pipeline_layout(
         &self,
         pipeline_layout: Arc<PipelineLayout>,
-        id_in: Option<PipelineLayoutId>,
+        id_in: PipelineLayoutId,
     ) -> PipelineLayoutId {
         let fid = self.hub.pipeline_layouts.prepare(id_in);
         fid.assign(pipeline_layout)
@@ -148,7 +131,7 @@ impl Global {
     pub fn import_bind_group_layout(
         &self,
         bind_group_layout: Arc<BindGroupLayout>,
-        id_in: Option<BindGroupLayoutId>,
+        id_in: BindGroupLayoutId,
     ) -> BindGroupLayoutId {
         let fid = self.hub.bind_group_layouts.prepare(id_in);
         fid.assign(bind_group_layout)
@@ -167,7 +150,7 @@ impl Global {
     pub fn import_command_encoder(
         &self,
         command_encoder: Arc<CommandEncoder>,
-        id_in: Option<CommandEncoderId>,
+        id_in: CommandEncoderId,
     ) -> CommandEncoderId {
         let fid = self.hub.command_encoders.prepare(id_in);
         fid.assign(command_encoder)
@@ -186,7 +169,7 @@ impl Global {
     pub fn import_command_buffer(
         &self,
         command_buffer: Arc<CommandBuffer>,
-        id_in: Option<CommandBufferId>,
+        id_in: CommandBufferId,
     ) -> CommandBufferId {
         let fid = self.hub.command_buffers.prepare(id_in);
         fid.assign(command_buffer)
@@ -205,7 +188,7 @@ impl Global {
     pub fn import_render_pipeline(
         &self,
         render_pipeline: Arc<RenderPipeline>,
-        id_in: Option<RenderPipelineId>,
+        id_in: RenderPipelineId,
     ) -> RenderPipelineId {
         let fid = self.hub.render_pipelines.prepare(id_in);
         fid.assign(render_pipeline)
@@ -224,7 +207,7 @@ impl Global {
     pub fn import_compute_pipeline(
         &self,
         compute_pipeline: Arc<ComputePipeline>,
-        id_in: Option<ComputePipelineId>,
+        id_in: ComputePipelineId,
     ) -> ComputePipelineId {
         let fid = self.hub.compute_pipelines.prepare(id_in);
         fid.assign(compute_pipeline)
@@ -240,11 +223,7 @@ impl Global {
 
     /// Import [`Arc<QuerySet>`] into the global hub,
     /// returning a [`QuerySetId`] under which the query set is stored.
-    pub fn import_query_set(
-        &self,
-        query_set: Arc<QuerySet>,
-        id_in: Option<QuerySetId>,
-    ) -> QuerySetId {
+    pub fn import_query_set(&self, query_set: Arc<QuerySet>, id_in: QuerySetId) -> QuerySetId {
         let fid = self.hub.query_sets.prepare(id_in);
         fid.assign(query_set)
     }
@@ -256,7 +235,7 @@ impl Global {
 
     /// Import [`Arc<Buffer>`] into the global hub,
     /// returning a [`BufferId`] under which the buffer is stored.
-    pub fn import_buffer(&self, buffer: Arc<Buffer>, id_in: Option<BufferId>) -> BufferId {
+    pub fn import_buffer(&self, buffer: Arc<Buffer>, id_in: BufferId) -> BufferId {
         let fid = self.hub.buffers.prepare(id_in);
         fid.assign(buffer)
     }
@@ -268,7 +247,7 @@ impl Global {
 
     /// Import [`Arc<Texture>`] into the global hub,
     /// returning a [`TextureId`] under which the texture is stored.
-    pub fn import_texture(&self, texture: Arc<Texture>, id_in: Option<TextureId>) -> TextureId {
+    pub fn import_texture(&self, texture: Arc<Texture>, id_in: TextureId) -> TextureId {
         let fid = self.hub.textures.prepare(id_in);
         fid.assign(texture)
     }

--- a/wgpu-core-remote/src/global/mod.rs
+++ b/wgpu-core-remote/src/global/mod.rs
@@ -263,8 +263,3 @@ impl fmt::Debug for Global {
         f.debug_struct("Global").finish()
     }
 }
-
-fn _test_send_sync(global: &Global) {
-    fn test_internal<T: Send + Sync>(_: T) {}
-    test_internal(global)
-}

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -45,7 +45,7 @@ impl Global {
         &self,
         encoder_id: id::CommandEncoderId,
         desc: &RenderPassDescriptor<'_>,
-        id_in: Option<id::RenderPassEncoderId>,
+        id_in: id::RenderPassEncoderId,
     ) -> (id::RenderPassEncoderId, Option<CommandEncoderError>) {
         let hub = &self.hub;
         let fid = hub.render_passes.prepare(id_in);

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -1,8 +1,6 @@
 use alloc::borrow::Cow;
-use alloc::sync::Arc;
 use core::num::NonZeroU32;
 
-use parking_lot::Mutex;
 use wgpu_core::command::{
     CommandEncoderError, EncoderStateError, PassStateError, PassTimestampWrites,
     RenderPassColorAttachment, RenderPassDepthStencilAttachment, ResolvedRenderPassDescriptor,
@@ -101,18 +99,12 @@ impl Global {
 
         let (render_pass, error) = cmd_enc.begin_render_pass(desc);
 
-        // no lock rank here because only one thread should be using renderpass
-        // and it's only used by id variants of render pass methods on global
-        // so no deadlock (or concurrent lock) should happen in practise
-        let id = fid.assign(Arc::new(Mutex::new(render_pass)));
+        let id = fid.assign(render_pass);
         (id, error)
     }
 
     pub fn render_pass_end(&self, pass: id::RenderPassEncoderId) -> Result<(), EncoderStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be accessed concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.end()
     }
 
@@ -137,10 +129,7 @@ impl Global {
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[DynamicOffset],
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.set_bind_group(
             index,
             bind_group_id.map(|id| self.hub.bind_groups.get(id)),
@@ -153,10 +142,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         pipeline_id: id::RenderPipelineId,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         let pipeline = self.resolve_render_pipeline_id(pipeline_id);
         pass.set_pipeline(pipeline)
     }
@@ -169,10 +155,7 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.set_index_buffer(
             self.resolve_buffer_id(buffer_id),
             index_format,
@@ -189,10 +172,7 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.set_vertex_buffer(
             slot,
             buffer_id.map(|id| self.resolve_buffer_id(id)),
@@ -206,10 +186,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         color: Color,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.set_blend_constant(color)
     }
 
@@ -218,10 +195,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         value: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.set_stencil_reference(value)
     }
 
@@ -235,10 +209,7 @@ impl Global {
         depth_min: f32,
         depth_max: f32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.set_viewport(x, y, w, h, depth_min, depth_max)
     }
 
@@ -250,10 +221,7 @@ impl Global {
         w: u32,
         h: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.set_scissor_rect(x, y, w, h)
     }
 
@@ -263,10 +231,7 @@ impl Global {
         offset: u32,
         data: &[u8],
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.set_immediates(offset, data)
     }
 
@@ -278,10 +243,7 @@ impl Global {
         first_vertex: u32,
         first_instance: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.draw(vertex_count, instance_count, first_vertex, first_instance)
     }
 
@@ -294,10 +256,7 @@ impl Global {
         base_vertex: i32,
         first_instance: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.draw_indexed(
             index_count,
             instance_count,
@@ -313,10 +272,7 @@ impl Global {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.draw_indirect(self.resolve_buffer_id(buffer_id), offset)
     }
 
@@ -326,10 +282,7 @@ impl Global {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.draw_indexed_indirect(self.resolve_buffer_id(buffer_id), offset)
     }
 
@@ -339,10 +292,7 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.push_debug_group(label, color)
     }
 
@@ -350,10 +300,7 @@ impl Global {
         &self,
         pass: id::RenderPassEncoderId,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.pop_debug_group()
     }
 
@@ -363,10 +310,7 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.insert_debug_marker(label, color)
     }
 
@@ -376,10 +320,7 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.write_timestamp(self.resolve_query_set_id(query_set_id), query_index)
     }
 
@@ -388,10 +329,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.begin_occlusion_query(query_index)
     }
 
@@ -399,10 +337,7 @@ impl Global {
         &self,
         pass: id::RenderPassEncoderId,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.end_occlusion_query()
     }
 
@@ -412,10 +347,7 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.begin_pipeline_statistics_query(self.resolve_query_set_id(query_set_id), query_index)
     }
 
@@ -423,10 +355,7 @@ impl Global {
         &self,
         pass: id::RenderPassEncoderId,
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         pass.end_pipeline_statistics_query()
     }
 
@@ -435,10 +364,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         render_bundle_ids: &[id::RenderBundleId],
     ) -> Result<(), PassStateError> {
-        let pass = self.hub.render_passes.get(pass);
-        let mut pass = pass
-            .try_lock()
-            .expect("RenderPasses should not be used concurrently");
+        let mut pass = self.hub.render_passes.get_mut(pass);
         let hub = &self.hub;
         let bundles = hub.render_bundles.read();
         let render_bundles = render_bundle_ids

--- a/wgpu-core-remote/src/hub.rs
+++ b/wgpu-core-remote/src/hub.rs
@@ -104,9 +104,8 @@ flagged as errors as well.
 */
 
 use alloc::sync::Arc;
-use core::fmt::Debug;
 
-use crate::registry::{Registry, RegistryReport};
+use crate::registry::Registry;
 use wgpu_core::{
     binding_model::{BindGroup, BindGroupLayout, PipelineLayout},
     command::{
@@ -119,38 +118,6 @@ use wgpu_core::{
 };
 
 use parking_lot::Mutex;
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct HubReport {
-    pub adapters: RegistryReport,
-    pub devices: RegistryReport,
-    pub queues: RegistryReport,
-    pub pipeline_layouts: RegistryReport,
-    pub shader_modules: RegistryReport,
-    pub bind_group_layouts: RegistryReport,
-    pub bind_groups: RegistryReport,
-    pub command_encoders: RegistryReport,
-    pub command_buffers: RegistryReport,
-    pub render_bundles: RegistryReport,
-    pub render_pipelines: RegistryReport,
-    pub compute_pipelines: RegistryReport,
-    pub pipeline_caches: RegistryReport,
-    pub query_sets: RegistryReport,
-    pub buffers: RegistryReport,
-    pub textures: RegistryReport,
-    pub texture_views: RegistryReport,
-    pub external_textures: RegistryReport,
-    pub samplers: RegistryReport,
-    pub render_passes: RegistryReport,
-    pub compute_passes: RegistryReport,
-    pub render_bundle_encoders: RegistryReport,
-}
-
-impl HubReport {
-    pub fn is_empty(&self) -> bool {
-        self.adapters.is_empty()
-    }
-}
 
 #[allow(rustdoc::private_intra_doc_links)]
 /// All the resources tracked by a [`crate::global::Global`].
@@ -230,33 +197,6 @@ impl Hub {
             render_passes: Registry::new(),
             compute_passes: Registry::new(),
             render_bundle_encoders: Registry::new(),
-        }
-    }
-
-    pub fn generate_report(&self) -> HubReport {
-        HubReport {
-            adapters: self.adapters.generate_report(),
-            devices: self.devices.generate_report(),
-            queues: self.queues.generate_report(),
-            pipeline_layouts: self.pipeline_layouts.generate_report(),
-            shader_modules: self.shader_modules.generate_report(),
-            bind_group_layouts: self.bind_group_layouts.generate_report(),
-            bind_groups: self.bind_groups.generate_report(),
-            command_encoders: self.command_encoders.generate_report(),
-            command_buffers: self.command_buffers.generate_report(),
-            render_bundles: self.render_bundles.generate_report(),
-            render_pipelines: self.render_pipelines.generate_report(),
-            compute_pipelines: self.compute_pipelines.generate_report(),
-            pipeline_caches: self.pipeline_caches.generate_report(),
-            query_sets: self.query_sets.generate_report(),
-            buffers: self.buffers.generate_report(),
-            textures: self.textures.generate_report(),
-            texture_views: self.texture_views.generate_report(),
-            external_textures: self.external_textures.generate_report(),
-            samplers: self.samplers.generate_report(),
-            render_passes: self.render_passes.generate_report(),
-            compute_passes: self.compute_passes.generate_report(),
-            render_bundle_encoders: self.render_bundle_encoders.generate_report(),
         }
     }
 }

--- a/wgpu-core-remote/src/hub.rs
+++ b/wgpu-core-remote/src/hub.rs
@@ -161,7 +161,7 @@ pub struct Hub {
     pub(crate) external_textures: Registry<Arc<ExternalTexture>>,
     pub(crate) samplers: Registry<Arc<Sampler>>,
     pub(crate) render_passes: Registry<RenderPass>,
-    pub(crate) compute_passes: Registry<Arc<Mutex<ComputePass>>>,
+    pub(crate) compute_passes: Registry<ComputePass>,
     pub(crate) render_bundle_encoders: Registry<Arc<Mutex<RenderBundleEncoder>>>,
 }
 

--- a/wgpu-core-remote/src/hub.rs
+++ b/wgpu-core-remote/src/hub.rs
@@ -160,7 +160,7 @@ pub struct Hub {
     pub(crate) texture_views: Registry<Arc<TextureView>>,
     pub(crate) external_textures: Registry<Arc<ExternalTexture>>,
     pub(crate) samplers: Registry<Arc<Sampler>>,
-    pub(crate) render_passes: Registry<Arc<Mutex<RenderPass>>>,
+    pub(crate) render_passes: Registry<RenderPass>,
     pub(crate) compute_passes: Registry<Arc<Mutex<ComputePass>>>,
     pub(crate) render_bundle_encoders: Registry<Arc<Mutex<RenderBundleEncoder>>>,
 }

--- a/wgpu-core-remote/src/hub.rs
+++ b/wgpu-core-remote/src/hub.rs
@@ -117,8 +117,6 @@ use wgpu_core::{
     resource::{Buffer, ExternalTexture, QuerySet, Sampler, Texture, TextureView},
 };
 
-use parking_lot::Mutex;
-
 #[allow(rustdoc::private_intra_doc_links)]
 /// All the resources tracked by a [`crate::global::Global`].
 ///
@@ -162,7 +160,7 @@ pub struct Hub {
     pub(crate) samplers: Registry<Arc<Sampler>>,
     pub(crate) render_passes: Registry<RenderPass>,
     pub(crate) compute_passes: Registry<ComputePass>,
-    pub(crate) render_bundle_encoders: Registry<Arc<Mutex<RenderBundleEncoder>>>,
+    pub(crate) render_bundle_encoders: Registry<RenderBundleEncoder>,
 }
 
 impl Hub {

--- a/wgpu-core-remote/src/identity.rs
+++ b/wgpu-core-remote/src/identity.rs
@@ -2,14 +2,7 @@ use alloc::vec::Vec;
 use core::{fmt::Debug, marker::PhantomData};
 use parking_lot::Mutex;
 
-use crate::{id::Id, id::Marker, Epoch, Index};
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-enum IdSource {
-    External,
-    Allocated,
-    None,
-}
+use crate::{id::markers, id::Id, id::Marker, Epoch, Index};
 
 /// A simple structure to allocate [`Id`] identifiers.
 ///
@@ -33,40 +26,19 @@ enum IdSource {
 ///   index in an `Id`. Index values are reused, but only with a different
 ///   epoch.
 ///
-/// `IdentityValues` can also be used to track the count of IDs allocated by
-/// some external allocator. Combining internal and external allocation is not
-/// allowed; calling both `alloc` and `mark_as_used` on the same
-/// `IdentityValues` will result in a panic. The external mode is used when
-/// [playing back a trace of wgpu operations][player].
-///
 /// [`Id`]: crate::id::Id
 /// [`alloc`]: IdentityValues::alloc
 /// [`release`]: IdentityValues::release
-/// [player]: https://github.com/gfx-rs/wgpu/tree/trunk/player/
 #[derive(Debug)]
 pub(super) struct IdentityValues {
     free: Vec<(Index, Epoch)>,
     next_index: Index,
     count: usize,
-    // Sanity check: The allocation logic works under the assumption that we don't
-    // do a mix of allocating ids from here and providing ids manually for the same
-    // storage container.
-    id_source: IdSource,
 }
 
 impl IdentityValues {
     /// Allocate a fresh, never-before-seen ID.
-    ///
-    /// # Panics
-    ///
-    /// If `mark_as_used` has previously been called on this `IdentityValues`.
     pub fn alloc<T: Marker>(&mut self) -> Id<T> {
-        assert!(
-            self.id_source != IdSource::External,
-            "Mix of internally allocated and externally provided IDs"
-        );
-        self.id_source = IdSource::Allocated;
-
         self.count += 1;
         match self.free.pop() {
             Some((index, epoch)) => Id::zip(index, epoch + 1),
@@ -79,35 +51,13 @@ impl IdentityValues {
         }
     }
 
-    /// Increment the count of used IDs.
-    ///
-    /// # Panics
-    ///
-    /// If `alloc` has previously been called on this `IdentityValues`.
-    pub fn mark_as_used<T: Marker>(&mut self, id: Id<T>) -> Id<T> {
-        assert!(
-            self.id_source != IdSource::Allocated,
-            "Mix of internally allocated and externally provided IDs"
-        );
-        self.id_source = IdSource::External;
-
-        self.count += 1;
-        id
-    }
-
     /// Free `id` and/or decrement the count of used IDs.
     ///
     /// Freed IDs will never be returned from `alloc` again.
     pub fn release<T: Marker>(&mut self, id: Id<T>) {
-        if let IdSource::Allocated = self.id_source {
-            let (index, epoch) = id.unzip();
-            self.free.push((index, epoch));
-        }
+        let (index, epoch) = id.unzip();
+        self.free.push((index, epoch));
         self.count -= 1;
-    }
-
-    pub fn count(&self) -> usize {
-        self.count
     }
 }
 
@@ -121,9 +71,7 @@ impl<T: Marker> IdentityManager<T> {
     pub fn process(&self) -> Id<T> {
         self.values.lock().alloc()
     }
-    pub fn mark_as_used(&self, id: Id<T>) -> Id<T> {
-        self.values.lock().mark_as_used(id)
-    }
+
     pub fn free(&self, id: Id<T>) {
         self.values.lock().release(id)
     }
@@ -136,7 +84,6 @@ impl<T: Marker> IdentityManager<T> {
                 free: Vec::new(),
                 next_index: 0,
                 count: 0,
-                id_source: IdSource::None,
             }),
             _phantom: PhantomData,
         }
@@ -149,10 +96,45 @@ impl<T: Marker> Default for IdentityManager<T> {
     }
 }
 
+/// A collection of identity managers for all resource types.
+///
+/// This is to be used in content process for ID generation.
+/// IDs are then sent to the GPU process for resource creation in [`crate::hub::Hub`].
+#[derive(Debug, Default)]
+pub struct IdentityHub {
+    pub adapters: IdentityManager<markers::Adapter>,
+    pub devices: IdentityManager<markers::Device>,
+    pub queues: IdentityManager<markers::Queue>,
+    pub pipeline_layouts: IdentityManager<markers::PipelineLayout>,
+    pub shader_modules: IdentityManager<markers::ShaderModule>,
+    pub bind_group_layouts: IdentityManager<markers::BindGroupLayout>,
+    pub bind_groups: IdentityManager<markers::BindGroup>,
+    pub command_encoders: IdentityManager<markers::CommandEncoder>,
+    pub command_buffers: IdentityManager<markers::CommandBuffer>,
+    pub render_bundles: IdentityManager<markers::RenderBundle>,
+    pub render_pipelines: IdentityManager<markers::RenderPipeline>,
+    pub compute_pipelines: IdentityManager<markers::ComputePipeline>,
+    pub pipeline_caches: IdentityManager<markers::PipelineCache>,
+    pub query_sets: IdentityManager<markers::QuerySet>,
+    pub buffers: IdentityManager<markers::Buffer>,
+    pub textures: IdentityManager<markers::Texture>,
+    pub texture_views: IdentityManager<markers::TextureView>,
+    pub external_textures: IdentityManager<markers::ExternalTexture>,
+    pub samplers: IdentityManager<markers::Sampler>,
+    pub render_passes: IdentityManager<markers::RenderPassEncoder>,
+    pub compute_passes: IdentityManager<markers::ComputePassEncoder>,
+    pub render_bundle_encoders: IdentityManager<markers::RenderBundleEncoder>,
+}
+
+impl IdentityHub {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 #[test]
 fn test_epoch_end_of_life() {
-    use crate::id;
-    let man = IdentityManager::<id::markers::Buffer>::new();
+    let man = IdentityManager::<markers::Buffer>::new();
     let id1 = man.process();
     assert_eq!(id1.unzip(), (0, 1));
     man.free(id1);

--- a/wgpu-core-remote/src/identity.rs
+++ b/wgpu-core-remote/src/identity.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
+use core::cell::RefCell;
 use core::{fmt::Debug, marker::PhantomData};
-use parking_lot::Mutex;
 
 use crate::{id::markers, id::Id, id::Marker, Epoch, Index};
 
@@ -63,24 +63,24 @@ impl IdentityValues {
 
 #[derive(Debug)]
 pub struct IdentityManager<T: Marker> {
-    pub(super) values: Mutex<IdentityValues>,
+    pub(super) values: RefCell<IdentityValues>,
     _phantom: PhantomData<T>,
 }
 
 impl<T: Marker> IdentityManager<T> {
     pub fn process(&self) -> Id<T> {
-        self.values.lock().alloc()
+        self.values.borrow_mut().alloc()
     }
 
     pub fn free(&self, id: Id<T>) {
-        self.values.lock().release(id)
+        self.values.borrow_mut().release(id)
     }
 }
 
 impl<T: Marker> IdentityManager<T> {
     pub fn new() -> Self {
         Self {
-            values: Mutex::new(IdentityValues {
+            values: RefCell::new(IdentityValues {
                 free: Vec::new(),
                 next_index: 0,
                 count: 0,

--- a/wgpu-core-remote/src/registry.rs
+++ b/wgpu-core-remote/src/registry.rs
@@ -1,4 +1,4 @@
-use parking_lot::{RwLock, RwLockReadGuard};
+use core::cell::{Ref, RefCell};
 
 use crate::{
     id::Id,
@@ -18,13 +18,13 @@ use crate::{
 ///
 #[derive(Debug)]
 pub(crate) struct Registry<T: StorageItem> {
-    storage: RwLock<Storage<T>>,
+    storage: RefCell<Storage<T>>,
 }
 
 impl<T: StorageItem> Registry<T> {
     pub(crate) fn new() -> Self {
         Self {
-            storage: RwLock::new(Storage::new()),
+            storage: RefCell::new(Storage::new()),
         }
     }
 }
@@ -32,7 +32,7 @@ impl<T: StorageItem> Registry<T> {
 #[must_use]
 pub(crate) struct FutureId<'a, T: StorageItem> {
     id: Id<T::Marker>,
-    data: &'a RwLock<Storage<T>>,
+    data: &'a RefCell<Storage<T>>,
 }
 
 impl<T: StorageItem> FutureId<'_, T> {
@@ -40,7 +40,7 @@ impl<T: StorageItem> FutureId<'_, T> {
     ///
     /// Registers it with the registry.
     pub fn assign(self, value: T) -> Id<T::Marker> {
-        let mut data = self.data.write();
+        let mut data = self.data.borrow_mut();
         data.insert(self.id, value);
         self.id
     }
@@ -55,12 +55,12 @@ impl<T: StorageItem> Registry<T> {
     }
 
     #[track_caller]
-    pub(crate) fn read<'a>(&'a self) -> RwLockReadGuard<'a, Storage<T>> {
-        self.storage.read()
+    pub(crate) fn read<'a>(&'a self) -> Ref<'a, Storage<T>> {
+        self.storage.borrow()
     }
 
     pub(crate) fn remove(&self, id: Id<T::Marker>) -> T {
-        let value = self.storage.write().remove(id);
+        let value = self.storage.borrow_mut().remove(id);
         value
     }
 }

--- a/wgpu-core-remote/src/registry.rs
+++ b/wgpu-core-remote/src/registry.rs
@@ -1,4 +1,4 @@
-use core::cell::{Ref, RefCell};
+use core::cell::{Ref, RefCell, RefMut};
 
 use crate::{
     id::Id,
@@ -68,5 +68,11 @@ impl<T: StorageItem> Registry<T> {
 impl<T: StorageItem + Clone> Registry<T> {
     pub(crate) fn get(&self, id: Id<T::Marker>) -> T {
         self.read().get(id)
+    }
+}
+
+impl<T: StorageItem> Registry<T> {
+    pub(crate) fn get_mut<'a>(&'a self, id: Id<T::Marker>) -> RefMut<'a, T> {
+        RefMut::map(self.storage.borrow_mut(), |storage| storage.get_mut(id))
     }
 }

--- a/wgpu-core-remote/src/registry.rs
+++ b/wgpu-core-remote/src/registry.rs
@@ -1,30 +1,9 @@
-use alloc::sync::Arc;
 use parking_lot::{RwLock, RwLockReadGuard};
 
 use crate::{
     id::Id,
-    identity::IdentityManager,
-    storage::{Element, Storage, StorageItem},
+    storage::{Storage, StorageItem},
 };
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct RegistryReport {
-    /// Count of IDs allocated by [`IdentityManager`]
-    ///
-    /// This may be inconsistent with other fields of the report if
-    /// IDs are allocated or released concurrently with report
-    /// generation.
-    pub num_allocated: usize,
-    pub num_kept_from_user: usize,
-    pub num_released_from_user: usize,
-    pub element_size: usize,
-}
-
-impl RegistryReport {
-    pub fn is_empty(&self) -> bool {
-        self.num_allocated + self.num_kept_from_user == 0
-    }
-}
 
 /// Registry is the primary holder of each resource type
 /// Every resource is now arcanized so the last arc released
@@ -39,15 +18,12 @@ impl RegistryReport {
 ///
 #[derive(Debug)]
 pub(crate) struct Registry<T: StorageItem> {
-    // Must only contain an id which has either never been used or has been released from `storage`
-    identity: Arc<IdentityManager<T::Marker>>,
     storage: RwLock<Storage<T>>,
 }
 
 impl<T: StorageItem> Registry<T> {
     pub(crate) fn new() -> Self {
         Self {
-            identity: Arc::new(IdentityManager::new()),
             storage: RwLock::new(Storage::new()),
         }
     }
@@ -71,15 +47,9 @@ impl<T: StorageItem> FutureId<'_, T> {
 }
 
 impl<T: StorageItem> Registry<T> {
-    pub(crate) fn prepare(&self, id_in: Option<Id<T::Marker>>) -> FutureId<'_, T> {
+    pub(crate) fn prepare(&self, id_in: Id<T::Marker>) -> FutureId<'_, T> {
         FutureId {
-            id: match id_in {
-                Some(id_in) => {
-                    self.identity.mark_as_used(id_in);
-                    id_in
-                }
-                None => self.identity.process(),
-            },
+            id: id_in,
             data: &self.storage,
         }
     }
@@ -88,79 +58,15 @@ impl<T: StorageItem> Registry<T> {
     pub(crate) fn read<'a>(&'a self) -> RwLockReadGuard<'a, Storage<T>> {
         self.storage.read()
     }
+
     pub(crate) fn remove(&self, id: Id<T::Marker>) -> T {
         let value = self.storage.write().remove(id);
-        // This needs to happen *after* removing it from the storage, to maintain the
-        // invariant that `self.identity` only contains ids which are actually available
-        // See https://github.com/gfx-rs/wgpu/issues/5372
-        self.identity.free(id);
-        //Returning None is legal if it's an error ID
         value
-    }
-
-    pub(crate) fn generate_report(&self) -> RegistryReport {
-        let mut report = RegistryReport {
-            element_size: size_of::<T>(),
-            ..Default::default()
-        };
-
-        // Acquiring the identity values lock while holding the storage lock
-        // would require adding an edge in the lock graph, and would still not
-        // ensure a consistent report, because the storage lock is not otherwise
-        // acquired when managing IDs.
-        report.num_allocated = self.identity.values.lock().count();
-
-        let storage = self.storage.read();
-        for element in storage.map.iter() {
-            match *element {
-                Element::Occupied(..) => report.num_kept_from_user += 1,
-                Element::Vacant => report.num_released_from_user += 1,
-            }
-        }
-        report
     }
 }
 
 impl<T: StorageItem + Clone> Registry<T> {
     pub(crate) fn get(&self, id: Id<T::Marker>) -> T {
         self.read().get(id)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Registry;
-    use crate::{id::Marker, storage::StorageItem};
-    use alloc::sync::Arc;
-    use wgpu_core::resource::ResourceType;
-
-    struct TestData;
-    struct TestDataId;
-    impl Marker for TestDataId {
-        const TYPE: &'static str = "TestData";
-    }
-
-    impl ResourceType for TestData {
-        const TYPE: &'static str = "TestData";
-    }
-    impl StorageItem for TestData {
-        type Marker = TestDataId;
-    }
-
-    #[test]
-    fn simultaneous_registration() {
-        let registry = Registry::new();
-        std::thread::scope(|s| {
-            for _ in 0..5 {
-                s.spawn(|| {
-                    for _ in 0..1000 {
-                        let value = Arc::new(TestData);
-                        let new_id = registry.prepare(None);
-                        let id = new_id.assign(value);
-                        registry.remove(id);
-                    }
-                });
-            }
-        })
     }
 }

--- a/wgpu-core-remote/src/storage.rs
+++ b/wgpu-core-remote/src/storage.rs
@@ -122,6 +122,30 @@ where
     }
 }
 
+impl<T> Storage<T>
+where
+    T: StorageItem,
+{
+    /// Get a mutable reference to an item.
+    /// Panics if there is an epoch mismatch, the entry is empty or in error.
+    pub(crate) fn get_mut(&mut self, id: Id<T::Marker>) -> &mut T {
+        let (index, epoch) = id.unzip();
+        let (result, storage_epoch) = match self.map.get_mut(index as usize) {
+            Some(Element::Occupied(v, epoch)) => (v, *epoch),
+            None | Some(Element::Vacant) => {
+                panic!("Cannot get non-existent resource {id:?}");
+            }
+        };
+        assert_eq!(
+            epoch,
+            storage_epoch,
+            "Cannot get {id:?}, found other resource {other:?}",
+            other = Id::<T::Marker>::zip(index, storage_epoch),
+        );
+        result
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::id::Marker;


### PR DESCRIPTION
**Connections**
Towards #10073

**Description**
First commit deals with always providing IDs, removing duality of IdentityManager by removing it for global (it only remains in IdentitiyHub which is ID generator/alloc that should live in content process, this type already exisited in servo https://github.com/servo/servo/blob/2b2dcbd1deefbd8011f0076e045f5f988f8e8141/components/script_webgpu/identityhub.rs and in firefox: https://searchfox.org/firefox-main/rev/ee8e457ae20efb27313476fed0bed50571c1199f/gfx/wgpu_bindings/src/client.rs#303)

All other commits deal with removing restriction of send/sync in global as browser impl do not need it and simplification this brings (discussed https://github.com/gfx-rs/wgpu/pull/9740#issuecomment-4808504685). We replaced all mutexes with RefCell 🎉. For encoders we reuse interior mutability of Registery to get &mut as outlined in https://github.com/gfx-rs/wgpu/pull/9740#issuecomment-4806248960

**Testing**
Just refactor

**Squash or Rebase?**
Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
