### PR TITLE
Move erroring of encoders into wgpu-core

### DIFF
--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -132,13 +132,10 @@ impl GPUCommandEncoder {
       multiview_mask: NonZero::new(descriptor.multiview_mask),
     };
 
-    let (render_pass, err) =
+    let render_pass =
       self.wgpu_command_encoder.begin_render_pass(wgpu_descriptor);
 
-    self.error_handler.push_error(err);
-
     Ok(GPURenderPassEncoder {
-      error_handler: self.error_handler.clone(),
       render_pass: RefCell::new(render_pass),
       label: descriptor.label,
     })

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -26,8 +26,6 @@ use crate::render_pass::GPURenderPassEncoder;
 use crate::webidl::GPUExtent3D;
 
 pub struct GPUCommandEncoder {
-  pub error_handler: super::error::ErrorHandler,
-
   pub wgpu_command_encoder: Arc<wgpu_core::command::CommandEncoder>,
   pub label: String,
 
@@ -244,18 +242,13 @@ impl GPUCommandEncoder {
       )?;
     }
 
-    let err = self
-      .wgpu_command_encoder
-      .copy_buffer_to_buffer(
-        source.wgpu_buffer.clone(),
-        source_offset,
-        destination.wgpu_buffer.clone(),
-        destination_offset,
-        size,
-      )
-      .err();
-
-    self.error_handler.push_error(err);
+    self.wgpu_command_encoder.copy_buffer_to_buffer(
+      source.wgpu_buffer.clone(),
+      source_offset,
+      destination.wgpu_buffer.clone(),
+      destination_offset,
+      size,
+    );
 
     Ok(())
   }
@@ -283,12 +276,11 @@ impl GPUCommandEncoder {
       aspect: destination.aspect.into(),
     };
 
-    let err = self
-      .wgpu_command_encoder
-      .copy_buffer_to_texture(&source, &destination, &copy_size.into())
-      .err();
-
-    self.error_handler.push_error(err);
+    self.wgpu_command_encoder.copy_buffer_to_texture(
+      &source,
+      &destination,
+      &copy_size.into(),
+    );
   }
 
   #[required(3)]
@@ -314,12 +306,11 @@ impl GPUCommandEncoder {
       },
     };
 
-    let err = self
-      .wgpu_command_encoder
-      .copy_texture_to_buffer(&source, &destination, &copy_size.into())
-      .err();
-
-    self.error_handler.push_error(err);
+    self.wgpu_command_encoder.copy_texture_to_buffer(
+      &source,
+      &destination,
+      &copy_size.into(),
+    );
   }
 
   #[required(3)]
@@ -343,12 +334,11 @@ impl GPUCommandEncoder {
       aspect: destination.aspect.into(),
     };
 
-    let err = self
-      .wgpu_command_encoder
-      .copy_texture_to_texture(&source, &destination, &copy_size.into())
-      .err();
-
-    self.error_handler.push_error(err);
+    self.wgpu_command_encoder.copy_texture_to_texture(
+      &source,
+      &destination,
+      &copy_size.into(),
+    );
   }
 
   #[required(1)]
@@ -359,11 +349,11 @@ impl GPUCommandEncoder {
     #[webidl(default = 0, options(enforce_range = true))] offset: u64,
     #[webidl(options(enforce_range = true))] size: Option<u64>,
   ) {
-    let err = self
-      .wgpu_command_encoder
-      .clear_buffer(buffer.wgpu_buffer.clone(), offset, size)
-      .err();
-    self.error_handler.push_error(err);
+    self.wgpu_command_encoder.clear_buffer(
+      buffer.wgpu_buffer.clone(),
+      offset,
+      size,
+    );
   }
 
   #[required(5)]
@@ -376,18 +366,13 @@ impl GPUCommandEncoder {
     #[webidl] destination: Ptr<GPUBuffer>,
     #[webidl(options(enforce_range = true))] destination_offset: u64,
   ) {
-    let err = self
-      .wgpu_command_encoder
-      .resolve_query_set(
-        query_set.wgpu_query_set.clone(),
-        first_query,
-        query_count,
-        destination.wgpu_buffer.clone(),
-        destination_offset,
-      )
-      .err();
-
-    self.error_handler.push_error(err);
+    self.wgpu_command_encoder.resolve_query_set(
+      query_set.wgpu_query_set.clone(),
+      first_query,
+      query_count,
+      destination.wgpu_buffer.clone(),
+      destination_offset,
+    );
   }
 
   #[cppgc]
@@ -399,12 +384,8 @@ impl GPUCommandEncoder {
       label: crate::transform_label(descriptor.label.clone()),
     };
 
-    let (wgpu_command_buffer, opt_label_and_err) =
+    let wgpu_command_buffer =
       self.wgpu_command_encoder.finish(&wgpu_descriptor);
-
-    self
-      .error_handler
-      .push_error(opt_label_and_err.map(|(_label, err)| err));
 
     GPUCommandBuffer {
       wgpu_command_buffer,
@@ -413,25 +394,16 @@ impl GPUCommandEncoder {
   }
 
   fn push_debug_group(&self, #[webidl] group_label: String) {
-    let err = self
-      .wgpu_command_encoder
-      .push_debug_group(&group_label)
-      .err();
-    self.error_handler.push_error(err);
+    self.wgpu_command_encoder.push_debug_group(&group_label);
   }
 
   #[fast]
   fn pop_debug_group(&self) {
-    let err = self.wgpu_command_encoder.pop_debug_group().err();
-    self.error_handler.push_error(err);
+    self.wgpu_command_encoder.pop_debug_group();
   }
 
   fn insert_debug_marker(&self, #[webidl] marker_label: String) {
-    let err = self
-      .wgpu_command_encoder
-      .insert_debug_marker(&marker_label)
-      .err();
-    self.error_handler.push_error(err);
+    self.wgpu_command_encoder.insert_debug_marker(&marker_label);
   }
 }
 

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -164,14 +164,11 @@ impl GPUCommandEncoder {
       timestamp_writes,
     };
 
-    let (compute_pass, err) = self
+    let compute_pass = self
       .wgpu_command_encoder
       .begin_compute_pass(&wgpu_descriptor);
 
-    self.error_handler.push_error(err);
-
     GPUComputePassEncoder {
-      error_handler: self.error_handler.clone(),
       compute_pass: RefCell::new(compute_pass),
       label: descriptor.label,
     }

--- a/deno_webgpu/compute_pass.rs
+++ b/deno_webgpu/compute_pass.rs
@@ -18,8 +18,6 @@ use crate::error::GPUGenericError;
 use crate::get_data_slice;
 
 pub struct GPUComputePassEncoder {
-  pub error_handler: super::error::ErrorHandler,
-
   pub compute_pass: RefCell<wgpu_core::command::ComputePass>,
   pub label: String,
 }
@@ -54,12 +52,10 @@ impl GPUComputePassEncoder {
     &self,
     #[webidl] pipeline: Ptr<crate::compute_pipeline::GPUComputePipeline>,
   ) {
-    let err = self
+    self
       .compute_pass
       .borrow_mut()
-      .set_pipeline(pipeline.wgpu_compute_pipeline.clone())
-      .err();
-    self.error_handler.push_error(err);
+      .set_pipeline(pipeline.wgpu_compute_pipeline.clone());
   }
 
   #[undefined]
@@ -71,16 +67,11 @@ impl GPUComputePassEncoder {
     #[webidl(default = 1, options(enforce_range = true))]
     work_group_count_z: u32,
   ) {
-    let err = self
-      .compute_pass
-      .borrow_mut()
-      .dispatch_workgroups(
-        work_group_count_x,
-        work_group_count_y,
-        work_group_count_z,
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.compute_pass.borrow_mut().dispatch_workgroups(
+      work_group_count_x,
+      work_group_count_y,
+      work_group_count_z,
+    );
   }
 
   #[undefined]
@@ -89,55 +80,38 @@ impl GPUComputePassEncoder {
     #[webidl] indirect_buffer: Ptr<crate::buffer::GPUBuffer>,
     #[webidl(options(enforce_range = true))] indirect_offset: u64,
   ) {
-    let err = self
-      .compute_pass
-      .borrow_mut()
-      .dispatch_workgroups_indirect(
-        indirect_buffer.wgpu_buffer.clone(),
-        indirect_offset,
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.compute_pass.borrow_mut().dispatch_workgroups_indirect(
+      indirect_buffer.wgpu_buffer.clone(),
+      indirect_offset,
+    );
   }
 
   #[fast]
   #[undefined]
   fn end(&self) {
-    let err = self.compute_pass.borrow_mut().end().err();
-    self.error_handler.push_error(err);
+    self.compute_pass.borrow_mut().end();
   }
 
   #[undefined]
   fn push_debug_group(&self, #[webidl] group_label: String) {
-    let err = self
-      .compute_pass
-      .borrow_mut()
-      .push_debug_group(
-        &group_label,
-        0, // wgpu#975
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.compute_pass.borrow_mut().push_debug_group(
+      &group_label,
+      0, // wgpu#975
+    );
   }
 
   #[fast]
   #[undefined]
   fn pop_debug_group(&self) {
-    let err = self.compute_pass.borrow_mut().pop_debug_group().err();
-    self.error_handler.push_error(err);
+    self.compute_pass.borrow_mut().pop_debug_group();
   }
 
   #[undefined]
   fn insert_debug_marker(&self, #[webidl] marker_label: String) {
-    let err = self
-      .compute_pass
-      .borrow_mut()
-      .insert_debug_marker(
-        &marker_label,
-        0, // wgpu#975
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.compute_pass.borrow_mut().insert_debug_marker(
+      &marker_label,
+      0, // wgpu#975
+    );
   }
 
   #[undefined]
@@ -152,8 +126,7 @@ impl GPUComputePassEncoder {
   ) -> Result<(), WebIdlError> {
     const PREFIX: &str =
       "Failed to execute 'setBindGroup' on 'GPUComputePassEncoder'";
-    let err = if let Ok(uint_32) = dynamic_offsets.try_cast::<v8::Uint32Array>()
-    {
+    if let Ok(uint_32) = dynamic_offsets.try_cast::<v8::Uint32Array>() {
       let start = u64::convert(
         scope,
         dynamic_offsets_data_start,
@@ -185,17 +158,13 @@ impl GPUComputePassEncoder {
 
       let offsets = &data[start..(start + len)];
 
-      self
-        .compute_pass
-        .borrow_mut()
-        .set_bind_group(
-          index,
-          bind_group
-            .into_option()
-            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
-          offsets,
-        )
-        .err()
+      self.compute_pass.borrow_mut().set_bind_group(
+        index,
+        bind_group
+          .into_option()
+          .map(|bind_group| bind_group.wgpu_bind_group.clone()),
+        offsets,
+      )
     } else {
       let offsets = <Option<Vec<u32>>>::convert(
         scope,
@@ -209,20 +178,14 @@ impl GPUComputePassEncoder {
       )?
       .unwrap_or_default();
 
-      self
-        .compute_pass
-        .borrow_mut()
-        .set_bind_group(
-          index,
-          bind_group
-            .into_option()
-            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
-          &offsets,
-        )
-        .err()
+      self.compute_pass.borrow_mut().set_bind_group(
+        index,
+        bind_group
+          .into_option()
+          .map(|bind_group| bind_group.wgpu_bind_group.clone()),
+        &offsets,
+      )
     };
-
-    self.error_handler.push_error(err);
 
     Ok(())
   }
@@ -239,12 +202,7 @@ impl GPUComputePassEncoder {
   ) -> Result<(), JsErrorBox> {
     let data = get_data_slice(scope, data_arg, data_offset, data_size)?;
 
-    let err = self
-      .compute_pass
-      .borrow_mut()
-      .set_immediates(offset, data)
-      .err();
-    self.error_handler.push_error(err);
+    self.compute_pass.borrow_mut().set_immediates(offset, data);
     Ok(())
   }
 }

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -576,13 +576,10 @@ impl GPUDevice {
     #[cfg(target_vendor = "apple")]
     scope.adjust_amount_of_external_allocated_memory(EXTERNAL_MEMORY_AMOUNT);
 
-    let (wgpu_command_encoder, err) =
+    let wgpu_command_encoder =
       self.wgpu_device.create_command_encoder(&wgpu_descriptor);
 
-    self.error_handler.push_error(err);
-
     let encoder = GPUCommandEncoder {
-      error_handler: self.error_handler.clone(),
       wgpu_command_encoder,
       label,
       #[cfg(target_vendor = "apple")]

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -649,7 +649,6 @@ impl GPUDevice {
     self.error_handler.push_error(err);
 
     GPURenderBundleEncoder {
-      error_handler: self.error_handler.clone(),
       encoder: RefCell::new(encoder),
       label: descriptor.label,
     }

--- a/deno_webgpu/render_bundle.rs
+++ b/deno_webgpu/render_bundle.rs
@@ -23,8 +23,6 @@ use crate::get_data_slice;
 use crate::texture::GPUTextureFormat;
 
 pub struct GPURenderBundleEncoder {
-  pub error_handler: super::error::ErrorHandler,
-
   pub encoder: RefCell<Box<wgpu_core::command::RenderBundleEncoder>>,
   pub label: String,
 }
@@ -62,10 +60,7 @@ impl GPURenderBundleEncoder {
     let wgpu_descriptor = wgpu_core::command::RenderBundleDescriptor {
       label: crate::transform_label(descriptor.label.clone()),
     };
-    let (wgpu_render_bundle, err) =
-      self.encoder.borrow_mut().finish(&wgpu_descriptor);
-
-    self.error_handler.push_error(err);
+    let wgpu_render_bundle = self.encoder.borrow_mut().finish(&wgpu_descriptor);
 
     GPURenderBundle {
       wgpu_render_bundle,
@@ -81,9 +76,7 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder.push_debug_group(&group_label).err();
-
-    self.error_handler.push_error(err);
+    encoder.push_debug_group(&group_label);
 
     Ok(())
   }
@@ -94,9 +87,7 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder.pop_debug_group().err();
-
-    self.error_handler.push_error(err);
+    encoder.pop_debug_group();
 
     Ok(())
   }
@@ -109,9 +100,8 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder.insert_debug_marker(&marker_label).err();
+    encoder.insert_debug_marker(&marker_label);
 
-    self.error_handler.push_error(err);
     Ok(())
   }
 
@@ -162,17 +152,13 @@ impl GPURenderBundleEncoder {
 
       let offsets = &data[start..(start + len)];
 
-      let err = encoder
-        .set_bind_group(
-          index,
-          bind_group
-            .into_option()
-            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
-          offsets,
-        )
-        .err();
-
-      self.error_handler.push_error(err);
+      encoder.set_bind_group(
+        index,
+        bind_group
+          .into_option()
+          .map(|bind_group| bind_group.wgpu_bind_group.clone()),
+        offsets,
+      );
     } else {
       let offsets = <Option<Vec<u32>>>::convert(
         scope,
@@ -186,17 +172,13 @@ impl GPURenderBundleEncoder {
       )?
       .unwrap_or_default();
 
-      let err = encoder
-        .set_bind_group(
-          index,
-          bind_group
-            .into_option()
-            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
-          &offsets,
-        )
-        .err();
-
-      self.error_handler.push_error(err);
+      encoder.set_bind_group(
+        index,
+        bind_group
+          .into_option()
+          .map(|bind_group| bind_group.wgpu_bind_group.clone()),
+        &offsets,
+      );
     }
 
     Ok(())
@@ -210,11 +192,8 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder
-      .set_pipeline(pipeline.wgpu_render_pipeline.clone())
-      .err();
+    encoder.set_pipeline(pipeline.wgpu_render_pipeline.clone());
 
-    self.error_handler.push_error(err);
     Ok(())
   }
 
@@ -230,16 +209,12 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder
-      .set_index_buffer(
-        buffer.wgpu_buffer.clone(),
-        index_format.into(),
-        offset,
-        size.and_then(NonZeroU64::new),
-      )
-      .err();
-
-    self.error_handler.push_error(err);
+    encoder.set_index_buffer(
+      buffer.wgpu_buffer.clone(),
+      index_format.into(),
+      offset,
+      size.and_then(NonZeroU64::new),
+    );
 
     Ok(())
   }
@@ -256,17 +231,15 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder
-      .set_vertex_buffer(
-        slot,
-        buffer
-          .into_option()
-          .map(|buffer| buffer.wgpu_buffer.clone()),
-        offset,
-        size.and_then(NonZeroU64::new),
-      )
-      .err();
-    self.error_handler.push_error(err);
+    encoder.set_vertex_buffer(
+      slot,
+      buffer
+        .into_option()
+        .map(|buffer| buffer.wgpu_buffer.clone()),
+      offset,
+      size.and_then(NonZeroU64::new),
+    );
+
     Ok(())
   }
 
@@ -282,10 +255,8 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder
-      .draw(vertex_count, instance_count, first_vertex, first_instance)
-      .err();
-    self.error_handler.push_error(err);
+    encoder.draw(vertex_count, instance_count, first_vertex, first_instance);
+
     Ok(())
   }
 
@@ -302,16 +273,14 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder
-      .draw_indexed(
-        index_count,
-        instance_count,
-        first_index,
-        base_vertex,
-        first_instance,
-      )
-      .err();
-    self.error_handler.push_error(err);
+    encoder.draw_indexed(
+      index_count,
+      instance_count,
+      first_index,
+      base_vertex,
+      first_instance,
+    );
+
     Ok(())
   }
 
@@ -325,10 +294,8 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder
-      .draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset)
-      .err();
-    self.error_handler.push_error(err);
+    encoder.draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset);
+
     Ok(())
   }
 
@@ -342,13 +309,11 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder
-      .draw_indexed_indirect(
-        indirect_buffer.wgpu_buffer.clone(),
-        indirect_offset,
-      )
-      .err();
-    self.error_handler.push_error(err);
+    encoder.draw_indexed_indirect(
+      indirect_buffer.wgpu_buffer.clone(),
+      indirect_offset,
+    );
+
     Ok(())
   }
 
@@ -367,8 +332,8 @@ impl GPURenderBundleEncoder {
     let mut encoder = self.encoder.borrow_mut();
     let encoder = encoder.as_mut();
 
-    let err = encoder.set_immediates(offset, data).err();
-    self.error_handler.push_error(err);
+    encoder.set_immediates(offset, data);
+
     Ok(())
   }
 }

