### PR TITLE
Give a clear error when `dxc` is missing in the passthrough tests

### DIFF
--- a/tests/tests/wgpu-gpu/passthrough/mod.rs
+++ b/tests/tests/wgpu-gpu/passthrough/mod.rs
@@ -269,7 +269,9 @@ fn compile_dxil(entry: &str, stage_str: &str, test_hash: u64) -> Cow<'static, [u
             &out_path,
         ])
         .output()
-        .unwrap();
+        .unwrap_or_else(|e| {
+            panic!("failed to run `dxc` (required to compile the passthrough test shaders; install the DirectX Shader Compiler and ensure `dxc` is on PATH): {e}")
+        });
     let file = std::fs::read(&out_path);
     let _ = std::fs::remove_file(out_path);
     // Remove the file before checking for status
@@ -358,7 +360,9 @@ fn spirv_source(test_hash: u64) -> Cow<'static, [u32]> {
             &out_path,
         ])
         .output()
-        .unwrap();
+        .unwrap_or_else(|e| {
+            panic!("failed to run `dxc` (required to compile the passthrough test shaders; install the DirectX Shader Compiler and ensure `dxc` is on PATH): {e}")
+        });
     let file = std::fs::read(&out_path);
     let _ = std::fs::remove_file(out_path);
     // Remove the file before checking for status


### PR DESCRIPTION
**Connections**

None.

**Description**

The SPIR-V and DXIL passthrough tests compile `shader.hlsl` at runtime by shelling out to `dxc`, but the spawn result is bare-unwrapped. On a machine without the DirectX Shader Compiler, every passthrough test fails with only `No such file or directory (os error 2)` and no hint as to which tool is missing. CI installs dxc via `.github/actions/install-dxc`, so only local runs ever hit this. This names the tool and the remedy in the panic instead.

**Testing**

Without `dxc` on `PATH`, `spirv_passthrough_shader` now panics with:

```
failed to run `dxc` (required to compile the passthrough test shaders; install the DirectX Shader Compiler and ensure `dxc` is on PATH): No such file or directory (os error 2)
```

where trunk panics with the bare unwrap message:

```
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

With dxc installed, the passthrough tests pass in full on this machine, 50 of 50, on Vulkan (NVIDIA, Intel and llvmpipe) and GL (NVIDIA), on Linux.

**Squash or Rebase?**

Squash.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
