### PR TITLE
naga: don't emit trailing whitespace after own-line WGSL attributes

### DIFF
--- a/naga/src/back/wgsl/writer.rs
+++ b/naga/src/back/wgsl/writer.rs
@@ -257,9 +257,7 @@ impl<W: Write> Writer<W> {
                     ]
                 }
             };
-            self.write_attributes(&attributes)?;
-            // Add a newline after attribute
-            writeln!(self.out)?;
+            self.write_attributes_line(&attributes)?;
 
             let func_ctx = back::FunctionCtx {
                 ty: back::FunctionType::EntryPoint(index as u16),
@@ -579,15 +577,17 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    /// Helper method to write a attribute
-    fn write_attributes(&mut self, attributes: &[Attribute]) -> BackendResult {
+    /// Helper method to write an attribute.
+    ///
+    /// Write `attributes` to `out`, with each one followed by a trailing space.
+    fn write_attributes_to(out: &mut impl Write, attributes: &[Attribute]) -> BackendResult {
         for attribute in attributes {
             match *attribute {
-                Attribute::Location(id) => write!(self.out, "@location({id}) ")?,
-                Attribute::BlendSrc(blend_src) => write!(self.out, "@blend_src({blend_src}) ")?,
+                Attribute::Location(id) => write!(out, "@location({id}) ")?,
+                Attribute::BlendSrc(blend_src) => write!(out, "@blend_src({blend_src}) ")?,
                 Attribute::BuiltIn(builtin_attrib) => {
                     let builtin = builtin_attrib.to_wgsl_if_implemented()?;
-                    write!(self.out, "@builtin({builtin}) ")?;
+                    write!(out, "@builtin({builtin}) ")?;
                 }
                 Attribute::Stage(shader_stage) => {
                     let stage_str = match shader_stage {
@@ -603,46 +603,62 @@ impl<W: Write> Writer<W> {
                         ShaderStage::Miss => "miss",
                     };
 
-                    write!(self.out, "@{stage_str} ")?;
+                    write!(out, "@{stage_str} ")?;
                 }
                 Attribute::WorkGroupSize(size) => {
                     write!(
-                        self.out,
+                        out,
                         "@workgroup_size({}, {}, {}) ",
                         size[0], size[1], size[2]
                     )?;
                 }
-                Attribute::Binding(id) => write!(self.out, "@binding({id}) ")?,
-                Attribute::Group(id) => write!(self.out, "@group({id}) ")?,
-                Attribute::Invariant => write!(self.out, "@invariant ")?,
+                Attribute::Binding(id) => write!(out, "@binding({id}) ")?,
+                Attribute::Group(id) => write!(out, "@group({id}) ")?,
+                Attribute::Invariant => write!(out, "@invariant ")?,
                 Attribute::Interpolate(interpolation, sampling) => {
                     if sampling.is_some() && sampling != Some(crate::Sampling::Center) {
                         let interpolation = interpolation
                             .unwrap_or(crate::Interpolation::Perspective)
                             .to_wgsl();
                         let sampling = sampling.unwrap_or(crate::Sampling::Center).to_wgsl();
-                        write!(self.out, "@interpolate({interpolation}, {sampling}) ")?;
+                        write!(out, "@interpolate({interpolation}, {sampling}) ")?;
                     } else if interpolation.is_some()
                         && interpolation != Some(crate::Interpolation::Perspective)
                     {
                         let interpolation = interpolation
                             .unwrap_or(crate::Interpolation::Perspective)
                             .to_wgsl();
-                        write!(self.out, "@interpolate({interpolation}) ")?;
+                        write!(out, "@interpolate({interpolation}) ")?;
                     }
                 }
                 Attribute::MeshStage(ref name) => {
-                    write!(self.out, "@mesh({name}) ")?;
+                    write!(out, "@mesh({name}) ")?;
                 }
                 Attribute::TaskPayload(ref payload_name) => {
-                    write!(self.out, "@payload({payload_name}) ")?;
+                    write!(out, "@payload({payload_name}) ")?;
                 }
-                Attribute::PerPrimitive => write!(self.out, "@per_primitive ")?,
+                Attribute::PerPrimitive => write!(out, "@per_primitive ")?,
                 Attribute::IncomingRayPayload(ref payload_name) => {
-                    write!(self.out, "@incoming_payload({payload_name}) ")?;
+                    write!(out, "@incoming_payload({payload_name}) ")?;
                 }
             };
         }
+        Ok(())
+    }
+
+    /// Write `attributes` followed by a single trailing space, for use where more
+    /// content follows on the same line (e.g. before a parameter name).
+    fn write_attributes(&mut self, attributes: &[Attribute]) -> BackendResult {
+        Self::write_attributes_to(&mut self.out, attributes)
+    }
+
+    /// Write `attributes` on their own line, followed by a newline. Attributes are
+    /// rendered into a buffer first so the trailing space `write_attributes_to`
+    /// puts after the last one can be trimmed before it reaches the line.
+    fn write_attributes_line(&mut self, attributes: &[Attribute]) -> BackendResult {
+        let mut buf = String::new();
+        Self::write_attributes_to(&mut buf, attributes)?;
+        writeln!(self.out, "{}", buf.trim_end())?;
         Ok(())
     }
 
@@ -1995,11 +2011,10 @@ impl<W: Write> Writer<W> {
     ) -> BackendResult {
         // Write group and binding attributes if present
         if let Some(ref binding) = global.binding {
-            self.write_attributes(&[
+            self.write_attributes_line(&[
                 Attribute::Group(binding.group),
                 Attribute::Binding(binding.binding),
             ])?;
-            writeln!(self.out)?;
         }
 
         if global

--- a/naga/tests/out/wgsl/glsl-210-bevy-2d-shader.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-210-bevy-2d-shader.frag.wgsl
@@ -8,7 +8,7 @@ struct FragmentOutput {
 
 var<private> v_Uv_1: vec2<f32>;
 var<private> o_Target: vec4<f32>;
-@group(1) @binding(0) 
+@group(1) @binding(0)
 var<uniform> global: ColorMaterial_color;
 
 fn main_1() {
@@ -21,7 +21,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main(@location(0) v_Uv: vec2<f32>) -> FragmentOutput {
     v_Uv_1 = v_Uv;
     main_1();

--- a/naga/tests/out/wgsl/glsl-210-bevy-2d-shader.vert.wgsl
+++ b/naga/tests/out/wgsl/glsl-210-bevy-2d-shader.vert.wgsl
@@ -19,11 +19,11 @@ var<private> Vertex_Position_1: vec3<f32>;
 var<private> Vertex_Normal_1: vec3<f32>;
 var<private> Vertex_Uv_1: vec2<f32>;
 var<private> v_Uv: vec2<f32>;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> global: Camera;
-@group(2) @binding(0) 
+@group(2) @binding(0)
 var<uniform> global_1: Transform;
-@group(2) @binding(1) 
+@group(2) @binding(1)
 var<uniform> global_2: Sprite_size;
 var<private> gl_Position: vec4<f32>;
 
@@ -42,7 +42,7 @@ fn main_1() {
     return;
 }
 
-@vertex 
+@vertex
 fn main(@location(0) Vertex_Position: vec3<f32>, @location(1) Vertex_Normal: vec3<f32>, @location(2) Vertex_Uv: vec2<f32>) -> VertexOutput {
     Vertex_Position_1 = Vertex_Position;
     Vertex_Normal_1 = Vertex_Normal;

--- a/naga/tests/out/wgsl/glsl-210-bevy-shader.vert.wgsl
+++ b/naga/tests/out/wgsl/glsl-210-bevy-shader.vert.wgsl
@@ -19,9 +19,9 @@ var<private> Vertex_Uv_1: vec2<f32>;
 var<private> v_Position: vec3<f32>;
 var<private> v_Normal: vec3<f32>;
 var<private> v_Uv: vec2<f32>;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> global: Camera;
-@group(2) @binding(0) 
+@group(2) @binding(0)
 var<uniform> global_1: Transform;
 var<private> gl_Position: vec4<f32>;
 
@@ -43,7 +43,7 @@ fn main_1() {
     return;
 }
 
-@vertex 
+@vertex
 fn main(@location(0) Vertex_Position: vec3<f32>, @location(1) Vertex_Normal: vec3<f32>, @location(2) Vertex_Uv: vec2<f32>) -> VertexOutput {
     Vertex_Position_1 = Vertex_Position;
     Vertex_Normal_1 = Vertex_Normal;

--- a/naga/tests/out/wgsl/glsl-246-collatz.comp.wgsl
+++ b/naga/tests/out/wgsl/glsl-246-collatz.comp.wgsl
@@ -2,7 +2,7 @@ struct PrimeIndices {
     indices: array<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global: PrimeIndices;
 var<private> gl_GlobalInvocationID_1: vec3<u32>;
 
@@ -51,7 +51,7 @@ fn main_1() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main(@builtin(global_invocation_id) gl_GlobalInvocationID: vec3<u32>) {
     gl_GlobalInvocationID_1 = gl_GlobalInvocationID;
     main_1();

--- a/naga/tests/out/wgsl/glsl-277-casting.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-277-casting.frag.wgsl
@@ -4,7 +4,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-280-matrix-cast.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-280-matrix-cast.frag.wgsl
@@ -4,7 +4,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-484-preprocessor-if.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-484-preprocessor-if.frag.wgsl
@@ -2,7 +2,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-5246-dual-iteration.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-5246-dual-iteration.frag.wgsl
@@ -44,7 +44,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-800-out-of-bounds-panic.vert.wgsl
+++ b/naga/tests/out/wgsl/glsl-800-out-of-bounds-panic.vert.wgsl
@@ -11,7 +11,7 @@ struct VertexOutput {
     @builtin(position) gl_Position: vec4<f32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> global: Globals;
 var<immediate> global_1: VertexPushConstants;
 var<private> position_1: vec2<f32>;
@@ -32,7 +32,7 @@ fn main_1() {
     return;
 }
 
-@vertex 
+@vertex
 fn main(@location(0) position: vec2<f32>, @location(1) color: vec4<f32>) -> VertexOutput {
     position_1 = position;
     color_1 = color;

--- a/naga/tests/out/wgsl/glsl-896-push-constant.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-896-push-constant.frag.wgsl
@@ -2,7 +2,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-900-implicit-conversions.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-900-implicit-conversions.frag.wgsl
@@ -26,7 +26,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-901-lhs-field-select.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-901-lhs-field-select.frag.wgsl
@@ -5,7 +5,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-931-constant-emitting.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-931-constant-emitting.frag.wgsl
@@ -9,7 +9,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-932-for-loop-if.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-932-for-loop-if.frag.wgsl
@@ -16,7 +16,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-anonymous-entry-point-type.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-anonymous-entry-point-type.frag.wgsl
@@ -9,7 +9,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() -> FragmentOutput {
     main_1();
     let _e1 = o_Target;

--- a/naga/tests/out/wgsl/glsl-bevy-pbr.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-bevy-pbr.frag.wgsl
@@ -53,39 +53,39 @@ var<private> v_WorldNormal_1: vec3<f32>;
 var<private> v_Uv_1: vec2<f32>;
 var<private> v_WorldTangent_1: vec4<f32>;
 var<private> o_Target: vec4<f32>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<uniform> global: CameraPosition;
-@group(1) @binding(0) 
+@group(1) @binding(0)
 var<uniform> global_1: Lights;
-@group(3) @binding(0) 
+@group(3) @binding(0)
 var<uniform> global_2: StandardMaterial_base_color;
-@group(3) @binding(1) 
+@group(3) @binding(1)
 var StandardMaterial_base_color_texture: texture_2d<f32>;
-@group(3) @binding(2) 
+@group(3) @binding(2)
 var StandardMaterial_base_color_texture_sampler: sampler;
-@group(3) @binding(3) 
+@group(3) @binding(3)
 var<uniform> global_3: StandardMaterial_roughness;
-@group(3) @binding(4) 
+@group(3) @binding(4)
 var<uniform> global_4: StandardMaterial_metallic;
-@group(3) @binding(5) 
+@group(3) @binding(5)
 var StandardMaterial_metallic_roughness_texture: texture_2d<f32>;
-@group(3) @binding(6) 
+@group(3) @binding(6)
 var StandardMaterial_metallic_roughness_texture_sampler: sampler;
-@group(3) @binding(7) 
+@group(3) @binding(7)
 var<uniform> global_5: StandardMaterial_reflectance;
-@group(3) @binding(8) 
+@group(3) @binding(8)
 var StandardMaterial_normal_map: texture_2d<f32>;
-@group(3) @binding(9) 
+@group(3) @binding(9)
 var StandardMaterial_normal_map_sampler: sampler;
-@group(3) @binding(10) 
+@group(3) @binding(10)
 var StandardMaterial_occlusion_texture: texture_2d<f32>;
-@group(3) @binding(11) 
+@group(3) @binding(11)
 var StandardMaterial_occlusion_texture_sampler: sampler;
-@group(3) @binding(12) 
+@group(3) @binding(12)
 var<uniform> global_6: StandardMaterial_emissive;
-@group(3) @binding(13) 
+@group(3) @binding(13)
 var StandardMaterial_emissive_texture: texture_2d<f32>;
-@group(3) @binding(14) 
+@group(3) @binding(14)
 var StandardMaterial_emissive_texture_sampler: sampler;
 var<private> gl_FrontFacing_1: bool;
 
@@ -789,7 +789,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main(@location(0) v_WorldPosition: vec3<f32>, @location(1) v_WorldNormal: vec3<f32>, @location(2) v_Uv: vec2<f32>, @location(3) v_WorldTangent: vec4<f32>, @builtin(front_facing) gl_FrontFacing: bool) -> FragmentOutput {
     v_WorldPosition_1 = v_WorldPosition;
     v_WorldNormal_1 = v_WorldNormal;

--- a/naga/tests/out/wgsl/glsl-bevy-pbr.vert.wgsl
+++ b/naga/tests/out/wgsl/glsl-bevy-pbr.vert.wgsl
@@ -21,10 +21,10 @@ var<private> Vertex_Tangent_1: vec4<f32>;
 var<private> v_WorldPosition: vec3<f32>;
 var<private> v_WorldNormal: vec3<f32>;
 var<private> v_Uv: vec2<f32>;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> global: CameraViewProj;
 var<private> v_WorldTangent: vec4<f32>;
-@group(2) @binding(0) 
+@group(2) @binding(0)
 var<uniform> global_1: Transform;
 var<private> gl_Position: vec4<f32>;
 
@@ -52,7 +52,7 @@ fn main_1() {
     return;
 }
 
-@vertex 
+@vertex
 fn main(@location(0) Vertex_Position: vec3<f32>, @location(1) Vertex_Normal: vec3<f32>, @location(2) Vertex_Uv: vec2<f32>, @location(3) Vertex_Tangent: vec4<f32>) -> VertexOutput {
     Vertex_Position_1 = Vertex_Position;
     Vertex_Normal_1 = Vertex_Normal;

--- a/naga/tests/out/wgsl/glsl-bits.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-bits.frag.wgsl
@@ -105,7 +105,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-bool-select.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-bool-select.frag.wgsl
@@ -36,7 +36,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() -> FragmentOutput {
     main_1();
     let _e1 = o_color;

--- a/naga/tests/out/wgsl/glsl-buffer.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-buffer.frag.wgsl
@@ -6,9 +6,9 @@ struct testBufferReadOnlyBlock {
     data: array<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> testBuffer: testBufferBlock;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage> testBufferReadOnly: testBufferReadOnlyBlock;
 
 fn main_1() {
@@ -23,7 +23,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-clamp-splat.vert.wgsl
+++ b/naga/tests/out/wgsl/glsl-clamp-splat.vert.wgsl
@@ -12,7 +12,7 @@ fn main_1() {
     return;
 }
 
-@vertex 
+@vertex
 fn main(@location(0) a_pos: vec2<f32>) -> VertexOutput {
     a_pos_1 = a_pos;
     main_1();

--- a/naga/tests/out/wgsl/glsl-const-global-swizzle.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-const-global-swizzle.frag.wgsl
@@ -17,7 +17,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main(@location(0) v_Uv: vec2<f32>) -> FragmentOutput {
     v_Uv_1 = v_Uv;
     main_1();

--- a/naga/tests/out/wgsl/glsl-constant-array-size.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-constant-array-size.frag.wgsl
@@ -4,7 +4,7 @@ struct Data {
 
 const NUM_VECS: i32 = 42i;
 
-@group(1) @binding(0) 
+@group(1) @binding(0)
 var<uniform> global: Data;
 
 fn function_() -> vec4<f32> {
@@ -36,7 +36,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-declarations.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-declarations.frag.wgsl
@@ -55,7 +55,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main(@location(0) position: vec2<f32>, @location(1) a: vec2<f32>, @location(2) in_array: vec4<f32>, @location(3) in_array_1: vec4<f32>) -> FragmentOutput {
     vert.position = position;
     vert.a = a;

--- a/naga/tests/out/wgsl/glsl-double-math-functions.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-double-math-functions.frag.wgsl
@@ -93,7 +93,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-dual-source-blending.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-dual-source-blending.frag.wgsl
@@ -14,7 +14,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() -> FragmentOutput {
     main_1();
     let _e1 = output0_;

--- a/naga/tests/out/wgsl/glsl-expressions.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-expressions.frag.wgsl
@@ -17,7 +17,7 @@ struct FragmentOutput {
 const strct: TestStruct = TestStruct(array<vec4<u32>, 2>(vec4(0u), vec4(1u)));
 
 var<private> global: f32;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global_1: a_buf;
 var<private> o_color: vec4<f32>;
 
@@ -459,7 +459,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() -> FragmentOutput {
     main_1();
     let _e1 = o_color;

--- a/naga/tests/out/wgsl/glsl-f16-glsl.comp.wgsl
+++ b/naga/tests/out/wgsl/glsl-f16-glsl.comp.wgsl
@@ -23,9 +23,9 @@ struct B {
     b_mat4_: mat4x4<f16>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> global: A;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> global_1: B;
 
 fn main_1() {
@@ -40,7 +40,7 @@ fn main_1() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-fma.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-fma.frag.wgsl
@@ -44,7 +44,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() -> FragmentOutput {
     main_1();
     let _e1 = o_color;

--- a/naga/tests/out/wgsl/glsl-functions_call.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-functions_call.frag.wgsl
@@ -61,7 +61,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-global-constant-array.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-global-constant-array.frag.wgsl
@@ -6,7 +6,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-images.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-images.frag.wgsl
@@ -1,16 +1,16 @@
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var img1D: texture_storage_1d<rgba8unorm,read_write>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var img2D: texture_storage_2d<rgba8unorm,read_write>;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var img3D: texture_storage_3d<rgba8unorm,read_write>;
-@group(0) @binding(5) 
+@group(0) @binding(5)
 var img2DArray: texture_storage_2d_array<rgba8unorm,read_write>;
-@group(0) @binding(7) 
+@group(0) @binding(7)
 var imgReadOnly: texture_storage_2d<rgba8unorm,read>;
-@group(0) @binding(8) 
+@group(0) @binding(8)
 var imgWriteOnly: texture_storage_2d<rgba8unorm,write>;
-@group(0) @binding(9) 
+@group(0) @binding(9)
 var imgWriteReadOnly: texture_storage_2d<rgba8unorm,write>;
 
 fn testImg1D(coord: i32) {
@@ -125,7 +125,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-interpolate.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-interpolate.frag.wgsl
@@ -13,7 +13,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main(@location(0) tex_coord: vec2<f32>, @location(1) @interpolate(flat) index: i32) -> FragmentOutput {
     tex_coord_1 = tex_coord;
     index_1 = index;

--- a/naga/tests/out/wgsl/glsl-inverse-polyfill.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-inverse-polyfill.frag.wgsl
@@ -28,7 +28,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-local-var-init-in-loop.comp.wgsl
+++ b/naga/tests/out/wgsl/glsl-local-var-init-in-loop.comp.wgsl
@@ -22,7 +22,7 @@ fn main_1() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-long-form-matrix.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-long-form-matrix.frag.wgsl
@@ -11,7 +11,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-math-functions.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-math-functions.frag.wgsl
@@ -152,7 +152,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-multipart-for-loop.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-multipart-for-loop.frag.wgsl
@@ -26,7 +26,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-prepostfix.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-prepostfix.frag.wgsl
@@ -32,7 +32,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-quad_glsl.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-quad_glsl.frag.wgsl
@@ -10,7 +10,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main(@location(0) v_uv: vec2<f32>) -> FragmentOutput {
     v_uv_1 = v_uv;
     main_1();

--- a/naga/tests/out/wgsl/glsl-quad_glsl.vert.wgsl
+++ b/naga/tests/out/wgsl/glsl-quad_glsl.vert.wgsl
@@ -19,7 +19,7 @@ fn main_1() {
     return;
 }
 
-@vertex 
+@vertex
 fn main(@location(0) a_pos: vec2<f32>, @location(1) a_uv: vec2<f32>) -> VertexOutput {
     a_pos_1 = a_pos;
     a_uv_1 = a_uv;

--- a/naga/tests/out/wgsl/glsl-sampler-functions.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-sampler-functions.frag.wgsl
@@ -1,6 +1,6 @@
-@group(1) @binding(0) 
+@group(1) @binding(0)
 var tex2D: texture_depth_2d;
-@group(1) @binding(1) 
+@group(1) @binding(1)
 var sampShadow: sampler_comparison;
 
 fn CalcShadowPCF1_(T_P_t_TextureDepth: texture_depth_2d, S_P_t_TextureDepth: sampler_comparison, t_ProjCoord: vec3<f32>) -> f32 {
@@ -37,7 +37,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-samplers.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-samplers.frag.wgsl
@@ -1,32 +1,32 @@
-@group(1) @binding(0) 
+@group(1) @binding(0)
 var tex1D: texture_1d<f32>;
-@group(1) @binding(2) 
+@group(1) @binding(2)
 var tex2D: texture_2d<f32>;
-@group(1) @binding(3) 
+@group(1) @binding(3)
 var tex2DArray: texture_2d_array<f32>;
-@group(1) @binding(4) 
+@group(1) @binding(4)
 var texCube: texture_cube<f32>;
-@group(1) @binding(5) 
+@group(1) @binding(5)
 var texCubeArray: texture_cube_array<f32>;
-@group(1) @binding(6) 
+@group(1) @binding(6)
 var tex3D: texture_3d<f32>;
-@group(1) @binding(7) 
+@group(1) @binding(7)
 var utex2D: texture_2d<u32>;
-@group(1) @binding(8) 
+@group(1) @binding(8)
 var itex2D: texture_2d<i32>;
-@group(2) @binding(0) 
+@group(2) @binding(0)
 var samp: sampler;
-@group(1) @binding(12) 
+@group(1) @binding(12)
 var tex2DShadow: texture_depth_2d;
-@group(1) @binding(13) 
+@group(1) @binding(13)
 var tex2DArrayShadow: texture_depth_2d_array;
-@group(1) @binding(14) 
+@group(1) @binding(14)
 var texCubeShadow: texture_depth_cube;
-@group(1) @binding(15) 
+@group(1) @binding(15)
 var texCubeArrayShadow: texture_depth_cube_array;
-@group(1) @binding(17) 
+@group(1) @binding(17)
 var sampShadow: sampler_comparison;
-@group(0) @binding(18) 
+@group(0) @binding(18)
 var tex2DMS: texture_multisampled_2d<f32>;
 
 fn testTex1D(coord: f32) {
@@ -579,7 +579,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-spec-constant.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-spec-constant.frag.wgsl
@@ -25,7 +25,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() -> FragmentOutput {
     main_1();
     let _e1 = o_color;

--- a/naga/tests/out/wgsl/glsl-statements.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-statements.frag.wgsl
@@ -61,7 +61,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/glsl-vector-functions.frag.wgsl
+++ b/naga/tests/out/wgsl/glsl-vector-functions.frag.wgsl
@@ -165,7 +165,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
     return;

--- a/naga/tests/out/wgsl/spv-8151-barrier-reorder.wgsl
+++ b/naga/tests/out/wgsl/spv-8151-barrier-reorder.wgsl
@@ -3,7 +3,7 @@ struct type_3 {
 }
 
 var<private> global: vec3<u32>;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global_1: type_3;
 var<workgroup> global_2: u32;
 
@@ -23,7 +23,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(2, 1, 1) 
+@compute @workgroup_size(2, 1, 1)
 fn barrier_reorder_bug(@builtin(local_invocation_id) param: vec3<u32>) {
     global = param;
     function_();

--- a/naga/tests/out/wgsl/spv-atomic_compare_exchange.wgsl
+++ b/naga/tests/out/wgsl/spv-atomic_compare_exchange.wgsl
@@ -11,9 +11,9 @@ struct type_5 {
     member: atomic<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global: type_5;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> global_1: type_3;
 
 fn function_() {
@@ -60,7 +60,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(32, 1, 1) 
+@compute @workgroup_size(32, 1, 1)
 fn stage_test_atomic_compare_exchange() {
     function_();
 }

--- a/naga/tests/out/wgsl/spv-atomic_exchange.wgsl
+++ b/naga/tests/out/wgsl/spv-atomic_exchange.wgsl
@@ -11,9 +11,9 @@ struct type_5 {
     member: atomic<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global: type_5;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> global_1: type_3;
 
 fn function_() {
@@ -74,7 +74,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(32, 1, 1) 
+@compute @workgroup_size(32, 1, 1)
 fn stage_test_atomic_exchange() {
     function_();
 }

--- a/naga/tests/out/wgsl/spv-atomic_global_struct_field_vertex.wgsl
+++ b/naga/tests/out/wgsl/spv-atomic_global_struct_field_vertex.wgsl
@@ -8,7 +8,7 @@ struct type_6 {
     member: type_5,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global: type_6;
 var<private> global_1: vec4<f32> = vec4<f32>(0f, 0f, 0f, 1f);
 
@@ -21,7 +21,7 @@ fn function_() {
     return;
 }
 
-@vertex 
+@vertex
 fn global_field_vertex() -> @builtin(position) vec4<f32> {
     function_();
     let _e1 = global_1;

--- a/naga/tests/out/wgsl/spv-atomic_i_add_sub.wgsl
+++ b/naga/tests/out/wgsl/spv-atomic_i_add_sub.wgsl
@@ -6,9 +6,9 @@ struct type_4 {
     member: atomic<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global: type_4;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> global_1: type_2;
 
 fn function_() {
@@ -20,7 +20,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(32, 1, 1) 
+@compute @workgroup_size(32, 1, 1)
 fn stage_test_atomic_i_add_sub() {
     function_();
 }

--- a/naga/tests/out/wgsl/spv-atomic_i_decrement.wgsl
+++ b/naga/tests/out/wgsl/spv-atomic_i_decrement.wgsl
@@ -6,9 +6,9 @@ struct type_5 {
     member: atomic<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global: type_5;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> global_1: type_3;
 
 fn function_() {
@@ -31,7 +31,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(32, 1, 1) 
+@compute @workgroup_size(32, 1, 1)
 fn stage_test_atomic_i_decrement() {
     function_();
 }

--- a/naga/tests/out/wgsl/spv-atomic_i_increment.wgsl
+++ b/naga/tests/out/wgsl/spv-atomic_i_increment.wgsl
@@ -6,9 +6,9 @@ struct type_4 {
     member: atomic<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global: type_4;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> global_1: type_2;
 
 fn function_() {
@@ -36,7 +36,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(32, 1, 1) 
+@compute @workgroup_size(32, 1, 1)
 fn stage_test_atomic_i_increment() {
     function_();
 }

--- a/naga/tests/out/wgsl/spv-atomic_load_and_store.wgsl
+++ b/naga/tests/out/wgsl/spv-atomic_load_and_store.wgsl
@@ -11,9 +11,9 @@ struct type_5 {
     member: atomic<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global: type_5;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> global_1: type_3;
 
 fn function_() {
@@ -66,7 +66,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(32, 1, 1) 
+@compute @workgroup_size(32, 1, 1)
 fn stage_test_atomic_load_and_store() {
     function_();
 }

--- a/naga/tests/out/wgsl/spv-barrier.wgsl
+++ b/naga/tests/out/wgsl/spv-barrier.wgsl
@@ -14,7 +14,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(64, 1, 1) 
+@compute @workgroup_size(64, 1, 1)
 fn main() {
     function_();
 }

--- a/naga/tests/out/wgsl/spv-binding-arrays.dynamic.wgsl
+++ b/naga/tests/out/wgsl/spv-binding-arrays.dynamic.wgsl
@@ -1,8 +1,8 @@
 enable wgpu_binding_array;
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var global: binding_array<texture_2d<f32>>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var global_1: binding_array<sampler>;
 var<private> global_2: vec4<f32>;
 
@@ -12,7 +12,7 @@ fn function_() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() -> @location(0) vec4<f32> {
     function_();
     let _e1 = global_2;

--- a/naga/tests/out/wgsl/spv-binding-arrays.runtime.wgsl
+++ b/naga/tests/out/wgsl/spv-binding-arrays.runtime.wgsl
@@ -2,9 +2,9 @@ enable wgpu_binding_array;
 
 var<private> input_u002e_texture_coordinates_1: vec2<f32>;
 var<private> input_u002e_texture_index_1: u32;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var textures: binding_array<texture_2d<f32>>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var linear_sampler: sampler;
 var<private> entryPointParam_main: vec4<f32>;
 
@@ -16,7 +16,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main(@location(0) input_u002e_texture_coordinates: vec2<f32>, @location(1) @interpolate(flat) input_u002e_texture_index: u32) -> @location(0) vec4<f32> {
     input_u002e_texture_coordinates_1 = input_u002e_texture_coordinates;
     input_u002e_texture_index_1 = input_u002e_texture_index;

--- a/naga/tests/out/wgsl/spv-binding-arrays.static.wgsl
+++ b/naga/tests/out/wgsl/spv-binding-arrays.static.wgsl
@@ -1,8 +1,8 @@
 enable wgpu_binding_array;
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var global: binding_array<texture_2d<f32>, 256>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var global_1: binding_array<sampler, 256>;
 var<private> global_2: vec4<f32>;
 
@@ -12,7 +12,7 @@ fn function_() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() -> @location(0) vec4<f32> {
     function_();
     let _e1 = global_2;

--- a/naga/tests/out/wgsl/spv-builtin-accessed-outside-entrypoint.wgsl
+++ b/naga/tests/out/wgsl/spv-builtin-accessed-outside-entrypoint.wgsl
@@ -20,7 +20,7 @@ fn main_1() {
     return;
 }
 
-@vertex 
+@vertex
 fn main(@builtin(vertex_index) gl_VertexIndex: u32) -> @builtin(position) vec4<f32> {
     gl_VertexIndex_1 = i32(gl_VertexIndex);
     main_1();

--- a/naga/tests/out/wgsl/spv-do-while.wgsl
+++ b/naga/tests/out/wgsl/spv-do-while.wgsl
@@ -17,7 +17,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
 }

--- a/naga/tests/out/wgsl/spv-dual-source-blending.wgsl
+++ b/naga/tests/out/wgsl/spv-dual-source-blending.wgsl
@@ -14,7 +14,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() -> FragmentOutput {
     main_1();
     let _e2 = output0_;

--- a/naga/tests/out/wgsl/spv-empty-global-name.wgsl
+++ b/naga/tests/out/wgsl/spv-empty-global-name.wgsl
@@ -2,7 +2,7 @@ struct type_1 {
     member: i32,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> unnamed: type_1;
 
 fn function_() {
@@ -11,7 +11,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     function_();
 }

--- a/naga/tests/out/wgsl/spv-f16-spv.wgsl
+++ b/naga/tests/out/wgsl/spv-f16-spv.wgsl
@@ -23,9 +23,9 @@ struct A {
     a_vec4_: vec4<f16>,
 }
 
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> unnamed: B;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> unnamed_1: A;
 
 fn main_1() {
@@ -40,7 +40,7 @@ fn main_1() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     main_1();
 }

--- a/naga/tests/out/wgsl/spv-fetch_depth.wgsl
+++ b/naga/tests/out/wgsl/spv-fetch_depth.wgsl
@@ -6,11 +6,11 @@ struct type_4 {
     member: vec2<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> global: type_2;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> global_1: type_4;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var global_2: texture_depth_2d;
 
 fn function_() {
@@ -20,7 +20,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(32, 1, 1) 
+@compute @workgroup_size(32, 1, 1)
 fn cull_fetch_depth() {
     function_();
 }

--- a/naga/tests/out/wgsl/spv-gather-cmp.wgsl
+++ b/naga/tests/out/wgsl/spv-gather-cmp.wgsl
@@ -1,7 +1,7 @@
 var<private> input_u002e_texture_coordinates_1: vec2<f32>;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var texture: texture_depth_2d;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var depth_sampler: sampler_comparison;
 var<private> entryPointParam_main: vec4<f32>;
 
@@ -12,7 +12,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main(@location(0) input_u002e_texture_coordinates: vec2<f32>) -> @location(0) vec4<f32> {
     input_u002e_texture_coordinates_1 = input_u002e_texture_coordinates;
     main_1();

--- a/naga/tests/out/wgsl/spv-gather.wgsl
+++ b/naga/tests/out/wgsl/spv-gather.wgsl
@@ -1,7 +1,7 @@
 var<private> input_u002e_texture_coordinates_1: vec2<f32>;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var texture: texture_2d<f32>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var linear_sampler: sampler;
 var<private> entryPointParam_main: vec4<f32>;
 
@@ -12,7 +12,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main(@location(0) input_u002e_texture_coordinates: vec2<f32>) -> @location(0) vec4<f32> {
     input_u002e_texture_coordinates_1 = input_u002e_texture_coordinates;
     main_1();

--- a/naga/tests/out/wgsl/spv-inv-hyperbolic-trig-functions.wgsl
+++ b/naga/tests/out/wgsl/spv-inv-hyperbolic-trig-functions.wgsl
@@ -14,7 +14,7 @@ fn main_1() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     main_1();
 }

--- a/naga/tests/out/wgsl/spv-load-ms-texture.wgsl
+++ b/naga/tests/out/wgsl/spv-load-ms-texture.wgsl
@@ -1,6 +1,6 @@
 var<private> global: vec4<f32>;
 var<private> entryPointParam_fs_main: vec4<f32>;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var texture: texture_multisampled_2d<f32>;
 
 fn fs_main() {
@@ -28,7 +28,7 @@ fn fs_main() {
     return;
 }
 
-@fragment 
+@fragment
 fn main(@builtin(position) param: vec4<f32>) -> @location(0) vec4<f32> {
     global = param;
     fs_main();

--- a/naga/tests/out/wgsl/spv-non-semantic-debug.wgsl
+++ b/naga/tests/out/wgsl/spv-non-semantic-debug.wgsl
@@ -2,7 +2,7 @@ fn main_1() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     main_1();
 }

--- a/naga/tests/out/wgsl/spv-per-vertex.wgsl
+++ b/naga/tests/out/wgsl/spv-per-vertex.wgsl
@@ -9,7 +9,7 @@ fn function_() {
     return;
 }
 
-@fragment 
+@fragment
 fn fs_main(@location(0) @interpolate(per_vertex) param: array<f32, 3>) -> @location(0) vec4<f32> {
     global = param;
     function_();

--- a/naga/tests/out/wgsl/spv-quad-vert.wgsl
+++ b/naga/tests/out/wgsl/spv-quad-vert.wgsl
@@ -23,7 +23,7 @@ fn main_1() {
     return;
 }
 
-@vertex 
+@vertex
 fn main(@location(1) a_uv: vec2<f32>, @location(0) a_pos: vec2<f32>) -> VertexOutput {
     a_uv_1 = a_uv;
     a_pos_1 = a_pos;

--- a/naga/tests/out/wgsl/spv-subgroup-barrier.wgsl
+++ b/naga/tests/out/wgsl/spv-subgroup-barrier.wgsl
@@ -4,7 +4,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(64, 1, 1) 
+@compute @workgroup_size(64, 1, 1)
 fn main() {
     function_();
 }

--- a/naga/tests/out/wgsl/spv-subgroup-operations-s.wgsl
+++ b/naga/tests/out/wgsl/spv-subgroup-operations-s.wgsl
@@ -30,7 +30,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main(@builtin(num_subgroups) param: u32, @builtin(subgroup_id) param_1: u32, @builtin(subgroup_size) param_2: u32, @builtin(subgroup_invocation_id) param_3: u32) {
     global = param;
     global_1 = param_1;

--- a/naga/tests/out/wgsl/spv-subgroup-reduce-issue-8389.wgsl
+++ b/naga/tests/out/wgsl/spv-subgroup-reduce-issue-8389.wgsl
@@ -21,7 +21,7 @@ fn function_() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main(@builtin(local_invocation_index) param: u32) {
     global = param;
     function_();

--- a/naga/tests/out/wgsl/spv-unnamed-gl-per-vertex.wgsl
+++ b/naga/tests/out/wgsl/spv-unnamed-gl-per-vertex.wgsl
@@ -14,7 +14,7 @@ fn function_() {
     return;
 }
 
-@vertex 
+@vertex
 fn main(@builtin(vertex_index) param: u32) -> @builtin(position) vec4<f32> {
     global_1 = i32(param);
     function_();

--- a/naga/tests/out/wgsl/wgsl-6438-conflicting-idents.wgsl
+++ b/naga/tests/out/wgsl/wgsl-6438-conflicting-idents.wgsl
@@ -3,7 +3,7 @@ struct OurVertexShaderOutput {
     @location(0) texcoord: vec2<f32>,
 }
 
-@vertex 
+@vertex
 fn vs(@location(0) xy: vec2<f32>) -> OurVertexShaderOutput {
     var vsOutput: OurVertexShaderOutput;
 
@@ -12,7 +12,7 @@ fn vs(@location(0) xy: vec2<f32>) -> OurVertexShaderOutput {
     return _e6;
 }
 
-@fragment 
+@fragment
 fn fs() -> @location(0) vec4<f32> {
     return vec4<f32>(1f, 0f, 0f, 1f);
 }

--- a/naga/tests/out/wgsl/wgsl-6772-unpack-expr-accesses.wgsl
+++ b/naga/tests/out/wgsl/wgsl-6772-unpack-expr-accesses.wgsl
@@ -1,4 +1,4 @@
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let phony = unpack4xI8(12u)[2i];
     let phony_1 = unpack4xU8(12u).y;

--- a/naga/tests/out/wgsl/wgsl-7995-unicode-idents.wgsl
+++ b/naga/tests/out/wgsl/wgsl-7995-unicode-idents.wgsl
@@ -1,4 +1,4 @@
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage> asdf: f32;
 
 fn compute() -> f32 {
@@ -7,7 +7,7 @@ fn compute() -> f32 {
     return u03b8_2_;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let _e0 = compute();
     return;

--- a/naga/tests/out/wgsl/wgsl-8820-multiple-local-invocation-index-id.wgsl
+++ b/naga/tests/out/wgsl/wgsl-8820-multiple-local-invocation-index-id.wgsl
@@ -5,7 +5,7 @@ struct Input {
 
 var<workgroup> wg_var: u32;
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn compute1_(input: Input) {
     wg_var = (input.local_invocation_index * 2u);
     let _e6 = wg_var;

--- a/naga/tests/out/wgsl/wgsl-9489-loop-local-var-init.wgsl
+++ b/naga/tests/out/wgsl/wgsl-9489-loop-local-var-init.wgsl
@@ -1,9 +1,9 @@
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage> input: array<f32, 64>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> output: array<f32, 8>;
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     var t: u32 = 0u;
     var acc_noinit: vec4<f32>;

--- a/naga/tests/out/wgsl/wgsl-9883-atomic_sub-negative.wgsl
+++ b/naga/tests/out/wgsl/wgsl-9883-atomic_sub-negative.wgsl
@@ -1,6 +1,6 @@
 var<workgroup> a: atomic<i32>;
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let _e2 = atomicSub((&a), -1i);
     return;

--- a/naga/tests/out/wgsl/wgsl-abstract-types-atomic.wgsl
+++ b/naga/tests/out/wgsl/wgsl-abstract-types-atomic.wgsl
@@ -1,6 +1,6 @@
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> atomic_i32_: atomic<i32>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> atomic_u32_: atomic<u32>;
 
 fn test_atomic_i32_() {
@@ -33,7 +33,7 @@ fn test_atomic_u32_() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     test_atomic_i32_();
     test_atomic_u32_();

--- a/naga/tests/out/wgsl/wgsl-abstract-types-builtins.wgsl
+++ b/naga/tests/out/wgsl/wgsl-abstract-types-builtins.wgsl
@@ -1,4 +1,4 @@
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn f() {
     var clamp_aiaiai: i32 = 1i;
     var clamp_aiaiaf: f32 = 1f;

--- a/naga/tests/out/wgsl/wgsl-abstract-types-function-calls.wgsl
+++ b/naga/tests/out/wgsl/wgsl-abstract-types-function-calls.wgsl
@@ -42,7 +42,7 @@ fn func_f_i(a_10: f32, b: i32) {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     func_f(0f);
     func_f(0f);

--- a/naga/tests/out/wgsl/wgsl-abstract-types-let.wgsl
+++ b/naga/tests/out/wgsl/wgsl-abstract-types-let.wgsl
@@ -110,7 +110,7 @@ fn mixed_constant_and_runtime_arguments() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     all_constant_arguments();
     mixed_constant_and_runtime_arguments();

--- a/naga/tests/out/wgsl/wgsl-abstract-types-operators.wgsl
+++ b/naga/tests/out/wgsl/wgsl-abstract-types-operators.wgsl
@@ -96,7 +96,7 @@ fn wgpu_4435_() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     runtime_values();
     wgpu_4445_();

--- a/naga/tests/out/wgsl/wgsl-abstract-types-return.wgsl
+++ b/naga/tests/out/wgsl/wgsl-abstract-types-return.wgsl
@@ -30,7 +30,7 @@ fn return_vec2f32_const_ai() -> vec2<f32> {
     return vec2(1f);
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let _e0 = return_i32_ai();
     let _e1 = return_u32_ai();

--- a/naga/tests/out/wgsl/wgsl-abstract-types-var.wgsl
+++ b/naga/tests/out/wgsl/wgsl-abstract-types-var.wgsl
@@ -343,7 +343,7 @@ fn mixed_constant_and_runtime_arguments() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     globals();
     all_constant_arguments();

--- a/naga/tests/out/wgsl/wgsl-access.wgsl
+++ b/naga/tests/out/wgsl/wgsl-access.wgsl
@@ -43,13 +43,13 @@ struct Outer {
 }
 
 var<private> msl_padding_global_const: GlobalConst = GlobalConst(0u, vec3<u32>(0u, 0u, 0u), 0i);
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> bar: Bar;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<uniform> baz: Baz;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage, read_write> qux: vec2<i32>;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var<uniform> nested_mat_cx2_: MatCx2InArray;
 
 fn test_matrix_within_struct_accesses() {
@@ -223,7 +223,7 @@ fn var_members_of_members() -> i32 {
     return _e15;
 }
 
-@vertex 
+@vertex
 fn foo_vert(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4<f32> {
     var foo: f32 = 0f;
     var c2_: array<i32, 5>;
@@ -247,7 +247,7 @@ fn foo_vert(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4<f32> {
     return vec4<f32>((_matrix * vec4<f32>(vec4(value_1))), 2f);
 }
 
-@fragment 
+@fragment
 fn foo_frag() -> @location(0) vec4<f32> {
     bar._matrix[1][2] = 1f;
     bar._matrix = mat4x3<f32>(vec3(0f), vec3(1f), vec3(2f), vec3(3f));
@@ -257,7 +257,7 @@ fn foo_frag() -> @location(0) vec4<f32> {
     return vec4(0f);
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn foo_compute() {
     assign_through_ptr();
     assign_to_ptr_components();

--- a/naga/tests/out/wgsl/wgsl-array-in-ctor.wgsl
+++ b/naga/tests/out/wgsl/wgsl-array-in-ctor.wgsl
@@ -2,10 +2,10 @@ struct Ah {
     inner: array<f32, 2>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage> ah: Ah;
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn cs_main() {
     let ah_1 = ah;
     return;

--- a/naga/tests/out/wgsl/wgsl-array-in-function-return-type.wgsl
+++ b/naga/tests/out/wgsl/wgsl-array-in-function-return-type.wgsl
@@ -9,7 +9,7 @@ fn ret_array_array() -> array<array<f32, 2>, 3> {
     return array<array<f32, 2>, 3>(_e0, _e1, _e2);
 }
 
-@fragment 
+@fragment
 fn main() -> @location(0) vec4<f32> {
     let _e0 = ret_array_array();
     return vec4<f32>(_e0[0][0], _e0[0][1], 0f, 1f);

--- a/naga/tests/out/wgsl/wgsl-atomicCompareExchange-int64.wgsl
+++ b/naga/tests/out/wgsl/wgsl-atomicCompareExchange-int64.wgsl
@@ -1,11 +1,11 @@
 const SIZE: u32 = 128u;
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> arr_i64_: array<atomic<i64>, 128>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> arr_u64_: array<atomic<u64>, 128>;
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn test_atomic_compare_exchange_i64_() {
     var i: u32 = 0u;
     var old: i64;
@@ -47,7 +47,7 @@ fn test_atomic_compare_exchange_i64_() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn test_atomic_compare_exchange_u64_() {
     var i_1: u32 = 0u;
     var old_1: u64;

--- a/naga/tests/out/wgsl/wgsl-atomicCompareExchange.wgsl
+++ b/naga/tests/out/wgsl/wgsl-atomicCompareExchange.wgsl
@@ -1,11 +1,11 @@
 const SIZE: u32 = 128u;
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> arr_i32_: array<atomic<i32>, 128>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> arr_u32_: array<atomic<u32>, 128>;
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn test_atomic_compare_exchange_i32_() {
     var i: u32 = 0u;
     var old: i32;
@@ -47,7 +47,7 @@ fn test_atomic_compare_exchange_i32_() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn test_atomic_compare_exchange_u32_() {
     var i_1: u32 = 0u;
     var old_1: u32;

--- a/naga/tests/out/wgsl/wgsl-atomicOps-float32.wgsl
+++ b/naga/tests/out/wgsl/wgsl-atomicOps-float32.wgsl
@@ -3,14 +3,14 @@ struct Struct {
     atomic_arr: array<atomic<f32>, 2>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> storage_atomic_scalar: atomic<f32>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> storage_atomic_arr: array<atomic<f32>, 2>;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage, read_write> storage_struct: Struct;
 
-@compute @workgroup_size(2, 1, 1) 
+@compute @workgroup_size(2, 1, 1)
 fn cs_main(@builtin(local_invocation_id) id: vec3<u32>) {
     atomicStore((&storage_atomic_scalar), 1.5f);
     atomicStore((&storage_atomic_arr[1]), 1.5f);

--- a/naga/tests/out/wgsl/wgsl-atomicOps-int64-min-max.wgsl
+++ b/naga/tests/out/wgsl/wgsl-atomicOps-int64-min-max.wgsl
@@ -3,16 +3,16 @@ struct Struct {
     atomic_arr: array<atomic<u64>, 2>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> storage_atomic_scalar: atomic<u64>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> storage_atomic_arr: array<atomic<u64>, 2>;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage, read_write> storage_struct: Struct;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var<uniform> input: u64;
 
-@compute @workgroup_size(2, 1, 1) 
+@compute @workgroup_size(2, 1, 1)
 fn cs_main(@builtin(local_invocation_id) id: vec3<u32>) {
     let _e3 = input;
     atomicMax((&storage_atomic_scalar), _e3);

--- a/naga/tests/out/wgsl/wgsl-atomicOps-int64.wgsl
+++ b/naga/tests/out/wgsl/wgsl-atomicOps-int64.wgsl
@@ -3,17 +3,17 @@ struct Struct {
     atomic_arr: array<atomic<i64>, 2>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> storage_atomic_scalar: atomic<u64>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> storage_atomic_arr: array<atomic<i64>, 2>;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage, read_write> storage_struct: Struct;
 var<workgroup> workgroup_atomic_scalar: atomic<u64>;
 var<workgroup> workgroup_atomic_arr: array<atomic<i64>, 2>;
 var<workgroup> workgroup_struct: Struct;
 
-@compute @workgroup_size(2, 1, 1) 
+@compute @workgroup_size(2, 1, 1)
 fn cs_main(@builtin(local_invocation_id) id: vec3<u32>) {
     atomicStore((&storage_atomic_scalar), 1lu);
     atomicStore((&storage_atomic_arr[1]), 1li);

--- a/naga/tests/out/wgsl/wgsl-atomicOps.wgsl
+++ b/naga/tests/out/wgsl/wgsl-atomicOps.wgsl
@@ -3,17 +3,17 @@ struct Struct {
     atomic_arr: array<atomic<i32>, 2>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> storage_atomic_scalar: atomic<u32>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> storage_atomic_arr: array<atomic<i32>, 2>;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage, read_write> storage_struct: Struct;
 var<workgroup> workgroup_atomic_scalar: atomic<u32>;
 var<workgroup> workgroup_atomic_arr: array<atomic<i32>, 2>;
 var<workgroup> workgroup_struct: Struct;
 
-@compute @workgroup_size(2, 1, 1) 
+@compute @workgroup_size(2, 1, 1)
 fn cs_main(@builtin(local_invocation_id) id: vec3<u32>) {
     atomicStore((&storage_atomic_scalar), 1u);
     atomicStore((&storage_atomic_arr[1]), 1i);

--- a/naga/tests/out/wgsl/wgsl-atomicTexture-int64.wgsl
+++ b/naga/tests/out/wgsl/wgsl-atomicTexture-int64.wgsl
@@ -1,7 +1,7 @@
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var image: texture_storage_2d<r64uint,atomic>;
 
-@compute @workgroup_size(2, 1, 1) 
+@compute @workgroup_size(2, 1, 1)
 fn cs_main(@builtin(local_invocation_id) id: vec3<u32>) {
     textureAtomicMax(image, vec2<i32>(0i, 0i), 1lu);
     workgroupBarrier();

--- a/naga/tests/out/wgsl/wgsl-atomicTexture.wgsl
+++ b/naga/tests/out/wgsl/wgsl-atomicTexture.wgsl
@@ -1,9 +1,9 @@
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var image_u: texture_storage_2d<r32uint,atomic>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var image_s: texture_storage_2d<r32sint,atomic>;
 
-@compute @workgroup_size(2, 1, 1) 
+@compute @workgroup_size(2, 1, 1)
 fn cs_main(@builtin(local_invocation_id) id: vec3<u32>) {
     textureAtomicMax(image_u, vec2<i32>(0i, 0i), 1u);
     textureAtomicMin(image_u, vec2<i32>(0i, 0i), 1u);

--- a/naga/tests/out/wgsl/wgsl-barycentrics.wgsl
+++ b/naga/tests/out/wgsl/wgsl-barycentrics.wgsl
@@ -1,9 +1,9 @@
-@fragment 
+@fragment
 fn fs_main(@builtin(barycentric) bary: vec3<f32>) -> @location(0) vec4<f32> {
     return vec4<f32>(bary, 1f);
 }
 
-@fragment 
+@fragment
 fn fs_main_no_perspective(@builtin(barycentric_no_perspective) bary_1: vec3<f32>) -> @location(0) vec4<f32> {
     return vec4<f32>(bary_1, 1f);
 }

--- a/naga/tests/out/wgsl/wgsl-binding-arrays.wgsl
+++ b/naga/tests/out/wgsl/wgsl-binding-arrays.wgsl
@@ -8,26 +8,26 @@ struct FragmentIn {
     @location(0) @interpolate(flat) index: u32,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var texture_array_unbounded: binding_array<texture_2d<f32>>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var texture_array_bounded: binding_array<texture_2d<f32>, 5>;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var texture_array_2darray: binding_array<texture_2d_array<f32>, 5>;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var texture_array_multisampled: binding_array<texture_multisampled_2d<f32>, 5>;
-@group(0) @binding(4) 
+@group(0) @binding(4)
 var texture_array_depth: binding_array<texture_depth_2d, 5>;
-@group(0) @binding(5) 
+@group(0) @binding(5)
 var texture_array_storage: binding_array<texture_storage_2d<rgba32float,write>, 5>;
-@group(0) @binding(6) 
+@group(0) @binding(6)
 var samp: binding_array<sampler, 5>;
-@group(0) @binding(7) 
+@group(0) @binding(7)
 var samp_comp: binding_array<sampler_comparison, 5>;
-@group(0) @binding(8) 
+@group(0) @binding(8)
 var<uniform> uni: UniformIndex;
 
-@fragment 
+@fragment
 fn main(fragment_in: FragmentIn) -> @location(0) vec4<f32> {
     var u1_: u32 = 0u;
     var u2_: vec2<u32> = vec2(0u);

--- a/naga/tests/out/wgsl/wgsl-binding-buffer-arrays.wgsl
+++ b/naga/tests/out/wgsl/wgsl-binding-buffer-arrays.wgsl
@@ -22,14 +22,14 @@ struct FragmentIn {
     @location(0) @interpolate(flat) index: u32,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage> storage_array: binding_array<Foo>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> plain_storage: PlainData;
-@group(0) @binding(10) 
+@group(0) @binding(10)
 var<uniform> uni: UniformIndex;
 
-@fragment 
+@fragment
 fn main(fragment_in: FragmentIn) -> @location(0) u32 {
     var u1_: u32 = 0u;
 

--- a/naga/tests/out/wgsl/wgsl-bitcast.wgsl
+++ b/naga/tests/out/wgsl/wgsl-bitcast.wgsl
@@ -1,4 +1,4 @@
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     var i2_: vec2<i32> = vec2(0i);
     var i3_: vec3<i32> = vec3(0i);

--- a/naga/tests/out/wgsl/wgsl-bits.wgsl
+++ b/naga/tests/out/wgsl/wgsl-bits.wgsl
@@ -1,4 +1,4 @@
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     var i: i32 = 0i;
     var i2_: vec2<i32> = vec2(0i);

--- a/naga/tests/out/wgsl/wgsl-boids.wgsl
+++ b/naga/tests/out/wgsl/wgsl-boids.wgsl
@@ -19,14 +19,14 @@ struct Particles {
 
 const NUM_PARTICLES: u32 = 1500u;
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> params: SimParams;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> particlesSrc: Particles;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage, read_write> particlesDst: Particles;
 
-@compute @workgroup_size(64, 1, 1) 
+@compute @workgroup_size(64, 1, 1)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     var vPos: vec2<f32>;
     var vVel: vec2<f32>;

--- a/naga/tests/out/wgsl/wgsl-break-if.wgsl
+++ b/naga/tests/out/wgsl/wgsl-break-if.wgsl
@@ -53,7 +53,7 @@ fn breakIfSeparateVariable() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     breakIfEmpty();
     breakIfEmptyBody(false);

--- a/naga/tests/out/wgsl/wgsl-clip-distances.wgsl
+++ b/naga/tests/out/wgsl/wgsl-clip-distances.wgsl
@@ -5,7 +5,7 @@ struct VertexOutput {
     @builtin(clip_distances) clip_distances: array<f32, 1>,
 }
 
-@vertex 
+@vertex
 fn main() -> VertexOutput {
     var out: VertexOutput;
 

--- a/naga/tests/out/wgsl/wgsl-collatz.wgsl
+++ b/naga/tests/out/wgsl/wgsl-collatz.wgsl
@@ -2,7 +2,7 @@ struct PrimeIndices {
     data: array<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> v_indices: PrimeIndices;
 
 fn collatz_iterations(n_base: u32) -> u32 {
@@ -33,7 +33,7 @@ fn collatz_iterations(n_base: u32) -> u32 {
     return _e23;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let _e9 = v_indices.data[global_id.x];
     let _e10 = collatz_iterations(_e9);

--- a/naga/tests/out/wgsl/wgsl-const-exprs.wgsl
+++ b/naga/tests/out/wgsl/wgsl-const-exprs.wgsl
@@ -137,7 +137,7 @@ fn abstract_access(i: u32) {
     return;
 }
 
-@compute @workgroup_size(2, 3, 1) 
+@compute @workgroup_size(2, 3, 1)
 fn main() {
     swizzle_of_compose();
     index_of_compose();

--- a/naga/tests/out/wgsl/wgsl-const_assert.wgsl
+++ b/naga/tests/out/wgsl/wgsl-const_assert.wgsl
@@ -1,6 +1,6 @@
 const g_false: bool = false;
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn foo() {
     return;
 }

--- a/naga/tests/out/wgsl/wgsl-constructors.wgsl
+++ b/naga/tests/out/wgsl/wgsl-constructors.wgsl
@@ -16,7 +16,7 @@ const cz6_: array<Foo, 3> = array<Foo, 3>();
 const cz7_: Foo = Foo();
 const cp1_: vec2<u32> = vec2(0u);
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     var foo: Foo;
 

--- a/naga/tests/out/wgsl/wgsl-control-flow.wgsl
+++ b/naga/tests/out/wgsl/wgsl-control-flow.wgsl
@@ -235,7 +235,7 @@ fn loop_switch_omit_continue_variable_checks(x_2: i32, y_1: i32, z_1: i32, w: i3
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     control_flow();
     switch_default_break(1i);

--- a/naga/tests/out/wgsl/wgsl-conversion-float-to-int.wgsl
+++ b/naga/tests/out/wgsl/wgsl-conversion-float-to-int.wgsl
@@ -136,7 +136,7 @@ fn test_f64_to_u64_vec(f_23: vec2<f64>) -> vec2<u64> {
     return vec2<u64>(f_23);
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     test_const_eval();
     let _e1 = test_f16_to_i32_(1h);

--- a/naga/tests/out/wgsl/wgsl-conversions.wgsl
+++ b/naga/tests/out/wgsl/wgsl-conversions.wgsl
@@ -1,6 +1,6 @@
 const ic0_: vec2<f32> = vec2<f32>(2f, 2f);
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     var vc0_: vec2<f32> = vec2<f32>(2f, 2f);
 

--- a/naga/tests/out/wgsl/wgsl-cooperative-matrix-mixed-accumulator.wgsl
+++ b/naga/tests/out/wgsl/wgsl-cooperative-matrix-mixed-accumulator.wgsl
@@ -1,12 +1,12 @@
 enable f16;
 enable wgpu_cooperative_matrix;
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> ab: array<f16>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> accum: array<f32>;
 
-@compute @workgroup_size(8, 8, 1) 
+@compute @workgroup_size(8, 8, 1)
 fn main() {
     var c: coop_mat8x8<f32,C>;
 

--- a/naga/tests/out/wgsl/wgsl-cooperative-matrix.wgsl
+++ b/naga/tests/out/wgsl/wgsl-cooperative-matrix.wgsl
@@ -2,10 +2,10 @@ enable wgpu_cooperative_matrix;
 
 var<private> a: coop_mat8x8<f32,A>;
 var<private> b: coop_mat8x8<f32,B>;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> ext: array<f32>;
 
-@compute @workgroup_size(8, 8, 1) 
+@compute @workgroup_size(8, 8, 1)
 fn main() {
     var c: coop_mat8x8<f32,C>;
     var d: coop_mat8x8<f32,C>;

--- a/naga/tests/out/wgsl/wgsl-cross.wgsl
+++ b/naga/tests/out/wgsl/wgsl-cross.wgsl
@@ -1,4 +1,4 @@
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let a = vec3<f32>(0f, 0f, 1f);
     return;

--- a/naga/tests/out/wgsl/wgsl-draw-index.wgsl
+++ b/naga/tests/out/wgsl/wgsl-draw-index.wgsl
@@ -4,7 +4,7 @@ struct Input {
     @builtin(draw_index) draw_index: u32,
 }
 
-@vertex 
+@vertex
 fn vertex(input: Input) -> @builtin(position) vec4<f32> {
     return vec4<f32>(f32(input.draw_index), 1f, 1f, 1f);
 }

--- a/naga/tests/out/wgsl/wgsl-dualsource.wgsl
+++ b/naga/tests/out/wgsl/wgsl-dualsource.wgsl
@@ -5,7 +5,7 @@ struct FragmentOutput {
     @location(0) @blend_src(1) output1_: vec4<f32>,
 }
 
-@fragment 
+@fragment
 fn main() -> FragmentOutput {
     return FragmentOutput(vec4<f32>(0.4f, 0.3f, 0.2f, 0.1f), vec4<f32>(0.9f, 0.8f, 0.7f, 0.6f));
 }

--- a/naga/tests/out/wgsl/wgsl-empty-if.wgsl
+++ b/naga/tests/out/wgsl/wgsl-empty-if.wgsl
@@ -1,4 +1,4 @@
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn comp(@builtin(global_invocation_id) id: vec3<u32>) {
     if (id.x == 0u) {
     }

--- a/naga/tests/out/wgsl/wgsl-empty.wgsl
+++ b/naga/tests/out/wgsl/wgsl-empty.wgsl
@@ -1,4 +1,4 @@
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     return;
 }

--- a/naga/tests/out/wgsl/wgsl-extra.wgsl
+++ b/naga/tests/out/wgsl/wgsl-extra.wgsl
@@ -12,7 +12,7 @@ struct FragmentIn {
 
 var<immediate> im: ImmediateData;
 
-@fragment 
+@fragment
 fn main(in: FragmentIn) -> @location(0) vec4<f32> {
     let _e4 = im.index;
     if (in.primitive_index == _e4) {

--- a/naga/tests/out/wgsl/wgsl-f16.wgsl
+++ b/naga/tests/out/wgsl/wgsl-f16.wgsl
@@ -36,15 +36,15 @@ struct LayoutTest {
 const constant_variable: f16 = 15.203125h;
 
 var<private> private_variable: f16 = 1h;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> input_uniform: UniformCompatible;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> input_storage: UniformCompatible;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage> input_arrays: StorageCompatible;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var<storage, read_write> output: UniformCompatible;
-@group(0) @binding(4) 
+@group(0) @binding(4)
 var<storage, read_write> output_arrays: StorageCompatible;
 
 fn f16_function(x: f16) -> f16 {
@@ -167,7 +167,7 @@ fn f16_function(x: f16) -> f16 {
     return _e287;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let _e3 = f16_function(2h);
     output.final_value = _e3;

--- a/naga/tests/out/wgsl/wgsl-f64.wgsl
+++ b/naga/tests/out/wgsl/wgsl-f64.wgsl
@@ -12,7 +12,7 @@ fn f(x: f64) -> f64 {
     return (((x + y) + k) + 5.0lf);
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let _e1 = f(6.0lf);
     return;

--- a/naga/tests/out/wgsl/wgsl-fragment-output.wgsl
+++ b/naga/tests/out/wgsl/wgsl-fragment-output.wgsl
@@ -16,7 +16,7 @@ struct FragmentOutputVec2Scalar {
     @location(5) scalaru: u32,
 }
 
-@fragment 
+@fragment
 fn main_vec4vec3_() -> FragmentOutputVec4Vec3_ {
     var output: FragmentOutputVec4Vec3_;
 
@@ -30,7 +30,7 @@ fn main_vec4vec3_() -> FragmentOutputVec4Vec3_ {
     return _e19;
 }
 
-@fragment 
+@fragment
 fn main_vec2scalar() -> FragmentOutputVec2Scalar {
     var output_1: FragmentOutputVec2Scalar;
 

--- a/naga/tests/out/wgsl/wgsl-functions.wgsl
+++ b/naga/tests/out/wgsl/wgsl-functions.wgsl
@@ -23,7 +23,7 @@ fn test_packed_integer_dot_product() -> u32 {
     return c_8_;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let _e0 = test_fma();
     let _e1 = test_integer_dot_product();

--- a/naga/tests/out/wgsl/wgsl-globals.wgsl
+++ b/naga/tests/out/wgsl/wgsl-globals.wgsl
@@ -7,19 +7,19 @@ const Foo_1: bool = true;
 
 var<workgroup> wg: array<f32, 10>;
 var<workgroup> at_1: atomic<u32>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> alignment: FooStruct;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage> dummy: array<vec2<f32>>;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var<uniform> float_vecs: array<vec4<f32>, 20>;
-@group(0) @binding(4) 
+@group(0) @binding(4)
 var<uniform> global_vec: vec3<f32>;
-@group(0) @binding(5) 
+@group(0) @binding(5)
 var<uniform> global_mat: mat3x2<f32>;
-@group(0) @binding(6) 
+@group(0) @binding(6)
 var<uniform> global_nested_arrays_of_matrices_2x4_: array<array<mat2x4<f32>, 2>, 2>;
-@group(0) @binding(7) 
+@group(0) @binding(7)
 var<uniform> global_nested_arrays_of_matrices_4x2_: array<array<mat4x2<f32>, 2>, 2>;
 
 fn test_msl_packed_vec3_as_arg(arg: vec3<f32>) {
@@ -45,7 +45,7 @@ fn test_msl_packed_vec3_() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     var Foo: f32 = 1f;
     var at: bool = true;

--- a/naga/tests/out/wgsl/wgsl-image.wgsl
+++ b/naga/tests/out/wgsl/wgsl-image.wgsl
@@ -1,49 +1,49 @@
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var image_mipmapped_src: texture_2d<u32>;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var image_multisampled_src: texture_multisampled_2d<u32>;
-@group(0) @binding(4) 
+@group(0) @binding(4)
 var image_depth_multisampled_src: texture_depth_multisampled_2d;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var image_storage_src: texture_storage_2d<rgba8uint,read>;
-@group(0) @binding(5) 
+@group(0) @binding(5)
 var image_array_src: texture_2d_array<u32>;
-@group(0) @binding(6) 
+@group(0) @binding(6)
 var image_dup_src: texture_storage_1d<r32uint,read>;
-@group(0) @binding(7) 
+@group(0) @binding(7)
 var image_1d_src: texture_1d<u32>;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var image_dst: texture_storage_1d<r32uint,write>;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var image_1d: texture_1d<f32>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var image_2d: texture_2d<f32>;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var image_2d_u32_: texture_2d<u32>;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var image_2d_i32_: texture_2d<i32>;
-@group(0) @binding(4) 
+@group(0) @binding(4)
 var image_2d_array: texture_2d_array<f32>;
-@group(0) @binding(5) 
+@group(0) @binding(5)
 var image_cube: texture_cube<f32>;
-@group(0) @binding(6) 
+@group(0) @binding(6)
 var image_cube_array: texture_cube_array<f32>;
-@group(0) @binding(7) 
+@group(0) @binding(7)
 var image_3d: texture_3d<f32>;
-@group(0) @binding(8) 
+@group(0) @binding(8)
 var image_aa: texture_multisampled_2d<f32>;
-@group(1) @binding(0) 
+@group(1) @binding(0)
 var sampler_reg: sampler;
-@group(1) @binding(1) 
+@group(1) @binding(1)
 var sampler_cmp: sampler_comparison;
-@group(1) @binding(2) 
+@group(1) @binding(2)
 var image_2d_depth: texture_depth_2d;
-@group(1) @binding(3) 
+@group(1) @binding(3)
 var image_2d_array_depth: texture_depth_2d_array;
-@group(1) @binding(4) 
+@group(1) @binding(4)
 var image_cube_depth: texture_depth_cube;
 
-@compute @workgroup_size(16, 1, 1) 
+@compute @workgroup_size(16, 1, 1)
 fn main(@builtin(local_invocation_id) local_id: vec3<u32>) {
     let dim = textureDimensions(image_storage_src);
     let itc = (vec2<i32>((dim * local_id.xy)) % vec2<i32>(10i, 20i));
@@ -68,7 +68,7 @@ fn main(@builtin(local_invocation_id) local_id: vec3<u32>) {
     return;
 }
 
-@compute @workgroup_size(16, 1, 1) 
+@compute @workgroup_size(16, 1, 1)
 fn depth_load(@builtin(local_invocation_id) local_id_1: vec3<u32>) {
     let dim_1 = textureDimensions(image_storage_src);
     let itc_1 = (vec2<i32>((dim_1 * local_id_1.xy)) % vec2<i32>(10i, 20i));
@@ -77,7 +77,7 @@ fn depth_load(@builtin(local_invocation_id) local_id_1: vec3<u32>) {
     return;
 }
 
-@vertex 
+@vertex
 fn queries() -> @builtin(position) vec4<f32> {
     let dim_1d = textureDimensions(image_1d);
     let dim_1d_lod = textureDimensions(image_1d, i32(dim_1d));
@@ -96,7 +96,7 @@ fn queries() -> @builtin(position) vec4<f32> {
     return vec4(f32(sum));
 }
 
-@vertex 
+@vertex
 fn levels_queries() -> @builtin(position) vec4<f32> {
     let num_levels_2d = textureNumLevels(image_2d);
     let num_layers_2d = textureNumLayers(image_2d_array);
@@ -111,7 +111,7 @@ fn levels_queries() -> @builtin(position) vec4<f32> {
     return vec4(f32(sum_1));
 }
 
-@fragment 
+@fragment
 fn texture_sample() -> @location(0) vec4<f32> {
     var a: vec4<f32>;
 
@@ -191,7 +191,7 @@ fn texture_sample() -> @location(0) vec4<f32> {
     return _e148;
 }
 
-@fragment 
+@fragment
 fn texture_sample_comparison() -> @location(0) f32 {
     var a_1: f32;
 
@@ -225,7 +225,7 @@ fn texture_sample_comparison() -> @location(0) f32 {
     return _e50;
 }
 
-@fragment 
+@fragment
 fn gather() -> @location(0) vec4<f32> {
     let tc_1 = vec2(0.5f);
     let s2d = textureGather(1, image_2d, sampler_reg, tc_1);
@@ -238,7 +238,7 @@ fn gather() -> @location(0) vec4<f32> {
     return ((((s2d + s2d_offset) + s2d_depth) + s2d_depth_offset) + f);
 }
 
-@fragment 
+@fragment
 fn depth_no_comparison() -> @location(0) vec4<f32> {
     let tc_2 = vec2(0.5f);
     let s2d_1 = textureSample(image_2d_depth, sampler_reg, tc_2);

--- a/naga/tests/out/wgsl/wgsl-int16.wgsl
+++ b/naga/tests/out/wgsl/wgsl-int16.wgsl
@@ -24,15 +24,15 @@ const constant_variable: u16 = u16(20);
 const f16_to_i16_clamped: i16 = i16(32767);
 
 var<private> private_variable: i16 = i16(1);
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> input_uniform: UniformCompatible;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> input_storage: UniformCompatible;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage> input_arrays: StorageCompatible;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var<storage, read_write> output: UniformCompatible;
-@group(0) @binding(4) 
+@group(0) @binding(4)
 var<storage, read_write> output_arrays: StorageCompatible;
 var<workgroup> shared_val: u16;
 
@@ -205,7 +205,7 @@ fn uint16_function(x_1: u16) -> u16 {
     return _e115;
 }
 
-@compute @workgroup_size(64, 1, 1) 
+@compute @workgroup_size(64, 1, 1)
 fn main(@builtin(subgroup_invocation_id) subgroup_invocation_id: u32) {
     var sg_val: i16;
     var sg_uval: u16;

--- a/naga/tests/out/wgsl/wgsl-int64.wgsl
+++ b/naga/tests/out/wgsl/wgsl-int64.wgsl
@@ -21,15 +21,15 @@ struct StorageCompatible {
 const constant_variable: u64 = 20lu;
 
 var<private> private_variable: i64 = 1li;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> input_uniform: UniformCompatible;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> input_storage: UniformCompatible;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<storage> input_arrays: StorageCompatible;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var<storage, read_write> output: UniformCompatible;
-@group(0) @binding(4) 
+@group(0) @binding(4)
 var<storage, read_write> output_arrays: StorageCompatible;
 
 fn int64_function(x: i64) -> i64 {
@@ -184,7 +184,7 @@ fn uint64_function(x_1: u64) -> u64 {
     return _e144;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let _e3 = uint64_function(67lu);
     let _e5 = int64_function(60li);

--- a/naga/tests/out/wgsl/wgsl-interface.wgsl
+++ b/naga/tests/out/wgsl/wgsl-interface.wgsl
@@ -19,26 +19,26 @@ struct Input2_ {
 
 var<workgroup> output: array<u32, 1>;
 
-@vertex 
+@vertex
 fn vertex(@builtin(vertex_index) vertex_index: u32, @builtin(instance_index) instance_index: u32, @location(10) color: u32) -> VertexOutput {
     let tmp: u32 = ((vertex_index + instance_index) + color);
     return VertexOutput(vec4(1f), f32(tmp));
 }
 
-@fragment 
+@fragment
 fn fragment(in: VertexOutput, @builtin(front_facing) front_facing: bool, @builtin(sample_index) sample_index: u32, @builtin(sample_mask) sample_mask: u32) -> FragmentOutput {
     let mask: u32 = (sample_mask & (1u << sample_index));
     let color_1: f32 = select(0f, 1f, front_facing);
     return FragmentOutput(in._varying, mask, color_1);
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn compute(@builtin(global_invocation_id) global_id: vec3<u32>, @builtin(local_invocation_id) local_id: vec3<u32>, @builtin(local_invocation_index) local_index: u32, @builtin(workgroup_id) wg_id: vec3<u32>, @builtin(num_workgroups) num_wgs: vec3<u32>) {
     output[0] = ((((global_id.x + local_id.x) + local_index) + wg_id.x) + num_wgs.x);
     return;
 }
 
-@vertex 
+@vertex
 fn vertex_two_structs(in1_: Input1_, in2_: Input2_) -> @builtin(position) @invariant vec4<f32> {
     var index: u32 = 2u;
 

--- a/naga/tests/out/wgsl/wgsl-interpolate.wgsl
+++ b/naga/tests/out/wgsl/wgsl-interpolate.wgsl
@@ -13,7 +13,7 @@ struct FragmentInput {
     @location(11) perspective_center: f32,
 }
 
-@vertex 
+@vertex
 fn vert_main() -> FragmentInput {
     var out: FragmentInput;
 
@@ -33,7 +33,7 @@ fn vert_main() -> FragmentInput {
     return _e41;
 }
 
-@fragment 
+@fragment
 fn frag_main(val: FragmentInput) {
     return;
 }

--- a/naga/tests/out/wgsl/wgsl-interpolate_compat.wgsl
+++ b/naga/tests/out/wgsl/wgsl-interpolate_compat.wgsl
@@ -12,7 +12,7 @@ struct FragmentInput {
     @location(11) perspective_center: f32,
 }
 
-@vertex 
+@vertex
 fn vert_main() -> FragmentInput {
     var out: FragmentInput;
 
@@ -31,7 +31,7 @@ fn vert_main() -> FragmentInput {
     return _e39;
 }
 
-@fragment 
+@fragment
 fn frag_main(val: FragmentInput) {
     return;
 }

--- a/naga/tests/out/wgsl/wgsl-lexical-scopes.wgsl
+++ b/naga/tests/out/wgsl/wgsl-lexical-scopes.wgsl
@@ -64,7 +64,7 @@ fn switchLexicalScope(a_6: i32) {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     blockLexicalScope(false);
     ifLexicalScope(true);

--- a/naga/tests/out/wgsl/wgsl-local-const.wgsl
+++ b/naga/tests/out/wgsl/wgsl-local-const.wgsl
@@ -6,7 +6,7 @@ fn const_in_fn() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     const_in_fn();
     return;

--- a/naga/tests/out/wgsl/wgsl-math-functions.wgsl
+++ b/naga/tests/out/wgsl/wgsl-math-functions.wgsl
@@ -1,4 +1,4 @@
-@fragment 
+@fragment
 fn main() {
     let v = vec4(0f);
     let a = degrees(1f);

--- a/naga/tests/out/wgsl/wgsl-memory-decorations-coherent.wgsl
+++ b/naga/tests/out/wgsl/wgsl-memory-decorations-coherent.wgsl
@@ -2,12 +2,12 @@ struct Data {
     values: array<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 @coherent var<storage, read_write> coherent_buf: Data;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> plain_buf: Data;
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let _e6 = plain_buf.values[0];
     coherent_buf.values[0] = _e6;

--- a/naga/tests/out/wgsl/wgsl-memory-decorations.wgsl
+++ b/naga/tests/out/wgsl/wgsl-memory-decorations.wgsl
@@ -2,16 +2,16 @@ struct Data {
     values: array<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 @coherent var<storage, read_write> coherent_buf: Data;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 @volatile var<storage, read_write> volatile_buf: Data;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 @coherent @volatile var<storage, read_write> both_buf: Data;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var<storage, read_write> plain_buf: Data;
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let _e6 = volatile_buf.values[0];
     coherent_buf.values[0] = _e6;

--- a/naga/tests/out/wgsl/wgsl-mesh-shader-empty.wgsl
+++ b/naga/tests/out/wgsl/wgsl-mesh-shader-empty.wgsl
@@ -22,12 +22,12 @@ struct MeshOutput {
 var<task_payload> taskPayload: TaskPayload;
 var<workgroup> mesh_output: MeshOutput;
 
-@task @payload(taskPayload) @workgroup_size(64, 1, 1) 
+@task @payload(taskPayload) @workgroup_size(64, 1, 1)
 fn ts_main() -> @builtin(mesh_task_size) vec3<u32> {
     return vec3<u32>(1u, 1u, 1u);
 }
 
-@mesh(mesh_output) @workgroup_size(64, 1, 1) @payload(taskPayload) 
+@mesh(mesh_output) @workgroup_size(64, 1, 1) @payload(taskPayload)
 fn ms_main() {
     return;
 }

--- a/naga/tests/out/wgsl/wgsl-mesh-shader-lines.wgsl
+++ b/naga/tests/out/wgsl/wgsl-mesh-shader-lines.wgsl
@@ -22,12 +22,12 @@ struct MeshOutput {
 var<task_payload> taskPayload: TaskPayload;
 var<workgroup> mesh_output: MeshOutput;
 
-@task @payload(taskPayload) @workgroup_size(64, 1, 1) 
+@task @payload(taskPayload) @workgroup_size(64, 1, 1)
 fn ts_main() -> @builtin(mesh_task_size) vec3<u32> {
     return vec3<u32>(1u, 1u, 1u);
 }
 
-@mesh(mesh_output) @workgroup_size(64, 1, 1) @payload(taskPayload) 
+@mesh(mesh_output) @workgroup_size(64, 1, 1) @payload(taskPayload)
 fn ms_main() {
     return;
 }

--- a/naga/tests/out/wgsl/wgsl-mesh-shader-points.wgsl
+++ b/naga/tests/out/wgsl/wgsl-mesh-shader-points.wgsl
@@ -22,12 +22,12 @@ struct MeshOutput {
 var<task_payload> taskPayload: TaskPayload;
 var<workgroup> mesh_output: MeshOutput;
 
-@task @payload(taskPayload) @workgroup_size(64, 1, 1) 
+@task @payload(taskPayload) @workgroup_size(64, 1, 1)
 fn ts_main() -> @builtin(mesh_task_size) vec3<u32> {
     return vec3<u32>(1u, 1u, 1u);
 }
 
-@mesh(mesh_output) @workgroup_size(64, 1, 1) @payload(taskPayload) 
+@mesh(mesh_output) @workgroup_size(64, 1, 1) @payload(taskPayload)
 fn ms_main() {
     return;
 }

--- a/naga/tests/out/wgsl/wgsl-mesh-shader.wgsl
+++ b/naga/tests/out/wgsl/wgsl-mesh-shader.wgsl
@@ -41,7 +41,7 @@ fn helper_writer(value: bool) {
     return;
 }
 
-@task @payload(taskPayload) @workgroup_size(1, 1, 1) 
+@task @payload(taskPayload) @workgroup_size(1, 1, 1)
 fn ts_main() -> @builtin(mesh_task_size) vec3<u32> {
     workgroupData = 1f;
     taskPayload.colorMask = vec4<f32>(1f, 1f, 0f, 1f);
@@ -51,7 +51,7 @@ fn ts_main() -> @builtin(mesh_task_size) vec3<u32> {
     return vec3<u32>(1u, 1u, 1u);
 }
 
-@task @payload(taskPayload) @workgroup_size(2, 1, 1) 
+@task @payload(taskPayload) @workgroup_size(2, 1, 1)
 fn ts_divergent(@builtin(local_invocation_id) thread_id: vec3<u32>) -> @builtin(mesh_task_size) vec3<u32> {
     if (thread_id.x == 0u) {
         taskPayload.colorMask = vec4<f32>(1f, 1f, 0f, 1f);
@@ -61,7 +61,7 @@ fn ts_divergent(@builtin(local_invocation_id) thread_id: vec3<u32>) -> @builtin(
     return vec3<u32>(2u, 2u, 2u);
 }
 
-@mesh(mesh_output) @workgroup_size(1, 1, 1) @payload(taskPayload) 
+@mesh(mesh_output) @workgroup_size(1, 1, 1) @payload(taskPayload)
 fn ms_main() {
     mesh_output.vertex_count = 3u;
     mesh_output.primitive_count = 1u;
@@ -82,7 +82,7 @@ fn ms_main() {
     return;
 }
 
-@mesh(mesh_output) @workgroup_size(1, 1, 1) 
+@mesh(mesh_output) @workgroup_size(1, 1, 1)
 fn ms_no_ts() {
     mesh_output.vertex_count = 3u;
     mesh_output.primitive_count = 1u;
@@ -99,7 +99,7 @@ fn ms_no_ts() {
     return;
 }
 
-@mesh(mesh_output) @workgroup_size(2, 1, 1) 
+@mesh(mesh_output) @workgroup_size(2, 1, 1)
 fn ms_divergent(@builtin(local_invocation_id) thread_id_1: vec3<u32>) {
     if (thread_id_1.x == 0u) {
         mesh_output.vertex_count = 3u;
@@ -120,7 +120,7 @@ fn ms_divergent(@builtin(local_invocation_id) thread_id_1: vec3<u32>) {
     }
 }
 
-@fragment 
+@fragment
 fn fs_main(vertex: VertexOutput, primitive: PrimitiveInput) -> @location(0) vec4<f32> {
     return (vertex.color * primitive.colorMask);
 }

--- a/naga/tests/out/wgsl/wgsl-module-scope.wgsl
+++ b/naga/tests/out/wgsl/wgsl-module-scope.wgsl
@@ -4,9 +4,9 @@ struct S {
 
 const Value: i32 = 1i;
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var Texture: texture_2d<f32>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var Sampler: sampler;
 
 fn statement() {
@@ -24,7 +24,7 @@ fn call() {
     return;
 }
 
-@fragment 
+@fragment
 fn main() {
     call();
     statement();

--- a/naga/tests/out/wgsl/wgsl-multiview.wgsl
+++ b/naga/tests/out/wgsl/wgsl-multiview.wgsl
@@ -1,4 +1,4 @@
-@fragment 
+@fragment
 fn main(@builtin(view_index) view_index: u32) {
     return;
 }

--- a/naga/tests/out/wgsl/wgsl-operators.wgsl
+++ b/naga/tests/out/wgsl/wgsl-operators.wgsl
@@ -334,7 +334,7 @@ fn negation_avoids_prefix_decrement() {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main(@builtin(workgroup_id) id: vec3<u32>) {
     let _e1 = builtins();
     let _e6 = splat(f32(id.x), i32(id.y));

--- a/naga/tests/out/wgsl/wgsl-padding.wgsl
+++ b/naga/tests/out/wgsl/wgsl-padding.wgsl
@@ -17,14 +17,14 @@ struct Test3_ {
     b: f32,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> input1_: Test;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<uniform> input2_: Test2_;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<uniform> input3_: Test3_;
 
-@vertex 
+@vertex
 fn vertex() -> @builtin(position) vec4<f32> {
     let _e4 = input1_.b;
     let _e8 = input2_.b;

--- a/naga/tests/out/wgsl/wgsl-per-vertex.wgsl
+++ b/naga/tests/out/wgsl/wgsl-per-vertex.wgsl
@@ -1,6 +1,6 @@
 enable wgpu_per_vertex;
 
-@fragment 
+@fragment
 fn fs_main(@location(0) @interpolate(per_vertex) v: array<f32, 3>) -> @location(0) vec4<f32> {
     return vec4<f32>(v[0], v[1], v[2], 1f);
 }

--- a/naga/tests/out/wgsl/wgsl-phony_assignment.wgsl
+++ b/naga/tests/out/wgsl/wgsl-phony_assignment.wgsl
@@ -1,11 +1,11 @@
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> binding: f32;
 
 fn five() -> i32 {
     return 5i;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let phony = binding;
     let phony_1 = binding;

--- a/naga/tests/out/wgsl/wgsl-pointer-function-arg.wgsl
+++ b/naga/tests/out/wgsl/wgsl-pointer-function-arg.wgsl
@@ -70,7 +70,7 @@ fn let_binding(a_1: ptr<function, array<i32, 4>>, i_7: u32) {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     var vec: array<vec2<i32>, 4>;
     var mat: array<mat2x2<f32>, 4>;

--- a/naga/tests/out/wgsl/wgsl-pointers.wgsl
+++ b/naga/tests/out/wgsl/wgsl-pointers.wgsl
@@ -2,7 +2,7 @@ struct DynamicArray {
     arr: array<u32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> dynamic_array: DynamicArray;
 
 fn f() {
@@ -26,7 +26,7 @@ fn index_dynamic_array(i_1: i32, v_2: u32) {
     return;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     f();
     index_unsized(1i, 1u);

--- a/naga/tests/out/wgsl/wgsl-primitive-index.wgsl
+++ b/naga/tests/out/wgsl/wgsl-primitive-index.wgsl
@@ -1,6 +1,6 @@
 enable primitive_index;
 
-@fragment 
+@fragment
 fn func(@builtin(primitive_index) index: u32) -> @location(0) vec4<f32> {
     return vec4<f32>(f32(index), 1f, 1f, 1f);
 }

--- a/naga/tests/out/wgsl/wgsl-quad.wgsl
+++ b/naga/tests/out/wgsl/wgsl-quad.wgsl
@@ -5,17 +5,17 @@ struct VertexOutput {
 
 const c_scale: f32 = 1.2f;
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var u_texture: texture_2d<f32>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var u_sampler: sampler;
 
-@vertex 
+@vertex
 fn vert_main(@location(0) pos: vec2<f32>, @location(1) uv: vec2<f32>) -> VertexOutput {
     return VertexOutput(uv, vec4<f32>((c_scale * pos), 0f, 1f));
 }
 
-@fragment 
+@fragment
 fn frag_main(@location(0) uv_1: vec2<f32>) -> @location(0) vec4<f32> {
     let color = textureSample(u_texture, u_sampler, uv_1);
     if (color.w == 0f) {
@@ -25,7 +25,7 @@ fn frag_main(@location(0) uv_1: vec2<f32>) -> @location(0) vec4<f32> {
     return premultiplied;
 }
 
-@fragment 
+@fragment
 fn fs_extra() -> @location(0) vec4<f32> {
     return vec4<f32>(0f, 0.5f, 0f, 0.5f);
 }

--- a/naga/tests/out/wgsl/wgsl-ray-tracing-pipeline.wgsl
+++ b/naga/tests/out/wgsl/wgsl-ray-tracing-pipeline.wgsl
@@ -15,11 +15,11 @@ struct RayDesc {
 }
 
 var<ray_payload> hit_num: HitCounters;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var acc_struct: acceleration_structure;
 var<incoming_ray_payload> incoming_hit_num: HitCounters;
 
-@ray_generation 
+@ray_generation
 fn ray_gen_main(@builtin(ray_invocation_id) id: vec3<u32>, @builtin(num_ray_invocations) num_invocations: vec3<u32>) {
     hit_num = HitCounters();
     let shift = (vec3<f32>(id) / vec3<f32>(num_invocations));
@@ -28,12 +28,12 @@ fn ray_gen_main(@builtin(ray_invocation_id) id: vec3<u32>, @builtin(num_ray_invo
     return;
 }
 
-@miss @incoming_payload(incoming_hit_num) 
+@miss @incoming_payload(incoming_hit_num)
 fn miss(@builtin(world_ray_origin) origin: vec3<f32>, @builtin(world_ray_direction) dir: vec3<f32>, @builtin(ray_t_min) t_min: f32) {
     return;
 }
 
-@any_hit @incoming_payload(incoming_hit_num) 
+@any_hit @incoming_payload(incoming_hit_num)
 fn any_hit_main(@builtin(instance_custom_data) data: u32, @builtin(geometry_index) geo_idx: u32, @builtin(ray_t_current_max) max_: f32, @builtin(hit_kind) kind: u32) {
     let _e7 = incoming_hit_num.hit_num;
     incoming_hit_num.hit_num = (_e7 + 1u);
@@ -41,7 +41,7 @@ fn any_hit_main(@builtin(instance_custom_data) data: u32, @builtin(geometry_inde
     return;
 }
 
-@closest_hit @incoming_payload(incoming_hit_num) 
+@closest_hit @incoming_payload(incoming_hit_num)
 fn closest_hit_main(@builtin(object_ray_origin) origin_1: vec3<f32>, @builtin(object_ray_direction) dir_1: vec3<f32>, @builtin(object_to_world) obj_to_world: mat4x3<f32>, @builtin(world_to_object) world_to_obj: mat4x3<f32>) {
     return;
 }

--- a/naga/tests/out/wgsl/wgsl-select.wgsl
+++ b/naga/tests/out/wgsl/wgsl-select.wgsl
@@ -1,4 +1,4 @@
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     var x0_: vec2<i32> = vec2<i32>(1i, 2i);
     var i1_: vec2<f32>;

--- a/naga/tests/out/wgsl/wgsl-shadow.wgsl
+++ b/naga/tests/out/wgsl/wgsl-shadow.wgsl
@@ -23,17 +23,17 @@ struct Light {
 const c_ambient: vec3<f32> = vec3<f32>(0.05f, 0.05f, 0.05f);
 const c_max_lights: u32 = 10u;
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> u_globals: Globals;
-@group(1) @binding(0) 
+@group(1) @binding(0)
 var<uniform> u_entity: Entity;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage> s_lights: array<Light>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<uniform> u_lights: array<Light, 10>;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var t_shadow: texture_depth_2d_array;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var sampler_shadow: sampler_comparison;
 
 fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
@@ -47,7 +47,7 @@ fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
     return _e24;
 }
 
-@vertex 
+@vertex
 fn vs_main(@location(0) position: vec4<i32>, @location(1) normal: vec4<i32>) -> VertexOutput {
     var out: VertexOutput;
 
@@ -62,7 +62,7 @@ fn vs_main(@location(0) position: vec4<i32>, @location(1) normal: vec4<i32>) -> 
     return _e28;
 }
 
-@fragment 
+@fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var color: vec3<f32> = c_ambient;
     var i: u32 = 0u;
@@ -95,7 +95,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return (vec4<f32>(_e42, 1f) * _e47);
 }
 
-@fragment 
+@fragment
 fn fs_main_without_storage(in_1: VertexOutput) -> @location(0) vec4<f32> {
     var color_1: vec3<f32> = c_ambient;
     var i_1: u32 = 0u;

--- a/naga/tests/out/wgsl/wgsl-skybox.wgsl
+++ b/naga/tests/out/wgsl/wgsl-skybox.wgsl
@@ -8,14 +8,14 @@ struct Data {
     view: mat4x4<f32>,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> r_data: Data;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var r_texture: texture_cube<f32>;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var r_sampler: sampler;
 
-@vertex 
+@vertex
 fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     var tmp1_: i32;
     var tmp2_: i32;
@@ -34,7 +34,7 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     return VertexOutput(pos, (inv_model_view * unprojected.xyz));
 }
 
-@fragment 
+@fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let _e4 = textureSample(r_texture, r_sampler, in.uv);
     return _e4;

--- a/naga/tests/out/wgsl/wgsl-standard.wgsl
+++ b/naga/tests/out/wgsl/wgsl-standard.wgsl
@@ -2,7 +2,7 @@ fn test_any_and_all_for_bool() -> bool {
     return true;
 }
 
-@fragment 
+@fragment
 fn derivatives(@builtin(position) foo: vec4<f32>) -> @location(0) vec4<f32> {
     var x: vec4<f32>;
     var y: vec4<f32>;

--- a/naga/tests/out/wgsl/wgsl-struct-layout.wgsl
+++ b/naga/tests/out/wgsl/wgsl-struct-layout.wgsl
@@ -9,26 +9,26 @@ struct NeedsPadding {
     @location(2) f3_: f32,
 }
 
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<uniform> no_padding_uniform: NoPadding;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var<storage, read_write> no_padding_storage: NoPadding;
-@group(0) @binding(2) 
+@group(0) @binding(2)
 var<uniform> needs_padding_uniform: NeedsPadding;
-@group(0) @binding(3) 
+@group(0) @binding(3)
 var<storage, read_write> needs_padding_storage: NeedsPadding;
 
-@fragment 
+@fragment
 fn no_padding_frag(input: NoPadding) -> @location(0) vec4<f32> {
     return vec4(0f);
 }
 
-@vertex 
+@vertex
 fn no_padding_vert(input_1: NoPadding) -> @builtin(position) vec4<f32> {
     return vec4(0f);
 }
 
-@compute @workgroup_size(16, 1, 1) 
+@compute @workgroup_size(16, 1, 1)
 fn no_padding_comp() {
     var x: NoPadding;
 
@@ -39,17 +39,17 @@ fn no_padding_comp() {
     return;
 }
 
-@fragment 
+@fragment
 fn needs_padding_frag(input_2: NeedsPadding) -> @location(0) vec4<f32> {
     return vec4(0f);
 }
 
-@vertex 
+@vertex
 fn needs_padding_vert(input_3: NeedsPadding) -> @builtin(position) vec4<f32> {
     return vec4(0f);
 }
 
-@compute @workgroup_size(16, 1, 1) 
+@compute @workgroup_size(16, 1, 1)
 fn needs_padding_comp() {
     var x_1: NeedsPadding;
 

--- a/naga/tests/out/wgsl/wgsl-subgroup-barrier.wgsl
+++ b/naga/tests/out/wgsl/wgsl-subgroup-barrier.wgsl
@@ -1,4 +1,4 @@
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     subgroupBarrier();
     return;

--- a/naga/tests/out/wgsl/wgsl-subgroup-operations.wgsl
+++ b/naga/tests/out/wgsl/wgsl-subgroup-operations.wgsl
@@ -3,7 +3,7 @@ struct Structure {
     @builtin(subgroup_size) subgroup_size: u32,
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main(sizes: Structure, @builtin(subgroup_id) subgroup_id: u32, @builtin(subgroup_invocation_id) subgroup_invocation_id: u32) {
     let _e7 = subgroupBallot(((subgroup_invocation_id & 1u) == 1u));
     let _e8 = subgroupBallot();

--- a/naga/tests/out/wgsl/wgsl-texture-arg.wgsl
+++ b/naga/tests/out/wgsl/wgsl-texture-arg.wgsl
@@ -1,6 +1,6 @@
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var Texture: texture_2d<f32>;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var Sampler: sampler;
 
 fn test(Passed_Texture: texture_2d<f32>, Passed_Sampler: sampler) -> vec4<f32> {
@@ -8,7 +8,7 @@ fn test(Passed_Texture: texture_2d<f32>, Passed_Sampler: sampler) -> vec4<f32> {
     return _e5;
 }
 
-@fragment 
+@fragment
 fn main() -> @location(0) vec4<f32> {
     let _e2 = test(Texture, Sampler);
     return _e2;

--- a/naga/tests/out/wgsl/wgsl-texture-external.wgsl
+++ b/naga/tests/out/wgsl/wgsl-texture-external.wgsl
@@ -1,6 +1,6 @@
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var tex: texture_external;
-@group(0) @binding(1) 
+@group(0) @binding(1)
 var samp: sampler;
 
 fn test(t: texture_external) -> vec4<f32> {
@@ -24,19 +24,19 @@ fn test(t: texture_external) -> vec4<f32> {
     return (((_e16 + _e17) + _e19) + vec2<f32>(_e21).xyxy);
 }
 
-@fragment 
+@fragment
 fn fragment_main() -> @location(0) vec4<f32> {
     let _e1 = test(tex);
     return _e1;
 }
 
-@vertex 
+@vertex
 fn vertex_main() -> @builtin(position) vec4<f32> {
     let _e1 = test(tex);
     return _e1;
 }
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn compute_main() {
     let _e1 = test(tex);
     return;

--- a/naga/tests/out/wgsl/wgsl-type-alias.wgsl
+++ b/naga/tests/out/wgsl/wgsl-type-alias.wgsl
@@ -1,4 +1,4 @@
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let a = vec3<f32>(0f, 0f, 0f);
     let c = vec3(0f);

--- a/naga/tests/out/wgsl/wgsl-type-inference.wgsl
+++ b/naga/tests/out/wgsl/wgsl-type-inference.wgsl
@@ -4,7 +4,7 @@ const g4_: vec4<i32> = vec4<i32>();
 const g5_: vec4<i32> = vec4(1i);
 const g6_: mat2x2<f32> = mat2x2<f32>(vec2<f32>(0f, 0f), vec2<f32>(0f, 0f));
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     var g0x: i32 = 1i;
     var g2x: f32 = 1f;

--- a/naga/tests/out/wgsl/wgsl-workgroup-uniform-load-atomic.wgsl
+++ b/naga/tests/out/wgsl/wgsl-workgroup-uniform-load-atomic.wgsl
@@ -7,7 +7,7 @@ var<workgroup> wg_scalar: atomic<u32>;
 var<workgroup> wg_signed: atomic<i32>;
 var<workgroup> wg_struct: AtomicStruct;
 
-@compute @workgroup_size(64, 1, 1) 
+@compute @workgroup_size(64, 1, 1)
 fn test_atomic_workgroup_uniform_load(@builtin(workgroup_id) workgroup_id: vec3<u32>, @builtin(local_invocation_id) local_id: vec3<u32>) {
     var local: bool;
     var local_1: bool;

--- a/naga/tests/out/wgsl/wgsl-workgroup-uniform-load.wgsl
+++ b/naga/tests/out/wgsl/wgsl-workgroup-uniform-load.wgsl
@@ -2,7 +2,7 @@ const SIZE: u32 = 128u;
 
 var<workgroup> arr_i32_: array<i32, 128>;
 
-@compute @workgroup_size(4, 1, 1) 
+@compute @workgroup_size(4, 1, 1)
 fn test_workgroupUniformLoad(@builtin(workgroup_id) workgroup_id: vec3<u32>) {
     let x = (&arr_i32_[workgroup_id.x]);
     let _e4 = workgroupUniformLoad(x);

--- a/naga/tests/out/wgsl/wgsl-workgroup-var-init.wgsl
+++ b/naga/tests/out/wgsl/wgsl-workgroup-var-init.wgsl
@@ -5,10 +5,10 @@ struct WStruct {
 }
 
 var<workgroup> w_mem: WStruct;
-@group(0) @binding(0) 
+@group(0) @binding(0)
 var<storage, read_write> output: array<u32, 512>;
 
-@compute @workgroup_size(1, 1, 1) 
+@compute @workgroup_size(1, 1, 1)
 fn main() {
     let _e3 = w_mem.arr;
     output = _e3;


### PR DESCRIPTION
**Connections**

\-

**Description**

Extracted from https://github.com/gfx-rs/wgpu/pull/9966 to make life easier with no extra whitespaces in generated code that IDEs like to remove on save/commit.

I tried keeping changes minimal here.

**Testing**

This is a cosmetic change in generated code with no other side-effects.

**Squash or Rebase?**

\-

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
