### PR TITLE
Move erroring into Queue methods in core and some cleanup of queue methods in Global

### DIFF
--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -222,7 +222,6 @@ impl GPUAdapter {
     let queue_obj = deno_core::cppgc::make_cppgc_object(
       scope,
       GPUQueue {
-        error_handler: error_handler.clone(),
         label: descriptor.label.clone(),
         wgpu_queue: queue,
         wgpu_device: wgpu_device.clone(),

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -131,12 +131,11 @@ impl GPUQueue {
   ) -> Result<(), JsErrorBox> {
     let data = get_data_slice(scope, data_arg, data_offset, size)?;
 
-    let err = self
-      .wgpu_queue
-      .write_buffer(buffer.wgpu_buffer.clone(), buffer_offset, data)
-      .err();
-
-    self.error_handler.push_error(err);
+    self.wgpu_queue.write_buffer(
+      buffer.wgpu_buffer.clone(),
+      buffer_offset,
+      data,
+    );
 
     Ok(())
   }
@@ -163,12 +162,9 @@ impl GPUQueue {
       rows_per_image: data_layout.rows_per_image,
     };
 
-    let err = self
+    self
       .wgpu_queue
-      .write_texture(destination, buf, &data_layout, &size.into())
-      .err();
-
-    self.error_handler.push_error(err);
+      .write_texture(destination, buf, &data_layout, &size.into());
   }
 }
 

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -23,8 +23,6 @@ use crate::webidl::GPUExtent3D;
 use crate::webidl::GPUOrigin3D;
 
 pub struct GPUQueue {
-  pub error_handler: super::error::ErrorHandler,
-
   pub label: String,
 
   pub wgpu_queue: Arc<wgpu_core::device::queue::Queue>,
@@ -67,11 +65,7 @@ impl GPUQueue {
       .map(|cb| cb.wgpu_command_buffer.clone())
       .collect::<Vec<_>>();
 
-    let err = self.wgpu_queue.submit(&ids).err();
-
-    if let Some((_, err)) = err {
-      self.error_handler.push_error(Some(err));
-    }
+    self.wgpu_queue.submit(&ids);
 
     Ok(())
   }

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -396,7 +396,7 @@ impl Player {
                 queue.write_texture(to, &bin, &layout, &size);
             }
             Action::Submit(_index, ref commands) if commands.is_empty() => {
-                queue.submit(&[]).unwrap();
+                queue.submit(&[]);
             }
             Action::Submit(_index, commands) => {
                 let resolved_commands: Vec<_> = commands
@@ -404,7 +404,7 @@ impl Player {
                     .map(|cmd| self.resolve_command(cmd))
                     .collect();
                 let buffer = wgc::command::CommandBuffer::from_trace(device, resolved_commands);
-                queue.submit(&[buffer]).unwrap();
+                queue.submit(&[buffer]);
             }
             Action::FailedCommands {
                 commands,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -378,9 +378,7 @@ impl Player {
                 let buffer = self.resolve_buffer_id(id);
                 let bin = loader.load(&data);
                 if queued {
-                    queue
-                        .write_buffer(buffer, offset, &bin[..size.try_into().unwrap()])
-                        .expect("Queue::write_buffer error");
+                    queue.write_buffer(buffer, offset, &bin[..size.try_into().unwrap()]);
                 } else {
                     device
                         .set_buffer_data(&buffer, offset, &bin[..size.try_into().unwrap()])
@@ -395,9 +393,7 @@ impl Player {
             } => {
                 let to = self.resolve_texel_copy_texture_info(to);
                 let bin = loader.load(&data);
-                queue
-                    .write_texture(to, &bin, &layout, &size)
-                    .expect("Queue::write_texture error");
+                queue.write_texture(to, &bin, &layout, &size);
             }
             Action::Submit(_index, ref commands) if commands.is_empty() => {
                 queue.submit(&[]).unwrap();

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -54,8 +54,8 @@ fn trace_test(test_type: TestType) {
             device.push_error_scope(wgpu::ErrorFilter::Validation);
             encoder.clear_buffer(buffer, 0, None);
             let cmdbuf = encoder.finish(&wgt::CommandBufferDescriptor::default());
+            queue.submit(&[cmdbuf]);
             assert!(matches!(device.pop_error_scope(), Ok(None)));
-            queue.submit(&[cmdbuf]).unwrap();
         }
         TestType::FailedCommands => {
             device.push_error_scope(wgpu::ErrorFilter::Validation);
@@ -71,7 +71,9 @@ fn trace_test(test_type: TestType) {
             let cmdbuf = encoder.finish(&wgt::CommandBufferDescriptor::default());
             assert!(matches!(device.pop_error_scope(), Ok(None)));
             buffer.destroy();
-            queue.submit(&[cmdbuf]).unwrap_err();
+            device.push_error_scope(wgpu::ErrorFilter::Validation);
+            queue.submit(&[cmdbuf]);
+            assert!(matches!(device.pop_error_scope(), Ok(Some(_))));
         }
     }
 

--- a/wgpu-core-remote-types/src/lib.rs
+++ b/wgpu-core-remote-types/src/lib.rs
@@ -5,6 +5,8 @@ use alloc::borrow::Cow;
 
 pub type Index = u32;
 pub type Epoch = u32;
+pub type SubmissionIndex = u64;
+pub type SubmittedWorkDoneClosure = Box<dyn FnOnce() + Send + 'static>;
 
 pub mod id;
 pub mod identity;

--- a/wgpu-core-remote/src/global/queue.rs
+++ b/wgpu-core-remote/src/global/queue.rs
@@ -1,4 +1,4 @@
-use wgpu_core::device::queue::{QueueSubmitError, QueueWriteError, SubmittedWorkDoneClosure};
+use wgpu_core::device::queue::{QueueSubmitError, SubmittedWorkDoneClosure};
 use wgpu_core::SubmissionIndex;
 
 use crate::global::Global;
@@ -11,7 +11,7 @@ impl Global {
         buffer_id: BufferId,
         buffer_offset: wgt::BufferAddress,
         data: &[u8],
-    ) -> Result<(), QueueWriteError> {
+    ) {
         let hub = self.hub.borrow();
         let queue = hub.queues.get(queue_id);
         let buffer = hub.buffers.get(buffer_id);
@@ -26,7 +26,7 @@ impl Global {
         data: &[u8],
         data_layout: &wgt::TexelCopyBufferLayout,
         size: &wgt::Extent3d,
-    ) -> Result<(), QueueWriteError> {
+    ) {
         let hub = self.hub.borrow();
         let queue = hub.queues.get(queue_id);
         let texture = hub.textures.get(destination.texture);

--- a/wgpu-core-remote/src/global/queue.rs
+++ b/wgpu-core-remote/src/global/queue.rs
@@ -1,4 +1,4 @@
-use wgpu_core::device::queue::{QueueSubmitError, SubmittedWorkDoneClosure};
+use wgpu_core::device::queue::SubmittedWorkDoneClosure;
 use wgpu_core::SubmissionIndex;
 
 use crate::global::Global;
@@ -44,7 +44,7 @@ impl Global {
         &self,
         queue_id: QueueId,
         command_buffer_ids: &[CommandBufferId],
-    ) -> Result<SubmissionIndex, (SubmissionIndex, QueueSubmitError)> {
+    ) -> SubmissionIndex {
         let hub = self.hub.borrow();
         let queue = hub.queues.get(queue_id);
         let command_buffers = command_buffer_ids

--- a/wgpu-core-remote/src/global/queue.rs
+++ b/wgpu-core-remote/src/global/queue.rs
@@ -1,5 +1,4 @@
-use wgpu_core::device::queue::SubmittedWorkDoneClosure;
-use wgpu_core::SubmissionIndex;
+use wgpu_core_remote_types::{SubmissionIndex, SubmittedWorkDoneClosure};
 
 use crate::global::Global;
 use crate::id::{BufferId, CommandBufferId, QueueId, TextureId};

--- a/wgpu-core-remote/src/global/queue.rs
+++ b/wgpu-core-remote/src/global/queue.rs
@@ -19,19 +19,6 @@ impl Global {
         queue.write_buffer(buffer, buffer_offset, data)
     }
 
-    pub fn queue_validate_write_buffer(
-        &self,
-        queue_id: QueueId,
-        buffer_id: BufferId,
-        buffer_offset: u64,
-        buffer_size: wgt::BufferSize,
-    ) -> Result<(), QueueWriteError> {
-        let hub = self.hub.borrow();
-        let queue = hub.queues.get(queue_id);
-        let buffer = hub.buffers.get(buffer_id);
-        queue.validate_write_buffer(buffer, buffer_offset, buffer_size)
-    }
-
     pub fn queue_write_texture(
         &self,
         queue_id: QueueId,
@@ -65,13 +52,6 @@ impl Global {
             .map(|id| hub.command_buffers.get(*id))
             .collect::<Vec<_>>();
         queue.submit(&command_buffers)
-    }
-
-    pub fn queue_get_timestamp_period(&self, queue_id: QueueId) -> f32 {
-        let hub = self.hub.borrow();
-        let queue = hub.queues.get(queue_id);
-
-        queue.get_timestamp_period()
     }
 
     pub fn queue_on_submitted_work_done(

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -1502,7 +1502,7 @@ impl Queue {
         }
     }
 
-    pub fn submit(
+    fn submit_inner(
         &self,
         command_buffers: &[Arc<CommandBuffer>],
     ) -> Result<SubmissionIndex, (SubmissionIndex, QueueSubmitError)> {
@@ -1757,6 +1757,17 @@ impl Queue {
         api_log!("Queue::submit returned submit index {submit_index}");
 
         Ok(submit_index)
+    }
+
+    pub fn submit(&self, command_buffers: &[Arc<CommandBuffer>]) -> SubmissionIndex {
+        match self.submit_inner(command_buffers) {
+            Ok(submit_index) => submit_index,
+            Err((submit_index, e)) => {
+                self.device
+                    .handle_error(e, Some(self.label()), "Queue::submit");
+                submit_index
+            }
+        }
     }
 
     /// Allocate a submission index and prepare for a submission.

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -719,7 +719,7 @@ impl<'a> PendingSubmission<'a> {
 //TODO: move out common parts of write_xxx.
 
 impl Queue {
-    pub fn write_buffer(
+    pub(crate) fn write_buffer_inner(
         &self,
         buffer: Arc<Buffer>,
         buffer_offset: wgt::BufferAddress,
@@ -787,6 +787,18 @@ impl Queue {
         pending_writes.consume(staging_buffer);
 
         result
+    }
+
+    pub fn write_buffer(
+        &self,
+        buffer: Arc<Buffer>,
+        buffer_offset: wgt::BufferAddress,
+        data: &[u8],
+    ) {
+        if let Err(error) = self.write_buffer_inner(buffer, buffer_offset, data) {
+            self.device
+                .handle_error(error, Some(self.label()), "Queue::write_buffer");
+        }
     }
 
     pub fn create_staging_buffer(
@@ -950,7 +962,7 @@ impl Queue {
         Ok(())
     }
 
-    pub fn write_texture(
+    pub fn write_texture_inner(
         &self,
         destination: wgt::TexelCopyTextureInfo<Arc<Texture>>,
         data: &[u8],
@@ -1199,6 +1211,19 @@ impl Queue {
         pending_writes.insert_texture(&dst);
 
         Ok(())
+    }
+
+    pub fn write_texture(
+        &self,
+        destination: wgt::TexelCopyTextureInfo<Arc<Texture>>,
+        data: &[u8],
+        data_layout: &wgt::TexelCopyBufferLayout,
+        size: &wgt::Extent3d,
+    ) {
+        if let Err(error) = self.write_texture_inner(destination, data, data_layout, size) {
+            self.device
+                .handle_error(error, Some(self.label()), "Queue::write_texture");
+        }
     }
 
     #[cfg(webgl)]

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2285,7 +2285,7 @@ impl Device {
             mapped_at_creation: false,
         };
         let params = self.create_buffer_inner(&params_desc)?;
-        self.get_queue().unwrap().write_buffer(
+        self.get_queue().unwrap().write_buffer_inner(
             params.clone(),
             0,
             bytemuck::bytes_of(&params_data),

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1601,16 +1601,8 @@ impl dispatch::QueueInterface for CoreQueue {
     ) {
         let buffer = buffer.as_core();
 
-        match self
-            .wgpu_queue
+        self.wgpu_queue
             .write_buffer(buffer.wgpu_buffer.clone(), offset, data)
-        {
-            Ok(()) => (),
-            Err(err) => self
-                .wgpu_queue
-                .device()
-                .handle_error_nolabel(err, "Queue::write_buffer"),
-        }
     }
 
     fn create_staging_buffer(
@@ -1702,18 +1694,8 @@ impl dispatch::QueueInterface for CoreQueue {
         data_layout: crate::TexelCopyBufferLayout,
         size: crate::Extent3d,
     ) {
-        match self.wgpu_queue.write_texture(
-            map_texture_copy_view(texture),
-            data,
-            &data_layout,
-            &size,
-        ) {
-            Ok(()) => (),
-            Err(err) => self
-                .wgpu_queue
-                .device()
-                .handle_error_nolabel(err, "Queue::write_texture"),
-        }
+        self.wgpu_queue
+            .write_texture(map_texture_copy_view(texture), data, &data_layout, &size);
     }
 
     // This method needs to exist if either webgpu or webgl is enabled,

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1732,15 +1732,7 @@ impl dispatch::QueueInterface for CoreQueue {
             .map(|cmdbuf| cmdbuf.as_core().wgpu_command_buffer.clone())
             .collect::<SmallVec<[_; 4]>>();
 
-        let index = match self.wgpu_queue.submit(&command_buffers) {
-            Ok(index) => index,
-            Err((index, err)) => {
-                self.wgpu_queue
-                    .device()
-                    .handle_error_nolabel(err, "Queue::submit");
-                index
-            }
-        };
+        let index = self.wgpu_queue.submit(&command_buffers);
 
         drop(temp_command_buffers);
 


### PR DESCRIPTION
**Connections**
Part of #8911
Towards #10073

**Description**
I only moved erroring of methods defined by spec, staging buffer usually has some special error handling so it might be the best to stay as is. No content timeline validation was needed for those methods (as it's Rust not JS). I also removed non-spec queue methods from Global and add type aliases to remote-types so we use no wgc types for queue methods.

**Testing**
Just refactor

**Squash or Rebase?**
Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
