### PR TITLE
[core-remote] Write/update docs and make Global as Instance wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,8 @@ jobs:
 
           cargo --locked doc --target ${{ matrix.target }} ${{ matrix.extra-flags }} \
                 --package wgpu-core \
+                --package wgpu-core-remote \
+                --package wgpu-core-remote-types \
                 --package wgpu-hal \
                 --package naga \
                 --package wgpu \
@@ -529,8 +531,8 @@ jobs:
         run: |
           set -e
 
-          # check `wgpu-core` with all features. This will also get `wgpu-hal` and `wgpu-types`.
-          cargo check --target ${{ matrix.target }} --all-features -p wgpu-core
+          # check `wgpu-core-remote` and `wgpu-core` all features. This will also get `wgpu-core-remote-types` and `wgpu-hal` and `wgpu-types`.
+          cargo check --target ${{ matrix.target }} --all-features -p wgpu-core -p wgpu-core-remote
 
   # Check that the libraries build — but not that there are no warnings or that tests pass -
   # with `-Zdirect-minimal-versions` which lowers all dependencies from the workspace packages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ default-members = [
     "tests",
     "wgpu-core",
     "wgpu-core/platform-deps/*",
+    "wgpu-core-remote",
+    "wgpu-core-remote-types",
     "wgpu-hal",
     "wgpu-info",
     "wgpu-naga-bridge",

--- a/wgpu-core-remote-types/Cargo.toml
+++ b/wgpu-core-remote-types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wgpu-core-remote-types"
 version.workspace = true
 edition.workspace = true
-description = "Remoting version of wgpu-core"
+description = "Types for remoting version of wgpu-core for browser implementing WebGPU"
 homepage.workspace = true
 repository.workspace = true
 keywords.workspace = true

--- a/wgpu-core-remote-types/src/binding_model.rs
+++ b/wgpu-core-remote-types/src/binding_model.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::id::{BindGroupLayoutId, BufferId, ExternalTextureId, SamplerId, TextureViewId};
 use crate::Label;
 
+/// Corresponds to [`GPUBufferBinding`](https://www.w3.org/TR/webgpu/#dictdef-gpubufferbinding).
 #[repr(C)]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BufferBinding {
@@ -21,6 +22,7 @@ pub struct BufferBinding {
     pub size: Option<wgt::BufferAddress>,
 }
 
+/// Corresponds to [`GPUBindingResource`](https://www.w3.org/TR/webgpu/#typedefdef-gpubindingresource).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BindingResource {
     Buffer(BufferBinding),
@@ -30,6 +32,8 @@ pub enum BindingResource {
 }
 
 /// Bindable resource and the slot to bind it to.
+///
+/// This corresponds to [`GPUBindGroupEntry`](https://www.w3.org/TR/webgpu/#dictdef-gpubindgroupentry).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BindGroupEntry {
     /// Slot for which binding provides resource. Corresponds to an entry of the same
@@ -40,6 +44,8 @@ pub struct BindGroupEntry {
 }
 
 /// Describes a group of bindings and the resources to be bound.
+///
+/// This corresponds to [`GPUBindGroupDescriptor`](https://www.w3.org/TR/webgpu/#dictdef-gpubindgroupdescriptor).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BindGroupDescriptor<'a> {
     /// Debug label of the bind group.
@@ -52,7 +58,7 @@ pub struct BindGroupDescriptor<'a> {
     pub entries: Cow<'a, [BindGroupEntry]>,
 }
 
-/// Describes a [`BindGroupLayout`].
+/// Corresponds to [`GPUBindGroupLayoutDescriptor`](https://www.w3.org/TR/webgpu/#dictdef-gpubindgrouplayoutdescriptor).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BindGroupLayoutDescriptor<'a> {
     /// Debug label of the bind group layout.

