### PR TITLE
[core-remote] Use mutability from `RefCell<Hub>` for `Registry` and remove `FutureId`

### DIFF
--- a/wgpu-core-remote/src/global/as_hal.rs
+++ b/wgpu-core-remote/src/global/as_hal.rs
@@ -11,7 +11,7 @@ impl Global {
         &self,
         id: BufferId,
     ) -> Option<impl Deref<Target = A::Buffer>> {
-        let hub = &self.hub;
+        let hub = &self.hub.borrow();
 
         let buffer = hub.buffers.get(id);
 
@@ -25,7 +25,7 @@ impl Global {
         &self,
         id: TextureId,
     ) -> Option<impl Deref<Target = A::Texture>> {
-        let hub = &self.hub;
+        let hub = &self.hub.borrow();
 
         let texture = hub.textures.get(id);
 
@@ -39,7 +39,7 @@ impl Global {
         &self,
         id: TextureViewId,
     ) -> Option<impl Deref<Target = A::TextureView>> {
-        let hub = &self.hub;
+        let hub = &self.hub.borrow();
 
         let view = hub.texture_views.get(id);
 
@@ -53,7 +53,7 @@ impl Global {
         &self,
         id: AdapterId,
     ) -> Option<impl Deref<Target = A::Adapter>> {
-        let hub = &self.hub;
+        let hub = &self.hub.borrow();
         let adapter = hub.adapters.get(id);
 
         unsafe { adapter.as_hal::<A>() }
@@ -66,7 +66,8 @@ impl Global {
         &self,
         id: DeviceId,
     ) -> Option<impl Deref<Target = A::Device>> {
-        let device = self.hub.devices.get(id);
+        let hub = &self.hub.borrow();
+        let device = hub.devices.get(id);
 
         unsafe { device.as_hal::<A>() }
     }
@@ -78,7 +79,8 @@ impl Global {
         &self,
         id: DeviceId,
     ) -> Option<impl Deref<Target = A::Fence>> {
-        let device = self.hub.devices.get(id);
+        let hub = &self.hub.borrow();
+        let device = hub.devices.get(id);
 
         unsafe { device.fence_as_hal::<A>() }
     }
@@ -101,7 +103,7 @@ impl Global {
         id: CommandEncoderId,
         hal_command_encoder_callback: F,
     ) -> R {
-        let hub = &self.hub;
+        let hub = &self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(id);
         unsafe { cmd_enc.as_hal_mut::<A, F, R>(hal_command_encoder_callback) }
@@ -114,7 +116,8 @@ impl Global {
         &self,
         id: QueueId,
     ) -> Option<impl Deref<Target = A::Queue>> {
-        let queue = self.hub.queues.get(id);
+        let hub = &self.hub.borrow();
+        let queue = hub.queues.get(id);
 
         unsafe { queue.as_hal::<A>() }
     }

--- a/wgpu-core-remote/src/global/bundle.rs
+++ b/wgpu-core-remote/src/global/bundle.rs
@@ -1,3 +1,4 @@
+use crate::hub::Hub;
 use crate::id;
 use wgpu_core::command::PassStateError;
 
@@ -9,13 +10,15 @@ impl crate::global::Global {
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[wgt::DynamicOffset],
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_bundle_encoders,
+            bind_groups,
+            ..
+        } = &mut *hub;
+        let bundle_encoder = render_bundle_encoders.get_mut(bundle_encoder);
 
-        bundle_encoder.set_bind_group(
-            index,
-            bind_group_id.map(|id| self.hub.bind_groups.get(id)),
-            offsets,
-        )
+        bundle_encoder.set_bind_group(index, bind_group_id.map(|id| bind_groups.get(id)), offsets)
     }
 
     pub fn render_bundle_encoder_set_pipeline(
@@ -23,9 +26,15 @@ impl crate::global::Global {
         bundle_encoder: id::RenderBundleEncoderId,
         pipeline_id: id::RenderPipelineId,
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_bundle_encoders,
+            render_pipelines,
+            ..
+        } = &mut *hub;
+        let bundle_encoder = render_bundle_encoders.get_mut(bundle_encoder);
 
-        bundle_encoder.set_pipeline(self.hub.render_pipelines.get(pipeline_id))
+        bundle_encoder.set_pipeline(render_pipelines.get(pipeline_id))
     }
 
     pub fn render_bundle_encoder_set_vertex_buffer(
@@ -36,14 +45,15 @@ impl crate::global::Global {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_bundle_encoders,
+            buffers,
+            ..
+        } = &mut *hub;
+        let bundle_encoder = render_bundle_encoders.get_mut(bundle_encoder);
 
-        bundle_encoder.set_vertex_buffer(
-            slot,
-            buffer_id.map(|id| self.hub.buffers.get(id)),
-            offset,
-            size,
-        )
+        bundle_encoder.set_vertex_buffer(slot, buffer_id.map(|id| buffers.get(id)), offset, size)
     }
 
     pub fn render_bundle_encoder_set_index_buffer(
@@ -54,9 +64,15 @@ impl crate::global::Global {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_bundle_encoders,
+            buffers,
+            ..
+        } = &mut *hub;
+        let bundle_encoder = render_bundle_encoders.get_mut(bundle_encoder);
 
-        bundle_encoder.set_index_buffer(self.hub.buffers.get(buffer), index_format, offset, size)
+        bundle_encoder.set_index_buffer(buffers.get(buffer), index_format, offset, size)
     }
 
     pub fn render_bundle_encoder_set_immediates(
@@ -65,7 +81,8 @@ impl crate::global::Global {
         offset: u32,
         data: &[u8],
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.set_immediates(offset, data)
     }
@@ -78,7 +95,8 @@ impl crate::global::Global {
         first_vertex: u32,
         first_instance: u32,
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.draw(vertex_count, instance_count, first_vertex, first_instance)
     }
@@ -92,7 +110,8 @@ impl crate::global::Global {
         base_vertex: i32,
         first_instance: u32,
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.draw_indexed(
             index_count,
@@ -109,9 +128,15 @@ impl crate::global::Global {
         buffer_id: id::BufferId,
         offset: wgt::BufferAddress,
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_bundle_encoders,
+            buffers,
+            ..
+        } = &mut *hub;
+        let bundle_encoder = render_bundle_encoders.get_mut(bundle_encoder);
 
-        bundle_encoder.draw_indirect(self.hub.buffers.get(buffer_id), offset)
+        bundle_encoder.draw_indirect(buffers.get(buffer_id), offset)
     }
 
     pub fn render_bundle_encoder_draw_indexed_indirect(
@@ -120,9 +145,15 @@ impl crate::global::Global {
         buffer_id: id::BufferId,
         offset: wgt::BufferAddress,
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_bundle_encoders,
+            buffers,
+            ..
+        } = &mut *hub;
+        let bundle_encoder = render_bundle_encoders.get_mut(bundle_encoder);
 
-        bundle_encoder.draw_indexed_indirect(self.hub.buffers.get(buffer_id), offset)
+        bundle_encoder.draw_indexed_indirect(buffers.get(buffer_id), offset)
     }
 
     pub fn render_bundle_encoder_push_debug_group(
@@ -130,7 +161,8 @@ impl crate::global::Global {
         bundle_encoder: id::RenderBundleEncoderId,
         label: &str,
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.push_debug_group(label)
     }
@@ -139,7 +171,8 @@ impl crate::global::Global {
         &self,
         bundle_encoder: id::RenderBundleEncoderId,
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.pop_debug_group()
     }
@@ -149,7 +182,8 @@ impl crate::global::Global {
         bundle_encoder: id::RenderBundleEncoderId,
         label: &str,
     ) -> Result<(), PassStateError> {
-        let mut bundle_encoder = self.hub.render_bundle_encoders.get_mut(bundle_encoder);
+        let mut hub = self.hub.borrow_mut();
+        let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.insert_debug_marker(label)
     }

--- a/wgpu-core-remote/src/global/command_encoder.rs
+++ b/wgpu-core-remote/src/global/command_encoder.rs
@@ -30,7 +30,7 @@ impl Global {
         let cmd_enc = command_encoders.get(encoder_id);
 
         let (cmd_buf, opt_error) = cmd_enc.finish(desc);
-        let cmd_buf_id = command_buffers.prepare(id_in).assign(cmd_buf);
+        let cmd_buf_id = command_buffers.assign(id_in, cmd_buf);
 
         (cmd_buf_id, opt_error)
     }

--- a/wgpu-core-remote/src/global/command_encoder.rs
+++ b/wgpu-core-remote/src/global/command_encoder.rs
@@ -3,6 +3,7 @@ use wgpu_core::Label;
 use wgt::{BufferAddress, Extent3d, ImageSubresourceRange};
 
 use crate::global::Global;
+use crate::hub::Hub;
 use crate::id::{BufferId, CommandEncoderId, TextureId};
 use crate::{id, TexelCopyBufferInfo};
 
@@ -20,11 +21,16 @@ impl Global {
         desc: &wgt::CommandBufferDescriptor<Label>,
         id_in: id::CommandBufferId,
     ) -> (id::CommandBufferId, Option<(String, CommandEncoderError)>) {
-        let hub = &self.hub;
-        let cmd_enc = hub.command_encoders.get(encoder_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            command_encoders,
+            command_buffers,
+            ..
+        } = &mut *hub;
+        let cmd_enc = command_encoders.get(encoder_id);
 
         let (cmd_buf, opt_error) = cmd_enc.finish(desc);
-        let cmd_buf_id = hub.command_buffers.prepare(id_in).assign(cmd_buf);
+        let cmd_buf_id = command_buffers.prepare(id_in).assign(cmd_buf);
 
         (cmd_buf_id, opt_error)
     }
@@ -34,7 +40,7 @@ impl Global {
         encoder_id: CommandEncoderId,
         label: &str,
     ) -> Result<(), EncoderStateError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(encoder_id);
         cmd_enc.push_debug_group(label)
@@ -45,7 +51,7 @@ impl Global {
         encoder_id: CommandEncoderId,
         label: &str,
     ) -> Result<(), EncoderStateError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(encoder_id);
         cmd_enc.insert_debug_marker(label)
@@ -55,7 +61,7 @@ impl Global {
         &self,
         encoder_id: CommandEncoderId,
     ) -> Result<(), EncoderStateError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(encoder_id);
         cmd_enc.pop_debug_group()
@@ -70,7 +76,7 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferAddress>,
     ) -> Result<(), EncoderStateError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
         cmd_enc.clear_buffer(hub.buffers.get(dst), offset, size)
@@ -82,7 +88,7 @@ impl Global {
         dst: TextureId,
         subresource_range: &ImageSubresourceRange,
     ) -> Result<(), EncoderStateError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
 
@@ -97,7 +103,7 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), EncoderStateError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
         cmd_enc.write_timestamp(hub.query_sets.get(query_set_id), query_index)
@@ -112,7 +118,7 @@ impl Global {
         destination: BufferId,
         destination_offset: BufferAddress,
     ) -> Result<(), EncoderStateError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
 
@@ -136,11 +142,11 @@ impl Global {
         destination_offset: BufferAddress,
         size: Option<BufferAddress>,
     ) -> Result<(), EncoderStateError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
-        let source = self.resolve_buffer_id(source);
-        let destination = self.resolve_buffer_id(destination);
+        let source = hub.buffers.get(source);
+        let destination = hub.buffers.get(destination);
         cmd_enc.copy_buffer_to_buffer(source, source_offset, destination, destination_offset, size)
     }
 
@@ -151,13 +157,14 @@ impl Global {
         destination: &wgt::TexelCopyTextureInfo<TextureId>,
         copy_size: &Extent3d,
     ) -> Result<(), EncoderStateError> {
-        let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
+        let hub = self.hub.borrow();
+        let cmd_enc = hub.command_encoders.get(command_encoder_id);
         let source = wgt::TexelCopyBufferInfo {
-            buffer: self.resolve_buffer_id(source.buffer),
+            buffer: hub.buffers.get(source.buffer),
             layout: source.layout,
         };
         let destination = wgt::TexelCopyTextureInfo {
-            texture: self.resolve_texture_id(destination.texture),
+            texture: hub.textures.get(destination.texture),
             mip_level: destination.mip_level,
             origin: destination.origin,
             aspect: destination.aspect,
@@ -172,16 +179,17 @@ impl Global {
         destination: &TexelCopyBufferInfo,
         copy_size: &Extent3d,
     ) -> Result<(), EncoderStateError> {
-        let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
+        let hub = self.hub.borrow();
+        let cmd_enc = hub.command_encoders.get(command_encoder_id);
 
         let source = wgt::TexelCopyTextureInfo {
-            texture: self.resolve_texture_id(source.texture),
+            texture: hub.textures.get(source.texture),
             mip_level: source.mip_level,
             origin: source.origin,
             aspect: source.aspect,
         };
         let destination = wgt::TexelCopyBufferInfo {
-            buffer: self.resolve_buffer_id(destination.buffer),
+            buffer: hub.buffers.get(destination.buffer),
             layout: destination.layout,
         };
         cmd_enc.copy_texture_to_buffer(&source, &destination, copy_size)
@@ -194,16 +202,17 @@ impl Global {
         destination: &wgt::TexelCopyTextureInfo<TextureId>,
         copy_size: &Extent3d,
     ) -> Result<(), EncoderStateError> {
-        let cmd_enc = self.hub.command_encoders.get(command_encoder_id);
+        let hub = self.hub.borrow();
+        let cmd_enc = hub.command_encoders.get(command_encoder_id);
 
         let source = wgt::TexelCopyTextureInfo {
-            texture: self.resolve_texture_id(source.texture),
+            texture: hub.textures.get(source.texture),
             mip_level: source.mip_level,
             origin: source.origin,
             aspect: source.aspect,
         };
         let destination = wgt::TexelCopyTextureInfo {
-            texture: self.resolve_texture_id(destination.texture),
+            texture: hub.textures.get(destination.texture),
             mip_level: destination.mip_level,
             origin: destination.origin,
             aspect: destination.aspect,
@@ -219,7 +228,7 @@ impl Global {
         buffer_transitions: impl Iterator<Item = wgt::BufferTransition<BufferId>>,
         texture_transitions: impl Iterator<Item = wgt::TextureTransition<TextureId>>,
     ) -> Result<(), EncoderStateError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
         let buffer_transitions = buffer_transitions

--- a/wgpu-core-remote/src/global/compute_pass.rs
+++ b/wgpu-core-remote/src/global/compute_pass.rs
@@ -7,6 +7,7 @@ use wgpu_core::command::{
 use wgt::{BufferAddress, DynamicOffset};
 
 use crate::global::Global;
+use crate::hub::Hub;
 use crate::id;
 
 impl Global {
@@ -26,9 +27,16 @@ impl Global {
         desc: &ComputePassDescriptor<'_, PassTimestampWrites<id::QuerySetId>>,
         id_in: id::ComputePassEncoderId,
     ) -> (id::ComputePassEncoderId, Option<CommandEncoderError>) {
-        let fid = self.hub.compute_passes.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            command_encoders,
+            compute_passes,
+            query_sets,
+            ..
+        } = &mut *hub;
+        let fid = compute_passes.prepare(id_in);
 
-        let cmd_enc = self.hub.command_encoders.get(encoder_id);
+        let cmd_enc = command_encoders.get(encoder_id);
 
         let desc = ComputePassDescriptor {
             label: desc.label.as_deref().map(Cow::Borrowed),
@@ -36,7 +44,7 @@ impl Global {
                 .timestamp_writes
                 .as_ref()
                 .map(|tw| PassTimestampWrites {
-                    query_set: self.hub.query_sets.get(tw.query_set),
+                    query_set: query_sets.get(tw.query_set),
                     beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
                     end_of_pass_write_index: tw.end_of_pass_write_index,
                 }),
@@ -53,12 +61,14 @@ impl Global {
         &self,
         pass_id: id::ComputePassEncoderId,
     ) -> Result<(), EncoderStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.compute_passes.get_mut(pass_id);
         pass.end()
     }
 
     pub fn compute_pass_drop(&self, pass_id: id::ComputePassEncoderId) {
-        self.hub.compute_passes.remove(pass_id);
+        let mut hub = self.hub.borrow_mut();
+        hub.compute_passes.remove(pass_id);
     }
 }
 
@@ -78,10 +88,16 @@ impl Global {
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[DynamicOffset],
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            compute_passes,
+            bind_groups,
+            ..
+        } = &mut *hub;
+        let pass = compute_passes.get_mut(pass_id);
         pass.set_bind_group(
             index,
-            bind_group_id.map(|bind_group_id| self.hub.bind_groups.get(bind_group_id)),
+            bind_group_id.map(|bind_group_id| bind_groups.get(bind_group_id)),
             offsets,
         )
     }
@@ -91,8 +107,14 @@ impl Global {
         pass_id: id::ComputePassEncoderId,
         pipeline_id: id::ComputePipelineId,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
-        let pipeline = self.hub.compute_pipelines.get(pipeline_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            compute_passes,
+            compute_pipelines,
+            ..
+        } = &mut *hub;
+        let pass = compute_passes.get_mut(pass_id);
+        let pipeline = compute_pipelines.get(pipeline_id);
         pass.set_pipeline(pipeline)
     }
 
@@ -102,7 +124,8 @@ impl Global {
         offset: u32,
         data: &[u8],
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.compute_passes.get_mut(pass_id);
         pass.set_immediates(offset, data)
     }
 
@@ -113,7 +136,8 @@ impl Global {
         groups_y: u32,
         groups_z: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.compute_passes.get_mut(pass_id);
         pass.dispatch_workgroups(groups_x, groups_y, groups_z)
     }
 
@@ -123,8 +147,14 @@ impl Global {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
-        pass.dispatch_workgroups_indirect(self.hub.buffers.get(buffer_id), offset)
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            compute_passes,
+            buffers,
+            ..
+        } = &mut *hub;
+        let pass = compute_passes.get_mut(pass_id);
+        pass.dispatch_workgroups_indirect(buffers.get(buffer_id), offset)
     }
 
     pub fn compute_pass_push_debug_group(
@@ -133,7 +163,8 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.compute_passes.get_mut(pass_id);
         pass.push_debug_group(label, color)
     }
 
@@ -141,7 +172,8 @@ impl Global {
         &self,
         pass_id: id::ComputePassEncoderId,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.compute_passes.get_mut(pass_id);
         pass.pop_debug_group()
     }
 
@@ -151,7 +183,8 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.compute_passes.get_mut(pass_id);
         pass.insert_debug_marker(label, color)
     }
 
@@ -161,8 +194,14 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
-        let query_set = self.hub.query_sets.get(query_set_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            compute_passes,
+            query_sets,
+            ..
+        } = &mut *hub;
+        let pass = compute_passes.get_mut(pass_id);
+        let query_set = query_sets.get(query_set_id);
         pass.write_timestamp(query_set, query_index)
     }
 
@@ -172,8 +211,14 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
-        let query_set = self.hub.query_sets.get(query_set_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            compute_passes,
+            query_sets,
+            ..
+        } = &mut *hub;
+        let pass = compute_passes.get_mut(pass_id);
+        let query_set = query_sets.get(query_set_id);
         pass.begin_pipeline_statistics_query(query_set, query_index)
     }
 
@@ -181,7 +226,8 @@ impl Global {
         &self,
         pass_id: id::ComputePassEncoderId,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.compute_passes.get_mut(pass_id);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.compute_passes.get_mut(pass_id);
         pass.end_pipeline_statistics_query()
     }
 }

--- a/wgpu-core-remote/src/global/compute_pass.rs
+++ b/wgpu-core-remote/src/global/compute_pass.rs
@@ -34,7 +34,6 @@ impl Global {
             query_sets,
             ..
         } = &mut *hub;
-        let fid = compute_passes.prepare(id_in);
 
         let cmd_enc = command_encoders.get(encoder_id);
 
@@ -52,7 +51,7 @@ impl Global {
 
         let (pass, err) = cmd_enc.begin_compute_pass(&desc);
 
-        let id = fid.assign(pass);
+        let id = compute_passes.assign(id_in, pass);
 
         (id, err)
     }

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -103,13 +103,12 @@ impl Global {
         let Hub {
             buffers, devices, ..
         } = &mut *hub;
-        let fid = buffers.prepare(id_in);
 
         let device = devices.get(device_id);
 
         let (buffer, error) = device.create_buffer(desc);
 
-        let id = fid.assign(buffer);
+        let id = buffers.assign(id_in, buffer);
 
         (id, error)
     }
@@ -152,9 +151,8 @@ impl Global {
         let Hub {
             buffers, devices, ..
         } = &mut *hub;
-        let fid = buffers.prepare(id_in);
         let device = devices.get(device_id);
-        fid.assign(resource::Buffer::invalid(device, desc));
+        buffers.assign(id_in, resource::Buffer::invalid(device, desc));
     }
 
     /// Assign `id_in` an error with the given `label`.
@@ -173,8 +171,7 @@ impl Global {
             ..
         } = &mut *hub;
         let device = devices.get(device_id);
-        let fid = render_bundles.prepare(id_in);
-        fid.assign(command::RenderBundle::invalid(device, desc));
+        render_bundles.assign(id_in, command::RenderBundle::invalid(device, desc));
     }
 
     /// Assign `id_in` an error with the given `label`.
@@ -190,10 +187,9 @@ impl Global {
         let Hub {
             textures, devices, ..
         } = &mut *hub;
-        let fid = textures.prepare(id_in);
         let device = devices.get(device_id);
         let texture = device.create_texture_error(desc);
-        fid.assign(texture)
+        textures.assign(id_in, texture)
     }
 
     /// Assign `id_in` an error with the given `label`.
@@ -211,9 +207,8 @@ impl Global {
             devices,
             ..
         } = &mut *hub;
-        let fid = external_textures.prepare(id_in);
         let device = devices.get(device_id);
-        fid.assign(resource::ExternalTexture::invalid(device, desc));
+        external_textures.assign(id_in, resource::ExternalTexture::invalid(device, desc));
     }
 
     /// Assign `id_in` an error with the given `label`.
@@ -236,12 +231,11 @@ impl Global {
             devices,
             ..
         } = &mut *hub;
-        let fid = bind_group_layouts.prepare(id_in);
         let device = devices.get(device_id);
-        fid.assign(binding_model::BindGroupLayout::invalid(
-            &device,
-            label.to_string(),
-        ));
+        bind_group_layouts.assign(
+            id_in,
+            binding_model::BindGroupLayout::invalid(&device, label.to_string()),
+        );
     }
 
     pub fn buffer_destroy(&self, buffer_id: id::BufferId) {
@@ -269,13 +263,12 @@ impl Global {
         let Hub {
             textures, devices, ..
         } = &mut *hub;
-        let fid = textures.prepare(id_in);
 
         let device = devices.get(device_id);
 
         let (texture, error) = device.create_texture(desc);
 
-        let id = fid.assign(texture);
+        let id = textures.assign(id_in, texture);
 
         (id, error)
     }
@@ -311,14 +304,13 @@ impl Global {
         let Hub {
             textures, devices, ..
         } = &mut *hub;
-        let fid = textures.prepare(id_in);
 
         let device = devices.get(device_id);
 
         let (texture, error) =
             unsafe { device.create_texture_from_hal(hal_texture, desc, initial_state) };
 
-        let id = fid.assign(texture);
+        let id = textures.assign(id_in, texture);
         (id, error)
     }
 
@@ -339,13 +331,12 @@ impl Global {
         let Hub {
             buffers, devices, ..
         } = &mut *hub;
-        let fid = buffers.prepare(id_in);
 
         let device = devices.get(device_id);
 
         let (buffer, err) = unsafe { device.create_buffer_from_hal(Box::new(hal_buffer), desc) };
 
-        let id = fid.assign(buffer);
+        let id = buffers.assign(id_in, buffer);
 
         (id, err)
     }
@@ -377,13 +368,11 @@ impl Global {
             ..
         } = &mut *hub;
 
-        let fid = texture_views.prepare(id_in);
-
         let texture = textures.get(texture_id);
 
         let (view, error) = texture.create_view(desc);
 
-        let id = fid.assign(view);
+        let id = texture_views.assign(id_in, view);
 
         (id, error)
     }
@@ -412,8 +401,6 @@ impl Global {
             ..
         } = &mut *hub;
 
-        let fid = external_textures.prepare(id_in);
-
         let device = devices.get(device_id);
 
         let planes = planes
@@ -423,7 +410,7 @@ impl Global {
 
         let (external_texture, error) = device.create_external_texture(desc, &planes);
 
-        let id = fid.assign(external_texture);
+        let id = external_textures.assign(id_in, external_texture);
 
         (id, error)
     }
@@ -452,13 +439,12 @@ impl Global {
         let Hub {
             samplers, devices, ..
         } = &mut *hub;
-        let fid = samplers.prepare(id_in);
 
         let device = devices.get(device_id);
 
         let (sampler, error) = device.create_sampler(desc);
 
-        let id = fid.assign(sampler);
+        let id = samplers.assign(id_in, sampler);
 
         (id, error)
     }
@@ -484,13 +470,12 @@ impl Global {
             devices,
             ..
         } = &mut *hub;
-        let fid = bind_group_layouts.prepare(id_in);
 
         let device = devices.get(device_id);
 
         let (bgl, error) = device.create_bind_group_layout(desc);
 
-        let id = fid.assign(bgl);
+        let id = bind_group_layouts.assign(id_in, bgl);
 
         (id, error)
     }
@@ -517,7 +502,6 @@ impl Global {
             bind_group_layouts,
             ..
         } = &mut *hub;
-        let fid = pipeline_layouts.prepare(id_in);
 
         let device = devices.get(device_id);
 
@@ -534,7 +518,7 @@ impl Global {
         };
 
         let (layout, error) = device.create_pipeline_layout(&desc);
-        let id = fid.assign(layout);
+        let id = pipeline_layouts.assign(id_in, layout);
         (id, error)
     }
 