--- a/deno_webgpu/render_pass.rs
+++ b/deno_webgpu/render_pass.rs
@@ -29,8 +29,6 @@ use crate::texture::GPUTextureView;
 use crate::webidl::GPUColor;
 
 pub struct GPURenderPassEncoder {
-  pub error_handler: super::error::ErrorHandler,
-
   pub render_pass: RefCell<wgpu_core::command::RenderPass>,
   pub label: String,
 }
@@ -71,12 +69,10 @@ impl GPURenderPassEncoder {
     #[webidl] min_depth: f32,
     #[webidl] max_depth: f32,
   ) {
-    let err = self
+    self
       .render_pass
       .borrow_mut()
-      .set_viewport(x, y, width, height, min_depth, max_depth)
-      .err();
-    self.error_handler.push_error(err);
+      .set_viewport(x, y, width, height, min_depth, max_depth);
   }
 
   #[required(4)]
@@ -88,23 +84,19 @@ impl GPURenderPassEncoder {
     #[webidl(options(enforce_range = true))] width: u32,
     #[webidl(options(enforce_range = true))] height: u32,
   ) {
-    let err = self
+    self
       .render_pass
       .borrow_mut()
-      .set_scissor_rect(x, y, width, height)
-      .err();
-    self.error_handler.push_error(err);
+      .set_scissor_rect(x, y, width, height);
   }
 
   #[required(1)]
   #[undefined]
   fn set_blend_constant(&self, #[webidl] color: GPUColor) {
-    let err = self
+    self
       .render_pass
       .borrow_mut()
-      .set_blend_constant(color.into())
-      .err();
-    self.error_handler.push_error(err);
+      .set_blend_constant(color.into());
   }
 
   #[required(1)]
@@ -113,12 +105,10 @@ impl GPURenderPassEncoder {
     &self,
     #[webidl(options(enforce_range = true))] reference: u32,
   ) {
-    let err = self
+    self
       .render_pass
       .borrow_mut()
-      .set_stencil_reference(reference)
-      .err();
-    self.error_handler.push_error(err);
+      .set_stencil_reference(reference);
   }
 
   #[required(1)]