--- a/wgpu-core-remote-types/src/id.rs
+++ b/wgpu-core-remote-types/src/id.rs
@@ -50,10 +50,7 @@ impl RawId {
 
 /// An identifier for a wgpu object.
 ///
-/// An `Id<T>` value identifies a value stored in a [`Global`]'s [`Hub`].
-///
-/// [`Global`]: crate::global::Global
-/// [`Hub`]: crate::hub::Hub
+/// An `Id<T>` value identifies a value stored in a `Global`'s `Hub`.
 #[repr(transparent)]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]

--- a/wgpu-core-remote-types/src/identity.rs
+++ b/wgpu-core-remote-types/src/identity.rs
@@ -100,7 +100,7 @@ impl<T: Marker> Default for IdentityManager<T> {
 /// A collection of identity managers for all resource types.
 ///
 /// This is to be used in content process for ID generation.
-/// IDs are then sent to the GPU process for resource creation in [`crate::hub::Hub`].
+/// IDs are then sent to the GPU process for resource creation in `Hub`.
 #[derive(Debug, Default)]
 pub struct IdentityHub {
     pub adapters: IdentityManager<markers::Adapter>,

--- a/wgpu-core-remote-types/src/lib.rs
+++ b/wgpu-core-remote-types/src/lib.rs
@@ -1,3 +1,17 @@
+//! This crate contains types for the remoting version of wgpu-core for browser implementing WebGPU.
+//!
+//! It contains types that are used for IPC communication between the browser's untrusted content process
+//! and the browser's trusted GPU process and [`IdentityHub`](crate::identity::IdentityHub) for Id generation.
+//! All in all it contains all types needed for content process.
+//!
+//! All IPC types implement `serde::Serialize` and `serde::Deserialize` so that they can be sent over IPC.
+//!
+//! Types are defined entirely separately from wgpu-core's (and eventually wgpu-types's) public types,
+//! so that even as experimental features like raytracing and native wpgu features that are not standard WebGPU,
+//! cannot be expressed in untrusted (thus potentially malicious) content processes,
+//! as Serde's standard deserialization rejects invalid values of the IPC types.
+//!
+//! For more information about the remoting architecture, see the wgpu-core-remote crate's documentation.
 extern crate alloc;
 extern crate wgpu_types as wgt;
 

--- a/wgpu-core-remote/Cargo.toml
+++ b/wgpu-core-remote/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wgpu-core-remote"
 version.workspace = true
 edition.workspace = true
-description = "Remoting version of wgpu-core"
+description = "Remoting version of wgpu-core for browser implementing WebGPU"
 homepage.workspace = true
 repository.workspace = true
 keywords.workspace = true

--- a/wgpu-core-remote/src/global/compute_pass.rs
+++ b/wgpu-core-remote/src/global/compute_pass.rs
@@ -19,9 +19,7 @@ impl Global {
     /// ultimately be generated when the parent encoder is finished, and it is
     /// not possible to run any commands from the invalid pass.
     ///
-    /// If successful, puts the encoder into the [`Locked`] state.
-    ///
-    /// [`Locked`]: crate::command::CommandEncoderStatus::Locked
+    /// If successful, puts the encoder into the `Locked` state.
     pub fn command_encoder_begin_compute_pass<'a>(
         &self,
         encoder_id: id::CommandEncoderId,

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -112,7 +112,7 @@ impl Global {
     /// [`GPUBufferDescriptor`]: https://www.w3.org/TR/webgpu/#dictdef-gpubufferdescriptor
     /// [`GPUBuffer`]: https://www.w3.org/TR/webgpu/#gpubuffer
     /// [`wgpu_types::BufferDescriptor`]: wgt::BufferDescriptor
-    /// [`Device::create_buffer`]: crate::device::Device::create_buffer
+    /// [`Device::create_buffer`]: wgpu_core::device::Device::create_buffer
     /// [`usage`]: https://www.w3.org/TR/webgpu/#dom-gputexturedescriptor-usage
     /// [`wgpu_types::BufferUsages`]: wgt::BufferUsages
     pub fn create_buffer_error(

--- a/wgpu-core-remote/src/global/instance.rs
+++ b/wgpu-core-remote/src/global/instance.rs
@@ -32,14 +32,14 @@ impl Global {
     /// The HAL adapter may be obtained e.g. by calling `enumerate_adapters` on
     /// the HAL directly.
     ///
-    /// If [limit bucketing][lt] is desired, [`crate::limits::apply_limit_buckets`]
+    /// If [limit bucketing][lt] is desired, [`wgpu_core::limits::apply_limit_buckets`]
     /// should be called with the HAL adapter before calling this function.
     ///
     /// # Safety
     ///
     /// `hal_adapter` must be created from this global internal instance handle.
     ///
-    /// [lt]: crate::limits#Limit-bucketing
+    /// [lt]: wgpu_core::limits#Limit-bucketing
     pub unsafe fn create_adapter_from_hal(
         &self,
         hal_adapter: hal::DynExposedAdapter,

--- a/wgpu-core-remote/src/global/mod.rs
+++ b/wgpu-core-remote/src/global/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::ToOwned as _, sync::Arc};
+use alloc::sync::Arc;
 use core::cell::RefCell;
 use core::fmt;
 use wgpu_core::binding_model::{BindGroupLayout, PipelineLayout};
@@ -24,6 +24,13 @@ mod instance;
 mod queue;
 mod render_pass;
 
+/// Wrapper around [`Instance`] that uses [`Hub`] to store all resources created by the instance behind an [`Id`].
+///
+/// All resource methods are implemented on [`Global`] and accept types from [`wgpu_core_remote_types`]
+/// (which use [`Id`]s instead of concrete resources) and maps them into [`wgpu_core`] types
+/// (the process which also includes resolving the IDs).
+///
+/// [`Id`]: crate::id::Id
 pub struct Global {
     pub(crate) hub: RefCell<Hub>,
     // the instance must be dropped last
@@ -42,31 +49,15 @@ impl Global {
         }
     }
 
-    /// # Safety
-    ///
-    /// Refer to the creation of wgpu-hal Instance for every backend.
-    pub unsafe fn from_hal_instance<A: hal::Api>(name: &str, hal_instance: A::Instance) -> Self {
-        Self {
-            instance: Instance::from_hal_instance::<A>(name.to_owned(), hal_instance),
-            hub: RefCell::new(Hub::new()),
-        }
-    }
-
-    /// # Safety
-    ///
-    /// - The raw instance handle returned must not be manually destroyed.
-    pub unsafe fn instance_as_hal<A: hal::Api>(&self) -> Option<&A::Instance> {
-        unsafe { self.instance.as_hal::<A>() }
-    }
-
-    /// # Safety
-    ///
-    /// - The raw handles obtained from the Instance must not be manually destroyed
-    pub unsafe fn from_instance(instance: Arc<Instance>) -> Self {
+    pub fn from_instance(instance: Arc<Instance>) -> Self {
         Self {
             instance,
             hub: RefCell::new(Hub::new()),
         }
+    }
+
+    pub fn instance(&self) -> &Arc<Instance> {
+        &self.instance
     }
 }
 

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -40,9 +40,7 @@ impl Global {
     /// ultimately be generated when the parent encoder is finished, and it is
     /// not possible to run any commands from the invalid pass.
     ///
-    /// If successful, puts the encoder into the [`Locked`] state.
-    ///
-    /// [`Locked`]: crate::command::CommandEncoderStatus::Locked
+    /// If successful, puts the encoder into the `Locked` state.
     pub fn command_encoder_begin_render_pass<'a>(
         &self,
         encoder_id: id::CommandEncoderId,

--- a/wgpu-core-remote/src/hub.rs
+++ b/wgpu-core-remote/src/hub.rs
@@ -9,66 +9,45 @@ of course `Debug`.
 [`id::DeviceId`]: crate::id::DeviceId
 [`id::BufferId`]: crate::id::BufferId
 
-Each `Id` contains not only an index for the resource it denotes but
-also a Backend indicating which `wgpu` backend it belongs to.
-
-`Id`s also incorporate a generation number, for additional validation.
+[`Id`]s also incorporate a generation number, for additional validation.
 
 The resources to which identifiers refer are freed explicitly.
 Attempting to use an identifier for a resource that has been freed
-elicits an error result.
-
-Eventually, we would like to remove numeric IDs from wgpu-core.
-See <https://github.com/gfx-rs/wgpu/issues/5121>.
+elicits an panic.
 
 ## Assigning ids to resources
 
-The users of `wgpu_core` generally want resource ids to be assigned
-in one of two ways:
+Firefox and Servo allocate ids themselves in the content process using [`IdentityHub`],
+then pass then via IPC to GPU process where it's passed down to
+`Global::device_create_buffer` and friends the id to assign the new
+resource.
 
-- Users like `wgpu` want `wgpu_core` to assign ids to resources itself.
-  For example, `wgpu` expects to call `Global::device_create_buffer`
-  and have the return value indicate the newly created buffer's id.
-
-- Users like Firefox want to allocate ids themselves, and pass
-  `Global::device_create_buffer` and friends the id to assign the new
-  resource.
-
-To accommodate either pattern, `wgpu_core` methods that create
-resources all expect an `id_in` argument that the caller can use to
-specify the id, and they all return the id used. For example, the
+Methods that create resources all expect an `id_in` argument
+that the caller uses to specify the id. For example, the
 declaration of `Global::device_create_buffer` looks like this:
 
 ```ignore
 impl Global {
     /* ... */
-    pub fn device_create_buffer<A: HalApi>(
+    pub fn device_create_buffer(
         &self,
         device_id: id::DeviceId,
-        desc: &resource::BufferDescriptor,
-        id_in: Input<G>,
-    ) -> (id::BufferId, Option<resource::CreateBufferError>) {
+        desc: &BufferDescriptor,
+        id_in: id::BufferId,
+    ) {
         /* ... */
     }
     /* ... */
 }
 ```
 
-Users that want to assign resource ids themselves pass in the id they
-want as the `id_in` argument, whereas users that want `wgpu_core`
-itself to choose ids always pass `()`. In either case, the id
-ultimately assigned is returned as the first element of the tuple.
-
-Producing true identifiers from `id_in` values is the job of an
-[`crate::identity::IdentityManager`] or ids will be received from outside through `Option<Id>` arguments.
-
 ## Id allocation and streaming
 
-Perhaps surprisingly, allowing users to assign resource ids themselves
+Allowing users to assign resource ids themselves
 enables major performance improvements in some applications.
 
-The `wgpu_core` API is designed for use by Firefox's [WebGPU]
-implementation. For security, web content and GPU use must be kept
+This is designed for use by Firefox's and Servo's [WebGPU] implementation.
+For security, web content and GPU use must be kept
 segregated in separate processes, with all interaction between them
 mediated by an inter-process communication protocol. As web content uses
 the WebGPU API, the content process sends messages to the GPU process,
@@ -94,12 +73,13 @@ activity to be pipelined greatly improves throughput.
 To help propagate errors correctly in this style of usage, when resource
 creation fails, the id supplied for that resource is marked to indicate
 as much, allowing subsequent operations using that id to be properly
-flagged as errors as well.
+flagged as errors as well. This is called [Contagious Invalidity].
 
-[`process`]: crate::identity::IdentityManager::process
 [`Id<R>`]: crate::id::Id
-[wrapped in a mutex]: trait.IdentityHandler.html#impl-IdentityHandler%3CI%3E-for-Mutex%3CIdentityManager%3E
+[`Id`]: crate::id::Id
 [WebGPU]: https://www.w3.org/TR/webgpu/
+[`IdentityHub`]: wgpu_core_remote_types::identity::IdentityHub
+[Contagious Invalidity]: https://www.w3.org/TR/webgpu/#invalidity
 
 */
 
@@ -120,24 +100,22 @@ use wgpu_core::{
 #[allow(rustdoc::private_intra_doc_links)]
 /// All the resources tracked by a [`crate::global::Global`].
 ///
-/// ## Locking
+/// Each field in [`Hub`] is a [`Registry`] holding all the values of a
+/// particular type of resource.
 ///
-/// Each field in `Hub` is a [`Registry`] holding all the values of a
-/// particular type of resource, all protected by a single RwLock.
-/// So for example, to access any [`Buffer`], you must acquire a read
-/// lock on the `Hub`s entire buffers registry. The lock guard
-/// gives you access to the `Registry`'s [`Storage`], which you can
-/// then index with the buffer's id. (Yes, this design causes
-/// contention; see [#2272].)
-///
-/// But most `wgpu` operations require access to several different
-/// kinds of resource, so you often need to hold locks on several
-/// different fields of your [`Hub`] simultaneously.
-///
-/// Inside the `Registry` there are `Arc<T>` where `T` is a Resource
-/// Lock of `Registry` happens only when accessing to get the specific resource
-///
-/// [`Storage`]: crate::storage::Storage
+/// Most `wgpu` operations require access to several different
+/// kinds of resource, so to obtain mutable references
+/// to different fields of your [`Hub`] simultaneously, use
+/// destructing:
+/// ```ignore
+/// fn f(hub: &mut Hub) {
+///     let Hub {
+///         command_encoders,
+///         command_buffers,
+///         ..
+///     } = hub;
+/// }
+/// ```
 pub struct Hub {
     pub(crate) adapters: Registry<Arc<Adapter>>,
     pub(crate) devices: Registry<Arc<Device>>,
@@ -165,13 +143,6 @@ pub struct Hub {
 
 impl Hub {
     pub(crate) fn new() -> Self {
-        // Unique lock ranks are required only for registries that are accessed concurrently.
-        // This happens in render pass/bundle encoding, and bind group creation. (Concurrent
-        // access could probably be avoided even in those cases, but acquiring all the locks
-        // at once simplifies the code.)
-        //
-        // The _first_ concurrently-held registry lock uses REGISTRY_STORAGE. Others have
-        // their own named lock rank.
         Self {
             adapters: Registry::new(),
             devices: Registry::new(),

--- a/wgpu-core-remote/src/id.rs
+++ b/wgpu-core-remote/src/id.rs
@@ -1,6 +1,6 @@
 pub use wgpu_core_remote_types::id::*;
 
-/// Reference wgpu objects via numeric IDs assigned by [`crate::identity::IdentityManager`].
+/// Reference wgpu objects via numeric IDs assigned by [`wgpu_core_remote_types::identity::IdentityManager`].
 #[derive(Clone, Debug)]
 pub struct IdReferences;
 

--- a/wgpu-core-remote/src/lib.rs
+++ b/wgpu-core-remote/src/lib.rs
@@ -1,3 +1,16 @@
+/*!
+This crate is a remoting version of [`wgpu_core`] for browser implementing WebGPU.
+
+Modern browsers have content processes that are untrusted and cannot directly access the GPU.
+Instead, they communicate with a trusted GPU process that has access to the GPU.
+
+wgpu-core-remote provides a remoting wrapper around [`wgpu_core`] named [`Global`](crate::global::Global),
+that is used in the GPU process to execute commands from the content process.
+All stuff that is needed in the content process is provided in the [`wgpu_core_remote_types`] crate.
+
+The key part of remoting are [`Id`](crate::id::Id) which are described in [`crate::hub`].
+*/
+
 #![allow(
     // Need many arguments for some core functions to be able to re-use code in many situations.
     clippy::too_many_arguments,

--- a/wgpu-core-remote/src/storage.rs
+++ b/wgpu-core-remote/src/storage.rs
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "Cannot insert UntypedId(0,1), found existing resource UntypedId(0,1)"
+        expected = "Cannot insert TestMarkerId(0,1), found existing resource TestMarkerId(0,1)"
     )]
     fn insert_occupied_same_epoch() {
         let mut storage = Storage::new();
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "Cannot insert UntypedId(0,2), found existing resource UntypedId(0,1)"
+        expected = "Cannot insert TestMarkerId(0,2), found existing resource TestMarkerId(0,1)"
     )]
     fn insert_occupied_different_epoch() {
         let mut storage = Storage::new();
@@ -194,7 +194,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Cannot remove UntypedId(0,2), found other resource UntypedId(0,1)")]
+    #[should_panic(
+        expected = "Cannot remove TestMarkerId(0,2), found other resource TestMarkerId(0,1)"
+    )]
     fn remove_epoch_mismatch() {
         let mut storage = Storage::new();
         storage.insert(id(0, 1), TestItem);
@@ -202,21 +204,23 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Cannot remove non-existent resource UntypedId(0,1)")]
+    #[should_panic(expected = "Cannot remove non-existent resource TestMarkerId(0,1)")]
     fn remove_vacant() {
         let mut storage = Storage::<TestItem>::new();
         storage.remove(id(0, 1));
     }
 
     #[test]
-    #[should_panic(expected = "Cannot get non-existent resource UntypedId(0,1)")]
+    #[should_panic(expected = "Cannot get non-existent resource TestMarkerId(0,1)")]
     fn get_vacant() {
         let storage = Storage::<TestItem>::new();
         storage.get(id(0, 1));
     }
 
     #[test]
-    #[should_panic(expected = "Cannot get UntypedId(0,2), found other resource UntypedId(0,1)")]
+    #[should_panic(
+        expected = "Cannot get TestMarkerId(0,2), found other resource TestMarkerId(0,1)"
+    )]
     fn get_epoch_mismatch() {
         let mut storage = Storage::new();
         storage.insert(id(0, 1), TestItem);


### PR DESCRIPTION
**Connections**
Towards #10073 

**Description**
Some docs were very out of date and I also write main docs for remote crates, which include motivation and design goals in prose. Also includes some stuff from #10103. Many docs also needed compilation fixes.

As for the global I made it fully as Instance wrapper. So you just put instance in and get wrapper around it (and this is safe, unsafe and docs there were stale). It's also easy to get inner instance back, so there is no need for re-exporting hal methods there as one should use the one provided on instance. This way we also prevent that safety comment become out of date.

Second commits makes sure that we include remote crates in appropriate CI checks.

**Testing**
Docs and some refactor
CI changes work because I've manually tested them.

**Squash or Rebase?**
Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
