### PR TITLE
fix(core): Add missing `DISCARD_HAL_LABELS` checks in ray tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ By @sagudev in [#10115](https://github.com/gfx-rs/wgpu/pull/10115).
 - Fix `PendingSubmission` releasing its lock guards out of stacking order, which tripped `--cfg wgpu_validate_locks` on any submission. By @AdrianEddy in [#9960](https://github.com/gfx-rs/wgpu/pull/9960).
 - Fix initialization tracking for some cases of array textures, 3d textures, and depth/stencil textures with divergent usage in a render pass. By @andyleiserson in [#10002](https://github.com/gfx-rs/wgpu/pull/10002) and [#10060](https://github.com/gfx-rs/wgpu/pull/10060).
 - Fixed a deadlock between `Queue::compact_blas` and `Queue::submit`, which acquired `Device::command_indices` and `Queue::pending_writes` in opposite orders. By @mstampfli in [#10118](https://github.com/gfx-rs/wgpu/pull/10118).
+- Fixed some cases of passing object labels to platform APIs despite `InstanceFlags::DISCARD_HAL_LABELS` being set. By @andyleiserson in [#10121](https://github.com/gfx-rs/wgpu/pull/10121) and [#10123](https://github.com/gfx-rs/wgpu/pull/10123).
 
 #### naga
 

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -180,7 +180,7 @@ impl Device {
         let raw = unsafe {
             self.raw()
                 .create_acceleration_structure(&hal::AccelerationStructureDescriptor {
-                    label: blas_desc.label.as_deref(),
+                    label: hal_label(blas_desc.label.as_deref(), self.instance_flags),
                     size: size_info.acceleration_structure_size,
                     format: hal::AccelerationStructureFormat::BottomLevel,
                     allow_compaction: blas_desc
@@ -197,7 +197,10 @@ impl Device {
             Some(ManuallyDrop::new(unsafe {
                 self.raw()
                     .create_buffer(&hal::BufferDescriptor {
-                        label: Some("(wgpu internal) compaction read-back buffer"),
+                        label: hal_label(
+                            Some("(wgpu internal) compaction read-back buffer"),
+                            self.instance_flags,
+                        ),
                         size: size_of::<wgpu_types::BufferAddress>() as wgpu_types::BufferAddress,
                         usage: wgpu_types::BufferUses::ACCELERATION_STRUCTURE_QUERY
                             | wgpu_types::BufferUses::MAP_READ,
@@ -301,7 +304,7 @@ impl Device {
         let raw = unsafe {
             self.raw()
                 .create_acceleration_structure(&hal::AccelerationStructureDescriptor {
-                    label: desc.label.as_deref(),
+                    label: hal_label(desc.label.as_deref(), self.instance_flags),
                     size: size_info.acceleration_structure_size,
                     format: hal::AccelerationStructureFormat::TopLevel,
                     allow_compaction: false,


### PR DESCRIPTION
Adds some missing `hal_label` calls needed to honor `DISCARD_HAL_LABELS`.

**Testing**
Untested

**Squash or Rebase?** Squash