### PR TITLE
meta: disable default features for `wgpu-core` and `wgpu-hal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,10 +95,10 @@ wgpu = { version = "30.0.0", path = "./wgpu", default-features = false, features
     "angle",
     "static-dxc",
 ] }
-wgpu-core = { version = "30.0.0", path = "./wgpu-core" }
+wgpu-core = { version = "30.0.0", path = "./wgpu-core", default-features = false }
 wgpu-core-remote = { version = "30.0.0", path = "./wgpu-core-remote" }
 wgpu-core-remote-types = { version = "30.0.0", path = "./wgpu-core-remote-types" }
-wgpu-hal = { version = "30.0.0", path = "./wgpu-hal" }
+wgpu-hal = { version = "30.0.0", path = "./wgpu-hal", default-features = false }
 wgpu-naga-bridge = { version = "30.0.0", path = "./wgpu-naga-bridge" }
 wgpu-sync = { version = "30.0.0", path = "./wgpu-sync", default-features = false }
 wgpu-test = { version = "30.0.0", path = "./tests" }

--- a/cts_runner/Cargo.toml
+++ b/cts_runner/Cargo.toml
@@ -24,7 +24,7 @@ log.workspace = true
 pico-args.workspace = true
 tokio = { workspace = true, features = ["full"] }
 termcolor.workspace = true
-wgpu-hal = { workspace = true, features = ["internal_error_panic"] }
+wgpu-hal = { workspace = true, default-features = true, features = ["internal_error_panic"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/deno_webgpu/Cargo.toml
+++ b/deno_webgpu/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 # We make all dependencies conditional on not being wasm,
 # so the whole workspace can built as wasm.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-wgpu-core = { workspace = true, features = [
+wgpu-core = { workspace = true, default-features = true, features = [
     "trace",
     "replay",
     "serde",
@@ -41,16 +41,16 @@ deno_unsync.workspace = true
 #
 # We want the Metal backend.
 [target.'cfg(target_vendor = "apple")'.dependencies]
-wgpu-core = { workspace = true, features = ["metal"] }
+wgpu-core = { workspace = true, default-features = true, features = ["metal"] }
 
 # Windows
 #
 # We want the DX12 backend.
 [target.'cfg(windows)'.dependencies]
-wgpu-core = { workspace = true, features = ["dx12"] }
+wgpu-core = { workspace = true, default-features = true, features = ["dx12"] }
 
 # Windows and Unix (not Emscripten)
 #
 # We want the Vulkan backend.
 [target.'cfg(any(windows, all(unix, not(target_os = "emscripten"))))'.dependencies]
-wgpu-core = { workspace = true, features = ["vulkan"] }
+wgpu-core = { workspace = true, default-features = true, features = ["vulkan"] }

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -33,6 +33,7 @@ bytemuck.workspace = true
 # We are a non-wasm only crate, and this allows us to compile.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgpu-core]
 workspace = true
+default-features = true
 features = [
     "replay",
     "strict_asserts",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -45,8 +45,8 @@ test-build-with-profiling = ["profiling/type-check"]
 # Passthrough backend uses as_hal for the GLES backend, and there's not a great way to cfg-gate that.
 # These are all enabled for any testing on CI anyway, and won't do anything if no devices are detected.
 wgpu = { workspace = true, features = ["noop", "gles", "webgl", "angle"] }
-wgpu-core = { workspace = true, features = ["trace"] }
-wgpu-hal = { workspace = true, features = ["validation_canary"] }
+wgpu-core = { workspace = true, default-features = true, features = ["trace"] }
+wgpu-hal = { workspace = true, default-features = true, features = ["validation_canary"] }
 wgpu-sync.workspace = true
 wgpu-types.workspace = true
 naga = { workspace = true, features = [

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -185,7 +185,7 @@ wgpu-core-deps-windows = { workspace = true, optional = true }
 naga.workspace = true
 naga-types.workspace = true
 wgpu-naga-bridge.workspace = true
-wgpu-hal.workspace = true
+wgpu-hal = { workspace = true, default-features = true }
 wgpu-sync = { workspace = true, default-features = false }
 wgpu-types.workspace = true
 

--- a/wgpu-core/platform-deps/apple/Cargo.toml
+++ b/wgpu-core/platform-deps/apple/Cargo.toml
@@ -22,7 +22,7 @@ vulkan-portability = ["wgpu-hal/vulkan", "wgpu-hal/renderdoc"]
 
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
 [target.'cfg(target_vendor = "apple")'.dependencies]
-wgpu-hal.workspace = true
+wgpu-hal = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/wgpu-core/platform-deps/emscripten/Cargo.toml
+++ b/wgpu-core/platform-deps/emscripten/Cargo.toml
@@ -20,7 +20,7 @@ gles = ["wgpu-hal/gles"]
 
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
 [target.'cfg(target_os = "emscripten")'.dependencies]
-wgpu-hal.workspace = true
+wgpu-hal = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/wgpu-core/platform-deps/linux-android-bsd/Cargo.toml
+++ b/wgpu-core/platform-deps/linux-android-bsd/Cargo.toml
@@ -25,4 +25,4 @@ drm = ["wgpu-hal/drm"]
 
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
-wgpu-hal.workspace = true
+wgpu-hal = { workspace = true, default-features = true }

--- a/wgpu-core/platform-deps/wasm/Cargo.toml
+++ b/wgpu-core/platform-deps/wasm/Cargo.toml
@@ -20,7 +20,7 @@ webgl = ["wgpu-hal/gles"]
 
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
 [target.'cfg(all(target_family = "wasm", not(target_os = "emscripten")))'.dependencies]
-wgpu-hal.workspace = true
+wgpu-hal = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/wgpu-core/platform-deps/windows/Cargo.toml
+++ b/wgpu-core/platform-deps/windows/Cargo.toml
@@ -26,7 +26,7 @@ drm = ["wgpu-hal/drm"]
 
 # Depend on wgpu-hal conditionally, so that the above features only apply to wgpu-hal on this set of platforms.
 [target.'cfg(windows)'.dependencies]
-wgpu-hal.workspace = true
+wgpu-hal = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -198,7 +198,6 @@ exhaust = ["wgpu-types/exhaust"]
 
 [dependencies]
 naga = { workspace = true, optional = true, features = ["termcolor"] }
-wgpu-core = { workspace = true, optional = true }
 wgpu-sync = { workspace = true, default-features = false }
 wgpu-types.workspace = true
 
@@ -223,12 +222,12 @@ static_assertions.workspace = true
 ###################
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 # Needed for only wgpu-core backend. Not optional as only wgpu-core backend exists on native platforms.
-wgpu-core = { workspace = true, features = [
+wgpu-core = { workspace = true, default-features = true, features = [
     "renderdoc",
     "wgsl", # needed for indirect draw/dispatch validation
     "portable-atomic",
 ] }
-wgpu-hal.workspace = true
+wgpu-hal = { workspace = true, default-features = true }
 
 smallvec.workspace = true
 
@@ -245,8 +244,8 @@ web-sys = { workspace = true, optional = true, features = [
 ] }
 
 # Needed for only wgpu-core backend. Optional as webgl is optional on WebAssembly.
-wgpu-core = { workspace = true, optional = true }
-wgpu-hal = { workspace = true, optional = true }
+wgpu-core = { workspace = true, optional = true, default-features = true }
+wgpu-hal = { workspace = true, optional = true, default-features = true }
 
 smallvec = { workspace = true, optional = true }
 
@@ -257,8 +256,8 @@ wasm-bindgen-futures = { workspace = true, optional = true }
 # Emscripten #
 ##############
 [target.'cfg(target_os = "emscripten")'.dependencies]
-wgpu-core.workspace = true
-wgpu-hal.workspace = true
+wgpu-core = { workspace = true, default-features = true }
+wgpu-hal = { workspace = true, default-features = true }
 
 smallvec.workspace = true
 


### PR DESCRIPTION
**Connections**

None

**Description**

Project currently emits warnings during build because `wgpu-core-remote` relies on `wgpu-core` and `wgpu-hal` from the workspace with default features disabled.

```
$> cargo check
warning: .\wgpu\wgpu-core-remote\Cargo.toml: `default-features` is ignored for wgpu-core, since `default-features` was not specified for `workspace.dependencies.wgpu-core`, this could become a hard error in the future
warning: .\wgpu\wgpu-core-remote\Cargo.toml: `default-features` is ignored for wgpu-hal, since `default-features` was not specified for `workspace.dependencies.wgpu-hal`, this could become a hard error in the future
```

Fix is trivial, disable default features across the workspace and enable it within each other member.

**Testing**

`cargo check`

**Squash or Rebase?**

Rebase.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
