### PR TITLE
[wgpu-hal]: Remove `gles::MaybeMutex`

### DIFF
--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -12,8 +12,9 @@ use core::{cmp::max, convert::TryInto, num::NonZeroU32, ptr, sync::atomic::Order
 use arrayvec::ArrayVec;
 use glow::HasContext;
 use naga::FastHashMap;
+use wgpu_sync::Mutex;
 
-use super::{conv, lock, MaybeMutex, PrivateCapabilities};
+use super::{conv, PrivateCapabilities};
 use crate::auxil::map_naga_stage;
 use crate::TlasInstance;
 
@@ -233,7 +234,7 @@ impl super::Device {
             target,
             size: desc.size,
             map_flags,
-            map_state: Arc::new(MaybeMutex::new(super::BufferMapState {
+            map_state: Arc::new(Mutex::new(super::BufferMapState {
                 mapped: false,
                 data: None,
                 offset_of_current_mapping: 0,
@@ -637,7 +638,7 @@ impl crate::Device for super::Device {
                 target,
                 size: desc.size,
                 map_flags: 0,
-                map_state: Arc::new(MaybeMutex::new(super::BufferMapState {
+                map_state: Arc::new(Mutex::new(super::BufferMapState {
                     mapped: false,
                     data: Some(vec![0; desc.size as usize]),
                     offset_of_current_mapping: 0,
@@ -741,7 +742,7 @@ impl crate::Device for super::Device {
             target,
             size: desc.size,
             map_flags,
-            map_state: Arc::new(MaybeMutex::new(super::BufferMapState {
+            map_state: Arc::new(Mutex::new(super::BufferMapState {
                 mapped: false,
                 data,
                 offset_of_current_mapping: 0,
@@ -777,7 +778,7 @@ impl crate::Device for super::Device {
         let is_coherent = buffer.map_flags & glow::MAP_COHERENT_BIT != 0;
         let ptr = match buffer.raw {
             None => {
-                let mut map_state = lock(&buffer.map_state);
+                let mut map_state = buffer.map_state.lock();
                 let vec = map_state.data.as_mut().unwrap();
                 let slice = &mut vec.as_mut_slice()[range.start as usize..range.end as usize];
                 slice.as_mut_ptr()
@@ -785,7 +786,7 @@ impl crate::Device for super::Device {
             Some(raw) => {
                 let gl = &self.shared.context.lock();
                 unsafe { gl.bind_buffer(buffer.target, Some(raw)) };
-                let mut map_state = lock(&buffer.map_state);
+                let mut map_state = buffer.map_state.lock();
                 let ptr = if let Some(map_read_allocation) = map_state.data.as_mut() {
                     let slice = map_read_allocation.as_mut_slice();
                     unsafe { self.shared.get_buffer_sub_data(gl, buffer.target, 0, slice) };
@@ -827,7 +828,7 @@ impl crate::Device for super::Device {
     }
     unsafe fn unmap_buffer(&self, buffer: &super::Buffer) {
         let gl = &self.shared.context.lock();
-        let mut map_state = lock(&buffer.map_state);
+        let mut map_state = buffer.map_state.lock();
         if core::mem::replace(&mut map_state.mapped, false) {
             if let Some(raw) = buffer.raw {
                 if map_state.data.is_none() {
@@ -844,7 +845,7 @@ impl crate::Device for super::Device {
         I: Iterator<Item = crate::MemoryRange>,
     {
         let gl = &self.shared.context.lock();
-        let map_state = lock(&buffer.map_state);
+        let map_state = buffer.map_state.lock();
         if map_state.mapped {
             if let Some(raw) = buffer.raw {
                 if map_state.data.is_none() {

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -391,7 +391,7 @@ pub struct Buffer {
     /// Buffer mapping state.
     ///
     /// If locked concurrently with the GL context, the GL context should be locked first.
-    map_state: Arc<MaybeMutex<BufferMapState>>,
+    map_state: Arc<Mutex<BufferMapState>>,
     /// Set when the buffer wraps an externally-owned GL name created via
     /// [`Device::buffer_from_raw`](crate::gles::Device::buffer_from_raw).
     ///
@@ -1184,28 +1184,5 @@ fn gl_debug_message_callback(source: u32, gltype: u32, id: u32, severity: u32, m
     if cfg!(debug_assertions) && log_severity == log::Level::Error {
         // Set canary and continue
         crate::VALIDATION_CANARY.add(message.to_string());
-    }
-}
-
-// If we are using `std`, then use `Mutex` to provide `Send` and `Sync`
-cfg_if::cfg_if! {
-    if #[cfg(gles_with_std)] {
-        type MaybeMutex<T> = std::sync::Mutex<T>;
-
-        fn lock<T>(mutex: &MaybeMutex<T>) -> std::sync::MutexGuard<'_, T> {
-            mutex.lock().unwrap()
-        }
-    } else {
-        // It should be impossible for any build configuration to trigger this error
-        // It is intended only as a guard against changes elsewhere causing the use of
-        // `RefCell` here to become unsound.
-        #[cfg(all(send_sync, not(feature = "fragile-send-sync-non-atomic-wasm")))]
-        compile_error!("cannot provide non-fragile Send+Sync without std");
-
-        type MaybeMutex<T> = core::cell::RefCell<T>;
-
-        fn lock<T>(mutex: &MaybeMutex<T>) -> core::cell::RefMut<'_, T> {
-            mutex.borrow_mut()
-        }
     }
 }

--- a/wgpu-hal/src/gles/queue.rs
+++ b/wgpu-hal/src/gles/queue.rs
@@ -5,7 +5,7 @@ use core::sync::atomic::Ordering;
 use arrayvec::ArrayVec;
 use glow::HasContext;
 
-use super::{conv::is_layered_target, lock, Command as C, PrivateCapabilities};
+use super::{conv::is_layered_target, Command as C, PrivateCapabilities};
 
 const DEBUG_ID: u32 = 0;
 
@@ -377,7 +377,7 @@ impl super::Queue {
                     }
                 }
                 None => {
-                    let mut map_state = lock(&dst.map_state);
+                    let mut map_state = dst.map_state.lock();
                     map_state.data.as_mut().unwrap().as_mut_slice()
                         [range.start as usize..range.end as usize]
                         .fill(0);
@@ -420,7 +420,7 @@ impl super::Queue {
                         };
                     }
                     (Some(src), None) => {
-                        let mut map_state = lock(&dst.map_state);
+                        let mut map_state = dst.map_state.lock();
                         let dst_data = &mut map_state.data.as_mut().unwrap().as_mut_slice()
                             [copy.dst_offset as usize..copy.dst_offset as usize + size];
 
@@ -435,7 +435,7 @@ impl super::Queue {
                         };
                     }
                     (None, Some(dst)) => {
-                        let map_state = lock(&src.map_state);
+                        let map_state = src.map_state.lock();
                         let src_data = &map_state.data.as_ref().unwrap().as_slice()
                             [copy.src_offset as usize..copy.src_offset as usize + size];
                         unsafe { gl.bind_buffer(copy_dst_target, Some(dst)) };
@@ -784,7 +784,7 @@ impl super::Queue {
                             glow::PixelUnpackData::BufferOffset(copy.buffer_layout.offset as u32)
                         }
                         None => {
-                            map_state = lock(&src.map_state);
+                            map_state = src.map_state.lock();
                             let src_data = &map_state.data.as_ref().unwrap().as_slice()
                                 [copy.buffer_layout.offset as usize..];
                             glow::PixelUnpackData::Slice(Some(src_data))
@@ -848,7 +848,7 @@ impl super::Queue {
                             )
                         }
                         None => {
-                            map_state = lock(&src.map_state);
+                            map_state = src.map_state.lock();
                             let src_data = &map_state.data.as_ref().unwrap().as_slice()
                                 [(offset as usize)..(offset + bytes_in_upload) as usize];
                             glow::CompressedPixelUnpackData::Slice(src_data)
@@ -929,7 +929,7 @@ impl super::Queue {
                             glow::PixelPackData::BufferOffset(offset as u32)
                         }
                         None => {
-                            map_state = lock(&dst.map_state);
+                            map_state = dst.map_state.lock();
                             let dst_data = &mut map_state.data.as_mut().unwrap().as_mut_slice()
                                 [offset as usize..];
                             glow::PixelPackData::Slice(Some(dst_data))
@@ -1096,7 +1096,7 @@ impl super::Queue {
                             };
                         }
                         None => {
-                            let mut map_state = lock(&dst.map_state);
+                            let mut map_state = dst.map_state.lock();
                             let data = map_state.data.as_mut().unwrap();
                             let len = query_data.len().min(data.len());
                             data[..len].copy_from_slice(&query_data[..len]);


### PR DESCRIPTION
**Connections**

None

**Description**

Noticed that `wgpu-hal` includes a custom fallback for `std::sync::Mutex` for `no_std` configurations, which isn't required now that `wgpu-sync` is able to handle that itself.

**Testing**

`cargo check`, the change is entirely internal.

**Squash or Rebase?**

Rebase.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [X] Validation and feature gates are in place to confine behavioral changes.
- [X] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
