### PR TITLE
[wgpu-sync]: Centralize usage of `once_cell`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
           # Check with all compatible features
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-types --no-default-features --features strict_asserts,fragile-send-sync-non-atomic-wasm,serde,counters
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p naga-types --no-default-features --features serialize,deserialize
-          cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-sync --no-default-features --features alloc
+          cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-sync --no-default-features
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p naga --no-default-features --features dot-out,spv-in,spv-out,glsl-out,msl-out,serialize,deserialize,wgsl-in,wgsl-out,hlsl-out
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-hal --no-default-features --features fragile-send-sync-non-atomic-wasm
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-core --no-default-features --features api_log_info,resource_log_info,strict_asserts,serde,wgsl,spirv,counters,noop

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5037,6 +5037,7 @@ version = "30.0.0"
 dependencies = [
  "cfg-if",
  "lock_api",
+ "once_cell",
  "parking_lot",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4983,7 +4983,6 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
  "objc2-quartz-core 0.3.2",
- "once_cell",
  "ordered-float",
  "portable-atomic",
  "portable-atomic-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,7 +4795,6 @@ dependencies = [
  "naga",
  "naga-types",
  "num-traits",
- "once_cell",
  "portable-atomic",
  "profiling",
  "proptest",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -111,7 +111,7 @@ fragile-send-sync-non-atomic-wasm = [
 
 ## Enable certain items to be `Send` and `Sync` when they would not otherwise be.
 ## Also enables backtraces in some error cases when also under cfg(debug_assertions).
-std = ["wgpu-sync/std", "once_cell/std"]
+std = ["wgpu-sync/std"]
 
 #! ### External libraries
 # --------------------------------------------------------------------
@@ -200,7 +200,6 @@ indexmap.workspace = true
 log.workspace = true
 macro_rules_attribute = { workspace = true, optional = true }
 num-traits = { workspace = true }
-once_cell = { workspace = true, default-features = false }
 profiling = { workspace = true, default-features = false }
 raw-window-handle.workspace = true
 ron = { workspace = true, optional = true }

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
+use wgpu_sync::OnceCell;
 use wgt::error::{ErrorType, WebGpuError};
 
 use crate::{
@@ -793,7 +794,7 @@ pub struct BindGroupLayout {
     pub(crate) state: ResourceState<BindGroupLayoutState>,
     pub(crate) device: Arc<Device>,
     pub(crate) entries: bgl::EntryMap,
-    pub(crate) exclusive_pipeline: crate::OnceCellOrLock<ExclusivePipeline>,
+    pub(crate) exclusive_pipeline: OnceCell<ExclusivePipeline>,
     /// The `label` from the descriptor used to create the resource.
     pub(crate) label: String,
 }
@@ -874,7 +875,7 @@ impl BindGroupLayout {
             }),
             device: device.clone(),
             entries: bgl::EntryMap::default(),
-            exclusive_pipeline: crate::OnceCellOrLock::from(exclusive_pipeline),
+            exclusive_pipeline: OnceCell::from(exclusive_pipeline),
             label: String::new(),
         })
     }
@@ -884,7 +885,7 @@ impl BindGroupLayout {
             state: ResourceState::Invalid,
             device: device.clone(),
             entries: bgl::EntryMap::default(),
-            exclusive_pipeline: crate::OnceCellOrLock::from(ExclusivePipeline::None),
+            exclusive_pipeline: OnceCell::from(ExclusivePipeline::None),
             label,
         })
     }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -16,6 +16,7 @@ use hal::ShouldBeNonZeroExt;
 use arrayvec::ArrayVec;
 use bitflags::Flags;
 use smallvec::SmallVec;