@@ -127,75 +117,55 @@ impl GPURenderPassEncoder {
     &self,
     #[webidl(options(enforce_range = true))] query_index: u32,
   ) {
-    let err = self
+    self
       .render_pass
       .borrow_mut()
-      .begin_occlusion_query(query_index)
-      .err();
-    self.error_handler.push_error(err);
+      .begin_occlusion_query(query_index);
   }
 
   #[fast]
   #[undefined]
   fn end_occlusion_query(&self) {
-    let err = self.render_pass.borrow_mut().end_occlusion_query().err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().end_occlusion_query();
   }
 
   #[required(1)]
   #[undefined]
   fn execute_bundles(&self, #[webidl] bundles: Vec<Ptr<GPURenderBundle>>) {
-    let err = self
-      .render_pass
-      .borrow_mut()
-      .execute_bundles(
-        &bundles
-          .into_iter()
-          .map(|bundle| bundle.wgpu_render_bundle.clone())
-          .collect::<Vec<_>>(),
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().execute_bundles(
+      &bundles
+        .into_iter()
+        .map(|bundle| bundle.wgpu_render_bundle.clone())
+        .collect::<Vec<_>>(),
+    );
   }
 
   #[fast]
   #[undefined]
   fn end(&self) {
-    let err = self.render_pass.borrow_mut().end().err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().end();
   }
 
   #[undefined]
   fn push_debug_group(&self, #[webidl] group_label: String) {
-    let err = self
-      .render_pass
-      .borrow_mut()
-      .push_debug_group(
-        &group_label,
-        0, // wgpu#975
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().push_debug_group(
+      &group_label,
+      0, // wgpu#975
+    );
   }
 
   #[fast]
   #[undefined]
   fn pop_debug_group(&self) {
-    let err = self.render_pass.borrow_mut().pop_debug_group().err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().pop_debug_group();
   }
 
   #[undefined]
   fn insert_debug_marker(&self, #[webidl] marker_label: String) {
-    let err = self
-      .render_pass
-      .borrow_mut()
-      .insert_debug_marker(
-        &marker_label,
-        0, // wgpu#975
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().insert_debug_marker(
+      &marker_label,
+      0, // wgpu#975
+    );
   }
 
   #[undefined]
@@ -211,8 +181,7 @@ impl GPURenderPassEncoder {
     const PREFIX: &str =
       "Failed to execute 'setBindGroup' on 'GPUComputePassEncoder'";
 
-    let err = if let Ok(uint_32) = dynamic_offsets.try_cast::<v8::Uint32Array>()
-    {
+    if let Ok(uint_32) = dynamic_offsets.try_cast::<v8::Uint32Array>() {
       let start = u64::convert(
         scope,
         dynamic_offsets_data_start,
@@ -244,17 +213,13 @@ impl GPURenderPassEncoder {
 
       let offsets = &data[start..(start + len)];
 
-      self
-        .render_pass
-        .borrow_mut()
-        .set_bind_group(
-          index,
-          bind_group
-            .into_option()
-            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
-          offsets,
-        )
-        .err()
+      self.render_pass.borrow_mut().set_bind_group(
+        index,
+        bind_group
+          .into_option()
+          .map(|bind_group| bind_group.wgpu_bind_group.clone()),
+        offsets,
+      )
     } else {
       let offsets = <Option<Vec<u32>>>::convert(
         scope,
@@ -268,20 +233,14 @@ impl GPURenderPassEncoder {
       )?
       .unwrap_or_default();
 
-      self
-        .render_pass
-        .borrow_mut()
-        .set_bind_group(
-          index,
-          bind_group
-            .into_option()
-            .map(|bind_group| bind_group.wgpu_bind_group.clone()),
-          &offsets,
-        )
-        .err()
+      self.render_pass.borrow_mut().set_bind_group(
+        index,
+        bind_group
+          .into_option()
+          .map(|bind_group| bind_group.wgpu_bind_group.clone()),
+        &offsets,
+      )
     };
-
-    self.error_handler.push_error(err);
 
     Ok(())
   }
@@ -291,12 +250,10 @@ impl GPURenderPassEncoder {
     &self,
     #[webidl] pipeline: Ptr<crate::render_pipeline::GPURenderPipeline>,
   ) {
-    let err = self
+    self
       .render_pass
       .borrow_mut()
-      .set_pipeline(pipeline.wgpu_render_pipeline.clone())
-      .err();
-    self.error_handler.push_error(err);
+      .set_pipeline(pipeline.wgpu_render_pipeline.clone());
   }
 
   #[required(2)]
@@ -308,17 +265,12 @@ impl GPURenderPassEncoder {
     #[webidl(default = 0, options(enforce_range = true))] offset: u64,
     #[webidl(options(enforce_range = true))] size: Option<u64>,
   ) {
-    let err = self
-      .render_pass
-      .borrow_mut()
-      .set_index_buffer(
-        buffer.wgpu_buffer.clone(),
-        index_format.into(),
-        offset,
-        size.and_then(NonZeroU64::new),
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().set_index_buffer(
+      buffer.wgpu_buffer.clone(),
+      index_format.into(),
+      offset,
+      size.and_then(NonZeroU64::new),
+    );
   }
 
   #[required(2)]
@@ -330,19 +282,14 @@ impl GPURenderPassEncoder {
     #[webidl(default = 0, options(enforce_range = true))] offset: u64,
     #[webidl(options(enforce_range = true))] size: Option<u64>,
   ) {
-    let err = self
-      .render_pass
-      .borrow_mut()
-      .set_vertex_buffer(
-        slot,
-        buffer
-          .into_option()
-          .map(|buffer| buffer.wgpu_buffer.clone()),
-        offset,
-        size.and_then(NonZeroU64::new),
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().set_vertex_buffer(
+      slot,
+      buffer
+        .into_option()
+        .map(|buffer| buffer.wgpu_buffer.clone()),
+      offset,
+      size.and_then(NonZeroU64::new),
+    );
   }
 
   #[required(1)]
@@ -354,12 +301,12 @@ impl GPURenderPassEncoder {
     #[webidl(default = 0, options(enforce_range = true))] first_vertex: u32,
     #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
   ) {
-    let err = self
-      .render_pass
-      .borrow_mut()
-      .draw(vertex_count, instance_count, first_vertex, first_instance)
-      .err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().draw(
+      vertex_count,
+      instance_count,
+      first_vertex,
+      first_instance,
+    );
   }
 
   #[required(1)]
@@ -372,18 +319,13 @@ impl GPURenderPassEncoder {
     #[webidl(default = 0, options(enforce_range = true))] base_vertex: i32,
     #[webidl(default = 0, options(enforce_range = true))] first_instance: u32,
   ) {
-    let err = self
-      .render_pass
-      .borrow_mut()
-      .draw_indexed(
-        index_count,
-        instance_count,
-        first_index,
-        base_vertex,
-        first_instance,
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().draw_indexed(
+      index_count,
+      instance_count,
+      first_index,
+      base_vertex,
+      first_instance,
+    );
   }
 
   #[required(2)]
@@ -393,12 +335,10 @@ impl GPURenderPassEncoder {
     #[webidl] indirect_buffer: Ptr<GPUBuffer>,
     #[webidl(options(enforce_range = true))] indirect_offset: u64,
   ) {
-    let err = self
+    self
       .render_pass
       .borrow_mut()
-      .draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset)
-      .err();
-    self.error_handler.push_error(err);
+      .draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset);
   }
 
   #[required(2)]
@@ -408,15 +348,10 @@ impl GPURenderPassEncoder {
     #[webidl] indirect_buffer: Ptr<GPUBuffer>,
     #[webidl(options(enforce_range = true))] indirect_offset: u64,
   ) {
-    let err = self
-      .render_pass
-      .borrow_mut()
-      .draw_indexed_indirect(
-        indirect_buffer.wgpu_buffer.clone(),
-        indirect_offset,
-      )
-      .err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().draw_indexed_indirect(
+      indirect_buffer.wgpu_buffer.clone(),
+      indirect_offset,
+    );
   }
 
   #[required(2)]
@@ -431,12 +366,7 @@ impl GPURenderPassEncoder {
   ) -> Result<(), JsErrorBox> {
     let data = get_data_slice(scope, data_arg, data_offset, data_size)?;
 
-    let err = self
-      .render_pass
-      .borrow_mut()
-      .set_immediates(offset, data)
-      .err();
-    self.error_handler.push_error(err);
+    self.render_pass.borrow_mut().set_immediates(offset, data);
     Ok(())
   }
 }

--- a/tests/tests/wgpu-validation/api/encoding.rs
+++ b/tests/tests/wgpu-validation/api/encoding.rs
@@ -51,7 +51,7 @@ fn mix_apis_hal_then_wgpu() {
 
 /// Test that the command encoder’s label is remembered and used in errors.
 #[test]
-#[should_panic = "In a CommandEncoder, label = 'my encoder'"]
+#[should_panic = "In CommandEncoder::finish, label = 'my encoder'"]
 fn encoding_error_contains_label_of_encoder() {
     let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
     let buffer = device.create_buffer(&wgpu::BufferDescriptor {

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -45,27 +45,31 @@ fn trace_test(test_type: TestType) {
     });
     assert!(error.is_none());
 
-    let (encoder, error) = device.create_command_encoder(&wgt::CommandEncoderDescriptor::default());
-    assert!(error.is_none());
+    device.push_error_scope(wgpu::ErrorFilter::Validation);
+    let encoder = device.create_command_encoder(&wgt::CommandEncoderDescriptor::default());
+    assert!(matches!(device.pop_error_scope(), Ok(None)));
 
     match test_type {
         TestType::Normal => {
-            encoder.clear_buffer(buffer, 0, None).unwrap();
-            let (cmdbuf, error) = encoder.finish(&wgt::CommandBufferDescriptor::default());
-            assert!(error.is_none());
+            device.push_error_scope(wgpu::ErrorFilter::Validation);
+            encoder.clear_buffer(buffer, 0, None);
+            let cmdbuf = encoder.finish(&wgt::CommandBufferDescriptor::default());
+            assert!(matches!(device.pop_error_scope(), Ok(None)));
             queue.submit(&[cmdbuf]).unwrap();
         }
         TestType::FailedCommands => {
+            device.push_error_scope(wgpu::ErrorFilter::Validation);
             // Try to clear past the end of the buffer.
-            encoder.clear_buffer(buffer, 0, Some(2048)).unwrap();
-            let (_cmdbuf, error) = encoder.finish(&wgt::CommandBufferDescriptor::default());
-            assert!(error.is_some());
+            encoder.clear_buffer(buffer, 0, Some(2048));
+            let _cmdbuf = encoder.finish(&wgt::CommandBufferDescriptor::default());
+            assert!(matches!(device.pop_error_scope(), Ok(Some(_))));
         }
         TestType::FailedSubmit => {
+            device.push_error_scope(wgpu::ErrorFilter::Validation);
             // Destroy the buffer after encoding the clear command, before submitting it.
-            encoder.clear_buffer(buffer.clone(), 0, None).unwrap();
-            let (cmdbuf, error) = encoder.finish(&wgt::CommandBufferDescriptor::default());
-            assert!(error.is_none());
+            encoder.clear_buffer(buffer.clone(), 0, None);
+            let cmdbuf = encoder.finish(&wgt::CommandBufferDescriptor::default());
+            assert!(matches!(device.pop_error_scope(), Ok(None)));
             buffer.destroy();
             queue.submit(&[cmdbuf]).unwrap_err();
         }

--- a/wgpu-core-remote-types/src/encoders.rs
+++ b/wgpu-core-remote-types/src/encoders.rs
@@ -1,0 +1,108 @@
+use crate::id;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+/// Corresponds to [`GPURenderPassEncoder`](https://www.w3.org/TR/webgpu/#gpurenderpassencoder).
+pub enum RenderPassEncoderCommand {
+    SetViewport {
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+        min_depth: f32,
+        max_depth: f32,
+    },
+    SetScissorRect {
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    },
+    SetBlendConstant(wgt::Color),
+    SetStencilReference(u32),
+    BeginOcclusionQuery(u32),
+    EndOcclusionQuery,
+    ExecuteBundles(Vec<id::RenderBundleId>),
+    BindingCommand(BindingCommand),
+    RenderCommand(RenderCommand),
+    DebugCommand(DebugCommand),
+    End,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+/// Corresponds to [`GPUComputePassEncoder`](https://www.w3.org/TR/webgpu/#gpucomputepassencoder).
+pub enum ComputePassEncoderCommand {
+    BindingCommand(BindingCommand),
+    SetPipeline(id::ComputePipelineId),
+    DispatchWorkgroups {
+        workgroup_count_x: u32,
+        workgroup_count_y: u32, // optional, defaults to 1
+        workgroup_count_z: u32, // optional, defaults to 1
+    },
+    DispatchWorkgroupsIndirect {
+        indirect_buffer: id::BufferId,
+        indirect_offset: u64,
+    },
+    DebugCommand(DebugCommand),
+    End,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+/// Corresponds to [`GPUDebugCommandsMixin`](https://www.w3.org/TR/webgpu/#gpudebugcommandsmixin).
+pub enum DebugCommand {
+    PushDebugGroup(String),
+    PopDebugGroup,
+    InsertDebugMarker(String),
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+/// Corresponds to [`GPUBindingCommandsMixin`](https://www.w3.org/TR/webgpu/#gpubindingcommandsmixin).
+pub enum BindingCommand {
+    SetBindGroup {
+        index: u32,
+        bind_group: Option<id::BindGroupId>,
+        dynamic_offsets: Vec<u32>, // optional, defaults to []
+    },
+    SetImmediates {
+        range_offset: u32,
+        data: Vec<u8>,
+    },
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+/// Corresponds to [`GPURenderCommandsMixin`](https://www.w3.org/TR/webgpu/#gpurendercommandsmixin).
+pub enum RenderCommand {
+    SetPipeline(id::RenderPipelineId),
+    SetIndexBuffer {
+        buffer: id::BufferId,
+        index_format: wgt::IndexFormat,
+        offset: u64, // optional, defaults to 0
+        size: Option<u64>,
+    },
+    SetVertexBuffer {
+        slot: u32,
+        buffer: Option<id::BufferId>,
+        offset: u64, // optional, defaults to 0
+        size: Option<u64>,
+    },
+    Draw {
+        vertex_count: u32,
+        instance_count: u32, // optional, defaults to 1
+        first_vertex: u32,   // optional, defaults to 0
+        first_instance: u32, // optional, defaults to 0
+    },
+    DrawIndexed {
+        index_count: u32,
+        instance_count: u32, // optional, defaults to 1
+        first_index: u32,    // optional, defaults to 0
+        base_vertex: i32,    // optional, defaults to 0
+        first_instance: u32, // optional, defaults to 0
+    },
+    DrawIndirect {
+        indirect_buffer: id::BufferId,
+        indirect_offset: u64,
+    },
+    DrawIndexedIndirect {
+        indirect_buffer: id::BufferId,
+        indirect_offset: u64,
+    },
+}

--- a/wgpu-core-remote-types/src/lib.rs
+++ b/wgpu-core-remote-types/src/lib.rs
@@ -10,5 +10,6 @@ pub mod id;
 pub mod identity;
 
 pub mod binding_model;
+pub mod encoders;
 
 pub type Label<'a> = Option<Cow<'a, str>>;

--- a/wgpu-core-remote/src/global/bundle.rs
+++ b/wgpu-core-remote/src/global/bundle.rs
@@ -1,6 +1,5 @@
 use crate::hub::Hub;
 use crate::id;
-use wgpu_core::command::PassStateError;
 
 impl crate::global::Global {
     pub fn render_bundle_encoder_set_bind_group(
@@ -9,7 +8,7 @@ impl crate::global::Global {
         index: u32,
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[wgt::DynamicOffset],
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_bundle_encoders,
@@ -25,7 +24,7 @@ impl crate::global::Global {
         &self,
         bundle_encoder: id::RenderBundleEncoderId,
         pipeline_id: id::RenderPipelineId,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_bundle_encoders,
@@ -44,7 +43,7 @@ impl crate::global::Global {
         buffer_id: Option<id::BufferId>,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_bundle_encoders,
@@ -63,7 +62,7 @@ impl crate::global::Global {
         index_format: wgt::IndexFormat,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_bundle_encoders,
@@ -80,7 +79,7 @@ impl crate::global::Global {
         bundle_encoder: id::RenderBundleEncoderId,
         offset: u32,
         data: &[u8],
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
@@ -94,7 +93,7 @@ impl crate::global::Global {
         instance_count: u32,
         first_vertex: u32,
         first_instance: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
@@ -109,7 +108,7 @@ impl crate::global::Global {
         first_index: u32,
         base_vertex: i32,
         first_instance: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
@@ -127,7 +126,7 @@ impl crate::global::Global {
         bundle_encoder: id::RenderBundleEncoderId,
         buffer_id: id::BufferId,
         offset: wgt::BufferAddress,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_bundle_encoders,
@@ -144,7 +143,7 @@ impl crate::global::Global {
         bundle_encoder: id::RenderBundleEncoderId,
         buffer_id: id::BufferId,
         offset: wgt::BufferAddress,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_bundle_encoders,
@@ -160,17 +159,14 @@ impl crate::global::Global {
         &self,
         bundle_encoder: id::RenderBundleEncoderId,
         label: &str,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.push_debug_group(label)
     }
 
-    pub fn render_bundle_encoder_pop_debug_group(
-        &self,
-        bundle_encoder: id::RenderBundleEncoderId,
-    ) -> Result<(), PassStateError> {
+    pub fn render_bundle_encoder_pop_debug_group(&self, bundle_encoder: id::RenderBundleEncoderId) {
         let mut hub = self.hub.borrow_mut();
         let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
@@ -181,7 +177,7 @@ impl crate::global::Global {
         &self,
         bundle_encoder: id::RenderBundleEncoderId,
         label: &str,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 

--- a/wgpu-core-remote/src/global/command_encoder.rs
+++ b/wgpu-core-remote/src/global/command_encoder.rs
@@ -1,4 +1,3 @@
-use wgpu_core::command::{CommandEncoderError, EncoderStateError};
 use wgpu_core::Label;
 use wgt::{BufferAddress, Extent3d, ImageSubresourceRange};
 
@@ -20,7 +19,7 @@ impl Global {
         encoder_id: CommandEncoderId,
         desc: &wgt::CommandBufferDescriptor<Label>,
         id_in: id::CommandBufferId,
-    ) -> (id::CommandBufferId, Option<(String, CommandEncoderError)>) {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             command_encoders,
@@ -29,38 +28,25 @@ impl Global {
         } = &mut *hub;
         let cmd_enc = command_encoders.get(encoder_id);
 
-        let (cmd_buf, opt_error) = cmd_enc.finish(desc);
-        let cmd_buf_id = command_buffers.assign(id_in, cmd_buf);
-
-        (cmd_buf_id, opt_error)
+        let cmd_buf = cmd_enc.finish(desc);
+        command_buffers.assign(id_in, cmd_buf);
     }
 
-    pub fn command_encoder_push_debug_group(
-        &self,
-        encoder_id: CommandEncoderId,
-        label: &str,
-    ) -> Result<(), EncoderStateError> {
+    pub fn command_encoder_push_debug_group(&self, encoder_id: CommandEncoderId, label: &str) {
         let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(encoder_id);
         cmd_enc.push_debug_group(label)
     }
 
-    pub fn command_encoder_insert_debug_marker(
-        &self,
-        encoder_id: CommandEncoderId,
-        label: &str,
-    ) -> Result<(), EncoderStateError> {
+    pub fn command_encoder_insert_debug_marker(&self, encoder_id: CommandEncoderId, label: &str) {
         let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(encoder_id);
         cmd_enc.insert_debug_marker(label)
     }
 
-    pub fn command_encoder_pop_debug_group(
-        &self,
-        encoder_id: CommandEncoderId,
-    ) -> Result<(), EncoderStateError> {
+    pub fn command_encoder_pop_debug_group(&self, encoder_id: CommandEncoderId) {
         let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(encoder_id);
@@ -75,7 +61,7 @@ impl Global {
         dst: BufferId,
         offset: BufferAddress,
         size: Option<BufferAddress>,
-    ) -> Result<(), EncoderStateError> {
+    ) {
         let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
@@ -87,7 +73,7 @@ impl Global {
         command_encoder_id: CommandEncoderId,
         dst: TextureId,
         subresource_range: &ImageSubresourceRange,
-    ) -> Result<(), EncoderStateError> {
+    ) {
         let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
@@ -102,7 +88,7 @@ impl Global {
         command_encoder_id: CommandEncoderId,
         query_set_id: id::QuerySetId,
         query_index: u32,
-    ) -> Result<(), EncoderStateError> {
+    ) {
         let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
@@ -117,7 +103,7 @@ impl Global {
         query_count: u32,
         destination: BufferId,
         destination_offset: BufferAddress,
-    ) -> Result<(), EncoderStateError> {
+    ) {
         let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
@@ -141,7 +127,7 @@ impl Global {
         destination: BufferId,
         destination_offset: BufferAddress,
         size: Option<BufferAddress>,
-    ) -> Result<(), EncoderStateError> {
+    ) {
         let hub = self.hub.borrow();
 
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
@@ -156,7 +142,7 @@ impl Global {
         source: &TexelCopyBufferInfo,
         destination: &wgt::TexelCopyTextureInfo<TextureId>,
         copy_size: &Extent3d,
-    ) -> Result<(), EncoderStateError> {
+    ) {
         let hub = self.hub.borrow();
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
         let source = wgt::TexelCopyBufferInfo {
@@ -178,7 +164,7 @@ impl Global {
         source: &wgt::TexelCopyTextureInfo<TextureId>,
         destination: &TexelCopyBufferInfo,
         copy_size: &Extent3d,
-    ) -> Result<(), EncoderStateError> {
+    ) {
         let hub = self.hub.borrow();
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
 
@@ -201,7 +187,7 @@ impl Global {
         source: &wgt::TexelCopyTextureInfo<TextureId>,
         destination: &wgt::TexelCopyTextureInfo<TextureId>,
         copy_size: &Extent3d,
-    ) -> Result<(), EncoderStateError> {
+    ) {
         let hub = self.hub.borrow();
         let cmd_enc = hub.command_encoders.get(command_encoder_id);
 
@@ -218,41 +204,5 @@ impl Global {
             aspect: destination.aspect,
         };
         cmd_enc.copy_texture_to_texture(&source, &destination, copy_size)
-    }
-}
-
-impl Global {
-    pub fn command_encoder_transition_resources(
-        &self,
-        command_encoder_id: CommandEncoderId,
-        buffer_transitions: impl Iterator<Item = wgt::BufferTransition<BufferId>>,
-        texture_transitions: impl Iterator<Item = wgt::TextureTransition<TextureId>>,
-    ) -> Result<(), EncoderStateError> {
-        let hub = self.hub.borrow();
-
-        let cmd_enc = hub.command_encoders.get(command_encoder_id);
-        let buffer_transitions = buffer_transitions
-            .map(|t| {
-                let buffer = hub.buffers.get(t.buffer);
-                wgt::BufferTransition {
-                    buffer,
-                    state: t.state,
-                }
-            })
-            .collect::<Vec<_>>();
-        let texture_transitions = texture_transitions
-            .map(|t| {
-                let texture = hub.textures.get(t.texture);
-                wgt::TextureTransition {
-                    texture,
-                    selector: t.selector,
-                    state: t.state,
-                }
-            })
-            .collect::<Vec<_>>();
-        cmd_enc.transition_resources(
-            buffer_transitions.into_iter(),
-            texture_transitions.into_iter(),
-        )
     }
 }

--- a/wgpu-core-remote/src/global/compute_pass.rs
+++ b/wgpu-core-remote/src/global/compute_pass.rs
@@ -1,9 +1,6 @@
 use alloc::borrow::Cow;
 
-use wgpu_core::command::{
-    CommandEncoderError, ComputePassDescriptor, EncoderStateError, PassStateError,
-    PassTimestampWrites,
-};
+use wgpu_core::command::{ComputePassDescriptor, PassTimestampWrites};
 use wgt::{BufferAddress, DynamicOffset};
 
 use crate::global::Global;
@@ -26,7 +23,7 @@ impl Global {
         encoder_id: id::CommandEncoderId,
         desc: &ComputePassDescriptor<'_, PassTimestampWrites<id::QuerySetId>>,
         id_in: id::ComputePassEncoderId,
-    ) -> (id::ComputePassEncoderId, Option<CommandEncoderError>) {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             command_encoders,
@@ -49,17 +46,12 @@ impl Global {
                 }),
         };
 
-        let (pass, err) = cmd_enc.begin_compute_pass(&desc);
+        let pass = cmd_enc.begin_compute_pass(&desc);
 
-        let id = compute_passes.assign(id_in, pass);
-
-        (id, err)
+        compute_passes.assign(id_in, pass);
     }
 
-    pub fn compute_pass_end(
-        &self,
-        pass_id: id::ComputePassEncoderId,
-    ) -> Result<(), EncoderStateError> {
+    pub fn compute_pass_end(&self, pass_id: id::ComputePassEncoderId) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.compute_passes.get_mut(pass_id);
         pass.end()
@@ -86,7 +78,7 @@ impl Global {
         index: u32,
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[DynamicOffset],
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             compute_passes,
@@ -105,7 +97,7 @@ impl Global {
         &self,
         pass_id: id::ComputePassEncoderId,
         pipeline_id: id::ComputePipelineId,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             compute_passes,
@@ -122,7 +114,7 @@ impl Global {
         pass_id: id::ComputePassEncoderId,
         offset: u32,
         data: &[u8],
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.compute_passes.get_mut(pass_id);
         pass.set_immediates(offset, data)
@@ -134,7 +126,7 @@ impl Global {
         groups_x: u32,
         groups_y: u32,
         groups_z: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.compute_passes.get_mut(pass_id);
         pass.dispatch_workgroups(groups_x, groups_y, groups_z)
@@ -145,7 +137,7 @@ impl Global {
         pass_id: id::ComputePassEncoderId,
         buffer_id: id::BufferId,
         offset: BufferAddress,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             compute_passes,
@@ -161,16 +153,13 @@ impl Global {
         pass_id: id::ComputePassEncoderId,
         label: &str,
         color: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.compute_passes.get_mut(pass_id);
         pass.push_debug_group(label, color)
     }
 
-    pub fn compute_pass_pop_debug_group(
-        &self,
-        pass_id: id::ComputePassEncoderId,
-    ) -> Result<(), PassStateError> {
+    pub fn compute_pass_pop_debug_group(&self, pass_id: id::ComputePassEncoderId) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.compute_passes.get_mut(pass_id);
         pass.pop_debug_group()
@@ -181,7 +170,7 @@ impl Global {
         pass_id: id::ComputePassEncoderId,
         label: &str,
         color: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.compute_passes.get_mut(pass_id);
         pass.insert_debug_marker(label, color)
@@ -192,7 +181,7 @@ impl Global {
         pass_id: id::ComputePassEncoderId,
         query_set_id: id::QuerySetId,
         query_index: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             compute_passes,
@@ -209,7 +198,7 @@ impl Global {
         pass_id: id::ComputePassEncoderId,
         query_set_id: id::QuerySetId,
         query_index: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             compute_passes,
@@ -221,10 +210,7 @@ impl Global {
         pass.begin_pipeline_statistics_query(query_set, query_index)
     }
 
-    pub fn compute_pass_end_pipeline_statistics_query(
-        &self,
-        pass_id: id::ComputePassEncoderId,
-    ) -> Result<(), PassStateError> {
+    pub fn compute_pass_end_pipeline_statistics_query(&self, pass_id: id::ComputePassEncoderId) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.compute_passes.get_mut(pass_id);
         pass.end_pipeline_statistics_query()

--- a/wgpu-core-remote/src/global/compute_pass.rs
+++ b/wgpu-core-remote/src/global/compute_pass.rs
@@ -1,6 +1,7 @@
 use alloc::borrow::Cow;
 
 use wgpu_core::command::{ComputePassDescriptor, PassTimestampWrites};
+use wgpu_core_remote_types::encoders::{BindingCommand, ComputePassEncoderCommand, DebugCommand};
 use wgt::{BufferAddress, DynamicOffset};
 
 use crate::global::Global;
@@ -214,5 +215,57 @@ impl Global {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.compute_passes.get_mut(pass_id);
         pass.end_pipeline_statistics_query()
+    }
+}
+
+impl Global {
+    pub fn handle_compute_pass_command(
+        &self,
+        pass_id: id::ComputePassEncoderId,
+        command: ComputePassEncoderCommand,
+    ) {
+        match command {
+            ComputePassEncoderCommand::BindingCommand(command) => match command {
+                BindingCommand::SetBindGroup {
+                    index,
+                    bind_group,
+                    dynamic_offsets,
+                } => self.compute_pass_set_bind_group(pass_id, index, bind_group, &dynamic_offsets),
+                BindingCommand::SetImmediates { range_offset, data } => {
+                    self.compute_pass_set_immediates(pass_id, range_offset, &data)
+                }
+            },
+            ComputePassEncoderCommand::SetPipeline(pipeline_id) => {
+                self.compute_pass_set_pipeline(pass_id, pipeline_id)
+            }
+            ComputePassEncoderCommand::DispatchWorkgroups {
+                workgroup_count_x,
+                workgroup_count_y,
+                workgroup_count_z,
+            } => self.compute_pass_dispatch_workgroups(
+                pass_id,
+                workgroup_count_x,
+                workgroup_count_y,
+                workgroup_count_z,
+            ),
+            ComputePassEncoderCommand::DispatchWorkgroupsIndirect {
+                indirect_buffer,
+                indirect_offset,
+            } => self.compute_pass_dispatch_workgroups_indirect(
+                pass_id,
+                indirect_buffer,
+                indirect_offset,
+            ),
+            ComputePassEncoderCommand::DebugCommand(debug_command) => match debug_command {
+                DebugCommand::PushDebugGroup(label) => {
+                    self.compute_pass_push_debug_group(pass_id, &label, 0)
+                }
+                DebugCommand::PopDebugGroup => self.compute_pass_pop_debug_group(pass_id),
+                DebugCommand::InsertDebugMarker(label) => {
+                    self.compute_pass_insert_debug_marker(pass_id, &label, 0)
+                }
+            },
+            ComputePassEncoderCommand::End => self.compute_pass_end(pass_id),
+        }
     }
 }

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -721,7 +721,7 @@ impl Global {
         render_bundle_encoder_id: id::RenderBundleEncoderId,
         desc: &command::RenderBundleDescriptor,
         id_in: id::RenderBundleId,
-    ) -> (id::RenderBundleId, Option<command::RenderBundleError>) {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_bundle_encoders,
@@ -730,11 +730,9 @@ impl Global {
         } = &mut *hub;
         let bundle_encoder = render_bundle_encoders.get_mut(render_bundle_encoder_id);
 
-        let (render_bundle, error) = bundle_encoder.finish(desc);
+        let render_bundle = bundle_encoder.finish(desc);
 
-        let id = render_bundles.assign(id_in, render_bundle);
-
-        (id, error)
+        render_bundles.assign(id_in, render_bundle);
     }
 
     pub fn render_bundle_encoder_drop(&self, render_bundle_encoder_id: id::RenderBundleEncoderId) {

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -4,7 +4,7 @@ use core::ptr::NonNull;
 use wgpu_core::{
     binding_model::{self},
     command,
-    device::{DeviceError, DeviceLostClosure, WaitIdleError},
+    device::{DeviceLostClosure, WaitIdleError},
     error::EmptyErrorScopeStack,
     pipeline::{
         self, ProgrammableStageDescriptor, RenderPipelineVertexProcessor,
@@ -666,7 +666,7 @@ impl Global {
         device_id: DeviceId,
         desc: &wgt::CommandEncoderDescriptor<Label>,
         id_in: id::CommandEncoderId,
-    ) -> (id::CommandEncoderId, Option<DeviceError>) {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             command_encoders,
@@ -676,10 +676,9 @@ impl Global {
 
         let device = devices.get(device_id);
 
-        let (cmd_enc, error) = device.create_command_encoder(desc);
+        let cmd_enc = device.create_command_encoder(desc);
 
-        let id = command_encoders.assign(id_in, cmd_enc);
-        (id, error)
+        command_encoders.assign(id_in, cmd_enc);
     }
 
     pub fn command_encoder_drop(&self, command_encoder_id: id::CommandEncoderId) {

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -2,8 +2,8 @@ use alloc::borrow::Cow;
 use core::num::NonZeroU32;
 
 use wgpu_core::command::{
-    CommandEncoderError, EncoderStateError, PassStateError, PassTimestampWrites,
-    RenderPassColorAttachment, RenderPassDepthStencilAttachment, ResolvedRenderPassDescriptor,
+    PassTimestampWrites, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
+    ResolvedRenderPassDescriptor,
 };
 use wgpu_core::Label;
 use wgt::{BufferAddress, BufferSize, Color, DynamicOffset, IndexFormat};
@@ -45,7 +45,7 @@ impl Global {
         encoder_id: id::CommandEncoderId,
         desc: &RenderPassDescriptor<'_>,
         id_in: id::RenderPassEncoderId,
-    ) -> (id::RenderPassEncoderId, Option<CommandEncoderError>) {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             command_encoders,
@@ -98,13 +98,12 @@ impl Global {
             multiview_mask: desc.multiview_mask,
         };
 
-        let (render_pass, error) = cmd_enc.begin_render_pass(desc);
+        let render_pass = cmd_enc.begin_render_pass(desc);
 
-        let id = render_passes.assign(id_in, render_pass);
-        (id, error)
+        render_passes.assign(id_in, render_pass);
     }
 
-    pub fn render_pass_end(&self, pass: id::RenderPassEncoderId) -> Result<(), EncoderStateError> {
+    pub fn render_pass_end(&self, pass: id::RenderPassEncoderId) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.end()
@@ -131,7 +130,7 @@ impl Global {
         index: u32,
         bind_group_id: Option<id::BindGroupId>,
         offsets: &[DynamicOffset],
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_passes,
@@ -146,7 +145,7 @@ impl Global {
         &self,
         pass: id::RenderPassEncoderId,
         pipeline_id: id::RenderPipelineId,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_passes,
@@ -165,7 +164,7 @@ impl Global {
         index_format: IndexFormat,
         offset: BufferAddress,
         size: Option<BufferSize>,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_passes,
@@ -183,7 +182,7 @@ impl Global {
         buffer_id: Option<id::BufferId>,
         offset: BufferAddress,
         size: Option<BufferSize>,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_passes,
@@ -194,21 +193,13 @@ impl Global {
         pass.set_vertex_buffer(slot, buffer_id.map(|id| buffers.get(id)), offset, size)
     }
 
-    pub fn render_pass_set_blend_constant(
-        &self,
-        pass: id::RenderPassEncoderId,
-        color: Color,
-    ) -> Result<(), PassStateError> {
+    pub fn render_pass_set_blend_constant(&self, pass: id::RenderPassEncoderId, color: Color) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.set_blend_constant(color)
     }
 
-    pub fn render_pass_set_stencil_reference(
-        &self,
-        pass: id::RenderPassEncoderId,
-        value: u32,
-    ) -> Result<(), PassStateError> {
+    pub fn render_pass_set_stencil_reference(&self, pass: id::RenderPassEncoderId, value: u32) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.set_stencil_reference(value)
@@ -223,7 +214,7 @@ impl Global {
         h: f32,
         depth_min: f32,
         depth_max: f32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.set_viewport(x, y, w, h, depth_min, depth_max)
@@ -236,7 +227,7 @@ impl Global {
         y: u32,
         w: u32,
         h: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.set_scissor_rect(x, y, w, h)
@@ -247,7 +238,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         offset: u32,
         data: &[u8],
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.set_immediates(offset, data)
@@ -260,7 +251,7 @@ impl Global {
         instance_count: u32,
         first_vertex: u32,
         first_instance: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.draw(vertex_count, instance_count, first_vertex, first_instance)
@@ -274,7 +265,7 @@ impl Global {
         first_index: u32,
         base_vertex: i32,
         first_instance: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.draw_indexed(
@@ -291,7 +282,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         buffer_id: id::BufferId,
         offset: BufferAddress,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_passes,
@@ -307,7 +298,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         buffer_id: id::BufferId,
         offset: BufferAddress,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_passes,
@@ -323,16 +314,13 @@ impl Global {
         pass: id::RenderPassEncoderId,
         label: &str,
         color: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.push_debug_group(label, color)
     }
 
-    pub fn render_pass_pop_debug_group(
-        &self,
-        pass: id::RenderPassEncoderId,
-    ) -> Result<(), PassStateError> {
+    pub fn render_pass_pop_debug_group(&self, pass: id::RenderPassEncoderId) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.pop_debug_group()
@@ -343,7 +331,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         label: &str,
         color: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.insert_debug_marker(label, color)
@@ -354,7 +342,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         query_set_id: id::QuerySetId,
         query_index: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_passes,
@@ -369,16 +357,13 @@ impl Global {
         &self,
         pass: id::RenderPassEncoderId,
         query_index: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.begin_occlusion_query(query_index)
     }
 
-    pub fn render_pass_end_occlusion_query(
-        &self,
-        pass: id::RenderPassEncoderId,
-    ) -> Result<(), PassStateError> {
+    pub fn render_pass_end_occlusion_query(&self, pass: id::RenderPassEncoderId) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.end_occlusion_query()
@@ -389,7 +374,7 @@ impl Global {
         pass: id::RenderPassEncoderId,
         query_set_id: id::QuerySetId,
         query_index: u32,
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_passes,
@@ -400,10 +385,7 @@ impl Global {
         pass.begin_pipeline_statistics_query(query_sets.get(query_set_id), query_index)
     }
 
-    pub fn render_pass_end_pipeline_statistics_query(
-        &self,
-        pass: id::RenderPassEncoderId,
-    ) -> Result<(), PassStateError> {
+    pub fn render_pass_end_pipeline_statistics_query(&self, pass: id::RenderPassEncoderId) {
         let mut hub = self.hub.borrow_mut();
         let pass = hub.render_passes.get_mut(pass);
         pass.end_pipeline_statistics_query()
@@ -413,7 +395,7 @@ impl Global {
         &self,
         pass: id::RenderPassEncoderId,
         render_bundle_ids: &[id::RenderBundleId],
-    ) -> Result<(), PassStateError> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_passes,

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -1,5 +1,8 @@
 use alloc::borrow::Cow;
 use core::num::NonZeroU32;
+use wgpu_core_remote_types::encoders::{
+    BindingCommand, DebugCommand, RenderCommand, RenderPassEncoderCommand,
+};
 
 use wgpu_core::command::{
     PassTimestampWrites, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
@@ -409,5 +412,132 @@ impl Global {
             .collect::<Vec<_>>();
 
         pass.execute_bundles(&render_bundles)
+    }
+}
+
+impl Global {
+    pub fn handle_render_pass_command(
+        &self,
+        pass_id: id::RenderPassEncoderId,
+        command: RenderPassEncoderCommand,
+    ) {
+        match command {
+            RenderPassEncoderCommand::SetViewport {
+                x,
+                y,
+                width,
+                height,
+                min_depth,
+                max_depth,
+            } => self.render_pass_set_viewport(pass_id, x, y, width, height, min_depth, max_depth),
+            RenderPassEncoderCommand::SetScissorRect {
+                x,
+                y,
+                width,
+                height,
+            } => self.render_pass_set_scissor_rect(pass_id, x, y, width, height),
+            RenderPassEncoderCommand::SetBlendConstant(color) => {
+                self.render_pass_set_blend_constant(pass_id, color)
+            }
+            RenderPassEncoderCommand::SetStencilReference(value) => {
+                self.render_pass_set_stencil_reference(pass_id, value)
+            }
+            RenderPassEncoderCommand::BeginOcclusionQuery(query_index) => {
+                self.render_pass_begin_occlusion_query(pass_id, query_index)
+            }
+            RenderPassEncoderCommand::EndOcclusionQuery => {
+                self.render_pass_end_occlusion_query(pass_id)
+            }
+            RenderPassEncoderCommand::ExecuteBundles(ids) => {
+                self.render_pass_execute_bundles(pass_id, &ids)
+            }
+            RenderPassEncoderCommand::BindingCommand(binding_command) => match binding_command {
+                BindingCommand::SetBindGroup {
+                    index,
+                    bind_group,
+                    dynamic_offsets,
+                } => self.render_pass_set_bind_group(pass_id, index, bind_group, &dynamic_offsets),
+                BindingCommand::SetImmediates { range_offset, data } => {
+                    self.render_pass_set_immediates(pass_id, range_offset, &data)
+                }
+            },
+            RenderPassEncoderCommand::RenderCommand(render_command) => match render_command {
+                RenderCommand::SetPipeline(pipeline_id) => {
+                    self.render_pass_set_pipeline(pass_id, pipeline_id)
+                }
+                RenderCommand::SetIndexBuffer {
+                    buffer,
+                    index_format,
+                    offset,
+                    size,
+                } => self.render_pass_set_index_buffer(
+                    pass_id,
+                    buffer,
+                    index_format,
+                    offset,
+                    size.and_then(core::num::NonZeroU64::new), // pass size directly once https://github.com/gfx-rs/wgpu/issues/3170 is resolved
+                ),
+                RenderCommand::SetVertexBuffer {
+                    slot,
+                    buffer,
+                    offset,
+                    size,
+                } => self.render_pass_set_vertex_buffer(
+                    pass_id,
+                    slot,
+                    buffer,
+                    offset,
+                    size.and_then(core::num::NonZeroU64::new), // pass size directly once https://github.com/gfx-rs/wgpu/issues/3170 is resolved
+                ),
+                RenderCommand::Draw {
+                    vertex_count,
+                    instance_count,
+                    first_vertex,
+                    first_instance,
+                } => self.render_pass_draw(
+                    pass_id,
+                    vertex_count,
+                    instance_count,
+                    first_vertex,
+                    first_instance,
+                ),
+                RenderCommand::DrawIndexed {
+                    index_count,
+                    instance_count,
+                    first_index,
+                    base_vertex,
+                    first_instance,
+                } => self.render_pass_draw_indexed(
+                    pass_id,
+                    index_count,
+                    instance_count,
+                    first_index,
+                    base_vertex,
+                    first_instance,
+                ),
+                RenderCommand::DrawIndirect {
+                    indirect_buffer,
+                    indirect_offset,
+                } => self.render_pass_draw_indirect(pass_id, indirect_buffer, indirect_offset),
+                RenderCommand::DrawIndexedIndirect {
+                    indirect_buffer,
+                    indirect_offset,
+                } => self.render_pass_draw_indexed_indirect(
+                    pass_id,
+                    indirect_buffer,
+                    indirect_offset,
+                ),
+            },
+            RenderPassEncoderCommand::DebugCommand(debug_command) => match debug_command {
+                DebugCommand::PushDebugGroup(label) => {
+                    self.render_pass_push_debug_group(pass_id, &label, 0)
+                }
+                DebugCommand::PopDebugGroup => self.render_pass_pop_debug_group(pass_id),
+                DebugCommand::InsertDebugMarker(label) => {
+                    self.render_pass_insert_debug_marker(pass_id, &label, 0)
+                }
+            },
+            RenderPassEncoderCommand::End => self.render_pass_end(pass_id),
+        }
     }
 }

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -303,10 +303,7 @@ impl RenderBundleEncoder {
     /// and accumulate buffer and texture initialization actions.
     ///
     /// [`ExecuteBundle`]: RenderCommand::ExecuteBundle
-    pub fn finish(
-        &mut self,
-        desc: &RenderBundleDescriptor,
-    ) -> (Arc<RenderBundle>, Option<RenderBundleError>) {
+    pub fn finish(&mut self, desc: &RenderBundleDescriptor) -> Arc<RenderBundle> {
         profiling::scope!("RenderBundleEncoder::finish");
         #[cfg(feature = "trace")]
         let trace_desc = crate::device::trace::new_render_bundle_encoder_descriptor(
@@ -316,13 +313,11 @@ impl RenderBundleEncoder {
             self.is_stencil_read_only,
         );
 
-        let (render_bundle, error) = match self.finish_inner(desc) {
-            Ok(render_bundle) => (render_bundle, None),
-            Err(e) => (
-                RenderBundle::invalid(Arc::clone(&self.device), desc),
-                Some(e),
-            ),
-        };
+        let render_bundle = self.finish_inner(desc).unwrap_or_else(|error| {
+            self.device
+                .handle_error(error, self.label(), "RenderBundleEncoder::finish");
+            RenderBundle::invalid(Arc::clone(&self.device), desc)
+        });
 
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *self.device.trace.lock() {
@@ -339,7 +334,7 @@ impl RenderBundleEncoder {
             Arc::as_ptr(&render_bundle)
         );
 
-        (render_bundle, error)
+        render_bundle
     }
 
     /// Convert this encoder's commands into a [`RenderBundle`].
@@ -576,7 +571,7 @@ impl RenderBundleEncoder {
         Ok(render_bundle)
     }
 
-    pub fn set_index_buffer(
+    fn set_index_buffer_inner(
         &mut self,
         buffer: Arc<Buffer>,
         index_format: wgt::IndexFormat,
@@ -593,7 +588,20 @@ impl RenderBundleEncoder {
         Ok(())
     }
 
-    pub fn set_bind_group(
+    pub fn set_index_buffer(
+        &mut self,
+        buffer: Arc<Buffer>,
+        index_format: wgt::IndexFormat,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) {
+        if let Err(err) = self.set_index_buffer_inner(buffer, index_format, offset, size) {
+            self.device
+                .handle_error(err, self.label(), "RenderBundleEncoder::set_index_buffer");
+        }
+    }
+
+    fn set_bind_group_inner(
         &mut self,
         index: u32,
         bind_group: Option<Arc<BindGroup>>,
@@ -619,7 +627,19 @@ impl RenderBundleEncoder {
         Ok(())
     }
 
-    pub fn set_pipeline(&mut self, pipeline: Arc<RenderPipeline>) -> Result<(), PassStateError> {
+    pub fn set_bind_group(
+        &mut self,
+        index: u32,
+        bind_group: Option<Arc<BindGroup>>,
+        offsets: &[wgt::DynamicOffset],
+    ) {
+        if let Err(err) = self.set_bind_group_inner(index, bind_group, offsets) {
+            self.device
+                .handle_error(err, self.label(), "RenderBundleEncoder::set_bind_group");
+        }
+    }
+
+    fn set_pipeline_inner(&mut self, pipeline: Arc<RenderPipeline>) -> Result<(), PassStateError> {
         pass_base!(self, PassErrorScope::SetPipelineRender);
         if self.current_pipeline.set_and_check_redundant(&pipeline) {
             return Ok(());
@@ -631,7 +651,14 @@ impl RenderBundleEncoder {
         Ok(())
     }
 
-    pub fn set_vertex_buffer(
+    pub fn set_pipeline(&mut self, pipeline: Arc<RenderPipeline>) {
+        if let Err(err) = self.set_pipeline_inner(pipeline) {
+            self.device
+                .handle_error(err, self.label(), "RenderBundleEncoder::set_pipeline");
+        }
+    }
+
+    fn set_vertex_buffer_inner(
         &mut self,
         slot: u32,
         buffer: Option<Arc<Buffer>>,
@@ -648,7 +675,20 @@ impl RenderBundleEncoder {
         Ok(())
     }
 
-    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) -> Result<(), PassStateError> {
+    pub fn set_vertex_buffer(
+        &mut self,
+        slot: u32,
+        buffer: Option<Arc<Buffer>>,
+        offset: wgt::BufferAddress,
+        size: Option<wgt::BufferSize>,
+    ) {
+        if let Err(err) = self.set_vertex_buffer_inner(slot, buffer, offset, size) {
+            self.device
+                .handle_error(err, self.label(), "RenderBundleEncoder::set_vertex_buffer");
+        }
+    }
+
+    fn set_immediates_inner(&mut self, offset: u32, data: &[u8]) -> Result<(), PassStateError> {
         pass_base!(self, PassErrorScope::SetImmediate);
 
         // This should have been validated in content timeline
@@ -664,7 +704,14 @@ impl RenderBundleEncoder {
         Ok(())
     }
 
-    pub fn draw(
+    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) {
+        if let Err(err) = self.set_immediates_inner(offset, data) {
+            self.device
+                .handle_error(err, self.label(), "RenderBundleEncoder::set_immediates");
+        }
+    }
+
+    fn draw_inner(
         &mut self,
         vertex_count: u32,
         instance_count: u32,
@@ -687,7 +734,22 @@ impl RenderBundleEncoder {
         Ok(())
     }
 
-    pub fn draw_indexed(
+    pub fn draw(
+        &mut self,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) {
+        if let Err(err) =
+            self.draw_inner(vertex_count, instance_count, first_vertex, first_instance)
+        {
+            self.device
+                .handle_error(err, self.label(), "RenderBundleEncoder::draw");
+        }
+    }
+
+    fn draw_indexed_inner(
         &mut self,
         index_count: u32,
         instance_count: u32,
@@ -712,7 +774,27 @@ impl RenderBundleEncoder {
         Ok(())
     }
 
-    pub fn draw_indirect(
+    pub fn draw_indexed(
+        &mut self,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        first_instance: u32,
+    ) {
+        if let Err(err) = self.draw_indexed_inner(
+            index_count,
+            instance_count,
+            first_index,
+            base_vertex,
+            first_instance,
+        ) {
+            self.device
+                .handle_error(err, self.label(), "RenderBundleEncoder::draw_indexed");
+        }
+    }
+
+    fn draw_indirect_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: wgt::BufferAddress,
@@ -735,7 +817,14 @@ impl RenderBundleEncoder {
         Ok(())
     }
 
-    pub fn draw_indexed_indirect(
+    pub fn draw_indirect(&mut self, buffer: Arc<Buffer>, offset: wgt::BufferAddress) {
+        if let Err(err) = self.draw_indirect_inner(buffer, offset) {
+            self.device
+                .handle_error(err, self.label(), "RenderBundleEncoder::draw_indirect");
+        }
+    }
+
+    fn draw_indexed_indirect_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: wgt::BufferAddress,
@@ -758,22 +847,56 @@ impl RenderBundleEncoder {
         Ok(())
     }
 
-    pub fn push_debug_group(&mut self, _label: &str) -> Result<(), PassStateError> {
+    pub fn draw_indexed_indirect(&mut self, buffer: Arc<Buffer>, offset: wgt::BufferAddress) {
+        if let Err(err) = self.draw_indexed_indirect_inner(buffer, offset) {
+            self.device.handle_error(
+                err,
+                self.label(),
+                "RenderBundleEncoder::draw_indexed_indirect",
+            );
+        }
+    }
+
+    fn push_debug_group_inner(&mut self, _label: &str) -> Result<(), PassStateError> {
         pass_base!(self, PassErrorScope::PushDebugGroup);
         //TODO
         Ok(())
     }
 
-    pub fn pop_debug_group(&mut self) -> Result<(), PassStateError> {
+    pub fn push_debug_group(&mut self, label: &str) {
+        if let Err(err) = self.push_debug_group_inner(label) {
+            self.device
+                .handle_error(err, self.label(), "RenderBundleEncoder::push_debug_group");
+        }
+    }
+
+    fn pop_debug_group_inner(&mut self) -> Result<(), PassStateError> {
         pass_base!(self, PassErrorScope::PopDebugGroup);
         //TODO
         Ok(())
     }
 
-    pub fn insert_debug_marker(&mut self, _label: &str) -> Result<(), PassStateError> {
+    pub fn pop_debug_group(&mut self) {
+        if let Err(err) = self.pop_debug_group_inner() {
+            self.device
+                .handle_error(err, self.label(), "RenderBundleEncoder::pop_debug_group");
+        }
+    }
+
+    fn insert_debug_marker_inner(&mut self, _label: &str) -> Result<(), PassStateError> {
         pass_base!(self, PassErrorScope::InsertDebugMarker);
         //TODO
         Ok(())
+    }
+
+    pub fn insert_debug_marker(&mut self, label: &str) {
+        if let Err(err) = self.insert_debug_marker_inner(label) {
+            self.device.handle_error(
+                err,
+                self.label(),
+                "RenderBundleEncoder::insert_debug_marker",
+            );
+        }
     }
 }
 

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -108,7 +108,7 @@ impl WebGpuError for ClearError {
 }
 
 impl super::CommandEncoder {
-    pub fn clear_buffer(
+    fn clear_buffer_inner(
         self: &Arc<Self>,
         dst: Arc<Buffer>,
         offset: BufferAddress,
@@ -125,7 +125,19 @@ impl super::CommandEncoder {
         })
     }
 
-    pub fn clear_texture(
+    pub fn clear_buffer(
+        self: &Arc<Self>,
+        dst: Arc<Buffer>,
+        offset: BufferAddress,
+        size: Option<BufferAddress>,
+    ) {
+        if let Err(err) = self.clear_buffer_inner(dst, offset, size) {
+            self.device
+                .handle_error(err, Some(self.label()), "CommandEncoder::clear_buffer");
+        }
+    }
+
+    fn clear_texture_inner(
         self: &Arc<Self>,
         dst: Arc<Texture>,
         subresource_range: &ImageSubresourceRange,
@@ -142,6 +154,17 @@ impl super::CommandEncoder {
                 subresource_range: *subresource_range,
             })
         })
+    }
+
+    pub fn clear_texture(
+        self: &Arc<Self>,
+        dst: Arc<Texture>,
+        subresource_range: &ImageSubresourceRange,
+    ) {
+        if let Err(err) = self.clear_texture_inner(dst, subresource_range) {
+            self.device
+                .handle_error(err, Some(self.label()), "CommandEncoder::clear_texture");
+        }
     }
 }
 

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -470,7 +470,7 @@ fn transition_resources(
 }
 
 impl CommandEncoder {
-    pub fn begin_compute_pass(
+    fn begin_compute_pass_inner(
         self: &Arc<Self>,
         desc: &ComputePassDescriptor<'_, PassTimestampWrites<Arc<QuerySet>>>,
     ) -> (ComputePass, Option<CommandEncoderError>) {
@@ -557,11 +557,23 @@ impl CommandEncoder {
             }
         }
     }
+
+    pub fn begin_compute_pass(
+        self: &Arc<Self>,
+        desc: &ComputePassDescriptor<'_, PassTimestampWrites<Arc<QuerySet>>>,
+    ) -> ComputePass {
+        let (pass, err) = self.begin_compute_pass_inner(desc);
+        if let Some(err) = err {
+            self.device
+                .handle_error(err, pass.label(), "CommandEncoder::begin_compute_pass");
+        }
+        pass
+    }
 }
 
 // Running the compute pass.
 impl ComputePass {
-    pub fn end(&mut self) -> Result<(), EncoderStateError> {
+    fn end_inner(&mut self) -> Result<(), EncoderStateError> {
         profiling::scope!(
             "CommandEncoder::run_compute_pass {}",
             self.base.label.as_deref().unwrap_or("")
@@ -597,6 +609,13 @@ impl ComputePass {
                 timestamp_writes: self.timestamp_writes.take(),
             })
         })
+    }
+
+    pub fn end(&mut self) {
+        if let Err(err) = self.end_inner() {
+            self.device
+                .handle_error(err, self.label(), "ComputePass::end");
+        }
     }
 }
 
@@ -1153,7 +1172,7 @@ fn dispatch_workgroups_indirect(
 // that the `pass_try!` and `pass_base!` macros may return early from the
 // function that invokes them, like the `?` operator.
 impl ComputePass {
-    pub fn set_bind_group(
+    fn set_bind_group_inner(
         &mut self,
         index: u32,
         bind_group: Option<Arc<BindGroup>>,
@@ -1191,7 +1210,19 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn set_pipeline(
+    pub fn set_bind_group(
+        &mut self,
+        index: u32,
+        bind_group: Option<Arc<BindGroup>>,
+        offsets: &[DynamicOffset],
+    ) {
+        if let Err(error) = self.set_bind_group_inner(index, bind_group, offsets) {
+            self.device
+                .handle_error(error, self.label(), "ComputePass::set_bind_group");
+        }
+    }
+
+    fn set_pipeline_inner(
         &mut self,
         compute_pipeline: Arc<ComputePipeline>,
     ) -> Result<(), PassStateError> {
@@ -1217,7 +1248,14 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) -> Result<(), PassStateError> {
+    pub fn set_pipeline(&mut self, compute_pipeline: Arc<ComputePipeline>) {
+        if let Err(error) = self.set_pipeline_inner(compute_pipeline) {
+            self.device
+                .handle_error(error, self.label(), "ComputePass::set_pipeline");
+        }
+    }
+
+    fn set_immediates_inner(&mut self, offset: u32, data: &[u8]) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetImmediate;
         let base = pass_base!(self, scope);
 
@@ -1238,7 +1276,14 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn dispatch_workgroups(
+    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) {
+        if let Err(error) = self.set_immediates_inner(offset, data) {
+            self.device
+                .handle_error(error, self.label(), "ComputePass::set_immediates");
+        }
+    }
+
+    fn dispatch_workgroups_inner(
         &mut self,
         groups_x: u32,
         groups_y: u32,
@@ -1255,7 +1300,14 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn dispatch_workgroups_indirect(
+    pub fn dispatch_workgroups(&mut self, groups_x: u32, groups_y: u32, groups_z: u32) {
+        if let Err(error) = self.dispatch_workgroups_inner(groups_x, groups_y, groups_z) {
+            self.device
+                .handle_error(error, self.label(), "ComputePass::dispatch_workgroups");
+        }
+    }
+
+    fn dispatch_workgroups_indirect_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
@@ -1271,7 +1323,17 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn push_debug_group(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
+    pub fn dispatch_workgroups_indirect(&mut self, buffer: Arc<Buffer>, offset: BufferAddress) {
+        if let Err(error) = self.dispatch_workgroups_indirect_inner(buffer, offset) {
+            self.device.handle_error(
+                error,
+                self.label(),
+                "ComputePass::dispatch_workgroups_indirect",
+            );
+        }
+    }
+
+    fn push_debug_group_inner(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
         let base = pass_base!(self, PassErrorScope::PushDebugGroup);
 
         let bytes = label.as_bytes();
@@ -1285,7 +1347,14 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn pop_debug_group(&mut self) -> Result<(), PassStateError> {
+    pub fn push_debug_group(&mut self, label: &str, color: u32) {
+        if let Err(error) = self.push_debug_group_inner(label, color) {
+            self.device
+                .handle_error(error, self.label(), "ComputePass::push_debug_group");
+        }
+    }
+
+    fn pop_debug_group_inner(&mut self) -> Result<(), PassStateError> {
         let base = pass_base!(self, PassErrorScope::PopDebugGroup);
 
         base.commands.push(ArcComputeCommand::PopDebugGroup);
@@ -1293,7 +1362,14 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn insert_debug_marker(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
+    pub fn pop_debug_group(&mut self) {
+        if let Err(error) = self.pop_debug_group_inner() {
+            self.device
+                .handle_error(error, self.label(), "ComputePass::pop_debug_group");
+        }
+    }
+
+    fn insert_debug_marker_inner(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
         let base = pass_base!(self, PassErrorScope::InsertDebugMarker);
 
         let bytes = label.as_bytes();
@@ -1307,7 +1383,14 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn write_timestamp(
+    pub fn insert_debug_marker(&mut self, label: &str, color: u32) {
+        if let Err(error) = self.insert_debug_marker_inner(label, color) {
+            self.device
+                .handle_error(error, self.label(), "ComputePass::insert_debug_marker");
+        }
+    }
+
+    fn write_timestamp_inner(
         &mut self,
         query_set: Arc<QuerySet>,
         query_index: u32,
@@ -1325,7 +1408,14 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn begin_pipeline_statistics_query(
+    pub fn write_timestamp(&mut self, query_set: Arc<QuerySet>, query_index: u32) {
+        if let Err(error) = self.write_timestamp_inner(query_set, query_index) {
+            self.device
+                .handle_error(error, self.label(), "ComputePass::write_timestamp");
+        }
+    }
+
+    fn begin_pipeline_statistics_query_inner(
         &mut self,
         query_set: Arc<QuerySet>,
         query_index: u32,
@@ -1344,7 +1434,17 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn end_pipeline_statistics_query(&mut self) -> Result<(), PassStateError> {
+    pub fn begin_pipeline_statistics_query(&mut self, query_set: Arc<QuerySet>, query_index: u32) {
+        if let Err(error) = self.begin_pipeline_statistics_query_inner(query_set, query_index) {
+            self.device.handle_error(
+                error,
+                self.label(),
+                "ComputePass::begin_pipeline_statistics_query",
+            );
+        }
+    }
+
+    fn end_pipeline_statistics_query_inner(&mut self) -> Result<(), PassStateError> {
         pass_base!(self, PassErrorScope::EndPipelineStatisticsQuery)
             .commands
             .push(ArcComputeCommand::EndPipelineStatisticsQuery);
@@ -1352,7 +1452,17 @@ impl ComputePass {
         Ok(())
     }
 
-    pub fn transition_resources(
+    pub fn end_pipeline_statistics_query(&mut self) {
+        if let Err(error) = self.end_pipeline_statistics_query_inner() {
+            self.device.handle_error(
+                error,
+                self.label(),
+                "ComputePass::end_pipeline_statistics_query",
+            );
+        }
+    }
+
+    fn transition_resources_inner(
         &mut self,
         buffer_transitions: impl Iterator<Item = wgt::BufferTransition<Arc<Buffer>>>,
         texture_transitions: impl Iterator<Item = wgt::TextureTransition<Arc<TextureView>>>,
@@ -1397,5 +1507,17 @@ impl ComputePass {
         });
 
         Ok(())
+    }
+
+    pub fn transition_resources(
+        &mut self,
+        buffer_transitions: impl Iterator<Item = wgt::BufferTransition<Arc<Buffer>>>,
+        texture_transitions: impl Iterator<Item = wgt::TextureTransition<Arc<TextureView>>>,
+    ) {
+        if let Err(error) = self.transition_resources_inner(buffer_transitions, texture_transitions)
+        {
+            self.device
+                .handle_error(error, self.label(), "ComputePass::transition_resources");
+        }
     }
 }

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -1311,15 +1311,10 @@ impl CommandEncoder {
 
     /// Finishes a command encoder, creating a command buffer and returning errors that were
     /// deferred until now.
-    ///
-    /// The returned `String` is the label of the command encoder, supplied so that `wgpu` can
-    /// include the label when printing deferred errors without having its own copy of the label.
-    /// This is a kludge and should be replaced if we think of a better solution to propagating
-    /// labels.
-    pub fn finish(
+    fn finish_inner(
         self: &Arc<Self>,
         desc: &wgt::CommandBufferDescriptor<Label>,
-    ) -> (Arc<CommandBuffer>, Option<(String, CommandEncoderError)>) {
+    ) -> (Arc<CommandBuffer>, Option<CommandEncoderError>) {
         profiling::scope!("CommandEncoder::finish");
 
         let status = self.data.lock().finish();
@@ -1377,7 +1372,19 @@ impl CommandEncoder {
             data: Mutex::new(rank::COMMAND_BUFFER_DATA, data),
         });
 
-        (cmd_buf, error.map(|e| (self.label.clone(), e)))
+        (cmd_buf, error)
+    }
+
+    pub fn finish(
+        self: &Arc<Self>,
+        desc: &wgt::CommandBufferDescriptor<Label>,
+    ) -> Arc<CommandBuffer> {
+        let (cmd_buf, error) = self.finish_inner(desc);
+        if let Some(error) = error {
+            self.device
+                .handle_error(error, Some(self.label()), "CommandEncoder::finish");
+        }
+        cmd_buf
     }
 }
 
@@ -1389,18 +1396,12 @@ impl CommandBuffer {
     /// entrypoints provide.
     #[doc(hidden)]
     pub fn from_trace(device: &Arc<Device>, commands: Vec<Command<ArcReferences>>) -> Arc<Self> {
-        let (encoder, _error) =
-            device.create_command_encoder(&wgt::CommandEncoderDescriptor { label: None });
+        let encoder = device.create_command_encoder(&wgt::CommandEncoderDescriptor { label: None });
         let mut cmd_enc_status = encoder.data.lock();
         cmd_enc_status.replay(commands);
         drop(cmd_enc_status);
 
-        let (cmd_buf, error) = encoder.finish(&wgt::CommandBufferDescriptor { label: None });
-        if let Some((_, err)) = error {
-            panic!("CommandEncoder::finish failed: {err}");
-        }
-
-        cmd_buf
+        encoder.finish(&wgt::CommandBufferDescriptor { label: None })
     }
 
     pub fn take_finished(&self) -> Result<CommandBufferMutable, CommandEncoderError> {
@@ -1753,7 +1754,7 @@ impl WebGpuError for TimestampWritesError {
 }
 
 impl CommandEncoder {
-    pub fn push_debug_group(self: &Arc<Self>, label: &str) -> Result<(), EncoderStateError> {
+    fn push_debug_group_inner(self: &Arc<Self>, label: &str) -> Result<(), EncoderStateError> {
         profiling::scope!("CommandEncoder::push_debug_group");
         api_log!("CommandEncoder::push_debug_group {label}");
 
@@ -1764,7 +1765,14 @@ impl CommandEncoder {
         })
     }
 
-    pub fn insert_debug_marker(self: &Arc<Self>, label: &str) -> Result<(), EncoderStateError> {
+    pub fn push_debug_group(self: &Arc<Self>, label: &str) {
+        if let Err(err) = self.push_debug_group_inner(label) {
+            self.device
+                .handle_error(err, Some(self.label()), "CommandEncoder::push_debug_group");
+        }
+    }
+
+    fn insert_debug_marker_inner(self: &Arc<Self>, label: &str) -> Result<(), EncoderStateError> {
         profiling::scope!("CommandEncoder::insert_debug_marker");
         api_log!("CommandEncoder::insert_debug_marker {label}");
 
@@ -1775,7 +1783,17 @@ impl CommandEncoder {
         })
     }
 
-    pub fn pop_debug_group(self: &Arc<Self>) -> Result<(), EncoderStateError> {
+    pub fn insert_debug_marker(self: &Arc<Self>, label: &str) {
+        if let Err(err) = self.insert_debug_marker_inner(label) {
+            self.device.handle_error(
+                err,
+                Some(self.label()),
+                "CommandEncoder::insert_debug_marker",
+            );
+        }
+    }
+
+    fn pop_debug_group_inner(self: &Arc<Self>) -> Result<(), EncoderStateError> {
         profiling::scope!("CommandEncoder::pop_debug_marker");
         api_log!("CommandEncoder::pop_debug_group");
 
@@ -1783,6 +1801,13 @@ impl CommandEncoder {
 
         cmd_buf_data
             .push_with(|| -> Result<_, CommandEncoderError> { Ok(ArcCommand::PopDebugGroup) })
+    }
+
+    pub fn pop_debug_group(self: &Arc<Self>) {
+        if let Err(err) = self.pop_debug_group_inner() {
+            self.device
+                .handle_error(err, Some(self.label()), "CommandEncoder::pop_debug_group");
+        }
     }
 }
 

--- a/wgpu-core/src/command/query.rs
+++ b/wgpu-core/src/command/query.rs
@@ -7,8 +7,8 @@ use crate::{
     device::{Device, DeviceError, MissingFeatures},
     init_tracker::MemoryInitKind,
     resource::{
-        Buffer, DestroyedResourceError, InvalidResourceError, MissingBufferUsageError,
-        ParentDevice, QuerySet, RawResourceAccess, Trackable,
+        Buffer, DestroyedResourceError, InvalidResourceError, Labeled as _,
+        MissingBufferUsageError, ParentDevice, QuerySet, RawResourceAccess, Trackable,
     },
     snatch::SnatchGuard,
     track::{QuerySetTracker, TrackerIndex},
@@ -426,7 +426,7 @@ pub(super) fn end_pipeline_statistics_query(
 }
 
 impl super::CommandEncoder {
-    pub fn write_timestamp(
+    fn write_timestamp_inner(
         self: &Arc<Self>,
         query_set: Arc<QuerySet>,
         query_index: u32,
@@ -442,7 +442,14 @@ impl super::CommandEncoder {
         })
     }
 
-    pub fn resolve_query_set(
+    pub fn write_timestamp(self: &Arc<Self>, query_set: Arc<QuerySet>, query_index: u32) {
+        if let Err(err) = self.write_timestamp_inner(query_set, query_index) {
+            self.device
+                .handle_error(err, None, "CommandEncoder::write_timestamp");
+        }
+    }
+
+    fn resolve_query_set_inner(
         self: &Arc<Self>,
         query_set: Arc<QuerySet>,
         start_query: u32,
@@ -463,6 +470,26 @@ impl super::CommandEncoder {
                 destination_offset,
             })
         })
+    }
+
+    pub fn resolve_query_set(
+        self: &Arc<Self>,
+        query_set: Arc<QuerySet>,
+        start_query: u32,
+        query_count: u32,
+        destination: Arc<Buffer>,
+        destination_offset: BufferAddress,
+    ) {
+        if let Err(err) = self.resolve_query_set_inner(
+            query_set,
+            start_query,
+            query_count,
+            destination,
+            destination_offset,
+        ) {
+            self.device
+                .handle_error(err, Some(self.label()), "CommandEncoder::resolve_query_set");
+        }
     }
 }
 

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -48,7 +48,7 @@ struct TlasStore<'a> {
 }
 
 impl super::CommandEncoder {
-    pub fn mark_acceleration_structures_built(
+    fn mark_acceleration_structures_built_inner(
         self: &Arc<Self>,
         blases: &[Arc<Blas>],
         tlases: &[Arc<Tlas>],
@@ -86,7 +86,21 @@ impl super::CommandEncoder {
         )
     }
 
-    pub fn build_acceleration_structures<'a>(
+    pub fn mark_acceleration_structures_built(
+        self: &Arc<Self>,
+        blases: &[Arc<Blas>],
+        tlases: &[Arc<Tlas>],
+    ) {
+        if let Err(err) = self.mark_acceleration_structures_built_inner(blases, tlases) {
+            self.device.handle_error(
+                err,
+                Some(self.label()),
+                "CommandEncoder::mark_acceleration_structures_built",
+            );
+        }
+    }
+
+    fn build_acceleration_structures_inner<'a>(
         self: &Arc<Self>,
         blas_iter: impl Iterator<Item = BlasBuildEntry<'a, Arc<Blas>, Arc<Buffer>>>,
         tlas_iter: impl Iterator<Item = TlasPackage<'a, Arc<Tlas>, Arc<Blas>>>,
@@ -183,6 +197,20 @@ impl super::CommandEncoder {
 
             Ok(ArcCommand::BuildAccelerationStructures { blas, tlas })
         })
+    }
+
+    pub fn build_acceleration_structures<'a>(
+        self: &Arc<Self>,
+        blas_iter: impl Iterator<Item = BlasBuildEntry<'a, Arc<Blas>, Arc<Buffer>>>,
+        tlas_iter: impl Iterator<Item = TlasPackage<'a, Arc<Tlas>, Arc<Blas>>>,
+    ) {
+        if let Err(err) = self.build_acceleration_structures_inner(blas_iter, tlas_iter) {
+            self.device.handle_error(
+                err,
+                Some(self.label()),
+                "CommandEncoder::build_acceleration_structures",
+            );
+        }
     }
 }
 

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -1812,7 +1812,7 @@ fn check_transient_attachment_ops<V>(load_op: LoadOp<V>, store_op: StoreOp) -> b
 }
 
 impl CommandEncoder {
-    pub fn begin_render_pass(
+    fn begin_render_pass_inner(
         self: &Arc<Self>,
         desc: ResolvedRenderPassDescriptor<'_>,
     ) -> (RenderPass, Option<CommandEncoderError>) {
@@ -2129,10 +2129,22 @@ impl CommandEncoder {
             }
         }
     }
+
+    pub fn begin_render_pass(
+        self: &Arc<Self>,
+        desc: ResolvedRenderPassDescriptor<'_>,
+    ) -> RenderPass {
+        let (pass, err) = self.begin_render_pass_inner(desc);
+        if let Some(err) = err {
+            self.device
+                .handle_error(err, pass.label(), "CommandEncoder::begin_render_pass");
+        }
+        pass
+    }
 }
 
 impl RenderPass {
-    pub fn end(&mut self) -> Result<(), EncoderStateError> {
+    fn end_inner(&mut self) -> Result<(), EncoderStateError> {
         profiling::scope!(
             "CommandEncoder::run_render_pass {}",
             self.base.label.as_deref().unwrap_or("")
@@ -2170,6 +2182,13 @@ impl RenderPass {
                 multiview_mask: self.multiview_mask,
             })
         })
+    }
+
+    pub fn end(&mut self) {
+        if let Err(err) = self.end_inner() {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::end");
+        }
     }
 }
 
@@ -3535,7 +3554,7 @@ fn execute_bundle(
 // that the `pass_try!` and `pass_base!` macros may return early from the
 // function that invokes them, like the `?` operator.
 impl RenderPass {
-    pub fn set_bind_group(
+    fn set_bind_group_inner(
         &mut self,
         index: u32,
         bind_group: Option<Arc<BindGroup>>,
@@ -3573,7 +3592,19 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn set_pipeline(&mut self, pipeline: Arc<RenderPipeline>) -> Result<(), PassStateError> {
+    pub fn set_bind_group(
+        &mut self,
+        index: u32,
+        bind_group: Option<Arc<BindGroup>>,
+        offsets: &[DynamicOffset],
+    ) {
+        if let Err(err) = self.set_bind_group_inner(index, bind_group, offsets) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::set_bind_group");
+        }
+    }
+
+    fn set_pipeline_inner(&mut self, pipeline: Arc<RenderPipeline>) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetPipelineRender;
 
         let redundant = self.current_pipeline.set_and_check_redundant(&pipeline);
@@ -3593,7 +3624,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn set_index_buffer(
+    pub fn set_pipeline(&mut self, pipeline: Arc<RenderPipeline>) {
+        if let Err(err) = self.set_pipeline_inner(pipeline) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::set_pipeline");
+        }
+    }
+
+    fn set_index_buffer_inner(
         &mut self,
         buffer: Arc<Buffer>,
         index_format: IndexFormat,
@@ -3615,7 +3653,20 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn set_vertex_buffer(
+    pub fn set_index_buffer(
+        &mut self,
+        buffer: Arc<Buffer>,
+        index_format: IndexFormat,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) {
+        if let Err(err) = self.set_index_buffer_inner(buffer, index_format, offset, size) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::set_index_buffer");
+        }
+    }
+
+    fn set_vertex_buffer_inner(
         &mut self,
         slot: u32,
         buffer: Option<Arc<Buffer>>,
@@ -3642,7 +3693,20 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn set_blend_constant(&mut self, color: Color) -> Result<(), PassStateError> {
+    pub fn set_vertex_buffer(
+        &mut self,
+        slot: u32,
+        buffer: Option<Arc<Buffer>>,
+        offset: BufferAddress,
+        size: Option<BufferSize>,
+    ) {
+        if let Err(err) = self.set_vertex_buffer_inner(slot, buffer, offset, size) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::set_vertex_buffer");
+        }
+    }
+
+    fn set_blend_constant_inner(&mut self, color: Color) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetBlendConstant;
         let base = pass_base!(self, scope);
 
@@ -3652,7 +3716,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn set_stencil_reference(&mut self, value: u32) -> Result<(), PassStateError> {
+    pub fn set_blend_constant(&mut self, color: Color) {
+        if let Err(err) = self.set_blend_constant_inner(color) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::set_blend_constant");
+        }
+    }
+
+    fn set_stencil_reference_inner(&mut self, value: u32) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetStencilReference;
         let base = pass_base!(self, scope);
         let value = convert_stencil_value(
@@ -3667,7 +3738,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn set_viewport(
+    pub fn set_stencil_reference(&mut self, value: u32) {
+        if let Err(err) = self.set_stencil_reference_inner(value) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::set_stencil_reference");
+        }
+    }
+
+    fn set_viewport_inner(
         &mut self,
         x: f32,
         y: f32,
@@ -3688,7 +3766,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn set_scissor_rect(
+    pub fn set_viewport(&mut self, x: f32, y: f32, w: f32, h: f32, depth_min: f32, depth_max: f32) {
+        if let Err(err) = self.set_viewport_inner(x, y, w, h, depth_min, depth_max) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::set_viewport");
+        }
+    }
+
+    fn set_scissor_rect_inner(
         &mut self,
         x: u32,
         y: u32,
@@ -3704,7 +3789,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) -> Result<(), PassStateError> {
+    pub fn set_scissor_rect(&mut self, x: u32, y: u32, w: u32, h: u32) {
+        if let Err(err) = self.set_scissor_rect_inner(x, y, w, h) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::set_scissor_rect");
+        }
+    }
+
+    fn set_immediates_inner(&mut self, offset: u32, data: &[u8]) -> Result<(), PassStateError> {
         let scope = PassErrorScope::SetImmediate;
         let base = pass_base!(self, scope);
 
@@ -3725,7 +3817,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn draw(
+    pub fn set_immediates(&mut self, offset: u32, data: &[u8]) {
+        if let Err(err) = self.set_immediates_inner(offset, data) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::set_immediates");
+        }
+    }
+
+    fn draw_inner(
         &mut self,
         vertex_count: u32,
         instance_count: u32,
@@ -3748,7 +3847,22 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn draw_indexed(
+    pub fn draw(
+        &mut self,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) {
+        if let Err(err) =
+            self.draw_inner(vertex_count, instance_count, first_vertex, first_instance)
+        {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::draw");
+        }
+    }
+
+    fn draw_indexed_inner(
         &mut self,
         index_count: u32,
         instance_count: u32,
@@ -3773,7 +3887,27 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn draw_mesh_tasks(
+    pub fn draw_indexed(
+        &mut self,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        first_instance: u32,
+    ) {
+        if let Err(err) = self.draw_indexed_inner(
+            index_count,
+            instance_count,
+            first_index,
+            base_vertex,
+            first_instance,
+        ) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::draw_indexed");
+        }
+    }
+
+    fn draw_mesh_tasks_inner(
         &mut self,
         group_count_x: u32,
         group_count_y: u32,
@@ -3793,7 +3927,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn draw_indirect(
+    pub fn draw_mesh_tasks(&mut self, group_count_x: u32, group_count_y: u32, group_count_z: u32) {
+        if let Err(err) = self.draw_mesh_tasks_inner(group_count_x, group_count_y, group_count_z) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::draw_mesh_tasks");
+        }
+    }
+
+    fn draw_indirect_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
@@ -3819,7 +3960,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn draw_indexed_indirect(
+    pub fn draw_indirect(&mut self, buffer: Arc<Buffer>, offset: BufferAddress) {
+        if let Err(err) = self.draw_indirect_inner(buffer, offset) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::draw_indirect");
+        }
+    }
+
+    fn draw_indexed_indirect_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
@@ -3845,7 +3993,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn draw_mesh_tasks_indirect(
+    pub fn draw_indexed_indirect(&mut self, buffer: Arc<Buffer>, offset: BufferAddress) {
+        if let Err(err) = self.draw_indexed_indirect_inner(buffer, offset) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::draw_indexed_indirect");
+        }
+    }
+
+    fn draw_mesh_tasks_indirect_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
@@ -3871,7 +4026,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn multi_draw_indirect(
+    pub fn draw_mesh_tasks_indirect(&mut self, buffer: Arc<Buffer>, offset: BufferAddress) {
+        if let Err(err) = self.draw_mesh_tasks_indirect_inner(buffer, offset) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::draw_mesh_tasks_indirect");
+        }
+    }
+
+    fn multi_draw_indirect_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
@@ -3890,6 +4052,40 @@ impl RenderPass {
             offset,
             count,
             family: DrawCommandFamily::Draw,
+
+            vertex_or_index_limit: None,
+            instance_limit: None,
+        });
+
+        Ok(())
+    }
+
+    pub fn multi_draw_indirect(&mut self, buffer: Arc<Buffer>, offset: BufferAddress, count: u32) {
+        if let Err(err) = self.multi_draw_indirect_inner(buffer, offset, count) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::multi_draw_indirect");
+        }
+    }
+
+    fn multi_draw_indexed_indirect_inner(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count: u32,
+    ) -> Result<(), PassStateError> {
+        let scope = PassErrorScope::Draw {
+            kind: DrawKind::MultiDrawIndirect,
+            family: DrawCommandFamily::DrawIndexed,
+        };
+        let base = pass_base!(self, scope);
+
+        pass_try!(base, scope, buffer.check_is_valid());
+
+        base.commands.push(ArcRenderCommand::DrawIndirect {
+            buffer,
+            offset,
+            count,
+            family: DrawCommandFamily::DrawIndexed,
 
             vertex_or_index_limit: None,
             instance_limit: None,
@@ -3903,29 +4099,14 @@ impl RenderPass {
         buffer: Arc<Buffer>,
         offset: BufferAddress,
         count: u32,
-    ) -> Result<(), PassStateError> {
-        let scope = PassErrorScope::Draw {
-            kind: DrawKind::MultiDrawIndirect,
-            family: DrawCommandFamily::DrawIndexed,
-        };
-        let base = pass_base!(self, scope);
-
-        pass_try!(base, scope, buffer.check_is_valid());
-
-        base.commands.push(ArcRenderCommand::DrawIndirect {
-            buffer,
-            offset,
-            count,
-            family: DrawCommandFamily::DrawIndexed,
-
-            vertex_or_index_limit: None,
-            instance_limit: None,
-        });
-
-        Ok(())
+    ) {
+        if let Err(err) = self.multi_draw_indexed_indirect_inner(buffer, offset, count) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::multi_draw_indexed_indirect");
+        }
     }
 
-    pub fn multi_draw_mesh_tasks_indirect(
+    fn multi_draw_mesh_tasks_indirect_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
@@ -3952,7 +4133,22 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn multi_draw_indirect_count(
+    pub fn multi_draw_mesh_tasks_indirect(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count: u32,
+    ) {
+        if let Err(err) = self.multi_draw_mesh_tasks_indirect_inner(buffer, offset, count) {
+            self.device.handle_error(
+                err,
+                self.label(),
+                "RenderPass::multi_draw_mesh_tasks_indirect",
+            );
+        }
+    }
+
+    fn multi_draw_indirect_count_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
@@ -3981,7 +4177,27 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn multi_draw_indexed_indirect_count(
+    pub fn multi_draw_indirect_count(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count_buffer: Arc<Buffer>,
+        count_buffer_offset: BufferAddress,
+        max_count: u32,
+    ) {
+        if let Err(err) = self.multi_draw_indirect_count_inner(
+            buffer,
+            offset,
+            count_buffer,
+            count_buffer_offset,
+            max_count,
+        ) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::multi_draw_indirect_count");
+        }
+    }
+
+    fn multi_draw_indexed_indirect_count_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
@@ -4011,7 +4227,30 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn multi_draw_mesh_tasks_indirect_count(
+    pub fn multi_draw_indexed_indirect_count(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count_buffer: Arc<Buffer>,
+        count_buffer_offset: BufferAddress,
+        max_count: u32,
+    ) {
+        if let Err(err) = self.multi_draw_indexed_indirect_count_inner(
+            buffer,
+            offset,
+            count_buffer,
+            count_buffer_offset,
+            max_count,
+        ) {
+            self.device.handle_error(
+                err,
+                self.label(),
+                "RenderPass::multi_draw_indexed_indirect_count",
+            );
+        }
+    }
+
+    fn multi_draw_mesh_tasks_indirect_count_inner(
         &mut self,
         buffer: Arc<Buffer>,
         offset: BufferAddress,
@@ -4041,7 +4280,30 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn push_debug_group(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
+    pub fn multi_draw_mesh_tasks_indirect_count(
+        &mut self,
+        buffer: Arc<Buffer>,
+        offset: BufferAddress,
+        count_buffer: Arc<Buffer>,
+        count_buffer_offset: BufferAddress,
+        max_count: u32,
+    ) {
+        if let Err(err) = self.multi_draw_mesh_tasks_indirect_count_inner(
+            buffer,
+            offset,
+            count_buffer,
+            count_buffer_offset,
+            max_count,
+        ) {
+            self.device.handle_error(
+                err,
+                self.label(),
+                "RenderPass::multi_draw_mesh_tasks_indirect_count",
+            );
+        }
+    }
+
+    fn push_debug_group_inner(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
         let base = pass_base!(self, PassErrorScope::PushDebugGroup);
 
         let bytes = label.as_bytes();
@@ -4055,7 +4317,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn pop_debug_group(&mut self) -> Result<(), PassStateError> {
+    pub fn push_debug_group(&mut self, label: &str, color: u32) {
+        if let Err(err) = self.push_debug_group_inner(label, color) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::push_debug_group");
+        }
+    }
+
+    fn pop_debug_group_inner(&mut self) -> Result<(), PassStateError> {
         let base = pass_base!(self, PassErrorScope::PopDebugGroup);
 
         base.commands.push(ArcRenderCommand::PopDebugGroup);
@@ -4063,7 +4332,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn insert_debug_marker(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
+    pub fn pop_debug_group(&mut self) {
+        if let Err(err) = self.pop_debug_group_inner() {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::pop_debug_group");
+        }
+    }
+
+    fn insert_debug_marker_inner(&mut self, label: &str, color: u32) -> Result<(), PassStateError> {
         let base = pass_base!(self, PassErrorScope::InsertDebugMarker);
 
         let bytes = label.as_bytes();
@@ -4077,7 +4353,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn write_timestamp(
+    pub fn insert_debug_marker(&mut self, label: &str, color: u32) {
+        if let Err(err) = self.insert_debug_marker_inner(label, color) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::insert_debug_marker");
+        }
+    }
+
+    fn write_timestamp_inner(
         &mut self,
         query_set: Arc<QuerySet>,
         query_index: u32,
@@ -4094,7 +4377,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn begin_occlusion_query(&mut self, query_index: u32) -> Result<(), PassStateError> {
+    pub fn write_timestamp(&mut self, query_set: Arc<QuerySet>, query_index: u32) {
+        if let Err(err) = self.write_timestamp_inner(query_set, query_index) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::write_timestamp");
+        }
+    }
+
+    fn begin_occlusion_query_inner(&mut self, query_index: u32) -> Result<(), PassStateError> {
         let scope = PassErrorScope::BeginOcclusionQuery;
         let base = pass_base!(self, scope);
 
@@ -4104,7 +4394,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn end_occlusion_query(&mut self) -> Result<(), PassStateError> {
+    pub fn begin_occlusion_query(&mut self, query_index: u32) {
+        if let Err(err) = self.begin_occlusion_query_inner(query_index) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::begin_occlusion_query");
+        }
+    }
+
+    fn end_occlusion_query_inner(&mut self) -> Result<(), PassStateError> {
         let scope = PassErrorScope::EndOcclusionQuery;
         let base = pass_base!(self, scope);
 
@@ -4113,7 +4410,14 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn begin_pipeline_statistics_query(
+    pub fn end_occlusion_query(&mut self) {
+        if let Err(err) = self.end_occlusion_query_inner() {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::end_occlusion_query");
+        }
+    }
+
+    fn begin_pipeline_statistics_query_inner(
         &mut self,
         query_set: Arc<QuerySet>,
         query_index: u32,
@@ -4131,7 +4435,17 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn end_pipeline_statistics_query(&mut self) -> Result<(), PassStateError> {
+    pub fn begin_pipeline_statistics_query(&mut self, query_set: Arc<QuerySet>, query_index: u32) {
+        if let Err(err) = self.begin_pipeline_statistics_query_inner(query_set, query_index) {
+            self.device.handle_error(
+                err,
+                self.label(),
+                "RenderPass::begin_pipeline_statistics_query",
+            );
+        }
+    }
+
+    fn end_pipeline_statistics_query_inner(&mut self) -> Result<(), PassStateError> {
         let scope = PassErrorScope::EndPipelineStatisticsQuery;
         let base = pass_base!(self, scope);
 
@@ -4141,7 +4455,17 @@ impl RenderPass {
         Ok(())
     }
 
-    pub fn execute_bundles(
+    pub fn end_pipeline_statistics_query(&mut self) {
+        if let Err(err) = self.end_pipeline_statistics_query_inner() {
+            self.device.handle_error(
+                err,
+                self.label(),
+                "RenderPass::end_pipeline_statistics_query",
+            );
+        }
+    }
+
+    fn execute_bundles_inner(
         &mut self,
         render_bundles: &[Arc<RenderBundle>],
     ) -> Result<(), PassStateError> {
@@ -4158,6 +4482,13 @@ impl RenderPass {
         self.current_bind_groups.reset();
 
         Ok(())
+    }
+
+    pub fn execute_bundles(&mut self, render_bundles: &[Arc<RenderBundle>]) {
+        if let Err(err) = self.execute_bundles_inner(render_bundles) {
+            self.device
+                .handle_error(err, self.label(), "RenderPass::execute_bundles");
+        }
     }
 }
 

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -19,8 +19,8 @@ use crate::{
         TextureInitTrackerAction,
     },
     resource::{
-        Buffer, MissingBufferUsageError, MissingTextureUsageError, ParentDevice, RawResourceAccess,
-        Texture, TextureErrorDimension,
+        Buffer, Labeled, MissingBufferUsageError, MissingTextureUsageError, ParentDevice,
+        RawResourceAccess, Texture, TextureErrorDimension,
     },
 };
 
@@ -823,7 +823,7 @@ fn handle_buffer_init(
 }
 
 impl super::CommandEncoder {
-    pub fn copy_buffer_to_buffer(
+    fn copy_buffer_to_buffer_inner(
         self: &Arc<Self>,
         source: Arc<Buffer>,
         source_offset: BufferAddress,
@@ -853,7 +853,30 @@ impl super::CommandEncoder {
         })
     }
 
-    pub fn copy_buffer_to_texture(
+    pub fn copy_buffer_to_buffer(
+        self: &Arc<Self>,
+        source: Arc<Buffer>,
+        source_offset: BufferAddress,
+        destination: Arc<Buffer>,
+        destination_offset: BufferAddress,
+        size: Option<BufferAddress>,
+    ) {
+        if let Err(err) = self.copy_buffer_to_buffer_inner(
+            source,
+            source_offset,
+            destination,
+            destination_offset,
+            size,
+        ) {
+            self.device.handle_error(
+                err,
+                Some(self.label()),
+                "CommandEncoder::copy_buffer_to_buffer",
+            );
+        }
+    }
+
+    fn copy_buffer_to_texture_inner(
         self: &Arc<Self>,
         source: &wgt::TexelCopyBufferInfo<Arc<Buffer>>,
         destination: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
@@ -889,7 +912,22 @@ impl super::CommandEncoder {
         })
     }
 
-    pub fn copy_texture_to_buffer(
+    pub fn copy_buffer_to_texture(
+        self: &Arc<Self>,
+        source: &wgt::TexelCopyBufferInfo<Arc<Buffer>>,
+        destination: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
+        copy_size: &Extent3d,
+    ) {
+        if let Err(err) = self.copy_buffer_to_texture_inner(source, destination, copy_size) {
+            self.device.handle_error(
+                err,
+                Some(self.label()),
+                "CommandEncoder::copy_buffer_to_texture",
+            );
+        }
+    }
+
+    fn copy_texture_to_buffer_inner(
         self: &Arc<Self>,
         source: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
         destination: &wgt::TexelCopyBufferInfo<Arc<Buffer>>,
@@ -925,7 +963,22 @@ impl super::CommandEncoder {
         })
     }
 
-    pub fn copy_texture_to_texture(
+    pub fn copy_texture_to_buffer(
+        self: &Arc<Self>,
+        source: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
+        destination: &wgt::TexelCopyBufferInfo<Arc<Buffer>>,
+        copy_size: &Extent3d,
+    ) {
+        if let Err(err) = self.copy_texture_to_buffer_inner(source, destination, copy_size) {
+            self.device.handle_error(
+                err,
+                Some(self.label()),
+                "CommandEncoder::copy_texture_to_buffer",
+            );
+        }
+    }
+
+    fn copy_texture_to_texture_inner(
         self: &Arc<Self>,
         source: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
         destination: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
@@ -961,6 +1014,21 @@ impl super::CommandEncoder {
                 size: *copy_size,
             })
         })
+    }
+
+    pub fn copy_texture_to_texture(
+        self: &Arc<Self>,
+        source: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
+        destination: &wgt::TexelCopyTextureInfo<Arc<Texture>>,
+        copy_size: &Extent3d,
+    ) {
+        if let Err(err) = self.copy_texture_to_texture_inner(source, destination, copy_size) {
+            self.device.handle_error(
+                err,
+                Some(self.label()),
+                "CommandEncoder::copy_texture_to_texture",
+            );
+        }
     }
 }
 

--- a/wgpu-core/src/command/transition_resources.rs
+++ b/wgpu-core/src/command/transition_resources.rs
@@ -6,12 +6,12 @@ use wgt::error::{ErrorType, WebGpuError};
 use crate::{
     command::{encoder::EncodingState, ArcCommand, CommandEncoder, EncoderStateError},
     device::DeviceError,
-    resource::{Buffer, InvalidResourceError, ParentDevice, Texture},
+    resource::{Buffer, InvalidResourceError, Labeled as _, ParentDevice, Texture},
     track::ResourceUsageCompatibilityError,
 };
 
 impl CommandEncoder {
-    pub fn transition_resources(
+    fn transition_resources_inner(
         self: &Arc<Self>,
         buffer_transitions: impl Iterator<Item = wgt::BufferTransition<Arc<Buffer>>>,
         texture_transitions: impl Iterator<Item = wgt::TextureTransition<Arc<Texture>>>,
@@ -43,6 +43,20 @@ impl CommandEncoder {
                     .collect::<Result<_, TransitionResourcesError>>()?,
             })
         })
+    }
+
+    pub fn transition_resources(
+        self: &Arc<Self>,
+        buffer_transitions: impl Iterator<Item = wgt::BufferTransition<Arc<Buffer>>>,
+        texture_transitions: impl Iterator<Item = wgt::TextureTransition<Arc<Texture>>>,
+    ) {
+        if let Err(err) = self.transition_resources_inner(buffer_transitions, texture_transitions) {
+            self.device.handle_error(
+                err,
+                Some(self.label()),
+                "CommandEncoder::transition_resources",
+            );
+        }
     }
 }
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2800,23 +2800,27 @@ impl Device {
     pub fn create_command_encoder(
         self: &Arc<Self>,
         desc: &wgt::CommandEncoderDescriptor<crate::Label>,
-    ) -> (Arc<command::CommandEncoder>, Option<DeviceError>) {
+    ) -> Arc<command::CommandEncoder> {
         profiling::scope!("Device::create_command_encoder");
 
-        let (cmd_enc, error) = match self.create_command_encoder_inner(&desc.label) {
-            Ok(cmd_enc) => (cmd_enc, None),
-            Err(e) => (
-                command::CommandEncoder::new_invalid(self, &desc.label, e.clone().into()),
-                Some(e),
-            ),
-        };
+        let cmd_enc = self
+            .create_command_encoder_inner(&desc.label)
+            .unwrap_or_else(|err| {
+                let error = err.clone().into();
+                self.handle_error(
+                    err,
+                    desc.label.as_ref().map(|l| l.as_ref()),
+                    "Device::create_command_encoder",
+                );
+                command::CommandEncoder::new_invalid(self, &desc.label, error)
+            });
 
         api_log!(
             "Device::create_command_encoder -> {:?}",
             Arc::as_ptr(&cmd_enc)
         );
 
-        (cmd_enc, error)
+        cmd_enc
     }
 
     pub(crate) fn create_command_encoder_inner(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2134,20 +2134,12 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
                     end_of_pass_write_index: tw.end_of_pass_write_index,
                 });
 
-        let (pass, err) =
+        let pass =
             self.wgpu_command_encoder
                 .begin_compute_pass(&wgc::command::ComputePassDescriptor {
                     label: desc.label.map(Borrowed),
                     timestamp_writes,
                 });
-
-        if let Some(cause) = err {
-            self.wgpu_command_encoder.device().handle_error(
-                cause,
-                desc.label,
-                "CommandEncoder::begin_compute_pass",
-            );
-        }
 
         CoreComputePass {
             pass,
@@ -2470,14 +2462,8 @@ impl dispatch::ComputePassInterface for CoreComputePass {
     fn set_pipeline(&mut self, pipeline: &dispatch::DispatchComputePipeline) {
         let pipeline = pipeline.as_core();
 
-        if let Err(cause) = self
-            .pass
-            .set_pipeline(pipeline.wgpu_compute_pipeline.clone())
-        {
-            self.pass
-                .device()
-                .handle_error(cause, self.pass.label(), "ComputePass::set_pipeline");
-        }
+        self.pass
+            .set_pipeline(pipeline.wgpu_compute_pipeline.clone());
     }
 
     fn set_bind_group(
@@ -2488,68 +2474,30 @@ impl dispatch::ComputePassInterface for CoreComputePass {
     ) {
         let bg = bind_group.map(|bg| bg.as_core().wgpu_bind_group.clone());
 
-        if let Err(cause) = self.pass.set_bind_group(index, bg, offsets) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::set_bind_group",
-            );
-        }
+        self.pass.set_bind_group(index, bg, offsets);
     }
 
     fn set_immediates(&mut self, offset: u32, data: &[u8]) {
-        if let Err(cause) = self.pass.set_immediates(offset, data) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::set_immediates",
-            );
-        }
+        self.pass.set_immediates(offset, data);
     }
 
     fn insert_debug_marker(&mut self, label: &str) {
-        if let Err(cause) = self.pass.insert_debug_marker(label, 0) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::insert_debug_marker",
-            );
-        }
+        self.pass.insert_debug_marker(label, 0);
     }
 
     fn push_debug_group(&mut self, group_label: &str) {
-        if let Err(cause) = self.pass.push_debug_group(group_label, 0) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::push_debug_group",
-            );
-        }
+        self.pass.push_debug_group(group_label, 0);
     }
 
     fn pop_debug_group(&mut self) {
-        if let Err(cause) = self.pass.pop_debug_group() {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::pop_debug_group",
-            );
-        }
+        self.pass.pop_debug_group();
     }
 
     fn write_timestamp(&mut self, query_set: &dispatch::DispatchQuerySet, query_index: u32) {
         let query_set = query_set.as_core();
 
-        if let Err(cause) = self
-            .pass
-            .write_timestamp(query_set.wgpu_query_set.clone(), query_index)
-        {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::write_timestamp",
-            );
-        }
+        self.pass
+            .write_timestamp(query_set.wgpu_query_set.clone(), query_index);
     }
 
     fn begin_pipeline_statistics_query(
@@ -2559,36 +2507,16 @@ impl dispatch::ComputePassInterface for CoreComputePass {
     ) {
         let query_set = query_set.as_core();
 
-        if let Err(cause) = self
-            .pass
-            .begin_pipeline_statistics_query(query_set.wgpu_query_set.clone(), query_index)
-        {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::begin_pipeline_statistics_query",
-            );
-        }
+        self.pass
+            .begin_pipeline_statistics_query(query_set.wgpu_query_set.clone(), query_index);
     }
 
     fn end_pipeline_statistics_query(&mut self) {
-        if let Err(cause) = self.pass.end_pipeline_statistics_query() {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::end_pipeline_statistics_query",
-            );
-        }
+        self.pass.end_pipeline_statistics_query();
     }
 
     fn dispatch_workgroups(&mut self, x: u32, y: u32, z: u32) {
-        if let Err(cause) = self.pass.dispatch_workgroups(x, y, z) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::dispatch_workgroups",
-            );
-        }
+        self.pass.dispatch_workgroups(x, y, z);
     }
 
     fn dispatch_workgroups_indirect(
@@ -2598,16 +2526,8 @@ impl dispatch::ComputePassInterface for CoreComputePass {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        if let Err(cause) = self
-            .pass
-            .dispatch_workgroups_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset)
-        {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::dispatch_workgroups_indirect",
-            );
-        }
+        self.pass
+            .dispatch_workgroups_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset);
     }
 
     fn transition_resources<'a>(
@@ -2619,7 +2539,7 @@ impl dispatch::ComputePassInterface for CoreComputePass {
             Item = wgt::TextureTransition<&'a dispatch::DispatchTextureView>,
         >,
     ) {
-        let result = self.pass.transition_resources(
+        self.pass.transition_resources(
             buffer_transitions.map(|t| wgt::BufferTransition {
                 buffer: t.buffer.as_core().wgpu_buffer.clone(),
                 state: t.state,
@@ -2630,24 +2550,12 @@ impl dispatch::ComputePassInterface for CoreComputePass {
                 state: t.state,
             }),
         );
-
-        if let Err(cause) = result {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "ComputePass::transition_resources",
-            );
-        }
     }
 }
 
 impl Drop for CoreComputePass {
     fn drop(&mut self) {
-        if let Err(cause) = self.pass.end() {
-            self.pass
-                .device()
-                .handle_error(cause, self.pass.label(), "ComputePass::end");
-        }
+        self.pass.end();
     }
 }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1503,13 +1503,9 @@ impl dispatch::DeviceInterface for CoreDevice {
         &self,
         desc: &crate::CommandEncoderDescriptor<'_>,
     ) -> dispatch::DispatchCommandEncoder {
-        let (wgpu_command_encoder, error) = self
+        let wgpu_command_encoder = self
             .wgpu_device
             .create_command_encoder(&desc.map_label(|l| l.map(Borrowed)));
-        if let Some(cause) = error {
-            self.wgpu_device
-                .handle_error(cause, desc.label, "Device::create_command_encoder");
-        }
 
         CoreCommandEncoder {
             context: self.context.clone(),
@@ -2057,17 +2053,13 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
         let source = source.as_core();
         let destination = destination.as_core();
 
-        if let Err(cause) = self.wgpu_command_encoder.copy_buffer_to_buffer(
+        self.wgpu_command_encoder.copy_buffer_to_buffer(
             source.wgpu_buffer.clone(),
             source_offset,
             destination.wgpu_buffer.clone(),
             destination_offset,
             copy_size,
-        ) {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::copy_buffer_to_buffer");
-        }
+        )
     }
 
     fn copy_buffer_to_texture(
@@ -2076,15 +2068,11 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
         destination: crate::TexelCopyTextureInfo<'_>,
         copy_size: crate::Extent3d,
     ) {
-        if let Err(cause) = self.wgpu_command_encoder.copy_buffer_to_texture(
+        self.wgpu_command_encoder.copy_buffer_to_texture(
             &map_buffer_copy_view(source),
             &map_texture_copy_view(destination),
             &copy_size,
-        ) {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::copy_buffer_to_texture");
-        }
+        )
     }
 
     fn copy_texture_to_buffer(
@@ -2093,15 +2081,11 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
         destination: crate::TexelCopyBufferInfo<'_>,
         copy_size: crate::Extent3d,
     ) {
-        if let Err(cause) = self.wgpu_command_encoder.copy_texture_to_buffer(
+        self.wgpu_command_encoder.copy_texture_to_buffer(
             &map_texture_copy_view(source),
             &map_buffer_copy_view(destination),
             &copy_size,
-        ) {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::copy_texture_to_buffer");
-        }
+        );
     }
 
     fn copy_texture_to_texture(
@@ -2110,15 +2094,11 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
         destination: crate::TexelCopyTextureInfo<'_>,
         copy_size: crate::Extent3d,
     ) {
-        if let Err(cause) = self.wgpu_command_encoder.copy_texture_to_texture(
+        self.wgpu_command_encoder.copy_texture_to_texture(
             &map_texture_copy_view(source),
             &map_texture_copy_view(destination),
             &copy_size,
-        ) {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::copy_texture_to_texture");
-        }
+        );
     }
 
     fn begin_compute_pass(
@@ -2208,15 +2188,7 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
 
     fn finish(&mut self) -> dispatch::DispatchCommandBuffer {
         let descriptor = wgt::CommandBufferDescriptor::default();
-        let (wgpu_command_buffer, opt_label_and_error) =
-            self.wgpu_command_encoder.finish(&descriptor);
-        if let Some((label, cause)) = opt_label_and_error {
-            self.wgpu_command_encoder.device().handle_error(
-                cause,
-                Some(&label),
-                "a CommandEncoder",
-            );
-        }
+        let wgpu_command_buffer = self.wgpu_command_encoder.finish(&descriptor);
         CoreCommandBuffer {
             context: self.context.clone(),
             wgpu_command_buffer,
@@ -2231,14 +2203,8 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
     ) {
         let texture = texture.as_core();
 
-        if let Err(cause) = self
-            .wgpu_command_encoder
+        self.wgpu_command_encoder
             .clear_texture(texture.wgpu_texture.clone(), subresource_range)
-        {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::clear_texture");
-        }
     }
 
     fn clear_buffer(
@@ -2249,51 +2215,27 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
     ) {
         let buffer = buffer.as_core();
 
-        if let Err(cause) =
-            self.wgpu_command_encoder
-                .clear_buffer(buffer.wgpu_buffer.clone(), offset, size)
-        {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::fill_buffer");
-        }
+        self.wgpu_command_encoder
+            .clear_buffer(buffer.wgpu_buffer.clone(), offset, size)
     }
 
     fn insert_debug_marker(&self, label: &str) {
-        if let Err(cause) = self.wgpu_command_encoder.insert_debug_marker(label) {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::insert_debug_marker");
-        }
+        self.wgpu_command_encoder.insert_debug_marker(label)
     }
 
     fn push_debug_group(&self, label: &str) {
-        if let Err(cause) = self.wgpu_command_encoder.push_debug_group(label) {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::push_debug_group");
-        }
+        self.wgpu_command_encoder.push_debug_group(label)
     }
 
     fn pop_debug_group(&self) {
-        if let Err(cause) = self.wgpu_command_encoder.pop_debug_group() {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::pop_debug_group");
-        }
+        self.wgpu_command_encoder.pop_debug_group()
     }
 
     fn write_timestamp(&self, query_set: &dispatch::DispatchQuerySet, query_index: u32) {
         let query_set = query_set.as_core();
 
-        if let Err(cause) = self
-            .wgpu_command_encoder
+        self.wgpu_command_encoder
             .write_timestamp(query_set.wgpu_query_set.clone(), query_index)
-        {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::write_timestamp");
-        }
     }
 
     fn resolve_query_set(
@@ -2307,17 +2249,13 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
         let query_set = query_set.as_core();
         let destination = destination.as_core();
 
-        if let Err(cause) = self.wgpu_command_encoder.resolve_query_set(
+        self.wgpu_command_encoder.resolve_query_set(
             query_set.wgpu_query_set.clone(),
             first_query,
             query_count,
             destination.wgpu_buffer.clone(),
             destination_offset,
-        ) {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::resolve_query_set");
-        }
+        );
     }
 
     fn mark_acceleration_structures_built<'a>(
@@ -2331,15 +2269,8 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
         let tlas = tlas
             .map(|t| t.inner.as_core().wgpu_tlas.clone())
             .collect::<SmallVec<[_; 4]>>();
-        if let Err(cause) = self
-            .wgpu_command_encoder
+        self.wgpu_command_encoder
             .mark_acceleration_structures_built(&blas, &tlas)
-        {
-            self.wgpu_command_encoder.device().handle_error_nolabel(
-                cause,
-                "CommandEncoder::build_acceleration_structures_unsafe_tlas",
-            );
-        }
     }
 
     fn build_acceleration_structures<'a>(
@@ -2408,15 +2339,8 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
             }
         });
 
-        if let Err(cause) = self
-            .wgpu_command_encoder
+        self.wgpu_command_encoder
             .build_acceleration_structures(blas, tlas)
-        {
-            self.wgpu_command_encoder.device().handle_error_nolabel(
-                cause,
-                "CommandEncoder::build_acceleration_structures_unsafe_tlas",
-            );
-        }
     }
 
     fn transition_resources<'a>(
@@ -2428,7 +2352,7 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
             Item = wgt::TextureTransition<&'a dispatch::DispatchTexture>,
         >,
     ) {
-        let result = self.wgpu_command_encoder.transition_resources(
+        self.wgpu_command_encoder.transition_resources(
             buffer_transitions.map(|t| wgt::BufferTransition {
                 buffer: t.buffer.as_core().wgpu_buffer.clone(),
                 state: t.state,
@@ -2439,12 +2363,6 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
                 state: t.state,
             }),
         );
-
-        if let Err(cause) = result {
-            self.wgpu_command_encoder
-                .device()
-                .handle_error_nolabel(cause, "CommandEncoder::transition_resources");
-        }
     }
 }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2186,7 +2186,7 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
                     end_of_pass_write_index: tw.end_of_pass_write_index,
                 });
 
-        let (pass, err) = self.wgpu_command_encoder.begin_render_pass(
+        let pass = self.wgpu_command_encoder.begin_render_pass(
             wgc::command::ResolvedRenderPassDescriptor {
                 label: desc.label.map(Borrowed),
                 timestamp_writes,
@@ -2198,14 +2198,6 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
                 multiview_mask: desc.multiview_mask,
             },
         );
-
-        if let Some(cause) = err {
-            self.wgpu_command_encoder.device().handle_error(
-                cause,
-                desc.label,
-                "CommandEncoder::begin_render_pass",
-            );
-        }
 
         CoreRenderPass {
             pass,
@@ -2563,14 +2555,8 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     fn set_pipeline(&mut self, pipeline: &dispatch::DispatchRenderPipeline) {
         let pipeline = pipeline.as_core();
 
-        if let Err(cause) = self
-            .pass
-            .set_pipeline(pipeline.wgpu_render_pipeline.clone())
-        {
-            self.pass
-                .device()
-                .handle_error(cause, self.pass.label(), "RenderPass::set_pipeline");
-        }
+        self.pass
+            .set_pipeline(pipeline.wgpu_render_pipeline.clone());
     }
 
     fn set_bind_group(
@@ -2581,11 +2567,7 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     ) {
         let bg = bind_group.map(|bg| bg.as_core().wgpu_bind_group.clone());
 
-        if let Err(cause) = self.pass.set_bind_group(index, bg, offsets) {
-            self.pass
-                .device()
-                .handle_error(cause, self.pass.label(), "RenderPass::set_bind_group");
-        }
+        self.pass.set_bind_group(index, bg, offsets);
     }
 
     fn set_index_buffer(
@@ -2597,16 +2579,8 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     ) {
         let buffer = buffer.as_core();
 
-        if let Err(cause) =
-            self.pass
-                .set_index_buffer(buffer.wgpu_buffer.clone(), index_format, offset, size)
-        {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::set_index_buffer",
-            );
-        }
+        self.pass
+            .set_index_buffer(buffer.wgpu_buffer.clone(), index_format, offset, size)
     }
 
     fn set_vertex_buffer(
@@ -2618,41 +2592,19 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     ) {
         let buffer = buffer.map(|buffer| buffer.as_core().wgpu_buffer.clone());
 
-        if let Err(cause) = self.pass.set_vertex_buffer(slot, buffer, offset, size) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::set_vertex_buffer",
-            );
-        }
+        self.pass.set_vertex_buffer(slot, buffer, offset, size);
     }
 
     fn set_immediates(&mut self, offset: u32, data: &[u8]) {
-        if let Err(cause) = self.pass.set_immediates(offset, data) {
-            self.pass
-                .device()
-                .handle_error(cause, self.pass.label(), "RenderPass::set_immediates");
-        }
+        self.pass.set_immediates(offset, data);
     }
 
     fn set_blend_constant(&mut self, color: crate::Color) {
-        if let Err(cause) = self.pass.set_blend_constant(color) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::set_blend_constant",
-            );
-        }
+        self.pass.set_blend_constant(color);
     }
 
     fn set_scissor_rect(&mut self, x: u32, y: u32, width: u32, height: u32) {
-        if let Err(cause) = self.pass.set_scissor_rect(x, y, width, height) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::set_scissor_rect",
-            );
-        }
+        self.pass.set_scissor_rect(x, y, width, height);
     }
 
     fn set_viewport(
@@ -2664,64 +2616,36 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
         min_depth: f32,
         max_depth: f32,
     ) {
-        if let Err(cause) = self
-            .pass
-            .set_viewport(x, y, width, height, min_depth, max_depth)
-        {
-            self.pass
-                .device()
-                .handle_error(cause, self.pass.label(), "RenderPass::set_viewport");
-        }
+        self.pass
+            .set_viewport(x, y, width, height, min_depth, max_depth);
     }
 
     fn set_stencil_reference(&mut self, reference: u32) {
-        if let Err(cause) = self.pass.set_stencil_reference(reference) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::set_stencil_reference",
-            );
-        }
+        self.pass.set_stencil_reference(reference);
     }
 
     fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
-        if let Err(cause) = self.pass.draw(
+        self.pass.draw(
             vertices.end - vertices.start,
             instances.end - instances.start,
             vertices.start,
             instances.start,
-        ) {
-            self.pass
-                .device()
-                .handle_error(cause, self.pass.label(), "RenderPass::draw");
-        }
+        );
     }
 
     fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
-        if let Err(cause) = self.pass.draw_indexed(
+        self.pass.draw_indexed(
             indices.end - indices.start,
             instances.end - instances.start,
             indices.start,
             base_vertex,
             instances.start,
-        ) {
-            self.pass
-                .device()
-                .handle_error(cause, self.pass.label(), "RenderPass::draw_indexed");
-        }
+        );
     }
 
     fn draw_mesh_tasks(&mut self, group_count_x: u32, group_count_y: u32, group_count_z: u32) {
-        if let Err(cause) = self
-            .pass
-            .draw_mesh_tasks(group_count_x, group_count_y, group_count_z)
-        {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::draw_mesh_tasks",
-            );
-        }
+        self.pass
+            .draw_mesh_tasks(group_count_x, group_count_y, group_count_z);
     }
 
     fn draw_indirect(
@@ -2731,14 +2655,8 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        if let Err(cause) = self
-            .pass
-            .draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset)
-        {
-            self.pass
-                .device()
-                .handle_error(cause, self.pass.label(), "RenderPass::draw_indirect");
-        }
+        self.pass
+            .draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset);
     }
 
     fn draw_indexed_indirect(
@@ -2748,16 +2666,8 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        if let Err(cause) = self
-            .pass
-            .draw_indexed_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset)
-        {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::draw_indexed_indirect",
-            );
-        }
+        self.pass
+            .draw_indexed_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset);
     }
 
     fn draw_mesh_tasks_indirect(
@@ -2767,16 +2677,8 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        if let Err(cause) = self
-            .pass
-            .draw_mesh_tasks_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset)
-        {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::draw_mesh_tasks_indirect",
-            );
-        }
+        self.pass
+            .draw_mesh_tasks_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset);
     }
 
     fn multi_draw_indirect(
@@ -2787,17 +2689,8 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        if let Err(cause) = self.pass.multi_draw_indirect(
-            indirect_buffer.wgpu_buffer.clone(),
-            indirect_offset,
-            count,
-        ) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::multi_draw_indirect",
-            );
-        }
+        self.pass
+            .multi_draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset, count);
     }
 
     fn multi_draw_indexed_indirect(
@@ -2808,17 +2701,11 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        if let Err(cause) = self.pass.multi_draw_indexed_indirect(
+        self.pass.multi_draw_indexed_indirect(
             indirect_buffer.wgpu_buffer.clone(),
             indirect_offset,
             count,
-        ) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::multi_draw_indexed_indirect",
-            );
-        }
+        );
     }
 
     fn multi_draw_mesh_tasks_indirect(
@@ -2829,17 +2716,11 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     ) {
         let indirect_buffer = indirect_buffer.as_core();
 
-        if let Err(cause) = self.pass.multi_draw_mesh_tasks_indirect(
+        self.pass.multi_draw_mesh_tasks_indirect(
             indirect_buffer.wgpu_buffer.clone(),
             indirect_offset,
             count,
-        ) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::multi_draw_mesh_tasks_indirect",
-            );
-        }
+        );
     }
 
     fn multi_draw_indirect_count(
@@ -2853,19 +2734,13 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
         let indirect_buffer = indirect_buffer.as_core();
         let count_buffer = count_buffer.as_core();
 
-        if let Err(cause) = self.pass.multi_draw_indirect_count(
+        self.pass.multi_draw_indirect_count(
             indirect_buffer.wgpu_buffer.clone(),
             indirect_offset,
             count_buffer.wgpu_buffer.clone(),
             count_buffer_offset,
             max_count,
-        ) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::multi_draw_indirect_count",
-            );
-        }
+        );
     }
 
     fn multi_draw_indexed_indirect_count(
@@ -2879,19 +2754,13 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
         let indirect_buffer = indirect_buffer.as_core();
         let count_buffer = count_buffer.as_core();
 
-        if let Err(cause) = self.pass.multi_draw_indexed_indirect_count(
+        self.pass.multi_draw_indexed_indirect_count(
             indirect_buffer.wgpu_buffer.clone(),
             indirect_offset,
             count_buffer.wgpu_buffer.clone(),
             count_buffer_offset,
             max_count,
-        ) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::multi_draw_indexed_indirect_count",
-            );
-        }
+        );
     }
 
     fn multi_draw_mesh_tasks_indirect_count(
@@ -2905,84 +2774,40 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
         let indirect_buffer = indirect_buffer.as_core();
         let count_buffer = count_buffer.as_core();
 
-        if let Err(cause) = self.pass.multi_draw_mesh_tasks_indirect_count(
+        self.pass.multi_draw_mesh_tasks_indirect_count(
             indirect_buffer.wgpu_buffer.clone(),
             indirect_offset,
             count_buffer.wgpu_buffer.clone(),
             count_buffer_offset,
             max_count,
-        ) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::multi_draw_mesh_tasks_indirect_count",
-            );
-        }
+        );
     }
 
     fn insert_debug_marker(&mut self, label: &str) {
-        if let Err(cause) = self.pass.insert_debug_marker(label, 0) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::insert_debug_marker",
-            );
-        }
+        self.pass.insert_debug_marker(label, 0);
     }
 
     fn push_debug_group(&mut self, group_label: &str) {
-        if let Err(cause) = self.pass.push_debug_group(group_label, 0) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::push_debug_group",
-            );
-        }
+        self.pass.push_debug_group(group_label, 0);
     }
 
     fn pop_debug_group(&mut self) {
-        if let Err(cause) = self.pass.pop_debug_group() {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::pop_debug_group",
-            );
-        }
+        self.pass.pop_debug_group();
     }
 
     fn write_timestamp(&mut self, query_set: &dispatch::DispatchQuerySet, query_index: u32) {
         let query_set = query_set.as_core();
 
-        if let Err(cause) = self
-            .pass
-            .write_timestamp(query_set.wgpu_query_set.clone(), query_index)
-        {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::write_timestamp",
-            );
-        }
+        self.pass
+            .write_timestamp(query_set.wgpu_query_set.clone(), query_index);
     }
 
     fn begin_occlusion_query(&mut self, query_index: u32) {
-        if let Err(cause) = self.pass.begin_occlusion_query(query_index) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::begin_occlusion_query",
-            );
-        }
+        self.pass.begin_occlusion_query(query_index);
     }
 
     fn end_occlusion_query(&mut self) {
-        if let Err(cause) = self.pass.end_occlusion_query() {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::end_occlusion_query",
-            );
-        }
+        self.pass.end_occlusion_query();
     }
 
     fn begin_pipeline_statistics_query(
@@ -2992,26 +2817,12 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
     ) {
         let query_set = query_set.as_core();
 
-        if let Err(cause) = self
-            .pass
-            .begin_pipeline_statistics_query(query_set.wgpu_query_set.clone(), query_index)
-        {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::begin_pipeline_statistics_query",
-            );
-        }
+        self.pass
+            .begin_pipeline_statistics_query(query_set.wgpu_query_set.clone(), query_index);
     }
 
     fn end_pipeline_statistics_query(&mut self) {
-        if let Err(cause) = self.pass.end_pipeline_statistics_query() {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::end_pipeline_statistics_query",
-            );
-        }
+        self.pass.end_pipeline_statistics_query();
     }
 
     fn execute_bundles(
@@ -3021,23 +2832,13 @@ impl dispatch::RenderPassInterface for CoreRenderPass {
         let temp_render_bundles = render_bundles
             .map(|rb| rb.as_core().wgpu_render_bundle.clone())
             .collect::<SmallVec<[_; 4]>>();
-        if let Err(cause) = self.pass.execute_bundles(&temp_render_bundles) {
-            self.pass.device().handle_error(
-                cause,
-                self.pass.label(),
-                "RenderPass::execute_bundles",
-            );
-        }
+        self.pass.execute_bundles(&temp_render_bundles);
     }
 }
 
 impl Drop for CoreRenderPass {
     fn drop(&mut self) {
-        if let Err(cause) = self.pass.end() {
-            self.pass
-                .device()
-                .handle_error(cause, self.pass.label(), "RenderPass::end");
-        }
+        self.pass.end()
     }
 }
 
@@ -3047,7 +2848,6 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
 
         self.encoder
             .set_pipeline(pipeline.wgpu_render_pipeline.clone())
-            .expect("RenderBundleEncoder should not have ended")
     }
 
     fn set_bind_group(
@@ -3058,9 +2858,7 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let bg = bind_group.map(|bg| bg.as_core().wgpu_bind_group.clone());
 
-        self.encoder
-            .set_bind_group(index, bg, offsets)
-            .expect("RenderBundleEncoder should not have ended");
+        self.encoder.set_bind_group(index, bg, offsets);
     }
 
     fn set_index_buffer(
@@ -3073,8 +2871,7 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
         let buffer = buffer.as_core();
 
         self.encoder
-            .set_index_buffer(buffer.wgpu_buffer.clone(), index_format, offset, size)
-            .expect("RenderBundleEncoder should not have ended");
+            .set_index_buffer(buffer.wgpu_buffer.clone(), index_format, offset, size);
     }
 
     fn set_vertex_buffer(
@@ -3086,9 +2883,7 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
     ) {
         let buffer = buffer.map(|buffer| buffer.as_core().wgpu_buffer.clone());
 
-        self.encoder
-            .set_vertex_buffer(slot, buffer, offset, size)
-            .expect("RenderBundleEncoder should not have ended");
+        self.encoder.set_vertex_buffer(slot, buffer, offset, size);
     }
 
     fn set_immediates(&mut self, offset: u32, data: &[u8]) {
@@ -3104,32 +2899,26 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
             return;
         }
 
-        self.encoder
-            .set_immediates(offset, data)
-            .expect("RenderBundleEncoder should not have ended");
+        self.encoder.set_immediates(offset, data);
     }
 
     fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
-        self.encoder
-            .draw(
-                vertices.end - vertices.start,
-                instances.end - instances.start,
-                vertices.start,
-                instances.start,
-            )
-            .expect("RenderBundleEncoder should not have ended");
+        self.encoder.draw(
+            vertices.end - vertices.start,
+            instances.end - instances.start,
+            vertices.start,
+            instances.start,
+        );
     }
 
     fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
-        self.encoder
-            .draw_indexed(
-                indices.end - indices.start,
-                instances.end - instances.start,
-                indices.start,
-                base_vertex,
-                instances.start,
-            )
-            .expect("RenderBundleEncoder should not have ended");
+        self.encoder.draw_indexed(
+            indices.end - indices.start,
+            instances.end - instances.start,
+            indices.start,
+            base_vertex,
+            instances.start,
+        );
     }
 
     fn draw_indirect(
@@ -3140,8 +2929,7 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
         let indirect_buffer = indirect_buffer.as_core();
 
         self.encoder
-            .draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset)
-            .expect("RenderBundleEncoder should not have ended");
+            .draw_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset);
     }
 
     fn draw_indexed_indirect(
@@ -3152,23 +2940,14 @@ impl dispatch::RenderBundleEncoderInterface for CoreRenderBundleEncoder {
         let indirect_buffer = indirect_buffer.as_core();
 
         self.encoder
-            .draw_indexed_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset)
-            .expect("RenderBundleEncoder should not have ended");
+            .draw_indexed_indirect(indirect_buffer.wgpu_buffer.clone(), indirect_offset);
     }
 
     fn finish(mut self, desc: &crate::RenderBundleDescriptor<'_>) -> dispatch::DispatchRenderBundle
     where
         Self: Sized,
     {
-        let label = self.encoder.label().map(alloc::string::ToString::to_string);
-        let (wgpu_render_bundle, error) = self.encoder.finish(&desc.map_label(|l| l.map(Borrowed)));
-        if let Some(err) = error {
-            self.encoder.device().handle_error(
-                err,
-                label.as_deref(),
-                "RenderBundleEncoder::finish",
-            );
-        }
+        let wgpu_render_bundle = self.encoder.finish(&desc.map_label(|l| l.map(Borrowed)));
         CoreRenderBundle { wgpu_render_bundle }.into()
     }
 


### PR DESCRIPTION
**Connections**
Towards #8911 and last commit is towards #10073

**Description**
Move erroring of encoders (CommandPassEncoder, RenderPassEncoder, RenderBundleEncoder, CommandEncoder) into wgpu-core. All content timeline validation written is spec is for JS, so one can consider those methods covered.

Last commits demonstrates https://github.com/gfx-rs/wgpu/issues/10073#issuecomment-5309351478. Types and behaviors are stolen from firefox. 

**Testing**
Just refactor, but it's covered by existing tests.

**Squash or Rebase?**

Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
