### PR TITLE
Use edition 2024 in standalone examples

### DIFF
--- a/examples/standalone/01_hello_compute/Cargo.toml
+++ b/examples/standalone/01_hello_compute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-example-01-hello-compute"
-edition = "2021"
+edition = "2024"
 rust-version = "1.87"
 publish = false
 

--- a/examples/standalone/02_hello_window/Cargo.toml
+++ b/examples/standalone/02_hello_window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-example-02-hello-window"
-edition = "2021"
+edition = "2024"
 rust-version = "1.87"
 publish = false
 

--- a/examples/standalone/03_hdr_surface/Cargo.toml
+++ b/examples/standalone/03_hdr_surface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-example-03-hdr-surface"
-edition = "2021"
+edition = "2024"
 rust-version = "1.87"
 publish = false
 

--- a/examples/standalone/03_hdr_surface/src/main.rs
+++ b/examples/standalone/03_hdr_surface/src/main.rs
@@ -162,7 +162,9 @@ fn pick_mode(caps: &wgpu::SurfaceCapabilities, forced: Option<&str>) -> ModeChoi
         Some("extended-display-p3") => cs == Cs::ExtendedDisplayP3,
         Some("srgb") => false,
         Some(other) => {
-            panic!("unknown mode {other:?} (use hdr10|hlg|scrgb|extended-srgb|extended-display-p3|srgb)")
+            panic!(
+                "unknown mode {other:?} (use hdr10|hlg|scrgb|extended-srgb|extended-display-p3|srgb)"
+            )
         }
     };
 

--- a/examples/standalone/custom_backend/Cargo.toml
+++ b/examples/standalone/custom_backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-example-custom-backend"
-edition = "2021"
+edition = "2024"
 rust-version = "1.87"
 publish = false
 


### PR DESCRIPTION
**Connections**
None.

**Description**
A generated example is its own workspace root, so its edition selects the resolver. Resolver 3 holds dependencies to the declared `rust-version` of 1.87; resolver 2 does not, so the `cargo-generate` jobs pick `ordered-float 5.5.0`, which needs Rust 1.90, and fail.

Edition 2024 also selects the 2024 rustfmt style edition, which rewraps one `panic!` in `03_hdr_surface`.

**Testing**
`cargo +1.87 clippy --all-targets` on the four examples.

**Squash or Rebase?**
One commit. Rebase.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
