### PR TITLE
[core-remote-types] Add binding_model types

### DIFF
--- a/wgpu-core-remote-types/src/binding_model.rs
+++ b/wgpu-core-remote-types/src/binding_model.rs
@@ -1,0 +1,64 @@
+use alloc::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+use crate::id::{BindGroupLayoutId, BufferId, ExternalTextureId, SamplerId, TextureViewId};
+use crate::Label;
+
+#[repr(C)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BufferBinding {
+    pub buffer: BufferId,
+    pub offset: wgt::BufferAddress,
+
+    /// Size of the binding. If `None`, the binding spans from `offset` to the
+    /// end of the buffer.
+    ///
+    /// We use `BufferAddress` to allow a size of zero on this `wgpu_core` type,
+    /// because JavaScript bindings cannot readily express `Option<NonZeroU64>`.
+    /// The `wgpu` API uses `Option<BufferSize>` (i.e. `NonZeroU64`) for this
+    /// field.
+    pub size: Option<wgt::BufferAddress>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BindingResource {
+    Buffer(BufferBinding),
+    Sampler(SamplerId),
+    TextureView(TextureViewId),
+    ExternalTexture(ExternalTextureId),
+}
+
+/// Bindable resource and the slot to bind it to.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BindGroupEntry {
+    /// Slot for which binding provides resource. Corresponds to an entry of the same
+    /// binding index in the [`BindGroupLayoutDescriptor`].
+    pub binding: u32,
+    /// Resource to attach to the binding
+    pub resource: BindingResource,
+}
+
+/// Describes a group of bindings and the resources to be bound.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BindGroupDescriptor<'a> {
+    /// Debug label of the bind group.
+    ///
+    /// This will show up in graphics debuggers for easy identification.
+    pub label: Label<'a>,
+    /// The BindGroupLayout that corresponds to this bind group.
+    pub layout: BindGroupLayoutId,
+    /// The resources to bind to this bind group.
+    pub entries: Cow<'a, [BindGroupEntry]>,
+}
+
+/// Describes a [`BindGroupLayout`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BindGroupLayoutDescriptor<'a> {
+    /// Debug label of the bind group layout.
+    ///
+    /// This will show up in graphics debuggers for easy identification.
+    pub label: Label<'a>,
+    /// Array of entries in this BindGroupLayout
+    pub entries: Cow<'a, [wgt::BindGroupLayoutEntry]>,
+}

--- a/wgpu-core-remote-types/src/lib.rs
+++ b/wgpu-core-remote-types/src/lib.rs
@@ -1,7 +1,14 @@
 extern crate alloc;
+extern crate wgpu_types as wgt;
+
+use alloc::borrow::Cow;
 
 pub type Index = u32;
 pub type Epoch = u32;
 
 pub mod id;
 pub mod identity;
+
+pub mod binding_model;
+
+pub type Label<'a> = Option<Cow<'a, str>>;

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -24,35 +24,7 @@ use crate::{
 
 use wgt::BufferAddress;
 
-pub type BindGroupDescriptor<'a> = binding_model::BindGroupDescriptor<
-    'a,
-    id::BindGroupLayoutId,
-    id::BufferId,
-    id::SamplerId,
-    id::TextureViewId,
-    id::TlasId,
-    id::ExternalTextureId,
->;
-
-pub type BindGroupEntry<'a> = binding_model::BindGroupEntry<
-    'a,
-    id::BufferId,
-    id::SamplerId,
-    id::TextureViewId,
-    id::TlasId,
-    id::ExternalTextureId,
->;
-
-pub type BufferBinding = binding_model::BufferBinding<id::BufferId>;
-
-pub type BindingResource<'a> = binding_model::BindingResource<
-    'a,
-    id::BufferId,
-    id::SamplerId,
-    id::TextureViewId,
-    id::TlasId,
-    id::ExternalTextureId,
->;
+pub use wgpu_core_remote_types::binding_model::*;
 
 pub type ComputePipelineDescriptor<'a> = pipeline::ComputePipelineDescriptor<
     'a,
@@ -551,7 +523,7 @@ impl Global {
         let layout = bind_group_layouts.get(desc.layout);
 
         fn resolve_entry<'a>(
-            e: &BindGroupEntry<'a>,
+            e: &'a BindGroupEntry,
             buffers: &mut Registry<Arc<resource::Buffer>>,
             samplers: &mut Registry<Arc<resource::Sampler>>,
             texture_views: &mut Registry<Arc<resource::TextureView>>,
@@ -572,29 +544,11 @@ impl Global {
                 BindingResource::Buffer(ref buffer) => {
                     binding_model::BindingResource::Buffer(resolve_buffer(buffer))
                 }
-                BindingResource::BufferArray(ref buffers) => {
-                    let buffers = buffers.iter().map(resolve_buffer).collect::<Vec<_>>();
-                    binding_model::BindingResource::BufferArray(Cow::Owned(buffers))
-                }
                 BindingResource::Sampler(ref sampler) => {
                     binding_model::BindingResource::Sampler(resolve_sampler(sampler))
                 }
-                BindingResource::SamplerArray(ref samplers) => {
-                    let samplers = samplers.iter().map(resolve_sampler).collect::<Vec<_>>();
-                    binding_model::BindingResource::SamplerArray(Cow::Owned(samplers))
-                }
                 BindingResource::TextureView(ref view) => {
                     binding_model::BindingResource::TextureView(resolve_view(view))
-                }
-                BindingResource::TextureViewArray(ref views) => {
-                    let views = views.iter().map(resolve_view).collect::<Vec<_>>();
-                    binding_model::BindingResource::TextureViewArray(Cow::Owned(views))
-                }
-                BindingResource::AccelerationStructure(_) => {
-                    unimplemented!()
-                }
-                BindingResource::AccelerationStructureArray(_) => {
-                    unimplemented!()
                 }
                 BindingResource::ExternalTexture(ref et) => {
                     binding_model::BindingResource::ExternalTexture(resolve_external_texture(et))


### PR DESCRIPTION
**Connections**
Towards #10073
Continuation of #10084

**Description**
Copy binding model types from wgc and sanitize them for usage in browsers (no *Array or raytracing stuff, no generics as we always use IDs).

**Testing**
It compiles

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
