### PR TITLE
Discover standalone examples in cargo-generate CI

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -27,21 +27,41 @@ concurrency:
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 jobs:
+  discover-standalone-examples:
+    timeout-minutes: 5
+
+    runs-on: ubuntu-latest
+
+    name: "Discover Standalone Examples"
+
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Find standalone examples
+        id: discover
+        run: |
+          matrix=$(jq -nc --args '{
+            include: [$ARGS.positional[] | rtrimstr("/") | {
+              path: .,
+              name: (split("/")[-1] | gsub("_"; "-"))
+            }]
+          }' examples/standalone/*/)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "$matrix"
+
   cargo-generate:
     timeout-minutes: 5
 
     runs-on: ubuntu-latest
 
+    needs: discover-standalone-examples
+
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: "01-hello-compute"
-            path: "examples/standalone/01_hello_compute"
-          - name: "02-hello-window"
-            path: "examples/standalone/02_hello_window"
-          - name: "custom_backend"
-            path: "examples/standalone/custom_backend"
+      matrix: ${{ fromJSON(needs.discover-standalone-examples.outputs.matrix) }}
 
     name: "${{ matrix.name }}"
 


### PR DESCRIPTION
**Connections**
Depends on #10139.

**Description**
The matrix listed each example by hand, so `03_hdr_surface` was never generated. The job name now comes from the directory name.

**Testing**
CI. Discovery emits all four examples.

**Squash or Rebase?**
Rebase. The first commit is #10139.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
