### PR TITLE
Add immediates support to WebGPU and remove `Features::IMMEDIATES`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Bottom level categories:
 - Remove the never-constructed `CreateBlasError::InvalidAabbStride` variant. `create_blas` takes no stride, so it could never be produced; AABB stride is validated at build time as `BuildAccelerationStructureError::InvalidAabbStride`. By @mstampfli in [#9935](https://github.com/gfx-rs/wgpu/pull/9935).
 
 - Added `DownlevelFlags::LINEAR_INTERPOLATION`, indicating that the adapter supports `@interpolate(linear)`. It is absent on GLES/WebGL2, since GLSL ES has no `noperspective` qualifier. By @emilk in [#9972](https://github.com/gfx-rs/wgpu/pull/9972).
+- Add immediates support to WebGPU backend and remove `Features::IMMEDIATES` as it is unconditionally available on all platforms. By @beicause in [#10098](https://github.com/gfx-rs/wgpu/pull/10098).
 
 #### naga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Bottom level categories:
 - Remove the never-constructed `CreateBlasError::InvalidAabbStride` variant. `create_blas` takes no stride, so it could never be produced; AABB stride is validated at build time as `BuildAccelerationStructureError::InvalidAabbStride`. By @mstampfli in [#9935](https://github.com/gfx-rs/wgpu/pull/9935).
 
 - Added `DownlevelFlags::LINEAR_INTERPOLATION`, indicating that the adapter supports `@interpolate(linear)`. It is absent on GLES/WebGL2, since GLSL ES has no `noperspective` qualifier. By @emilk in [#9972](https://github.com/gfx-rs/wgpu/pull/9972).
-- Add immediates support to WebGPU backend and remove `Features::IMMEDIATES` as it is unconditionally available on all platforms. By @beicause in [#10098](https://github.com/gfx-rs/wgpu/pull/10098).
+- Add immediates support to WebGPU backend and remove `Features::IMMEDIATES` and `naga::valid::Capabilities::IMMEDIATES`, as it is unconditionally available on all platforms. By @beicause in [#10098](https://github.com/gfx-rs/wgpu/pull/10098).
 
 #### naga
 

--- a/benches/benches/wgpu-benchmark/shader.rs
+++ b/benches/benches/wgpu-benchmark/shader.rs
@@ -443,7 +443,14 @@ pub fn backends(ctx: BenchmarkContext) -> anyhow::Result<Vec<SubBenchResult>> {
     }));
 
     results.push(iter_auto(&ctx, "hlsl", "bytes", total_bytes, || {
-        let options = naga::back::hlsl::Options::default();
+        let options = naga::back::hlsl::Options {
+            immediates_target: Some(naga::back::hlsl::BindTarget {
+                space: 0,
+                register: 0,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
         let mut string = String::new();
         for input in &inputs.inner {
             if input.options.targets.unwrap().contains(Targets::HLSL) {

--- a/examples/features/src/ray_shadows/mod.rs
+++ b/examples/features/src/ray_shadows/mod.rs
@@ -82,7 +82,7 @@ fn create_matrix(config: &wgpu::SurfaceConfiguration) -> Uniforms {
 
 impl crate::framework::Example for Example {
     fn required_features() -> wgpu::Features {
-        wgpu::Features::EXPERIMENTAL_RAY_QUERY | wgpu::Features::IMMEDIATES
+        wgpu::Features::EXPERIMENTAL_RAY_QUERY
     }
 
     fn required_downlevel_capabilities() -> wgpu::DownlevelCapabilities {

--- a/naga/src/back/glsl/mod.rs
+++ b/naga/src/back/glsl/mod.rs
@@ -483,8 +483,7 @@ pub fn supported_capabilities() -> valid::Capabilities {
 
     // Lots of these aren't supported on GLES in general, but naga is able to write them without panicking.
 
-    Caps::IMMEDIATES
-        | Caps::FLOAT64
+    Caps::FLOAT64
         | Caps::PRIMITIVE_INDEX
         | Caps::CLIP_DISTANCES
         | Caps::MULTIVIEW

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -786,8 +786,7 @@ pub struct Writer<'a, W> {
 
 pub fn supported_capabilities() -> crate::valid::Capabilities {
     use crate::valid::Capabilities as Caps;
-    Caps::IMMEDIATES
-        | Caps::FLOAT64 // Unsupported by wgpu but supported by naga
+    Caps::FLOAT64 // Unsupported by wgpu but supported by naga
         | Caps::PRIMITIVE_INDEX
         | Caps::TEXTURE_AND_SAMPLER_BINDING_ARRAY
         // No BUFFER_BINDING_ARRAY

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -832,9 +832,8 @@ pub fn write_string(
 
 pub fn supported_capabilities() -> crate::valid::Capabilities {
     use crate::valid::Capabilities as Caps;
-    Caps::IMMEDIATES
-        // No FLOAT64
-        | Caps::PRIMITIVE_INDEX
+    // No FLOAT64
+    Caps::PRIMITIVE_INDEX
         | Caps::TEXTURE_AND_SAMPLER_BINDING_ARRAY
         // No BUFFER_BINDING_ARRAY
         | Caps::STORAGE_TEXTURE_BINDING_ARRAY

--- a/naga/src/back/spv/mod.rs
+++ b/naga/src/back/spv/mod.rs
@@ -1182,8 +1182,7 @@ pub fn write_vec(
 pub fn supported_capabilities() -> crate::valid::Capabilities {
     use crate::valid::Capabilities as Caps;
 
-    Caps::IMMEDIATES
-        | Caps::FLOAT64
+    Caps::FLOAT64
         | Caps::PRIMITIVE_INDEX
         | Caps::TEXTURE_AND_SAMPLER_BINDING_ARRAY
         | Caps::BUFFER_BINDING_ARRAY

--- a/naga/src/valid/interface.rs
+++ b/naga/src/valid/interface.rs
@@ -1089,11 +1089,6 @@ impl super::Validator {
                 (TypeFlags::DATA | TypeFlags::SIZED, false)
             }
             crate::AddressSpace::Immediate => {
-                if !self.capabilities.contains(Capabilities::IMMEDIATES) {
-                    return Err(GlobalVariableError::UnsupportedCapability(
-                        Capabilities::IMMEDIATES,
-                    ));
-                }
                 if let Err(ref err) = type_info.immediates_compatibility {
                     return Err(GlobalVariableError::InvalidImmediateType(err.clone()));
                 }

--- a/naga/src/valid/mod.rs
+++ b/naga/src/valid/mod.rs
@@ -86,53 +86,49 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct Capabilities: u64 {
-        /// Support for [`AddressSpace::Immediate`][1].
-        ///
-        /// [1]: crate::AddressSpace::Immediate
-        const IMMEDIATES = 1 << 0;
         /// Float values with width = 8.
-        const FLOAT64 = 1 << 1;
+        const FLOAT64 = 1 << 0;
         /// Support for [`BuiltIn::PrimitiveIndex`][1].
         ///
         /// [1]: crate::BuiltIn::PrimitiveIndex
-        const PRIMITIVE_INDEX = 1 << 2;
+        const PRIMITIVE_INDEX = 1 << 1;
         /// Support for binding arrays of sampled textures and samplers.
-        const TEXTURE_AND_SAMPLER_BINDING_ARRAY = 1 << 3;
+        const TEXTURE_AND_SAMPLER_BINDING_ARRAY = 1 << 2;
         /// Support for binding arrays of uniform buffers.
-        const BUFFER_BINDING_ARRAY = 1 << 4;
+        const BUFFER_BINDING_ARRAY = 1 << 3;
         /// Support for binding arrays of storage textures.
-        const STORAGE_TEXTURE_BINDING_ARRAY = 1 << 5;
+        const STORAGE_TEXTURE_BINDING_ARRAY = 1 << 4;
         /// Support for binding arrays of storage buffers.
-        const STORAGE_BUFFER_BINDING_ARRAY = 1 << 6;
+        const STORAGE_BUFFER_BINDING_ARRAY = 1 << 5;
         /// Support for [`BuiltIn::ClipDistances`].
         ///
         /// [`BuiltIn::ClipDistances`]: crate::BuiltIn::ClipDistances
-        const CLIP_DISTANCES = 1 << 7;
+        const CLIP_DISTANCES = 1 << 6;
         /// Support for [`BuiltIn::CullDistance`].
         ///
         /// [`BuiltIn::CullDistance`]: crate::BuiltIn::CullDistance
-        const CULL_DISTANCE = 1 << 8;
+        const CULL_DISTANCE = 1 << 7;
         /// Support for 16-bit normalized storage texture formats.
-        const STORAGE_TEXTURE_16BIT_NORM_FORMATS = 1 << 9;
+        const STORAGE_TEXTURE_16BIT_NORM_FORMATS = 1 << 8;
         /// Support for [`BuiltIn::ViewIndex`].
         ///
         /// [`BuiltIn::ViewIndex`]: crate::BuiltIn::ViewIndex
-        const MULTIVIEW = 1 << 10;
+        const MULTIVIEW = 1 << 9;
         /// Support for `early_depth_test`.
-        const EARLY_DEPTH_TEST = 1 << 11;
+        const EARLY_DEPTH_TEST = 1 << 10;
         /// Support for [`BuiltIn::SampleIndex`] and [`Sampling::Sample`].
         ///
         /// [`BuiltIn::SampleIndex`]: crate::BuiltIn::SampleIndex
         /// [`Sampling::Sample`]: crate::Sampling::Sample
-        const MULTISAMPLED_SHADING = 1 << 12;
+        const MULTISAMPLED_SHADING = 1 << 11;
         /// Support for ray queries and acceleration structures.
-        const RAY_QUERY = 1 << 13;
+        const RAY_QUERY = 1 << 12;
         /// Support for generating two sources for blending from fragment shaders.
-        const DUAL_SOURCE_BLENDING = 1 << 14;
+        const DUAL_SOURCE_BLENDING = 1 << 13;
         /// Support for arrayed cube textures.
-        const CUBE_ARRAY_TEXTURES = 1 << 15;
+        const CUBE_ARRAY_TEXTURES = 1 << 14;
         /// Support for 64-bit signed and unsigned integers.
-        const SHADER_INT64 = 1 << 16;
+        const SHADER_INT64 = 1 << 15;
         /// Support for subgroup operations (except barriers) in fragment and compute shaders.
         ///
         /// Subgroup operations in the vertex stage require
@@ -143,17 +139,17 @@ bitflags::bitflags! {
         ///
         /// Subgroup barriers require [`Capabilities::SUBGROUP_BARRIER`] in addition to
         /// `Capabilities::SUBGROUP`.
-        const SUBGROUP = 1 << 17;
+        const SUBGROUP = 1 << 16;
         /// Support for subgroup barriers in compute shaders.
         ///
         /// Requires [`Capabilities::SUBGROUP`]. Without it, enables nothing.
-        const SUBGROUP_BARRIER = 1 << 18;
+        const SUBGROUP_BARRIER = 1 << 17;
         /// Support for subgroup operations (not including barriers) in the vertex stage.
         ///
         /// Without [`Capabilities::SUBGROUP`], enables nothing. (But note that
         /// `create_validator` automatically sets `Capabilities::SUBGROUP`
         /// whenever `Features::SUBGROUP_VERTEX` is available.)
-        const SUBGROUP_VERTEX_STAGE = 1 << 19;
+        const SUBGROUP_VERTEX_STAGE = 1 << 18;
         /// Support for [`AtomicFunction::Min`] and [`AtomicFunction::Max`] on
         /// 64-bit integers in the [`Storage`] address space, when the return
         /// value is not used.
@@ -163,9 +159,9 @@ bitflags::bitflags! {
         /// [`AtomicFunction::Min`]: crate::AtomicFunction::Min
         /// [`AtomicFunction::Max`]: crate::AtomicFunction::Max
         /// [`Storage`]: crate::AddressSpace::Storage
-        const SHADER_INT64_ATOMIC_MIN_MAX = 1 << 20;
+        const SHADER_INT64_ATOMIC_MIN_MAX = 1 << 19;
         /// Support for all atomic operations on 64-bit integers.
-        const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 21;
+        const SHADER_INT64_ATOMIC_ALL_OPS = 1 << 20;
         /// Support for [`AtomicFunction::Add`], [`AtomicFunction::Sub`],
         /// and [`AtomicFunction::Exchange { compare: None }`] on 32-bit floating-point numbers
         /// in the [`Storage`] address space.
@@ -174,56 +170,56 @@ bitflags::bitflags! {
         /// [`AtomicFunction::Sub`]: crate::AtomicFunction::Sub
         /// [`AtomicFunction::Exchange { compare: None }`]: crate::AtomicFunction::Exchange
         /// [`Storage`]: crate::AddressSpace::Storage
-        const SHADER_FLOAT32_ATOMIC = 1 << 22;
+        const SHADER_FLOAT32_ATOMIC = 1 << 21;
         /// Support for atomic operations on images.
-        const TEXTURE_ATOMIC = 1 << 23;
+        const TEXTURE_ATOMIC = 1 << 22;
         /// Support for atomic operations on 64-bit images.
-        const TEXTURE_INT64_ATOMIC = 1 << 24;
+        const TEXTURE_INT64_ATOMIC = 1 << 23;
         /// Support for ray queries returning vertex position
-        const RAY_HIT_VERTEX_POSITION = 1 << 25;
+        const RAY_HIT_VERTEX_POSITION = 1 << 24;
         /// Support for 16-bit floating-point types.
-        const SHADER_FLOAT16 = 1 << 26;
+        const SHADER_FLOAT16 = 1 << 25;
         /// Support for [`ImageClass::External`]
-        const TEXTURE_EXTERNAL = 1 << 27;
+        const TEXTURE_EXTERNAL = 1 << 26;
         /// Support for `quantizeToF16`, `pack2x16float`, and `unpack2x16float`, which store
         /// `f16`-precision values in `f32`s.
-        const SHADER_FLOAT16_IN_FLOAT32 = 1 << 28;
+        const SHADER_FLOAT16_IN_FLOAT32 = 1 << 27;
         /// Support for fragment shader barycentric coordinates.
-        const SHADER_BARYCENTRICS = 1 << 29;
+        const SHADER_BARYCENTRICS = 1 << 28;
         /// Support for task shaders, mesh shaders, and per-primitive fragment inputs
-        const MESH_SHADER = 1 << 30;
+        const MESH_SHADER = 1 << 29;
         /// Support for mesh shaders which output points.
-        const MESH_SHADER_POINT_TOPOLOGY = 1 << 31;
+        const MESH_SHADER_POINT_TOPOLOGY = 1 << 30;
         /// Support for non-uniform indexing of binding arrays of sampled textures and samplers.
-        const TEXTURE_AND_SAMPLER_BINDING_ARRAY_NON_UNIFORM_INDEXING = 1 << 32;
+        const TEXTURE_AND_SAMPLER_BINDING_ARRAY_NON_UNIFORM_INDEXING = 1 << 31;
         /// Support for non-uniform indexing of binding arrays of uniform buffers.
-        const BUFFER_BINDING_ARRAY_NON_UNIFORM_INDEXING = 1 << 33;
+        const BUFFER_BINDING_ARRAY_NON_UNIFORM_INDEXING = 1 << 32;
         /// Support for non-uniform indexing of binding arrays of storage textures.
-        const STORAGE_TEXTURE_BINDING_ARRAY_NON_UNIFORM_INDEXING = 1 << 34;
+        const STORAGE_TEXTURE_BINDING_ARRAY_NON_UNIFORM_INDEXING = 1 << 33;
         /// Support for non-uniform indexing of binding arrays of storage buffers.
-        const STORAGE_BUFFER_BINDING_ARRAY_NON_UNIFORM_INDEXING = 1 << 35;
+        const STORAGE_BUFFER_BINDING_ARRAY_NON_UNIFORM_INDEXING = 1 << 34;
         /// Support for cooperative matrix types and operations
-        const COOPERATIVE_MATRIX = 1 << 36;
+        const COOPERATIVE_MATRIX = 1 << 35;
         /// Support for per-vertex fragment input.
-        const PER_VERTEX = 1 << 37;
+        const PER_VERTEX = 1 << 36;
         /// Support for ray generation, any hit, closest hit, and miss shaders.
-        const RAY_TRACING_PIPELINE = 1 << 38;
+        const RAY_TRACING_PIPELINE = 1 << 37;
         /// Support for draw index builtin
-        const DRAW_INDEX = 1 << 39;
+        const DRAW_INDEX = 1 << 38;
         /// Support for binding arrays of acceleration structures.
-        const ACCELERATION_STRUCTURE_BINDING_ARRAY = 1 << 40;
+        const ACCELERATION_STRUCTURE_BINDING_ARRAY = 1 << 39;
         /// Support for the `@coherent` memory decoration on storage buffers.
-        const MEMORY_DECORATION_COHERENT = 1 << 41;
+        const MEMORY_DECORATION_COHERENT = 1 << 40;
         /// Support for the `@volatile` memory decoration on storage buffers.
-        const MEMORY_DECORATION_VOLATILE = 1 << 42;
+        const MEMORY_DECORATION_VOLATILE = 1 << 41;
         /// Support for 16-bit integer types.
-        const SHADER_INT16 = 1 << 43;
+        const SHADER_INT16 = 1 << 42;
         /// Support for [`Interpolation::Linear`] (`@interpolate(linear)` in WGSL).
         ///
         /// This is core WebGPU, but GLSL ES (and thus WebGL) has no `noperspective` qualifier (unless enabled by extensions).
         ///
         /// [`Interpolation::Linear`]: crate::Interpolation::Linear
-        const LINEAR_INTERPOLATION = 1 << 44;
+        const LINEAR_INTERPOLATION = 1 << 43;
     }
 }
 

--- a/naga/tests/in/glsl/800-out-of-bounds-panic.toml
+++ b/naga/tests/in/glsl/800-out-of-bounds-panic.toml
@@ -1,1 +1,0 @@
-capabilities = "IMMEDIATES"

--- a/naga/tests/in/glsl/896-push-constant.toml
+++ b/naga/tests/in/glsl/896-push-constant.toml
@@ -1,1 +1,0 @@
-capabilities = "IMMEDIATES"

--- a/naga/tests/in/wgsl/extra.toml
+++ b/naga/tests/in/wgsl/extra.toml
@@ -1,4 +1,4 @@
-capabilities = "IMMEDIATES | PRIMITIVE_INDEX"
+capabilities = "PRIMITIVE_INDEX"
 targets = "SPIRV | METAL | WGSL"
 
 [msl]

--- a/naga/tests/in/wgsl/push-constant-dynamic-vector-index.toml
+++ b/naga/tests/in/wgsl/push-constant-dynamic-vector-index.toml
@@ -1,4 +1,3 @@
-capabilities = "IMMEDIATES"
 targets = "SPIRV"
 
 [bounds_check_policies]

--- a/naga/tests/in/wgsl/push-constants.toml
+++ b/naga/tests/in/wgsl/push-constants.toml
@@ -1,4 +1,3 @@
-capabilities = "IMMEDIATES"
 targets = "GLSL | HLSL | ANALYSIS"
 
 [hlsl]

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -1591,7 +1591,7 @@ fn int16_in_immediate() {
             ),
             ..
         }),
-        naga::valid::Capabilities::SHADER_INT16 | naga::valid::Capabilities::IMMEDIATES
+        naga::valid::Capabilities::SHADER_INT16
     }
 }
 

--- a/tests/tests/wgpu-gpu/dispatch_workgroups_indirect.rs
+++ b/tests/tests/wgpu-gpu/dispatch_workgroups_indirect.rs
@@ -16,7 +16,6 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 static NUM_WORKGROUPS_BUILTIN: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(wgpu::Features::IMMEDIATES)
             .downlevel_flags(
                 wgpu::DownlevelFlags::COMPUTE_SHADERS | wgpu::DownlevelFlags::INDIRECT_EXECUTION,
             )
@@ -36,7 +35,6 @@ static NUM_WORKGROUPS_BUILTIN: GpuTestConfiguration = GpuTestConfiguration::new(
 static DISCARD_DISPATCH: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(wgpu::Features::IMMEDIATES)
             .downlevel_flags(
                 wgpu::DownlevelFlags::COMPUTE_SHADERS | wgpu::DownlevelFlags::INDIRECT_EXECUTION,
             )
@@ -67,7 +65,6 @@ static DISCARD_DISPATCH: GpuTestConfiguration = GpuTestConfiguration::new()
 static RESET_BIND_GROUPS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(wgpu::Features::IMMEDIATES)
             .downlevel_flags(
                 wgpu::DownlevelFlags::COMPUTE_SHADERS | wgpu::DownlevelFlags::INDIRECT_EXECUTION,
             )
@@ -109,7 +106,6 @@ static RESET_BIND_GROUPS: GpuTestConfiguration = GpuTestConfiguration::new()
 static ZERO_SIZED_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(wgpu::Features::IMMEDIATES)
             .downlevel_flags(
                 wgpu::DownlevelFlags::COMPUTE_SHADERS | wgpu::DownlevelFlags::INDIRECT_EXECUTION,
             )

--- a/tests/tests/wgpu-gpu/immediates.rs
+++ b/tests/tests/wgpu-gpu/immediates.rs
@@ -20,14 +20,10 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 /// will remain unchanged.
 #[apply(gpu_test!)]
 static PARTIAL_UPDATE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .features(wgpu::Features::IMMEDIATES)
-            .limits(wgpu::Limits {
-                max_immediate_size: 32,
-                ..Default::default()
-            }),
-    )
+    .parameters(TestParameters::default().limits(wgpu::Limits {
+        max_immediate_size: 32,
+        ..Default::default()
+    }))
     .run_async(partial_update_test);
 
 const SHADER: &str = r#"
@@ -163,7 +159,7 @@ async fn partial_update_test(ctx: TestingContext) {
 static RENDER_PASS_TEST: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::IMMEDIATES | Features::VERTEX_WRITABLE_STORAGE)
+            .features(Features::VERTEX_WRITABLE_STORAGE)
             .limits(wgpu::Limits {
                 max_immediate_size: 64,
                 ..Default::default()

--- a/tests/tests/wgpu-gpu/regression/issue_3349.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_3349.rs
@@ -29,14 +29,10 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 /// We then validate the data is correct from every position.
 #[apply(gpu_test!)]
 static MULTI_STAGE_DATA_BINDING: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .features(wgpu::Features::IMMEDIATES)
-            .limits(wgpu::Limits {
-                max_immediate_size: 16,
-                ..Default::default()
-            }),
-    )
+    .parameters(TestParameters::default().limits(wgpu::Limits {
+        max_immediate_size: 16,
+        ..Default::default()
+    }))
     .run_async(multi_stage_data_binding_test);
 
 async fn multi_stage_data_binding_test(ctx: TestingContext) {

--- a/tests/tests/wgpu-gpu/regression/issue_9115.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_9115.rs
@@ -15,14 +15,10 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
 /// See <https://github.com/gfx-rs/wgpu/issues/9115>.
 #[apply(gpu_test!)]
 static IMMEDIATES_WITH_UNIFORM_IN_SINGLE_MODULE: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(
-        TestParameters::default()
-            .features(wgpu::Features::IMMEDIATES)
-            .limits(wgpu::Limits {
-                max_immediate_size: 32,
-                ..Default::default()
-            }),
-    )
+    .parameters(TestParameters::default().limits(wgpu::Limits {
+        max_immediate_size: 32,
+        ..Default::default()
+    }))
     .run_async(immediates_with_uniform_in_single_module);
 
 #[repr(C)]

--- a/tests/tests/wgpu-gpu/shader/struct_layout.rs
+++ b/tests/tests/wgpu-gpu/shader/struct_layout.rs
@@ -56,7 +56,6 @@ static STORAGE_INPUT: GpuTestConfiguration = GpuTestConfiguration::new()
 static IMMEDIATES_INPUT: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::IMMEDIATES)
             .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
             .limits(Limits {
                 max_immediate_size: MAX_BUFFER_SIZE as u32,
@@ -635,7 +634,7 @@ static STORAGE_INPUT_INT64: GpuTestConfiguration = GpuTestConfiguration::new()
 static IMMEDIATES_INPUT_INT64: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .features(Features::SHADER_INT64 | Features::IMMEDIATES)
+            .features(Features::SHADER_INT64)
             .downlevel_flags(DownlevelFlags::COMPUTE_SHADERS)
             .limits(Limits {
                 max_immediate_size: MAX_BUFFER_SIZE as u32,

--- a/tests/tests/wgpu-validation/api/immediates.rs
+++ b/tests/tests/wgpu-validation/api/immediates.rs
@@ -21,7 +21,6 @@ fn setup_compute() -> (
     wgpu::BindGroup,
 ) {
     let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor {
-        required_features: wgpu::Features::IMMEDIATES,
         required_limits: wgpu::Limits {
             max_immediate_size: 64,
             ..Default::default()
@@ -162,7 +161,6 @@ const STRUCT_SHADER: &str = "
 #[test]
 fn struct_padding_slots_not_required() {
     let (device, _q) = wgpu::Device::noop(&wgpu::DeviceDescriptor {
-        required_features: wgpu::Features::IMMEDIATES,
         required_limits: wgpu::Limits {
             max_immediate_size: 64,
             ..Default::default()
@@ -310,7 +308,6 @@ fn pipeline_without_immediates_needs_none() {
 #[test]
 fn auto_layout_infers_immediate_size() {
     let (device, _q) = wgpu::Device::noop(&wgpu::DeviceDescriptor {
-        required_features: wgpu::Features::IMMEDIATES,
         required_limits: wgpu::Limits {
             max_immediate_size: 64,
             ..Default::default()
@@ -412,7 +409,7 @@ fn begin_render_pass<'b, 'a: 'b>(
 
 fn setup_render() -> (wgpu::Device, wgpu::Queue, wgpu::TextureView) {
     let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor {
-        required_features: wgpu::Features::IMMEDIATES | wgpu::Features::SHADER_F16,
+        required_features: wgpu::Features::SHADER_F16,
         required_limits: wgpu::Limits {
             max_immediate_size: 64,
             ..Default::default()

--- a/tests/tests/wgpu-validation/limit_buckets.rs
+++ b/tests/tests/wgpu-validation/limit_buckets.rs
@@ -22,7 +22,6 @@ const UPLEVEL_FEATURES: wgt::Features = {
         .union(Features::DUAL_SOURCE_BLENDING)
         .union(Features::PRIMITIVE_INDEX)
         .union(Features::SUBGROUP)
-        .union(Features::IMMEDIATES)
 };
 
 fn create_noop_instance(options: wgt::NoopBackendOptions) -> Arc<wgc::instance::Instance> {

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -998,8 +998,6 @@ where
     /// The number of bytes of immediate data that are allocated for use
     /// in the shader. The `var<immediate>`s in the shader attached to
     /// this pipeline must be equal or smaller than this size.
-    ///
-    /// If this value is non-zero, [`wgt::Features::IMMEDIATES`] must be enabled.
     pub immediate_size: u32,
 }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4163,9 +4163,6 @@ impl Device {
             });
         }
 
-        if desc.immediate_size != 0 {
-            self.require_features(wgt::Features::IMMEDIATES)?;
-        }
         if self.limits.max_immediate_size < desc.immediate_size {
             return Err(Error::ImmediateRangeTooLarge {
                 size: desc.immediate_size,

--- a/wgpu-core/src/indirect_validation/dispatch.rs
+++ b/wgpu-core/src/indirect_validation/dispatch.rs
@@ -93,7 +93,7 @@ impl Dispatch {
         let module = panic!("Indirect validation requires the wgsl feature flag to be enabled!");
 
         let info = crate::device::create_validator(
-            wgt::Features::IMMEDIATES,
+            wgt::Features::empty(),
             wgt::DownlevelFlags::empty(),
             naga::valid::ValidationFlags::all(),
         )

--- a/wgpu-core/src/indirect_validation/draw.rs
+++ b/wgpu-core/src/indirect_validation/draw.rs
@@ -538,7 +538,7 @@ fn create_validation_module(
     let module = panic!("Indirect validation requires the wgsl feature flag to be enabled!");
 
     let info = crate::device::create_validator(
-        wgt::Features::IMMEDIATES,
+        wgt::Features::empty(),
         wgt::DownlevelFlags::empty(),
         naga::valid::ValidationFlags::all(),
     )

--- a/wgpu-core/src/limits.rs
+++ b/wgpu-core/src/limits.rs
@@ -351,8 +351,7 @@ const UPLEVEL: Bucket = Bucket {
         // TIER1/TIER2 not implemented in wgpu; https://github.com/gfx-rs/wgpu/issues/8122
         .union(Features::PRIMITIVE_INDEX)
         // TEXTURE_COMPONENT_SWIZZLE not implemented in wgpu; https://github.com/gfx-rs/wgpu/issues/1028
-        .union(Features::SUBGROUP)
-        .union(Features::IMMEDIATES),
+        .union(Features::SUBGROUP),
 };
 
 // e.g. Apple M Series
@@ -561,10 +560,7 @@ mod tests {
                 .union(Features::SUBGROUP)
                 //.union(Features::TEXTURE_FORMATS_TIER1) not implemented
                 //.union(Features::TEXTURE_FORMATS_TIER2) not implemented
-                .union(Features::PRIMITIVE_INDEX)
-                //.union(Features::TEXTURE_COMPONENT_SWIZZLE) not implemented
-                // Standard-track features not in official spec
-                .union(Features::IMMEDIATES),
+                .union(Features::PRIMITIVE_INDEX), //.union(Features::TEXTURE_COMPONENT_SWIZZLE) not implemented
         );
         assert!(
             difference.is_empty(),

--- a/wgpu-core/src/timestamp_normalization/mod.rs
+++ b/wgpu-core/src/timestamp_normalization/mod.rs
@@ -151,7 +151,7 @@ impl TimestampNormalizer {
                 panic!("Timestamp normalization requires the wgsl feature flag to be enabled!");
 
             let info = crate::device::create_validator(
-                wgt::Features::IMMEDIATES,
+                wgt::Features::empty(),
                 wgt::DownlevelFlags::empty(),
                 naga::valid::ValidationFlags::all(),
             )

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -474,7 +474,6 @@ impl super::Adapter {
             | wgt::Features::TEXTURE_COMPRESSION_BC_SLICED_3D
             | wgt::Features::CLEAR_TEXTURE
             | wgt::Features::TEXTURE_FORMAT_16BIT_NORM
-            | wgt::Features::IMMEDIATES
             | wgt::Features::PRIMITIVE_INDEX
             | wgt::Features::RG11B10UFLOAT_RENDERABLE
             | wgt::Features::DUAL_SOURCE_BLENDING

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -490,7 +490,6 @@ impl super::Adapter {
         let mut features = wgt::Features::empty()
             | wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
             | wgt::Features::CLEAR_TEXTURE
-            | wgt::Features::IMMEDIATES
             | wgt::Features::DEPTH32FLOAT_STENCIL8
             | wgt::Features::PASSTHROUGH_SHADERS;
         features.set(

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1190,7 +1190,6 @@ impl super::CapabilitiesQuery {
             | F::MAPPABLE_PRIMARY_BUFFERS
             | F::VERTEX_WRITABLE_STORAGE
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-            | F::IMMEDIATES
             | F::POLYGON_MODE_LINE
             | F::CLEAR_TEXTURE
             | F::TEXTURE_FORMAT_16BIT_NORM

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -669,7 +669,6 @@ impl PhysicalDeviceFeatures {
         use wgt::{DownlevelFlags as Df, Features as F};
         let mut features = F::empty()
             | F::MAPPABLE_PRIMARY_BUFFERS
-            | F::IMMEDIATES
             | F::ADDRESS_MODE_CLAMP_TO_BORDER
             | F::ADDRESS_MODE_CLAMP_TO_ZERO
             | F::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES

--- a/wgpu-naga-bridge/src/lib.rs
+++ b/wgpu-naga-bridge/src/lib.rs
@@ -11,7 +11,6 @@ pub fn features_to_naga_capabilities(
     downlevel: wgt::DownlevelFlags,
 ) -> Caps {
     let mut caps = Caps::empty();
-    caps.set(Caps::IMMEDIATES, true);
     caps.set(Caps::FLOAT64, features.contains(wgt::Features::SHADER_F64));
     caps.set(
         Caps::SHADER_FLOAT16,

--- a/wgpu-naga-bridge/src/lib.rs
+++ b/wgpu-naga-bridge/src/lib.rs
@@ -11,10 +11,7 @@ pub fn features_to_naga_capabilities(
     downlevel: wgt::DownlevelFlags,
 ) -> Caps {
     let mut caps = Caps::empty();
-    caps.set(
-        Caps::IMMEDIATES,
-        features.contains(wgt::Features::IMMEDIATES),
-    );
+    caps.set(Caps::IMMEDIATES, true);
     caps.set(Caps::FLOAT64, features.contains(wgt::Features::SHADER_F64));
     caps.set(
         Caps::SHADER_FLOAT16,

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -14,7 +14,7 @@
 //! [`bitflags`] does not currently support customized flag naming.
 //! See <https://github.com/bitflags/bitflags/issues/470>.
 
-use crate::{link_to_wgpu_docs, link_to_wgpu_item, VertexFormat};
+use crate::{link_to_wgpu_docs, VertexFormat};
 #[cfg(feature = "serde")]
 use alloc::fmt;
 use alloc::vec::Vec;
@@ -84,10 +84,7 @@ mod webgpu_impl {
     pub const WEBGPU_FEATURE_CLIP_DISTANCES: u64 = 1 << 15;
 
     #[doc(hidden)]
-    pub const WEBGPU_FEATURE_IMMEDIATES: u64 = 1 << 16;
-
-    #[doc(hidden)]
-    pub const WEBGPU_FEATURE_PRIMITIVE_INDEX: u64 = 1 << 17;
+    pub const WEBGPU_FEATURE_PRIMITIVE_INDEX: u64 = 1 << 16;
 }
 
 macro_rules! bitflags_array_impl {
@@ -1777,38 +1774,6 @@ bitflags_array! {
         #[name("clip-distances")]
         const CLIP_DISTANCES = WEBGPU_FEATURE_CLIP_DISTANCES;
 
-        /// Allows the use of immediate data: small, fast bits of memory that can be updated
-        /// inside a [`RenderPass`].
-        ///
-        /// Allows the user to call [`RenderPass::set_immediates`], provide a non-zero immediate data size
-        /// to [`PipelineLayoutDescriptor`], and provide a non-zero limit to [`Limits::max_immediate_size`].
-        ///
-        /// A block of immediate data can be declared in WGSL with `var<immediate>`:
-        ///
-        /// ```rust,ignore
-        /// struct Immediates { example: f32, }
-        /// var<immediate> c: Immediates;
-        /// ```
-        ///
-        /// In GLSL, this corresponds to `layout(immediates) uniform Name {..}`.
-        ///
-        /// Supported platforms:
-        /// - DX12
-        /// - Vulkan
-        /// - Metal
-        /// - OpenGL (emulated with uniforms)
-        /// - WebGPU
-        ///
-        /// WebGPU support is currently a proposal and will be available in browsers in the future.
-        ///
-        /// This is a web and native feature.
-        ///
-        #[doc = link_to_wgpu_item!(struct RenderPass)]
-        #[doc = link_to_wgpu_item!(struct PipelineLayoutDescriptor)]
-        #[doc = link_to_wgpu_docs!(["`RenderPass::set_immediates`"]: "struct.RenderPass.html#method.set_immediates")]
-        /// [`Limits::max_immediate_size`]: super::Limits
-        #[name("immediates")]
-        const IMMEDIATES = WEBGPU_FEATURE_IMMEDIATES;
 
         /// Enables `builtin(primitive_index)` in fragment shaders.
         ///

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -249,7 +249,6 @@ pub struct Limits {
     pub max_compute_workgroups_per_dimension: u32,
 
     /// Amount of storage available for immediates in bytes. Defaults to 0. Higher is "better".
-    /// Requesting more than 0 during device creation requires [`Features::IMMEDIATES`] to be enabled.
     ///
     /// Expect the size to be:
     /// - Vulkan: 128-256 bytes

--- a/wgpu/src/api/compute_pass.rs
+++ b/wgpu/src/api/compute_pass.rs
@@ -158,7 +158,6 @@ impl ComputePass<'_> {
     }
 }
 
-/// [`Features::IMMEDIATES`] must be enabled on the device in order to call these functions.
 impl ComputePass<'_> {
     /// Set immediate data for subsequent dispatch calls.
     ///

--- a/wgpu/src/api/pipeline_layout.rs
+++ b/wgpu/src/api/pipeline_layout.rs
@@ -39,8 +39,6 @@ pub struct PipelineLayoutDescriptor<'a> {
     /// The number of bytes of immediate data that are allocated for use
     /// in the shader. The `var<immediate>`s in the shader attached to
     /// this pipeline must be equal or smaller than this size.
-    ///
-    /// If this value is non-zero, [`Features::IMMEDIATES`] must be enabled.
     pub immediate_size: u32,
 }
 #[cfg(send_sync)]

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -214,7 +214,6 @@ impl<'a> RenderBundleEncoder<'a> {
     }
 }
 
-/// [`Features::IMMEDIATES`] must be enabled on the device in order to call these functions.
 impl RenderBundleEncoder<'_> {
     /// Set immediate data for subsequent draw calls within the render bundle.
     ///

--- a/wgpu/src/api/render_pass.rs
+++ b/wgpu/src/api/render_pass.rs
@@ -523,7 +523,6 @@ impl RenderPass<'_> {
     }
 }
 
-/// [`Features::IMMEDIATES`] must be enabled on the device in order to call these functions.
 impl RenderPass<'_> {
     /// Set immediate data for subsequent draw calls.
     ///

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -3547,8 +3547,10 @@ impl dispatch::ComputePassInterface for WebComputePassEncoder {
         }
     }
 
-    fn set_immediates(&mut self, _offset: u32, _data: &[u8]) {
-        panic!("IMMEDIATES feature must be enabled to call set_immediates")
+    fn set_immediates(&mut self, offset: u32, data: &[u8]) {
+        self.inner
+            .set_immediates_with_u8_slice(offset, data)
+            .unwrap();
     }
 
     fn insert_debug_marker(&mut self, label: &str) {
@@ -3688,8 +3690,10 @@ impl dispatch::RenderPassInterface for WebRenderPassEncoder {
         }
     }
 
-    fn set_immediates(&mut self, _offset: u32, _data: &[u8]) {
-        panic!("IMMEDIATES feature must be enabled to call set_immediates")
+    fn set_immediates(&mut self, offset: u32, data: &[u8]) {
+        self.inner
+            .set_immediates_with_u8_slice(offset, data)
+            .unwrap();
     }
 
     fn set_blend_constant(&mut self, color: crate::Color) {
@@ -3979,8 +3983,10 @@ impl dispatch::RenderBundleEncoderInterface for WebRenderBundleEncoder {
         }
     }
 
-    fn set_immediates(&mut self, _offset: u32, _data: &[u8]) {
-        panic!("IMMEDIATES feature must be enabled to call set_immediates")
+    fn set_immediates(&mut self, offset: u32, data: &[u8]) {
+        self.inner
+            .set_immediates_with_u8_slice(offset, data)
+            .unwrap();
     }
 
     fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuComputePassEncoder.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuComputePassEncoder.rs
@@ -338,7 +338,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice(
         this: &GpuComputePassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderBundleEncoder.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderBundleEncoder.rs
@@ -249,7 +249,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice(
         this: &GpuRenderBundleEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPassEncoder.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPassEncoder.rs
@@ -359,7 +359,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice(
         this: &GpuRenderPassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(

--- a/wgpu/src/util/encoder.rs
+++ b/wgpu/src/util/encoder.rs
@@ -71,8 +71,6 @@ pub trait RenderEncoder<'a> {
         indirect_offset: BufferAddress,
     );
 
-    /// [`wgt::Features::IMMEDIATES`] must be enabled on the device in order to call this function.
-    ///
     /// Set immediate data for subsequent draw calls.
     ///
     /// Write the bytes in `data` at offset `offset` within immediate data


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/issues/8556

**Description**
Add immediates support to WebGPU and remove `Features::IMMEDIATES`

**Testing**
CI

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
