### PR TITLE
Remove one Arc level of indirection in Dispatch* by implementing clone on Core*

### DIFF
--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -308,7 +308,7 @@ pub struct CoreSurface {
     pub(crate) wgpu_surface: Arc<wgc::instance::Surface>,
     /// Configured device is needed to know which backend
     /// code to execute when acquiring a new frame.
-    configured_device: Mutex<Option<Arc<wgc::device::Device>>>,
+    configured_device: Arc<Mutex<Option<Arc<wgc::device::Device>>>>,
 }
 
 impl fmt::Debug for CoreSurface {
@@ -653,7 +653,7 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
         Ok(CoreSurface {
             context: self.clone(),
             wgpu_surface,
-            configured_device: Mutex::default(),
+            configured_device: Arc::new(Mutex::default()),
         }
         .into())
     }

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -107,7 +107,6 @@ impl ContextWgpuCore {
         let device = CoreDevice {
             context: self.clone(),
             wgpu_device: device.clone(),
-            features: desc.required_features,
         };
         let queue = CoreQueue {
             context: self.clone(),
@@ -340,7 +339,6 @@ impl fmt::Debug for CoreAdapter {
 pub struct CoreDevice {
     pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_device: Arc<wgc::device::Device>,
-    features: Features,
 }
 
 #[derive(Debug)]
@@ -753,7 +751,6 @@ impl dispatch::AdapterInterface for CoreAdapter {
         let device = CoreDevice {
             context: self.context.clone(),
             wgpu_device: device,
-            features: desc.required_features,
         };
         let queue = CoreQueue {
             context: self.context.clone(),
@@ -945,7 +942,11 @@ impl dispatch::DeviceInterface for CoreDevice {
 
         let mut arrayed_texture_views = Vec::new();
         let mut arrayed_samplers = Vec::new();
-        if self.features.contains(Features::TEXTURE_BINDING_ARRAY) {
+        if self
+            .wgpu_device
+            .features()
+            .contains(Features::TEXTURE_BINDING_ARRAY)
+        {
             // gather all the array view first
             for entry in desc.entries.iter() {
                 if let BindingResource::TextureViewArray(array) = entry.resource {
@@ -968,7 +969,11 @@ impl dispatch::DeviceInterface for CoreDevice {
         let mut remaining_arrayed_samplers = &arrayed_samplers[..];
 
         let mut arrayed_buffer_bindings = Vec::new();
-        if self.features.contains(Features::BUFFER_BINDING_ARRAY) {
+        if self
+            .wgpu_device
+            .features()
+            .contains(Features::BUFFER_BINDING_ARRAY)
+        {
             // gather all the buffers first
             for entry in desc.entries.iter() {
                 if let BindingResource::BufferArray(array) = entry.resource {
@@ -984,7 +989,8 @@ impl dispatch::DeviceInterface for CoreDevice {
 
         let mut arrayed_acceleration_structures = Vec::new();
         if self
-            .features
+            .wgpu_device
+            .features()
             .contains(Features::ACCELERATION_STRUCTURE_BINDING_ARRAY)
         {
             // Gather all the TLAS IDs used by TLAS arrays first (same pattern as other arrayed resources).

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -303,6 +303,7 @@ fn map_pass_channel<V: Copy>(ops: Option<&Operations<V>>) -> wgc::command::PassC
     }
 }
 
+#[derive(Clone)]
 pub struct CoreSurface {
     pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_surface: Arc<wgc::instance::Surface>,
@@ -321,6 +322,7 @@ impl fmt::Debug for CoreSurface {
     }
 }
 
+#[derive(Clone)]
 pub struct CoreAdapter {
     pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_adapter: Arc<wgc::instance::Adapter>,
@@ -335,67 +337,67 @@ impl fmt::Debug for CoreAdapter {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreDevice {
     pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_device: Arc<wgc::device::Device>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreBuffer {
     pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_buffer: Arc<wgc::resource::Buffer>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreShaderModule {
     pub(crate) wgpu_shader_module: Arc<wgc::pipeline::ShaderModule>,
     compilation_info: CompilationInfo,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreBindGroupLayout {
     pub(crate) wgpu_bind_group_layout: Arc<wgc::binding_model::BindGroupLayout>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreBindGroup {
     pub(crate) wgpu_bind_group: Arc<wgc::binding_model::BindGroup>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreTexture {
     pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_texture: Arc<wgc::resource::Texture>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreTextureView {
     pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_texture_view: Arc<wgc::resource::TextureView>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreExternalTexture {
     pub(crate) wgpu_external_texture: Arc<wgc::resource::ExternalTexture>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreSampler {
     pub(crate) wgpu_sampler: Arc<wgc::resource::Sampler>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreQuerySet {
     pub(crate) wgpu_query_set: Arc<wgc::resource::QuerySet>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CorePipelineLayout {
     pub(crate) wgpu_pipeline_layout: Arc<wgc::binding_model::PipelineLayout>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CorePipelineCache {
     pub(crate) wgpu_pipeline_cache: Arc<wgc::pipeline::PipelineCache>,
 }
@@ -422,11 +424,12 @@ pub struct CoreRenderBundleEncoder {
     encoder: Box<wgc::command::RenderBundleEncoder>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreRenderBundle {
     pub(crate) wgpu_render_bundle: Arc<wgc::command::RenderBundle>,
 }
 
+#[derive(Clone)]
 pub struct CoreQueue {
     pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_queue: Arc<wgc::device::queue::Queue>,
@@ -441,12 +444,12 @@ impl fmt::Debug for CoreQueue {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreComputePipeline {
     pub(crate) wgpu_compute_pipeline: Arc<wgc::pipeline::ComputePipeline>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreRenderPipeline {
     pub(crate) wgpu_render_pipeline: Arc<wgc::pipeline::RenderPipeline>,
 }
@@ -482,18 +485,19 @@ impl fmt::Debug for CoreCommandEncoder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreBlas {
     pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_blas: Arc<wgc::resource::Blas>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CoreTlas {
     pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_tlas: Arc<wgc::resource::Tlas>,
 }
 
+#[derive(Clone)]
 pub struct CoreSurfaceOutputDetail {
     pub(crate) context: ContextWgpuCore,
     wgpu_surface: Arc<wgc::instance::Surface>,

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -693,8 +693,7 @@ pub trait BufferMappedRangeInterface: CommonTraits {
 /// a `DerefMut` implementation, and `as_*_mut` methods that return `&mut` references.
 /// This `D` does not implement `Clone`.
 ///
-/// The macro's `ref type` form defines `D` to hold an `Arc` pointing to the backend type,
-/// permitting `Clone` and `Deref`, but losing exclusive, mutable access.
+/// The macro's `ref type` form defines `D` to be `Clone` and `Deref`, but losing exclusive, mutable access.
 ///
 /// For example:
 ///
@@ -709,7 +708,7 @@ pub trait BufferMappedRangeInterface: CommonTraits {
 /// ```ignore
 /// pub enum DispatchBuffer {
 ///     #[cfg(wgpu_core)]
-///     Core(Arc<CoreBuffer>),
+///     Core(CoreBuffer),
 ///     #[cfg(webgpu)]
 ///     WebGPU(WebBuffer),
 ///     #[cfg(custom)]
@@ -748,7 +747,7 @@ macro_rules! dispatch_types {
         #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
         pub enum $name {
             #[cfg(wgpu_core)]
-            Core(Arc<$core_type>),
+            Core($core_type),
             #[cfg(webgpu)]
             WebGPU($webgpu_type),
             #[allow(clippy::allow_attributes, private_interfaces)]
@@ -818,7 +817,7 @@ macro_rules! dispatch_types {
         impl From<$core_type> for $name {
             #[inline]
             fn from(value: $core_type) -> Self {
-                Self::Core(Arc::new(value))
+                Self::Core(value)
             }
         }
 
@@ -837,7 +836,7 @@ macro_rules! dispatch_types {
             fn deref(&self) -> &Self::Target {
                 match self {
                     #[cfg(wgpu_core)]
-                    Self::Core(value) => value.as_ref(),
+                    Self::Core(value) => value,
                     #[cfg(webgpu)]
                     Self::WebGPU(value) => value,
                     #[cfg(custom)]


### PR DESCRIPTION
**Connections**
Part of #10073
https://github.com/gfx-rs/wgpu/pull/6850#issuecomment-2569041238

**Description**
Firstly we need to make sure that all types in Core* struct are cloneable, so first few commits do that.
Then we can simply impl Clone on all Core* structs and make Dispatch* store unarced Core*

**Testing**
Just refactor

**Squash or Rebase?**
Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
