### PR TITLE
[wgpu-sync]: Centralize usage of `portable-atomic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4722,7 +4722,6 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5038,6 +5038,8 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,7 +4795,6 @@ dependencies = [
  "naga",
  "naga-types",
  "num-traits",
- "portable-atomic",
  "profiling",
  "proptest",
  "raw-window-handle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4984,8 +4984,6 @@ dependencies = [
  "objc2-metal 0.3.2",
  "objc2-quartz-core 0.3.2",
  "ordered-float",
- "portable-atomic",
- "portable-atomic-util",
  "profiling",
  "range-alloc",
  "raw-window-handle",

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -121,7 +121,7 @@ std = ["wgpu-sync/std"]
 static-dxc = ["wgpu-hal/static-dxc"]
 
 ## Enable portable atomics on platforms that do not support 64bit atomics.
-portable-atomic = ["dep:portable-atomic", "wgpu-hal/portable-atomic"]
+portable-atomic = ["wgpu-sync/portable-atomic", "wgpu-hal/portable-atomic"]
 
 #! ### Target Conditional Features
 # --------------------------------------------------------------------
@@ -207,9 +207,6 @@ rustc-hash.workspace = true
 serde = { workspace = true, features = ["derive"], default-features = false, optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
-
-[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
-portable-atomic = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 proptest.workspace = true

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -25,7 +25,5 @@ fn main() {
             any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")
         ) },
         metal: { all(target_vendor = "apple", feature = "metal") },
-
-        supports_64bit_atomics: { target_has_atomic = "64" }
     }
 }

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -9,13 +9,13 @@ use core::{
     fmt,
     mem::{self, ManuallyDrop},
     num::NonZeroU32,
-    sync::atomic::{AtomicBool, Ordering},
 };
 use hal::ShouldBeNonZeroExt;
 
 use arrayvec::ArrayVec;
 use bitflags::Flags;
 use smallvec::SmallVec;
+use wgpu_sync::atomic::{AtomicBool, Ordering};
 use wgpu_sync::OnceCell;
 use wgt::{
     math::align_to, ColorWrites, DeviceLostReason, TextureFormat, TextureSampleType,
@@ -66,10 +66,7 @@ use super::{
     ENTRYPOINT_FAILURE_ERROR, ZERO_BUFFER_SIZE,
 };
 
-#[cfg(supports_64bit_atomics)]
-use core::sync::atomic::AtomicU64;
-#[cfg(not(supports_64bit_atomics))]
-use portable_atomic::AtomicU64;
+use wgpu_sync::atomic::AtomicU64;
 
 pub(crate) struct CommandIndices {
     /// The index of the last command submission that was attempted.

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -87,7 +87,6 @@ metal = [
     "dep:profiling",
     "dep:smallvec",
     "dep:raw-window-metal",
-    "dep:wgpu-sync",
 ]
 vulkan = [
     "naga/spv-out",
@@ -102,7 +101,6 @@ vulkan = [
     "dep:profiling",
     "dep:raw-window-metal",
     "dep:smallvec",
-    "dep:wgpu-sync",
     "dep:windows",
     "dep:windows-core",
     "gpu-allocator/vulkan",
@@ -127,7 +125,6 @@ gles = [
     "dep:wasm-bindgen",
     "dep:wayland-sys",
     "dep:web-sys",
-    "dep:wgpu-sync",
     "dep:windows-result",
     "naga/glsl-out",
     "wgpu-sync/std", # Required for send/sync
@@ -148,7 +145,6 @@ dx12 = [
     "dep:ordered-float",
     "dep:profiling",
     "dep:range-alloc",
-    "dep:wgpu-sync",
     "dep:windows-core",
     "gpu-allocator/d3d12",
     "naga/hlsl-out",
@@ -179,7 +175,7 @@ renderdoc = ["dep:libloading", "dep:renderdoc-sys"]
 fragile-send-sync-non-atomic-wasm = [
     "wgpu-types/fragile-send-sync-non-atomic-wasm",
 ]
-portable-atomic = ["dep:portable-atomic", "dep:portable-atomic-util"]
+portable-atomic = ["wgpu-sync/portable-atomic"]
 
 ###################################
 ### Internal Debugging Features ###
@@ -196,7 +192,6 @@ device_lost_panic = []
 internal_error_panic = []
 # Tracks validation errors in a `VALIDATION_CANARY` static.
 validation_canary = [
-    "dep:wgpu-sync",
     "wgpu-sync/std", # Required for send/sync
 ]
 
@@ -215,7 +210,7 @@ required-features = ["gles"]
 naga.workspace = true
 wgpu-naga-bridge.workspace = true
 naga-types = { workspace = true }
-wgpu-sync = { workspace = true, default-features = false, optional = true }
+wgpu-sync = { workspace = true, default-features = false }
 wgpu-types = { workspace = true, default-features = false }
 
 # Dependencies in the lib and empty backend
@@ -347,14 +342,6 @@ khronos-egl = { workspace = true, optional = true, features = [
 ] }
 # Note: it's unused by emscripten, but we keep it to have single code base in egl.rs
 libloading = { workspace = true, optional = true }
-
-[target.'cfg(any(not(target_has_atomic = "64"), not(target_has_atomic = "ptr")))'.dependencies]
-portable-atomic = { workspace = true, optional = true }
-
-[target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
-portable-atomic-util = { workspace = true, features = [
-    "alloc",
-], optional = true }
 
 ### Platform: Windows + MacOS + Linux for "raw-gles" example ###
 [target.'cfg(not(any(target_family = "wasm", target_os = "ios", target_os = "visionos", target_env = "ohos")))'.dev-dependencies]

--- a/wgpu-hal/build.rs
+++ b/wgpu-hal/build.rs
@@ -30,7 +30,5 @@ fn main() {
         any_backend: { any(dx12, metal, vulkan, gles) },
         // ⚠️ Keep in sync with target.cfg() definition in Cargo.toml and cfg_alias in `wgpu` crate ⚠️
         static_dxc: { all(target_os = "windows", feature = "static-dxc", not(target_arch = "aarch64"), target_env = "msvc") },
-        supports_64bit_atomics: { target_has_atomic = "64" },
-        supports_ptr_atomics: { target_has_atomic = "ptr" }
     }
 }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -1,8 +1,8 @@
 use alloc::{string::String, sync::Arc, vec::Vec};
-use core::{ptr, sync::atomic::AtomicU64};
+use core::ptr;
 use std::thread;
 
-use wgpu_sync::Mutex;
+use wgpu_sync::{atomic::AtomicU64, Mutex};
 use windows::{
     core::Interface as _,
     Win32::{

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -93,11 +93,12 @@ mod types;
 mod view;
 
 use alloc::{borrow::ToOwned as _, string::String, sync::Arc, vec::Vec};
-use core::{ffi, fmt, mem, ops::Deref, sync::atomic::AtomicU64};
+use core::{ffi, fmt, mem, ops::Deref};
 
 use arrayvec::ArrayVec;
 use hashbrown::HashMap;
 use suballocation::Allocator;
+use wgpu_sync::atomic::AtomicU64;
 use wgpu_sync::{Mutex, RwLock};
 use windows::{
     core::{Free as _, Interface},

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -1,8 +1,7 @@
 use alloc::{borrow::ToOwned as _, format, string::String, sync::Arc, vec, vec::Vec};
-use core::sync::atomic::AtomicU8;
 
 use glow::HasContext;
-use wgpu_sync::Mutex;
+use wgpu_sync::{atomic::AtomicU8, Mutex};
 use wgt::AstcChannel;
 
 use crate::auxil::db;

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -110,12 +110,11 @@ pub use self::wgl::{AdapterContext, AdapterContextLock, Instance, Surface};
 pub use fence::Fence;
 
 use alloc::{boxed::Box, string::String, string::ToString as _, sync::Arc, vec::Vec};
-use core::{
-    fmt,
-    ops::Range,
-    sync::atomic::{AtomicU32, AtomicU8},
+use core::{fmt, ops::Range};
+use wgpu_sync::{
+    atomic::{AtomicU32, AtomicU8},
+    Mutex,
 };
-use wgpu_sync::Mutex;
 
 use arrayvec::ArrayVec;
 use glow::HasContext;

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -308,15 +308,8 @@ use core::{
 use bitflags::bitflags;
 use raw_window_handle::DisplayHandle;
 use thiserror::Error;
+use wgpu_sync::Arc;
 use wgt::WasmNotSendSync;
-
-cfg_if::cfg_if! {
-    if #[cfg(supports_ptr_atomics)] {
-        use alloc::sync::Arc;
-    } else if #[cfg(feature = "portable-atomic")] {
-        use portable_atomic_util::Arc;
-    }
-}
 
 // - Vertex + Fragment
 // - Compute
@@ -334,10 +327,7 @@ pub const QUERY_SIZE: wgt::BufferAddress = 8;
 pub type Label<'a> = Option<&'a str>;
 pub type MemoryRange = Range<wgt::BufferAddress>;
 pub type FenceValue = u64;
-#[cfg(supports_64bit_atomics)]
-pub type AtomicFenceValue = core::sync::atomic::AtomicU64;
-#[cfg(not(supports_64bit_atomics))]
-pub type AtomicFenceValue = portable_atomic::AtomicU64;
+pub type AtomicFenceValue = wgpu_sync::atomic::AtomicU64;
 
 /// A callback to signal that wgpu is no longer using a resource.
 #[cfg(all(any(gles, vulkan, metal), not(webgl)))]
@@ -597,7 +587,7 @@ impl InstanceError {
     #[allow(dead_code, reason = "may be unused on some platforms")]
     pub(crate) fn with_source(message: String, source: impl Error + Send + Sync + 'static) -> Self {
         cfg_if::cfg_if! {
-            if #[cfg(supports_ptr_atomics)] {
+            if #[cfg(target_has_atomic = "ptr")] {
                 let source = Arc::new(source);
             } else {
                 // TODO(https://github.com/rust-lang/rust/issues/18598): avoid indirection via Box once arbitrary types support unsized coercion

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -10,8 +10,7 @@ use objc2_metal::{
 use wgt::{AstcBlock, AstcChannel};
 
 use alloc::{string::ToString as _, sync::Arc, vec::Vec};
-use core::sync::atomic;
-use wgpu_sync::{Mutex, OnceCell};
+use wgpu_sync::{atomic, Mutex, OnceCell};
 
 use crate::metal::QueueShared;
 

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -23,8 +23,9 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use core::{ops::Range, ptr::NonNull, sync::atomic};
+use core::{ops::Range, ptr::NonNull};
 use smallvec::SmallVec;
+use wgpu_sync::atomic;
 
 // has to match `Temp::binding_sizes`
 const WORD_SIZE: usize = 4;

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -33,7 +33,7 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use core::{fmt, iter, ops, ptr::NonNull, sync::atomic};
+use core::{fmt, iter, ops, ptr::NonNull};
 
 use bitflags::bitflags;
 use hashbrown::HashMap;
@@ -55,7 +55,7 @@ use objc2_metal::{
     MTLTriangleFillMode, MTLWinding,
 };
 use objc2_quartz_core::CAMetalLayer;
-use wgpu_sync::{Condvar, Mutex, OnceCell, RwLock};
+use wgpu_sync::{atomic, Condvar, Mutex, OnceCell, RwLock};
 
 #[derive(Clone, Debug)]
 pub struct Api;

--- a/wgpu-hal/src/noop/buffer.rs
+++ b/wgpu-hal/src/noop/buffer.rs
@@ -1,13 +1,7 @@
 use alloc::vec::Vec;
 use core::{cell::UnsafeCell, ops::Range, ptr};
 
-cfg_if::cfg_if! {
-    if #[cfg(supports_ptr_atomics)] {
-        use alloc::sync::Arc;
-    } else if #[cfg(feature = "portable-atomic")] {
-        use portable_atomic_util::Arc;
-    }
-}
+use wgpu_sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct Buffer {

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -3,10 +3,7 @@
 use alloc::{string::String, sync::Arc, vec, vec::Vec};
 use core::{ptr, sync::atomic::Ordering, time::Duration};
 
-#[cfg(supports_64bit_atomics)]
-use core::sync::atomic::AtomicU64;
-#[cfg(not(supports_64bit_atomics))]
-use portable_atomic::AtomicU64;
+use wgpu_sync::atomic::AtomicU64;
 
 use crate::TlasInstance;
 

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -1009,7 +1009,7 @@ struct ResourceIdentityFactory<T> {
     #[cfg(not(target_has_atomic = "64"))]
     next_id: Mutex<u64>,
     #[cfg(target_has_atomic = "64")]
-    next_id: core::sync::atomic::AtomicU64,
+    next_id: wgpu_sync::atomic::AtomicU64,
     _phantom: PhantomData<T>,
 }
 
@@ -1019,7 +1019,7 @@ impl<T> ResourceIdentityFactory<T> {
             #[cfg(not(target_has_atomic = "64"))]
             next_id: Mutex::new(0),
             #[cfg(target_has_atomic = "64")]
-            next_id: core::sync::atomic::AtomicU64::new(0),
+            next_id: wgpu_sync::atomic::AtomicU64::new(0),
             _phantom: PhantomData,
         }
     }

--- a/wgpu-sync/Cargo.toml
+++ b/wgpu-sync/Cargo.toml
@@ -31,8 +31,16 @@ alloc_instead_of_core = "warn"
 default = ["std"]
 std = ["dep:parking_lot", "once_cell/std"]
 
+portable-atomic = ["dep:portable-atomic", "dep:portable-atomic-util"]
+
 [dependencies]
 cfg-if.workspace = true
 lock_api = { workspace = true, default-features = false }
 parking_lot = { workspace = true, optional = true }
 once_cell = { workspace = true, default-features = false, features = ["alloc", "race"] }
+
+[target.'cfg(any(not(target_has_atomic = "ptr"), not(target_has_atomic = "64"), not(target_has_atomic = "32"), not(target_has_atomic = "16"), not(target_has_atomic = "8")))'.dependencies]
+portable-atomic = { workspace = true, optional = true }
+
+[target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
+portable-atomic-util = { workspace = true, optional = true, features = ["alloc"] }

--- a/wgpu-sync/src/atomic.rs
+++ b/wgpu-sync/src/atomic.rs
@@ -1,0 +1,43 @@
+//! Provides items for atomic operations.
+
+pub use core::sync::atomic::{compiler_fence, fence, Ordering};
+
+cfg_if::cfg_if! {
+    if #[cfg(target_has_atomic = "ptr")] {
+        pub use core::sync::atomic::{AtomicIsize, AtomicPtr, AtomicUsize};
+    } else if #[cfg(feature = "portable-atomic")] {
+        pub use portable_atomic::{AtomicIsize, AtomicPtr, AtomicUsize};
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(target_has_atomic = "64")] {
+        pub use core::sync::atomic::{AtomicI64, AtomicU64};
+    } else if #[cfg(feature = "portable-atomic")] {
+        pub use portable_atomic::{AtomicI64, AtomicU64};
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(target_has_atomic = "32")] {
+        pub use core::sync::atomic::{AtomicI32, AtomicU32};
+    } else if #[cfg(feature = "portable-atomic")] {
+        pub use portable_atomic::{AtomicI32, AtomicU32};
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(target_has_atomic = "16")] {
+        pub use core::sync::atomic::{AtomicI16, AtomicU16};
+    } else if #[cfg(feature = "portable-atomic")] {
+        pub use portable_atomic::{AtomicI16, AtomicU16};
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(target_has_atomic = "8")] {
+        pub use core::sync::atomic::{AtomicBool, AtomicI8, AtomicU8};
+    } else if #[cfg(feature = "portable-atomic")] {
+        pub use portable_atomic::{AtomicBool, AtomicI8, AtomicU8};
+    }
+}

--- a/wgpu-sync/src/lib.rs
+++ b/wgpu-sync/src/lib.rs
@@ -13,11 +13,20 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+pub mod atomic;
 mod mutex;
 mod rwlock;
 
 pub use mutex::RawMutex;
 pub use rwlock::RawRwLock;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_has_atomic = "ptr")] {
+        pub use alloc::sync::{Arc, Weak};
+    } else if #[cfg(feature = "portable-atomic")] {
+        pub use portable_atomic_util::{Arc, Weak};
+    }
+}
 
 // FIXME:
 // * `Condvar` is only available through `parking_lot` and not through `lock_api`.

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -198,7 +198,7 @@ exhaust = ["wgpu-types/exhaust"]
 
 [dependencies]
 naga = { workspace = true, optional = true, features = ["termcolor"] }
-wgpu-sync = { workspace = true, default-features = false }
+wgpu-sync = { workspace = true, default-features = false, features = ["portable-atomic"] }
 wgpu-types.workspace = true
 
 # Needed for both wgpu-core and webgpu
@@ -227,7 +227,7 @@ wgpu-core = { workspace = true, default-features = true, features = [
     "wgsl", # needed for indirect draw/dispatch validation
     "portable-atomic",
 ] }
-wgpu-hal = { workspace = true, default-features = true }
+wgpu-hal = { workspace = true, default-features = true, features = ["portable-atomic"] }
 
 smallvec.workspace = true
 
@@ -245,7 +245,7 @@ web-sys = { workspace = true, optional = true, features = [
 
 # Needed for only wgpu-core backend. Optional as webgl is optional on WebAssembly.
 wgpu-core = { workspace = true, optional = true, default-features = true }
-wgpu-hal = { workspace = true, optional = true, default-features = true }
+wgpu-hal = { workspace = true, optional = true, default-features = true, features = ["portable-atomic"] }
 
 smallvec = { workspace = true, optional = true }
 
@@ -257,12 +257,9 @@ wasm-bindgen-futures = { workspace = true, optional = true }
 ##############
 [target.'cfg(target_os = "emscripten")'.dependencies]
 wgpu-core = { workspace = true, default-features = true }
-wgpu-hal = { workspace = true, default-features = true }
+wgpu-hal = { workspace = true, default-features = true, features = ["portable-atomic"] }
 
 smallvec.workspace = true
-
-[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
-portable-atomic.workspace = true
 
 [dev-dependencies]
 # Used in doc-tests

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -50,7 +50,6 @@ fn main() {
         naga: { any(feature = "naga-ir", feature = "spirv", feature = "glsl") },
         // ⚠️ Keep in sync with target.cfg() definition in wgpu-hal/Cargo.toml and cfg_alias in `wgpu-hal` crate ⚠️
         static_dxc: { all(target_os = "windows", feature = "static-dxc", not(target_arch = "aarch64"), target_env = "msvc") },
-        supports_64bit_atomics: { target_has_atomic = "64" },
         custom: {any(feature = "custom")},
         std: { any(
             feature = "std",

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -20,9 +20,9 @@ use core::{
     future::Future,
     ops::Range,
     pin::Pin,
-    sync::atomic::{AtomicU8, Ordering},
     task::{self, Poll},
 };
+use wgpu_sync::atomic::{AtomicU8, Ordering};
 use wgt::Backends;
 
 use js_sys::Promise;

--- a/wgpu/src/cmp.rs
+++ b/wgpu/src/cmp.rs
@@ -4,12 +4,9 @@
 //!
 //! For types (like WebGPU) that don't have such a property, we generate an identifier and use that.
 
-#[cfg(supports_64bit_atomics)]
-pub use core::sync::atomic::AtomicU64;
-#[cfg(not(supports_64bit_atomics))]
-pub use portable_atomic::AtomicU64;
+pub use wgpu_sync::atomic::{AtomicU64, Ordering};
 
-use core::{num::NonZeroU64, sync::atomic::Ordering};
+use core::num::NonZeroU64;
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 


### PR DESCRIPTION
**Connections**

None.

**Description**

Centralize usage and configuration of `portable-atomic(-util)` in `wgpu-sync` rather than spread across `wgpu`, `wgpu-hal`, and `wgpu-core`. This avoids conditional compilation within these crates and simplifies non-standard platform support.

**Testing**

`cargo check`, no public behaviour is changed by this PR, purely import paths and crate organization.

**Squash or Rebase?**

Rebase.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [X] Validation and feature gates are in place to confine behavioral changes.
- [X] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
