### PR TITLE
Fix stale poll() doc comments referring to a bool return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 #### General
 
 - Fix the `BlasAabbGeometry` docs to refer to the `stride` field instead of a nonexistent `size.stride`, and document the packed AABB buffer layout (each primitive a minimum then a maximum corner, two consecutive `vec3<f32>`). By @mstampfli in [#9934](https://github.com/gfx-rs/wgpu/pull/9934).
+- Fix stale `poll()` docs that described a boolean return value instead of `PollStatus`/`PollError`. By @helgev-in-arcana in [#10151](https://github.com/gfx-rs/wgpu/pull/10151).
 
 ### Dependency Updates
 

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -1072,8 +1072,6 @@ impl Global {
     }
 
     /// Check `device_id` for freeable resources and completed buffer mappings.
-    ///
-    /// Return `queue_empty` indicating whether there are more queue submissions still in flight.
     pub fn device_poll(
         &self,
         device_id: DeviceId,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -871,8 +871,6 @@ impl Device {
     }
 
     /// Check device for freeable resources and completed buffer mappings.
-    ///
-    /// Return `queue_empty` indicating whether there are more queue submissions still in flight.
     pub fn poll(
         &self,
         poll_type: wgt::PollType<crate::SubmissionIndex>,
@@ -916,14 +914,9 @@ impl Device {
     /// This will process _all_ completed submissions, even if the caller only asked
     /// us to poll to a given submission index.
     ///
-    /// Return a pair `(closures, result)`, where:
-    ///
-    /// - `closures` is a list of callbacks that need to be invoked informing the user
-    ///   about various things occurring. These happen and should be handled even if
-    ///   this function returns an error, hence they are outside of the result.
-    ///
-    /// - `results` is a boolean indicating the result of the wait operation, including
-    ///   if there was a timeout or a validation error.
+    /// The returned [`UserClosures`] contains callbacks that need to be invoked informing
+    /// the user about various things occurring. These happen and should be handled even
+    /// if this function returns an error, hence they are outside of the result.
     pub(crate) fn maintain<'this>(
         &'this self,
         poll_type: wgt::PollType<crate::SubmissionIndex>,

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -95,11 +95,10 @@ impl Device {
 
     /// Check for resource cleanups and mapping callbacks. Will block if [`PollType::Wait`] is passed.
     ///
-    /// Return `true` if the queue is empty, or `false` if there are more queue
-    /// submissions still in flight. (Note that, unless access to the [`Queue`] is
-    /// coordinated somehow, this information could be out of date by the time
-    /// the caller receives it. `Queue`s can be shared between threads, so
-    /// other threads could submit new work at any time.)
+    /// (Note that, unless access to the [`Queue`] is coordinated somehow,
+    /// the returned [`PollStatus`] could be out of date by the time the caller
+    /// receives it. `Queue`s can be shared between threads, so other threads
+    /// could submit new work at any time.)
     ///
     /// When running on WebGPU, this is a no-op. `Device`s are automatically polled.
     pub fn poll(&self, poll_type: PollType) -> Result<crate::PollStatus, crate::PollError> {


### PR DESCRIPTION
**Connections**

(none — nothing to link)

**Description**

Device::poll (both the public wgpu::Device::poll and the internal wgpu-core version), the internal Device::maintain helper, and wgpu-core-remote's Global::device_poll all had doc comments describing their return value as a plain true/false. This is stale — these functions were changed to return Result<PollStatus, PollError> (or Result<PollStatus, WaitIdleError>) a while ago, but the docs were never updated to match.

This PR removes that stale prose. Since cargo doc already auto-links PollStatus/PollError/WaitIdleError from the function signatures, most of these doc comments don't need to re-explain the return value at all — simply removing the outdated description is enough. The one exception is maintain's doc, where the part of the return value that isn't self-explanatory from the type alone (that UserClosures need to be invoked even when this function returns an error) is kept, with an explicit link to [UserClosures].

**Testing**

Documentation-only change, no behavioral changes. cargo doc builds cleanly with no broken intra-doc-link warnings for the touched items.

**Squash or Rebase?**

Single commit; ready to land as-is.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally. (N/A — docs only)
- [ ] Validation and feature gates are in place to confine behavioral changes. (N/A)
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` --> (N/A — docs only)
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
