### PR TITLE
[core-remote] Types for the rest of encoders and handle them

### DIFF
--- a/wgpu-core-remote-types/src/encoders.rs
+++ b/wgpu-core-remote-types/src/encoders.rs
@@ -1,6 +1,59 @@
 use crate::{id, Label};
 
 pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
+pub type CommandBufferDescriptor<'a> = wgt::CommandBufferDescriptor<Label<'a>>;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+/// Corresponds to [`GPUCommandEncoder`](https://www.w3.org/TR/webgpu/#gpucommandencoder).
+pub enum CommandEncoderCommand<'a, RPD, CPD> {
+    BeginRenderPass {
+        desc: RPD,
+        render_pass_encoder_id: id::RenderPassEncoderId,
+    },
+    BeginComputePass {
+        desc: CPD, // optional, defaults to {}
+        compute_pass_encoder_id: id::ComputePassEncoderId,
+    },
+    CopyBufferToBuffer {
+        source: id::BufferId,
+        source_offset: u64,
+        destination: id::BufferId,
+        destination_offset: u64,
+        size: Option<u64>,
+    },
+    CopyBufferToTexture {
+        source: wgt::TexelCopyBufferInfo<id::BufferId>,
+        destination: wgt::TexelCopyTextureInfo<id::TextureId>,
+        copy_size: wgt::Extent3d,
+    },
+    CopyTextureToBuffer {
+        source: wgt::TexelCopyTextureInfo<id::TextureId>,
+        destination: wgt::TexelCopyBufferInfo<id::BufferId>,
+        copy_size: wgt::Extent3d,
+    },
+    CopyTextureToTexture {
+        source: wgt::TexelCopyTextureInfo<id::TextureId>,
+        destination: wgt::TexelCopyTextureInfo<id::TextureId>,
+        copy_size: wgt::Extent3d,
+    },
+    ClearBuffer {
+        buffer: id::BufferId,
+        offset: u64, // optional, defaults to 0
+        size: Option<u64>,
+    },
+    ResolveQuerySet {
+        query_set: id::QuerySetId,
+        first_query: u32,
+        query_count: u32,
+        destination: id::BufferId,
+        destination_offset: u64,
+    },
+    DebugCommand(DebugCommand),
+    Finish {
+        desc: CommandBufferDescriptor<'a>,
+        command_buffer_id: id::CommandBufferId,
+    },
+}
 
 #[derive(serde::Serialize, serde::Deserialize)]
 /// Corresponds to [`GPURenderPassEncoder`](https://www.w3.org/TR/webgpu/#gpurenderpassencoder).