@@ -561,7 +545,6 @@ impl Global {
             external_textures,
             ..
         } = &mut *hub;
-        let fid = bind_groups.prepare(id_in);
 
         let device = devices.get(device_id);
 
@@ -638,7 +621,7 @@ impl Global {
 
         let (bind_group, error) = device.create_bind_group(&desc);
 
-        let id = fid.assign(bind_group);
+        let id = bind_groups.assign(id_in, bind_group);
         (id, error)
     }
 
@@ -678,13 +661,12 @@ impl Global {
             devices,
             ..
         } = &mut *hub;
-        let fid = shader_modules.prepare(id_in);
 
         let device = devices.get(device_id);
 
         let (shader, error) = device.create_shader_module(desc, source);
 
-        let id = fid.assign(shader);
+        let id = shader_modules.assign(id_in, shader);
 
         (id, error)
     }
@@ -708,13 +690,12 @@ impl Global {
             devices,
             ..
         } = &mut *hub;
-        let fid = shader_modules.prepare(id_in);
 
         let device = devices.get(device_id);
 
         let (shader, error) = unsafe { device.create_shader_module_passthrough(desc) };
 
-        let id = fid.assign(shader);
+        let id = shader_modules.assign(id_in, shader);
 
         (id, error)
     }
@@ -737,13 +718,12 @@ impl Global {
             devices,
             ..
         } = &mut *hub;
