### PR TITLE
perf(core): reuse the acceleration structure build scratch buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 ### Performance
 
 - Added explicit `Send` and `Sync` implementations to key `wgpu` types so that the compiler can do less work checking those bounds. If you previously added a `#![recursion_limit = ...]` attribute to your crate due to overflow errors involving `wgpu` types, you may now be able to remove it. By @kpreid in [#10177](https://github.com/gfx-rs/wgpu/pull/10177).
+- Reuse the acceleration-structure build scratch buffer across `build_acceleration_structures` calls, instead of allocating and freeing a fresh one per build: the most recent scratch is parked on the device and taken by the next build that fits. Applications that rebuild a large acceleration structure every frame no longer pay a device memory allocation and free per build. Rebuilding a 1M-primitive AABB BLAS (76 MB of scratch) on Vulkan/NVIDIA went from 5.9-7.6 ms to 3.8-3.9 ms per rebuild. By @mstampfli in [#10155](https://github.com/gfx-rs/wgpu/pull/10155).
 
 ### Documentation
 

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -291,6 +291,12 @@ pub struct Device {
     pub(crate) ordered_texture_usages: wgt::TextureUses,
     pub(crate) instance_flags: wgt::InstanceFlags,
     pub(crate) deferred_destroy: Mutex<Vec<DeferredDestroy>>,
+    /// The most recent acceleration-structure build scratch buffer, parked here
+    /// by [`ScratchBuffer::drop`] for reuse by the next build (largest kept).
+    /// Holds no `Arc<Device>` (no cycle); destroyed in [`Device`]'s `Drop`.
+    ///
+    /// [`ScratchBuffer::drop`]: crate::scratch::ScratchBuffer
+    pub(crate) scratch_buffer_cache: Mutex<Option<crate::scratch::CachedScratchBuffer>>,
     /// This closures were created in [`Buffer::drop`] where we do not run them to prevent locking problems.
     pub(crate) deferred_buffer_map_pending_closures: DeferredBufferMapPendingClosures,
     pub(crate) usage_scopes: UsageScopePool,
@@ -347,6 +353,7 @@ impl Drop for Device {
         if let Some(timestamp_normalizer) = self.timestamp_normalizer.take() {
             timestamp_normalizer.dispose(self.raw.as_ref());
         }
+        self.destroy_cached_scratch_buffer();
         unsafe {
             self.raw.destroy_buffer(zero_buffer);
             self.raw.destroy_bind_group_layout(empty_bgl);
@@ -627,6 +634,7 @@ impl Device {
                 ordered_texture_usages,
                 instance_flags,
                 deferred_destroy: Mutex::new(rank::DEVICE_DEFERRED_DESTROY, Vec::new()),
+                scratch_buffer_cache: Mutex::new(rank::DEVICE_SCRATCH_BUFFER_CACHE, None),
                 usage_scopes: Mutex::new(rank::DEVICE_USAGE_SCOPES, Default::default()),
                 timestamp_normalizer: OnceCell::new(),
                 indirect_validation,
@@ -5719,6 +5727,22 @@ impl Device {
         }
         for texture in textures {
             texture.destroy();
+        }
+
+        // The parked scratch buffer can be large, and a lost device will not build again.
+        self.destroy_cached_scratch_buffer();
+    }
+
+    /// Destroy the acceleration-structure build scratch buffer parked in
+    /// [`Device::scratch_buffer_cache`], if there is one.
+    fn destroy_cached_scratch_buffer(&self) {
+        // Taking it under the lock means a concurrent build either takes it first, or misses it
+        // and allocates its own; nothing can observe the buffer after this point.
+        if let Some(cached) = self.scratch_buffer_cache.lock().take() {
+            resource_log!("Destroy raw ScratchBuffer");
+            // SAFETY: A parked buffer is idle - it is parked only once its submission retired, or
+            // before it was ever submitted.
+            unsafe { self.raw.destroy_buffer(cached.raw) };
         }
     }
 

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -108,6 +108,7 @@ define_lock_ranks! {
     // Non-leaf ranks, in topological order.
     rank COMMAND_BUFFER_DATA "CommandBuffer::data" followed by {
         DEVICE_SNATCHABLE_LOCK,
+        DEVICE_SCRATCH_BUFFER_CACHE,
         BUFFER_MAP_STATE,
         COMMAND_ALLOCATOR_FREE_ENCODERS,
         BUFFER_POOL,
@@ -123,6 +124,7 @@ define_lock_ranks! {
         TEXTURE_INITIALIZATION_STATUS,
         QUEUE_LIFE_TRACKER,
         BLAS_COMPACTION_STATE,
+        DEVICE_SCRATCH_BUFFER_CACHE,
         BUFFER_BIND_GROUPS,
         BUFFER_INITIALIZATION_STATUS,
         BUFFER_POOL,
@@ -143,10 +145,12 @@ define_lock_ranks! {
         QUEUE_LIFE_TRACKER,
         COMMAND_ALLOCATOR_FREE_ENCODERS,
         DEVICE_DEFERRED_DESTROY,
+        DEVICE_SCRATCH_BUFFER_CACHE,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
     rank QUEUE_PENDING_WRITES "Queue::pending_writes" followed by {
         BUFFER_MAP_STATE,
+        DEVICE_SCRATCH_BUFFER_CACHE,
         DEVICE_TRACKERS,
         COMMAND_ALLOCATOR_FREE_ENCODERS,
         BUFFER_INITIALIZATION_STATUS,
@@ -165,6 +169,7 @@ define_lock_ranks! {
         BUFFER_POOL,
         COMMAND_ALLOCATOR_FREE_ENCODERS,
         DEVICE_DEFERRED_DESTROY,
+        DEVICE_SCRATCH_BUFFER_CACHE,
         DEVICE_TRACE,
         SHARED_TRACKER_INDEX_ALLOCATOR_INNER,
     }
@@ -184,6 +189,7 @@ define_lock_ranks! {
     rank BUFFER_INITIALIZATION_STATUS "Buffer::initialization_status" followed by { }
     rank BUFFER_POOL "BufferPool::buffers" followed by { }
     rank DEVICE_DEFERRED_DESTROY "Device::deferred_destroy" followed by { }
+    rank DEVICE_SCRATCH_BUFFER_CACHE "Device::scratch_buffer_cache" followed by { }
     rank DEVICE_TRACE "Device::trace" followed by { }
     rank DEVICE_USAGE_SCOPES "Device::usage_scopes" followed by { }
     rank SHARED_TRACKER_INDEX_ALLOCATOR_INNER "SharedTrackerIndexAllocator::inner" followed by { }

--- a/wgpu-core/src/scratch.rs
+++ b/wgpu-core/src/scratch.rs
@@ -6,14 +6,58 @@ use wgt::BufferUses;
 use crate::device::{Device, DeviceError};
 use crate::{hal_label, resource_log};
 
+/// A scratch buffer parked in [`Device::scratch_buffer_cache`] between
+/// acceleration-structure builds, so repeated builds (streaming geometry,
+/// per-frame rebuilds) reuse one allocation instead of allocating and freeing
+/// a large buffer every build.
+///
+/// Holds the raw buffer only - deliberately no `Arc<Device>`, so the cache on
+/// the device does not create a reference cycle. The device destroys any parked
+/// buffer in its own `Drop`.
+#[derive(Debug)]
+pub(crate) struct CachedScratchBuffer {
+    pub(crate) raw: Box<dyn hal::DynBuffer>,
+    pub(crate) size: wgt::BufferSize,
+}
+
+/// A GPU buffer used as build scratch for acceleration-structure builds.
+///
+/// Scratch buffers can be large (proportional to the geometry being built), so
+/// rather than allocating one per build, [`ScratchBuffer::new`] reuses the
+/// device's parked scratch buffer when it is large enough, and `Drop` parks the
+/// buffer back in the cache, keeping the larger of the two. A `ScratchBuffer`
+/// only reaches `Drop` once the submission using it has retired (it is carried
+/// as a [`TempResource`] of that submission) or before it was ever submitted
+/// (encode error paths, device teardown), so a parked buffer is always idle and
+/// reusing it needs no additional synchronization.
+///
+/// [`TempResource`]: crate::device::queue::TempResource
 #[derive(Debug)]
 pub struct ScratchBuffer {
     raw: ManuallyDrop<Box<dyn hal::DynBuffer>>,
+    size: wgt::BufferSize,
     device: Arc<Device>,
 }
 
 impl ScratchBuffer {
     pub(crate) fn new(device: &Arc<Device>, size: wgt::BufferSize) -> Result<Self, DeviceError> {
+        // Reuse the parked scratch buffer if it is large enough. Its actual
+        // (possibly larger) size is carried along, so parking it again keeps
+        // the largest scratch the device has needed so far.
+        let cached = {
+            let mut cache = device.scratch_buffer_cache.lock();
+            match &*cache {
+                Some(c) if c.size >= size => cache.take(),
+                _ => None,
+            }
+        };
+        if let Some(cached) = cached {
+            return Ok(Self {
+                raw: ManuallyDrop::new(cached.raw),
+                size: cached.size,
+                device: device.clone(),
+            });
+        }
         let raw = unsafe {
             device
                 .raw()
@@ -27,6 +71,7 @@ impl ScratchBuffer {
         };
         Ok(Self {
             raw: ManuallyDrop::new(raw),
+            size,
             device: device.clone(),
         })
     }
@@ -37,9 +82,25 @@ impl ScratchBuffer {
 
 impl Drop for ScratchBuffer {
     fn drop(&mut self) {
-        resource_log!("Destroy raw ScratchBuffer");
         // SAFETY: We are in the Drop impl and we don't use self.raw anymore after this point.
         let raw = unsafe { ManuallyDrop::take(&mut self.raw) };
-        unsafe { self.device.raw().destroy_buffer(raw) };
+        // Park the buffer for the next build; keep the larger of this buffer
+        // and any already-parked one, and destroy the other.
+        let evicted = {
+            let mut cache = self.device.scratch_buffer_cache.lock();
+            match &*cache {
+                Some(c) if c.size >= self.size => Some(raw),
+                _ => cache
+                    .replace(CachedScratchBuffer {
+                        raw,
+                        size: self.size,
+                    })
+                    .map(|c| c.raw),
+            }
+        };
+        if let Some(buffer) = evicted {
+            resource_log!("Destroy raw ScratchBuffer");
+            unsafe { self.device.raw().destroy_buffer(buffer) };
+        }
     }
 }


### PR DESCRIPTION
**Connections**
None (found while building a streaming voxel world on the experimental
ray-tracing API; happy to file a tracking issue if preferred).

**Description**
`build_acceleration_structures` allocates a fresh scratch buffer per call and
frees it when the submission retires. Scratch is proportional to the geometry
being built, so once it is large enough that the allocator has to give it its
own memory block, an application rebuilding a large acceleration structure
every frame pays a device memory allocation and free on every build.

This parks the most recent scratch buffer on the device and reuses it:
`ScratchBuffer::new` takes the parked buffer when it is large enough, and
`Drop` parks it back, keeping the larger of the two. A `ScratchBuffer` only
drops once its submission retired (it rides `TempResource`) or before it was
ever submitted, so a parked buffer is always GPU-idle and reuse introduces no
new synchronization requirements. The cache holds the raw hal buffer only (no
`Arc<Device>`, so no reference cycle); the device destroys a parked buffer in
its own `Drop`, and in `release_gpu_resources` so a lost device does not
retain it.

Measured on Vulkan/NVIDIA (RTX 5060, default `MemoryHints::Performance`),
timing the whole build/submit/wait cycle of a repeatedly rebuilt AABB BLAS:

| scratch | trunk | with this change |
|---|---|---|
| 23 MB | 1.42 ms | 1.39 ms |
| 76 MB | 5.9-7.6 ms | 3.8-3.9 ms |
| 228 MB | 14.9 ms | 13.2 ms |

Timing the `create_buffer` call alone shows where it comes from: 0.002 ms at
65 MiB of scratch, 1.4 ms at 73 MiB, 3.9 ms at 228 MB. Below that threshold
the change is not measurable, which is why the table starts flat. It also
removes most of the variance - worst case at 76 MB goes from 11.9 ms to
4.2 ms.

Concurrent builds are safe by construction. The cache is a take-or-miss under a
single mutex, so a parked buffer is owned by exactly one build at a time: a
second concurrent build either finds the cache empty and allocates its own
scratch, exactly as today, or takes one that is large enough for it. Reuse
carries no ordering meaning, since scratch is private workspace for the build
that owns it and its contents are never read across builds.

Memory-wise the device retains at most one scratch buffer of the peak scratch
size, until device loss or teardown; happy to add a trim policy if you would
rather not retain it.

**Testing**
The ray tracing suite passes 155 of 155 here, on Vulkan and GL. The full GPU
test suite shows no change against trunk: the same pass count and the same set
of pre-existing backend failures, with no test failing on one side and not the
other.

Reuse itself was verified by instrumenting `ScratchBuffer::new`: trunk
allocates a fresh 22.8 MB scratch on every build, this allocates once and then
reuses it. The new `DEVICE_SCRATCH_BUFFER_CACHE` lock rank was checked with
`RUSTFLAGS='--cfg wgpu_validate_locks'`: removing its follower entries makes
validation panic on the new lock, restoring them clears it.

I also ran the repository CI checks locally at their pinned versions (clippy
for native, web and `wasm32v1-none` no_std, `doc` and
`doc --document-private-items`, doctests, wgpu and core MSRV 1.87, `cargo fmt`,
prettier, typos and `cargo deny`), with no failures.

**Squash or Rebase?**
Squash.
