### PR TITLE
Move data from wgpu's structure into underlying type and expose it via DispatchInterface trait

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -5638,9 +5638,8 @@ impl Device {
                 raw: Snatchable::new(raw),
             }),
             device: self.clone(),
-            label: desc.label.to_string(),
             tracking_data: TrackingData::new(self.tracker_indices.query_sets.clone()),
-            desc: desc.map_label(|_| ()),
+            desc: desc.map_label(|l| l.to_string()),
             initialized_slots: Mutex::new(
                 rank::QUERY_SET_INITIALIZED_SLOTS,
                 bit_vec::BitVec::from_elem(desc.count as usize, false),

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -3093,6 +3093,10 @@ impl QuerySet {
             life_lock.schedule_resource_destruction(temp, last_submit_index);
         }
     }
+
+    pub fn descriptor(&self) -> &wgt::QuerySetDescriptor<String> {
+        &self.desc
+    }
 }
 
 impl Drop for QuerySet {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -3008,10 +3008,8 @@ pub(crate) struct QuerySetState {
 pub struct QuerySet {
     pub(crate) state: ResourceState<QuerySetState>,
     pub(crate) device: Arc<Device>,
-    /// The `label` from the descriptor used to create the resource.
-    pub(crate) label: String,
     pub(crate) tracking_data: TrackingData,
-    pub(crate) desc: wgt::QuerySetDescriptor<()>,
+    pub(crate) desc: wgt::QuerySetDescriptor<String>,
     pub(crate) initialized_slots: Mutex<bit_vec::BitVec>,
 }
 
@@ -3038,9 +3036,8 @@ impl QuerySet {
     pub fn invalid(device: Arc<Device>, desc: &QuerySetDescriptor) -> Arc<Self> {
         Arc::new(QuerySet {
             state: ResourceState::Invalid,
-            label: desc.label.to_string(),
             tracking_data: TrackingData::new(device.tracker_indices.query_sets.clone()),
-            desc: desc.clone().map_label(|_| ()),
+            desc: desc.map_label(|l| l.to_string()),
             initialized_slots: Mutex::new(
                 rank::QUERY_SET_INITIALIZED_SLOTS,
                 bit_vec::BitVec::new(),
@@ -3123,7 +3120,11 @@ impl Drop for QuerySet {
 }
 
 crate::impl_resource_type!(QuerySet);
-crate::impl_labeled!(QuerySet);
+impl Labeled for QuerySet {
+    fn label(&self) -> &str {
+        &self.desc.label
+    }
+}
 crate::impl_parent_device!(QuerySet);
 crate::impl_storage_item!(QuerySet);
 crate::impl_trackable!(QuerySet);

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -1181,6 +1181,14 @@ impl Buffer {
             life_lock.schedule_resource_destruction(temp, last_submit_index);
         }
     }
+
+    pub fn size(&self) -> wgt::BufferAddress {
+        self.size
+    }
+
+    pub fn usage(&self) -> wgt::BufferUsages {
+        self.usage
+    }
 }
 
 #[derive(Clone, Debug, Error)]

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -222,8 +222,6 @@ use crate::*;
 pub struct Buffer {
     pub(crate) inner: dispatch::DispatchBuffer,
     pub(crate) map_context: Arc<Mutex<MapContext>>,
-    pub(crate) size: wgt::BufferAddress,
-    pub(crate) usage: BufferUsages,
     // Todo: missing map_state https://www.w3.org/TR/webgpu/#dom-gpubuffer-mapstate
 }
 #[cfg(send_sync)]
@@ -312,8 +310,8 @@ impl Buffer {
     /// - If `bounds` is outside of the bounds of `self`.
     #[track_caller]
     pub fn slice<S: RangeBounds<BufferAddress>>(&self, bounds: S) -> BufferSlice<'_> {
-        let (offset, size) = range_to_offset_size(bounds, self.size);
-        check_buffer_bounds(self.size, offset, size);
+        let (offset, size) = range_to_offset_size(bounds, self.size());
+        check_buffer_bounds(self.size(), offset, size);
         BufferSlice {
             buffer: self,
             offset,
@@ -339,14 +337,14 @@ impl Buffer {
     ///
     /// This is always equal to the `size` that was specified when creating the buffer.
     pub fn size(&self) -> BufferAddress {
-        self.size
+        self.inner.size()
     }
 
     /// Returns the allowed usages for this `Buffer`.
     ///
     /// This is always equal to the `usage` that was specified when creating the buffer.
     pub fn usage(&self) -> BufferUsages {
-        self.usage
+        self.inner.usage()
     }
 
     /// Map the buffer to host (CPU) memory, making it available for reading or writing via

--- a/wgpu/src/api/command_buffer_actions.rs
+++ b/wgpu/src/api/command_buffer_actions.rs
@@ -107,7 +107,7 @@ macro_rules! impl_deferred_command_buffer_actions {
             bounds: S,
             callback: impl FnOnce(Result<(), BufferAsyncError>) + WasmNotSend + 'static,
         ) {
-            let (offset, size) = range_to_offset_size(bounds, buffer.size);
+            let (offset, size) = range_to_offset_size(bounds, buffer.size());
             self.actions.lock().buffer_mappings.push(
                 crate::api::command_buffer_actions::DeferredBufferMapping {
                     buffer: buffer.clone(),

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -472,11 +472,7 @@ impl Device {
     #[must_use]
     pub fn create_query_set(&self, desc: &QuerySetDescriptor<'_>) -> QuerySet {
         let query_set = self.inner.create_query_set(desc);
-        QuerySet {
-            inner: query_set,
-            ty: desc.ty,
-            count: desc.count,
-        }
+        QuerySet { inner: query_set }
     }
 
     /// Set a callback which will be called for all errors that are not handled in error scopes.

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -282,8 +282,6 @@ impl Device {
         Buffer {
             inner: buffer,
             map_context: Arc::new(Mutex::new(map_context)),
-            size: desc.size,
-            usage: desc.usage,
         }
     }
 
@@ -458,8 +456,6 @@ impl Device {
         Buffer {
             inner: buffer.into(),
             map_context: Arc::new(Mutex::new(map_context)),
-            size: desc.size,
-            usage: desc.usage,
         }
     }
 

--- a/wgpu/src/api/query_set.rs
+++ b/wgpu/src/api/query_set.rs
@@ -25,8 +25,6 @@ use crate::*;
 #[derive(Debug, Clone)]
 pub struct QuerySet {
     pub(crate) inner: dispatch::DispatchQuerySet,
-    pub(crate) ty: QueryType,
-    pub(crate) count: u32,
 }
 #[cfg(send_sync)]
 #[cfg(send_sync)]
@@ -48,12 +46,12 @@ impl QuerySet {
 
     /// Returns the type of queries stored.
     pub fn ty(&self) -> QueryType {
-        self.ty
+        self.inner.ty()
     }
 
     /// Returns the number of query result slots.
     pub fn count(&self) -> u32 {
-        self.count
+        self.inner.count()
     }
 }
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1342,6 +1342,8 @@ pub struct WebBuffer {
     mapping: Rc<RefCell<WebBufferMapState>>,
     /// Unique identifier for this Buffer.
     ident: crate::cmp::Identifier,
+    size: wgt::BufferAddress,
+    usage: wgt::BufferUsages,
 }
 
 impl WebBuffer {
@@ -1354,6 +1356,8 @@ impl WebBuffer {
                 range: 0..desc.size,
             })),
             ident: crate::cmp::Identifier::create(),
+            size: desc.size,
+            usage: desc.usage,
         }
     }
 
@@ -2998,6 +3002,14 @@ impl dispatch::BufferInterface for WebBuffer {
 
     fn destroy(&self) {
         self.inner.destroy();
+    }
+
+    fn size(&self) -> crate::BufferAddress {
+        self.size
+    }
+
+    fn usage(&self) -> crate::BufferUsages {
+        self.usage
     }
 }
 impl Drop for WebBuffer {

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1434,6 +1434,8 @@ pub struct WebQuerySet {
     pub(crate) inner: webgpu_sys::GpuQuerySet,
     /// Unique identifier for this QuerySet.
     ident: crate::cmp::Identifier,
+    ty: wgt::QueryType,
+    count: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -2586,6 +2588,8 @@ impl dispatch::DeviceInterface for WebDevice {
         WebQuerySet {
             inner: query_set,
             ident: crate::cmp::Identifier::create(),
+            ty: desc.ty,
+            count: desc.count,
         }
         .into()
     }
@@ -3125,6 +3129,14 @@ impl Drop for WebTlas {
 impl dispatch::QuerySetInterface for WebQuerySet {
     fn destroy(&self) {
         self.inner.destroy();
+    }
+
+    fn ty(&self) -> crate::QueryType {
+        self.ty
+    }
+
+    fn count(&self) -> u32 {
+        self.count
     }
 }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2218,6 +2218,14 @@ impl dispatch::BufferInterface for CoreBuffer {
     fn destroy(&self) {
         self.wgpu_buffer.destroy();
     }
+
+    fn size(&self) -> crate::BufferAddress {
+        self.wgpu_buffer.size()
+    }
+
+    fn usage(&self) -> crate::BufferUsages {
+        self.wgpu_buffer.usage()
+    }
 }
 
 impl dispatch::TextureInterface for CoreTexture {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2327,6 +2327,14 @@ impl dispatch::QuerySetInterface for CoreQuerySet {
     fn destroy(&self) {
         self.wgpu_query_set.destroy();
     }
+
+    fn ty(&self) -> crate::QueryType {
+        self.wgpu_query_set.descriptor().ty
+    }
+
+    fn count(&self) -> u32 {
+        self.wgpu_query_set.descriptor().count
+    }
 }
 
 impl dispatch::PipelineLayoutInterface for CorePipelineLayout {}

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -287,6 +287,10 @@ pub trait BufferInterface: CommonTraits {
     fn unmap(&self);
 
     fn destroy(&self);
+
+    fn size(&self) -> crate::BufferAddress;
+
+    fn usage(&self) -> crate::BufferUsages;
 }
 pub trait TextureInterface: CommonTraits {
     fn create_view(&self, desc: &crate::TextureViewDescriptor<'_>) -> DispatchTextureView;

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -319,6 +319,10 @@ pub trait BlasInterface: CommonTraits {
 pub trait TlasInterface: CommonTraits {}
 pub trait QuerySetInterface: CommonTraits {
     fn destroy(&self);
+
+    fn ty(&self) -> crate::QueryType;
+
+    fn count(&self) -> u32;
 }
 pub trait PipelineLayoutInterface: CommonTraits {}
 pub trait RenderPipelineInterface: CommonTraits {


### PR DESCRIPTION
**Connections**
Towards #10073
Continuation of #10100

**Description**
Move data from wgpu's structure into underlying type and expose it via DispatchInterface trait. This mean we can reuse wgc's descriptors. We also store label as part of desc in QuerySet instead of erasing it there and storing it separately.

**Testing**
Just refactor

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