+use wgpu_sync::OnceCell;
 use wgt::{
     math::align_to, ColorWrites, DeviceLostReason, TextureFormat, TextureSampleType,
     TextureViewDimension,
@@ -56,7 +57,7 @@ use crate::{
     track::{BindGroupStates, DeviceTracker, TrackerIndexAllocators, UsageScope, UsageScopePool},
     validation::{self, check_color_attachment_count, PassthroughInterface, ShaderMetaData},
     weak_vec::WeakVec,
-    FastHashMap, LabelHelpers, OnceCellOrLock,
+    FastHashMap, LabelHelpers,
 };
 
 use super::{
@@ -242,7 +243,7 @@ struct DeviceResources<'a> {
 pub struct Device {
     raw: Box<dyn hal::DynDevice>,
     pub(crate) adapter: Arc<Adapter>,
-    pub(crate) queue: OnceCellOrLock<Weak<Queue>>,
+    pub(crate) queue: OnceCell<Weak<Queue>>,
     pub(crate) zero_buffer: ManuallyDrop<Box<dyn hal::DynBuffer>>,
     pub(crate) empty_bgl: ManuallyDrop<Box<dyn hal::DynBindGroupLayout>>,
     /// The `label` from the descriptor used to create the resource.
@@ -310,8 +311,7 @@ pub struct Device {
     pub(crate) usage_scopes: UsageScopePool,
     pub(crate) indirect_validation: Option<crate::indirect_validation::IndirectValidation>,
     // Optional so that we can late-initialize this after the queue is created.
-    pub(crate) timestamp_normalizer:
-        OnceCellOrLock<crate::timestamp_normalization::TimestampNormalizer>,
+    pub(crate) timestamp_normalizer: OnceCell<crate::timestamp_normalization::TimestampNormalizer>,
     /// Uniform buffer containing [`ExternalTextureParams`] with values such
     /// that a [`TextureView`] bound to a [`wgt::BindingType::ExternalTexture`]
     /// binding point will be rendered correctly. Intended to be used as the
@@ -633,7 +633,7 @@ impl Device {
             Ok(Self {
                 raw: raw_device,
                 adapter: adapter.clone(),
-                queue: OnceCellOrLock::new(),
+                queue: OnceCell::new(),
                 zero_buffer: ManuallyDrop::new(zero_buffer),
                 empty_bgl: ManuallyDrop::new(empty_bgl),
                 default_external_texture_params_buffer: ManuallyDrop::new(
@@ -671,7 +671,7 @@ impl Device {
                 instance_flags,
                 deferred_destroy: Mutex::new(rank::DEVICE_DEFERRED_DESTROY, Vec::new()),
                 usage_scopes: Mutex::new(rank::DEVICE_USAGE_SCOPES, Default::default()),
-                timestamp_normalizer: OnceCellOrLock::new(),
+                timestamp_normalizer: OnceCell::new(),
                 indirect_validation,
                 deferred_buffer_map_pending_closures: DeferredBufferMapPendingClosures::new(),
             })
@@ -3225,7 +3225,7 @@ impl Device {
             }),
             device: self.clone(),
             entries: entry_map,
-            exclusive_pipeline: OnceCellOrLock::new(),
+            exclusive_pipeline: OnceCell::new(),
             label: label.to_string(),
         };
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -220,11 +220,6 @@ pub(crate) fn get_greatest_common_divisor(mut a: u32, mut b: u32) -> u32 {
     }
 }
 
-#[cfg(not(feature = "std"))]
-use core::cell::OnceCell as OnceCellOrLock;
-#[cfg(feature = "std")]
-use std::sync::OnceLock as OnceCellOrLock;
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/wgpu-core/src/pool.rs
+++ b/wgpu-core/src/pool.rs
@@ -2,14 +2,10 @@ use alloc::sync::{Arc, Weak};
 use core::hash::Hash;
 
 use hashbrown::{hash_map::Entry, HashMap};
+use wgpu_sync::OnceCell;
 
 use crate::lock::{rank, Mutex};
 use crate::FastHashMap;
-
-#[cfg(feature = "std")]
-use once_cell::sync::OnceCell;
-#[cfg(not(feature = "std"))]
-use once_cell::unsync::OnceCell;
 
 type SlotInner<V> = Weak<V>;
 type ResourcePoolSlot<V> = Arc<OnceCell<SlotInner<V>>>;

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -145,7 +145,6 @@ dx12 = [
     "dep:bytemuck",
     "dep:gpu-allocator",
     "dep:libloading",
-    "dep:once_cell",
     "dep:ordered-float",
     "dep:profiling",
     "dep:range-alloc",
@@ -154,7 +153,6 @@ dx12 = [
     "gpu-allocator/d3d12",
     "naga/hlsl-out",
     "wgpu-sync/std", # Required for send/sync
-    "once_cell/std",
     "windows/Win32_Devices_DeviceAndDriverInstallation",
     "windows/Win32_Devices_Display",
     "windows/Win32_Graphics_Direct3D_Dxc",
@@ -283,7 +281,6 @@ windows-result = { workspace = true, optional = true }
 # Backend: Dx12
 bit-set = { workspace = true, optional = true }
 range-alloc = { workspace = true, optional = true }
-once_cell = { workspace = true, optional = true }
 # backend: GLES
 glutin_wgl_sys = { workspace = true, optional = true }
 

--- a/wgpu-hal/src/dx12/dcomp.rs
+++ b/wgpu-hal/src/dx12/dcomp.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 use core::{ffi, ptr};
 
-use once_cell::sync::Lazy;
+use wgpu_sync::Lazy;
 use windows::{
     core::Interface as _,
     Win32::{Foundation::HWND, Graphics::DirectComposition},

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1,10 +1,9 @@
 use alloc::{string::String, sync::Arc, vec::Vec};
 use core::{ffi, mem::ManuallyDrop, ptr, time::Duration};
-use std::sync::LazyLock;
 
 use glow::HasContext;
 use hashbrown::HashMap;
-use wgpu_sync::{MappedMutexGuard, Mutex, MutexGuard, RwLock};
+use wgpu_sync::{Lazy, MappedMutexGuard, Mutex, MutexGuard, RwLock};
 
 /// The amount of time to wait while trying to obtain a lock to the adapter context
 const CONTEXT_LOCK_TIMEOUT_SECS: u64 = 6;
@@ -363,8 +362,7 @@ unsafe impl Sync for Inner {}
 // Different calls to `eglGetPlatformDisplay` may return the same `Display`, making it a global
 // state of all our `EglContext`s. This forces us to track the number of such context to prevent
 // terminating the display if it's currently used by another `EglContext`.
-static DISPLAYS_REFERENCE_COUNT: LazyLock<Mutex<HashMap<usize, usize>>> =
-    LazyLock::new(Default::default);
+static DISPLAYS_REFERENCE_COUNT: Lazy<Mutex<HashMap<usize, usize>>> = Lazy::new(Default::default);
 
 fn initialize_display(
     egl: &EglInstance,

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -11,10 +11,7 @@ use core::{
     time::Duration,
 };
 use std::{
-    sync::{
-        mpsc::{sync_channel, SyncSender},
-        LazyLock,
-    },
+    sync::mpsc::{sync_channel, SyncSender},
     thread,
 };
 
@@ -25,7 +22,7 @@ use glutin_wgl_sys::wgl_extra::{
 };
 use hashbrown::HashSet;
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
-use wgpu_sync::{Mutex, MutexGuard, RwLock};
+use wgpu_sync::{Lazy, Mutex, MutexGuard, RwLock};
 use wgt::InstanceFlags;
 use windows::{
     core::{Error, PCSTR},
@@ -341,8 +338,8 @@ fn create_global_window_class() -> Result<CString, crate::InstanceError> {
 }
 
 fn get_global_window_class() -> Result<CString, crate::InstanceError> {
-    static GLOBAL: LazyLock<Result<CString, crate::InstanceError>> =
-        LazyLock::new(create_global_window_class);
+    static GLOBAL: Lazy<Result<CString, crate::InstanceError>> =
+        Lazy::new(create_global_window_class);
     GLOBAL.clone()
 }
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -11,8 +11,7 @@ use wgt::{AstcBlock, AstcChannel};
 
 use alloc::{string::ToString as _, sync::Arc, vec::Vec};
 use core::sync::atomic;
-use std::sync::OnceLock;
-use wgpu_sync::Mutex;
+use wgpu_sync::{Mutex, OnceCell};
 
 use crate::metal::QueueShared;
 
@@ -117,7 +116,7 @@ impl crate::Adapter for super::Adapter {
                         command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
                         pending_waits: Mutex::new(Vec::new()),
                         pending_signals: Mutex::new(Vec::new()),
-                        relay: OnceLock::new(),
+                        relay: OnceCell::new(),
                     }),
                     timestamp_period,
                 },

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -34,7 +34,6 @@ use alloc::{
     vec::Vec,
 };
 use core::{fmt, iter, ops, ptr::NonNull, sync::atomic};
-use std::sync::OnceLock;
 
 use bitflags::bitflags;
 use hashbrown::HashMap;
@@ -56,7 +55,7 @@ use objc2_metal::{
     MTLTriangleFillMode, MTLWinding,
 };
 use objc2_quartz_core::CAMetalLayer;
-use wgpu_sync::{Condvar, Mutex, RwLock};
+use wgpu_sync::{Condvar, Mutex, OnceCell, RwLock};
 
 #[derive(Clone, Debug)]
 pub struct Api;
@@ -483,7 +482,7 @@ impl Queue {
                 command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
                 pending_waits: Mutex::new(Vec::new()),
                 pending_signals: Mutex::new(Vec::new()),
-                relay: OnceLock::new(),
+                relay: OnceCell::new(),
             }),
             timestamp_period,
         }
@@ -628,7 +627,7 @@ pub struct QueueShared {
     command_buffer_created_not_submitted: atomic::AtomicUsize,
     pending_waits: PendingEvents,
     pending_signals: PendingEvents,
-    relay: OnceLock<Relay>,
+    relay: OnceCell<Relay>,
 }
 
 #[derive(Debug)]

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,5 +1,3 @@
-use std::sync::LazyLock;
-
 use alloc::borrow::ToOwned as _;
 
 use objc2::{
@@ -13,7 +11,7 @@ use objc2_core_graphics::CGColorSpace;
 use objc2_foundation::NSObjectProtocol;
 use objc2_metal::MTLTextureType;
 use objc2_quartz_core::{CAMetalDrawable, CAMetalLayer};
-use wgpu_sync::{Mutex, RwLock};
+use wgpu_sync::{Lazy, Mutex, RwLock};
 
 use super::OsFeatures;
 
@@ -79,15 +77,15 @@ impl super::Surface {
                 // environmental), so leave a breadcrumb instead of failing
                 // silently. Warn once per process so a caller that polls this
                 // per frame is not spammed.
-                static WARN_ONCE: std::sync::Once = std::sync::Once::new();
-                WARN_ONCE.call_once(|| {
+                static WARN_ONCE: wgpu_sync::OnceCell<()> = wgpu_sync::OnceCell::new();
+                if WARN_ONCE.set(()).is_ok() {
                     log::warn!(
                         "Surface::display_hdr_info() was called from thread {:?} \
                          and will return None. On the Metal backend, it must be \
                          called from the main thread to succeed.",
                         std::thread::current().id()
                     );
-                });
+                }
                 return None;
             }
 
@@ -216,7 +214,7 @@ struct ColorSpaces {
     itur_bt2100_hlg: &'static CFString,
 }
 
-static COLOR_SPACES: LazyLock<Result<ColorSpaces, crate::SurfaceError>> = LazyLock::new(|| {
+static COLOR_SPACES: Lazy<Result<ColorSpaces, crate::SurfaceError>> = Lazy::new(|| {
     // Stable Rust doesn't support weak linkage, so objc2 doesn't
     // offer it. To avoid link errors on old OS versions, resolve
     // these dynamically.

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -213,10 +213,9 @@ fn error_is_waived(message_id_number: i32) -> bool {
     not(target_vendor = "apple")
 ))]
 fn cts_error_is_waived(message_id_number: i32) -> bool {
-    use std::sync::LazyLock;
+    use wgpu_sync::Lazy;
 
-    static WGPU_CTS_XTASK: LazyLock<bool> =
-        LazyLock::new(|| std::env::var_os("WGPU_CTS_XTASK").is_some());
+    static WGPU_CTS_XTASK: Lazy<bool> = Lazy::new(|| std::env::var_os("WGPU_CTS_XTASK").is_some());
 
     if !*WGPU_CTS_XTASK {
         return false;

--- a/wgpu-sync/Cargo.toml
+++ b/wgpu-sync/Cargo.toml
@@ -29,11 +29,10 @@ alloc_instead_of_core = "warn"
 
 [features]
 default = ["std"]
-std = ["alloc", "dep:parking_lot", "once_cell/std"]
-alloc = ["once_cell/alloc"]
+std = ["dep:parking_lot", "once_cell/std"]
 
 [dependencies]
 cfg-if.workspace = true
 lock_api = { workspace = true, default-features = false }
 parking_lot = { workspace = true, optional = true }
-once_cell = { workspace = true, default-features = false, features = ["race"] }
+once_cell = { workspace = true, default-features = false, features = ["alloc", "race"] }

--- a/wgpu-sync/Cargo.toml
+++ b/wgpu-sync/Cargo.toml
@@ -29,10 +29,11 @@ alloc_instead_of_core = "warn"
 
 [features]
 default = ["std"]
-std = ["alloc", "dep:parking_lot"]
-alloc = []
+std = ["alloc", "dep:parking_lot", "once_cell/std"]
+alloc = ["once_cell/alloc"]
 
 [dependencies]
 cfg-if.workspace = true
 lock_api = { workspace = true, default-features = false }
 parking_lot = { workspace = true, optional = true }
+once_cell = { workspace = true, default-features = false, features = ["race"] }

--- a/wgpu-sync/src/lib.rs
+++ b/wgpu-sync/src/lib.rs
@@ -9,8 +9,6 @@
 
 //! Provides [`Mutex`] and [`RwLock`] types with an appropriate implementation.
 
-// alloc and std aren't directly used by this crate, but we reserve features
-// for them and ensure the respective crates and linked to allow future usage.
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "std")]

--- a/wgpu-sync/src/lib.rs
+++ b/wgpu-sync/src/lib.rs
@@ -9,7 +9,6 @@
 
 //! Provides [`Mutex`] and [`RwLock`] types with an appropriate implementation.
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
@@ -26,9 +25,7 @@ pub use rwlock::RawRwLock;
 #[cfg(feature = "std")]
 pub use parking_lot::{Condvar, Mutex as CondvarMutex};
 
-#[cfg(feature = "alloc")]
-pub use once_cell::race::OnceBox;
-pub use once_cell::race::{OnceBool, OnceNonZeroUsize, OnceRef};
+pub use once_cell::race::{OnceBool, OnceBox, OnceNonZeroUsize, OnceRef};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {

--- a/wgpu-sync/src/lib.rs
+++ b/wgpu-sync/src/lib.rs
@@ -28,6 +28,18 @@ pub use rwlock::RawRwLock;
 #[cfg(feature = "std")]
 pub use parking_lot::{Condvar, Mutex as CondvarMutex};
 
+#[cfg(feature = "alloc")]
+pub use once_cell::race::OnceBox;
+pub use once_cell::race::{OnceBool, OnceNonZeroUsize, OnceRef};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
+        pub use once_cell::sync::{Lazy, OnceCell};
+    } else {
+        pub use once_cell::unsync::{Lazy, OnceCell};
+    }
+}
+
 /// A [`Mutex`](lock_api::Mutex) using [`RawMutex`] for its backing implementation.
 pub type Mutex<T> = lock_api::Mutex<RawMutex, T>;
 


### PR DESCRIPTION
**Connections**

None.

**Description**

While working on #9780, I noticed `once_cell` and `std::sync` are inconsistently used across `wgpu-hal` and `wgpu-core`. Similar to that PR, I'm proposing we centralize usage of `Lazy`, `OnceCell`, etc. to `wgpu-sync`, to make `no_std` configuration simpler and reduce maintenance burden.

**Testing**

`cargo check`, as there are no changes in the public API or behaviour (beyond exporting `once_cell` in the psuedo-public `wgpu-sync` API).

**Squash or Rebase?**

Rebase.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [X] Validation and feature gates are in place to confine behavioral changes.
- [X] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
  - Could split each commit into its own PR but it feels excessive, happy to if requested!
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