--- a/wgpu-core-remote-types/src/encoders.rs
+++ b/wgpu-core-remote-types/src/encoders.rs
@@ -1,4 +1,6 @@
-use crate::id;
+use crate::{id, Label};
+
+pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 /// Corresponds to [`GPURenderPassEncoder`](https://www.w3.org/TR/webgpu/#gpurenderpassencoder).
@@ -26,6 +28,18 @@ pub enum RenderPassEncoderCommand {
     RenderCommand(RenderCommand),
     DebugCommand(DebugCommand),
     End,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+/// Corresponds to [`GPURenderBundleEncoder`](https://www.w3.org/TR/webgpu/#gpurenderbundleencoder).
+pub enum RenderBundleEncoderCommand<'a> {
+    BindingCommand(BindingCommand),
+    RenderCommand(RenderCommand),
+    DebugCommand(DebugCommand),
+    Finish {
+        desc: RenderBundleDescriptor<'a>, // optional, defaults to {}
+        render_bundle_id: id::RenderBundleId,
+    },
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/wgpu-core-remote/src/global/bundle.rs
+++ b/wgpu-core-remote/src/global/bundle.rs
@@ -1,3 +1,7 @@
+use wgpu_core_remote_types::encoders::{
+    BindingCommand, DebugCommand, RenderBundleEncoderCommand, RenderCommand,
+};
+
 use crate::hub::Hub;
 use crate::id;
 
@@ -182,5 +186,117 @@ impl crate::global::Global {
         let bundle_encoder = hub.render_bundle_encoders.get_mut(bundle_encoder);
 
         bundle_encoder.insert_debug_marker(label)
+    }
+}
+
+impl crate::global::Global {
+    pub fn handle_render_bundle_encoder_command<'a>(
+        &self,
+        bundle_encoder: id::RenderBundleEncoderId,
+        command: RenderBundleEncoderCommand<'a>,
+    ) {
+        match command {
+            RenderBundleEncoderCommand::BindingCommand(binding_command) => match binding_command {
+                BindingCommand::SetBindGroup {
+                    index,
+                    bind_group,
+                    dynamic_offsets,
+                } => self.render_bundle_encoder_set_bind_group(
+                    bundle_encoder,
+                    index,
+                    bind_group,
+                    &dynamic_offsets,
+                ),
+                BindingCommand::SetImmediates { range_offset, data } => {
+                    self.render_bundle_encoder_set_immediates(bundle_encoder, range_offset, &data)
+                }
+            },
+            RenderBundleEncoderCommand::RenderCommand(render_command) => match render_command {
+                RenderCommand::SetPipeline(id) => {
+                    self.render_bundle_encoder_set_pipeline(bundle_encoder, id)
+                }
+                RenderCommand::SetIndexBuffer {
+                    buffer,
+                    index_format,
+                    offset,
+                    size,
+                } => self.render_bundle_encoder_set_index_buffer(
+                    bundle_encoder,
+                    buffer,
+                    index_format,
+                    offset,
+                    size.and_then(core::num::NonZeroU64::new), // pass size directly once https://github.com/gfx-rs/wgpu/issues/3170 is resolved
+                ),
+                RenderCommand::SetVertexBuffer {
+                    slot,
+                    buffer,
+                    offset,
+                    size,
+                } => self.render_bundle_encoder_set_vertex_buffer(
+                    bundle_encoder,
+                    slot,
+                    buffer,
+                    offset,
+                    size.and_then(core::num::NonZeroU64::new), // pass size directly once https://github.com/gfx-rs/wgpu/issues/3170 is resolved
+                ),
+                RenderCommand::Draw {
+                    vertex_count,
+                    instance_count,
+                    first_vertex,
+                    first_instance,
+                } => self.render_bundle_encoder_draw(
+                    bundle_encoder,
+                    vertex_count,
+                    instance_count,
+                    first_vertex,
+                    first_instance,
+                ),
+                RenderCommand::DrawIndexed {
+                    index_count,
+                    instance_count,
+                    first_index,
+                    base_vertex,
+                    first_instance,
+                } => self.render_bundle_encoder_draw_indexed(
+                    bundle_encoder,
+                    index_count,
+                    instance_count,
+                    first_index,
+                    base_vertex,
+                    first_instance,
+                ),
+                RenderCommand::DrawIndirect {
+                    indirect_buffer,
+                    indirect_offset,
+                } => self.render_bundle_encoder_draw_indirect(
+                    bundle_encoder,
+                    indirect_buffer,
+                    indirect_offset,
+                ),
+                RenderCommand::DrawIndexedIndirect {
+                    indirect_buffer,
+                    indirect_offset,
+                } => self.render_bundle_encoder_draw_indexed_indirect(
+                    bundle_encoder,
+                    indirect_buffer,
+                    indirect_offset,
+                ),
+            },
+            RenderBundleEncoderCommand::DebugCommand(debug_command) => match debug_command {
+                DebugCommand::PushDebugGroup(label) => {
+                    self.render_bundle_encoder_push_debug_group(bundle_encoder, &label)
+                }
+                DebugCommand::PopDebugGroup => {
+                    self.render_bundle_encoder_pop_debug_group(bundle_encoder)
+                }
+                DebugCommand::InsertDebugMarker(label) => {
+                    self.render_bundle_encoder_insert_debug_marker(bundle_encoder, &label)
+                }
+            },
+            RenderBundleEncoderCommand::Finish {
+                desc,
+                render_bundle_id,
+            } => self.render_bundle_encoder_finish(bundle_encoder, desc, render_bundle_id),
+        }
     }
 }

