### PR TITLE
RenderPassDescriptor&ComputePassDescriptor and it's subtypes in remote-types

### DIFF
--- a/wgpu-core-remote-types/src/binding_model.rs
+++ b/wgpu-core-remote-types/src/binding_model.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::ffi::FfiOption;
 use crate::id::{BindGroupLayoutId, BufferId, ExternalTextureId, SamplerId, TextureViewId};
-use crate::Label;
+use crate::{assert_ffi_safe, Label};
 
 /// Corresponds to [`GPUBufferBinding`](https://www.w3.org/TR/webgpu/#dictdef-gpubufferbinding).
 #[repr(C)]
@@ -23,6 +23,8 @@ pub struct BufferBinding {
     pub size: FfiOption<wgt::BufferAddress>,
 }
 
+assert_ffi_safe!(BufferBinding);
+
 /// Corresponds to [`GPUBindingResource`](https://www.w3.org/TR/webgpu/#typedefdef-gpubindingresource).
 #[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,6 +34,8 @@ pub enum BindingResource {
     TextureView(TextureViewId),
     ExternalTexture(ExternalTextureId),
 }
+
+assert_ffi_safe!(BindingResource);
 
 /// Bindable resource and the slot to bind it to.
 ///
@@ -45,6 +49,8 @@ pub struct BindGroupEntry {
     /// Resource to attach to the binding
     pub resource: BindingResource,
 }
+
+assert_ffi_safe!(BindGroupEntry);
 
 /// Describes a group of bindings and the resources to be bound.
 ///

--- a/wgpu-core-remote-types/src/binding_model.rs
+++ b/wgpu-core-remote-types/src/binding_model.rs
@@ -2,6 +2,7 @@ use alloc::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
+use crate::ffi::FfiOption;
 use crate::id::{BindGroupLayoutId, BufferId, ExternalTextureId, SamplerId, TextureViewId};
 use crate::Label;
 
