### PR TITLE
Fix f16 and allow i16 in immediates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Bottom level categories:
 - [`immediate_address_space`](https://www.w3.org/TR/WGSL/#language_extension-immediate_address_space) WGSL language extension is implemented. By @beicause in [#9711](https://github.com/gfx-rs/wgpu/pull/9711).
 - `TextureFormat::is_srgb()` has been renamed to `TextureFormat::has_srgb_suffix()` to clarify its function. By @kpreid in [#9758](https://github.com/gfx-rs/wgpu/pull/9758).
 - Remove the never-constructed `CreateBlasError::InvalidAabbStride` variant. `create_blas` takes no stride, so it could never be produced; AABB stride is validated at build time as `BuildAccelerationStructureError::InvalidAabbStride`. By @mstampfli in [#9935](https://github.com/gfx-rs/wgpu/pull/9935).
+- Allow using 16-bit integer in immediates. By @beicause in [#10082](https://github.com/gfx-rs/wgpu/pull/10082).
 
 #### naga
 
@@ -117,6 +118,7 @@ Bottom level categories:
 
 - Add OpenHarmony surface support via `VK_OHOS_surface`. Previously the Vulkan backend could not create a surface on OpenHarmony, leaving GLES as the only usable backend. By @ozongzi in [#9908](https://github.com/gfx-rs/wgpu/pull/9908).
 - Stop passing an un-waited fence to `vkAcquireNextImageKHR` on non-Windows platforms, which triggered `VUID-vkAcquireNextImageKHR-fence-10066` validation errors every frame since v30.0.0. By @ErichDonGubler in [#9855](https://github.com/gfx-rs/wgpu/issues/9855).
+- Fix vulkan validation error when using f16 in immediates. By @beicause in [#10082](https://github.com/gfx-rs/wgpu/pull/10082).
 
 #### Metal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Bottom level categories:
 - Reject bind group layout entries with `RAY_GENERATION`, `ANY_HIT`, `CLOSEST_HIT`, or `MISS` visibility unless `Features::EXPERIMENTAL_RAY_TRACING_PIPELINES` is enabled. By @teoxoy in [#10042](https://github.com/gfx-rs/wgpu/issues/10042).
 - Numeric types must now match exactly on inter-stage interfaces. Previously, the receiving type was only required to be a subtype of the originating type. By @andyleiserson in [#9999](https://github.com/gfx-rs/wgpu/pull/9999).
 - Relaxed requirement that the pipeline scalar type for a color output be at least as wide as the shader output type. Now, only the scalar kind must match. By @andyleiserson in [#9999](https://github.com/gfx-rs/wgpu/pull/9999).
+- Disallow array types in `var<immediate>`. By @beicause in [#10081](https://github.com/gfx-rs/wgpu/pull/10081).
 
 #### Naga
 

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -386,8 +386,7 @@ webgpu:shader,validation,decl,immediate:binding_attributes:*
 webgpu:shader,validation,decl,immediate:entry_point_interface:*
 webgpu:shader,validation,decl,immediate:pointers:*
 webgpu:shader,validation,decl,immediate:scope:*
-//FAIL: Fixed array should be disallowed in immediates
-// webgpu:shader,validation,decl,immediate:store_type,invalid:*
+webgpu:shader,validation,decl,immediate:store_type,invalid:*
 webgpu:shader,validation,decl,immediate:store_type,valid:*
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_neg"
 webgpu:shader,validation,expression,access,array:early_eval_errors:case="override_array_cnt_size_one"

--- a/naga/src/valid/type.rs
+++ b/naga/src/valid/type.rs
@@ -185,6 +185,8 @@ pub enum WidthError {
 pub enum ImmediateError {
     #[error("The scalar type {0:?} is not supported in immediates")]
     InvalidScalar(crate::Scalar),
+    #[error("Arrays are not supported in the immediate address space")]
+    InvalidArray,
 }
 
 // Only makes sense if `flags.contains(HOST_SHAREABLE)`
@@ -661,7 +663,7 @@ impl super::Validator {
                     flags: base_info.flags & type_info_mask,
                     uniform_layout,
                     storage_layout,
-                    immediates_compatibility: base_info.immediates_compatibility.clone(),
+                    immediates_compatibility: Err(ImmediateError::InvalidArray),
                 }
             }
             Ti::Struct { ref members, span } => {

--- a/naga/src/valid/type.rs
+++ b/naga/src/valid/type.rs
@@ -183,8 +183,6 @@ pub enum WidthError {
 #[derive(Clone, Debug, thiserror::Error)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum ImmediateError {
-    #[error("The scalar type {0:?} is not supported in immediates")]
-    InvalidScalar(crate::Scalar),
     #[error("Arrays are not supported in the immediate address space")]
     InvalidArray,
 }
@@ -290,7 +288,7 @@ impl super::Validator {
         &self,
         scalar: crate::Scalar,
     ) -> Result<ImmediateCompatibility, WidthError> {
-        let mut immediates_compatibility = Ok(());
+        let immediates_compatibility = Ok(());
         let good = match scalar.kind {
             crate::ScalarKind::Bool => scalar.width == crate::BOOL_WIDTH,
             crate::ScalarKind::Float => match scalar.width {
@@ -324,8 +322,6 @@ impl super::Validator {
                         });
                     }
 
-                    immediates_compatibility = Err(ImmediateError::InvalidScalar(scalar));
-
                     true
                 } else if scalar.width == 8 {
                     if !self.capabilities.contains(Capabilities::SHADER_INT64) {
@@ -347,8 +343,6 @@ impl super::Validator {
                             flag: "SHADER_INT16",
                         });
                     }
-
-                    immediates_compatibility = Err(ImmediateError::InvalidScalar(scalar));
 
                     true
                 } else if scalar.width == 8 {

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -1566,6 +1566,22 @@ fn int16_in_immediate() {
 }
 
 #[test]
+fn array_in_immediate() {
+    check_validation! {
+        "var<immediate> input: array<u32, 4>;",
+        "var<immediate> input: array<u32>;",
+        "struct S { a: array<u32, 4> }; var<immediate> input: S;":
+        Err(naga::valid::ValidationError::GlobalVariable {
+            source: naga::valid::GlobalVariableError::InvalidImmediateType(
+                naga::valid::ImmediateError::InvalidArray
+            ),
+            ..
+        }),
+        naga::valid::Capabilities::IMMEDIATES
+    }
+}
+
+#[test]
 fn float16_in_atomic() {
     check_validation! {
         "enable f16; var<storage> a: atomic<f16>;":

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -1549,23 +1549,6 @@ fn int16_subgroup_bitwise_rejected() {
 }
 
 #[test]
-fn int16_in_immediate() {
-    check_validation! {
-        "enable wgpu_int16; var<immediate> input: i16;",
-        "enable wgpu_int16; var<immediate> input: u16;",
-        "enable wgpu_int16; var<immediate> input: vec2<i16>;",
-        "enable wgpu_int16; struct S { a: u16 }; var<immediate> input: S;":
-        Err(naga::valid::ValidationError::GlobalVariable {
-            source: naga::valid::GlobalVariableError::InvalidImmediateType(
-                naga::valid::ImmediateError::InvalidScalar(_)
-            ),
-            ..
-        }),
-        naga::valid::Capabilities::SHADER_INT16 | naga::valid::Capabilities::IMMEDIATES
-    }
-}
-
-#[test]
 fn array_in_immediate() {
     check_validation! {
         "var<immediate> input: array<u32, 4>;",

--- a/tests/tests/wgpu-gpu/shader/mod.rs
+++ b/tests/tests/wgpu-gpu/shader/mod.rs
@@ -89,6 +89,10 @@ struct ShaderTest {
     ///
     /// Defaults to Backends::empty().
     failures: Backends,
+    /// Which backends this test will skip.
+    ///
+    /// Defaults to Backends::empty().
+    skip: Backends,
 }
 impl ShaderTest {
     fn default_comparison_function<O: bytemuck::Pod + Debug + PartialEq>(
@@ -158,6 +162,7 @@ impl ShaderTest {
             output_comparison_fn: Self::default_comparison_function::<O>,
             output_initialization: u32::MAX,
             failures: Backends::empty(),
+            skip: Backends::empty(),
         }
     }
 
@@ -189,6 +194,12 @@ impl ShaderTest {
 
     fn failures(mut self, failures: Backends) -> Self {
         self.failures = failures;
+
+        self
+    }
+
+    fn skip(mut self, skip: Backends) -> Self {
+        self.skip = skip;
 
         self
     }
@@ -292,6 +303,15 @@ async fn shader_input_output_test(
         assert!(test.output_values.len() <= MAX_BUFFER_SIZE as usize / 4);
 
         let test_name = test.name;
+
+        if test.skip == ctx.adapter_info.backend.into() {
+            log::info!(
+                "Skip shader test {} on {}",
+                test_name,
+                ctx.adapter_info.backend
+            );
+            return;
+        }
 
         // -- Building shader + pipeline --
 

--- a/tests/tests/wgpu-gpu/shader/struct_layout.rs
+++ b/tests/tests/wgpu-gpu/shader/struct_layout.rs
@@ -1035,17 +1035,25 @@ fn create_16bit_struct_layout_test(storage_type: InputStorageType) -> Vec<Shader
                     28, 29, 30, 31, // m4[3]
                 ],
             )
-            .failures(if storage_type == InputStorageType::Immediate {
-                // TODO: Fails on dx12.
-                Backends::DX12
-            } else if storage_type == InputStorageType::Uniform {
-                // TODO: Fails on vulkan and dx12.
+            .failures(
+                if storage_type == InputStorageType::Immediate
+                    || storage_type == InputStorageType::Uniform
+                {
+                    // TODO: Fails on dx12.
+                    // https://github.com/gfx-rs/wgpu/issues/10083
+                    Backends::DX12
+                } else {
+                    Backends::empty()
+                },
+            )
+            .skip(if storage_type == InputStorageType::Uniform {
+                // TODO: Fails on vulkan:
+                // https://github.com/gfx-rs/wgpu/issues/10083
                 //
-                // On vulkan:
                 // VALIDATION [VUID-VkShaderModuleCreateInfo-pCode-08737 (0xa5625282)]
                 // vkCreateShaderModule(): pCreateInfo->pCode (spirv-val produced an error):
                 // Structure id 14 decorated as Block for variable in Uniform storage class must follow relaxed uniform buffer layout rules: member 2 at offset 8 is not aligned to 16
-                Backends::VULKAN | Backends::DX12
+                Backends::VULKAN
             } else {
                 Backends::empty()
             }),

--- a/tests/tests/wgpu-gpu/shader/struct_layout.rs
+++ b/tests/tests/wgpu-gpu/shader/struct_layout.rs
@@ -1036,7 +1036,16 @@ fn create_16bit_struct_layout_test(storage_type: InputStorageType) -> Vec<Shader
                 ],
             )
             .failures(if storage_type == InputStorageType::Immediate {
+                // TODO: Fails on dx12.
                 Backends::DX12
+            } else if storage_type == InputStorageType::Uniform {
+                // TODO: Fails on vulkan and dx12.
+                //
+                // On vulkan:
+                // VALIDATION [VUID-VkShaderModuleCreateInfo-pCode-08737 (0xa5625282)]
+                // vkCreateShaderModule(): pCreateInfo->pCode (spirv-val produced an error):
+                // Structure id 14 decorated as Block for variable in Uniform storage class must follow relaxed uniform buffer layout rules: member 2 at offset 8 is not aligned to 16
+                Backends::VULKAN | Backends::DX12
             } else {
                 Backends::empty()
             }),

--- a/tests/tests/wgpu-gpu/shader/struct_layout.rs
+++ b/tests/tests/wgpu-gpu/shader/struct_layout.rs
@@ -820,8 +820,8 @@ static UNIFORM_INPUT_F16: GpuTestConfiguration = GpuTestConfiguration::new()
     .run_async(|ctx| {
         shader_input_output_test(
             ctx,
-            InputStorageType::Storage,
-            create_16bit_struct_layout_test(),
+            InputStorageType::Uniform,
+            create_16bit_struct_layout_test(InputStorageType::Uniform),
         )
     });
 
@@ -837,7 +837,7 @@ static STORAGE_INPUT_F16: GpuTestConfiguration = GpuTestConfiguration::new()
         shader_input_output_test(
             ctx,
             InputStorageType::Storage,
-            create_16bit_struct_layout_test(),
+            create_16bit_struct_layout_test(InputStorageType::Storage),
         )
     });
 
@@ -856,7 +856,7 @@ static IMMEDIATES_INPUT_F16: GpuTestConfiguration = GpuTestConfiguration::new()
         shader_input_output_test(
             ctx,
             InputStorageType::Immediate,
-            create_16bit_struct_layout_test(),
+            create_16bit_struct_layout_test(InputStorageType::Immediate),
         )
     });
 
@@ -911,7 +911,7 @@ static IMMEDIATES_INPUT_I16: GpuTestConfiguration = GpuTestConfiguration::new()
         )
     });
 
-fn create_16bit_struct_layout_test() -> Vec<ShaderTest> {
+fn create_16bit_struct_layout_test(storage_type: InputStorageType) -> Vec<ShaderTest> {
     let mut tests = Vec::new();
 
     fn f16asu16(f32: f32) -> u16 {
@@ -1015,25 +1015,32 @@ fn create_16bit_struct_layout_test() -> Vec<ShaderTest> {
         ",
         );
 
-        tests.push(ShaderTest::new(
-            "f16 matrix alignment".into(),
-            members.into(),
-            direct,
-            &(0..32).map(|x| f16asu16(x as f32)).collect::<Vec<_>>(),
-            &[
-                0, 1, // m2[0]
-                2, 3, // m2[1]
-                //
-                4, 5, 6, // m3[0]
-                8, 9, 10, // m3[1]
-                12, 13, 14, // m3[2]
-                //
-                16, 17, 18, 19, // m4[0]
-                20, 21, 22, 23, // m4[1]
-                24, 25, 26, 27, // m4[2]
-                28, 29, 30, 31, // m4[3]
-            ],
-        ));
+        tests.push(
+            ShaderTest::new(
+                "f16 matrix alignment".into(),
+                members.into(),
+                direct,
+                &(0..32).map(|x| f16asu16(x as f32)).collect::<Vec<_>>(),
+                &[
+                    0, 1, // m2[0]
+                    2, 3, // m2[1]
+                    //
+                    4, 5, 6, // m3[0]
+                    8, 9, 10, // m3[1]
+                    12, 13, 14, // m3[2]
+                    //
+                    16, 17, 18, 19, // m4[0]
+                    20, 21, 22, 23, // m4[1]
+                    24, 25, 26, 27, // m4[2]
+                    28, 29, 30, 31, // m4[3]
+                ],
+            )
+            .failures(if storage_type == InputStorageType::Immediate {
+                Backends::DX12
+            } else {
+                Backends::empty()
+            }),
+        );
     }
 
     // Insert `enable f16;` header

--- a/tests/tests/wgpu-gpu/shader/struct_layout.rs
+++ b/tests/tests/wgpu-gpu/shader/struct_layout.rs
@@ -15,8 +15,10 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         IMMEDIATES_INPUT_INT64,
         UNIFORM_INPUT_F16,
         STORAGE_INPUT_F16,
+        IMMEDIATES_INPUT_F16,
         UNIFORM_INPUT_I16,
         STORAGE_INPUT_I16,
+        IMMEDIATES_INPUT_I16,
     ]);
 }
 
@@ -840,6 +842,25 @@ static STORAGE_INPUT_F16: GpuTestConfiguration = GpuTestConfiguration::new()
     });
 
 #[apply(gpu_test!)]
+static IMMEDIATES_INPUT_F16: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(Features::SHADER_F16 | Features::IMMEDIATES)
+            .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
+            .limits(Limits {
+                max_immediate_size: MAX_BUFFER_SIZE as u32,
+                ..Limits::downlevel_defaults()
+            }),
+    )
+    .run_async(|ctx| {
+        shader_input_output_test(
+            ctx,
+            InputStorageType::Immediate,
+            create_16bit_struct_layout_test(),
+        )
+    });
+
+#[apply(gpu_test!)]
 static UNIFORM_INPUT_I16: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
@@ -867,6 +888,25 @@ static STORAGE_INPUT_I16: GpuTestConfiguration = GpuTestConfiguration::new()
         shader_input_output_test(
             ctx,
             InputStorageType::Storage,
+            create_int16_struct_layout_test(),
+        )
+    });
+
+#[apply(gpu_test!)]
+static IMMEDIATES_INPUT_I16: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(Features::SHADER_I16 | Features::IMMEDIATES)
+            .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
+            .limits(Limits {
+                max_immediate_size: MAX_BUFFER_SIZE as u32,
+                ..Limits::downlevel_defaults()
+            }),
+    )
+    .run_async(|ctx| {
+        shader_input_output_test(
+            ctx,
+            InputStorageType::Immediate,
             create_int16_struct_layout_test(),
         )
     });

--- a/tests/tests/wgpu-gpu/shader/struct_layout.rs
+++ b/tests/tests/wgpu-gpu/shader/struct_layout.rs
@@ -72,6 +72,8 @@ static IMMEDIATES_INPUT: GpuTestConfiguration = GpuTestConfiguration::new()
     });
 
 fn create_struct_layout_tests(storage_type: InputStorageType) -> Vec<ShaderTest> {
+    // Immediates don't support array types
+    let no_array_types = storage_type == InputStorageType::Immediate;
     let input_values: Vec<_> = (0..(MAX_BUFFER_SIZE as u32 / 4)).collect();
 
     let mut tests = Vec::new();
@@ -271,185 +273,189 @@ fn create_struct_layout_tests(storage_type: InputStorageType) -> Vec<ShaderTest>
     }
 
     // Array of matrix tests
-    for columns in [2, 4] {
-        for rows in [2, 3, 4] {
-            let array_size = 2;
-            let ty = format!("mat{columns}x{rows}<f32>");
-            let input_members = format!("members: array<{ty}, {array_size}>");
-            // There's 4 possible ways to load a component of a matrix in an array:
-            // - Do `input.members[0][0].x` (direct)
-            // - Store `input.members[0][0]` in a variable; do `var.x` (vector_loaded)
-            // - Store `input.members[0]` in a variable; do `var[0].x` (matrix_loaded)
-            // - Store `input.members` in a variable; do `var[0][0].x` (fully_loaded)
-            // For each of these, we can either use a static or dynamic index.
-            let mut direct_static = String::new();
-            let mut direct_dynamic = String::new();
-            let mut vector_loaded_static = String::new();
-            let mut vector_loaded_dynamic = String::new();
-            let mut matrix_loaded_static = String::new();
-            let mut matrix_loaded_dynamic = String::new();
-            let mut fully_loaded_static = String::from("let loaded = input.members;");
-            let mut fully_loaded_dynamic = String::from("let loaded = input.members;");
-            let column_index_names = ["zero", "one", "two", "three"];
-            for (column, column_str) in column_index_names.iter().enumerate().take(columns) {
-                writeln!(direct_dynamic, "var {column_str} = {column};").unwrap();
-                writeln!(vector_loaded_dynamic, "var {column_str} = {column};").unwrap();
-                writeln!(matrix_loaded_dynamic, "var {column_str} = {column};").unwrap();
-            }
-            for element in 0..array_size {
-                writeln!(
-                    matrix_loaded_static,
-                    "let mat_{element} = input.members[{element}];"
-                )
-                .unwrap();
-                writeln!(
-                    matrix_loaded_dynamic,
-                    "let mat_{element} = input.members[{element}];"
-                )
-                .unwrap();
+    if !no_array_types {
+        for columns in [2, 4] {
+            for rows in [2, 3, 4] {
+                let array_size = 2;
+                let ty = format!("mat{columns}x{rows}<f32>");
+                let input_members = format!("members: array<{ty}, {array_size}>");
+                // There's 4 possible ways to load a component of a matrix in an array:
+                // - Do `input.members[0][0].x` (direct)
+                // - Store `input.members[0][0]` in a variable; do `var.x` (vector_loaded)
+                // - Store `input.members[0]` in a variable; do `var[0].x` (matrix_loaded)
+                // - Store `input.members` in a variable; do `var[0][0].x` (fully_loaded)
+                // For each of these, we can either use a static or dynamic index.
+                let mut direct_static = String::new();
+                let mut direct_dynamic = String::new();
+                let mut vector_loaded_static = String::new();
+                let mut vector_loaded_dynamic = String::new();
+                let mut matrix_loaded_static = String::new();
+                let mut matrix_loaded_dynamic = String::new();
+                let mut fully_loaded_static = String::from("let loaded = input.members;");
+                let mut fully_loaded_dynamic = String::from("let loaded = input.members;");
+                let column_index_names = ["zero", "one", "two", "three"];
                 for (column, column_str) in column_index_names.iter().enumerate().take(columns) {
+                    writeln!(direct_dynamic, "var {column_str} = {column};").unwrap();
+                    writeln!(vector_loaded_dynamic, "var {column_str} = {column};").unwrap();
+                    writeln!(matrix_loaded_dynamic, "var {column_str} = {column};").unwrap();
+                }
+                for element in 0..array_size {
                     writeln!(
-                        vector_loaded_static,
-                        "let mat_{element}_vec_{column} = input.members[{element}][{column}];"
+                        matrix_loaded_static,
+                        "let mat_{element} = input.members[{element}];"
                     )
                     .unwrap();
                     writeln!(
+                        matrix_loaded_dynamic,
+                        "let mat_{element} = input.members[{element}];"
+                    )
+                    .unwrap();
+                    for (column, column_str) in column_index_names.iter().enumerate().take(columns)
+                    {
+                        writeln!(
+                            vector_loaded_static,
+                            "let mat_{element}_vec_{column} = input.members[{element}][{column}];"
+                        )
+                        .unwrap();
+                        writeln!(
                         vector_loaded_dynamic,
                         "let mat_{element}_vec_{column} = input.members[{element}][{column_str}];",
                     )
-                    .unwrap();
+                        .unwrap();
+                    }
                 }
-            }
 
-            let mut output_values = Vec::new();
+                let mut output_values = Vec::new();
 
-            let mut current_output_idx = 0;
-            let mut current_input_idx = 0;
-            for element in 0..array_size {
-                for (column, column_str) in column_index_names.iter().enumerate().take(columns) {
-                    let component_accessors = ["x", "y", "z", "w"].into_iter().take(rows);
-                    for component in component_accessors {
-                        writeln!(
+                let mut current_output_idx = 0;
+                let mut current_input_idx = 0;
+                for element in 0..array_size {
+                    for (column, column_str) in column_index_names.iter().enumerate().take(columns)
+                    {
+                        let component_accessors = ["x", "y", "z", "w"].into_iter().take(rows);
+                        for component in component_accessors {
+                            writeln!(
                             direct_static,
                             "output[{current_output_idx}] = bitcast<u32>(input.members[{element}][{column}].{component});"
                         )
                         .unwrap();
-                        writeln!(
+                            writeln!(
                             direct_dynamic,
                             "output[{current_output_idx}] = bitcast<u32>(input.members[{element}][{column_str}].{component});"
                         )
                         .unwrap();
-                        writeln!(
+                            writeln!(
                             vector_loaded_static,
                             "output[{current_output_idx}] = bitcast<u32>(mat_{element}_vec_{column}.{component});"
                         )
                         .unwrap();
-                        writeln!(
+                            writeln!(
                             vector_loaded_dynamic,
                             "output[{current_output_idx}] = bitcast<u32>(mat_{element}_vec_{column}.{component});"
                         )
                         .unwrap();
-                        writeln!(
+                            writeln!(
                             matrix_loaded_static,
                             "output[{current_output_idx}] = bitcast<u32>(mat_{element}[{column}].{component});"
                         )
                         .unwrap();
-                        writeln!(
+                            writeln!(
                             matrix_loaded_dynamic,
                             "output[{current_output_idx}] = bitcast<u32>(mat_{element}[{column_str}].{component});"
                         )
                         .unwrap();
-                        writeln!(
+                            writeln!(
                             fully_loaded_static,
                             "output[{current_output_idx}] = bitcast<u32>(loaded[{column}].{component});"
                         )
                         .unwrap();
-                        writeln!(
+                            writeln!(
                             fully_loaded_dynamic,
                             "output[{current_output_idx}] = bitcast<u32>(loaded[{column_str}].{component});"
                         )
                         .unwrap();
 
-                        output_values.push(current_input_idx);
-                        current_input_idx += 1;
-                        current_output_idx += 1;
-                    }
-                    // Round to next vec4 if we're matrices with vec3 columns
-                    if rows == 3 {
-                        current_input_idx += 1;
+                            output_values.push(current_input_idx);
+                            current_input_idx += 1;
+                            current_output_idx += 1;
+                        }
+                        // Round to next vec4 if we're matrices with vec3 columns
+                        if rows == 3 {
+                            current_input_idx += 1;
+                        }
                     }
                 }
+
+                // https://github.com/gfx-rs/wgpu/issues/4371
+                let failures = if storage_type == InputStorageType::Uniform && rows == 2 {
+                    Backends::GL
+                } else {
+                    Backends::empty()
+                };
+
+                tests.push(
+                    ShaderTest::new(
+                        format!("{ty} - direct, static index"),
+                        input_members.clone(),
+                        direct_static,
+                        &input_values,
+                        &output_values,
+                    )
+                    .failures(failures),
+                );
+                tests.push(
+                    ShaderTest::new(
+                        format!("{ty} - direct, dynamic index"),
+                        input_members.clone(),
+                        direct_dynamic,
+                        &input_values,
+                        &output_values,
+                    )
+                    .failures(failures),
+                );
+
+                tests.push(
+                    ShaderTest::new(
+                        format!("{ty} - vector loaded, static index"),
+                        input_members.clone(),
+                        vector_loaded_static,
+                        &input_values,
+                        &output_values,
+                    )
+                    .failures(failures),
+                );
+                tests.push(
+                    ShaderTest::new(
+                        format!("{ty} - vector loaded, dynamic index"),
+                        input_members.clone(),
+                        vector_loaded_dynamic,
+                        &input_values,
+                        &output_values,
+                    )
+                    .failures(failures),
+                );
+
+                tests.push(
+                    ShaderTest::new(
+                        format!("{ty} - matrix loaded, static index"),
+                        input_members.clone(),
+                        matrix_loaded_static,
+                        &input_values,
+                        &output_values,
+                    )
+                    .failures(failures),
+                );
+                tests.push(
+                    ShaderTest::new(
+                        format!("{ty} - matrix loaded, dynamic index"),
+                        input_members.clone(),
+                        matrix_loaded_dynamic,
+                        &input_values,
+                        &output_values,
+                    )
+                    .failures(failures),
+                );
             }
-
-            // https://github.com/gfx-rs/wgpu/issues/4371
-            let failures = if storage_type == InputStorageType::Uniform && rows == 2 {
-                Backends::GL
-            } else {
-                Backends::empty()
-            };
-
-            tests.push(
-                ShaderTest::new(
-                    format!("{ty} - direct, static index"),
-                    input_members.clone(),
-                    direct_static,
-                    &input_values,
-                    &output_values,
-                )
-                .failures(failures),
-            );
-            tests.push(
-                ShaderTest::new(
-                    format!("{ty} - direct, dynamic index"),
-                    input_members.clone(),
-                    direct_dynamic,
-                    &input_values,
-                    &output_values,
-                )
-                .failures(failures),
-            );
-
-            tests.push(
-                ShaderTest::new(
-                    format!("{ty} - vector loaded, static index"),
-                    input_members.clone(),
-                    vector_loaded_static,
-                    &input_values,
-                    &output_values,
-                )
-                .failures(failures),
-            );
-            tests.push(
-                ShaderTest::new(
-                    format!("{ty} - vector loaded, dynamic index"),
-                    input_members.clone(),
-                    vector_loaded_dynamic,
-                    &input_values,
-                    &output_values,
-                )
-                .failures(failures),
-            );
-
-            tests.push(
-                ShaderTest::new(
-                    format!("{ty} - matrix loaded, static index"),
-                    input_members.clone(),
-                    matrix_loaded_static,
-                    &input_values,
-                    &output_values,
-                )
-                .failures(failures),
-            );
-            tests.push(
-                ShaderTest::new(
-                    format!("{ty} - matrix loaded, dynamic index"),
-                    input_members.clone(),
-                    matrix_loaded_dynamic,
-                    &input_values,
-                    &output_values,
-                )
-                .failures(failures),
-            );
         }
     }
 
@@ -505,11 +511,12 @@ fn create_struct_layout_tests(storage_type: InputStorageType) -> Vec<ShaderTest>
     // Test for https://github.com/gfx-rs/wgpu/issues/5262.
     //
     // The struct is supposed to have a size of 32 and alignment of 16.
-    for ty in ["f32", "u32", "i32"] {
-        let header = format!("struct Inner {{ vec: vec3<{ty}>, scalar1: u32, scalar2: u32 }}");
-        let members = String::from("arr: array<Inner, 2>");
-        let direct = String::from(
-            "\
+    if !no_array_types {
+        for ty in ["f32", "u32", "i32"] {
+            let header = format!("struct Inner {{ vec: vec3<{ty}>, scalar1: u32, scalar2: u32 }}");
+            let members = String::from("arr: array<Inner, 2>");
+            let direct = String::from(
+                "\
             output[0] = bitcast<u32>(input.arr[0].vec.x);
             output[1] = bitcast<u32>(input.arr[0].vec.y);
             output[2] = bitcast<u32>(input.arr[0].vec.z);
@@ -521,18 +528,19 @@ fn create_struct_layout_tests(storage_type: InputStorageType) -> Vec<ShaderTest>
             output[8] = bitcast<u32>(input.arr[1].scalar1);
             output[9] = bitcast<u32>(input.arr[1].scalar2);
         ",
-        );
+            );
 
-        tests.push(
-            ShaderTest::new(
-                format!("Alignment of 24 byte struct with a vec3<{ty}>"),
-                members,
-                direct,
-                &input_values,
-                &[0, 1, 2, 3, 4, 8, 9, 10, 11, 12],
-            )
-            .header(header),
-        );
+            tests.push(
+                ShaderTest::new(
+                    format!("Alignment of 24 byte struct with a vec3<{ty}>"),
+                    members,
+                    direct,
+                    &input_values,
+                    &[0, 1, 2, 3, 4, 8, 9, 10, 11, 12],
+                )
+                .header(header),
+            );
+        }
     }
 
     // Mat3 alignment tests
@@ -555,18 +563,19 @@ fn create_struct_layout_tests(storage_type: InputStorageType) -> Vec<ShaderTest>
     //
     // This tries to exploit all the weird edge cases of the struct layout algorithm.
     {
-        let header =
-            String::from("struct Inner { scalar: f32, member: array<vec3<f32>, 2>, scalar2: f32 }");
+        let header = format!(
+            "struct Inner {{ scalar: f32, {}scalar2: f32 }}",
+            if no_array_types {
+                ""
+            } else {
+                "member: array<vec3<f32>, 2>, "
+            }
+        );
         let members = String::from("inner: Inner, scalar3: f32, vector: vec3<f32>, scalar4: f32");
-        let direct = String::from(
+        let direct = format!(
             "\
             output[0] = bitcast<u32>(input.inner.scalar);
-            output[1] = bitcast<u32>(input.inner.member[0].x);
-            output[2] = bitcast<u32>(input.inner.member[0].y);
-            output[3] = bitcast<u32>(input.inner.member[0].z);
-            output[4] = bitcast<u32>(input.inner.member[1].x);
-            output[5] = bitcast<u32>(input.inner.member[1].y);
-            output[6] = bitcast<u32>(input.inner.member[1].z);
+            {}
             output[7] = bitcast<u32>(input.inner.scalar2);
             output[8] = bitcast<u32>(input.scalar3);
             output[9] = bitcast<u32>(input.vector.x);
@@ -574,6 +583,18 @@ fn create_struct_layout_tests(storage_type: InputStorageType) -> Vec<ShaderTest>
             output[11] = bitcast<u32>(input.vector.z);
             output[12] = bitcast<u32>(input.scalar4);
         ",
+            if no_array_types {
+                ""
+            } else {
+                "\
+            output[1] = bitcast<u32>(input.inner.member[0].x);
+            output[2] = bitcast<u32>(input.inner.member[0].y);
+            output[3] = bitcast<u32>(input.inner.member[0].z);
+            output[4] = bitcast<u32>(input.inner.member[1].x);
+            output[5] = bitcast<u32>(input.inner.member[1].y);
+            output[6] = bitcast<u32>(input.inner.member[1].z);
+            "
+            }
         );
 
         tests.push(
@@ -582,15 +603,27 @@ fn create_struct_layout_tests(storage_type: InputStorageType) -> Vec<ShaderTest>
                 members,
                 direct,
                 &input_values,
-                &[
-                    0, // inner.scalar
-                    4, 5, 6, // inner.member[0]
-                    8, 9, 10, // inner.member[1]
-                    12, // scalar2
-                    16, // scalar3
-                    20, 21, 22, // vector
-                    23, // scalar4
-                ],
+                if no_array_types {
+                    &[
+                        0, // inner.scalar
+                        -1, -1, -1, // inner.member[0]
+                        -1, -1, -1, // inner.member[1]
+                        1,  // scalar2
+                        2,  // scalar3
+                        4, 5, 6, // vector
+                        7, // scalar4
+                    ]
+                } else {
+                    &[
+                        0, // inner.scalar
+                        4, 5, 6, // inner.member[0]
+                        8, 9, 10, // inner.member[1]
+                        12, // scalar2
+                        16, // scalar3
+                        20, 21, 22, // vector
+                        23, // scalar4
+                    ]
+                },
             )
             .header(header),
         );
@@ -611,7 +644,7 @@ static UNIFORM_INPUT_INT64: GpuTestConfiguration = GpuTestConfiguration::new()
         shader_input_output_test(
             ctx,
             InputStorageType::Storage,
-            create_64bit_struct_layout_tests(),
+            create_64bit_struct_layout_tests(false),
         )
     });
 
@@ -627,7 +660,7 @@ static STORAGE_INPUT_INT64: GpuTestConfiguration = GpuTestConfiguration::new()
         shader_input_output_test(
             ctx,
             InputStorageType::Storage,
-            create_64bit_struct_layout_tests(),
+            create_64bit_struct_layout_tests(false),
         )
     });
 
@@ -646,11 +679,12 @@ static IMMEDIATES_INPUT_INT64: GpuTestConfiguration = GpuTestConfiguration::new(
         shader_input_output_test(
             ctx,
             InputStorageType::Immediate,
-            create_64bit_struct_layout_tests(),
+            // Immediates don't support array types
+            create_64bit_struct_layout_tests(true),
         )
     });
 
-fn create_64bit_struct_layout_tests() -> Vec<ShaderTest> {
+fn create_64bit_struct_layout_tests(no_array_types: bool) -> Vec<ShaderTest> {
     let input_values: Vec<_> = (0..(MAX_BUFFER_SIZE as u32 / 4)).collect();
 
     let mut tests = Vec::new();
@@ -680,22 +714,34 @@ fn create_64bit_struct_layout_tests() -> Vec<ShaderTest> {
     // We dont go as all-out as the other nested struct test because
     // all our primitives are twice as wide and we have only so much buffer to spare.
     {
-        let header = String::from(
-            "struct Inner { scalar: u64, scalar32: u32, member: array<vec3<u64>, 2> }",
+        let header = format!(
+            "struct Inner {{ scalar: u64, scalar32: u32{} }}",
+            if no_array_types {
+                ""
+            } else {
+                ", member: array<vec3<u64>, 2>"
+            }
         );
         let members = String::from("inner: Inner");
-        let direct = String::from(
+        let direct = format!(
             "\
             output[0] = u32(bitcast<u64>(input.inner.scalar) & 0xFFFFFFFF);
             output[1] = u32((bitcast<u64>(input.inner.scalar) >> 32) & 0xFFFFFFFF);
             output[2] = bitcast<u32>(input.inner.scalar32);
+            {}
+        ",
+            if no_array_types {
+                ""
+            } else {
+                "\
             for (var index = 0u; index < 2u; index += 1u) {
                 for (var component = 0u; component < 3u; component += 1u) {
                     output[3 + index * 6 + component * 2] = u32(bitcast<u64>(input.inner.member[index][component]) & 0xFFFFFFFF);
                     output[4 + index * 6 + component * 2] = u32((bitcast<u64>(input.inner.member[index][component]) >> 32) & 0xFFFFFFFF);
                 }
             }
-        ",
+        "
+            }
         );
 
         tests.push(
@@ -704,12 +750,21 @@ fn create_64bit_struct_layout_tests() -> Vec<ShaderTest> {
                 members,
                 direct,
                 &input_values,
-                &[
-                    0, 1, // inner.scalar
-                    2, // inner.scalar32
-                    8, 9, 10, 11, 12, 13, // inner.member[0]
-                    16, 17, 18, 19, 20, 21, // inner.member[1]
-                ],
+                if no_array_types {
+                    &[
+                        0, 1, // inner.scalar
+                        2, // inner.scalar32
+                        -1, -1, -1, -1, -1, -1, // inner.member[0]
+                        -1, -1, -1, -1, -1, -1, // inner.member[1]
+                    ]
+                } else {
+                    &[
+                        0, 1, // inner.scalar
+                        2, // inner.scalar32
+                        8, 9, 10, 11, 12, 13, // inner.member[0]
+                        16, 17, 18, 19, 20, 21, // inner.member[1]
+                    ]
+                },
             )
             .header(header),
         );

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -449,7 +449,8 @@ impl PhysicalDeviceFeatures {
                     vk::PhysicalDevice16BitStorageFeatures::default()
                         .storage_buffer16_bit_access(true)
                         .storage_input_output16(phd_features.supports_storage_input_output_16())
-                        .uniform_and_storage_buffer16_bit_access(true),
+                        .uniform_and_storage_buffer16_bit_access(true)
+                        .storage_push_constant16(true),
                 )
             } else {
                 None


### PR DESCRIPTION
**Connections**
Depends on #10081

**Description**
In https://github.com/gfx-rs/wgpu/pull/9711 naga allows f16 in immediates. However we don't enable vulkan `PhysicalDevice16BitStorageFeatures` `storage_push_constant16` so it is not actually supported and if you use f16 in immediates you will get validation error:
```
[2026-08-15T07:15:45Z ERROR wgpu_test::expectations] Validation Error: vkCreateShaderModule(): SPIR-V contains a 16-bit OpVariable with PushConstant storage class, but storagePushConstant16 was not enabled.
        %14 = OpVariable %16 9
        The Vulkan spec states: If storagePushConstant16 is VK_FALSE, then objects containing 16-bit integer or 16-bit floating-point elements must not have Storage Class of PushConstant unless: StoragePushConstant8 is VK_TRUE, or elements are accessed in 32-bit multiples if shaderUntypedPointers is VK_TRUE (https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#VUID-RuntimeSpirv-storagePushConstant16-06333)
```

Enabling `storage_push_constant16` reduces the device coverage of `SHADER_F16` (search `VK_KHR_16bit_storage` on https://vulkan.gpuinfo.org/listfeaturesextensions.php). We need Naga polyfill (decompose the type into u32 array) to avoid requiring this feature. However, implementing it could be quite complex.

**Testing**
`cargo nextest run --test wgpu-gpu struct_layout`

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
