### PR TITLE
style(info): normalize capitalization of human-readable limit labels

### DIFF
--- a/wgpu-info/src/human.rs
+++ b/wgpu-info/src/human.rs
@@ -231,12 +231,12 @@ fn print_adapter(output: &mut impl io::Write, report: &AdapterReport, idx: usize
     writeln!(output, "\t\t                                 Max Vertex Buffers: {max_vertex_buffers}")?;
     writeln!(output, "\t\t                              Max Vertex Attributes: {max_vertex_attributes}")?;
     writeln!(output, "\t\t                     Max Vertex Buffer Array Stride: {max_vertex_buffer_array_stride}")?;
-    writeln!(output, "\t\t                            Max Immediate data Size: {max_immediate_size}")?;
+    writeln!(output, "\t\t                            Max Immediate Data Size: {max_immediate_size}")?;
     writeln!(output, "\t\t                   Max Inter-stage Shader Variables: {max_inter_stage_shader_variables}")?;
     writeln!(output, "\t\t                Min Uniform Buffer Offset Alignment: {min_uniform_buffer_offset_alignment}")?;
     writeln!(output, "\t\t                Min Storage Buffer Offset Alignment: {min_storage_buffer_offset_alignment}")?;
     writeln!(output, "\t\t                              Max Color Attachments: {max_color_attachments}")?;
-    writeln!(output, "\t\t              Max Color Attachment Bytes per sample: {max_color_attachment_bytes_per_sample}")?;
+    writeln!(output, "\t\t              Max Color Attachment Bytes Per Sample: {max_color_attachment_bytes_per_sample}")?;
     writeln!(output, "\t\t                 Max Compute Workgroup Storage Size: {max_compute_workgroup_storage_size}")?;
     writeln!(output, "\t\t              Max Compute Invocations Per Workgroup: {max_compute_invocations_per_workgroup}")?;
     writeln!(output, "\t\t                       Max Compute Workgroup Size X: {max_compute_workgroup_size_x}")?;
@@ -259,9 +259,9 @@ fn print_adapter(output: &mut impl io::Write, report: &AdapterReport, idx: usize
     writeln!(output, "\t\t                             Max Mesh Output Layers: {max_mesh_output_layers}")?;
     writeln!(output, "\t\t                      Max Mesh Multiview View Count: {max_mesh_multiview_view_count}")?;
 
-    writeln!(output, "\t\t                           Max BLAS Primitive count: {max_blas_primitive_count}")?;
-    writeln!(output, "\t\t                            Max BLAS Geometry count: {max_blas_geometry_count}")?;
-    writeln!(output, "\t\t                            Max TLAS Instance count: {max_tlas_instance_count}")?;
+    writeln!(output, "\t\t                           Max BLAS Primitive Count: {max_blas_primitive_count}")?;
+    writeln!(output, "\t\t                            Max BLAS Geometry Count: {max_blas_geometry_count}")?;
+    writeln!(output, "\t\t                            Max TLAS Instance Count: {max_tlas_instance_count}")?;
     writeln!(output, "\t\t       Max Acceleration Structures Per Shader Stage: {max_acceleration_structures_per_shader_stage}")?;
     writeln!(output, "   Max Buffers And Acceleration Structures Per Shader Stage: {max_buffers_and_acceleration_structures_per_shader_stage}")?;
 


### PR DESCRIPTION
Five labels in `wgpu-info`'s human output deviated from the Title Case used everywhere else:

```
Max Immediate data Size              -> Max Immediate Data Size
Max Color Attachment Bytes per sample -> Max Color Attachment Bytes Per Sample
Max BLAS Primitive count             -> Max BLAS Primitive Count
Max BLAS Geometry count              -> Max BLAS Geometry Count
Max TLAS Instance count              -> Max TLAS Instance Count
```

Same spirit as #10072. No string lengths changed, so column alignment is untouched; verified locally on macOS (Metal) with `wgpu-info -v`, plus `cargo fmt --check` and `cargo clippy -p wgpu-info`.