### PR TITLE
Resolve dependencies against the declared MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "cts_runner",
     "deno_webgpu",

--- a/naga-cli/Cargo.toml
+++ b/naga-cli/Cargo.toml
@@ -6,12 +6,7 @@ description = "CLI for the naga shader translator and validator. Part of the wgp
 repository.workspace = true
 keywords = ["shader", "SPIR-V", "GLSL", "MSL"]
 license.workspace = true
-
-# Override the workspace's `rust-version` key. Firefox uses `cargo vendor` to
-# copy the crates it actually uses out of the workspace, so it's meaningful for
-# them to have less restrictive MSRVs individually than the workspace as a
-# whole, if their code permits. See `../README.md` for details.
-rust-version = "1.76"
+rust-version.workspace = true
 
 [[bin]]
 name = "naga"

--- a/wgpu-core/platform-deps/apple/Cargo.toml
+++ b/wgpu-core/platform-deps/apple/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.76"
+rust-version = "1.87"
 
 [features]
 metal = ["wgpu-hal/metal"]

--- a/wgpu-core/platform-deps/emscripten/Cargo.toml
+++ b/wgpu-core/platform-deps/emscripten/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.76"
+rust-version = "1.87"
 
 [features]
 gles = ["wgpu-hal/gles"]

--- a/wgpu-core/platform-deps/linux-android-bsd/Cargo.toml
+++ b/wgpu-core/platform-deps/linux-android-bsd/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.76"
+rust-version = "1.87"
 
 [features]
 gles = ["wgpu-hal/gles"]

--- a/wgpu-core/platform-deps/wasm/Cargo.toml
+++ b/wgpu-core/platform-deps/wasm/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.76"
+rust-version = "1.87"
 
 [features]
 webgl = ["wgpu-hal/gles"]

--- a/wgpu-core/platform-deps/windows/Cargo.toml
+++ b/wgpu-core/platform-deps/windows/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 # copy the crates it actually uses out of the workspace, so it's meaningful for
 # them to have less restrictive MSRVs individually than the workspace as a
 # whole, if their code permits. See `../README.md` for details.
-rust-version = "1.76"
+rust-version = "1.87"
 
 [features]
 gles = ["wgpu-hal/gles"]


### PR DESCRIPTION
**Connections**
Found while investigating #10139.

**Description**
We had some errant 1.78 versions sitting around.

Resolver 3 is MSRV-aware so a lockfile update can no longer break the MSRV jobs.

**Squash or Rebase?**
It's a commit

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
