### PR TITLE
Move TextureDescriptor down into underlying type and expose it via TextureInterface

### DIFF
--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2158,6 +2158,10 @@ impl Texture {
 
         (view, error)
     }
+
+    pub fn descriptor(&self) -> &wgt::TextureDescriptor<String, Vec<wgt::TextureFormat>> {
+        &self.desc
+    }
 }
 
 /// A texture that has been marked as destroyed and is staged for actual deletion soon.

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -294,14 +294,7 @@ impl Device {
     pub fn create_texture(&self, desc: &TextureDescriptor<'_>) -> Texture {
         let texture = self.inner.create_texture(desc);
 
-        Texture {
-            inner: texture,
-            descriptor: TextureDescriptor {
-                label: None,
-                view_formats: &[],
-                ..desc.clone()
-            },
-        }
+        Texture { inner: texture }
     }
 
     /// Creates a [`Texture`] from a wgpu-hal Texture.
@@ -355,11 +348,6 @@ impl Device {
         };
         Texture {
             inner: texture.into(),
-            descriptor: TextureDescriptor {
-                label: None,
-                view_formats: &[],
-                ..desc.clone()
-            },
         }
     }
 
@@ -409,15 +397,8 @@ impl Device {
         let inner = self
             .inner
             .as_webgpu()
-            .wrap_external_texture(texture, drop_callback);
-        Texture {
-            inner,
-            descriptor: TextureDescriptor {
-                label: None,
-                view_formats: &[],
-                ..desc.clone()
-            },
-        }
+            .wrap_external_texture(texture, desc, drop_callback);
+        Texture { inner }
     }
 
     /// Returns the underlying [`webgpu::GpuDevice`] handle if this `Device`

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -146,7 +146,24 @@ impl Surface<'_> {
     /// See the documentation of [`CurrentSurfaceTexture`] for how each possible result
     /// should be handled.
     pub fn get_current_texture(&self) -> CurrentSurfaceTexture {
-        let (texture, status, detail) = self.inner.get_current_texture();
+        let desc = {
+            let guard = self.config.lock();
+            guard.as_ref().map(|config| TextureDescriptor {
+                label: None,
+                size: Extent3d {
+                    width: config.width,
+                    height: config.height,
+                    depth_or_array_layers: 1,
+                },
+                format: config.format,
+                usage: config.usage,
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: TextureDimension::D2,
+                view_formats: &[],
+            })
+        };
+        let (texture, status, detail) = self.inner.get_current_texture(desc);
 
         let suboptimal = match status {
             SurfaceStatus::Good => false,
@@ -158,33 +175,10 @@ impl Surface<'_> {
             SurfaceStatus::Validation => return CurrentSurfaceTexture::Validation,
         };
 
-        let guard = self.config.lock();
-        let config = guard
-            .as_ref()
-            .expect("This surface has not been configured yet.");
-
-        let descriptor = TextureDescriptor {
-            label: None,
-            size: Extent3d {
-                width: config.width,
-                height: config.height,
-                depth_or_array_layers: 1,
-            },
-            format: config.format,
-            usage: config.usage,
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: TextureDimension::D2,
-            view_formats: &[],
-        };
-
         match texture {
             Some(texture) => {
                 let surface_texture = SurfaceTexture {
-                    texture: Texture {
-                        inner: texture,
-                        descriptor,
-                    },
+                    texture: Texture { inner: texture },
                     presented: false,
                     detail,
                 };

--- a/wgpu/src/api/texture.rs
+++ b/wgpu/src/api/texture.rs
@@ -11,7 +11,6 @@ use crate::*;
 #[derive(Debug, Clone)]
 pub struct Texture {
     pub(crate) inner: dispatch::DispatchTexture,
-    pub(crate) descriptor: TextureDescriptor<'static>,
 }
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Texture: Send, Sync);
@@ -85,17 +84,9 @@ impl Texture {
 
     #[cfg(custom)]
     /// Creates a texture from already created custom implementation with the given description
-    pub fn from_custom<T: custom::TextureInterface>(
-        texture: T,
-        desc: &TextureDescriptor<'_>,
-    ) -> Self {
+    pub fn from_custom<T: custom::TextureInterface>(texture: T) -> Self {
         Self {
             inner: dispatch::DispatchTexture::custom(texture),
-            descriptor: TextureDescriptor {
-                label: None,
-                view_formats: &[],
-                ..desc.clone()
-            },
         }
     }
 
@@ -132,63 +123,63 @@ impl Texture {
     ///
     /// This is always equal to the `size` that was specified when creating the texture.
     pub fn size(&self) -> Extent3d {
-        self.descriptor.size
+        self.inner.size()
     }
 
     /// Returns the width of this `Texture`.
     ///
     /// This is always equal to the `size.width` that was specified when creating the texture.
     pub fn width(&self) -> u32 {
-        self.descriptor.size.width
+        self.inner.size().width
     }
 
     /// Returns the height of this `Texture`.
     ///
     /// This is always equal to the `size.height` that was specified when creating the texture.
     pub fn height(&self) -> u32 {
-        self.descriptor.size.height
+        self.inner.size().height
     }
 
     /// Returns the depth or layer count of this `Texture`.
     ///
     /// This is always equal to the `size.depth_or_array_layers` that was specified when creating the texture.
     pub fn depth_or_array_layers(&self) -> u32 {
-        self.descriptor.size.depth_or_array_layers
+        self.inner.size().depth_or_array_layers
     }
 
     /// Returns the mip_level_count of this `Texture`.
     ///
     /// This is always equal to the `mip_level_count` that was specified when creating the texture.
     pub fn mip_level_count(&self) -> u32 {
-        self.descriptor.mip_level_count
+        self.inner.mip_level_count()
     }
 
     /// Returns the sample_count of this `Texture`.
     ///
     /// This is always equal to the `sample_count` that was specified when creating the texture.
     pub fn sample_count(&self) -> u32 {
-        self.descriptor.sample_count
+        self.inner.sample_count()
     }
 
     /// Returns the dimension of this `Texture`.
     ///
     /// This is always equal to the `dimension` that was specified when creating the texture.
     pub fn dimension(&self) -> TextureDimension {
-        self.descriptor.dimension
+        self.inner.dimension()
     }
 
     /// Returns the format of this `Texture`.
     ///
     /// This is always equal to the `format` that was specified when creating the texture.
     pub fn format(&self) -> TextureFormat {
-        self.descriptor.format
+        self.inner.format()
     }
 
     /// Returns the allowed usages of this `Texture`.
     ///
     /// This is always equal to the `usage` that was specified when creating the texture.
     pub fn usage(&self) -> TextureUsages {
-        self.descriptor.usage
+        self.inner.usage()
     }
 }
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1404,6 +1404,7 @@ pub struct WebTexture {
     drop_guard: Option<Rc<DropGuard>>,
     /// Unique identifier for this Texture.
     ident: crate::cmp::Identifier,
+    desc: crate::TextureDescriptor<'static>,
 }
 
 #[derive(Debug, Clone)]
@@ -1885,12 +1886,18 @@ impl WebDevice {
     pub(crate) fn wrap_external_texture(
         &self,
         texture: webgpu_sys::GpuTexture,
+        desc: &crate::TextureDescriptor<'_>,
         drop_callback: Option<DropCallback>,
     ) -> dispatch::DispatchTexture {
         WebTexture {
             inner: texture,
             drop_guard: Some(Rc::new(DropGuard::new(drop_callback))),
             ident: crate::cmp::Identifier::create(),
+            desc: crate::TextureDescriptor {
+                label: None,
+                view_formats: &[],
+                ..desc.clone()
+            },
         }
         .into()
     }
@@ -2503,6 +2510,11 @@ impl dispatch::DeviceInterface for WebDevice {
             inner: texture,
             drop_guard: None,
             ident: crate::cmp::Identifier::create(),
+            desc: crate::TextureDescriptor {
+                label: None,
+                view_formats: &[],
+                ..desc.clone()
+            },
         }
         .into()
     }
@@ -3033,6 +3045,30 @@ impl dispatch::TextureInterface for WebTexture {
         if self.drop_guard.is_none() {
             self.inner.destroy();
         }
+    }
+
+    fn size(&self) -> wgt::Extent3d {
+        self.desc.size
+    }
+
+    fn mip_level_count(&self) -> u32 {
+        self.desc.mip_level_count
+    }
+
+    fn sample_count(&self) -> u32 {
+        self.desc.sample_count
+    }
+
+    fn dimension(&self) -> wgt::TextureDimension {
+        self.desc.dimension
+    }
+
+    fn format(&self) -> wgt::TextureFormat {
+        self.desc.format
+    }
+
+    fn usage(&self) -> wgt::TextureUsages {
+        self.desc.usage
     }
 }
 impl Drop for WebTexture {
@@ -4347,6 +4383,7 @@ impl dispatch::SurfaceInterface for WebSurface {
 
     fn get_current_texture(
         &self,
+        desc: Option<crate::TextureDescriptor<'static>>,
     ) -> (
         Option<dispatch::DispatchTexture>,
         crate::SurfaceStatus,
@@ -4371,6 +4408,7 @@ impl dispatch::SurfaceInterface for WebSurface {
         };
 
         let web_surface_texture = WebTexture {
+            desc: desc.unwrap(),
             inner: surface_texture,
             drop_guard: None,
             ident: crate::cmp::Identifier::create(),

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2253,6 +2253,30 @@ impl dispatch::TextureInterface for CoreTexture {
     fn destroy(&self) {
         self.wgpu_texture.destroy();
     }
+
+    fn size(&self) -> wgt::Extent3d {
+        self.wgpu_texture.descriptor().size
+    }
+
+    fn mip_level_count(&self) -> u32 {
+        self.wgpu_texture.descriptor().mip_level_count
+    }
+
+    fn sample_count(&self) -> u32 {
+        self.wgpu_texture.descriptor().sample_count
+    }
+
+    fn dimension(&self) -> wgt::TextureDimension {
+        self.wgpu_texture.descriptor().dimension
+    }
+
+    fn format(&self) -> wgt::TextureFormat {
+        self.wgpu_texture.descriptor().format
+    }
+
+    fn usage(&self) -> wgt::TextureUsages {
+        self.wgpu_texture.descriptor().usage
+    }
 }
 
 impl dispatch::BlasInterface for CoreBlas {
@@ -3696,6 +3720,7 @@ impl dispatch::SurfaceInterface for CoreSurface {
 
     fn get_current_texture(
         &self,
+        _desc: Option<crate::TextureDescriptor<'static>>,
     ) -> (
         Option<dispatch::DispatchTexture>,
         crate::SurfaceStatus,

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -292,6 +292,18 @@ pub trait TextureInterface: CommonTraits {
     fn create_view(&self, desc: &crate::TextureViewDescriptor<'_>) -> DispatchTextureView;
 
     fn destroy(&self);
+
+    fn size(&self) -> wgt::Extent3d;
+
+    fn mip_level_count(&self) -> u32;
+
+    fn sample_count(&self) -> u32;
+
+    fn dimension(&self) -> wgt::TextureDimension;
+
+    fn format(&self) -> wgt::TextureFormat;
+
+    fn usage(&self) -> wgt::TextureUsages;
 }
 pub trait ExternalTextureInterface: CommonTraits {
     fn destroy(&self);
@@ -609,6 +621,7 @@ pub trait SurfaceInterface: CommonTraits {
     fn configure(&self, device: &DispatchDevice, config: &crate::SurfaceConfiguration);
     fn get_current_texture(
         &self,
+        desc: Option<crate::TextureDescriptor<'static>>,
     ) -> (
         Option<DispatchTexture>,
         crate::SurfaceStatus,


### PR DESCRIPTION
**Connections**
Towards #10073

**Description**
Move data from wgpu's structure into underlying type and expose it via DispatchInterface trait. This mean we can reuse wgc's descriptors.

**Testing**
Just refactor

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
