### PR TITLE
fix(core): deadlock between `Queue::compact_blas` and `Queue::submit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ By @sagudev in [#10115](https://github.com/gfx-rs/wgpu/pull/10115).
 - Fix a spurious assertion failure in `Device::maintain` when multiple threads race polling the same device. By @AdrianEddy in [#9958](https://github.com/gfx-rs/wgpu/pull/9958).
 - Fix `PendingSubmission` releasing its lock guards out of stacking order, which tripped `--cfg wgpu_validate_locks` on any submission. By @AdrianEddy in [#9960](https://github.com/gfx-rs/wgpu/pull/9960).
 - Fix initialization tracking for some cases of array textures, 3d textures, and depth/stencil textures with divergent usage in a render pass. By @andyleiserson in [#10002](https://github.com/gfx-rs/wgpu/pull/10002) and [#10060](https://github.com/gfx-rs/wgpu/pull/10060).
+- Fixed a deadlock between `Queue::compact_blas` and `Queue::submit`, which acquired `Device::command_indices` and `Queue::pending_writes` in opposite orders. By @mstampfli in [#10118](https://github.com/gfx-rs/wgpu/pull/10118).
 
 #### naga
 

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -2045,6 +2045,7 @@ impl Queue {
         let mut size_info = blas.size_info;
         size_info.acceleration_structure_size = size;
 
+        let mut command_indices_lock = device.command_indices.write();
         let mut pending_writes = self.pending_writes.lock();
         let cmd_buf_raw = pending_writes.activate();
 
@@ -2076,9 +2077,6 @@ impl Queue {
                 .get_acceleration_structure_device_address(raw.as_ref())
         };
 
-        drop(snatch_guard);
-
-        let mut command_indices_lock = device.command_indices.write();
         command_indices_lock.next_acceleration_structure_build_command_index += 1;
         let built_index =
             NonZeroU64::new(command_indices_lock.next_acceleration_structure_build_command_index)


### PR DESCRIPTION
**Connections**

Fixes #9981. The same reordering is already present in @andyleiserson's draft #9479 (Enable `wgpu_validate_locks`). This is offered as a standalone split-out so the reported deadlock can be fixed without waiting on that larger change; happy to close it if you would rather land it as part of #9479.

**Description**

`Queue::submit` acquires `Device::command_indices` (in `allocate_submission`) and then `Queue::pending_writes`. `Queue::compact_blas_inner` acquired them in the opposite order, so a thread in `submit` and a thread in `compact_blas` on the same queue can each end up holding the lock the other is waiting for. #9981 has a concrete repro from a Bevy render schedule.

This takes the acceleration structure build index before locking pending writes, so compaction uses the same order as submission. Bumping that counter on a path that later fails only leaves a gap in it, which is harmless: it orders builds, it does not count them.

It also removes an out-of-order guard release in the same function, which acquired `Device::snatchable_lock`, then `Queue::pending_writes`, then dropped the snatch guard while still holding pending writes. The snatch guard now lives to the end of the function, so the guards unwind in reverse acquisition order.

**Testing**

The ray tracing test suite passes in full on this machine, 155 of 155, on Vulkan (NVIDIA RTX 5060, Intel, llvmpipe) and GL, on Linux. That includes `as_build::blas_compaction`, which exercises this path.

Under `RUSTFLAGS='--cfg wgpu_validate_locks'` this code path is not reachable on trunk, because submission trips a violation first. With the remaining lock order divergences fixed locally so that it is reachable, the ray tracing suite goes from 121 passed / 34 failed to 155 passed / 0 failed, with no lock violations reported.

I also ran the repository CI checks locally at their pinned versions (clippy for native, web and `wasm32v1-none` no_std, `doc` and `doc --document-private-items`, doctests, wgpu and core MSRV 1.87, `cargo fmt`, prettier, typos and `cargo deny`). Every job that this machine can run passes, and matches an unmodified trunk run used as a control.

**Squash or Rebase?**

Squash.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