-        let fid = command_encoders.prepare(id_in);
 
         let device = devices.get(device_id);
 
         let (cmd_enc, error) = device.create_command_encoder(desc);
 
-        let id = fid.assign(cmd_enc);
+        let id = command_encoders.assign(id_in, cmd_enc);
         (id, error)
     }
 
@@ -772,12 +752,11 @@ impl Global {
             devices,
             ..
         } = &mut *hub;
-        let fid = render_bundle_encoders.prepare(id_in);
 
         let device = devices.get(device_id);
         let (render_bundle_encoder, error) = device.create_render_bundle_encoder(desc);
 
-        let id = fid.assign(*render_bundle_encoder);
+        let id = render_bundle_encoders.assign(id_in, *render_bundle_encoder);
 
         (id, error)
     }
@@ -796,11 +775,9 @@ impl Global {
         } = &mut *hub;
         let bundle_encoder = render_bundle_encoders.get_mut(render_bundle_encoder_id);
 
-        let fid = render_bundles.prepare(id_in);
-
         let (render_bundle, error) = bundle_encoder.finish(desc);
 
-        let id = fid.assign(render_bundle);
+        let id = render_bundles.assign(id_in, render_bundle);
 
         (id, error)
     }
@@ -827,13 +804,12 @@ impl Global {
             devices,
             ..
         } = &mut *hub;
-        let fid = query_sets.prepare(id_in);
 
         let device = devices.get(device_id);
 
         let (query_set, error) = device.create_query_set(desc);
 
-        let id = fid.assign(query_set);
+        let id = query_sets.assign(id_in, query_set);
 
         (id, error)
     }
@@ -870,8 +846,6 @@ impl Global {
             pipeline_caches,
             ..
         } = &mut *hub;
-
-        let fid = render_pipelines.prepare(id_in);
 
         let device = devices.get(device_id);
 
@@ -927,7 +901,7 @@ impl Global {
 
         let (pipeline, error) = device.create_render_pipeline(desc);
 
-        let id = fid.assign(pipeline);
+        let id = render_pipelines.assign(id_in, pipeline);
 
         (id, error)
     }
@@ -950,13 +924,11 @@ impl Global {
             ..
         } = &mut *hub;
 
-        let fid = bind_group_layouts.prepare(id_in);
-
         let pipeline = render_pipelines.get(pipeline_id);
 
         let (bgl, error) = pipeline.get_bind_group_layout(index);
 
-        let id = fid.assign(bgl);
+        let id = bind_group_layouts.assign(id_in, bgl);
 
         (id, error)
     }
@@ -986,8 +958,6 @@ impl Global {
             ..
         } = &mut *hub;
 
-        let fid = compute_pipelines.prepare(id_in);
-
         let device = devices.get(device_id);
 
         let layout = desc.layout.map(|layout| pipeline_layouts.get(layout));
@@ -1012,7 +982,7 @@ impl Global {
 
         let (pipeline, error) = device.create_compute_pipeline(desc);
 
-        let id = fid.assign(pipeline);
+        let id = compute_pipelines.assign(id_in, pipeline);
 
         (id, error)
     }
@@ -1035,13 +1005,11 @@ impl Global {
             ..
         } = &mut *hub;
 
-        let fid = bind_group_layouts.prepare(id_in);
-
         let pipeline = compute_pipelines.get(pipeline_id);
 
         let (bgl, error) = pipeline.get_bind_group_layout(index);
 
-        let id = fid.assign(bgl);
+        let id = bind_group_layouts.assign(id_in, bgl);
 
         (id, error)
     }
@@ -1070,12 +1038,11 @@ impl Global {
             ..
         } = &mut *hub;
 
-        let fid = pipeline_caches.prepare(id_in);
         let device = devices.get(device_id);
 
         let (cache, error) = unsafe { device.create_pipeline_cache(desc) };
 