--- a/wgpu-core-remote/src/global/command_encoder.rs
+++ b/wgpu-core-remote/src/global/command_encoder.rs
@@ -1,6 +1,9 @@
 use wgpu_core::Label;
+use wgpu_core_remote_types::encoders::{CommandEncoderCommand, DebugCommand};
 use wgt::{BufferAddress, Extent3d, ImageSubresourceRange};
 
+use crate::global::compute_pass::ComputePassDescriptor;
+use crate::global::render_pass::RenderPassDescriptor;
 use crate::global::Global;
 use crate::hub::Hub;
 use crate::id::{BufferId, CommandEncoderId, TextureId};
@@ -204,5 +207,110 @@ impl Global {
             aspect: destination.aspect,
         };
         cmd_enc.copy_texture_to_texture(&source, &destination, copy_size)
+    }
+}
+
+impl Global {
+    pub fn handle_command_encoder_command<'a>(
+        &self,
+        command_encoder_id: CommandEncoderId,
+        command: CommandEncoderCommand<'a, RenderPassDescriptor<'a>, ComputePassDescriptor<'a>>,
+    ) {
+        match command {
+            CommandEncoderCommand::BeginRenderPass {
+                desc,
+                render_pass_encoder_id,
+            } => self.command_encoder_begin_render_pass(
+                command_encoder_id,
+                &desc,
+                render_pass_encoder_id,
+            ),
+            CommandEncoderCommand::BeginComputePass {
+                desc,
+                compute_pass_encoder_id,
+            } => self.command_encoder_begin_compute_pass(
+                command_encoder_id,
+                &desc,
+                compute_pass_encoder_id,
+            ),
+            CommandEncoderCommand::CopyBufferToBuffer {
+                source,
+                source_offset,
+                destination,
+                destination_offset,
+                size,
+            } => self.command_encoder_copy_buffer_to_buffer(
+                command_encoder_id,
+                source,
+                source_offset,
+                destination,
+                destination_offset,
+                size,
+            ),
+            CommandEncoderCommand::CopyBufferToTexture {
+                source,
+                destination,
+                copy_size,
+            } => self.command_encoder_copy_buffer_to_texture(
+                command_encoder_id,
+                &source,
+                &destination,
+                &copy_size,
+            ),
+            CommandEncoderCommand::CopyTextureToBuffer {
+                source,
+                destination,
+                copy_size,
+            } => self.command_encoder_copy_texture_to_buffer(
+                command_encoder_id,
+                &source,
+                &destination,
+                &copy_size,
+            ),
+            CommandEncoderCommand::CopyTextureToTexture {
+                source,
+                destination,
+                copy_size,
+            } => self.command_encoder_copy_texture_to_texture(
+                command_encoder_id,
+                &source,
+                &destination,
+                &copy_size,
+            ),
+            CommandEncoderCommand::ClearBuffer {
+                buffer,
+                offset,
+                size,
+            } => self.command_encoder_clear_buffer(command_encoder_id, buffer, offset, size),
+            CommandEncoderCommand::ResolveQuerySet {
+                query_set,
+                first_query,
+                query_count,
+                destination,
+                destination_offset,
+            } => self.command_encoder_resolve_query_set(
+                command_encoder_id,
+                query_set,
+                first_query,
+                query_count,
+                destination,
+                destination_offset,
+            ),
+            CommandEncoderCommand::DebugCommand(debug_command) => match debug_command {
+                DebugCommand::PushDebugGroup(label) => {
+                    self.command_encoder_push_debug_group(command_encoder_id, &label)
+                }
+                DebugCommand::PopDebugGroup => {
+                    self.command_encoder_pop_debug_group(command_encoder_id)
+                }
+                DebugCommand::InsertDebugMarker(label) => {
+                    self.command_encoder_insert_debug_marker(command_encoder_id, &label)
+                }
+            },
+            CommandEncoderCommand::Finish {
+                desc,
+                command_buffer_id,
+            } => self.command_encoder_finish(command_encoder_id, &desc, command_buffer_id),
+        }
     }
 }

