### PR TITLE
fix(hal/vulkan): Respect `InstanceFlags::DISCARD_HAL_LABELS`

### DIFF
--- a/wgpu-hal/src/vulkan/command.rs
+++ b/wgpu-hal/src/vulkan/command.rs
@@ -134,9 +134,16 @@ impl crate::CommandEncoder for super::CommandEncoder {
         }
         let raw = self.free.pop().unwrap();
 
-        // Set the name unconditionally, since there might be a
-        // previous name assigned to this.
-        unsafe { self.device.set_object_name(raw, label.unwrap_or_default()) };
+        if !self
+            .device
+            .instance
+            .flags
+            .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS)
+        {
+            // Set the name even if it is empty, since there might be a
+            // previous name assigned to the command buffer.
+            unsafe { self.device.set_object_name(raw, label.unwrap_or_default()) };
+        }
 
         // Reset some state in case the last renderpass was never ended.
         self.rpass_debug_marker_active = false;

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -3030,7 +3030,13 @@ impl super::DeviceShared {
                 .create_semaphore(&vk::SemaphoreCreateInfo::default(), None)
                 .map_err(super::map_host_device_oom_err)?;
 
-            self.set_object_name(semaphore, name);
+            if !self
+                .instance
+                .flags
+                .contains(wgt::InstanceFlags::DISCARD_HAL_LABELS)
+            {
+                self.set_object_name(semaphore, name);
+            }
 
             Ok(semaphore)
         }


### PR DESCRIPTION
Prompted by https://github.com/gfx-rs/wgpu/issues/10085#issuecomment-5354319339. Fixes a couple places where labels are set despite `DISCARD_HAL_LABELS` being active.

**Testing**
Untested

**Squash or Rebase?** Squash

**Checklist**

- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
  - #10123 adds a changelog entry that also covers this PR. 
