### PR TITLE
Increase timeout for wasm-test to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,7 +582,8 @@ jobs:
 
   wasm-test:
     # runtime is normally 2 minutes
-    timeout-minutes: 10
+    # but sometimes APT takes very long
+    timeout-minutes: 30
 
     name: Test WebAssembly
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/actions/runs/32233575993/job/96008496884?pr=10086

**Description**
Increased timeout for WebAssembly tests to accommodate longer APT times.

**Testing**
CI

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