--- a/wgpu-core-remote/src/global/compute_pass.rs
+++ b/wgpu-core-remote/src/global/compute_pass.rs
@@ -1,12 +1,15 @@
 use alloc::borrow::Cow;
 
-use wgpu_core::command::{ComputePassDescriptor, PassTimestampWrites};
+use wgpu_core::command::PassTimestampWrites;
 use wgpu_core_remote_types::encoders::{BindingCommand, ComputePassEncoderCommand, DebugCommand};
 use wgt::{BufferAddress, DynamicOffset};
 
 use crate::global::Global;
 use crate::hub::Hub;
 use crate::id;
+
+pub type ComputePassDescriptor<'a> =
+    wgpu_core::command::ComputePassDescriptor<'a, PassTimestampWrites<id::QuerySetId>>;
 
 impl Global {
     /// Creates a compute pass.
@@ -19,10 +22,10 @@ impl Global {
     /// If successful, puts the encoder into the [`Locked`] state.
     ///
     /// [`Locked`]: crate::command::CommandEncoderStatus::Locked
-    pub fn command_encoder_begin_compute_pass(
+    pub fn command_encoder_begin_compute_pass<'a>(
         &self,
         encoder_id: id::CommandEncoderId,
-        desc: &ComputePassDescriptor<'_, PassTimestampWrites<id::QuerySetId>>,
+        desc: &ComputePassDescriptor<'a>,
         id_in: id::ComputePassEncoderId,
     ) {
         let mut hub = self.hub.borrow_mut();
@@ -35,7 +38,7 @@ impl Global {
 
         let cmd_enc = command_encoders.get(encoder_id);
 
-        let desc = ComputePassDescriptor {
+        let desc = wgpu_core::command::ComputePassDescriptor {
             label: desc.label.as_deref().map(Cow::Borrowed),
             timestamp_writes: desc
                 .timestamp_writes

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -1,5 +1,6 @@
 use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use core::ptr::NonNull;
+use wgpu_core_remote_types::encoders::RenderBundleDescriptor;
 
 use wgpu_core::{
     binding_model::{self},
@@ -718,7 +719,7 @@ impl Global {
     pub fn render_bundle_encoder_finish(
         &self,
         render_bundle_encoder_id: id::RenderBundleEncoderId,
-        desc: &command::RenderBundleDescriptor,
+        desc: RenderBundleDescriptor,
         id_in: id::RenderBundleId,
     ) {
         let mut hub = self.hub.borrow_mut();
@@ -729,7 +730,10 @@ impl Global {
         } = &mut *hub;
         let bundle_encoder = render_bundle_encoders.get_mut(render_bundle_encoder_id);
 
-        let render_bundle = bundle_encoder.finish(desc);
+        let RenderBundleDescriptor { label } = desc;
+        let desc = wgt::RenderBundleDescriptor { label };
+
+        let render_bundle = bundle_encoder.finish(&desc);
 
         render_bundles.assign(id_in, render_bundle);
     }

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -43,10 +43,10 @@ impl Global {
     /// If successful, puts the encoder into the [`Locked`] state.
     ///
     /// [`Locked`]: crate::command::CommandEncoderStatus::Locked
-    pub fn command_encoder_begin_render_pass(
+    pub fn command_encoder_begin_render_pass<'a>(
         &self,
         encoder_id: id::CommandEncoderId,
-        desc: &RenderPassDescriptor<'_>,
+        desc: &RenderPassDescriptor<'a>,
         id_in: id::RenderPassEncoderId,
     ) {
         let mut hub = self.hub.borrow_mut();


### PR DESCRIPTION
**Connections**
Towards https://github.com/gfx-rs/wgpu/issues/10073

**Description**
As said in https://github.com/gfx-rs/wgpu/issues/10073#issuecomment-5309351478 and demonstrated in #10111. Types and behaviors are stolen from firefox.
To keep stuff simple CommandEncoderCommand is generic over render/compute pass desc as moving them in remote-types is hard task (firefox currently uses types from wgc).

**Testing**
It compiles

**Squash or Rebase?**
Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