@@ -19,10 +20,11 @@ pub struct BufferBinding {
     /// because JavaScript bindings cannot readily express `Option<NonZeroU64>`.
     /// The `wgpu` API uses `Option<BufferSize>` (i.e. `NonZeroU64`) for this
     /// field.
-    pub size: Option<wgt::BufferAddress>,
+    pub size: FfiOption<wgt::BufferAddress>,
 }
 
 /// Corresponds to [`GPUBindingResource`](https://www.w3.org/TR/webgpu/#typedefdef-gpubindingresource).
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BindingResource {
     Buffer(BufferBinding),
@@ -34,6 +36,7 @@ pub enum BindingResource {
 /// Bindable resource and the slot to bind it to.
 ///
 /// This corresponds to [`GPUBindGroupEntry`](https://www.w3.org/TR/webgpu/#dictdef-gpubindgroupentry).
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BindGroupEntry {
     /// Slot for which binding provides resource. Corresponds to an entry of the same

--- a/wgpu-core-remote-types/src/encoders.rs
+++ b/wgpu-core-remote-types/src/encoders.rs
@@ -1,5 +1,6 @@
 use alloc::borrow::Cow;
 
+use crate::ffi::FfiOption;
 use crate::{id, Label};
 
 pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
@@ -14,7 +15,7 @@ pub struct RenderPassColorAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
     /// The depth slice index of a 3D view. It must not be provided if the view is not 3D.
-    pub depth_slice: Option<u32>,
+    pub depth_slice: FfiOption<u32>,
     /// The view that will receive the resolved output if multisampling is used.
     pub resolve_target: Option<id::TextureViewId>,
     /// Operation to perform to the output attachment at the start of a
@@ -39,9 +40,9 @@ pub struct PassChannel<V> {
     ///
     /// This must be clear if it is the first renderpass rendering to a swap
     /// chain image.
-    pub load_op: Option<wgt::LoadOp<V>>,
+    pub load_op: FfiOption<wgt::LoadOp<V>>,
     /// Operation to perform to the output attachment at the end of a renderpass.
-    pub store_op: Option<wgt::StoreOp>,
+    pub store_op: FfiOption<wgt::StoreOp>,
     /// If true, the relevant channel is not changed by a renderpass, and the
     /// corresponding attachment can be used inside the pass by other read-only
     /// usages.
@@ -57,9 +58,9 @@ pub struct RenderPassDepthStencilAttachment {
     /// The view to use as an attachment.
     pub view: id::TextureViewId,
     /// What operations will be performed on the depth part of the attachment.
-    pub depth: PassChannel<Option<f32>>,
+    pub depth: PassChannel<FfiOption<f32>>,
     /// What operations will be performed on the stencil part of the attachment.
-    pub stencil: PassChannel<Option<u32>>,
+    pub stencil: PassChannel<FfiOption<u32>>,
 }
 
 /// Describes the writing of timestamp values in a render or compute pass.
@@ -71,9 +72,9 @@ pub struct PassTimestampWrites {
     /// The query set to write the timestamps to.
     pub query_set: id::QuerySetId,
     /// The index of the query set at which a start timestamp of this pass is written, if any.
-    pub beginning_of_pass_write_index: Option<u32>,
+    pub beginning_of_pass_write_index: FfiOption<u32>,
     /// The index of the query set at which an end timestamp of this pass is written, if any.
-    pub end_of_pass_write_index: Option<u32>,
+    pub end_of_pass_write_index: FfiOption<u32>,
 }
 
 /// Describes the attachments of a render pass.

--- a/wgpu-core-remote-types/src/encoders.rs
+++ b/wgpu-core-remote-types/src/encoders.rs
@@ -92,15 +92,23 @@ pub struct RenderPassDescriptor<'a> {
     pub timestamp_writes: Option<PassTimestampWrites>,
 }
 
+/// Corresponds to [`GPUComputePassDescriptor`](https://gpuweb.github.io/gpuweb/#dictdef-gpucomputepassdescriptor)
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct ComputePassDescriptor<'a> {
+    pub label: Label<'a>,
+    /// Defines where and when timestamp values will be written for this pass.
+    pub timestamp_writes: Option<PassTimestampWrites>,
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 /// Corresponds to [`GPUCommandEncoder`](https://www.w3.org/TR/webgpu/#gpucommandencoder).
-pub enum CommandEncoderCommand<'a, CPD> {
+pub enum CommandEncoderCommand<'a> {
     BeginRenderPass {
         desc: RenderPassDescriptor<'a>,
         render_pass_encoder_id: id::RenderPassEncoderId,
     },
     BeginComputePass {
-        desc: CPD, // optional, defaults to {}
+        desc: ComputePassDescriptor<'a>, // optional, defaults to {}
         compute_pass_encoder_id: id::ComputePassEncoderId,
     },
     CopyBufferToBuffer {

--- a/wgpu-core-remote-types/src/encoders.rs
+++ b/wgpu-core-remote-types/src/encoders.rs
@@ -1,13 +1,102 @@
+use alloc::borrow::Cow;
+
 use crate::{id, Label};
 
 pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
 pub type CommandBufferDescriptor<'a> = wgt::CommandBufferDescriptor<Label<'a>>;
 
+/// Describes a color attachment to a render pass.
+///
+/// Corresponds to [`GPURenderColorAttachment`](https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpasscolorattachment)
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RenderPassColorAttachment {
+    /// The view to use as an attachment.
+    pub view: id::TextureViewId,
+    /// The depth slice index of a 3D view. It must not be provided if the view is not 3D.
+    pub depth_slice: Option<u32>,
+    /// The view that will receive the resolved output if multisampling is used.
+    pub resolve_target: Option<id::TextureViewId>,
+    /// Operation to perform to the output attachment at the start of a
+    /// renderpass.
+    ///
+    /// This must be clear if it is the first renderpass rendering to a swap
+    /// chain image.
+    pub load_op: wgt::LoadOp<wgt::Color>,
+    /// Operation to perform to the output attachment at the end of a renderpass.
+    pub store_op: wgt::StoreOp,
+}
+
+/// Describes an individual channel within a render pass, such as color, depth, or stencil.
+///
+/// A channel must either be read-only, or it must specify both load and store
+/// operations.
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PassChannel<V> {
+    /// Operation to perform to the output attachment at the start of a
+    /// renderpass.
+    ///
+    /// This must be clear if it is the first renderpass rendering to a swap
+    /// chain image.
+    pub load_op: Option<wgt::LoadOp<V>>,
+    /// Operation to perform to the output attachment at the end of a renderpass.
+    pub store_op: Option<wgt::StoreOp>,
+    /// If true, the relevant channel is not changed by a renderpass, and the
+    /// corresponding attachment can be used inside the pass by other read-only
+    /// usages.
+    pub read_only: bool,
+}
+
+/// Describes a depth/stencil attachment to a render pass.
+///
+/// Corresponds to [`GPURenderDepthStencilAttachment`](https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpassdepthstencilattachment)
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RenderPassDepthStencilAttachment {
+    /// The view to use as an attachment.
+    pub view: id::TextureViewId,
+    /// What operations will be performed on the depth part of the attachment.
+    pub depth: PassChannel<Option<f32>>,
+    /// What operations will be performed on the stencil part of the attachment.
+    pub stencil: PassChannel<Option<u32>>,
+}
+
+/// Describes the writing of timestamp values in a render or compute pass.
+///
+/// Corresponds to [`GPURenderPassTimestampWrites`](https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpasstimestampwrites)
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PassTimestampWrites {
+    /// The query set to write the timestamps to.
+    pub query_set: id::QuerySetId,
+    /// The index of the query set at which a start timestamp of this pass is written, if any.
+    pub beginning_of_pass_write_index: Option<u32>,
+    /// The index of the query set at which an end timestamp of this pass is written, if any.
+    pub end_of_pass_write_index: Option<u32>,
+}
+
+/// Describes the attachments of a render pass.
+///
+/// Corresponds to [`GPURenderPassDescriptor`](https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpassdescriptor)
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RenderPassDescriptor<'a> {
+    pub label: Label<'a>,
+    /// The color attachments of the render pass.
+    pub color_attachments: Cow<'a, [Option<RenderPassColorAttachment>]>,
+    /// The depth and stencil attachment of the render pass, if any.
+    pub depth_stencil_attachment: Option<RenderPassDepthStencilAttachment>,
+    /// Defines where the occlusion query results will be stored for this pass.
+    pub occlusion_query_set: Option<id::QuerySetId>,
+    /// Defines where and when timestamp values will be written for this pass.
+    pub timestamp_writes: Option<PassTimestampWrites>,
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 /// Corresponds to [`GPUCommandEncoder`](https://www.w3.org/TR/webgpu/#gpucommandencoder).
-pub enum CommandEncoderCommand<'a, RPD, CPD> {
+pub enum CommandEncoderCommand<'a, CPD> {
     BeginRenderPass {
-        desc: RPD,
+        desc: RenderPassDescriptor<'a>,
         render_pass_encoder_id: id::RenderPassEncoderId,
     },
     BeginComputePass {

--- a/wgpu-core-remote-types/src/encoders.rs
+++ b/wgpu-core-remote-types/src/encoders.rs
@@ -6,6 +6,45 @@ use crate::{assert_ffi_safe, id, Label};
 pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
 pub type CommandBufferDescriptor<'a> = wgt::CommandBufferDescriptor<Label<'a>>;
 
+/// Operation to perform to the output attachment at the start of a render pass.
+///
+/// Corresponds to [WebGPU `GPULoadOp`](https://gpuweb.github.io/gpuweb/#enumdef-gpuloadop),
+/// plus the corresponding clearValue.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoadOp<V> {
+    /// Loads the specified value for this attachment into the render pass.
+    ///
+    /// On some GPU hardware (primarily mobile), "clear" is significantly cheaper
+    /// because it avoids loading data from main memory into tile-local memory.
+    ///
+    /// On other GPU hardware, there isn’t a significant difference.
+    ///
+    /// As a result, it is recommended to use "clear" rather than "load" in cases
+    /// where the initial value doesn’t matter
+    /// (e.g. the render target will be cleared using a skybox).
+    Clear(V) = 0,
+    /// Loads the existing value for this attachment into the render pass.
+    Load = 1,
+}
+
+impl<T> LoadOp<T> {
+    pub fn to_wgt(self) -> wgt::LoadOp<T> {
+        match self {
+            Self::Clear(value) => wgt::LoadOp::Clear(value),
+            Self::Load => wgt::LoadOp::Load,
+        }
+    }
+
+    pub fn map_clear_value<U>(self, f: impl FnOnce(T) -> U) -> LoadOp<U> {
+        match self {
+            Self::Clear(value) => LoadOp::Clear(f(value)),
+            Self::Load => LoadOp::Load,
+        }
+    }
+}
+
 /// Describes a color attachment to a render pass.
 ///
 /// Corresponds to [`GPURenderColorAttachment`](https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpasscolorattachment)
@@ -23,12 +62,12 @@ pub struct RenderPassColorAttachment {
     ///
     /// This must be clear if it is the first renderpass rendering to a swap
     /// chain image.
-    pub load_op: wgt::LoadOp<wgt::Color>,
+    pub load_op: LoadOp<wgt::Color>,
     /// Operation to perform to the output attachment at the end of a renderpass.
     pub store_op: wgt::StoreOp,
 }
 
-//assert_ffi_safe!(RenderPassColorAttachment);
+assert_ffi_safe!(RenderPassColorAttachment);
 
 /// Describes an individual channel within a render pass, such as color, depth, or stencil.
 ///
@@ -42,7 +81,7 @@ pub struct PassChannel<V> {
     ///
     /// This must be clear if it is the first renderpass rendering to a swap
     /// chain image.
-    pub load_op: FfiOption<wgt::LoadOp<V>>,
+    pub load_op: FfiOption<LoadOp<V>>,
     /// Operation to perform to the output attachment at the end of a renderpass.
     pub store_op: FfiOption<wgt::StoreOp>,
     /// If true, the relevant channel is not changed by a renderpass, and the
@@ -65,7 +104,7 @@ pub struct RenderPassDepthStencilAttachment {
     pub stencil: PassChannel<FfiOption<u32>>,
 }
 
-//assert_ffi_safe!(RenderPassDepthStencilAttachment);
+assert_ffi_safe!(RenderPassDepthStencilAttachment);
 
 /// Describes the writing of timestamp values in a render or compute pass.
 ///

--- a/wgpu-core-remote-types/src/encoders.rs
+++ b/wgpu-core-remote-types/src/encoders.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
 
 use crate::ffi::FfiOption;
-use crate::{id, Label};
+use crate::{assert_ffi_safe, id, Label};
 
 pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
 pub type CommandBufferDescriptor<'a> = wgt::CommandBufferDescriptor<Label<'a>>;
@@ -27,6 +27,8 @@ pub struct RenderPassColorAttachment {
     /// Operation to perform to the output attachment at the end of a renderpass.
     pub store_op: wgt::StoreOp,
 }
+
+//assert_ffi_safe!(RenderPassColorAttachment);
 
 /// Describes an individual channel within a render pass, such as color, depth, or stencil.
 ///
@@ -63,6 +65,8 @@ pub struct RenderPassDepthStencilAttachment {
     pub stencil: PassChannel<FfiOption<u32>>,
 }
 
+//assert_ffi_safe!(RenderPassDepthStencilAttachment);
+
 /// Describes the writing of timestamp values in a render or compute pass.
 ///
 /// Corresponds to [`GPURenderPassTimestampWrites`](https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpasstimestampwrites)
@@ -76,6 +80,8 @@ pub struct PassTimestampWrites {
     /// The index of the query set at which an end timestamp of this pass is written, if any.
     pub end_of_pass_write_index: FfiOption<u32>,
 }
+
+assert_ffi_safe!(PassTimestampWrites);
 
 /// Describes the attachments of a render pass.
 ///

--- a/wgpu-core-remote-types/src/ffi.rs
+++ b/wgpu-core-remote-types/src/ffi.rs
@@ -30,3 +30,14 @@ impl<T> FfiOption<T> {
         }
     }
 }
+
+#[macro_export]
+macro_rules! assert_ffi_safe {
+    ($ty:ty) => {
+        const _: () = {
+            #[deny(improper_ctypes_definitions)]
+            #[export_name = concat!("_compile_check_ffi_export_", stringify!($ty))]
+            pub extern "C" fn _compile_check_ffi_export(_x: $ty) {}
+        };
+    };
+}

--- a/wgpu-core-remote-types/src/ffi.rs
+++ b/wgpu-core-remote-types/src/ffi.rs
@@ -1,0 +1,32 @@
+/// FFI-friendly analogue of [`std::option::Option`].
+///
+/// In some cases, Rust's standard `Option` type is FFI-friendly, in that `T` and `Option<T>` map
+/// to the same C++ type. For example, both `&U` and `Option<&U>` can be represented as `U *` in
+/// C++.
+///
+/// For other types, `Option<T>` may not be FFI-safe. For such cases, this type is a `repr(u8)`
+/// analog to the standard
+///
+/// See also: <https://doc.rust-lang.org/nomicon/ffi.html#the-nullable-pointer-optimization>
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum FfiOption<T> {
+    Some(T),
+    None,
+}
+
+impl<T> FfiOption<T> {
+    pub fn to_std(self) -> std::option::Option<T> {
+        match self {
+            Self::Some(value) => Some(value),
+            Self::None => None,
+        }
+    }
+
+    pub fn as_ref(&self) -> std::option::Option<&T> {
+        match *self {
+            Self::Some(ref value) => Some(value),
+            Self::None => None,
+        }
+    }
+}

--- a/wgpu-core-remote-types/src/lib.rs
+++ b/wgpu-core-remote-types/src/lib.rs
@@ -27,5 +27,6 @@ pub mod identity;
 
 pub mod binding_model;
 pub mod encoders;
+pub mod ffi;
 
 pub type Label<'a> = Option<Cow<'a, str>>;

--- a/wgpu-core-remote/src/global/command_encoder.rs
+++ b/wgpu-core-remote/src/global/command_encoder.rs
@@ -3,7 +3,6 @@ use wgpu_core_remote_types::encoders::{CommandEncoderCommand, DebugCommand};
 use wgt::{BufferAddress, Extent3d, ImageSubresourceRange};
 
 use crate::global::compute_pass::ComputePassDescriptor;
-use crate::global::render_pass::RenderPassDescriptor;
 use crate::global::Global;
 use crate::hub::Hub;
 use crate::id::{BufferId, CommandEncoderId, TextureId};
@@ -214,7 +213,7 @@ impl Global {
     pub fn handle_command_encoder_command<'a>(
         &self,
         command_encoder_id: CommandEncoderId,
-        command: CommandEncoderCommand<'a, RenderPassDescriptor<'a>, ComputePassDescriptor<'a>>,
+        command: CommandEncoderCommand<'a, ComputePassDescriptor<'a>>,
     ) {
         match command {
             CommandEncoderCommand::BeginRenderPass {

--- a/wgpu-core-remote/src/global/command_encoder.rs
+++ b/wgpu-core-remote/src/global/command_encoder.rs
@@ -2,7 +2,6 @@ use wgpu_core::Label;
 use wgpu_core_remote_types::encoders::{CommandEncoderCommand, DebugCommand};
 use wgt::{BufferAddress, Extent3d, ImageSubresourceRange};
 
-use crate::global::compute_pass::ComputePassDescriptor;
 use crate::global::Global;
 use crate::hub::Hub;
 use crate::id::{BufferId, CommandEncoderId, TextureId};
@@ -213,7 +212,7 @@ impl Global {
     pub fn handle_command_encoder_command<'a>(
         &self,
         command_encoder_id: CommandEncoderId,
-        command: CommandEncoderCommand<'a, ComputePassDescriptor<'a>>,
+        command: CommandEncoderCommand<'a>,
     ) {
         match command {
             CommandEncoderCommand::BeginRenderPass {

--- a/wgpu-core-remote/src/global/compute_pass.rs
+++ b/wgpu-core-remote/src/global/compute_pass.rs
@@ -42,8 +42,8 @@ impl Global {
                 .as_ref()
                 .map(|tw| PassTimestampWrites {
                     query_set: query_sets.get(tw.query_set),
-                    beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
-                    end_of_pass_write_index: tw.end_of_pass_write_index,
+                    beginning_of_pass_write_index: tw.beginning_of_pass_write_index.to_std(),
+                    end_of_pass_write_index: tw.end_of_pass_write_index.to_std(),
                 }),
         };
 

--- a/wgpu-core-remote/src/global/compute_pass.rs
+++ b/wgpu-core-remote/src/global/compute_pass.rs
@@ -1,15 +1,14 @@
 use alloc::borrow::Cow;
 
 use wgpu_core::command::PassTimestampWrites;
-use wgpu_core_remote_types::encoders::{BindingCommand, ComputePassEncoderCommand, DebugCommand};
+use wgpu_core_remote_types::encoders::{
+    BindingCommand, ComputePassDescriptor, ComputePassEncoderCommand, DebugCommand,
+};
 use wgt::{BufferAddress, DynamicOffset};
 
 use crate::global::Global;
 use crate::hub::Hub;
 use crate::id;
-
-pub type ComputePassDescriptor<'a> =
-    wgpu_core::command::ComputePassDescriptor<'a, PassTimestampWrites<id::QuerySetId>>;
 
 impl Global {
     /// Creates a compute pass.

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -525,7 +525,7 @@ impl Global {
                 binding_model::BufferBinding {
                     buffer,
                     offset: bb.offset,
-                    size: bb.size,
+                    size: bb.size.to_std(),
                 }
             };
             let resolve_sampler = |id: &id::SamplerId| samplers.get(*id);

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -7,11 +7,20 @@ use wgpu_core::command::{
     PassTimestampWrites, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
     ResolvedRenderPassDescriptor,
 };
+use wgpu_core_remote_types::ffi::FfiOption;
 use wgt::{BufferAddress, BufferSize, Color, DynamicOffset, IndexFormat};
 
 use crate::global::Global;
 use crate::hub::Hub;
 use crate::id;
+
+fn map_clear_value<V1, V2>(load_op: wgt::LoadOp<V1>, f: impl FnOnce(V1) -> V2) -> wgt::LoadOp<V2> {
+    match load_op {
+        wgt::LoadOp::Clear(value) => wgt::LoadOp::Clear(f(value)),
+        wgt::LoadOp::Load => wgt::LoadOp::Load,
+        wgt::LoadOp::DontCare(token) => wgt::LoadOp::DontCare(token),
+    }
+}
 
 impl Global {
     /// Creates a render pass.
@@ -47,7 +56,7 @@ impl Global {
                     .map(|at| {
                         at.as_ref().map(|at| RenderPassColorAttachment {
                             view: texture_views.get(at.view),
-                            depth_slice: at.depth_slice,
+                            depth_slice: at.depth_slice.to_std(),
                             resolve_target: at
                                 .resolve_target
                                 .as_ref()
@@ -62,13 +71,21 @@ impl Global {
                 RenderPassDepthStencilAttachment {
                     view: texture_views.get(at.view),
                     depth: wgpu_core::command::PassChannel {
-                        load_op: at.depth.load_op,
-                        store_op: at.depth.store_op,
+                        load_op: at
+                            .depth
+                            .load_op
+                            .to_std()
+                            .map(|x| map_clear_value(x, FfiOption::to_std)),
+                        store_op: at.depth.store_op.to_std(),
                         read_only: at.depth.read_only,
                     },
                     stencil: wgpu_core::command::PassChannel {
-                        load_op: at.stencil.load_op,
-                        store_op: at.stencil.store_op,
+                        load_op: at
+                            .stencil
+                            .load_op
+                            .to_std()
+                            .map(|x| map_clear_value(x, FfiOption::to_std)),
+                        store_op: at.stencil.store_op.to_std(),
                         read_only: at.stencil.read_only,
                     },
                 }
@@ -78,8 +95,8 @@ impl Global {
                 .as_ref()
                 .map(|tw| PassTimestampWrites {
                     query_set: query_sets.get(tw.query_set),
-                    beginning_of_pass_write_index: tw.beginning_of_pass_write_index,
-                    end_of_pass_write_index: tw.end_of_pass_write_index,
+                    beginning_of_pass_write_index: tw.beginning_of_pass_write_index.to_std(),
+                    end_of_pass_write_index: tw.end_of_pass_write_index.to_std(),
                 }),
             occlusion_query_set: desc
                 .occlusion_query_set

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -1,36 +1,17 @@
 use alloc::borrow::Cow;
-use core::num::NonZeroU32;
 use wgpu_core_remote_types::encoders::{
-    BindingCommand, DebugCommand, RenderCommand, RenderPassEncoderCommand,
+    BindingCommand, DebugCommand, RenderCommand, RenderPassDescriptor, RenderPassEncoderCommand,
 };
 
 use wgpu_core::command::{
     PassTimestampWrites, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
     ResolvedRenderPassDescriptor,
 };
-use wgpu_core::Label;
 use wgt::{BufferAddress, BufferSize, Color, DynamicOffset, IndexFormat};
 
 use crate::global::Global;
 use crate::hub::Hub;
 use crate::id;
-
-/// Describes the attachments of a render pass.
-#[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct RenderPassDescriptor<'a> {
-    pub label: Label<'a>,
-    /// The color attachments of the render pass.
-    pub color_attachments: Cow<'a, [Option<RenderPassColorAttachment<id::TextureViewId>>]>,
-    /// The depth and stencil attachment of the render pass, if any.
-    pub depth_stencil_attachment: Option<RenderPassDepthStencilAttachment<id::TextureViewId>>,
-    /// Defines where and when timestamp values will be written for this pass.
-    pub timestamp_writes: Option<PassTimestampWrites<id::QuerySetId>>,
-    /// Defines where the occlusion query results will be stored for this pass.
-    pub occlusion_query_set: Option<id::QuerySetId>,
-    /// The multiview array layers that will be used
-    pub multiview_mask: Option<NonZeroU32>,
-}
 
 impl Global {
     /// Creates a render pass.
@@ -80,8 +61,16 @@ impl Global {
             depth_stencil_attachment: desc.depth_stencil_attachment.as_ref().map(|at| {
                 RenderPassDepthStencilAttachment {
                     view: texture_views.get(at.view),
-                    depth: at.depth.clone(),
-                    stencil: at.stencil.clone(),
+                    depth: wgpu_core::command::PassChannel {
+                        load_op: at.depth.load_op,
+                        store_op: at.depth.store_op,
+                        read_only: at.depth.read_only,
+                    },
+                    stencil: wgpu_core::command::PassChannel {
+                        load_op: at.stencil.load_op,
+                        store_op: at.stencil.store_op,
+                        read_only: at.stencil.read_only,
+                    },
                 }
             }),
             timestamp_writes: desc
@@ -96,7 +85,7 @@ impl Global {
                 .occlusion_query_set
                 .as_ref()
                 .map(|query_set| query_sets.get(*query_set)),
-            multiview_mask: desc.multiview_mask,
+            multiview_mask: None,
         };
 
         let render_pass = cmd_enc.begin_render_pass(desc);

--- a/wgpu-core-remote/src/global/render_pass.rs
+++ b/wgpu-core-remote/src/global/render_pass.rs
@@ -14,14 +14,6 @@ use crate::global::Global;
 use crate::hub::Hub;
 use crate::id;
 
-fn map_clear_value<V1, V2>(load_op: wgt::LoadOp<V1>, f: impl FnOnce(V1) -> V2) -> wgt::LoadOp<V2> {
-    match load_op {
-        wgt::LoadOp::Clear(value) => wgt::LoadOp::Clear(f(value)),
-        wgt::LoadOp::Load => wgt::LoadOp::Load,
-        wgt::LoadOp::DontCare(token) => wgt::LoadOp::DontCare(token),
-    }
-}
-
 impl Global {
     /// Creates a render pass.
     ///
@@ -61,7 +53,7 @@ impl Global {
                                 .resolve_target
                                 .as_ref()
                                 .map(|rt| texture_views.get(*rt)),
-                            load_op: at.load_op,
+                            load_op: at.load_op.to_wgt(),
                             store_op: at.store_op,
                         })
                     })
@@ -75,7 +67,7 @@ impl Global {
                             .depth
                             .load_op
                             .to_std()
-                            .map(|x| map_clear_value(x, FfiOption::to_std)),
+                            .map(|x| x.map_clear_value(FfiOption::to_std).to_wgt()),
                         store_op: at.depth.store_op.to_std(),
                         read_only: at.depth.read_only,
                     },
@@ -84,7 +76,7 @@ impl Global {
                             .stencil
                             .load_op
                             .to_std()
-                            .map(|x| map_clear_value(x, FfiOption::to_std)),
+                            .map(|x| x.map_clear_value(FfiOption::to_std).to_wgt()),
                         store_op: at.stencil.store_op.to_std(),
                         read_only: at.stencil.read_only,
                     },


### PR DESCRIPTION
**Connections**
Towards #10073

**Description**
This time I cloned structs from wgc. The only difference between our types and firefox types is that firefox uses FfiOption. I think FfiOption is idiomatic enough to be used in remote-types so https://github.com/gfx-rs/wgpu/pull/10132/commits/d0aa867f77aa94810b50c84221ec7f863c7fddd3 uses it.

**Testing**
In rust we trust.

**Squash or Rebase?**
Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
