### PR TITLE
Implement spec compilant erroring of `create_render_bundle_encoder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,17 @@ Bottom level categories:
 
 By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
+#### `Device::create_render_bundle_encoder` now returns error
+
+Error is raised if for provided texture formats required features are not enabled on the device as per spec.
+
+```diff
+- device.create_render_bundle_encoder(&RenderBundleEncoderDescriptor::default())
++ device.create_render_bundle_encoder(&RenderBundleEncoderDescriptor::default()).unwrap()
+```
+
+By @sagudev in [#10115](https://github.com/gfx-rs/wgpu/pull/10115).
+
 ### Added/New Features
 
 #### General

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -78,6 +78,7 @@ webgpu:api,validation,buffer,create:size,*
 webgpu:api,validation,buffer,create:usage,*
 webgpu:api,validation,buffer,destroy:*
 webgpu:api,validation,capability_checks,features,clip_distances:*
+webgpu:api,validation,capability_checks,features,texture_formats:render_bundle_encoder_descriptor_depth_stencil_format:*
 webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
 webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:validate,*
 webgpu:api,validation,capability_checks,limits,maxBufferSize:*

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -618,7 +618,7 @@ impl GPUDevice {
     &self,
     #[webidl]
     descriptor: super::render_bundle::GPURenderBundleEncoderDescriptor,
-  ) -> GPURenderBundleEncoder {
+  ) -> Result<GPURenderBundleEncoder, JsErrorBox> {
     let wgpu_descriptor = wgpu_core::command::RenderBundleEncoderDescriptor {
       label: crate::transform_label(descriptor.label.clone()),
       color_formats: Cow::Owned(
@@ -639,16 +639,18 @@ impl GPUDevice {
       multiview: None,
     };
 
-    let (encoder, err) = self
+    let encoder = self
       .wgpu_device
-      .create_render_bundle_encoder(&wgpu_descriptor);
+      .create_render_bundle_encoder(&wgpu_descriptor)
+      .map_err(|err| {
+        let err = fmt_err(&err);
+        JsErrorBox::type_error(err)
+      })?;
 
-    self.error_handler.push_error(err);
-
-    GPURenderBundleEncoder {
+    Ok(GPURenderBundleEncoder {
       encoder: RefCell::new(encoder),
       label: descriptor.label,
-    }
+    })
   }
 
   #[required(1)]

--- a/examples/features/src/msaa_line/mod.rs
+++ b/examples/features/src/msaa_line/mod.rs
@@ -80,14 +80,15 @@ impl Example {
             multiview_mask: None,
             cache: None,
         });
-        let mut encoder =
-            device.create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+        let mut encoder = device
+            .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
                 label: None,
                 color_formats: &[Some(config.view_formats[0])],
                 depth_stencil: None,
                 sample_count,
                 multiview: None,
-            });
+            })
+            .unwrap();
         encoder.set_pipeline(&pipeline);
         encoder.set_vertex_buffer(0, vertex_buffer.slice(..));
         encoder.draw(0..vertex_count, 0..1);

--- a/examples/features/src/water/mod.rs
+++ b/examples/features/src/water/mod.rs
@@ -610,8 +610,8 @@ impl crate::framework::Example for Example {
 
         // A render bundle to draw the terrain.
         let terrain_bundle = {
-            let mut encoder =
-                device.create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+            let mut encoder = device
+                .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
                     label: None,
                     color_formats: &[Some(config.view_formats[0])],
                     depth_stencil: Some(wgpu::RenderBundleDepthStencil {
@@ -621,7 +621,8 @@ impl crate::framework::Example for Example {
                     }),
                     sample_count: 1,
                     multiview: None,
-                });
+                })
+                .unwrap();
             encoder.set_pipeline(&terrain_pipeline);
             encoder.set_bind_group(0, &terrain_flipped_bind_group, &[]);
             encoder.set_vertex_buffer(0, terrain_vertex_buf.slice(..));

--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -247,7 +247,8 @@ impl DeviceInterface for CustomDevice {
     fn create_render_bundle_encoder(
         &self,
         _desc: &wgpu::RenderBundleEncoderDescriptor<'_>,
-    ) -> wgpu::custom::DispatchRenderBundleEncoder {
+    ) -> Result<wgpu::custom::DispatchRenderBundleEncoder, wgpu::CreateRenderBundleEncoderError>
+    {
         unimplemented!()
     }
 

--- a/tests/tests/wgpu-gpu/immediates.rs
+++ b/tests/tests/wgpu-gpu/immediates.rs
@@ -344,13 +344,14 @@ async fn render_pass_test(ctx: &TestingContext, use_render_bundle: bool) {
         let mut render_pass = command_encoder.begin_render_pass(&render_pass_desc);
         if use_render_bundle {
             // Execute the commands in a render_bundle_encoder.
-            let mut render_bundle_encoder =
-                ctx.device
-                    .create_render_bundle_encoder(&RenderBundleEncoderDescriptor {
-                        color_formats: &[Some(output_texture.format())],
-                        sample_count: 1,
-                        ..RenderBundleEncoderDescriptor::default()
-                    });
+            let mut render_bundle_encoder = ctx
+                .device
+                .create_render_bundle_encoder(&RenderBundleEncoderDescriptor {
+                    color_formats: &[Some(output_texture.format())],
+                    sample_count: 1,
+                    ..RenderBundleEncoderDescriptor::default()
+                })
+                .unwrap();
             do_encoding(&mut render_bundle_encoder, &pipeline, &bind_group, &data);
             let render_bundle = render_bundle_encoder.finish(&RenderBundleDescriptor::default());
             render_pass.execute_bundles([&render_bundle]);

--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -310,15 +310,16 @@ fn record_encoder_with_resource(
                 pass.set_bind_group(0, &bind_group, &[]);
                 pass.draw(0..0, 0..0);
             } else {
-                let mut rbe =
-                    ctx.device
-                        .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
-                            label: None,
-                            color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
-                            depth_stencil: None,
-                            sample_count: 1,
-                            multiview: None,
-                        });
+                let mut rbe = ctx
+                    .device
+                    .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+                        label: None,
+                        color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
+                        depth_stencil: None,
+                        sample_count: 1,
+                        multiview: None,
+                    })
+                    .unwrap();
                 rbe.set_pipeline(&pipeline);
                 rbe.set_bind_group(0, &bind_group, &[]);
                 rbe.draw(0..0, 0..0);
@@ -1024,15 +1025,16 @@ fn test_replaced_bind_group(ctx: &TestingContext, usage: UsageKind) {
                 pass.set_bind_group(0, &bind_group_b, &[]);
                 pass.draw(0..0, 0..0);
             } else {
-                let mut rbe =
-                    ctx.device
-                        .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
-                            label: None,
-                            color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
-                            depth_stencil: None,
-                            sample_count: 1,
-                            multiview: None,
-                        });
+                let mut rbe = ctx
+                    .device
+                    .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+                        label: None,
+                        color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
+                        depth_stencil: None,
+                        sample_count: 1,
+                        multiview: None,
+                    })
+                    .unwrap();
                 rbe.set_pipeline(&pipeline);
                 rbe.set_bind_group(0, &bind_group_a, &[]);
                 rbe.set_bind_group(0, &bind_group_b, &[]);

--- a/tests/tests/wgpu-gpu/vertex_indices/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_indices/mod.rs
@@ -375,15 +375,17 @@ async fn vertex_index_common(ctx: TestingContext) {
             // (it is dropped via `take` + `finish` earlier, but compiler does not take this into account)
             let mut render_bundle_encoder = match test.encoder_kind {
                 EncoderKind::RenderPass => None,
-                EncoderKind::RenderBundle => Some(ctx.device.create_render_bundle_encoder(
-                    &wgpu::RenderBundleEncoderDescriptor {
-                        label: Some("test renderbundle encoder"),
-                        color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
-                        depth_stencil: None,
-                        sample_count: 1,
-                        multiview: None,
-                    },
-                )),
+                EncoderKind::RenderBundle => Some(
+                    ctx.device
+                        .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+                            label: Some("test renderbundle encoder"),
+                            color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
+                            depth_stencil: None,
+                            sample_count: 1,
+                            multiview: None,
+                        })
+                        .unwrap(),
+                ),
             };
 
             let render_encoder: &mut dyn RenderEncoder = render_bundle_encoder

--- a/tests/tests/wgpu-validation/api/immediates.rs
+++ b/tests/tests/wgpu-validation/api/immediates.rs
@@ -537,12 +537,13 @@ fn render_multi_immediates_auto_layout_with_all_immediates_set_succeeds() {
     wgpu_test::valid(&device, || encoder.finish());
 
     let mut encoder = device.create_command_encoder(&Default::default());
-    let mut bundle_encoder =
-        device.create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+    let mut bundle_encoder = device
+        .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
             color_formats: &[Some(output_texture_view.texture().format())],
             sample_count: 1,
             ..wgpu::RenderBundleEncoderDescriptor::default()
-        });
+        })
+        .unwrap();
     do_encoding(&mut bundle_encoder, &pipeline);
     let bundle = bundle_encoder.finish(&wgpu::RenderBundleDescriptor::default());
 

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -5,7 +5,7 @@ use wgpu_core_remote_types::encoders::RenderBundleDescriptor;
 use wgpu_core::{
     binding_model::{self},
     command,
-    device::{DeviceLostClosure, WaitIdleError},
+    device::{DeviceLostClosure, MissingFeatures, WaitIdleError},
     error::EmptyErrorScopeStack,
     pipeline::{
         self, ProgrammableStageDescriptor, RenderPipelineVertexProcessor,
@@ -697,10 +697,7 @@ impl Global {
         device_id: DeviceId,
         desc: &command::RenderBundleEncoderDescriptor,
         id_in: id::RenderBundleEncoderId,
-    ) -> (
-        id::RenderBundleEncoderId,
-        Option<command::CreateRenderBundleError>,
-    ) {
+    ) -> Result<(), MissingFeatures> {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_bundle_encoders,
@@ -709,11 +706,11 @@ impl Global {
         } = &mut *hub;
 
         let device = devices.get(device_id);
-        let (render_bundle_encoder, error) = device.create_render_bundle_encoder(desc);
+        let render_bundle_encoder = device.create_render_bundle_encoder(desc)?;
 
-        let id = render_bundle_encoders.assign(id_in, *render_bundle_encoder);
+        render_bundle_encoders.assign(id_in, *render_bundle_encoder);
 
-        (id, error)
+        Ok(())
     }
 
     pub fn render_bundle_encoder_finish(

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -242,10 +242,23 @@ fn validate_render_bundle_encoder_descriptor(
 
 impl RenderBundleEncoder {
     /// Create a new `RenderBundleEncoder`.
+    ///
+    /// <https://www.w3.org/TR/webgpu/#dom-gpudevice-createrenderbundleencoder>
     pub fn new(
         device: &Arc<Device>,
         desc: &RenderBundleEncoderDescriptor,
     ) -> Result<Self, CreateRenderBundleError> {
+        // 1. Validate texture format required features of each non-null element of descriptor.colorFormats with this.[[device]].
+        for &format in desc.color_formats.iter().flatten() {
+            device.require_features(format.required_features())?;
+        }
+
+        // 2. If descriptor.depthStencilFormat is provided:
+        if let Some(ds) = desc.depth_stencil {
+            // Validate texture format required features of descriptor.depthStencilFormat with this.[[device]].
+            device.require_features(ds.format.required_features())?;
+        }
+
         device.check_is_valid()?;
         let (is_depth_read_only, is_stencil_read_only) =
             validate_render_bundle_encoder_descriptor(desc, device)?;

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2846,17 +2846,22 @@ impl Device {
     pub fn create_render_bundle_encoder(
         self: &Arc<Self>,
         desc: &command::RenderBundleEncoderDescriptor,
-    ) -> (
-        Box<command::RenderBundleEncoder>,
-        Option<command::CreateRenderBundleError>,
-    ) {
+    ) -> Result<Box<command::RenderBundleEncoder>, MissingFeatures> {
         profiling::scope!("Device::create_render_bundle_encoder");
         api_log!("Device::create_render_bundle_encoder");
-        let (encoder, error) = match command::RenderBundleEncoder::new(self, desc) {
-            Ok(encoder) => (encoder, None),
-            Err(e) => (command::RenderBundleEncoder::dummy(self), Some(e)),
-        };
-        (Box::new(encoder), error)
+        command::RenderBundleEncoder::new(self, desc)
+            .or_else(|err| match err {
+                command::CreateRenderBundleError::MissingFeatures(missing) => Err(missing),
+                err => {
+                    self.handle_error(
+                        err,
+                        desc.label.as_ref().map(|l| l.as_ref()),
+                        "Device::create_render_bundle_encoder",
+                    );
+                    Ok(command::RenderBundleEncoder::dummy(self))
+                }
+            })
+            .map(Box::new)
     }
 
     /// Generate information about late-validated buffer bindings for pipelines.

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -225,16 +225,15 @@ impl Device {
     }
 
     /// Creates an empty [`RenderBundleEncoder`].
-    #[must_use]
     pub fn create_render_bundle_encoder<'a>(
         &self,
         desc: &RenderBundleEncoderDescriptor<'_>,
-    ) -> RenderBundleEncoder<'a> {
-        let encoder = self.inner.create_render_bundle_encoder(desc);
-        RenderBundleEncoder {
+    ) -> Result<RenderBundleEncoder<'a>, CreateRenderBundleEncoderError> {
+        let encoder = self.inner.create_render_bundle_encoder(desc)?;
+        Ok(RenderBundleEncoder {
             inner: encoder,
             _p: PhantomData,
-        }
+        })
     }
 
     /// Creates a new [`BindGroup`].

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -1,7 +1,29 @@
+use alloc::string::String;
+use core::error::Error;
+use core::fmt::Display;
 use core::{marker::PhantomData, num::NonZeroU32, ops::Range};
 
 use crate::dispatch::RenderBundleEncoderInterface;
 use crate::*;
+
+/// Error type for [`Device::create_render_bundle_encoder`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateRenderBundleEncoderError(String);
+
+impl CreateRenderBundleEncoderError {
+    /// Creates a new `CreateRenderBundleEncoderError` with the given message.
+    pub fn new(msg: String) -> Self {
+        Self(msg)
+    }
+}
+
+impl Display for CreateRenderBundleEncoderError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        write!(f, "Error while creating render bundle encoder: {}", self.0)
+    }
+}
+
+impl Error for CreateRenderBundleEncoderError {}
 
 /// Encodes a series of GPU operations into a reusable "render bundle".
 ///

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2621,7 +2621,7 @@ impl dispatch::DeviceInterface for WebDevice {
     fn create_render_bundle_encoder(
         &self,
         desc: &crate::RenderBundleEncoderDescriptor<'_>,
-    ) -> dispatch::DispatchRenderBundleEncoder {
+    ) -> Result<dispatch::DispatchRenderBundleEncoder, crate::CreateRenderBundleEncoderError> {
         let mapped_color_formats = desc
             .color_formats
             .iter()
@@ -2648,13 +2648,16 @@ impl dispatch::DeviceInterface for WebDevice {
         let render_bundle_encoder = self
             .inner
             .create_render_bundle_encoder(&mapped_desc)
-            .unwrap();
+            .map_err(|e| {
+                let e = e.dyn_ref::<js_sys::Error>().expect("Expected a JS Error");
+                crate::CreateRenderBundleEncoderError::new(e.message().as_string().unwrap())
+            })?;
 
-        WebRenderBundleEncoder {
+        Ok(WebRenderBundleEncoder {
             inner: render_bundle_encoder,
             ident: crate::cmp::Identifier::create(),
         }
-        .into()
+        .into())
     }
 
     fn set_device_lost_callback(&self, device_lost_callback: dispatch::BoxDeviceLostCallback) {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1517,7 +1517,7 @@ impl dispatch::DeviceInterface for CoreDevice {
     fn create_render_bundle_encoder(
         &self,
         desc: &crate::RenderBundleEncoderDescriptor<'_>,
-    ) -> dispatch::DispatchRenderBundleEncoder {
+    ) -> Result<dispatch::DispatchRenderBundleEncoder, crate::CreateRenderBundleEncoderError> {
         let descriptor = wgc::command::RenderBundleEncoderDescriptor {
             label: desc.label.map(Borrowed),
             color_formats: Borrowed(desc.color_formats),
@@ -1525,16 +1525,12 @@ impl dispatch::DeviceInterface for CoreDevice {
             sample_count: desc.sample_count,
             multiview: desc.multiview,
         };
-        let (encoder, error) = self.wgpu_device.create_render_bundle_encoder(&descriptor);
-        if let Some(cause) = error {
-            self.wgpu_device.handle_error(
-                cause,
-                desc.label,
-                "Device::create_render_bundle_encoder",
-            );
-        }
+        let encoder = self
+            .wgpu_device
+            .create_render_bundle_encoder(&descriptor)
+            .map_err(|e| crate::CreateRenderBundleEncoderError::new(e.to_string()))?;
 
-        CoreRenderBundleEncoder { encoder }.into()
+        Ok(CoreRenderBundleEncoder { encoder }.into())
     }
 
     fn set_device_lost_callback(&self, device_lost_callback: dispatch::BoxDeviceLostCallback) {

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -202,7 +202,7 @@ pub trait DeviceInterface: CommonTraits {
     fn create_render_bundle_encoder(
         &self,
         desc: &crate::RenderBundleEncoderDescriptor<'_>,
-    ) -> DispatchRenderBundleEncoder;
+    ) -> Result<DispatchRenderBundleEncoder, crate::CreateRenderBundleEncoderError>;
 
     fn set_device_lost_callback(&self, device_lost_callback: BoxDeviceLostCallback);
 


### PR DESCRIPTION
**Connections**
Part of #8911
Part of #9710
Towards #10073

**Description**

Firstly we impl require feature validation at the start to better match the order of the spec. This is important because we map MissingFeatures (checks that are done in content timeline per spec: https://www.w3.org/TR/webgpu/#ref-for-abstract-opdef-validate-texture-format-required-features%E2%91%A5) to Err variant. We were also missing one point of validation: https://www.w3.org/TR/webgpu/#ref-for-abstract-opdef-validate-texture-format-required-features%E2%91%A6
The rest of errors will be handled by error sink in wgc.
The "content timeline" error are then passed all the way to the wgpu consumers (even if they run on webgpu). Deno can actually use this for own "content timeline" validation 🎉
I expect firefox and servo to be either unwraping or raising internal error as validation should already happen in content process.

**Testing**
One new passing CTS test and `webgpu:api,validation,capability_checks,features,texture_formats:render_bundle_encoder_descriptor_color_format:*` should also cover it but it get's skipped because we do not really support it cases in other places.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
