### PR TITLE
fix(player): Handle occluded window

### DIFF
--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -115,6 +115,7 @@ fn main() {
     {
         struct App<'a> {
             window: Option<Arc<Window>>,
+            occluded: bool,
             surface: Option<Arc<wgc::instance::Surface>>,
             configured_surface_id: Option<wgc::id::PointerId<wgc::id::markers::Surface>>,
             instance: &'a wgc::instance::Instance,
@@ -170,67 +171,97 @@ fn main() {
                 let surface = self.surface.as_ref().unwrap();
 
                 match event {
-                    WindowEvent::RedrawRequested if self.resize_config.is_none() => loop {
-                        match self.actions.pop() {
-                            Some(trace::Action::ConfigureSurface(surface_id, config)) => {
-                                log::info!("Configuring the surface");
-                                let current_size: (u32, u32) = window.inner_size().into();
-                                let size = (config.width, config.height);
-                                if current_size != size {
-                                    let _ = window.request_inner_size(
-                                        winit::dpi::PhysicalSize::new(config.width, config.height),
-                                    );
-                                    self.resize_config = Some(config);
-                                    break;
-                                } else {
-                                    let error = surface.configure(self.device, &config);
-                                    self.configured_surface_id = Some(surface_id);
-                                    if let Some(e) = error {
-                                        panic!("{e:?}");
+                    WindowEvent::RedrawRequested => {
+                        if self.resize_config.is_some() || self.occluded {
+                            return;
+                        }
+                        loop {
+                            match self.actions.pop() {
+                                Some(trace::Action::ConfigureSurface(surface_id, config)) => {
+                                    log::info!("Configuring the surface");
+                                    let current_size: (u32, u32) = window.inner_size().into();
+                                    let size = (config.width, config.height);
+                                    if current_size != size {
+                                        let _ = window.request_inner_size(
+                                            winit::dpi::PhysicalSize::new(
+                                                config.width,
+                                                config.height,
+                                            ),
+                                        );
+                                        self.resize_config = Some(config);
+                                        break;
+                                    } else {
+                                        let error = surface.configure(self.device, &config);
+                                        self.configured_surface_id = Some(surface_id);
+                                        if let Some(e) = error {
+                                            panic!("{e:?}");
+                                        }
                                     }
                                 }
-                            }
-                            Some(trace::Action::GetSurfaceTexture { id, parent }) => {
-                                log::debug!("Get surface texture for frame {}", self.frame_count);
-                                assert!(
-                                    self.configured_surface_id == Some(parent),
-                                    "rendering to an unexpected surface"
-                                );
-                                self.player.get_surface_texture(id, surface);
-                            }
-                            Some(trace::Action::Present(_id)) => {
-                                self.frame_count += 1;
-                                log::debug!("Presenting frame {}", self.frame_count);
-                                surface.present().unwrap();
-                                break;
-                            }
-                            Some(trace::Action::DiscardSurfaceTexture(_id)) => {
-                                log::debug!("Discarding frame {}", self.frame_count);
-                                surface.discard().unwrap();
-                                break;
-                            }
-                            Some(action) => {
-                                self.player.process(
-                                    self.device,
-                                    self.queue,
-                                    action,
-                                    trace::DiskTraceLoader::new(self.dir),
-                                );
-                            }
-                            None => {
-                                if !self.done {
-                                    println!("Finished the end at frame {}", self.frame_count);
-                                    self.done = true;
+                                Some(action @ trace::Action::GetSurfaceTexture { id, parent }) => {
+                                    log::debug!(
+                                        "Get surface texture for frame {}",
+                                        self.frame_count
+                                    );
+                                    assert!(
+                                        self.configured_surface_id == Some(parent),
+                                        "rendering to an unexpected surface"
+                                    );
+                                    let status = self.player.get_surface_texture(id, surface);
+                                    if !matches!(
+                                        status,
+                                        wgt::SurfaceStatus::Good | wgt::SurfaceStatus::Suboptimal
+                                    ) {
+                                        // Process other window messages and retry
+                                        self.actions.push(action);
+                                        break;
+                                    }
                                 }
-                                break;
+                                Some(trace::Action::Present(_id)) => {
+                                    self.frame_count += 1;
+                                    log::debug!("Presenting frame {}", self.frame_count);
+                                    surface.present().unwrap();
+                                    window.request_redraw();
+                                    break;
+                                }
+                                Some(trace::Action::DiscardSurfaceTexture(_id)) => {
+                                    log::debug!("Discarding frame {}", self.frame_count);
+                                    surface.discard().unwrap();
+                                    break;
+                                }
+                                Some(action) => {
+                                    self.player.process(
+                                        self.device,
+                                        self.queue,
+                                        action,
+                                        trace::DiskTraceLoader::new(self.dir),
+                                    );
+                                }
+                                None => {
+                                    if !self.done {
+                                        println!("Finished the end at frame {}", self.frame_count);
+                                        self.done = true;
+                                    }
+                                    break;
+                                }
                             }
                         }
-                    },
+                    }
                     WindowEvent::Resized(_) => {
                         if let Some(config) = self.resize_config.take() {
                             let error = surface.configure(self.device, &config);
                             if let Some(e) = error {
                                 panic!("{e:?}");
+                            }
+                        }
+                        window.request_redraw();
+                    }
+                    WindowEvent::Occluded(is_occluded) => {
+                        self.occluded = is_occluded;
+                        // Resume rendering when un-occluded.
+                        if !is_occluded {
+                            if let Some(window) = &self.window {
+                                window.request_redraw();
                             }
                         }
                     }
@@ -251,6 +282,7 @@ fn main() {
 
         let mut app = App {
             window: None,
+            occluded: false,
             surface: None,
             configured_surface_id: None,
             instance: &instance,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -6,7 +6,14 @@
 extern crate wgpu_core as wgc;
 extern crate wgpu_types as wgt;
 
-use std::{borrow::Cow, convert::Infallible, sync::Arc};
+use std::{
+    borrow::Cow,
+    convert::Infallible,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use hashbrown::HashMap;
 
@@ -447,12 +454,23 @@ impl Player {
         &mut self,
         id: wgc::id::PointerId<wgc::id::markers::Texture>,
         surface: &Arc<wgc::instance::Surface>,
-    ) {
+    ) -> wgt::SurfaceStatus {
+        static SURFACE_ERROR_COUNT: AtomicUsize = AtomicUsize::new(0);
         let frame = surface
             .get_current_texture()
             .expect("get_current_texture error");
-        let texture = frame.texture.expect("did not obtain a surface texture");
-        self.textures.insert(id, texture);
+        if matches!(
+            frame.status,
+            wgt::SurfaceStatus::Good | wgt::SurfaceStatus::Suboptimal
+        ) {
+            let texture = frame.texture.expect("did not obtain a surface texture");
+            self.textures.insert(id, texture);
+        } else {
+            log::warn!("getCurrentTexture returned {:?}", frame.status);
+            let prev_error_count = SURFACE_ERROR_COUNT.fetch_add(1, Ordering::SeqCst);
+            assert!(prev_error_count <= 10, "Too many surface errors, giving up",);
+        }
+        frame.status
     }
 
     pub fn resolve_buffer_id(


### PR DESCRIPTION
#9141 made some changes to the necessary `winit` boilerplate. It updated the examples, but didn't update the trace player. This PR adds occluded window handling to the trace player. It still doesn't have a real frame scheduling mechanism.

Fixes #10087.

**Testing**
Tested manually.

**Squash or Rebase?** Squash
