### PR TITLE
Add `DeviceDescriptor::default_queue: QueueDescriptor` to support setting label to queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,24 @@ Bottom level categories:
 
 ## Unreleased
 
+### Major changes
+
+#### `DeviceDescriptor` has new field `default_queue`
+
+`DeviceDescriptor` has new field `default_queue` of type `QueueDescriptor`, which allows setting label for default device queue:
+
+```diff
+ wgpu::DeviceDescriptor {
+   label: None
+   required_features: adapter.features(),
+   required_limits: adapter.limits(),
++  default_queue: wgpu::QueueDescriptor { label: None },
+   // ...
+ }
+```
+
+By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
+
 ### Added/New Features
 
 #### General

--- a/benches/benches/wgpu-benchmark/main.rs
+++ b/benches/benches/wgpu-benchmark/main.rs
@@ -47,6 +47,7 @@ impl DeviceState {
         let (device, queue) = block_on(adapter.request_device(&wgpu::DeviceDescriptor {
             required_features: adapter.features(),
             required_limits: adapter.limits(),
+            default_queue: wgpu::QueueDescriptor { label: None },
             memory_hints: wgpu::MemoryHints::Performance,
             experimental_features: unsafe { wgpu::ExperimentalFeatures::enabled() },
             label: None,

--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -37,6 +37,13 @@ pub(crate) enum GPUPowerPreference {
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
+struct GPUQueueDescriptor {
+  #[webidl(default = String::new())]
+  label: String,
+}
+
+#[derive(WebIDL)]
+#[webidl(dictionary)]
 struct GPUDeviceDescriptor {
   #[webidl(default = String::new())]
   label: String,
@@ -46,6 +53,8 @@ struct GPUDeviceDescriptor {
   #[webidl(default = Default::default())]
   #[options(enforce_range = true)]
   required_limits: indexmap::IndexMap<String, Option<u64>>,
+  #[webidl(default = GPUQueueDescriptor { label: String::new() })]
+  default_queue: GPUQueueDescriptor,
 }
 
 pub struct GPUAdapter {
@@ -149,6 +158,9 @@ impl GPUAdapter {
       label: crate::transform_label(descriptor.label.clone()),
       required_features,
       required_limits,
+      default_queue: wgpu_types::QueueDescriptor {
+        label: crate::transform_label(descriptor.default_queue.label),
+      },
       experimental_features: wgpu_types::ExperimentalFeatures::disabled(),
       memory_hints: Default::default(),
       trace,

--- a/examples/features/src/cooperative_matrix/mod.rs
+++ b/examples/features/src/cooperative_matrix/mod.rs
@@ -155,6 +155,9 @@ async fn run() {
                 label: Some("Cooperative Matrix Device"),
                 required_features,
                 required_limits: wgpu::Limits::downlevel_defaults(),
+                default_queue: wgpu::QueueDescriptor {
+                    label: Some("Cooperative Matrix Queue"),
+                },
                 experimental_features: wgpu::ExperimentalFeatures::enabled(),
                 memory_hints: wgpu::MemoryHints::Performance,
                 trace: wgpu::Trace::Off,

--- a/examples/features/src/error_scope/mod.rs
+++ b/examples/features/src/error_scope/mod.rs
@@ -56,6 +56,7 @@ async fn run() {
             label: None,
             required_features: wgpu::Features::empty(),
             required_limits: wgpu::Limits::downlevel_webgl2_defaults(),
+            default_queue: wgpu::QueueDescriptor { label: None },
             experimental_features: wgpu::ExperimentalFeatures::disabled(),
             memory_hints: wgpu::MemoryHints::MemoryUsage,
             trace: wgpu::Trace::Off,

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -290,6 +290,7 @@ impl ExampleContext {
                 required_features: (E::optional_features() & adapter.features())
                     | E::required_features(),
                 required_limits: needed_limits,
+                default_queue: wgpu::QueueDescriptor { label: None },
                 experimental_features: unsafe { wgpu::ExperimentalFeatures::enabled() },
                 memory_hints: wgpu::MemoryHints::MemoryUsage,
                 trace: match std::env::var_os("WGPU_TRACE") {

--- a/examples/features/src/hello_synchronization/mod.rs
+++ b/examples/features/src/hello_synchronization/mod.rs
@@ -16,6 +16,7 @@ async fn run() {
             label: None,
             required_features: wgpu::Features::empty(),
             required_limits: wgpu::Limits::downlevel_defaults(),
+            default_queue: wgpu::QueueDescriptor { label: None },
             experimental_features: wgpu::ExperimentalFeatures::disabled(),
             memory_hints: wgpu::MemoryHints::Performance,
             trace: wgpu::Trace::Off,

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -144,6 +144,7 @@ impl ApplicationHandler<TriangleAction> for App {
                     // so we can support images the size of the swapchain.
                     required_limits: wgpu::Limits::downlevel_webgl2_defaults()
                         .using_resolution(adapter.limits()),
+                    default_queue: wgpu::QueueDescriptor { label: None },
                     experimental_features: wgpu::ExperimentalFeatures::disabled(),
                     memory_hints: wgpu::MemoryHints::MemoryUsage,
                     trace: wgpu::Trace::Off,

--- a/examples/features/src/hello_windows/mod.rs
+++ b/examples/features/src/hello_windows/mod.rs
@@ -147,6 +147,7 @@ impl ApplicationHandler for App {
                     label: None,
                     required_features: wgpu::Features::empty(),
                     required_limits: wgpu::Limits::downlevel_defaults(),
+                    default_queue: wgpu::QueueDescriptor { label: None },
                     experimental_features: wgpu::ExperimentalFeatures::disabled(),
                     memory_hints: wgpu::MemoryHints::MemoryUsage,
                     trace: wgpu::Trace::Off,

--- a/examples/features/src/hello_workgroups/mod.rs
+++ b/examples/features/src/hello_workgroups/mod.rs
@@ -31,6 +31,7 @@ async fn run() {
             label: None,
             required_features: wgpu::Features::empty(),
             required_limits: wgpu::Limits::downlevel_defaults(),
+            default_queue: wgpu::QueueDescriptor { label: None },
             experimental_features: wgpu::ExperimentalFeatures::disabled(),
             memory_hints: wgpu::MemoryHints::MemoryUsage,
             trace: wgpu::Trace::Off,

--- a/examples/features/src/render_to_texture/mod.rs
+++ b/examples/features/src/render_to_texture/mod.rs
@@ -20,6 +20,7 @@ async fn run(_path: Option<String>) {
             label: None,
             required_features: wgpu::Features::empty(),
             required_limits: wgpu::Limits::downlevel_defaults(),
+            default_queue: wgpu::QueueDescriptor { label: None },
             experimental_features: wgpu::ExperimentalFeatures::disabled(),
             memory_hints: wgpu::MemoryHints::MemoryUsage,
             trace: wgpu::Trace::Off,

--- a/examples/features/src/repeated_compute/mod.rs
+++ b/examples/features/src/repeated_compute/mod.rs
@@ -168,6 +168,7 @@ impl WgpuContext {
                 label: None,
                 required_features: wgpu::Features::empty(),
                 required_limits: wgpu::Limits::downlevel_defaults(),
+                default_queue: wgpu::QueueDescriptor { label: None },
                 experimental_features: wgpu::ExperimentalFeatures::disabled(),
                 memory_hints: wgpu::MemoryHints::Performance,
                 trace: wgpu::Trace::Off,

--- a/examples/features/src/storage_texture/mod.rs
+++ b/examples/features/src/storage_texture/mod.rs
@@ -34,6 +34,7 @@ async fn run(_path: Option<String>) {
             label: None,
             required_features: wgpu::Features::empty(),
             required_limits: wgpu::Limits::downlevel_defaults(),
+            default_queue: wgpu::QueueDescriptor { label: None },
             experimental_features: wgpu::ExperimentalFeatures::disabled(),
             memory_hints: wgpu::MemoryHints::MemoryUsage,
             trace: wgpu::Trace::Off,

--- a/examples/features/src/timestamp_queries/mod.rs
+++ b/examples/features/src/timestamp_queries/mod.rs
@@ -211,6 +211,7 @@ async fn run() {
             label: None,
             required_features: features,
             required_limits: wgpu::Limits::downlevel_defaults(),
+            default_queue: wgpu::QueueDescriptor { label: None },
             experimental_features: wgpu::ExperimentalFeatures::disabled(),
             memory_hints: wgpu::MemoryHints::MemoryUsage,
             trace: wgpu::Trace::Off,

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -132,6 +132,7 @@ impl WgpuContext {
                 label: None,
                 required_features: wgpu::Features::empty(),
                 required_limits: wgpu::Limits::downlevel_defaults(),
+                default_queue: wgpu::QueueDescriptor { label: None },
                 experimental_features: wgpu::ExperimentalFeatures::disabled(),
                 memory_hints: wgpu::MemoryHints::MemoryUsage,
                 trace: wgpu::Trace::Off,

--- a/examples/standalone/01_hello_compute/src/main.rs
+++ b/examples/standalone/01_hello_compute/src/main.rs
@@ -70,6 +70,7 @@ fn main() {
         label: None,
         required_features: wgpu::Features::empty(),
         required_limits: wgpu::Limits::downlevel_defaults(),
+        default_queue: wgpu::QueueDescriptor { label: None },
         experimental_features: wgpu::ExperimentalFeatures::disabled(),
         memory_hints: wgpu::MemoryHints::MemoryUsage,
         trace: wgpu::Trace::Off,

--- a/player/tests/player/main.rs
+++ b/player/tests/player/main.rs
@@ -80,6 +80,7 @@ impl Test<'_> {
                 label: None,
                 required_features: self.features,
                 required_limits: wgt::Limits::default(),
+                default_queue: wgt::QueueDescriptor { label: None },
                 experimental_features: unsafe { wgt::ExperimentalFeatures::enabled() },
                 memory_hints: wgt::MemoryHints::default(),
                 trace: wgt::Trace::Off,

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -202,6 +202,7 @@ pub async fn initialize_device(
             label: None,
             required_features: features,
             required_limits: limits,
+            default_queue: wgpu::QueueDescriptor { label: None },
             experimental_features: unsafe { wgpu::ExperimentalFeatures::enabled() },
             memory_hints: wgpu::MemoryHints::MemoryUsage,
             trace: wgpu::Trace::Off,

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -38,6 +38,7 @@ pub(crate) const ZERO_BUFFER_SIZE: BufferAddress = 512 << 10;
 pub(crate) const ENTRYPOINT_FAILURE_ERROR: &str = "The given EntryPoint is Invalid";
 
 pub type DeviceDescriptor<'a> = wgt::DeviceDescriptor<Label<'a>>;
+pub type QueueDescriptor<'a> = wgt::QueueDescriptor<Label<'a>>;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "trace")]
 use alloc::string::ToString as _;
-use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc, vec, vec::Vec};
 use core::{
     iter,
     mem::{self, ManuallyDrop},
@@ -26,7 +26,7 @@ use crate::{
         CommandAllocator, CommandBuffer, CommandEncoder, CommandEncoderError, CopySide,
         TransferError,
     },
-    device::{DeviceError, WaitIdleError},
+    device::{DeviceError, QueueDescriptor, WaitIdleError},
     get_lowest_common_denom, hal_label,
     init_tracker::{has_copy_partial_init_tracker_coverage, TextureInitRange},
     lock::{rank, Mutex, MutexGuard, RwLock, RwLockWriteGuard},
@@ -42,7 +42,7 @@ use crate::{
     scratch::ScratchBuffer,
     snatch::{SnatchGuard, Snatchable},
     track::{self, Tracker, TrackerIndex},
-    FastHashMap, SubmissionIndex,
+    FastHashMap, LabelHelpers, SubmissionIndex,
 };
 use crate::{device::resource::CommandIndices, resource::RawResourceAccess};
 
@@ -50,6 +50,7 @@ pub struct Queue {
     raw: Box<dyn hal::DynQueue>,
     pub(crate) pending_writes: Mutex<PendingWrites>,
     life_tracker: Mutex<LifetimeTracker>,
+    label: String,
     // The device needs to be dropped last (`Device.zero_buffer` might be referenced by the encoder in pending writes).
     pub(crate) device: Arc<Device>,
 }
@@ -58,6 +59,7 @@ impl Queue {
     pub(crate) fn new(
         device: Arc<Device>,
         raw: Box<dyn hal::DynQueue>,
+        desc: QueueDescriptor,
         instance_flags: wgt::InstanceFlags,
     ) -> Result<Self, DeviceError> {
         let pending_encoder = device
@@ -103,6 +105,7 @@ impl Queue {
         Ok(Queue {
             raw,
             device,
+            label: desc.label.to_string(),
             pending_writes: Mutex::new(rank::QUEUE_PENDING_WRITES, pending_writes),
             life_tracker: Mutex::new(rank::QUEUE_LIFE_TRACKER, LifetimeTracker::new()),
         })
@@ -262,12 +265,7 @@ impl Queue {
 }
 
 crate::impl_resource_type!(Queue);
-// TODO: https://github.com/gfx-rs/wgpu/issues/4014
-impl Labeled for Queue {
-    fn label(&self) -> &str {
-        ""
-    }
-}
+crate::impl_labeled!(Queue);
 crate::impl_parent_device!(Queue);
 crate::impl_storage_item!(Queue);
 
@@ -1468,7 +1466,7 @@ impl Queue {
         &self,
         submit_index: SubmissionIndex,
         commands: Option<Vec<crate::command::Command<crate::command::PointerReferences>>>,
-        error: alloc::string::String,
+        error: String,
     ) {
         if let Some(ref mut trace) = *self.device.trace.lock() {
             trace.add(Action::FailedCommands {

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1187,10 +1187,17 @@ impl Adapter {
         profiling::scope!("Adapter::create_device_and_queue_from_hal");
         api_log!("Adapter::create_device_and_queue_from_hal");
 
+        let default_queue_desc = desc.default_queue.clone();
+
         let device = Device::new(hal_device.device, self, desc, self.instance.flags)?;
         let device = Arc::new(device);
 
-        let queue = Queue::new(device.clone(), hal_device.queue, self.instance.flags)?;
+        let queue = Queue::new(
+            device.clone(),
+            hal_device.queue,
+            default_queue_desc,
+            self.instance.flags,
+        )?;
         let queue = Arc::new(queue);
 
         device.set_queue(&queue);

--- a/wgpu-types/src/device.rs
+++ b/wgpu-types/src/device.rs
@@ -7,6 +7,27 @@ use crate::ConstDefault;
 #[cfg(any(feature = "serde", test))]
 use serde::{Deserialize, Serialize};
 
+/// Describes a [`Queue`](../wgpu/struct.Queue.html).
+///
+/// Corresponds to [WebGPU `GPUQueueDescriptor`](
+/// https://gpuweb.github.io/gpuweb/#gpuqueuedescriptor).
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct QueueDescriptor<L> {
+    /// Debug label for the queue.
+    pub label: L,
+}
+
+impl<L> QueueDescriptor<L> {
+    /// Takes a closure and maps the label of the queue descriptor into another.
+    #[must_use]
+    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> QueueDescriptor<K> {
+        QueueDescriptor {
+            label: fun(&self.label),
+        }
+    }
+}
+
 /// Describes a [`Device`](../wgpu/struct.Device.html).
 ///
 /// Corresponds to [WebGPU `GPUDeviceDescriptor`](
@@ -28,6 +49,10 @@ pub struct DeviceDescriptor<L> {
     /// Exactly the specified limits, and no better or worse,
     /// will be allowed in validation of API calls on the resulting device.
     pub required_limits: crate::Limits,
+    /// Specifies the descriptor of the default queue for the device request.
+    ///
+    /// Corresponds to [WebGPU `GPUDeviceDescriptor.defaultQueue`](https://gpuweb.github.io/gpuweb/#dom-gpudevicedescriptor-defaultqueue).
+    pub default_queue: QueueDescriptor<L>,
     /// Specifies whether `self.required_features` is allowed to contain experimental features.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub experimental_features: crate::ExperimentalFeatures,
@@ -39,13 +64,14 @@ pub struct DeviceDescriptor<L> {
 }
 
 impl<L> DeviceDescriptor<L> {
-    /// Takes a closure and maps the label of the device descriptor into another.
+    /// Takes a closure and maps the labels of the descriptors into another.
     #[must_use]
-    pub fn map_label<'a, K>(&'a self, fun: impl FnOnce(&'a L) -> K) -> DeviceDescriptor<K> {
+    pub fn map_label<'a, K>(&'a self, fun: impl Fn(&'a L) -> K) -> DeviceDescriptor<K> {
         DeviceDescriptor {
             label: fun(&self.label),
             required_features: self.required_features,
             required_limits: self.required_limits.clone(),
+            default_queue: self.default_queue.map_label(fun),
             experimental_features: self.experimental_features,
             memory_hints: self.memory_hints.clone(),
             trace: self.trace.clone(),

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -34,6 +34,15 @@ crate::cmp::impl_eq_ord_hash_proxy!(Device => .inner);
 pub type DeviceDescriptor<'a> = wgt::DeviceDescriptor<Label<'a>>;
 static_assertions::assert_impl_all!(DeviceDescriptor<'_>: Send, Sync);
 
+/// Describes a [`Queue`].
+///
+/// For use within a [`DeviceDescriptor`].
+///
+/// Corresponds to [WebGPU `GPUQueueDescriptor`](
+/// https://gpuweb.github.io/gpuweb/#dictdef-gpuqueuedescriptor).
+pub type QueueDescriptor<'a> = wgt::QueueDescriptor<Label<'a>>;
+static_assertions::assert_impl_all!(QueueDescriptor<'_>: Send, Sync);
+
 impl Device {
     #[cfg(custom)]
     /// Returns custom implementation of Device (if custom backend and is internally T)

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1818,6 +1818,12 @@ impl dispatch::AdapterInterface for WebAdapter {
             mapped_desc.set_label(label);
         }
 
+        if let Some(default_queue_label) = desc.default_queue.label {
+            let default_queue_desc = webgpu_sys::GpuQueueDescriptor::new();
+            default_queue_desc.set_label(default_queue_label);
+            mapped_desc.set_default_queue(&default_queue_desc);
+        }
+
         let device_promise = self.inner.request_device_with_descriptor(&mapped_desc);
 
         Box::pin(MakeSendFuture::new(


### PR DESCRIPTION
**Connections**
Fixes #4014

**Description**
We introduce `QueueDescriptor` which is used for queue creation to set queue label. This is very breaking change as we add `DeviceDescriptor::default_queue: QueueDescriptor`.

**Testing**
It compiles.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
