### PR TITLE
[core] Report missing passthrough shader entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
 #### Validation
 
+- Report an accurate validation error when a passthrough shader module has no entry points. By @ksh368-bit in [#10079](https://github.com/gfx-rs/wgpu/pull/10079).
 - Validate that the arguments are within the indirect buffer when encoding an indirect draw to a render bundle. Moves some indirect draw errors from `RenderPassErrorInner` to `RenderCommandError`. By @andyleiserson in [#9871](https://github.com/gfx-rs/wgpu/pull/9871).
 - When creating render pipelines, validate that a corresponding shader output is present for each color attachment with non-zero write mask, and that shader output includes alpha when the blend operation uses source alpha. By @andyleiserson in [#9939](https://github.com/gfx-rs/wgpu/pull/9939).
 - Reject bind group layout entries with `TASK` or `MESH` visibility unless `Features::EXPERIMENTAL_MESH_SHADER` is enabled. By @teoxoy in [#10042](https://github.com/gfx-rs/wgpu/issues/10042).

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -154,25 +154,33 @@ impl ShaderModule {
                 interface.finalize_entry_point_name(stage, entry_point)
             }
             ShaderMetaData::Passthrough(ref interface) => {
-                if let Some(ep) = entry_point {
-                    if interface.entry_point_names.contains(ep) {
-                        Ok(ep.to_owned())
-                    } else {
-                        Err(validation::StageError::MissingEntryPoint(ep.to_owned()))
-                    }
-                } else {
-                    if interface.entry_point_names.len() != 1 {
-                        return Err(validation::StageError::MultipleEntryPointsFound);
-                    }
-                    Ok(interface
-                        .entry_point_names
-                        .iter()
-                        .next()
-                        .unwrap()
-                        .to_owned())
-                }
+                finalize_passthrough_entry_point_name(interface, entry_point)
             }
         }
+    }
+}
+
+fn finalize_passthrough_entry_point_name(
+    interface: &validation::PassthroughInterface,
+    entry_point: Option<&str>,
+) -> Result<String, validation::StageError> {
+    if let Some(ep) = entry_point {
+        return if interface.entry_point_names.contains(ep) {
+            Ok(ep.to_owned())
+        } else {
+            Err(validation::StageError::MissingEntryPoint(ep.to_owned()))
+        };
+    }
+
+    match interface.entry_point_names.len() {
+        0 => Err(validation::StageError::NoEntryPointFound),
+        1 => Ok(interface
+            .entry_point_names
+            .iter()
+            .next()
+            .unwrap()
+            .to_owned()),
+        _ => Err(validation::StageError::MultipleEntryPointsFound),
     }
 }
 
@@ -1148,5 +1156,53 @@ impl RenderPipeline {
             });
         };
         (bgl, error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn passthrough_interface(entry_point_names: &[&str]) -> validation::PassthroughInterface {
+        validation::PassthroughInterface {
+            entry_point_names: entry_point_names
+                .iter()
+                .map(|name| (*name).to_owned())
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn select_implicit_passthrough_entry_point() {
+        let empty = passthrough_interface(&[]);
+        assert!(matches!(
+            finalize_passthrough_entry_point_name(&empty, None),
+            Err(validation::StageError::NoEntryPointFound)
+        ));
+
+        let single = passthrough_interface(&["main"]);
+        assert_eq!(
+            finalize_passthrough_entry_point_name(&single, None).unwrap(),
+            "main"
+        );
+
+        let multiple = passthrough_interface(&["vertex", "fragment"]);
+        assert!(matches!(
+            finalize_passthrough_entry_point_name(&multiple, None),
+            Err(validation::StageError::MultipleEntryPointsFound)
+        ));
+    }
+
+    #[test]
+    fn select_explicit_passthrough_entry_point() {
+        let interface = passthrough_interface(&["main"]);
+        assert_eq!(
+            finalize_passthrough_entry_point_name(&interface, Some("main")).unwrap(),
+            "main"
+        );
+        assert!(matches!(
+            finalize_passthrough_entry_point_name(&interface, Some("missing")),
+            Err(validation::StageError::MissingEntryPoint(name)) if name == "missing"
+        ));
     }
 }


### PR DESCRIPTION
**Connections**

Fixes #9993.

**Description**

When a passthrough shader module had no entry points and the pipeline descriptor omitted the entry-point name, the selection logic reported `MultipleEntryPointsFound`. The same `len() != 1` branch handled both empty and ambiguous entry-point sets.

This change separates those cases: an empty set now returns `NoEntryPointFound`, a single entry point is selected, and multiple entry points continue to return `MultipleEntryPointsFound`. Explicit entry-point selection keeps its existing behavior.

**Testing**

- `cargo test -p wgpu-core`
- `cargo test -p wgpu-core --all-features`
- `cargo clippy -p wgpu-core --tests -- -D warnings`
- `cargo clippy --tests`
- `cargo check -p wgpu-core --no-default-features`
- `cargo fmt --all -- --check`
- `cargo xtask changelog`

**Squash or Rebase?**

This is a single, logically scoped commit that is ready to rebase onto `trunk`.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and does not make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