-        let id = fid.assign(cache);
+        let id = pipeline_caches.assign(id_in, cache);
 
         (id, error)
     }

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -17,8 +17,9 @@ use wgpu_core::{
 
 use crate::{
     global::Global,
+    hub::Hub,
     id::{self, DeviceId, QueueId},
-    storage::Storage,
+    registry::Registry,
 };
 
 use wgt::BufferAddress;
@@ -69,22 +70,26 @@ pub type RenderPipelineDescriptor<'a> = pipeline::RenderPipelineDescriptor<
 
 impl Global {
     pub fn device_features(&self, device_id: DeviceId) -> wgt::Features {
-        let device = self.hub.devices.get(device_id);
+        let hub = self.hub.borrow();
+        let device = hub.devices.get(device_id);
         *device.features()
     }
 
     pub fn device_limits(&self, device_id: DeviceId) -> wgt::Limits {
-        let device = self.hub.devices.get(device_id);
+        let hub = self.hub.borrow();
+        let device = hub.devices.get(device_id);
         device.limits().clone()
     }
 
     pub fn device_adapter_info(&self, device_id: DeviceId) -> wgt::AdapterInfo {
-        let device = self.hub.devices.get(device_id);
+        let hub = self.hub.borrow();
+        let device = hub.devices.get(device_id);
         device.adapter_info()
     }
 
     pub fn device_downlevel_properties(&self, device_id: DeviceId) -> wgt::DownlevelCapabilities {
-        let device = self.hub.devices.get(device_id);
+        let hub = self.hub.borrow();
+        let device = hub.devices.get(device_id);
         device.downlevel().clone()
     }
 
@@ -94,10 +99,13 @@ impl Global {
         desc: &resource::BufferDescriptor,
         id_in: id::BufferId,
     ) -> (id::BufferId, Option<CreateBufferError>) {
-        let hub = &self.hub;
-        let fid = hub.buffers.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            buffers, devices, ..
+        } = &mut *hub;
+        let fid = buffers.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let (buffer, error) = device.create_buffer(desc);
 
@@ -140,8 +148,12 @@ impl Global {
         id_in: id::BufferId,
         desc: &resource::BufferDescriptor,
     ) {
-        let fid = self.hub.buffers.prepare(id_in);
-        let device = self.hub.devices.get(device_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            buffers, devices, ..
+        } = &mut *hub;
+        let fid = buffers.prepare(id_in);
+        let device = devices.get(device_id);
         fid.assign(resource::Buffer::invalid(device, desc));
     }
 
@@ -154,8 +166,14 @@ impl Global {
         id_in: id::RenderBundleId,
         desc: &command::RenderBundleDescriptor,
     ) {
-        let device = self.hub.devices.get(device_id);
-        let fid = self.hub.render_bundles.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_bundles,
+            devices,
+            ..
+        } = &mut *hub;
+        let device = devices.get(device_id);
+        let fid = render_bundles.prepare(id_in);
         fid.assign(command::RenderBundle::invalid(device, desc));
     }
 
@@ -168,8 +186,12 @@ impl Global {
         id_in: id::TextureId,
         desc: &resource::TextureDescriptor,
     ) -> id::TextureId {
-        let fid = self.hub.textures.prepare(id_in);
-        let device = self.hub.devices.get(device_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            textures, devices, ..
+        } = &mut *hub;
+        let fid = textures.prepare(id_in);
+        let device = devices.get(device_id);
         let texture = device.create_texture_error(desc);
         fid.assign(texture)
     }
@@ -183,8 +205,14 @@ impl Global {
         id_in: id::ExternalTextureId,
         desc: &resource::ExternalTextureDescriptor,
     ) {
-        let fid = self.hub.external_textures.prepare(id_in);
-        let device = self.hub.devices.get(device_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            external_textures,
+            devices,
+            ..
+        } = &mut *hub;
+        let fid = external_textures.prepare(id_in);
+        let device = devices.get(device_id);
         fid.assign(resource::ExternalTexture::invalid(device, desc));
     }
 
@@ -202,8 +230,14 @@ impl Global {
         id_in: id::BindGroupLayoutId,
         label: Option<Cow<'_, str>>,
     ) {
-        let fid = self.hub.bind_group_layouts.prepare(id_in);
-        let device = self.hub.devices.get(device_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            bind_group_layouts,
+            devices,
+            ..
+        } = &mut *hub;
+        let fid = bind_group_layouts.prepare(id_in);
+        let device = devices.get(device_id);
         fid.assign(binding_model::BindGroupLayout::invalid(
             &device,
             label.to_string(),
@@ -211,7 +245,7 @@ impl Global {
     }
 
     pub fn buffer_destroy(&self, buffer_id: id::BufferId) {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let buffer = hub.buffers.get(buffer_id);
 
@@ -219,7 +253,7 @@ impl Global {
     }
 
     pub fn buffer_drop(&self, buffer_id: id::BufferId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _buffer = hub.buffers.remove(buffer_id);
     }
@@ -230,11 +264,14 @@ impl Global {
         desc: &resource::TextureDescriptor,
         id_in: id::TextureId,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
-        let fid = hub.textures.prepare(id_in);
+        let Hub {
+            textures, devices, ..
+        } = &mut *hub;
+        let fid = textures.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let (texture, error) = device.create_texture(desc);
 
@@ -248,8 +285,8 @@ impl Global {
         device_id: DeviceId,
         desc: &resource::TextureDescriptor,
     ) -> Option<resource::CreateTextureError> {
-        self.hub
-            .devices
+        let hub = self.hub.borrow();
+        hub.devices
             .get(device_id)
             .validate_texture_descriptor(desc)
             .err()
@@ -270,11 +307,13 @@ impl Global {
         initial_state: wgt::TextureUses,
         id_in: id::TextureId,
     ) -> (id::TextureId, Option<resource::CreateTextureError>) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            textures, devices, ..
+        } = &mut *hub;
+        let fid = textures.prepare(id_in);
 
-        let fid = hub.textures.prepare(id_in);
-
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let (texture, error) =
             unsafe { device.create_texture_from_hal(hal_texture, desc, initial_state) };
@@ -296,10 +335,13 @@ impl Global {
         desc: &resource::BufferDescriptor,
         id_in: id::BufferId,
     ) -> (id::BufferId, Option<CreateBufferError>) {
-        let hub = &self.hub;
-        let fid = hub.buffers.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            buffers, devices, ..
+        } = &mut *hub;
+        let fid = buffers.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let (buffer, err) = unsafe { device.create_buffer_from_hal(Box::new(hal_buffer), desc) };
 
@@ -309,7 +351,7 @@ impl Global {
     }
 
     pub fn texture_destroy(&self, texture_id: id::TextureId) {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let texture = hub.textures.get(texture_id);
 
@@ -317,7 +359,7 @@ impl Global {
     }
 
     pub fn texture_drop(&self, texture_id: id::TextureId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         hub.textures.remove(texture_id);
     }
@@ -328,11 +370,16 @@ impl Global {
         desc: &resource::TextureViewDescriptor,
         id_in: id::TextureViewId,
     ) -> (id::TextureViewId, Option<resource::CreateTextureViewError>) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            textures,
+            texture_views,
+            ..
+        } = &mut *hub;
 
-        let fid = hub.texture_views.prepare(id_in);
+        let fid = texture_views.prepare(id_in);
 
-        let texture = hub.textures.get(texture_id);
+        let texture = textures.get(texture_id);
 
         let (view, error) = texture.create_view(desc);
 
@@ -342,7 +389,7 @@ impl Global {
     }
 
     pub fn texture_view_drop(&self, texture_view_id: id::TextureViewId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _view = hub.texture_views.remove(texture_view_id);
     }
@@ -357,15 +404,21 @@ impl Global {
         id::ExternalTextureId,
         Option<resource::CreateExternalTextureError>,
     ) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            external_textures,
+            devices,
+            texture_views,
+            ..
+        } = &mut *hub;
 
-        let fid = hub.external_textures.prepare(id_in);
+        let fid = external_textures.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let planes = planes
             .iter()
-            .map(|plane_id| self.hub.texture_views.get(*plane_id))
+            .map(|plane_id| texture_views.get(*plane_id))
             .collect::<Vec<_>>();
 
         let (external_texture, error) = device.create_external_texture(desc, &planes);
@@ -376,7 +429,7 @@ impl Global {
     }
 
     pub fn external_texture_destroy(&self, external_texture_id: id::ExternalTextureId) {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let external_texture = hub.external_textures.get(external_texture_id);
 
@@ -384,7 +437,7 @@ impl Global {
     }
 
     pub fn external_texture_drop(&self, external_texture_id: id::ExternalTextureId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _external_texture = hub.external_textures.remove(external_texture_id);
     }
@@ -395,10 +448,13 @@ impl Global {
         desc: &resource::SamplerDescriptor,
         id_in: id::SamplerId,
     ) -> (id::SamplerId, Option<resource::CreateSamplerError>) {
-        let hub = &self.hub;
-        let fid = hub.samplers.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            samplers, devices, ..
+        } = &mut *hub;
+        let fid = samplers.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let (sampler, error) = device.create_sampler(desc);
 
@@ -408,7 +464,7 @@ impl Global {
     }
 
     pub fn sampler_drop(&self, sampler_id: id::SamplerId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _sampler = hub.samplers.remove(sampler_id);
     }
@@ -422,10 +478,15 @@ impl Global {
         id::BindGroupLayoutId,
         Option<binding_model::CreateBindGroupLayoutError>,
     ) {
-        let hub = &self.hub;
-        let fid = hub.bind_group_layouts.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            bind_group_layouts,
+            devices,
+            ..
+        } = &mut *hub;
+        let fid = bind_group_layouts.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let (bgl, error) = device.create_bind_group_layout(desc);
 
@@ -435,7 +496,7 @@ impl Global {
     }
 
     pub fn bind_group_layout_drop(&self, bind_group_layout_id: id::BindGroupLayoutId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _layout = hub.bind_group_layouts.remove(bind_group_layout_id);
     }
@@ -449,18 +510,22 @@ impl Global {
         id::PipelineLayoutId,
         Option<binding_model::CreatePipelineLayoutError>,
     ) {
-        let hub = &self.hub;
-        let fid = hub.pipeline_layouts.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            pipeline_layouts,
+            devices,
+            bind_group_layouts,
+            ..
+        } = &mut *hub;
+        let fid = pipeline_layouts.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
-        let bind_group_layouts = {
-            let bind_group_layouts_guard = hub.bind_group_layouts.read();
-            desc.bind_group_layouts
-                .iter()
-                .map(|bgl_id| bgl_id.map(|bgl_id| bind_group_layouts_guard.get(bgl_id)))
-                .collect::<Vec<_>>()
-        };
+        let bind_group_layouts = desc
+            .bind_group_layouts
+            .iter()
+            .map(|bgl_id| bgl_id.map(|bgl_id| bind_group_layouts.get(bgl_id)))
+            .collect::<Vec<_>>();
 
         let desc = binding_model::PipelineLayoutDescriptor {
             label: desc.label.clone(),
@@ -474,7 +539,7 @@ impl Global {
     }
 
     pub fn pipeline_layout_drop(&self, pipeline_layout_id: id::PipelineLayoutId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _layout = hub.pipeline_layouts.remove(pipeline_layout_id);
     }
@@ -485,32 +550,41 @@ impl Global {
         desc: &BindGroupDescriptor,
         id_in: id::BindGroupId,
     ) -> (id::BindGroupId, Option<binding_model::CreateBindGroupError>) {
-        let hub = &self.hub;
-        let fid = hub.bind_groups.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            bind_groups,
+            devices,
+            bind_group_layouts,
+            buffers,
+            samplers,
+            texture_views,
+            external_textures,
+            ..
+        } = &mut *hub;
+        let fid = bind_groups.prepare(id_in);
 
-        let device = hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
-        let layout = hub.bind_group_layouts.get(desc.layout);
+        let layout = bind_group_layouts.get(desc.layout);
 
         fn resolve_entry<'a>(
             e: &BindGroupEntry<'a>,
-            buffer_storage: &Storage<Arc<resource::Buffer>>,
-            sampler_storage: &Storage<Arc<resource::Sampler>>,
-            texture_view_storage: &Storage<Arc<resource::TextureView>>,
-            external_texture_storage: &Storage<Arc<resource::ExternalTexture>>,
+            buffers: &mut Registry<Arc<resource::Buffer>>,
+            samplers: &mut Registry<Arc<resource::Sampler>>,
+            texture_views: &mut Registry<Arc<resource::TextureView>>,
+            external_textures: &mut Registry<Arc<resource::ExternalTexture>>,
         ) -> binding_model::BindGroupEntry<'a> {
             let resolve_buffer = |bb: &BufferBinding| {
-                let buffer = buffer_storage.get(bb.buffer);
+                let buffer = buffers.get(bb.buffer);
                 binding_model::BufferBinding {
                     buffer,
                     offset: bb.offset,
                     size: bb.size,
                 }
             };
-            let resolve_sampler = |id: &id::SamplerId| sampler_storage.get(*id);
-            let resolve_view = |id: &id::TextureViewId| texture_view_storage.get(*id);
-            let resolve_external_texture =
-                |id: &id::ExternalTextureId| external_texture_storage.get(*id);
+            let resolve_sampler = |id: &id::SamplerId| samplers.get(*id);
+            let resolve_view = |id: &id::TextureViewId| texture_views.get(*id);
+            let resolve_external_texture = |id: &id::ExternalTextureId| external_textures.get(*id);
             let resource = match e.resource {
                 BindingResource::Buffer(ref buffer) => {
                     binding_model::BindingResource::Buffer(resolve_buffer(buffer))
@@ -549,24 +623,11 @@ impl Global {
             }
         }
 
-        let entries = {
-            let buffer_guard = hub.buffers.read();
-            let texture_view_guard = hub.texture_views.read();
-            let sampler_guard = hub.samplers.read();
-            let external_texture_guard = hub.external_textures.read();
-            desc.entries
-                .iter()
-                .map(|e| {
-                    resolve_entry(
-                        e,
-                        &buffer_guard,
-                        &sampler_guard,
-                        &texture_view_guard,
-                        &external_texture_guard,
-                    )
-                })
-                .collect::<Vec<_>>()
-        };
+        let entries = desc
+            .entries
+            .iter()
+            .map(|e| resolve_entry(e, buffers, samplers, texture_views, external_textures))
+            .collect::<Vec<_>>();
         let entries = Cow::Owned(entries);
 
         let desc = binding_model::BindGroupDescriptor {
@@ -582,7 +643,7 @@ impl Global {
     }
 
     pub fn bind_group_drop(&self, bind_group_id: id::BindGroupId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _bind_group = hub.bind_groups.remove(bind_group_id);
     }
@@ -611,10 +672,15 @@ impl Global {
         id::ShaderModuleId,
         Option<pipeline::CreateShaderModuleError>,
     ) {
-        let hub = &self.hub;
-        let fid = hub.shader_modules.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            shader_modules,
+            devices,
+            ..
+        } = &mut *hub;
+        let fid = shader_modules.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let (shader, error) = device.create_shader_module(desc, source);
 
@@ -636,10 +702,15 @@ impl Global {
         id::ShaderModuleId,
         Option<pipeline::CreateShaderModuleError>,
     ) {
-        let hub = &self.hub;
-        let fid = hub.shader_modules.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            shader_modules,
+            devices,
+            ..
+        } = &mut *hub;
+        let fid = shader_modules.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let (shader, error) = unsafe { device.create_shader_module_passthrough(desc) };
 
@@ -649,7 +720,7 @@ impl Global {
     }
 
     pub fn shader_module_drop(&self, shader_module_id: id::ShaderModuleId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _shader_module = hub.shader_modules.remove(shader_module_id);
     }
@@ -660,10 +731,15 @@ impl Global {
         desc: &wgt::CommandEncoderDescriptor<Label>,
         id_in: id::CommandEncoderId,
     ) -> (id::CommandEncoderId, Option<DeviceError>) {
-        let hub = &self.hub;
-        let fid = hub.command_encoders.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            command_encoders,
+            devices,
+            ..
+        } = &mut *hub;
+        let fid = command_encoders.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let (cmd_enc, error) = device.create_command_encoder(desc);
 
@@ -672,11 +748,13 @@ impl Global {
     }
 
     pub fn command_encoder_drop(&self, command_encoder_id: id::CommandEncoderId) {
-        let _cmd_enc = self.hub.command_encoders.remove(command_encoder_id);
+        let mut hub = self.hub.borrow_mut();
+        let _cmd_enc = hub.command_encoders.remove(command_encoder_id);
     }
 
     pub fn command_buffer_drop(&self, command_buffer_id: id::CommandBufferId) {
-        let _cmd_buf = self.hub.command_buffers.remove(command_buffer_id);
+        let mut hub = self.hub.borrow_mut();
+        let _cmd_buf = hub.command_buffers.remove(command_buffer_id);
     }
 
     pub fn device_create_render_bundle_encoder(
@@ -688,9 +766,15 @@ impl Global {
         id::RenderBundleEncoderId,
         Option<command::CreateRenderBundleError>,
     ) {
-        let fid = self.hub.render_bundle_encoders.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_bundle_encoders,
+            devices,
+            ..
+        } = &mut *hub;
+        let fid = render_bundle_encoders.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
         let (render_bundle_encoder, error) = device.create_render_bundle_encoder(desc);
 
         let id = fid.assign(*render_bundle_encoder);
@@ -704,12 +788,15 @@ impl Global {
         desc: &command::RenderBundleDescriptor,
         id_in: id::RenderBundleId,
     ) -> (id::RenderBundleId, Option<command::RenderBundleError>) {
-        let mut bundle_encoder = self
-            .hub
-            .render_bundle_encoders
-            .get_mut(render_bundle_encoder_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_bundle_encoders,
+            render_bundles,
+            ..
+        } = &mut *hub;
+        let bundle_encoder = render_bundle_encoders.get_mut(render_bundle_encoder_id);
 
-        let fid = self.hub.render_bundles.prepare(id_in);
+        let fid = render_bundles.prepare(id_in);
 
         let (render_bundle, error) = bundle_encoder.finish(desc);
 
@@ -719,14 +806,12 @@ impl Global {
     }
 
     pub fn render_bundle_encoder_drop(&self, render_bundle_encoder_id: id::RenderBundleEncoderId) {
-        let hub = &self.hub;
-
+        let mut hub = self.hub.borrow_mut();
         let _bundle_encoder = hub.render_bundle_encoders.remove(render_bundle_encoder_id);
     }
 
     pub fn render_bundle_drop(&self, render_bundle_id: id::RenderBundleId) {
-        let hub = &self.hub;
-
+        let mut hub = self.hub.borrow_mut();
         let _bundle = hub.render_bundles.remove(render_bundle_id);
     }
 
@@ -736,10 +821,15 @@ impl Global {
         desc: &resource::QuerySetDescriptor,
         id_in: id::QuerySetId,
     ) -> (id::QuerySetId, Option<resource::CreateQuerySetError>) {
-        let hub = &self.hub;
-        let fid = hub.query_sets.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            query_sets,
+            devices,
+            ..
+        } = &mut *hub;
+        let fid = query_sets.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
         let (query_set, error) = device.create_query_set(desc);
 
@@ -749,7 +839,7 @@ impl Global {
     }
 
     pub fn query_set_destroy(&self, query_set_id: id::QuerySetId) {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let query_set = hub.query_sets.get(query_set_id);
 
@@ -757,7 +847,7 @@ impl Global {
     }
 
     pub fn query_set_drop(&self, query_set_id: id::QuerySetId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _query_set = hub.query_sets.remove(query_set_id);
     }
@@ -771,18 +861,26 @@ impl Global {
         id::RenderPipelineId,
         Option<pipeline::CreateRenderPipelineError>,
     ) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_pipelines,
+            devices,
+            shader_modules,
+            pipeline_layouts,
+            pipeline_caches,
+            ..
+        } = &mut *hub;
 
-        let fid = hub.render_pipelines.prepare(id_in);
+        let fid = render_pipelines.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
-        let layout = desc.layout.map(|layout| hub.pipeline_layouts.get(layout));
+        let layout = desc.layout.map(|layout| pipeline_layouts.get(layout));
 
-        let cache = desc.cache.map(|cache| hub.pipeline_caches.get(cache));
+        let cache = desc.cache.map(|cache| pipeline_caches.get(cache));
 
         let vertex = {
-            let module = hub.shader_modules.get(desc.vertex.stage.module);
+            let module = shader_modules.get(desc.vertex.stage.module);
             let stage = ProgrammableStageDescriptor {
                 module,
                 entry_point: desc.vertex.stage.entry_point.clone(),
@@ -799,7 +897,7 @@ impl Global {
         };
 
         let fragment = if let Some(ref state) = desc.fragment {
-            let module = hub.shader_modules.get(state.stage.module);
+            let module = shader_modules.get(state.stage.module);
 
             let stage = ProgrammableStageDescriptor {
                 module,
@@ -845,11 +943,16 @@ impl Global {
         id::BindGroupLayoutId,
         Option<binding_model::GetBindGroupLayoutError>,
     ) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            bind_group_layouts,
+            render_pipelines,
+            ..
+        } = &mut *hub;
 
-        let fid = hub.bind_group_layouts.prepare(id_in);
+        let fid = bind_group_layouts.prepare(id_in);
 
-        let pipeline = hub.render_pipelines.get(pipeline_id);
+        let pipeline = render_pipelines.get(pipeline_id);
 
         let (bgl, error) = pipeline.get_bind_group_layout(index);
 
@@ -859,7 +962,7 @@ impl Global {
     }
 
     pub fn render_pipeline_drop(&self, render_pipeline_id: id::RenderPipelineId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _pipeline = hub.render_pipelines.remove(render_pipeline_id);
     }
@@ -873,17 +976,25 @@ impl Global {
         id::ComputePipelineId,
         Option<pipeline::CreateComputePipelineError>,
     ) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            compute_pipelines,
+            devices,
+            shader_modules,
+            pipeline_layouts,
+            pipeline_caches,
+            ..
+        } = &mut *hub;
 
-        let fid = hub.compute_pipelines.prepare(id_in);
+        let fid = compute_pipelines.prepare(id_in);
 
-        let device = self.hub.devices.get(device_id);
+        let device = devices.get(device_id);
 
-        let layout = desc.layout.map(|layout| hub.pipeline_layouts.get(layout));
+        let layout = desc.layout.map(|layout| pipeline_layouts.get(layout));
 
-        let cache = desc.cache.map(|cache| hub.pipeline_caches.get(cache));
+        let cache = desc.cache.map(|cache| pipeline_caches.get(cache));
 
-        let module = hub.shader_modules.get(desc.stage.module);
+        let module = shader_modules.get(desc.stage.module);
 
         let stage = ProgrammableStageDescriptor {
             module,
@@ -917,11 +1028,16 @@ impl Global {
         id::BindGroupLayoutId,
         Option<binding_model::GetBindGroupLayoutError>,
     ) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            bind_group_layouts,
+            compute_pipelines,
+            ..
+        } = &mut *hub;
 
-        let fid = hub.bind_group_layouts.prepare(id_in);
+        let fid = bind_group_layouts.prepare(id_in);
 
-        let pipeline = hub.compute_pipelines.get(pipeline_id);
+        let pipeline = compute_pipelines.get(pipeline_id);
 
         let (bgl, error) = pipeline.get_bind_group_layout(index);
 
@@ -931,8 +1047,7 @@ impl Global {
     }
 
     pub fn compute_pipeline_drop(&self, compute_pipeline_id: id::ComputePipelineId) {
-        let hub = &self.hub;
-
+        let mut hub = self.hub.borrow_mut();
         let _pipeline = hub.compute_pipelines.remove(compute_pipeline_id);
     }
 
@@ -948,10 +1063,15 @@ impl Global {
         id::PipelineCacheId,
         Option<pipeline::CreatePipelineCacheError>,
     ) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            pipeline_caches,
+            devices,
+            ..
+        } = &mut *hub;
 
-        let fid = hub.pipeline_caches.prepare(id_in);
-        let device = self.hub.devices.get(device_id);
+        let fid = pipeline_caches.prepare(id_in);
+        let device = devices.get(device_id);
 
         let (cache, error) = unsafe { device.create_pipeline_cache(desc) };
 
@@ -961,7 +1081,7 @@ impl Global {
     }
 
     pub fn pipeline_cache_drop(&self, pipeline_cache_id: id::PipelineCacheId) {
-        let hub = &self.hub;
+        let mut hub = self.hub.borrow_mut();
 
         let _cache = hub.pipeline_caches.remove(pipeline_cache_id);
     }
@@ -974,7 +1094,8 @@ impl Global {
         device_id: DeviceId,
         poll_type: wgt::PollType<SubmissionIndex>,
     ) -> Result<wgt::PollStatus, WaitIdleError> {
-        let device = self.hub.devices.get(device_id);
+        let hub = self.hub.borrow();
+        let device = hub.devices.get(device_id);
 
         device.poll(poll_type)
     }
@@ -995,11 +1116,9 @@ impl Global {
     ///
     /// [api]: ../../wgpu/struct.Device.html#method.start_graphics_debugger_capture
     pub unsafe fn device_start_graphics_debugger_capture(&self, device_id: DeviceId) {
+        let hub = self.hub.borrow();
         unsafe {
-            self.hub
-                .devices
-                .get(device_id)
-                .start_graphics_debugger_capture();
+            hub.devices.get(device_id).start_graphics_debugger_capture();
         }
     }
 
@@ -1009,22 +1128,21 @@ impl Global {
     ///
     /// [api]: ../../wgpu/struct.Device.html#method.stop_graphics_debugger_capture
     pub unsafe fn device_stop_graphics_debugger_capture(&self, device_id: DeviceId) {
+        let hub = self.hub.borrow();
         unsafe {
-            self.hub
-                .devices
-                .get(device_id)
-                .stop_graphics_debugger_capture();
+            hub.devices.get(device_id).stop_graphics_debugger_capture();
         }
     }
 
     pub fn pipeline_cache_get_data(&self, id: id::PipelineCacheId) -> Option<Vec<u8>> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         hub.pipeline_caches.get(id).get_data()
     }
 
     pub fn device_drop(&self, device_id: DeviceId) {
-        self.hub.devices.remove(device_id);
+        let mut hub = self.hub.borrow_mut();
+        hub.devices.remove(device_id);
     }
 
     /// `device_lost_closure` might never be called.
@@ -1033,18 +1151,23 @@ impl Global {
         device_id: DeviceId,
         device_lost_closure: DeviceLostClosure,
     ) {
-        let device = self.hub.devices.get(device_id);
+        let hub = self.hub.borrow();
+        let device = hub.devices.get(device_id);
 
         device.set_device_lost_closure(device_lost_closure);
     }
 
     pub fn device_destroy(&self, device_id: DeviceId) {
-        let device = self.hub.devices.get(device_id);
+        let hub = self.hub.borrow();
+        let device = hub.devices.get(device_id);
+
         device.destroy();
     }
 
     pub fn device_get_internal_counters(&self, device_id: DeviceId) -> wgt::InternalCounters {
-        let device = self.hub.devices.get(device_id);
+        let hub = self.hub.borrow();
+        let device = hub.devices.get(device_id);
+
         device.get_internal_counters()
     }
 
@@ -1052,12 +1175,15 @@ impl Global {
         &self,
         device_id: DeviceId,
     ) -> Option<wgt::AllocatorReport> {
-        let device = self.hub.devices.get(device_id);
+        let hub = self.hub.borrow();
+        let device = hub.devices.get(device_id);
+
         device.generate_allocator_report()
     }
 
     pub fn queue_drop(&self, queue_id: QueueId) {
-        self.hub.queues.remove(queue_id);
+        let mut hub = self.hub.borrow_mut();
+        hub.queues.remove(queue_id);
     }
 
     /// `op.callback` is always called, even in case of errors.
@@ -1068,7 +1194,7 @@ impl Global {
         size: Option<BufferAddress>,
         op: BufferMapOperation,
     ) -> Result<SubmissionIndex, BufferAccessError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let buffer = hub.buffers.get(buffer_id);
 
@@ -1081,7 +1207,7 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferAddress>,
     ) -> Result<(NonNull<u8>, u64), BufferAccessError> {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let buffer = hub.buffers.get(buffer_id);
 
@@ -1089,7 +1215,7 @@ impl Global {
     }
 
     pub fn buffer_unmap(&self, buffer_id: id::BufferId) -> BufferAccessResult {
-        let hub = &self.hub;
+        let hub = self.hub.borrow();
 
         let buffer = hub.buffers.get(buffer_id);
 

--- a/wgpu-core-remote/src/global/instance.rs
+++ b/wgpu-core-remote/src/global/instance.rs
@@ -23,7 +23,7 @@ impl Global {
             apply_limit_buckets: desc.apply_limit_buckets,
         };
         let adapter = self.instance.request_adapter(&desc, backends)?;
-        let id = hub.adapters.prepare(id_in).assign(adapter);
+        let id = hub.adapters.assign(id_in, adapter);
         Ok(id)
     }
 
@@ -46,8 +46,9 @@ impl Global {
         id_in: AdapterId,
     ) -> AdapterId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.adapters.prepare(id_in);
-        fid.assign(unsafe { self.instance.create_adapter_from_hal(hal_adapter) })
+        hub.adapters.assign(id_in, unsafe {
+            self.instance.create_adapter_from_hal(hal_adapter)
+        })
     }
 
     pub fn adapter_get_info(&self, adapter_id: AdapterId) -> wgt::AdapterInfo {
@@ -126,15 +127,13 @@ impl Global {
             queues,
             ..
         } = &mut *hub;
-        let device_fid = devices.prepare(device_id_in);
-        let queue_fid = queues.prepare(queue_id_in);
 
         let adapter = adapters.get(adapter_id);
         let (device, queue) = adapter.request_device(desc)?;
 
-        let device_id = device_fid.assign(device);
+        let device_id = devices.assign(device_id_in, device);
 
-        let queue_id = queue_fid.assign(queue);
+        let queue_id = queues.assign(queue_id_in, queue);
 
         Ok((device_id, queue_id))
     }
@@ -168,16 +167,14 @@ impl Global {
             queues,
             ..
         } = &mut *hub;
-        let devices_fid = devices.prepare(device_id_in);
-        let queues_fid = queues.prepare(queue_id_in);
 
         let adapter = adapters.get(adapter_id);
         let (device, queue) =
             unsafe { adapter.create_device_and_queue_from_hal(hal_device, desc) }?;
 
-        let device_id = devices_fid.assign(device);
+        let device_id = devices.assign(device_id_in, device);
 
-        let queue_id = queues_fid.assign(queue);
+        let queue_id = queues.assign(queue_id_in, queue);
 
         Ok((device_id, queue_id))
     }

--- a/wgpu-core-remote/src/global/instance.rs
+++ b/wgpu-core-remote/src/global/instance.rs
@@ -3,6 +3,7 @@ use wgpu_core::instance::RequestDeviceError;
 use wgt::Backends;
 
 use crate::global::Global;
+use crate::hub::Hub;
 use crate::id::{AdapterId, DeviceId, QueueId};
 
 pub type RequestAdapterOptions = wgt::RequestAdapterOptions<()>;
@@ -14,6 +15,7 @@ impl Global {
         backends: Backends,
         id_in: AdapterId,
     ) -> Result<AdapterId, wgt::RequestAdapterError> {
+        let mut hub = self.hub.borrow_mut();
         let desc = wgt::RequestAdapterOptions {
             power_preference: desc.power_preference,
             force_fallback_adapter: desc.force_fallback_adapter,
@@ -21,7 +23,7 @@ impl Global {
             apply_limit_buckets: desc.apply_limit_buckets,
         };
         let adapter = self.instance.request_adapter(&desc, backends)?;
-        let id = self.hub.adapters.prepare(id_in).assign(adapter);
+        let id = hub.adapters.prepare(id_in).assign(adapter);
         Ok(id)
     }
 
@@ -43,12 +45,14 @@ impl Global {
         hal_adapter: hal::DynExposedAdapter,
         id_in: AdapterId,
     ) -> AdapterId {
-        let fid = self.hub.adapters.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.adapters.prepare(id_in);
         fid.assign(unsafe { self.instance.create_adapter_from_hal(hal_adapter) })
     }
 
     pub fn adapter_get_info(&self, adapter_id: AdapterId) -> wgt::AdapterInfo {
-        let adapter = self.hub.adapters.get(adapter_id);
+        let hub = self.hub.borrow();
+        let adapter = hub.adapters.get(adapter_id);
         adapter.get_info()
     }
 
@@ -57,17 +61,20 @@ impl Global {
         adapter_id: AdapterId,
         format: wgt::TextureFormat,
     ) -> wgt::TextureFormatFeatures {
-        let adapter = self.hub.adapters.get(adapter_id);
+        let hub = self.hub.borrow();
+        let adapter = hub.adapters.get(adapter_id);
         adapter.get_texture_format_features(format)
     }
 
     pub fn adapter_features(&self, adapter_id: AdapterId) -> wgt::Features {
-        let adapter = self.hub.adapters.get(adapter_id);
+        let hub = self.hub.borrow();
+        let adapter = hub.adapters.get(adapter_id);
         adapter.features()
     }
 
     pub fn adapter_limits(&self, adapter_id: AdapterId) -> wgt::Limits {
-        let adapter = self.hub.adapters.get(adapter_id);
+        let hub = self.hub.borrow();
+        let adapter = hub.adapters.get(adapter_id);
         adapter.limits()
     }
 
@@ -75,7 +82,8 @@ impl Global {
         &self,
         adapter_id: AdapterId,
     ) -> wgt::DownlevelCapabilities {
-        let adapter = self.hub.adapters.get(adapter_id);
+        let hub = self.hub.borrow();
+        let adapter = hub.adapters.get(adapter_id);
         adapter.downlevel_capabilities()
     }
 
@@ -83,7 +91,8 @@ impl Global {
         &self,
         adapter_id: AdapterId,
     ) -> wgt::PresentationTimestamp {
-        let adapter = self.hub.adapters.get(adapter_id);
+        let hub = self.hub.borrow();
+        let adapter = hub.adapters.get(adapter_id);
         adapter.get_presentation_timestamp()
     }
 
@@ -91,12 +100,14 @@ impl Global {
         &self,
         adapter_id: AdapterId,
     ) -> Vec<wgt::CooperativeMatrixProperties> {
-        let adapter = self.hub.adapters.get(adapter_id);
+        let hub = self.hub.borrow();
+        let adapter = hub.adapters.get(adapter_id);
         adapter.cooperative_matrix_properties()
     }
 
     pub fn adapter_drop(&self, adapter_id: AdapterId) {
-        self.hub.adapters.remove(adapter_id);
+        let mut hub = self.hub.borrow_mut();
+        hub.adapters.remove(adapter_id);
     }
 }
 
@@ -108,10 +119,17 @@ impl Global {
         device_id_in: DeviceId,
         queue_id_in: QueueId,
     ) -> Result<(DeviceId, QueueId), RequestDeviceError> {
-        let device_fid = self.hub.devices.prepare(device_id_in);
-        let queue_fid = self.hub.queues.prepare(queue_id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            adapters,
+            devices,
+            queues,
+            ..
+        } = &mut *hub;
+        let device_fid = devices.prepare(device_id_in);
+        let queue_fid = queues.prepare(queue_id_in);
 
-        let adapter = self.hub.adapters.get(adapter_id);
+        let adapter = adapters.get(adapter_id);
         let (device, queue) = adapter.request_device(desc)?;
 
         let device_id = device_fid.assign(device);
@@ -126,7 +144,8 @@ impl Global {
         adapter_id: AdapterId,
         desc: &mut DeviceDescriptor,
     ) -> Result<(), RequestDeviceError> {
-        let adapter = self.hub.adapters.get(adapter_id);
+        let hub = self.hub.borrow();
+        let adapter = hub.adapters.get(adapter_id);
         adapter.validate_device_descriptor(desc)
     }
 
@@ -142,10 +161,17 @@ impl Global {
         device_id_in: DeviceId,
         queue_id_in: QueueId,
     ) -> Result<(DeviceId, QueueId), RequestDeviceError> {
-        let devices_fid = self.hub.devices.prepare(device_id_in);
-        let queues_fid = self.hub.queues.prepare(queue_id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            adapters,
+            devices,
+            queues,
+            ..
+        } = &mut *hub;
+        let devices_fid = devices.prepare(device_id_in);
+        let queues_fid = queues.prepare(queue_id_in);
 
-        let adapter = self.hub.adapters.get(adapter_id);
+        let adapter = adapters.get(adapter_id);
         let (device, queue) =
             unsafe { adapter.create_device_and_queue_from_hal(hal_device, desc) }?;
 

--- a/wgpu-core-remote/src/global/mod.rs
+++ b/wgpu-core-remote/src/global/mod.rs
@@ -1,4 +1,5 @@
 use alloc::{borrow::ToOwned as _, sync::Arc};
+use core::cell::RefCell;
 use core::fmt;
 use wgpu_core::binding_model::{BindGroupLayout, PipelineLayout};
 use wgpu_core::command::{CommandBuffer, CommandEncoder};
@@ -24,7 +25,7 @@ mod queue;
 mod render_pass;
 
 pub struct Global {
-    pub(crate) hub: Hub,
+    pub(crate) hub: RefCell<Hub>,
     // the instance must be dropped last
     pub instance: Arc<Instance>,
 }
@@ -37,7 +38,7 @@ impl Global {
     ) -> Self {
         Self {
             instance: Instance::new(name, instance_desc, telemetry),
-            hub: Hub::new(),
+            hub: RefCell::new(Hub::new()),
         }
     }
 
@@ -47,7 +48,7 @@ impl Global {
     pub unsafe fn from_hal_instance<A: hal::Api>(name: &str, hal_instance: A::Instance) -> Self {
         Self {
             instance: Instance::from_hal_instance::<A>(name.to_owned(), hal_instance),
-            hub: Hub::new(),
+            hub: RefCell::new(Hub::new()),
         }
     }
 
@@ -64,7 +65,7 @@ impl Global {
     pub unsafe fn from_instance(instance: Arc<Instance>) -> Self {
         Self {
             instance,
-            hub: Hub::new(),
+            hub: RefCell::new(Hub::new()),
         }
     }
 }
@@ -74,37 +75,40 @@ impl Global {
     /// Import [`Arc<Adapter>`] into the global hub,
     /// returning an [`AdapterId`] under which the adapter is stored.
     pub fn import_adapter(&self, adapter: Arc<Adapter>, id_in: AdapterId) -> AdapterId {
-        let fid = self.hub.adapters.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.adapters.prepare(id_in);
         fid.assign(adapter)
     }
 
     /// Resolve an [`AdapterId`] to the corresponding [`Arc<Adapter>`] in the global hub.
     pub fn resolve_adapter_id(&self, adapter_id: AdapterId) -> Arc<Adapter> {
-        self.hub.adapters.get(adapter_id)
+        self.hub.borrow().adapters.get(adapter_id)
     }
 
     /// Import [`Arc<Device>`] into the global hub,
     /// returning a [`DeviceId`] under which the device is stored.
     pub fn import_device(&self, device: Arc<Device>, id_in: DeviceId) -> DeviceId {
-        let fid = self.hub.devices.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.devices.prepare(id_in);
         fid.assign(device)
     }
 
     /// Resolve a [`DeviceId`] to the corresponding [`Arc<Device>`] in the global hub.
     pub fn resolve_device_id(&self, device_id: DeviceId) -> Arc<Device> {
-        self.hub.devices.get(device_id)
+        self.hub.borrow().devices.get(device_id)
     }
 
     /// Import [`Arc<Queue>`] into the global hub,
     /// returning a [`QueueId`] under which the queue is stored.
     pub fn import_queue(&self, queue: Arc<Queue>, id_in: QueueId) -> QueueId {
-        let fid = self.hub.queues.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.queues.prepare(id_in);
         fid.assign(queue)
     }
 
     /// Resolve a [`QueueId`] to the corresponding [`Arc<Queue>`] in the global hub.
     pub fn resolve_queue_id(&self, queue_id: QueueId) -> Arc<Queue> {
-        self.hub.queues.get(queue_id)
+        self.hub.borrow().queues.get(queue_id)
     }
 
     /// Import [`Arc<PipelineLayout>`] into the global hub,
@@ -114,7 +118,8 @@ impl Global {
         pipeline_layout: Arc<PipelineLayout>,
         id_in: PipelineLayoutId,
     ) -> PipelineLayoutId {
-        let fid = self.hub.pipeline_layouts.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.pipeline_layouts.prepare(id_in);
         fid.assign(pipeline_layout)
     }
 
@@ -123,7 +128,7 @@ impl Global {
         &self,
         pipeline_layout_id: PipelineLayoutId,
     ) -> Arc<PipelineLayout> {
-        self.hub.pipeline_layouts.get(pipeline_layout_id)
+        self.hub.borrow().pipeline_layouts.get(pipeline_layout_id)
     }
 
     /// Import [`Arc<BindGroupLayout>`] into the global hub,
@@ -133,7 +138,8 @@ impl Global {
         bind_group_layout: Arc<BindGroupLayout>,
         id_in: BindGroupLayoutId,
     ) -> BindGroupLayoutId {
-        let fid = self.hub.bind_group_layouts.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.bind_group_layouts.prepare(id_in);
         fid.assign(bind_group_layout)
     }
 
@@ -142,7 +148,10 @@ impl Global {
         &self,
         bind_group_layout_id: BindGroupLayoutId,
     ) -> Arc<BindGroupLayout> {
-        self.hub.bind_group_layouts.get(bind_group_layout_id)
+        self.hub
+            .borrow()
+            .bind_group_layouts
+            .get(bind_group_layout_id)
     }
 
     /// Import [`Arc<CommandEncoder>`] into the global hub,
@@ -152,7 +161,8 @@ impl Global {
         command_encoder: Arc<CommandEncoder>,
         id_in: CommandEncoderId,
     ) -> CommandEncoderId {
-        let fid = self.hub.command_encoders.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.command_encoders.prepare(id_in);
         fid.assign(command_encoder)
     }
 
@@ -161,7 +171,7 @@ impl Global {
         &self,
         command_encoder_id: CommandEncoderId,
     ) -> Arc<CommandEncoder> {
-        self.hub.command_encoders.get(command_encoder_id)
+        self.hub.borrow().command_encoders.get(command_encoder_id)
     }
 
     /// Import [`Arc<CommandBuffer>`] into the global hub,
@@ -171,7 +181,8 @@ impl Global {
         command_buffer: Arc<CommandBuffer>,
         id_in: CommandBufferId,
     ) -> CommandBufferId {
-        let fid = self.hub.command_buffers.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.command_buffers.prepare(id_in);
         fid.assign(command_buffer)
     }
 
@@ -180,7 +191,7 @@ impl Global {
         &self,
         command_buffer_id: CommandBufferId,
     ) -> Arc<CommandBuffer> {
-        self.hub.command_buffers.get(command_buffer_id)
+        self.hub.borrow().command_buffers.get(command_buffer_id)
     }
 
     /// Import [`Arc<RenderPipeline>`] into the global hub,
@@ -190,7 +201,8 @@ impl Global {
         render_pipeline: Arc<RenderPipeline>,
         id_in: RenderPipelineId,
     ) -> RenderPipelineId {
-        let fid = self.hub.render_pipelines.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.render_pipelines.prepare(id_in);
         fid.assign(render_pipeline)
     }
 
@@ -199,7 +211,7 @@ impl Global {
         &self,
         render_pipeline_id: RenderPipelineId,
     ) -> Arc<RenderPipeline> {
-        self.hub.render_pipelines.get(render_pipeline_id)
+        self.hub.borrow().render_pipelines.get(render_pipeline_id)
     }
 
     /// Import [`Arc<ComputePipeline>`] into the global hub,
@@ -209,7 +221,8 @@ impl Global {
         compute_pipeline: Arc<ComputePipeline>,
         id_in: ComputePipelineId,
     ) -> ComputePipelineId {
-        let fid = self.hub.compute_pipelines.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.compute_pipelines.prepare(id_in);
         fid.assign(compute_pipeline)
     }
 
@@ -218,43 +231,46 @@ impl Global {
         &self,
         compute_pipeline_id: ComputePipelineId,
     ) -> Arc<ComputePipeline> {
-        self.hub.compute_pipelines.get(compute_pipeline_id)
+        self.hub.borrow().compute_pipelines.get(compute_pipeline_id)
     }
 
     /// Import [`Arc<QuerySet>`] into the global hub,
     /// returning a [`QuerySetId`] under which the query set is stored.
     pub fn import_query_set(&self, query_set: Arc<QuerySet>, id_in: QuerySetId) -> QuerySetId {
-        let fid = self.hub.query_sets.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.query_sets.prepare(id_in);
         fid.assign(query_set)
     }
 
     /// Resolve a [`QuerySetId`] to the corresponding [`Arc<QuerySet>`] in the global hub.
     pub fn resolve_query_set_id(&self, query_set_id: QuerySetId) -> Arc<QuerySet> {
-        self.hub.query_sets.get(query_set_id)
+        self.hub.borrow().query_sets.get(query_set_id)
     }
 
     /// Import [`Arc<Buffer>`] into the global hub,
     /// returning a [`BufferId`] under which the buffer is stored.
     pub fn import_buffer(&self, buffer: Arc<Buffer>, id_in: BufferId) -> BufferId {
-        let fid = self.hub.buffers.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.buffers.prepare(id_in);
         fid.assign(buffer)
     }
 
     /// Resolve a [`BufferId`] to the corresponding [`Arc<Buffer>`] in the global hub.
     pub fn resolve_buffer_id(&self, buffer_id: BufferId) -> Arc<Buffer> {
-        self.hub.buffers.get(buffer_id)
+        self.hub.borrow().buffers.get(buffer_id)
     }
 
     /// Import [`Arc<Texture>`] into the global hub,
     /// returning a [`TextureId`] under which the texture is stored.
     pub fn import_texture(&self, texture: Arc<Texture>, id_in: TextureId) -> TextureId {
-        let fid = self.hub.textures.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let fid = hub.textures.prepare(id_in);
         fid.assign(texture)
     }
 
     /// Resolve a [`TextureId`] to the corresponding [`Arc<Texture>`] in the global hub.
     pub fn resolve_texture_id(&self, texture_id: TextureId) -> Arc<Texture> {
-        self.hub.textures.get(texture_id)
+        self.hub.borrow().textures.get(texture_id)
     }
 }
 

--- a/wgpu-core-remote/src/global/mod.rs
+++ b/wgpu-core-remote/src/global/mod.rs
@@ -76,8 +76,7 @@ impl Global {
     /// returning an [`AdapterId`] under which the adapter is stored.
     pub fn import_adapter(&self, adapter: Arc<Adapter>, id_in: AdapterId) -> AdapterId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.adapters.prepare(id_in);
-        fid.assign(adapter)
+        hub.adapters.assign(id_in, adapter)
     }
 
     /// Resolve an [`AdapterId`] to the corresponding [`Arc<Adapter>`] in the global hub.
@@ -89,8 +88,7 @@ impl Global {
     /// returning a [`DeviceId`] under which the device is stored.
     pub fn import_device(&self, device: Arc<Device>, id_in: DeviceId) -> DeviceId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.devices.prepare(id_in);
-        fid.assign(device)
+        hub.devices.assign(id_in, device)
     }
 
     /// Resolve a [`DeviceId`] to the corresponding [`Arc<Device>`] in the global hub.
@@ -102,8 +100,7 @@ impl Global {
     /// returning a [`QueueId`] under which the queue is stored.
     pub fn import_queue(&self, queue: Arc<Queue>, id_in: QueueId) -> QueueId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.queues.prepare(id_in);
-        fid.assign(queue)
+        hub.queues.assign(id_in, queue)
     }
 
     /// Resolve a [`QueueId`] to the corresponding [`Arc<Queue>`] in the global hub.
@@ -119,8 +116,7 @@ impl Global {
         id_in: PipelineLayoutId,
     ) -> PipelineLayoutId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.pipeline_layouts.prepare(id_in);
-        fid.assign(pipeline_layout)
+        hub.pipeline_layouts.assign(id_in, pipeline_layout)
     }
 
     /// Resolve a [`PipelineLayoutId`] to the corresponding [`Arc<PipelineLayout>`] in the global hub.
@@ -139,8 +135,7 @@ impl Global {
         id_in: BindGroupLayoutId,
     ) -> BindGroupLayoutId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.bind_group_layouts.prepare(id_in);
-        fid.assign(bind_group_layout)
+        hub.bind_group_layouts.assign(id_in, bind_group_layout)
     }
 
     /// Resolve a [`BindGroupLayoutId`] to the corresponding [`Arc<BindGroupLayout>`] in the global hub.
@@ -162,8 +157,7 @@ impl Global {
         id_in: CommandEncoderId,
     ) -> CommandEncoderId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.command_encoders.prepare(id_in);
-        fid.assign(command_encoder)
+        hub.command_encoders.assign(id_in, command_encoder)
     }
 
     /// Resolve a [`CommandEncoderId`] to the corresponding [`Arc<CommandEncoder>`] in the global hub.
@@ -182,8 +176,7 @@ impl Global {
         id_in: CommandBufferId,
     ) -> CommandBufferId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.command_buffers.prepare(id_in);
-        fid.assign(command_buffer)
+        hub.command_buffers.assign(id_in, command_buffer)
     }
 
     /// Resolve a [`CommandBufferId`] to the corresponding [`Arc<CommandBuffer>`] in the global hub.
@@ -202,8 +195,7 @@ impl Global {
         id_in: RenderPipelineId,
     ) -> RenderPipelineId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.render_pipelines.prepare(id_in);
-        fid.assign(render_pipeline)
+        hub.render_pipelines.assign(id_in, render_pipeline)
     }
 
     /// Resolve a [`RenderPipelineId`] to the corresponding [`Arc<RenderPipeline>`] in the global hub.
@@ -222,8 +214,7 @@ impl Global {
         id_in: ComputePipelineId,
     ) -> ComputePipelineId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.compute_pipelines.prepare(id_in);
-        fid.assign(compute_pipeline)
+        hub.compute_pipelines.assign(id_in, compute_pipeline)
     }
 
     /// Resolve a [`ComputePipelineId`] to the corresponding [`Arc<ComputePipeline>`] in the global hub.
@@ -238,8 +229,7 @@ impl Global {
     /// returning a [`QuerySetId`] under which the query set is stored.
     pub fn import_query_set(&self, query_set: Arc<QuerySet>, id_in: QuerySetId) -> QuerySetId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.query_sets.prepare(id_in);
-        fid.assign(query_set)
+        hub.query_sets.assign(id_in, query_set)
     }
 
     /// Resolve a [`QuerySetId`] to the corresponding [`Arc<QuerySet>`] in the global hub.
@@ -251,8 +241,7 @@ impl Global {
     /// returning a [`BufferId`] under which the buffer is stored.
     pub fn import_buffer(&self, buffer: Arc<Buffer>, id_in: BufferId) -> BufferId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.buffers.prepare(id_in);
-        fid.assign(buffer)
+        hub.buffers.assign(id_in, buffer)
     }
 
     /// Resolve a [`BufferId`] to the corresponding [`Arc<Buffer>`] in the global hub.
@@ -264,8 +253,7 @@ impl Global {
     /// returning a [`TextureId`] under which the texture is stored.
     pub fn import_texture(&self, texture: Arc<Texture>, id_in: TextureId) -> TextureId {
         let mut hub = self.hub.borrow_mut();
-        let fid = hub.textures.prepare(id_in);
-        fid.assign(texture)
+        hub.textures.assign(id_in, texture)
     }
 
     /// Resolve a [`TextureId`] to the corresponding [`Arc<Texture>`] in the global hub.

--- a/wgpu-core-remote/src/global/queue.rs
+++ b/wgpu-core-remote/src/global/queue.rs
@@ -12,8 +12,9 @@ impl Global {
         buffer_offset: wgt::BufferAddress,
         data: &[u8],
     ) -> Result<(), QueueWriteError> {
-        let queue = self.hub.queues.get(queue_id);
-        let buffer = self.hub.buffers.get(buffer_id);
+        let hub = self.hub.borrow();
+        let queue = hub.queues.get(queue_id);
+        let buffer = hub.buffers.get(buffer_id);
 
         queue.write_buffer(buffer, buffer_offset, data)
     }
@@ -25,8 +26,9 @@ impl Global {
         buffer_offset: u64,
         buffer_size: wgt::BufferSize,
     ) -> Result<(), QueueWriteError> {
-        let queue = self.hub.queues.get(queue_id);
-        let buffer = self.hub.buffers.get(buffer_id);
+        let hub = self.hub.borrow();
+        let queue = hub.queues.get(queue_id);
+        let buffer = hub.buffers.get(buffer_id);
         queue.validate_write_buffer(buffer, buffer_offset, buffer_size)
     }
 
@@ -38,8 +40,9 @@ impl Global {
         data_layout: &wgt::TexelCopyBufferLayout,
         size: &wgt::Extent3d,
     ) -> Result<(), QueueWriteError> {
-        let queue = self.hub.queues.get(queue_id);
-        let texture = self.hub.textures.get(destination.texture);
+        let hub = self.hub.borrow();
+        let queue = hub.queues.get(queue_id);
+        let texture = hub.textures.get(destination.texture);
         let destination = wgt::TexelCopyTextureInfo {
             texture,
             mip_level: destination.mip_level,
@@ -55,18 +58,18 @@ impl Global {
         queue_id: QueueId,
         command_buffer_ids: &[CommandBufferId],
     ) -> Result<SubmissionIndex, (SubmissionIndex, QueueSubmitError)> {
-        let queue = self.hub.queues.get(queue_id);
-        let command_buffer_guard = self.hub.command_buffers.read();
+        let hub = self.hub.borrow();
+        let queue = hub.queues.get(queue_id);
         let command_buffers = command_buffer_ids
             .iter()
-            .map(|id| command_buffer_guard.get(*id))
+            .map(|id| hub.command_buffers.get(*id))
             .collect::<Vec<_>>();
-        drop(command_buffer_guard);
         queue.submit(&command_buffers)
     }
 
     pub fn queue_get_timestamp_period(&self, queue_id: QueueId) -> f32 {
-        let queue = self.hub.queues.get(queue_id);
+        let hub = self.hub.borrow();
+        let queue = hub.queues.get(queue_id);
 
         queue.get_timestamp_period()
     }
@@ -76,7 +79,8 @@ impl Global {
         queue_id: QueueId,
         closure: SubmittedWorkDoneClosure,
     ) -> SubmissionIndex {
-        let queue = self.hub.queues.get(queue_id);
+        let hub = self.hub.borrow();
+        let queue = hub.queues.get(queue_id);
         let result = queue.on_submitted_work_done(closure);
         result.unwrap_or(0) // '0' means no wait is necessary
     }

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -9,6 +9,7 @@ use wgpu_core::Label;
 use wgt::{BufferAddress, BufferSize, Color, DynamicOffset, IndexFormat};
 
 use crate::global::Global;
+use crate::hub::Hub;
 use crate::id;
 
 /// Describes the attachments of a render pass.
@@ -45,13 +46,17 @@ impl Global {
         desc: &RenderPassDescriptor<'_>,
         id_in: id::RenderPassEncoderId,
     ) -> (id::RenderPassEncoderId, Option<CommandEncoderError>) {
-        let hub = &self.hub;
-        let fid = hub.render_passes.prepare(id_in);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            command_encoders,
+            render_passes,
+            texture_views,
+            query_sets,
+            ..
+        } = &mut *hub;
+        let fid = render_passes.prepare(id_in);
 
-        let cmd_enc = hub.command_encoders.get(encoder_id);
-
-        let texture_views = hub.texture_views.read();
-        let query_sets = hub.query_sets.read();
+        let cmd_enc = command_encoders.get(encoder_id);
 
         let desc = ResolvedRenderPassDescriptor {
             label: desc.label.as_deref().map(Cow::Borrowed),
@@ -94,9 +99,6 @@ impl Global {
             multiview_mask: desc.multiview_mask,
         };
 
-        drop(texture_views);
-        drop(query_sets);
-
         let (render_pass, error) = cmd_enc.begin_render_pass(desc);
 
         let id = fid.assign(render_pass);
@@ -104,12 +106,14 @@ impl Global {
     }
 
     pub fn render_pass_end(&self, pass: id::RenderPassEncoderId) -> Result<(), EncoderStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.end()
     }
 
     pub fn render_pass_drop(&self, pass: id::RenderPassEncoderId) {
-        self.hub.render_passes.remove(pass);
+        let mut hub = self.hub.borrow_mut();
+        hub.render_passes.remove(pass);
     }
 }
 
@@ -129,12 +133,14 @@ impl Global {
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[DynamicOffset],
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
-        pass.set_bind_group(
-            index,
-            bind_group_id.map(|id| self.hub.bind_groups.get(id)),
-            offsets,
-        )
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_passes,
+            bind_groups,
+            ..
+        } = &mut *hub;
+        let pass = render_passes.get_mut(pass);
+        pass.set_bind_group(index, bind_group_id.map(|id| bind_groups.get(id)), offsets)
     }
 
     pub fn render_pass_set_pipeline(
@@ -142,8 +148,14 @@ impl Global {
         pass: id::RenderPassEncoderId,
         pipeline_id: id::RenderPipelineId,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
-        let pipeline = self.resolve_render_pipeline_id(pipeline_id);
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_passes,
+            render_pipelines,
+            ..
+        } = &mut *hub;
+        let pass = render_passes.get_mut(pass);
+        let pipeline = render_pipelines.get(pipeline_id);
         pass.set_pipeline(pipeline)
     }
 
@@ -155,13 +167,14 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
-        pass.set_index_buffer(
-            self.resolve_buffer_id(buffer_id),
-            index_format,
-            offset,
-            size,
-        )
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_passes,
+            buffers,
+            ..
+        } = &mut *hub;
+        let pass = render_passes.get_mut(pass);
+        pass.set_index_buffer(buffers.get(buffer_id), index_format, offset, size)
     }
 
     pub fn render_pass_set_vertex_buffer(
@@ -172,13 +185,14 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferSize>,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
-        pass.set_vertex_buffer(
-            slot,
-            buffer_id.map(|id| self.resolve_buffer_id(id)),
-            offset,
-            size,
-        )
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_passes,
+            buffers,
+            ..
+        } = &mut *hub;
+        let pass = render_passes.get_mut(pass);
+        pass.set_vertex_buffer(slot, buffer_id.map(|id| buffers.get(id)), offset, size)
     }
 
     pub fn render_pass_set_blend_constant(
@@ -186,7 +200,8 @@ impl Global {
         pass: id::RenderPassEncoderId,
         color: Color,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.set_blend_constant(color)
     }
 
@@ -195,7 +210,8 @@ impl Global {
         pass: id::RenderPassEncoderId,
         value: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.set_stencil_reference(value)
     }
 
@@ -209,7 +225,8 @@ impl Global {
         depth_min: f32,
         depth_max: f32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.set_viewport(x, y, w, h, depth_min, depth_max)
     }
 
@@ -221,7 +238,8 @@ impl Global {
         w: u32,
         h: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.set_scissor_rect(x, y, w, h)
     }
 
@@ -231,7 +249,8 @@ impl Global {
         offset: u32,
         data: &[u8],
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.set_immediates(offset, data)
     }
 
@@ -243,7 +262,8 @@ impl Global {
         first_vertex: u32,
         first_instance: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.draw(vertex_count, instance_count, first_vertex, first_instance)
     }
 
@@ -256,7 +276,8 @@ impl Global {
         base_vertex: i32,
         first_instance: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.draw_indexed(
             index_count,
             instance_count,
@@ -272,8 +293,14 @@ impl Global {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
-        pass.draw_indirect(self.resolve_buffer_id(buffer_id), offset)
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_passes,
+            buffers,
+            ..
+        } = &mut *hub;
+        let pass = render_passes.get_mut(pass);
+        pass.draw_indirect(buffers.get(buffer_id), offset)
     }
 
     pub fn render_pass_draw_indexed_indirect(
@@ -282,8 +309,14 @@ impl Global {
         buffer_id: id::BufferId,
         offset: BufferAddress,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
-        pass.draw_indexed_indirect(self.resolve_buffer_id(buffer_id), offset)
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_passes,
+            buffers,
+            ..
+        } = &mut *hub;
+        let pass = render_passes.get_mut(pass);
+        pass.draw_indexed_indirect(buffers.get(buffer_id), offset)
     }
 
     pub fn render_pass_push_debug_group(
@@ -292,7 +325,8 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.push_debug_group(label, color)
     }
 
@@ -300,7 +334,8 @@ impl Global {
         &self,
         pass: id::RenderPassEncoderId,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.pop_debug_group()
     }
 
@@ -310,7 +345,8 @@ impl Global {
         label: &str,
         color: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.insert_debug_marker(label, color)
     }
 
@@ -320,8 +356,14 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
-        pass.write_timestamp(self.resolve_query_set_id(query_set_id), query_index)
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_passes,
+            query_sets,
+            ..
+        } = &mut *hub;
+        let pass = render_passes.get_mut(pass);
+        pass.write_timestamp(query_sets.get(query_set_id), query_index)
     }
 
     pub fn render_pass_begin_occlusion_query(
@@ -329,7 +371,8 @@ impl Global {
         pass: id::RenderPassEncoderId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.begin_occlusion_query(query_index)
     }
 
@@ -337,7 +380,8 @@ impl Global {
         &self,
         pass: id::RenderPassEncoderId,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.end_occlusion_query()
     }
 
@@ -347,15 +391,22 @@ impl Global {
         query_set_id: id::QuerySetId,
         query_index: u32,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
-        pass.begin_pipeline_statistics_query(self.resolve_query_set_id(query_set_id), query_index)
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_passes,
+            query_sets,
+            ..
+        } = &mut *hub;
+        let pass = render_passes.get_mut(pass);
+        pass.begin_pipeline_statistics_query(query_sets.get(query_set_id), query_index)
     }
 
     pub fn render_pass_end_pipeline_statistics_query(
         &self,
         pass: id::RenderPassEncoderId,
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
+        let mut hub = self.hub.borrow_mut();
+        let pass = hub.render_passes.get_mut(pass);
         pass.end_pipeline_statistics_query()
     }
 
@@ -364,12 +415,16 @@ impl Global {
         pass: id::RenderPassEncoderId,
         render_bundle_ids: &[id::RenderBundleId],
     ) -> Result<(), PassStateError> {
-        let mut pass = self.hub.render_passes.get_mut(pass);
-        let hub = &self.hub;
-        let bundles = hub.render_bundles.read();
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_passes,
+            render_bundles,
+            ..
+        } = &mut *hub;
+        let pass = render_passes.get_mut(pass);
         let render_bundles = render_bundle_ids
             .iter()
-            .map(|&id| bundles.get(id))
+            .map(|&id| render_bundles.get(id))
             .collect::<Vec<_>>();
 
         pass.execute_bundles(&render_bundles)

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -54,7 +54,6 @@ impl Global {
             query_sets,
             ..
         } = &mut *hub;
-        let fid = render_passes.prepare(id_in);
 
         let cmd_enc = command_encoders.get(encoder_id);
 
@@ -101,7 +100,7 @@ impl Global {
 
         let (render_pass, error) = cmd_enc.begin_render_pass(desc);
 
-        let id = fid.assign(render_pass);
+        let id = render_passes.assign(id_in, render_pass);
         (id, error)
     }
 

--- a/wgpu-core-remote/src/registry.rs
+++ b/wgpu-core-remote/src/registry.rs
@@ -1,5 +1,3 @@
-use core::cell::{Ref, RefCell, RefMut};
-
 use crate::{
     id::Id,
     storage::{Storage, StorageItem},
@@ -18,13 +16,13 @@ use crate::{
 ///
 #[derive(Debug)]
 pub(crate) struct Registry<T: StorageItem> {
-    storage: RefCell<Storage<T>>,
+    storage: Storage<T>,
 }
 
 impl<T: StorageItem> Registry<T> {
     pub(crate) fn new() -> Self {
         Self {
-            storage: RefCell::new(Storage::new()),
+            storage: Storage::new(),
         }
     }
 }
@@ -32,7 +30,7 @@ impl<T: StorageItem> Registry<T> {
 #[must_use]
 pub(crate) struct FutureId<'a, T: StorageItem> {
     id: Id<T::Marker>,
-    data: &'a RefCell<Storage<T>>,
+    data: &'a mut Storage<T>,
 }
 
 impl<T: StorageItem> FutureId<'_, T> {
@@ -40,39 +38,32 @@ impl<T: StorageItem> FutureId<'_, T> {
     ///
     /// Registers it with the registry.
     pub fn assign(self, value: T) -> Id<T::Marker> {
-        let mut data = self.data.borrow_mut();
-        data.insert(self.id, value);
+        self.data.insert(self.id, value);
         self.id
     }
 }
 
 impl<T: StorageItem> Registry<T> {
-    pub(crate) fn prepare(&self, id_in: Id<T::Marker>) -> FutureId<'_, T> {
+    pub(crate) fn prepare(&mut self, id_in: Id<T::Marker>) -> FutureId<'_, T> {
         FutureId {
             id: id_in,
-            data: &self.storage,
+            data: &mut self.storage,
         }
     }
 
-    #[track_caller]
-    pub(crate) fn read<'a>(&'a self) -> Ref<'a, Storage<T>> {
-        self.storage.borrow()
-    }
-
-    pub(crate) fn remove(&self, id: Id<T::Marker>) -> T {
-        let value = self.storage.borrow_mut().remove(id);
-        value
+    pub(crate) fn remove(&mut self, id: Id<T::Marker>) -> T {
+        self.storage.remove(id)
     }
 }
 
 impl<T: StorageItem + Clone> Registry<T> {
     pub(crate) fn get(&self, id: Id<T::Marker>) -> T {
-        self.read().get(id)
+        self.storage.get(id)
     }
 }
 
 impl<T: StorageItem> Registry<T> {
-    pub(crate) fn get_mut<'a>(&'a self, id: Id<T::Marker>) -> RefMut<'a, T> {
-        RefMut::map(self.storage.borrow_mut(), |storage| storage.get_mut(id))
+    pub(crate) fn get_mut(&mut self, id: Id<T::Marker>) -> &mut T {
+        self.storage.get_mut(id)
     }
 }

--- a/wgpu-core-remote/src/registry.rs
+++ b/wgpu-core-remote/src/registry.rs
@@ -27,28 +27,10 @@ impl<T: StorageItem> Registry<T> {
     }
 }
 
-#[must_use]
-pub(crate) struct FutureId<'a, T: StorageItem> {
-    id: Id<T::Marker>,
-    data: &'a mut Storage<T>,
-}
-
-impl<T: StorageItem> FutureId<'_, T> {
-    /// Assign a new resource to this ID.
-    ///
-    /// Registers it with the registry.
-    pub fn assign(self, value: T) -> Id<T::Marker> {
-        self.data.insert(self.id, value);
-        self.id
-    }
-}
-
 impl<T: StorageItem> Registry<T> {
-    pub(crate) fn prepare(&mut self, id_in: Id<T::Marker>) -> FutureId<'_, T> {
-        FutureId {
-            id: id_in,
-            data: &mut self.storage,
-        }
+    pub(crate) fn assign(&mut self, id: Id<T::Marker>, value: T) -> Id<T::Marker> {
+        self.storage.insert(id, value);
+        id
     }
 
     pub(crate) fn remove(&mut self, id: Id<T::Marker>) -> T {


### PR DESCRIPTION
**Connections**
Towards #10073 

**Description**
As outlined in https://github.com/gfx-rs/wgpu/pull/10074#issuecomment-5297624475 we replace refcell in Registery with RefCell<Hub>. I am very happy with end results as there are no more guards and much only one borrow per global method.

In second commit I remove `FutureId` because we do not need it really anymore (it made sense when it did not hold &mut) and it's unnecessary complication.

**Testing**
Just refactor.

**Squash or Rebase?**
Rebase.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
