### PR TITLE
[naga msl] lower subgroup ops inside a `switch` to nested if/else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Fix invalid HLSL generated for `textureSampleLevel` with non-2D textures. By @mvanhorn in [#9717](https://github.com/gfx-rs/wgpu/issues/9717).
 - Reject return types on compute shader entrypoints. By @ErichDonGubler in [#10026](https://github.com/gfx-rs/wgpu/pull/10026).
 - Reject `@location(…)`s in compute shaders. By @ErichDonGubler in [#10026](https://github.com/gfx-rs/wgpu/pull/10026).
+- MSL: emit subgroup operations inside a `switch` as nested `if`/`else` statements, working around an Apple Metal compiler bug that ignores the branch's active mask. By @matthargett in [#10135](https://github.com/gfx-rs/wgpu/pull/10135).
 
 #### DX12
 

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -943,6 +943,63 @@ pub(super) struct StatementContext<'a> {
     pub(super) result_struct: Option<&'a str>,
 }
 
+/// Does any case body perform a subgroup operation?
+///
+/// Used to decide whether a `switch` needs the nested-`if` workaround for
+/// Apple's Metal compiler; see the use site in `put_block`.
+fn cases_use_subgroup_ops(cases: &[crate::SwitchCase]) -> bool {
+    cases.iter().any(|case| block_uses_subgroup_ops(&case.body))
+}
+
+fn block_uses_subgroup_ops(block: &crate::Block) -> bool {
+    block.iter().any(|stmt| match *stmt {
+        crate::Statement::SubgroupBallot { .. }
+        | crate::Statement::SubgroupGather { .. }
+        | crate::Statement::SubgroupCollectiveOperation { .. } => true,
+        crate::Statement::Block(ref inner) => block_uses_subgroup_ops(inner),
+        crate::Statement::If {
+            ref accept,
+            ref reject,
+            ..
+        } => block_uses_subgroup_ops(accept) || block_uses_subgroup_ops(reject),
+        crate::Statement::Loop {
+            ref body,
+            ref continuing,
+            ..
+        } => block_uses_subgroup_ops(body) || block_uses_subgroup_ops(continuing),
+        crate::Statement::Switch { ref cases, .. } => cases_use_subgroup_ops(cases),
+        _ => false,
+    })
+}
+
+/// Is this `switch` equivalent to a chain of `if`/`else` statements?
+///
+/// It is when no case falls through and no case body contains a `break` bound
+/// to the switch itself: in an if/else chain such a `break` would bind to an
+/// enclosing loop instead, changing the meaning of the program.
+fn cases_convertible_to_if_chain(cases: &[crate::SwitchCase]) -> bool {
+    cases
+        .iter()
+        .all(|case| !case.fall_through && !block_breaks_out_of_switch(&case.body))
+}
+
+/// Does this block `break` out of the enclosing `switch`?
+///
+/// Deliberately does not recurse into `Loop` or nested `Switch` statements: a
+/// `break` inside those binds to the inner construct, not to our switch.
+fn block_breaks_out_of_switch(block: &crate::Block) -> bool {
+    block.iter().any(|stmt| match *stmt {
+        crate::Statement::Break => true,
+        crate::Statement::Block(ref inner) => block_breaks_out_of_switch(inner),
+        crate::Statement::If {
+            ref accept,
+            ref reject,
+            ..
+        } => block_breaks_out_of_switch(accept) || block_breaks_out_of_switch(reject),
+        _ => false,
+    })
+}
+
 impl<W: Write> Writer<W> {
     /// Creates a new `Writer` instance.
     pub fn new(out: W) -> Self {
@@ -3920,6 +3977,73 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
+    /// Emit a `switch` as nested `if`/`else` statements.
+    ///
+    /// Only valid for switches satisfying [`cases_convertible_to_if_chain`].
+    /// The `default` case becomes the innermost `else`, regardless of where it
+    /// appears in the case list, matching `switch` semantics.
+    ///
+    /// Emits *nested* `else { if ... }` rather than a flat `else if` chain so
+    /// the output has the same shape as this backend's [`crate::Statement::If`]
+    /// lowering, which is the form observed to be compiled correctly.
+    fn put_switch_as_if_chain(
+        &mut self,
+        level: back::Level,
+        selector: Handle<crate::Expression>,
+        cases: &[crate::SwitchCase],
+        context: &StatementContext,
+    ) -> BackendResult {
+        let default_body = cases
+            .iter()
+            .find(|case| matches!(case.value, crate::SwitchValue::Default))
+            .map(|case| &case.body);
+        let value_cases: Vec<&crate::SwitchCase> = cases
+            .iter()
+            .filter(|case| !matches!(case.value, crate::SwitchValue::Default))
+            .collect();
+
+        self.put_switch_if_chain_tail(level, selector, &value_cases, default_body, context)
+    }
+
+    fn put_switch_if_chain_tail(
+        &mut self,
+        level: back::Level,
+        selector: Handle<crate::Expression>,
+        cases: &[&crate::SwitchCase],
+        default_body: Option<&crate::Block>,
+        context: &StatementContext,
+    ) -> BackendResult {
+        let Some((case, rest)) = cases.split_first() else {
+            // No value cases left: whatever remains runs unconditionally.
+            if let Some(body) = default_body {
+                self.put_block(level, body, context)?;
+            }
+            return Ok(());
+        };
+
+        let value = match case.value {
+            crate::SwitchValue::I32(value) => value.to_string(),
+            crate::SwitchValue::U32(value) => format!("{value}u"),
+            // Filtered out by `put_switch_as_if_chain`.
+            crate::SwitchValue::Default => unreachable!(),
+        };
+
+        write!(self.out, "{level}if (")?;
+        self.put_expression(selector, &context.expression, true)?;
+        writeln!(self.out, " == {value}) {{")?;
+        self.put_block(level.next(), &case.body, context)?;
+
+        if rest.is_empty() && default_body.is_none() {
+            writeln!(self.out, "{level}}}")?;
+        } else {
+            writeln!(self.out, "{level}}} else {{")?;
+            self.put_switch_if_chain_tail(level.next(), selector, rest, default_body, context)?;
+            writeln!(self.out, "{level}}}")?;
+        }
+
+        Ok(())
+    }
+
     fn put_block(
         &mut self,
         level: back::Level,
@@ -4040,6 +4164,21 @@ impl<W: Write> Writer<W> {
                     selector,
                     ref cases,
                 } => {
+                    // Apple's Metal compiler miscompiles subgroup operations
+                    // performed inside a `switch`: on A14 / iOS 26.5,
+                    // `simd_broadcast_first` in a switch case returns lane 0's
+                    // value for every lane, ignoring the branch's active mask.
+                    // Emitting the same control flow as nested `if`/`else`
+                    // statements produces spec-conformant results.
+                    //
+                    // Restricted to switches that are provably equivalent to an
+                    // if/else chain: no fall-through, and no `break` bound to
+                    // this switch (in an if/else chain such a `break` would
+                    // bind to an enclosing loop instead).
+                    if cases_use_subgroup_ops(cases) && cases_convertible_to_if_chain(cases) {
+                        self.put_switch_as_if_chain(level, selector, cases, context)?;
+                        continue;
+                    }
                     write!(self.out, "{level}switch(")?;
                     self.put_expression(selector, &context.expression, true)?;
                     writeln!(self.out, ") {{")?;

--- a/naga/tests/in/wgsl/subgroup-operations-switch.toml
+++ b/naga/tests/in/wgsl/subgroup-operations-switch.toml
@@ -1,0 +1,20 @@
+capabilities = "SUBGROUP"
+
+[msl]
+fake_missing_bindings = false
+lang_version = [2, 4]
+spirv_cross_compatibility = false
+zero_initialize_workgroup_memory = true
+
+[hlsl]
+shader_model = "V6_0"
+fake_missing_bindings = true
+restrict_indexing = true
+zero_initialize_workgroup_memory = true
+
+[glsl]
+version.Desktop = 430
+zero_initialize_workgroup_memory = true
+
+[spv]
+version = [1, 3]

--- a/naga/tests/in/wgsl/subgroup-operations-switch.wgsl
+++ b/naga/tests/in/wgsl/subgroup-operations-switch.wgsl
@@ -1,0 +1,61 @@
+// Subgroup operations inside a `switch`.
+//
+// The MSL backend lowers these to nested `if`/`else` statements, because
+// Apple's Metal compiler miscompiles subgroup operations performed in a
+// `switch` case. The remaining functions cover the cases where that lowering
+// must not be applied.
+
+// Lowered: no fall-through, no `break` bound to the switch.
+fn lowered(sid: u32) -> u32 {
+    var v = 0u;
+    switch sid % 3u {
+        case 0u: { v = subgroupBroadcastFirst(sid); }
+        case 1u: { v = subgroupAdd(sid); }
+        default: { v = subgroupBroadcastFirst(sid); }
+    }
+    return v;
+}
+
+// Not lowered: a case falls through, which an if/else chain cannot express.
+fn kept_fallthrough(sid: u32) -> u32 {
+    var v = 0u;
+    switch sid % 2u {
+        case 0u, default: { v = subgroupBroadcastFirst(sid); }
+    }
+    return v;
+}
+
+// Not lowered: the `break` binds to the switch, and would bind to the
+// enclosing loop if this became an if/else chain.
+fn kept_break(sid: u32) -> u32 {
+    var v = 0u;
+    loop {
+        switch sid % 2u {
+            case 0u: {
+                v = subgroupBroadcastFirst(sid);
+                break;
+            }
+            default: { v = 1u; }
+        }
+        break;
+    }
+    return v;
+}
+
+// Not lowered: no subgroup operations in any case body.
+fn kept_no_subgroup_ops(sid: u32) -> u32 {
+    var v = 0u;
+    switch sid % 2u {
+        case 0u: { v = 10u; }
+        default: { v = 20u; }
+    }
+    return v;
+}
+
+@compute @workgroup_size(32)
+fn main(@builtin(subgroup_invocation_id) sid: u32) {
+    _ = lowered(sid);
+    _ = kept_fallthrough(sid);
+    _ = kept_break(sid);
+    _ = kept_no_subgroup_ops(sid);
+}

--- a/naga/tests/out/glsl/wgsl-subgroup-operations-switch.main.Compute.glsl
+++ b/naga/tests/out/glsl/wgsl-subgroup-operations-switch.main.Compute.glsl
@@ -1,0 +1,90 @@
+#version 430 core
+#extension GL_ARB_compute_shader : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_vote : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+#extension GL_KHR_shader_subgroup_ballot : require
+#extension GL_KHR_shader_subgroup_shuffle : require
+#extension GL_KHR_shader_subgroup_shuffle_relative : require
+#extension GL_KHR_shader_subgroup_quad : require
+layout(local_size_x = 32, local_size_y = 1, local_size_z = 1) in;
+
+
+uint lowered(uint sid_1) {
+    uint v = 0u;
+    switch((sid_1 - 3u * (sid_1 / 3u))) {
+        case 0u: {
+            uint _e5 = subgroupBroadcastFirst(sid_1);
+            v = _e5;
+            break;
+        }
+        case 1u: {
+            uint _e6 = subgroupAdd(sid_1);
+            v = _e6;
+            break;
+        }
+        default: {
+            uint _e7 = subgroupBroadcastFirst(sid_1);
+            v = _e7;
+            break;
+        }
+    }
+    uint _e8 = v;
+    return _e8;
+}
+
+uint kept_fallthrough(uint sid_2) {
+    uint v_1 = 0u;
+    do {
+        uint _e5 = subgroupBroadcastFirst(sid_2);
+        v_1 = _e5;
+    } while(false);
+    uint _e6 = v_1;
+    return _e6;
+}
+
+uint kept_break(uint sid_3) {
+    uint v_2 = 0u;
+    while(true) {
+        switch((sid_3 - 2u * (sid_3 / 2u))) {
+            case 0u: {
+                uint _e5 = subgroupBroadcastFirst(sid_3);
+                v_2 = _e5;
+                break;
+            }
+            default: {
+                v_2 = 1u;
+                break;
+            }
+        }
+        break;
+    }
+    uint _e7 = v_2;
+    return _e7;
+}
+
+uint kept_no_subgroup_ops(uint sid_4) {
+    uint v_3 = 0u;
+    switch((sid_4 - 2u * (sid_4 / 2u))) {
+        case 0u: {
+            v_3 = 10u;
+            break;
+        }
+        default: {
+            v_3 = 20u;
+            break;
+        }
+    }
+    uint _e7 = v_3;
+    return _e7;
+}
+
+void main() {
+    uint sid = gl_SubgroupInvocationID;
+    uint _e1 = lowered(sid);
+    uint _e2 = kept_fallthrough(sid);
+    uint _e3 = kept_break(sid);
+    uint _e4 = kept_no_subgroup_ops(sid);
+    return;
+}
+

--- a/naga/tests/out/hlsl/wgsl-subgroup-operations-switch.hlsl
+++ b/naga/tests/out/hlsl/wgsl-subgroup-operations-switch.hlsl
@@ -1,0 +1,98 @@
+struct ComputeInput_main {
+};
+
+uint naga_mod(uint lhs, uint rhs) {
+    return lhs % (rhs == 0u ? 1u : rhs);
+}
+
+uint lowered(uint sid_1)
+{
+    uint v = 0u;
+
+    switch(naga_mod(sid_1, 3u)) {
+        case 0u: {
+            const uint _e5 = WaveReadLaneFirst(sid_1);
+            v = _e5;
+            break;
+        }
+        case 1u: {
+            const uint _e6 = WaveActiveSum(sid_1);
+            v = _e6;
+            break;
+        }
+        default: {
+            const uint _e7 = WaveReadLaneFirst(sid_1);
+            v = _e7;
+            break;
+        }
+    }
+    uint _e8 = v;
+    return _e8;
+}
+
+uint kept_fallthrough(uint sid_2)
+{
+    uint v_1 = 0u;
+
+    do {
+        const uint _e5 = WaveReadLaneFirst(sid_2);
+        v_1 = _e5;
+    } while(false);
+    uint _e6 = v_1;
+    return _e6;
+}
+
+uint kept_break(uint sid_3)
+{
+    uint v_2 = 0u;
+
+    uint2 loop_bound = uint2(4294967295u, 4294967295u);
+    while(true) {
+        if (all(loop_bound == uint2(0u, 0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
+        bool should_continue = false;
+        switch(naga_mod(sid_3, 2u)) {
+            case 0u: {
+                const uint _e5 = WaveReadLaneFirst(sid_3);
+                v_2 = _e5;
+                break;
+            }
+            default: {
+                v_2 = 1u;
+                break;
+            }
+        }
+        break;
+    }
+    uint _e7 = v_2;
+    return _e7;
+}
+
+uint kept_no_subgroup_ops(uint sid_4)
+{
+    uint v_3 = 0u;
+
+    switch(naga_mod(sid_4, 2u)) {
+        case 0u: {
+            v_3 = 10u;
+            break;
+        }
+        default: {
+            v_3 = 20u;
+            break;
+        }
+    }
+    uint _e7 = v_3;
+    return _e7;
+}
+
+[numthreads(32, 1, 1)]
+void main(ComputeInput_main computeinput_main)
+{
+    uint sid = WaveGetLaneIndex();
+    const uint _e1 = lowered(sid);
+    const uint _e2 = kept_fallthrough(sid);
+    const uint _e3 = kept_break(sid);
+    const uint _e4 = kept_no_subgroup_ops(sid);
+    return;
+}

--- a/naga/tests/out/hlsl/wgsl-subgroup-operations-switch.ron
+++ b/naga/tests/out/hlsl/wgsl-subgroup-operations-switch.ron
@@ -1,0 +1,16 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"main",
+            target_profile:"cs_6_0",
+        ),
+    ],
+    task:[
+    ],
+    mesh:[
+    ],
+)

--- a/naga/tests/out/msl/wgsl-subgroup-operations-switch.metal
+++ b/naga/tests/out/msl/wgsl-subgroup-operations-switch.metal
@@ -1,0 +1,101 @@
+// language: metal2.4
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+
+uint naga_mod(uint lhs, uint rhs) {
+    return lhs % metal::select(rhs, 1u, rhs == 0u);
+}
+
+uint lowered(
+    uint sid_1
+) {
+    uint v = 0u;
+    if (naga_mod(sid_1, 3u) == 0u) {
+        uint unnamed = metal::simd_broadcast_first(sid_1);
+        v = unnamed;
+    } else {
+        if (naga_mod(sid_1, 3u) == 1u) {
+            uint unnamed_1 = metal::simd_sum(sid_1);
+            v = unnamed_1;
+        } else {
+            uint unnamed_2 = metal::simd_broadcast_first(sid_1);
+            v = unnamed_2;
+        }
+    }
+    uint _e8 = v;
+    return _e8;
+}
+
+uint kept_fallthrough(
+    uint sid_2
+) {
+    uint v_1 = 0u;
+    switch(naga_mod(sid_2, 2u)) {
+        case 0u:
+        default: {
+            uint unnamed_3 = metal::simd_broadcast_first(sid_2);
+            v_1 = unnamed_3;
+            break;
+        }
+    }
+    uint _e6 = v_1;
+    return _e6;
+}
+
+uint kept_break(
+    uint sid_3
+) {
+    uint v_2 = 0u;
+    uint2 loop_bound = uint2(4294967295u);
+    while(true) {
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
+        switch(naga_mod(sid_3, 2u)) {
+            case 0u: {
+                uint unnamed_4 = metal::simd_broadcast_first(sid_3);
+                v_2 = unnamed_4;
+                break;
+            }
+            default: {
+                v_2 = 1u;
+                break;
+            }
+        }
+        break;
+    }
+    uint _e7 = v_2;
+    return _e7;
+}
+
+uint kept_no_subgroup_ops(
+    uint sid_4
+) {
+    uint v_3 = 0u;
+    switch(naga_mod(sid_4, 2u)) {
+        case 0u: {
+            v_3 = 10u;
+            break;
+        }
+        default: {
+            v_3 = 20u;
+            break;
+        }
+    }
+    uint _e7 = v_3;
+    return _e7;
+}
+
+struct main_Input {
+};
+[[max_total_threads_per_threadgroup(32)]] kernel void main_(
+  uint sid [[thread_index_in_simdgroup]]
+) {
+    uint _e1 = lowered(sid);
+    uint _e2 = kept_fallthrough(sid);
+    uint _e3 = kept_break(sid);
+    uint _e4 = kept_no_subgroup_ops(sid);
+    return;
+}

--- a/naga/tests/out/spv/wgsl-subgroup-operations-switch.spvasm
+++ b/naga/tests/out/spv/wgsl-subgroup-operations-switch.spvasm
@@ -1,0 +1,159 @@
+; SPIR-V
+; Version: 1.3
+; Generator: rspirv
+; Bound: 98
+OpCapability Shader
+OpCapability GroupNonUniformBallot
+OpCapability GroupNonUniformArithmetic
+OpCapability GroupNonUniform
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %91 "main" %88
+OpExecutionMode %91 LocalSize 32 1 1
+OpDecorate %88 BuiltIn SubgroupLocalInvocationId
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%5 = OpTypeFunction %3 %3 %3
+%9 = OpTypeBool
+%10 = OpConstant  %3  0
+%12 = OpConstant  %3  1
+%18 = OpTypeFunction %3 %3
+%19 = OpConstant  %3  3
+%21 = OpTypePointer Function %3
+%35 = OpConstant  %3  2
+%52 = OpTypeVector %3 2
+%53 = OpTypePointer Function %52
+%54 = OpTypeVector %9 2
+%55 = OpConstantComposite  %52  %10 %10
+%56 = OpConstant  %3  4294967295
+%57 = OpConstantComposite  %52  %56 %56
+%78 = OpConstant  %3  10
+%79 = OpConstant  %3  20
+%89 = OpTypePointer Input %3
+%88 = OpVariable  %89  Input
+%92 = OpTypeFunction %2
+%4 = OpFunction  %3  None %5
+%6 = OpFunctionParameter  %3
+%7 = OpFunctionParameter  %3
+%8 = OpLabel
+%11 = OpIEqual  %9  %7 %10
+%13 = OpSelect  %3  %11 %12 %7
+%14 = OpUMod  %3  %6 %13
+OpReturnValue %14
+OpFunctionEnd
+%17 = OpFunction  %3  None %18
+%16 = OpFunctionParameter  %3
+%15 = OpLabel
+%20 = OpVariable  %21  Function %10
+OpBranch %22
+%22 = OpLabel
+%23 = OpFunctionCall  %3  %4 %16 %19
+OpSelectionMerge %24 None
+OpSwitch %23 %27 0 %25 1 %26
+%25 = OpLabel
+%28 = OpGroupNonUniformBroadcastFirst  %3  %19 %16
+OpStore %20 %28
+OpBranch %24
+%26 = OpLabel
+%29 = OpGroupNonUniformIAdd  %3  %19 Reduce %16
+OpStore %20 %29
+OpBranch %24
+%27 = OpLabel
+%30 = OpGroupNonUniformBroadcastFirst  %3  %19 %16
+OpStore %20 %30
+OpBranch %24
+%24 = OpLabel
+%31 = OpLoad  %3  %20
+OpReturnValue %31
+OpFunctionEnd
+%34 = OpFunction  %3  None %18
+%33 = OpFunctionParameter  %3
+%32 = OpLabel
+%36 = OpVariable  %21  Function %10
+OpBranch %37
+%37 = OpLabel
+%38 = OpFunctionCall  %3  %4 %33 %35
+OpSelectionMerge %39 None
+OpSwitch %38 %40 0 %40
+%40 = OpLabel
+%41 = OpGroupNonUniformBroadcastFirst  %3  %19 %33
+OpStore %36 %41
+OpBranch %39
+%39 = OpLabel
+%42 = OpLoad  %3  %36
+OpReturnValue %42
+OpFunctionEnd
+%45 = OpFunction  %3  None %18
+%44 = OpFunctionParameter  %3
+%43 = OpLabel
+%46 = OpVariable  %21  Function %10
+%58 = OpVariable  %53  Function %57
+OpBranch %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+OpLoopMerge %49 %51 None
+OpBranch %59
+%59 = OpLabel
+%60 = OpLoad  %52  %58
+%61 = OpIEqual  %54  %55 %60
+%62 = OpAll  %9  %61
+OpSelectionMerge %63 None
+OpBranchConditional %62 %49 %63
+%63 = OpLabel
+%64 = OpCompositeExtract  %3  %60 1
+%65 = OpIEqual  %9  %64 %10
+%66 = OpSelect  %3  %65 %12 %10
+%67 = OpCompositeConstruct  %52  %66 %12
+%68 = OpISub  %52  %60 %67
+OpStore %58 %68
+OpBranch %50
+%50 = OpLabel
+%69 = OpFunctionCall  %3  %4 %44 %35
+OpSelectionMerge %70 None
+OpSwitch %69 %72 0 %71
+%71 = OpLabel
+%73 = OpGroupNonUniformBroadcastFirst  %3  %19 %44
+OpStore %46 %73
+OpBranch %70
+%72 = OpLabel
+OpStore %46 %12
+OpBranch %70
+%70 = OpLabel
+OpBranch %49
+%51 = OpLabel
+OpBranch %48
+%49 = OpLabel
+%74 = OpLoad  %3  %46
+OpReturnValue %74
+OpFunctionEnd
+%77 = OpFunction  %3  None %18
+%76 = OpFunctionParameter  %3
+%75 = OpLabel
+%80 = OpVariable  %21  Function %10
+OpBranch %81
+%81 = OpLabel
+%82 = OpFunctionCall  %3  %4 %76 %35
+OpSelectionMerge %83 None
+OpSwitch %82 %85 0 %84
+%84 = OpLabel
+OpStore %80 %78
+OpBranch %83
+%85 = OpLabel
+OpStore %80 %79
+OpBranch %83
+%83 = OpLabel
+%86 = OpLoad  %3  %80
+OpReturnValue %86
+OpFunctionEnd
+%91 = OpFunction  %2  None %92
+%87 = OpLabel
+%90 = OpLoad  %3  %88
+OpBranch %93
+%93 = OpLabel
+%94 = OpFunctionCall  %3  %17 %90
+%95 = OpFunctionCall  %3  %34 %90
+%96 = OpFunctionCall  %3  %45 %90
+%97 = OpFunctionCall  %3  %77 %90
+OpReturn
+OpFunctionEnd

--- a/naga/tests/out/spv/wgsl-subgroup-operations-switch.spvasm.glsl
+++ b/naga/tests/out/spv/wgsl-subgroup-operations-switch.spvasm.glsl
@@ -1,0 +1,101 @@
+#version 460
+#extension GL_KHR_shader_subgroup_ballot : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+#extension GL_KHR_shader_subgroup_basic : require
+layout(local_size_x = 32, local_size_y = 1, local_size_z = 1) in;
+
+uint _4(uint _6, uint _7)
+{
+    return _6 % ((_7 == 0u) ? 1u : _7);
+}
+
+uint _17(uint _16)
+{
+    uint _20 = 0u;
+    switch (_4(_16, 3u))
+    {
+        case 0u:
+        {
+            _20 = subgroupBroadcastFirst(_16);
+            break;
+        }
+        case 1u:
+        {
+            _20 = subgroupAdd(_16);
+            break;
+        }
+        default:
+        {
+            _20 = subgroupBroadcastFirst(_16);
+            break;
+        }
+    }
+    return _20;
+}
+
+uint _34(uint _33)
+{
+    uint _36 = 0u;
+    switch (_4(_33, 2u))
+    {
+        default:
+        {
+            _36 = subgroupBroadcastFirst(_33);
+            break;
+        }
+    }
+    return _36;
+}
+
+uint _45(uint _44)
+{
+    uint _46 = 0u;
+    uvec2 _58 = uvec2(4294967295u);
+    for (;;)
+    {
+        if (all(equal(uvec2(0u), _58)))
+        {
+            break;
+        }
+        _58 -= uvec2(uint(_58.y == 0u), 1u);
+        switch (_4(_44, 2u))
+        {
+            case 0u:
+            {
+                _46 = subgroupBroadcastFirst(_44);
+                break;
+            }
+            default:
+            {
+                _46 = 1u;
+                break;
+            }
+        }
+        break;
+    }
+    return _46;
+}
+
+uint _77(uint _76)
+{
+    uint _80 = 0u;
+    switch (_4(_76, 2u))
+    {
+        case 0u:
+        {
+            _80 = 10u;
+            break;
+        }
+        default:
+        {
+            _80 = 20u;
+            break;
+        }
+    }
+    return _80;
+}
+
+void main()
+{
+}
+

--- a/naga/tests/out/wgsl/wgsl-subgroup-operations-switch.wgsl
+++ b/naga/tests/out/wgsl/wgsl-subgroup-operations-switch.wgsl
@@ -1,0 +1,77 @@
+fn lowered(sid_1: u32) -> u32 {
+    var v: u32 = 0u;
+
+    switch (sid_1 % 3u) {
+        case 0u: {
+            let _e5 = subgroupBroadcastFirst(sid_1);
+            v = _e5;
+        }
+        case 1u: {
+            let _e6 = subgroupAdd(sid_1);
+            v = _e6;
+        }
+        default: {
+            let _e7 = subgroupBroadcastFirst(sid_1);
+            v = _e7;
+        }
+    }
+    let _e8 = v;
+    return _e8;
+}
+
+fn kept_fallthrough(sid_2: u32) -> u32 {
+    var v_1: u32 = 0u;
+
+    switch (sid_2 % 2u) {
+        case 0u, default: {
+            let _e5 = subgroupBroadcastFirst(sid_2);
+            v_1 = _e5;
+        }
+    }
+    let _e6 = v_1;
+    return _e6;
+}
+
+fn kept_break(sid_3: u32) -> u32 {
+    var v_2: u32 = 0u;
+
+    loop {
+        switch (sid_3 % 2u) {
+            case 0u: {
+                let _e5 = subgroupBroadcastFirst(sid_3);
+                v_2 = _e5;
+                break;
+            }
+            default: {
+                v_2 = 1u;
+            }
+        }
+        break;
+    }
+    let _e7 = v_2;
+    return _e7;
+}
+
+fn kept_no_subgroup_ops(sid_4: u32) -> u32 {
+    var v_3: u32 = 0u;
+
+    switch (sid_4 % 2u) {
+        case 0u: {
+            v_3 = 10u;
+        }
+        default: {
+            v_3 = 20u;
+        }
+    }
+    let _e7 = v_3;
+    return _e7;
+}
+
+@compute @workgroup_size(32, 1, 1) 
+fn main(@builtin(subgroup_invocation_id) sid: u32) {
+    let _e1 = lowered(sid);
+    let _e2 = kept_fallthrough(sid);
+    let _e3 = kept_break(sid);
+    let _e4 = kept_no_subgroup_ops(sid);
+    return;
+}


### PR DESCRIPTION
## Summary

Apple's Metal compiler miscompiles subgroup operations performed inside a `switch`. On A14 / iOS 26.5, `simd_broadcast_first` in a switch case returns lane 0's value for **every** lane, ignoring the branch's active mask. The MSL backend now emits such switches as nested `if`/`else` statements — the shape it already produces for `Statement::If` — which is compiled correctly.

This is what makes `wgpu_gpu::subgroup_operations` sub-test 28 fail on Metal, the case annotated `// Mac/Apple will fail this test.` and covered by the `FailureCase::backend(Backends::METAL)` expectation.

## Effect on real hardware

Measured with the `subgroup_operations` shader run on an iPhone 12 (A14, iOS 26.5), wgpu v30:

| | threads passing all 37 sub-tests |
|---|---|
| before | 44 / 128 (3 runs, stable) |
| after | **128 / 128** (5 runs, stable) |

The 44 that passed before are exactly the lanes where `subgroup_invocation_id % 3 == 0`, i.e. the lanes for which the wrong answer (lane 0's value) happens to be the right one.

## Scope of the rewrite

Only switches provably equivalent to an if/else chain are rewritten:

- no case falls through;
- no case body contains a `break` bound to the switch, because in an if/else chain that `break` would bind to an enclosing loop instead;
- at least one case body performs a subgroup operation, so ordinary switches are untouched.

`default` becomes the innermost `else` regardless of its position in the case list.

The rewrite deliberately emits **nested** `else { if … }` rather than a flat `else if` chain: I first implemented the flat form and it is miscompiled on device the same way the `switch` is. Only the nested shape — identical to this backend's `Statement::If` output — produces correct results. The snapshot pins that shape for exactly this reason.

## Tests

New snapshot `subgroup-operations-switch` covers all four paths: one lowered switch, and fall-through / switch-bound-`break` / no-subgroup-ops switches that must keep their `switch`. `cargo test -p naga --all-features` passes (369 tests); no existing snapshot changes, since no existing test had a subgroup operation inside a `switch`.

## What this does not claim

This is a workaround for a driver bug, not a fix for it, and the underlying operation is not fully reliable on Apple hardware. Probing `simd_broadcast_first` under divergence in small standalone compute shaders (32-thread workgroup, one subgroup) gives results that vary **between runs of the same binary** — sometimes spec-conformant, sometimes lane 0 everywhere — for both the `switch` and hand-written if/else forms. The 128/128 above was stable across 5 runs, and the 44/128 baseline across 3, so the improvement to the actual test is reproducible; but I would not treat correct `broadcastFirst` under divergent control flow as guaranteed on Metal on the strength of this change.

Consequently I have **not** touched the `FailureCase` expectations for `subgroup_operations`. If this makes the test pass on the CI Metal runners, the Metal expectation will start reporting an unexpected pass (compare #10019, where the expectation is already outrun by newer hardware) and will need updating — I can push that in whichever direction CI shows, but I did not want to guess at hardware I cannot test.

## Devices tested

- iPhone 12, A14 (Apple7), iOS 26.5 — the case above
- iPhone XS Max, A12 (Apple5), iOS 18.7.9 — unaffected: `AGXMetalA12` has no lowering for any `air.simd_*` intrinsic at all (`Encountered unlowered function call to air.simd_broadcast_first.u.i32`), for every control-flow shape, so this changes nothing there and does not make `SUBGROUP` newly viable on that family
- MacBook Pro, M4 Max, macOS 27.0 — already passed 37/37 before this change, still does
