### PR TITLE
Added cleared field to create_texture_from_hal

### DIFF
--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -265,6 +265,7 @@ impl Global {
         desc: &TextureDescriptor,
         initial_state: wgt::TextureUses,
         id_in: id::TextureId,
+        cleared: bool,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
@@ -274,7 +275,7 @@ impl Global {
         let device = devices.get(device_id);
 
         let (texture, error) =
-            unsafe { device.create_texture_from_hal(hal_texture, desc, initial_state) };
+            unsafe { device.create_texture_from_hal(hal_texture, desc, initial_state, cleared) };
 
         let id = textures.assign(id_in, texture);
         (id, error)

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1537,11 +1537,12 @@ impl Device {
         hal_texture: Box<dyn hal::DynTexture>,
         desc: &resource::TextureDescriptor,
         initial_state: wgt::TextureUses,
+        cleared: bool,
     ) -> (Arc<Texture>, Option<resource::CreateTextureError>) {
         profiling::scope!("Device::create_texture_from_hal");
 
         let (texture, error) =
-            match self.create_texture_from_hal_inner(hal_texture, desc, initial_state) {
+            match self.create_texture_from_hal_inner(hal_texture, desc, initial_state, cleared) {
                 Ok(texture) => (texture, None),
                 Err(e) => (Texture::invalid(self, desc), Some(e)),
             };
@@ -1569,6 +1570,7 @@ impl Device {
         hal_texture: Box<dyn hal::DynTexture>,
         desc: &resource::TextureDescriptor,
         initial_state: wgt::TextureUses,
+        cleared: bool,
     ) -> Result<Arc<Texture>, resource::CreateTextureError> {
         self.check_is_valid()?;
 
@@ -1585,7 +1587,7 @@ impl Device {
             desc,
             format_features,
             resource::TextureClearMode::None,
-            false,
+            !cleared, // inverted so it marks the tracker properly
         );
 
         let texture = Arc::new(texture);

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -343,6 +343,7 @@ impl Device {
         hal_texture: A::Texture,
         desc: &TextureDescriptor<'_>,
         initial_state: wgt::TextureUses,
+        cleared: bool,
     ) -> Texture {
         let texture = unsafe {
             let core_device = self.inner.as_core();
@@ -351,6 +352,7 @@ impl Device {
                 core_device,
                 desc,
                 initial_state,
+                cleared,
             )
         };
         Texture {

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -335,7 +335,9 @@ impl Device {
     /// texture's subresources on first use to avoid exposing undefined
     /// memory. Set `cleared` to `true` if the contents are already valid
     /// (e.g. just cleared or written to on the driver side), or `false` if
-    /// they're undefined, so wgpu clears them before they are read.
+    /// they're undefined, so wgpu clears them before they are read. Falsely
+    /// passing `true` skips that clear and exposes uninitialized/stale GPU
+    /// memory to subsequent reads.
     ///
     /// This is unrelated to `initial_state`, which only describes the
     /// tracker's usage state, not the validity of the contents.
@@ -348,6 +350,8 @@ impl Device {
     /// - `initial_state`, if it is not `TextureUses::UNINITIALIZED`, must
     ///   match the actual driver-side layout/state of the wrapped resource at
     ///   the moment of wrap.
+    /// - `cleared` must not be `true` unless the resource's contents are
+    ///   actually valid/defined
     #[cfg(wgpu_core)]
     #[must_use]
     pub unsafe fn create_texture_from_hal<A: hal::Api>(

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -328,6 +328,18 @@ impl Device {
     /// may be discarded), `initial_state` may be set to
     /// `TextureUses::UNINITIALIZED`.
     ///
+    /// # `cleared`
+    ///
+    /// Whether the wrapped resource's contents are already valid/defined.
+    /// This drives wgpu's lazy-clear tracking, which otherwise clears a
+    /// texture's subresources on first use to avoid exposing undefined
+    /// memory. Set `cleared` to `true` if the contents are already valid
+    /// (e.g. just cleared or written to on the driver side), or `false` if
+    /// they're undefined, so wgpu clears them before they are read.
+    ///
+    /// This is unrelated to `initial_state`, which only describes the
+    /// tracker's usage state, not the validity of the contents.
+    ///
     /// # Safety
     ///
     /// - `hal_texture` must be created from this device internal handle

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -122,6 +122,7 @@ impl ContextWgpuCore {
         device: &CoreDevice,
         desc: &TextureDescriptor<'_>,
         initial_state: wgt::TextureUses,
+        cleared: bool,
     ) -> CoreTexture {
         let descriptor = desc.map_label_and_view_formats(|l| l.map(Borrowed), |v| v.to_vec());
         let (wgpu_texture, error) = unsafe {
@@ -129,6 +130,7 @@ impl ContextWgpuCore {
                 Box::new(hal_texture),
                 &descriptor,
                 initial_state,
+                cleared,
             )
         };
         if let Some(cause) = error {


### PR DESCRIPTION
**Connections**
Follow up to #10075 and address the comment from #10009 

**Description**
`create_texture_from_hal` now has a cleared field that if set to false wgpu will clear the texture instead of writing .

**Testing**
_Explain how this change is tested._

**Squash or Rebase?**
Squash


<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
